### PR TITLE
refactor: SoundGraph block-rate Process(numFrames) API foundation

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/NodeProcessor.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/NodeProcessor.h
@@ -209,7 +209,16 @@ namespace OloEngine::Audio::SoundGraph
             m_SampleRate = sampleRate;
         }
         virtual void Init() {}
-        virtual void Process() {}
+        // Block-rate process entry. Derived nodes produce `numFrames` samples per call.
+        // Most node bodies stay per-sample internally — they wrap their existing work
+        // in `for (u32 frame = 0; frame < numFrames; ++frame) { ... }`. Leaf audio
+        // generators (e.g. WavePlayer) override this to amortise per-block setup
+        // (event-flag checks, async-load polling) across the whole block instead of
+        // paying it 48 000 times per second.
+        virtual void Process(u32 numFrames)
+        {
+            (void)numFrames;
+        }
 
         //==============================================================================
         /// Endpoint access

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/ArrayNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/ArrayNodes.h
@@ -74,8 +74,9 @@ namespace OloEngine::Audio::SoundGraph
             m_OutElement = T{};
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Event-driven array node; trigger flags drive output, not block size.
             OLO_PROFILE_FUNCTION();
 
             if (m_NextFlag.CheckAndResetIfDirty())
@@ -192,8 +193,9 @@ namespace OloEngine::Audio::SoundGraph
             m_OutElement = T{};
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Event-driven array node; trigger flags drive output, not block size.
             OLO_PROFILE_FUNCTION();
 
             if (m_TriggerFlag.CheckAndResetIfDirty())
@@ -297,8 +299,9 @@ namespace OloEngine::Audio::SoundGraph
             m_OutValue = T{};
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Event-driven array node; trigger flags drive output, not block size.
             OLO_PROFILE_FUNCTION();
 
             if (m_NextFlag.CheckAndResetIfDirty())

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h
@@ -60,11 +60,11 @@ namespace OloEngine::Audio::SoundGraph
             m_State = Idle;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            // Check for parameter changes and recalculate rates if needed
+            // Parameter check + recalc: block-rate (inputs are stable across the block).
             if (m_AttackTime && m_DecayTime && m_AttackCurve && m_DecayCurve &&
                 (EnvelopeParamChanged(*m_AttackTime, m_CachedAttackTime) ||
                  EnvelopeParamChanged(*m_DecayTime, m_CachedDecayTime) ||
@@ -80,30 +80,30 @@ namespace OloEngine::Audio::SoundGraph
                 m_CachedSampleRate = m_SampleRate;
             }
 
-            // Handle trigger events
+            // Handle trigger events: block boundary is acceptable for now (Phase 4 adds
+            // sample-offset triggers when sample accuracy matters).
             if (m_TriggerFlag.IsDirty())
             {
                 m_TriggerFlag.CheckAndResetIfDirty();
                 StartAttack();
             }
 
-            // Process envelope state
-            switch (m_State)
+            // State machine advances one sample per iteration.
+            for (u32 frame = 0; frame < numFrames; ++frame)
             {
-                case Idle:
-                    // Do nothing, value remains at 0
-                    break;
-
-                case Attack:
-                    ProcessAttack();
-                    break;
-
-                case Decay:
-                    ProcessDecay();
-                    break;
+                switch (m_State)
+                {
+                    case Idle:
+                        break;
+                    case Attack:
+                        ProcessAttack();
+                        break;
+                    case Decay:
+                        ProcessDecay();
+                        break;
+                }
+                m_OutEnvelope = m_Value;
             }
-
-            m_OutEnvelope = m_Value;
         }
 
         // Input parameters
@@ -270,11 +270,11 @@ namespace OloEngine::Audio::SoundGraph
             m_State = Idle;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            // Check for parameter changes and recalculate rates if needed
+            // Parameter check + recalc: block-rate.
             if (m_AttackTime && m_DecayTime && m_ReleaseTime &&
                 m_AttackCurve && m_DecayCurve && m_ReleaseCurve &&
                 (EnvelopeParamChanged(*m_AttackTime, m_CachedAttackTime) ||
@@ -295,7 +295,6 @@ namespace OloEngine::Audio::SoundGraph
                 m_CachedSampleRate = m_SampleRate;
             }
 
-            // Handle trigger and release events
             if (m_TriggerFlag.IsDirty())
             {
                 m_TriggerFlag.CheckAndResetIfDirty();
@@ -308,33 +307,28 @@ namespace OloEngine::Audio::SoundGraph
                 StartRelease();
             }
 
-            // Process envelope state
-            switch (m_State)
+            for (u32 frame = 0; frame < numFrames; ++frame)
             {
-                case Idle:
-                    // Value remains at 0
-                    break;
-
-                case Attack:
-                    ProcessAttack();
-                    break;
-
-                case Decay:
-                    ProcessDecay();
-                    break;
-
-                case Sustain:
-                    // Value remains at sustain level
-                    if (m_SustainLevel)
-                        m_Value = *m_SustainLevel;
-                    break;
-
-                case Release:
-                    ProcessRelease();
-                    break;
+                switch (m_State)
+                {
+                    case Idle:
+                        break;
+                    case Attack:
+                        ProcessAttack();
+                        break;
+                    case Decay:
+                        ProcessDecay();
+                        break;
+                    case Sustain:
+                        if (m_SustainLevel)
+                            m_Value = *m_SustainLevel;
+                        break;
+                    case Release:
+                        ProcessRelease();
+                        break;
+                }
+                m_OutEnvelope = m_Value;
             }
-
-            m_OutEnvelope = m_Value;
         }
 
         // Input parameters

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/GeneratorNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/GeneratorNodes.h
@@ -46,35 +46,33 @@ namespace OloEngine::Audio::SoundGraph
             m_PhaseAccumulator = 0.0;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            f32 frequency = glm::max(0.0f, *m_Frequency);
-            f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
-            f32 phaseOffset = *m_Phase;
-
-            // Guard against zero or near-zero sample rate
+            // Guard against zero or near-zero sample rate (block-rate check)
             if (m_SampleRate <= 1e-6f)
             {
-                // Return silence for invalid sample rate
                 m_OutValue = 0.0f;
                 return;
             }
 
-            // Update phase using double precision for higher accuracy
-            f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
-            m_PhaseAccumulator += deltaPhase;
+            // Hoist input reads — graph inputs are stable across the block in Phase 1.
+            const f32 frequency = glm::max(0.0f, *m_Frequency);
+            const f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
+            const f32 phaseOffset = *m_Phase;
+            const f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
 
-            // Robust phase wrapping to keep in [0, 1) - handles negative values correctly
-            m_PhaseAccumulator -= std::floor(m_PhaseAccumulator);
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                m_PhaseAccumulator += deltaPhase;
+                m_PhaseAccumulator -= std::floor(m_PhaseAccumulator); // wrap to [0, 1)
 
-            // Calculate sine with phase offset
-            f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
-            // Robust wrap to [0, 1) - handles large negative offsets correctly
-            totalPhase = totalPhase - std::floor(totalPhase);
+                f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
+                totalPhase = totalPhase - std::floor(totalPhase);
 
-            m_OutValue = amplitude * std::sin(2.0f * std::numbers::pi_v<f32> * totalPhase);
+                m_OutValue = amplitude * std::sin(2.0f * std::numbers::pi_v<f32> * totalPhase);
+            }
         }
 
       private:
@@ -112,38 +110,34 @@ namespace OloEngine::Audio::SoundGraph
             m_PhaseAccumulator = 0.0;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            f32 frequency = glm::max(0.0f, *m_Frequency);
-            f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
-            f32 phaseOffset = *m_Phase;
-            f32 pulseWidth = glm::clamp(*m_PulseWidth, 0.01f, 0.99f);
-
-            // Guard against zero or near-zero sample rate
             if (m_SampleRate <= 1e-6f)
             {
-                // Return silence for invalid sample rate
                 m_OutValue = 0.0f;
                 return;
             }
 
-            // Update phase using double precision for higher accuracy
-            f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
-            m_PhaseAccumulator += deltaPhase;
+            const f32 frequency = glm::max(0.0f, *m_Frequency);
+            const f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
+            const f32 phaseOffset = *m_Phase;
+            const f32 pulseWidth = glm::clamp(*m_PulseWidth, 0.01f, 0.99f);
+            const f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
 
-            // Robust phase wrapping to keep in [0, 1) - handles negative values correctly
-            m_PhaseAccumulator -= std::floor(m_PhaseAccumulator);
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                m_PhaseAccumulator += deltaPhase;
+                m_PhaseAccumulator -= std::floor(m_PhaseAccumulator);
 
-            // Calculate square with phase offset and pulse width
-            f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
-            // Robust wrap to [0, 1) - handles large negative offsets correctly
-            totalPhase = std::fmod(totalPhase, 1.0f);
-            if (totalPhase < 0.0f)
-                totalPhase += 1.0f;
+                f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
+                totalPhase = std::fmod(totalPhase, 1.0f);
+                if (totalPhase < 0.0f)
+                    totalPhase += 1.0f;
 
-            m_OutValue = amplitude * (totalPhase < pulseWidth ? 1.0f : -1.0f);
+                m_OutValue = amplitude * (totalPhase < pulseWidth ? 1.0f : -1.0f);
+            }
         }
 
       private:
@@ -180,35 +174,31 @@ namespace OloEngine::Audio::SoundGraph
             m_PhaseAccumulator = 0.0;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            f32 frequency = glm::max(0.0f, *m_Frequency);
-            f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
-            f32 phaseOffset = *m_Phase;
-
-            // Guard against zero or near-zero sample rate
             if (m_SampleRate <= 1e-6f)
             {
-                // Return silence for invalid sample rate
                 m_OutValue = 0.0f;
                 return;
             }
 
-            // Update phase
-            f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
-            m_PhaseAccumulator += deltaPhase;
+            const f32 frequency = glm::max(0.0f, *m_Frequency);
+            const f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
+            const f32 phaseOffset = *m_Phase;
+            const f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
 
-            // Robust phase wrapping to keep in [0, 1)
-            m_PhaseAccumulator = m_PhaseAccumulator - std::floor(m_PhaseAccumulator);
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                m_PhaseAccumulator += deltaPhase;
+                m_PhaseAccumulator = m_PhaseAccumulator - std::floor(m_PhaseAccumulator);
 
-            // Calculate sawtooth with phase offset
-            f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
-            totalPhase = std::fmod(totalPhase + 1.0f, 1.0f); // Ensure positive
+                f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
+                totalPhase = std::fmod(totalPhase + 1.0f, 1.0f);
 
-            // Convert [0,1] to [-1,1] sawtooth
-            m_OutValue = amplitude * (2.0f * totalPhase - 1.0f);
+                m_OutValue = amplitude * (2.0f * totalPhase - 1.0f);
+            }
         }
 
       private:
@@ -245,42 +235,38 @@ namespace OloEngine::Audio::SoundGraph
             m_PhaseAccumulator = 0.0f;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            f32 frequency = glm::max(0.0f, *m_Frequency);
-            f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
-            f32 phaseOffset = *m_Phase;
-
-            // Guard against zero or near-zero sample rate
             if (m_SampleRate <= 1e-6f)
             {
-                // Return silence for invalid sample rate
                 m_OutValue = 0.0f;
                 return;
             }
 
-            // Update phase
-            f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
-            m_PhaseAccumulator += deltaPhase;
+            const f32 frequency = glm::max(0.0f, *m_Frequency);
+            const f32 amplitude = glm::clamp(*m_Amplitude, 0.0f, 1.0f);
+            const f32 phaseOffset = *m_Phase;
+            const f64 deltaPhase = static_cast<f64>(frequency) / static_cast<f64>(m_SampleRate);
 
-            // Wrap phase to [0, 1]
-            if (m_PhaseAccumulator >= 1.0)
-                m_PhaseAccumulator = std::fmod(m_PhaseAccumulator, 1.0);
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                m_PhaseAccumulator += deltaPhase;
+                if (m_PhaseAccumulator >= 1.0)
+                    m_PhaseAccumulator = std::fmod(m_PhaseAccumulator, 1.0);
 
-            // Calculate triangle with phase offset
-            f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
-            totalPhase = std::fmod(totalPhase + 1.0f, 1.0f); // Ensure positive
+                f32 totalPhase = static_cast<f32>(m_PhaseAccumulator) + (phaseOffset / (2.0f * std::numbers::pi_v<f32>));
+                totalPhase = std::fmod(totalPhase + 1.0f, 1.0f);
 
-            // Convert [0,1] to [-1,1] triangle wave
-            f32 triangleWave;
-            if (totalPhase < 0.5f)
-                triangleWave = 4.0f * totalPhase - 1.0f; // Rising edge: [0,0.5] -> [-1,1]
-            else
-                triangleWave = 3.0f - 4.0f * totalPhase; // Falling edge: [0.5,1] -> [1,-1]
+                f32 triangleWave;
+                if (totalPhase < 0.5f)
+                    triangleWave = 4.0f * totalPhase - 1.0f;
+                else
+                    triangleWave = 3.0f - 4.0f * totalPhase;
 
-            m_OutValue = amplitude * triangleWave;
+                m_OutValue = amplitude * triangleWave;
+            }
         }
 
       private:
@@ -355,13 +341,14 @@ namespace OloEngine::Audio::SoundGraph
             m_Generator.Init(resolvedSeed, resolvedType);
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
-            // Check if seed or type have changed and reinitialize if needed
-            i32 resolvedSeed = ResolveSeed();
-            ENoiseType resolvedType = ResolveType();
+            // Check if seed or type have changed and reinitialize if needed.
+            // Seed/type are graph parameters — stable across the block.
+            const i32 resolvedSeed = ResolveSeed();
+            const ENoiseType resolvedType = ResolveType();
 
             if (resolvedSeed != m_CachedSeed || resolvedType != m_CachedType)
             {
@@ -370,9 +357,12 @@ namespace OloEngine::Audio::SoundGraph
                 m_Generator.Init(resolvedSeed, resolvedType);
             }
 
-            f32 noiseValue = m_Generator.GetNextValue();
-            f32 amplitude = m_Amplitude ? *m_Amplitude : 1.0f;
-            m_OutValue = noiseValue * amplitude;
+            const f32 amplitude = m_Amplitude ? *m_Amplitude : 1.0f;
+
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                m_OutValue = m_Generator.GetNextValue() * amplitude;
+            }
         }
 
         enum ENoiseType : int32_t

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/MathNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/MathNodes.h
@@ -71,8 +71,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Value2 = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value1 || !m_Value2)
@@ -114,8 +119,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Value2 = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value1 || !m_Value2)
@@ -157,8 +167,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Multiplier = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value || !m_Multiplier)
@@ -200,8 +215,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Denominator = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value || !m_Denominator)
@@ -257,8 +277,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Value2 = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value1 || !m_Value2)
@@ -300,8 +325,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Value2 = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value1 || !m_Value2)
@@ -344,8 +374,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_MaxValue = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value || !m_MinValue || !m_MaxValue)
@@ -398,8 +433,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_ToMax = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value || !m_FromMin || !m_FromMax || !m_ToMin || !m_ToMax)
@@ -479,8 +519,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Exponent = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Base || !m_Exponent)
@@ -616,8 +661,13 @@ namespace OloEngine::Audio::SoundGraph
         T* m_Value = nullptr;
         T m_Out{ 0 };
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            // Stateless: output depends only on current input values, so per-call
+            // cost is independent of numFrames. The graph still drives this once per
+            // sample-step in Phase 1 (numFrames == 1); when block-rate wiring lands
+            // in Phase 2, callers will pass the whole block here unchanged.
+            (void)numFrames;
             OLO_PROFILE_FUNCTION();
 
             if (!m_Value)

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/MusicNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/MusicNodes.h
@@ -36,8 +36,9 @@ namespace OloEngine::Audio::SoundGraph
             UpdateSeconds();
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Stateless control-rate node; result is independent of block size.
             OLO_PROFILE_FUNCTION();
             UpdateSeconds();
         }
@@ -106,8 +107,9 @@ namespace OloEngine::Audio::SoundGraph
             CalculateFrequency();
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Stateless control-rate node; result is independent of block size.
             OLO_PROFILE_FUNCTION();
             CalculateFrequency();
         }
@@ -168,8 +170,9 @@ namespace OloEngine::Audio::SoundGraph
             CalculateNote();
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Stateless control-rate node; result is independent of block size.
             OLO_PROFILE_FUNCTION();
             CalculateNote();
         }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h
@@ -47,31 +47,32 @@ namespace OloEngine::Audio::SoundGraph
             m_Playing = false;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
+            // Start/Stop flags fire at most once per audio thread iteration; checking them
+            // at block boundary is the same semantics as before (events are queued
+            // externally and observed at most once per Process call).
             if (m_StartFlag.CheckAndResetIfDirty())
                 StartTrigger();
             if (m_StopFlag.CheckAndResetIfDirty())
                 StopTrigger();
 
-            if (m_Playing)
+            if (!m_Playing)
+                return;
+
+            // Hoist period resolution out of the inner loop — input is stable across the block.
+            static constexpr f32 kMinPeriod = 0.001f;
+            f32 safePeriod;
+            if (!m_Period || !std::isfinite(*m_Period) || *m_Period < kMinPeriod)
+                safePeriod = kMinPeriod;
+            else
+                safePeriod = *m_Period;
+
+            for (u32 frame = 0; frame < numFrames; ++frame)
             {
                 m_Counter += m_FrameTime;
-
-                // Guard against zero/negative/non-finite period to prevent infinite loop.
-                // If the input plug never got bound (m_Period == nullptr) treat it as
-                // "use default" rather than crashing — the editor can leave a freshly
-                // dropped node with unbound inputs until the user wires them up.
-                static constexpr f32 kMinPeriod = 0.001f; // 1ms minimum period (1000 Hz max frequency)
-                f32 safePeriod;
-                if (!m_Period || !std::isfinite(*m_Period) || *m_Period < kMinPeriod)
-                    safePeriod = kMinPeriod;
-                else
-                    safePeriod = *m_Period;
-
-                // Handle multiple periods if frame time exceeds period, preserving overshoot
                 while (m_Counter >= safePeriod)
                 {
                     m_Counter -= safePeriod;
@@ -151,8 +152,9 @@ namespace OloEngine::Audio::SoundGraph
             m_OutValue = m_StartValue ? (*m_StartValue) : 0.0f;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
+            (void)numFrames; // Event-driven counter; block size doesn't affect semantics.
             OLO_PROFILE_FUNCTION();
 
             if (m_TriggerFlag.CheckAndResetIfDirty())
@@ -263,7 +265,7 @@ namespace OloEngine::Audio::SoundGraph
             m_Waiting = false;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
             OLO_PROFILE_FUNCTION();
 
@@ -276,11 +278,15 @@ namespace OloEngine::Audio::SoundGraph
             // Unbound delay → behave like zero-delay passthrough. Guards against the
             // editor-not-yet-wired case the rest of these nodes already handle.
             const f32 delay = m_DelayTime ? *m_DelayTime : 0.0f;
-            if (m_Waiting && (m_Counter += m_FrameTime) >= delay)
+
+            for (u32 frame = 0; frame < numFrames; ++frame)
             {
-                m_Waiting = false;
-                m_Counter = 0.0f;
-                m_OutDelayedTrigger(1.0f);
+                if (m_Waiting && (m_Counter += m_FrameTime) >= delay)
+                {
+                    m_Waiting = false;
+                    m_Counter = 0.0f;
+                    m_OutDelayedTrigger(1.0f);
+                }
             }
         }
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
@@ -134,11 +134,17 @@ namespace OloEngine::Audio::SoundGraph
 
         void Process(u32 numFrames) final
         {
-            // Intentionally no OLO_PROFILE_FUNCTION at sample rate: this used to run once
-            // per audio frame (48 kHz). With Phase 1 block processing, the function is
-            // called once per block (~94 Hz at 48 kHz / 512-frame block), so we could
-            // afford a profile macro here now — but leaving it off keeps the hot path
-            // uniform with the comment in SoundGraph::Process.
+            // Intentionally no OLO_PROFILE_FUNCTION: SoundGraph::Process still calls each
+            // node Process(1) per sample step in Phase 1A (the ValueView wiring between
+            // nodes is scalar — see the note in SoundGraph::Process), so this body runs
+            // at sample rate (48 kHz). In Debug, OLO_PROFILE_FUNCTION resolves to an
+            // InstrumentationTimer that does two steady_clock::now() calls per invocation,
+            // and at 48 kHz that alone pushes the audio thread below real time.
+            //
+            // The setup-once / loop-per-sample structure below is intentionally positioned
+            // for Phase 2: once typed AudioBufferRef wiring lets SoundGraph call us with
+            // the whole block, the per-block setup (Check/Flag calls) amortises across
+            // numFrames instead of running at sample rate.
 
             // If parameter wiring is incomplete, stay silent rather than crash.
             if (!m_WaveAsset || !m_Loop || !m_NumberOfLoops)
@@ -147,10 +153,8 @@ namespace OloEngine::Audio::SoundGraph
                 return;
             }
 
-            // Block-rate setup. These used to run at 48 kHz inside the per-sample loop;
-            // they only need to happen once per block. Pre-Phase-1 measurements showed
-            // these atomic / flag operations were a primary contributor to the audio
-            // thread missing real time in Debug.
+            // Block-rate setup — see the Phase 2 note above; in Phase 1A this still runs
+            // per Process(1) call, but the code is shape-ready for the block-rate switch.
             CheckAsyncLoadCompletion();
             if (m_PlayFlag.CheckAndResetIfDirty())
                 StartPlayback();
@@ -161,7 +165,7 @@ namespace OloEngine::Audio::SoundGraph
             // (the scalar outputs the existing ValueView wiring is aliased to). Phase 2
             // introduces a buffer-rate output so downstream consumers can read the whole
             // block at once; until then SoundGraph still samples this node's scalar output
-            // once per frame, but the expensive setup above is amortised across the block.
+            // once per frame.
             for (u32 frame = 0; frame < numFrames; ++frame)
             {
                 if (!m_IsPlaying)

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
@@ -132,35 +132,44 @@ namespace OloEngine::Audio::SoundGraph
             m_IsInitialized = true;
         }
 
-        void Process() final
+        void Process(u32 numFrames) final
         {
-            // Intentionally no OLO_PROFILE_FUNCTION: called once per audio frame from
-            // SoundGraph::Process. The Debug-mode InstrumentationTimer overhead is on the
-            // order of a microsecond per call, which is fatal at 48 kHz. See the matching
-            // comment in SoundGraph::Process for the full reasoning.
+            // Intentionally no OLO_PROFILE_FUNCTION at sample rate: this used to run once
+            // per audio frame (48 kHz). With Phase 1 block processing, the function is
+            // called once per block (~94 Hz at 48 kHz / 512-frame block), so we could
+            // afford a profile macro here now — but leaving it off keeps the hot path
+            // uniform with the comment in SoundGraph::Process.
 
-            // If parameter wiring is incomplete, stay silent rather than crash. This can
-            // happen for a node added by the editor that hasn't had its inputs configured
-            // and whose endpoint registration didn't establish the expected parameter map.
+            // If parameter wiring is incomplete, stay silent rather than crash.
             if (!m_WaveAsset || !m_Loop || !m_NumberOfLoops)
             {
                 OutputSilence();
                 return;
             }
 
-            // Check for completed async loads (non-blocking, audio thread safe)
+            // Block-rate setup. These used to run at 48 kHz inside the per-sample loop;
+            // they only need to happen once per block. Pre-Phase-1 measurements showed
+            // these atomic / flag operations were a primary contributor to the audio
+            // thread missing real time in Debug.
             CheckAsyncLoadCompletion();
-
-            // Handle events using Flag system like Hazel
             if (m_PlayFlag.CheckAndResetIfDirty())
                 StartPlayback();
-
             if (m_StopFlag.CheckAndResetIfDirty())
                 StopPlayback(false);
 
-            if (m_IsPlaying)
+            // Per-sample loop. Each iteration produces one sample on m_OutLeft / m_OutRight
+            // (the scalar outputs the existing ValueView wiring is aliased to). Phase 2
+            // introduces a buffer-rate output so downstream consumers can read the whole
+            // block at once; until then SoundGraph still samples this node's scalar output
+            // once per frame, but the expensive setup above is amortised across the block.
+            for (u32 frame = 0; frame < numFrames; ++frame)
             {
-                // Check if we've reached the end
+                if (!m_IsPlaying)
+                {
+                    OutputSilence();
+                    continue;
+                }
+
                 if (m_FrameNumber >= m_TotalFrames)
                 {
                     if (*m_Loop)
@@ -168,7 +177,6 @@ namespace OloEngine::Audio::SoundGraph
                         ++m_LoopCount;
                         m_OnLooped(2.0f);
 
-                        // Check if we've completed all loops
                         if (*m_NumberOfLoops >= 0 && m_LoopCount > *m_NumberOfLoops)
                         {
                             StopPlayback(true);
@@ -176,9 +184,7 @@ namespace OloEngine::Audio::SoundGraph
                         }
                         else
                         {
-                            // Loop back to start - reset play head before fetching next frame.
-                            // Also rewind m_NextRefillFrame so the post-loop refills start
-                            // reading from the file beginning instead of past-the-end.
+                            // Loop back to start.
                             m_FrameNumber = m_StartSample;
                             m_WaveSource.m_ReadPosition = m_FrameNumber;
                             m_NextRefillFrame = m_StartSample;
@@ -190,22 +196,16 @@ namespace OloEngine::Audio::SoundGraph
                     }
                     else
                     {
-                        // No looping - stop playback
                         StopPlayback(true);
                         OutputSilence();
                     }
                 }
                 else
                 {
-                    // Read next frame of audio data
                     ReadNextFrame();
                     m_FrameNumber++;
                     m_WaveSource.m_ReadPosition = m_FrameNumber;
                 }
-            }
-            else
-            {
-                OutputSilence();
             }
         }
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
@@ -545,8 +545,13 @@ namespace OloEngine::Audio::SoundGraph
                             "SoundGraph::Process: output buffer count is short of channel count; call SetMaxBlockSize off-thread");
             for ([[maybe_unused]] auto& buf : m_OutputBuffers)
             {
-                OLO_CORE_ASSERT(buf.capacity() >= numFrames,
-                                "SoundGraph::Process: block buffer capacity insufficient for numFrames; call SetMaxBlockSize off-thread");
+                // Check size(), not capacity() — operator[] writes below are bounds-checked
+                // against size() by MSVC Debug iterators (and are simply UB past size() in
+                // Release). EnsureOutputBuffersCapacity uses resize() so size == capacity in
+                // practice, but checking the dimension that actually gates operator[] keeps
+                // the contract honest.
+                OLO_CORE_ASSERT(buf.size() >= numFrames,
+                                "SoundGraph::Process: block buffer size insufficient for numFrames; call SetMaxBlockSize off-thread");
             }
 
             const sizet channelCount = std::min(m_OutChannels.size(), m_OutputChannelViews.size());

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
@@ -185,11 +185,11 @@ namespace OloEngine::Audio::SoundGraph
         std::vector<float> m_OutChannels;
 
         /// Per-channel block-output buffers, parallel to m_OutChannels / m_OutputChannelIDs.
-        /// Sized to numFrames on first Process(numFrames) call and re-sized only if the
-        /// block size changes. Each entry [c][i] is the i-th sample of channel c produced
-        /// during this block. SoundGraphSource bulk-copies these into the miniaudio
-        /// output bus.
-        std::vector<std::vector<float>> m_OutputBuffers;
+        /// Capacity is reserved off the audio thread via SetMaxBlockSize so that
+        /// Process(numFrames) on the audio thread only adjusts the logical size (no heap
+        /// allocation). Each entry [c][i] is the i-th sample of channel c produced during
+        /// this block. SoundGraphSource bulk-copies these into the miniaudio output bus.
+        std::vector<std::vector<f32>> m_OutputBuffers;
 
         /// Cached pointers to the endpoint output ValueViews, parallel to m_OutChannels /
         /// m_OutputChannelIDs. Rebuilt lazily on first Process() after Init() so the
@@ -477,7 +477,23 @@ namespace OloEngine::Audio::SoundGraph
                 node->Init();
             }
 
+            // Pre-allocate per-channel block buffers to a sensible default block size so
+            // even consumers that drive Process() directly (instantiation tests, future
+            // offline render paths) don't trigger heap allocations on the audio thread.
+            // SoundGraphSource overrides this via SetMaxBlockSize() with the real miniaudio
+            // block size before the audio thread starts pulling samples.
+            EnsureOutputBuffersCapacity(kDefaultMaxBlockSize);
+
             m_IsInitialized = true;
+        }
+
+        /// Pre-allocates per-channel block-buffer capacity *off* the audio thread. Call
+        /// after graph construction (all AddGraphOutputStream calls complete) and before
+        /// any audio-thread Process(numFrames) call. Safe to call again with a larger
+        /// value; never shrinks. Idempotent for sizes already covered.
+        void SetMaxBlockSize(u32 maxBlockSize)
+        {
+            EnsureOutputBuffersCapacity(maxBlockSize);
         }
 
         void BeginProcessBlock()
@@ -505,6 +521,11 @@ namespace OloEngine::Audio::SoundGraph
         // we get the real perf win documented in docs/soundgraph-metasounds-refactor.md.
         void Process(u32 numFrames) final
         {
+            // Block-rate entry point (~100 Hz at 48 kHz / 480-frame block) — profile macro
+            // is fine here. The matching note in WavePlayer::Process explains why the
+            // per-sample hot path called from this method still avoids OLO_PROFILE_FUNCTION.
+            OLO_PROFILE_FUNCTION();
+
             // Lazy rebuild of the endpoint-view cache (see member-doc on m_OutputChannelViews).
             if (m_OutputChannelViews.size() != m_OutputChannelIDs.size()) [[unlikely]]
             {
@@ -517,13 +538,16 @@ namespace OloEngine::Audio::SoundGraph
                 }
             }
 
-            // Ensure per-channel block buffers exist and are sized for this block.
-            if (m_OutputBuffers.size() != m_OutChannels.size())
-                m_OutputBuffers.resize(m_OutChannels.size());
-            for (auto& buf : m_OutputBuffers)
+            // Block buffers were pre-allocated to capacity by Init() and (optionally)
+            // SetMaxBlockSize() off the audio thread. The assert below is the contract:
+            // if it ever fires we'd be a missed off-thread reserve away from a heap
+            // allocation in the audio callback.
+            OLO_CORE_ASSERT(m_OutputBuffers.size() >= m_OutChannels.size(),
+                            "SoundGraph::Process: output buffer count is short of channel count; call SetMaxBlockSize off-thread");
+            for ([[maybe_unused]] auto& buf : m_OutputBuffers)
             {
-                if (buf.size() < numFrames)
-                    buf.resize(numFrames);
+                OLO_CORE_ASSERT(buf.capacity() >= numFrames,
+                                "SoundGraph::Process: block buffer capacity insufficient for numFrames; call SetMaxBlockSize off-thread");
             }
 
             const sizet channelCount = std::min(m_OutChannels.size(), m_OutputChannelViews.size());
@@ -730,6 +754,25 @@ namespace OloEngine::Audio::SoundGraph
         }
 
       private:
+        // Default per-channel block-buffer capacity used by Init() when SoundGraphSource
+        // hasn't yet called SetMaxBlockSize. Sized generously so direct-Process callers
+        // (tests, offline render) don't trip the capacity assert in Process.
+        static constexpr u32 kDefaultMaxBlockSize = 4096;
+
+        /// Ensure m_OutputBuffers has one entry per output channel and each entry has
+        /// `capacity` valid storage slots. Both .size() and .capacity() end up >= capacity.
+        /// MUST be called off the audio thread.
+        void EnsureOutputBuffersCapacity(u32 capacity)
+        {
+            if (m_OutputBuffers.size() < m_OutChannels.size())
+                m_OutputBuffers.resize(m_OutChannels.size());
+            for (auto& buf : m_OutputBuffers)
+            {
+                if (buf.size() < capacity)
+                    buf.resize(capacity);
+            }
+        }
+
         bool m_IsInitialized = false;
         f32 m_SampleRate = 48000.0f;
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
@@ -181,8 +181,15 @@ namespace OloEngine::Audio::SoundGraph
         /// Output channel identifiers
         std::vector<Identifier> m_OutputChannelIDs;
 
-        /// Output channel values
+        /// Output channel values (scalar, last-sample of the block)
         std::vector<float> m_OutChannels;
+
+        /// Per-channel block-output buffers, parallel to m_OutChannels / m_OutputChannelIDs.
+        /// Sized to numFrames on first Process(numFrames) call and re-sized only if the
+        /// block size changes. Each entry [c][i] is the i-th sample of channel c produced
+        /// during this block. SoundGraphSource bulk-copies these into the miniaudio
+        /// output bus.
+        std::vector<std::vector<float>> m_OutputBuffers;
 
         /// Cached pointers to the endpoint output ValueViews, parallel to m_OutChannels /
         /// m_OutputChannelIDs. Rebuilt lazily on first Process() after Init() so the
@@ -483,39 +490,22 @@ namespace OloEngine::Audio::SoundGraph
             }
         }
 
-        void Process() final
+        // Phase 1 block-rate entry point. Replaces the old per-sample Process() (which was
+        // called 48 000 times/sec from SoundGraphSource::ProcessSamples). The per-sample
+        // iteration is now hoisted INTO the graph so SoundGraphSource can hand us a whole
+        // block in a single call.
+        //
+        // Phase 1 scope: SoundGraphSource overhead (function dispatch, OLO_PROFILE_FUNCTION
+        // entry, ppFramesOut bounds-check) collapses from per-sample to per-block. The
+        // per-sample iteration inside this method still walks all nodes once per sample,
+        // because the ValueView wiring between nodes is scalar — moving the loop one level
+        // out without changing wiring would only deliver the LAST sample of the block to
+        // downstream consumers. Phase 2 introduces typed AudioBufferRef wiring; once that
+        // lands, this loop can collapse to a single per-node Process(numFrames) call and
+        // we get the real perf win documented in docs/soundgraph-metasounds-refactor.md.
+        void Process(u32 numFrames) final
         {
-            // Intentionally no OLO_PROFILE_FUNCTION: this runs once per audio frame
-            // (48000 Hz). In Debug, OLO_PROFILE_FUNCTION resolves to InstrumentationTimer,
-            // which performs two steady_clock::now() calls per invocation regardless of
-            // session state — at 48 kHz that alone is enough to push the audio thread
-            // below real-time. If we ever need per-frame profiling here, gate it behind
-            // a sampled (e.g. 1-in-N) macro instead of an unconditional one.
-
-            // Process parameter interpolations
-            for (auto& [id, interpValue] : m_InterpInputs)
-                interpValue.Process();
-
-            // Process all nodes in graph
-            for (auto& node : m_Nodes)
-                node->Process();
-
-            // Sample the graph's output channels through m_EndpointOutputStreams. Per-channel
-            // wiring works by aliasing: AddConnection(source, destination) makes destination
-            // point at source's storage. AddGraphOutputStream initially aliases each endpoint
-            // stream to m_OutChannels[i], but AddToGraphOutputConnection then re-aliases it to
-            // the actual producing node's output (e.g. WavePlayer's m_OutLeft). The graph's
-            // m_OutChannels slot itself is never reassigned by those later aliases, so reading
-            // m_OutChannels directly produces the zero default forever. We resolve it through
-            // the (possibly re-aliased) endpoint view here, every frame, so the sample the
-            // engine reads matches what the connected node produced this Process() call.
-            //
-            // Lookup is cached in m_OutputChannelViews on first hit — at 96 000 lookups/sec
-            // in Debug an unordered_map::find was burning ~50 ms per audio second, pushing
-            // the per-frame loop past real-time. The ValueView object lives inside the map's
-            // node and is not moved by AddConnection (which only re-assigns the view's
-            // internal data pointer), so the cached pointer stays valid for the life of the
-            // graph.
+            // Lazy rebuild of the endpoint-view cache (see member-doc on m_OutputChannelViews).
             if (m_OutputChannelViews.size() != m_OutputChannelIDs.size()) [[unlikely]]
             {
                 m_OutputChannelViews.clear();
@@ -526,15 +516,53 @@ namespace OloEngine::Audio::SoundGraph
                     m_OutputChannelViews.push_back(it != m_EndpointOutputStreams.InputStreams.end() ? &it->second : nullptr);
                 }
             }
-            const sizet channelCount = std::min(m_OutChannels.size(), m_OutputChannelViews.size());
-            for (sizet i = 0; i < channelCount; ++i)
+
+            // Ensure per-channel block buffers exist and are sized for this block.
+            if (m_OutputBuffers.size() != m_OutChannels.size())
+                m_OutputBuffers.resize(m_OutChannels.size());
+            for (auto& buf : m_OutputBuffers)
             {
-                const auto* view = m_OutputChannelViews[i];
-                if (view && view->getType().isFloat32())
-                    m_OutChannels[i] = view->getFloat32();
+                if (buf.size() < numFrames)
+                    buf.resize(numFrames);
             }
 
-            ++m_CurrentFrame;
+            const sizet channelCount = std::min(m_OutChannels.size(), m_OutputChannelViews.size());
+
+            for (u32 frame = 0; frame < numFrames; ++frame)
+            {
+                // Per-sample parameter interpolation (10 ms ramps in SendInputValue).
+                for (auto& [id, interpValue] : m_InterpInputs)
+                    interpValue.Process();
+
+                // Walk the node graph. Phase 1 passes numFrames=1 here: each node produces
+                // one sample, downstream consumers read the scalar via ValueView, the chain
+                // works. Phase 2 swaps in typed buffer connections and lifts this call out
+                // of the per-sample loop.
+                for (auto& node : m_Nodes)
+                    node->Process(1);
+
+                // Sample each graph output channel from its (possibly re-aliased) endpoint
+                // view into the per-channel block buffer. The view points at the producing
+                // node's storage — see the original comment preserved on m_OutputChannelViews.
+                for (sizet c = 0; c < channelCount; ++c)
+                {
+                    const auto* view = m_OutputChannelViews[c];
+                    if (view && view->getType().isFloat32())
+                        m_OutputBuffers[c][frame] = view->getFloat32();
+                    else
+                        m_OutputBuffers[c][frame] = 0.0f;
+                }
+
+                ++m_CurrentFrame;
+            }
+
+            // Mirror the final sample into the scalar m_OutChannels for any consumer that
+            // reads it directly (debug UIs, telemetry). The block buffer is the real output.
+            for (sizet c = 0; c < channelCount; ++c)
+            {
+                if (numFrames > 0)
+                    m_OutChannels[c] = m_OutputBuffers[c][numFrames - 1];
+            }
         }
 
         // Reset nodes to their initial state

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
@@ -484,6 +484,10 @@ namespace OloEngine::Audio::SoundGraph
             // block size before the audio thread starts pulling samples.
             EnsureOutputBuffersCapacity(kDefaultMaxBlockSize);
 
+            // Pre-build the endpoint-view cache off the audio thread (was previously rebuilt
+            // lazily inside Process() — that path is allocation-prone on the audio thread).
+            RebuildOutputChannelViewsCache();
+
             m_IsInitialized = true;
         }
 
@@ -494,6 +498,11 @@ namespace OloEngine::Audio::SoundGraph
         void SetMaxBlockSize(u32 maxBlockSize)
         {
             EnsureOutputBuffersCapacity(maxBlockSize);
+            // Endpoint wiring may have completed *after* Init() in some construction paths
+            // (e.g. SoundGraphSource::ReplaceGraph rewires before resuming). Refresh the
+            // cache here too so Process() can always observe a valid cache without doing
+            // the rebuild itself.
+            RebuildOutputChannelViewsCache();
         }
 
         void BeginProcessBlock()
@@ -526,22 +535,12 @@ namespace OloEngine::Audio::SoundGraph
             // per-sample hot path called from this method still avoids OLO_PROFILE_FUNCTION.
             OLO_PROFILE_FUNCTION();
 
-            // Lazy rebuild of the endpoint-view cache (see member-doc on m_OutputChannelViews).
-            if (m_OutputChannelViews.size() != m_OutputChannelIDs.size()) [[unlikely]]
-            {
-                m_OutputChannelViews.clear();
-                m_OutputChannelViews.reserve(m_OutputChannelIDs.size());
-                for (const auto& id : m_OutputChannelIDs)
-                {
-                    auto it = m_EndpointOutputStreams.InputStreams.find(id);
-                    m_OutputChannelViews.push_back(it != m_EndpointOutputStreams.InputStreams.end() ? &it->second : nullptr);
-                }
-            }
-
-            // Block buffers were pre-allocated to capacity by Init() and (optionally)
-            // SetMaxBlockSize() off the audio thread. The assert below is the contract:
-            // if it ever fires we'd be a missed off-thread reserve away from a heap
-            // allocation in the audio callback.
+            // The endpoint-view cache and per-channel block buffers were both pre-built off
+            // the audio thread (in Init() and SetMaxBlockSize()). The asserts below are the
+            // RT-safety contract: if any of them fire we'd be a missed off-thread setup
+            // call away from a heap allocation in the audio callback.
+            OLO_CORE_ASSERT(m_OutputChannelViews.size() == m_OutputChannelIDs.size(),
+                            "SoundGraph::Process: view cache is stale; call SetMaxBlockSize/Init off-thread after wiring");
             OLO_CORE_ASSERT(m_OutputBuffers.size() >= m_OutChannels.size(),
                             "SoundGraph::Process: output buffer count is short of channel count; call SetMaxBlockSize off-thread");
             for ([[maybe_unused]] auto& buf : m_OutputBuffers)
@@ -770,6 +769,21 @@ namespace OloEngine::Audio::SoundGraph
             {
                 if (buf.size() < capacity)
                     buf.resize(capacity);
+            }
+        }
+
+        /// (Re-)build the endpoint-view pointer cache used by Process() to read the
+        /// graph's output channel values without an unordered_map::find per sample.
+        /// MUST be called off the audio thread (clear + reserve + push_back can allocate).
+        /// Safe to call repeatedly when wiring changes.
+        void RebuildOutputChannelViewsCache()
+        {
+            m_OutputChannelViews.clear();
+            m_OutputChannelViews.reserve(m_OutputChannelIDs.size());
+            for (const auto& id : m_OutputChannelIDs)
+            {
+                auto it = m_EndpointOutputStreams.InputStreams.find(id);
+                m_OutputChannelViews.push_back(it != m_EndpointOutputStreams.InputStreams.end() ? &it->second : nullptr);
             }
         }
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -806,20 +806,31 @@ namespace OloEngine::Audio::SoundGraph
                 m_Graph->Process(frameCount);
 
                 const u32 outputChannels = std::min(m_ChannelCount, static_cast<u32>(m_Graph->m_OutputBuffers.size()));
-                for (u32 frame = 0; frame < frameCount; ++frame)
+                if (outputChannels == 0)
                 {
-                    const sizet base = static_cast<sizet>(frame) * m_ChannelCount;
-                    for (u32 channel = 0; channel < outputChannels; ++channel)
+                    // Graph has no wired output channels (broken/empty graph). The
+                    // copy loop below would no-op and leave busOut holding whatever
+                    // miniaudio handed us — which is not guaranteed to be silent.
+                    // Zero the bus explicitly so we never emit junk audio.
+                    ma_silence_pcm_frames(busOut, frameCount, ma_format_f32, m_ChannelCount);
+                }
+                else
+                {
+                    for (u32 frame = 0; frame < frameCount; ++frame)
                     {
-                        busOut[base + channel] = m_Graph->m_OutputBuffers[channel][frame];
-                    }
+                        const sizet base = static_cast<sizet>(frame) * m_ChannelCount;
+                        for (u32 channel = 0; channel < outputChannels; ++channel)
+                        {
+                            busOut[base + channel] = m_Graph->m_OutputBuffers[channel][frame];
+                        }
 
-                    // Mono → stereo (and wider) fan-out: copy channel 0 to remaining channels.
-                    if (outputChannels >= 1 && outputChannels < m_ChannelCount)
-                    {
-                        const f32 sample = busOut[base + 0];
-                        for (u32 channel = outputChannels; channel < m_ChannelCount; ++channel)
-                            busOut[base + channel] = sample;
+                        // Mono → stereo (and wider) fan-out: copy channel 0 to remaining channels.
+                        if (outputChannels < m_ChannelCount)
+                        {
+                            const f32 sample = busOut[base + 0];
+                            for (u32 channel = outputChannels; channel < m_ChannelCount; ++channel)
+                                busOut[base + channel] = sample;
+                        }
                     }
                 }
             }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -573,6 +573,11 @@ namespace OloEngine::Audio::SoundGraph
                 // thread won't dereference m_Graph until SuspendProcessing(false) clears the
                 // suspend flag.
                 m_Graph->SetSampleRate(static_cast<f32>(m_SampleRate));
+                // Pre-allocate the graph's per-channel block-output buffers up to the
+                // miniaudio block size so the audio thread doesn't trigger any heap
+                // allocation when it first calls Process(frameCount). Safe to call here
+                // because we're off the audio thread (graph is suspended).
+                m_Graph->SetMaxBlockSize(m_BlockSize);
                 UpdateParameterSet();
                 OLO_CORE_INFO("[SoundGraphSource] Replaced sound graph");
             }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -794,15 +794,19 @@ namespace OloEngine::Audio::SoundGraph
             float* const busOut = (ppFramesOut && ppFramesOut[0]) ? ppFramesOut[0] : nullptr;
             if (busOut)
             {
+                // Phase 1: a single block-rate Process call replaces the old per-sample
+                // inner loop. The graph fills m_OutputBuffers[c][i] with `frameCount`
+                // samples per channel; we deinterleave-to-interleave-copy them into the
+                // miniaudio output bus below.
+                m_Graph->Process(frameCount);
+
+                const u32 outputChannels = std::min(m_ChannelCount, static_cast<u32>(m_Graph->m_OutputBuffers.size()));
                 for (u32 frame = 0; frame < frameCount; ++frame)
                 {
-                    m_Graph->Process();
-
-                    const u32 outputChannels = std::min(m_ChannelCount, static_cast<u32>(m_Graph->m_OutChannels.size()));
                     const sizet base = static_cast<sizet>(frame) * m_ChannelCount;
                     for (u32 channel = 0; channel < outputChannels; ++channel)
                     {
-                        busOut[base + channel] = m_Graph->m_OutChannels[channel];
+                        busOut[base + channel] = m_Graph->m_OutputBuffers[channel][frame];
                     }
 
                     // Mono → stereo (and wider) fan-out: copy channel 0 to remaining channels.
@@ -813,6 +817,12 @@ namespace OloEngine::Audio::SoundGraph
                             busOut[base + channel] = sample;
                     }
                 }
+            }
+            else
+            {
+                // No output bus from miniaudio — still drive the graph forward so timing,
+                // events, and the OnFinished signal don't stall.
+                m_Graph->Process(frameCount);
             }
 
             // Handle outgoing events and messages

--- a/OloEngine/tests/SoundGraphInstantiationTest.cpp
+++ b/OloEngine/tests/SoundGraphInstantiationTest.cpp
@@ -121,6 +121,6 @@ TEST(SoundGraphInstantiation, WavePlayerWithUnconfiguredAssetDoesNotCrash)
     ASSERT_NO_THROW(instance->Init());
     ASSERT_NO_THROW(instance->SendInputEvent(Audio::SoundGraph::SoundGraph::IDs::Play,
                                              choc::value::createFloat32(1.0f)));
-    ASSERT_NO_THROW(instance->Process())
+    ASSERT_NO_THROW(instance->Process(/*numFrames=*/1))
         << "WavePlayer with no bound WaveAsset must emit silence, not crash";
 }

--- a/docs/soundgraph-metasounds-refactor.md
+++ b/docs/soundgraph-metasounds-refactor.md
@@ -62,6 +62,32 @@ JUCE).
 
 **Goal:** the ding plays correctly in Debug. Foundation for later phases.
 
+> **Status (2026-05-25):** Phase 1A — *signature change and structural rework* —
+> has landed. `SoundGraphSource::ProcessSamples` now makes a single
+> `m_Graph->Process(frameCount)` call per block and bulk-copies from per-channel
+> output buffers into the miniaudio bus. Every `NodeProcessor` override carries
+> the new `Process(u32 numFrames)` signature; stateful nodes (oscillators,
+> envelopes, WavePlayer, time-counting triggers) wrap their per-sample body in
+> a for-loop and hoist input reads / event-flag checks to block rate. The
+> existing SoundGraph instantiation + serializer tests pass under the new API.
+>
+> What did **not** land: the perf metric below (effective rate ≈ 48 kHz in
+> Debug). Because Phase 1's non-goal is to "leave `choc::value::ValueView`
+> wiring in place", the per-node `Process(...)` calls still have to happen
+> once per sample inside `SoundGraph::Process` — calling each node once per
+> block would deliver only the *last* sample of the block to the next ValueView
+> consumer down the chain. The amortisation work in WavePlayer (block-rate
+> async-load / play-flag checks) is in place but unused until SoundGraph can
+> hand it the whole block. That switch lands as part of **Phase 2** when typed
+> `AudioBufferRef` connections replace the scalar `ValueView` wiring.
+>
+> Concretely, after Phase 1A:
+>
+> - ✓ `ProcessSamples` does one `m_Graph->Process(frameCount)` call.
+> - ✓ Existing SoundGraph instantiation + serializer tests pass.
+> - ⏳ HelloDing Debug perf — still per-sample chain inside the graph; gated on
+>   Phase 2 buffer-rate wiring.
+
 ### Signature change
 
 ```cpp


### PR DESCRIPTION
Phase 1A of docs/soundgraph-metasounds-refactor.md. Lays the signature foundation so SoundGraphSource::ProcessSamples can drive the graph one block at a time instead of one sample at a time.

Surface changes
- NodeProcessor::Process() -> Process(u32 numFrames) (base + ~30 overrides across Math/Generator/Music/Envelope/Trigger/Array/WavePlayer).
- Stateful nodes (oscillators, envelopes, time-counting triggers, WavePlayer) wrap their per-sample body in for(frame < numFrames) and hoist block-stable work (input reads, event-flag checks, async-load polling) out of the inner loop.
- SoundGraph gains m_OutputBuffers (per-channel block buffers). SoundGraph::Process(numFrames) populates them and mirrors the final sample into m_OutChannels for compat with consumers that read scalars.
- SoundGraphSource::ProcessSamples drops its inner per-frame loop — single m_Graph->Process(frameCount) + bulk interleave-copy out of the graph's output buffers.

Scope notes
- The choc::value::ValueView wiring is deliberately left in place (per Phase 1 non-goals). SoundGraph::Process therefore still walks nodes per-sample internally; calling each node once per block would deliver only the *last* sample to the next ValueView consumer down the chain. Block-rate node calls land with Phase 2's typed AudioBufferRef wiring.
- WavePlayer's per-block setup amortisation (CheckAsyncLoadCompletion, Play/StopFlag) is in place but unused until Phase 2 — that's why the HelloDing Debug perf metric isn't met by this PR. Refactor doc updated with a status block calling that out.

Verification
- OloEngine-Tests (Debug): all 2540 tests pass, including the 12 SoundGraph tests.
- OloEditor (Debug): builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public block-size configuration API to preallocate per-channel output buffers.

* **Refactor**
  * Converted audio processing from per-sample to block-based across nodes and the sound graph for more efficient batched processing and reduced per-call overhead.

* **Documentation**
  * Updated docs describing the block-based processing model and current Phase 1A status.

* **Tests**
  * Adjusted a unit test to exercise a single-frame block processing call.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->