### PR TITLE
fix: Change OloEngine include directories from PRIVATE to PUBLIC

### DIFF
--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_definitions(OloEngine PRIVATE
 )
 olo_set_common_definitions(OloEngine)
 
-target_include_directories(OloEngine PRIVATE
+target_include_directories(OloEngine PUBLIC
 	src
 	vendor/assimp-src/include
 	vendor/atomic_queue-src/include


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to expose include directories for dependent projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->