### PR TITLE
Parallel CI test execution landed on feature/ci-parallel-test-executi…

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -218,7 +218,24 @@ jobs:
       # sanitizer workflows (asan.yml): a retry there would mask the very races
       # those jobs exist to surface. Requires ctest >= 3.17 (windows-latest
       # ships >= 3.29).
-      run: ctest -V --timeout 120 --repeat until-pass:3 -C ${{env.BUILD_TYPE}} --exclude-regex '^NetworkIntegrationTest\.|^TaskSystemTest\.|^TaskEventTest\.|^NestedTasksTest\.|^PipeTest\.|^TaskDependenciesTest\.|^TaskStressTest\.|^MakeCompletedTaskTest\.|^IsAwaitableTest\.|^WaitAnyTest\.|^AnyTest\.|^DeepRetractionTest\.|^InlineTaskTest\.|^MoveOnlyResultTest\.|^TaskSelfAccessTest\.|^NestedTaskStressTest\.|^ConcurrentEventTriggerTest\.|^CancellationTokenTest\.|^WorkerRestartTest\.|^TaskConcurrencyLimiterTest\.'
+      #
+      # --parallel 4 runs up to 4 test processes at once (windows-latest has 4
+      # vCPUs). Every test is its own ctest entry (gtest_discover_tests → one
+      # OloEngine-Tests.exe per test), so serial execution pays full engine
+      # static-init ~3,200x back-to-back; a 4-wide run is a large per-PR
+      # wall-clock win. The suite is parallel-safe by construction: tests key
+      # their temp paths by PID / gtest case name, and the handful that share the
+      # engine's repo-relative mesh cache are serialized with a ctest
+      # RESOURCE_LOCK (OloEngine/tests/CMakeLists.txt). Functional/Jolt tests
+      # oversubscribe cores under -j but run stable (verified to 16x locally);
+      # the --repeat above still nets the rare #281 race. See the "Parallel-safety
+      # contract" in docs/agent-rules/testing-architecture.md.
+      #
+      # --output-on-failure replaces -V: full verbosity interleaves illegibly
+      # across parallel workers and bloats the runner log. This keeps green runs
+      # quiet and prints captured output only for failing tests; the per-test
+      # JUnit XML uploaded below keeps the complete record either way.
+      run: ctest --parallel 4 --output-on-failure --timeout 120 --repeat until-pass:3 -C ${{env.BUILD_TYPE}} --exclude-regex '^NetworkIntegrationTest\.|^TaskSystemTest\.|^TaskEventTest\.|^NestedTasksTest\.|^PipeTest\.|^TaskDependenciesTest\.|^TaskStressTest\.|^MakeCompletedTaskTest\.|^IsAwaitableTest\.|^WaitAnyTest\.|^AnyTest\.|^DeepRetractionTest\.|^InlineTaskTest\.|^MoveOnlyResultTest\.|^TaskSelfAccessTest\.|^NestedTaskStressTest\.|^ConcurrentEventTriggerTest\.|^CancellationTokenTest\.|^WorkerRestartTest\.|^TaskConcurrencyLimiterTest\.'
 
     - name: Upload test results
       uses: actions/upload-artifact@v7

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -416,8 +416,36 @@ target_include_directories(OloEngine-Tests PRIVATE
 # 120s is very generous under normal conditions but gives sanitizer builds
 # ample headroom without masking a genuinely hung binary.
 include(GoogleTest)
+
+# Parallel-safety: CI runs the suite with `ctest --parallel`, and because
+# gtest_discover_tests registers every gtest case as its own ctest entry, each
+# case runs in its own OloEngine-Tests.exe process — different cases of the same
+# fixture run concurrently. Most tests are process-isolated already (temp paths
+# keyed by PID / gtest case name); see the "Parallel-safety contract" section in
+# docs/agent-rules/testing-architecture.md.
+#
+# The one resource that is NOT process-isolated is the engine's SHARED,
+# repo-relative mesh cache (OloEditor/assets/cache/mesh/, content-hash keyed).
+# These cases each load assets/backpack/backpack.obj and call
+# MeshCache::InvalidateCache on it, so under `--parallel` one case's invalidate
+# deletes another's just-written cache mid-test (observed:
+# ModelLoadDeterminism.Backpack_FreshVsCache failing IsMeshCacheValid). The cache
+# path is the engine's real on-disk location, not a test-controlled temp dir, so
+# we serialize these offenders against EACH OTHER with a shared RESOURCE_LOCK;
+# they still overlap freely with every unrelated test. Keep this list in sync if
+# a new test loads + invalidates a shared model cache.
+set(OLO_MESH_CACHE_TESTS
+	"ModelLoadDeterminism.Backpack_FreshVsCache:DataRoundTripTest.BackpackLegacyObjImportsPbrCompanionMaps:DataRoundTripTest.BackpackLegacyObjFlipsUvsToMatchTextureUploads")
+
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
+	TEST_FILTER "${OLO_MESH_CACHE_TESTS}"
+	PROPERTIES RESOURCE_LOCK "olo_mesh_cache"
+)
+gtest_discover_tests(OloEngine-Tests
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+	DISCOVERY_TIMEOUT 120
+	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
 )
 

--- a/OloEngine/tests/InputActionTest.cpp
+++ b/OloEngine/tests/InputActionTest.cpp
@@ -8,8 +8,15 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <string_view>
 #include <unordered_set>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace OloEngine;
 
@@ -220,7 +227,17 @@ class InputActionSerializerTest : public ::testing::Test
 
     void SetUp() override
     {
-        m_TempDir = std::filesystem::temp_directory_path() / "OloEngine_InputActionTest";
+        // Per-process directory: under `ctest -j` each gtest case runs as its own
+        // OloEngine-Tests.exe process. A shared fixed dir would let one process's
+        // TearDown remove_all() delete a concurrent process's .yaml between its
+        // write and read. Keying by PID isolates each process. (Matches the
+        // PID-keyed pattern in ShaderBinaryCacheRoundTripTest.)
+#ifdef _WIN32
+        const auto pid = static_cast<long long>(_getpid());
+#else
+        const auto pid = static_cast<long long>(::getpid());
+#endif
+        m_TempDir = std::filesystem::temp_directory_path() / ("OloEngine_InputActionTest_" + std::to_string(pid));
         std::filesystem::create_directories(m_TempDir);
     }
 

--- a/OloEngine/tests/Rendering/ShaderPackTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderPackTest.cpp
@@ -5,6 +5,13 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
 
@@ -123,7 +130,17 @@ namespace
 
         void SetUp() override
         {
-            m_TestDir = std::filesystem::temp_directory_path() / "olo_shaderpack_test";
+            // Per-process directory: under `ctest -j` each gtest case runs as its
+            // own OloEngine-Tests.exe process. A shared fixed dir would let one
+            // process's SetUp/TearDown remove_all() delete a concurrent process's
+            // .osp mid-test. Keying by PID isolates each process. (Matches the
+            // PID-keyed pattern in ShaderBinaryCacheRoundTripTest.)
+#ifdef _WIN32
+            const auto pid = static_cast<long long>(_getpid());
+#else
+            const auto pid = static_cast<long long>(::getpid());
+#endif
+            m_TestDir = std::filesystem::temp_directory_path() / ("olo_shaderpack_test_" + std::to_string(pid));
             std::filesystem::remove_all(m_TestDir);
             std::filesystem::create_directories(m_TestDir);
         }

--- a/OloEngine/tests/Serialization/MeshBinarySerializerTest.cpp
+++ b/OloEngine/tests/Serialization/MeshBinarySerializerTest.cpp
@@ -12,6 +12,13 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace)
 
@@ -88,7 +95,17 @@ static Ref<MeshSource> MakeRiggedMesh()
 
 static std::filesystem::path GetTestCacheDir()
 {
-    return std::filesystem::temp_directory_path() / "olo_test_cache";
+    // Per-process directory: under `ctest -j` every gtest case runs as its own
+    // OloEngine-Tests.exe process, so a shared fixed dir would let one process's
+    // TearDownTestSuite remove_all() wipe a concurrent process's cache files
+    // mid-test. Keying by PID isolates each process. (Matches the PID-keyed
+    // pattern in ShaderBinaryCacheRoundTripTest / RuntimeAssetManagerTest.)
+#ifdef _WIN32
+    const auto pid = static_cast<long long>(_getpid());
+#else
+    const auto pid = static_cast<long long>(::getpid());
+#endif
+    return std::filesystem::temp_directory_path() / ("olo_test_cache_" + std::to_string(pid));
 }
 
 static std::filesystem::path GetTestCachePath(const std::string& filename)

--- a/docs/agent-rules/testing-architecture.md
+++ b/docs/agent-rules/testing-architecture.md
@@ -108,7 +108,35 @@ Working directory matters: run from the repo root so asset paths resolve.
 
 ---
 
-## 6. Relevant files
+## 6. Parallel-safety contract (`ctest --parallel`)
+
+CI runs the suite with `ctest --parallel` ([`.github/workflows/Windows.yml`](../../.github/workflows/Windows.yml)). Because `gtest_discover_tests` registers **every** `TEST` / `TEST_F` case as its own ctest entry, each case runs in its **own `OloEngine-Tests.exe` process** — and under `-j`, *different cases of the same fixture run concurrently in different processes*. Two rules follow for every test you write:
+
+### 6.1 Never share a mutable OS resource between test cases
+
+A fixed filesystem path, a fixed network port, or a named OS object that a **second** test case also touches will race across processes. The classic bug is a fixture whose `SetUp` / `TearDown` / `TearDownTestSuite` does `remove_all()` (or `InvalidateCache`) on a **fixed shared** location: one process's teardown deletes a concurrent process's files mid-test.
+
+**Fix — key any path you write by the process or the case**, mirroring the existing patterns:
+
+- **By PID** — `temp_directory_path() / ("olo_..._" + std::to_string(_getpid()))`. See [ShaderBinaryCacheRoundTripTest.cpp](../../OloEngine/tests/Rendering/ShaderBinaryCacheRoundTripTest.cpp), [MeshBinarySerializerTest.cpp](../../OloEngine/tests/Serialization/MeshBinarySerializerTest.cpp), [ShaderPackTest.cpp](../../OloEngine/tests/Rendering/ShaderPackTest.cpp), [InputActionTest.cpp](../../OloEngine/tests/InputActionTest.cpp).
+- **By gtest case name** — `temp_directory_path() / (test_info()->test_suite_name() + "." + test_info()->name())`. See [MeshAssetSerializerTest.cpp](../../OloEngine/tests/Serialization/MeshAssetSerializerTest.cpp), [AutoSaveTest.cpp](../../OloEngine/tests/AutoSaveTest.cpp), and the Functional Lua tests.
+
+A fixed path used by **exactly one** case is fine — only one process ever touches it. Fixed ports are fine here only because the offenders either never bind (GNS uninitialised → `StartListening` returns false) or are in the workflow's `--exclude-regex` (`NetworkIntegrationTest`).
+
+When you add a test that writes files, grep your new file for `temp_directory_path` and confirm the path is PID- or case-keyed.
+
+### 6.2 Shared resources that can't be process-keyed → serialize in CMake
+
+Some resources are **not** test-controlled and can't be PID-keyed — chiefly the engine's repo-relative **mesh cache** (`OloEditor/assets/cache/mesh/`, content-hash keyed). Tests that load the *same* model and call `MeshCache::InvalidateCache` race on the same `.omesh` file. These are serialized **against each other** with a shared ctest `RESOURCE_LOCK` in [OloEngine/tests/CMakeLists.txt](../../OloEngine/tests/CMakeLists.txt) (`OLO_MESH_CACHE_TESTS` → `RESOURCE_LOCK "olo_mesh_cache"`), applied via a filtered second `gtest_discover_tests` call. They still overlap freely with unrelated tests. **If you add a test that loads + invalidates a shared model cache, add its `Suite.Case` name to that filter.**
+
+### 6.3 GPU and CPU oversubscription are tolerated, not isolated
+
+- **GL-context tests** (`RendererAttachedTest` subclasses; the `*VisualEvidence*` / `*Bake*` / GPU-contract families) **SKIP** on CI (no GL 4.6 context), so they are no-ops under `-j` there. Locally they *run* and contend for the single GPU — expect them to be slow or to hit the per-test `--timeout` at high `-j`; that is a local artifact, **not** a CI failure. Verify GPU tests at a low `-j`.
+- **Functional / physics tests** each start an `FScheduler` worker pool sized to `hardware_concurrency` ([FunctionalTest.cpp](../../OloEngine/tests/Functional/FunctionalTest.cpp)), so concurrent physics processes oversubscribe the cores. We deliberately do **not** serialize them: the workflow's `--repeat until-pass:3` nets the rare #281 Jolt race, and the suite runs stable under heavy local oversubscription (verified at `-j16` on a 28-core box ≈ 16×, well above CI's 4-core `-j4` ≈ 4×). If a future change makes physics flakier under `-j`, the lever is a ctest `RESOURCE_LOCK` / `PROCESSORS` property on those cases — not lowering `-j` globally.
+
+---
+
+## 7. Relevant files
 
 | Purpose | Path |
 |---|---|


### PR DESCRIPTION
…on (slice of this issue).

The Windows ctest step ran the ~3,200-test suite serially with -V. Since every test is its own ctest entry (gtest_discover_tests → one process per test), serial paid full engine static-init ~3,200× back-to-back. Change: ctest --parallel 4 --output-on-failure … (kept timeout/repeat/exclude). Local measurement (Debug, 28-core; CI is Release/4-core, ratio is what transfers): serial ≈74 min → -j4 11 min, -j16 4.4 min. On CI's 4 cores expect ~4×. Parallel-safety: fixed 3 fixtures that wiped a shared temp dir (PID-keyed them); serialized the 3 tests sharing the engine mesh cache with a ctest RESOURCE_LOCK; left physics tests unserialized (stable under 16× oversubscription + --repeat net). Contract documented in docs/agent-rules/testing-architecture.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled parallel test execution in CI for faster feedback cycles
  * Improved test isolation with process-based directory keying to prevent concurrent test conflicts
  * Added resource locking mechanism for tests that share critical resources

* **Documentation**
  * Added parallel-safety guidelines documenting best practices for concurrent test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->