### PR TITLE
feat(asset): fire AssetLoadedEvent on async-load completion

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,18 +2,15 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Bash(build/OloEngine/tests/Debug/OloEngine-Tests.exe --gtest_filter=\"SHProjectionTest.*\")",
       "Bash(git add *)",
       "Bash(cmake --build build --target OloEngine OloEngine-Tests OloEditor --config Debug --parallel)",
       "Bash(gh run *)",
       "Bash(git worktree *)",
-      "Bash(build/OloEngine/tests/Debug/OloEngine-Tests.exe --gtest_filter=TextureSaveRoundTripTest.*)",
       "Bash(build/OloEngine/tests/Debug/OloEngine-Tests.exe)",
       "Bash(tasklist)",
       "Bash(git rebase --abort)",
       "Bash(git rebase --continue)",
-      "Bash(git rebase --skip)",
-      "Bash(git branch *)"
+      "Bash(git rebase --skip)"
     ],
     "additionalDirectories": [
       "\\tmp"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,8 @@
       "Bash(tasklist)",
       "Bash(git rebase --abort)",
       "Bash(git rebase --continue)",
-      "Bash(git rebase --skip)"
+      "Bash(git rebase --skip)",
+      "Bash(git branch *)"
     ],
     "additionalDirectories": [
       "\\tmp"

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -2913,6 +2913,8 @@ namespace OloEngine
 
     bool EditorLayer::OnAssetLoaded(AssetLoadedEvent const& e)
     {
+        OLO_PROFILE_FUNCTION();
+
         // First-time async-load completion. Unlike OnAssetReloaded we do NOT
         // patch in-scene references: a newly loaded asset wasn't present in
         // any cache yet, so the very next frame's normal resolution path will

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1510,6 +1510,7 @@ namespace OloEngine
         EventDispatcher dispatcher(e);
         dispatcher.Dispatch<KeyPressedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnKeyPressed));
         dispatcher.Dispatch<MouseButtonPressedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnMouseButtonPressed));
+        dispatcher.Dispatch<AssetLoadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetLoaded));
         dispatcher.Dispatch<AssetReloadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetReloaded));
         dispatcher.Dispatch<WindowCloseEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnWindowClose));
     }
@@ -2908,6 +2909,40 @@ namespace OloEngine
                     std::make_unique<InvertedCommand>(std::move(compound)));
             }
         }
+    }
+
+    bool EditorLayer::OnAssetLoaded(AssetLoadedEvent const& e)
+    {
+        // First-time async-load completion. Unlike OnAssetReloaded we do NOT
+        // patch in-scene references: a newly loaded asset wasn't present in
+        // any cache yet, so the very next frame's normal resolution path will
+        // pick it up. The only thing worth doing here is dropping any
+        // placeholder thumbnail the Content Browser may have shown while the
+        // asset was still streaming in — the panel will then re-resolve and
+        // render the real preview on its next paint.
+        if (m_ContentBrowserPanel)
+        {
+            const AssetType type = e.GetAssetType();
+            if (type == AssetType::Material || type == AssetType::Mesh)
+            {
+                m_ContentBrowserPanel->InvalidateThumbnail(e.GetHandle(), e.GetPath());
+            }
+            else if (type == AssetType::Texture2D)
+            {
+                // Same reasoning as OnAssetReloaded: without a per-material
+                // dependency graph, a newly available texture might be
+                // referenced by any cached material thumbnail. Cheapest fix
+                // is to drop them all and re-render lazily on next paint.
+                m_ContentBrowserPanel->ClearThumbnails();
+            }
+        }
+
+        OLO_TRACE("📦 Asset Loaded Event Received!");
+        OLO_TRACE("   Handle: {}", static_cast<u64>(e.GetHandle()));
+        OLO_TRACE("   Type: {}", (int)e.GetAssetType());
+        OLO_TRACE("   Path: {}", e.GetPath().string());
+
+        return false; // Don't consume — other listeners may want this too.
     }
 
     bool EditorLayer::OnAssetReloaded(AssetReloadedEvent const& e)

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -40,6 +40,7 @@
 
 namespace OloEngine
 {
+    class AssetLoadedEvent;
     class AssetReloadedEvent;
     class AssetPackBuilderPanel;
     class BuildGamePanel;
@@ -60,6 +61,7 @@ namespace OloEngine
       private:
         bool OnKeyPressed(KeyPressedEvent const& e);
         bool OnMouseButtonPressed(MouseButtonPressedEvent const& e);
+        bool OnAssetLoaded(AssetLoadedEvent const& e);
         bool OnAssetReloaded(AssetReloadedEvent const& e);
 
         void OnOverlayRender() const;

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -755,6 +755,16 @@ namespace OloEngine
 
         OLO_PROFILER_SCOPE("EditorAssetManager::SyncWithAssetThread");
 
+        // Events collected during integration are dispatched after locks are released,
+        // so listeners can call back into the asset manager without risking deadlock.
+        struct PendingLoadEvent
+        {
+            AssetHandle Handle;
+            AssetType Type;
+            std::filesystem::path Path;
+        };
+        std::vector<PendingLoadEvent> loadedEvents;
+
         // First, process raw assets that need GPU finalization (main thread work)
         std::vector<PendingRawAsset> rawAssets;
         if (m_AssetThread->RetrievePendingRawAssets(rawAssets))
@@ -780,6 +790,8 @@ namespace OloEngine
                             m_AssetRegistry.UpdateMetadata(pending.Metadata.Handle, metadata);
                         }
                     }
+
+                    loadedEvents.push_back({ pending.Metadata.Handle, pending.Metadata.Type, pending.Metadata.FilePath });
 
                     OLO_CORE_TRACE("SyncWithAssetThread: Finalized GPU resources for asset {}",
                                    (u64)pending.Metadata.Handle);
@@ -821,12 +833,27 @@ namespace OloEngine
                             }
                         }
 
-                        // TODO: Fire AssetLoadedEvent for listeners
+                        loadedEvents.push_back({ response.Metadata.Handle, response.Metadata.Type, response.Metadata.FilePath });
                     }
                 }
             }
 
             OLO_CORE_TRACE("SyncWithAssetThread: Integrated {} assets from async loading", freshAssets.size());
+        }
+
+        // Fire AssetLoadedEvent for listeners — done after locks release so handlers
+        // can safely call back into the asset manager. SyncWithAssetThread is already
+        // running on the main thread, so the dispatch is in-line (no task hop).
+        if (!loadedEvents.empty())
+        {
+            if (Application* app = Application::TryGet())
+            {
+                for (const auto& evtData : loadedEvents)
+                {
+                    AssetLoadedEvent evt(evtData.Handle, evtData.Type, evtData.Path);
+                    app->OnEvent(evt);
+                }
+            }
         }
 
         // Log telemetry information

--- a/OloEngine/src/OloEngine/Core/Events/EditorEvents.h
+++ b/OloEngine/src/OloEngine/Core/Events/EditorEvents.h
@@ -65,6 +65,53 @@ namespace OloEngine
     };
 
     /**
+     * @brief Engine event fired after an asset has been newly loaded into the manager.
+     *
+     * Mirrors `AssetReloadedEvent`, but for the first-time load path: the
+     * async asset thread or main-thread GPU finalization step has just
+     * brought a previously-unloaded asset into the cache. Listeners can
+     * react (e.g., resolve deferred references, refresh inspectors)
+     * without waiting for a hot-reload to fire.
+     *
+     * Dispatched on the main thread by `EditorAssetManager::SyncWithAssetThread`.
+     */
+    class AssetLoadedEvent : public Event
+    {
+      public:
+        AssetLoadedEvent(AssetHandle handle, AssetType type, const std::filesystem::path& path)
+            : m_Handle(handle), m_Type(type), m_Path(path) {}
+
+        EVENT_CLASS_TYPE(AssetLoaded)
+        EVENT_CLASS_CATEGORY(EventCategory::Application)
+
+        AssetHandle GetHandle() const
+        {
+            return m_Handle;
+        }
+        AssetType GetAssetType() const
+        {
+            return m_Type;
+        }
+        const std::filesystem::path& GetPath() const
+        {
+            return m_Path;
+        }
+
+        std::string ToString() const override
+        {
+            return std::format("AssetLoadedEvent: handle={}, type={}, path={}",
+                               static_cast<u64>(m_Handle),
+                               static_cast<int>(m_Type),
+                               m_Path.string());
+        }
+
+      private:
+        AssetHandle m_Handle = 0;
+        AssetType m_Type = AssetType::None;
+        std::filesystem::path m_Path;
+    };
+
+    /**
      * @brief Engine event fired after an asset has been successfully reloaded/replaced
      *
      * This integrates with the engine's Event system so editor/runtime layers can

--- a/OloEngine/src/OloEngine/Events/Event.h
+++ b/OloEngine/src/OloEngine/Events/Event.h
@@ -38,6 +38,7 @@ namespace OloEngine
         GamepadConnected,
         GamepadDisconnected,
         // Editor/Engine custom events
+        AssetLoaded,
         AssetReloaded,
         LocaleChanged,
     };

--- a/OloEngine/tests/AssetLoadedEventTest.cpp
+++ b/OloEngine/tests/AssetLoadedEventTest.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Events/Event.h"
 #include "OloEngine/Asset/AssetTypes.h"
 
+#include <algorithm>
 #include <filesystem>
 
 using namespace OloEngine;
@@ -45,9 +46,16 @@ TEST(AssetLoadedEventTest, ToStringContainsPayload)
 
     const std::string s = evt.ToString();
 
+    // Normalize path separators: std::filesystem::path::string() returns the
+    // native format, which on Windows can yield backslashes depending on how
+    // the path was constructed. The handle/name assertions don't care, but
+    // the path substring check would be brittle without normalization.
+    std::string sNormalized = s;
+    std::replace(sNormalized.begin(), sNormalized.end(), '\\', '/');
+
     EXPECT_NE(s.find("AssetLoadedEvent"), std::string::npos);
     EXPECT_NE(s.find(std::to_string(handle)), std::string::npos);
-    EXPECT_NE(s.find("meshes/character.olomesh"), std::string::npos);
+    EXPECT_NE(sNormalized.find("meshes/character.olomesh"), std::string::npos);
 }
 
 TEST(AssetLoadedEventTest, DispatcherInvokesMatchingHandler)

--- a/OloEngine/tests/AssetLoadedEventTest.cpp
+++ b/OloEngine/tests/AssetLoadedEventTest.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include "OloEngine/Core/Events/EditorEvents.h"
+#include "OloEngine/Events/Event.h"
+#include "OloEngine/Asset/AssetTypes.h"
+
+#include <filesystem>
+
+using namespace OloEngine;
+
+TEST(AssetLoadedEventTest, ExposesPayload)
+{
+    const AssetHandle handle = 1234567ULL;
+    const AssetType type = AssetType::Texture2D;
+    const std::filesystem::path path = "textures/foo.png";
+
+    AssetLoadedEvent evt(handle, type, path);
+
+    EXPECT_EQ(evt.GetHandle(), handle);
+    EXPECT_EQ(evt.GetAssetType(), type);
+    EXPECT_EQ(evt.GetPath(), path);
+}
+
+TEST(AssetLoadedEventTest, IdentifiesItselfAsAssetLoaded)
+{
+    AssetLoadedEvent evt(1ULL, AssetType::Scene, "scenes/main.olo");
+
+    EXPECT_EQ(AssetLoadedEvent::GetStaticType(), EventType::AssetLoaded);
+    EXPECT_EQ(evt.GetEventType(), EventType::AssetLoaded);
+    EXPECT_STREQ(evt.GetName(), "AssetLoaded");
+    EXPECT_TRUE(evt.IsInCategory(EventCategory::Application));
+}
+
+TEST(AssetLoadedEventTest, IsDistinctFromAssetReloaded)
+{
+    // The two events must not collide on the EventDispatcher.Dispatch<T> path —
+    // listeners wired up for one should never fire for the other.
+    EXPECT_NE(AssetLoadedEvent::GetStaticType(), AssetReloadedEvent::GetStaticType());
+}
+
+TEST(AssetLoadedEventTest, ToStringContainsPayload)
+{
+    const AssetHandle handle = 0xDEADBEEFULL;
+    AssetLoadedEvent evt(handle, AssetType::Mesh, "meshes/character.olomesh");
+
+    const std::string s = evt.ToString();
+
+    EXPECT_NE(s.find("AssetLoadedEvent"), std::string::npos);
+    EXPECT_NE(s.find(std::to_string(handle)), std::string::npos);
+    EXPECT_NE(s.find("meshes/character.olomesh"), std::string::npos);
+}
+
+TEST(AssetLoadedEventTest, DispatcherInvokesMatchingHandler)
+{
+    AssetLoadedEvent evt(42ULL, AssetType::Material, "materials/m.olo");
+
+    bool handlerRan = false;
+    AssetHandle observedHandle = 0;
+
+    EventDispatcher dispatcher(evt);
+    const bool dispatched = dispatcher.Dispatch<AssetLoadedEvent>(
+        [&](AssetLoadedEvent& e)
+        {
+            handlerRan = true;
+            observedHandle = e.GetHandle();
+            return true; // mark handled
+        });
+
+    EXPECT_TRUE(dispatched);
+    EXPECT_TRUE(handlerRan);
+    EXPECT_EQ(observedHandle, 42ULL);
+    EXPECT_TRUE(evt.Handled);
+}
+
+TEST(AssetLoadedEventTest, DispatcherSkipsMismatchedHandler)
+{
+    AssetLoadedEvent evt(7ULL, AssetType::Texture2D, "t.png");
+
+    bool reloadedHandlerRan = false;
+    EventDispatcher dispatcher(evt);
+    const bool dispatched = dispatcher.Dispatch<AssetReloadedEvent>(
+        [&](AssetReloadedEvent&)
+        {
+            reloadedHandlerRan = true;
+            return true;
+        });
+
+    EXPECT_FALSE(dispatched);
+    EXPECT_FALSE(reloadedHandlerRan);
+    EXPECT_FALSE(evt.Handled);
+}

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(OloEngine-Tests
 		AssetCSharpScriptValidityTest.cpp
 		AssetPackTest.cpp
 		AssetRegistryInvariantsTest.cpp
+		AssetLoadedEventTest.cpp
 		ComponentRoundTripTest.cpp
 		ComponentSerializerCoverageTest.cpp
 		SceneSerializerFuzzRegressionTest.cpp


### PR DESCRIPTION
Replaces the `// TODO: Fire AssetLoadedEvent for listeners` stub in EditorAssetManager::SyncWithAssetThread. The reload event already had a parallel construct (AssetReloadedEvent); first-time async loads did not, so subsystems had no way to learn when an asset became available short of polling IsAssetLoaded each frame.

- Add EventType::AssetLoaded and AssetLoadedEvent (parallel to the existing AssetReloadedEvent), so handlers can EventDispatcher::Dispatch on the right type without colliding.
- Fire the event from both SyncWithAssetThread integration paths: raw-asset GPU finalization and fully-loaded fresh assets.
- Collect events while iterating, dispatch after locks release — a handler that calls back into the asset manager (GetAsset, ReloadData, ...) would otherwise re-enter m_AssetsMutex and deadlock.
- Dispatch inline via Application::TryGet()->OnEvent: the sync function is already on the main thread, so the EnqueueGameThreadTask hop used by the reload path would just add a one-frame delay for no benefit.

No consumers wired up in this commit — follow-ups will adopt the event in the content browser and elsewhere.

Test: AssetLoadedEventTest (6 cases) pins payload accessors, event type identity, distinction from AssetReloadedEvent, ToString contents, and EventDispatcher routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an AssetLoaded event that triggers after an asset's initial load; the editor updates Content Browser thumbnails for materials, meshes, and textures.

* **Tests**
  * Added tests validating the AssetLoaded event payload, identity, string output, and dispatcher behavior.

* **Chores**
  * Adjusted editor settings and test/build configuration to include the new tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->