### PR TITLE
build: make unity (jumbo) build of OloEngine compile + measure it (#304)

### DIFF
--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -1257,6 +1257,66 @@ add_library(OloEngine STATIC
 		${SOURCES}
 )
 
+# Unity (jumbo) build exclusions. The OloEngine target's UNITY_BUILD property is set in the
+# parent OloEngine/CMakeLists.txt (gated on OLO_ENABLE_UNITY_BUILD); the per-source
+# SKIP_UNITY_BUILD_INCLUSION below must live here, in the directory scope where the sources
+# are added to the target. See docs/BUILD.md "Unity (jumbo) builds for faster cold builds".
+#
+# Two groups, each empirically required (a unity ON build fails to compile without them):
+#
+# GROUP 1 — single-header third-party amalgamations. Each #defines a *_IMPLEMENTATION macro
+# and pulls an entire single-header library into one TU. They gain nothing from batching
+# (each is already a maximal, self-contained compile) and they poison the rest of the batch:
+# the implementation macros and the platform headers they drag in (miniaudio pulls
+# <windows.h> with its min/max + near/far macros; the FFmpeg C headers define a huge macro
+# surface) leak into the files concatenated after them in the same jumbo and break the build.
+#
+# GROUP 2 — engine TUs that define a file-local helper (an anonymous-namespace function or a
+# file-scope `static`/`const` constant) whose *name* is duplicated, by copy-paste, in a
+# sibling TU. In a jumbo the siblings concatenate into one TU and the duplicate names collide
+# (redefinition / ambiguous-overload). The clean fix is to de-duplicate the helpers into a
+# shared header — deliberately deferred as a follow-up to keep THIS change a low-risk,
+# CMake-only build-config PR (no source-logic edits). Excluding them is cheap: ~20 of ~470
+# TUs, so the remaining files still batch and the cold-build speedup stands. The one
+# engine-code collision fixed in place rather than excluded was a true root-cause bug, not a
+# name clash: Renderer/Vertex.h pulled the experimental <glm/gtx/integer.hpp> it never used,
+# so any jumbo that included it before GLM_ENABLE_EXPERIMENTAL was active #error'd — the unused
+# include is simply removed.
+if(OLO_ENABLE_UNITY_BUILD)
+	set_source_files_properties(
+		# GROUP 1 — third-party single-header amalgamations
+		"OloEngine/Audio/AudioEngine.cpp"          # miniaudio (MINIAUDIO_IMPLEMENTATION) + <windows.h>
+		"Platform/OpenGL/OpenGLTexture.cpp"        # stb_image (STB_IMAGE_IMPLEMENTATION)
+		"OloEngine/SaveGame/ThumbnailCapture.cpp"  # stb_image_write (STB_IMAGE_WRITE_IMPLEMENTATION)
+		"OloEngine/Renderer/Font.cpp"              # stb_truetype (STB_TRUETYPE_IMPLEMENTATION)
+		"OloEngine/Video/PlMpeg.cpp"               # pl_mpeg (PL_MPEG_IMPLEMENTATION)
+		"OloEngine/Video/FFmpegBackend.cpp"        # FFmpeg C headers (avcodec/avformat/...) — heavy macro surface
+		"OloEngine/ImGui/ImGuiBuild.cpp"           # Dear ImGui backend implementation TU
+		# GROUP 2 — duplicated file-local helper names that collide across a jumbo (de-dup TODO)
+		"OloEngine/Renderer/RenderPipeline.cpp"            # anon IsTruthyEnvironmentVariable / IsRenderGraphDiagnosticsEnabled
+		"OloEngine/Renderer/RenderGraph.cpp"              #   "
+		"OloEngine/Renderer/Renderer3DFrameExecution.cpp" #   "
+		"OloEngine/Renderer/Renderer3DLifecycle.cpp"      #   "
+		"OloEngine/Renderer/Renderer3DRenderGraphSetup.cpp" # "
+		"OloEngine/Renderer/Model.cpp"             # anon FindTextureInDirectory (+ IsTruthyEnvironmentVariable)
+		"OloEngine/Renderer/AnimatedModel.cpp"     # anon FindTextureInDirectory
+		"OloEngine/Renderer/Ocean/OceanFFT.cpp"    # anon constant kTwoPi
+		"OloEngine/Renderer/Ocean/OceanFFTGpu.cpp" # anon constant kTwoPi
+		"OloEngine/Renderer/Ocean/OceanSpectrum.cpp" # anon constant kTwoPi
+		"OloEngine/Renderer/WaterSurface.cpp"      # anon constant kTwoPi
+		"OloEngine/Animation/IK/FABRIKSolver.cpp"  # anon SafeNormalize
+		"OloEngine/Animation/IK/LimbIKSolver.cpp"  # anon SafeNormalize
+		"OloEngine/Animation/Procedural/SpringBoneSolver.cpp" # anon SafeNormalize + IsFiniteVec3
+		"OloEngine/Animation/Procedural/NoiseSolver.cpp"      # anon IsFiniteVec3
+		"OloEngine/Cinematic/CinematicCurve.cpp"   # anon SafeNormalize
+		"OloEngine/Scripting/C#/ScriptGlue.cpp"    # static IsFiniteVec3 (+ macro-heavy Mono glue)
+		"OloEngine/Scripting/Lua/LuaScriptGlue.cpp" # static IsFiniteVec3 (+ macro-heavy Sol2 glue)
+		"OloEngine/Audio/DSP/HighPassFilter.cpp"   # namespace-scope consts FilterOrder/Min/MaxFrequencyHz
+		"OloEngine/Audio/DSP/LowPassFilter.cpp"    #   "
+		PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+	)
+endif()
+
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
 			FILES ${SOURCES}
 )

--- a/OloEngine/src/OloEngine/Renderer/Vertex.h
+++ b/OloEngine/src/OloEngine/Renderer/Vertex.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <glm/glm.hpp>
-#include <glm/gtx/integer.hpp>
 #include "OloEngine/Renderer/Buffer.h"
 
 namespace OloEngine

--- a/cmake/CompilerCache.cmake
+++ b/cmake/CompilerCache.cmake
@@ -69,6 +69,17 @@ if(OLO_ENABLE_COMPILER_CACHE)
         # in the top-level CMakeLists; override it here.
         set(OLO_ENABLE_PCH OFF CACHE BOOL "Disabled: MSVC PCH (/Fp) is non-cacheable under sccache/ccache" FORCE)
 
+        # Disable unity (jumbo) builds while caching — same reasoning as PCH above, opposite
+        # trade-off. Unity batches 16 TUs into one object; editing a single line in any file
+        # of a batch changes that whole jumbo object's inputs, so its cache key misses and all
+        # 16 TUs recompile. On CI's common case (incremental push = warm cache) that turns a
+        # 1-TU recompile into a 16-TU recompile — a net loss. Unity speeds *cold* builds (it
+        # amortizes header re-parsing across the batch); the cache speeds *warm* builds. They
+        # optimize opposite cases and don't compose, so when caching is on the cache wins and
+        # unity is forced off. OLO_ENABLE_UNITY_BUILD is an option() in the top-level
+        # CMakeLists; override it here (mirrors the PCH override above).
+        set(OLO_ENABLE_UNITY_BUILD OFF CACHE BOOL "Disabled: jumbo TUs bust the per-object cache key under sccache/ccache" FORCE)
+
         # NOTE: a few vendored libraries force MSVC /Zi + a separate PDB regardless
         # of the format above, which sccache/ccache cannot cache. Those are turned
         # off (only when caching) next to their other options in

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -173,6 +173,47 @@ cd OloEditor && ../bin/Debug/OloEditor/OloEditor
 
 ---
 
+## Build speed options
+
+The build is tuned for fast compiles out of the box. Four CMake options control the levers;
+the defaults are what you want for local dev.
+
+| Option                     | Default | Helps               | Notes                                                         |
+|----------------------------|---------|---------------------|--------------------------------------------------------------|
+| `OLO_ENABLE_PCH`           | `ON`    | cold **and** warm   | Precompiles `OloEnginePCH.h`; PUBLIC, so editor/runtime/tests inherit it. This is the single biggest cold-build lever. |
+| `OLO_ENABLE_LTO`           | `ON`    | runtime perf        | Release/Dist only (it would cripple Debug link times).       |
+| `OLO_ENABLE_COMPILER_CACHE`| `OFF`   | warm/incremental    | sccache/ccache; Ninja-only (the VS generator ignores compiler launchers). CI's win. Force-disables PCH **and** unity (both are non-cacheable). |
+| `OLO_ENABLE_UNITY_BUILD`   | `OFF`   | cold (situationally)| Jumbo/unity build of `OloEngine`. See below — measured, marginal. |
+
+### Unity (jumbo) builds — `-DOLO_ENABLE_UNITY_BUILD=ON`
+
+Batches the `OloEngine` TUs 16-per-jumbo (`UNITY_BUILD_BATCH_SIZE`) so headers parse once per
+batch instead of once per file. **Opt-in and OFF by default**, and it auto-disables when the
+compiler cache is on (a one-line edit busts the whole 16-file jumbo's cache key — a net loss on
+warm-cache incremental builds; see `cmake/CompilerCache.cmake`). CI uses the cache, so CI never
+runs unity.
+
+**Measured cold-build result (isolated `OloEngine` recompile, vendor warm, Debug, MSVC, 28-core,
+cache OFF):** across 11 runs the median was **identical at 336s** ON vs OFF; the best run favoured
+ON (220s vs 275s, ~20%) and ON won 3 of 4 load-matched pairs, but one pair favoured OFF. So unity
+is **a modest, situational cold-build win at best, easily masked by machine load.** The reason it
+isn't bigger: **PCH already amortizes the header-parsing cost that unity targets**, so they don't
+stack — and on a many-core machine the 56 coarse unity TUs schedule across cores slightly worse
+than the ~470 fine ones. Unity is most likely to pay off on a **core-starved machine without
+PCH** — which OloEngine is not. **Recommendation: leave it OFF unless you're on a low-core machine
+doing repeated cold builds and have measured a win for your hardware.**
+
+Enabling it required two build-only changes (no engine-logic edits): `Renderer/Vertex.h` no longer
+pulls the unused experimental `<glm/gtx/integer.hpp>` (which `#error`'d in jumbos before
+`GLM_ENABLE_EXPERIMENTAL` was active), and 27 TUs are excluded from batching via
+`SKIP_UNITY_BUILD_INCLUSION` in `OloEngine/src/CMakeLists.txt` — 7 third-party single-header
+amalgamations (miniaudio/stb/pl_mpeg/ImGui/FFmpeg) plus 20 engine TUs whose copy-pasted
+file-local helpers (`IsTruthyEnvironmentVariable`, `SafeNormalize`, `kTwoPi`, …) collide when
+concatenated. De-duplicating those helpers into shared headers would let them rejoin the batches;
+it's deliberately left as a follow-up so this stays a low-risk, CMake-only change.
+
+---
+
 ## Troubleshooting
 
 ### Missing shaders / Mono assemblies at runtime


### PR DESCRIPTION
Turn the half-wired OLO_ENABLE_UNITY_BUILD option into a functional opt-in for the OloEngine target. It had never actually been compiled; enabling it surfaced the classic jumbo-build collisions.

Build-only changes (no engine logic touched):
- Renderer/Vertex.h: drop the unused experimental <glm/gtx/integer.hpp> include -- it #error'd in any jumbo that reached it before GLM_ENABLE_EXPERIMENTAL was active, and the header was never actually used.
- OloEngine/src/CMakeLists.txt: exclude 27 TUs from batching via SKIP_UNITY_BUILD_INCLUSION -- 7 third-party single-header amalgamations (miniaudio/stb/pl_mpeg/ImGui/FFmpeg) + 20 engine TUs whose copy-pasted file-local helpers (IsTruthyEnvironmentVariable, SafeNormalize, kTwoPi, ...) collide when concatenated.
- cmake/CompilerCache.cmake: force unity OFF when the compiler cache is on (jumbo TUs bust the per-object cache key), mirroring the PCH handling.
- docs/BUILD.md: document the option and the measured result.

Measured (isolated OloEngine cold recompile, vendor warm, Debug, MSVC, 28-core, cache OFF, 11 runs): median identical at 336s ON vs OFF; best-case ON 220s vs OFF 275s. Unity is a modest, situational cold-build win at best -- PCH already amortizes the header-parsing cost it targets. Kept opt-in/OFF; CI (sccache) is unaffected.