### PR TITLE
chore(skills): add run-oloengine skill to launch + screenshot the editor

### DIFF
--- a/.claude/skills/run-oloengine/SKILL.md
+++ b/.claude/skills/run-oloengine/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: run-oloengine
+description: Build, run, and screenshot the OloEngine apps on Windows — the OloEditor GUI, the OloServer headless dedicated server, and the GoogleTest suite. Use when asked to start/launch/run the editor, screenshot the editor, build OloEditor/OloServer/OloRuntime, run the tests, or confirm a change works in the real running app.
+---
+
+OloEngine is a native C++23 / OpenGL 4.6 desktop engine. The headline binary,
+**OloEditor**, is a GLFW + ImGui window — there is no DOM and no Playwright
+handle, so it is driven through the Win32 window manager by
+[driver.ps1](.claude/skills/run-oloengine/driver.ps1): it launches the process
+with the correct working directory, waits for the top-level window, and captures
+the window's own surface with `PrintWindow` (works even when the editor is **not**
+the focused/top-most window — which it usually isn't, since a background process
+can't steal foreground on Windows). OloServer is headless (`curl`/log-driven, no
+window); the tests are a plain console exe.
+
+All paths below are relative to the repo root (`e:\repos\OloEngineBaseTwo`). All
+commands were run on Windows 11 + VS 2026 + an RTX 4090 (real OpenGL 4.6).
+
+## Prerequisites
+
+Already provisioned on this machine; listed for a clean box. There is no
+`apt-get` — this is Windows:
+
+- **CMake 4.2+** — the `msvc` preset uses the `Visual Studio 18 2026` generator, which only exists in CMake 4.2+. (`cmake --version` → 4.2.0 here.)
+- **Visual Studio 2026** (Community is fine) with the C++ desktop workload. VS 2022 also works via `scripts\Win-GenerateProjectVS2022.bat`.
+- **Vulkan SDK 1.3+** with `VULKAN_SDK` set (provides `glslc` for SPIR-V shader compilation). Here: `C:\VulkanSDK\1.4.309.0`.
+- **Python 3.10+** with `jinja2` (used to generate the glad2 GL loader at configure time).
+- **A GPU with real OpenGL 4.6** for OloEditor/OloRuntime. WSL2's software GL is only 4.5 and will not run the editor.
+- **PowerShell 7 (`pwsh`)** to run the driver (Windows PowerShell 5.1 also works; the driver is `#requires -version 5.1`).
+
+## Build
+
+The `build/` tree already exists here. Configure (only needed on a clean clone,
+or after editing a `CMakeLists.txt`):
+
+```powershell
+cmake --preset msvc
+```
+
+Build the targets you need (each line verified, exit 0):
+
+```powershell
+cmake --build build --target OloEditor       --config Debug --parallel
+cmake --build build --target OloServer        --config Debug --parallel
+cmake --build build --target OloEngine-Tests  --config Debug --parallel
+```
+
+- OloEditor links to `bin\Debug\OloEditor\OloEditor.exe` (note: `bin\`, not `build\`).
+- A first full editor build is long; here only the editor + networking objects were stale, so it linked in a few minutes off the 899 prebuilt engine objects.
+
+## Run the editor (agent path)
+
+One shot — launch, wait out the 42-shader warmup, screenshot, kill:
+
+```powershell
+pwsh -NoProfile -File .claude\skills\run-oloengine\driver.ps1 -Action capture
+```
+
+The PNG lands at `.claude\skills\run-oloengine\shots\OloEditor-Debug.png` and the
+driver prints its size + a luminance mean/spread (a near-zero `StdLum` warns that
+the frame is blank — see Gotchas). **Open the PNG and look at it** — a good
+capture shows the menu bar, Scene Hierarchy (left), the 3D Viewport, and the
+docked Console/Content Browser.
+
+The driver also **snapshots `OloEngine.log` next to the PNG** (`OloEditor-Debug.png`
+→ `OloEditor-Debug.log`) on every `capture`/`shot`, because the editor truncates
+that file on the *next* launch. If the editor crashes during init (no window
+appears), the driver prints the last 30 log lines inline and points you at the
+snapshot — read it for shader compile/link errors.
+
+Interactive — leave it running and shoot it repeatedly (e.g. after poking the UI):
+
+```powershell
+pwsh -NoProfile -File .claude\skills\run-oloengine\driver.ps1 -Action launch   # detached; stores the PID
+pwsh -NoProfile -File .claude\skills\run-oloengine\driver.ps1 -Action shot -Out .claude\skills\run-oloengine\shots\after.png
+pwsh -NoProfile -File .claude\skills\run-oloengine\driver.ps1 -Action stop
+```
+
+Driver options:
+
+| flag | meaning |
+|---|---|
+| `-Action capture\|launch\|shot\|stop` | one-shot capture (default), or detached launch / shoot / kill |
+| `-Target OloEditor\|OloRuntime` | which GUI binary (default `OloEditor`) |
+| `-Config Debug\|Release\|Dist` | build config to launch (default `Debug`) |
+| `-SettleSeconds <n>` | render-settle before capture (default 30 — covers the shader warmup) |
+| `-WaitSeconds <n>` | max wait for the window to appear (default 60) |
+| `-Method print\|screen` | `print` (default) = `PrintWindow`, captures the window even when occluded. `screen` = desktop BitBlt at the window rect, **only** correct if OloEditor is the top-most window |
+| `-Out <path>` | output PNG (default `shots\<Target>-<Config>.png`) |
+| `-KeepOpen` | with `capture`: leave the app running after the shot |
+
+## Run the server (headless)
+
+No window — it binds a UDP port and reads stdin console commands. Run from the
+`OloEditor\` working directory (assets resolve relative to it):
+
+```powershell
+$p = Start-Process bin\Debug\OloServer\OloServer.exe -WorkingDirectory OloEditor `
+       -RedirectStandardOutput "$env:TEMP\oloserver.log" -PassThru
+Start-Sleep 5; Stop-Process -Id $p.Id -Force
+Select-String "Listening on port" "$env:TEMP\oloserver.log"
+```
+
+Expected: `[Server] Listening on port 7777` (defaults: port 7777, 64 players,
+60 Hz). Override with CLI args parsed by `ServerConfigSerializer::ParseCommandLine`.
+
+## Test
+
+The test binary runs from the **repo root** (not `OloEditor\`):
+
+```powershell
+build\OloEngine\tests\Debug\OloEngine-Tests.exe --gtest_filter=FastRandomTest.*:ContainerSmoke.*
+```
+
+→ `[ PASSED ] 13 tests.` Drop the filter to run the whole suite. List suites with
+`--gtest_list_tests`. Note: a guessed filter that matches nothing exits 0 with a
+`did not match any test` warning — confirm tests actually ran.
+
+## Run the editor (human path)
+
+```powershell
+# from a normal terminal; a 1280x720 window opens, Ctrl-C or close it to quit
+cd OloEditor; ..\bin\Debug\OloEditor\OloEditor.exe
+```
+
+Useless from a non-interactive/disconnected session (no visible window to see).
+
+## Gotchas
+
+- **`SetForegroundWindow` from a background process is silently blocked by Windows.** So `-Method screen` (desktop BitBlt at the window rect) captures whatever is actually on top — in testing it grabbed the VS Code window sitting over OloEditor, not OloEditor. The driver defaults to `-Method print` (`PrintWindow` with `PW_RENDERFULLCONTENT`), which copies the window's *own* surface regardless of z-order/occlusion. Only use `-Method screen` if you've confirmed the "correct" OloEditor is the visible top-most window.
+- **The editor shows a warmup splash for loading shaders for ~10–25 s before the real dockspace UI renders.** Capturing too early gets the splash, not the editor. Default `-SettleSeconds 30` clears it. First launch is slowest (SPIR-V cross-compile + GL link of 42 PBR variants); later launches hit the mesh/shader cache and are faster.
+- **`-Action launch` must detach the process** (the driver uses `UseShellExecute=$true` for it). An earlier version started the editor as a console child of the launching `pwsh`; when that `pwsh` exited, the editor died with it ("Renderer Memory Tracker shutdown" right after launch) and the follow-up `shot` found no window. `capture` is immune because one `pwsh` owns the whole launch→shot→kill sequence.
+- **Working directory must be `OloEditor\`.** Editor, runtime, and server resolve shaders, assets, and Mono assemblies relative to it. The driver sets this for you; the raw exe will fail to find shaders if run from elsewhere.
+- **The editor and server both write `OloEngine.log` to the cwd (`OloEditor\OloEngine.log`), truncating on open** — a server run clobbers the editor's log and vice-versa, and the *next* editor launch wipes the previous run's log. That's why the driver snapshots it to `shots\<name>.log` per run; for the server, use `-RedirectStandardOutput` instead of relying on the shared file.
+- **Captured PNG size varies** (1924×1127 vs 3840×2088 here) because the window opens at whatever size `OloEditor\imgui.ini` last saved — sometimes 1280×720, sometimes maximized to the desktop.
+- **Editing any `CMakeLists.txt` forces a full CMake reconfigure on the next build** (~45–50 s, and FetchContent re-checks several vendored repos). Expected, not an error.
+
+## Troubleshooting
+
+- **`Could not find OloEditor.exe`**: it isn't built. Run the `cmake --build ... --target OloEditor` line above. The driver also searches `bin\` and `build\` for the freshest matching exe as a fallback.
+- **Capture is black / `StdLum` < 3 (driver warns)**: the session is non-interactive or RDP-disconnected, so the DWM never composited the window. Run from an interactive desktop session; `PrintWindow` needs the window to have been drawn at least once.
+- **`Process exited early ... before a window appeared`**: the editor crashed during init. The driver prints the last 30 log lines inline; read the full `shots\<name>.log` snapshot for shader compile/link errors or a missing asset.
+- **Server exits a few seconds after `Listening on port 7777` when launched non-interactively**: its console reads stdin EOF and shuts down. Fine for a smoke check; for a real session launch it in an interactive terminal.

--- a/.claude/skills/run-oloengine/driver.ps1
+++ b/.claude/skills/run-oloengine/driver.ps1
@@ -1,0 +1,295 @@
+#requires -version 5.1
+<#
+.SYNOPSIS
+  Launch and screenshot an OloEngine GUI binary (OloEditor / OloRuntime) on Windows.
+
+  This is the agent-facing harness for the run-oloengine skill. OloEditor is a
+  native GLFW + OpenGL 4.6 + ImGui desktop app, so there is no DOM and no
+  Playwright/chromium handle. Instead we drive it through the Win32 window
+  manager: launch the process with the correct working directory, wait for its
+  top-level window to appear, bring it to the foreground, and capture the
+  DWM-composited pixels with GDI BitBlt (PrintWindow as a fallback).
+
+.EXAMPLE
+  # One-shot: build must already exist. Launch, wait, screenshot, kill.
+  pwsh -File driver.ps1 -Action capture
+
+.EXAMPLE
+  # Leave it running for interactive poking, then shoot / stop by stored PID.
+  pwsh -File driver.ps1 -Action launch
+  pwsh -File driver.ps1 -Action shot -Out shots/again.png
+  pwsh -File driver.ps1 -Action stop
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('capture', 'launch', 'shot', 'stop')]
+    [string]$Action = 'capture',
+
+    [ValidateSet('OloEditor', 'OloRuntime')]
+    [string]$Target = 'OloEditor',
+
+    [ValidateSet('Debug', 'Release', 'Dist')]
+    [string]$Config = 'Debug',
+
+    [string]$Exe,                       # explicit exe path; overrides the templated lookup
+    [string]$Out,                       # output PNG path (default: shots/<Target>-<Config>.png)
+    [int]$WaitSeconds = 60,             # max wait for the window to appear (GL init can be slow)
+    [int]$SettleSeconds = 30,           # render-settle delay; the editor warms up 42 PBR shaders first
+    [int]$ProcId = 0,                   # for shot/stop against an already-running process
+    [switch]$KeepOpen,                  # capture: leave the app running afterwards
+    # 'print' (default) uses PrintWindow -> captures THIS window's own surface even
+    # when occluded/not focused. 'screen' BitBlts the desktop at the window rect and
+    # only works if OloEditor is genuinely the top-most visible window (it usually is
+    # NOT, because a background process cannot steal foreground on Windows).
+    [ValidateSet('print', 'screen')]
+    [string]$Method = 'print'
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Drawing
+
+# --- Win32 plumbing -------------------------------------------------------
+if (-not ('WinShot' -as [type])) {
+    Add-Type @'
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+public static class WinShot {
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int n);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr hdc, uint flags);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr l);
+    [DllImport("dwmapi.dll")] public static extern int DwmGetWindowAttribute(IntPtr h, int attr, out RECT r, int size);
+
+    public delegate bool EnumProc(IntPtr h, IntPtr l);
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
+
+    // Largest visible top-level window owned by the given process id (0 = none).
+    public static IntPtr MainWindowForPid(uint target) {
+        IntPtr best = IntPtr.Zero; long bestArea = 0;
+        EnumWindows((h, l) => {
+            uint pid; GetWindowThreadProcessId(h, out pid);
+            if (pid == target && IsWindowVisible(h)) {
+                RECT r; GetWindowRect(h, out r);
+                long area = (long)(r.Right - r.Left) * (r.Bottom - r.Top);
+                if ((r.Right - r.Left) > 200 && (r.Bottom - r.Top) > 200 && area > bestArea) {
+                    bestArea = area; best = h;
+                }
+            }
+            return true;
+        }, IntPtr.Zero);
+        return best;
+    }
+}
+'@
+}
+
+$DWMWA_EXTENDED_FRAME_BOUNDS = 9
+$SW_RESTORE = 9
+$rectSize = [System.Runtime.InteropServices.Marshal]::SizeOf([type]'WinShot+RECT')
+
+function Resolve-RepoRoot {
+    (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+}
+
+function Resolve-Exe {
+    param($repo)
+    if ($Exe) { return $Exe }
+    $templated = Join-Path $repo "bin\$Config\$Target\$Target.exe"
+    if (Test-Path $templated) { return $templated }
+    # Fallback: search both output trees for the freshest matching exe.
+    $hit = Get-ChildItem -Recurse -Path (Join-Path $repo 'bin'), (Join-Path $repo 'build') `
+        -Filter "$Target.exe" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($hit) { return $hit.FullName }
+    throw "Could not find $Target.exe. Build it first: cmake --build build --target $Target --config $Config --parallel  (looked for $templated)"
+}
+
+function Get-WindowRectFor {
+    param($hwnd)
+    $r = New-Object WinShot+RECT
+    $hr = [WinShot]::DwmGetWindowAttribute($hwnd, $DWMWA_EXTENDED_FRAME_BOUNDS, [ref]$r, $rectSize)
+    if ($hr -ne 0) { [WinShot]::GetWindowRect($hwnd, [ref]$r) | Out-Null }
+    return $r
+}
+
+function Save-Shot {
+    param($hwnd, $path)
+    [WinShot]::ShowWindow($hwnd, $SW_RESTORE) | Out-Null
+    [WinShot]::SetForegroundWindow($hwnd) | Out-Null
+    Start-Sleep -Seconds $SettleSeconds
+
+    $r = Get-WindowRectFor $hwnd
+    $w = $r.Right - $r.Left; $h = $r.Bottom - $r.Top
+    if ($w -le 0 -or $h -le 0) { throw "Window has zero size ($w x $h)" }
+
+    $bmp = New-Object System.Drawing.Bitmap $w, $h
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    if ($Method -eq 'print') {
+        $hdc = $g.GetHdc()
+        [WinShot]::PrintWindow($hwnd, $hdc, 2) | Out-Null   # PW_RENDERFULLCONTENT
+        $g.ReleaseHdc($hdc)
+    }
+    else {
+        $g.CopyFromScreen($r.Left, $r.Top, 0, 0, (New-Object System.Drawing.Size($w, $h)))
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path $path) | Out-Null
+    $bmp.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
+
+    # Cheap blank-frame check: sample a 16x16 grid, report mean + spread so the
+    # caller knows whether the capture actually has content (a black/uniform
+    # frame usually means the session is non-interactive or the window is hidden).
+    $sum = 0.0; $sumSq = 0.0; $n = 0
+    for ($yy = 0; $yy -lt 16; $yy++) {
+        for ($xx = 0; $xx -lt 16; $xx++) {
+            $px = $bmp.GetPixel([int]($xx * ($w - 1) / 15), [int]($yy * ($h - 1) / 15))
+            $lum = ($px.R + $px.G + $px.B) / 3.0
+            $sum += $lum; $sumSq += $lum * $lum; $n++
+        }
+    }
+    $g.Dispose(); $bmp.Dispose()
+    $mean = $sum / $n
+    $std = [math]::Sqrt([math]::Max(0, ($sumSq / $n) - ($mean * $mean)))
+    [pscustomobject]@{ Path = $path; Width = $w; Height = $h; MeanLum = [math]::Round($mean, 1); StdLum = [math]::Round($std, 1) }
+}
+
+function Start-Editor {
+    param($exePath, $workDir, [bool]$detached)
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $exePath
+    $psi.WorkingDirectory = $workDir
+    # detached (launch): ShellExecute starts it in its own console so it
+    # survives this script exiting. inline (capture): inherit the console so
+    # the editor's log streams here, and we kill it ourselves before exiting.
+    $psi.UseShellExecute = $detached
+    return [System.Diagnostics.Process]::Start($psi)
+}
+
+function Wait-Window {
+    param($proc, $timeoutSec)
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if ($proc.HasExited) {
+            throw "Process exited early (exit code $($proc.ExitCode)) before a window appeared. Check OloEditor/OloEngine.log."
+        }
+        $proc.Refresh()
+        $h = $proc.MainWindowHandle
+        if ($h -ne [IntPtr]::Zero) { return $h }
+        $h = [WinShot]::MainWindowForPid([uint32]$proc.Id)
+        if ($h -ne [IntPtr]::Zero) { return $h }
+        Start-Sleep -Milliseconds 500
+    }
+    throw "Window for $Target did not appear within $timeoutSec s"
+}
+
+# Read OloEngine.log even while the editor still holds it open (shared read).
+# The editor truncates this file on every launch, so we snapshot it per run.
+function Read-EngineLog {
+    param($workDir)
+    $src = Join-Path $workDir 'OloEngine.log'
+    if (-not (Test-Path $src)) { return $null }
+    try {
+        $fs = [System.IO.File]::Open($src, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        $sr = New-Object System.IO.StreamReader($fs)
+        $text = $sr.ReadToEnd()
+        $sr.Close(); $fs.Close()
+        return $text
+    }
+    catch { return $null }
+}
+
+# Snapshot OloEngine.log next to the screenshot (foo.png -> foo.log). Returns the path.
+function Save-Log {
+    param($workDir, $pngPath)
+    $text = Read-EngineLog $workDir
+    if ($null -eq $text) { return $null }
+    $dest = [System.IO.Path]::ChangeExtension($pngPath, '.log')
+    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+    Set-Content -Path $dest -Value $text -NoNewline
+    return $dest
+}
+
+function Write-LogTail {
+    param($workDir, $n = 30)
+    $text = Read-EngineLog $workDir
+    if ($null -eq $text) { Write-Output "(no OloEngine.log found in $workDir)"; return }
+    Write-Output "---- last $n lines of $workDir\OloEngine.log ----"
+    ($text -split "`r?`n") | Select-Object -Last $n | Write-Output
+}
+
+# --- main -----------------------------------------------------------------
+$repo = Resolve-RepoRoot
+$workDir = Join-Path $repo 'OloEditor'          # editor & runtime resolve assets relative to here
+$skillDir = $PSScriptRoot
+$pidFile = Join-Path $skillDir 'shots\.pid'
+if (-not $Out) { $Out = Join-Path $skillDir "shots\$Target-$Config.png" }
+
+switch ($Action) {
+    'launch' {
+        $exePath = Resolve-Exe $repo
+        $proc = Start-Editor $exePath $workDir $true   # detached: survives this script
+        $hwnd = Wait-Window $proc $WaitSeconds
+        New-Item -ItemType Directory -Force -Path (Split-Path $pidFile) | Out-Null
+        Set-Content -Path $pidFile -Value $proc.Id
+        Write-Output "LAUNCHED $Target pid=$($proc.Id) hwnd=$hwnd (left running; use -Action shot / stop)"
+    }
+    'capture' {
+        $exePath = Resolve-Exe $repo
+        Write-Output "Launching $exePath (cwd=$workDir)"
+        $proc = Start-Editor $exePath $workDir $false  # inline: log streams here, we kill it
+        try {
+            $hwnd = Wait-Window $proc $WaitSeconds
+            $info = Save-Shot $hwnd $Out
+            $info | Format-List | Out-String | Write-Output
+            if ($info.StdLum -lt 3) {
+                Write-Warning "Capture looks nearly uniform (StdLum=$($info.StdLum)). The session may be non-interactive/RDP-disconnected, or the window is occluded. Try -Method print."
+            }
+        }
+        catch {
+            Write-Warning "Capture failed: $($_.Exception.Message)"
+            Write-LogTail $workDir 30
+            throw
+        }
+        finally {
+            if (-not $KeepOpen) {
+                if (-not $proc.HasExited) { $proc.Kill(); $proc.WaitForExit(3000) | Out-Null }
+                $log = Save-Log $workDir $Out
+                if ($log) { Write-Output "Log snapshot: $log" }
+                Write-Output "Stopped $Target (pid=$($proc.Id))"
+            }
+            else {
+                New-Item -ItemType Directory -Force -Path (Split-Path $pidFile) | Out-Null
+                Set-Content -Path $pidFile -Value $proc.Id
+                $log = Save-Log $workDir $Out
+                if ($log) { Write-Output "Log snapshot (live): $log" }
+                Write-Output "Left $Target running (pid=$($proc.Id))"
+            }
+        }
+    }
+    'shot' {
+        if (-not $ProcId) {
+            if (Test-Path $pidFile) { $ProcId = [int](Get-Content $pidFile | Select-Object -First 1) }
+            else { throw "No -ProcId given and no $pidFile. Launch with -Action launch first." }
+        }
+        $hwnd = [WinShot]::MainWindowForPid([uint32]$ProcId)
+        if ($hwnd -eq [IntPtr]::Zero) { throw "No visible window for pid $ProcId" }
+        $info = Save-Shot $hwnd $Out
+        $info | Format-List | Out-String | Write-Output
+        $log = Save-Log $workDir $Out
+        if ($log) { Write-Output "Log snapshot (live): $log" }
+    }
+    'stop' {
+        if (-not $ProcId) {
+            if (Test-Path $pidFile) { $ProcId = [int](Get-Content $pidFile | Select-Object -First 1) }
+            else { throw "No -ProcId given and no $pidFile." }
+        }
+        Stop-Process -Id $ProcId -Force -ErrorAction SilentlyContinue
+        Remove-Item $pidFile -ErrorAction SilentlyContinue
+        Write-Output "Stopped pid $ProcId"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -81,9 +81,13 @@ build-*/
 OloEditor/cmake_test_discovery_*.json
 
 # Per-user Claude Code state (project-local instructions, skills, agents)
-# Ignore the entire .claude/ tree except .claude/settings.json, which is the
-# shared project hooks/permissions config and IS version-controlled.
+# Ignore the entire .claude/ tree except .claude/settings.json (shared project
+# hooks/permissions config) and .claude/skills/ (shared, version-controlled
+# project skills — e.g. run-oloengine). Each skill's own .gitignore handles
+# its generated artifacts (screenshots/logs).
 .claude/*
 !.claude/settings.json
+!.claude/skills/
+.claude/skills/**/shots/
 skills-lock.json
 docs/agents/


### PR DESCRIPTION
A Claude Code skill that builds, launches, and drives the OloEngine binaries from a clean machine.

- driver.ps1: Win32 window-capture harness for the native GLFW/OpenGL OloEditor (no DOM / Playwright handle). Launches with cwd=OloEditor/, waits for the top-level window, and captures its surface via PrintWindow (z-order independent, unlike a desktop BitBlt that a background process can't bring to the foreground). Actions: capture (one-shot), launch/shot/stop (interactive). Snapshots OloEngine.log next to each screenshot since the editor truncates it on the next launch.
- SKILL.md: verified build/run/test/server commands, plus the gotchas hit while bringing it up (foreground-steal block, shader-warmup splash, console-child process lifetime, shared-log truncation).
- .gitignore: track .claude/skills/ as shared project skills, but keep each skill's generated shots/ (screenshots + log snapshots) out.