### PR TITLE
Implement Phase 4 Sample-Accurate Triggers in SoundGraph

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/NodeProcessor.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/NodeProcessor.h
@@ -112,22 +112,37 @@ namespace OloEngine::Audio::SoundGraph
         struct InputEvent : public Input
         {
             using EventFunction = std::function<void(f32)>;
+            // Phase 4: sample-accurate handler — receives the trigger's frame
+            // offset within the block (docs/soundgraph-metasounds-refactor.md).
+            // Trigger-consuming nodes register one of these so they can Fire their
+            // TriggerRef at the exact offset; value-only handlers ignore the offset.
+            using OffsetEventFunction = std::function<void(f32, i32)>;
 
             explicit InputEvent(NodeProcessor& owner, EventFunction ev) noexcept
                 : Input(owner), m_Event(std::move(ev))
             {
             }
+            explicit InputEvent(NodeProcessor& owner, OffsetEventFunction ev) noexcept
+                : Input(owner), m_OffsetEvent(std::move(ev))
+            {
+            }
 
-            inline virtual void operator()(f32 value) noexcept
+            // sampleOffset defaults to 0 ("at the start of the block") so legacy
+            // single-argument callers and routes keep their block-boundary timing.
+            inline virtual void operator()(f32 value, i32 sampleOffset = 0) noexcept
             {
                 OLO_PROFILE_FUNCTION();
 
-                if (m_Event)
+                if (m_OffsetEvent)
+                    m_OffsetEvent(value, sampleOffset);
+                else if (m_Event)
                     m_Event(value);
             }
 
-            // Should be bound to NodeProcessor member method
+            // Exactly one is bound (the active ctor picks). m_OffsetEvent takes
+            // precedence in operator() when set.
             EventFunction m_Event;
+            OffsetEventFunction m_OffsetEvent;
         };
 
         struct OutputEvent : public Output
@@ -137,7 +152,11 @@ namespace OloEngine::Audio::SoundGraph
             {
             }
 
-            inline void operator()(f32 value) noexcept
+            // sampleOffset (Phase 4) is forwarded to every destination so a node
+            // firing a trigger mid-block (at frame `sampleOffset`) lets downstream
+            // trigger consumers act at that exact frame. Defaults to 0 so existing
+            // single-argument fires keep their block-boundary timing.
+            inline void operator()(f32 value, i32 sampleOffset = 0) noexcept
             {
                 OLO_PROFILE_FUNCTION();
 
@@ -147,7 +166,7 @@ namespace OloEngine::Audio::SoundGraph
                 {
                     if (auto dest = it->lock()) // Check if still valid
                     {
-                        (*dest)(value);
+                        (*dest)(value, sampleOffset);
                         ++it;
                     }
                     else
@@ -177,7 +196,21 @@ namespace OloEngine::Audio::SoundGraph
         {
             OLO_PROFILE_FUNCTION();
 
-            auto inputEvent = std::make_shared<InputEvent>(*this, function);
+            auto inputEvent = std::make_shared<InputEvent>(*this, std::move(function));
+            const auto& [element, inserted] = InEvents.try_emplace(id, inputEvent);
+            OLO_CORE_ASSERT(inserted, "Input event with this ID already exists");
+            return *element->second;
+        }
+
+        // Phase 4 overload: registers a sample-offset-aware handler (a lambda taking
+        // (f32 value, i32 sampleOffset)). Distinct from the value-only overload by
+        // the handler's arity, so existing AddInEvent(id, [](f32){...}) call sites
+        // keep resolving to the legacy overload above.
+        InputEvent& AddInEvent(Identifier id, InputEvent::OffsetEventFunction function)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            auto inputEvent = std::make_shared<InputEvent>(*this, std::move(function));
             const auto& [element, inserted] = InEvents.try_emplace(id, inputEvent);
             OLO_CORE_ASSERT(inserted, "Input event with this ID already exists");
             return *element->second;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h
@@ -51,9 +51,11 @@ namespace OloEngine::Audio::SoundGraph
 
         explicit ADEnvelope(const char* dbgName, UUID id) : NodeProcessor(dbgName, id)
         {
-            // Input events
-            AddInEvent(IDs::s_Trigger, [this](float v)
-                       { (void)v; m_TriggerFlag.SetDirty(); });
+            // Phase 4: the trigger handler records the event's frame offset within
+            // the block (docs/soundgraph-metasounds-refactor.md); Process() starts
+            // the attack at that exact frame. A block-boundary event fires at frame 0.
+            AddInEvent(IDs::s_Trigger, [this](float v, i32 sampleOffset)
+                       { (void)v; m_TriggerInput.Fire(sampleOffset); });
 
             RegisterEndpoints();
         }
@@ -96,18 +98,22 @@ namespace OloEngine::Audio::SoundGraph
                 m_CachedSampleRate = m_SampleRate;
             }
 
-            // Handle trigger events: block boundary is acceptable for now (Phase 4 adds
-            // sample-offset triggers when sample accuracy matters).
-            if (m_TriggerFlag.IsDirty())
-            {
-                m_TriggerFlag.CheckAndResetIfDirty();
-                StartAttack();
-            }
+            // Phase 4: the trigger carries a frame offset within the block. Consume
+            // it and start the attack at that exact frame inside the loop, instead
+            // of quantising to the block boundary. kNotFired (-1) never matches a
+            // frame; an offset at/after numFrames clamps to the last frame.
+            i32 triggerOffset = m_TriggerInput.Consume();
+            if (numFrames > 0 && triggerOffset > static_cast<i32>(numFrames) - 1)
+                triggerOffset = static_cast<i32>(numFrames) - 1;
 
             // State machine advances one sample per iteration.
             f32* out = m_OutEnvelope.Data();
             for (u32 frame = 0; frame < numFrames; ++frame)
             {
+                const i32 frameIdx = static_cast<i32>(frame);
+                if (triggerOffset == frameIdx)
+                    StartAttack(frameIdx);
+
                 switch (m_State)
                 {
                     case Idle:
@@ -116,7 +122,7 @@ namespace OloEngine::Audio::SoundGraph
                         ProcessAttack();
                         break;
                     case Decay:
-                        ProcessDecay();
+                        ProcessDecay(frameIdx);
                         break;
                 }
                 out[frame] = m_Value;
@@ -162,7 +168,10 @@ namespace OloEngine::Audio::SoundGraph
         f32 m_AttackProgress{ 0.0f };
         f32 m_DecayProgress{ 0.0f };
 
-        Flag m_TriggerFlag;
+        // Phase 4: sample-accurate retrigger. The InputEvent handler Fire()s this
+        // with the event's frame offset; Process() Consume()s it to start the attack
+        // at that exact frame (replaces the old block-boundary Flag).
+        TriggerRef m_TriggerInput;
 
         // Cached parameter values for runtime change detection
         f32 m_CachedAttackTime = -1.0f;
@@ -194,11 +203,13 @@ namespace OloEngine::Audio::SoundGraph
                 m_DecayRate = 1.0f / (decayTime * m_SampleRate);
         }
 
-        void StartAttack()
+        // triggerOffset (Phase 4) is the frame the attack started at, forwarded to
+        // the OnTrigger output event so chained trigger consumers stay sample-accurate.
+        void StartAttack(i32 triggerOffset = 0)
         {
             m_State = Attack;
             m_AttackProgress = 0.0f; // Reset attack progress
-            m_OnTrigger(1.0f);
+            m_OnTrigger(1.0f, triggerOffset);
         }
 
         void ProcessAttack()
@@ -222,7 +233,10 @@ namespace OloEngine::Audio::SoundGraph
             }
         }
 
-        void ProcessDecay()
+        // frame (Phase 4) is the current block frame, so a decay that completes
+        // mid-block fires OnComplete — and, when looping, the retrigger's OnTrigger —
+        // at that exact frame rather than at the block boundary.
+        void ProcessDecay(i32 frame)
         {
             // Increment normalized progress using the solved rate (preserves timing)
             m_DecayProgress += m_DecayRate;
@@ -239,12 +253,12 @@ namespace OloEngine::Audio::SoundGraph
             {
                 m_Value = 0.0f;
                 m_State = Idle;
-                m_OnComplete(1.0f);
+                m_OnComplete(1.0f, frame);
 
                 // Handle looping
                 if (m_Looping.Get())
                 {
-                    StartAttack();
+                    StartAttack(frame);
                 }
             }
         }
@@ -266,11 +280,13 @@ namespace OloEngine::Audio::SoundGraph
 
         explicit ADSREnvelope(const char* dbgName, UUID id) : NodeProcessor(dbgName, id)
         {
-            // Input events
-            AddInEvent(IDs::s_Trigger, [this](float v)
-                       { (void)v; m_TriggerFlag.SetDirty(); });
-            AddInEvent(IDs::s_Release, [this](float v)
-                       { (void)v; m_ReleaseFlag.SetDirty(); });
+            // Phase 4: the trigger / release handlers record the event's frame
+            // offset within the block; Process() starts the attack / release at that
+            // exact frame. A block-boundary event fires at frame 0.
+            AddInEvent(IDs::s_Trigger, [this](float v, i32 sampleOffset)
+                       { (void)v; m_TriggerInput.Fire(sampleOffset); });
+            AddInEvent(IDs::s_Release, [this](float v, i32 sampleOffset)
+                       { (void)v; m_ReleaseInput.Fire(sampleOffset); });
 
             RegisterEndpoints();
         }
@@ -320,21 +336,33 @@ namespace OloEngine::Audio::SoundGraph
                 m_CachedSampleRate = m_SampleRate;
             }
 
-            if (m_TriggerFlag.IsDirty())
+            // Phase 4: trigger and release each carry a frame offset within the
+            // block. Consume them and apply the attack / release at their exact
+            // frames inside the loop. kNotFired (-1) never matches a frame; an
+            // offset at/after numFrames clamps to the last frame.
+            i32 triggerOffset = m_TriggerInput.Consume();
+            i32 releaseOffset = m_ReleaseInput.Consume();
+            if (numFrames > 0)
             {
-                m_TriggerFlag.CheckAndResetIfDirty();
-                StartAttack();
-            }
-
-            if (m_ReleaseFlag.IsDirty())
-            {
-                m_ReleaseFlag.CheckAndResetIfDirty();
-                StartRelease();
+                const i32 lastFrame = static_cast<i32>(numFrames) - 1;
+                if (triggerOffset > lastFrame)
+                    triggerOffset = lastFrame;
+                if (releaseOffset > lastFrame)
+                    releaseOffset = lastFrame;
             }
 
             f32* out = m_OutEnvelope.Data();
             for (u32 frame = 0; frame < numFrames; ++frame)
             {
+                const i32 frameIdx = static_cast<i32>(frame);
+                // Sample-accurate trigger / release. Trigger before release so a
+                // same-frame trigger+release ends up releasing (matches the old
+                // block-boundary order where trigger was checked first).
+                if (triggerOffset == frameIdx)
+                    StartAttack(frameIdx);
+                if (releaseOffset == frameIdx)
+                    StartRelease(frameIdx);
+
                 switch (m_State)
                 {
                     case Idle:
@@ -352,7 +380,7 @@ namespace OloEngine::Audio::SoundGraph
                         m_Value = glm::clamp(SanitizeEnvelopeParam(m_SustainLevel.Get(), 0.0f), 0.0f, 1.0f);
                         break;
                     case Release:
-                        ProcessRelease();
+                        ProcessRelease(frameIdx);
                         break;
                 }
                 out[frame] = m_Value;
@@ -406,8 +434,11 @@ namespace OloEngine::Audio::SoundGraph
         f32 m_DecayProgress{ 0.0f };
         f32 m_ReleaseProgress{ 0.0f };
 
-        Flag m_TriggerFlag;
-        Flag m_ReleaseFlag;
+        // Phase 4: sample-accurate trigger / release. The InputEvent handlers Fire()
+        // these with the event's frame offset; Process() Consume()s them to start the
+        // attack / release at that exact frame (replaces the old block-boundary Flags).
+        TriggerRef m_TriggerInput;
+        TriggerRef m_ReleaseInput;
 
         // Cached parameter values for runtime change detection
         f32 m_CachedAttackTime = -1.0f;
@@ -446,21 +477,24 @@ namespace OloEngine::Audio::SoundGraph
                 m_ReleaseRate = 1.0f / (releaseTime * m_SampleRate);
         }
 
-        void StartAttack()
+        // triggerOffset / releaseOffset (Phase 4): the frame the attack / release
+        // started at, forwarded to OnTrigger / OnRelease so chained trigger consumers
+        // stay sample-accurate.
+        void StartAttack(i32 triggerOffset = 0)
         {
             m_State = Attack;
             m_AttackProgress = 0.0f; // Reset attack progress
-            m_OnTrigger(1.0f);
+            m_OnTrigger(1.0f, triggerOffset);
         }
 
-        void StartRelease()
+        void StartRelease(i32 releaseOffset = 0)
         {
             if (m_State != Idle && m_State != Release)
             {
                 m_State = Release;
                 m_SustainStartValue = m_Value;
                 m_ReleaseProgress = 0.0f; // Reset release progress
-                m_OnRelease(1.0f);
+                m_OnRelease(1.0f, releaseOffset);
             }
         }
 
@@ -506,7 +540,9 @@ namespace OloEngine::Audio::SoundGraph
             }
         }
 
-        void ProcessRelease()
+        // frame (Phase 4) is the current block frame, so a release that completes
+        // mid-block fires OnComplete at that exact frame rather than the block boundary.
+        void ProcessRelease(i32 frame)
         {
             // Increment normalized progress using the solved rate (preserves timing)
             m_ReleaseProgress += m_ReleaseRate;
@@ -523,7 +559,7 @@ namespace OloEngine::Audio::SoundGraph
             {
                 m_Value = 0.0f;
                 m_State = Idle;
-                m_OnComplete(1.0f);
+                m_OnComplete(1.0f, frame);
             }
         }
     };

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h
@@ -72,7 +72,10 @@ namespace OloEngine::Audio::SoundGraph
                 while (m_Counter >= safePeriod)
                 {
                     m_Counter -= safePeriod;
-                    m_OutTrigger(1.0f);
+                    // Phase 4: fire at this frame's offset so downstream trigger
+                    // consumers (WavePlayer, envelopes) retrigger sample-accurately
+                    // instead of snapping every tick to the block boundary.
+                    m_OutTrigger(1.0f, static_cast<i32>(frame));
                 }
             }
         }
@@ -274,7 +277,9 @@ namespace OloEngine::Audio::SoundGraph
                 {
                     m_Waiting = false;
                     m_Counter = 0.0f;
-                    m_OutDelayedTrigger(1.0f);
+                    // Phase 4: fire at this frame's offset so the delayed trigger lands
+                    // sample-accurately on downstream consumers (not the block boundary).
+                    m_OutDelayedTrigger(1.0f, static_cast<i32>(frame));
                 }
             }
         }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
@@ -52,11 +52,14 @@ namespace OloEngine::Audio::SoundGraph
 
         explicit WavePlayer(const char* dbgName, UUID id) : NodeProcessor(dbgName, id)
         {
-            // Input events using Flag system like Hazel
-            AddInEvent(IDs::Play, [this](float v)
-                       { (void)v; m_PlayFlag.SetDirty(); });
-            AddInEvent(IDs::Stop, [this](float v)
-                       { (void)v; m_StopFlag.SetDirty(); });
+            // Phase 4: sample-accurate Play/Stop. The handlers record the trigger's
+            // frame offset within the block (docs/soundgraph-metasounds-refactor.md);
+            // Process() applies Start/StopPlayback at that exact frame. A
+            // block-boundary event (no offset) fires at frame 0 — the old behavior.
+            AddInEvent(IDs::Play, [this](float v, i32 sampleOffset)
+                       { (void)v; m_PlayTrigger.Fire(sampleOffset); });
+            AddInEvent(IDs::Stop, [this](float v, i32 sampleOffset)
+                       { (void)v; m_StopTrigger.Fire(sampleOffset); });
 
             RegisterEndpoints();
         }
@@ -140,10 +143,23 @@ namespace OloEngine::Audio::SoundGraph
             OLO_PROFILE_FUNCTION();
 
             CheckAsyncLoadCompletion();
-            if (m_PlayFlag.CheckAndResetIfDirty())
-                StartPlayback();
-            if (m_StopFlag.CheckAndResetIfDirty())
-                StopPlayback(false);
+
+            // Phase 4: Play/Stop carry a frame offset within the block. Consume the
+            // pending offsets and apply the state change at the exact frame inside
+            // the per-sample loop below, instead of quantising to the block boundary.
+            // kNotFired (-1) never matches a frame index, so an un-fired trigger is a
+            // no-op. An offset at/after numFrames is clamped to the last frame so it
+            // still takes effect this block.
+            i32 playOffset = m_PlayTrigger.Consume();
+            i32 stopOffset = m_StopTrigger.Consume();
+            if (numFrames > 0)
+            {
+                const i32 lastFrame = static_cast<i32>(numFrames) - 1;
+                if (playOffset > lastFrame)
+                    playOffset = lastFrame;
+                if (stopOffset > lastFrame)
+                    stopOffset = lastFrame;
+            }
 
             f32* outLeft = m_OutLeft.Data();
             f32* outRight = m_OutRight.Data();
@@ -151,6 +167,15 @@ namespace OloEngine::Audio::SoundGraph
             // Per-sample loop writing straight into the block output buffers.
             for (u32 frame = 0; frame < numFrames; ++frame)
             {
+                const i32 frameIdx = static_cast<i32>(frame);
+                // Sample-accurate Play/Stop: apply at the trigger's frame. Play
+                // before Stop so a same-frame play+stop ends stopped (matches the
+                // old block-boundary order where Play was checked first).
+                if (playOffset == frameIdx)
+                    StartPlayback(frameIdx);
+                if (stopOffset == frameIdx)
+                    StopPlayback(false, frameIdx);
+
                 if (!m_IsPlaying)
                 {
                     outLeft[frame] = 0.0f;
@@ -163,11 +188,11 @@ namespace OloEngine::Audio::SoundGraph
                     if (m_Loop.Get())
                     {
                         ++m_LoopCount;
-                        m_OnLooped(2.0f);
+                        m_OnLooped(2.0f, frameIdx);
 
                         if (m_NumberOfLoops.Get() >= 0 && m_LoopCount > m_NumberOfLoops.Get())
                         {
-                            StopPlayback(true);
+                            StopPlayback(true, frameIdx);
                             outLeft[frame] = 0.0f;
                             outRight[frame] = 0.0f;
                         }
@@ -185,7 +210,7 @@ namespace OloEngine::Audio::SoundGraph
                     }
                     else
                     {
-                        StopPlayback(true);
+                        StopPlayback(true, frameIdx);
                         outLeft[frame] = 0.0f;
                         outRight[frame] = 0.0f;
                     }
@@ -200,7 +225,11 @@ namespace OloEngine::Audio::SoundGraph
         }
 
       private:
-        void StartPlayback()
+        // triggerOffset (Phase 4) is the frame within the current block at which
+        // the Play fired; it is forwarded to the OnPlay output event so chained
+        // trigger consumers stay sample-accurate. Defaults to 0 (block boundary)
+        // for the pending-playback path in CheckAsyncLoadCompletion.
+        void StartPlayback(i32 triggerOffset = 0)
         {
             // Check for completed async loads first (non-blocking)
             CheckAsyncLoadCompletion();
@@ -212,7 +241,7 @@ namespace OloEngine::Audio::SoundGraph
             if (!m_WaveSource.m_WaveHandle)
             {
                 OLO_CORE_WARN("[WavePlayer] StartPlayback: no wave asset handle bound — bailing");
-                StopPlayback(false);
+                StopPlayback(false, triggerOffset);
                 return;
             }
 
@@ -242,11 +271,13 @@ namespace OloEngine::Audio::SoundGraph
 
             m_IsPlaying = true;
             m_PendingPlayback.store(false, std::memory_order_relaxed);
-            m_OnPlay(2.0f);
+            m_OnPlay(2.0f, triggerOffset);
             DBG("WavePlayer: Started playing");
         }
 
-        void StopPlayback(bool notifyOnFinish)
+        // triggerOffset (Phase 4): the frame at which the Stop / natural-finish
+        // occurred, forwarded to OnStop / OnFinished. Defaults to 0 (block boundary).
+        void StopPlayback(bool notifyOnFinish, i32 triggerOffset = 0)
         {
             m_IsPlaying = false;
             m_PendingPlayback.store(false, std::memory_order_relaxed); // Cancel any pending playback
@@ -266,9 +297,9 @@ namespace OloEngine::Audio::SoundGraph
             CheckAsyncLoadCompletion();
 
             if (notifyOnFinish)
-                m_OnFinished(2.0f); // Natural completion
+                m_OnFinished(2.0f, triggerOffset); // Natural completion
             else
-                m_OnStop(2.0f); // Manual stop or error
+                m_OnStop(2.0f, triggerOffset); // Manual stop or error
 
             DBG("WavePlayer: Stopped playing");
         }
@@ -658,9 +689,12 @@ namespace OloEngine::Audio::SoundGraph
         FMutex m_LoadTasksMutex;
         std::vector<Tasks::TTask<void>> m_LoadTasks;
 
-        // Flag system for events (like Hazel)
-        Flag m_PlayFlag;
-        Flag m_StopFlag;
+        // Phase 4: sample-accurate Play/Stop triggers. The InputEvent handlers
+        // Fire() these with the event's frame offset; Process() Consume()s them and
+        // splits its per-sample loop at that frame. (Replaces the old block-boundary
+        // Flag dirty-bits.)
+        TriggerRef m_PlayTrigger;
+        TriggerRef m_StopTrigger;
 
         // Wave source using OloEngine's system
         Audio::WaveSource m_WaveSource;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/StreamRefs.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/StreamRefs.h
@@ -182,11 +182,107 @@ namespace OloEngine::Audio::SoundGraph
                                                                           : EStreamType::Bool;
 
     //==============================================================================
-    /// Placeholder for Phase 4 sample-accurate triggers. Until then trigger events
-    /// fire at block boundaries through the InputEvent/OutputEvent system.
+    /// Sample-accurate trigger (Phase 4 — docs/soundgraph-metasounds-refactor.md).
+    ///
+    /// Carries the frame offset within the current block at which a trigger fires.
+    /// kNotFired (-1) means "did not fire this block". Trigger-consuming nodes
+    /// (WavePlayer Play/Stop, envelope retrigger/release) read the offset in
+    /// Process() and split their per-frame loop at that frame, so an event that
+    /// arrives mid-block takes effect at the exact sample instead of being
+    /// quantised to the block boundary.
+    ///
+    /// Single-fire-per-block model: a node holds one Trigger per trigger input.
+    /// Fire() records the *earliest* pending offset for the block — multiple fires
+    /// in one block collapse to the first, matching the old Flag/dirty semantics
+    /// (N SetDirty()s = one action) while keeping the earliest moment requested.
+    /// Genuine sub-block multi-fire needs the full event-queue scheduling that is
+    /// out of Phase 4's scope.
+    struct Trigger
+    {
+        static constexpr i32 kNotFired = -1;
+
+        i32 m_SampleOffset = kNotFired; // [0, numFrames) when fired; kNotFired otherwise
+
+        [[nodiscard]] bool IsFired() const noexcept
+        {
+            return m_SampleOffset != kNotFired;
+        }
+        [[nodiscard]] i32 Offset() const noexcept
+        {
+            return m_SampleOffset;
+        }
+
+        /// Record a fire at `sampleOffset` (negative offsets — e.g. a legacy
+        /// block-boundary event with no frame info — clamp to frame 0). If the
+        /// trigger already fired earlier this block, keep the earlier offset so
+        /// the node acts at the earliest requested frame (first-fire-wins).
+        void Fire(i32 sampleOffset) noexcept
+        {
+            const i32 offset = sampleOffset < 0 ? 0 : sampleOffset;
+            if (m_SampleOffset == kNotFired || offset < m_SampleOffset)
+                m_SampleOffset = offset;
+        }
+
+        void Reset() noexcept
+        {
+            m_SampleOffset = kNotFired;
+        }
+
+        /// Read-and-clear: returns the pending offset (or kNotFired) and resets.
+        [[nodiscard]] i32 Consume() noexcept
+        {
+            const i32 offset = m_SampleOffset;
+            m_SampleOffset = kNotFired;
+            return offset;
+        }
+    };
+
+    //==============================================================================
+    /// Trigger input reference (Phase 4). Mirrors AudioBufferRef / ValueRef: it
+    /// owns an inline default Trigger and points at it until Bind() repoints it at
+    /// a producer's Trigger. Trigger-consuming nodes own a TriggerRef per trigger
+    /// input; the node's InputEvent handler Fire()s it with the event's sample
+    /// offset, and Process() Consume()s the offset to split its per-frame loop.
+    ///
+    /// Bind() is the seam for future typed trigger connections (the doc's "snapshot
+    /// TriggerRef pointers"); nothing wires them yet, so today every node uses its
+    /// inline default. On a bound ref, prefer the non-destructive IsFired()/Offset()
+    /// reads (Consume() read-clears the shared producer trigger).
     struct TriggerRef
     {
-        i32 m_SampleOffset = -1; // frame offset within the block; -1 = not fired
+        TriggerRef() noexcept : m_Trigger(&m_Default) {}
+
+        // Self-referential default pointer: copying would alias another ref's
+        // default cell, so forbid it (same contract as the other refs).
+        TriggerRef(const TriggerRef&) = delete;
+        TriggerRef& operator=(const TriggerRef&) = delete;
+        TriggerRef(TriggerRef&&) = delete;
+        TriggerRef& operator=(TriggerRef&&) = delete;
+
+        void Fire(i32 sampleOffset) noexcept
+        {
+            m_Trigger->Fire(sampleOffset);
+        }
+        [[nodiscard]] bool IsFired() const noexcept
+        {
+            return m_Trigger->IsFired();
+        }
+        [[nodiscard]] i32 Offset() const noexcept
+        {
+            return m_Trigger->Offset();
+        }
+        [[nodiscard]] i32 Consume() noexcept
+        {
+            return m_Trigger->Consume();
+        }
+
+        void Bind(Trigger* producer) noexcept
+        {
+            m_Trigger = producer;
+        }
+
+        Trigger* m_Trigger;
+        Trigger m_Default;
     };
 
 } // namespace OloEngine::Audio::SoundGraph

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(OloEngine-Tests
 		SoundGraphBasicTest.cpp
 		SoundGraphInstantiationTest.cpp
 		SoundGraphTypedConnectionTest.cpp
+		SoundGraphSampleAccurateTriggerTest.cpp
 		AudioEventQueueTest.cpp
 		AudioDSPTest.cpp
 		AudioSpatializerTest.cpp

--- a/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
+++ b/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
@@ -55,8 +55,7 @@ namespace
             AddInEvent(Identifier("In"), [this](f32 value, i32 sampleOffset)
                        {
                            m_Values.push_back(value);
-                           m_Offsets.push_back(sampleOffset);
-                       });
+                           m_Offsets.push_back(sampleOffset); });
         }
 
         std::vector<f32> m_Values;
@@ -241,10 +240,10 @@ TEST_F(SoundGraphSampleAccurateTriggerTest, ADSREnvelopeReleaseTakesEffectAtItsE
     constexpr f32 kSustain = 0.5f;
 
     sg::ADSREnvelope env("ADSR", UUID());
-    env.m_AttackTime.SetDefault(0.0f);    // immediate attack
-    env.m_DecayTime.SetDefault(0.0f);     // immediate decay -> straight to sustain
+    env.m_AttackTime.SetDefault(0.0f); // immediate attack
+    env.m_DecayTime.SetDefault(0.0f);  // immediate decay -> straight to sustain
     env.m_SustainLevel.SetDefault(kSustain);
-    env.m_ReleaseTime.SetDefault(0.05f);  // ~2400-sample release
+    env.m_ReleaseTime.SetDefault(0.05f); // ~2400-sample release
     env.SetSampleRate(kSampleRate);
     env.Init();
 

--- a/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
+++ b/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
@@ -1,0 +1,409 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// SoundGraphSampleAccurateTriggerTest — Phase 4 sample-accurate triggers
+// (docs/soundgraph-metasounds-refactor.md)
+//
+// Phase 4 makes trigger-consuming nodes split their per-frame Process() at the
+// frame offset a trigger carries, so an event that arrives mid-block takes
+// effect at the exact sample instead of being quantised to the block boundary
+// (the Phase 1-3 behavior). The mechanism:
+//   * Trigger / TriggerRef (StreamRefs.h) carry an i32 frame offset.
+//   * InputEvent / OutputEvent thread an i32 sampleOffset through the event
+//     system (NodeProcessor.h) so a producer firing mid-block tells consumers
+//     the exact frame.
+//   * WavePlayer (Play/Stop) and the AD / ADSR envelopes (trigger/release)
+//     apply their state change at that frame and propagate the offset on their
+//     own output events.
+//
+// These tests pin (no GL / no audio asset needed):
+//   * The Trigger value type: fire/consume/clamp/first-fire-wins.
+//   * Offset plumbing through OutputEvent -> InputEvent.
+//   * AD envelope: a trigger at offset N shifts the whole attack by exactly N
+//     frames; offset 0 matches the legacy block-boundary start.
+//   * ADSR envelope: trigger and release each take effect at their exact frame.
+//   * End-to-end: a producer firing mid-block retriggers a wired envelope at
+//     that frame; RepeatTrigger emits sample-accurate offsets.
+//   * WavePlayer: Play/Stop are consumed at their exact frame (observed through
+//     the OnStop / OnFinished output-event offset, since audio output needs a
+//     loaded asset which a unit test does not mount).
+// =============================================================================
+
+#include "OloEngine/Audio/SoundGraph/NodeProcessor.h"
+#include "OloEngine/Audio/SoundGraph/StreamRefs.h"
+#include "OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h"
+#include "OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h"
+#include "OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h"
+#include "OloEngine/Core/Identifier.h"
+#include "OloEngine/Core/Log.h"
+#include "OloEngine/Core/UUID.h"
+
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace)
+namespace sg = OloEngine::Audio::SoundGraph;
+
+namespace
+{
+    /// Captures every (value, sampleOffset) delivered to an offset-aware input
+    /// event. Used to observe the offset a producer's OutputEvent forwards.
+    struct OffsetCaptureNode : public sg::NodeProcessor
+    {
+        explicit OffsetCaptureNode(UUID id) : NodeProcessor("OffsetCapture", id)
+        {
+            AddInEvent(Identifier("In"), [this](f32 value, i32 sampleOffset)
+                       {
+                           m_Values.push_back(value);
+                           m_Offsets.push_back(sampleOffset);
+                       });
+        }
+
+        std::vector<f32> m_Values;
+        std::vector<i32> m_Offsets;
+    };
+
+    /// Test-only producer: fires its trigger output once per Process at a fixed
+    /// frame offset. Exercises the OutputEvent -> InputEvent offset path end to end.
+    struct FireAtOffsetNode : public sg::NodeProcessor
+    {
+        explicit FireAtOffsetNode(UUID id) : NodeProcessor("FireAtOffset", id) {}
+
+        i32 m_Offset = 0;
+        OutputEvent m_Out{ *this };
+
+        void Process(u32 numFrames) final
+        {
+            (void)numFrames;
+            m_Out(1.0f, m_Offset);
+        }
+    };
+
+    constexpr u32 kBlock = 480;
+    constexpr f32 kSampleRate = 48000.0f;
+
+    std::vector<f32> RunADEnvelope(i32 triggerOffset)
+    {
+        sg::ADEnvelope env("AD", UUID());
+        // 50 ms attack / decay: ~2400 samples each, so the envelope is still
+        // rising for the whole 480-frame block — the per-frame shape is easy to
+        // compare against a shifted copy.
+        env.m_AttackTime.SetDefault(0.05f);
+        env.m_DecayTime.SetDefault(0.05f);
+        env.SetSampleRate(kSampleRate);
+        env.Init();
+
+        env.InEvent(sg::ADEnvelope::IDs::s_Trigger)(1.0f, triggerOffset);
+        env.Process(kBlock);
+
+        const f32* out = env.m_OutEnvelope.Data();
+        return std::vector<f32>(out, out + kBlock);
+    }
+} // namespace
+
+class SoundGraphSampleAccurateTriggerTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        Log::Initialize(); // WavePlayer's no-asset bail logs a warning.
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Trigger value type
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, TriggerStartsUnfired)
+{
+    sg::Trigger t;
+    EXPECT_FALSE(t.IsFired());
+    EXPECT_EQ(t.Offset(), sg::Trigger::kNotFired);
+    EXPECT_EQ(t.Consume(), sg::Trigger::kNotFired);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, TriggerFireRecordsOffsetAndConsumeClears)
+{
+    sg::Trigger t;
+    t.Fire(137);
+    EXPECT_TRUE(t.IsFired());
+    EXPECT_EQ(t.Offset(), 137);
+
+    EXPECT_EQ(t.Consume(), 137);
+    // Consume read-and-clears.
+    EXPECT_FALSE(t.IsFired());
+    EXPECT_EQ(t.Consume(), sg::Trigger::kNotFired);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, TriggerFirstFireWinsWithinABlock)
+{
+    sg::Trigger t;
+    t.Fire(200);
+    t.Fire(50);  // earlier — should win
+    t.Fire(300); // later — ignored
+    EXPECT_EQ(t.Offset(), 50);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, TriggerNegativeOffsetClampsToBlockStart)
+{
+    sg::Trigger t;
+    t.Fire(-1); // a legacy block-boundary event with no frame info
+    EXPECT_TRUE(t.IsFired());
+    EXPECT_EQ(t.Offset(), 0);
+}
+
+// -----------------------------------------------------------------------------
+// Event-system offset plumbing
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, OutputEventForwardsSampleOffsetToInputEvent)
+{
+    FireAtOffsetNode producer{ UUID() };
+    producer.m_Offset = 271;
+
+    OffsetCaptureNode capture{ UUID() };
+    producer.m_Out.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    producer.Process(kBlock);
+
+    ASSERT_EQ(capture.m_Offsets.size(), 1u);
+    EXPECT_EQ(capture.m_Offsets[0], 271);
+    EXPECT_FLOAT_EQ(capture.m_Values[0], 1.0f);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, LegacySingleArgFireDeliversBlockBoundaryOffset)
+{
+    OffsetCaptureNode capture{ UUID() };
+    sg::NodeProcessor::OutputEvent out{ capture }; // owner is irrelevant for the fire
+    out.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    out(1.0f); // single-argument legacy fire
+
+    ASSERT_EQ(capture.m_Offsets.size(), 1u);
+    EXPECT_EQ(capture.m_Offsets[0], 0) << "a value-only fire must land at the block start";
+}
+
+// -----------------------------------------------------------------------------
+// AD envelope split
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ADEnvelopeTriggerOffsetShiftsAttackByExactlyThatManyFrames)
+{
+    constexpr i32 kOffset = 137;
+
+    const std::vector<f32> base = RunADEnvelope(0);
+    const std::vector<f32> shifted = RunADEnvelope(kOffset);
+
+    // The attack actually produced rising signal in the baseline.
+    ASSERT_GT(base[0], 0.0f) << "attack must start at frame 0 for offset 0";
+    EXPECT_GT(base[100], base[0]) << "attack must be rising";
+
+    // Frames before the trigger are pure silence (Idle).
+    for (i32 f = 0; f < kOffset; ++f)
+        EXPECT_FLOAT_EQ(shifted[static_cast<u32>(f)], 0.0f)
+            << "frame " << f << " before the trigger must be silent";
+
+    // The envelope shape is identical, just delayed by exactly kOffset frames.
+    for (u32 f = 0; f + static_cast<u32>(kOffset) < kBlock; ++f)
+        EXPECT_NEAR(shifted[f + static_cast<u32>(kOffset)], base[f], 1e-6f)
+            << "shifted output must equal the baseline at frame " << f;
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ADEnvelopeOffsetZeroStartsAtFrameZero)
+{
+    const std::vector<f32> out = RunADEnvelope(0);
+    EXPECT_GT(out[0], 0.0f) << "offset 0 must apply the attack at frame 0 (legacy block-boundary timing)";
+    EXPECT_GT(out[1], out[0]) << "attack must already be rising from frame 0";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ADEnvelopeWithoutTriggerStaysSilent)
+{
+    sg::ADEnvelope env("AD", UUID());
+    env.m_AttackTime.SetDefault(0.05f);
+    env.m_DecayTime.SetDefault(0.05f);
+    env.SetSampleRate(kSampleRate);
+    env.Init();
+
+    env.Process(kBlock); // no trigger fired
+
+    const f32* out = env.m_OutEnvelope.Data();
+    for (u32 f = 0; f < kBlock; ++f)
+        EXPECT_FLOAT_EQ(out[f], 0.0f) << "an un-triggered envelope must be silent at frame " << f;
+}
+
+// -----------------------------------------------------------------------------
+// ADSR envelope split
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ADSREnvelopeReleaseTakesEffectAtItsExactFrame)
+{
+    constexpr i32 kReleaseOffset = 200;
+    constexpr f32 kSustain = 0.5f;
+
+    sg::ADSREnvelope env("ADSR", UUID());
+    env.m_AttackTime.SetDefault(0.0f);    // immediate attack
+    env.m_DecayTime.SetDefault(0.0f);     // immediate decay -> straight to sustain
+    env.m_SustainLevel.SetDefault(kSustain);
+    env.m_ReleaseTime.SetDefault(0.05f);  // ~2400-sample release
+    env.SetSampleRate(kSampleRate);
+    env.Init();
+
+    // Trigger at the block start, release mid-block.
+    env.InEvent(sg::ADSREnvelope::IDs::s_Trigger)(1.0f, 0);
+    env.InEvent(sg::ADSREnvelope::IDs::s_Release)(1.0f, kReleaseOffset);
+    env.Process(kBlock);
+
+    const f32* out = env.m_OutEnvelope.Data();
+
+    // Immediate attack+decay settle onto the sustain level within a couple of frames.
+    EXPECT_NEAR(out[10], kSustain, 1e-6f) << "envelope must hold the sustain level before release";
+    EXPECT_NEAR(out[static_cast<u32>(kReleaseOffset) - 1], kSustain, 1e-6f)
+        << "sustain must hold right up to the frame before release";
+
+    // Release begins exactly at kReleaseOffset and declines afterward.
+    EXPECT_LT(out[static_cast<u32>(kReleaseOffset)], kSustain) << "release must begin at its trigger frame";
+    EXPECT_LT(out[static_cast<u32>(kReleaseOffset) + 100], out[static_cast<u32>(kReleaseOffset)])
+        << "release must keep declining";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ADSREnvelopeTriggerOffsetShiftsAttackByExactlyThatManyFrames)
+{
+    constexpr i32 kOffset = 90;
+
+    auto run = [](i32 triggerOffset)
+    {
+        sg::ADSREnvelope env("ADSR", UUID());
+        env.m_AttackTime.SetDefault(0.05f);
+        env.m_DecayTime.SetDefault(0.05f);
+        env.m_SustainLevel.SetDefault(0.5f);
+        env.m_ReleaseTime.SetDefault(0.05f);
+        env.SetSampleRate(kSampleRate);
+        env.Init();
+        env.InEvent(sg::ADSREnvelope::IDs::s_Trigger)(1.0f, triggerOffset);
+        env.Process(kBlock);
+        const f32* out = env.m_OutEnvelope.Data();
+        return std::vector<f32>(out, out + kBlock);
+    };
+
+    const std::vector<f32> base = run(0);
+    const std::vector<f32> shifted = run(kOffset);
+
+    ASSERT_GT(base[0], 0.0f);
+    for (i32 f = 0; f < kOffset; ++f)
+        EXPECT_FLOAT_EQ(shifted[static_cast<u32>(f)], 0.0f) << "frame " << f << " before trigger must be silent";
+    for (u32 f = 0; f + static_cast<u32>(kOffset) < kBlock; ++f)
+        EXPECT_NEAR(shifted[f + static_cast<u32>(kOffset)], base[f], 1e-6f) << "shifted frame " << f;
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end: producer fires mid-block, wired consumer reacts at that frame
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ProducerFiringMidBlockRetriggersWiredEnvelopeAtThatFrame)
+{
+    constexpr i32 kOffset = 222;
+
+    FireAtOffsetNode producer{ UUID() };
+    producer.m_Offset = kOffset;
+
+    sg::ADEnvelope env("AD", UUID());
+    env.m_AttackTime.SetDefault(0.05f);
+    env.m_DecayTime.SetDefault(0.05f);
+    env.SetSampleRate(kSampleRate);
+    env.Init();
+
+    // Wire producer's trigger output into the envelope's trigger input.
+    producer.m_Out.AddDestination(env.GetInputEvent(sg::ADEnvelope::IDs::s_Trigger));
+
+    // Producer before consumer, exactly as SoundGraph's process order would run them.
+    producer.Process(kBlock);
+    env.Process(kBlock);
+
+    const f32* out = env.m_OutEnvelope.Data();
+    for (i32 f = 0; f < kOffset; ++f)
+        EXPECT_FLOAT_EQ(out[static_cast<u32>(f)], 0.0f) << "envelope must be silent before the producer fired";
+    EXPECT_GT(out[static_cast<u32>(kOffset)], 0.0f) << "envelope must start the attack at the producer's fire frame";
+    EXPECT_GT(out[static_cast<u32>(kOffset) + 50], out[static_cast<u32>(kOffset)]) << "attack must be rising";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, RepeatTriggerEmitsSampleAccurateOffsets)
+{
+    sg::RepeatTrigger rt("Repeat", UUID());
+    rt.m_Period.SetDefault(100.0f / kSampleRate); // fire roughly every 100 samples
+    rt.SetSampleRate(kSampleRate);
+    rt.Init();
+
+    OffsetCaptureNode capture{ UUID() };
+    rt.m_OutTrigger.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    rt.InEvent(sg::RepeatTrigger::IDs::s_Start)(1.0f);
+    rt.Process(kBlock);
+
+    // Start fires once at the block boundary, then periodic fires land mid-block.
+    ASSERT_GE(capture.m_Offsets.size(), 3u) << "a 480-frame block at ~100-sample period must fire several times";
+
+    // Offsets are non-decreasing and span the block — i.e. the periodic fires are
+    // NOT all collapsed to the block boundary (that was the pre-Phase-4 behavior).
+    for (sizet i = 1; i < capture.m_Offsets.size(); ++i)
+        EXPECT_GE(capture.m_Offsets[i], capture.m_Offsets[i - 1]) << "offsets must be non-decreasing";
+    EXPECT_GT(capture.m_Offsets.back(), 0) << "later fires must carry non-zero frame offsets";
+    EXPECT_LT(capture.m_Offsets.back(), static_cast<i32>(kBlock)) << "offsets stay within the block";
+}
+
+// -----------------------------------------------------------------------------
+// WavePlayer: Play/Stop consumed at their exact frame (observed via output events)
+// -----------------------------------------------------------------------------
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, WavePlayerStopTriggerFiresOnStopAtItsExactFrame)
+{
+    constexpr i32 kStopOffset = 305;
+
+    sg::WavePlayer wp("WavePlayer", UUID());
+    wp.SetSampleRate(kSampleRate);
+    wp.Init();
+
+    OffsetCaptureNode capture{ UUID() };
+    wp.m_OnStop.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    wp.InEvent(sg::WavePlayer::IDs::Stop)(1.0f, kStopOffset);
+    wp.Process(kBlock);
+
+    ASSERT_EQ(capture.m_Offsets.size(), 1u) << "Stop must fire OnStop exactly once";
+    EXPECT_EQ(capture.m_Offsets[0], kStopOffset) << "OnStop must carry the Stop trigger's frame offset";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, WavePlayerPlayWithoutAssetIsConsumedAtItsExactFrame)
+{
+    constexpr i32 kPlayOffset = 150;
+
+    sg::WavePlayer wp("WavePlayer", UUID());
+    wp.SetSampleRate(kSampleRate);
+    wp.Init();
+
+    OffsetCaptureNode capture{ UUID() };
+    // With no wave asset bound, StartPlayback bails into StopPlayback -> OnStop,
+    // carrying the Play trigger's frame offset. That proves the Play trigger was
+    // consumed at frame kPlayOffset, not at the block boundary.
+    wp.m_OnStop.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    wp.InEvent(sg::WavePlayer::IDs::Play)(1.0f, kPlayOffset);
+    wp.Process(kBlock);
+
+    ASSERT_EQ(capture.m_Offsets.size(), 1u);
+    EXPECT_EQ(capture.m_Offsets[0], kPlayOffset) << "Play must be consumed at its trigger frame";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, WavePlayerWithoutTriggersFiresNoEvents)
+{
+    sg::WavePlayer wp("WavePlayer", UUID());
+    wp.SetSampleRate(kSampleRate);
+    wp.Init();
+
+    OffsetCaptureNode capture{ UUID() };
+    wp.m_OnStop.AddDestination(capture.GetInputEvent(Identifier("In")));
+    wp.m_OnPlay.AddDestination(capture.GetInputEvent(Identifier("In")));
+
+    wp.Process(kBlock);
+
+    EXPECT_TRUE(capture.m_Offsets.empty()) << "no trigger fired -> no Play/Stop events";
+}

--- a/OloEngine/tests/scripts/test_catalogue.json
+++ b/OloEngine/tests/scripts/test_catalogue.json
@@ -351,6 +351,7 @@
     "OloEngine/tests/SnowSettingsTest.cpp": "unit",
     "OloEngine/tests/SoundGraphBasicTest.cpp": "unit",
     "OloEngine/tests/SoundGraphInstantiationTest.cpp": "unit",
+    "OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp": "unit",
     "OloEngine/tests/SoundGraphTypedConnectionTest.cpp": "unit",
     "OloEngine/tests/StateMachineTest.cpp": "unit",
     "OloEngine/tests/Tasks/TaskSystemTest.cpp": "unit",

--- a/docs/soundgraph-metasounds-refactor.md
+++ b/docs/soundgraph-metasounds-refactor.md
@@ -276,6 +276,45 @@ struct Trigger {
 Nodes that consume triggers (WavePlayer Play/Stop, envelope retrigger, etc.)
 inspect `SampleOffset` and split their `Execute` at that frame index.
 
+> **Status (2026-06-21): landed (node-level mechanism).** Trigger-consuming nodes
+> now split their per-frame `Process()` at a trigger's frame offset; the firing
+> path threads that offset end to end. What shipped (see `StreamRefs.h`):
+>
+> - **`Trigger` value type + `TriggerRef` input ref** (`StreamRefs.h`). `Trigger`
+>   carries `i32 m_SampleOffset` (`kNotFired = -1`) with `Fire()/Consume()/IsFired()/
+>   Offset()/Reset()`. `Fire()` is *first-fire-wins* within a block (multiple fires
+>   collapse to the earliest offset — the old Flag/dirty "N sets = one action"
+>   semantics, kept sample-aware) and clamps a negative (no-frame-info) offset to
+>   frame 0. `TriggerRef` mirrors `AudioBufferRef`/`ValueRef`: an inline default
+>   `Trigger` plus a `Bind()` seam for future typed trigger connections (nothing
+>   wires them yet — every node uses its inline default).
+> - **Offset-aware events** (`NodeProcessor.h`). `OutputEvent::operator()` and
+>   `InputEvent::operator()` take an `i32 sampleOffset = 0`, forwarded producer →
+>   consumer; a new `AddInEvent` overload registers an offset-aware handler
+>   (`void(f32, i32)`). Both default to offset 0, so every existing value-only fire
+>   and route keeps its block-boundary timing — no other node changed behavior.
+> - **WavePlayer Play/Stop** and the **AD / ADSR envelopes** (trigger + release)
+>   replaced their block-boundary `Flag`s with `TriggerRef`s, `Consume()` the offset
+>   each block, and apply `StartPlayback`/`StopPlayback` / `StartAttack` /
+>   `StartRelease` at that exact frame — propagating the offset onto their own
+>   `OnPlay`/`OnStop`/`OnTrigger`/`OnComplete`/… outputs so chains stay accurate.
+> - **Producers** `RepeatTrigger` and `DelayedTrigger` now fire their outputs at the
+>   loop's frame offset, so a metronome → envelope / WavePlayer chain retriggers
+>   sample-accurately instead of snapping every tick to the block boundary.
+> - **Tests.** `SoundGraphSampleAccurateTriggerTest.cpp` pins the `Trigger` type, the
+>   event offset plumbing, the AD/ADSR split (a trigger at offset N shifts the whole
+>   envelope by exactly N frames; offset 0 == legacy frame-0 start), an end-to-end
+>   producer-fires-mid-block → wired-consumer-reacts case, and WavePlayer Play/Stop
+>   consumed at their exact frame (observed via the output-event offset, since audio
+>   output needs a loaded asset a unit test doesn't mount).
+> - **Out of scope (follow-on).** External triggers from game code still arrive via
+>   `SoundGraphSource`'s `SendInputEvent`/lock-free queue, which is drained *before*
+>   `Process` and carries no per-event frame index, so an externally-scheduled
+>   footstep is still block-quantised until that queue learns to carry offsets. The
+>   node-level machinery and the intra-graph producer→consumer path are sample-accurate
+>   today; wiring the external scheduler and typed `TriggerRef` connections is the
+>   remaining increment.
+
 ## Decision log
 
 - **2026-05-20.** Chose block-based runtime over LLVM-backed JIT. Block

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1308,7 +1308,7 @@ level of `tests/`). Grouped by directory.
 
 > **Do not edit by hand.** Generated from [test_catalogue.json](../OloEngine/tests/scripts/test_catalogue.json) by [generate_test_catalogue.py](../OloEngine/tests/scripts/generate_test_catalogue.py). Add new test files to the config and run the script (or pre-commit will run it with `--check`).
 
-#### (top-level) (64 files)
+#### (top-level) (65 files)
 
 | File | Tests | Cases |
 |---|---:|---|
@@ -1370,6 +1370,7 @@ level of `tests/`). Grouped by directory.
 | [SnowSettingsTest.cpp](../OloEngine/tests/SnowSettingsTest.cpp) | 7 | **SnowUBOData** &mdash; `SizeIs80Bytes`, `FieldOffsets_Std140Compatible`, `DefaultsMatchSettings`<br/>**SSSUBOData** &mdash; `SizeIs32Bytes`, `FieldOffsets_Std140Compatible`, `DefaultsMatchSettings`<br/>**ShaderBindingLayout** &mdash; `SnowAndSSSBindingsExist` |
 | [SoundGraphBasicTest.cpp](../OloEngine/tests/SoundGraphBasicTest.cpp) | 8 | **SoundGraphBasicTest** &mdash; `SoundGraphAssetBasicOperations`, `SoundGraphConnections`, `SoundGraphRemoveConnection`, `CircularBufferSingleChannel`, `CircularBufferMultiChannel`, `SampleBufferOperationsInterleaving`, `SampleBufferOperationsGain`, `SoundGraphValidation` |
 | [SoundGraphInstantiationTest.cpp](../OloEngine/tests/SoundGraphInstantiationTest.cpp) | 2 | **SoundGraphInstantiation** &mdash; `NoiseToGraphOutputCompilesAndInstantiates`, `WavePlayerWithUnconfiguredAssetDoesNotCrash` |
+| [SoundGraphSampleAccurateTriggerTest.cpp](../OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp) | 16 | **SoundGraphSampleAccurateTriggerTest** &mdash; `TriggerStartsUnfired`, `TriggerFireRecordsOffsetAndConsumeClears`, `TriggerFirstFireWinsWithinABlock`, `TriggerNegativeOffsetClampsToBlockStart`, `OutputEventForwardsSampleOffsetToInputEvent`, `LegacySingleArgFireDeliversBlockBoundaryOffset`, `ADEnvelopeTriggerOffsetShiftsAttackByExactlyThatManyFrames`, `ADEnvelopeOffsetZeroStartsAtFrameZero`, `ADEnvelopeWithoutTriggerStaysSilent`, `ADSREnvelopeReleaseTakesEffectAtItsExactFrame`, `ADSREnvelopeTriggerOffsetShiftsAttackByExactlyThatManyFrames`, `ProducerFiringMidBlockRetriggersWiredEnvelopeAtThatFrame`, `RepeatTriggerEmitsSampleAccurateOffsets`, `WavePlayerStopTriggerFiresOnStopAtItsExactFrame`, `WavePlayerPlayWithoutAssetIsConsumedAtItsExactFrame`, `WavePlayerWithoutTriggersFiresNoEvents` |
 | [SoundGraphTypedConnectionTest.cpp](../OloEngine/tests/SoundGraphTypedConnectionTest.cpp) | 9 | **SoundGraphTypedConnections** &mdash; `NodeToNodeAudioConnectionDeliversSamples`, `AssetDefaultPlugsReachNodeInputs`, `EachNodeIsProcessedOncePerBlock`, `TypeMismatchedConnectionIsRejected`, `ScalarConnectionFlowsBetweenNodes`, `GraphFloatParameterRampsPerSample`, `DebugBlockProcessingKeepsRealTimeHeadroom`<br/>**SoundGraphCompiledPlan** &mdash; `FactoryNodeThunkIsDevirtualizedAndInvokesProcess`, `NodeOutputBuffersArePooledContiguously` |
 | [StateMachineTest.cpp](../OloEngine/tests/StateMachineTest.cpp) | 12 | **StateMachineTest** &mdash; `StartCallsOnEnter`, `UpdateCallsOnUpdate`, `TransitionChangesState`, `ForceTransition`, `ForceTransition_ToSameState_DoesNothing`, `ForceTransition_InvalidState_DoesNothing`, `UpdateBeforeStart_DoesNothing`, `MultipleTransitions_FirstMatchWins`<br/>**StateMachineAssetTest** &mdash; `HasCorrectAssetType`, `StoresStatesAndTransitions`<br/>**FSMStateRegistryTest** &mdash; `RegisterAndCreate`, `UnknownTypeReturnsNull` |
 | [StaticMeshColliderGenerationTest.cpp](../OloEngine/tests/StaticMeshColliderGenerationTest.cpp) | 5 | **StaticMeshColliderGenerationTest** &mdash; `GenerateFlagWiresColliderAssetToMeshSource`, `GenerateFlagOffProducesNoCollider`, `EmptyMeshSourceSkipsGeneration`, `ReSetupKeepsColliderHandleStable`, `GeneratedColliderCooksAndIsHitByRaycast` |
@@ -1561,7 +1562,7 @@ level of `tests/`). Grouped by directory.
 |---|---:|---|
 | [TerrainGeneratorTest.cpp](../OloEngine/tests/Terrain/TerrainGeneratorTest.cpp) | 15 | **TerrainGeneratorTest** &mdash; `HeightFieldIsDeterministic`, `HeightFieldIsNormalizedAndFinite`, `LargeSeedStillProducesVariedTerrain`, `DifferentSeedsProduceDifferentTerrain`, `RidgedAndWarpAndExponentStayValid`, `TerraceShapingStaysValidAndDeterministic`, `TerraceEndpointsAndIdentity`, `TerraceIsMonotonicAndBounded`, `TerraceProducesFlatPlateaus`, `RuleWeightPeaksInsideBandAndZeroOutside`, `SlopeBandSelectsRule`, `DefaultRulesAssignExpectedLayers`, `LayerWeightsAreNormalized`, `NoMatchingRuleFallsBackToLayerZero`, `PackLayerWeightsQuantizesToBothSplatmaps` |
 
-**Totals.** 148 unit / subsystem test files, 1819 TEST / TEST_F declarations across all subsystems.
+**Totals.** 149 unit / subsystem test files, 1835 TEST / TEST_F declarations across all subsystems.
 
 <!-- END: unit-catalogue -->
 


### PR DESCRIPTION
- Introduced `Trigger` and `TriggerRef` structures to support sample-accurate event handling.
- Updated `WavePlayer` and envelope nodes (AD/ADSR) to utilize the new trigger system, allowing for precise timing of Play/Stop and trigger events.
- Modified event handling to carry frame offsets, ensuring that events fired mid-block are processed at the correct sample.
- Added comprehensive unit tests in `SoundGraphSampleAccurateTriggerTest.cpp` to validate the new trigger functionality, including edge cases and integration with existing nodes.
- Updated documentation to reflect changes and outline the new sample-accurate behavior.