### PR TITLE
Expose SoundGraphHandle for scripting

### DIFF
--- a/OloEngine-ScriptCore/src/OloEngine/InternalCalls.Generated.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/InternalCalls.Generated.cs
@@ -23,6 +23,10 @@ namespace OloEngine
 		internal static extern bool AudioSoundGraphComponent_GetPlayOnAwake(ulong entityID);
 		[MethodImpl(MethodImplOptions.InternalCall)]
 		internal static extern void AudioSoundGraphComponent_SetPlayOnAwake(ulong entityID, bool value);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern ulong AudioSoundGraphComponent_GetSoundGraphHandle(ulong entityID);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern void AudioSoundGraphComponent_SetSoundGraphHandle(ulong entityID, ulong value);
 		#endregion
 
 		#region AudioSourceComponent

--- a/OloEngine-ScriptCore/src/OloEngine/Scene/Components.Generated.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/Scene/Components.Generated.cs
@@ -27,6 +27,12 @@ namespace OloEngine
 			get => InternalCalls.AudioSoundGraphComponent_GetPlayOnAwake(Entity.ID);
 			set => InternalCalls.AudioSoundGraphComponent_SetPlayOnAwake(Entity.ID, value);
 		}
+
+		public ulong SoundGraphHandle
+		{
+			get => InternalCalls.AudioSoundGraphComponent_GetSoundGraphHandle(Entity.ID);
+			set => InternalCalls.AudioSoundGraphComponent_SetSoundGraphHandle(Entity.ID, value);
+		}
 	}
 
 	public partial class AudioSourceComponent : Component

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -784,6 +784,10 @@ namespace OloEngine
         OLO_PROPERTY(Name = "Pitch", Type = "float", Get = "comp.PitchMultiplier", Set = "comp.PitchMultiplier = {v}")
         OLO_PROPERTY(Name = "Looping", Type = "bool", Get = "comp.Looping", Set = "comp.Looping = {v}")
         OLO_PROPERTY(Name = "PlayOnAwake", Type = "bool", Get = "comp.PlayOnAwake", Set = "comp.PlayOnAwake = {v}")
+        // Exposed as ulong so scripts can swap the graph at runtime (e.g. pick
+        // a stinger per gameplay state). The bound Sound is not torn down here;
+        // it rebinds on next Play().
+        OLO_PROPERTY()
         AssetHandle SoundGraphHandle = 0;
         f32 VolumeMultiplier = 1.0f;
         f32 PitchMultiplier = 1.0f;

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
@@ -89,6 +89,26 @@ static void AudioSoundGraphComponent_SetPlayOnAwake(UUID entityID, bool value)
     comp.PlayOnAwake = value;
 }
 
+static u64 AudioSoundGraphComponent_GetSoundGraphHandle(UUID entityID)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    auto& comp = entity.GetComponent<AudioSoundGraphComponent>();
+    return comp.SoundGraphHandle;
+}
+
+static void AudioSoundGraphComponent_SetSoundGraphHandle(UUID entityID, u64 value)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    auto& comp = entity.GetComponent<AudioSoundGraphComponent>();
+    comp.SoundGraphHandle = value;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 // AudioSourceComponent                                                           //
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueRegistrations.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueRegistrations.inl
@@ -9,6 +9,8 @@ OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_GetLooping);
 OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_SetLooping);
 OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_GetPlayOnAwake);
 OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_SetPlayOnAwake);
+OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_GetSoundGraphHandle);
+OLO_ADD_INTERNAL_CALL(AudioSoundGraphComponent_SetSoundGraphHandle);
 
 // AudioSourceComponent
 OLO_ADD_INTERNAL_CALL(AudioSourceComponent_GetVolume);

--- a/docs/soundgraph-followups.md
+++ b/docs/soundgraph-followups.md
@@ -11,26 +11,7 @@ connections, flat operator list).
 
 ---
 
-## 1. `AudioSoundGraphComponent::SoundGraphHandle` exposed to scripting
-
-**State:** the C# binding for `AudioSoundGraphComponent` exposes
-`Volume` / `Pitch` / `Looping` / `PlayOnAwake` via `OLO_PROPERTY`, but not the
-`SoundGraphHandle` asset reference.
-
-**Why deferred:** `OloHeaderTool`'s type mapper
-([tools/OloHeaderTool/main.cpp:58-77](../tools/OloHeaderTool/main.cpp#L58-L77))
-only supports `float`/`bool`/`int`/`uint`/`vec2-4`/`string`. There's no
-`u64`/`AssetHandle` mapping. `AudioSourceComponent` follows the same pattern
-(its audio clip handle has no `OLO_PROPERTY` either — set by the editor, not
-scripts).
-
-**Fix sketch:** extend `OloHeaderTool` to handle `AssetHandle`/`u64`, mapping
-them to `ulong` on the C# side. Wire that into `Components.h` for both
-`AudioSoundGraphComponent` and `AudioSourceComponent`.
-
----
-
-## 2. `AudioSoundGraphComponent::operator==` bitwise float comparison
+## 1. `AudioSoundGraphComponent::operator==` bitwise float comparison
 
 **State:** the equality operator uses direct `==` on `VolumeMultiplier` and
 `PitchMultiplier`. Project convention is to avoid float `==` (see
@@ -51,7 +32,7 @@ so this is a sweep, not a one-line fix.
 
 ---
 
-## 3. `AnimationGraphEditorPanel` no-op undo entries
+## 2. `AnimationGraphEditorPanel` no-op undo entries
 
 **State:** `BeginEditSession` always takes a snapshot, and `EndEditSession`
 flushes it once `GImGui->ActiveId == 0`. If a session is bracketed without
@@ -78,7 +59,7 @@ the top of the panel render and gate it on `GImGui->ActiveId != 0`.
 
 ---
 
-## 4. `WavePlayer::Tasks::Launch` lambda lifetime / UAF risk
+## 3. `WavePlayer::Tasks::Launch` lambda lifetime / UAF risk
 
 **State:** [`WavePlayer::StartAsyncLoad`](../OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h)
 launches a background task whose lambda captures raw `this`. The destructor
@@ -119,7 +100,7 @@ node ownership — covered by Phase 3 of the
 
 ---
 
-## 5. `Scene::OnComponentAdded<AudioSoundGraphComponent>` runtime init
+## 4. `Scene::OnComponentAdded<AudioSoundGraphComponent>` runtime init
 
 **State:** the `OnComponentAdded<AudioSoundGraphComponent>` hook is a no-op,
 so components added during runtime (script-spawned entities, networked actors

--- a/tools/OloHeaderTool/main.cpp
+++ b/tools/OloHeaderTool/main.cpp
@@ -30,6 +30,7 @@ enum class PropType
     Bool,
     Int,
     UInt,
+    U64,
     Vec2,
     Vec3,
     Vec4,
@@ -65,6 +66,12 @@ static PropType CppTypeToPropType(const std::string& t)
         return PropType::Int;
     if (t == "u32")
         return PropType::UInt;
+    // AssetHandle is a UUID typedef (u64 wrapper) with implicit operator u64() /
+    // implicit ctor(u64), so getter/setter codegen can treat it as a plain 64-bit
+    // scalar. UUID itself isn't mapped here — entity IDs cross the Mono boundary
+    // separately and exposing them as authored properties would be a footgun.
+    if (t == "u64" || t == "AssetHandle")
+        return PropType::U64;
     if (t == "glm::vec2")
         return PropType::Vec2;
     if (t == "glm::vec3")
@@ -86,6 +93,8 @@ static PropType StringToPropType(const std::string& s)
         return PropType::Int;
     if (s == "uint")
         return PropType::UInt;
+    if (s == "ulong" || s == "u64" || s == "AssetHandle")
+        return PropType::U64;
     if (s == "vec2")
         return PropType::Vec2;
     if (s == "vec3")
@@ -99,7 +108,7 @@ static PropType StringToPropType(const std::string& s)
 
 static bool IsScalar(PropType t)
 {
-    return t == PropType::Float || t == PropType::Bool || t == PropType::Int || t == PropType::UInt;
+    return t == PropType::Float || t == PropType::Bool || t == PropType::Int || t == PropType::UInt || t == PropType::U64;
 }
 
 static std::string CppReturnType(PropType t)
@@ -114,6 +123,8 @@ static std::string CppReturnType(PropType t)
             return "int";
         case PropType::UInt:
             return "unsigned int";
+        case PropType::U64:
+            return "u64";
         default:
             return "void";
     }
@@ -146,6 +157,8 @@ static std::string CsType(PropType t)
             return "int";
         case PropType::UInt:
             return "uint";
+        case PropType::U64:
+            return "ulong";
         case PropType::Vec2:
             return "Vector2";
         case PropType::Vec3:


### PR DESCRIPTION
Expose the SoundGraphHandle in the AudioSoundGraphComponent to allow scripts to access and modify it at runtime. This change enhances the flexibility of audio management within the engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SoundGraphHandle` property to audio sound graph components, enabling runtime modification and dynamic swapping of sound graphs through scripts and code.
  * Enhanced code generation tooling with native support for 64-bit unsigned scalar properties, streamlining property binding generation across the engine.

* **Documentation**
  * Updated follow-up documentation to reflect recently completed items and reorganized remaining work items for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->