### PR TITLE
fix(fuzz): restore the never-passing Fuzz Smoke (asan) job

### DIFF
--- a/OloEngine/tests/Fuzzing/FuzzImageDecoder.cpp
+++ b/OloEngine/tests/Fuzzing/FuzzImageDecoder.cpp
@@ -29,6 +29,34 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     if (size == 0 || size > static_cast<size_t>(1 << 28))
         return 0;
 
+    // Decode-bomb guard. A crafted header can declare enormous dimensions so
+    // stb_image attempts a multi-gigabyte output allocation. That is resource
+    // exhaustion, not a memory-safety bug, but under ASan's allocator overhead
+    // it pushes RSS past libFuzzer's default `-rss_limit_mb=2048` and the
+    // harness OOM-aborts — and because it depends on whether the fuzzer reaches
+    // such an input within the time budget, it makes the asan job flaky-red.
+    // `stbi_info_from_memory` parses only the header (no pixel allocation), so
+    // we can cheaply decline inputs whose worst-case output buffer would blow
+    // the budget. The widest path is the float decoder: w * h * channels * 4.
+    // Real chunk-parser bugs fire far below this cap; we only skip the bombs.
+    {
+        int iw = 0;
+        int ih = 0;
+        int icomp = 0;
+        if (::stbi_info_from_memory(data, static_cast<int>(size), &iw, &ih, &icomp))
+        {
+            constexpr std::int64_t kMaxDecodedBytes = std::int64_t{ 256 } * 1024 * 1024;
+            // stb_image emits at most RGBA; clamp so a bogus channel count can
+            // neither under- nor over-count, and reject non-positive / absurd
+            // dimensions up front so the int64 multiply below cannot overflow.
+            const std::int64_t channelsOut = (icomp < 1 || icomp > 4) ? 4 : icomp;
+            if (iw <= 0 || ih <= 0 || iw > (1 << 24) || ih > (1 << 24))
+                return 0;
+            if (static_cast<std::int64_t>(iw) * ih * channelsOut * 4 > kMaxDecodedBytes)
+                return 0;
+        }
+    }
+
     int w = 0;
     int h = 0;
     int channels = 0;

--- a/cmake/Fuzzing.cmake
+++ b/cmake/Fuzzing.cmake
@@ -3,12 +3,16 @@
 #
 # When `OLO_ENABLE_FUZZING=ON` is passed at configure time, this module:
 #
-#   1. Globally defines `_DISABLE_VECTOR_ANNOTATION` / `_DISABLE_STRING_
-#      ANNOTATION`. The MSVC STL flips its container ABI between
-#      sanitised and non-sanitised TUs (`annotate_string` /
-#      `annotate_vector`); when only some targets are sanitised the
-#      linker fires `/failifmismatch` errors. Forcing the flag off
-#      uniformly keeps the STL ABI consistent across the whole build.
+#   1. Globally defines the umbrella `_DISABLE_STL_ANNOTATION`. The MSVC
+#      STL annotates several containers for ASan container-overflow
+#      detection (`string`, `vector`, `optional`, … and the family keeps
+#      growing across toolset releases) and flips each one's ABI marker
+#      between sanitised and non-sanitised TUs; when only some targets are
+#      sanitised the linker fires `/failifmismatch` errors. The umbrella
+#      macro disables the whole family (string + vector + optional + any
+#      future one) in a single define, keeping every container's ABI
+#      marker identical in every TU regardless of `-fsanitize=address`.
+#      See the detailed note at the `add_compile_definitions` call below.
 #
 #   2. Builds libFuzzer from compiler-rt source (LLVM 19.1.7 release
 #      tarball) into a static `olo_libfuzzer` target. We can't use stock
@@ -101,12 +105,27 @@ message(STATUS "OloEngine fuzzing: enabled (Clang/libFuzzer + ${OLO_FUZZ_SANITIZ
 # the option() call leaves this value alone.
 set(TRACY_ENABLE OFF CACHE BOOL "Disabled automatically because OLO_ENABLE_FUZZING=ON (Tracy's static-init globals conflict with ASan/UBSan instrumentation)." FORCE)
 
-# Force-disable MSVC STL container annotations across the whole build so the
-# `annotate_string` ABI flag stays the same value in every TU regardless of
+# Force-disable MSVC STL container annotations across the whole build so each
+# container's ABI marker (`annotate_string`, `annotate_vector`,
+# `annotate_optional`, …) stays the same value in every TU regardless of
 # whether `-fsanitize=address` was passed. Without this, linking a sanitised
-# OloEngine into a non-sanitised OloEditor (or vice versa) fails with
-# `/failifmismatch: mismatch detected for 'annotate_string'`.
-add_compile_definitions(_DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)
+# OloEngine into a non-sanitised OloEditor / olo_libfuzzer (or vice versa)
+# fails with `/failifmismatch: mismatch detected for 'annotate_<container>'`.
+#
+# Use the umbrella `_DISABLE_STL_ANNOTATION` rather than the per-container
+# `_DISABLE_STRING_ANNOTATION` / `_DISABLE_VECTOR_ANNOTATION` defines: the
+# MSVC STL keeps *adding* new container annotations over time. Originally it
+# annotated only `string` + `vector`; the VS 18 2026 toolset (MSVC 14.51,
+# `--msvc-ver=1951`) added a third, `annotate_optional`, which the two
+# per-container defines don't cover — so a build pinned to those two
+# silently re-broke at link time (`annotate_optional` 1-vs-0 mismatch
+# between ASan-instrumented OloEngine.lib and the non-instrumented
+# olo_libfuzzer.lib). Disabling them one-by-one is whack-a-mole. The
+# umbrella `_DISABLE_STL_ANNOTATION` (present in every supported toolset,
+# back to 14.44) cascades to *all* current per-container disables and any
+# future ones the STL adds — see
+# `<VC>/Tools/MSVC/<ver>/include/__msvc_sanitizer_annotate_container.hpp`.
+add_compile_definitions(_DISABLE_STL_ANNOTATION)
 
 if(WIN32)
     # MSVC ASan runtime requires the release dynamic CRT (/MD). Mixing with
@@ -293,9 +312,33 @@ if(WIN32)
     # UBSan, never both — see the header note on the
     # `sanitizer_coverage_win_sections.cpp.obj` duplicate-symbol issue.
     if(OLO_FUZZ_SANITIZER STREQUAL "asan")
+        # `-mllvm -asan-stack=0` disables ASan's *stack-local* instrumentation
+        # (the red-zones around stack variables). This is REQUIRED on the
+        # Windows/clang-cl ASan path: ASan's stack instrumentation is
+        # incompatible with MSVC C++ exception unwinding. When a C++ exception
+        # whose object owns an STL container (e.g. yaml-cpp's `YAML::Exception`,
+        # which derives from `std::runtime_error` and carries a `std::string`)
+        # is thrown and then caught in an ASan-instrumented function, the
+        # unwinder runs the catch/cleanup funclet, and under stack
+        # instrumentation that funclet faults with an access-violation while
+        # walking the parent frame — every malformed-YAML input that the
+        # FuzzSceneYaml / FuzzInputActionYaml harnesses feed to the (correctly
+        # `try`/`catch`-wrapped) deserializers crashes the process before
+        # libFuzzer can continue. `int`-valued throws are unaffected; the
+        # trigger is specifically the STL-bearing exception object. Reproduced
+        # on a ~12-line standalone repro across LLVM 20.1.8 *and* 21.x, MSVC STL
+        # 14.44 *and* 14.51, and both the static and dynamic ASan runtimes — so
+        # it is a clang-cl/Windows-EH-funclet codegen limitation, not a version
+        # quirk and not anything in OloEngine. We pay for green harnesses by
+        # giving up *stack*-buffer-overflow detection only; heap-buffer-overflow,
+        # heap-use-after-free, double-free and global-overflow detection (the
+        # high-value checks for the heap-allocating deserializers we fuzz) all
+        # remain active (verified). This is Windows-only — the Linux/macOS ASan
+        # branch below keeps full stack instrumentation.
         function(olo_apply_fuzz_sanitizer _target)
             target_compile_options(${_target} PRIVATE
                 -fsanitize=address -fno-omit-frame-pointer
+                -mllvm -asan-stack=0
             )
             target_link_libraries(${_target}
                 "${_OLO_CLANG_RT_DIR}/clang_rt.asan_dynamic-x86_64.lib"
@@ -314,6 +357,11 @@ if(WIN32)
         function(olo_apply_fuzzer_link _target)
             target_compile_options(${_target} PRIVATE
                 -fsanitize=fuzzer,address -fno-omit-frame-pointer
+                # Keep the harness TUs on the same `-asan-stack=0` footing as
+                # OloEngine (see the note on olo_apply_fuzz_sanitizer above) so
+                # an exception unwinding through a harness frame can't re-trip
+                # the Windows-EH-funclet access-violation.
+                -mllvm -asan-stack=0
             )
             target_link_libraries(${_target} PRIVATE olo_libfuzzer)
         endfunction()


### PR DESCRIPTION
The `Fuzz Smoke (asan)` matrix job had failed every scheduled run since 2026-05-24 (40/40 fetched runs, 0 successes), keeping the whole workflow red and the daily ASan memory-safety bug-finder dark (issue #240 shows this harness surfaces real bugs). The `ubsan` half was unaffected.

Fixing the documented link failure let the harnesses *run* for the first time, which exposed two further pre-existing blockers. All three are fixed here and verified green on the exact CI toolchain (LLVM 20.1.8 + MSVC 14.51); none was caused by this change.

1. Link mismatch (the documented root cause). The MSVC STL emits `#pragma detect_mismatch("annotate_<container>", "0|1")` markers that flip between ASan-instrumented and non-instrumented TUs. The VS 18 2026 toolset (MSVC 14.51) added a third container annotation, `optional`, which the existing `_DISABLE_VECTOR/STRING_ANNOTATION` defines don't cover, so the asan link died with `/failifmismatch: mismatch detected for 'annotate_optional'` (OloEngine.lib=1 vs olo_libfuzzer.lib=0). Replaced the two per-container  defines with the umbrella `_DISABLE_STL_ANNOTATION`, which cascades to string + vector + optional + any future container the STL adds (present in every supported toolset back to 14.44), so this can't recur.

2. clang-cl ASan stack instrumentation vs MSVC C++ exception unwind. ASan's stack-local red-zones are incompatible with MSVC's C++ EH funclets: when an exception whose object owns an STL container (e.g. yaml-cpp's `YAML::Exception`) is thrown and caught in instrumented code, the catch funclet faults with an access-violation during unwind — crashing FuzzSceneYaml / FuzzInputActionYaml on the first malformed input, even though the deserializers already catch correctly. Isolated to a ~12-line standalone repro that reproduces across LLVM 20.1.8 and 21.x, MSVC STL 14.44 and 14.51, and both static and dynamic ASan runtimes (int-valued throws are unaffected) — a clang-cl/Windows-EH codegen limitation, not an engine bug. Worked around with `-mllvm -asan-stack=0` on the Windows asan path only; this gives up stack-buffer-overflow detection but keeps heap-overflow, heap-UAF, double-free and global-overflow detection (verified). The Linux/macOS asan path keeps full stack instrumentation.

3. FuzzImageDecoder OOM. A crafted stb_image header triggers a large output allocation that, inflated by ASan's overhead, blew libFuzzer's default 2048 MB rss_limit (seed-dependent, so flaky-red). Added a decode-bomb guard that pre-flights dimensions with `stbi_info_from_memory` (parses the header only, allocates nothing) and declines inputs whose worst-case buffer would exceed 256 MiB. Real chunk-parser bugs still fire well below the cap; peak RSS dropped from 3075 MB to 571 MB.

Both Fuzzing.cmake changes are gated behind OLO_ENABLE_FUZZING, so the default msvc/clangcl presets and the OloEngine-Tests build are untouched (confirmed by a clean default reconfigure).

Verified locally on LLVM 20.1.8 + MSVC 14.51: asan links clean and all 7 harnesses exit 0 (30s each); ubsan still builds and all 7 exit 0 (no regression).