### PR TITLE
refactor(threading): unify engine/editor/server onto FMutex/FSharedMutex/FThread (#115)

### DIFF
--- a/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
@@ -47,6 +47,8 @@ namespace OloEngine
 
     void AssetPackBuilderPanel::OnImGuiRender(bool& isOpen)
     {
+        OLO_PROFILE_FUNCTION();
+
         // One-time initialization of UI buffers from settings
         static bool s_UIInitialized = false;
         if (!s_UIInitialized)
@@ -357,17 +359,18 @@ namespace OloEngine
             return;
         }
 
-        // Signal the build thread to stop; it polls m_CancelRequested.
+        // Signal the build thread to stop; it polls m_CancelRequested. We must
+        // NOT clear m_IsBuildInProgress here: the worker is still running and
+        // only it clears the flag when it actually exits. Clearing it early would
+        // make OnImGuiRender's join branch (!m_IsBuildInProgress && IsJoinable())
+        // fire and block the UI thread on Join() until the worker observes the
+        // cancellation.
         m_CancelRequested.store(true);
-
-        // Update UI state immediately for responsive feedback
-        m_IsBuildInProgress.store(false);
-        m_BuildProgressPermille.store(0);
 
         OLO_CORE_INFO("Asset pack build cancellation requested");
 
-        // Note: the actual build may continue in the background until it observes
-        // the cancellation flag; OnImGuiRender (or the destructor) joins it.
+        // The build keeps running until it observes the cancellation flag, then
+        // sets m_IsBuildInProgress=false; OnImGuiRender (or the destructor) joins.
     }
 
     bool AssetPackBuilderPanel::ValidateOutputPath(const std::string& path, std::string& errorMessage) const

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
@@ -6,9 +6,6 @@
 #include "OloEngine/Project/Project.h"
 
 #include <imgui.h>
-#include <future>
-#include <chrono>
-#include <thread>
 #include <cstring>
 #include <filesystem>
 #include <regex>
@@ -28,11 +25,12 @@ namespace OloEngine
 
     AssetPackBuilderPanel::~AssetPackBuilderPanel()
     {
-        // Request cancellation and wait for thread to complete
-        if (m_BuildThread.joinable())
+        // Request cancellation and wait for the thread to complete. FThread must
+        // be joined before destruction; the build observes m_CancelRequested.
+        m_CancelRequested.store(true);
+        if (m_BuildThread.IsJoinable())
         {
-            m_BuildThread.request_stop();
-            // jthread automatically joins in its destructor
+            m_BuildThread.Join();
         }
     }
 
@@ -60,10 +58,10 @@ namespace OloEngine
         if (ImGui::Begin("Asset Pack Builder", &isOpen))
         {
             // Check if build thread has completed (it will set m_IsBuildInProgress to false when done)
-            if (!m_IsBuildInProgress.load() && m_BuildThread.joinable())
+            if (!m_IsBuildInProgress.load() && m_BuildThread.IsJoinable())
             {
                 // Join the completed thread
-                m_BuildThread.join();
+                m_BuildThread.Join();
 
                 m_HasBuildResult.store(true);
                 m_BuildProgressPermille.store(1000); // 100% in permille
@@ -86,6 +84,12 @@ namespace OloEngine
 
             if (m_IsBuildInProgress.load())
             {
+                // Convert the build thread's real-time float progress to permille
+                // each frame (replaces the old dedicated progress-monitor thread).
+                m_BuildProgressPermille.store(
+                    static_cast<i32>(m_BuildProgress.load(std::memory_order_relaxed) * 1000.0f),
+                    std::memory_order_relaxed);
+
                 RenderBuildProgress();
                 ImGui::Separator();
             }
@@ -311,44 +315,31 @@ namespace OloEngine
         // Update settings from UI
         m_BuildSettings.m_OutputPath = std::filesystem::path(m_OutputPathBuffer.data());
 
-        // Reset progress and results
+        // Reset progress, cancellation, and results
+        m_BuildProgress.store(0.0f);
         m_BuildProgressPermille.store(0);
+        m_CancelRequested.store(false);
         m_HasBuildResult.store(false);
         m_LastBuildResult = {};
 
-        // Start build thread
+        // A previous build's thread may still be joinable if the panel was
+        // hidden when it finished. It has already completed, so Join() returns
+        // immediately and keeps the move-assignment below legal.
+        if (m_BuildThread.IsJoinable())
+        {
+            m_BuildThread.Join();
+        }
+
+        // Start build thread. Progress is written straight into m_BuildProgress
+        // (polled by OnImGuiRender) and cancellation is observed via
+        // m_CancelRequested — no separate monitor threads needed.
         m_IsBuildInProgress.store(true);
-        m_BuildThread = std::jthread([this](std::stop_token stopToken)
-                                     {
-            // Create a cancellation flag bridge for the AssetPackBuilder API
-            std::atomic<bool> cancelRequested{false};
-
-            // Create a float progress tracker for the AssetPackBuilder API
-            std::atomic<f32> floatProgress{0.0f};
-
-            // Launch a progress monitoring thread that checks for cancellation
-            std::jthread progressMonitor([this, &floatProgress, stopToken](std::stop_token) {
-                while (!stopToken.stop_requested()) {
-                    f32 progress = floatProgress.load();
-                    i32 permille = static_cast<i32>(progress * 1000.0f);
-                    m_BuildProgressPermille.store(permille);
-                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                }
-            });
-
-            // Monitor stop token and update cancellation flag
-            std::jthread cancellationMonitor([&cancelRequested, stopToken](std::stop_token) {
-                while (!stopToken.stop_requested()) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                }
-                cancelRequested.store(true);
-            });
-
-            // Perform the actual build
-            auto result = AssetPackBuilder::BuildFromActiveProject(m_BuildSettings, floatProgress, &cancelRequested);
+        m_BuildThread = FThread("AssetPackBuild", [this]()
+                                {
+            auto result = AssetPackBuilder::BuildFromActiveProject(m_BuildSettings, m_BuildProgress, &m_CancelRequested);
 
             // Final progress update
-            if (result.m_Success && !cancelRequested.load()) {
+            if (result.m_Success && !m_CancelRequested.load()) {
                 m_BuildProgressPermille.store(1000); // 100%
             }
 
@@ -366,11 +357,8 @@ namespace OloEngine
             return;
         }
 
-        // Request cancellation using C++20 structured cancellation
-        if (m_BuildThread.joinable())
-        {
-            m_BuildThread.request_stop();
-        }
+        // Signal the build thread to stop; it polls m_CancelRequested.
+        m_CancelRequested.store(true);
 
         // Update UI state immediately for responsive feedback
         m_IsBuildInProgress.store(false);
@@ -378,8 +366,8 @@ namespace OloEngine
 
         OLO_CORE_INFO("Asset pack build cancellation requested");
 
-        // Note: The actual build may continue in the background until completion
-        // The destructor will wait() on the future to ensure proper cleanup
+        // Note: the actual build may continue in the background until it observes
+        // the cancellation flag; OnImGuiRender (or the destructor) joins it.
     }
 
     bool AssetPackBuilderPanel::ValidateOutputPath(const std::string& path, std::string& errorMessage) const

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
@@ -247,10 +247,10 @@ namespace OloEngine
             ImGui::Indent();
 
             i32 permilleProgress = m_BuildProgressPermille.load();
-            f32 progress = static_cast<f32>(permilleProgress) / 10.0f; // Convert permille to percentage
+            f32 fraction = static_cast<f32>(permilleProgress) / 1000.0f; // permille -> 0..1 for ProgressBar
             ImGui::Text("Building asset pack...");
-            ImGui::ProgressBar(progress, ImVec2(-1.0f, 0.0f), nullptr);
-            ImGui::Text("Progress: %.1f%%", progress * 100.0f);
+            ImGui::ProgressBar(fraction, ImVec2(-1.0f, 0.0f), nullptr);
+            ImGui::Text("Progress: %.1f%%", fraction * 100.0f);
 
             ImGui::Unindent();
         }
@@ -332,13 +332,18 @@ namespace OloEngine
             m_BuildThread.Join();
         }
 
+        // Snapshot the settings on the UI thread so the worker reads a stable
+        // copy; RenderBuildSettings keeps mutating m_BuildSettings each frame
+        // while the build runs, which would otherwise be a data race.
+        AssetPackBuilder::BuildSettings settingsCopy = m_BuildSettings;
+
         // Start build thread. Progress is written straight into m_BuildProgress
         // (polled by OnImGuiRender) and cancellation is observed via
         // m_CancelRequested — no separate monitor threads needed.
         m_IsBuildInProgress.store(true);
-        m_BuildThread = FThread("AssetPackBuild", [this]()
+        m_BuildThread = FThread("AssetPackBuild", [this, settingsCopy]()
                                 {
-            auto result = AssetPackBuilder::BuildFromActiveProject(m_BuildSettings, m_BuildProgress, &m_CancelRequested);
+            auto result = AssetPackBuilder::BuildFromActiveProject(settingsCopy, m_BuildProgress, &m_CancelRequested);
 
             // Final progress update
             if (result.m_Success && !m_CancelRequested.load()) {

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.h
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.h
@@ -4,10 +4,10 @@
 #include "OloEngine/ImGui/ImGuiLayer.h"
 #include "OloEngine/Asset/AssetPackBuilder.h"
 #include "OloEngine/Threading/Mutex.h"
+#include "OloEngine/HAL/Thread.h"
 
 #include <array>
 #include <atomic>
-#include <thread>
 
 namespace OloEngine
 {
@@ -24,7 +24,7 @@ namespace OloEngine
 
         ~AssetPackBuilderPanel();
 
-        // Delete copy and move operations due to std::atomic and std::future members
+        // Delete copy and move operations due to std::atomic and FThread members
         AssetPackBuilderPanel(const AssetPackBuilderPanel&) = delete;
         AssetPackBuilderPanel& operator=(const AssetPackBuilderPanel&) = delete;
         AssetPackBuilderPanel(AssetPackBuilderPanel&&) = delete;
@@ -86,9 +86,11 @@ namespace OloEngine
         AssetPackBuilder::BuildSettings m_BuildSettings;
 
         // Progress tracking
+        std::atomic<f32> m_BuildProgress{ 0.0f };      // 0.0-1.0 real progress written by AssetPackBuilder
         std::atomic<i32> m_BuildProgressPermille{ 0 }; // Progress in permille (0-1000, where 1000 = 100%)
         std::atomic<bool> m_IsBuildInProgress{ false };
-        std::jthread m_BuildThread;
+        std::atomic<bool> m_CancelRequested{ false };
+        FThread m_BuildThread;
 
         // Results
         AssetPackBuilder::BuildResult m_LastBuildResult;

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.h
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <atomic>
+#include <string>
 
 namespace OloEngine
 {

--- a/OloEditor/src/Panels/BuildGamePanel.cpp
+++ b/OloEditor/src/Panels/BuildGamePanel.cpp
@@ -37,7 +37,12 @@ namespace OloEngine
     BuildGamePanel::~BuildGamePanel()
     {
         m_CancelRequested.store(true, std::memory_order_release);
-        // jthread destructor handles request_stop() + join()
+        // FThread must be joined before destruction; the build observes
+        // m_CancelRequested and exits promptly.
+        if (m_BuildThread.IsJoinable())
+        {
+            m_BuildThread.Join();
+        }
     }
 
     void BuildGamePanel::OnImGuiRender(bool& isOpen)
@@ -45,9 +50,9 @@ namespace OloEngine
         if (ImGui::Begin("Build Game", &isOpen))
         {
             // Check if build thread has completed
-            if (!m_IsBuildInProgress.load() && m_BuildThread.joinable())
+            if (!m_IsBuildInProgress.load() && m_BuildThread.IsJoinable())
             {
-                m_BuildThread.join();
+                m_BuildThread.Join();
                 m_HasBuildResult.store(true);
                 m_BuildProgressPermille.store(1000);
 
@@ -319,8 +324,17 @@ namespace OloEngine
         // Capture settings by value for the build thread
         GameBuildSettings settings = m_Settings;
 
-        m_BuildThread = std::jthread([this, settings](std::stop_token)
-                                     {
+        // A previous build's thread may still be joinable if the panel was
+        // collapsed when it finished (the OnImGuiRender join branch is skipped
+        // while collapsed). It has already completed, so Join() returns at once
+        // and keeps the move-assignment below legal (FThread asserts otherwise).
+        if (m_BuildThread.IsJoinable())
+        {
+            m_BuildThread.Join();
+        }
+
+        m_BuildThread = FThread("GameBuildThread", [this, settings]()
+                                {
             // Use the member atomic directly so the UI thread can read real-time progress
             auto result = GameBuildPipeline::Build(settings, m_BuildProgress, &m_CancelRequested);
 

--- a/OloEditor/src/Panels/BuildGamePanel.cpp
+++ b/OloEditor/src/Panels/BuildGamePanel.cpp
@@ -47,6 +47,8 @@ namespace OloEngine
 
     void BuildGamePanel::OnImGuiRender(bool& isOpen)
     {
+        OLO_PROFILE_FUNCTION();
+
         if (ImGui::Begin("Build Game", &isOpen))
         {
             // Check if build thread has completed

--- a/OloEditor/src/Panels/BuildGamePanel.h
+++ b/OloEditor/src/Panels/BuildGamePanel.h
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <functional>
 #include <string>
+#include <utility>
 
 namespace OloEngine
 {

--- a/OloEditor/src/Panels/BuildGamePanel.h
+++ b/OloEditor/src/Panels/BuildGamePanel.h
@@ -7,7 +7,9 @@
 
 #include <array>
 #include <atomic>
+#include <filesystem>
 #include <functional>
+#include <string>
 
 namespace OloEngine
 {

--- a/OloEditor/src/Panels/BuildGamePanel.h
+++ b/OloEditor/src/Panels/BuildGamePanel.h
@@ -3,11 +3,11 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Build/GameBuildSettings.h"
 #include "OloEngine/Build/GameBuildPipeline.h"
+#include "OloEngine/HAL/Thread.h"
 
 #include <array>
 #include <atomic>
 #include <functional>
-#include <thread>
 
 namespace OloEngine
 {
@@ -77,7 +77,7 @@ namespace OloEngine
         std::atomic<i32> m_BuildProgressPermille{ 0 };
         std::atomic<bool> m_IsBuildInProgress{ false };
         std::atomic<bool> m_CancelRequested{ false };
-        std::jthread m_BuildThread;
+        FThread m_BuildThread;
 
         // Scene selection
         std::filesystem::path m_EditorScenePath; // currently open scene (absolute)

--- a/OloEditor/src/Panels/ConsolePanel.cpp
+++ b/OloEditor/src/Panels/ConsolePanel.cpp
@@ -1,5 +1,6 @@
 #include "ConsolePanel.h"
 #include "OloEngine/Debug/Profiler.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <imgui.h>
 #include <spdlog/sinks/callback_sink.h>
@@ -84,7 +85,7 @@ namespace OloEngine
 
     void ConsolePanel::PushMessage(const std::string& message, Log::Level level, Log::Type source)
     {
-        std::lock_guard lock(m_Mutex);
+        TUniqueLock<FMutex> lock(m_Mutex);
         if (m_Entries.size() >= s_MaxEntries)
         {
             m_Entries.pop_front();
@@ -94,7 +95,7 @@ namespace OloEngine
 
     void ConsolePanel::Clear()
     {
-        std::lock_guard lock(m_Mutex);
+        TUniqueLock<FMutex> lock(m_Mutex);
         m_Entries.clear();
     }
 
@@ -148,7 +149,7 @@ namespace OloEngine
         // Log entries
         ImGui::BeginChild("LogEntries", ImVec2(0, 0), ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar);
         {
-            std::lock_guard lock(m_Mutex);
+            TUniqueLock<FMutex> lock(m_Mutex);
 
             std::string_view filterStr(m_FilterText);
 

--- a/OloEditor/src/Panels/ConsolePanel.h
+++ b/OloEditor/src/Panels/ConsolePanel.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Threading/Mutex.h"
 
 #include <deque>
-#include <mutex>
 #include <string>
 
 namespace OloEngine
@@ -30,7 +30,7 @@ namespace OloEngine
         // Ring buffer of log entries
         static constexpr size_t s_MaxEntries = 2048;
         std::deque<LogEntry> m_Entries;
-        mutable std::mutex m_Mutex;
+        mutable FMutex m_Mutex;
 
         // Filter state
         bool m_ShowTrace = true;

--- a/OloEngine/src/OloEngine/Asset/AssetManager/AssetManagerBase.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/AssetManagerBase.h
@@ -5,11 +5,13 @@
 #include "OloEngine/Asset/Asset.h"
 #include "OloEngine/Asset/AssetTypes.h"
 #include "OloEngine/Asset/AssetMetadata.h"
+#include "OloEngine/Threading/SharedMutex.h"
+#include "OloEngine/Threading/SharedLock.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <unordered_set>
 #include <unordered_map>
 #include <functional>
-#include <shared_mutex>
 
 namespace OloEngine
 {
@@ -233,7 +235,7 @@ namespace OloEngine
          */
         u32 GetAssetGeneration(AssetHandle handle) const noexcept
         {
-            std::shared_lock lock(m_AssetGenerationsMutex);
+            TSharedLock<FSharedMutex> lock(m_AssetGenerationsMutex);
             auto it = m_AssetGenerations.find(handle);
             return (it != m_AssetGenerations.end()) ? it->second : 0;
         }
@@ -247,7 +249,7 @@ namespace OloEngine
          */
         void IncrementAssetGeneration(AssetHandle handle) noexcept
         {
-            std::unique_lock lock(m_AssetGenerationsMutex);
+            TUniqueLock<FSharedMutex> lock(m_AssetGenerationsMutex);
             ++m_AssetGenerations[handle];
         }
 
@@ -259,7 +261,7 @@ namespace OloEngine
          */
         void ResetAssetGeneration(AssetHandle handle) noexcept
         {
-            std::unique_lock lock(m_AssetGenerationsMutex);
+            TUniqueLock<FSharedMutex> lock(m_AssetGenerationsMutex);
             m_AssetGenerations.erase(handle);
         }
 
@@ -268,14 +270,14 @@ namespace OloEngine
          */
         void ResetAllAssetGenerations() noexcept
         {
-            std::unique_lock lock(m_AssetGenerationsMutex);
+            TUniqueLock<FSharedMutex> lock(m_AssetGenerationsMutex);
             m_AssetGenerations.clear();
         }
 
       private:
         // Per-asset reload generation counter for stale-handle detection
         std::unordered_map<AssetHandle, u32> m_AssetGenerations;
-        mutable std::shared_mutex m_AssetGenerationsMutex;
+        mutable FSharedMutex m_AssetGenerationsMutex;
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Core/PerformanceProfiler.h
+++ b/OloEngine/src/OloEngine/Core/PerformanceProfiler.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "OloEngine/Core/Timer.h"
+#include "OloEngine/Threading/Mutex.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
-#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -19,7 +20,7 @@ namespace OloEngine
       public:
         void SetPerFrameTiming(const char* name, f32 timeMs)
         {
-            std::scoped_lock lock(m_Mutex);
+            TUniqueLock<FMutex> lock(m_Mutex);
             auto& data = m_CurrentFrameData[std::string(name)];
             data.Time += timeMs;
             ++data.Samples;
@@ -29,7 +30,7 @@ namespace OloEngine
         // Call once per frame from the main loop.
         void EndFrame()
         {
-            std::scoped_lock lock(m_Mutex);
+            TUniqueLock<FMutex> lock(m_Mutex);
             m_PreviousFrameData.swap(m_CurrentFrameData);
             m_CurrentFrameData.clear();
         }
@@ -42,13 +43,13 @@ namespace OloEngine
 
         void Clear()
         {
-            std::scoped_lock lock(m_Mutex);
+            TUniqueLock<FMutex> lock(m_Mutex);
             m_CurrentFrameData.clear();
             m_PreviousFrameData.clear();
         }
 
       private:
-        std::mutex m_Mutex;
+        FMutex m_Mutex;
         std::unordered_map<std::string, PerFrameData> m_CurrentFrameData;
         std::unordered_map<std::string, PerFrameData> m_PreviousFrameData;
     };

--- a/OloEngine/src/OloEngine/Localization/LocalizationManager.cpp
+++ b/OloEngine/src/OloEngine/Localization/LocalizationManager.cpp
@@ -2,6 +2,8 @@
 #include "OloEngine/Localization/LocalizationManager.h"
 #include "OloEngine/Localization/LocalizationEvents.h"
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Threading/SharedLock.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <yaml-cpp/yaml.h>
 
@@ -23,9 +25,9 @@ namespace OloEngine
         return s_State;
     }
 
-    std::shared_mutex& LocalizationManager::GetMutex()
+    FSharedMutex& LocalizationManager::GetMutex()
     {
-        static std::shared_mutex s_Mutex;
+        static FSharedMutex s_Mutex;
         return s_Mutex;
     }
 
@@ -72,7 +74,7 @@ namespace OloEngine
         }
 
         {
-            std::unique_lock lock(GetMutex());
+            TUniqueLock<FSharedMutex> lock(GetMutex());
             state.Tables = std::move(newTables);
             state.SourcePaths = std::move(newSources);
 
@@ -101,7 +103,7 @@ namespace OloEngine
 
     void LocalizationManager::Shutdown()
     {
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         state.Tables.clear();
         state.SourcePaths.clear();
@@ -122,7 +124,7 @@ namespace OloEngine
             return false;
         }
 
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         state.SourcePaths[code] = filePath;
         state.Tables.insert_or_assign(code, std::move(table));
@@ -138,7 +140,7 @@ namespace OloEngine
         std::string previous;
 
         {
-            std::unique_lock lock(GetMutex());
+            TUniqueLock<FSharedMutex> lock(GetMutex());
             State& state = GetState();
             if (!state.Tables.contains(localeCode))
             {
@@ -170,7 +172,7 @@ namespace OloEngine
         std::filesystem::path sourcePath;
         std::string code;
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             const State& state = GetState();
             if (state.CurrentLocale.empty())
                 return false;
@@ -193,7 +195,7 @@ namespace OloEngine
         // on disk.
         const std::string newCode = fresh.GetLocaleInfo().Code;
 
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         if (!newCode.empty() && newCode != code)
         {
@@ -228,7 +230,7 @@ namespace OloEngine
     {
         // Fast path: shared lock, look up, return if present.
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             const State& state = GetState();
             if (state.CurrentLocale.empty())
             {
@@ -242,7 +244,7 @@ namespace OloEngine
         }
         // Slow path: record the miss under a unique lock.
         {
-            std::unique_lock lock(GetMutex());
+            TUniqueLock<FSharedMutex> lock(GetMutex());
             State& state = GetState();
             state.MissingKeys.insert(key);
             return state.MissingKeyFallback;
@@ -256,7 +258,7 @@ namespace OloEngine
         std::string fallback;
         bool hit = false;
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             const State& state = GetState();
             fallback = state.MissingKeyFallback;
             if (state.CurrentLocale.empty())
@@ -271,7 +273,7 @@ namespace OloEngine
         }
         if (!hit)
         {
-            std::unique_lock lock(GetMutex());
+            TUniqueLock<FSharedMutex> lock(GetMutex());
             GetState().MissingKeys.insert(key);
             return fallback;
         }
@@ -286,13 +288,13 @@ namespace OloEngine
 
     std::string LocalizationManager::GetCurrentLocale()
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         return GetState().CurrentLocale;
     }
 
     std::vector<LocaleDefinition> LocalizationManager::GetAvailableLocales()
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         std::vector<LocaleDefinition> out;
         out.reserve(state.Tables.size());
@@ -305,7 +307,7 @@ namespace OloEngine
 
     bool LocalizationManager::HasKey(const std::string& key)
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         if (state.CurrentLocale.empty())
             return false;
@@ -317,7 +319,7 @@ namespace OloEngine
 
     std::string LocalizationManager::Get(const std::string& key, const std::string& localeCode)
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         const auto it = state.Tables.find(localeCode);
         if (it == state.Tables.end() || !it->second.Has(key))
@@ -327,7 +329,7 @@ namespace OloEngine
 
     bool LocalizationManager::HasKey(const std::string& key, const std::string& localeCode)
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         const auto it = state.Tables.find(localeCode);
         if (it == state.Tables.end())
@@ -337,7 +339,7 @@ namespace OloEngine
 
     std::vector<std::string> LocalizationManager::GetAllKeys(const std::string& localeCode)
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         const auto it = state.Tables.find(localeCode);
         if (it == state.Tables.end())
@@ -347,7 +349,7 @@ namespace OloEngine
 
     StringEntryMetadata LocalizationManager::GetMetadata(const std::string& key, const std::string& localeCode)
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         const auto it = state.Tables.find(localeCode);
         if (it == state.Tables.end())
@@ -398,7 +400,7 @@ namespace OloEngine
 
     bool LocalizationManager::SetKey(const std::string& localeCode, const std::string& key, const std::string& value)
     {
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         const auto it = state.Tables.find(localeCode);
         if (it == state.Tables.end())
@@ -464,7 +466,7 @@ namespace OloEngine
         // we don't hold the mutex while running PseudoifyAscii on every value.
         std::vector<std::pair<std::string, std::string>> source;
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             const State& state = GetState();
             const auto it = state.Tables.find(sourceLocaleCode);
             if (it == state.Tables.end())
@@ -487,7 +489,7 @@ namespace OloEngine
             pseudo.Set(k, "[!! " + PseudoifyAscii(v) + " !!]");
         }
 
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         state.Tables.insert_or_assign(pseudoCode, std::move(pseudo));
         state.Generation.fetch_add(1, std::memory_order_release);
@@ -496,7 +498,7 @@ namespace OloEngine
 
     std::vector<std::string> LocalizationManager::GetMissingKeysSnapshot()
     {
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         std::vector<std::string> out(state.MissingKeys.begin(), state.MissingKeys.end());
         std::sort(out.begin(), out.end());
@@ -505,7 +507,7 @@ namespace OloEngine
 
     void LocalizationManager::ClearMissingKeys()
     {
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         GetState().MissingKeys.clear();
     }
 
@@ -514,7 +516,7 @@ namespace OloEngine
         StringTable snapshot;
         std::filesystem::path resolvedPath = pathOverride;
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             const State& state = GetState();
             const auto it = state.Tables.find(localeCode);
             if (it == state.Tables.end())
@@ -640,7 +642,7 @@ namespace OloEngine
     {
         std::string locale;
         {
-            std::shared_lock lock(GetMutex());
+            TSharedLock<FSharedMutex> lock(GetMutex());
             locale = GetState().CurrentLocale;
         }
 
@@ -690,7 +692,7 @@ namespace OloEngine
         if (prefs.empty())
             return {};
 
-        std::shared_lock lock(GetMutex());
+        TSharedLock<FSharedMutex> lock(GetMutex());
         const State& state = GetState();
         if (state.Tables.empty())
             return {};
@@ -1243,7 +1245,7 @@ namespace OloEngine
 
     void LocalizationManager::SetMissingKeyFallback(const std::string& fallback)
     {
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         GetState().MissingKeyFallback = fallback;
     }
 
@@ -1251,7 +1253,7 @@ namespace OloEngine
     {
         if (!listener)
             return 0;
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         const u64 id = state.NextSubscriptionId++;
         state.Listeners.emplace(id, std::move(listener));
@@ -1262,7 +1264,7 @@ namespace OloEngine
     {
         if (subscriptionId == 0)
             return;
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         GetState().Listeners.erase(subscriptionId);
     }
 
@@ -1276,7 +1278,7 @@ namespace OloEngine
 
     void LocalizationManager::ResetForTesting()
     {
-        std::unique_lock lock(GetMutex());
+        TUniqueLock<FSharedMutex> lock(GetMutex());
         State& state = GetState();
         state.Tables.clear();
         state.SourcePaths.clear();

--- a/OloEngine/src/OloEngine/Localization/LocalizationManager.h
+++ b/OloEngine/src/OloEngine/Localization/LocalizationManager.h
@@ -4,12 +4,12 @@
 #include "OloEngine/Localization/LocaleDefinition.h"
 #include "OloEngine/Localization/StringTable.h"
 #include "OloEngine/Localization/TextFormatter.h"
+#include "OloEngine/Threading/SharedMutex.h"
 
 #include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <functional>
-#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -287,6 +287,6 @@ namespace OloEngine
         };
 
         static State& GetState();
-        static std::shared_mutex& GetMutex();
+        static FSharedMutex& GetMutex();
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Font.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Font.cpp
@@ -228,6 +228,8 @@ namespace OloEngine
 
     Ref<Font> Font::Create(const std::filesystem::path& font)
     {
+        OLO_PROFILE_FUNCTION();
+
         auto canonical = std::filesystem::weakly_canonical(font).string();
         static std::unordered_map<std::string, WeakRef<Font>> s_FontCache;
         static FMutex s_FontCacheMutex;

--- a/OloEngine/src/OloEngine/Renderer/Font.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Font.cpp
@@ -247,7 +247,17 @@ namespace OloEngine
 
         if (newFont->IsLoaded())
         {
+            // Double-checked: another thread may have loaded and cached the same
+            // font while we were loading outside the lock. Re-check and reuse its
+            // entry so concurrent callers share a single Font instance.
             TUniqueLock<FMutex> lock(s_FontCacheMutex);
+            auto it = s_FontCache.find(canonical);
+            if (it != s_FontCache.end())
+            {
+                if (auto cached = it->second.Lock())
+                    return cached;
+                s_FontCache.erase(it);
+            }
             s_FontCache[canonical] = newFont;
         }
         return newFont;

--- a/OloEngine/src/OloEngine/Renderer/Font.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Font.cpp
@@ -4,6 +4,8 @@
 #include "SlugFontProcessor.h"
 
 #include "OloEngine/Core/UTF8.h"
+#include "OloEngine/Threading/Mutex.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #define STB_TRUETYPE_IMPLEMENTATION
 #include <stb_image/stb_truetype.h>
@@ -228,10 +230,10 @@ namespace OloEngine
     {
         auto canonical = std::filesystem::weakly_canonical(font).string();
         static std::unordered_map<std::string, WeakRef<Font>> s_FontCache;
-        static std::mutex s_FontCacheMutex;
+        static FMutex s_FontCacheMutex;
 
         {
-            std::lock_guard lock(s_FontCacheMutex);
+            TUniqueLock<FMutex> lock(s_FontCacheMutex);
             auto it = s_FontCache.find(canonical);
             if (it != s_FontCache.end())
             {
@@ -245,7 +247,7 @@ namespace OloEngine
 
         if (newFont->IsLoaded())
         {
-            std::lock_guard lock(s_FontCacheMutex);
+            TUniqueLock<FMutex> lock(s_FontCacheMutex);
             s_FontCache[canonical] = newFont;
         }
         return newFont;

--- a/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.cpp
+++ b/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.cpp
@@ -8,6 +8,7 @@
 #include "OloEngine/Scene/SceneSerializer.h"
 #include "OloEngine/Physics3D/JoltScene.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 // Box2D
 #include <box2d/box2d.h>
@@ -67,7 +68,7 @@ namespace OloEngine
         // Unload all ready regions
         std::vector<RegionID> toUnload;
         {
-            std::lock_guard lock(m_RegionMutex);
+            TUniqueLock<FMutex> lock(m_RegionMutex);
             for (auto& [id, region] : m_Regions)
             {
                 if (region->m_State == StreamingRegion::State::Ready)
@@ -82,7 +83,7 @@ namespace OloEngine
             UnloadRegion(id);
         }
 
-        std::lock_guard lock(m_RegionMutex);
+        TUniqueLock<FMutex> lock(m_RegionMutex);
         m_Regions.clear();
         m_Scene = nullptr;
     }
@@ -103,7 +104,7 @@ namespace OloEngine
             return;
         }
 
-        std::lock_guard lock(m_RegionMutex);
+        TUniqueLock<FMutex> lock(m_RegionMutex);
 
         for (const auto& entry : std::filesystem::directory_iterator(regionDir))
         {
@@ -171,7 +172,7 @@ namespace OloEngine
 
             RegionID regionId(static_cast<u64>(vol.RegionAssetHandle));
 
-            std::unique_lock lock(m_RegionMutex);
+            TDynamicUniqueLock<FMutex> lock(m_RegionMutex);
             auto it = m_Regions.find(regionId);
             if (it == m_Regions.end())
             {
@@ -188,7 +189,7 @@ namespace OloEngine
             else if (distSq > vol.UnloadRadius * vol.UnloadRadius && region->m_State == StreamingRegion::State::Ready)
             {
                 // Release lock before UnloadRegion (it acquires lock internally)
-                lock.unlock();
+                lock.Unlock();
                 UnloadRegion(regionId);
                 vol.IsLoaded = false;
             }
@@ -205,7 +206,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::lock_guard lock(m_RegionMutex);
+        TUniqueLock<FMutex> lock(m_RegionMutex);
         auto it = m_Regions.find(regionId);
         if (it == m_Regions.end())
         {
@@ -225,7 +226,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::lock_guard lock(m_RegionMutex);
+        TUniqueLock<FMutex> lock(m_RegionMutex);
         auto it = m_Regions.find(regionId);
         if (it == m_Regions.end() || it->second->m_State != StreamingRegion::State::Ready)
         {
@@ -291,7 +292,7 @@ namespace OloEngine
 
     u32 SceneStreamer::GetLoadedRegionCount() const
     {
-        std::lock_guard lock(m_RegionMutex);
+        TUniqueLock<FMutex> lock(m_RegionMutex);
         u32 count = 0;
         for (auto& [id, region] : m_Regions)
         {
@@ -331,7 +332,7 @@ namespace OloEngine
                 {
                     return false;
                 }
-                std::lock_guard lock(mutex);
+                TUniqueLock<FMutex> lock(mutex);
                 region->m_RawData = std::move(data);
                 region->m_State = StreamingRegion::State::Loaded;
                 return true;
@@ -367,7 +368,7 @@ namespace OloEngine
             StreamingRegion::State regionState;
             YAML::Node rawData;
             {
-                std::lock_guard lock(m_RegionMutex);
+                TUniqueLock<FMutex> lock(m_RegionMutex);
                 regionState = region->m_State;
                 rawData = std::move(region->m_RawData);
             }
@@ -388,7 +389,7 @@ namespace OloEngine
                 InitializeStreamedEntities(region->m_EntityUUIDs);
 
                 {
-                    std::lock_guard lock(m_RegionMutex);
+                    TUniqueLock<FMutex> lock(m_RegionMutex);
                     region->m_State = StreamingRegion::State::Ready;
                 }
 
@@ -408,7 +409,7 @@ namespace OloEngine
             else if (!success)
             {
                 OLO_CORE_ERROR("SceneStreamer: Failed to load region '{0}'", region->m_Name);
-                std::lock_guard lock(m_RegionMutex);
+                TUniqueLock<FMutex> lock(m_RegionMutex);
                 region->m_State = StreamingRegion::State::Unloaded;
             }
 
@@ -420,7 +421,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::unique_lock lock(m_RegionMutex);
+        TDynamicUniqueLock<FMutex> lock(m_RegionMutex);
 
         // Count ready regions
         u32 readyCount = 0;
@@ -457,9 +458,9 @@ namespace OloEngine
         for (u32 i = 0; i < toEvict && i < static_cast<u32>(sortedRegions.size()); ++i)
         {
             // Release lock before UnloadRegion (it acquires lock internally)
-            lock.unlock();
+            lock.Unlock();
             UnloadRegion(sortedRegions[i].first);
-            lock.lock();
+            lock.Lock();
         }
     }
 

--- a/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.h
+++ b/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.h
@@ -4,10 +4,11 @@
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Core/UUID.h"
 #include "OloEngine/Task/Task.h"
+#include "OloEngine/Threading/Mutex.h"
+#include "OloEngine/Threading/UniqueLock.h"
 #include "StreamingRegion.h"
 
 #include <glm/glm.hpp>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -58,7 +59,7 @@ namespace OloEngine
         [[nodiscard]] u32 GetPendingLoadCount() const;
         [[nodiscard]] std::unordered_map<RegionID, Ref<StreamingRegion>> GetRegions() const
         {
-            std::lock_guard lock(m_RegionMutex);
+            TUniqueLock<FMutex> lock(m_RegionMutex);
             return m_Regions;
         }
 
@@ -84,7 +85,7 @@ namespace OloEngine
         };
         std::vector<PendingLoad> m_PendingLoads;
 
-        mutable std::mutex m_RegionMutex; // Protects m_Regions
+        mutable FMutex m_RegionMutex; // Protects m_Regions
         u64 m_CurrentFrame = 0;
         UUID m_ActivationEntityId{}; // 0 = use primary camera
     };

--- a/OloEngine/src/OloEngine/Server/ServerConsole.cpp
+++ b/OloEngine/src/OloEngine/Server/ServerConsole.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Server/ServerConsolePlatform.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <algorithm>
 #include <cctype>
@@ -50,7 +51,8 @@ namespace OloEngine
 
         // Launch background thread that blocks on std::getline
         m_InputThreadRunning = true;
-        m_InputThread = std::thread(&ServerConsole::InputThreadFunc, this);
+        m_InputThread = FThread("ServerConsoleInput", [this]()
+                                { InputThreadFunc(); });
 
         OLO_CORE_INFO("[ServerConsole] Initialized. Type 'help' for available commands.");
     }
@@ -73,9 +75,9 @@ namespace OloEngine
             ServerConsolePlatform::Signal(*m_AbortState);
         }
 
-        if (m_InputThread.joinable())
+        if (m_InputThread.IsJoinable())
         {
-            m_InputThread.join();
+            m_InputThread.Join();
         }
 
         // Release platform abort state (closes pipes on POSIX).
@@ -86,7 +88,7 @@ namespace OloEngine
 
         m_Commands.clear();
         {
-            std::lock_guard lock(m_InputQueueMutex);
+            TUniqueLock<FMutex> lock(m_InputQueueMutex);
             std::queue<std::string> empty;
             std::swap(m_InputQueue, empty);
         }
@@ -125,7 +127,7 @@ namespace OloEngine
 
             if (!line.empty())
             {
-                std::lock_guard lock(m_InputQueueMutex);
+                TUniqueLock<FMutex> lock(m_InputQueueMutex);
                 m_InputQueue.push(std::move(line));
                 line = {}; // reset after move
             }
@@ -140,7 +142,7 @@ namespace OloEngine
         std::queue<std::string> pending;
         {
             OLO_PROFILE_SCOPE("ServerConsole::ProcessInputDrain");
-            std::lock_guard lock(m_InputQueueMutex);
+            TUniqueLock<FMutex> lock(m_InputQueueMutex);
             std::swap(pending, m_InputQueue);
         }
 
@@ -179,7 +181,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::lock_guard lock(m_InputQueueMutex);
+        TUniqueLock<FMutex> lock(m_InputQueueMutex);
         m_InputQueue.push(line);
     }
 

--- a/OloEngine/src/OloEngine/Server/ServerConsole.h
+++ b/OloEngine/src/OloEngine/Server/ServerConsole.h
@@ -2,13 +2,13 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Server/ServerConsolePlatform.h"
+#include "OloEngine/HAL/Thread.h"
+#include "OloEngine/Threading/Mutex.h"
 
 #include <atomic>
 #include <functional>
-#include <mutex>
 #include <queue>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -76,9 +76,9 @@ namespace OloEngine
         bool m_Initialized = false;
 
         // Background input thread + thread-safe queue
-        std::thread m_InputThread;
+        FThread m_InputThread;
         std::atomic<bool> m_InputThreadRunning{ false };
-        std::mutex m_InputQueueMutex;
+        FMutex m_InputQueueMutex;
         std::queue<std::string> m_InputQueue;
 
         // Platform-specific state used to abort a blocking stdin read during shutdown.

--- a/OloEngine/src/OloEngine/Terrain/TerrainStreamer.cpp
+++ b/OloEngine/src/OloEngine/Terrain/TerrainStreamer.cpp
@@ -1,6 +1,8 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Terrain/TerrainStreamer.h"
 #include "OloEngine/Terrain/TerrainMaterial.h"
+#include "OloEngine/Threading/SharedLock.h"
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -41,31 +43,37 @@ namespace OloEngine
 
         i32 radius = static_cast<i32>(m_Config.LoadRadius);
 
-        // Mark all tiles in the load radius as needed
-        for (i32 dz = -radius; dz <= radius; ++dz)
+        // Mark all tiles in the load radius as needed. One exclusive lock spans the
+        // whole scan; the loop body is fast and the per-iteration lock the previous
+        // implementation took had no concurrency benefit.
         {
-            for (i32 dx = -radius; dx <= radius; ++dx)
+            TUniqueLock<FSharedMutex> lock(m_TileMutex);
+            for (i32 dz = -radius; dz <= radius; ++dz)
             {
-                i32 gx = cameraTileX + dx;
-                i32 gz = cameraTileZ + dz;
-                TileCoord coord{ gx, gz };
+                for (i32 dx = -radius; dx <= radius; ++dx)
+                {
+                    i32 gx = cameraTileX + dx;
+                    i32 gz = cameraTileZ + dz;
+                    TileCoord coord{ gx, gz };
 
-                std::lock_guard lock(m_TileMutex);
-                auto it = m_Tiles.find(coord);
-                if (it != m_Tiles.end())
-                {
-                    // Tile exists — update LRU timestamp
-                    it->second->LastUsedFrame = frameNumber;
-                }
-                else
-                {
-                    // Need to load this tile
-                    RequestTileLoad(gx, gz);
+                    auto it = m_Tiles.find(coord);
+                    if (it != m_Tiles.end())
+                    {
+                        // Tile exists — update LRU timestamp
+                        it->second->LastUsedFrame = frameNumber;
+                    }
+                    else
+                    {
+                        // Need to load this tile
+                        RequestTileLoad(gx, gz);
+                    }
                 }
             }
         }
 
-        // Process completed async loads (GPU upload on main thread)
+        // Process completed async loads (GPU upload on main thread). Takes its own
+        // exclusive lock when committing the new tile; must run with the scan lock
+        // released so we don't recursively acquire FSharedMutex.
         ProcessCompletedLoads();
 
         // Evict tiles over budget
@@ -95,8 +103,10 @@ namespace OloEngine
                         tile->SetMaterial(m_SharedMaterial);
                     }
 
-                    std::lock_guard lock(m_TileMutex);
-                    m_Tiles[it->Coord] = tile;
+                    {
+                        TUniqueLock<FSharedMutex> lock(m_TileMutex);
+                        m_Tiles[it->Coord] = tile;
+                    }
 
                     OLO_CORE_TRACE("TerrainStreamer: Tile[{},{}] ready", it->Coord.X, it->Coord.Z);
                 }
@@ -116,7 +126,7 @@ namespace OloEngine
 
     void TerrainStreamer::GetReadyTiles(std::vector<Ref<TerrainTile>>& outTiles) const
     {
-        std::lock_guard lock(m_TileMutex);
+        TSharedLock<FSharedMutex> lock(m_TileMutex);
         outTiles.clear();
         outTiles.reserve(m_Tiles.size());
         for (auto& [coord, tile] : m_Tiles)
@@ -130,7 +140,7 @@ namespace OloEngine
 
     void TerrainStreamer::SetMaterial(const Ref<TerrainMaterial>& material)
     {
-        std::lock_guard lock(m_TileMutex);
+        TUniqueLock<FSharedMutex> lock(m_TileMutex);
         m_SharedMaterial = material;
         for (auto& [coord, tile] : m_Tiles)
         {
@@ -142,7 +152,11 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::lock_guard lock(m_TileMutex);
+        // StitchEdge mutates the tile's GPU mesh, but the read-side aliasing here is
+        // safe: tile pointers are stable for the lifetime of the entry in m_Tiles, and
+        // the only writers (ProcessCompletedLoads / EvictOverBudget / UnloadAll) take
+        // an exclusive lock that excludes this scan.
+        TSharedLock<FSharedMutex> lock(m_TileMutex);
         for (auto& [coord, tile] : m_Tiles)
         {
             if (tile->GetState() != TerrainTile::State::Ready)
@@ -168,7 +182,7 @@ namespace OloEngine
 
     u32 TerrainStreamer::GetLoadedTileCount() const
     {
-        std::lock_guard lock(m_TileMutex);
+        TSharedLock<FSharedMutex> lock(m_TileMutex);
         u32 count = 0;
         for (auto& [coord, tile] : m_Tiles)
         {
@@ -187,7 +201,7 @@ namespace OloEngine
 
     Ref<TerrainTile> TerrainStreamer::GetTile(i32 gridX, i32 gridZ) const
     {
-        std::lock_guard lock(m_TileMutex);
+        TSharedLock<FSharedMutex> lock(m_TileMutex);
         auto it = m_Tiles.find({ gridX, gridZ });
         if (it != m_Tiles.end())
         {
@@ -207,7 +221,7 @@ namespace OloEngine
         }
         m_PendingLoads.clear();
 
-        std::lock_guard lock(m_TileMutex);
+        TUniqueLock<FSharedMutex> lock(m_TileMutex);
         for (auto& [coord, tile] : m_Tiles)
         {
             tile->Unload();
@@ -281,7 +295,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::lock_guard lock(m_TileMutex);
+        TUniqueLock<FSharedMutex> lock(m_TileMutex);
 
         if (m_Tiles.size() <= m_Config.MaxLoadedTiles)
         {

--- a/OloEngine/src/OloEngine/Terrain/TerrainStreamer.h
+++ b/OloEngine/src/OloEngine/Terrain/TerrainStreamer.h
@@ -4,12 +4,12 @@
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Terrain/TerrainTile.h"
 #include "OloEngine/Task/Task.h"
+#include "OloEngine/Threading/SharedMutex.h"
 
 #include <glm/glm.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <mutex>
 
 namespace OloEngine
 {
@@ -131,8 +131,11 @@ namespace OloEngine
         };
         std::vector<PendingLoad> m_PendingLoads;
 
-        // Protects m_Tiles during async load completion
-        mutable std::mutex m_TileMutex;
+        // Protects m_Tiles and m_SharedMaterial during async load completion.
+        // Reader/writer separation: GetReadyTiles / GetTile / GetLoadedTileCount /
+        // StitchLoadedTiles take shared locks; ProcessCompletedLoads / SetMaterial /
+        // EvictOverBudget / UnloadAll and the camera-tile scan in Update take exclusive locks.
+        mutable FSharedMutex m_TileMutex;
 
         // Current frame number for LRU tracking of newly requested tiles
         u64 m_CurrentFrame = 0;

--- a/OloEngine/tests/AssetGenerationTest.cpp
+++ b/OloEngine/tests/AssetGenerationTest.cpp
@@ -211,13 +211,22 @@ TEST_F(AssetGenerationTest, ConcurrentReadersAndWriter)
     constexpr int writes = 20000;
     constexpr int readerCount = 4;
     std::atomic<bool> done{ false };
+    std::atomic<int> readyCount{ 0 };
 
     std::vector<std::thread> readers;
     readers.reserve(readerCount);
     for (int r = 0; r < readerCount; ++r)
     {
-        readers.emplace_back([this, h, &done]
+        readers.emplace_back([this, h, &done, &readyCount]
                              {
+            // Signal readiness, then spin until every reader is live so reads are
+            // guaranteed to overlap the writer loop below.
+            readyCount.fetch_add(1, std::memory_order_relaxed);
+            while (readyCount.load(std::memory_order_relaxed) < readerCount)
+            {
+                std::this_thread::yield();
+            }
+
             u32 last = 0;
             while (!done.load(std::memory_order_relaxed))
             {
@@ -226,6 +235,12 @@ TEST_F(AssetGenerationTest, ConcurrentReadersAndWriter)
                 EXPECT_LE(gen, static_cast<u32>(writes));
                 last = gen;
             } });
+    }
+
+    // Don't start writing until all readers are running.
+    while (readyCount.load(std::memory_order_relaxed) < readerCount)
+    {
+        std::this_thread::yield();
     }
 
     for (int i = 0; i < writes; ++i)

--- a/OloEngine/tests/AssetGenerationTest.cpp
+++ b/OloEngine/tests/AssetGenerationTest.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 #include "OloEngine/Asset/AssetManager/AssetManagerBase.h"
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 using namespace OloEngine;
 
 // Minimal concrete subclass to test non-virtual generation counter methods
@@ -136,4 +140,104 @@ TEST_F(AssetGenerationTest, ZeroHandleTracked)
     AssetHandle h{ 0 };
     mgr.IncrementAssetGeneration(h);
     EXPECT_EQ(mgr.GetAssetGeneration(h), 1u);
+}
+
+// --- Concurrency tests (exercise the FSharedMutex backing the counter) ---
+
+// Many writers hammering the same handle must not lose updates: the exclusive
+// lock in IncrementAssetGeneration has to serialise the read-modify-write.
+TEST_F(AssetGenerationTest, ConcurrentIncrementsSameHandleNoLostUpdates)
+{
+    AssetHandle h{ 1000 };
+    constexpr int threadCount = 8;
+    constexpr int incrementsPerThread = 5000;
+
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+    for (int t = 0; t < threadCount; ++t)
+    {
+        threads.emplace_back([this, h]
+                             {
+            for (int i = 0; i < incrementsPerThread; ++i)
+            {
+                mgr.IncrementAssetGeneration(h);
+            } });
+    }
+    for (auto& th : threads)
+    {
+        th.join();
+    }
+
+    EXPECT_EQ(mgr.GetAssetGeneration(h), static_cast<u32>(threadCount * incrementsPerThread));
+}
+
+// Writers touching distinct handles must each land their full count, with no
+// cross-handle interference even under heavy contention on the shared map.
+TEST_F(AssetGenerationTest, ConcurrentIncrementsDistinctHandles)
+{
+    constexpr int threadCount = 8;
+    constexpr int incrementsPerThread = 5000;
+
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+    for (int t = 0; t < threadCount; ++t)
+    {
+        threads.emplace_back([this, t]
+                             {
+            AssetHandle h{ static_cast<u64>(2000 + t) };
+            for (int i = 0; i < incrementsPerThread; ++i)
+            {
+                mgr.IncrementAssetGeneration(h);
+            } });
+    }
+    for (auto& th : threads)
+    {
+        th.join();
+    }
+
+    for (int t = 0; t < threadCount; ++t)
+    {
+        AssetHandle h{ static_cast<u64>(2000 + t) };
+        EXPECT_EQ(mgr.GetAssetGeneration(h), static_cast<u32>(incrementsPerThread));
+    }
+}
+
+// Concurrent shared (read) locks must coexist with exclusive (write) locks
+// without deadlock or data race; readers only ever observe a monotonically
+// non-decreasing value bounded by the final count.
+TEST_F(AssetGenerationTest, ConcurrentReadersAndWriter)
+{
+    AssetHandle h{ 3000 };
+    constexpr int writes = 20000;
+    constexpr int readerCount = 4;
+    std::atomic<bool> done{ false };
+
+    std::vector<std::thread> readers;
+    readers.reserve(readerCount);
+    for (int r = 0; r < readerCount; ++r)
+    {
+        readers.emplace_back([this, h, &done]
+                             {
+            u32 last = 0;
+            while (!done.load(std::memory_order_relaxed))
+            {
+                u32 gen = mgr.GetAssetGeneration(h);
+                EXPECT_GE(gen, last);
+                EXPECT_LE(gen, static_cast<u32>(writes));
+                last = gen;
+            } });
+    }
+
+    for (int i = 0; i < writes; ++i)
+    {
+        mgr.IncrementAssetGeneration(h);
+    }
+    done.store(true, std::memory_order_relaxed);
+
+    for (auto& th : readers)
+    {
+        th.join();
+    }
+
+    EXPECT_EQ(mgr.GetAssetGeneration(h), static_cast<u32>(writes));
 }


### PR DESCRIPTION
Replace the remaining raw std synchronization primitives across the engine, editor, and dedicated server with the engine-native threading layer (UE5-derived FMutex / FSharedMutex / FThread + TUniqueLock / TSharedLock / TDynamicUniqueLock). This finishes the threading-system unification: the only std primitives left are deliberate and documented below.

Mutexes -> FMutex / FSharedMutex:
- AssetManagerBase: shared_mutex -> FSharedMutex for the asset-generation counter (direct reader/writer substitution).
- TerrainStreamer: mutex -> FSharedMutex with a proper reader/writer split (GetReadyTiles / GetTile / GetLoadedTileCount / StitchLoadedTiles take shared locks; the camera scan, ProcessCompletedLoads, SetMaterial, EvictOverBudget, UnloadAll take exclusive locks). The per-iteration lock in Update() is consolidated into a single scan lock, released before ProcessCompletedLoads (FSharedMutex is non-recursive).
- SceneStreamer: mutex -> FMutex; the two unlock/relock sites use TDynamicUniqueLock (PascalCase Lock()/Unlock()).
- LocalizationManager: shared_mutex -> FSharedMutex (29 lock sites).
- PerformanceProfiler, Font cache, editor ConsolePanel: mutex -> FMutex.

Threads -> FThread:
- ServerConsole: std::thread input thread -> FThread (Join/IsJoinable), queue mutex -> FMutex.
- BuildGamePanel: std::jthread -> FThread; cancellation already flowed through the existing m_CancelRequested atomic. Destructor and StartBuild join defensively since FThread asserts on move-assign/destroy while joinable.
- AssetPackBuilderPanel: collapse 3 std::jthreads into 1 FThread. The dedicated progress-monitor and cancellation-monitor threads are removed in favor of member atomics: m_BuildProgress (converted to permille per-frame in OnImGuiRender) and m_CancelRequested (set directly by CancelBuild).

Tests:
- AssetGenerationTest: add three concurrency stress tests exercising the FSharedMutex-backed counter (same-handle no-lost-updates, distinct-handle isolation, concurrent readers + writer).

Intentionally left on std primitives:
- Core/Log.h spdlog ringbuffer_sink<std::mutex> requires a std BasicLockable (lowercase lock()/unlock()); FMutex is incompatible.
- Memory/PlatformMallocCrash.h recursive_mutex must stay dependency-free at crash time (engine primitives allocate / use TLS via ParkingLot).
- Platform/Linux/LinuxEvent.h mutex + condition_variable is the platform FEvent primitive that underlies the engine threading layer; unique_lock is required for cv.wait.
- std::thread::id / this_thread / hardware_concurrency and the HAL SetThreadPriority(std::thread&) API are standard utility usage.

Verified: OloEngine-Tests, OloEditor, OloRuntime, and OloServer all build clean; full test suite passes (PerfRegression wall-clock budget tests pass in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified threading and locking across editor and engine for more consistent background work; build tasks now start/stop and finalize deterministically, cancel requests propagate reliably, and progress reporting is updated per-frame for smoother UI feedback.

* **Tests**
  * Added multithreaded tests validating asset generation counters under concurrent access to ensure correctness in parallel workloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drsnuggles8/OloEngineBase/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->