### PR TITLE
Fixed the double allocation of memory

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandAllocator.h
@@ -52,6 +52,25 @@ namespace OloEngine
             
             return packet;
         }
+		
+        template<typename T>
+        CommandPacket* AllocatePacketWithCommand(const PacketMetadata& metadata = {})
+        {
+            constexpr sizet packetSize = sizeof(CommandPacket);
+            constexpr sizet commandSize = sizeof(T);
+            constexpr sizet totalSize = packetSize + commandSize;
+            void* block = AllocateCommandMemory(totalSize);
+            OLO_CORE_ASSERT(block, "CommandAllocator::AllocatePacketWithCommand: Allocation failed!");
+            // Placement-new the packet at the start
+            auto* packet = new (block) CommandPacket();
+            // Placement-new the command immediately after
+            void* commandMem = static_cast<u8*>(block) + packetSize;
+            T* cmd = new (commandMem) T();
+			
+            packet->SetCommandData(cmd, commandSize);
+            packet->SetMetadata(metadata);
+            return packet;
+        }
         
         // Reset the allocator - doesn't free memory, just resets offsets
         void Reset();

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
@@ -69,7 +69,7 @@ namespace OloEngine
 		if (!packet)
 			return;
 
-		std::lock_guard<std::mutex> lock(m_Mutex);
+		packet->SetNext(nullptr); 
 
 		if (!m_Head)
 		{

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
@@ -111,20 +111,18 @@ namespace OloEngine
 		sizet GetCommandCount() const { return m_CommandCount; }
 
 		template<typename T>
-		T* CreateDrawCall()
+		CommandPacket* CreateDrawCall()
 		{
 			OLO_CORE_ASSERT(m_Allocator, "CommandBucket::CreateDrawCall: No allocator available!");
-			void* mem = m_Allocator->AllocateCommandMemory(sizeof(T));
-			OLO_CORE_ASSERT(mem, "CommandBucket::CreateDrawCall: Allocation failed!");
-			T* cmd = new (mem) T();
-			return cmd;
+			PacketMetadata initialMetadata; // Default metadata, to be enhanced later
+			return m_Allocator->AllocatePacketWithCommand<T>(initialMetadata);
 		}
 
-		template<typename T>
-		void SubmitDrawCall(T* cmd, const PacketMetadata& metadata)
+		void SubmitPacket(CommandPacket* packet)
 		{
-			OLO_CORE_ASSERT(cmd, "CommandBucket::SubmitDrawCall: Null command pointer!");
-			CommandPacket* packet = m_Allocator->CreateCommandPacket(*cmd, metadata);
+			OLO_CORE_ASSERT(packet, "CommandBucket::SubmitPacket: Null packet!");
+			std::lock_guard<std::mutex> lock(m_Mutex);
+			
 			AddCommand(packet);
 		}
 

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandPacket.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandPacket.h
@@ -106,18 +106,22 @@ namespace OloEngine
         // Returns true if this packet can be batched with another packet
         bool CanBatchWith(const CommandPacket& other) const;
 
-        // Get the command data for direct access (needed for batching)
+        // Set external command data pointer and size
+        void SetCommandData(void* data, sizet size)
+        {
+            m_CommandData = data;
+            m_CommandSize = size;
+        }
+
         template<typename T>
         T* GetCommandData()
         {
-            static_assert(sizeof(T) <= MAX_COMMAND_SIZE, "Command exceeds maximum size");
             return reinterpret_cast<T*>(m_CommandData);
         }
 
         template<typename T>
         const T* GetCommandData() const
         {
-            static_assert(sizeof(T) <= MAX_COMMAND_SIZE, "Command exceeds maximum size");
             return reinterpret_cast<const T*>(m_CommandData);
         }
 
@@ -153,16 +157,11 @@ namespace OloEngine
         void SetMetadata(const PacketMetadata& metadata) { m_Metadata = metadata; }
         
     private:
-        // Command data
-        u8 m_CommandData[MAX_COMMAND_SIZE];
+        void* m_CommandData = nullptr;
         sizet m_CommandSize = 0;
         CommandType m_CommandType = CommandType::Invalid;
         CommandDispatchFn m_DispatchFn = nullptr;
-        
-        // Metadata
         PacketMetadata m_Metadata;
-        
-        // Linked list
         CommandPacket* m_Next = nullptr;
     };
 }

--- a/OloEngine/src/OloEngine/Renderer/Model.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Model.cpp
@@ -205,14 +205,14 @@ namespace OloEngine
 		m_BoundingSphere = BoundingSphere(center, radius);
 	}
 
-	void Model::GetDrawCommands(const glm::mat4& transform, const Material& material, std::vector<DrawMeshCommand*>& outCommands) const
+	void Model::GetDrawCommands(const glm::mat4& transform, const Material& material, std::vector<CommandPacket*>& outCommands) const
 	{
 		OLO_PROFILE_FUNCTION();
 		outCommands.clear();
 		outCommands.reserve(m_Meshes.size());
 		for (const auto& mesh : m_Meshes)
 		{
-			DrawMeshCommand* cmd = OloEngine::Renderer3D::DrawMesh(mesh, transform, material);
+			CommandPacket* cmd = OloEngine::Renderer3D::DrawMesh(mesh, transform, material);
 			if (cmd)
 				outCommands.push_back(cmd);
 		}

--- a/OloEngine/src/OloEngine/Renderer/Model.h
+++ b/OloEngine/src/OloEngine/Renderer/Model.h
@@ -27,8 +27,7 @@ namespace OloEngine
 		void LoadModel(const std::string& path);
 		void Draw(const glm::mat4& transform, const Material& material) const;
 
-		// New: Collect draw commands for all meshes in the model
-		void GetDrawCommands(const glm::mat4& transform, const Material& material, std::vector<DrawMeshCommand*>& outCommands) const;
+		void GetDrawCommands(const glm::mat4& transform, const Material& material, std::vector<CommandPacket*>& outCommands) const;
 		
 		// Calculate bounding volumes for the entire model
 		void CalculateBounds();

--- a/OloEngine/src/OloEngine/Renderer/Passes/RenderPass.h
+++ b/OloEngine/src/OloEngine/Renderer/Passes/RenderPass.h
@@ -47,11 +47,10 @@ namespace OloEngine
             m_Allocator = allocator ? allocator : m_OwnedAllocator.get(); 
         }
 
-        template<typename T>
-        CommandPacket* SubmitCommand(const T& commandData)
-        {
-            return m_CommandBucket.Submit(commandData, PacketMetadata{}, m_Allocator);
-        }
+        void SubmitPacket(CommandPacket* packet)
+		{
+			m_CommandBucket.SubmitPacket(packet);
+		}
 		
         CommandBucket& GetCommandBucket() { return m_CommandBucket; }
     protected:

--- a/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
@@ -58,7 +58,7 @@ namespace OloEngine
         rendererAPI.SetCullFace(GL_BACK);
         rendererAPI.SetPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
         
-		m_CommandBucket.SortCommands();
+		//m_CommandBucket.SortCommands();
 		m_CommandBucket.Execute(rendererAPI);
 
 

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -45,11 +45,11 @@ namespace OloEngine
 		static void BeginScene(const PerspectiveCamera& camera);
 		static void EndScene();
 
-		static DrawMeshCommand* DrawMesh(const Ref<Mesh>& mesh, const glm::mat4& modelMatrix, const Material& material, bool isStatic = true);
-		static DrawQuadCommand* DrawQuad(const glm::mat4& modelMatrix, const Ref<Texture2D>& texture);
-		static DrawMeshInstancedCommand* DrawMeshInstanced(const Ref<Mesh>& mesh, const std::vector<glm::mat4>& transforms, const Material& material, bool isStatic = true);
-		static DrawMeshCommand* DrawLightCube(const glm::mat4& modelMatrix);
-		static DrawMeshCommand* DrawCube(const glm::mat4& modelMatrix, const Material& material, bool isStatic = true);
+		static CommandPacket* DrawMesh(const Ref<Mesh>& mesh, const glm::mat4& modelMatrix, const Material& material, bool isStatic = true);
+		static CommandPacket* DrawQuad(const glm::mat4& modelMatrix, const Ref<Texture2D>& texture);
+		static CommandPacket* DrawMeshInstanced(const Ref<Mesh>& mesh, const std::vector<glm::mat4>& transforms, const Material& material, bool isStatic = true);
+		static CommandPacket* DrawLightCube(const glm::mat4& modelMatrix);
+		static CommandPacket* DrawCube(const glm::mat4& modelMatrix, const Material& material, bool isStatic = true);
 	
 		static void SetLight(const Light& light);
 		static void SetViewPosition(const glm::vec3& position);
@@ -73,10 +73,21 @@ namespace OloEngine
 		static const Ref<RenderGraph>& GetRenderGraph() { return s_Data.RGraph; }
 
 		template<typename T>
-		static void SubmitDrawCall(T* drawCall)
+		static CommandPacket* CreateDrawCall()
 		{
 			OLO_PROFILE_FUNCTION();
-			s_Data.ScenePass->SubmitCommand(*drawCall); // Pass by value, not pointer
+			return s_Data.ScenePass->GetCommandBucket().CreateDrawCall<T>();
+		}
+
+		static void SubmitPacket(CommandPacket* packet)
+		{
+			OLO_PROFILE_FUNCTION();
+			if (!packet)
+			{
+				OLO_CORE_WARN("Renderer3D::SubmitPacket: Attempted to submit a null CommandPacket pointer!");
+				return;
+			}
+			s_Data.ScenePass->SubmitPacket(packet);
 		}
 
 	private:

--- a/Sandbox3D/src/Sandbox3D.cpp
+++ b/Sandbox3D/src/Sandbox3D.cpp
@@ -162,8 +162,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			planeMaterial.Diffuse = glm::vec3(0.3f);
 			planeMaterial.Specular = glm::vec3(0.2f);
 			planeMaterial.Shininess = 8.0f;
-			auto* cmd = OloEngine::Renderer3D::DrawMesh(m_PlaneMesh, planeMatrix, planeMaterial, true);
-			OloEngine::Renderer3D::SubmitDrawCall(cmd);
+			auto* planePacket = OloEngine::Renderer3D::DrawMesh(m_PlaneMesh, planeMatrix, planeMaterial, true);
+			if (planePacket) OloEngine::Renderer3D::SubmitPacket(planePacket);
 		}
 
 		// Draw a grass quad
@@ -172,8 +172,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			grassMatrix = glm::translate(grassMatrix, glm::vec3(0.0f, 0.5f, -1.0f));
 			// Make it face the camera by rotating around X axis
 			grassMatrix = glm::rotate(grassMatrix, glm::radians(-90.0f), glm::vec3(1.0f, 0.0f, 0.0f));
-			auto* grassCmd = OloEngine::Renderer3D::DrawQuad(grassMatrix, m_GrassTexture);
-			OloEngine::Renderer3D::SubmitDrawCall(grassCmd);
+			auto* grassPacket = OloEngine::Renderer3D::DrawQuad(grassMatrix, m_GrassTexture);
+			if (grassPacket) OloEngine::Renderer3D::SubmitPacket(grassPacket);
 		}
 
 		// Draw backpack model using command-based renderer
@@ -182,12 +182,11 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			modelMatrix = glm::translate(modelMatrix, glm::vec3(0.0f, 1.0f, -2.0f)); // Raise it up and move it back
 			modelMatrix = glm::scale(modelMatrix, glm::vec3(0.5f)); // Scale down to reasonable size
 			modelMatrix = glm::rotate(modelMatrix, glm::radians(m_RotationAngleY), glm::vec3(0.0f, 1.0f, 0.0f));
-			std::vector<OloEngine::DrawMeshCommand*> backpackDrawCommands;
+			std::vector<OloEngine::CommandPacket*> backpackDrawCommands;
 			m_BackpackModel->GetDrawCommands(modelMatrix, m_TexturedMaterial, backpackDrawCommands);
-			for (auto* cmd : backpackDrawCommands)
+			for (auto* drawCmd : backpackDrawCommands)
 			{
-				// Optionally configure per-mesh state here
-				OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				OloEngine::Renderer3D::SubmitPacket(drawCmd);
 			}
 		}
 
@@ -197,26 +196,24 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			modelMatrix = glm::rotate(modelMatrix, glm::radians(m_RotationAngleX), glm::vec3(1.0f, 0.0f, 0.0f));
 			modelMatrix = glm::rotate(modelMatrix, glm::radians(m_RotationAngleY), glm::vec3(0.0f, 1.0f, 0.0f));
 			// Draw filled mesh (normal)
-			auto* solidCmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, modelMatrix, m_GoldMaterial);
-			if (solidCmd)
-			{
-				OloEngine::Renderer3D::SubmitDrawCall(solidCmd);
-			}
+			auto* solidPacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, modelMatrix, m_GoldMaterial);
+			if (solidPacket) OloEngine::Renderer3D::SubmitPacket(solidPacket);
 			// Overlay wireframe
 			OloEngine::Material wireMaterial;
 			wireMaterial.Ambient = glm::vec3(0.0f);
 			wireMaterial.Diffuse = glm::vec3(0.0f, 0.0f, 0.0f);
 			wireMaterial.Specular = glm::vec3(0.0f);
 			wireMaterial.Shininess = 1.0f;
-			auto* wireCmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, modelMatrix, wireMaterial);
-			if (wireCmd)
+			auto* wirePacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, modelMatrix, wireMaterial);
+			if (wirePacket)
 			{
-				wireCmd->renderState->PolygonMode.Mode = GL_LINE;
-				wireCmd->renderState->LineWidth.Width = 2.5f; // Thicker line
-				wireCmd->renderState->PolygonOffset.Enabled = true;
-				wireCmd->renderState->PolygonOffset.Factor = -1.0f;
-				wireCmd->renderState->PolygonOffset.Units = -1.0f;
-				OloEngine::Renderer3D::SubmitDrawCall(wireCmd);
+				auto* drawCmd = wirePacket->GetCommandData<OloEngine::DrawMeshCommand>();
+				drawCmd->renderState->PolygonMode.Mode = GL_LINE;
+				drawCmd->renderState->LineWidth.Width = 2.5f; // Thicker line
+				drawCmd->renderState->PolygonOffset.Enabled = true;
+				drawCmd->renderState->PolygonOffset.Factor = -1.0f;
+				drawCmd->renderState->PolygonOffset.Units = -1.0f;
+				OloEngine::Renderer3D::SubmitPacket(wirePacket);
 			}
 		}
 
@@ -229,8 +226,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 				auto silverCubeMatrix = glm::mat4(1.0f);
 				silverCubeMatrix = glm::translate(silverCubeMatrix, glm::vec3(2.0f, 0.0f, 0.0f));
 				silverCubeMatrix = glm::rotate(silverCubeMatrix, glm::radians(m_RotationAngleY * 1.5f), glm::vec3(0.0f, 1.0f, 0.0f));
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, silverCubeMatrix, m_SilverMaterial);
-				if (cmd) OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* silverPacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, silverCubeMatrix, m_SilverMaterial);
+				if (silverPacket) OloEngine::Renderer3D::SubmitPacket(silverPacket);
 			}
 
 			// Draw left chrome cube
@@ -238,8 +235,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 				auto chromeCubeMatrix = glm::mat4(1.0f);
 				chromeCubeMatrix = glm::translate(chromeCubeMatrix, glm::vec3(-2.0f, 0.0f, 0.0f));
 				chromeCubeMatrix = glm::rotate(chromeCubeMatrix, glm::radians(m_RotationAngleX * 1.5f), glm::vec3(1.0f, 0.0f, 0.0f));
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, chromeCubeMatrix, m_ChromeMaterial);
-				if (cmd) OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* chromePacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, chromeCubeMatrix, m_ChromeMaterial);
+				if (chromePacket) OloEngine::Renderer3D::SubmitPacket(chromePacket);
 			}
 			break;
 
@@ -247,24 +244,24 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 				// Draw center gold sphere
 			{
 				auto modelMatrix = glm::mat4(1.0f);
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, modelMatrix, m_GoldMaterial);
-				OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* goldPacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, modelMatrix, m_GoldMaterial);
+				if (goldPacket) OloEngine::Renderer3D::SubmitPacket(goldPacket);
 			}
 
 			// Draw right silver sphere
 			{
 				auto silverSphereMatrix = glm::mat4(1.0f);
 				silverSphereMatrix = glm::translate(silverSphereMatrix, glm::vec3(2.0f, 0.0f, 0.0f));
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, silverSphereMatrix, m_SilverMaterial);
-				OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* silverPacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, silverSphereMatrix, m_SilverMaterial);
+				if (silverPacket) OloEngine::Renderer3D::SubmitPacket(silverPacket);
 			}
 
 			// Draw left chrome sphere
 			{
 				auto chromeSphereMatrix = glm::mat4(1.0f);
 				chromeSphereMatrix = glm::translate(chromeSphereMatrix, glm::vec3(-2.0f, 0.0f, 0.0f));
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, chromeSphereMatrix, m_ChromeMaterial);
-				OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* chromePacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, chromeSphereMatrix, m_ChromeMaterial);
+				if (chromePacket) OloEngine::Renderer3D::SubmitPacket(chromePacket);
 			}
 			break;
 
@@ -274,15 +271,15 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 				// Draw right silver sphere
 				auto silverSphereMatrix = glm::mat4(1.0f);
 				silverSphereMatrix = glm::translate(silverSphereMatrix, glm::vec3(2.0f, 0.0f, 0.0f));
-				auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, silverSphereMatrix, m_SilverMaterial);
-				OloEngine::Renderer3D::SubmitDrawCall(cmd);
+				auto* silverPacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, silverSphereMatrix, m_SilverMaterial);
+				if (silverPacket) OloEngine::Renderer3D::SubmitPacket(silverPacket);
 
 				// Draw left chrome cube
 				auto chromeCubeMatrix = glm::mat4(1.0f);
 				chromeCubeMatrix = glm::translate(chromeCubeMatrix, glm::vec3(-2.0f, 0.0f, 0.0f));
 				chromeCubeMatrix = glm::rotate(chromeCubeMatrix, glm::radians(m_RotationAngleX * 1.5f), glm::vec3(1.0f, 0.0f, 0.0f));
-				auto* cmdChrome = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, chromeCubeMatrix, m_ChromeMaterial);
-				OloEngine::Renderer3D::SubmitDrawCall(cmdChrome);
+				auto* chromePacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, chromeCubeMatrix, m_ChromeMaterial);
+				if (chromePacket) OloEngine::Renderer3D::SubmitPacket(chromePacket);
 			}
 			break;
 		}
@@ -293,9 +290,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			sphereMatrix = glm::translate(sphereMatrix, glm::vec3(0.0f, 2.0f, 0.0f));
 			sphereMatrix = glm::rotate(sphereMatrix, glm::radians(m_RotationAngleX * 0.8f), glm::vec3(1.0f, 0.0f, 0.0f));
 			sphereMatrix = glm::rotate(sphereMatrix, glm::radians(m_RotationAngleY * 0.8f), glm::vec3(0.0f, 1.0f, 0.0f));
-			auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, m_TexturedMaterial);
-			if (cmd) OloEngine::Renderer3D::SubmitDrawCall(cmd);
-				
+			auto* texturedPacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, m_TexturedMaterial);
+			if (texturedPacket) OloEngine::Renderer3D::SubmitPacket(texturedPacket);
 		}
 
 		// Light cube (only for point and spot lights)
@@ -304,8 +300,8 @@ void Sandbox3D::OnUpdate(const OloEngine::Timestep ts)
 			auto lightCubeModelMatrix = glm::mat4(1.0f);
 			lightCubeModelMatrix = glm::translate(lightCubeModelMatrix, m_Light.Position);
 			lightCubeModelMatrix = glm::scale(lightCubeModelMatrix, glm::vec3(0.2f));
-			auto* cmdLightCube = OloEngine::Renderer3D::DrawLightCube(lightCubeModelMatrix);
-			OloEngine::Renderer3D::SubmitDrawCall(cmdLightCube);
+			auto* lightCubePacket = OloEngine::Renderer3D::DrawLightCube(lightCubeModelMatrix);
+			if (lightCubePacket) OloEngine::Renderer3D::SubmitPacket(lightCubePacket);
 		}
 
 		// Draw our state test objects to demonstrate the new state system
@@ -703,8 +699,8 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
         markerMaterial.Diffuse = glm::vec3(1.0f, 0.0f, 0.0f);
         markerMaterial.Specular = glm::vec3(1.0f);
         markerMaterial.Shininess = 32.0f;
-        auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, markerMatrix, markerMaterial);
-        if (cmd) OloEngine::Renderer3D::SubmitDrawCall(cmd);
+        auto* markerPacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, markerMatrix, markerMaterial);
+        if (markerPacket) OloEngine::Renderer3D::SubmitPacket(markerPacket);
     }
     switch (m_StateTestMode)
     {
@@ -720,13 +716,14 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
                 cubeMaterial.Diffuse = glm::vec3((i + 1) * 0.25f, 0.5f, 0.7f);
                 cubeMaterial.Specular = glm::vec3(0.5f);
                 cubeMaterial.Shininess = 32.0f;
-                auto* cmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, cubeMaterial);
-				if (cmd)
-				{
-					cmd->renderState->PolygonMode.Mode = GL_LINE;
-					cmd->renderState->LineWidth.Width = 2.0f + i;
-					OloEngine::Renderer3D::SubmitDrawCall(cmd);
-				}
+                auto* packet = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, cubeMaterial);
+                if (packet)
+                {
+                    auto* drawCmd = packet->GetCommandData<OloEngine::DrawMeshCommand>();
+                    drawCmd->renderState->PolygonMode.Mode = GL_LINE;
+                    drawCmd->renderState->LineWidth.Width = 2.0f + i;
+                    OloEngine::Renderer3D::SubmitPacket(packet);
+                }
                 
             }
             break;
@@ -747,13 +744,13 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
                 }
                 sphereMaterial.Specular = glm::vec3(0.5f);
                 sphereMaterial.Shininess = 32.0f;
-                auto* cmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, sphereMaterial);
-                if (cmd) {
-                    // Set alpha blend state per draw call
-                    cmd->renderState->Blend.Enabled = true;
-                    cmd->renderState->Blend.SrcFactor = GL_SRC_ALPHA;
-                    cmd->renderState->Blend.DstFactor = GL_ONE_MINUS_SRC_ALPHA;
-                    OloEngine::Renderer3D::SubmitDrawCall(cmd);
+                auto* packet = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, sphereMaterial);
+                if (packet) {
+                    auto* drawCmd = packet->GetCommandData<OloEngine::DrawMeshCommand>();
+                    drawCmd->renderState->Blend.Enabled = true;
+                    drawCmd->renderState->Blend.SrcFactor = GL_SRC_ALPHA;
+                    drawCmd->renderState->Blend.DstFactor = GL_ONE_MINUS_SRC_ALPHA;
+                    OloEngine::Renderer3D::SubmitPacket(packet);
                 }
             }
             break;
@@ -769,9 +766,9 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
             solidMaterial.Diffuse = glm::vec3(0.7f, 0.7f, 0.2f);
             solidMaterial.Specular = glm::vec3(0.5f);
             solidMaterial.Shininess = 32.0f;
-            auto* solidCmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, solidMaterial);
-            if (solidCmd) {
-                OloEngine::Renderer3D::SubmitDrawCall(solidCmd);
+            auto* solidPacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, solidMaterial);
+            if (solidPacket) {
+                OloEngine::Renderer3D::SubmitPacket(solidPacket);
             }
             // Overlay wireframe
             OloEngine::Material wireMaterial;
@@ -779,14 +776,15 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
             wireMaterial.Diffuse = glm::vec3(0.0f, 0.0f, 0.0f);
             wireMaterial.Specular = glm::vec3(0.0f);
             wireMaterial.Shininess = 1.0f;
-            auto* wireCmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, wireMaterial);
-            if (wireCmd) {
-                wireCmd->renderState->PolygonMode.Mode = GL_LINE;
-                wireCmd->renderState->LineWidth.Width = 1.5f;
-                wireCmd->renderState->PolygonOffset.Enabled = true;
-                wireCmd->renderState->PolygonOffset.Factor = -1.0f;
-                wireCmd->renderState->PolygonOffset.Units = -1.0f;
-                OloEngine::Renderer3D::SubmitDrawCall(wireCmd);
+            auto* wirePacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, wireMaterial);
+            if (wirePacket) {
+                auto* drawCmd = wirePacket->GetCommandData<OloEngine::DrawMeshCommand>();
+                drawCmd->renderState->PolygonMode.Mode = GL_LINE;
+                drawCmd->renderState->LineWidth.Width = 1.5f;
+                drawCmd->renderState->PolygonOffset.Enabled = true;
+                drawCmd->renderState->PolygonOffset.Factor = -1.0f;
+                drawCmd->renderState->PolygonOffset.Units = -1.0f;
+                OloEngine::Renderer3D::SubmitPacket(wirePacket);
             }
             break;
         }
@@ -801,11 +799,12 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
             wireMaterial.Diffuse = glm::vec3(1.0f, 1.0f, 0.0f);
             wireMaterial.Specular = glm::vec3(1.0f);
             wireMaterial.Shininess = 32.0f;
-            auto* wireCmd = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, wireMaterial);
-            if (wireCmd) {
-                wireCmd->renderState->PolygonMode.Mode = GL_LINE;
-                wireCmd->renderState->LineWidth.Width = 2.0f;
-                OloEngine::Renderer3D::SubmitDrawCall(wireCmd);
+            auto* wirePacket = OloEngine::Renderer3D::DrawMesh(m_SphereMesh, sphereMatrix, wireMaterial);
+            if (wirePacket) {
+                auto* drawCmd = wirePacket->GetCommandData<OloEngine::DrawMeshCommand>();
+                drawCmd->renderState->PolygonMode.Mode = GL_LINE;
+                drawCmd->renderState->LineWidth.Width = 2.0f;
+                OloEngine::Renderer3D::SubmitPacket(wirePacket);
             }
             // Transparent cubes around sphere
             for (int i = 0; i < 3; i++)
@@ -825,12 +824,13 @@ void Sandbox3D::RenderStateTestObjects(f32 rotationAngle)
                 }
                 glassMaterial.Specular = glm::vec3(0.8f);
                 glassMaterial.Shininess = 64.0f;
-                auto* glassCmd = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, glassMaterial);
-                if (glassCmd) {
-                    glassCmd->renderState->Blend.Enabled = true;
-                    glassCmd->renderState->Blend.SrcFactor = GL_SRC_ALPHA;
-                    glassCmd->renderState->Blend.DstFactor = GL_ONE_MINUS_SRC_ALPHA;
-                    OloEngine::Renderer3D::SubmitDrawCall(glassCmd);
+                auto* glassPacket = OloEngine::Renderer3D::DrawMesh(m_CubeMesh, cubeMatrix, glassMaterial);
+                if (glassPacket) {
+                    auto* drawCmd = glassPacket->GetCommandData<OloEngine::DrawMeshCommand>();
+                    drawCmd->renderState->Blend.Enabled = true;
+                    drawCmd->renderState->Blend.SrcFactor = GL_SRC_ALPHA;
+                    drawCmd->renderState->Blend.DstFactor = GL_ONE_MINUS_SRC_ALPHA;
+                    OloEngine::Renderer3D::SubmitPacket(glassPacket);
                 }
             }
             break;


### PR DESCRIPTION
Refactor command handling to use CommandPacket system

Updated the command handling system in OloEngine to utilize a generalized CommandPacket system instead of specific command types like DrawMeshCommand.

In CommandAllocator.h, introduced AllocatePacketWithCommand to allocate command packets with associated command data using placement new.

Modified CommandBucket.cpp and CommandBucket.h to replace CreateDrawCall with a method that returns CommandPacket* and updated submission methods to use SubmitPacket.

Enhanced CommandPacket.h to include methods for setting command data and metadata, changing the internal representation of command data to a pointer for dynamic sizes.

Revised Model.cpp and Model.h to retrieve draw commands using CommandPacket instead of DrawMeshCommand.

Significant changes in Renderer3D to return CommandPacket* for all draw command methods, with submission handled through the new SubmitPacket method.

Updated Sandbox3D.cpp to create and submit draw commands using the new CommandPacket system, improving flexibility and maintainability.