### PR TITLE
Clean up MSVC warnings and improve code consistency

### DIFF
--- a/OloEditor/CMakeLists.txt
+++ b/OloEditor/CMakeLists.txt
@@ -16,3 +16,8 @@ olo_set_common_include_directories(OloEditor)
 target_link_libraries(OloEditor
                     OloEngine
 )
+
+# Suppress MSVC's "use the _s variant" CRT warnings (C4996 on strncpy/sscanf/etc.).
+# OloEngine already adopts the same stance for the engine library; matching here
+# keeps the editor consistent and avoids per-call-site noise across the panels.
+target_compile_definitions(OloEditor PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -468,20 +468,20 @@ namespace OloEngine
                     // TerrainRaycast hit. The normal is needed for slope
                     // filtering (§1.4) and align-to-normal (§1.5 style).
                     auto view = m_ActiveScene->GetAllEntitiesWith<TransformComponent, TerrainComponent>();
-                    for (auto entityID : view)
+                    if (auto it = view.begin(); it != view.end())
                     {
-                        Entity terrainEntity(entityID, m_ActiveScene.get());
+                        Entity terrainEntity(*it, m_ActiveScene.get());
                         const auto& tc = terrainEntity.GetComponent<TerrainComponent>();
                         const auto& tx = terrainEntity.GetComponent<TransformComponent>();
-                        if (!tc.m_TerrainData || tc.m_WorldSizeX <= 0.0f || tc.m_WorldSizeZ <= 0.0f)
-                            break;
-                        const f32 normX = (hitPos.x - tx.Translation.x) / tc.m_WorldSizeX;
-                        const f32 normZ = (hitPos.z - tx.Translation.z) / tc.m_WorldSizeZ;
-                        surfaceNormal = tc.m_TerrainData->GetNormalAt(
-                            glm::clamp(normX, 0.0f, 1.0f),
-                            glm::clamp(normZ, 0.0f, 1.0f),
-                            tc.m_WorldSizeX, tc.m_WorldSizeZ, tc.m_HeightScale);
-                        break;
+                        if (tc.m_TerrainData && tc.m_WorldSizeX > 0.0f && tc.m_WorldSizeZ > 0.0f)
+                        {
+                            const f32 normX = (hitPos.x - tx.Translation.x) / tc.m_WorldSizeX;
+                            const f32 normZ = (hitPos.z - tx.Translation.z) / tc.m_WorldSizeZ;
+                            surfaceNormal = tc.m_TerrainData->GetNormalAt(
+                                glm::clamp(normX, 0.0f, 1.0f),
+                                glm::clamp(normZ, 0.0f, 1.0f),
+                                tc.m_WorldSizeX, tc.m_WorldSizeZ, tc.m_HeightScale);
+                        }
                     }
                 }
                 const bool mouseDown = Input::IsMouseButtonPressed(Mouse::ButtonLeft) &&
@@ -2624,10 +2624,9 @@ namespace OloEngine
         // Find a terrain entity in the active scene
         Entity terrainEntity;
         auto view = m_ActiveScene->GetAllEntitiesWith<TransformComponent, TerrainComponent>();
-        for (auto entityID : view)
+        if (auto it = view.begin(); it != view.end())
         {
-            terrainEntity = Entity(entityID, m_ActiveScene.get());
-            break;
+            terrainEntity = Entity(*it, m_ActiveScene.get());
         }
         if (!terrainEntity || !terrainEntity.GetComponent<TerrainComponent>().m_TerrainData)
         {

--- a/OloEditor/src/Panels/ContentBrowser/DirectoryTree.cpp
+++ b/OloEditor/src/Panels/ContentBrowser/DirectoryTree.cpp
@@ -60,9 +60,9 @@ namespace OloEngine
             bool anyFound = false;
             for (auto ancestor = relativePath.parent_path(); !ancestor.empty() && ancestor != "."; ancestor = ancestor.parent_path())
             {
-                if (auto* dir = FindDirectory(ancestor))
+                if (auto* ancestorDir = FindDirectory(ancestor))
                 {
-                    for (auto* d = dir; d != nullptr; d = d->Parent)
+                    for (auto* d = ancestorDir; d != nullptr; d = d->Parent)
                         d->NeedsRefresh = true;
                     anyFound = true;
                     break;

--- a/OloEditor/src/Panels/DialogueEditorPanel.cpp
+++ b/OloEditor/src/Panels/DialogueEditorPanel.cpp
@@ -694,7 +694,7 @@ namespace OloEngine
     // Interaction
     // =========================================================================
 
-    void DialogueEditorPanel::HandleCanvasInput(const ImVec2& canvasOrigin, const ImVec2& canvasSize)
+    void DialogueEditorPanel::HandleCanvasInput(const ImVec2& canvasOrigin, [[maybe_unused]] const ImVec2& canvasSize)
     {
         bool const isHovered = ImGui::IsItemHovered();
 

--- a/OloEditor/src/Panels/ShaderGraphEditorPanel.cpp
+++ b/OloEditor/src/Panels/ShaderGraphEditorPanel.cpp
@@ -479,7 +479,7 @@ namespace OloEngine
     // Input handling
     // =========================================================================
 
-    void ShaderGraphEditorPanel::HandleCanvasInput(const ImVec2& canvasOrigin, const ImVec2& canvasSize)
+    void ShaderGraphEditorPanel::HandleCanvasInput([[maybe_unused]] const ImVec2& canvasOrigin, [[maybe_unused]] const ImVec2& canvasSize)
     {
         bool const isHovered = ImGui::IsItemHovered();
 

--- a/OloEditor/src/Panels/TerrainEditorPanel.cpp
+++ b/OloEditor/src/Panels/TerrainEditorPanel.cpp
@@ -29,13 +29,8 @@ namespace OloEngine
         }
 
         // Check if any terrain exists in scene
-        bool hasTerrain = false;
         auto terrainView = m_Context->GetAllEntitiesWith<TransformComponent, TerrainComponent>();
-        for ([[maybe_unused]] auto entity : terrainView)
-        {
-            hasTerrain = true;
-            break;
-        }
+        const bool hasTerrain = terrainView.begin() != terrainView.end();
 
         if (!hasTerrain)
         {

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetEvaluator.cpp
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetEvaluator.cpp
@@ -79,7 +79,7 @@ namespace OloEngine
         u32 weightsSSBO,
         u32 outputVertexSSBO,
         u32 vertexCount,
-        u32 targetCount)
+        [[maybe_unused]] u32 targetCount)
     {
         OLO_PROFILE_FUNCTION();
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -412,13 +412,19 @@ namespace OloEngine
         Tasks::EnqueueGameThreadTask(
             [this, assetHandle]()
             {
-                ReloadData(assetHandle);
+                if (!ReloadData(assetHandle))
+                {
+                    OLO_CORE_WARN_TAG("AssetManager", "Async reload failed for asset {}", static_cast<u64>(assetHandle));
+                }
                 m_ActiveReloadTasks.fetch_sub(1, std::memory_order_relaxed);
             },
             "AssetReloadAsync");
 #else
         // Synchronous fallback when async assets are disabled
-        ReloadData(assetHandle);
+        if (!ReloadData(assetHandle))
+        {
+            OLO_CORE_WARN_TAG("AssetManager", "Reload failed for asset {}", static_cast<u64>(assetHandle));
+        }
 #endif
     }
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -250,12 +250,12 @@ namespace OloEngine
                 UpdateDependencies(metadata.Handle);
                 IncrementAssetGeneration(metadata.Handle);
                 // Dispatch AssetReloadedEvent on main thread so UI layers can handle it safely
-                auto handle = metadata.Handle;
-                auto type = metadata.Type;
-                auto path = metadata.FilePath;
-                Tasks::EnqueueGameThreadTask([handle, type, path]() mutable
+                auto reloadHandle = metadata.Handle;
+                auto reloadType = metadata.Type;
+                auto reloadPath = metadata.FilePath;
+                Tasks::EnqueueGameThreadTask([reloadHandle, reloadType, reloadPath]() mutable
                                              {
-                    AssetReloadedEvent evt(handle, type, path);
+                    AssetReloadedEvent evt(reloadHandle, reloadType, reloadPath);
                     Application::Get().OnEvent(evt); }, "AssetReloadedEvent");
             }
 

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -1888,7 +1888,8 @@ namespace OloEngine
         const auto& vertices = meshSource->GetVertices();
         const auto& indices = meshSource->GetIndices();
         const auto& submeshes = meshSource->GetSubmeshes();
-        const auto& materials = meshSource->GetMaterials();
+        // Use the const overload to read materials — the non-const overload is deprecated.
+        const auto& materials = std::as_const(*meshSource).GetMaterials();
 
         auto vertexCount = static_cast<u32>(vertices.Num());
         auto indexCount = static_cast<u32>(indices.Num());

--- a/OloEngine/src/OloEngine/Audio/AudioEvents/AudioEventsManager.cpp
+++ b/OloEngine/src/OloEngine/Audio/AudioEvents/AudioEventsManager.cpp
@@ -53,7 +53,7 @@ namespace OloEngine::Audio
         return eventID;
     }
 
-    void AudioEventsManager::Update(Timestep ts)
+    void AudioEventsManager::Update([[maybe_unused]] Timestep ts)
     {
         if (!m_Registry)
         {

--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
@@ -104,7 +104,7 @@ namespace OloEngine::Audio::DSP
     // Audio callback
 
     void spatializer_node_process_pcm_frames(ma_node* pNode, const float** ppFramesIn, ma_uint32* pFrameCountIn,
-                                             float** ppFramesOut, ma_uint32* pFrameCountOut)
+                                             float** ppFramesOut, [[maybe_unused]] ma_uint32* pFrameCountOut)
     {
         const float* pFramesIn_0 = ppFramesIn[0];
         float* pFramesOut_0 = ppFramesOut[0];
@@ -342,7 +342,7 @@ namespace OloEngine::Audio::DSP
         auto [it, success] = m_Sources.try_emplace(sourceID);
         auto& source = it->second;
 
-        auto abortIfFailed = [&](ma_result result, const char* errorMessage)
+        auto abortIfFailed = [&](ma_result result, [[maybe_unused]] const char* errorMessage)
         {
             if (result != MA_SUCCESS)
             {

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphPatchPreset.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphPatchPreset.cpp
@@ -739,7 +739,10 @@ namespace OloEngine::Audio::SoundGraph
             {
                 return v ? "true" : "false";
             }
-            return ""; }, value);
+            else
+            {
+                static_assert(!sizeof(T*), "Unhandled ParameterValue alternative in SerializeParameterValue");
+            } }, value);
     }
 
     ParameterValue SoundGraphPatchPreset::DeserializeParameterValue(const std::string& valueStr, const ParameterValue& defaultValue) const
@@ -764,7 +767,10 @@ namespace OloEngine::Audio::SoundGraph
             {
                 return valueStr == "true" || valueStr == "1";
             }
-            return defaultVal; }, defaultValue);
+            else
+            {
+                static_assert(!sizeof(T*), "Unhandled ParameterValue alternative in DeserializeParameterValue");
+            } }, defaultValue);
     }
 
     //==============================================================================

--- a/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
+++ b/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
@@ -315,7 +315,7 @@ namespace OloEngine
     bool GameBuildPipeline::CopyDependencyDLLs(
         const GameBuildSettings& settings,
         const std::filesystem::path& outputDir,
-        std::string& errorMessage)
+        [[maybe_unused]] std::string& errorMessage)
     {
         OLO_PROFILE_FUNCTION();
 

--- a/OloEngine/src/OloEngine/Containers/ContainerAllocationPolicies.h
+++ b/OloEngine/src/OloEngine/Containers/ContainerAllocationPolicies.h
@@ -318,13 +318,13 @@ namespace OloEngine
 
     namespace Detail
     {
-        [[noreturn]] inline void OnInvalidAlignedHeapAllocatorNum(i32 NewNum, sizet NumBytesPerElement)
+        [[noreturn]] inline void OnInvalidAlignedHeapAllocatorNum([[maybe_unused]] i32 NewNum, [[maybe_unused]] sizet NumBytesPerElement)
         {
             OLO_CORE_ASSERT(false, "Invalid heap allocator num: NewNum={}, NumBytesPerElement={}", NewNum, NumBytesPerElement);
             std::abort(); // In case asserts are disabled
         }
 
-        [[noreturn]] inline void OnInvalidSizedHeapAllocatorNum(i32 IndexSize, i64 NewNum, sizet NumBytesPerElement)
+        [[noreturn]] inline void OnInvalidSizedHeapAllocatorNum([[maybe_unused]] i32 IndexSize, [[maybe_unused]] i64 NewNum, [[maybe_unused]] sizet NumBytesPerElement)
         {
             OLO_CORE_ASSERT(false, "Invalid sized heap allocator num: IndexSize={}, NewNum={}, NumBytesPerElement={}",
                             IndexSize, NewNum, NumBytesPerElement);

--- a/OloEngine/src/OloEngine/Containers/SparseSetElement.h
+++ b/OloEngine/src/OloEngine/Containers/SparseSetElement.h
@@ -77,7 +77,7 @@ namespace OloEngine
     namespace SparseSetPrivate
     {
         /** Error handler for invalid set operations */
-        [[noreturn]] inline void OnInvalidSetNum(u64 NewNum)
+        [[noreturn]] inline void OnInvalidSetNum([[maybe_unused]] u64 NewNum)
         {
             OLO_CORE_ASSERT(false, "Invalid set size: {}", NewNum);
             std::abort();

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/GameplayAbilitySystem.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/GameplayAbilitySystem.cpp
@@ -164,7 +164,7 @@ namespace OloEngine
         return true;
     }
 
-    void GameplayAbilitySystem::CancelAbility(Scene* scene, Entity owner, const GameplayTag& abilityTag)
+    void GameplayAbilitySystem::CancelAbility([[maybe_unused]] Scene* scene, Entity owner, const GameplayTag& abilityTag)
     {
         if (!owner.HasComponent<AbilityComponent>())
         {
@@ -187,7 +187,7 @@ namespace OloEngine
         }
     }
 
-    void GameplayAbilitySystem::ApplyDamage(Scene* scene, const DamageEvent& event)
+    void GameplayAbilitySystem::ApplyDamage([[maybe_unused]] Scene* scene, const DamageEvent& event)
     {
         Entity target = event.Target;
         if (!target || !target.HasComponent<AbilityComponent>())

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
@@ -157,8 +157,11 @@ namespace OloEngine
                                                       {
                                                           return;
                                                       }
-                                                      s_ServerInputHandler.ProcessInput(*s_ActiveScene, senderClientID,
-                                                                                        data, size);
+                                                      if (!s_ServerInputHandler.ProcessInput(*s_ActiveScene, senderClientID,
+                                                                                             data, size))
+                                                      {
+                                                          OLO_CORE_WARN_TAG("Networking", "Server rejected input from client {}", senderClientID);
+                                                      }
                                                   });
 
         return true;

--- a/OloEngine/src/OloEngine/Networking/Replication/SnapshotInterpolator.cpp
+++ b/OloEngine/src/OloEngine/Networking/Replication/SnapshotInterpolator.cpp
@@ -55,7 +55,7 @@ namespace OloEngine
         }
     }
 
-    void SnapshotInterpolator::Interpolate(Scene& scene, f32 dt)
+    void SnapshotInterpolator::Interpolate(Scene& scene, [[maybe_unused]] f32 dt)
     {
         OLO_PROFILE_FUNCTION();
 

--- a/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
@@ -1599,7 +1599,6 @@ namespace OloEngine
                             // like "Textures/Characters" and case mismatches ("textures/" vs "Textures/").
                             if (discovered.empty())
                             {
-                                auto parentPath = filenamePath.parent_path();
                                 std::filesystem::path resolvedDir = m_Directory;
                                 bool resolved = true;
 

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
@@ -1147,7 +1147,6 @@ namespace OloEngine
                 modelData._paddingEntity[2] = 0;
                 modelData.PrevModel = cmd->prevTransform;
 
-                constexpr u32 expectedSize = ShaderBindingLayout::ModelUBO::GetSize();
                 UploadModelInstance(modelData, s_Data.ModelInstanceBuffer);
                 // Legacy ModelMatrixUBO binding retired — all shaders now read transforms from the InstanceBuffer SSBO at binding 15.
             }

--- a/OloEngine/src/OloEngine/Renderer/ShaderConstants.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderConstants.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ShaderBindingLayout.h"
-#include <string>
 
 namespace OloEngine
 {
@@ -68,83 +67,5 @@ namespace OloEngine
         constexpr int MAX_TEXTURE_UNITS = 16;
         constexpr int MAX_CUBEMAP_SIZE = 2048;
         constexpr int MAX_TEXTURE_SIZE = 4096;
-
-        // =============================================================================
-        // GLSL CONSTANT DEFINITIONS
-        // This section provides GLSL-compatible constant definitions
-        // that can be included in shader files
-        // =============================================================================
-
-        static const char* GetGLSLConstants()
-        {
-            return R"(
-// =============================================================================
-// SHADER CONSTANTS
-// =============================================================================
-
-// Light types
-const int DIRECTIONAL_LIGHT = 0;
-const int POINT_LIGHT = 1;
-const int SPOT_LIGHT = 2;
-
-// PBR constants
-const float PI = 3.14159265359;
-const float EPSILON = 0.0001;
-
-// Default material values
-const float DEFAULT_DIELECTRIC_F0 = 0.04;
-const float DEFAULT_ROUGHNESS = 0.5;
-const float DEFAULT_METALLIC = 0.0;
-const float DEFAULT_NORMAL_SCALE = 1.0;
-const float DEFAULT_OCCLUSION_STRENGTH = 1.0;
-
-// IBL constants
-const float MAX_REFLECTION_LOD = 4.0;
-
-// Rendering constants
-const int MAX_LIGHTS = 256;
-const int MAX_BONES = UBOStructures::AnimationConstants::MAX_BONES;
-
-// Shadow mapping constants
-const float SHADOW_BIAS = 0.005;
-
-// Tone mapping constants
-const float GAMMA = 2.2;
-const float EXPOSURE = 1.0;
-
-// Tone mapping operators
-const int TONEMAP_NONE = 0;
-const int TONEMAP_REINHARD = 1;
-const int TONEMAP_ACES = 2;
-const int TONEMAP_UNCHARTED2 = 3;
-)";
-        }
-
-        // =============================================================================
-        // HELPER FUNCTIONS FOR SHADER GENERATION
-        // =============================================================================
-
-        // @brief Get GLSL preprocessor defines for constants
-        // @return String containing #define statements for all constants
-        static std::string GetGLSLDefines()
-        {
-            return std::string(R"(
-#define DIRECTIONAL_LIGHT 0
-#define POINT_LIGHT 1
-#define SPOT_LIGHT 2
-#define PI 3.14159265359
-#define EPSILON 0.0001
-#define DEFAULT_DIELECTRIC_F0 0.04
-#define MAX_REFLECTION_LOD 4.0
-#define MAX_LIGHTS 256
-#define MAX_BONES )") +
-                   std::to_string(UBOStructures::AnimationConstants::MAX_BONES) + R"(
-#define GAMMA 2.2
-#define TONEMAP_NONE 0
-#define TONEMAP_REINHARD 1
-#define TONEMAP_ACES 2
-#define TONEMAP_UNCHARTED2 3
-)";
-        }
     } // namespace ShaderConstants
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/ShaderGraph/ShaderGraphCompiler.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderGraph/ShaderGraphCompiler.cpp
@@ -282,7 +282,7 @@ namespace OloEngine
             pinVarNames[static_cast<u64>(node.FindPinByName("RGBA", ShaderGraphPinDirection::Output)->ID)] = sampleVar;
 
             // Derive sub-outputs
-            auto emitDerived = [&](const std::string& name, const std::string& swizzle, ShaderGraphPinType type)
+            auto emitDerived = [&](const std::string& name, const std::string& swizzle, [[maybe_unused]] ShaderGraphPinType type)
             {
                 const auto* pin = node.FindPinByName(name, ShaderGraphPinDirection::Output);
                 if (pin)

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -1027,7 +1027,6 @@ namespace OloEngine
                         // Sample morph target keyframes from the current animation clip
                         if (!animState.m_CurrentClip->MorphKeyframes.empty())
                         {
-                            Entity entity = { e, this };
                             if (entity.HasComponent<MorphTargetComponent>())
                             {
                                 auto& morphComp = entity.GetComponent<MorphTargetComponent>();

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
@@ -282,8 +282,8 @@ namespace OloEngine
     }
 
     void FoliageRenderer::Render(
-        const Frustum& frustum,
-        const glm::vec3& cameraPos,
+        [[maybe_unused]] const Frustum& frustum,
+        [[maybe_unused]] const glm::vec3& cameraPos,
         const Ref<Shader>& shader)
     {
         OLO_PROFILE_FUNCTION();

--- a/OloEngine/src/OloEngine/Terrain/TerrainQuadtree.cpp
+++ b/OloEngine/src/OloEngine/Terrain/TerrainQuadtree.cpp
@@ -257,7 +257,6 @@ namespace OloEngine
             f32 cx = (node.MinX + node.MaxX) * 0.5f;
             f32 cz = (node.MinZ + node.MaxZ) * 0.5f;
             f32 halfW = (node.MaxX - node.MinX) * 0.5f;
-            f32 halfH = (node.MaxZ - node.MinZ) * 0.5f;
             f32 eps = halfW * 0.1f; // Small offset into neighbor
 
             // +X neighbor

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1566,7 +1566,7 @@ namespace OloEngine
             m_CompilationStatus = ShaderCompilationStatus::Failed;
         }
 
-        const bool success = (m_CompilationStatus == ShaderCompilationStatus::Ready);
+        [[maybe_unused]] const bool success = (m_CompilationStatus == ShaderCompilationStatus::Ready);
         OLO_SHADER_RELOAD_END(m_RendererID, success);
     }
 

--- a/OloEngine/tests/Audio/AudioCommandRegistryTest.cpp
+++ b/OloEngine/tests/Audio/AudioCommandRegistryTest.cpp
@@ -120,8 +120,8 @@ TEST_F(AudioCommandRegistryTest, RemoveActionOutOfRange)
 
 TEST_F(AudioCommandRegistryTest, Clear)
 {
-    m_Registry.AddTrigger("A");
-    m_Registry.AddTrigger("B");
+    (void)m_Registry.AddTrigger("A");
+    (void)m_Registry.AddTrigger("B");
     m_Registry.Clear();
     EXPECT_EQ(m_Registry.GetTriggerCount(), 0u);
 }
@@ -167,9 +167,9 @@ TEST_F(AudioCommandRegistryTest, DeserializeNonExistentFile)
 
 TEST_F(AudioCommandRegistryTest, MultipleTriggersRoundTrip)
 {
-    m_Registry.AddTrigger("Play_Gunshot");
-    m_Registry.AddTrigger("Stop_Music");
-    m_Registry.AddTrigger("Pause_Ambience");
+    (void)m_Registry.AddTrigger("Play_Gunshot");
+    (void)m_Registry.AddTrigger("Stop_Music");
+    (void)m_Registry.AddTrigger("Pause_Ambience");
 
     ScopedTempFile tmp("MultiTriggers");
     ASSERT_TRUE(m_Registry.Serialize(tmp.Path));
@@ -227,7 +227,7 @@ TEST_F(AudioCommandRegistryTest, DeserializeSanitizesInvalidMultipliers)
 
 TEST_F(AudioCommandRegistryTest, SerializeReturnsFalseOnBadPath)
 {
-    m_Registry.AddTrigger("Test");
+    (void)m_Registry.AddTrigger("Test");
     // Construct a guaranteed-missing directory under temp
     auto badPath = std::filesystem::temp_directory_path() / "olo_test_SerializeBadPath_8f3a1b" / "impossible.yaml";
     EXPECT_FALSE(m_Registry.Serialize(badPath));

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -70,8 +70,11 @@ endfunction()
 # Configure common compiler options
 function(olo_set_compiler_options target_name)
     if(MSVC)
-        target_compile_options(${target_name} PRIVATE 
+        target_compile_options(${target_name} PRIVATE
             /W4
+            /wd4324   # 'X': structure padded due to alignment specifier — alignas() is intentional.
+                      # Fires across Task/, Containers/, Audio/ for every cache-line-aligned struct
+                      # we deliberately request; the padding is the point, not a defect.
             /MP       # Multi-processor compilation (parallel file compilation)
             /FS       # Force synchronous PDB writes (fixes PDB contention with /MP)
             /utf-8    # Enable UTF-8 encoding for source files


### PR DESCRIPTION
Address MSVC warnings by applying consistent usage of `[[maybe_unused]]` across various functions and suppressing specific CRT warnings. This enhances code clarity and maintains consistency throughout the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset reload failures now generate warnings for visibility
  * Network input processing failures are reported with identifying details
  * Shader constant validation tightened to catch unsupported variants at compile time

* **Improvements**
  * Shader constants expanded with texture limit and IBL sample-count parameters
  * Terrain detection and normal calculation refined
  * Code quality enhancements and compiler warning handling throughout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->