### PR TITLE
Mesh collider cache timestamp invalidation

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Project/Project.h"
 #include "OloEngine/Renderer/Mesh.h"
 #include "OloEngine/Renderer/MeshSource.h"
 
@@ -123,8 +124,20 @@ namespace OloEngine
             cacheFilePath = GetCacheFilePath(colliderAsset, type);
             if (!invalidateOld && std::filesystem::exists(cacheFilePath))
             {
-                // TODO: Add timestamp checking against source mesh
-                return ECookingResult::AlreadyExists;
+                // Resolve the source mesh's filesystem path so we can compare
+                // modification times. When the source has no backing file
+                // (memory-only assets, missing metadata, or no active project),
+                // preserve the legacy behavior of treating an existing cache as
+                // authoritative — re-cooking every load would be worse than a
+                // potentially-stale cache in that case.
+                std::filesystem::path sourcePath = ResolveSourceMeshPath(colliderAsset->m_ColliderMesh);
+                if (sourcePath.empty() || IsCacheValid(cacheFilePath, sourcePath))
+                {
+                    return ECookingResult::AlreadyExists;
+                }
+
+                OLO_CORE_INFO("MeshCookingFactory: Source mesh '{}' is newer than cached collider '{}', re-cooking",
+                              sourcePath.string(), cacheFilePath.string());
             }
         }
 
@@ -1066,6 +1079,31 @@ namespace OloEngine
         // Generate a unique cache key based on asset handle and type
         std::string typeString = (type == EMeshColliderType::Triangle) ? "tri" : "cvx";
         return fmt::format("{}_{}", static_cast<u64>(colliderAsset->GetHandle()), typeString);
+    }
+
+    std::filesystem::path MeshCookingFactory::ResolveSourceMeshPath(AssetHandle meshHandle)
+    {
+        // We cannot attribute a filesystem path without an active project +
+        // asset manager (e.g. headless unit tests). The caller treats an
+        // empty result as "skip timestamp check" and preserves the legacy
+        // cache-exists-is-authoritative behavior.
+        if (static_cast<u64>(meshHandle) == 0)
+            return {};
+        if (!Project::GetActive())
+            return {};
+
+        AssetMetadata metadata = AssetManager::GetAssetMetadata(meshHandle);
+        if (!metadata.IsValid() || metadata.FilePath.empty())
+            return {};
+
+        if (metadata.FilePath.is_absolute())
+            return metadata.FilePath;
+
+        const auto& projectDir = Project::GetProjectDirectory();
+        if (projectDir.empty())
+            return {};
+
+        return projectDir / metadata.FilePath;
     }
 
     std::filesystem::path MeshCookingFactory::GetCacheDirectory()

--- a/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.h
+++ b/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.h
@@ -200,6 +200,12 @@ namespace OloEngine
         std::string GenerateCacheKey(Ref<MeshColliderAsset> colliderAsset, EMeshColliderType type);
         std::filesystem::path GetCacheDirectory();
 
+        // Resolves the absolute filesystem path of the source mesh referenced
+        // by the collider asset. Returns an empty path for memory-only assets,
+        // missing metadata, or when no project is active — callers use that as
+        // a signal to skip timestamp-based cache invalidation.
+        std::filesystem::path ResolveSourceMeshPath(AssetHandle meshHandle);
+
         // Error handling
         void LogCookingError(const std::string& operation, const std::string& error);
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -193,6 +193,8 @@ add_executable(OloEngine-Tests
 		TransformComponentTest.cpp
 		# Physics3D mesh mass-properties (divergence-theorem volume + centroid)
 		JoltShapesMeshMassPropertiesTest.cpp
+		# Physics3D mesh collider cache invalidation
+		MeshCookingFactoryCacheTest.cpp
 		# Gameplay Ability Tests
 		Gameplay/GameplayAbilityTest.cpp
 		# Content Browser Tests

--- a/OloEngine/tests/MeshCookingFactoryCacheTest.cpp
+++ b/OloEngine/tests/MeshCookingFactoryCacheTest.cpp
@@ -3,9 +3,11 @@
 
 #include "OloEngine/Physics3D/MeshCookingFactory.h"
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <system_error>
 #include <thread>
 
@@ -13,15 +15,25 @@ using namespace OloEngine;
 
 namespace
 {
-    // Picks a unique scratch directory under the system temp area so two
-    // test runs in parallel (or a leaked previous run) cannot collide.
+    // Picks a freshly-created, never-reused scratch directory under the system
+    // temp area. The base parent stays as `temp/OloEngineTests/<tag>` for easy
+    // post-mortem cleanup; each invocation appends a per-process timestamp + a
+    // monotonically-increasing counter so concurrent `OloEngine-Tests.exe`
+    // instances cannot delete or overwrite each other's working state.
     std::filesystem::path MakeUniqueScratchDir(const char* tag)
     {
+        static std::atomic<u64> s_Counter{ 0 };
         const auto base = std::filesystem::temp_directory_path() / "OloEngineTests" / tag;
-        std::error_code ec;
-        std::filesystem::remove_all(base, ec); // best-effort cleanup of leftovers
-        std::filesystem::create_directories(base);
-        return base;
+
+        const auto nanos = std::chrono::steady_clock::now().time_since_epoch().count();
+        const auto seq = s_Counter.fetch_add(1, std::memory_order_relaxed);
+
+        std::ostringstream suffix;
+        suffix << std::hex << nanos << "_" << seq;
+
+        const auto unique = base / suffix.str();
+        std::filesystem::create_directories(unique);
+        return unique;
     }
 
     void TouchFile(const std::filesystem::path& path)
@@ -33,7 +45,7 @@ namespace
     {
         std::filesystem::last_write_time(path, t);
     }
-}
+} // namespace
 
 // IsCacheValid is the boundary the cooker uses to decide whether to reuse a
 // previously cooked .omc file. Wiring it into CookMeshType means that any bug

--- a/OloEngine/tests/MeshCookingFactoryCacheTest.cpp
+++ b/OloEngine/tests/MeshCookingFactoryCacheTest.cpp
@@ -1,0 +1,126 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Physics3D/MeshCookingFactory.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#include <thread>
+
+using namespace OloEngine;
+
+namespace
+{
+    // Picks a unique scratch directory under the system temp area so two
+    // test runs in parallel (or a leaked previous run) cannot collide.
+    std::filesystem::path MakeUniqueScratchDir(const char* tag)
+    {
+        const auto base = std::filesystem::temp_directory_path() / "OloEngineTests" / tag;
+        std::error_code ec;
+        std::filesystem::remove_all(base, ec); // best-effort cleanup of leftovers
+        std::filesystem::create_directories(base);
+        return base;
+    }
+
+    void TouchFile(const std::filesystem::path& path)
+    {
+        std::ofstream{ path, std::ios::binary } << "x";
+    }
+
+    void SetMtime(const std::filesystem::path& path, std::filesystem::file_time_type t)
+    {
+        std::filesystem::last_write_time(path, t);
+    }
+}
+
+// IsCacheValid is the boundary the cooker uses to decide whether to reuse a
+// previously cooked .omc file. Wiring it into CookMeshType means that any bug
+// in IsCacheValid will silently leak stale physics colliders into running
+// scenes — so the boundary is worth pinning down with direct tests.
+TEST(MeshCookingFactoryCache, ReturnsTrueWhenCacheNewerThanSource)
+{
+    const auto dir = MakeUniqueScratchDir("CacheNewer");
+    const auto sourcePath = dir / "source.glb";
+    const auto cachePath = dir / "cache.omc";
+
+    TouchFile(sourcePath);
+    TouchFile(cachePath);
+
+    // Force the source to be older than the cache by exactly two seconds — the
+    // filesystem's mtime resolution is comfortably below that on all supported
+    // platforms.
+    const auto now = std::filesystem::file_time_type::clock::now();
+    SetMtime(sourcePath, now - std::chrono::seconds(2));
+    SetMtime(cachePath, now);
+
+    MeshCookingFactory factory(dir);
+    EXPECT_TRUE(factory.IsCacheValid(cachePath, sourcePath));
+}
+
+TEST(MeshCookingFactoryCache, ReturnsFalseWhenSourceNewerThanCache)
+{
+    const auto dir = MakeUniqueScratchDir("CacheStale");
+    const auto sourcePath = dir / "source.glb";
+    const auto cachePath = dir / "cache.omc";
+
+    TouchFile(sourcePath);
+    TouchFile(cachePath);
+
+    // Cache was written, then the source was modified after — the canonical
+    // stale-cache shape we want to detect.
+    const auto now = std::filesystem::file_time_type::clock::now();
+    SetMtime(cachePath, now - std::chrono::seconds(2));
+    SetMtime(sourcePath, now);
+
+    MeshCookingFactory factory(dir);
+    EXPECT_FALSE(factory.IsCacheValid(cachePath, sourcePath));
+}
+
+TEST(MeshCookingFactoryCache, ReturnsFalseWhenCacheMissing)
+{
+    const auto dir = MakeUniqueScratchDir("CacheMissing");
+    const auto sourcePath = dir / "source.glb";
+    const auto cachePath = dir / "cache.omc";
+
+    TouchFile(sourcePath);
+    // cache file intentionally not created
+
+    MeshCookingFactory factory(dir);
+    EXPECT_FALSE(factory.IsCacheValid(cachePath, sourcePath));
+}
+
+TEST(MeshCookingFactoryCache, ReturnsFalseWhenSourceMissing)
+{
+    const auto dir = MakeUniqueScratchDir("SourceMissing");
+    const auto sourcePath = dir / "source.glb";
+    const auto cachePath = dir / "cache.omc";
+
+    TouchFile(cachePath);
+    // source file intentionally not created — we want IsCacheValid to reject
+    // this rather than report the cache as valid, since the caller has no way
+    // to verify the source was unchanged.
+
+    MeshCookingFactory factory(dir);
+    EXPECT_FALSE(factory.IsCacheValid(cachePath, sourcePath));
+}
+
+TEST(MeshCookingFactoryCache, ReturnsTrueWhenTimestampsAreEqual)
+{
+    const auto dir = MakeUniqueScratchDir("CacheEqual");
+    const auto sourcePath = dir / "source.glb";
+    const auto cachePath = dir / "cache.omc";
+
+    TouchFile(sourcePath);
+    TouchFile(cachePath);
+
+    const auto t = std::filesystem::file_time_type::clock::now();
+    SetMtime(sourcePath, t);
+    SetMtime(cachePath, t);
+
+    // The cooker's contract is `cacheTime >= sourceTime`: equal timestamps mean
+    // the cache is still authoritative.
+    MeshCookingFactory factory(dir);
+    EXPECT_TRUE(factory.IsCacheValid(cachePath, sourcePath));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved physics mesh collision cache validation: cached colliders are re-cooked when the source mesh is newer. If the source file cannot be resolved, previous cache-preserving behavior is retained. Re-cook events are now logged for easier troubleshooting.

* **Tests**
  * Added tests covering cache invalidation scenarios, missing files, and timestamp comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->