### PR TITLE
feat(mcp): camera control, viewport sizing, and render-target capture…

### DIFF
--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -161,7 +161,63 @@ Show-Tool 'olo_log_tail' @{ count = 5; minLevel = 'warn' } | Out-Null
 # 22. Crash reports
 Show-Tool 'olo_crash_list' @{} | Out-Null
 
-# 23-24. Prompts (third MCP primitive)
+# 25-29. Tier-0 camera / viewport control + render-target capture (#316)
+$camGet = Show-Tool 'olo_camera_get' @{}
+$camObj = $camGet.result.content[0].text | ConvertFrom-Json
+Show-Tool 'olo_camera_set_pose' @{ position = @(0, 5, 10); target = @(0, 0, 0) } | Out-Null
+Show-Tool 'olo_camera_orbit' @{ target = @(0, 0, 0); yaw = 45; pitch = 30; distance = 15 } | Out-Null
+
+# frame an entity if one exists
+if ($listObj.entities.Count -gt 0) {
+    Show-Tool 'olo_camera_frame_entity' @{ id = $listObj.entities[0].id } | Out-Null
+}
+
+# restore something close to the original camera pose
+Show-Tool 'olo_camera_set_pose' @{ position = @($camObj.position[0], $camObj.position[1], $camObj.position[2]); yaw = $camObj.yawDegrees; pitch = $camObj.pitchDegrees } | Out-Null
+
+# viewport override + reset
+Show-Tool 'olo_viewport_set_size' @{ width = 1280; height = 720 } | Out-Null
+Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
+
+# 30. olo_screenshot with a one-shot camera pose (save/restore path).
+# Orbit the sandbox terrain's centre (terrain spans [0,256]^2) — orbiting the
+# world origin puts the camera underground here and captures a black frame.
+$posedShot = Invoke-Rpc 'tools/call' @{ name = 'olo_screenshot'; arguments = @{ maxWidth = 512; orbit = @{ target = @(128, 24, 128); yaw = 90; pitch = 35; distance = 300 }; settleFrames = 2 } }
+$posedBlock = $posedShot.result.content | Where-Object { $_.type -eq 'image' } | Select-Object -First 1
+if ($posedBlock -and $posedBlock.data) {
+    $bytes = [Convert]::FromBase64String($posedBlock.data)
+    $outPng = Join-Path $env:TEMP 'olo-mcp-screenshot-posed.png'
+    [IO.File]::WriteAllBytes($outPng, $bytes)
+    Write-Host "tools/call olo_screenshot(orbit) -> $($bytes.Length) bytes, saved to $outPng" -ForegroundColor Green
+} else {
+    Write-Error 'Posed screenshot did not return an image content block'
+}
+
+# 31-32. Render-target listing + capture
+$targets = Show-Tool 'olo_render_list_targets' @{}
+$targetsObj = $targets.result.content[0].text | ConvertFrom-Json
+if ($targetsObj.count -gt 0) {
+    foreach ($targetName in @('SceneColor', 'SceneDepth')) {
+        if ($targetsObj.targets | Where-Object { $_.name -eq $targetName }) {
+            $cap = Invoke-Rpc 'tools/call' @{ name = 'olo_render_capture_target'; arguments = @{ name = $targetName; maxWidth = 512 } }
+            $img = $cap.result.content | Where-Object { $_.type -eq 'image' } | Select-Object -First 1
+            $meta = $cap.result.content | Where-Object { $_.type -eq 'text' } | Select-Object -First 1
+            if ($img -and $img.data) {
+                $bytes = [Convert]::FromBase64String($img.data)
+                $outPng = Join-Path $env:TEMP "olo-mcp-target-$targetName.png"
+                [IO.File]::WriteAllBytes($outPng, $bytes)
+                Write-Host "tools/call olo_render_capture_target($targetName) -> $($bytes.Length) bytes, saved to $outPng" -ForegroundColor Green
+                Write-Host "  meta: $(($meta.text -replace '\s+', ' '))"
+            } else {
+                Write-Error "olo_render_capture_target($targetName) did not return an image"
+            }
+        }
+    }
+} else {
+    Write-Host '(no render targets — editor not in 3D mode?)' -ForegroundColor Yellow
+}
+
+# 33-34. Prompts (third MCP primitive)
 $plist = Invoke-Rpc 'prompts/list' $null
 Write-Host "prompts/list -> $($plist.result.prompts.Count) prompts: $(@($plist.result.prompts | ForEach-Object { $_.name }) -join ', ')" -ForegroundColor Green
 $pget = Invoke-Rpc 'prompts/get' @{ name = 'diagnose-performance' }

--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -172,8 +172,14 @@ if ($listObj.entities.Count -gt 0) {
     Show-Tool 'olo_camera_frame_entity' @{ id = $listObj.entities[0].id } | Out-Null
 }
 
-# restore something close to the original camera pose
-Show-Tool 'olo_camera_set_pose' @{ position = @($camObj.position[0], $camObj.position[1], $camObj.position[2]); yaw = $camObj.yawDegrees; pitch = $camObj.pitchDegrees } | Out-Null
+# restore the original camera state: when it had a live orbit pivot (distance > 0)
+# restore via olo_camera_orbit so focal point + distance survive; otherwise restore
+# the free pose. Either way restore the FOV too.
+if ($camObj.distance -gt 0) {
+    Show-Tool 'olo_camera_orbit' @{ target = @($camObj.focalPoint[0], $camObj.focalPoint[1], $camObj.focalPoint[2]); yaw = $camObj.yawDegrees; pitch = $camObj.pitchDegrees; distance = $camObj.distance; fov = $camObj.fovDegrees } | Out-Null
+} else {
+    Show-Tool 'olo_camera_set_pose' @{ position = @($camObj.position[0], $camObj.position[1], $camObj.position[2]); yaw = $camObj.yawDegrees; pitch = $camObj.pitchDegrees; fov = $camObj.fovDegrees } | Out-Null
+}
 
 # viewport override + reset
 Show-Tool 'olo_viewport_set_size' @{ width = 1280; height = 720 } | Out-Null
@@ -193,10 +199,16 @@ if ($posedBlock -and $posedBlock.data) {
     Write-Error 'Posed screenshot did not return an image content block'
 }
 
-# 31-32. Render-target listing + capture
+# 31-32. Render-target listing + capture. The tool errors (plain-text content,
+# not JSON) when no render graph is active, so guard before parsing.
 $targets = Show-Tool 'olo_render_list_targets' @{}
-$targetsObj = $targets.result.content[0].text | ConvertFrom-Json
-if ($targetsObj.count -gt 0) {
+$targetsObj = $null
+if (-not $targets.result -or $targets.result.isError -or -not $targets.result.content) {
+    Write-Host '(no render targets — editor not in 3D mode?)' -ForegroundColor Yellow
+} else {
+    $targetsObj = $targets.result.content[0].text | ConvertFrom-Json
+}
+if ($targetsObj -and $targetsObj.count -gt 0) {
     foreach ($targetName in @('SceneColor', 'SceneDepth')) {
         if ($targetsObj.targets | Where-Object { $_.name -eq $targetName }) {
             $cap = Invoke-Rpc 'tools/call' @{ name = 'olo_render_capture_target'; arguments = @{ name = $targetName; maxWidth = 512 } }
@@ -213,7 +225,7 @@ if ($targetsObj.count -gt 0) {
             }
         }
     }
-} else {
+} elseif ($targetsObj) {
     Write-Host '(no render targets — editor not in 3D mode?)' -ForegroundColor Yellow
 }
 

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -350,6 +350,14 @@ namespace OloEngine
             { return FrameEditorCameraOnEntity(entityUuid); };
             mcpContext.SetViewportSizeOverride = [this](u32 width, u32 height)
             {
+                // The MCP tool layer already clamps to [64, 8192]; re-clamp here so
+                // the framebuffer/render-graph resize in OnUpdate can never see an
+                // oversized request even if another caller appears. 0,0 = clear.
+                if (width != 0 || height != 0)
+                {
+                    width = std::clamp(width, 64u, 8192u);
+                    height = std::clamp(height, 64u, 8192u);
+                }
                 m_McpViewportSizeOverride = { width, height };
             };
             mcpContext.GetFrameIndex = [this]() -> u64
@@ -2593,9 +2601,14 @@ namespace OloEngine
             radius = std::max({ sx, sy, sz, 0.5f });
         }
 
-        // Keep the current view direction; just re-pivot and fit. 2.5x the
-        // bounding radius comfortably fits the entity at the default 30-45 FOV.
-        m_EditorCamera.Focus(center, radius * 2.5f, m_EditorCamera.GetYaw(), m_EditorCamera.GetPitch());
+        // Keep the current view direction; just re-pivot and fit. Derive the
+        // distance from the camera's vertical FOV so the bounding sphere fills
+        // the frame at any FOV (a fixed multiplier underfits at the editor's
+        // default 30 degrees), with a small margin so silhouettes don't touch
+        // the frame edge.
+        const f32 fovRadians = glm::radians(m_EditorCamera.GetFOV());
+        const f32 fitDistance = (radius / std::tan(fovRadians * 0.5f)) * 1.05f;
+        m_EditorCamera.Focus(center, fitDistance, m_EditorCamera.GetYaw(), m_EditorCamera.GetPitch());
         return true;
     }
 

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -312,6 +312,60 @@ namespace OloEngine
                 }
                 return CaptureFramebufferPng(target, maxWidth);
             };
+
+            // Tier-0 camera / viewport control (#316). Editor-only inspection
+            // state; nothing here touches the project.
+            mcpContext.GetCameraPose = [this]() -> MCP::McpCameraPose
+            {
+                MCP::McpCameraPose pose;
+                pose.Position = m_EditorCamera.GetPosition();
+                pose.FocalPoint = m_EditorCamera.GetFocalPoint();
+                pose.Forward = m_EditorCamera.GetForwardDirection();
+                pose.Distance = m_EditorCamera.GetDistance();
+                pose.YawRadians = m_EditorCamera.GetYaw();
+                pose.PitchRadians = m_EditorCamera.GetPitch();
+                pose.FovDegrees = m_EditorCamera.GetFOV();
+                pose.NearClip = m_EditorCamera.GetNearClip();
+                pose.FarClip = m_EditorCamera.GetFarClip();
+                pose.ViewportWidth = static_cast<u32>(m_ViewportSize.x);
+                pose.ViewportHeight = static_cast<u32>(m_ViewportSize.y);
+                return pose;
+            };
+            mcpContext.SetCameraPose = [this](const glm::vec3& eye, f32 yawRadians, f32 pitchRadians, f32 fovDegrees)
+            {
+                if (fovDegrees > 0.0f)
+                    m_EditorCamera.SetFOV(fovDegrees);
+                m_EditorCamera.SetPose(eye, yawRadians, pitchRadians);
+            };
+            mcpContext.OrbitCamera = [this](const glm::vec3& target, f32 yawRadians, f32 pitchRadians, f32 distance)
+            {
+                m_EditorCamera.Focus(target, distance, yawRadians, pitchRadians);
+            };
+            mcpContext.RestoreCameraPose = [this](const MCP::McpCameraPose& pose)
+            {
+                m_EditorCamera.SetFOV(pose.FovDegrees);
+                m_EditorCamera.Focus(pose.FocalPoint, pose.Distance, pose.YawRadians, pose.PitchRadians);
+            };
+            mcpContext.FrameEntity = [this](u64 entityUuid) -> bool
+            { return FrameEditorCameraOnEntity(entityUuid); };
+            mcpContext.SetViewportSizeOverride = [this](u32 width, u32 height)
+            {
+                m_McpViewportSizeOverride = { width, height };
+            };
+            mcpContext.GetFrameIndex = [this]() -> u64
+            { return m_FrameIndex; };
+            mcpContext.IsCaptureUnready = [this]() -> bool
+            {
+                // Unready while throttled, or within a few frames of a viewport
+                // resize: freshly resized render-graph framebuffers render black
+                // for the first couple of frames (verified against the live
+                // editor — 2 frames after a resize still captured black, 6 were
+                // clean), so wait out a conservative window.
+                constexpr u64 kResizeSettleFrames = 6;
+                return m_ViewportRenderSkipped ||
+                       (m_FrameIndex < m_LastViewportResizeFrame + kResizeSettleFrames);
+            };
+
             m_McpServer = CreateScope<MCP::McpServer>(std::move(mcpContext));
             MCP::RegisterBuiltinTools(*m_McpServer);
             // Apply the persisted redaction preference (loaded by OpenProject above).
@@ -393,6 +447,8 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
         OLO_PERF_SCOPE("EditorLayer::OnUpdate", Application::Get().GetPerformanceProfiler());
 
+        ++m_FrameIndex; // MCP capture tools key off this to await a rendered frame
+
         m_LastFrameTimeMs = ts.GetMilliseconds();
 
         // Sync with async asset loading thread
@@ -420,6 +476,7 @@ namespace OloEngine
             ((std::abs(static_cast<f32>(spec.Width) - static_cast<f32>(fbWidth)) > epsilon) || (std::abs(static_cast<f32>(spec.Height) - static_cast<f32>(fbHeight)) > epsilon)))
         {
             m_Framebuffer->Resize(fbWidth, fbHeight);
+            m_LastViewportResizeFrame = m_FrameIndex; // MCP captures must wait out the resize transient
             m_CameraController.OnResize(m_ViewportSize.x, m_ViewportSize.y);
             m_EditorCamera.SetViewportSize(m_ViewportSize.x, m_ViewportSize.y);
 
@@ -987,7 +1044,13 @@ namespace OloEngine
         Application::Get().GetImGuiLayer()->BlockEvents(!m_ViewportHovered);
 
         ImVec2 const viewportPanelSize = ImGui::GetContentRegionAvail();
-        m_ViewportSize = { viewportPanelSize.x, viewportPanelSize.y };
+        // MCP viewport override (#316): pin the render size for deterministic
+        // captures regardless of the panel's layout. The image is still drawn
+        // into the panel rect below (clipped/letterboxed as needed).
+        if (m_McpViewportSizeOverride.x > 0 && m_McpViewportSizeOverride.y > 0)
+            m_ViewportSize = { static_cast<f32>(m_McpViewportSizeOverride.x), static_cast<f32>(m_McpViewportSizeOverride.y) };
+        else
+            m_ViewportSize = { viewportPanelSize.x, viewportPanelSize.y };
 
         // Display appropriate framebuffer based on mode
         u64 textureID = 0;
@@ -2465,6 +2528,75 @@ namespace OloEngine
             // (grass) tops rather than a grazing angle full of steep rock faces.
             m_EditorCamera.Focus(center, distance, 0.0f, 0.65f);
         }
+    }
+
+    bool EditorLayer::FrameEditorCameraOnEntity(u64 entityUuid)
+    {
+        const Ref<Scene> scene = m_ActiveScene;
+        if (!scene)
+            return false;
+        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+        if (!entityOpt)
+            return false;
+        Entity entity = *entityOpt;
+        if (!entity.HasComponent<TransformComponent>())
+            return false;
+
+        // World transform: compose local transforms up the parent chain (the
+        // scene stores parent-relative transforms; gizmos and rendering do the
+        // same composition).
+        glm::mat4 world = entity.GetComponent<TransformComponent>().GetTransform();
+        for (UUID parentId = entity.GetParentUUID(); static_cast<u64>(parentId) != 0;)
+        {
+            const auto parentOpt = scene->TryGetEntityWithUUID(parentId);
+            if (!parentOpt)
+                break;
+            Entity parent = *parentOpt;
+            if (parent.HasComponent<TransformComponent>())
+                world = parent.GetComponent<TransformComponent>().GetTransform() * world;
+            parentId = parent.GetParentUUID();
+        }
+
+        // Bounds: prefer real mesh bounds, fall back to a scale-derived radius.
+        glm::vec3 center = glm::vec3(world[3]);
+        f32 radius = 0.0f;
+        if (entity.HasComponent<ModelComponent>())
+        {
+            if (const auto& model = entity.GetComponent<ModelComponent>().m_Model; model)
+            {
+                const BoundingBox worldBox = model->GetTransformedBoundingBox(world);
+                center = worldBox.GetCenter();
+                radius = glm::length(worldBox.GetExtents());
+            }
+        }
+        else if (entity.HasComponent<MeshComponent>())
+        {
+            if (const auto& meshSource = entity.GetComponent<MeshComponent>().m_MeshSource; meshSource)
+            {
+                const BoundingBox worldBox = meshSource->GetBoundingBox().Transform(world);
+                center = worldBox.GetCenter();
+                radius = glm::length(worldBox.GetExtents());
+            }
+        }
+        else if (entity.HasComponent<TerrainComponent>())
+        {
+            const auto& tc = entity.GetComponent<TerrainComponent>();
+            center += glm::vec3(tc.m_WorldSizeX * 0.5f, tc.m_HeightScale * 0.4f, tc.m_WorldSizeZ * 0.5f);
+            radius = std::max(tc.m_WorldSizeX, tc.m_WorldSizeZ) * 0.5f;
+        }
+        if (radius < 0.5f)
+        {
+            // Scale-derived fallback: length of the world matrix's basis columns.
+            const f32 sx = glm::length(glm::vec3(world[0]));
+            const f32 sy = glm::length(glm::vec3(world[1]));
+            const f32 sz = glm::length(glm::vec3(world[2]));
+            radius = std::max({ sx, sy, sz, 0.5f });
+        }
+
+        // Keep the current view direction; just re-pivot and fit. 2.5x the
+        // bounding radius comfortably fits the entity at the default 30-45 FOV.
+        m_EditorCamera.Focus(center, radius * 2.5f, m_EditorCamera.GetYaw(), m_EditorCamera.GetPitch());
+        return true;
     }
 
     bool EditorLayer::SaveScene()

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -86,6 +86,9 @@ namespace OloEngine
         // [0, worldSize] from its transform, so the default origin-focused camera
         // would otherwise look right past it). No-op when the scene has no terrain.
         void FrameEditorCameraOnTerrain(const Ref<Scene>& scene);
+        // Orbit-frame the editor camera on one entity (MCP olo_camera_frame_entity).
+        // Returns false when the entity doesn't exist in the active scene.
+        bool FrameEditorCameraOnEntity(u64 entityUuid);
         bool SaveScene();
         bool SaveSceneAs();
 
@@ -272,6 +275,18 @@ namespace OloEngine
         // default), stopped in OnDetach. The user starts it from Window > MCP Server.
         Scope<MCP::McpServer> m_McpServer;
         bool m_ShowMcpPanel = false;
+        // Tier-0 MCP viewport-size override (#316): when non-zero, UI_Viewport
+        // uses this logical size instead of the ImGui panel size so captures
+        // have a deterministic resolution. Set/cleared via olo_viewport_set_size.
+        glm::uvec2 m_McpViewportSizeOverride{ 0, 0 };
+        // Monotonic frame counter, exposed (with m_ViewportRenderSkipped and
+        // m_LastViewportResizeFrame) to the MCP tools so a camera change can be
+        // confirmed rendered before a capture is taken.
+        u64 m_FrameIndex = 0;
+        // Frame at which the viewport framebuffer was last resized. Freshly
+        // resized render-graph framebuffers render black for a couple of
+        // frames, so captures must not trust the first frames after a resize.
+        u64 m_LastViewportResizeFrame = 0;
 
         // Undo/Redo
         CommandHistory m_CommandHistory;

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -14,7 +14,10 @@
 //   * Every request must carry "Authorization: Bearer <token>"; the editor
 //     displays the token for the user to paste into their agent config.
 //   * The Origin header is validated (DNS-rebinding defence).
-//   * Read-only: the dispatch layer exposes only query tools; nothing mutates.
+//   * Read-only with respect to the user's PROJECT: no tool writes scenes,
+//     assets, or files. Tier-0 inspection tools (issue #316) may adjust
+//     editor-only viewport state — the editor camera pose and the viewport
+//     capture size — which is never persisted.
 //
 // Threading: cpp-httplib handles each request on its own worker thread. The
 // already-FMutex-guarded diagnostics (Profiler / MemoryTracker / ShaderDebugger /
@@ -25,6 +28,7 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Scene/Scene.h"
 
+#include <glm/glm.hpp>
 #include <nlohmann/json.hpp>
 
 #include <atomic>
@@ -83,6 +87,24 @@ namespace OloEngine::MCP
         bool MainMarshaled = false;
     };
 
+    // Snapshot of the editor camera's full pose, returned by GetCameraPose and
+    // accepted by RestoreCameraPose. Angles are radians (EditorCamera's units);
+    // FOV is vertical degrees. Distance 0 means a collapsed orbit (free pose).
+    struct McpCameraPose
+    {
+        glm::vec3 Position{ 0.0f };
+        glm::vec3 FocalPoint{ 0.0f };
+        glm::vec3 Forward{ 0.0f, 0.0f, -1.0f };
+        f32 Distance = 0.0f;
+        f32 YawRadians = 0.0f;
+        f32 PitchRadians = 0.0f;
+        f32 FovDegrees = 45.0f;
+        f32 NearClip = 0.1f;
+        f32 FarClip = 1000.0f;
+        u32 ViewportWidth = 0;
+        u32 ViewportHeight = 0;
+    };
+
     // Editor state the main-marshaled tools read. EditorLayer fills these in; the
     // std::function bodies are ONLY safe to call on the main (game) thread, i.e.
     // from inside a MarshalRead() job.
@@ -95,6 +117,37 @@ namespace OloEngine::MCP
         // thread (does GL readback), so call it from inside a MarshalRead job.
         // Returns empty bytes on failure.
         std::function<std::vector<u8>(int maxWidth)> CaptureViewportPng;
+
+        // ---- Tier-0 camera / viewport control (issue #316) -----------------
+        // All main-thread-only, like the readers above. These mutate editor-only
+        // inspection state (never the project): the EditorCamera pose and the
+        // viewport's capture-size override.
+
+        std::function<McpCameraPose()> GetCameraPose;
+        // Pose the camera at an explicit eye position looking along yaw/pitch
+        // (radians); fovDegrees <= 0 keeps the current FOV. Collapses the orbit
+        // (EditorCamera::SetPose) so the pose renders exactly as requested.
+        std::function<void(const glm::vec3& eye, f32 yawRadians, f32 pitchRadians, f32 fovDegrees)> SetCameraPose;
+        // Orbit-frame the camera around `target` (EditorCamera::Focus).
+        std::function<void(const glm::vec3& target, f32 yawRadians, f32 pitchRadians, f32 distance)> OrbitCamera;
+        // Restore a previously captured pose (focal point / distance / angles /
+        // FOV) — the save/restore half of multi-angle screenshot capture.
+        std::function<void(const McpCameraPose& pose)> RestoreCameraPose;
+        // Orbit-frame the camera on the entity with this UUID so it fills the
+        // view. Returns false when the entity doesn't exist in the active scene.
+        std::function<bool(u64 entityUuid)> FrameEntity;
+        // Override the viewport's logical size (deterministic capture
+        // resolution); width/height 0 clears the override and returns the
+        // viewport to the ImGui panel size.
+        std::function<void(u32 width, u32 height)> SetViewportSizeOverride;
+        // Monotonic editor frame counter + whether the framebuffer is currently
+        // NOT capture-ready: the last frame skipped scene rendering (frame-budget
+        // throttle), or a viewport resize happened within the last few frames
+        // (resized render-graph framebuffers render black for a couple of frames).
+        // Together these let a tool wait until a camera change has actually been
+        // rendered before capturing.
+        std::function<u64()> GetFrameIndex;
+        std::function<bool()> IsCaptureUnready;
     };
 
     // An MCP resource: a passive, addressable blob (vs. an active tool). The reader

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -11,9 +11,15 @@
 #include "OloEngine/Project/Project.h"
 #include "OloEngine/Renderer/Debug/CapturedFrameData.h"
 #include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
+#include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
+#include "OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h"
 #include "OloEngine/Renderer/Debug/RendererMemoryTracker.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Debug/ShaderDebugger.h"
+#include "OloEngine/Renderer/Framebuffer.h"
+#include "OloEngine/Renderer/RenderGraph.h"
+#include "OloEngine/Renderer/Renderer3D.h"
+#include "OloEngine/Renderer/ResourceHandle.h"
 #include "OloEngine/Scripting/ScriptError.h"
 #include "OloEngine/Scene/Components.h"
 #include "OloEngine/Scene/Entity.h"
@@ -917,9 +923,279 @@ namespace OloEngine::MCP
             return ToolResult::Text(out.dump(2));
         }
 
+        // ---- Camera tool helpers (Tier 0, #316) --------------------------------
+
+        // Parse a [x, y, z] JSON array of finite numbers.
+        bool ParseVec3(const Json& value, glm::vec3& out)
+        {
+            if (!value.is_array() || value.size() != 3)
+                return false;
+            for (int i = 0; i < 3; ++i)
+            {
+                if (!value[static_cast<sizet>(i)].is_number())
+                    return false;
+                const f32 v = value[static_cast<sizet>(i)].get<f32>();
+                if (!std::isfinite(v))
+                    return false;
+                out[i] = v;
+            }
+            return true;
+        }
+
+        // Invert EditorCamera's orientation convention. Its forward vector is
+        // (cos(pitch)·sin(yaw), -sin(pitch), -cos(pitch)·cos(yaw)), so a look
+        // direction maps back to yaw = atan2(x, -z), pitch = asin(-y).
+        void DirectionToYawPitch(const glm::vec3& direction, f32& yawRadians, f32& pitchRadians)
+        {
+            const glm::vec3 d = glm::normalize(direction);
+            yawRadians = std::atan2(d.x, -d.z);
+            pitchRadians = std::asin(std::clamp(-d.y, -1.0f, 1.0f));
+        }
+
+        Json PoseToJson(const McpCameraPose& pose)
+        {
+            Json j;
+            j["position"] = Json::array({ pose.Position.x, pose.Position.y, pose.Position.z });
+            j["focalPoint"] = Json::array({ pose.FocalPoint.x, pose.FocalPoint.y, pose.FocalPoint.z });
+            j["forward"] = Json::array({ pose.Forward.x, pose.Forward.y, pose.Forward.z });
+            j["yawDegrees"] = glm::degrees(pose.YawRadians);
+            j["pitchDegrees"] = glm::degrees(pose.PitchRadians);
+            j["distance"] = pose.Distance;
+            j["fovDegrees"] = pose.FovDegrees;
+            j["nearClip"] = pose.NearClip;
+            j["farClip"] = pose.FarClip;
+            j["viewportWidth"] = pose.ViewportWidth;
+            j["viewportHeight"] = pose.ViewportHeight;
+            return j;
+        }
+
+        // A camera placement request shared by olo_camera_set_pose, olo_camera_orbit
+        // and olo_screenshot's optional camera argument.
+        struct CameraRequest
+        {
+            bool IsOrbit = false;
+            glm::vec3 EyeOrTarget{ 0.0f }; // eye (pose) or orbit target
+            f32 YawRadians = 0.0f;
+            f32 PitchRadians = 0.0f;
+            f32 Distance = 10.0f;   // orbit only
+            f32 FovDegrees = -1.0f; // <= 0 keeps the current FOV
+        };
+
+        // Parse {position, target|yaw+pitch, fov} (pose form). Returns an error
+        // message, or empty on success.
+        std::string ParsePoseRequest(const Json& args, CameraRequest& out)
+        {
+            out.IsOrbit = false;
+            if (!args.contains("position") || !ParseVec3(args["position"], out.EyeOrTarget))
+                return "Missing or invalid 'position': expected [x, y, z] finite numbers.";
+
+            const bool hasTarget = args.contains("target");
+            const bool hasAngles = args.contains("yaw") || args.contains("pitch");
+            if (hasTarget && hasAngles)
+                return "Give either 'target' or 'yaw'/'pitch', not both.";
+            if (hasTarget)
+            {
+                glm::vec3 target{ 0.0f };
+                if (!ParseVec3(args["target"], target))
+                    return "Invalid 'target': expected [x, y, z] finite numbers.";
+                const glm::vec3 direction = target - out.EyeOrTarget;
+                if (glm::dot(direction, direction) < 1e-12f)
+                    return "'target' must differ from 'position'.";
+                DirectionToYawPitch(direction, out.YawRadians, out.PitchRadians);
+            }
+            else if (hasAngles)
+            {
+                const f32 yawDeg = args.value("yaw", 0.0f);
+                const f32 pitchDeg = args.value("pitch", 0.0f);
+                if (!std::isfinite(yawDeg) || !std::isfinite(pitchDeg))
+                    return "Invalid 'yaw'/'pitch': expected finite numbers (degrees).";
+                out.YawRadians = glm::radians(yawDeg);
+                out.PitchRadians = glm::radians(pitchDeg);
+            }
+            else
+            {
+                return "Missing look direction: give 'target' [x,y,z] or 'yaw'/'pitch' (degrees).";
+            }
+
+            if (args.contains("fov"))
+            {
+                const f32 fov = args.value("fov", 0.0f);
+                if (!std::isfinite(fov) || fov < 1.0f || fov > 170.0f)
+                    return "Invalid 'fov': expected degrees in [1, 170].";
+                out.FovDegrees = fov;
+            }
+            return {};
+        }
+
+        // Parse {target, yaw, pitch, distance} (orbit form).
+        std::string ParseOrbitRequest(const Json& args, CameraRequest& out)
+        {
+            out.IsOrbit = true;
+            if (!args.contains("target") || !ParseVec3(args["target"], out.EyeOrTarget))
+                return "Missing or invalid 'target': expected [x, y, z] finite numbers.";
+            const f32 yawDeg = args.value("yaw", 0.0f);
+            const f32 pitchDeg = args.value("pitch", 30.0f);
+            const f32 distance = args.value("distance", 10.0f);
+            if (!std::isfinite(yawDeg) || !std::isfinite(pitchDeg) || !std::isfinite(distance) || distance <= 0.0f)
+                return "Invalid 'yaw'/'pitch'/'distance': expected finite numbers, distance > 0.";
+            out.YawRadians = glm::radians(yawDeg);
+            out.PitchRadians = glm::radians(pitchDeg);
+            out.Distance = distance;
+            if (args.contains("fov"))
+            {
+                const f32 fov = args.value("fov", 0.0f);
+                if (!std::isfinite(fov) || fov < 1.0f || fov > 170.0f)
+                    return "Invalid 'fov': expected degrees in [1, 170].";
+                out.FovDegrees = fov;
+            }
+            return {};
+        }
+
+        bool CameraContextAvailable(const EditorMcpContext& ctx)
+        {
+            return ctx.GetCameraPose && ctx.SetCameraPose && ctx.OrbitCamera && ctx.RestoreCameraPose;
+        }
+
+        // Apply a CameraRequest. MUST run on the main thread (inside MarshalRead).
+        void ApplyCameraRequest(const EditorMcpContext& ctx, const CameraRequest& request)
+        {
+            if (request.IsOrbit)
+            {
+                if (request.FovDegrees > 0.0f)
+                    ctx.SetCameraPose(glm::vec3(0.0f), 0.0f, 0.0f, request.FovDegrees); // FOV only; pose follows
+                ctx.OrbitCamera(request.EyeOrTarget, request.YawRadians, request.PitchRadians, request.Distance);
+            }
+            else
+            {
+                ctx.SetCameraPose(request.EyeOrTarget, request.YawRadians, request.PitchRadians, request.FovDegrees);
+            }
+        }
+
+        // ---- olo_camera_get (main-marshaled) -----------------------------------
+        ToolResult Handle_CameraGet(McpServer& server, const Json& /*args*/)
+        {
+            if (!server.Context().GetCameraPose)
+                return ToolResult::Error("Camera control is not available in this editor build.");
+            const Json pose = server.MarshalRead([&server]() -> Json
+                                                 { return PoseToJson(server.Context().GetCameraPose()); });
+            return ToolResult::Text(pose.dump(2));
+        }
+
+        // ---- olo_camera_set_pose (main-marshaled; mutates editor camera) -------
+        ToolResult Handle_CameraSetPose(McpServer& server, const Json& args)
+        {
+            if (!CameraContextAvailable(server.Context()))
+                return ToolResult::Error("Camera control is not available in this editor build.");
+            CameraRequest request;
+            if (const std::string error = ParsePoseRequest(args, request); !error.empty())
+                return ToolResult::Error(error);
+
+            const Json pose = server.MarshalRead([&server, request]() -> Json
+                                                 {
+                ApplyCameraRequest(server.Context(), request);
+                return PoseToJson(server.Context().GetCameraPose()); });
+            return ToolResult::Text(pose.dump(2));
+        }
+
+        // ---- olo_camera_orbit (main-marshaled; mutates editor camera) ----------
+        ToolResult Handle_CameraOrbit(McpServer& server, const Json& args)
+        {
+            if (!CameraContextAvailable(server.Context()))
+                return ToolResult::Error("Camera control is not available in this editor build.");
+            CameraRequest request;
+            if (const std::string error = ParseOrbitRequest(args, request); !error.empty())
+                return ToolResult::Error(error);
+
+            const Json pose = server.MarshalRead([&server, request]() -> Json
+                                                 {
+                ApplyCameraRequest(server.Context(), request);
+                return PoseToJson(server.Context().GetCameraPose()); });
+            return ToolResult::Text(pose.dump(2));
+        }
+
+        // ---- olo_camera_frame_entity (main-marshaled; mutates editor camera) ---
+        ToolResult Handle_CameraFrameEntity(McpServer& server, const Json& args)
+        {
+            if (!server.Context().FrameEntity || !server.Context().GetCameraPose)
+                return ToolResult::Error("Camera control is not available in this editor build.");
+            if (!args.contains("id"))
+                return ToolResult::Error("Missing required argument 'id' (entity UUID).");
+            u64 idValue = 0;
+            if (!ParseUuid(args["id"], idValue))
+                return ToolResult::Error("Invalid 'id': expected a UUID as a string or number.");
+
+            const Json result = server.MarshalRead([&server, idValue]() -> Json
+                                                   {
+                if (!server.Context().FrameEntity(idValue))
+                    return Json{ { "__error", "No entity with that UUID in the active scene." } };
+                Json j = PoseToJson(server.Context().GetCameraPose());
+                j["framedEntity"] = std::to_string(idValue);
+                return j; });
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
+        // ---- olo_viewport_set_size (main-marshaled; mutates viewport override) -
+        ToolResult Handle_ViewportSetSize(McpServer& server, const Json& args)
+        {
+            if (!server.Context().SetViewportSizeOverride)
+                return ToolResult::Error("Viewport control is not available in this editor build.");
+
+            u32 width = 0;
+            u32 height = 0;
+            const bool reset = args.value("reset", false);
+            if (!reset)
+            {
+                if (!args.contains("width") || !args.contains("height") ||
+                    !args["width"].is_number_integer() || !args["height"].is_number_integer())
+                    return ToolResult::Error("Give 'width' and 'height' (pixels), or 'reset': true.");
+                width = static_cast<u32>(std::clamp<long long>(args["width"].get<long long>(), 64, 8192));
+                height = static_cast<u32>(std::clamp<long long>(args["height"].get<long long>(), 64, 8192));
+            }
+
+            const Json result = server.MarshalRead([&server, width, height, reset]() -> Json
+                                                   {
+                server.Context().SetViewportSizeOverride(width, height);
+                Json j;
+                j["override"] = !reset;
+                if (!reset)
+                {
+                    j["width"] = width;
+                    j["height"] = height;
+                }
+                return j; });
+            return ToolResult::Text(result.dump(2));
+        }
+
+        // Wait until the editor has rendered `settleFrames` frames after
+        // `baseFrame` and the framebuffer is capture-ready (not throttle-skipped
+        // and not mid viewport-resize transient), so a camera change is actually
+        // visible in the framebuffer before a capture. Returns false on timeout.
+        bool AwaitRenderedFrames(McpServer& server, u64 baseFrame, int settleFrames)
+        {
+            if (!server.Context().GetFrameIndex || !server.Context().IsCaptureUnready)
+                return true; // older context: best effort, capture immediately
+            const u64 targetFrame = baseFrame + static_cast<u64>(settleFrames);
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                const Json state = server.MarshalRead([&server]() -> Json
+                                                      { return Json{ { "frame", server.Context().GetFrameIndex() },
+                                                                     { "unready", server.Context().IsCaptureUnready() } }; });
+                if (state.value("frame", static_cast<u64>(0)) >= targetFrame && !state.value("unready", false))
+                    return true;
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            return false;
+        }
+
         // ---- olo_screenshot (main-marshaled; GL readback) ----------------------
         // Captures the editor viewport framebuffer as a PNG and returns it as an MCP
-        // image content block so the agent can SEE the rendered frame.
+        // image content block so the agent can SEE the rendered frame. With the
+        // optional 'camera'/'orbit' argument it poses the editor camera first, waits
+        // for the pose to be rendered, captures, and restores the prior camera —
+        // multi-angle inspection without disturbing the user's viewport (#316).
         ToolResult Handle_Screenshot(McpServer& server, const Json& args)
         {
             int maxWidth = 1024;
@@ -929,22 +1205,276 @@ namespace OloEngine::MCP
             if (!server.Context().CaptureViewportPng)
                 return ToolResult::Error("Screenshot capture is not available in this editor build.");
 
-            const Json marshaled = server.MarshalRead([&server, maxWidth]() -> Json
-                                                      {
-                const std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
-                if (png.empty())
-                    return Json{ { "__error", "Viewport capture failed (no framebuffer or empty viewport)." } };
-                return Json{ { "b64", Base64Encode(png) }, { "bytes", static_cast<u64>(png.size()) } }; });
+            // Optional camera placement for this capture only.
+            const bool hasCamera = args.contains("camera");
+            const bool hasOrbit = args.contains("orbit");
+            if (hasCamera && hasOrbit)
+                return ToolResult::Error("Give either 'camera' or 'orbit', not both.");
+            CameraRequest request;
+            if (hasCamera || hasOrbit)
+            {
+                if (!CameraContextAvailable(server.Context()))
+                    return ToolResult::Error("Camera control is not available in this editor build.");
+                const std::string error = hasCamera ? ParsePoseRequest(args["camera"], request)
+                                                    : ParseOrbitRequest(args["orbit"], request);
+                if (!error.empty())
+                    return ToolResult::Error(error);
+            }
+
+            int settleFrames = 2;
+            if (args.contains("settleFrames") && args["settleFrames"].is_number_integer())
+                settleFrames = static_cast<int>(std::clamp<long long>(args["settleFrames"].get<long long>(), 1, 30));
+
+            bool posed = false;
+            Json savedPose; // round-trips the prior pose through JSON for the restore job
+            bool waitTimedOut = false;
+            if (hasCamera || hasOrbit)
+            {
+                // 1. Save the user's pose and apply the requested one.
+                const Json applied = server.MarshalRead([&server, request]() -> Json
+                                                        {
+                    const McpCameraPose prior = server.Context().GetCameraPose();
+                    ApplyCameraRequest(server.Context(), request);
+                    Json j;
+                    j["focalPoint"] = Json::array({ prior.FocalPoint.x, prior.FocalPoint.y, prior.FocalPoint.z });
+                    j["distance"] = prior.Distance;
+                    j["yaw"] = prior.YawRadians;
+                    j["pitch"] = prior.PitchRadians;
+                    j["fov"] = prior.FovDegrees;
+                    j["frame"] = server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0;
+                    return j; });
+                savedPose = applied;
+                posed = true;
+            }
+
+            // The restore half of the save/restore contract, runnable from both
+            // the success path (inside the capture job) and the error path.
+            const auto restorePriorPose = [&server, &savedPose]()
+            {
+                McpCameraPose prior;
+                prior.FocalPoint = glm::vec3{ savedPose["focalPoint"][0].get<f32>(),
+                                              savedPose["focalPoint"][1].get<f32>(),
+                                              savedPose["focalPoint"][2].get<f32>() };
+                prior.Distance = savedPose.value("distance", 0.0f);
+                prior.YawRadians = savedPose.value("yaw", 0.0f);
+                prior.PitchRadians = savedPose.value("pitch", 0.0f);
+                prior.FovDegrees = savedPose.value("fov", 45.0f);
+                server.Context().RestoreCameraPose(prior);
+            };
+
+            Json marshaled;
+            try
+            {
+                // 2. Wait until the new pose has actually been rendered.
+                if (posed)
+                    waitTimedOut = !AwaitRenderedFrames(server, savedPose.value("frame", static_cast<u64>(0)), settleFrames);
+
+                // 3. Capture — and restore the user's camera in the same main-thread
+                // job, so the restore happens exactly once whatever the capture did.
+                marshaled = server.MarshalRead([&server, maxWidth, posed, &restorePriorPose]() -> Json
+                                               {
+                    const std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
+                    if (posed)
+                        restorePriorPose();
+                    if (png.empty())
+                        return Json{ { "__error", "Viewport capture failed (no framebuffer or empty viewport)." } };
+                    return Json{ { "b64", Base64Encode(png) }, { "bytes", static_cast<u64>(png.size()) } }; });
+            }
+            catch (...)
+            {
+                // Don't leave the user's camera stranded at the capture pose if a
+                // marshal failed mid-flow. Best effort — if the editor is truly
+                // stalled this will fail too, and the original exception matters more.
+                if (posed)
+                {
+                    try
+                    {
+                        (void)server.MarshalRead([&restorePriorPose]() -> Json
+                                                 {
+                            restorePriorPose();
+                            return Json{}; });
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+                throw;
+            }
 
             if (marshaled.is_object() && marshaled.contains("__error"))
                 return ToolResult::Error(marshaled["__error"].get<std::string>());
 
             ToolResult result;
-            result.Content = Json::array({ Json{ { "type", "image" },
-                                                 { "data", marshaled["b64"] },
-                                                 { "mimeType", "image/png" } } });
+            result.Content = Json::array();
+            if (waitTimedOut)
+                result.Content.push_back(Json{ { "type", "text" },
+                                               { "text", "Warning: timed out waiting for the new camera pose to render; "
+                                                         "the image may show a stale frame." } });
+            result.Content.push_back(Json{ { "type", "image" },
+                                           { "data", marshaled["b64"] },
+                                           { "mimeType", "image/png" } });
             result.IsError = false;
             return result;
+        }
+
+        // ---- Render-target capture (Part 4 of #316) ----------------------------
+
+        const char* RGFormatName(RGResourceFormat format)
+        {
+            switch (format)
+            {
+                case RGResourceFormat::Unknown:
+                    return "Unknown";
+                case RGResourceFormat::R8UNorm:
+                    return "R8UNorm";
+                case RGResourceFormat::R32Float:
+                    return "R32Float";
+                case RGResourceFormat::RG16Float:
+                    return "RG16Float";
+                case RGResourceFormat::RGBA8UNorm:
+                    return "RGBA8UNorm";
+                case RGResourceFormat::RGBA16Float:
+                    return "RGBA16Float";
+                case RGResourceFormat::RGBA32Float:
+                    return "RGBA32Float";
+                case RGResourceFormat::Depth24Stencil8:
+                    return "Depth24Stencil8";
+                case RGResourceFormat::Depth32Float:
+                    return "Depth32Float";
+                case RGResourceFormat::R32Int:
+                    return "R32Int";
+            }
+            return "Unknown";
+        }
+
+        // ---- olo_render_list_targets (main-marshaled) --------------------------
+        ToolResult Handle_RenderListTargets(McpServer& server, const Json& /*args*/)
+        {
+            Json result = server.MarshalRead([]() -> Json
+                                             {
+                const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
+                if (!graph)
+                    return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
+
+                Json targets = Json::array();
+                for (const auto& resource : graph->GetRegisteredResources())
+                {
+                    // Only capturable resources: those backed by a texture or a
+                    // framebuffer. Buffers (UBO/SSBO) are not image-capturable.
+                    if (!resource.TextureHandle.IsValid() && !resource.FramebufferHandle.IsValid())
+                        continue;
+                    Json e;
+                    e["name"] = resource.Name;
+                    e["kind"] = std::string(ToString(resource.Desc.Kind));
+                    if (resource.Desc.Format != RGResourceFormat::Unknown)
+                        e["format"] = RGFormatName(resource.Desc.Format);
+                    if (resource.Desc.Width > 0 && resource.Desc.Height > 0)
+                    {
+                        e["width"] = resource.Desc.Width;
+                        e["height"] = resource.Desc.Height;
+                    }
+                    if (!resource.Producers.empty())
+                        e["producers"] = resource.Producers;
+                    targets.push_back(std::move(e));
+                }
+                Json j;
+                j["count"] = static_cast<int>(targets.size());
+                j["targets"] = std::move(targets);
+                return j; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
+        // ---- olo_render_capture_target (main-marshaled; GL readback) -----------
+        ToolResult Handle_RenderCaptureTarget(McpServer& server, const Json& args)
+        {
+            if (!args.contains("name") || !args["name"].is_string())
+                return ToolResult::Error("Missing required argument 'name' (render-graph resource name; see olo_render_list_targets).");
+            const std::string name = args["name"].get<std::string>();
+
+            u32 mipLevel = 0;
+            if (args.contains("mip") && args["mip"].is_number_integer())
+                mipLevel = static_cast<u32>(std::clamp<long long>(args["mip"].get<long long>(), 0, 16));
+            u32 faceOrLayer = 0;
+            if (args.contains("face") && args["face"].is_number_integer())
+                faceOrLayer = static_cast<u32>(std::clamp<long long>(args["face"].get<long long>(), 0, 64));
+            int maxWidth = 1024;
+            if (args.contains("maxWidth") && args["maxWidth"].is_number_integer())
+                maxWidth = static_cast<int>(std::clamp<long long>(args["maxWidth"].get<long long>(), 16, 4096));
+
+            auto normalizeMode = GPUResourceInspector::CaptureNormalizeMode::Auto;
+            if (args.contains("normalize") && args["normalize"].is_boolean())
+                normalizeMode = args["normalize"].get<bool>() ? GPUResourceInspector::CaptureNormalizeMode::On
+                                                              : GPUResourceInspector::CaptureNormalizeMode::Off;
+
+            Json result = server.MarshalRead([name, mipLevel, faceOrLayer, normalizeMode, maxWidth]() -> Json
+                                             {
+                const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
+                if (!graph)
+                    return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
+
+                // Resolve the name to a physical GL texture: first as a graph
+                // texture (covers attachment views like SceneDepth / GBufferAlbedo
+                // and imported textures like ShadowMapCSM), then as a framebuffer
+                // (capture colour attachment 0, or the depth attachment for
+                // depth-only targets).
+                u32 textureId = Renderer3D::ResolveFrameGraphTexture(name);
+                if (textureId == 0)
+                {
+                    if (const Ref<Framebuffer> framebuffer = Renderer3D::ResolveFrameGraphFramebuffer(name); framebuffer)
+                    {
+                        bool hasColor = false;
+                        for (const auto& attachment : framebuffer->GetSpecification().Attachments.Attachments)
+                        {
+                            if (attachment.TextureFormat != FramebufferTextureFormat::DEPTH24STENCIL8 &&
+                                attachment.TextureFormat != FramebufferTextureFormat::DEPTH_COMPONENT32F &&
+                                attachment.TextureFormat != FramebufferTextureFormat::None)
+                            {
+                                hasColor = true;
+                                break;
+                            }
+                        }
+                        textureId = hasColor ? framebuffer->GetColorAttachmentRendererID(0)
+                                             : framebuffer->GetDepthAttachmentRendererID();
+                    }
+                }
+                if (textureId == 0)
+                    return Json{ { "__error", "Unknown render-graph resource '" + name +
+                                                  "' (or it has no GPU backing this frame). Call olo_render_list_targets for the live list." } };
+
+                auto capture = GPUResourceInspector::CaptureTexturePng(textureId, mipLevel, faceOrLayer, normalizeMode, maxWidth);
+                if (!capture.Error.empty())
+                    return Json{ { "__error", "Capture of '" + name + "' failed: " + capture.Error } };
+
+                Json meta;
+                meta["name"] = name;
+                meta["width"] = capture.Width;
+                meta["height"] = capture.Height;
+                meta["sourceWidth"] = capture.SourceWidth;
+                meta["sourceHeight"] = capture.SourceHeight;
+                meta["format"] = capture.FormatName;
+                meta["isDepth"] = capture.IsDepth;
+                meta["normalized"] = capture.Normalized;
+                if (capture.MaxValue > capture.MinValue)
+                {
+                    meta["minValue"] = capture.MinValue;
+                    meta["maxValue"] = capture.MaxValue;
+                }
+                return Json{ { "meta", std::move(meta) },
+                             { "b64", Base64Encode(capture.PngBytes) } }; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+
+            ToolResult toolResult;
+            toolResult.Content = Json::array({ Json{ { "type", "text" }, { "text", result["meta"].dump(2) } },
+                                               Json{ { "type", "image" },
+                                                     { "data", result["b64"] },
+                                                     { "mimeType", "image/png" } } });
+            toolResult.IsError = false;
+            return toolResult;
         }
     } // namespace
 
@@ -1252,15 +1782,176 @@ namespace OloEngine::MCP
             tool.Description =
                 "Capture the editor's 3D viewport as a PNG image so you can SEE the rendered frame — "
                 "decisive for visual problems ('my material looks wrong', 'I can't see my object'). "
-                "Returns an image content block (downscaled to maxWidth, default 1024).";
+                "Returns an image content block (downscaled to maxWidth, default 1024). Optionally pose "
+                "the camera for this capture only via 'camera' (explicit position + target/yaw/pitch) or "
+                "'orbit' (target + yaw/pitch/distance): the prior camera is saved, the new pose is "
+                "rendered ('settleFrames' frames, default 2, for TAA/temporal effects to settle), the "
+                "frame is captured, and the user's camera is restored — so multiple angles can be "
+                "captured without disturbing the viewport.";
             tool.InputSchema = Json{
                 { "type", "object" },
                 { "properties",
-                  { { "maxWidth", { { "type", "integer" }, { "minimum", 16 }, { "maximum", 4096 }, { "description", "Max output width in pixels (default 1024); aspect ratio preserved." } } } } },
+                  { { "maxWidth", { { "type", "integer" }, { "minimum", 16 }, { "maximum", 4096 }, { "description", "Max output width in pixels (default 1024); aspect ratio preserved." } } },
+                    { "camera",
+                      { { "type", "object" },
+                        { "description", "Capture from this pose, then restore the prior camera. Same shape as olo_camera_set_pose: position [x,y,z] plus target [x,y,z] or yaw/pitch (degrees); optional fov." } } },
+                    { "orbit",
+                      { { "type", "object" },
+                        { "description", "Capture from this orbit pose, then restore. Same shape as olo_camera_orbit: target [x,y,z], yaw/pitch (degrees), distance; optional fov." } } },
+                    { "settleFrames", { { "type", "integer" }, { "minimum", 1 }, { "maximum", 30 }, { "description", "Frames to render at the new pose before capturing (default 2). Raise for temporal effects (TAA, fog history) to settle." } } } } },
                 { "additionalProperties", false }
             };
             tool.MainMarshaled = true;
             tool.Handler = Handle_Screenshot;
+            server.RegisterTool(std::move(tool));
+        }
+
+        // ---- Tier-0 camera / viewport control (issue #316) ---------------------
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_camera_get";
+            tool.Description =
+                "Get the editor camera's current pose: position, focal point, forward vector, yaw/pitch "
+                "(degrees), orbit distance, FOV, near/far clip, and the viewport size in logical pixels. "
+                "Read this before moving the camera so you can put it back, or to reason about what the "
+                "viewport is looking at.";
+            tool.InputSchema = Json{ { "type", "object" }, { "properties", Json::object() }, { "additionalProperties", false } };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_CameraGet;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_camera_set_pose";
+            tool.Description =
+                "Move the editor camera to an explicit pose (Tier-0 inspection state; never touches the "
+                "project). Give 'position' plus either 'target' (a point to look at) or 'yaw'/'pitch' in "
+                "degrees; optional 'fov' (vertical, degrees). Returns the resulting pose. The viewport "
+                "renders the new pose from the next frame.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "position", { { "type", "array" }, { "items", Json{ { "type", "number" } } }, { "minItems", 3 }, { "maxItems", 3 }, { "description", "Camera eye position [x, y, z] (world units)." } } },
+                    { "target", { { "type", "array" }, { "items", Json{ { "type", "number" } } }, { "minItems", 3 }, { "maxItems", 3 }, { "description", "Point to look at [x, y, z]. Alternative to yaw/pitch." } } },
+                    { "yaw", { { "type", "number" }, { "description", "Yaw in degrees (0 looks along -Z; positive turns right). Alternative to target." } } },
+                    { "pitch", { { "type", "number" }, { "description", "Pitch in degrees (positive looks down). Alternative to target." } } },
+                    { "fov", { { "type", "number" }, { "minimum", 1 }, { "maximum", 170 }, { "description", "Vertical field of view in degrees (omit to keep current)." } } } } },
+                { "required", Json::array({ "position" }) },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_CameraSetPose;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_camera_orbit";
+            tool.Description =
+                "Orbit-frame the editor camera around a world-space target point: the camera pivots at "
+                "'distance' from 'target' looking at it, with 'yaw'/'pitch' in degrees (positive pitch "
+                "looks down). Keeps a live orbit pivot so subsequent user orbiting feels natural. "
+                "Returns the resulting pose.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "target", { { "type", "array" }, { "items", Json{ { "type", "number" } } }, { "minItems", 3 }, { "maxItems", 3 }, { "description", "Orbit centre [x, y, z] (world units)." } } },
+                    { "yaw", { { "type", "number" }, { "description", "Orbit yaw in degrees (default 0)." } } },
+                    { "pitch", { { "type", "number" }, { "description", "Orbit pitch in degrees, positive looks down (default 30)." } } },
+                    { "distance", { { "type", "number" }, { "exclusiveMinimum", 0 }, { "description", "Distance from the target in world units (default 10)." } } },
+                    { "fov", { { "type", "number" }, { "minimum", 1 }, { "maximum", 170 }, { "description", "Vertical field of view in degrees (omit to keep current)." } } } } },
+                { "required", Json::array({ "target" }) },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_CameraOrbit;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_camera_frame_entity";
+            tool.Description =
+                "Point the editor camera at one entity and fit it in view (like pressing 'frame selected' "
+                "in a DCC tool). Uses the entity's mesh/model/terrain bounds when available, otherwise its "
+                "transform scale. Keeps the current view direction. Get the UUID from "
+                "olo_scene_list_entities. Returns the resulting pose.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "id", { { "type", "string" }, { "description", "Entity UUID (as a string; also accepts a number)." } } } } },
+                { "required", Json::array({ "id" }) },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_CameraFrameEntity;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_viewport_set_size";
+            tool.Description =
+                "Override the editor viewport's logical render size for deterministic capture resolution "
+                "(e.g. 1280x720 golden-image comparisons), independent of the panel layout. Pass "
+                "'reset': true to return control to the ImGui panel size. The override persists until "
+                "reset — reset it when you are done capturing.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "width", { { "type", "integer" }, { "minimum", 64 }, { "maximum", 8192 }, { "description", "Viewport width in logical pixels." } } },
+                    { "height", { { "type", "integer" }, { "minimum", 64 }, { "maximum", 8192 }, { "description", "Viewport height in logical pixels." } } },
+                    { "reset", { { "type", "boolean" }, { "description", "true = clear the override and use the panel size again." } } } } },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_ViewportSetSize;
+            server.RegisterTool(std::move(tool));
+        }
+
+        // ---- Render-target capture (Part 4 of #316) -----------------------------
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_render_list_targets";
+            tool.Description =
+                "List the render graph's live texture/framebuffer resources for the current frame — "
+                "scene colour, depth, G-buffer attachments, shadow maps, AO, post-process chain stages, "
+                "water/OIT buffers, etc. Each entry has the canonical resource name (pass to "
+                "olo_render_capture_target), kind, format, size, and producing passes. Requires the "
+                "editor to be rendering in 3D mode.";
+            tool.InputSchema = Json{ { "type", "object" }, { "properties", Json::object() }, { "additionalProperties", false } };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_RenderListTargets;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_render_capture_target";
+            tool.Description =
+                "Read back one intermediate render target as a PNG image — THE tool for rendering-feature "
+                "development: inspect depth, normals, G-buffer albedo/emissive, shadow maps, AO, bloom, or "
+                "any post-process stage directly instead of guessing from the final frame. 'name' is a "
+                "render-graph resource name from olo_render_list_targets (e.g. SceneColor, SceneDepth, "
+                "GBufferNormal, ShadowMapCSM, AOBuffer, BloomColor). Float/HDR sources are clamped to "
+                "[0,1]; depth is min-max normalised by default ('normalize' overrides). Returns metadata "
+                "(format, size, value range) plus the image.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "name", { { "type", "string" }, { "description", "Render-graph resource name (see olo_render_list_targets)." } } },
+                    { "mip", { { "type", "integer" }, { "minimum", 0 }, { "maximum", 16 }, { "description", "Mip level to capture (default 0)." } } },
+                    { "face", { { "type", "integer" }, { "minimum", 0 }, { "maximum", 64 }, { "description", "Cubemap face (0..5 = +X,-X,+Y,-Y,+Z,-Z) or texture-array layer (default 0)." } } },
+                    { "normalize", { { "type", "boolean" }, { "description", "Min-max normalise float values to [0,1] before encoding (default: true for depth, false otherwise)." } } },
+                    { "maxWidth", { { "type", "integer" }, { "minimum", 16 }, { "maximum", 4096 }, { "description", "Max output width in pixels (default 1024); aspect ratio preserved." } } } } },
+                { "required", Json::array({ "name" }) },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_RenderCaptureTarget;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -1005,6 +1005,9 @@ namespace OloEngine::MCP
             }
             else if (hasAngles)
             {
+                if ((args.contains("yaw") && !args["yaw"].is_number()) ||
+                    (args.contains("pitch") && !args["pitch"].is_number()))
+                    return "Invalid 'yaw'/'pitch': expected numbers (degrees).";
                 const f32 yawDeg = args.value("yaw", 0.0f);
                 const f32 pitchDeg = args.value("pitch", 0.0f);
                 if (!std::isfinite(yawDeg) || !std::isfinite(pitchDeg))
@@ -1019,6 +1022,8 @@ namespace OloEngine::MCP
 
             if (args.contains("fov"))
             {
+                if (!args["fov"].is_number())
+                    return "Invalid 'fov': expected a number (degrees).";
                 const f32 fov = args.value("fov", 0.0f);
                 if (!std::isfinite(fov) || fov < 1.0f || fov > 170.0f)
                     return "Invalid 'fov': expected degrees in [1, 170].";
@@ -1033,6 +1038,10 @@ namespace OloEngine::MCP
             out.IsOrbit = true;
             if (!args.contains("target") || !ParseVec3(args["target"], out.EyeOrTarget))
                 return "Missing or invalid 'target': expected [x, y, z] finite numbers.";
+            if ((args.contains("yaw") && !args["yaw"].is_number()) ||
+                (args.contains("pitch") && !args["pitch"].is_number()) ||
+                (args.contains("distance") && !args["distance"].is_number()))
+                return "Invalid 'yaw'/'pitch'/'distance': expected numbers.";
             const f32 yawDeg = args.value("yaw", 0.0f);
             const f32 pitchDeg = args.value("pitch", 30.0f);
             const f32 distance = args.value("distance", 10.0f);
@@ -1043,6 +1052,8 @@ namespace OloEngine::MCP
             out.Distance = distance;
             if (args.contains("fov"))
             {
+                if (!args["fov"].is_number())
+                    return "Invalid 'fov': expected a number (degrees).";
                 const f32 fov = args.value("fov", 0.0f);
                 if (!std::isfinite(fov) || fov < 1.0f || fov > 170.0f)
                     return "Invalid 'fov': expected degrees in [1, 170].";

--- a/OloEditor/src/MCP/McpTools.h
+++ b/OloEditor/src/MCP/McpTools.h
@@ -4,9 +4,10 @@ namespace OloEngine::MCP
 {
     class McpServer;
 
-    // Register the read-only diagnostic tools onto `server`. Phase 0/1 surface:
-    //   * olo_log_tail      — recent engine log lines (lock-safe)
-    //   * olo_scene_summary — active-scene overview (main-marshaled)
-    // Call once after constructing the server, before Start().
+    // Register the built-in diagnostic + inspection tools onto `server`: the
+    // read-only diagnostics from #285 (logs, scene/ECS, perf, memory, shaders,
+    // assets, scripts, crashes, screenshot) and the Tier-0 rendering-dev
+    // harness from #316 (camera control, viewport size override, render-target
+    // capture). Call once after constructing the server, before Start().
     void RegisterBuiltinTools(McpServer& server);
 } // namespace OloEngine::MCP

--- a/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
+++ b/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
@@ -7,6 +7,8 @@
 
 #include <glm/glm.hpp>
 
+#include <algorithm> // std::clamp (SetFOV), std::max (SetFlySpeed) — keep the header self-contained
+
 namespace OloEngine
 {
     class Gamepad;

--- a/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
+++ b/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
@@ -74,6 +74,23 @@ namespace OloEngine
             UpdateView();
         }
 
+        // Vertical field of view in degrees. Setting it rebuilds the projection
+        // immediately (used by the MCP camera tools for deterministic captures).
+        [[nodiscard("Store this!")]] f32 GetFOV() const
+        {
+            return m_FOV;
+        }
+        void SetFOV(const f32 fovDegrees)
+        {
+            m_FOV = std::clamp(fovDegrees, 1.0f, 170.0f);
+            UpdateProjection();
+        }
+
+        [[nodiscard("Store this!")]] const glm::vec3& GetFocalPoint() const
+        {
+            return m_FocalPoint;
+        }
+
         [[nodiscard("Store this!")]] const glm::mat4& GetViewMatrix() const
         {
             return m_ViewMatrix;

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
@@ -9,6 +9,7 @@
 #include <stb_image/stb_image_write.h>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <sstream>
 #include <iomanip>
@@ -17,6 +18,7 @@
 #include <cstring>
 #include <algorithm>
 #include <cctype>
+#include <limits>
 
 namespace OloEngine
 {
@@ -793,6 +795,251 @@ namespace OloEngine
         }
 
         return true;
+    }
+
+    GPUResourceInspector::TextureCaptureResult GPUResourceInspector::CaptureTexturePng(u32 textureId, u32 mipLevel,
+                                                                                       u32 faceOrLayer,
+                                                                                       CaptureNormalizeMode normalize,
+                                                                                       int maxWidth)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        TextureCaptureResult result;
+        if (textureId == 0 || glIsTexture(textureId) == GL_FALSE)
+        {
+            result.Error = "invalid texture id";
+            return result;
+        }
+
+        // GL 4.5 DSA: a texture object knows its own target.
+        GLint target = 0;
+        glGetTextureParameteriv(textureId, GL_TEXTURE_TARGET, &target);
+        const bool isLayered = target == GL_TEXTURE_CUBE_MAP || target == GL_TEXTURE_CUBE_MAP_ARRAY ||
+                               target == GL_TEXTURE_2D_ARRAY || target == GL_TEXTURE_3D;
+
+        GLint width = 0;
+        GLint height = 0;
+        GLint internalFormat = 0;
+        glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mipLevel), GL_TEXTURE_WIDTH, &width);
+        glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mipLevel), GL_TEXTURE_HEIGHT, &height);
+        glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mipLevel), GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
+        if (width <= 0 || height <= 0)
+        {
+            result.Error = "texture has no storage at the requested mip level";
+            return result;
+        }
+
+        // Map the internal format to a readback (format, type). Same table as
+        // QueryTextureInfo, except packed depth-stencil reads as depth-only
+        // float — glGetTextureSubImage(GL_DEPTH_COMPONENT) legally extracts the
+        // depth plane, which is exactly what an inspection capture wants.
+        GLenum format = GL_NONE;
+        GLenum dataType = GL_NONE;
+        bool isDepth = false;
+        switch (internalFormat)
+        {
+            case GL_RGBA8:
+            case GL_SRGB8_ALPHA8:
+                format = GL_RGBA;
+                dataType = GL_UNSIGNED_BYTE;
+                break;
+            case GL_RGB8:
+            case GL_SRGB8:
+                format = GL_RGB;
+                dataType = GL_UNSIGNED_BYTE;
+                break;
+            case GL_RG8:
+                format = GL_RG;
+                dataType = GL_UNSIGNED_BYTE;
+                break;
+            case GL_R8:
+                format = GL_RED;
+                dataType = GL_UNSIGNED_BYTE;
+                break;
+            case GL_RGBA16F:
+            case GL_RGBA32F:
+                format = GL_RGBA;
+                dataType = GL_FLOAT;
+                break;
+            case GL_RGB16F:
+            case GL_RGB32F:
+            case GL_R11F_G11F_B10F:
+                format = GL_RGB;
+                dataType = GL_FLOAT;
+                break;
+            case GL_RG16F:
+            case GL_RG32F:
+                format = GL_RG;
+                dataType = GL_FLOAT;
+                break;
+            case GL_R16F:
+            case GL_R32F:
+                format = GL_RED;
+                dataType = GL_FLOAT;
+                break;
+            case GL_DEPTH_COMPONENT16:
+            case GL_DEPTH_COMPONENT24:
+            case GL_DEPTH_COMPONENT32:
+            case GL_DEPTH_COMPONENT32F:
+            case GL_DEPTH24_STENCIL8:
+            case GL_DEPTH32F_STENCIL8:
+                format = GL_DEPTH_COMPONENT;
+                dataType = GL_FLOAT;
+                isDepth = true;
+                break;
+            default:
+                result.Error = "unsupported internal format 0x" + std::format("{:X}", static_cast<u32>(internalFormat));
+                return result;
+        }
+
+        const i32 channels = ChannelsFromGLFormat(format);
+        const bool sourceIsFloat = (dataType == GL_FLOAT);
+        const sizet bytesPerChannel = sourceIsFloat ? sizeof(f32) : sizeof(u8);
+        const sizet rowStride = static_cast<sizet>(width) * static_cast<sizet>(channels) * bytesPerChannel;
+        const sizet bufferBytes = rowStride * static_cast<sizet>(height);
+        std::vector<u8> readBuffer(bufferBytes);
+
+        // Tight packing + PBO unbind guard — same rationale as SaveTextureToFile.
+        GLint prevPackAlignment = 4;
+        glGetIntegerv(GL_PACK_ALIGNMENT, &prevPackAlignment);
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        GLint prevPackPBO = 0;
+        glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &prevPackPBO);
+        if (prevPackPBO != 0)
+            glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+        glGetTextureSubImage(textureId,
+                             static_cast<GLint>(mipLevel),
+                             0, 0, isLayered ? static_cast<GLint>(faceOrLayer) : 0,
+                             width, height, 1,
+                             format, sourceIsFloat ? GL_FLOAT : GL_UNSIGNED_BYTE,
+                             static_cast<GLsizei>(bufferBytes), readBuffer.data());
+
+        if (prevPackPBO != 0)
+            glBindBuffer(GL_PIXEL_PACK_BUFFER, static_cast<GLuint>(prevPackPBO));
+        glPixelStorei(GL_PACK_ALIGNMENT, prevPackAlignment);
+
+        if (GLenum err = glGetError(); err != GL_NO_ERROR)
+        {
+            result.Error = "glGetTextureSubImage failed (GL 0x" + std::format("{:X}", err) + ")";
+            return result;
+        }
+
+        // Convert to 8-bit. Float sources optionally min-max normalise first
+        // (Auto = depth only) so a depth buffer / HDR target isn't a flat
+        // white/black image after the [0,1] clamp.
+        const sizet valueCount = static_cast<sizet>(width) * static_cast<sizet>(height) * static_cast<sizet>(channels);
+        std::vector<u8> pixels8;
+        if (sourceIsFloat)
+        {
+            const f32* src = reinterpret_cast<const f32*>(readBuffer.data());
+            const bool wantNormalize = normalize == CaptureNormalizeMode::On ||
+                                       (normalize == CaptureNormalizeMode::Auto && isDepth);
+            f32 minV = std::numeric_limits<f32>::max();
+            f32 maxV = std::numeric_limits<f32>::lowest();
+            for (sizet i = 0; i < valueCount; ++i)
+            {
+                if (std::isfinite(src[i]))
+                {
+                    minV = std::min(minV, src[i]);
+                    maxV = std::max(maxV, src[i]);
+                }
+            }
+            const bool haveRange = maxV > minV;
+            if (haveRange)
+            {
+                result.MinValue = minV;
+                result.MaxValue = maxV;
+            }
+            const bool doNormalize = wantNormalize && haveRange;
+            result.Normalized = doNormalize;
+            const f32 scale = doNormalize ? 1.0f / (maxV - minV) : 1.0f;
+            const f32 bias = doNormalize ? -minV : 0.0f;
+            pixels8.resize(valueCount);
+            for (sizet i = 0; i < valueCount; ++i)
+            {
+                const f32 safe = std::isnan(src[i]) ? 0.0f : src[i];
+                const f32 clamped = std::clamp((safe + bias) * scale, 0.0f, 1.0f);
+                pixels8[i] = static_cast<u8>(clamped * 255.0f + 0.5f);
+            }
+        }
+        else
+        {
+            pixels8 = std::move(readBuffer);
+        }
+
+        // Widen 2-channel output to RGB (B = 0): PNG comp=2 means grey+alpha,
+        // which would hide the G channel of an RG target in the alpha plane.
+        i32 outChannels = channels;
+        if (channels == 2)
+        {
+            outChannels = 3;
+            std::vector<u8> widened(static_cast<sizet>(width) * static_cast<sizet>(height) * 3, 0);
+            for (sizet i = 0; i < static_cast<sizet>(width) * static_cast<sizet>(height); ++i)
+            {
+                widened[i * 3 + 0] = pixels8[i * 2 + 0];
+                widened[i * 3 + 1] = pixels8[i * 2 + 1];
+            }
+            pixels8 = std::move(widened);
+        }
+
+        // Flip to PNG top-down orientation so the capture is upright when an
+        // agent views it (matches CaptureViewportPng / olo_screenshot, and
+        // intentionally differs from SaveTextureToFile's raw-memory dump).
+        const sizet outRowBytes = static_cast<sizet>(width) * static_cast<sizet>(outChannels);
+        std::vector<u8> flipped(pixels8.size());
+        for (sizet y = 0; y < static_cast<sizet>(height); ++y)
+            std::memcpy(flipped.data() + y * outRowBytes,
+                        pixels8.data() + (static_cast<sizet>(height) - 1 - y) * outRowBytes, outRowBytes);
+
+        // Optional nearest-neighbour downscale so width <= maxWidth.
+        u32 outW = static_cast<u32>(width);
+        u32 outH = static_cast<u32>(height);
+        const std::vector<u8>* encodeSrc = &flipped;
+        std::vector<u8> scaled;
+        if (maxWidth > 0 && outW > static_cast<u32>(maxWidth))
+        {
+            const u32 srcW = outW;
+            const u32 srcH = outH;
+            outW = static_cast<u32>(maxWidth);
+            outH = std::max<u32>(1, static_cast<u32>((static_cast<u64>(srcH) * outW) / srcW));
+            scaled.assign(static_cast<sizet>(outW) * outH * outChannels, 0);
+            for (u32 y = 0; y < outH; ++y)
+            {
+                const u32 sy = std::min(srcH - 1, static_cast<u32>((static_cast<u64>(y) * srcH) / outH));
+                for (u32 x = 0; x < outW; ++x)
+                {
+                    const u32 sx = std::min(srcW - 1, static_cast<u32>((static_cast<u64>(x) * srcW) / outW));
+                    std::memcpy(&scaled[(static_cast<sizet>(y) * outW + x) * outChannels],
+                                &flipped[(static_cast<sizet>(sy) * srcW + sx) * outChannels],
+                                static_cast<sizet>(outChannels));
+                }
+            }
+            encodeSrc = &scaled;
+        }
+
+        std::vector<u8> png;
+        const auto appendToVector = [](void* context, void* data, int size)
+        {
+            auto* out = static_cast<std::vector<u8>*>(context);
+            const auto* bytes = static_cast<const u8*>(data);
+            out->insert(out->end(), bytes, bytes + size);
+        };
+        if (stbi_write_png_to_func(appendToVector, &png, static_cast<int>(outW), static_cast<int>(outH),
+                                   outChannels, encodeSrc->data(), static_cast<int>(outW) * outChannels) == 0)
+        {
+            result.Error = "PNG encode failed";
+            return result;
+        }
+
+        result.PngBytes = std::move(png);
+        result.Width = outW;
+        result.Height = outH;
+        result.SourceWidth = static_cast<u32>(width);
+        result.SourceHeight = static_cast<u32>(height);
+        result.FormatName = GetInstance().FormatTextureFormat(static_cast<GLenum>(internalFormat));
+        result.IsDepth = isDepth;
+        return result;
     }
 
     GLenum GPUResourceInspector::GetBufferBindingQuery(GLenum target)

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
@@ -814,7 +814,16 @@ namespace OloEngine
         // GL 4.5 DSA: a texture object knows its own target.
         GLint target = 0;
         glGetTextureParameteriv(textureId, GL_TEXTURE_TARGET, &target);
-        const bool isLayered = target == GL_TEXTURE_CUBE_MAP || target == GL_TEXTURE_CUBE_MAP_ARRAY ||
+        // Cube-map arrays encode the glGetTextureSubImage z offset as
+        // layer * 6 + face — a single faceOrLayer parameter can't express that
+        // contract unambiguously, so reject rather than guess. No engine render
+        // target uses cube-map arrays today; split the parameter if one appears.
+        if (target == GL_TEXTURE_CUBE_MAP_ARRAY)
+        {
+            result.Error = "cube-map-array textures are not supported (faceOrLayer cannot express layer+face)";
+            return result;
+        }
+        const bool isLayered = target == GL_TEXTURE_CUBE_MAP ||
                                target == GL_TEXTURE_2D_ARRAY || target == GL_TEXTURE_3D;
 
         GLint width = 0;

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.h
@@ -221,6 +221,50 @@ namespace OloEngine
         // @return true on success; false if the texture is invalid, the format is unsupported, or the file write fails.
         bool SaveTextureToFile(const TextureInfo& info, const std::string& filePath, u32 mipLevel, u32 faceIndex = 0) const;
 
+        // Whether float-valued sources should be min-max normalised to [0,1]
+        // before PNG quantisation in CaptureTexturePng. Auto = normalise depth
+        // formats only (raw depth is ~1.0 everywhere and encodes near-white).
+        enum class CaptureNormalizeMode : u8
+        {
+            Auto = 0,
+            Off,
+            On
+        };
+
+        // Result of CaptureTexturePng. PngBytes is empty (and Error non-empty)
+        // on failure. MinValue/MaxValue report the finite value range of float
+        // sources before quantisation — useful to interpret normalised output.
+        struct TextureCaptureResult
+        {
+            std::vector<u8> PngBytes;
+            u32 Width = 0;
+            u32 Height = 0;
+            u32 SourceWidth = 0;
+            u32 SourceHeight = 0;
+            std::string FormatName;
+            bool IsDepth = false;
+            bool Normalized = false;
+            f32 MinValue = 0.0f;
+            f32 MaxValue = 0.0f;
+            std::string Error;
+        };
+
+        // @brief Encode one mip/face of an arbitrary GL texture to PNG bytes in memory.
+        //        The in-memory sibling of SaveTextureToFile, built for the MCP
+        //        render-target capture tools (issue #316): same DSA readback and
+        //        float->u8 conversion, but returns the encoded PNG instead of
+        //        writing a file, supports min-max normalisation for depth/HDR
+        //        inspection, optionally downscales so width <= maxWidth (<=0 =
+        //        native), and — unlike SaveTextureToFile — flips rows to PNG
+        //        top-down orientation so the image is upright when viewed.
+        //        `faceOrLayer` selects the cubemap face / array layer (0 for 2D).
+        //        Packed depth-stencil textures are read back as depth-only.
+        //        Requires an active OpenGL 4.5+ context (main thread).
+        [[nodiscard]] static TextureCaptureResult CaptureTexturePng(u32 textureId, u32 mipLevel = 0,
+                                                                    u32 faceOrLayer = 0,
+                                                                    CaptureNormalizeMode normalize = CaptureNormalizeMode::Auto,
+                                                                    int maxWidth = 0);
+
         // @brief Get total number of tracked resources
         u32 GetResourceCount() const
         {

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -4,7 +4,9 @@ OloEditor can host a **localhost-only, read-only [MCP](https://modelcontextproto
 server** so you can point your own LLM agent (Claude Code, Claude Desktop, …) at the
 *running editor* and get grounded help debugging your game — using the diagnostics the
 engine already collects (logs, scene/ECS state, scripting errors and API, performance,
-memory, shaders, assets, crash reports, and a live screenshot).
+memory, shaders, assets, crash reports, and a live screenshot) — plus a Tier-0
+rendering-dev harness (camera control, viewport sizing, intermediate render-target
+capture; issue #316).
 
 Strategy is **"expose, don't embed"**: OloEditor does not ship a chat panel, an API key,
 or a model. It exposes data over a standard protocol; you bring your own agent. (Issue #285.)
@@ -16,7 +18,9 @@ or a model. It exposes data over a standard protocol; you bring your own agent. 
 - Every request must carry a **bearer token** the editor generates and displays. A fresh
   token is minted each time you start the server.
 - The `Origin` header is validated (DNS-rebinding defence) and the dispatch layer is
-  **read-only** — no tool modifies your project.
+  **read-only with respect to your project** — no tool writes scenes, assets, or files.
+  The Tier-0 inspection tools (issue #316) may adjust *editor-only viewport state* — the
+  editor camera pose and the viewport capture size — which is never persisted.
 - Optional **path redaction** scrubs absolute filesystem paths from text output (toggle in
   the panel) for when you don't want project layout / usernames leaving the process.
 
@@ -103,7 +107,30 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_script_get_api` | C# / Lua scripting API digest (types + members), with a type filter |
 | `olo_script_get_last_errors` | recent C# (Mono) / Lua (Sol2) script exceptions |
 | `olo_crash_list` / `olo_crash_get` | crash reports under `CrashReports/` |
-| `olo_screenshot` | the viewport rendered to a PNG image block |
+| `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera |
+| `olo_camera_get` | the editor camera's pose (position, focal point, yaw/pitch, FOV, clips, viewport size) |
+| `olo_camera_set_pose` | move the editor camera: `position` + (`target` \| `yaw`/`pitch`), optional `fov` |
+| `olo_camera_orbit` | orbit-frame the camera around a world point: `target`, `yaw`, `pitch`, `distance` |
+| `olo_camera_frame_entity` | point the camera at an entity (by UUID) and fit it in view |
+| `olo_viewport_set_size` | override the viewport's logical render size for deterministic captures (`reset` to clear) |
+| `olo_render_list_targets` | the render graph's live texture/framebuffer resources (name, kind, format, size, producers) |
+| `olo_render_capture_target` | read back one intermediate render target (depth, normals, G-buffer, shadow map, AO, post-process stages, …) as a PNG image block; depth is min-max normalised by default |
+
+### Multi-angle visual verification (the CLAUDE.md water pattern)
+
+The camera tools exist so an agent can verify a rendering change from the angles where
+it is most likely to break, without touching the user's viewport. The intended loop:
+
+1. `olo_render_list_targets` → discover what the frame graph produced this frame.
+2. `olo_screenshot { camera: { position, target } }` (or `orbit`) per angle — e.g. for
+   water: from the side, straddling the waterline, fully submerged, top-down. Each call
+   saves the user's camera, renders the pose for `settleFrames` frames, captures, and
+   restores.
+3. `olo_render_capture_target { name: "SceneDepth" }` (or `GBufferNormal`,
+   `ShadowMapCSM`, `AOBuffer`, `BloomColor`, …) when the *final* frame looks wrong and
+   you need to see which intermediate buffer broke.
+4. `olo_viewport_set_size { width, height }` first when a deterministic resolution
+   matters (golden comparisons); `{ reset: true }` when done.
 
 ### Resources
 


### PR DESCRIPTION
… for the rendering-dev harness (#316 parts 3+4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera pose control with get, set, orbit, and restore operations
  * Screenshots now support explicit camera positioning before capture
  * Added ability to frame and center camera view on specific entities
  * Viewport size override for deterministic capture control
  * Render target inspection and multi-format capture support

* **Documentation**
  * Expanded MCP diagnostics server documentation with camera and render workflow examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->