### PR TITLE
Refactor bitwise comparison to use Math::BitwiseEqual

### DIFF
--- a/OloEngine/src/OloEngine/Animation/BlendUtils.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendUtils.cpp
@@ -1,9 +1,9 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Animation/BlendUtils.h"
+#include "OloEngine/Math/Math.h"
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 #include <glm/gtc/matrix_inverse.hpp>
 #include <glm/gtx/matrix_decompose.hpp>
 
@@ -84,7 +84,7 @@ namespace OloEngine::Animation::BlendUtils
             if (i < preTransforms.size())
             {
                 static constexpr glm::mat4 kIdentity{ 1.0f };
-                if (std::memcmp(&preTransforms[i], &kIdentity, sizeof(glm::mat4)) != 0)
+                if (!Math::BitwiseEqual(preTransforms[i], kIdentity))
                 {
                     auto pre = DecomposeMatrix(preTransforms[i]);
                     effectiveLocal = MultiplyTransforms(pre, localPose[i]);
@@ -120,7 +120,7 @@ namespace OloEngine::Animation::BlendUtils
             if (idx < preTransforms.size())
             {
                 static constexpr glm::mat4 kIdentity{ 1.0f };
-                if (std::memcmp(&preTransforms[idx], &kIdentity, sizeof(glm::mat4)) != 0)
+                if (!Math::BitwiseEqual(preTransforms[idx], kIdentity))
                 {
                     return MultiplyTransforms(DecomposeMatrix(preTransforms[idx]), localPose[idx]);
                 }

--- a/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Animation/IK/LimbIKSolver.h"
 #include "OloEngine/Animation/BlendUtils.h"
+#include "OloEngine/Math/Math.h"
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
@@ -9,7 +10,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 
 namespace OloEngine::Animation
 {
@@ -166,7 +166,7 @@ namespace OloEngine::Animation
             if (idx < preTransforms.size())
             {
                 static constexpr glm::mat4 kIdentity{ 1.0f };
-                if (std::memcmp(&preTransforms[idx], &kIdentity, sizeof(glm::mat4)) != 0)
+                if (!Math::BitwiseEqual(preTransforms[idx], kIdentity))
                 {
                     return BlendUtils::DecomposeMatrix(preTransforms[idx]);
                 }

--- a/OloEngine/src/OloEngine/Animation/IKTargetComponent.h
+++ b/OloEngine/src/OloEngine/Animation/IKTargetComponent.h
@@ -2,7 +2,7 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/UUID.h"
-#include <cstring>
+#include "OloEngine/Math/Math.h"
 #include <glm/glm.hpp>
 
 namespace OloEngine
@@ -36,10 +36,10 @@ namespace OloEngine
         UUID LimbTargetEntity = 0;
 
         // Manual operator== — UUID's implicit operator u64() causes C2666 on MSVC
-        // with defaulted ==; float members use memcmp for bitwise-exact undo detection.
+        // with defaulted ==; float members use Math::BitwiseEqual for bitwise-exact undo detection.
         auto operator==(const IKTargetComponent& o) const -> bool
         {
-            return AimIKEnabled == o.AimIKEnabled && AimBoneIndex == o.AimBoneIndex && std::memcmp(&AimTarget, &o.AimTarget, sizeof(glm::vec3)) == 0 && std::memcmp(&AimAxis, &o.AimAxis, sizeof(glm::vec3)) == 0 && std::memcmp(&AimOffset, &o.AimOffset, sizeof(glm::vec3)) == 0 && std::memcmp(&AimPoleVector, &o.AimPoleVector, sizeof(glm::vec3)) == 0 && AimChainLength == o.AimChainLength && std::memcmp(&AimChainFactor, &o.AimChainFactor, sizeof(f32)) == 0 && std::memcmp(&AimWeight, &o.AimWeight, sizeof(f32)) == 0 && static_cast<u64>(AimTargetEntity) == static_cast<u64>(o.AimTargetEntity) && LimbIKEnabled == o.LimbIKEnabled && LimbBoneIndex == o.LimbBoneIndex && std::memcmp(&LimbTarget, &o.LimbTarget, sizeof(glm::vec3)) == 0 && LimbChainLength == o.LimbChainLength && std::memcmp(&LimbWeight, &o.LimbWeight, sizeof(f32)) == 0 && static_cast<u64>(LimbTargetEntity) == static_cast<u64>(o.LimbTargetEntity);
+            return AimIKEnabled == o.AimIKEnabled && AimBoneIndex == o.AimBoneIndex && Math::BitwiseEqual(AimTarget, o.AimTarget) && Math::BitwiseEqual(AimAxis, o.AimAxis) && Math::BitwiseEqual(AimOffset, o.AimOffset) && Math::BitwiseEqual(AimPoleVector, o.AimPoleVector) && AimChainLength == o.AimChainLength && Math::BitwiseEqual(AimChainFactor, o.AimChainFactor) && Math::BitwiseEqual(AimWeight, o.AimWeight) && static_cast<u64>(AimTargetEntity) == static_cast<u64>(o.AimTargetEntity) && LimbIKEnabled == o.LimbIKEnabled && LimbBoneIndex == o.LimbBoneIndex && Math::BitwiseEqual(LimbTarget, o.LimbTarget) && LimbChainLength == o.LimbChainLength && Math::BitwiseEqual(LimbWeight, o.LimbWeight) && static_cast<u64>(LimbTargetEntity) == static_cast<u64>(o.LimbTargetEntity);
         }
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/InstancePlacementSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/InstancePlacementSerializer.cpp
@@ -2,6 +2,7 @@
 #include "OloEngine/Asset/AssetSerializer.h"
 #include "OloEngine/Asset/InstancePlacementAsset.h"
 #include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Project/Project.h"
 #include "OloEngine/Scene/Scene.h" // AssetSerializer.h forward-declares Scene; pulling it in here resolves Ref<Scene>::~Ref instantiation triggered by template instantiation chains.
 
@@ -32,7 +33,7 @@ namespace OloEngine
             // sentinel comparison per cpp-coding-quality §2a.
             {
                 constexpr f32 defaultCustom = 0.0f;
-                if (std::memcmp(&inst.Custom, &defaultCustom, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(inst.Custom, defaultCustom))
                     out << YAML::Key << "Custom" << YAML::Value << inst.Custom;
             }
             out << YAML::EndMap;

--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/VBAP.cpp
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/VBAP.cpp
@@ -1,9 +1,9 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Audio/DSP/Spatializer/VBAP.h"
+#include "OloEngine/Math/Math.h"
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 
 #include <glm/glm.hpp>
 
@@ -405,7 +405,7 @@ namespace OloEngine::Audio::DSP
         // overwritten via `ref = sqrtf(>0)`, so 0.0f means "no arch found".
         // See cpp-coding-quality §2a.
         constexpr float refSentinel = 0.0f;
-        return std::memcmp(&ref, &refSentinel, sizeof(float)) != 0;
+        return !Math::BitwiseEqual(ref, refSentinel);
     }
 
 } // namespace OloEngine::Audio::DSP

--- a/OloEngine/src/OloEngine/Math/Math.h
+++ b/OloEngine/src/OloEngine/Math/Math.h
@@ -2,7 +2,28 @@
 
 #include <glm/glm.hpp>
 
+#include <cstring>
+#include <type_traits>
+
 namespace OloEngine::Math
 {
     bool DecomposeTransform(const glm::mat4& transform, glm::vec3& translation, glm::vec3& rotation, glm::vec3& scale);
-}
+
+    // Bit-exact comparison of two trivially-copyable values.
+    //
+    // Use for change detection (undo/redo, component equality, sentinel checks)
+    // where every bit pattern must match — including NaN == NaN. Operator `==`
+    // on float / glm::vec / glm::mat is forbidden by cpp-coding-quality §2a;
+    // this is the canonical replacement for the bit-exact case (epsilon
+    // comparison is for tolerance-based predicates).
+    //
+    // Equivalent to `std::memcmp(&a, &b, sizeof(T)) == 0` but documents intent
+    // and prevents accidental size/type mismatches.
+    template<typename T>
+    [[nodiscard]] inline bool BitwiseEqual(const T& a, const T& b) noexcept
+    {
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "Math::BitwiseEqual requires a trivially-copyable type");
+        return std::memcmp(&a, &b, sizeof(T)) == 0;
+    }
+} // namespace OloEngine::Math

--- a/OloEngine/src/OloEngine/Physics3D/ColliderMaterial.h
+++ b/OloEngine/src/OloEngine/Physics3D/ColliderMaterial.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Math/Math.h"
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 
 namespace OloEngine
 {
@@ -97,10 +97,10 @@ namespace OloEngine
 
         /// @brief Bit-exact equality for undo/redo and serialization round-trip.
         /// Direct float == on m_* would trip the cpp-coding-quality rule; this
-        /// uses memcmp to document bit-exact intent (see cpp-coding-quality §2a).
+        /// uses Math::BitwiseEqual to document bit-exact intent (see cpp-coding-quality §2a).
         auto operator==(const ColliderMaterial& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(ColliderMaterial)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
 
       private:

--- a/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "AnimatedModel.h"
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Asset/MeshCache.h"
 #include "OloEngine/Renderer/MeshOptimization.h"
 #include "OloEngine/Animation/MorphTargets/MorphTarget.h"
@@ -1004,7 +1005,7 @@ namespace OloEngine
                 for (u32 i = 0; i < 4; ++i)
                 {
                     const f32 currentWeight = outBoneInfluences[vertexId].m_Weights[i];
-                    if (std::memcmp(&currentWeight, &emptySlotSentinel, sizeof(f32)) == 0)
+                    if (Math::BitwiseEqual(currentWeight, emptySlotSentinel))
                     {
                         outBoneInfluences[vertexId].SetBoneData(i, skeletonBoneId, weight);
                         slotFound = true;

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
@@ -2,6 +2,7 @@
 #include "CommandBucket.h"
 #include "FrameDataBuffer.h"
 #include "RenderCommand.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "OloEngine/Renderer/Debug/GPUTimerQueryPool.h"
 #include "OloEngine/Task/ParallelFor.h"
@@ -9,7 +10,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <cstring>
 #include <unordered_set>
 
 namespace OloEngine
@@ -654,10 +654,10 @@ namespace OloEngine
             {
                 auto const* meshCmd = m_Packets[indices[t]]->GetCommandData<DrawMeshCommand>();
                 // Bit-exact comparison to detect any per-entity override — instance defaults
-                // are bit-exactly 1.0f / 0.0f, so memcmp catches anything else (see cpp-coding-quality §2a).
-                if (std::memcmp(&meshCmd->color, &defaultColor, sizeof(glm::vec4)) != 0)
+                // are bit-exactly 1.0f / 0.0f, so BitwiseEqual catches anything else (see cpp-coding-quality §2a).
+                if (!Math::BitwiseEqual(meshCmd->color, defaultColor))
                     anyNonDefaultColor = true;
-                if (std::memcmp(&meshCmd->custom, &defaultCustom, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(meshCmd->custom, defaultCustom))
                     anyNonDefaultCustom = true;
                 if (anyNonDefaultColor && anyNonDefaultCustom)
                     break;

--- a/OloEngine/src/OloEngine/Renderer/LOD.h
+++ b/OloEngine/src/OloEngine/Renderer/LOD.h
@@ -3,10 +3,10 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Asset/Asset.h"
+#include "OloEngine/Math/Math.h"
 
 #include <glm/mat4x4.hpp>
 #include <glm/vec3.hpp>
-#include <cstring>
 #include <vector>
 
 namespace OloEngine
@@ -22,10 +22,11 @@ namespace OloEngine
         LODLevel(AssetHandle meshHandle, f32 maxDistance, u32 triangleCount = 0)
             : MeshHandle(meshHandle), MaxDistance(maxDistance), TriangleCount(triangleCount) {}
 
-        // Bitwise-exact comparison for undo/redo change detection (memcmp for float per rule 2b).
+        // Bitwise-exact comparison for undo/redo change detection — float field
+        // uses Math::BitwiseEqual per cpp-coding-quality §2a.
         auto operator==(const LODLevel& other) const -> bool
         {
-            return MeshHandle == other.MeshHandle && std::memcmp(&MaxDistance, &other.MaxDistance, sizeof(f32)) == 0 && TriangleCount == other.TriangleCount;
+            return MeshHandle == other.MeshHandle && Math::BitwiseEqual(MaxDistance, other.MaxDistance) && TriangleCount == other.TriangleCount;
         }
     };
 
@@ -39,7 +40,7 @@ namespace OloEngine
 
         auto operator==(const LODGroup& other) const -> bool
         {
-            return Levels == other.Levels && std::memcmp(&Bias, &other.Bias, sizeof(f32)) == 0;
+            return Levels == other.Levels && Math::BitwiseEqual(Bias, other.Bias);
         }
 
         // Returns the index of the appropriate LODLevel for the given distance.

--- a/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Renderer2D.h"
 
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/Shader.h"
 #include "OloEngine/Renderer/Buffer.h"
@@ -713,7 +714,7 @@ namespace OloEngine
         // Bit-exact comparison because the loop assigns from integer indices —
         // 0.0f appears only when nothing was assigned (see cpp-coding-quality §2a).
         constexpr f32 noTextureSlotSentinel = 0.0f;
-        if (std::memcmp(&textureIndex, &noTextureSlotSentinel, sizeof(f32)) == 0)
+        if (Math::BitwiseEqual(textureIndex, noTextureSlotSentinel))
         {
             if (s_Data.TextureSlotIndex >= Renderer2DData::MaxTextureSlots)
             {

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -1049,9 +1049,16 @@ namespace OloEngine
         LightProbeVolumeComponent() = default;
         LightProbeVolumeComponent(const LightProbeVolumeComponent&) = default;
 
+        // m_Dirty is set transiently by the property setters above and cleared
+        // by the bake pipeline; it is not authored data and not persisted by
+        // SceneSerializer. Including it in equality would make any bake / edit
+        // cycle look like an authored change to undo and scene-equality
+        // consumers. Compare the persisted fields field-wise instead — floats
+        // via Math::BitwiseEqual per cpp-coding-quality §2a, the asset handle
+        // via u64 to dodge UUID's C2666 ambiguity.
         auto operator==(const LightProbeVolumeComponent& other) const -> bool
         {
-            return Math::BitwiseEqual(*this, other);
+            return Math::BitwiseEqual(m_BoundsMin, other.m_BoundsMin) && Math::BitwiseEqual(m_BoundsMax, other.m_BoundsMax) && m_Resolution == other.m_Resolution && Math::BitwiseEqual(m_Spacing, other.m_Spacing) && Math::BitwiseEqual(m_Intensity, other.m_Intensity) && m_Active == other.m_Active && m_ShowDebugProbes == other.m_ShowDebugProbes && static_cast<u64>(m_BakedDataAsset) == static_cast<u64>(other.m_BakedDataAsset);
         }
     };
 

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -2,6 +2,7 @@
 #include "OloEngine/Scene/SceneCamera.h"
 #include "OloEngine/Core/UUID.h"
 #include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Renderer/Material.h"
 #include "OloEngine/Renderer/Font.h"
 #include "OloEngine/Audio/AudioSource.h"
@@ -334,7 +335,8 @@ namespace OloEngine
 
         // Manual operator== — SceneCamera lacks defaulted ==. Compare the
         // user-visible projection state via getters, which captures every
-        // serialized field. Other fields are POD and trivially compared.
+        // serialized field. Float members go through Math::BitwiseEqual
+        // (cpp-coding-quality §2a). Other fields are POD and trivially compared.
         auto operator==(const CameraComponent& other) const -> bool
         {
             if (Camera.GetProjectionType() != other.Camera.GetProjectionType())
@@ -342,37 +344,23 @@ namespace OloEngine
             const auto type = Camera.GetProjectionType();
             if (type == SceneCamera::ProjectionType::Perspective)
             {
-                const f32 fovL = Camera.GetPerspectiveVerticalFOV();
-                const f32 fovR = other.Camera.GetPerspectiveVerticalFOV();
-                const f32 nearL = Camera.GetPerspectiveNearClip();
-                const f32 nearR = other.Camera.GetPerspectiveNearClip();
-                const f32 farL = Camera.GetPerspectiveFarClip();
-                const f32 farR = other.Camera.GetPerspectiveFarClip();
-                if (std::memcmp(&fovL, &fovR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetPerspectiveVerticalFOV(), other.Camera.GetPerspectiveVerticalFOV()))
                     return false;
-                if (std::memcmp(&nearL, &nearR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetPerspectiveNearClip(), other.Camera.GetPerspectiveNearClip()))
                     return false;
-                if (std::memcmp(&farL, &farR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetPerspectiveFarClip(), other.Camera.GetPerspectiveFarClip()))
                     return false;
             }
             else
             {
-                const f32 sizeL = Camera.GetOrthographicSize();
-                const f32 sizeR = other.Camera.GetOrthographicSize();
-                const f32 nearL = Camera.GetOrthographicNearClip();
-                const f32 nearR = other.Camera.GetOrthographicNearClip();
-                const f32 farL = Camera.GetOrthographicFarClip();
-                const f32 farR = other.Camera.GetOrthographicFarClip();
-                if (std::memcmp(&sizeL, &sizeR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetOrthographicSize(), other.Camera.GetOrthographicSize()))
                     return false;
-                if (std::memcmp(&nearL, &nearR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetOrthographicNearClip(), other.Camera.GetOrthographicNearClip()))
                     return false;
-                if (std::memcmp(&farL, &farR, sizeof(f32)) != 0)
+                if (!Math::BitwiseEqual(Camera.GetOrthographicFarClip(), other.Camera.GetOrthographicFarClip()))
                     return false;
             }
-            const f32 flySpeedL = FlySpeed;
-            const f32 flySpeedR = other.FlySpeed;
-            return Primary == other.Primary && FixedAspectRatio == other.FixedAspectRatio && RuntimeControl == other.RuntimeControl && std::memcmp(&flySpeedL, &flySpeedR, sizeof(f32)) == 0;
+            return Primary == other.Primary && FixedAspectRatio == other.FixedAspectRatio && RuntimeControl == other.RuntimeControl && Math::BitwiseEqual(FlySpeed, other.FlySpeed);
         }
     };
 
@@ -406,10 +394,10 @@ namespace OloEngine
         // Compare only authored fields. RuntimeBody is a b2BodyId set by the
         // physics system when entering Play mode; including it in equality
         // would flag enter/exit-play as an authored change. Float fields use
-        // bit-exact memcmp per cpp-coding-quality §2a.
+        // Math::BitwiseEqual per cpp-coding-quality §2a.
         auto operator==(const Rigidbody2DComponent& other) const -> bool
         {
-            return Type == other.Type && FixedRotation == other.FixedRotation && std::memcmp(&LinearVelocity, &other.LinearVelocity, sizeof(glm::vec2)) == 0 && std::memcmp(&AngularVelocity, &other.AngularVelocity, sizeof(f32)) == 0;
+            return Type == other.Type && FixedRotation == other.FixedRotation && Math::BitwiseEqual(LinearVelocity, other.LinearVelocity) && Math::BitwiseEqual(AngularVelocity, other.AngularVelocity);
         }
     };
 
@@ -439,7 +427,7 @@ namespace OloEngine
         // from equality so play-mode enter/exit doesn't show as authored change.
         auto operator==(const BoxCollider2DComponent& other) const -> bool
         {
-            return std::memcmp(&Offset, &other.Offset, sizeof(glm::vec2)) == 0 && std::memcmp(&Size, &other.Size, sizeof(glm::vec2)) == 0 && std::memcmp(&Density, &other.Density, sizeof(f32)) == 0 && std::memcmp(&Friction, &other.Friction, sizeof(f32)) == 0 && std::memcmp(&Restitution, &other.Restitution, sizeof(f32)) == 0 && std::memcmp(&RestitutionThreshold, &other.RestitutionThreshold, sizeof(f32)) == 0;
+            return Math::BitwiseEqual(Offset, other.Offset) && Math::BitwiseEqual(Size, other.Size) && Math::BitwiseEqual(Density, other.Density) && Math::BitwiseEqual(Friction, other.Friction) && Math::BitwiseEqual(Restitution, other.Restitution) && Math::BitwiseEqual(RestitutionThreshold, other.RestitutionThreshold);
         }
     };
 
@@ -468,7 +456,7 @@ namespace OloEngine
         // RuntimeFixture (void*) is a Box2D handle populated on Play; excluded.
         auto operator==(const CircleCollider2DComponent& other) const -> bool
         {
-            return std::memcmp(&Offset, &other.Offset, sizeof(glm::vec2)) == 0 && std::memcmp(&Radius, &other.Radius, sizeof(f32)) == 0 && std::memcmp(&Density, &other.Density, sizeof(f32)) == 0 && std::memcmp(&Friction, &other.Friction, sizeof(f32)) == 0 && std::memcmp(&Restitution, &other.Restitution, sizeof(f32)) == 0 && std::memcmp(&RestitutionThreshold, &other.RestitutionThreshold, sizeof(f32)) == 0;
+            return Math::BitwiseEqual(Offset, other.Offset) && Math::BitwiseEqual(Radius, other.Radius) && Math::BitwiseEqual(Density, other.Density) && Math::BitwiseEqual(Friction, other.Friction) && Math::BitwiseEqual(Restitution, other.Restitution) && Math::BitwiseEqual(RestitutionThreshold, other.RestitutionThreshold);
         }
     };
 
@@ -514,7 +502,7 @@ namespace OloEngine
         // authored-state equality so play-mode enter/exit doesn't show as a change.
         auto operator==(const Rigidbody3DComponent& other) const -> bool
         {
-            return m_Type == other.m_Type && m_LayerID == other.m_LayerID && std::memcmp(&m_Mass, &other.m_Mass, sizeof(f32)) == 0 && std::memcmp(&m_LinearDrag, &other.m_LinearDrag, sizeof(f32)) == 0 && std::memcmp(&m_AngularDrag, &other.m_AngularDrag, sizeof(f32)) == 0 && m_DisableGravity == other.m_DisableGravity && m_IsTrigger == other.m_IsTrigger && m_LockedAxes == other.m_LockedAxes && std::memcmp(&m_InitialLinearVelocity, &other.m_InitialLinearVelocity, sizeof(glm::vec3)) == 0 && std::memcmp(&m_InitialAngularVelocity, &other.m_InitialAngularVelocity, sizeof(glm::vec3)) == 0 && std::memcmp(&m_MaxLinearVelocity, &other.m_MaxLinearVelocity, sizeof(f32)) == 0 && std::memcmp(&m_MaxAngularVelocity, &other.m_MaxAngularVelocity, sizeof(f32)) == 0;
+            return m_Type == other.m_Type && m_LayerID == other.m_LayerID && Math::BitwiseEqual(m_Mass, other.m_Mass) && Math::BitwiseEqual(m_LinearDrag, other.m_LinearDrag) && Math::BitwiseEqual(m_AngularDrag, other.m_AngularDrag) && m_DisableGravity == other.m_DisableGravity && m_IsTrigger == other.m_IsTrigger && m_LockedAxes == other.m_LockedAxes && Math::BitwiseEqual(m_InitialLinearVelocity, other.m_InitialLinearVelocity) && Math::BitwiseEqual(m_InitialAngularVelocity, other.m_InitialAngularVelocity) && Math::BitwiseEqual(m_MaxLinearVelocity, other.m_MaxLinearVelocity) && Math::BitwiseEqual(m_MaxAngularVelocity, other.m_MaxAngularVelocity);
         }
     };
 
@@ -533,7 +521,7 @@ namespace OloEngine
 
         auto operator==(const BoxCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(BoxCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -552,7 +540,7 @@ namespace OloEngine
 
         auto operator==(const SphereCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(SphereCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -573,7 +561,7 @@ namespace OloEngine
 
         auto operator==(const CapsuleCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(CapsuleCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -595,7 +583,7 @@ namespace OloEngine
 
         auto operator==(const MeshCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(MeshCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -618,7 +606,7 @@ namespace OloEngine
 
         auto operator==(const ConvexMeshCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(ConvexMeshCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -639,7 +627,7 @@ namespace OloEngine
 
         auto operator==(const TriangleMeshCollider3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(TriangleMeshCollider3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -663,7 +651,7 @@ namespace OloEngine
 
         auto operator==(const CharacterController3DComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(CharacterController3DComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -757,7 +745,7 @@ namespace OloEngine
         // Equality for undo/redo — compares serialized/editor-visible fields only
         auto operator==(const AudioSourceComponent& other) const -> bool
         {
-            return std::memcmp(&Config, &other.Config, sizeof(Config)) == 0 && StartEvent == other.StartEvent && StartCommandID == other.StartCommandID && UseEventSystem == other.UseEventSystem;
+            return Math::BitwiseEqual(Config, other.Config) && StartEvent == other.StartEvent && StartCommandID == other.StartCommandID && UseEventSystem == other.UseEventSystem;
         }
     };
 
@@ -824,10 +812,10 @@ namespace OloEngine
         }
 
         // Equality for undo/redo — compares serialized/editor-visible fields only.
-        // Float fields use bit-exact memcmp per cpp-coding-quality §2a.
+        // Float fields use Math::BitwiseEqual per cpp-coding-quality §2a.
         auto operator==(const AudioSoundGraphComponent& other) const -> bool
         {
-            return static_cast<u64>(SoundGraphHandle) == static_cast<u64>(other.SoundGraphHandle) && std::memcmp(&VolumeMultiplier, &other.VolumeMultiplier, sizeof(f32)) == 0 && std::memcmp(&PitchMultiplier, &other.PitchMultiplier, sizeof(f32)) == 0 && Looping == other.Looping && PlayOnAwake == other.PlayOnAwake;
+            return static_cast<u64>(SoundGraphHandle) == static_cast<u64>(other.SoundGraphHandle) && Math::BitwiseEqual(VolumeMultiplier, other.VolumeMultiplier) && Math::BitwiseEqual(PitchMultiplier, other.PitchMultiplier) && Looping == other.Looping && PlayOnAwake == other.PlayOnAwake;
         }
 
         // Gameplay-facing helpers to drive graph input parameters at runtime. Returns
@@ -859,26 +847,18 @@ namespace OloEngine
         MaterialComponent(const MaterialComponent&) = default;
 
         // Manual operator== — Material lacks defaulted ==, AssetHandle/UUID
-        // triggers C2666. Compare the PBR factors bit-exactly via memcmp and
-        // the asset handle via u64. Texture references are not compared (they
+        // triggers C2666. Compare the PBR factors bit-exactly via Math::BitwiseEqual
+        // and the asset handle via u64. Texture references are not compared (they
         // are loaded from disk and equal if the factors round-trip).
         auto operator==(const MaterialComponent& other) const -> bool
         {
-            const auto lhsBase = m_Material.GetBaseColorFactor();
-            const auto rhsBase = other.m_Material.GetBaseColorFactor();
-            if (std::memcmp(&lhsBase, &rhsBase, sizeof(lhsBase)) != 0)
+            if (!Math::BitwiseEqual(m_Material.GetBaseColorFactor(), other.m_Material.GetBaseColorFactor()))
                 return false;
-            const f32 lhsMetallic = m_Material.GetMetallicFactor();
-            const f32 rhsMetallic = other.m_Material.GetMetallicFactor();
-            if (std::memcmp(&lhsMetallic, &rhsMetallic, sizeof(f32)) != 0)
+            if (!Math::BitwiseEqual(m_Material.GetMetallicFactor(), other.m_Material.GetMetallicFactor()))
                 return false;
-            const f32 lhsRoughness = m_Material.GetRoughnessFactor();
-            const f32 rhsRoughness = other.m_Material.GetRoughnessFactor();
-            if (std::memcmp(&lhsRoughness, &rhsRoughness, sizeof(f32)) != 0)
+            if (!Math::BitwiseEqual(m_Material.GetRoughnessFactor(), other.m_Material.GetRoughnessFactor()))
                 return false;
-            const auto lhsEmissive = m_Material.GetEmissiveFactor();
-            const auto rhsEmissive = other.m_Material.GetEmissiveFactor();
-            if (std::memcmp(&lhsEmissive, &rhsEmissive, sizeof(lhsEmissive)) != 0)
+            if (!Math::BitwiseEqual(m_Material.GetEmissiveFactor(), other.m_Material.GetEmissiveFactor()))
                 return false;
             return static_cast<u64>(m_ShaderGraphHandle) == static_cast<u64>(other.m_ShaderGraphHandle);
         }
@@ -908,7 +888,7 @@ namespace OloEngine
 
         auto operator==(const DirectionalLightComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(DirectionalLightComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -933,7 +913,7 @@ namespace OloEngine
 
         auto operator==(const PointLightComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(PointLightComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -963,7 +943,7 @@ namespace OloEngine
 
         auto operator==(const SpotLightComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(SpotLightComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -1006,15 +986,7 @@ namespace OloEngine
                 return false;
             if (m_EnvironmentMap.Raw() != other.m_EnvironmentMap.Raw())
                 return false;
-            const f32 rotL = m_Rotation;
-            const f32 rotR = other.m_Rotation;
-            const f32 expL = m_Exposure;
-            const f32 expR = other.m_Exposure;
-            const f32 blurL = m_BlurAmount;
-            const f32 blurR = other.m_BlurAmount;
-            const f32 iblL = m_IBLIntensity;
-            const f32 iblR = other.m_IBLIntensity;
-            return m_IsCubemapFolder == other.m_IsCubemapFolder && m_EnableSkybox == other.m_EnableSkybox && m_EnableIBL == other.m_EnableIBL && std::memcmp(&rotL, &rotR, sizeof(f32)) == 0 && std::memcmp(&expL, &expR, sizeof(f32)) == 0 && std::memcmp(&blurL, &blurR, sizeof(f32)) == 0 && std::memcmp(&iblL, &iblR, sizeof(f32)) == 0 && std::memcmp(&m_Tint, &other.m_Tint, sizeof(m_Tint)) == 0;
+            return m_IsCubemapFolder == other.m_IsCubemapFolder && m_EnableSkybox == other.m_EnableSkybox && m_EnableIBL == other.m_EnableIBL && Math::BitwiseEqual(m_Rotation, other.m_Rotation) && Math::BitwiseEqual(m_Exposure, other.m_Exposure) && Math::BitwiseEqual(m_BlurAmount, other.m_BlurAmount) && Math::BitwiseEqual(m_IBLIntensity, other.m_IBLIntensity) && Math::BitwiseEqual(m_Tint, other.m_Tint);
         }
     };
 
@@ -1034,7 +1006,7 @@ namespace OloEngine
 
         auto operator==(const LightProbeComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(LightProbeComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -1079,7 +1051,7 @@ namespace OloEngine
 
         auto operator==(const LightProbeVolumeComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(LightProbeVolumeComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -1354,7 +1326,7 @@ namespace OloEngine
         // Manual operator== — UUID's implicit u64 conversion (C2666).
         auto operator==(const UIWorldAnchorComponent& other) const -> bool
         {
-            return static_cast<u64>(m_TargetEntity) == static_cast<u64>(other.m_TargetEntity) && std::memcmp(&m_WorldOffset, &other.m_WorldOffset, sizeof(m_WorldOffset)) == 0;
+            return static_cast<u64>(m_TargetEntity) == static_cast<u64>(other.m_TargetEntity) && Math::BitwiseEqual(m_WorldOffset, other.m_WorldOffset);
         }
     };
 
@@ -1617,17 +1589,7 @@ namespace OloEngine
         // so it's intentionally not considered for undo equality.
         auto operator==(const TerrainComponent& other) const -> bool
         {
-            const f32 worldXL = m_WorldSizeX, worldXR = other.m_WorldSizeX;
-            const f32 worldZL = m_WorldSizeZ, worldZR = other.m_WorldSizeZ;
-            const f32 heightL = m_HeightScale, heightR = other.m_HeightScale;
-            const f32 freqL = m_ProceduralFrequency, freqR = other.m_ProceduralFrequency;
-            const f32 lacL = m_ProceduralLacunarity, lacR = other.m_ProceduralLacunarity;
-            const f32 persL = m_ProceduralPersistence, persR = other.m_ProceduralPersistence;
-            const f32 triL = m_TargetTriangleSize, triR = other.m_TargetTriangleSize;
-            const f32 morphL = m_MorphRegion, morphR = other.m_MorphRegion;
-            const f32 tileSizeL = m_TileWorldSize, tileSizeR = other.m_TileWorldSize;
-            const f32 voxL = m_VoxelSize, voxR = other.m_VoxelSize;
-            return m_HeightmapPath == other.m_HeightmapPath && std::memcmp(&worldXL, &worldXR, sizeof(f32)) == 0 && std::memcmp(&worldZL, &worldZR, sizeof(f32)) == 0 && std::memcmp(&heightL, &heightR, sizeof(f32)) == 0 && m_ProceduralEnabled == other.m_ProceduralEnabled && m_ProceduralSeed == other.m_ProceduralSeed && m_ProceduralResolution == other.m_ProceduralResolution && m_ProceduralOctaves == other.m_ProceduralOctaves && std::memcmp(&freqL, &freqR, sizeof(f32)) == 0 && std::memcmp(&lacL, &lacR, sizeof(f32)) == 0 && std::memcmp(&persL, &persR, sizeof(f32)) == 0 && m_TessellationEnabled == other.m_TessellationEnabled && std::memcmp(&triL, &triR, sizeof(f32)) == 0 && std::memcmp(&morphL, &morphR, sizeof(f32)) == 0 && m_StreamingEnabled == other.m_StreamingEnabled && m_TileDirectory == other.m_TileDirectory && m_TileFilePattern == other.m_TileFilePattern && std::memcmp(&tileSizeL, &tileSizeR, sizeof(f32)) == 0 && m_TileResolution == other.m_TileResolution && m_StreamingLoadRadius == other.m_StreamingLoadRadius && m_StreamingMaxTiles == other.m_StreamingMaxTiles && m_VoxelEnabled == other.m_VoxelEnabled && std::memcmp(&voxL, &voxR, sizeof(f32)) == 0;
+            return m_HeightmapPath == other.m_HeightmapPath && Math::BitwiseEqual(m_WorldSizeX, other.m_WorldSizeX) && Math::BitwiseEqual(m_WorldSizeZ, other.m_WorldSizeZ) && Math::BitwiseEqual(m_HeightScale, other.m_HeightScale) && m_ProceduralEnabled == other.m_ProceduralEnabled && m_ProceduralSeed == other.m_ProceduralSeed && m_ProceduralResolution == other.m_ProceduralResolution && m_ProceduralOctaves == other.m_ProceduralOctaves && Math::BitwiseEqual(m_ProceduralFrequency, other.m_ProceduralFrequency) && Math::BitwiseEqual(m_ProceduralLacunarity, other.m_ProceduralLacunarity) && Math::BitwiseEqual(m_ProceduralPersistence, other.m_ProceduralPersistence) && m_TessellationEnabled == other.m_TessellationEnabled && Math::BitwiseEqual(m_TargetTriangleSize, other.m_TargetTriangleSize) && Math::BitwiseEqual(m_MorphRegion, other.m_MorphRegion) && m_StreamingEnabled == other.m_StreamingEnabled && m_TileDirectory == other.m_TileDirectory && m_TileFilePattern == other.m_TileFilePattern && Math::BitwiseEqual(m_TileWorldSize, other.m_TileWorldSize) && m_TileResolution == other.m_TileResolution && m_StreamingLoadRadius == other.m_StreamingLoadRadius && m_StreamingMaxTiles == other.m_StreamingMaxTiles && m_VoxelEnabled == other.m_VoxelEnabled && Math::BitwiseEqual(m_VoxelSize, other.m_VoxelSize);
         }
     };
 
@@ -1884,7 +1846,7 @@ namespace OloEngine
 
         auto operator==(const SnowDeformerComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(SnowDeformerComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -1922,7 +1884,7 @@ namespace OloEngine
 
         auto operator==(const FogVolumeComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(FogVolumeComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -2051,23 +2013,18 @@ namespace OloEngine
             if (TileMesh != other.TileMesh || Width != other.Width ||
                 Height != other.Height || MaterialIDs != other.MaterialIDs)
                 return false;
-            if (std::memcmp(&TileSize, &other.TileSize, sizeof(f32)) != 0)
+            if (!Math::BitwiseEqual(TileSize, other.TileSize))
                 return false;
-            if (Materials.size() != other.Materials.size())
+            const auto materialCount = Materials.size();
+            if (materialCount != other.Materials.size())
                 return false;
-            for (sizet i = 0; i < Materials.size(); ++i)
+            for (sizet i = 0; i < materialCount; ++i)
             {
-                auto lhs = Materials[i].GetBaseColorFactor();
-                auto rhs = other.Materials[i].GetBaseColorFactor();
-                if (std::memcmp(&lhs, &rhs, sizeof(lhs)) != 0)
+                if (!Math::BitwiseEqual(Materials[i].GetBaseColorFactor(), other.Materials[i].GetBaseColorFactor()))
                     return false;
-                auto lm = Materials[i].GetMetallicFactor();
-                auto rm = other.Materials[i].GetMetallicFactor();
-                if (std::memcmp(&lm, &rm, sizeof(lm)) != 0)
+                if (!Math::BitwiseEqual(Materials[i].GetMetallicFactor(), other.Materials[i].GetMetallicFactor()))
                     return false;
-                auto lr = Materials[i].GetRoughnessFactor();
-                auto rr = other.Materials[i].GetRoughnessFactor();
-                if (std::memcmp(&lr, &rr, sizeof(lr)) != 0)
+                if (!Math::BitwiseEqual(Materials[i].GetRoughnessFactor(), other.Materials[i].GetRoughnessFactor()))
                     return false;
                 if (Materials[i].GetFlags() != other.Materials[i].GetFlags())
                     return false;
@@ -2113,7 +2070,7 @@ namespace OloEngine
 
         auto operator==(const NetworkInterestComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(NetworkInterestComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -2205,8 +2162,7 @@ namespace OloEngine
         // changes as the only difference.
         auto operator==(const DialogueComponent& other) const -> bool
         {
-            const f32 radL = m_TriggerRadius, radR = other.m_TriggerRadius;
-            return static_cast<u64>(m_DialogueTree) == static_cast<u64>(other.m_DialogueTree) && m_AutoTrigger == other.m_AutoTrigger && std::memcmp(&radL, &radR, sizeof(f32)) == 0 && m_TriggerOnce == other.m_TriggerOnce;
+            return static_cast<u64>(m_DialogueTree) == static_cast<u64>(other.m_DialogueTree) && m_AutoTrigger == other.m_AutoTrigger && Math::BitwiseEqual(m_TriggerRadius, other.m_TriggerRadius) && m_TriggerOnce == other.m_TriggerOnce;
         }
     };
 
@@ -2247,7 +2203,7 @@ namespace OloEngine
 
         auto operator==(const NavMeshBoundsComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(NavMeshBoundsComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 
@@ -2332,12 +2288,7 @@ namespace OloEngine
         // intentionally excluded (it's path-finder-managed, not authoring-visible).
         auto operator==(const NavAgentComponent& other) const -> bool
         {
-            const f32 rL = m_Radius, rR = other.m_Radius;
-            const f32 hL = m_Height, hR = other.m_Height;
-            const f32 sL = m_MaxSpeed, sR = other.m_MaxSpeed;
-            const f32 aL = m_Acceleration, aR = other.m_Acceleration;
-            const f32 stopL = m_StoppingDistance, stopR = other.m_StoppingDistance;
-            return std::memcmp(&rL, &rR, sizeof(f32)) == 0 && std::memcmp(&hL, &hR, sizeof(f32)) == 0 && std::memcmp(&sL, &sR, sizeof(f32)) == 0 && std::memcmp(&aL, &aR, sizeof(f32)) == 0 && std::memcmp(&stopL, &stopR, sizeof(f32)) == 0 && m_AvoidancePriority == other.m_AvoidancePriority && m_LockYAxis == other.m_LockYAxis;
+            return Math::BitwiseEqual(m_Radius, other.m_Radius) && Math::BitwiseEqual(m_Height, other.m_Height) && Math::BitwiseEqual(m_MaxSpeed, other.m_MaxSpeed) && Math::BitwiseEqual(m_Acceleration, other.m_Acceleration) && Math::BitwiseEqual(m_StoppingDistance, other.m_StoppingDistance) && m_AvoidancePriority == other.m_AvoidancePriority && m_LockYAxis == other.m_LockYAxis;
         }
     };
 
@@ -2369,7 +2320,7 @@ namespace OloEngine
 
         auto operator==(const NameplateComponent& other) const -> bool
         {
-            return std::memcmp(this, &other, sizeof(NameplateComponent)) == 0;
+            return Math::BitwiseEqual(*this, other);
         }
     };
 

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -2,6 +2,7 @@
 #include "OloEngine/Scene/SceneSerializer.h"
 #include "OloEngine/Core/YAMLConverters.h"
 
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Components.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
@@ -3564,7 +3565,7 @@ namespace OloEngine
                 // because the loader assigns the literal 0.0f default (see cpp-coding-quality §2a).
                 {
                     constexpr f32 defaultCustom = 0.0f;
-                    if (std::memcmp(&inst.Custom, &defaultCustom, sizeof(f32)) != 0)
+                    if (!Math::BitwiseEqual(inst.Custom, defaultCustom))
                         out << YAML::Key << "Custom" << YAML::Value << inst.Custom;
                 }
                 out << YAML::EndMap;

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageLayer.h
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageLayer.h
@@ -2,10 +2,10 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/Ref.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Renderer/Texture.h"
 
 #include <glm/glm.hpp>
-#include <cstring>
 #include <string>
 
 namespace OloEngine
@@ -55,11 +55,11 @@ namespace OloEngine
         // Manual operator== — excludes the runtime AlbedoTexture (a re-load of
         // the same asset hands out a different Ref pointer, which would
         // spuriously flag layers as changed). Float / glm::vec3 fields use
-        // bit-exact memcmp per cpp-coding-quality §2a; AlbedoPath identifies
+        // Math::BitwiseEqual per cpp-coding-quality §2a; AlbedoPath identifies
         // the texture authoritatively for equality purposes.
         auto operator==(const FoliageLayer& other) const -> bool
         {
-            return Name == other.Name && MeshPath == other.MeshPath && AlbedoPath == other.AlbedoPath && std::memcmp(&Density, &other.Density, sizeof(f32)) == 0 && SplatmapChannel == other.SplatmapChannel && std::memcmp(&MinSlopeAngle, &other.MinSlopeAngle, sizeof(f32)) == 0 && std::memcmp(&MaxSlopeAngle, &other.MaxSlopeAngle, sizeof(f32)) == 0 && std::memcmp(&MinScale, &other.MinScale, sizeof(f32)) == 0 && std::memcmp(&MaxScale, &other.MaxScale, sizeof(f32)) == 0 && std::memcmp(&MinHeight, &other.MinHeight, sizeof(f32)) == 0 && std::memcmp(&MaxHeight, &other.MaxHeight, sizeof(f32)) == 0 && RandomRotation == other.RandomRotation && std::memcmp(&ViewDistance, &other.ViewDistance, sizeof(f32)) == 0 && std::memcmp(&FadeStartDistance, &other.FadeStartDistance, sizeof(f32)) == 0 && std::memcmp(&WindStrength, &other.WindStrength, sizeof(f32)) == 0 && std::memcmp(&WindSpeed, &other.WindSpeed, sizeof(f32)) == 0 && std::memcmp(&BaseColor, &other.BaseColor, sizeof(glm::vec3)) == 0 && std::memcmp(&Roughness, &other.Roughness, sizeof(f32)) == 0 && std::memcmp(&AlphaCutoff, &other.AlphaCutoff, sizeof(f32)) == 0 && Enabled == other.Enabled;
+            return Name == other.Name && MeshPath == other.MeshPath && AlbedoPath == other.AlbedoPath && Math::BitwiseEqual(Density, other.Density) && SplatmapChannel == other.SplatmapChannel && Math::BitwiseEqual(MinSlopeAngle, other.MinSlopeAngle) && Math::BitwiseEqual(MaxSlopeAngle, other.MaxSlopeAngle) && Math::BitwiseEqual(MinScale, other.MinScale) && Math::BitwiseEqual(MaxScale, other.MaxScale) && Math::BitwiseEqual(MinHeight, other.MinHeight) && Math::BitwiseEqual(MaxHeight, other.MaxHeight) && RandomRotation == other.RandomRotation && Math::BitwiseEqual(ViewDistance, other.ViewDistance) && Math::BitwiseEqual(FadeStartDistance, other.FadeStartDistance) && Math::BitwiseEqual(WindStrength, other.WindStrength) && Math::BitwiseEqual(WindSpeed, other.WindSpeed) && Math::BitwiseEqual(BaseColor, other.BaseColor) && Math::BitwiseEqual(Roughness, other.Roughness) && Math::BitwiseEqual(AlphaCutoff, other.AlphaCutoff) && Enabled == other.Enabled;
         }
     };
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(OloEngine-Tests
 		PrecipitationEmitterTest.cpp
 		PrecipitationSystemTest.cpp
 		CoreUtilitiesTest.cpp
+		MathTest.cpp
 		SlugFontRenderingTest.cpp
 		AssetCreationTest.cpp
 		AssetBinaryIntegrityTest.cpp

--- a/OloEngine/tests/MathTest.cpp
+++ b/OloEngine/tests/MathTest.cpp
@@ -117,4 +117,4 @@ namespace
         b.Y = 8;
         EXPECT_FALSE(BitwiseEqual(a, b));
     }
-}
+} // namespace

--- a/OloEngine/tests/MathTest.cpp
+++ b/OloEngine/tests/MathTest.cpp
@@ -1,0 +1,120 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Math/Math.h"
+
+#include <bit>
+#include <cmath>
+#include <limits>
+
+// =============================================================================
+// MathTest — contracts for the OloEngine::Math namespace helpers.
+//
+// Today only BitwiseEqual is covered. DecomposeTransform is exercised
+// transitively by TransformComponentTest and the gizmo paths.
+//
+// BitwiseEqual is the canonical bit-exact comparison for floats / glm types,
+// the documented replacement for ==/!= per cpp-coding-quality.md §2a. Three
+// invariants matter:
+//   1. Bit-equal inputs compare equal (including NaN payloads).
+//   2. +0.0f and -0.0f differ (== would falsely report them equal).
+//   3. Composite trivially-copyable types (glm::vec, glm::mat) work without
+//      special-casing.
+// =============================================================================
+
+namespace
+{
+    using OloEngine::Math::BitwiseEqual;
+
+    TEST(MathBitwiseEqualTest, EqualScalarsCompareEqual)
+    {
+        EXPECT_TRUE(BitwiseEqual(0.0f, 0.0f));
+        EXPECT_TRUE(BitwiseEqual(1.0f, 1.0f));
+        EXPECT_TRUE(BitwiseEqual(-3.14159f, -3.14159f));
+        EXPECT_TRUE(BitwiseEqual(0.0, 0.0));
+    }
+
+    TEST(MathBitwiseEqualTest, DifferentScalarsCompareUnequal)
+    {
+        EXPECT_FALSE(BitwiseEqual(1.0f, 1.0000001f));
+        EXPECT_FALSE(BitwiseEqual(0.0f, 1e-30f));
+    }
+
+    TEST(MathBitwiseEqualTest, PositiveAndNegativeZeroAreDistinct)
+    {
+        // The whole point of bit-exact comparison: +0 and -0 have different bit
+        // patterns, so a change from one to the other is a real authored edit
+        // that needs to round-trip through undo / save-game / network sync.
+        // operator== falsely reports them equal.
+        const f32 posZero = 0.0f;
+        const f32 negZero = -0.0f;
+        ASSERT_EQ(posZero, negZero); // sanity: operator== says equal
+        EXPECT_FALSE(BitwiseEqual(posZero, negZero));
+    }
+
+    TEST(MathBitwiseEqualTest, NaNIsBitwiseEqualToItself)
+    {
+        // operator== always returns false for NaN. BitwiseEqual returns true
+        // when the bit pattern is identical — required so that a serialized
+        // NaN round-tripping into a component doesn't constantly look like
+        // a fresh edit on every frame.
+        const f32 nan = std::numeric_limits<f32>::quiet_NaN();
+        ASSERT_NE(nan, nan); // sanity: operator== says not equal
+        const f32 nanCopy = nan;
+        EXPECT_TRUE(BitwiseEqual(nan, nanCopy));
+    }
+
+    TEST(MathBitwiseEqualTest, DifferentNaNPayloadsAreUnequal)
+    {
+        // Two NaNs with different bit payloads are distinct values for
+        // change-detection purposes.
+        const u32 quietPattern = 0x7FC00000;
+        const u32 signalingPattern = 0x7FA00001;
+        const f32 quietNaN = std::bit_cast<f32>(quietPattern);
+        const f32 signalingNaN = std::bit_cast<f32>(signalingPattern);
+        EXPECT_FALSE(BitwiseEqual(quietNaN, signalingNaN));
+    }
+
+    TEST(MathBitwiseEqualTest, GlmVecComparison)
+    {
+        const glm::vec3 a{ 1.0f, 2.0f, 3.0f };
+        const glm::vec3 b{ 1.0f, 2.0f, 3.0f };
+        const glm::vec3 c{ 1.0f, 2.0f, 3.0001f };
+        EXPECT_TRUE(BitwiseEqual(a, b));
+        EXPECT_FALSE(BitwiseEqual(a, c));
+    }
+
+    TEST(MathBitwiseEqualTest, GlmMat4Comparison)
+    {
+        const glm::mat4 identity{ 1.0f };
+        const glm::mat4 identityCopy{ 1.0f };
+        glm::mat4 perturbed{ 1.0f };
+        perturbed[3][0] = 1e-7f;
+        EXPECT_TRUE(BitwiseEqual(identity, identityCopy));
+        EXPECT_FALSE(BitwiseEqual(identity, perturbed));
+    }
+
+    TEST(MathBitwiseEqualTest, IntegerTypesAlsoWork)
+    {
+        // The helper isn't float-only — any trivially-copyable type can use
+        // it, which is convenient when a struct mixes scalars and bools.
+        EXPECT_TRUE(BitwiseEqual(42, 42));
+        EXPECT_FALSE(BitwiseEqual(42, 43));
+
+        struct Trivial
+        {
+            f32 X;
+            i32 Y;
+            bool Z;
+            // Pad to force a struct with implicit padding bytes. Bit-exact
+            // comparison includes padding, so callers must zero-init for
+            // predictable equality — same rule as std::memcmp.
+        };
+
+        const Trivial a{ 1.0f, 7, true };
+        Trivial b = a;
+        EXPECT_TRUE(BitwiseEqual(a, b));
+        b.Y = 8;
+        EXPECT_FALSE(BitwiseEqual(a, b));
+    }
+}

--- a/docs/agent-rules/cpp-coding-quality.md
+++ b/docs/agent-rules/cpp-coding-quality.md
@@ -46,16 +46,29 @@ constexpr f32 epsilon = 1e-6f;
 if (std::abs(distance) > epsilon) { ... }
 ```
 
-- **Bitwise-exact comparison** (undo/redo change detection, serialization round-trip): use `std::memcmp`.
+- **Bitwise-exact comparison** (undo/redo change detection, serialization round-trip): use `Math::BitwiseEqual` from `OloEngine/Math/Math.h`. It wraps `std::memcmp` with a `std::is_trivially_copyable_v` static_assert so misuse is a compile error.
 
 ```cpp
 // BAD
 if (a.GetBaseColorFactor() != b.GetBaseColorFactor()) return false;
 
-// GOOD — explicit bitwise, documents intent
+// BAD — verbose, easy to get sizeof wrong
 auto lhs = a.GetBaseColorFactor();
 auto rhs = b.GetBaseColorFactor();
 if (std::memcmp(&lhs, &rhs, sizeof(lhs)) != 0) return false;
+
+// GOOD — explicit bitwise, documents intent, size derived from the type
+if (!Math::BitwiseEqual(a.GetBaseColorFactor(), b.GetBaseColorFactor()))
+    return false;
+```
+
+For whole-struct bit-exact comparison (e.g. trivially-copyable POD components), call it with `*this` and `other`:
+
+```cpp
+auto operator==(const FogVolumeComponent& other) const -> bool
+{
+    return Math::BitwiseEqual(*this, other);
+}
 ```
 
 ### 2b. Validate deserialized / external floats
@@ -152,7 +165,7 @@ auto operator==(const MyComponent&) const -> bool = default;
 
 Plain `bool operator==(const MyComponent&) const = default;` works too on MSVC, but `auto operator==(...) const = default;` (no trailing return) does **not**.
 
-When the component contains a type without `operator==` (e.g., `Material`), write a manual implementation using `std::memcmp` for float members (rule 2).
+When the component contains a type without `operator==` (e.g., `Material`), write a manual implementation using `Math::BitwiseEqual` for float members (rule 2).
 
 `UUID` has implicit `operator u64()`. That causes **C2666 ambiguity** with any member `operator==`. In a manual `operator==`, compare UUIDs via `static_cast<u64>()` to disambiguate.
 


### PR DESCRIPTION
- Replaced std::memcmp with Math::BitwiseEqual in various components and systems for bit-exact comparison of floats and glm types.
- Updated equality operators in components such as CameraComponent, Rigidbody2DComponent, and others to utilize Math::BitwiseEqual for improved clarity and adherence to coding standards.
- Added unit tests for Math::BitwiseEqual to ensure correct functionality, covering edge cases like NaN and distinct zero values.
- Updated coding quality documentation to reflect the use of Math::BitwiseEqual instead of std::memcmp for bitwise comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified bit-exact comparison logic across animation, physics, rendering, and scene components to improve consistency and reliability

* **Tests**
  * Added comprehensive tests validating bitwise-equality behavior for scalars, vectors, matrices, and composite types

* **Documentation**
  * Updated C++ coding guidelines to recommend and document the new bitwise-equality utility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->