### PR TITLE
ci: add sscache to fuzz.yml; bin all action refs to commit SHAs

### DIFF
--- a/.github/actions/setup-vulkan/action.yml
+++ b/.github/actions/setup-vulkan/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Vulkan SDK
-      uses: humbletim/install-vulkan-sdk@033219e2d69dd4d3e873e217eb385fdd4b4438f4
+      uses: humbletim/install-vulkan-sdk@033219e2d69dd4d3e873e217eb385fdd4b4438f4 # main @ 2025-08-05 (no release tag; newest is v1.2)
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -26,12 +26,12 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Install Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
           
@@ -45,16 +45,28 @@ jobs:
         uses: ./.github/actions/setup-vulkan
       
       - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8.1.0
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
 
       - name: Run build-wrapper
+        # NO sccache here, on purpose (issue #304). Two independent blockers:
+        #   1. This uses CMake's default Visual Studio (MSBuild) generator, which
+        #      IGNORES CMAKE_<LANG>_COMPILER_LAUNCHER — sccache would never engage
+        #      (cmake/CompilerCache.cmake even warns in that case). Windows.yml had
+        #      to switch to Ninja Multi-Config for the launcher to take effect.
+        #   2. More fundamentally, sccache is INCOMPATIBLE with SonarQube's
+        #      build-wrapper even on Ninja: build-wrapper analyses C/C++ by
+        #      capturing each real compiler invocation. A warm sccache cache
+        #      serves objects WITHOUT invoking the compiler, so those translation
+        #      units would silently vanish from the analysis — a worse outcome
+        #      than a slow build. Caching is therefore deliberately omitted; the
+        #      cold build is the correct behaviour for this job.
         run: |
           New-Item -ItemType directory -Path build
           cmake -S . -B build -DPython_EXECUTABLE="${{ env.pythonLocation }}/python.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOLO_VIDEO_FFMPEG=OFF
           build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.1.0
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          # The scan reads local git blame (no network auth) and pushes nothing,
+          # so drop the persisted GITHUB_TOKEN to minimise its exposure. SONAR_TOKEN
+          # (the scan's own credential) is passed explicitly to that step below.
+          persist-credentials: false
 
       - name: Install Python 3.10
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -36,6 +36,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        # This job only builds, tests, and uploads artifacts — it makes no
+        # authenticated git writes — so don't leave the GITHUB_TOKEN in
+        # .git/config where a later step or a compromised dependency could read it.
+        persist-credentials: false
 
     - name: Install Python 3.10
       id: py

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -35,11 +35,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install Python 3.10
       id: py
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
        python-version: '3.10'
 
@@ -62,7 +62,7 @@ jobs:
     # still validated by the text-based AssetCSharpScriptValidityTest, and nothing
     # in the test/runtime build links against the assembly.)
     - name: Setup MSVC dev environment
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: x64
 
@@ -75,7 +75,7 @@ jobs:
     # Cache the built FFmpeg so only the first (or post-bump) run pays the ~10-15 min build.
     - name: Cache FFmpeg build
       id: ffcache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: OloEngine/vendor/ffmpeg-install
         key: ffmpeg-${{ runner.os }}-n7.1-${{ hashFiles('scripts/build-ffmpeg.sh') }}
@@ -91,7 +91,7 @@ jobs:
     # launcher, every compile fails. v0.10.0+ speaks the new cache service (ghac
     # v2, via opendal 0.52); we pin the current stable release for reproducibility.
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -254,7 +254,7 @@ jobs:
       run: ctest --parallel 4 --output-on-failure --timeout 120 -C ${{env.BUILD_TYPE}} --exclude-regex '^NetworkIntegrationTest\.|^CancellationTokenTest\.MultipleTasks$'
 
     - name: Upload test results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: googletest_results_xml
         path: ${{runner.workspace}}/OloEngineBase/test_results/*.xml

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -44,12 +44,12 @@ jobs:
     outputs:
       native: ${{ steps.filter.outputs.native }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
     - name: Detect changed paths
       id: filter
-      uses: dorny/paths-filter@v4
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: |
           native:
@@ -83,11 +83,11 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install Python 3.10
       id: py
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.10'
 
@@ -109,7 +109,7 @@ jobs:
     # OloEngine-ScriptCore project — it is gated on the VS generator — but the
     # OloEngine-Tests build never links that assembly, so ASan coverage is intact.)
     - name: Setup MSVC dev environment
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: x64
 
@@ -118,7 +118,7 @@ jobs:
     # resolves on PATH. See asan-lsan-linux for the action/sccache version-pin
     # rationale (older builds hit the decommissioned legacy cache API and fail).
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -199,7 +199,7 @@ jobs:
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: ASan (Windows)
         path: test_results/*.xml
@@ -223,7 +223,7 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Free up disk space
       # GitHub-hosted runners ship ~14 GB free; a sanitizer Debug link of
@@ -267,7 +267,7 @@ jobs:
     # the dead endpoint and fail to start (and, as the compiler launcher, would
     # break every compile). v0.15.0 is the current stable pin — matches Windows.yml.
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -333,7 +333,7 @@ jobs:
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: ASan + LSan (Linux)
         path: test_results/*.xml
@@ -355,7 +355,7 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Free up disk space
       # GitHub-hosted runners ship ~14 GB free; a sanitizer Debug link of
@@ -390,7 +390,7 @@ jobs:
     # Provisions sccache before Configure (see asan-lsan-linux for the version-
     # pin rationale and why no generator switch is needed on Linux).
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -445,7 +445,7 @@ jobs:
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: UBSan (Linux)
         path: test_results/*.xml
@@ -468,7 +468,7 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Free up disk space
       # GitHub-hosted runners ship ~14 GB free; a sanitizer Debug link of
@@ -503,7 +503,7 @@ jobs:
     # Provisions sccache before Configure (see asan-lsan-linux for the version-
     # pin rationale and why no generator switch is needed on Linux).
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -562,7 +562,7 @@ jobs:
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: dorny/test-reporter@v3
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: TSan (Linux)
         path: test_results/*.xml

--- a/.github/workflows/cross-vendor.yml
+++ b/.github/workflows/cross-vendor.yml
@@ -34,11 +34,11 @@ jobs:
     name: Windows / Mesa llvmpipe (software)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Python 3.10
         id: py
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
 
@@ -53,6 +53,16 @@ jobs:
       - name: Configure CMake
         # OLO_VIDEO_FFMPEG OFF: this job tests GPU-vendor rendering conformance, not video
         # decode; skip the ~15 min FFmpeg-from-source build (+ nasm dependency).
+        #
+        # NO sccache here, on purpose (issue #304). This uses CMake's default
+        # Visual Studio (MSBuild) generator, which IGNORES
+        # CMAKE_<LANG>_COMPILER_LAUNCHER, so sccache cannot engage without
+        # switching to Ninja (+ ilammy/msvc-dev-cmd, forcing cl.exe, LTO OFF, and
+        # the C#-project trade-off Windows.yml documents). That switch isn't worth
+        # it for this job: it's nightly (not per-PR), and its ~25 min wall-clock is
+        # dominated by the llvmpipe TEST run, not the build — caching the minority
+        # build slice on a nightly cadence (where the shared GHA cache is often
+        # cold) is a marginal win for a real complexity cost. Left as a cold build.
         run: cmake -S . -B build -DPython_EXECUTABLE="${{ steps.py.outputs.python-path }}" -DOLO_VIDEO_FFMPEG=OFF
 
       - name: Build tests
@@ -104,7 +114,7 @@ jobs:
 
       - name: Upload cross-vendor test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cross_vendor_results
           path: |
@@ -114,7 +124,7 @@ jobs:
 
       - name: Upload golden-image diffs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cross_vendor_golden_diffs
           path: |

--- a/.github/workflows/flaky-repro-281.yml
+++ b/.github/workflows/flaky-repro-281.yml
@@ -58,11 +58,11 @@ jobs:
     timeout-minutes: 110
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install Python 3.10
       id: py
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.10'
 
@@ -75,7 +75,7 @@ jobs:
       uses: ./.github/actions/setup-vulkan
 
     - name: Setup MSVC dev environment
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: x64
 
@@ -84,13 +84,13 @@ jobs:
 
     - name: Cache FFmpeg build
       id: ffcache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: OloEngine/vendor/ffmpeg-install
         key: ffmpeg-${{ runner.os }}-n7.1-${{ hashFiles('scripts/build-ffmpeg.sh') }}
 
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
 
@@ -197,7 +197,7 @@ jobs:
 
     - name: Upload repro evidence
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: repro-281-evidence
         path: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,6 +21,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
+env:
+  # Route sccache at its GitHub Actions cache backend (provisioned by the
+  # mozilla-actions/sccache-action step in each matrix leg below). Object files
+  # are reused across runs, so a nightly fuzz build only recompiles the TUs that
+  # actually changed instead of building the whole sanitised engine + harnesses
+  # cold every night. Mirrors the Windows.yml (#319) / asan.yml (#358) pattern.
+  # The clang-cl Ninja Multi-Config generator here honors
+  # CMAKE_<LANG>_COMPILER_LAUNCHER, so the launcher engages with no extra switch.
+  # The -fsanitize=fuzzer,address|undefined flags are part of each compile
+  # command line (and so part of sccache's hash), so the asan and ubsan matrix
+  # legs are distinct cache entries — a single shared backend cannot collide.
+  SCCACHE_GHA_ENABLED: "true"
+
 jobs:
   fuzz:
     # Two parallel jobs — `asan` and `ubsan` — because compiler-rt's Windows
@@ -37,11 +50,11 @@ jobs:
       matrix:
         sanitizer: [asan, ubsan]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Python 3.10
         id: py
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
 
@@ -58,7 +71,7 @@ jobs:
         # needs the Windows SDK libpath and MSVC's CRT import libs, which
         # come from MSVC's vcvars setup. ilammy/msvc-dev-cmd loads them
         # into the job env for every subsequent step.
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
 
@@ -84,10 +97,21 @@ jobs:
         # install root (so binaries live at `$LLVM_PATH/bin`) and caches the
         # download via actions/cache. Pinned to a specific 20.1.x release so
         # we don't drift with the action's "latest 20.x" interpretation.
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
         with:
           version: "20.1.8"
           cached: true
+
+      # Provisions sccache and wires it to the GitHub Actions cache backend
+      # (SCCACHE_GHA_ENABLED above). Must run before Configure so the launcher
+      # resolves on PATH. Action v0.0.10 + sccache >= v0.10.0 are REQUIRED:
+      # GitHub decommissioned the legacy Actions cache API on 2025-04-15 and
+      # older sccache builds hit the dead endpoint and fail to start (and, as the
+      # compiler launcher, would break every compile). v0.15.0 matches Windows.yml.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: "v0.15.0"
 
       - name: Configure CMake (standalone clang-cl via Ninja Multi-Config)
         # We replicate the `clangcl` CMake preset's settings inline instead
@@ -126,7 +150,18 @@ jobs:
                 "-DPython_EXECUTABLE=${{ steps.py.outputs.python-path }}" `
                 -DOLO_ENABLE_FUZZING=ON `
                 -DOLO_FUZZ_SANITIZER=${{ matrix.sanitizer }} `
-                -DOLO_VIDEO_FFMPEG=OFF
+                -DOLO_VIDEO_FFMPEG=OFF `
+                -DOLO_ENABLE_COMPILER_CACHE=ON `
+                -DOLO_ENABLE_LTO=OFF
+          # -DOLO_ENABLE_COMPILER_CACHE=ON: wires sccache as the compiler
+          #   launcher (cmake/CompilerCache.cmake). The Ninja generator honors
+          #   CMAKE_<LANG>_COMPILER_LAUNCHER, so clang-cl compiles route through
+          #   sccache; it also force-disables PCH and unity (both non-cacheable)
+          #   and switches MSVC-style debug info to /Z7 so objects are cacheable.
+          # -DOLO_ENABLE_LTO=OFF: LTO defaults ON, but a fuzz harness is never
+          #   shipped — its codegen quality is irrelevant, and ThinLTO would add a
+          #   slow whole-program link for no benefit. Dropping it also keeps every
+          #   object a pure function of its TU (cacheable). Mirrors Windows.yml.
 
       - name: Build fuzzers
         # OloEngine + fuzz harnesses are sanitised (see cmake/Fuzzing.cmake);
@@ -137,6 +172,14 @@ jobs:
         # path would need the DLL on PATH at build time. The "Run fuzz smoke"
         # step below handles the actual harness execution.
         run: cmake --build build-clang --target OloEngine-Fuzz --config Release --parallel
+
+      # Read the cache hit rate. A cold cache (first run / after a real source
+      # change) is mostly misses + writes; a warm cache shows a high hit rate,
+      # meaning the build step recompiled almost nothing. Two consecutive nightly
+      # runs of the same matrix leg are the cold-vs-warm proof.
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Run fuzz smoke (per-target 30s)
         working-directory: OloEditor
@@ -203,7 +246,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-sanitizer name so the asan and ubsan jobs don't try to
           # upload to the same artifact (actions/upload-artifact@v7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # `pre-commit run` only reads the working tree locally — no authenticated
+          # git writes — so drop the persisted GITHUB_TOKEN to minimise exposure.
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/video-ffmpeg.yml
+++ b/.github/workflows/video-ffmpeg.yml
@@ -28,11 +28,11 @@ jobs:
           - { name: windows, runner: windows-latest, os: Windows }
           - { name: linux,   runner: ubuntu-24.04,    os: Linux }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Python 3.10
         id: py
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
       - name: Python deps (OloHeaderTool)
@@ -63,7 +63,7 @@ jobs:
       # Cache the built FFmpeg so only the first (or post-bump) run pays the build cost.
       - name: Cache FFmpeg build
         id: ffcache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: OloEngine/vendor/ffmpeg-install
           key: ffmpeg-${{ runner.os }}-n7.1-${{ hashFiles('scripts/build-ffmpeg.sh') }}

--- a/.github/workflows/video-ffmpeg.yml
+++ b/.github/workflows/video-ffmpeg.yml
@@ -29,6 +29,10 @@ jobs:
           - { name: linux,   runner: ubuntu-24.04,    os: Linux }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Build + decode-test only; no authenticated git writes — so don't leave
+          # the GITHUB_TOKEN in .git/config for later steps/dependencies to read.
+          persist-credentials: false
 
       - name: Install Python 3.10
         id: py


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned multiple GitHub Actions across CI workflows to specific commit SHAs to improve reproducibility and supply chain security.
  * Added/expanded inline documentation in CI configurations, including clarifications about build-wrapper and intentional lack of compiler caching in certain jobs.
  * Enabled compiler caching for the nightly fuzz smoke build and added a step to report cache hit statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->