### PR TITLE
fix(memory): acquire loads for lock-free allocator page publish/consu…

### DIFF
--- a/OloEngine/src/OloEngine/Memory/LockFreeList.h
+++ b/OloEngine/src/OloEngine/Memory/LockFreeList.h
@@ -144,7 +144,10 @@ namespace OloEngine
                                      Index < MaxTotalItems &&
                                      BlockIndex < MaxBlocks &&
                                      m_Pages[BlockIndex].load(std::memory_order_relaxed));
-            return m_Pages[BlockIndex].load(std::memory_order_relaxed) + SubIndex;
+            // acquire (not relaxed) — pairs with the publishing CAS in GetRawItem so the
+            // page contents this pointer is dereferenced into happen-after publication.
+            // Deliberate divergence from UE5.8; see the m_Pages declaration note (#350).
+            return m_Pages[BlockIndex].load(std::memory_order_acquire) + SubIndex;
         }
 
       private:
@@ -174,7 +177,11 @@ namespace OloEngine
                     checkLockFreePointerList(m_Pages[BlockIndex].load(std::memory_order_relaxed));
                 }
             }
-            return static_cast<void*>(m_Pages[BlockIndex].load(std::memory_order_relaxed) + SubIndex);
+            // acquire (not relaxed) — pairs with the publishing CAS above so that when a
+            // racing thread lost the CAS and reads the winner's page here, the winner's
+            // allocation happens-before this dereference. Divergence from UE5.8; see the
+            // m_Pages declaration note (#350).
+            return static_cast<void*>(m_Pages[BlockIndex].load(std::memory_order_acquire) + SubIndex);
         }
 
         alignas(OLO_PLATFORM_CACHE_LINE_SIZE) std::atomic<u32> m_NextIndex{ 0 };
@@ -184,6 +191,19 @@ namespace OloEngine
         // an earlier port kept a plain array and only made the CAS atomic via
         // std::atomic_ref, leaving the reads as a data race that ThreadSanitizer
         // flagged.)
+        //
+        // Memory ordering — deliberate divergence from UE5.8 (#350): the two loads
+        // whose result is dereferenced (GetItem / GetRawItem return statements) use
+        // std::memory_order_acquire, pairing with the publishing CAS above to give a
+        // synchronizes-with / happens-before edge between the thread that mallocs+
+        // publishes a page and a thread that reads the pointer and constructs into it.
+        // UE5.8 leaves those loads relaxed; that is a formal C++ memory-model data race
+        // (TSan reports it) that is benign on x86-64 TSO but UB by the standard. We gate
+        // CI on TSan (job tsan-linux in asan.yml) and UE does not, so we strengthen here.
+        // Zero cost on x86-64: acquire and relaxed both lower to a plain mov. The
+        // remaining relaxed loads in this class are assertion guards / null-checks, not
+        // dereferenced values, and intentionally stay relaxed. A future "resync to UE"
+        // pass must not silently revert this.
         alignas(OLO_PLATFORM_CACHE_LINE_SIZE) std::atomic<T*> m_Pages[MaxBlocks];
     };
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(OloEngine-Tests
 		HAL/ThreadManagerTest.cpp
 		Containers/ConcurrentQueuesTest.cpp
 		Memory/MemoryViewTest.cpp
+		Memory/LockFreeAllocatorConcurrencyTest.cpp
 		Templates/FunctionWithContextTest.cpp
 		Templates/TypeTraitsTest.cpp
 

--- a/OloEngine/tests/Memory/LockFreeAllocatorConcurrencyTest.cpp
+++ b/OloEngine/tests/Memory/LockFreeAllocatorConcurrencyTest.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file LockFreeAllocatorConcurrencyTest.cpp
+ * @brief Concurrency regression test for TLockFreeAllocOnceIndexedAllocator (issue #350)
+ *
+ * Guards the memory-order hardening in LockFreeList.h: the page pointers in
+ * TLockFreeAllocOnceIndexedAllocator are published with a release CAS
+ * (GetRawItem) but were historically *consumed* with memory_order_relaxed loads
+ * whose result is dereferenced. That is a formal C++ memory-model data race —
+ * benign on x86-64 (TSO), but UB by the standard, and ThreadSanitizer flags it
+ * intermittently, reddening the gating tsan-linux job in asan.yml. The fix
+ * promotes the two dereferenced loads (GetItem return + GetRawItem return) to
+ * memory_order_acquire so they pair with the publishing CAS.
+ *
+ * The test does not assert the absence of a race directly — TSan does that in
+ * CI. It exists so the race is *exercised* under the sanitizer: many threads
+ * hammer the allocator so several first-touch the same page at once. One wins
+ * the publishing CAS; the losers take the consume load in GetRawItem and
+ * construct into the page. That is exactly the reported race — TSan saw a page
+ * malloc on one thread (GetRawItem, before the publish CAS) racing a
+ * placement-new on another (Alloc, after a relaxed consume). With the acquire
+ * fix the malloc happens-before the construct, so TSan is clean; weaken it back
+ * to relaxed and TSan reddens here again. On x86 the test also verifies the
+ * allocator's functional contract (disjoint indices, valid, dereferenceable
+ * items).
+ *
+ * Why there is no separate cross-thread *GetItem* test: GetItem's acquire load
+ * pairs with the publishing CAS, so it orders only what happened *before* the
+ * page was published. The link *contents* a consumer would read (the constructed
+ * item, a stored Payload) are written *after* the publish, so reading them
+ * across threads needs its own happens-before edge — a relaxed handoff of the
+ * index is itself UB (TSan flags the construct-vs-read, not anything the
+ * allocator's ordering controls), and a release/acquire handoff would mask
+ * GetItem's ordering entirely. GetItem's L147 load is the identical pattern to
+ * GetRawItem's L177 load and is fixed for symmetry/completeness (see the issue);
+ * the reproducible race lives on the Alloc/GetRawItem path covered below.
+ *
+ * Intentionally drives the real FLockFreeLinkPolicy::s_LinkAllocator singleton
+ * rather than a local allocator instance: TLockFreeAllocOnceIndexedAllocator
+ * never frees its pages (alloc-once, by design — matches UE5.8), so a local
+ * instance would leak its pages on destruction and trip LeakSanitizer in the
+ * asan-lsan-linux job. The singleton's pages stay reachable via its static
+ * m_Pages array at exit, so LSan does not report them — and this is the actual
+ * production allocation path.
+ */
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Memory/LockFreeList.h"
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace OloEngine;
+
+namespace
+{
+    // Number of worker threads. Oversubscription (more than physical cores)
+    // increases the odds of two threads being mid-GetRawItem on the same fresh
+    // page simultaneously, which is the window the fix protects.
+    u32 WorkerThreadCount()
+    {
+        u32 Hw = std::thread::hardware_concurrency();
+        if (Hw < 4u)
+        {
+            Hw = 4u;
+        }
+        return std::min(Hw, 8u);
+    }
+
+    // Start gate: every worker blocks until all of them have arrived, then they
+    // are released together. Maximises the burst of concurrent first-touch page
+    // allocations (page 0 first, then 1, 2, ... as the shared index advances).
+    class StartGate
+    {
+      public:
+        explicit StartGate(u32 Expected)
+            : m_Expected(Expected)
+        {
+        }
+
+        // Called by each worker: register arrival, then spin until released.
+        void Wait()
+        {
+            m_Arrived.fetch_add(1, std::memory_order_acq_rel);
+            while (!m_Go.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+        }
+
+        // Called by the orchestrating thread once all workers exist.
+        void ReleaseWhenAllArrived()
+        {
+            while (m_Arrived.load(std::memory_order_acquire) < m_Expected)
+            {
+                std::this_thread::yield();
+            }
+            m_Go.store(true, std::memory_order_release);
+        }
+
+      private:
+        const u32 m_Expected;
+        std::atomic<u32> m_Arrived{ 0 };
+        std::atomic<bool> m_Go{ false };
+    };
+} // namespace
+
+class LockFreeAllocatorConcurrencyTest : public ::testing::Test
+{
+};
+
+// Many threads allocate from the shared indexed allocator at the same instant.
+// FLockFreeLinkPolicy::s_LinkAllocator uses ItemsPerPage = 16384, so the first
+// ~16k allocations land in page 0: with a synchronized start, several threads
+// are inside GetRawItem first-touching page 0 concurrently — one publishes via
+// CAS, the rest consume the published pointer (the load the fix makes acquire)
+// and construct into the page. As the index advances, pages 1, 2, ... get
+// first-touched the same way while other threads are still in flight.
+//
+// Under TSan with relaxed consume loads this reddens; with acquire it is clean.
+// On x86 it asserts the allocator's contract: every index is unique (disjoint
+// fetch_add ranges), non-zero, and dereferences to a distinct valid item.
+TEST_F(LockFreeAllocatorConcurrencyTest, ConcurrentAllocFirstTouchesPagesWithoutRace)
+{
+    const u32 NumThreads = WorkerThreadCount();
+    // ~10 pages of 16384 across all threads, so first-touch races recur well
+    // past the initial page-0 burst without making the test slow under TSan.
+    constexpr u32 AllocsPerThread = 20000;
+
+    StartGate Gate(NumThreads);
+    std::vector<std::vector<u32>> PerThreadIndices(NumThreads);
+    std::vector<std::thread> Threads;
+    Threads.reserve(NumThreads);
+
+    for (u32 T = 0; T < NumThreads; ++T)
+    {
+        std::vector<u32>& MyIndices = PerThreadIndices[T];
+        MyIndices.reserve(AllocsPerThread);
+        Threads.emplace_back(
+            [&Gate, &MyIndices, T]
+            {
+                Gate.Wait();
+                for (u32 I = 0; I < AllocsPerThread; ++I)
+                {
+                    u32 Index = FLockFreeLinkPolicy::s_LinkAllocator.Alloc(1);
+                    // Dereference via GetItem (the load promoted to acquire at
+                    // line 147) and touch the page so the consume actually
+                    // accesses page memory, not just the pointer.
+                    FIndexedLockFreeLink* Link = FLockFreeLinkPolicy::s_LinkAllocator.GetItem(Index);
+                    ASSERT_NE(Link, nullptr);
+                    Link->Payload.store(reinterpret_cast<void*>(static_cast<uptr>(Index)),
+                                        std::memory_order_relaxed);
+                    MyIndices.push_back(Index);
+                }
+            });
+    }
+
+    Gate.ReleaseWhenAllArrived();
+    for (std::thread& Th : Threads)
+    {
+        Th.join();
+    }
+
+    // Functional contract (x86): all indices distinct, non-zero, and the
+    // sentinel we wrote round-trips through a fresh GetItem.
+    std::vector<u32> AllIndices;
+    AllIndices.reserve(static_cast<sizet>(NumThreads) * AllocsPerThread);
+    for (const std::vector<u32>& Indices : PerThreadIndices)
+    {
+        EXPECT_EQ(Indices.size(), AllocsPerThread);
+        for (u32 Index : Indices)
+        {
+            EXPECT_NE(Index, 0u);
+            FIndexedLockFreeLink* Link = FLockFreeLinkPolicy::s_LinkAllocator.GetItem(Index);
+            ASSERT_NE(Link, nullptr);
+            EXPECT_EQ(reinterpret_cast<uptr>(Link->Payload.load(std::memory_order_relaxed)),
+                      static_cast<uptr>(Index));
+        }
+        AllIndices.insert(AllIndices.end(), Indices.begin(), Indices.end());
+    }
+
+    std::sort(AllIndices.begin(), AllIndices.end());
+    const auto Duplicate = std::adjacent_find(AllIndices.begin(), AllIndices.end());
+    EXPECT_EQ(Duplicate, AllIndices.end()) << "fetch_add handed the same index to two threads";
+    EXPECT_EQ(AllIndices.size(), static_cast<sizet>(NumThreads) * AllocsPerThread);
+}

--- a/OloEngine/tests/scripts/test_catalogue.json
+++ b/OloEngine/tests/scripts/test_catalogue.json
@@ -295,6 +295,7 @@
     "OloEngine/tests/ModelImporterTest.cpp": "unit",
     "OloEngine/tests/SceneMeshRaycastTest.cpp": "unit",
     "OloEngine/tests/Memory/MemoryViewTest.cpp": "unit",
+    "OloEngine/tests/Memory/LockFreeAllocatorConcurrencyTest.cpp": "unit",
     "OloEngine/tests/MeshCookingFactoryCacheTest.cpp": "unit",
     "OloEngine/tests/StaticMeshColliderGenerationTest.cpp": "unit",
     "OloEngine/tests/NavMeshTest.cpp": "unit",

--- a/docs/adr/0004-lock-free-allocator-singleton-init.md
+++ b/docs/adr/0004-lock-free-allocator-singleton-init.md
@@ -86,3 +86,31 @@ synchronization.
   check is material on this path, the escape hatch is the "UE-literal + main
   thread prime" option above — but only with the priming invariant made
   explicit and enforced.
+
+## Related divergence: page publish/consume ordering (#350)
+
+The same "we gate CI on TSan, UE does not, so we strengthen the memory ordering
+and record the divergence" reasoning applies a second time inside this allocator
+— at the **page pointers**, not the singleton init. In
+`TLockFreeAllocOnceIndexedAllocator` (header,
+[`LockFreeList.h`](../../OloEngine/src/OloEngine/Memory/LockFreeList.h)), each
+`m_Pages[BlockIndex]` is published exactly once with a release CAS in
+`GetRawItem` but was historically *consumed* with `memory_order_relaxed` loads
+whose result is dereferenced (`GetItem` and `GetRawItem` return statements).
+That is a formal C++ memory-model data race between the thread that
+mallocs+publishes a page and a thread that reads the page pointer and constructs
+into / dereferences it — benign on x86-64 (a relaxed load lowers to a plain
+`mov`, which already has acquire ordering on TSO hardware, and threads get
+disjoint index ranges from `m_NextIndex.fetch_add`), but UB by the standard, and
+ThreadSanitizer flags it intermittently — reddening the gating `tsan-linux` job.
+
+We promote those two dereferenced loads to `memory_order_acquire` so they pair
+with the publishing CAS (zero cost on x86-64 — acquire and relaxed emit the same
+`mov`). The remaining relaxed loads in the class are assertion guards /
+null-checks, not dereferenced values, and stay relaxed. UE5.8 leaves all of them
+relaxed; as with the singleton init above, the divergence is recorded in a code
+comment at the `m_Pages` declaration so a future "resync to UE" pass does not
+silently revert it. A concurrency regression test
+([`tests/Memory/LockFreeAllocatorConcurrencyTest.cpp`](../../OloEngine/tests/Memory/LockFreeAllocatorConcurrencyTest.cpp))
+hammers the allocator from many threads so the race is exercised — and caught by
+TSan — if the ordering is ever weakened again.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1475,10 +1475,11 @@ level of `tests/`). Grouped by directory.
 | [McpRenderOverridesTest.cpp](../OloEngine/tests/MCP/McpRenderOverridesTest.cpp) | 15 | **McpRenderOverrides** &mdash; `ParsesEveryCanonicalPassToken`, `ParsePassIsCaseAndSeparatorInsensitive`, `ParsePassResolvesAliases`, `ParsePassRejectsUnknownAndEmpty`, `PassTokensCoversEveryPassAndDescribePassesMatches`, `ToggleResultJsonShape`, `ToggleResultIncludesNoteWhenSet`, `ToggleResultUnchangedWhenStateMatches`, `ParsesEveryDebugViewMode`, `ParseDebugViewTreatsEmptyAndOffAsNone`, `ParseDebugViewRejectsUnknown`, `DebugViewResultJsonShapeActive`, `DebugViewResultNotePresentWhenPassDisabled`, `DebugViewModesCoversEveryModeAndDescribeMatches`, `JoinTokensProducesCommaSeparatedList` |
 | [McpShaderReloadTest.cpp](../OloEngine/tests/MCP/McpShaderReloadTest.cpp) | 4 | **McpShaderReload** &mdash; `StatusTokenMapsEveryEnumToLowercase`, `CleanReloadIsReadyWithEmptyLog`, `FailedReloadCarriesStatusAndLog`, `NotFoundReportsFoundFalseAndNoLibraries` |
 
-#### Memory (1 file)
+#### Memory (2 files)
 
 | File | Tests | Cases |
 |---|---:|---|
+| [LockFreeAllocatorConcurrencyTest.cpp](../OloEngine/tests/Memory/LockFreeAllocatorConcurrencyTest.cpp) | 1 | **LockFreeAllocatorConcurrencyTest** &mdash; `ConcurrentAllocFirstTouchesPagesWithoutRace` |
 | [MemoryViewTest.cpp](../OloEngine/tests/Memory/MemoryViewTest.cpp) | 27 | **MemoryViewTest** &mdash; `DefaultConstruction`, `ConstructFromPointerAndSize`, `ConstructFromArray`, `ConstructFromStdArray`, `ConstructFromVector`, `LeftSlice`, `RightSlice`, `MidSlice`, `LeftChop`, `RightChop`, `Equality`, `CompareBytes`, `CompareBytesWithDifferentSizes`<br/>**MutableMemoryViewTest** &mdash; `DefaultConstruction`, `ConstructFromPointerAndSize`, `ModifyData`, `CopyFrom`, `CopyFromPartial`, `LeftSlice`, `RightSlice`, `MidSlice`, `ConversionToImmutable`<br/>**MemoryViewEdgeCasesTest** &mdash; `EmptySlices`, `SliceEntireView`, `EmptyViewOperations`, `SingleByteView`, `LargeView` |
 
 #### Networking (25 files)
@@ -1558,7 +1559,7 @@ level of `tests/`). Grouped by directory.
 |---|---:|---|
 | [TerrainGeneratorTest.cpp](../OloEngine/tests/Terrain/TerrainGeneratorTest.cpp) | 15 | **TerrainGeneratorTest** &mdash; `HeightFieldIsDeterministic`, `HeightFieldIsNormalizedAndFinite`, `LargeSeedStillProducesVariedTerrain`, `DifferentSeedsProduceDifferentTerrain`, `RidgedAndWarpAndExponentStayValid`, `TerraceShapingStaysValidAndDeterministic`, `TerraceEndpointsAndIdentity`, `TerraceIsMonotonicAndBounded`, `TerraceProducesFlatPlateaus`, `RuleWeightPeaksInsideBandAndZeroOutside`, `SlopeBandSelectsRule`, `DefaultRulesAssignExpectedLayers`, `LayerWeightsAreNormalized`, `NoMatchingRuleFallsBackToLayerZero`, `PackLayerWeightsQuantizesToBothSplatmaps` |
 
-**Totals.** 146 unit / subsystem test files, 1812 TEST / TEST_F declarations across all subsystems.
+**Totals.** 147 unit / subsystem test files, 1813 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: unit-catalogue -->
 


### PR DESCRIPTION
…me (#350)

Promote the two dereferenced page-pointer loads in TLockFreeAllocOnceIndexedAllocator (GetItem/GetRawItem) from relaxed to acquire, pairing them with the publishing CAS. Fixes a formal data race TSan flags intermittently (benign on x86-64). Adds a concurrency regression test driving the real s_LinkAllocator singleton, plus a UE5.8-divergence note and an ADR addendum.

Closes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety in memory allocation by correcting memory ordering when accessing shared data in concurrent scenarios.

* **Tests**
  * Added comprehensive concurrency regression tests to verify safe multi-threaded allocator behavior.

* **Documentation**
  * Updated documentation to explain concurrency-related changes and divergences from external frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->