### PR TITLE
fix(build): deploy FFmpeg runtime DLLs next to OloEditor/OloRuntime/OloServer

### DIFF
--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -99,3 +99,8 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
 			FILES ${EDITOR_SOURCES}
 )
 
+# Deploy the FFmpeg runtime libs next to the exe (no-op when OLO_VIDEO_FFMPEG=OFF).
+# Must live in the same directory scope as add_executable — see the note on
+# olo_copy_ffmpeg_runtime in cmake/CommonProperties.cmake.
+olo_copy_ffmpeg_runtime(OloEditor)
+

--- a/OloRuntime/src/CMakeLists.txt
+++ b/OloRuntime/src/CMakeLists.txt
@@ -9,3 +9,8 @@ else()
     )
 endif()
 
+# Deploy the FFmpeg runtime libs next to the exe (no-op when OLO_VIDEO_FFMPEG=OFF).
+# Must live in the same directory scope as add_executable — see the note on
+# olo_copy_ffmpeg_runtime in cmake/CommonProperties.cmake.
+olo_copy_ffmpeg_runtime(OloRuntime)
+

--- a/OloServer/src/CMakeLists.txt
+++ b/OloServer/src/CMakeLists.txt
@@ -1,3 +1,8 @@
 add_executable(OloServer
     OloServerApp.cpp
 )
+
+# Deploy the FFmpeg runtime libs next to the exe (no-op when OLO_VIDEO_FFMPEG=OFF).
+# Must live in the same directory scope as add_executable — see the note on
+# olo_copy_ffmpeg_runtime in cmake/CommonProperties.cmake.
+olo_copy_ffmpeg_runtime(OloServer)


### PR DESCRIPTION
## What

Adds `olo_copy_ffmpeg_runtime(<target>)` next to the `add_executable` of each app
target — **OloEditor**, **OloRuntime**, **OloServer** — so the FFmpeg runtime
DLLs are deployed next to their executables.

## Why

`OLO_VIDEO_FFMPEG` defaults **ON** (`cmake/ffmpeg.cmake:21`), so every target that
links OloEngine implicitly depends on `avcodec / avformat / avutil / swscale /
swresample / avdevice / avfilter` at runtime. The deploy helper
`olo_copy_ffmpeg_runtime()` (`cmake/CommonProperties.cmake:155`) was only called
for `OloEngine-Tests`, so on a clean default build the three apps shipped with no
FFmpeg DLLs next to their exe and aborted at startup with `STATUS_DLL_NOT_FOUND`
(`0xC0000135`) before a window appeared. `olo_configure_app()` intentionally does
not call the helper and leaves a note (`cmake/CommonProperties.cmake:180`) saying
each app must call it next to its own `add_executable` — that call was just never
added for the apps.

The helper is a no-op when `OLO_VIDEO_FFMPEG=OFF`, so the call is safe
unconditionally.

## Verification

Removed all seven DLLs from `bin/Debug/OloEditor/`, rebuilt `OloEditor`, and the
new `POST_BUILD` step re-deployed every one next to `OloEditor.exe`. The editor
then launches and renders (previously it died at process load).

## Scope

Addresses **problem 1** of #297. The second item in that issue —
`build-ffmpeg.sh` failing when invoked by MSBuild without git's `usr/bin` on PATH
— is **not** included here (it touches cross-platform build invocation and is left
for separate triage), so this PR does not close #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
