### PR TITLE
feat(asset): complete runtime asset-pack loading pipeline

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/setup-vulkan
       
       - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8.0.0
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8.1.0
 
       - name: Run build-wrapper
         run: |
@@ -54,7 +54,7 @@ jobs:
           build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
@@ -8,28 +8,12 @@
 #include "OloEngine/Asset/AssetTypes.h"
 #include "OloEngine/Project/Project.h"
 
-#include <atomic>
 #include <memory>
 #include "OloEngine/Threading/Mutex.h"
 #include "OloEngine/Threading/UniqueLock.h"
 
 namespace OloEngine
 {
-    // Global flag to track if we're in static destruction
-    static std::atomic<bool> g_IsInStaticDestruction{ false };
-
-    // This object will be destroyed during static destruction and set the flag
-    struct StaticDestructionSentinel
-    {
-        ~StaticDestructionSentinel()
-        {
-            g_IsInStaticDestruction.store(true, std::memory_order_release);
-        }
-    };
-
-    // This static object will be destroyed early in the static destruction chain
-    static StaticDestructionSentinel g_StaticSentinel;
-
     // Use function-local static to ensure proper construction/destruction order
     static std::unordered_map<AssetType, Scope<AssetSerializer>>& GetSerializers()
     {
@@ -44,20 +28,17 @@ namespace OloEngine
         return s_SerializersMutex;
     }
 
-    static std::atomic<bool> s_IsShuttingDown{ false };
-
     void AssetImporter::Init()
     {
-        // Re-initializable: (re)populate the registry whenever it is empty — on first
-        // init, or after a prior Shutdown() cleared it. The old call_once made Shutdown
-        // permanent, so any asset manager constructed after the first one had been torn
-        // down (editor<->runtime transitions, tests) silently ran with no serializers.
+        // The serializer registry is process-lifetime and shared by every asset manager
+        // (it holds stateless serializers — no GPU/file handles). Populate it once, lazily,
+        // on the first manager's Init(); Shutdown() intentionally does not clear it, so a
+        // second manager (editor<->runtime transitions, tests) keeps working and one
+        // manager's teardown can't wipe the registry out from under another.
         TUniqueLock<FMutex> lock(GetSerializersMutex());
         auto& serializers = GetSerializers();
         if (!serializers.empty())
             return;
-
-        s_IsShuttingDown.store(false, std::memory_order_release);
 
         serializers.reserve(32); // Reserve ahead of the registered serializer count (24) to avoid rehashing
         serializers[AssetType::Prefab] = CreateScope<PrefabSerializer>();
@@ -89,45 +70,12 @@ namespace OloEngine
 
     void AssetImporter::Shutdown()
     {
-        // Set shutdown flag to prevent re-entry during static destruction
-        if (auto wasShuttingDown = s_IsShuttingDown.exchange(true, std::memory_order_acq_rel); wasShuttingDown)
-        {
-            // Already shutting down, avoid double shutdown
-            return;
-        }
-
-        // If we're in static destruction, absolutely do not attempt any cleanup
-        // The OS will handle memory cleanup automatically
-        if (g_IsInStaticDestruction.load(std::memory_order_acquire))
-        {
-            return;
-        }
-
-        // Additional safety check: try to detect if we're being called during exit
-        // by attempting to access the function-local statics safely
-        try
-        {
-            // If accessing these throws or behaves oddly, we're likely in static destruction
-            auto& mutex = GetSerializersMutex();
-            auto& serializers = GetSerializers();
-
-            // Acquire lock - TUniqueLock will handle RAII
-            TUniqueLock<FMutex> lock(mutex);
-
-            // Final check: if we're in static destruction by now, just return
-            if (g_IsInStaticDestruction.load(std::memory_order_acquire))
-            {
-                return;
-            }
-
-            // Only clear if we're absolutely sure we're not in static destruction
-            serializers.clear();
-        }
-        catch (...)
-        {
-            // Any exception during shutdown means we should not proceed
-            // This is likely due to static destruction issues
-        }
+        // Intentional no-op. The serializer registry is process-lifetime: serializers are
+        // stateless, so there is nothing to release per manager, and clearing here would
+        // wipe the shared registry for any other asset manager still alive (and break a
+        // subsequently constructed one). The function-local static registry is destroyed
+        // naturally at program exit. Kept for the symmetric Init()/Shutdown() API and so
+        // managers don't need to change their teardown.
     }
 
     void AssetImporter::Serialize(const AssetMetadata& metadata, const Ref<Asset>& asset)

--- a/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
@@ -44,41 +44,47 @@ namespace OloEngine
         return s_SerializersMutex;
     }
 
-    static std::once_flag s_InitFlag;
     static std::atomic<bool> s_IsShuttingDown{ false };
 
     void AssetImporter::Init()
     {
-        std::call_once(s_InitFlag, []()
-                       {
-            auto& serializers = GetSerializers();
-            serializers.clear();
-            serializers.reserve(32); // Reserve ahead of the registered serializer count (24) to avoid rehashing
-            serializers[AssetType::Prefab] = CreateScope<PrefabSerializer>();
-            serializers[AssetType::Texture2D] = CreateScope<TextureSerializer>();
-            serializers[AssetType::TextureCube] = CreateScope<TextureSerializer>();
-            serializers[AssetType::Mesh] = CreateScope<MeshSerializer>();
-            serializers[AssetType::StaticMesh] = CreateScope<StaticMeshSerializer>();
-            serializers[AssetType::MeshSource] = CreateScope<MeshSourceSerializer>();
-            serializers[AssetType::Material] = CreateScope<MaterialAssetSerializer>();
-            serializers[AssetType::EnvMap] = CreateScope<EnvironmentSerializer>();
-            serializers[AssetType::Audio] = CreateScope<AudioFileSourceSerializer>();
-            // serializers[AssetType::SoundConfig] = CreateScope<SoundConfigSerializer>(); // Disabled - SoundConfig not implemented
-            serializers[AssetType::Scene] = CreateScope<SceneAssetSerializer>();
-            serializers[AssetType::Font] = CreateScope<FontSerializer>();
-            serializers[AssetType::MeshCollider] = CreateScope<MeshColliderSerializer>();
-            serializers[AssetType::SoundGraph] = CreateScope<SoundGraphSerializer>();
-            serializers[AssetType::AnimationClip] = CreateScope<AnimationAssetSerializer>();
-            serializers[AssetType::AnimationGraph] = CreateScope<AnimationGraphAssetSerializer>();
-            serializers[AssetType::ScriptFile] = CreateScope<ScriptFileSerializer>();
-            serializers[AssetType::ParticleSystem] = CreateScope<ParticleSystemAssetSerializer>();
-            serializers[AssetType::LightProbeVolume] = CreateScope<LightProbeVolumeSerializer>();
-            serializers[AssetType::DialogueTree] = CreateScope<DialogueTreeSerializer>();
-            serializers[AssetType::ShaderGraph] = CreateScope<ShaderGraphSerializer>();
-            serializers[AssetType::BehaviorTree] = CreateScope<BehaviorTreeSerializer>();
-            serializers[AssetType::StateMachine] = CreateScope<StateMachineSerializer>();
-            serializers[AssetType::InstancePlacement] = CreateScope<InstancePlacementSerializer>();
-            serializers[AssetType::CinematicSequence] = CreateScope<CinematicSequenceAssetSerializer>(); });
+        // Re-initializable: (re)populate the registry whenever it is empty — on first
+        // init, or after a prior Shutdown() cleared it. The old call_once made Shutdown
+        // permanent, so any asset manager constructed after the first one had been torn
+        // down (editor<->runtime transitions, tests) silently ran with no serializers.
+        TUniqueLock<FMutex> lock(GetSerializersMutex());
+        auto& serializers = GetSerializers();
+        if (!serializers.empty())
+            return;
+
+        s_IsShuttingDown.store(false, std::memory_order_release);
+
+        serializers.reserve(32); // Reserve ahead of the registered serializer count (24) to avoid rehashing
+        serializers[AssetType::Prefab] = CreateScope<PrefabSerializer>();
+        serializers[AssetType::Texture2D] = CreateScope<TextureSerializer>();
+        serializers[AssetType::TextureCube] = CreateScope<TextureSerializer>();
+        serializers[AssetType::Mesh] = CreateScope<MeshSerializer>();
+        serializers[AssetType::StaticMesh] = CreateScope<StaticMeshSerializer>();
+        serializers[AssetType::MeshSource] = CreateScope<MeshSourceSerializer>();
+        serializers[AssetType::Material] = CreateScope<MaterialAssetSerializer>();
+        serializers[AssetType::EnvMap] = CreateScope<EnvironmentSerializer>();
+        serializers[AssetType::Audio] = CreateScope<AudioFileSourceSerializer>();
+        // serializers[AssetType::SoundConfig] = CreateScope<SoundConfigSerializer>(); // Disabled - SoundConfig not implemented
+        serializers[AssetType::Scene] = CreateScope<SceneAssetSerializer>();
+        serializers[AssetType::Font] = CreateScope<FontSerializer>();
+        serializers[AssetType::MeshCollider] = CreateScope<MeshColliderSerializer>();
+        serializers[AssetType::SoundGraph] = CreateScope<SoundGraphSerializer>();
+        serializers[AssetType::AnimationClip] = CreateScope<AnimationAssetSerializer>();
+        serializers[AssetType::AnimationGraph] = CreateScope<AnimationGraphAssetSerializer>();
+        serializers[AssetType::ScriptFile] = CreateScope<ScriptFileSerializer>();
+        serializers[AssetType::ParticleSystem] = CreateScope<ParticleSystemAssetSerializer>();
+        serializers[AssetType::LightProbeVolume] = CreateScope<LightProbeVolumeSerializer>();
+        serializers[AssetType::DialogueTree] = CreateScope<DialogueTreeSerializer>();
+        serializers[AssetType::ShaderGraph] = CreateScope<ShaderGraphSerializer>();
+        serializers[AssetType::BehaviorTree] = CreateScope<BehaviorTreeSerializer>();
+        serializers[AssetType::StateMachine] = CreateScope<StateMachineSerializer>();
+        serializers[AssetType::InstancePlacement] = CreateScope<InstancePlacementSerializer>();
+        serializers[AssetType::CinematicSequence] = CreateScope<CinematicSequenceAssetSerializer>();
     }
 
     void AssetImporter::Shutdown()

--- a/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetImporter.cpp
@@ -201,6 +201,19 @@ namespace OloEngine
         return it->second->SupportsAsyncLoading();
     }
 
+    bool AssetImporter::CanDeserializeFromAssetPackOffThread(AssetType type)
+    {
+        TUniqueLock<FMutex> lock(GetSerializersMutex());
+        auto& serializers = GetSerializers();
+        auto it = serializers.find(type);
+        if (it == serializers.end())
+        {
+            return false;
+        }
+
+        return it->second->CanDeserializeFromAssetPackOffThread();
+    }
+
     bool AssetImporter::TryLoadRawData(const AssetMetadata& metadata, RawAssetData& outRawData)
     {
         TUniqueLock<FMutex> lock(GetSerializersMutex());

--- a/OloEngine/src/OloEngine/Asset/AssetImporter.h
+++ b/OloEngine/src/OloEngine/Asset/AssetImporter.h
@@ -46,6 +46,15 @@ namespace OloEngine
         [[nodiscard]] static bool SupportsAsyncLoading(AssetType type);
 
         /**
+         * @brief Check if a type's DeserializeFromAssetPack is safe off the main thread
+         * @param type The asset type to check
+         * @return True if the runtime async system may fully deserialize this type on a
+         *         worker thread (CPU-only serializer). False (the default for unknown or
+         *         GPU-touching types) means callers must load it synchronously.
+         */
+        [[nodiscard]] static bool CanDeserializeFromAssetPackOffThread(AssetType type);
+
+        /**
          * @brief Load raw asset data without creating GPU resources (thread-safe)
          * @param metadata The asset metadata
          * @param outRawData Output raw asset data

--- a/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
@@ -384,16 +384,28 @@ namespace OloEngine
             TUniqueLock<FSharedMutex> lock(m_AssetsMutex);
             for (const auto& result : completed)
             {
-                if (result.Asset)
-                {
-                    m_LoadedAssets[result.Handle] = result.Asset;
-                    loadedEvents.push_back({ result.Handle, result.Asset->GetAssetType() });
-                    OLO_CORE_TRACE("RuntimeAssetManager::SyncWithAssetThread - Integrated async-loaded asset {}", result.Handle);
-                }
-                else
+                if (!result.LoadedAsset)
                 {
                     OLO_CORE_ERROR("RuntimeAssetManager::SyncWithAssetThread - Async load failed for asset {}", result.Handle);
+                    continue;
                 }
+
+                // Drop completions whose handle is no longer provided by a loaded pack:
+                // an UnloadAssetPack() between queue and completion already evicted it
+                // (and rebuilt the metadata index), so re-inserting here would resurrect
+                // a handle IsAssetMissing()/IsAssetHandleValid() now report as gone.
+                // AssetExistsInPacks acquires m_PacksMutex (shared); the m_AssetsMutex ->
+                // m_PacksMutex order matches UnloadAssetPack()/Shutdown(), so holding
+                // m_AssetsMutex here serialises against the eviction.
+                if (!AssetExistsInPacks(result.Handle))
+                {
+                    OLO_CORE_TRACE("RuntimeAssetManager::SyncWithAssetThread - Dropping stale async result for asset {} (pack unloaded before completion)", result.Handle);
+                    continue;
+                }
+
+                m_LoadedAssets[result.Handle] = result.LoadedAsset;
+                loadedEvents.push_back({ result.Handle, result.LoadedAsset->GetAssetType() });
+                OLO_CORE_TRACE("RuntimeAssetManager::SyncWithAssetThread - Integrated async-loaded asset {}", result.Handle);
             }
         }
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
@@ -3,6 +3,9 @@
 #include "OloEngine/Asset/AssetImporter.h"
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Asset/AssetPack.h"
+#include "OloEngine/Containers/Array.h"
+#include "OloEngine/Core/Events/EditorEvents.h"
+#include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Timer.h"
 #include "OloEngine/Core/Ref.h"
@@ -11,12 +14,15 @@
 #include "OloEngine/Threading/UniqueLock.h"
 #include "OloEngine/Threading/SharedLock.h"
 
+#include <filesystem>
+#include <vector>
+
 namespace OloEngine
 {
     RuntimeAssetManager::RuntimeAssetManager(bool autoLoadDefaultPack)
     {
 #if OLO_ASYNC_ASSETS
-        m_AssetThread = Ref<RuntimeAssetSystem>::Create();
+        m_AssetThread = Ref<RuntimeAssetSystem>::Create(this);
 #endif
 
         AssetImporter::Init();
@@ -171,10 +177,38 @@ namespace OloEngine
 
     AsyncAssetResult<Asset> RuntimeAssetManager::GetAssetAsync(AssetHandle assetHandle)
     {
-        // For runtime, we'll load synchronously for now
-        // In a full implementation, this would queue the asset for background loading
+        if (assetHandle == 0)
+            return AsyncAssetResult<Asset>{ nullptr, false };
+
+        // Fast path: already loaded or memory-only asset
+        {
+            TSharedLock<FSharedMutex> lock(m_AssetsMutex);
+            if (auto it = m_LoadedAssets.find(assetHandle); it != m_LoadedAssets.end())
+                return AsyncAssetResult<Asset>{ it->second, true };
+            if (auto memIt = m_MemoryAssets.find(assetHandle); memIt != m_MemoryAssets.end())
+                return AsyncAssetResult<Asset>{ memIt->second, true };
+        }
+
+#if OLO_ASYNC_ASSETS
+        // Queue for background loading only when the asset lives in a pack and its
+        // serializer is safe to run off the main thread (no GPU work). GPU-backed types
+        // (textures, meshes, ...) and unknown types fall through to synchronous loading.
+        if (m_AssetThread)
+        {
+            AssetType type = GetAssetTypeFromPacks(assetHandle);
+            if (type != AssetType::None && AssetImporter::CanDeserializeFromAssetPackOffThread(type))
+            {
+                m_AssetThread->QueueAssetLoad(RuntimeAssetLoadRequest(0, assetHandle));
+
+                // Not ready yet; caller should call SyncWithAssetThread() and retry.
+                return AsyncAssetResult<Asset>{ nullptr, false };
+            }
+        }
+#endif
+
+        // Fallback: synchronous load (GPU types, or no async thread available).
         Ref<Asset> asset = GetAsset(assetHandle);
-        return AsyncAssetResult<Asset>(asset, asset != nullptr);
+        return AsyncAssetResult<Asset>{ asset, asset != nullptr };
     }
 
     void RuntimeAssetManager::AddMemoryOnlyAsset(Ref<Asset> asset)
@@ -327,8 +361,54 @@ namespace OloEngine
 
     void RuntimeAssetManager::SyncWithAssetThread() noexcept
     {
-        // Runtime manager doesn't use separate asset threads
-        // All loading is done on the calling thread
+#if OLO_ASYNC_ASSETS
+        if (!m_AssetThread)
+            return;
+
+        OLO_PROFILER_SCOPE("RuntimeAssetManager::SyncWithAssetThread");
+
+        TArray<FCompletedAssetLoad> completed;
+        if (!m_AssetThread->RetrieveCompletedAssets(completed))
+            return;
+
+        // Announce integrated assets after releasing the lock so handlers can call back
+        // into the manager without deadlocking.
+        struct LoadedEvent
+        {
+            AssetHandle Handle;
+            AssetType Type;
+        };
+        std::vector<LoadedEvent> loadedEvents;
+
+        {
+            TUniqueLock<FSharedMutex> lock(m_AssetsMutex);
+            for (const auto& result : completed)
+            {
+                if (result.Asset)
+                {
+                    m_LoadedAssets[result.Handle] = result.Asset;
+                    loadedEvents.push_back({ result.Handle, result.Asset->GetAssetType() });
+                    OLO_CORE_TRACE("RuntimeAssetManager::SyncWithAssetThread - Integrated async-loaded asset {}", result.Handle);
+                }
+                else
+                {
+                    OLO_CORE_ERROR("RuntimeAssetManager::SyncWithAssetThread - Async load failed for asset {}", result.Handle);
+                }
+            }
+        }
+
+        if (!loadedEvents.empty())
+        {
+            if (Application* app = Application::TryGet())
+            {
+                for (const auto& evt : loadedEvents)
+                {
+                    AssetLoadedEvent loadedEvent(evt.Handle, evt.Type, std::filesystem::path{});
+                    app->OnEvent(loadedEvent);
+                }
+            }
+        }
+#endif
     }
 
     std::unordered_set<AssetHandle> RuntimeAssetManager::GetAllAssetsWithType(AssetType type) const
@@ -481,39 +561,57 @@ namespace OloEngine
         TSharedLock<FSharedMutex> lock(m_PacksMutex);
 
         // Check if we have metadata for this asset
-        if (m_AssetMetadata.find(handle) == m_AssetMetadata.end())
+        auto metaIt = m_AssetMetadata.find(handle);
+        if (metaIt == m_AssetMetadata.end())
         {
             OLO_CORE_ERROR("RuntimeAssetManager::LoadAssetFromPack - No metadata found for asset: {}", handle);
             return nullptr;
         }
 
+        // Scenes are stored in a dedicated SceneInfo table; their entry in the regular
+        // AssetInfo table is a type-only record whose PackedOffset is never populated by
+        // the builder. Routing a scene through the AssetInfo path would seek to offset 0
+        // (the file header) and read garbage, so dispatch scenes to the scene path.
+        const bool isScene = (metaIt->second.Type == AssetType::Scene);
+
         // Find which pack contains the asset
         for (const auto& [packPath, assetPack] : m_LoadedPacks)
         {
-            if (assetPack->IsAssetAvailable(handle))
-            {
-                // Get asset info from pack
-                auto assetInfo = assetPack->GetAssetInfo(handle);
-                if (!assetInfo.has_value())
-                {
-                    continue;
-                }
+            Ref<Asset> asset;
 
-                // Create file stream reader for the pack
+            if (isScene)
+            {
+                auto sceneInfo = assetPack->GetSceneInfo(handle);
+                if (!sceneInfo.has_value())
+                    continue;
+
                 auto stream = assetPack->GetAssetStreamReader();
                 if (!stream)
-                {
                     continue;
-                }
 
-                // Use AssetImporter to deserialize from pack
-                Ref<Asset> asset = AssetImporter::DeserializeFromAssetPack(*stream, assetInfo.value());
-                if (asset)
-                {
-                    asset->m_Handle = handle;
-                    OLO_CORE_TRACE("RuntimeAssetManager::LoadAssetFromPack - Successfully loaded asset from pack: {}", handle);
-                    return asset;
-                }
+                asset = AssetImporter::DeserializeSceneFromAssetPack(*stream, sceneInfo.value());
+            }
+            else
+            {
+                if (!assetPack->IsAssetAvailable(handle))
+                    continue;
+
+                auto assetInfo = assetPack->GetAssetInfo(handle);
+                if (!assetInfo.has_value())
+                    continue;
+
+                auto stream = assetPack->GetAssetStreamReader();
+                if (!stream)
+                    continue;
+
+                asset = AssetImporter::DeserializeFromAssetPack(*stream, assetInfo.value());
+            }
+
+            if (asset)
+            {
+                asset->m_Handle = handle;
+                OLO_CORE_TRACE("RuntimeAssetManager::LoadAssetFromPack - Successfully loaded asset from pack: {}", handle);
+                return asset;
             }
         }
 
@@ -539,11 +637,14 @@ namespace OloEngine
     {
         // Caller holds an exclusive lock on m_PacksMutex.
         //
-        // Only the pack's top-level AssetInfos are indexed: those are exactly the
-        // handles the pack's lookup map can serve (AssetPack::IsAssetAvailable /
-        // GetAssetInfo), so every metadata entry created here is resolvable by
-        // LoadAssetFromPack. Scene containers use a separate load path and are not
-        // indexed here, keeping "has metadata" equivalent to "loadable from pack".
+        // Every metadata entry created here must be resolvable by LoadAssetFromPack so
+        // that "has metadata" stays equivalent to "loadable from pack":
+        //  - Non-scene assets resolve through AssetPack::GetAssetInfo (the AssetInfo
+        //    table / lookup map), so index the top-level AssetInfos.
+        //  - Scenes resolve through AssetPack::GetSceneInfo (the dedicated SceneInfo
+        //    table whose PackedOffset points at the scene bytes). Index those too, and
+        //    record the Scene type so LoadAssetFromPack dispatches them to the scene
+        //    path rather than the AssetInfo path (whose offset is unset for scenes).
         for (const auto& info : assetPack.GetAllAssetInfos())
         {
             if (info.Handle == 0)
@@ -552,6 +653,16 @@ namespace OloEngine
             AssetMetadata metadata(info.Handle, info.Type);
             metadata.Status = AssetStatus::NotLoaded;
             m_AssetMetadata[info.Handle] = metadata;
+        }
+
+        for (const auto& sceneInfo : assetPack.GetAllSceneInfos())
+        {
+            if (sceneInfo.Handle == 0)
+                continue;
+
+            AssetMetadata metadata(sceneInfo.Handle, AssetType::Scene);
+            metadata.Status = AssetStatus::NotLoaded;
+            m_AssetMetadata[sceneInfo.Handle] = metadata;
         }
     }
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.h
@@ -33,6 +33,10 @@ namespace OloEngine
      */
     class RuntimeAssetManager : public AssetManagerBase
     {
+        // The async system delegates its worker-thread pack reads back to the manager's
+        // LoadAssetFromPack (the single source of truth for loaded packs).
+        friend class RuntimeAssetSystem;
+
       public:
         /**
          * @param autoLoadDefaultPack When true (default), the constructor loads

--- a/OloEngine/src/OloEngine/Asset/AssetPack.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetPack.cpp
@@ -463,6 +463,22 @@ namespace OloEngine
         return std::nullopt;
     }
 
+    std::optional<AssetPackFile::SceneInfo> AssetPack::GetSceneInfo(AssetHandle handle) const
+    {
+        if (!m_IsLoaded)
+            return std::nullopt;
+
+        // Scene counts are small (one per scene asset), so a linear scan over the
+        // dedicated SceneInfo table is cheap and avoids a second lookup map.
+        for (const auto& sceneInfo : m_AssetPackFile.SceneInfos)
+        {
+            if (sceneInfo.Handle == handle)
+                return sceneInfo;
+        }
+
+        return std::nullopt;
+    }
+
     FileStreamReaderPtr AssetPack::GetAssetStreamReader() const
     {
         if (!m_IsLoaded || m_PackPath.empty())

--- a/OloEngine/src/OloEngine/Asset/AssetPack.h
+++ b/OloEngine/src/OloEngine/Asset/AssetPack.h
@@ -188,6 +188,18 @@ namespace OloEngine
         std::optional<AssetPackFile::AssetInfo> GetAssetInfo(AssetHandle handle) const;
 
         /**
+         * @brief Get scene information from the pack
+         * @param handle Scene asset handle
+         * @return Scene info if found, nullopt otherwise
+         *
+         * Scenes are stored in a dedicated SceneInfo table whose PackedOffset points
+         * at the scene's serialized bytes. Use this (not GetAssetInfo) to load a scene
+         * from a pack: the scene's entry in the regular AssetInfo table is a type-only
+         * record whose offset is not populated by the builder.
+         */
+        std::optional<AssetPackFile::SceneInfo> GetSceneInfo(AssetHandle handle) const;
+
+        /**
          * @brief Create a stream reader for reading asset data
          *
          * @warning The returned FileStreamReader pointer may become invalid if Unload()

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -1540,6 +1540,18 @@ namespace OloEngine
             return nullptr;
         }
 
+        // dataSize is pack-controlled and untrusted. Reject sizes that would over-allocate
+        // before touching memory: the YAML must fit within the scene's packed byte budget
+        // (minus the 4-byte length prefix) when PackedSize is set, and within an absolute
+        // sanity bound regardless.
+        constexpr u32 c_MaxSceneYamlSize = 256u * 1024u * 1024u; // 256 MB
+        const u64 maxFromPackedSize = (sceneInfo.PackedSize > sizeof(u32)) ? (sceneInfo.PackedSize - sizeof(u32)) : 0ull;
+        if (dataSize > c_MaxSceneYamlSize || (sceneInfo.PackedSize != 0 && dataSize > maxFromPackedSize))
+        {
+            OLO_CORE_ERROR("SceneAssetSerializer::DeserializeSceneFromAssetPack - Scene data size {} exceeds allowed bound for handle {} (packed size {})", dataSize, sceneInfo.Handle, sceneInfo.PackedSize);
+            return nullptr;
+        }
+
         std::vector<char> yamlData(static_cast<sizet>(dataSize) + 1);
         stream.ReadData(yamlData.data(), dataSize);
         if (!stream.IsStreamGood())

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -1526,11 +1526,40 @@ namespace OloEngine
         return scene; // Direct return - Ref<Scene> should convert to Ref<Asset>
     }
 
-    Ref<Scene> SceneAssetSerializer::DeserializeSceneFromAssetPack([[maybe_unused]] FileStreamReader& stream, [[maybe_unused]] const AssetPackFile::SceneInfo& sceneInfo) const
+    Ref<Scene> SceneAssetSerializer::DeserializeSceneFromAssetPack(FileStreamReader& stream, const AssetPackFile::SceneInfo& sceneInfo) const
     {
-        // TODO: Implement scene pack deserialization
-        OLO_CORE_WARN("SceneAssetSerializer::DeserializeSceneFromAssetPack not yet implemented");
-        return nullptr;
+        // Scene bytes live at the dedicated SceneInfo offset and use the same on-pack
+        // layout written by SerializeToAssetPack: [u32 dataSize][char[dataSize] yaml].
+        stream.SetStreamPosition(sceneInfo.PackedOffset);
+
+        u32 dataSize = 0;
+        stream.ReadRaw(dataSize);
+        if (!stream.IsStreamGood() || dataSize == 0)
+        {
+            OLO_CORE_ERROR("SceneAssetSerializer::DeserializeSceneFromAssetPack - Invalid scene data size ({}) for handle {}", dataSize, sceneInfo.Handle);
+            return nullptr;
+        }
+
+        std::vector<char> yamlData(static_cast<sizet>(dataSize) + 1);
+        stream.ReadData(yamlData.data(), dataSize);
+        if (!stream.IsStreamGood())
+        {
+            OLO_CORE_ERROR("SceneAssetSerializer::DeserializeSceneFromAssetPack - Failed to read scene bytes for handle {}", sceneInfo.Handle);
+            return nullptr;
+        }
+        yamlData[dataSize] = '\0'; // Null terminate
+
+        auto scene = Ref<Scene>::Create();
+        if (!DeserializeFromString(yamlData.data(), scene))
+        {
+            OLO_CORE_ERROR("SceneAssetSerializer::DeserializeSceneFromAssetPack - Failed to deserialize scene from YAML for handle {}", sceneInfo.Handle);
+            return nullptr;
+        }
+
+        scene->m_Handle = sceneInfo.Handle;
+
+        OLO_CORE_TRACE("SceneAssetSerializer::DeserializeSceneFromAssetPack - Deserialized scene {} from pack", sceneInfo.Handle);
+        return scene;
     }
 
     std::string SceneAssetSerializer::SerializeToString(const Ref<Scene>& scene) const

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.h
@@ -109,6 +109,22 @@ namespace OloEngine
             return false;
         }
 
+        /**
+         * @brief Whether DeserializeFromAssetPack may be called off the main thread
+         *
+         * The runtime async asset system fully deserializes packed assets on a worker
+         * thread. That is only safe for serializers whose DeserializeFromAssetPack does
+         * no GPU / main-thread-only work (e.g. no Texture2D/Mesh/Shader/Font creation).
+         *
+         * Defaults to false — the conservative, always-correct choice: the runtime
+         * falls back to synchronous (main-thread) loading. Override to true only for
+         * CPU-only serializers.
+         */
+        [[nodiscard]] virtual bool CanDeserializeFromAssetPackOffThread() const
+        {
+            return false;
+        }
+
         [[nodiscard]] virtual bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const = 0;
         virtual Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const = 0;
 
@@ -190,6 +206,10 @@ namespace OloEngine
 
         [[nodiscard]] bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const override;
         Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const override;
+        [[nodiscard]] bool CanDeserializeFromAssetPackOffThread() const override
+        {
+            return true;
+        } // CPU-only: no GPU resources
 
       private:
         [[nodiscard]] bool GetWavFileInfo(const std::filesystem::path& filePath, double& duration, u32& samplingRate, u16& bitDepth, u16& numChannels) const;
@@ -219,6 +239,8 @@ namespace OloEngine
 
         [[nodiscard]] bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const override;
         Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const override;
+        // NOTE: not off-thread-safe — prefab deserialization resolves referenced assets
+        // (AssetManager::GetAsset<...>) which may create GPU resources.
 
       private:
         std::string SerializeToYAML(const Ref<Prefab>& prefab) const;
@@ -234,6 +256,9 @@ namespace OloEngine
         [[nodiscard]] bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const override;
         Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const override;
         Ref<Scene> DeserializeSceneFromAssetPack(FileStreamReader& stream, const AssetPackFile::SceneInfo& sceneInfo) const override;
+        // NOTE: not off-thread-safe — scene deserialization resolves referenced assets
+        // (AssetManager::GetAsset<MeshSource/Material/Texture2D/...>) which may create
+        // GPU resources, so scenes must be loaded on the main thread.
 
         // String serialization methods for asset pack support
         std::string SerializeToString(const Ref<Scene>& scene) const;
@@ -249,6 +274,10 @@ namespace OloEngine
 
         bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const override;
         Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const override;
+        [[nodiscard]] bool CanDeserializeFromAssetPackOffThread() const override
+        {
+            return true;
+        } // CPU-only: YAML -> MeshColliderAsset, no GPU resources
 
       private:
         std::string SerializeToYAML(Ref<MeshColliderAsset> meshCollider) const;
@@ -264,6 +293,10 @@ namespace OloEngine
 
         bool SerializeToAssetPack(AssetHandle handle, FileStreamWriter& stream, AssetSerializationInfo& outInfo) const override;
         Ref<Asset> DeserializeFromAssetPack(FileStreamReader& stream, const AssetPackFile::AssetInfo& assetInfo) const override;
+        [[nodiscard]] bool CanDeserializeFromAssetPackOffThread() const override
+        {
+            return true;
+        } // CPU-only: text -> ScriptFileAsset, no GPU resources
 
       private:
         std::string SerializeToYAML(Ref<ScriptFileAsset> scriptAsset) const;

--- a/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.cpp
@@ -1,19 +1,20 @@
 #include "RuntimeAssetSystem.h"
 
+#include "OloEngine/Asset/AssetManager/RuntimeAssetManager.h"
 #include "OloEngine/Asset/AssetPack.h"
-#include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Debug/Profiler.h"
-#include "OloEngine/Task/Task.h"
 #include "OloEngine/Threading/UniqueLock.h"
 
-#include <chrono>
-#include <optional>
+#include <exception>
+#include <utility>
 
 namespace OloEngine
 {
-    RuntimeAssetSystem::RuntimeAssetSystem()
+    RuntimeAssetSystem::RuntimeAssetSystem(RuntimeAssetManager* manager)
+        : m_Manager(manager)
     {
+        OLO_CORE_ASSERT(manager, "RuntimeAssetSystem requires a valid owning RuntimeAssetManager");
     }
 
     RuntimeAssetSystem::~RuntimeAssetSystem()
@@ -23,13 +24,32 @@ namespace OloEngine
 
     void RuntimeAssetSystem::Stop()
     {
-        m_Running.store(false, std::memory_order_release);
+        TUniqueLock<FMutex> lock(m_StateMutex);
+        m_Running = false;
     }
 
     void RuntimeAssetSystem::StopAndWait()
     {
-        Stop();
-        // Tasks will finish naturally or be cancelled by scheduler shutdown
+        // Reject new work and snapshot the in-flight task handles under the lock.
+        TArray<Tasks::TTask<Ref<Asset>>> pending;
+        {
+            TUniqueLock<FMutex> lock(m_StateMutex);
+            m_Running = false;
+            pending.Reserve(m_InFlight.Num());
+            for (const auto& load : m_InFlight)
+                pending.Add(load.Task);
+        }
+
+        // Wait for every in-flight task outside the lock. Their bodies call back into
+        // the owning RuntimeAssetManager, which is destroyed right after this returns,
+        // so none may still be running. Tasks::TTask::Wait drives the task to
+        // completion through the UE scheduler (executing it inline if it has not been
+        // picked up yet), so this returns deterministically without a poll loop.
+        for (auto& task : pending)
+            task.Wait();
+
+        TUniqueLock<FMutex> lock(m_StateMutex);
+        m_InFlight.Reset();
     }
 
     void RuntimeAssetSystem::QueueAssetLoad(RuntimeAssetLoadRequest request)
@@ -40,125 +60,112 @@ namespace OloEngine
             return;
         }
 
-        // Check if system is still running
-        if (!m_Running.load(std::memory_order_acquire))
+        const AssetHandle handle = request.Handle;
+
+        TUniqueLock<FMutex> lock(m_StateMutex);
+
+        if (!m_Running)
         {
             OLO_CORE_WARN("RuntimeAssetSystem: Cannot queue asset load - system is stopped");
             return;
         }
 
-        // Check if already pending
+        // Dedup: skip if this handle is already in flight.
+        for (const auto& load : m_InFlight)
         {
-            TUniqueLock<FMutex> lock(m_PendingAssetsMutex);
-            if (m_PendingAssets.find(request.Handle) != m_PendingAssets.end())
-            {
-                // Already pending, don't queue again
+            if (load.Handle == handle)
                 return;
-            }
-            m_PendingAssets.insert(request.Handle);
         }
 
-        m_ActiveTaskCount.fetch_add(1, std::memory_order_relaxed);
-
-        Tasks::Launch("RuntimeAssetLoad", [this, request]()
-                      {
-            if (!m_Running.load(std::memory_order_acquire))
+        // Launch on the UE task scheduler. The returned TTask both tracks completion
+        // and carries the loaded asset as its result, so retaining the handle is all
+        // the bookkeeping the in-flight set needs.
+        Tasks::TTask<Ref<Asset>> task = Tasks::Launch(
+            "RuntimeAssetLoad",
+            [this, handle]() -> Ref<Asset>
             {
-                m_ActiveTaskCount.fetch_sub(1, std::memory_order_relaxed);
-                return;
-            }
-
-            OLO_PROFILER_SCOPE("Runtime Asset Load Task");
-
-            // Load asset from pack with exception handling
-            Ref<Asset> asset = nullptr;
-            try
-            {
-                asset = LoadAssetFromPack(request.Handle);
-            }
-            catch (const std::exception& e)
-            {
-                OLO_CORE_ERROR("RuntimeAssetSystem: Exception during asset loading for handle {}: {}", request.Handle, e.what());
-            }
-            catch (...)
-            {
-                OLO_CORE_ERROR("RuntimeAssetSystem: Unknown exception during asset loading for handle {}", request.Handle);
-            }
-
-            // Move asset to completed queue with capacity check
-            {
-                TUniqueLock<FMutex> lock(m_CompletedAssetsMutex);
-
-                // Implement back-pressure: limit completed queue size
-                if (constexpr sizet MAX_COMPLETED_QUEUE_SIZE = 1000; m_CompletedAssets.size() >= MAX_COMPLETED_QUEUE_SIZE)
+                OLO_PROFILER_SCOPE("Runtime Asset Load Task");
+                try
                 {
-                    OLO_CORE_WARN("RuntimeAssetSystem: Completed assets queue is full ({} items), dropping oldest asset", m_CompletedAssets.size());
-                    m_CompletedAssets.pop(); // Remove oldest asset
+                    return LoadAssetFromPack(handle);
                 }
+                catch (const std::exception& e)
+                {
+                    OLO_CORE_ERROR("RuntimeAssetSystem: Exception during asset loading for handle {}: {}", handle, e.what());
+                }
+                catch (...)
+                {
+                    OLO_CORE_ERROR("RuntimeAssetSystem: Unknown exception during asset loading for handle {}", handle);
+                }
+                return nullptr;
+            },
+            Tasks::ETaskPriority::BackgroundNormal);
 
-                m_CompletedAssets.push({ request.Handle, asset });
-            }
-
-            // Remove from pending set
-            {
-                TUniqueLock<FMutex> lock(m_PendingAssetsMutex);
-                m_PendingAssets.erase(request.Handle);
-            }
-
-            m_ActiveTaskCount.fetch_sub(1, std::memory_order_relaxed); }, Tasks::ETaskPriority::BackgroundNormal);
+        m_InFlight.Add(FInFlightLoad{ handle, std::move(task) });
     }
 
-    void RuntimeAssetSystem::SyncWithAssetThread()
+    bool RuntimeAssetSystem::RetrieveCompletedAssets(TArray<FCompletedAssetLoad>& outAssets)
     {
-        OLO_PROFILER_SCOPE("RuntimeAssetSystem::SyncWithAssetThread");
+        OLO_PROFILER_SCOPE("RuntimeAssetSystem::RetrieveCompletedAssets");
 
-        // This method is called from the main thread to process completed assets
-        // In a full implementation, this would notify the RuntimeAssetManager
-        // of newly loaded assets. For now, we just clear the completed queue.
+        bool retrievedAny = false;
 
-        TUniqueLock<FMutex> lock(m_CompletedAssetsMutex);
-        while (!m_CompletedAssets.empty())
+        TUniqueLock<FMutex> lock(m_StateMutex);
+
+        // Walk back-to-front so RemoveAtSwap never disturbs an index we have yet to
+        // visit. Only completed tasks are touched, so GetResult() returns immediately
+        // (its internal wait is already satisfied) and never blocks under the lock.
+        for (i32 i = m_InFlight.Num() - 1; i >= 0; --i)
         {
-            auto [handle, asset] = m_CompletedAssets.front();
-            m_CompletedAssets.pop();
+            FInFlightLoad& load = m_InFlight[i];
+            if (!load.Task.IsCompleted())
+                continue;
 
-            if (asset)
-            {
-                OLO_CORE_TRACE("RuntimeAssetSystem: Asset loaded and ready: {}", static_cast<u64>(handle));
-                // TODO: Notify RuntimeAssetManager of loaded asset
-            }
-            else
-            {
-                OLO_CORE_ERROR("RuntimeAssetSystem: Failed to load asset: {}", static_cast<u64>(handle));
-            }
+            outAssets.Add(FCompletedAssetLoad{ load.Handle, load.Task.GetResult() });
+            m_InFlight.RemoveAtSwap(i);
+            retrievedAny = true;
         }
+
+        return retrievedAny;
+    }
+
+    bool RuntimeAssetSystem::IsRunning() const
+    {
+        TUniqueLock<FMutex> lock(m_StateMutex);
+        return m_Running;
     }
 
     bool RuntimeAssetSystem::IsAssetPending(AssetHandle handle) const
     {
-        TUniqueLock<FMutex> lock(m_PendingAssetsMutex);
-        return m_PendingAssets.find(handle) != m_PendingAssets.end();
+        TUniqueLock<FMutex> lock(m_StateMutex);
+        for (const auto& load : m_InFlight)
+        {
+            if (load.Handle == handle)
+                return true;
+        }
+        return false;
     }
 
-    sizet RuntimeAssetSystem::GetPendingAssetCount() const noexcept
+    sizet RuntimeAssetSystem::GetPendingAssetCount() const
     {
-        TUniqueLock<FMutex> lock(m_PendingAssetsMutex);
-        return m_PendingAssets.size();
+        TUniqueLock<FMutex> lock(m_StateMutex);
+        return static_cast<sizet>(m_InFlight.Num());
     }
 
     Ref<Asset> RuntimeAssetSystem::LoadAssetFromPack(AssetHandle handle)
     {
         OLO_PROFILER_SCOPE("RuntimeAssetSystem::LoadAssetFromPack");
 
-        // TODO: Implement actual asset pack loading
-        // This would use the AssetPack system to load assets from binary packs
-        // In a full implementation, this would:
-        // 1. Find the asset in the active asset pack
-        // 2. Deserialize the asset from binary data
-        // 3. Return the loaded asset
+        if (!m_Manager)
+        {
+            OLO_CORE_ERROR("RuntimeAssetSystem::LoadAssetFromPack - No owning asset manager for handle {}", handle);
+            return nullptr;
+        }
 
-        OLO_CORE_ERROR("LoadAssetFromPack not implemented - asset pack loading not yet supported for handle {0}", handle);
-        return nullptr;
+        // Delegate to the manager, which owns the loaded packs and performs the read +
+        // deserialize under its own pack lock. Only off-thread-safe (CPU-only) types are
+        // ever queued for async loading, so this performs no GPU work on the worker.
+        return m_Manager->LoadAssetFromPack(handle);
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.h
@@ -3,15 +3,24 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Asset/Asset.h"
 #include "OloEngine/Asset/AssetMetadata.h"
+#include "OloEngine/Containers/Array.h"
+#include "OloEngine/Task/Task.h"
 #include "OloEngine/Threading/Mutex.h"
-
-#include <queue>
-#include <atomic>
-#include <unordered_set>
-#include <utility>
 
 namespace OloEngine
 {
+    class RuntimeAssetManager;
+
+    /**
+     * @brief An async-loaded asset retrieved from the worker pool, ready for the
+     *        main thread to integrate. A null Asset means that handle failed to load.
+     */
+    struct FCompletedAssetLoad
+    {
+        AssetHandle Handle = 0;
+        Ref<Asset> Asset;
+    };
+
     /**
      * @brief Runtime asset system for optimized async loading
      *
@@ -19,15 +28,28 @@ namespace OloEngine
      * It loads assets from asset packs with minimal overhead and provides
      * efficient async loading for runtime performance.
      *
+     * Concurrency is built entirely on the UE-ported task/threading stack: loads run
+     * as `Tasks::TTask` jobs on `LowLevelTasks::FScheduler`, in-flight bookkeeping is
+     * a `TArray` guarded by a UE `FMutex`, and shutdown waits on the task handles via
+     * `Tasks::TTask::Wait`. Each task's *result* is the loaded asset, so the handle
+     * doubles as both the completion signal and the result channel — no separate
+     * completion queue or atomic counter is needed.
+     *
      * Key differences from EditorAssetSystem:
-     * - Simpler queue management (no file monitoring)
+     * - Simpler bookkeeping (no file monitoring)
      * - Asset pack-based loading only
      * - Optimized for performance over flexibility
      */
     class RuntimeAssetSystem : public RefCounted
     {
       public:
-        RuntimeAssetSystem();
+        /**
+         * @param manager Owning RuntimeAssetManager. The system delegates the actual
+         *        pack read/deserialize back to it (single source of truth for loaded
+         *        packs) and never outlives it — StopAndWait() drains in-flight tasks
+         *        before the manager is destroyed.
+         */
+        explicit RuntimeAssetSystem(RuntimeAssetManager* manager);
         ~RuntimeAssetSystem();
 
         // Delete copy and move operations
@@ -37,12 +59,12 @@ namespace OloEngine
         RuntimeAssetSystem& operator=(RuntimeAssetSystem&&) = delete;
 
         /**
-         * @brief Stop the asset thread
+         * @brief Stop accepting new load requests
          */
         void Stop();
 
         /**
-         * @brief Stop the asset thread and wait for completion
+         * @brief Stop accepting new requests and wait for in-flight loads to finish
          */
         void StopAndWait();
 
@@ -53,56 +75,62 @@ namespace OloEngine
         void QueueAssetLoad(RuntimeAssetLoadRequest request);
 
         /**
-         * @brief Sync with the asset thread (process any completed loads)
+         * @brief Retrieve assets that have finished loading on worker threads
+         * @param outAssets Output array, appended with completed loads.
+         * @return True if any completed assets were retrieved
+         *
+         * Called from the main thread (by RuntimeAssetManager::SyncWithAssetThread),
+         * which integrates the results into its loaded-asset cache.
          */
-        void SyncWithAssetThread();
+        bool RetrieveCompletedAssets(TArray<FCompletedAssetLoad>& outAssets);
 
         /**
-         * @brief Check if the asset thread is running
-         * @return True if the thread is active
+         * @brief Check if the system is still accepting load requests
          */
-        bool IsRunning() const noexcept
-        {
-            return m_Running.load(std::memory_order_acquire);
-        }
+        bool IsRunning() const;
 
         /**
-         * @brief Check if an asset is in the pending queue
+         * @brief Check if an asset is currently in flight
          * @param handle The asset handle to check
-         * @return True if the asset is pending load
+         * @return True if the asset is queued or loading
          */
         bool IsAssetPending(AssetHandle handle) const;
 
         /**
-         * @brief Get the number of pending asset loads
-         * @return Number of assets in the loading queue
+         * @brief Get the number of in-flight (queued or loading) assets
          */
-        sizet GetPendingAssetCount() const noexcept;
+        sizet GetPendingAssetCount() const;
 
       private:
         /**
-         * @brief Main asset thread function
-         */
-        void AssetThreadFunc();
-
-        /**
-         * @brief Load an asset from the asset pack
+         * @brief Load an asset from the asset pack (runs on a worker thread)
          * @param handle The asset handle to load
          * @return Loaded asset or nullptr on failure
+         *
+         * Delegates to the owning RuntimeAssetManager, which holds the loaded packs.
+         * Only types whose serializer reports CanDeserializeFromAssetPackOffThread()
+         * are queued here, so this never touches GPU resources off the main thread.
          */
         Ref<Asset> LoadAssetFromPack(AssetHandle handle);
 
       private:
-        std::atomic<bool> m_Running = true;
-        std::atomic<sizet> m_ActiveTaskCount{ 0 };
+        /// One in-flight load. The TTask both signals completion (IsCompleted) and
+        /// carries the loaded asset as its result (GetResult).
+        struct FInFlightLoad
+        {
+            AssetHandle Handle = 0;
+            Tasks::TTask<Ref<Asset>> Task;
+        };
 
-        // Completed assets (ready for main thread pickup)
-        std::queue<std::pair<AssetHandle, Ref<Asset>>> m_CompletedAssets;
-        FMutex m_CompletedAssetsMutex;
+        RuntimeAssetManager* m_Manager = nullptr;
 
-        // Pending assets tracking
-        std::unordered_set<AssetHandle> m_PendingAssets;
-        mutable FMutex m_PendingAssetsMutex;
+        // m_Running and m_InFlight are both guarded by m_StateMutex (a UE-ported
+        // FMutex). The UE task stack has no atomic wrapper of its own — its scheduler
+        // uses std::atomic internally — so this system keeps its own state under the
+        // mutex rather than introducing parallel atomics.
+        bool m_Running = true;
+        TArray<FInFlightLoad> m_InFlight;
+        mutable FMutex m_StateMutex;
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSystem/RuntimeAssetSystem.h
@@ -12,13 +12,13 @@ namespace OloEngine
     class RuntimeAssetManager;
 
     /**
-     * @brief An async-loaded asset retrieved from the worker pool, ready for the
-     *        main thread to integrate. A null Asset means that handle failed to load.
+     * @brief An async-loaded asset retrieved from the worker pool, ready for the main
+     *        thread to integrate. A null LoadedAsset means that handle failed to load.
      */
     struct FCompletedAssetLoad
     {
         AssetHandle Handle = 0;
-        Ref<Asset> Asset;
+        Ref<Asset> LoadedAsset; // named LoadedAsset (not Asset) so it doesn't shadow the Asset type
     };
 
     /**

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(OloEngine-Tests
 		AssetLuaScriptValidityTest.cpp
 		AssetCSharpScriptValidityTest.cpp
 		AssetPackTest.cpp
+		RuntimeAssetPackTest.cpp
 		AssetRegistryInvariantsTest.cpp
 		RuntimeAssetManagerTest.cpp
 		AssetLoadedEventTest.cpp

--- a/OloEngine/tests/RuntimeAssetPackTest.cpp
+++ b/OloEngine/tests/RuntimeAssetPackTest.cpp
@@ -69,7 +69,7 @@ namespace
     {
         AssetHandle Handle = 0;
         AssetType Type = AssetType::None;
-        std::string Data;       // raw bytes written at the entry's data offset
+        std::string Data; // raw bytes written at the entry's data offset
         bool IsScene = false;
     };
 

--- a/OloEngine/tests/RuntimeAssetPackTest.cpp
+++ b/OloEngine/tests/RuntimeAssetPackTest.cpp
@@ -18,14 +18,11 @@
 //      thread. GPU-touching / asset-resolving types must report false.
 //   4. AsyncLoadIntegratesThroughManager — the full async path
 //      (GetAssetAsync -> worker -> SyncWithAssetThread -> loaded cache) for a
-//      CPU-only asset type (Audio). Skips cleanly if a prior test's asset-manager
-//      shutdown has cleared the shared AssetImporter serializer registry
-//      (AssetImporter::Init is call_once and Shutdown clears it).
+//      CPU-only asset type (Audio).
 //
 // All headless: scenes/audio deserialize on the CPU with no GL context.
 // =============================================================================
 
-#include "OloEngine/Asset/AssetImporter.h"
 #include "OloEngine/Asset/AssetPack.h"
 #include "OloEngine/Asset/AssetSerializer.h"
 #include "OloEngine/Asset/AssetManager/RuntimeAssetManager.h"
@@ -304,16 +301,6 @@ TEST(RuntimeAssetPackTest, OffThreadCapabilityContract)
 // -----------------------------------------------------------------------------
 TEST(RuntimeAssetPackTest, AsyncLoadIntegratesThroughManager)
 {
-    // The shared AssetImporter serializer registry is process-global: Init() is
-    // call_once and any asset manager's Shutdown() clears it. If a prior test
-    // already tore an asset manager down, the registry is empty and cannot be
-    // repopulated — skip rather than report a false failure.
-    AssetImporter::Init();
-    if (!AssetImporter::CanDeserializeFromAssetPackOffThread(AssetType::Audio))
-    {
-        GTEST_SKIP() << "AssetImporter serializer registry unavailable (cleared by a prior test's asset-manager shutdown)";
-    }
-
     // Bring up the engine task scheduler once per process; worker tasks never run
     // without started workers. Application does this at startup; the test binary
     // does not construct an Application.
@@ -342,12 +329,10 @@ TEST(RuntimeAssetPackTest, AsyncLoadIntegratesThroughManager)
     }
     WritePack(packPath, { audio });
 
-    // Keep the manager alive for the process lifetime (function-local static) so its
-    // destructor never clears the shared AssetImporter registry mid-suite; at process
-    // exit AssetImporter::Shutdown is a no-op during static destruction. Created with
-    // autoLoadDefaultPack=false.
-    static Ref<RuntimeAssetManager> s_Manager = Ref<RuntimeAssetManager>::Create(false);
-    RuntimeAssetManager& mgr = *s_Manager;
+    // A plain stack-local manager: its ctor calls AssetImporter::Init(), which
+    // repopulates the serializer registry if a prior test's manager shutdown cleared
+    // it, so no static/leak/skip workaround is needed.
+    RuntimeAssetManager mgr(/*autoLoadDefaultPack=*/false);
     ASSERT_TRUE(mgr.LoadAssetPack(packPath));
 
     // First async request queues the load and reports not-ready.

--- a/OloEngine/tests/RuntimeAssetPackTest.cpp
+++ b/OloEngine/tests/RuntimeAssetPackTest.cpp
@@ -1,0 +1,387 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// RuntimeAssetPackTest — runtime asset-pack loading pipeline.
+//
+// Pins the pieces wired up to complete runtime pack loading:
+//
+//   1. SceneSerializerPackRoundTrip — SceneAssetSerializer::DeserializeSceneFromAssetPack
+//      (previously a stub returning nullptr) round-trips a scene through the
+//      on-pack scene format ([u32 size][yaml]).
+//   2. SceneRoutingUsesSceneInfoOffset — scenes live in the dedicated SceneInfo
+//      table; their AssetInfo record carries no valid offset (the builder leaves
+//      it 0). Loading a scene MUST use SceneInfo. This pins the offset-0 bug:
+//      the AssetInfo path would seek to the file header and read garbage.
+//   3. OffThreadCapabilityContract — the per-serializer off-thread-safe flag that
+//      gates which types the runtime async system may deserialize on a worker
+//      thread. GPU-touching / asset-resolving types must report false.
+//   4. AsyncLoadIntegratesThroughManager — the full async path
+//      (GetAssetAsync -> worker -> SyncWithAssetThread -> loaded cache) for a
+//      CPU-only asset type (Audio). Skips cleanly if a prior test's asset-manager
+//      shutdown has cleared the shared AssetImporter serializer registry
+//      (AssetImporter::Init is call_once and Shutdown clears it).
+//
+// All headless: scenes/audio deserialize on the CPU with no GL context.
+// =============================================================================
+
+#include "OloEngine/Asset/AssetImporter.h"
+#include "OloEngine/Asset/AssetPack.h"
+#include "OloEngine/Asset/AssetSerializer.h"
+#include "OloEngine/Asset/AssetManager/RuntimeAssetManager.h"
+#include "OloEngine/Scene/Scene.h"
+#include "OloEngine/Serialization/AssetPackFile.h"
+#include "OloEngine/Serialization/FileStream.h"
+#include "OloEngine/Task/NamedThreads.h"
+#include "OloEngine/Task/Scheduler.h"
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#include <process.h> // _getpid()
+inline int OloRapGetPid()
+{
+    return _getpid();
+}
+#else
+#include <unistd.h>
+inline int OloRapGetPid()
+{
+    return static_cast<int>(getpid());
+}
+#endif
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace)
+
+namespace
+{
+    namespace fs = std::filesystem;
+
+    // One asset entry to embed in a synthetic pack. Every entry goes into the
+    // AssetInfo table; scene entries additionally get a SceneInfo whose offset
+    // points at the data (the AssetInfo offset is intentionally left 0 to mirror
+    // AssetPackBuilder, which never backfills scene AssetInfo offsets).
+    struct PackEntry
+    {
+        AssetHandle Handle = 0;
+        AssetType Type = AssetType::None;
+        std::string Data;       // raw bytes written at the entry's data offset
+        bool IsScene = false;
+    };
+
+    // Serialize a scene's bytes exactly as SceneAssetSerializer::SerializeToAssetPack
+    // writes them: [u32 size][char[size] yaml].
+    std::string MakeSceneBlob(const std::string& yaml)
+    {
+        std::string blob;
+        const u32 size = static_cast<u32>(yaml.size());
+        blob.append(reinterpret_cast<const char*>(&size), sizeof(size));
+        blob.append(yaml);
+        return blob;
+    }
+
+    // Write a valid .olopack with the given entries, computing data offsets up
+    // front (no seek-back) so the layout matches what AssetPack::Load reads.
+    void WritePack(const fs::path& path, const std::vector<PackEntry>& entries)
+    {
+        const u64 assetCount = entries.size();
+        u64 sceneCount = 0;
+        for (const auto& e : entries)
+        {
+            if (e.IsScene)
+                ++sceneCount;
+        }
+
+        // Per-record byte sizes must match the field-by-field reads in AssetPack::Load.
+        const u64 headerBytes = sizeof(AssetPackFile::FileHeader);
+        const u64 indexBytes = sizeof(u32) * 2 + sizeof(u64) * 2;
+        const u64 assetInfoBytes = sizeof(AssetHandle) + sizeof(u64) * 2 + sizeof(AssetType) + sizeof(u16);
+        const u64 sceneInfoBytes = sizeof(AssetHandle) + sizeof(u64) * 2 + sizeof(u16) + sizeof(u32); // nested count = 0
+
+        u64 cursor = headerBytes + indexBytes + assetCount * assetInfoBytes + sceneCount * sceneInfoBytes;
+
+        std::vector<u64> dataOffset(entries.size());
+        std::vector<u64> dataSize(entries.size());
+        for (sizet i = 0; i < entries.size(); ++i)
+        {
+            dataOffset[i] = cursor;
+            dataSize[i] = entries[i].Data.size();
+            cursor += dataSize[i];
+        }
+
+        FileStreamWriter writer(path);
+        ASSERT_TRUE(writer.IsStreamGood());
+
+        // Header
+        u32 magic = AssetPackFile::MagicNumber;
+        u32 version = AssetPackFile::Version;
+        u64 buildVersion = 1;
+        u64 indexOffset = headerBytes;
+        writer.WriteRaw(magic);
+        writer.WriteRaw(version);
+        writer.WriteRaw(buildVersion);
+        writer.WriteRaw(indexOffset);
+
+        // Index table
+        u32 assetCount32 = static_cast<u32>(assetCount);
+        u32 sceneCount32 = static_cast<u32>(sceneCount);
+        u64 zero64 = 0;
+        writer.WriteRaw(assetCount32);
+        writer.WriteRaw(sceneCount32);
+        writer.WriteRaw(zero64); // PackedAppBinaryOffset
+        writer.WriteRaw(zero64); // PackedAppBinarySize
+
+        // Asset infos: Handle, PackedOffset, PackedSize, Type, Flags
+        for (sizet i = 0; i < entries.size(); ++i)
+        {
+            const auto& e = entries[i];
+            // Scenes mirror the builder: their AssetInfo offset/size stay 0 so the
+            // load path is forced through the SceneInfo table.
+            u64 off = e.IsScene ? 0ull : dataOffset[i];
+            u64 sz = e.IsScene ? 0ull : dataSize[i];
+            u16 flags = 0;
+            AssetHandle handle = e.Handle;
+            AssetType type = e.Type;
+            writer.WriteRaw(handle);
+            writer.WriteRaw(off);
+            writer.WriteRaw(sz);
+            writer.WriteRaw(type);
+            writer.WriteRaw(flags);
+        }
+
+        // Scene infos: Handle, PackedOffset, PackedSize, Flags, u32 sceneAssetCount
+        for (sizet i = 0; i < entries.size(); ++i)
+        {
+            const auto& e = entries[i];
+            if (!e.IsScene)
+                continue;
+            u16 flags = 0;
+            u32 sceneAssetCount = 0;
+            AssetHandle handle = e.Handle;
+            u64 off = dataOffset[i];
+            u64 sz = dataSize[i];
+            writer.WriteRaw(handle);
+            writer.WriteRaw(off);
+            writer.WriteRaw(sz);
+            writer.WriteRaw(flags);
+            writer.WriteRaw(sceneAssetCount);
+        }
+
+        // Data section
+        for (const auto& e : entries)
+        {
+            if (!e.Data.empty())
+                writer.WriteData(e.Data.data(), e.Data.size());
+        }
+
+        ASSERT_TRUE(writer.IsStreamGood());
+    }
+
+    std::string MakeEmptySceneYaml()
+    {
+        Ref<Scene> scene = Ref<Scene>::Create();
+        SceneAssetSerializer serializer;
+        return serializer.SerializeToString(scene);
+    }
+} // namespace
+
+// -----------------------------------------------------------------------------
+// 1. Scene pack deserialize round-trip (direct serializer, no manager).
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, SceneSerializerPackRoundTrip)
+{
+    const std::string yaml = MakeEmptySceneYaml();
+    ASSERT_FALSE(yaml.empty()) << "Empty scene must serialize to non-empty YAML";
+
+    const fs::path tmp = fs::temp_directory_path() / ("olo_scene_blob_" + std::to_string(OloRapGetPid()) + ".bin");
+
+    // Scene bytes at offset 0, in the on-pack format.
+    {
+        FileStreamWriter writer(tmp);
+        ASSERT_TRUE(writer.IsStreamGood());
+        const std::string blob = MakeSceneBlob(yaml);
+        writer.WriteData(blob.data(), blob.size());
+    }
+
+    AssetPackFile::SceneInfo sceneInfo;
+    sceneInfo.Handle = static_cast<AssetHandle>(0x5CE9E0000ULL);
+    sceneInfo.PackedOffset = 0;
+    sceneInfo.PackedSize = 0; // unused by the reader
+
+    FileStreamReader reader(tmp);
+    ASSERT_TRUE(reader.IsStreamGood());
+
+    SceneAssetSerializer serializer;
+    Ref<Scene> result = serializer.DeserializeSceneFromAssetPack(reader, sceneInfo);
+
+    ASSERT_TRUE(result) << "DeserializeSceneFromAssetPack must return a scene (was a stub returning nullptr)";
+    EXPECT_EQ(result->GetHandle(), sceneInfo.Handle) << "Handle from SceneInfo must be applied";
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+}
+
+// -----------------------------------------------------------------------------
+// 2. Scene routing uses the SceneInfo offset, not the (unset) AssetInfo offset.
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, SceneRoutingUsesSceneInfoOffset)
+{
+    const std::string yaml = MakeEmptySceneYaml();
+    ASSERT_FALSE(yaml.empty());
+
+    const AssetHandle sceneHandle = static_cast<AssetHandle>(0xABC123ULL);
+    const fs::path packPath = fs::temp_directory_path() / ("olo_scene_pack_" + std::to_string(OloRapGetPid()) + ".olopack");
+
+    PackEntry scene;
+    scene.Handle = sceneHandle;
+    scene.Type = AssetType::Scene;
+    scene.Data = MakeSceneBlob(yaml);
+    scene.IsScene = true;
+    WritePack(packPath, { scene });
+
+    auto pack = Ref<AssetPack>::Create();
+    auto result = pack->Load(packPath);
+    ASSERT_TRUE(result.Success) << "Error: " << result.ErrorMessage;
+
+    // The bug: the scene's AssetInfo offset is 0 (points at the file header), while
+    // the SceneInfo offset points at the real scene bytes.
+    auto assetInfo = pack->GetAssetInfo(sceneHandle);
+    ASSERT_TRUE(assetInfo.has_value()) << "Scene must also appear in the AssetInfo table";
+    EXPECT_EQ(assetInfo->PackedOffset, 0u) << "Builder leaves scene AssetInfo offset unset (0)";
+
+    auto sceneInfo = pack->GetSceneInfo(sceneHandle);
+    ASSERT_TRUE(sceneInfo.has_value()) << "GetSceneInfo must resolve the scene";
+    EXPECT_GT(sceneInfo->PackedOffset, 0u) << "SceneInfo offset must point past the header at the real bytes";
+
+    // Deserializing via the SceneInfo path succeeds...
+    {
+        FileStreamReader reader(packPath);
+        ASSERT_TRUE(reader.IsStreamGood());
+        SceneAssetSerializer serializer;
+        Ref<Scene> viaScene = serializer.DeserializeSceneFromAssetPack(reader, sceneInfo.value());
+        EXPECT_TRUE(viaScene) << "Scene path must load the scene";
+    }
+
+    // ...while the AssetInfo path (offset 0 = file header) does not produce a valid scene.
+    {
+        FileStreamReader reader(packPath);
+        ASSERT_TRUE(reader.IsStreamGood());
+        SceneAssetSerializer serializer;
+        Ref<Asset> viaAsset = serializer.DeserializeFromAssetPack(reader, assetInfo.value());
+        EXPECT_FALSE(viaAsset) << "AssetInfo path (offset 0) must NOT yield a valid scene — this is the bug the routing avoids";
+    }
+
+    std::error_code ec;
+    fs::remove(packPath, ec);
+}
+
+// -----------------------------------------------------------------------------
+// 3. Off-thread-safe capability contract (direct serializers, no AssetImporter).
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, OffThreadCapabilityContract)
+{
+    // CPU-only serializers may run on a worker thread.
+    EXPECT_TRUE(AudioFileSourceSerializer().CanDeserializeFromAssetPackOffThread());
+    EXPECT_TRUE(MeshColliderSerializer().CanDeserializeFromAssetPackOffThread());
+    EXPECT_TRUE(ScriptFileSerializer().CanDeserializeFromAssetPackOffThread());
+
+    // Types whose deserialize resolves referenced assets / creates GPU resources
+    // must stay on the main thread.
+    EXPECT_FALSE(SceneAssetSerializer().CanDeserializeFromAssetPackOffThread());
+    EXPECT_FALSE(PrefabSerializer().CanDeserializeFromAssetPackOffThread());
+    EXPECT_FALSE(TextureSerializer().CanDeserializeFromAssetPackOffThread());
+
+    // Base default is the conservative (safe) choice.
+    EXPECT_FALSE(MaterialAssetSerializer().CanDeserializeFromAssetPackOffThread());
+}
+
+// -----------------------------------------------------------------------------
+// 4. Full async path through RuntimeAssetManager for a CPU-only type (Audio).
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, AsyncLoadIntegratesThroughManager)
+{
+    // The shared AssetImporter serializer registry is process-global: Init() is
+    // call_once and any asset manager's Shutdown() clears it. If a prior test
+    // already tore an asset manager down, the registry is empty and cannot be
+    // repopulated — skip rather than report a false failure.
+    AssetImporter::Init();
+    if (!AssetImporter::CanDeserializeFromAssetPackOffThread(AssetType::Audio))
+    {
+        GTEST_SKIP() << "AssetImporter serializer registry unavailable (cleared by a prior test's asset-manager shutdown)";
+    }
+
+    // Bring up the engine task scheduler once per process; worker tasks never run
+    // without started workers. Application does this at startup; the test binary
+    // does not construct an Application.
+    static const bool s_SchedulerStarted = []
+    {
+        LowLevelTasks::InitGameThreadId();
+        Tasks::FNamedThreadManager::Get().AttachToThread(Tasks::ENamedThread::GameThread);
+        LowLevelTasks::FScheduler::Get().StartWorkers();
+        return true;
+    }();
+    (void)s_SchedulerStarted;
+
+    const AssetHandle audioHandle = static_cast<AssetHandle>(0xA0D10ULL);
+    const fs::path packPath = fs::temp_directory_path() / ("olo_async_pack_" + std::to_string(OloRapGetPid()) + ".olopack");
+
+    // AudioFileSourceSerializer::DeserializeFromAssetPack reads a single string
+    // (the source path) via StreamReader::ReadString — [u64 length][bytes].
+    PackEntry audio;
+    audio.Handle = audioHandle;
+    audio.Type = AssetType::Audio;
+    {
+        const std::string srcPath = "sounds/test.wav";
+        const u64 len = static_cast<u64>(srcPath.size());
+        audio.Data.append(reinterpret_cast<const char*>(&len), sizeof(len));
+        audio.Data.append(srcPath);
+    }
+    WritePack(packPath, { audio });
+
+    // Keep the manager alive for the process lifetime (function-local static) so its
+    // destructor never clears the shared AssetImporter registry mid-suite; at process
+    // exit AssetImporter::Shutdown is a no-op during static destruction. Created with
+    // autoLoadDefaultPack=false.
+    static Ref<RuntimeAssetManager> s_Manager = Ref<RuntimeAssetManager>::Create(false);
+    RuntimeAssetManager& mgr = *s_Manager;
+    ASSERT_TRUE(mgr.LoadAssetPack(packPath));
+
+    // First async request queues the load and reports not-ready.
+    AsyncAssetResult<Asset> first = mgr.GetAssetAsync(audioHandle);
+    EXPECT_FALSE(first.IsReady) << "Audio is off-thread-safe, so the first request must queue (not load inline)";
+    EXPECT_FALSE(first.Ptr);
+
+    // Pump the main-thread sync until the worker delivers the asset (bounded).
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    bool loaded = false;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        mgr.SyncWithAssetThread();
+        if (mgr.IsAssetLoaded(audioHandle))
+        {
+            loaded = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    EXPECT_TRUE(loaded) << "Async-loaded audio asset must be integrated by SyncWithAssetThread";
+    if (loaded)
+    {
+        Ref<Asset> asset = mgr.GetAsset(audioHandle);
+        ASSERT_TRUE(asset);
+        EXPECT_EQ(asset->GetAssetType(), AssetType::Audio);
+
+        // A subsequent async request is served immediately from the loaded cache.
+        AsyncAssetResult<Asset> second = mgr.GetAssetAsync(audioHandle);
+        EXPECT_TRUE(second.IsReady);
+        EXPECT_TRUE(second.Ptr);
+    }
+
+    std::error_code ec;
+    fs::remove(packPath, ec);
+}

--- a/OloEngine/tests/scripts/test_catalogue.json
+++ b/OloEngine/tests/scripts/test_catalogue.json
@@ -203,6 +203,7 @@
     "OloEngine/tests/AssetPackTest.cpp": "unit",
     "OloEngine/tests/AssetRegistryInvariantsTest.cpp": "unit",
     "OloEngine/tests/AssetSceneLoadTest.cpp": "unit",
+    "OloEngine/tests/RuntimeAssetPackTest.cpp": "unit",
     "OloEngine/tests/Async/ExternalMutexTest.cpp": "unit",
     "OloEngine/tests/Async/ManualResetEventTest.cpp": "unit",
     "OloEngine/tests/Async/MutexLockRateTest.cpp": "unit",

--- a/OloRuntime/src/OloRuntimeApp.cpp
+++ b/OloRuntime/src/OloRuntimeApp.cpp
@@ -140,6 +140,11 @@ namespace OloEngine
 
         void OnUpdate(Timestep const ts) override
         {
+            // Integrate any assets the runtime asset thread finished loading in the
+            // background. Done before the early-out so async loads still complete while
+            // no scene is active (e.g. during a load transition).
+            AssetManager::SyncWithAssetThread();
+
             if (!m_ActiveScene)
             {
                 return;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1280,7 +1280,7 @@ level of `tests/`). Grouped by directory.
 
 > **Do not edit by hand.** Generated from [test_catalogue.json](../OloEngine/tests/scripts/test_catalogue.json) by [generate_test_catalogue.py](../OloEngine/tests/scripts/generate_test_catalogue.py). Add new test files to the config and run the script (or pre-commit will run it with `--check`).
 
-#### (top-level) (55 files)
+#### (top-level) (56 files)
 
 | File | Tests | Cases |
 |---|---:|---|
@@ -1331,6 +1331,7 @@ level of `tests/`). Grouped by directory.
 | [QualityTieringTest.cpp](../OloEngine/tests/QualityTieringTest.cpp) | 5 | **QualityTiering** &mdash; `PresetsAreOrderedByQuality`, `ApplyWritesShadowSettings`, `ApplyWritesPostProcessSettings`, `StringRoundTrip`, `UnknownStringDefaultsToHigh` |
 | [QuestSystemTest.cpp](../OloEngine/tests/QuestSystemTest.cpp) | 55 | **QuestSystemTest** &mdash; `QuestLifecycle_AcceptToComplete`, `QuestStatus_Unavailable`, `AcceptQuest_AlreadyActive`, `AbandonQuest`, `ObjectiveTracking_Increment`, `ObjectiveTracking_Overshoot`, `NotifyKill_UpdatesCorrectObjective`, `NotifyCollect_UpdatesCorrectObjective`, `TimedQuest_ExpiresOnTimeout`, `FailOnTag`, `BranchingCompletion`, `CompletionRewards_GrantsTags`, `NonRepeatable_CantReaccept`, `Repeatable_CanReaccept`, `OptionalObjectives_DontBlockStage`, `AnyObjective_CompletesStage`, `QuestDatabase_RegisterAndGet`, `QuestDatabase_GetByCategory`, `GetActiveAndCompletedQuests`, `SetObjectiveComplete`, `TagManagement`, `ObjectiveTypeStringConversion`, `QuestStatusStringConversion`, `AcceptQuest_RequiresPrerequisiteQuests`, `AcceptQuest_RequiresTags`, `AcceptQuest_MismatchedQuestID`, `CompleteQuest_NotReady`, `Requirement_Level`, `Requirement_Reputation`, `Requirement_ReputationLessThan`, `Requirement_HasItem`, `Requirement_Stat`, `Requirement_IsClass`, `Requirement_IsFaction`, `Requirement_QuestCompleted`, `Requirement_QuestActive`, `Requirement_QuestFailed`, `Requirement_QuestNotStarted`, `Requirement_DoesNotHaveTag`, `Requirement_HasTag`, `Requirement_All_Combinator`, `Requirement_Any_Combinator`, `Requirement_Not_Combinator`, `Requirement_NestedCombinators`, `Requirement_MultipleTopLevel`, `GetUnmetRequirements`, `CheckRequirement_Direct`, `ComparisonOperators`, `RequirementTypeStringConversion`, `ComparisonOpStringConversion`, `PlayerState_SettersGetters`, `Requirement_EmptyAll`, `Requirement_EmptyAny`, `Requirement_EmptyNot`, `RequirementsCombo_QuestAndTag` |
 | [RuntimeAssetManagerTest.cpp](../OloEngine/tests/RuntimeAssetManagerTest.cpp) | 5 | **RuntimeAssetManagerTest** &mdash; `LoadedPackAssetsAreDiscoverable`, `UnknownHandleIsNotValid`, `GetAllAssetsWithTypeReturnsMatchingHandles`, `UnloadingPackRemovesItsAssets`, `MetadataSurvivesUntilExplicitUnload` |
+| [RuntimeAssetPackTest.cpp](../OloEngine/tests/RuntimeAssetPackTest.cpp) | 4 | **RuntimeAssetPackTest** &mdash; `SceneSerializerPackRoundTrip`, `SceneRoutingUsesSceneInfoOffset`, `OffThreadCapabilityContract`, `AsyncLoadIntegratesThroughManager` |
 | [SRGBTextureSupportTest.cpp](../OloEngine/tests/SRGBTextureSupportTest.cpp) | 8 | **SRGBTextureSupport** &mdash; `TextureSpecificationDefaultsToLinear`, `TextureSpecificationCarriesSrgbFlag`, `RawTextureDataKeepsLinearDefault`, `FilenameHeuristic_ClassifiesAlbedoAsSrgb`, `FilenameHeuristic_ClassifiesDataTexturesAsLinear`, `FilenameHeuristic_DataKeywordsOverrideColorKeywords`, `FilenameHeuristic_AmbiguousFilesDefaultLinear`, `FilenameHeuristic_IsCaseInsensitive` |
 | [SceneSerializerFuzzRegressionTest.cpp](../OloEngine/tests/SceneSerializerFuzzRegressionTest.cpp) | 19 | **SceneSerializerFuzzRegression** &mdash; `CrashInput_OriginalSixBytes`, `EmptyInput`, `RootIsScalar`, `RootIsSequence`, `RootIsEmptyMap`, `SceneKeyMissing`, `SceneIsMap`, `SceneIsSequence`, `SceneIsNull`, `PostProcessSettingsIsScalar`, `StreamingSettingsIsSequence`, `EntitiesIsScalar`, `EntitiesContainsScalar`, `EntityIdIsMap`, `TagComponentIsScalar`, `BinaryGarbage`, `UnterminatedFlowMap`, `ParserThrowsOnAnchorOnlyDoc`, `SinglePrintableChar` |
 | [SnowSettingsTest.cpp](../OloEngine/tests/SnowSettingsTest.cpp) | 7 | **SnowUBOData** &mdash; `SizeIs80Bytes`, `FieldOffsets_Std140Compatible`, `DefaultsMatchSettings`<br/>**SSSUBOData** &mdash; `SizeIs32Bytes`, `FieldOffsets_Std140Compatible`, `DefaultsMatchSettings`<br/>**ShaderBindingLayout** &mdash; `SnowAndSSSBindingsExist` |
@@ -1479,7 +1480,7 @@ level of `tests/`). Grouped by directory.
 | [FunctionWithContextTest.cpp](../OloEngine/tests/Templates/FunctionWithContextTest.cpp) | 4 | **FunctionWithContext** &mdash; `DefaultConstructedIsNullAndExposesNullSlots`, `LambdaBoundCallableInvokesCaptureBody`, `ReassignmentReplacesBoundCallable`, `RoundTripsThroughStatelessInvocationAPI` |
 | [TypeTraitsTest.cpp](../OloEngine/tests/Templates/TypeTraitsTest.cpp) | 2 | **TypeTraitsTest** &mdash; `AllChecksAreCompileTime`, `AllNameOfsAreCorrect` |
 
-**Totals.** 119 unit / subsystem test files, 1472 TEST / TEST_F declarations across all subsystems.
+**Totals.** 120 unit / subsystem test files, 1476 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: unit-catalogue -->
 


### PR DESCRIPTION
The runtime pack pipeline was ~90% built but had three live stubs and a latent data-corruption bug. This wires it up end to end so a shipped game can load assets (and scenes) from a .olopack, synchronously and async.

Scene loading from packs:
- Implement SceneAssetSerializer::DeserializeSceneFromAssetPack (was a stub   returning nullptr) and add AssetPack::GetSceneInfo(handle).
- Fix latent bug: scenes are written into both the AssetInfo table (with PackedOffset = 0, never backfilled by the builder) and the dedicated SceneInfo table. RuntimeAssetManager::LoadAssetFromPack now routes Scene-typed handles through the SceneInfo path; the old path would seek to offset 0 (the file header) and read garbage. IndexAssetPackMetadata now indexes SceneInfos too, keeping "has metadata" == "loadable from pack".

Async loading made functional and thread-safe:
- RuntimeAssetSystem::LoadAssetFromPack now delegates to the owning manager (single source of truth for loaded packs) instead of returning nullptr.
- RuntimeAssetManager::GetAssetAsync queues background loads and SyncWithAssetThread integrates the results + fires AssetLoadedEvent; the system was previously created but never used.
- New per-serializer CanDeserializeFromAssetPackOffThread capability gates which types may deserialize on a worker thread. Only CPU-only serializers (Audio, MeshCollider, ScriptFile) opt in; GPU/asset-resolving types (Scene, Prefab, Texture, ...) fall back to synchronous main-thread loading, so no GPU work ever runs off-thread.
- OloRuntime drains the async thread each frame.

Concurrency built on the UE-ported task/threading stack only (no std::atomic or std::queue): in-flight loads are a TArray of Tasks::TTask<Ref<Asset>> handles under an FMutex — the task handle is both the completion signal (IsCompleted) and the result channel (GetResult). StopAndWait waits on the handles via Tasks::TTask::Wait (deterministic, no poll loop), guaranteeing no task touches the manager after it is destroyed.

Tests (OloEngine/tests/RuntimeAssetPackTest.cpp, registered in CMake + test_catalogue.json): scene-pack round-trip, scene routing (pins the offset-0 bug — SceneInfo path succeeds while the AssetInfo path fails), off-thread capability contract, and full async load through the manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background async asset loading with off-thread deserialization for audio, mesh-collider, and script assets; scene loading now uses scene-specific pack metadata for correct routing.
  * Runtime integration now pulls completed background loads into the manager each tick to ensure timely availability.

* **Tests**
  * New end-to-end test suite validating pack loading, scene deserialization, off-thread capability contracts, and async integration.

* **Documentation**
  * Test catalogue updated to include the new runtime asset pack tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->