### PR TITLE
feat(physics): breakable 3D joints (break force / break torque)

### DIFF
--- a/OloEditor/src/GameplayEventLogger.cpp
+++ b/OloEditor/src/GameplayEventLogger.cpp
@@ -51,7 +51,10 @@ namespace OloEngine
 
         // --- Physics events ---------------------------------------------------
         bus.Subscribe<JointBrokeEvent>([](const JointBrokeEvent& e)
-                                       { OLO_CORE_INFO("[GameplayEvents] JointBroke      entity={} connected={} force={:.1f}N torque={:.1f}N·m by={}", static_cast<u64>(e.EntityID), static_cast<u64>(e.ConnectedEntityID), e.Force, e.Torque, e.BrokeByForce ? "force" : "torque"); });
+                                       {
+            // A single step can exceed both thresholds, so report both causes.
+            const char* cause = (e.BrokeByForce && e.BrokeByTorque) ? "force+torque" : (e.BrokeByForce ? "force" : "torque");
+            OLO_CORE_INFO("[GameplayEvents] JointBroke      entity={} connected={} force={:.1f}N torque={:.1f}N·m by={}", static_cast<u64>(e.EntityID), static_cast<u64>(e.ConnectedEntityID), e.Force, e.Torque, cause); });
 
         OLO_CORE_INFO("[GameplayEvents] Logger attached — quest/inventory/physics events will stream to the Console panel.");
     }

--- a/OloEditor/src/GameplayEventLogger.cpp
+++ b/OloEditor/src/GameplayEventLogger.cpp
@@ -6,6 +6,7 @@
 #include "OloEngine/Gameplay/GameplayEventBus.h"
 #include "OloEngine/Gameplay/Quest/QuestEvents.h"
 #include "OloEngine/Gameplay/Inventory/InventoryEvents.h"
+#include "OloEngine/Physics3D/PhysicsEvents.h"
 
 namespace OloEngine
 {
@@ -48,7 +49,11 @@ namespace OloEngine
         bus.Subscribe<ItemUnequippedEvent>([](const ItemUnequippedEvent& e)
                                            { OLO_CORE_INFO("[GameplayEvents] ItemUnequipped  entity={} instance={} slot='{}'", static_cast<u64>(e.EntityID), static_cast<u64>(e.ItemInstanceID), e.SlotName); });
 
-        OLO_CORE_INFO("[GameplayEvents] Logger attached — quest/inventory events will stream to the Console panel.");
+        // --- Physics events ---------------------------------------------------
+        bus.Subscribe<JointBrokeEvent>([](const JointBrokeEvent& e)
+                                       { OLO_CORE_INFO("[GameplayEvents] JointBroke      entity={} connected={} force={:.1f}N torque={:.1f}N·m by={}", static_cast<u64>(e.EntityID), static_cast<u64>(e.ConnectedEntityID), e.Force, e.Torque, e.BrokeByForce ? "force" : "torque"); });
+
+        OLO_CORE_INFO("[GameplayEvents] Logger attached — quest/inventory/physics events will stream to the Console panel.");
     }
 
 } // namespace OloEngine

--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -3545,7 +3545,15 @@ namespace OloEngine
                 case JointType3D::Point:
                 default:
                     break;
-            } });
+            }
+
+            // Breakable thresholds (any joint type). 0 = unbreakable on that axis;
+            // at runtime the joint snaps when its constraint force/torque exceeds
+            // the threshold, firing a JointBrokeEvent.
+            ImGui::Separator();
+            ImGui::TextDisabled("Breakable (0 = unbreakable)");
+            ImGui::DragFloat("Break Force (N)##PhysicsJoint3D", &component.m_BreakForce, 1.0f, 0.0f, 1.0e9f);
+            ImGui::DragFloat("Break Torque (N\xC2\xB7m)##PhysicsJoint3D", &component.m_BreakTorque, 1.0f, 0.0f, 1.0e9f); });
 
         // Audio Components
         DrawComponent<AudioSourceComponent>("Audio Source", entity, [this](auto& component)

--- a/OloEngine-ScriptCore/src/OloEngine/InternalCalls.Generated.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/InternalCalls.Generated.cs
@@ -469,6 +469,14 @@ namespace OloEngine
 		internal static extern float PhysicsJoint3DComponent_GetConeHalfAngleDeg(ulong entityID);
 		[MethodImpl(MethodImplOptions.InternalCall)]
 		internal static extern void PhysicsJoint3DComponent_SetConeHalfAngleDeg(ulong entityID, float value);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern float PhysicsJoint3DComponent_GetBreakForce(ulong entityID);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern void PhysicsJoint3DComponent_SetBreakForce(ulong entityID, float value);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern float PhysicsJoint3DComponent_GetBreakTorque(ulong entityID);
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern void PhysicsJoint3DComponent_SetBreakTorque(ulong entityID, float value);
 		#endregion
 
 		#region PointLightComponent

--- a/OloEngine-ScriptCore/src/OloEngine/Scene/Components.Generated.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/Scene/Components.Generated.cs
@@ -761,6 +761,18 @@ namespace OloEngine
 			get => InternalCalls.PhysicsJoint3DComponent_GetConeHalfAngleDeg(Entity.ID);
 			set => InternalCalls.PhysicsJoint3DComponent_SetConeHalfAngleDeg(Entity.ID, value);
 		}
+
+		public float BreakForce
+		{
+			get => InternalCalls.PhysicsJoint3DComponent_GetBreakForce(Entity.ID);
+			set => InternalCalls.PhysicsJoint3DComponent_SetBreakForce(Entity.ID, value);
+		}
+
+		public float BreakTorque
+		{
+			get => InternalCalls.PhysicsJoint3DComponent_GetBreakTorque(Entity.ID);
+			set => InternalCalls.PhysicsJoint3DComponent_SetBreakTorque(Entity.ID, value);
+		}
 	}
 
 	public partial class PointLightComponent : Component

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -755,6 +755,7 @@
 		"OloEngine/Renderer/Commands/FrameResourceManager.h"
 
 		"OloEngine/Physics3D/Physics3DTypes.h"
+		"OloEngine/Physics3D/PhysicsEvents.h"
 		"OloEngine/Physics3D/SceneQueries.h"
 		"OloEngine/Physics3D/PhysicsSettings.h"
 		"OloEngine/Physics3D/Physics3DSystem.h"

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -3,10 +3,12 @@
 #include "EntityExclusionBodyFilter.h"
 #include "SceneQueries.h"
 #include "JoltShapes.h"
+#include "PhysicsEvents.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/Components.h"
+#include "OloEngine/Gameplay/GameplayEventBus.h"
 
 #include <Jolt/RegisterTypes.h>
 #include <Jolt/Core/Factory.h>
@@ -34,6 +36,9 @@
 #include <Jolt/Physics/Constraints/ConeConstraint.h>
 
 #include <glm/gtc/constants.hpp>
+
+#include <cmath>
+#include <vector>
 
 namespace OloEngine
 {
@@ -189,6 +194,11 @@ namespace OloEngine
         {
             characterController->PostSimulate();
         }
+
+        // Break any joint whose accumulated constraint impulse this step exceeded
+        // its authored threshold. Done here (per fixed step) because the lambdas
+        // are per-step state that the next Update() overwrites.
+        BreakOverstressedJoints(fixedTimeStep);
     }
 
     glm::vec3 JoltScene::GetGravity() const
@@ -762,6 +772,69 @@ namespace OloEngine
             const glm::vec3 ref = (glm::abs(v.x) < 0.9f) ? glm::vec3(1.0f, 0.0f, 0.0f) : glm::vec3(0.0f, 1.0f, 0.0f);
             return glm::normalize(glm::cross(v, ref));
         }
+
+        // Read back the accumulated position (linear) and rotation (angular)
+        // constraint impulse magnitudes for the last solved step. The lambda
+        // accessors are type-specific, so dispatch on the concrete sub-type. The
+        // returned values are impulses (N·s / N·m·s); the caller divides by the
+        // step dt to get an average force/torque. Returns false for sub-types we
+        // don't monitor (none of ours, but keeps the switch total and safe if a
+        // new joint type is added without a break mapping). For each type the
+        // position impulse aggregates every locked translational part and the
+        // rotation impulse every locked angular part, so the magnitude reflects
+        // the full load the joint carries — not just one axis.
+        bool ReadConstraintImpulses(const JPH::Constraint& constraint, f32& outLinearImpulse, f32& outAngularImpulse)
+        {
+            switch (constraint.GetSubType())
+            {
+                case JPH::EConstraintSubType::Fixed:
+                {
+                    const auto& c = static_cast<const JPH::FixedConstraint&>(constraint);
+                    outLinearImpulse = c.GetTotalLambdaPosition().Length();
+                    outAngularImpulse = c.GetTotalLambdaRotation().Length();
+                    return true;
+                }
+                case JPH::EConstraintSubType::Point:
+                {
+                    const auto& c = static_cast<const JPH::PointConstraint&>(constraint);
+                    outLinearImpulse = c.GetTotalLambdaPosition().Length();
+                    outAngularImpulse = 0.0f; // rotation is unconstrained
+                    return true;
+                }
+                case JPH::EConstraintSubType::Distance:
+                {
+                    const auto& c = static_cast<const JPH::DistanceConstraint&>(constraint);
+                    outLinearImpulse = std::abs(c.GetTotalLambdaPosition()); // scalar along the axis
+                    outAngularImpulse = 0.0f;
+                    return true;
+                }
+                case JPH::EConstraintSubType::Hinge:
+                {
+                    const auto& c = static_cast<const JPH::HingeConstraint&>(constraint);
+                    outLinearImpulse = c.GetTotalLambdaPosition().Length();
+                    // Two locked rotational DOF + the angle-limit reaction.
+                    outAngularImpulse = c.GetTotalLambdaRotation().Length() + std::abs(c.GetTotalLambdaRotationLimits());
+                    return true;
+                }
+                case JPH::EConstraintSubType::Slider:
+                {
+                    const auto& c = static_cast<const JPH::SliderConstraint&>(constraint);
+                    // Two locked perpendicular axes + the translation-limit reaction.
+                    outLinearImpulse = c.GetTotalLambdaPosition().Length() + std::abs(c.GetTotalLambdaPositionLimits());
+                    outAngularImpulse = c.GetTotalLambdaRotation().Length();
+                    return true;
+                }
+                case JPH::EConstraintSubType::Cone:
+                {
+                    const auto& c = static_cast<const JPH::ConeConstraint&>(constraint);
+                    outLinearImpulse = c.GetTotalLambdaPosition().Length();
+                    outAngularImpulse = std::abs(c.GetTotalLambdaRotation()); // cone half-angle limit
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
     } // namespace
 
     void JoltScene::CreateConstraints()
@@ -1005,6 +1078,73 @@ namespace OloEngine
             }
         }
         m_Constraints.clear();
+    }
+
+    void JoltScene::BreakOverstressedJoints(f32 stepDeltaTime)
+    {
+        // Nothing to break, or no scene to publish on / look up components from.
+        if (m_Constraints.empty() || !m_Scene || stepDeltaTime <= 0.0f)
+            return;
+
+        // Scan first, mutate after: DestroyConstraint() erases from m_Constraints,
+        // which would invalidate this iteration, and event handlers may touch the
+        // scene. So gather the events, then break + publish outside the loop.
+        std::vector<JointBrokeEvent> broken;
+        for (const auto& [entityID, constraint] : m_Constraints)
+        {
+            if (constraint == nullptr)
+                continue;
+
+            Entity entity = m_Scene->GetEntityByUUID(entityID);
+            if (!entity || !entity.HasComponent<PhysicsJoint3DComponent>())
+                continue;
+
+            const auto& joint = entity.GetComponent<PhysicsJoint3DComponent>();
+            const bool forceEnabled = joint.m_BreakForce > 0.0f;
+            const bool torqueEnabled = joint.m_BreakTorque > 0.0f;
+            if (!forceEnabled && !torqueEnabled)
+                continue; // unbreakable joint — skip the read entirely
+
+            f32 linearImpulse = 0.0f;
+            f32 angularImpulse = 0.0f;
+            if (!ReadConstraintImpulses(*constraint, linearImpulse, angularImpulse))
+                continue;
+
+            // lambda is an impulse (force·dt / torque·dt); recover the average
+            // force/torque the joint carried over the step.
+            const f32 force = linearImpulse / stepDeltaTime;
+            const f32 torque = angularImpulse / stepDeltaTime;
+            const bool brokeByForce = forceEnabled && (force > joint.m_BreakForce);
+            const bool brokeByTorque = torqueEnabled && (torque > joint.m_BreakTorque);
+            if (!brokeByForce && !brokeByTorque)
+                continue;
+
+            broken.push_back(JointBrokeEvent{
+                .EntityID = entityID,
+                .ConnectedEntityID = joint.m_ConnectedEntity,
+                .Type = joint.m_Type,
+                .Force = force,
+                .Torque = torque,
+                .BrokeByForce = brokeByForce,
+                .BrokeByTorque = brokeByTorque });
+        }
+
+        for (const JointBrokeEvent& event : broken)
+        {
+            Entity entity = m_Scene->GetEntityByUUID(event.EntityID);
+            // Remove the Jolt constraint (erases the m_Constraints entry) and
+            // clear the component's runtime token so it reads as "no constraint".
+            DestroyConstraint(entity);
+            if (entity && entity.HasComponent<PhysicsJoint3DComponent>())
+                entity.GetComponent<PhysicsJoint3DComponent>().m_RuntimeConstraintToken = 0;
+
+            OLO_CORE_TRACE("PhysicsJoint3D on entity {0} broke (force={1} N, torque={2} N·m)",
+                           (u64)event.EntityID, event.Force, event.Torque);
+
+            // Publish last so a handler that inspects the joint/entity sees the
+            // already-broken state.
+            m_Scene->GetGameplayEvents().Publish(event);
+        }
     }
 
     void JoltScene::SynchronizeBody(Ref<JoltBody> body) const

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -173,6 +173,12 @@ namespace OloEngine
         // Remove and release every tracked constraint. Must run before the
         // bodies they reference are destroyed.
         void DestroyAllConstraints();
+        // After a simulation step, read back each breakable constraint's
+        // accumulated impulse (force/torque = impulse / dt), and for any that
+        // exceeds its authored PhysicsJoint3DComponent break threshold: remove
+        // the constraint, clear the component's m_RuntimeConstraintToken, and
+        // publish a JointBrokeEvent on the Scene's GameplayEventBus.
+        void BreakOverstressedJoints(f32 stepDeltaTime);
         void SynchronizeBody(Ref<JoltBody> body) const;
 
         // Internal Jolt setup

--- a/OloEngine/src/OloEngine/Physics3D/PhysicsEvents.h
+++ b/OloEngine/src/OloEngine/Physics3D/PhysicsEvents.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/UUID.h"
+#include "OloEngine/Scene/Components.h" // JointType3D
+
+namespace OloEngine
+{
+    // POD notification payloads published on the Scene's GameplayEventBus by the
+    // Physics3D subsystem. Mirrors the Gameplay event headers
+    // (Quest/QuestEvents.h, Inventory/InventoryEvents.h): plain structs, not
+    // Event-derived classes, dispatched synchronously by GameplayEventBus.
+
+    // Fired when a breakable PhysicsJoint3DComponent's constraint exceeds its
+    // authored break threshold and is removed at runtime. By the time a
+    // subscriber sees this, the Jolt constraint is already gone and the owning
+    // component's m_RuntimeConstraintToken has been cleared to 0 — the two
+    // bodies are free. Gameplay can react (spawn debris, play SFX, despawn the
+    // component) from the handler.
+    struct JointBrokeEvent
+    {
+        UUID EntityID;                         // entity carrying the PhysicsJoint3DComponent
+        UUID ConnectedEntityID;                // the other body the joint connected to (0 = world)
+        JointType3D Type = JointType3D::Fixed; // joint type that broke
+        f32 Force = 0.0f;                      // linear constraint force at the breaking step (N)
+        f32 Torque = 0.0f;                     // angular constraint torque at the breaking step (N·m)
+        bool BrokeByForce = false;             // the force threshold (m_BreakForce) was exceeded
+        bool BrokeByTorque = false;            // the torque threshold (m_BreakTorque) was exceeded
+    };
+
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
+++ b/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
@@ -677,6 +677,7 @@ namespace OloEngine
         ar << c.m_HingeMinAngleDeg << c.m_HingeMaxAngleDeg;
         ar << c.m_SliderMinLimit << c.m_SliderMaxLimit;
         ar << c.m_ConeHalfAngleDeg;
+        ar << c.m_BreakForce << c.m_BreakTorque;
         // m_RuntimeConstraintToken is a runtime Jolt handle — not serialized.
     }
 

--- a/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
+++ b/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
@@ -677,7 +677,34 @@ namespace OloEngine
         ar << c.m_HingeMinAngleDeg << c.m_HingeMaxAngleDeg;
         ar << c.m_SliderMinLimit << c.m_SliderMaxLimit;
         ar << c.m_ConeHalfAngleDeg;
-        ar << c.m_BreakForce << c.m_BreakTorque;
+
+        // Break thresholds were appended after m_ConeHalfAngleDeg (which legacy
+        // archives ended with), so probe AtEnd() on load and default to 0
+        // (unbreakable) when absent. Mirrors EnvironmentMapComponent above.
+        if (ar.IsLoading())
+        {
+            if (ar.AtEnd())
+            {
+                c.m_BreakForce = 0.0f;
+                c.m_BreakTorque = 0.0f;
+            }
+            else
+            {
+                ar << c.m_BreakForce << c.m_BreakTorque;
+            }
+
+            // Sanitize untrusted on-disk values; 0 means unbreakable.
+            if (!std::isfinite(c.m_BreakForce))
+                c.m_BreakForce = 0.0f;
+            c.m_BreakForce = std::clamp(c.m_BreakForce, 0.0f, 1.0e9f);
+            if (!std::isfinite(c.m_BreakTorque))
+                c.m_BreakTorque = 0.0f;
+            c.m_BreakTorque = std::clamp(c.m_BreakTorque, 0.0f, 1.0e9f);
+        }
+        else
+        {
+            ar << c.m_BreakForce << c.m_BreakTorque;
+        }
         // m_RuntimeConstraintToken is a runtime Jolt handle — not serialized.
     }
 

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -726,9 +726,23 @@ namespace OloEngine
         OLO_PROPERTY()
         f32 m_ConeHalfAngleDeg = 45.0f;
 
+        // Breakable joints. At runtime the per-step constraint impulse is read
+        // back from Jolt, converted to an average force/torque (impulse / dt),
+        // and compared against these thresholds; when either is exceeded the
+        // constraint is removed and a JointBrokeEvent (Physics3D/PhysicsEvents.h)
+        // is published on the Scene's GameplayEventBus. A non-positive threshold
+        // (<= 0) means "disabled" — that axis never breaks the joint. Both
+        // default to 0, so an authored joint is unbreakable until a designer
+        // opts in. m_BreakForce is in newtons, m_BreakTorque in newton-metres.
+        OLO_PROPERTY()
+        f32 m_BreakForce = 0.0f;
+        OLO_PROPERTY()
+        f32 m_BreakTorque = 0.0f;
+
         // Storage for runtime - non-zero once the Jolt constraint has been created.
         // Excluded from authored-state equality so play-mode enter/exit doesn't show
-        // as a change (mirrors Rigidbody3DComponent::m_RuntimeBodyToken).
+        // as a change (mirrors Rigidbody3DComponent::m_RuntimeBodyToken). Cleared
+        // back to 0 when the constraint breaks at runtime (see JoltScene).
         u64 m_RuntimeConstraintToken = 0;
 
         PhysicsJoint3DComponent() = default;
@@ -736,7 +750,7 @@ namespace OloEngine
 
         auto operator==(const PhysicsJoint3DComponent& other) const -> bool
         {
-            return m_Type == other.m_Type && m_ConnectedEntity == other.m_ConnectedEntity && Math::BitwiseEqual(m_LocalAnchorA, other.m_LocalAnchorA) && Math::BitwiseEqual(m_LocalAnchorB, other.m_LocalAnchorB) && Math::BitwiseEqual(m_Axis, other.m_Axis) && Math::BitwiseEqual(m_MinDistance, other.m_MinDistance) && Math::BitwiseEqual(m_MaxDistance, other.m_MaxDistance) && Math::BitwiseEqual(m_HingeMinAngleDeg, other.m_HingeMinAngleDeg) && Math::BitwiseEqual(m_HingeMaxAngleDeg, other.m_HingeMaxAngleDeg) && Math::BitwiseEqual(m_SliderMinLimit, other.m_SliderMinLimit) && Math::BitwiseEqual(m_SliderMaxLimit, other.m_SliderMaxLimit) && Math::BitwiseEqual(m_ConeHalfAngleDeg, other.m_ConeHalfAngleDeg);
+            return m_Type == other.m_Type && m_ConnectedEntity == other.m_ConnectedEntity && Math::BitwiseEqual(m_LocalAnchorA, other.m_LocalAnchorA) && Math::BitwiseEqual(m_LocalAnchorB, other.m_LocalAnchorB) && Math::BitwiseEqual(m_Axis, other.m_Axis) && Math::BitwiseEqual(m_MinDistance, other.m_MinDistance) && Math::BitwiseEqual(m_MaxDistance, other.m_MaxDistance) && Math::BitwiseEqual(m_HingeMinAngleDeg, other.m_HingeMinAngleDeg) && Math::BitwiseEqual(m_HingeMaxAngleDeg, other.m_HingeMaxAngleDeg) && Math::BitwiseEqual(m_SliderMinLimit, other.m_SliderMinLimit) && Math::BitwiseEqual(m_SliderMaxLimit, other.m_SliderMaxLimit) && Math::BitwiseEqual(m_ConeHalfAngleDeg, other.m_ConeHalfAngleDeg) && Math::BitwiseEqual(m_BreakForce, other.m_BreakForce) && Math::BitwiseEqual(m_BreakTorque, other.m_BreakTorque);
         }
     };
 

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -2438,6 +2438,8 @@ namespace OloEngine
             joint.m_SliderMinLimit = jointComponent["SliderMinLimit"].as<f32>(joint.m_SliderMinLimit);
             joint.m_SliderMaxLimit = jointComponent["SliderMaxLimit"].as<f32>(joint.m_SliderMaxLimit);
             joint.m_ConeHalfAngleDeg = jointComponent["ConeHalfAngleDeg"].as<f32>(joint.m_ConeHalfAngleDeg);
+            joint.m_BreakForce = jointComponent["BreakForce"].as<f32>(joint.m_BreakForce);
+            joint.m_BreakTorque = jointComponent["BreakTorque"].as<f32>(joint.m_BreakTorque);
 
             // Reject non-finite floats read from disk and clamp to physically/Jolt-valid ranges.
             SanitizeFloat(joint.m_MinDistance, -1.0f, 10000.0f, 0.0f);
@@ -2447,6 +2449,10 @@ namespace OloEngine
             SanitizeFloat(joint.m_SliderMinLimit, -10000.0f, 10000.0f, 0.0f);
             SanitizeFloat(joint.m_SliderMaxLimit, -10000.0f, 10000.0f, 1.0f);
             SanitizeFloat(joint.m_ConeHalfAngleDeg, 0.0f, 180.0f, 45.0f);
+            // Break thresholds: a non-positive value is the "disabled" sentinel,
+            // so clamp negatives to 0 and reject non-finite to 0 (unbreakable).
+            SanitizeFloat(joint.m_BreakForce, 0.0f, 1.0e9f, 0.0f);
+            SanitizeFloat(joint.m_BreakTorque, 0.0f, 1.0e9f, 0.0f);
         }
 
         if (auto relComponent = entity["RelationshipComponent"]; relComponent)
@@ -4331,6 +4337,8 @@ namespace OloEngine
             out << YAML::Key << "SliderMinLimit" << YAML::Value << joint.m_SliderMinLimit;
             out << YAML::Key << "SliderMaxLimit" << YAML::Value << joint.m_SliderMaxLimit;
             out << YAML::Key << "ConeHalfAngleDeg" << YAML::Value << joint.m_ConeHalfAngleDeg;
+            out << YAML::Key << "BreakForce" << YAML::Value << joint.m_BreakForce;
+            out << YAML::Key << "BreakTorque" << YAML::Value << joint.m_BreakTorque;
 
             out << YAML::EndMap; // PhysicsJoint3DComponent
         }

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
@@ -2329,6 +2329,50 @@ static void PhysicsJoint3DComponent_SetConeHalfAngleDeg(UUID entityID, float val
     comp.m_ConeHalfAngleDeg = value;
 }
 
+static float PhysicsJoint3DComponent_GetBreakForce(UUID entityID)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    auto& comp = entity.GetComponent<PhysicsJoint3DComponent>();
+    return comp.m_BreakForce;
+}
+
+static void PhysicsJoint3DComponent_SetBreakForce(UUID entityID, float value)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    if (!std::isfinite(value))
+        return;
+    auto& comp = entity.GetComponent<PhysicsJoint3DComponent>();
+    comp.m_BreakForce = value;
+}
+
+static float PhysicsJoint3DComponent_GetBreakTorque(UUID entityID)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    auto& comp = entity.GetComponent<PhysicsJoint3DComponent>();
+    return comp.m_BreakTorque;
+}
+
+static void PhysicsJoint3DComponent_SetBreakTorque(UUID entityID, float value)
+{
+    Scene* scene = ScriptEngine::GetSceneContext();
+    OLO_CORE_ASSERT(scene);
+    Entity entity = scene->GetEntityByUUID(entityID);
+    OLO_CORE_ASSERT(entity);
+    if (!std::isfinite(value))
+        return;
+    auto& comp = entity.GetComponent<PhysicsJoint3DComponent>();
+    comp.m_BreakTorque = value;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 // PointLightComponent                                                            //
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueRegistrations.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueRegistrations.inl
@@ -241,6 +241,10 @@ OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_GetSliderMaxLimit);
 OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_SetSliderMaxLimit);
 OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_GetConeHalfAngleDeg);
 OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_SetConeHalfAngleDeg);
+OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_GetBreakForce);
+OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_SetBreakForce);
+OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_GetBreakTorque);
+OLO_ADD_INTERNAL_CALL(PhysicsJoint3DComponent_SetBreakTorque);
 
 // PointLightComponent
 OLO_ADD_INTERNAL_CALL(PointLightComponent_GetColor);

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -1069,7 +1069,14 @@ namespace OloEngine
                                                                                   { if (std::isfinite(v)) j.m_SliderMaxLimit = v; }),
                                                   "coneHalfAngleDeg", sol::property([](const PhysicsJoint3DComponent& j)
                                                                                     { return j.m_ConeHalfAngleDeg; }, [](PhysicsJoint3DComponent& j, f32 v)
-                                                                                    { if (std::isfinite(v) && v >= 0.0f) j.m_ConeHalfAngleDeg = v; }));
+                                                                                    { if (std::isfinite(v) && v >= 0.0f) j.m_ConeHalfAngleDeg = v; }),
+                                                  // Break thresholds (N / N·m). <= 0 means unbreakable on that axis.
+                                                  "breakForce", sol::property([](const PhysicsJoint3DComponent& j)
+                                                                              { return j.m_BreakForce; }, [](PhysicsJoint3DComponent& j, f32 v)
+                                                                              { if (std::isfinite(v)) j.m_BreakForce = v; }),
+                                                  "breakTorque", sol::property([](const PhysicsJoint3DComponent& j)
+                                                                               { return j.m_BreakTorque; }, [](PhysicsJoint3DComponent& j, f32 v)
+                                                                               { if (std::isfinite(v)) j.m_BreakTorque = v; }));
 
         // --- PrefabComponent ---
         // Read-only window into prefab-instance identity & override state.

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -1070,13 +1070,15 @@ namespace OloEngine
                                                   "coneHalfAngleDeg", sol::property([](const PhysicsJoint3DComponent& j)
                                                                                     { return j.m_ConeHalfAngleDeg; }, [](PhysicsJoint3DComponent& j, f32 v)
                                                                                     { if (std::isfinite(v) && v >= 0.0f) j.m_ConeHalfAngleDeg = v; }),
-                                                  // Break thresholds (N / N·m). <= 0 means unbreakable on that axis.
+                                                  // Break thresholds (N / N·m). 0 means unbreakable on that axis.
+                                                  // Clamp to the same [0, 1e9] range the serializers enforce so a
+                                                  // script-set value round-trips through save/load unchanged.
                                                   "breakForce", sol::property([](const PhysicsJoint3DComponent& j)
                                                                               { return j.m_BreakForce; }, [](PhysicsJoint3DComponent& j, f32 v)
-                                                                              { if (std::isfinite(v)) j.m_BreakForce = v; }),
+                                                                              { if (std::isfinite(v)) j.m_BreakForce = std::clamp(v, 0.0f, 1.0e9f); }),
                                                   "breakTorque", sol::property([](const PhysicsJoint3DComponent& j)
                                                                                { return j.m_BreakTorque; }, [](PhysicsJoint3DComponent& j, f32 v)
-                                                                               { if (std::isfinite(v)) j.m_BreakTorque = v; }));
+                                                                               { if (std::isfinite(v)) j.m_BreakTorque = std::clamp(v, 0.0f, 1.0e9f); }));
 
         // --- PrefabComponent ---
         // Read-only window into prefab-instance identity & override state.

--- a/OloEngine/tests/ComponentRoundTripTest.cpp
+++ b/OloEngine/tests/ComponentRoundTripTest.cpp
@@ -887,6 +887,8 @@ namespace OloEngine::Tests
         const f32 expectedSliderMin = -2.5f;
         const f32 expectedSliderMax = 3.5f;
         const f32 expectedConeHalf = 60.0f; // within [0, 180]
+        const f32 expectedBreakForce = 250.0f;
+        const f32 expectedBreakTorque = 75.0f;
 
         std::string yaml;
         {
@@ -905,6 +907,8 @@ namespace OloEngine::Tests
             j.m_SliderMinLimit = expectedSliderMin;
             j.m_SliderMaxLimit = expectedSliderMax;
             j.m_ConeHalfAngleDeg = expectedConeHalf;
+            j.m_BreakForce = expectedBreakForce;
+            j.m_BreakTorque = expectedBreakTorque;
             yaml = SceneSerializer(scene).SerializeToYAML();
         }
 
@@ -933,6 +937,8 @@ namespace OloEngine::Tests
         EXPECT_NEAR(j.m_SliderMinLimit, expectedSliderMin, kFloatEpsilon);
         EXPECT_NEAR(j.m_SliderMaxLimit, expectedSliderMax, kFloatEpsilon);
         EXPECT_NEAR(j.m_ConeHalfAngleDeg, expectedConeHalf, kFloatEpsilon);
+        EXPECT_NEAR(j.m_BreakForce, expectedBreakForce, kFloatEpsilon);
+        EXPECT_NEAR(j.m_BreakTorque, expectedBreakTorque, kFloatEpsilon);
     }
 
     // -------------------------------------------------------------------------

--- a/OloEngine/tests/Functional/AnimationPhysics/PhysicsJoint3DTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/PhysicsJoint3DTest.cpp
@@ -26,10 +26,14 @@
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Components.h"
 #include "OloEngine/SaveGame/SaveGameSerializer.h"
+#include "OloEngine/Gameplay/GameplayEventBus.h"
+#include "OloEngine/Physics3D/PhysicsEvents.h"
+#include "OloEngine/Physics3D/JoltScene.h"
 
 #include <glm/glm.hpp>
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 using namespace OloEngine;
 using namespace OloEngine::Functional;
@@ -259,6 +263,145 @@ TEST_F(PhysicsJoint3DTest, ConeJointConfinesSwingWithinHalfAngle)
     EXPECT_GT(maxHoriz, 0.25f) << "bob never swung out — initial velocity wasn't applied";
 }
 
+// =============================================================================
+// Breakable joints (issue #308 item 2). At runtime the per-step constraint
+// impulse is read back, converted to a force/torque, and compared against the
+// authored m_BreakForce / m_BreakTorque thresholds; over-threshold joints are
+// removed and a JointBrokeEvent is published on the Scene's GameplayEventBus.
+// A non-positive threshold disables that axis.
+//
+// The force cases pin a 1 kg body in place against gravity, so the Point
+// constraint must carry exactly m·g ≈ 9.81 N every step — a stable load that
+// is trivially above/below a chosen threshold. The torque case welds a
+// spinning body, so the Fixed constraint must shed a large angular impulse.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Below-threshold: the joint must survive — constraint kept, token intact, no
+// event, body held in place.
+// -----------------------------------------------------------------------------
+TEST_F(PhysicsJoint3DTest, BreakableJointSurvivesLoadBelowBreakForce)
+{
+    Entity bob = MakeBox("HeldBob", { 0.0f, 3.0f, 0.0f }, BodyType3D::Dynamic, 0.25f);
+    auto& joint = bob.AddComponent<PhysicsJoint3DComponent>();
+    joint.m_Type = JointType3D::Point;
+    // m_ConnectedEntity defaults to 0 → world anchor at the body's own position.
+    joint.m_BreakForce = 50.0f; // well above the ~9.81 N the joint must carry
+
+    EnablePhysics3D();
+
+    std::vector<JointBrokeEvent> breaks;
+    GetScene().GetGameplayEvents().Subscribe<JointBrokeEvent>([&](const JointBrokeEvent& e)
+                                                              { breaks.push_back(e); });
+
+    TickFor(2.0f);
+
+    EXPECT_TRUE(breaks.empty()) << "joint broke under a load below its break force";
+    EXPECT_NE(bob.GetComponent<PhysicsJoint3DComponent>().m_RuntimeConstraintToken, 0u)
+        << "surviving joint lost its runtime constraint token";
+    ASSERT_NE(GetScene().GetPhysicsScene(), nullptr);
+    EXPECT_EQ(GetScene().GetPhysicsScene()->GetConstraintCount(), 1u)
+        << "surviving joint's Jolt constraint was removed";
+    EXPECT_NEAR(Pos(bob).y, 3.0f, 0.1f) << "body was not held in place; y=" << Pos(bob).y;
+}
+
+// -----------------------------------------------------------------------------
+// Above-threshold (force): the joint must break — constraint removed, token
+// cleared, exactly one JointBrokeEvent fired (BrokeByForce), body falls free.
+// -----------------------------------------------------------------------------
+TEST_F(PhysicsJoint3DTest, BreakableJointBreaksWhenForceExceedsBreakForce)
+{
+    Entity bob = MakeBox("BreakBob", { 0.0f, 3.0f, 0.0f }, BodyType3D::Dynamic, 0.25f);
+    const UUID bobID = bob.GetUUID();
+    auto& joint = bob.AddComponent<PhysicsJoint3DComponent>();
+    joint.m_Type = JointType3D::Point; // world anchor at the body's own position
+    joint.m_BreakForce = 2.0f;         // below the ~9.81 N gravity load → snaps
+
+    EnablePhysics3D();
+
+    std::vector<JointBrokeEvent> breaks;
+    GetScene().GetGameplayEvents().Subscribe<JointBrokeEvent>([&](const JointBrokeEvent& e)
+                                                              { breaks.push_back(e); });
+
+    TickFor(2.0f);
+
+    ASSERT_EQ(breaks.size(), 1u) << "expected exactly one JointBrokeEvent";
+    EXPECT_EQ(static_cast<u64>(breaks[0].EntityID), static_cast<u64>(bobID));
+    EXPECT_TRUE(breaks[0].BrokeByForce) << "break should be attributed to the force threshold";
+    EXPECT_FALSE(breaks[0].BrokeByTorque);
+    EXPECT_GT(breaks[0].Force, joint.m_BreakForce) << "reported force should exceed the threshold";
+    EXPECT_EQ(bob.GetComponent<PhysicsJoint3DComponent>().m_RuntimeConstraintToken, 0u)
+        << "broken joint did not clear its runtime constraint token";
+    ASSERT_NE(GetScene().GetPhysicsScene(), nullptr);
+    EXPECT_EQ(GetScene().GetPhysicsScene()->GetConstraintCount(), 0u)
+        << "broken joint's Jolt constraint was not removed";
+    // Freed body falls (~19 m in 2 s); it must drop well below its pinned height.
+    EXPECT_LT(Pos(bob).y, 2.0f) << "body did not fall after the joint broke; y=" << Pos(bob).y;
+}
+
+// -----------------------------------------------------------------------------
+// Above-threshold (torque): a Fixed joint welds a spinning body, so the
+// rotation constraint must shed a large angular impulse. With break force
+// disabled (0), only the torque threshold can trip — proving the torque path.
+// -----------------------------------------------------------------------------
+TEST_F(PhysicsJoint3DTest, BreakableJointBreaksWhenTorqueExceedsBreakTorque)
+{
+    Entity anchor = MakeBox("TorqueAnchor", { 0.0f, 3.0f, 0.0f }, BodyType3D::Static, 0.3f);
+    Entity welded = MakeBox("TorqueWelded", { 1.0f, 3.0f, 0.0f }, BodyType3D::Dynamic, 0.3f);
+    const UUID weldedID = welded.GetUUID();
+    welded.GetComponent<Rigidbody3DComponent>().m_InitialAngularVelocity = { 0.0f, 0.0f, 15.0f };
+
+    auto& joint = welded.AddComponent<PhysicsJoint3DComponent>();
+    joint.m_Type = JointType3D::Fixed;
+    joint.m_ConnectedEntity = anchor.GetUUID();
+    joint.m_BreakForce = 0.0f;  // disabled — only torque may break this joint
+    joint.m_BreakTorque = 5.0f; // the spin-arresting torque dwarfs this
+
+    EnablePhysics3D();
+
+    std::vector<JointBrokeEvent> breaks;
+    GetScene().GetGameplayEvents().Subscribe<JointBrokeEvent>([&](const JointBrokeEvent& e)
+                                                              { breaks.push_back(e); });
+
+    TickFor(1.0f);
+
+    ASSERT_EQ(breaks.size(), 1u) << "expected exactly one JointBrokeEvent";
+    EXPECT_EQ(static_cast<u64>(breaks[0].EntityID), static_cast<u64>(weldedID));
+    EXPECT_TRUE(breaks[0].BrokeByTorque) << "break should be attributed to the torque threshold";
+    EXPECT_FALSE(breaks[0].BrokeByForce) << "break force was disabled, so it must not be the cause";
+    EXPECT_GT(breaks[0].Torque, joint.m_BreakTorque);
+    EXPECT_EQ(welded.GetComponent<PhysicsJoint3DComponent>().m_RuntimeConstraintToken, 0u);
+    ASSERT_NE(GetScene().GetPhysicsScene(), nullptr);
+    EXPECT_EQ(GetScene().GetPhysicsScene()->GetConstraintCount(), 0u);
+    // Once free, the welded body falls away from its held height.
+    EXPECT_LT(Pos(welded).y, 2.5f) << "body did not fall after the weld broke; y=" << Pos(welded).y;
+}
+
+// -----------------------------------------------------------------------------
+// Backward compatibility: with both thresholds at the 0 default, a joint is
+// unbreakable no matter how it is loaded — existing scenes keep their joints.
+// -----------------------------------------------------------------------------
+TEST_F(PhysicsJoint3DTest, UnbreakableByDefaultIgnoresLoad)
+{
+    Entity bob = MakeBox("UnbreakableBob", { 0.0f, 3.0f, 0.0f }, BodyType3D::Dynamic, 0.25f);
+    bob.AddComponent<PhysicsJoint3DComponent>().m_Type = JointType3D::Point;
+    // m_BreakForce / m_BreakTorque left at their 0 defaults → unbreakable.
+
+    EnablePhysics3D();
+
+    std::vector<JointBrokeEvent> breaks;
+    GetScene().GetGameplayEvents().Subscribe<JointBrokeEvent>([&](const JointBrokeEvent& e)
+                                                              { breaks.push_back(e); });
+
+    TickFor(2.0f);
+
+    EXPECT_TRUE(breaks.empty()) << "a default (0/0) joint must never break";
+    EXPECT_NE(bob.GetComponent<PhysicsJoint3DComponent>().m_RuntimeConstraintToken, 0u);
+    ASSERT_NE(GetScene().GetPhysicsScene(), nullptr);
+    EXPECT_EQ(GetScene().GetPhysicsScene()->GetConstraintCount(), 1u);
+    EXPECT_NEAR(Pos(bob).y, 3.0f, 0.1f);
+}
+
 // -----------------------------------------------------------------------------
 // Save-game round-trip — the authored joint data must survive
 // CaptureSceneState → RestoreSceneState (exercises SaveGameComponentSerializer).
@@ -281,6 +424,8 @@ TEST_F(PhysicsJoint3DTest, ComponentSurvivesSaveGameRoundTrip)
     j.m_SliderMinLimit = -1.5f;
     j.m_SliderMaxLimit = 2.0f;
     j.m_ConeHalfAngleDeg = 75.0f;
+    j.m_BreakForce = 320.0f;
+    j.m_BreakTorque = 64.0f;
 
     auto payload = SaveGameSerializer::CaptureSceneState(GetScene());
     ASSERT_GT(payload.size(), 0u);
@@ -308,4 +453,6 @@ TEST_F(PhysicsJoint3DTest, ComponentSurvivesSaveGameRoundTrip)
     EXPECT_NEAR(rj.m_SliderMinLimit, -1.5f, kEps);
     EXPECT_NEAR(rj.m_SliderMaxLimit, 2.0f, kEps);
     EXPECT_NEAR(rj.m_ConeHalfAngleDeg, 75.0f, kEps);
+    EXPECT_NEAR(rj.m_BreakForce, 320.0f, kEps);
+    EXPECT_NEAR(rj.m_BreakTorque, 64.0f, kEps);
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1157,7 +1157,7 @@ subsystem unit tests (§9.3, grouped by directory).
 | [FreeFallLandingTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/FreeFallLandingTest.cpp) | 1 | **FreeFallLandingTest** &mdash; `BallLandsAndAnimationKeepsTicking` |
 | [InitialLinearVelocityIsAppliedTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/InitialLinearVelocityIsAppliedTest.cpp) | 1 | **InitialLinearVelocityIsAppliedTest** &mdash; `BodyTravelsFiveMetersInOneSecondAtFiveMetersPerSecond` |
 | [Physics2DSimulatesViaSceneTickTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/Physics2DSimulatesViaSceneTickTest.cpp) | 1 | **Physics2DSimulatesViaSceneTickTest** &mdash; `BoxFallsAndLandsOnStaticFloor` |
-| [PhysicsJoint3DTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/PhysicsJoint3DTest.cpp) | 7 | **PhysicsJoint3DTest** &mdash; `FixedJointWeldsDynamicBodyToStaticAnchor`, `PointJointActsAsBallSocketPendulum`, `DistanceJointCatchesFallingBodyAtMaxLength`, `HingeJointSwingsAboutAxisAndRespectsAngleLimit`, `SliderJointConstrainsMotionToAxisAndLimit`, `ConeJointConfinesSwingWithinHalfAngle`, `ComponentSurvivesSaveGameRoundTrip` |
+| [PhysicsJoint3DTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/PhysicsJoint3DTest.cpp) | 11 | **PhysicsJoint3DTest** &mdash; `FixedJointWeldsDynamicBodyToStaticAnchor`, `PointJointActsAsBallSocketPendulum`, `DistanceJointCatchesFallingBodyAtMaxLength`, `HingeJointSwingsAboutAxisAndRespectsAngleLimit`, `SliderJointConstrainsMotionToAxisAndLimit`, `ConeJointConfinesSwingWithinHalfAngle`, `BreakableJointSurvivesLoadBelowBreakForce`, `BreakableJointBreaksWhenForceExceedsBreakForce`, `BreakableJointBreaksWhenTorqueExceedsBreakTorque`, `UnbreakableByDefaultIgnoresLoad`, `ComponentSurvivesSaveGameRoundTrip` |
 | [PhysicsLayerFilteringTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/PhysicsLayerFilteringTest.cpp) | 1 | **PhysicsLayerFilteringTest** &mdash; `AlphaPassesThroughBetaAndBothLandOnGround` |
 | [RigidbodyDisableGravityFlagTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/RigidbodyDisableGravityFlagTest.cpp) | 1 | **RigidbodyDisableGravityFlagTest** &mdash; `BodyWithDisableGravityStaysAtRestWhileControlFalls` |
 | [TriggerEndEventFiresOnSeparationTest.cpp](../OloEngine/tests/Functional/AnimationPhysics/TriggerEndEventFiresOnSeparationTest.cpp) | 1 | **TriggerEndEventFiresOnSeparationTest** &mdash; `EnterAndExitBothInvokeTheCallback` |
@@ -1283,7 +1283,7 @@ subsystem unit tests (§9.3, grouped by directory).
 | [LuaScriptSetsRigidbody2DVelocityTest.cpp](../OloEngine/tests/Functional/Scripting/LuaScriptSetsRigidbody2DVelocityTest.cpp) | 1 | **LuaScriptSetsRigidbody2DVelocityTest** &mdash; `BodyTranslatesAfterLuaSetsLinearVelocity` |
 | [LuaSetsAbilityAttributeViaSceneTickTest.cpp](../OloEngine/tests/Functional/Scripting/LuaSetsAbilityAttributeViaSceneTickTest.cpp) | 1 | **LuaSetsAbilityAttributeViaSceneTickTest** &mdash; `LuaDrivenHealthToZeroFlipsAliveToDeadOnSubsequentTick` |
 
-**Totals.** 85 Functional test files, 111 TEST / TEST_F declarations across all subsystems.
+**Totals.** 85 Functional test files, 115 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: functional-catalogue -->
 


### PR DESCRIPTION
Joints snap at runtime when their constraint force/torque exceeds an authored threshold, firing a JointBrokeEvent on the GameplayEventBus. Implements issue #308 item 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Physics joints now support configurable break thresholds for force and torque.
  * Added "Breakable" controls in the physics joint inspector for setting break parameters.
  * Break events are logged to the console with entity and force/torque details.
  * Breakable joint controls are now accessible in C# and Lua scripting.
  * Physics joint break settings are preserved through save/load cycles.

* **Tests**
  * Added functional tests for breakable joint behavior and threshold validation.

* **Documentation**
  * Updated test documentation with new breakable joint test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->