### PR TITLE
test(ci): add app-launch smoke tests for OloEditor/OloRuntime/OloServ…

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -77,6 +77,62 @@ jobs:
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
+    # App-launch smoke test (issue #303). Run each shipped binary with
+    # `--smoke-test`: it performs full startup (runtime-DLL load, subsystem init,
+    # network listen for the server) and exits 0 after a few ticks. This catches
+    # the "missing runtime DLL" regression class — FFmpeg is a static PE import,
+    # so a binary whose avcodec/avformat/... DLLs weren't deployed fails in the
+    # OS loader before main(). The GUI apps run window-less under the flag, so the
+    # check needs no GL 4.6 context (hosted runners have none). cwd is OloEditor so
+    # shaders/assets/Mono resolve as in a real run; DLLs load from beside each .exe.
+    # The in-suite AppLaunchSmokeTest covers the same ground via CTest below; this
+    # explicit step makes a launch regression obvious in the job log.
+    - name: Smoke-test app launches
+      shell: pwsh
+      working-directory: ${{github.workspace}}/OloEditor
+      timeout-minutes: 5
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $bin = Join-Path '${{github.workspace}}' 'bin/${{env.BUILD_TYPE}}'
+        $cwd = Join-Path '${{github.workspace}}' 'OloEditor'
+        $apps = @(
+          @{ Name = 'OloServer';  Path = Join-Path $bin 'OloServer/OloServer.exe';   Args = '--smoke-test --port 28778' },
+          @{ Name = 'OloEditor';  Path = Join-Path $bin 'OloEditor/OloEditor.exe';   Args = '--smoke-test' },
+          @{ Name = 'OloRuntime'; Path = Join-Path $bin 'OloRuntime/OloRuntime.exe'; Args = '--smoke-test' }
+        )
+        $failed = $false
+        foreach ($a in $apps) {
+          if (-not (Test-Path $a.Path)) {
+            Write-Error "$($a.Name): binary not found at $($a.Path)"
+            $failed = $true
+            continue
+          }
+          Write-Host "::group::$($a.Name) launch smoke"
+          $psi = [System.Diagnostics.ProcessStartInfo]::new()
+          $psi.FileName = $a.Path
+          $psi.Arguments = $a.Args
+          $psi.WorkingDirectory = $cwd
+          $psi.UseShellExecute = $false
+          $proc = [System.Diagnostics.Process]::Start($psi)
+          if (-not $proc.WaitForExit(60000)) {
+            try { $proc.Kill() } catch {}
+            Write-Host "::endgroup::"
+            Write-Error "$($a.Name): did not exit within 60s — likely hung at startup."
+            $failed = $true
+            continue
+          }
+          $code = $proc.ExitCode
+          Write-Host "::endgroup::"
+          if ($code -ne 0) {
+            Write-Error "$($a.Name): exited with code $code — launch smoke FAILED (missing runtime DLL or startup crash)."
+            $failed = $true
+          } else {
+            Write-Host "$($a.Name): launched and exited cleanly (exit 0)."
+          }
+        }
+        if ($failed) { exit 1 }
+        Write-Host 'All shipped binaries passed the launch smoke test.'
+
     - name: Run tests with CTest
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # Execute tests defined by the CMake configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,24 @@ add_subdirectory(OloServer)
 set_target_properties(OloEngine-LuaScriptCore PROPERTIES FOLDER "Scripting")
 set_target_properties(OloServer PROPERTIES FOLDER "Applications")
 
+# App-launch smoke test wiring (issue #303). Hand OloEngine-Tests the on-disk
+# paths of the three shipped executables so AppLaunchSmokeTest can spawn each one
+# with `--smoke-test` and assert a clean exit. Done here — after every app target
+# exists — because OloEngine/tests is configured before the app subdirectories,
+# so an `if(TARGET ...)` check inside tests/CMakeLists.txt would be premature.
+# $<PATH:CMAKE_PATH,...> normalises the native path to forward slashes so it
+# stays a valid C string literal on Windows. A target absent on this platform
+# simply leaves its macro undefined and the matching test SKIPs at runtime.
+if(TARGET OloEngine-Tests)
+    foreach(_olo_app OloServer OloEditor OloRuntime)
+        if(TARGET ${_olo_app})
+            string(TOUPPER ${_olo_app} _olo_app_uc)
+            target_compile_definitions(OloEngine-Tests PRIVATE
+                "OLO_TEST_${_olo_app_uc}_EXE=\"$<PATH:CMAKE_PATH,$<TARGET_FILE:${_olo_app}>>\"")
+        endif()
+    endforeach()
+endif()
+
 # Auto-run OloHeaderTool before compiling targets that consume its output.
 # OloEngine includes the generated .inl files; OloEngine-ScriptCore includes
 # the generated .cs files.

--- a/OloEditor/src/OloEditorApp.cpp
+++ b/OloEditor/src/OloEditorApp.cpp
@@ -11,10 +11,16 @@ namespace OloEngine
     class OloEngineEditor : public Application
     {
       public:
-        explicit OloEngineEditor(const ApplicationSpecification& spec)
+        explicit OloEngineEditor(const ApplicationSpecification& spec, bool pushEditorLayer = true)
             : Application(spec)
         {
-            PushLayer(std::make_unique<EditorLayer>());
+            // In `--smoke-test` mode the EditorLayer is skipped: it drives the
+            // GL/ImGui editor UI which needs a real OpenGL 4.6 context, and the
+            // app runs window-less there. See CreateApplication below.
+            if (pushEditorLayer)
+            {
+                PushLayer(std::make_unique<EditorLayer>());
+            }
         }
 
         ~OloEngineEditor() final = default;
@@ -26,6 +32,21 @@ namespace OloEngine
         spec.Name = "OloEditor";
         spec.IsEditor = true;
         spec.CommandLineArgs = args;
+
+        // `--smoke-test`: validate that the binary launches and resolves all its
+        // statically-imported runtime DLLs (FFmpeg etc.), then exit cleanly. The
+        // missing-DLL bug class this guards against (issue #303) kills the process
+        // in the OS loader before main() is even reached, so simply reaching a
+        // clean exit proves the DLLs are present. The editor's GL/ImGui path needs
+        // a real OpenGL 4.6 context that CI runners don't have, so smoke mode runs
+        // window-less (IsHeadless) and skips the EditorLayer — mirroring the repo's
+        // "degrade gracefully where there's no GL" convention.
+        if (args.Contains("--smoke-test"))
+        {
+            spec.IsHeadless = true;
+            spec.SmokeTestTickLimit = SmokeTestTickCount;
+            return new OloEngineEditor(spec, /*pushEditorLayer=*/false);
+        }
 
         return new OloEngineEditor(spec);
     }

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -326,6 +326,15 @@ namespace OloEngine
 
             // Snapshot per-function performance data for this frame
             m_PerformanceProfiler.EndFrame();
+
+            // Launch-smoke-test mode: after the configured number of ticks the
+            // app has proven it starts and the loop advances — close cleanly.
+            if (m_Specification.SmokeTestTickLimit > 0 &&
+                ++m_SmokeTestTicksCompleted >= m_Specification.SmokeTestTickLimit)
+            {
+                OLO_CORE_INFO("[SmokeTest] Completed {} tick(s); shutting down cleanly.", m_SmokeTestTicksCompleted);
+                m_Running = false;
+            }
         }
     }
 
@@ -369,6 +378,16 @@ namespace OloEngine
                 }
 
                 accumulator -= tickInterval;
+
+                // Launch-smoke-test mode: stop once the loop has advanced the
+                // configured number of ticks (proves headless startup works).
+                if (m_Specification.SmokeTestTickLimit > 0 &&
+                    ++m_SmokeTestTicksCompleted >= m_Specification.SmokeTestTickLimit)
+                {
+                    OLO_CORE_INFO("[SmokeTest] Completed {} tick(s); shutting down cleanly.", m_SmokeTestTicksCompleted);
+                    m_Running = false;
+                    break;
+                }
             }
 
             m_PerformanceProfiler.EndFrame();

--- a/OloEngine/src/OloEngine/Core/Application.h
+++ b/OloEngine/src/OloEngine/Core/Application.h
@@ -9,6 +9,7 @@
 #include "OloEngine/Renderer/RendererTypes.h"
 
 #include <memory>
+#include <string_view>
 
 #ifndef OLO_HEADLESS
 #include "OloEngine/Core/Window.h"
@@ -38,7 +39,26 @@ namespace OloEngine
             OLO_CORE_ASSERT(index < Count);
             return Args[index];
         }
+
+        // True if `flag` appears among the arguments (argv[0] / program name is
+        // skipped). Used to detect mode-switch flags like `--smoke-test`.
+        [[nodiscard]] bool Contains(std::string_view flag) const
+        {
+            for (int i = 1; i < Count; ++i)
+            {
+                if (Args[i] != nullptr && flag == Args[i])
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     };
+
+    // Number of update ticks a `--smoke-test` launch runs before it auto-closes
+    // with EXIT_SUCCESS. A handful of ticks proves the main loop actually
+    // advances past construction while keeping the CI launch check fast.
+    inline constexpr u32 SmokeTestTickCount = 3;
 
     struct ApplicationSpecification
     {
@@ -49,6 +69,12 @@ namespace OloEngine
         bool IsHeadless = false;
         bool IsEditor = false;
         u32 HeadlessTickRate = 60; // Hz — only used when IsHeadless == true
+
+        // When > 0, the app runs in launch-smoke-test mode: it performs full
+        // startup (DLL load, subsystem init), runs this many ticks, then closes
+        // cleanly (EXIT_SUCCESS). 0 = normal run with no auto-close. See the
+        // `--smoke-test` handling in each app's CreateApplication.
+        u32 SmokeTestTickLimit = 0;
     };
 
     class Application
@@ -95,6 +121,21 @@ namespace OloEngine
         [[nodiscard("Store this!")]] bool IsHeadless() const
         {
             return m_Specification.IsHeadless;
+        }
+
+        // True if this app was launched in `--smoke-test` mode (auto-closes
+        // after SmokeTestTickLimit ticks). See main() in EntryPoint.h.
+        [[nodiscard("Store this!")]] bool IsSmokeTest() const
+        {
+            return m_Specification.SmokeTestTickLimit > 0;
+        }
+
+        // True once the run loop has completed the configured number of smoke
+        // ticks. If the app closed earlier (e.g. a layer aborted startup), this
+        // is false and main() reports the launch as failed.
+        [[nodiscard("Store this!")]] bool SmokeTestPassed() const
+        {
+            return m_SmokeTestTicksCompleted >= m_Specification.SmokeTestTickLimit;
         }
 
         [[nodiscard("Store this!")]] static const std::filesystem::path& GetStartupWorkingDirectory()
@@ -154,6 +195,7 @@ namespace OloEngine
         f32 m_LastFrameTime = 0.0f;
         f32 m_TimeScale = 1.0f;
         f32 m_UnscaledDeltaTime = 0.0f;
+        u32 m_SmokeTestTicksCompleted = 0; // see SmokeTestTickLimit / IsSmokeTest
         PerformanceProfiler m_PerformanceProfiler;
 
       private:

--- a/OloEngine/src/OloEngine/Core/Application.h
+++ b/OloEngine/src/OloEngine/Core/Application.h
@@ -130,12 +130,16 @@ namespace OloEngine
             return m_Specification.SmokeTestTickLimit > 0;
         }
 
-        // True once the run loop has completed the configured number of smoke
-        // ticks. If the app closed earlier (e.g. a layer aborted startup), this
-        // is false and main() reports the launch as failed.
+        // True only when a smoke test is active AND the run loop has completed
+        // the configured number of ticks. If the app closed earlier (e.g. a
+        // layer aborted startup), this is false and main() reports the launch as
+        // failed. The explicit SmokeTestTickLimit > 0 check means this is safe to
+        // call in any mode — it never reports "passed" for a normal (non-smoke)
+        // run, where the limit is 0.
         [[nodiscard("Store this!")]] bool SmokeTestPassed() const
         {
-            return m_SmokeTestTicksCompleted >= m_Specification.SmokeTestTickLimit;
+            return m_Specification.SmokeTestTickLimit > 0 &&
+                   m_SmokeTestTicksCompleted >= m_Specification.SmokeTestTickLimit;
         }
 
         [[nodiscard("Store this!")]] static const std::filesystem::path& GetStartupWorkingDirectory()

--- a/OloEngine/src/OloEngine/Core/EntryPoint.h
+++ b/OloEngine/src/OloEngine/Core/EntryPoint.h
@@ -42,6 +42,16 @@ int main(int argc, char** argv)
             app->Run();
         }
 #endif
+        // Launch-smoke-test mode (`--smoke-test`): the run loop auto-closes once
+        // it has completed the configured ticks. If the app instead shut down
+        // before that (e.g. a layer aborted startup), the launch did not fully
+        // succeed — report it as a failure so CI / the in-suite test catch it.
+        if (app->IsSmokeTest() && !app->SmokeTestPassed())
+        {
+            OLO_CORE_ERROR("[SmokeTest] FAILED — application shut down before completing startup validation.");
+            exitCode = EXIT_FAILURE;
+        }
+
         OLO_PROFILE_END_SESSION();
         profileSessionActive = false;
     }

--- a/OloEngine/tests/AppLaunchSmokeTest.cpp
+++ b/OloEngine/tests/AppLaunchSmokeTest.cpp
@@ -1,0 +1,256 @@
+// =============================================================================
+// AppLaunchSmokeTest.cpp
+//
+// Launch smoke tests for the three shipped executables — OloServer, OloEditor,
+// OloRuntime (issue #303). Each test spawns the real built binary with the
+// `--smoke-test` flag, which performs full startup (runtime-DLL load, subsystem
+// init, network listen for the server) and then exits cleanly with EXIT_SUCCESS
+// after a few ticks. The test asserts the process exits 0 within a timeout.
+//
+// What this guards against: the "missing runtime DLL" regression class. FFmpeg
+// (avcodec/avformat/avutil/swscale/swresample) is a *static* PE import on every
+// OloEngine binary, so if a DLL isn't deployed next to the .exe the Windows
+// loader fails the process before main() ever runs — a clean exit 0 proves the
+// imports all resolved. The smoke flag drives the GUI apps window-less so the
+// check runs without a GPU / GL 4.6 context (CI runners have none); it does not
+// claim to validate the GL rendering path. See docs/agent-rules and CLAUDE.md.
+//
+// The binary paths are injected by CMake (OLO_TEST_OLO*_EXE); the subprocess
+// working directory is the editor asset root (OLO_TEST_EDITOR_ROOT) so shaders /
+// assets / Mono assemblies resolve exactly as they do for a normal run. When a
+// target isn't built on this platform (or its binary is simply absent), the
+// matching test SKIPs cleanly rather than failing — mirroring the renderer
+// suite's "skip when the prerequisite is missing" convention.
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// CMake injects each shipped binary's on-disk path (forward-slashed). A target
+// that isn't configured/built on this platform leaves its macro undefined; fall
+// back to an empty string and SKIP at runtime.
+#ifndef OLO_TEST_OLOSERVER_EXE
+#define OLO_TEST_OLOSERVER_EXE ""
+#endif
+#ifndef OLO_TEST_OLOEDITOR_EXE
+#define OLO_TEST_OLOEDITOR_EXE ""
+#endif
+#ifndef OLO_TEST_OLORUNTIME_EXE
+#define OLO_TEST_OLORUNTIME_EXE ""
+#endif
+#ifndef OLO_TEST_EDITOR_ROOT
+#define OLO_TEST_EDITOR_ROOT ""
+#endif
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <sys/wait.h>
+#include <csignal>
+#include <ctime>
+#endif
+
+namespace
+{
+    struct LaunchResult
+    {
+        bool Launched = false;
+        bool TimedOut = false;
+        int ExitCode = 0;
+        std::string Error;
+    };
+
+#if defined(_WIN32)
+    LaunchResult RunProcessWithTimeout(const std::string& exePath,
+                                       const std::vector<std::string>& args,
+                                       const std::string& workingDir,
+                                       unsigned timeoutMs)
+    {
+        LaunchResult result;
+
+        // Build a single command line: quoted exe path followed by the args.
+        // The args used here ("--smoke-test", "--port", "28777") contain no
+        // spaces, so they're appended verbatim.
+        std::string cmdLine = "\"" + exePath + "\"";
+        for (const auto& a : args)
+        {
+            cmdLine += ' ';
+            cmdLine += a;
+        }
+        std::vector<char> mutableCmd(cmdLine.begin(), cmdLine.end());
+        mutableCmd.push_back('\0');
+
+        STARTUPINFOA si{};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi{};
+
+        const BOOL ok = ::CreateProcessA(
+            nullptr, // module taken from the (quoted) command line
+            mutableCmd.data(),
+            nullptr, nullptr, FALSE,
+            CREATE_NO_WINDOW,
+            nullptr,
+            workingDir.empty() ? nullptr : workingDir.c_str(),
+            &si, &pi);
+
+        if (!ok)
+        {
+            result.Error = "CreateProcessA failed (GetLastError=" + std::to_string(::GetLastError()) + ")";
+            return result;
+        }
+        result.Launched = true;
+
+        const DWORD wait = ::WaitForSingleObject(pi.hProcess, timeoutMs);
+        if (wait == WAIT_TIMEOUT)
+        {
+            result.TimedOut = true;
+            ::TerminateProcess(pi.hProcess, 1);
+            ::WaitForSingleObject(pi.hProcess, 5000);
+        }
+        else
+        {
+            DWORD code = 1;
+            ::GetExitCodeProcess(pi.hProcess, &code);
+            result.ExitCode = static_cast<int>(code);
+        }
+
+        ::CloseHandle(pi.hProcess);
+        ::CloseHandle(pi.hThread);
+        return result;
+    }
+#else
+    LaunchResult RunProcessWithTimeout(const std::string& exePath,
+                                       const std::vector<std::string>& args,
+                                       const std::string& workingDir,
+                                       unsigned timeoutMs)
+    {
+        LaunchResult result;
+
+        const pid_t pid = ::fork();
+        if (pid < 0)
+        {
+            result.Error = "fork failed";
+            return result;
+        }
+        if (pid == 0)
+        {
+            // Child: switch working directory, then exec the target binary.
+            if (!workingDir.empty() && ::chdir(workingDir.c_str()) != 0)
+            {
+                ::_exit(127);
+            }
+            std::vector<char*> argv;
+            argv.push_back(const_cast<char*>(exePath.c_str()));
+            for (const auto& a : args)
+            {
+                argv.push_back(const_cast<char*>(a.c_str()));
+            }
+            argv.push_back(nullptr);
+            ::execv(exePath.c_str(), argv.data());
+            ::_exit(127); // exec failed
+        }
+
+        result.Launched = true;
+
+        constexpr unsigned stepMs = 50;
+        unsigned waited = 0;
+        int status = 0;
+        for (;;)
+        {
+            const pid_t r = ::waitpid(pid, &status, WNOHANG);
+            if (r == pid)
+            {
+                break;
+            }
+            if (r < 0)
+            {
+                result.Error = "waitpid failed";
+                return result;
+            }
+            if (waited >= timeoutMs)
+            {
+                result.TimedOut = true;
+                ::kill(pid, SIGKILL);
+                ::waitpid(pid, &status, 0);
+                return result;
+            }
+            timespec ts{ 0, static_cast<long>(stepMs) * 1000000L };
+            ::nanosleep(&ts, nullptr);
+            waited += stepMs;
+        }
+
+        result.ExitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
+        return result;
+    }
+#endif
+
+    // Generous per-process cap. A real launch (DLL load + subsystem init + a few
+    // ticks + shutdown) is seconds; this only fires on a genuine startup hang,
+    // and stays well under the CTest per-test timeout.
+    constexpr unsigned kSmokeTimeoutMs = 30000;
+
+    void RunLaunchSmoke(const char* exePath, const std::vector<std::string>& args)
+    {
+        namespace fs = std::filesystem;
+
+        if (exePath == nullptr || exePath[0] == '\0')
+        {
+            GTEST_SKIP() << "Target binary path not provided by the build "
+                            "(app target not configured on this platform).";
+        }
+
+        std::error_code ec;
+        if (!fs::exists(exePath, ec))
+        {
+            GTEST_SKIP() << "Binary not found at " << exePath
+                         << " — build the app target to exercise this launch smoke test.";
+        }
+
+        // Run from the editor asset root so shaders / assets / Mono assemblies
+        // resolve exactly as in a normal launch (see CLAUDE.md "Working directory
+        // matters"). DLLs are found next to the .exe regardless of this cwd.
+        const std::string workingDir = OLO_TEST_EDITOR_ROOT;
+
+        const LaunchResult r = RunProcessWithTimeout(exePath, args, workingDir, kSmokeTimeoutMs);
+
+        ASSERT_TRUE(r.Launched) << "Failed to launch " << exePath << ": " << r.Error;
+        ASSERT_FALSE(r.TimedOut) << exePath << " did not exit within " << kSmokeTimeoutMs
+                                 << " ms — the app likely hung during startup.";
+        EXPECT_EQ(r.ExitCode, 0) << exePath << " exited with code " << r.ExitCode
+                                 << ". A non-zero exit means startup failed — most likely a missing "
+                                    "runtime DLL (the regression class issue #303 targets) or a "
+                                    "subsystem init crash.";
+    }
+} // namespace
+
+// OloServer is headless by design, so its --smoke-test runs the real server
+// startup (incl. a network listen) end-to-end. A dedicated port avoids clashing
+// with a developer's running server on the default 7777.
+TEST(AppLaunchSmoke, OloServerLaunchesCleanly)
+{
+    RunLaunchSmoke(OLO_TEST_OLOSERVER_EXE, { "--smoke-test", "--port", "28777" });
+}
+
+// OloEditor/OloRuntime need a real GL 4.6 context for their UI/render layers,
+// which CI runners lack — so --smoke-test runs them window-less, validating that
+// the binary starts and loads its DLLs. See OloEditorApp.cpp for the rationale.
+TEST(AppLaunchSmoke, OloEditorLaunchesCleanly)
+{
+    RunLaunchSmoke(OLO_TEST_OLOEDITOR_EXE, { "--smoke-test" });
+}
+
+TEST(AppLaunchSmoke, OloRuntimeLaunchesCleanly)
+{
+    RunLaunchSmoke(OLO_TEST_OLORUNTIME_EXE, { "--smoke-test" });
+}

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(OloEngine-Tests
 		ComponentSerializerCoverageTest.cpp
 		SceneSerializerFuzzRegressionTest.cpp
 		EngineSubsystemSmokeTest.cpp
+		AppLaunchSmokeTest.cpp
 		FunctionalTestFixtureCoverageTest.cpp
 		PreCommitToolingSmokeTest.cpp
 		PrefabOverrideTest.cpp

--- a/OloEngine/tests/scripts/test_catalogue.json
+++ b/OloEngine/tests/scripts/test_catalogue.json
@@ -214,6 +214,7 @@
     "OloEngine/tests/Terrain/TerrainGeneratorTest.cpp": "unit",
     "OloEngine/tests/AnimationStateMachineTest.cpp": "unit",
     "OloEngine/tests/AnimationSystemTest.cpp": "unit",
+    "OloEngine/tests/AppLaunchSmokeTest.cpp": "unit",
     "OloEngine/tests/AssetBinaryIntegrityTest.cpp": "unit",
     "OloEngine/tests/AssetCSharpScriptValidityTest.cpp": "unit",
     "OloEngine/tests/AssetContentValidityTest.cpp": "unit",

--- a/OloRuntime/src/OloRuntimeApp.cpp
+++ b/OloRuntime/src/OloRuntimeApp.cpp
@@ -357,14 +357,22 @@ namespace OloEngine
     class OloGameRuntime : public Application
     {
       public:
-        explicit OloGameRuntime(const ApplicationSpecification& spec)
+        explicit OloGameRuntime(const ApplicationSpecification& spec, bool pushRuntimeLayer = true)
             : Application(spec)
         {
-            // Disable ImGui ini persistence — the runtime doesn't need it and
-            // loading the editor's imgui.ini from CWD would cause stale state.
-            ImGui::GetIO().IniFilename = nullptr;
+            // In `--smoke-test` mode the RuntimeLayer is skipped: it loads the
+            // asset pack / start scene and renders through the GL pipeline, which
+            // needs a real OpenGL 4.6 context. ImGui isn't initialized in that
+            // window-less path either, so GetIO() must not be touched. See
+            // CreateApplication below.
+            if (pushRuntimeLayer)
+            {
+                // Disable ImGui ini persistence — the runtime doesn't need it and
+                // loading the editor's imgui.ini from CWD would cause stale state.
+                ImGui::GetIO().IniFilename = nullptr;
 
-            PushLayer(std::make_unique<RuntimeLayer>());
+                PushLayer(std::make_unique<RuntimeLayer>());
+            }
         }
 
         ~OloGameRuntime() final = default;
@@ -375,6 +383,17 @@ namespace OloEngine
         ApplicationSpecification spec;
         spec.Name = "OloEngine Game";
         spec.CommandLineArgs = args;
+
+        // `--smoke-test`: window-less launch validation — see OloEditorApp.cpp for
+        // the rationale. Proves the runtime binary starts and resolves its runtime
+        // DLLs (issue #303) without needing a GPU; the GL-dependent RuntimeLayer is
+        // skipped and the app auto-closes after a few ticks with EXIT_SUCCESS.
+        if (args.Contains("--smoke-test"))
+        {
+            spec.IsHeadless = true;
+            spec.SmokeTestTickLimit = SmokeTestTickCount;
+            return new OloGameRuntime(spec, /*pushRuntimeLayer=*/false);
+        }
 
         // Read game name from manifest if available.
         // PreferredRenderer stays as Renderer2D (the default) — Renderer3D is

--- a/OloServer/src/OloServerApp.cpp
+++ b/OloServer/src/OloServerApp.cpp
@@ -301,6 +301,16 @@ namespace OloEngine
         spec.HeadlessTickRate = config.TickRate;
         spec.CommandLineArgs = args;
 
+        // `--smoke-test`: run the full headless startup (DLL load, subsystem
+        // init, scene load if configured, network listen) and then auto-close
+        // after a few ticks with EXIT_SUCCESS. Used by CI and the in-suite
+        // AppLaunchSmokeTest to prove the shipped binary launches with all its
+        // runtime DLLs present (issue #303).
+        if (args.Contains("--smoke-test"))
+        {
+            spec.SmokeTestTickLimit = SmokeTestTickCount;
+        }
+
         return new OloServerApplication(spec, config);
     }
 } // namespace OloEngine

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1298,12 +1298,13 @@ level of `tests/`). Grouped by directory.
 
 > **Do not edit by hand.** Generated from [test_catalogue.json](../OloEngine/tests/scripts/test_catalogue.json) by [generate_test_catalogue.py](../OloEngine/tests/scripts/generate_test_catalogue.py). Add new test files to the config and run the script (or pre-commit will run it with `--check`).
 
-#### (top-level) (60 files)
+#### (top-level) (61 files)
 
 | File | Tests | Cases |
 |---|---:|---|
 | [AnimationStateMachineTest.cpp](../OloEngine/tests/AnimationStateMachineTest.cpp) | 10 | **AnimationStateMachineTest** &mdash; `ParameterSetAndGet`, `TriggerConsumption`, `TransitionConditionFloat`, `TransitionConditionBool`, `TransitionConditionTrigger`, `TransitionANDLogic`, `BasicTransition`, `AnyStateTransition`, `ExitTimeTransition`, `CrossFadeBlending` |
 | [AnimationSystemTest.cpp](../OloEngine/tests/AnimationSystemTest.cpp) | 4 | **AnimationSystem** &mdash; `NonAnimatedBonePreservesBindPoseTransform`, `BindPoseResetSkippedWhenNotInitialized`, `BlendingPreservesNonAnimatedBoneTransform`, `AnimatedBoneIsUpdatedFromKeyframes` |
+| [AppLaunchSmokeTest.cpp](../OloEngine/tests/AppLaunchSmokeTest.cpp) | 3 | **AppLaunchSmoke** &mdash; `OloServerLaunchesCleanly`, `OloEditorLaunchesCleanly`, `OloRuntimeLaunchesCleanly` |
 | [AssetBinaryIntegrityTest.cpp](../OloEngine/tests/AssetBinaryIntegrityTest.cpp) | 2 | **AssetBinaryIntegrity** &mdash; `AllPngFilesHaveValidPngMagic`, `AllWavFilesHaveValidRiffWavePrefix` |
 | [AssetCSharpScriptValidityTest.cpp](../OloEngine/tests/AssetCSharpScriptValidityTest.cpp) | 4 | **AssetCSharpScriptValidity** &mdash; `EveryCSharpFileDeclaresClassMatchingFilename`, `EveryEntityDerivedScriptIsReferencedByAtLeastOneScene`, `EveryCSharpFileIsListedInCMakeSources`, `EveryNonEntityHelperClassIsReferencedByAnotherSource` |
 | [AssetContentValidityTest.cpp](../OloEngine/tests/AssetContentValidityTest.cpp) | 24 | **AssetContentValidity** &mdash; `AllSandboxScenesAreStructurallyValid`, `AllSandboxItemsAreStructurallyValid`, `AllSandboxQuestsAreStructurallyValid`, `AllSandboxDialoguesAreStructurallyValid`, `AllSandboxScenesHaveUniqueEntityUUIDs`, `AllSandboxScenePrefabComponentsHaveRequiredUUIDs`, `AllSandboxScenesHaveUniquePrefabEntityIDsPerPrefab`, `AllSandboxShaderGraphsAreStructurallyValid`, `SandboxSceneReferencedScriptsExistOnDisk`, `SandboxAssetRegistryDeserialisesAndPathsResolve`, `EverySupportedAssetOnDiskIsInTheRegistry`, `SandboxAssetRegistryPathsMatchOnDiskCasing`, `AllSandboxSceneAssetHandlesAreInTheRegistry`, `ShaderCacheEntriesAllHaveLiveGlslSources`, `AllCacheFilesMatchKnownPattern`, `EveryProductionShaderIsReferencedFromSource`, `SandboxProjectFilePathsAreAllRelative`, `DISABLED_RebaseAssetRegistry`, `SceneScriptFieldNamesMatchCSharpDeclarations`, `SandboxEditorPreferencesAreStructurallyValid`, `AllSandboxScenePathReferencesResolve`, `AllSandboxScenePathsUseForwardSlashes`, `AllSandboxAssetYAMLPathsUseForwardSlashes`, `SandboxInputActionsAreStructurallyValid` |
@@ -1527,7 +1528,7 @@ level of `tests/`). Grouped by directory.
 |---|---:|---|
 | [TerrainGeneratorTest.cpp](../OloEngine/tests/Terrain/TerrainGeneratorTest.cpp) | 15 | **TerrainGeneratorTest** &mdash; `HeightFieldIsDeterministic`, `HeightFieldIsNormalizedAndFinite`, `LargeSeedStillProducesVariedTerrain`, `DifferentSeedsProduceDifferentTerrain`, `RidgedAndWarpAndExponentStayValid`, `TerraceShapingStaysValidAndDeterministic`, `TerraceEndpointsAndIdentity`, `TerraceIsMonotonicAndBounded`, `TerraceProducesFlatPlateaus`, `RuleWeightPeaksInsideBandAndZeroOutside`, `SlopeBandSelectsRule`, `DefaultRulesAssignExpectedLayers`, `LayerWeightsAreNormalized`, `NoMatchingRuleFallsBackToLayerZero`, `PackLayerWeightsQuantizesToBothSplatmaps` |
 
-**Totals.** 129 unit / subsystem test files, 1579 TEST / TEST_F declarations across all subsystems.
+**Totals.** 130 unit / subsystem test files, 1582 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: unit-catalogue -->
 


### PR DESCRIPTION
…er (#303)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--smoke-test` command-line flag support to OloServer, OloEditor, and OloRuntime for automated launch validation.

* **Tests**
  * Implemented automated smoke-test suite to verify all three shipped applications launch cleanly without errors.

* **Chores**
  * Enhanced Windows CI/CD pipeline with automated executable validation to catch launch regressions early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->