### PR TITLE
feat(editor): thread inspector panel backed by FThreadManager (#282)

### DIFF
--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -54,6 +54,8 @@
 		"Panels/StreamingPanel.h"
 		"Panels/NetworkDebugPanel.cpp"
 		"Panels/NetworkDebugPanel.h"
+		"Panels/ThreadInspectorPanel.cpp"
+		"Panels/ThreadInspectorPanel.h"
 		"Panels/SaveGamePanel.cpp"
 		"Panels/SaveGamePanel.h"
 		"Panels/LocalizationPanel.cpp"

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -784,6 +784,7 @@ namespace OloEngine
             ImGui::MenuItem("Scene Streaming", nullptr, &m_ShowStreamingPanel);
             ImGui::MenuItem("Input Settings", nullptr, &m_ShowInputSettings);
             ImGui::MenuItem("Network Debug", nullptr, &m_ShowNetworkDebug);
+            ImGui::MenuItem("Thread Inspector", nullptr, &m_ShowThreadInspector);
             ImGui::MenuItem("Dialogue Editor", nullptr, &m_ShowDialogueEditor);
             ImGui::MenuItem("Cinematic Timeline", nullptr, &m_ShowCinematicTimeline);
             ImGui::MenuItem("NavMesh Panel", nullptr, &m_ShowNavMeshPanel);
@@ -1291,6 +1292,12 @@ namespace OloEngine
         if (m_ShowNetworkDebug)
         {
             m_NetworkDebugPanel.OnImGuiRender(&m_ShowNetworkDebug);
+        }
+
+        // Thread Inspector Panel
+        if (m_ShowThreadInspector)
+        {
+            m_ThreadInspectorPanel.OnImGuiRender(&m_ShowThreadInspector);
         }
 
         // Dialogue Editor Panel

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -11,6 +11,7 @@
 #include "Panels/StreamingPanel.h"
 #include "Panels/InputSettingsPanel.h"
 #include "Panels/NetworkDebugPanel.h"
+#include "Panels/ThreadInspectorPanel.h"
 #include "Panels/ConsolePanel.h"
 #include "Panels/DialogueEditorPanel.h"
 #include "Panels/CinematicTimelinePanel.h"
@@ -216,6 +217,7 @@ namespace OloEngine
         StreamingPanel m_StreamingPanel;
         InputSettingsPanel m_InputSettingsPanel;
         NetworkDebugPanel m_NetworkDebugPanel;
+        ThreadInspectorPanel m_ThreadInspectorPanel;
         ConsolePanel m_ConsolePanel;
         StatisticsPanel m_StatisticsPanel;
         DialogueEditorPanel m_DialogueEditorPanel;
@@ -235,6 +237,7 @@ namespace OloEngine
         bool m_ShowStreamingPanel = false;
         bool m_ShowInputSettings = false;
         bool m_ShowNetworkDebug = false;
+        bool m_ShowThreadInspector = false;
         bool m_ShowDialogueEditor = false;
         NavMeshPanel m_NavMeshPanel;
         bool m_ShowNavMeshPanel = false;

--- a/OloEditor/src/Panels/ThreadInspectorPanel.cpp
+++ b/OloEditor/src/Panels/ThreadInspectorPanel.cpp
@@ -1,0 +1,342 @@
+#include "ThreadInspectorPanel.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/PlatformTLS.h"
+#include "OloEngine/Debug/Profiler.h"
+#include "OloEngine/HAL/PlatformProcess.h"
+#include "OloEngine/HAL/RunnableThread.h"
+#include "OloEngine/HAL/ThreadManager.h"
+#include "OloEngine/Task/NamedThreads.h"
+#include "OloEngine/Task/Scheduler.h"
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace OloEngine
+{
+    namespace
+    {
+        // Both OloEngine::EThreadPriority and OloEngine::LowLevelTasks::EThreadPriority
+        // declare the same enumerators in the same order, so a single mapper keyed on
+        // the underlying value serves both.
+        const char* PriorityName(i32 value)
+        {
+            switch (value)
+            {
+                case 0:
+                    return "Normal";
+                case 1:
+                    return "Above Normal";
+                case 2:
+                    return "Below Normal";
+                case 3:
+                    return "Highest";
+                case 4:
+                    return "Lowest";
+                case 5:
+                    return "Slightly Below";
+                case 6:
+                    return "Time Critical";
+                default:
+                    return "?";
+            }
+        }
+
+        const char* ThreadTypeName(FRunnableThread::ThreadType type)
+        {
+            switch (type)
+            {
+                case FRunnableThread::ThreadType::Real:
+                    return "Real";
+                case FRunnableThread::ThreadType::Fake:
+                    return "Fake";
+                case FRunnableThread::ThreadType::Forkable:
+                    return "Forkable";
+                default:
+                    return "?";
+            }
+        }
+
+        // Classify a thread into a human-friendly role from its registered name. The
+        // names are stable: the scheduler names its workers "Foreground Worker #N" /
+        // "Background Worker #N", the dedicated threads are "OloEngine::AudioThread"
+        // and "OloEngine::NetworkThread", Async() uses "TAsync N", and editor build
+        // threads carry "Build"/"AssetPack" in their name.
+        const char* ClassifyKind(std::string_view name)
+        {
+            if (name.starts_with("Foreground Worker"))
+            {
+                return "Worker (FG)";
+            }
+            if (name.starts_with("Background Worker"))
+            {
+                return "Worker (BG)";
+            }
+            if (name.find("AudioThread") != std::string_view::npos)
+            {
+                return "Audio";
+            }
+            if (name.find("NetworkThread") != std::string_view::npos)
+            {
+                return "Network";
+            }
+            if (name.starts_with("TAsync"))
+            {
+                return "Async";
+            }
+            if (name.find("Build") != std::string_view::npos || name.find("AssetPack") != std::string_view::npos)
+            {
+                return "Build";
+            }
+            return "Other";
+        }
+
+        struct ThreadRow
+        {
+            std::string Name;
+            const char* Kind = "Other";
+            u32 ThreadId = 0;
+            i32 Priority = -1; // -1 => unknown (synthetic game-thread row)
+            FRunnableThread::ThreadType Type = FRunnableThread::ThreadType::Real;
+            bool IsRunning = true;
+            bool IsGameThread = false;
+        };
+    } // namespace
+
+    void ThreadInspectorPanel::OnImGuiRender(bool* p_open)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        ImGui::SetNextWindowSize(ImVec2(540.0f, 640.0f), ImGuiCond_FirstUseEver);
+        if (!ImGui::Begin("Thread Inspector", p_open))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // --- Snapshot the live thread registry under its lock ----------------
+        std::vector<ThreadRow> rows;
+
+        // The game/main thread is not created via FRunnableThread, so it never
+        // registers. This panel renders on the game thread, so the current thread
+        // id IS the game thread id — synthesise the row directly.
+        {
+            ThreadRow game;
+            game.Name = "GameThread (Main)";
+            game.Kind = "Game";
+            game.ThreadId = FPlatformTLS::GetCurrentThreadId();
+            game.Priority = -1;
+            game.IsRunning = true;
+            game.IsGameThread = true;
+            rows.push_back(std::move(game));
+        }
+
+        // Cross-reference registry thread ids against the named-thread manager so named
+        // threads (audio/network/…) are labelled by role precisely instead of by name
+        // string. Both systems key by FPlatformTLS::GetCurrentThreadId().
+        struct NamedRole
+        {
+            const char* Label;
+            Tasks::ENamedThread Thread;
+            u32 Id;
+        };
+        NamedRole namedRoles[] = {
+            { "Game", Tasks::ENamedThread::GameThread, 0 },
+            { "Render", Tasks::ENamedThread::RenderThread, 0 },
+            { "Audio", Tasks::ENamedThread::AudioThread, 0 },
+            { "Network", Tasks::ENamedThread::NetworkThread, 0 },
+        };
+        {
+            auto& manager = Tasks::FNamedThreadManager::Get();
+            for (NamedRole& role : namedRoles)
+            {
+                role.Id = manager.GetThreadId(role.Thread);
+            }
+        }
+        const auto roleForId = [&namedRoles](u32 id) -> const char*
+        {
+            if (id != 0)
+            {
+                for (const NamedRole& role : namedRoles)
+                {
+                    if (role.Id == id)
+                    {
+                        return role.Label;
+                    }
+                }
+            }
+            return nullptr;
+        };
+
+        FThreadManager::Get().ForEachThread(
+            [&rows, &roleForId](u32 threadId, FRunnableThread* thread)
+            {
+                if (thread == nullptr)
+                {
+                    return;
+                }
+                ThreadRow row;
+                row.Name = thread->GetThreadName();
+                // Prefer the precise named-thread role; fall back to name-based heuristics
+                // for workers / async / build threads that aren't named threads.
+                const char* role = roleForId(threadId);
+                row.Kind = role ? role : ClassifyKind(row.Name);
+                row.ThreadId = threadId;
+                row.Priority = static_cast<i32>(thread->GetThreadPriority());
+                row.Type = thread->GetThreadType();
+                row.IsRunning = thread->IsRunning();
+                rows.push_back(std::move(row));
+            });
+
+        // Game thread first, then grouped by kind, then by name — stable display.
+        std::stable_sort(rows.begin(), rows.end(),
+                         [](const ThreadRow& a, const ThreadRow& b)
+                         {
+                             if (a.IsGameThread != b.IsGameThread)
+                             {
+                                 return a.IsGameThread;
+                             }
+                             if (const int kindCmp = std::strcmp(a.Kind, b.Kind); kindCmp != 0)
+                             {
+                                 return kindCmp < 0;
+                             }
+                             return a.Name < b.Name;
+                         });
+
+        const sizet runningCount = static_cast<sizet>(
+            std::count_if(rows.begin(), rows.end(), [](const ThreadRow& r) { return r.IsRunning; }));
+
+        // --- Summary ---------------------------------------------------------
+        auto& scheduler = LowLevelTasks::FScheduler::Get();
+        ImGui::Text("Live threads: %zu  (%zu running)", rows.size(), runningCount);
+        ImGui::Text("Hardware concurrency: %u logical cores", std::thread::hardware_concurrency());
+        ImGui::Text("Task scheduler: %u / %u workers active  (FG: %s, BG: %s)",
+                    scheduler.GetNumWorkers(), scheduler.GetMaxNumWorkers(),
+                    PriorityName(static_cast<i32>(scheduler.GetWorkerPriority())),
+                    PriorityName(static_cast<i32>(scheduler.GetBackgroundPriority())));
+
+        ImGui::Separator();
+        ImGui::Checkbox("Only running", &m_OnlyRunning);
+
+        // --- Live threads table ----------------------------------------------
+        constexpr ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                               ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY;
+        // Bound the table height so it scrolls past ~12 rows instead of growing the
+        // window unbounded — that keeps the named-thread section below reachable and
+        // stops the window from overflowing (and popping out as its own OS viewport).
+        const float tableHeight = ImGui::GetTextLineHeightWithSpacing() * 12.0f;
+        if (ImGui::BeginTable("ThreadsTable", 6, tableFlags, ImVec2(0.0f, tableHeight)))
+        {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Thread ID", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("Kind", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("Priority", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableHeadersRow();
+
+            for (const ThreadRow& row : rows)
+            {
+                if (m_OnlyRunning && !row.IsRunning)
+                {
+                    continue;
+                }
+
+                ImGui::TableNextRow();
+
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(row.Name.c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%u", row.ThreadId);
+
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(row.Kind);
+
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(row.IsGameThread ? "Real" : ThreadTypeName(row.Type));
+
+                ImGui::TableNextColumn();
+                if (row.Priority < 0)
+                {
+                    ImGui::TextDisabled("--");
+                }
+                else
+                {
+                    ImGui::TextUnformatted(PriorityName(row.Priority));
+                }
+
+                ImGui::TableNextColumn();
+                if (row.IsRunning)
+                {
+                    ImGui::TextColored(ImVec4(0.4f, 0.85f, 0.4f, 1.0f), "Running");
+                }
+                else
+                {
+                    ImGui::TextColored(ImVec4(0.85f, 0.5f, 0.3f, 1.0f), "Stopped");
+                }
+            }
+
+            ImGui::EndTable();
+        }
+
+        // --- Named-thread queue backlog --------------------------------------
+        if (ImGui::CollapsingHeader("Named Thread Queues"))
+        {
+            ImGui::TextDisabled("Logical threads with task queues; Thread ID is the live attached OS thread.");
+
+            if (ImGui::BeginTable("NamedThreadQueues", 3,
+                                  ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+            {
+                ImGui::TableSetupColumn("Named Thread");
+                ImGui::TableSetupColumn("Thread ID");
+                ImGui::TableSetupColumn("Pending Tasks");
+                ImGui::TableHeadersRow();
+
+                auto& manager = Tasks::FNamedThreadManager::Get();
+                for (const NamedRole& role : namedRoles)
+                {
+                    const bool attached = role.Id != 0;
+
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    ImGui::TextUnformatted(role.Label);
+
+                    ImGui::TableNextColumn();
+                    if (attached)
+                    {
+                        ImGui::Text("%u", role.Id);
+                    }
+                    else
+                    {
+                        ImGui::TextDisabled("not attached");
+                    }
+
+                    ImGui::TableNextColumn();
+                    if (!attached)
+                    {
+                        ImGui::TextDisabled("--");
+                    }
+                    else if (manager.GetQueue(role.Thread).HasPendingTasks(true))
+                    {
+                        ImGui::TextColored(ImVec4(0.9f, 0.8f, 0.3f, 1.0f), "yes");
+                    }
+                    else
+                    {
+                        ImGui::TextDisabled("idle");
+                    }
+                }
+                ImGui::EndTable();
+            }
+        }
+
+        ImGui::End();
+    }
+} // namespace OloEngine

--- a/OloEditor/src/Panels/ThreadInspectorPanel.cpp
+++ b/OloEditor/src/Panels/ThreadInspectorPanel.cpp
@@ -210,7 +210,8 @@ namespace OloEngine
                          });
 
         const sizet runningCount = static_cast<sizet>(
-            std::count_if(rows.begin(), rows.end(), [](const ThreadRow& r) { return r.IsRunning; }));
+            std::count_if(rows.begin(), rows.end(), [](const ThreadRow& r)
+                          { return r.IsRunning; }));
 
         // --- Summary ---------------------------------------------------------
         auto& scheduler = LowLevelTasks::FScheduler::Get();

--- a/OloEditor/src/Panels/ThreadInspectorPanel.h
+++ b/OloEditor/src/Panels/ThreadInspectorPanel.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace OloEngine
+{
+    // Editor debug panel that enumerates the engine's live OS threads.
+    //
+    // Backed by FThreadManager (HAL/ThreadManager.h): every thread created via
+    // FRunnableThread::Create — scheduler workers, the audio/network threads,
+    // async tasks and editor build threads — registers itself there. The game
+    // (main) thread is the only long-lived thread not created that way, so it is
+    // synthesised from the current thread id (this panel renders on the game
+    // thread). Also surfaces a scheduler summary and named-thread queue backlog.
+    class ThreadInspectorPanel
+    {
+      public:
+        ThreadInspectorPanel() = default;
+
+        void OnImGuiRender(bool* p_open = nullptr);
+
+      private:
+        bool m_OnlyRunning = false;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/HAL/RunnableThread.cpp
+++ b/OloEngine/src/OloEngine/HAL/RunnableThread.cpp
@@ -3,6 +3,7 @@
 
 #include "OloEnginePCH.h"
 #include "OloEngine/HAL/RunnableThread.h"
+#include "OloEngine/HAL/ThreadManager.h"
 
 #ifdef OLO_PLATFORM_WINDOWS
 #include "Platform/Windows/WindowsHWrapper.h"
@@ -22,6 +23,12 @@ namespace OloEngine
 
     FRunnableThread::~FRunnableThread()
     {
+        // Deregister from the global registry first, so an enumerator can never
+        // observe a pointer to a partially-destroyed thread. RemoveThread matches
+        // by pointer identity, so it is a safe no-op for threads that were never
+        // added (e.g. a failed Create()).
+        FThreadManager::Get().RemoveThread(this);
+
         // Ensure thread is stopped before destruction
         Kill(true);
 
@@ -47,6 +54,11 @@ namespace OloEngine
         FRunnableThread* NewThread = new FRunnableThread();
         if (NewThread->CreateInternal(InRunnable, ThreadName, InStackSize, InThreadPri, InThreadAffinityMask, InCreateFlags))
         {
+            // Register the live thread in the global registry. CreateInternal only
+            // returns true after the worker has signalled init, so m_ThreadID is
+            // already set to the real OS thread id by this point. The matching
+            // RemoveThread happens in ~FRunnableThread().
+            FThreadManager::Get().AddThread(NewThread->GetThreadID(), NewThread);
             return NewThread;
         }
         delete NewThread;

--- a/OloEngine/src/OloEngine/HAL/ThreadManager.h
+++ b/OloEngine/src/OloEngine/HAL/ThreadManager.h
@@ -14,7 +14,7 @@
  */
 
 #include "OloEngine/Core/Base.h"
-#include "OloEngine/Threading/CriticalSection.h"
+#include "OloEngine/Core/CriticalSection.h"
 
 #include <string>
 #include <unordered_map>
@@ -196,8 +196,15 @@ namespace OloEngine
 
     inline FThreadManager& FThreadManager::Get()
     {
-        static FThreadManager s_Instance;
-        return s_Instance;
+        // Leak-on-purpose singleton. The registry is touched from FRunnableThread's
+        // destructor (RemoveThread), and some FRunnableThread instances are owned by
+        // namespace-scope statics (e.g. AudioEngine's audio thread, NetworkThread's
+        // worker) that are destroyed during static teardown. A Meyers singleton would
+        // be destroyed *before* those statics (it is constructed later, on first
+        // AddThread), so RemoveThread would touch a destroyed object. Intentionally
+        // never destroying the manager removes that teardown-order hazard.
+        static FThreadManager* s_Instance = new FThreadManager();
+        return *s_Instance;
     }
 
     inline void FThreadManager::AddThread(u32 ThreadId, FRunnableThread* Thread)

--- a/OloEngine/src/OloEngine/Task/NamedThreads.cpp
+++ b/OloEngine/src/OloEngine/Task/NamedThreads.cpp
@@ -8,8 +8,21 @@
 
 #include "OloEngine/Task/NamedThreads.h"
 
+#include "OloEngine/Core/PlatformTLS.h"
+
 namespace OloEngine::Tasks
 {
+    // @brief Real OS thread id of the calling thread.
+    //
+    // Kept out-of-line so NamedThreads.h (a hot, widely-included header) doesn't pull
+    // in PlatformTLS.h / Windows.h. The value matches FRunnableThread::GetThreadID()
+    // and FThreadManager's keys, so named-thread registrations can be cross-referenced
+    // with the global thread registry.
+    u32 FNamedThreadManager::GetCurrentThreadIdInternal()
+    {
+        return FPlatformTLS::GetCurrentThreadId();
+    }
+
     // ============================================================================
     // Thread-local storage definitions
     // ============================================================================

--- a/OloEngine/src/OloEngine/Task/NamedThreads.h
+++ b/OloEngine/src/OloEngine/Task/NamedThreads.h
@@ -477,10 +477,11 @@ namespace OloEngine::Tasks
                             "Invalid named thread");
 
             u32 Index = static_cast<u32>(std::to_underlying(Thread));
-            m_ThreadIds[Index].store(OLO::FTaskTagScope::GetCurrentTag() != OLO::ETaskTag::ENone
-                                         ? static_cast<u32>(std::to_underlying(OLO::FTaskTagScope::GetCurrentTag()))
-                                         : GetCurrentThreadIdInternal(),
-                                     std::memory_order_release);
+            // Record the real OS thread id so this registration can be cross-referenced
+            // with FThreadManager / FRunnableThread::GetThreadID(), which key threads by
+            // the same FPlatformTLS::GetCurrentThreadId() value. (This slot used to hold a
+            // task-tag enum or a hashed std::thread::id, which agreed with nothing else.)
+            m_ThreadIds[Index].store(GetCurrentThreadIdInternal(), std::memory_order_release);
 
             s_CurrentNamedThread = Thread;
         }
@@ -511,6 +512,23 @@ namespace OloEngine::Tasks
         bool IsOnNamedThread() const
         {
             return s_CurrentNamedThread != ENamedThread::Invalid;
+        }
+
+        // @brief Get the OS thread id currently attached as the given named thread
+        // @return The real OS thread id (FPlatformTLS::GetCurrentThreadId), or 0 if no
+        //         thread is attached to that role. Comparable with FThreadManager and
+        //         FRunnableThread::GetThreadID(), which use the same id space.
+        u32 GetThreadId(ENamedThread Thread) const
+        {
+            OLO_CORE_ASSERT(Thread != ENamedThread::Invalid && Thread < ENamedThread::Count,
+                            "Invalid named thread");
+            return m_ThreadIds[static_cast<u32>(std::to_underlying(Thread))].load(std::memory_order_acquire);
+        }
+
+        // @brief Whether a live thread is currently attached to the given role
+        bool IsThreadAttached(ENamedThread Thread) const
+        {
+            return GetThreadId(Thread) != 0;
         }
 
         // @brief Enqueue a task to a named thread
@@ -631,10 +649,9 @@ namespace OloEngine::Tasks
         FNamedThreadManager() = default;
         ~FNamedThreadManager() = default;
 
-        static u32 GetCurrentThreadIdInternal()
-        {
-            return static_cast<u32>(std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFFFFF);
-        }
+        // Defined in NamedThreads.cpp to keep the platform TLS header (and Windows.h)
+        // out of this widely-included header. Returns FPlatformTLS::GetCurrentThreadId().
+        static u32 GetCurrentThreadIdInternal();
 
         FNamedThreadQueue m_Queues[static_cast<u32>(std::to_underlying(ENamedThread::Count))];
         std::atomic<u32> m_ThreadIds[static_cast<u32>(std::to_underlying(ENamedThread::Count))] = {};

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(OloEngine-Tests
 		Async/SharedRecursiveMutexTest.cpp
 		Async/ExternalMutexTest.cpp
 		Tasks/TaskSystemTest.cpp
+		HAL/ThreadManagerTest.cpp
 		Containers/ConcurrentQueuesTest.cpp
 		Memory/MemoryViewTest.cpp
 		Templates/FunctionWithContextTest.cpp

--- a/OloEngine/tests/HAL/ThreadManagerTest.cpp
+++ b/OloEngine/tests/HAL/ThreadManagerTest.cpp
@@ -186,8 +186,15 @@ TEST(ThreadManagerTest, NamedThreadIdAgreesWithRegistryId)
     FRunnableThread* thread = FRunnableThread::Create(&runnable, "OloTest::NamedWorker");
     ASSERT_NE(thread, nullptr);
 
+    // Wait for the worker to attach itself, bounded so a stuck thread fails CI fast
+    // instead of hanging forever.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (!runnable.m_Started.load(std::memory_order_acquire))
     {
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            GTEST_FAIL() << "Worker did not reach AttachToThread() / set runnable.m_Started within 5s";
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 

--- a/OloEngine/tests/HAL/ThreadManagerTest.cpp
+++ b/OloEngine/tests/HAL/ThreadManagerTest.cpp
@@ -1,0 +1,205 @@
+/**
+ * @file ThreadManagerTest.cpp
+ * @brief Unit tests for FThreadManager / FRunnableThread registration wiring.
+ *
+ * Verifies that every thread created via FRunnableThread::Create() registers
+ * itself in the global FThreadManager registry on creation and deregisters on
+ * destruction. This is the data source behind the editor's Thread Inspector
+ * panel, so the registration contract is what we pin here.
+ */
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Core/PlatformTLS.h"
+#include "OloEngine/HAL/Runnable.h"
+#include "OloEngine/HAL/RunnableThread.h"
+#include "OloEngine/HAL/ThreadManager.h"
+#include "OloEngine/Task/NamedThreads.h"
+
+#include <atomic>
+#include <chrono>
+#include <string_view>
+#include <thread>
+
+using namespace OloEngine;
+
+namespace
+{
+    // A runnable that parks in Run() until asked to stop, so the worker stays
+    // alive (and registered) while the test inspects the registry. Kill() on the
+    // owning FRunnableThread calls Stop() then joins, which releases the loop.
+    class ParkingRunnable final : public FRunnable
+    {
+      public:
+        u32 Run() override
+        {
+            m_Started.store(true, std::memory_order_release);
+            while (!m_Stop.load(std::memory_order_acquire))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            return 0;
+        }
+
+        void Stop() override
+        {
+            m_Stop.store(true, std::memory_order_release);
+        }
+
+        std::atomic<bool> m_Started{ false };
+        std::atomic<bool> m_Stop{ false };
+    };
+
+    // True iff a thread with the given name is currently in the registry. Only
+    // dereferences pointers for live (registered) threads, so it is safe to call
+    // after a thread has been destroyed.
+    bool RegistryContainsName(std::string_view name)
+    {
+        bool found = false;
+        FThreadManager::Get().ForEachThread(
+            [&](u32, FRunnableThread* thread)
+            {
+                if (thread != nullptr && thread->GetThreadName() == name)
+                {
+                    found = true;
+                }
+            });
+        return found;
+    }
+
+    // Attaches its worker thread to a named-thread role, then parks until stopped
+    // (detaching on the way out). Used to verify the named-thread manager and the
+    // global registry agree on the OS thread id.
+    class NamedAttachRunnable final : public FRunnable
+    {
+      public:
+        explicit NamedAttachRunnable(Tasks::ENamedThread role) : m_Role(role) {}
+
+        u32 Run() override
+        {
+            Tasks::FNamedThreadManager::Get().AttachToThread(m_Role);
+            m_AttachedId.store(FPlatformTLS::GetCurrentThreadId(), std::memory_order_release);
+            m_Started.store(true, std::memory_order_release);
+            while (!m_Stop.load(std::memory_order_acquire))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            Tasks::FNamedThreadManager::Get().DetachFromThread(m_Role);
+            return 0;
+        }
+
+        void Stop() override
+        {
+            m_Stop.store(true, std::memory_order_release);
+        }
+
+        Tasks::ENamedThread m_Role;
+        std::atomic<u32> m_AttachedId{ 0 };
+        std::atomic<bool> m_Started{ false };
+        std::atomic<bool> m_Stop{ false };
+    };
+} // namespace
+
+TEST(ThreadManagerTest, RegistersThreadOnCreateAndDeregistersOnDestroy)
+{
+    auto& manager = FThreadManager::Get();
+
+    constexpr const char* kThreadName = "OloTest::InspectorWorker";
+    ASSERT_FALSE(RegistryContainsName(kThreadName)) << "Stale registration from a prior run";
+
+    const i32 countBefore = manager.NumThreads();
+
+    ParkingRunnable runnable;
+    FRunnableThread* thread = FRunnableThread::Create(&runnable, kThreadName);
+    ASSERT_NE(thread, nullptr);
+
+    // Create() only returns after the worker signalled init, so the registry is
+    // already populated and the OS thread id is assigned.
+    EXPECT_EQ(manager.NumThreads(), countBefore + 1);
+    EXPECT_NE(thread->GetThreadID(), 0u);
+    EXPECT_TRUE(RegistryContainsName(kThreadName));
+
+    // The registry entry must point back at the exact thread object, keyed by id.
+    bool foundByPointer = false;
+    u32 foundId = 0;
+    manager.ForEachThread(
+        [&](u32 id, FRunnableThread* t)
+        {
+            if (t == thread)
+            {
+                foundByPointer = true;
+                foundId = id;
+            }
+        });
+    EXPECT_TRUE(foundByPointer);
+    EXPECT_EQ(foundId, thread->GetThreadID());
+
+    // Name lookup by id resolves through the registry.
+    EXPECT_EQ(FThreadManager::GetThreadName(thread->GetThreadID()), kThreadName);
+
+    const u32 threadId = thread->GetThreadID();
+
+    // Destruction (which stops + joins the worker) must deregister.
+    delete thread;
+
+    EXPECT_EQ(manager.NumThreads(), countBefore);
+    EXPECT_FALSE(RegistryContainsName(kThreadName));
+    // Unknown ids fall back to the sentinel name.
+    EXPECT_EQ(FThreadManager::GetThreadName(threadId), "UnknownThread");
+}
+
+TEST(ThreadManagerTest, TracksMultipleConcurrentThreads)
+{
+    auto& manager = FThreadManager::Get();
+    const i32 countBefore = manager.NumThreads();
+
+    constexpr i32 kCount = 4;
+    ParkingRunnable runnables[kCount];
+    FRunnableThread* threads[kCount] = {};
+
+    for (i32 i = 0; i < kCount; ++i)
+    {
+        threads[i] = FRunnableThread::Create(&runnables[i], "OloTest::MultiWorker");
+        ASSERT_NE(threads[i], nullptr);
+    }
+
+    EXPECT_EQ(manager.NumThreads(), countBefore + kCount);
+
+    for (i32 i = 0; i < kCount; ++i)
+    {
+        delete threads[i];
+    }
+
+    EXPECT_EQ(manager.NumThreads(), countBefore);
+}
+
+// The point of folding the id-consistency fix into #282: the named-thread manager
+// and the global registry must key threads by the same OS thread id, so the editor
+// can label registry rows with their precise named role.
+TEST(ThreadManagerTest, NamedThreadIdAgreesWithRegistryId)
+{
+    auto& named = Tasks::FNamedThreadManager::Get();
+    constexpr Tasks::ENamedThread kRole = Tasks::ENamedThread::NetworkThread;
+    ASSERT_EQ(named.GetThreadId(kRole), 0u) << "Role unexpectedly attached before test";
+
+    NamedAttachRunnable runnable(kRole);
+    FRunnableThread* thread = FRunnableThread::Create(&runnable, "OloTest::NamedWorker");
+    ASSERT_NE(thread, nullptr);
+
+    while (!runnable.m_Started.load(std::memory_order_acquire))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    const u32 osId = runnable.m_AttachedId.load(std::memory_order_acquire);
+    EXPECT_NE(osId, 0u);
+    // All three id sources must agree: the raw OS id captured on the worker, the
+    // FRunnableThread registry entry, and the named-thread manager's record.
+    EXPECT_EQ(thread->GetThreadID(), osId);
+    EXPECT_EQ(named.GetThreadId(kRole), osId);
+    EXPECT_TRUE(named.IsThreadAttached(kRole));
+
+    delete thread; // worker detaches from the role as it exits
+    EXPECT_EQ(named.GetThreadId(kRole), 0u);
+    EXPECT_FALSE(named.IsThreadAttached(kRole));
+}

--- a/OloEngine/tests/scripts/test_catalogue.json
+++ b/OloEngine/tests/scripts/test_catalogue.json
@@ -307,6 +307,7 @@
     "OloEngine/tests/SoundGraphInstantiationTest.cpp": "unit",
     "OloEngine/tests/StateMachineTest.cpp": "unit",
     "OloEngine/tests/Tasks/TaskSystemTest.cpp": "unit",
+    "OloEngine/tests/HAL/ThreadManagerTest.cpp": "unit",
     "OloEngine/tests/Templates/FunctionWithContextTest.cpp": "unit",
     "OloEngine/tests/Templates/TypeTraitsTest.cpp": "unit",
     "OloEngine/tests/TransformComponentTest.cpp": "unit",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1418,6 +1418,12 @@ level of `tests/`). Grouped by directory.
 |---|---:|---|
 | [GameplayAbilityTest.cpp](../OloEngine/tests/Gameplay/GameplayAbilityTest.cpp) | 40 | **GameplayTagTest** &mdash; `ConstructAndQuery`, `EmptyTag`, `ExactMatch`, `PartialMatch`, `PartialMatchNotSubstring`, `HashEquality`<br/>**GameplayTagContainerTest** &mdash; `AddAndQuery`, `NoDuplicates`, `RemoveTag`, `HasAll`, `HasAny`, `PartialQuery`<br/>**AttributeSetTest** &mdash; `DefineAndGet`, `SetBaseValue`, `AdditiveModifier`, `MultiplicativeModifier`, `OverrideModifier`, `StackedModifiers`, `RemoveModifiersBySource`, `GetAttributeNames`<br/>**CooldownManagerTest** &mdash; `StartAndCheck`, `TickReducesCooldown`, `CooldownExpires`, `CooldownFraction`, `ResetCooldown`<br/>**ActiveEffectsContainerTest** &mdash; `InstantEffect`, `DurationEffect`, `PeriodicEffect`, `StackingEffect`, `RequiredTagsBlocked`, `BlockedTagsPrevents`, `RefCountedTags`<br/>**DamageCalculationTest** &mdash; `BasicDamage`, `CriticalHit`, `Resistance`, `MinimumZeroDamage`, `CustomFormula`, `ScopedFormula`<br/>**AbilityComponentTest** &mdash; `InitializeDefaultRPG`, `EqualityOperator` |
 
+#### HAL (1 file)
+
+| File | Tests | Cases |
+|---|---:|---|
+| [ThreadManagerTest.cpp](../OloEngine/tests/HAL/ThreadManagerTest.cpp) | 3 | **ThreadManagerTest** &mdash; `RegistersThreadOnCreateAndDeregistersOnDestroy`, `TracksMultipleConcurrentThreads`, `NamedThreadIdAgreesWithRegistryId` |
+
 #### Lua (1 file)
 
 | File | Tests | Cases |
@@ -1493,7 +1499,7 @@ level of `tests/`). Grouped by directory.
 | [FunctionWithContextTest.cpp](../OloEngine/tests/Templates/FunctionWithContextTest.cpp) | 4 | **FunctionWithContext** &mdash; `DefaultConstructedIsNullAndExposesNullSlots`, `LambdaBoundCallableInvokesCaptureBody`, `ReassignmentReplacesBoundCallable`, `RoundTripsThroughStatelessInvocationAPI` |
 | [TypeTraitsTest.cpp](../OloEngine/tests/Templates/TypeTraitsTest.cpp) | 2 | **TypeTraitsTest** &mdash; `AllChecksAreCompileTime`, `AllNameOfsAreCorrect` |
 
-**Totals.** 124 unit / subsystem test files, 1528 TEST / TEST_F declarations across all subsystems.
+**Totals.** 125 unit / subsystem test files, 1531 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: unit-catalogue -->
 


### PR DESCRIPTION
Add a Window ▸ Thread Inspector panel that enumerates the engine's live OS threads (name, id, kind, type, priority, run state), plus a task-scheduler summary and per-named-thread queue backlog.

Engine wiring:
- Activate the dormant FThreadManager registry: register on a successful FRunnableThread::Create() and deregister in ~FRunnableThread(). This single  chokepoint captures every real OS thread, since scheduler workers, the audio and network threads, async tasks and editor build threads all route through FThread -> FRunnableThread::Create. The main/game thread (not an FRunnableThread) is synthesised by the panel from the current thread id.
- Make FThreadManager::Get() a leak-on-purpose singleton: the registry is now touched from FRunnableThread destructors, some of which run during static  teardown (e.g. AudioEngine's static FThread), after a Meyers singleton would already be gone.
- Fix a latent wrong include path in ThreadManager.h (Core/CriticalSection.h), which only surfaced now that the header is actually compiled.

Thread-id consistency:
- FNamedThreadManager::AttachToThread now records the real OS thread id (FPlatformTLS::GetCurrentThreadId()) instead of a hashed std::thread::id / task-tag value, so named-thread registrations share the registry's id space. Add GetThreadId()/IsThreadAttached() getters; the id helper is defined in the .cpp to keep Windows.h out of the widely-included header. The old value was  write-only, so the change has no existing consumers.
- The panel now labels registry rows by precise named role via OS-id match (Game/Render/Audio/Network), falling back to name heuristics only for workers/async/build threads, and shows each role's live attached id.

Tests: HAL/ThreadManagerTest.cpp covers create/destroy registration, multiple concurrent threads, and that the OS id agrees across the worker, the FRunnableThread registry, and FNamedThreadManager. Registered in the test catalogue.

Closes #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Thread Inspector panel to the Editor's Window menu for real-time monitoring and debugging of engine threads. Displays thread names, OS thread IDs, priorities, and states with optional filtering for active threads.

* **Tests**
  * Added comprehensive test coverage for thread registration and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->