### PR TITLE
build(deps): pin remaining floating vendor deps to fixed SHAs for reproducible builds (#294)

### DIFF
--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿include(CMakePrintHelpers)
+include(CMakePrintHelpers)
 include(CheckIPOSupported)
 
 project(OloEngine
@@ -8,10 +8,13 @@ project(OloEngine
 # Externally provided content
 add_subdirectory(vendor)
 
+# Vendor deps below are pinned to fixed commits for reproducible builds (#294); see the
+# rationale in vendor/CMakeLists.txt. GIT_SHALLOW must be FALSE for a commit-SHA pin.
 # Sol2 - for Lua scripting
 CPMAddPackage(NAME sol2
   GIT_REPOSITORY https://github.com/ThePhD/sol2.git
-  GIT_TAG develop
+  GIT_TAG c1f95a773c6f8f4fde8ca3efe872e7286afe4444  # develop @ 2026-06-05
+  GIT_SHALLOW FALSE
   DOWNLOAD_ONLY YES)
 if(sol2_ADDED)
   add_library(sol2 INTERFACE IMPORTED)
@@ -22,7 +25,8 @@ endif()
 # CHOC - for SoundGraph audio processing (Value system, FIFOs, real-time utilities)
 CPMAddPackage(NAME choc
   GIT_REPOSITORY https://github.com/Tracktion/choc.git
-  GIT_TAG main
+  GIT_TAG 5685fb59db9e60d31a35df7bff0ce7967beaaf25  # main @ 2026-06-05
+  GIT_SHALLOW FALSE
   DOWNLOAD_ONLY YES)
 if(choc_ADDED)
   add_library(choc INTERFACE IMPORTED)

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -8,17 +8,26 @@ endif()
 
 message(STATUS "Downloading third party libraries using CMake's FetchContent and CPM")
 
+# --- Vendor dependency pinning (#294: reproducible builds) ---
+# Every dependency below is pinned to a fixed commit. A floating branch (GIT_TAG
+# master/main/docking) lets CI silently fetch a newer version than any dev with zero
+# repo changes -- exactly how the #281 flaky physics crash hid (CI and local ran
+# different Jolt commits) -- and it defeats build caching. The SHAs are the branch
+# tips as of 2026-06-05 (the known-good versions built against today); each keeps a
+# trailing "# <branch> @ <date>" so a deliberate bump is a one-line, reviewable change.
+# NOTE: GIT_SHALLOW must be FALSE for a commit-SHA pin -- a shallow fetch only pulls
+# branch tips and cannot resolve an arbitrary historical commit (see Jolt below).
 FetchContent_Declare(
 	assimp
 	GIT_REPOSITORY	https://github.com/assimp/assimp.git
-	GIT_TAG			master
-	GIT_SHALLOW		TRUE
+	GIT_TAG			ace8c310f5d7452d7ef1e19e81957513326ccd07  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 FetchContent_Declare(
 	atomic_queue
 	GIT_REPOSITORY	https://github.com/max0x7ba/atomic_queue.git
-	GIT_TAG			master
-	GIT_SHALLOW		TRUE
+	GIT_TAG			705fe1acf5a0207ad0b2a24ac59d211b91e151a7  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 FetchContent_Declare(
 	box2d
@@ -29,14 +38,14 @@ FetchContent_Declare(
 FetchContent_Declare(
 	entt
 	GIT_REPOSITORY	https://github.com/skypjack/entt.git
-	GIT_TAG			main
-	GIT_SHALLOW		TRUE
+	GIT_TAG			1333fa53129e7cfded5a9640c4336a254049917b  # main @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 FetchContent_Declare(
 	filewatch
 	GIT_REPOSITORY	https://github.com/drsnuggles8/filewatch.git
-	GIT_TAG			master
-	GIT_SHALLOW		TRUE
+	GIT_TAG			2b24bd3bd513f7a6c9c9c566858a48a6124ad5af  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 
 FetchContent_Declare(
@@ -55,14 +64,14 @@ FetchContent_Declare(
 FetchContent_Declare(
 	glm
 	GIT_REPOSITORY https://github.com/g-truc/glm.git
-	GIT_TAG master
-	GIT_SHALLOW		TRUE
+	GIT_TAG 6f14f4792a0cde5d0cf2c910506724d61cb95834  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 FetchContent_Declare(
 	googletest
 	GIT_REPOSITORY https://github.com/google/googletest.git
-	GIT_TAG main
-	GIT_SHALLOW		TRUE
+	GIT_TAG 7140cd416cecd7462a8aae488024abeee55598e4  # main @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 # Pin Jolt to a fixed commit (not a floating branch). A floating `GIT_TAG master`
 # makes builds non-deterministic — CI can fetch a newer Jolt than any dev with zero
@@ -84,8 +93,8 @@ FetchContent_Declare(
 FetchContent_Declare(
 	miniaudio
 	GIT_REPOSITORY https://github.com/mackron/miniaudio.git
-	GIT_TAG master
-	GIT_SHALLOW		TRUE
+	GIT_TAG 9634bedb5b5a2ca38c1ee7108a9358a4e233f14d  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 
 # pl_mpeg: single-file, public-domain MPEG-1 video + MP2 audio decoder.
@@ -95,8 +104,8 @@ FetchContent_Declare(
 FetchContent_Declare(
 	pl_mpeg
 	GIT_REPOSITORY https://github.com/phoboslab/pl_mpeg.git
-	GIT_TAG master
-	GIT_SHALLOW		TRUE
+	GIT_TAG c871f2be022ece7ef4f64230b4fb8e1fb9eb6023  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 
 FetchContent_Declare(
@@ -127,8 +136,8 @@ FetchContent_Declare(
 FetchContent_Declare(
 	yaml-cpp
 	GIT_REPOSITORY	https://github.com/jbeder/yaml-cpp.git
-	GIT_TAG			master
-	GIT_SHALLOW		TRUE
+	GIT_TAG			2decf96e915d2b0c26c68c1659665789dfef2633  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 )
 FetchContent_Declare(
     zlib
@@ -158,8 +167,8 @@ FetchContent_Declare(
 FetchContent_Declare(
 	GameNetworkingSockets
 	GIT_REPOSITORY	https://github.com/ValveSoftware/GameNetworkingSockets.git
-	GIT_TAG			master
-	GIT_SHALLOW		TRUE
+	GIT_TAG			d67d1673abb1a3c00dfa9e62344860e15c741c1d  # master @ 2026-06-05
+	GIT_SHALLOW		FALSE
 	EXCLUDE_FROM_ALL
 )
 
@@ -248,7 +257,8 @@ glad_add_library(glad STATIC API gl:core=4.6 LOCATION ${PROJECT_SOURCE_DIR}/vend
 
 FetchContent_Declare(stb_image
 	GIT_REPOSITORY https://github.com/nothings/stb.git
-	GIT_TAG master)
+	GIT_TAG 31c1ad37456438565541f4919958214b6e762fb4  # master @ 2026-06-05
+	GIT_SHALLOW FALSE)
 FetchContent_MakeAvailable(stb_image)
 add_library(stb_image INTERFACE)
 
@@ -261,7 +271,8 @@ set(STBIMAGE_INSTALL_DIR "${PROJECT_SOURCE_DIR}/vendor/stb_image-build")
 
 CPMAddPackage(NAME imgui
 	GITHUB_REPOSITORY ocornut/imgui
-	GIT_TAG docking
+	GIT_TAG 2af6dd9694288e6befe1edb7ce25510911693c22  # docking @ 2026-06-05
+	GIT_SHALLOW FALSE
 	DOWNLOAD_ONLY YES)
 if(imgui_ADDED)
 	FILE(GLOB imgui_sources ${imgui_SOURCE_DIR}/*.cpp)
@@ -283,7 +294,8 @@ endif()
 
 CPMAddPackage(NAME imguizmo
 	GITHUB_REPOSITORY CedricGuillemet/ImGuizmo
-	GIT_TAG master
+	GIT_TAG be8aa4aeab86b402701c8c1df011bd8cd776760b  # master @ 2026-06-05
+	GIT_SHALLOW FALSE
 	DOWNLOAD_ONLY YES)
 if (imguizmo_ADDED)
 	# As of tag 1.9 the repository moved sources into a src/ subdirectory.


### PR DESCRIPTION
Closes #294 (step 4 — *pin the remaining floating vendor deps*).

## What
Pins the **15 dependencies still tracking a floating branch** to their branch-tip commit as of **2026-06-05**, each with `GIT_SHALLOW FALSE` and a `# <branch> @ <date>` provenance comment — mirroring the existing Jolt pin from #281.

- **`OloEngine/vendor/CMakeLists.txt`** (13): `assimp`, `atomic_queue`, `entt`, `filewatch`, `glm`, `googletest`, `miniaudio`, `pl_mpeg`, `yaml-cpp`, `GameNetworkingSockets`, `stb_image`, `imgui`, `imguizmo` — plus a header comment documenting the policy.
- **`OloEngine/CMakeLists.txt`** (2): `sol2`, `choc`.

Beyond the issue's enumeration, this also caught **`pl_mpeg`** (added by the recently-merged video work) and **`sol2`/`choc`** (a second declaration site in `OloEngine/CMakeLists.txt` the issue didn't list). `nlohmann_json` (3.12.0) and `ffmpeg` (tag `n7.1`) were already pinned and left untouched.

## Why
A floating `GIT_TAG master/main/develop/docking` lets CI silently fetch a newer version than any dev — with **zero repo changes**. That's the exact non-determinism behind the #281 flaky physics crash (CI and local ran different Jolt commits), and it also **defeats build caching** (prerequisite for steps 2 & 3 of #294). `GIT_SHALLOW FALSE` is required for a commit-SHA pin — a shallow fetch only pulls branch tips and can't resolve an arbitrary historical commit. (CPM auto-disables shallow for hashes; the explicit flag reinforces it.)

## Verification (Windows, MSVC, Debug)
- ✅ `cmake --preset msvc` configure + reconfigure resolve **all** pins; generated `*-subbuild` files show the SHAs + `GIT_SHALLOW FALSE` consumed verbatim, and `-src` checkouts match the pinned SHAs (cross-checked incl. CPM `imgui` and special-case `stb_image`).
- ✅ `OloEngine-Tests` builds clean — **0** compile/link/fatal errors (the only LNK4099s are pre-existing benign Mono-PDB warnings).
- ✅ Binary runs: 2914 tests enumerated; `FastRandomTest.*` 8/8 pass.

## Notes
- Behavior-preserving: each pin is the exact branch tip a fresh fetch gets today, so the built sources are identical to current `master` — this only *freezes* the version.
- To deliberately bump a dep later, update its one `GIT_TAG` line + date comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system with pinned dependency versions to ensure reproducible and consistent builds across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->