### PR TITLE
Implement toolsets and custom search method for tool discovery in MCP

### DIFF
--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -12,20 +12,24 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <map>
 #include <memory>
 #include <random>
 #include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 namespace OloEngine::MCP
 {
@@ -47,6 +51,55 @@ namespace OloEngine::MCP
             return Json{ { "jsonrpc", "2.0" },
                          { "id", id },
                          { "error", { { "code", code }, { "message", message } } } };
+        }
+
+        // Reverse-DNS-namespaced `_meta` key carrying a tool's toolset (grouping
+        // category) in tools/list / tools/search entries. `_meta` is the MCP-blessed
+        // extension point (spec 2025-06-18), so surfacing the category there keeps
+        // tools/list conformant — a strict client validating the Tool schema won't
+        // reject an unknown top-level field.
+        constexpr const char* kToolsetMetaKey = "io.oloengine/toolset";
+
+        // ASCII-lowercase a string for case-insensitive search/compare. The tool
+        // surface is all ASCII identifiers and English prose, so a locale-independent
+        // byte fold is correct and avoids std::tolower's locale baggage.
+        std::string ToLowerAscii(std::string_view s)
+        {
+            std::string out(s);
+            std::transform(out.begin(), out.end(), out.begin(),
+                           [](unsigned char c)
+                           { return static_cast<char>(std::tolower(c)); });
+            return out;
+        }
+
+        // Serialize one registered tool into its MCP tools/list entry. Shared by
+        // tools/list and the custom tools/search so both present byte-identical
+        // entries; the only optional field beyond the spec basics is the toolset,
+        // carried under `_meta` (omitted for uncategorized tools).
+        Json BuildToolEntry(const ToolDef& tool)
+        {
+            Json entry;
+            entry["name"] = tool.Name;
+            // Top-level display title (spec 2025-06-18); omitted when unset so the
+            // client falls back to the name.
+            if (!tool.Title.empty())
+                entry["title"] = tool.Title;
+            entry["description"] = tool.Description;
+            entry["inputSchema"] = tool.InputSchema.is_null()
+                                       ? Json{ { "type", "object" } }
+                                       : tool.InputSchema;
+            // JSON Schema for the structured result (spec 2025-06-18); omitted unless
+            // a non-empty object so text-only tools stay clean.
+            if (tool.OutputSchema.is_object() && !tool.OutputSchema.empty())
+                entry["outputSchema"] = tool.OutputSchema;
+            // Behavioural hints (readOnlyHint, etc.); omitted unless a non-empty object.
+            if (tool.Annotations.is_object() && !tool.Annotations.empty())
+                entry["annotations"] = tool.Annotations;
+            // Grouping category under the spec's `_meta` extension point; omitted for
+            // uncategorized tools so their entry is unchanged from before toolsets.
+            if (!tool.Toolset.empty())
+                entry["_meta"] = Json{ { kToolsetMetaKey, tool.Toolset } };
+            return entry;
         }
 
         // Random lowercase-hex string of `bytes` bytes (so 2*bytes characters).
@@ -530,6 +583,8 @@ namespace OloEngine::MCP
             return MakeResult(id, Json::object());
         if (method == "tools/list")
             return HandleToolsList(id);
+        if (method == "tools/search")
+            return HandleToolsSearch(id, request.value("params", Json::object()));
         if (method == "tools/call")
             return HandleToolsCall(id, request.value("params", Json::object()));
         if (method == "resources/list")
@@ -580,29 +635,74 @@ namespace OloEngine::MCP
     {
         Json tools = Json::array();
         for (const auto& tool : m_Tools)
-        {
-            Json entry;
-            entry["name"] = tool.Name;
-            // Top-level display title (spec 2025-06-18); omitted when unset so the
-            // client falls back to the name.
-            if (!tool.Title.empty())
-                entry["title"] = tool.Title;
-            entry["description"] = tool.Description;
-            entry["inputSchema"] = tool.InputSchema.is_null()
-                                       ? Json{ { "type", "object" } }
-                                       : tool.InputSchema;
-            // JSON Schema for the structured result (spec 2025-06-18); omitted unless
-            // a non-empty object so text-only tools stay clean. A client may validate
-            // a tool's structuredContent against this.
-            if (tool.OutputSchema.is_object() && !tool.OutputSchema.empty())
-                entry["outputSchema"] = tool.OutputSchema;
-            // Behavioural hints (readOnlyHint, etc.); omitted unless a non-empty
-            // object so a tool without annotations stays clean.
-            if (tool.Annotations.is_object() && !tool.Annotations.empty())
-                entry["annotations"] = tool.Annotations;
-            tools.push_back(std::move(entry));
-        }
+            tools.push_back(BuildToolEntry(tool));
         return MakeResult(id, Json{ { "tools", std::move(tools) } });
+    }
+
+    Json McpServer::HandleToolsSearch(const Json& id, const Json& params) const
+    {
+        // Both filters are optional, but a present-and-non-string filter is a client
+        // error (invalid params) rather than a silent no-op — matching the strictness
+        // of tools/call's `name` check.
+        if (params.contains("query") && !params["query"].is_string())
+            return MakeError(id, kInvalidParams, "Invalid params: 'query' must be a string");
+        if (params.contains("toolset") && !params["toolset"].is_string())
+            return MakeError(id, kInvalidParams, "Invalid params: 'toolset' must be a string");
+
+        const std::string toolsetFilter = params.contains("toolset")
+                                              ? ToLowerAscii(params["toolset"].get<std::string>())
+                                              : std::string{};
+
+        // Split the free-text query into whitespace-separated terms; a tool matches
+        // only when EVERY term appears (case-insensitive substring) somewhere in its
+        // searchable text. A missing / whitespace-only query matches everything
+        // (subject to the toolset filter), so tools/search with no useful query mirrors
+        // tools/list while still returning the toolset catalogue.
+        std::vector<std::string> terms;
+        if (params.contains("query"))
+        {
+            std::istringstream stream(ToLowerAscii(params["query"].get<std::string>()));
+            std::string term;
+            while (stream >> term)
+                terms.push_back(std::move(term));
+        }
+
+        Json matched = Json::array();
+        std::map<std::string, std::size_t> toolsetCounts; // sorted by toolset name
+        for (const auto& tool : m_Tools)
+        {
+            // Count every categorized tool for the catalogue before applying filters,
+            // so the catalogue always describes the full surface, not the matches.
+            if (!tool.Toolset.empty())
+                ++toolsetCounts[tool.Toolset];
+
+            if (!toolsetFilter.empty() && ToLowerAscii(tool.Toolset) != toolsetFilter)
+                continue;
+
+            if (!terms.empty())
+            {
+                const std::string haystack =
+                    ToLowerAscii(tool.Name + ' ' + tool.Title + ' ' + tool.Description + ' ' + tool.Toolset);
+                const bool allTermsMatch = std::all_of(terms.begin(), terms.end(),
+                                                       [&haystack](const std::string& t)
+                                                       { return haystack.find(t) != std::string::npos; });
+                if (!allTermsMatch)
+                    continue;
+            }
+
+            Json entry = BuildToolEntry(tool);
+            // Friendly top-level field on this custom method (we own its shape) so an
+            // agent reading search results doesn't have to dig into `_meta`.
+            if (!tool.Toolset.empty())
+                entry["toolset"] = tool.Toolset;
+            matched.push_back(std::move(entry));
+        }
+
+        Json toolsets = Json::array();
+        for (const auto& [name, count] : toolsetCounts)
+            toolsets.push_back(Json{ { "name", name }, { "count", count } });
+
+        return MakeResult(id, Json{ { "tools", std::move(matched) }, { "toolsets", std::move(toolsets) } });
     }
 
     Json McpServer::HandleToolsCall(const Json& id, const Json& params)

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -668,15 +668,22 @@ namespace OloEngine::MCP
         }
 
         Json matched = Json::array();
-        std::map<std::string, std::size_t> toolsetCounts; // sorted by toolset name
+        std::map<std::string, std::size_t> toolsetCounts; // sorted by canonical (lowercased) name
         for (const auto& tool : m_Tools)
         {
+            // Case-fold each tool's toolset once and reuse it for both the catalogue
+            // key and the filter compare. This keeps the two in lockstep: a mixed-case
+            // value (e.g. "Render" alongside "render") collapses into one catalogue
+            // entry instead of splitting into two that a single case-insensitive filter
+            // would still match — and it avoids re-lowercasing the toolset per tool.
+            const std::string toolsetKey = ToLowerAscii(tool.Toolset);
+
             // Count every categorized tool for the catalogue before applying filters,
             // so the catalogue always describes the full surface, not the matches.
-            if (!tool.Toolset.empty())
-                ++toolsetCounts[tool.Toolset];
+            if (!toolsetKey.empty())
+                ++toolsetCounts[toolsetKey];
 
-            if (!toolsetFilter.empty() && ToLowerAscii(tool.Toolset) != toolsetFilter)
+            if (!toolsetFilter.empty() && toolsetKey != toolsetFilter)
                 continue;
 
             if (!terms.empty())

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -641,6 +641,14 @@ namespace OloEngine::MCP
 
     Json McpServer::HandleToolsSearch(const Json& id, const Json& params) const
     {
+        // A non-object params (e.g. [] or "x") would otherwise skip both optional
+        // filters below and silently return the unfiltered catalogue. Reject it as a
+        // client error — matching the strictness of tools/call's `name` check. (An
+        // absent params is dispatched as an empty object, so the no-filter "search
+        // everything" call still passes here.)
+        if (!params.is_object())
+            return MakeError(id, kInvalidParams, "Invalid params: 'params' must be an object");
+
         // Both filters are optional, but a present-and-non-string filter is a client
         // error (invalid params) rather than a silent no-op — matching the strictness
         // of tools/call's `name` check.

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -110,6 +110,12 @@ namespace OloEngine::MCP
         // `destructiveHint`, `idempotentHint`, `openWorldHint`. Defaults to null;
         // emitted under `annotations` only when it is a non-empty object.
         Json Annotations;
+        // Lightweight grouping category (e.g. "render", "physics", "shader") so the
+        // 39-tool surface can be browsed/filtered instead of paged through flat. Used
+        // by `tools/search` (filter + catalogue) and surfaced under each tool's `_meta`
+        // in `tools/list`. Empty => uncategorized (omitted from the metadata). Purely
+        // descriptive — it does not affect dispatch or tool resolution.
+        std::string Toolset;
         ToolHandler Handler;
         bool MainMarshaled = false;
     };
@@ -354,6 +360,13 @@ namespace OloEngine::MCP
 
         [[nodiscard]] Json HandleInitialize(const Json& id, const Json& params);
         [[nodiscard]] Json HandleToolsList(const Json& id) const;
+        // Custom (non-standard) discovery method `tools/search`: filter the tool
+        // surface by a free-text `query` (whitespace-separated terms, all must match
+        // name/title/description/toolset, case-insensitive) and/or a `toolset`
+        // category, and return the matching tools plus a catalogue of every toolset
+        // with its tool count. Additive: `tools/list` is unchanged, so a standard MCP
+        // client that never calls this keeps working.
+        [[nodiscard]] Json HandleToolsSearch(const Json& id, const Json& params) const;
         [[nodiscard]] Json HandleToolsCall(const Json& id, const Json& params);
         [[nodiscard]] Json HandleResourcesList(const Json& id) const;
         [[nodiscard]] Json HandleResourcesRead(const Json& id, const Json& params);

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -3401,6 +3401,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_log_tail";
+            tool.Toolset = "diagnostics";
             tool.Title = "Tail engine log";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3427,6 +3428,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_scene_summary";
+            tool.Toolset = "scene";
             tool.Title = "Scene summary";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3456,6 +3458,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_scene_list_entities";
+            tool.Toolset = "scene";
             tool.Title = "List scene entities";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3478,6 +3481,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_scene_get_entity";
+            tool.Toolset = "scene";
             tool.Title = "Get entity components";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3510,6 +3514,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_memory_report";
+            tool.Toolset = "perf";
             tool.Title = "Renderer memory report";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3547,6 +3552,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_perf_snapshot";
+            tool.Toolset = "perf";
             tool.Title = "Performance snapshot";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3583,6 +3589,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_perf_bottlenecks";
+            tool.Toolset = "perf";
             tool.Title = "Bottleneck analysis";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3597,6 +3604,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_perf_frame_history";
+            tool.Toolset = "perf";
             tool.Title = "Frame-time history";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3615,6 +3623,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_perf_capture_frame";
+            tool.Toolset = "perf";
             tool.Title = "Capture frame profile";
             // Triggers a one-frame diagnostic capture but observes-only — no
             // camera/setting/file/scene change the caller can see (see builder note).
@@ -3636,6 +3645,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_frame_breakdown";
+            tool.Toolset = "render";
             tool.Title = "Frame command breakdown";
             // Same transient one-frame capture as olo_perf_capture_frame — read-only.
             tool.Annotations = ReadOnlyAnnotations();
@@ -3681,6 +3691,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_shader_errors";
+            tool.Toolset = "shader";
             tool.Title = "Shader compile errors";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3695,6 +3706,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_shader_get";
+            tool.Toolset = "shader";
             tool.Title = "Get shader details";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3716,6 +3728,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_shader_list";
+            tool.Toolset = "shader";
             tool.Title = "List shaders";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3730,6 +3743,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_shader_reload";
+            tool.Toolset = "shader";
             tool.Title = "Reload shader";
             // Recompiles a shader from disk (mutates GL program state, new program
             // id each call), so not read-only and not idempotent; destroys nothing.
@@ -3763,6 +3777,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_assets_list";
+            tool.Toolset = "assets";
             tool.Title = "List assets";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3784,6 +3799,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_assets_problems";
+            tool.Toolset = "assets";
             tool.Title = "List asset problems";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3798,6 +3814,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_crash_list";
+            tool.Toolset = "diagnostics";
             tool.Title = "List crash reports";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3812,6 +3829,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_crash_get";
+            tool.Toolset = "diagnostics";
             tool.Title = "Get crash report";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3831,6 +3849,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_script_get_api";
+            tool.Toolset = "scripting";
             tool.Title = "Get scripting API";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3853,6 +3872,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_script_get_last_errors";
+            tool.Toolset = "scripting";
             tool.Title = "Recent script errors";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3873,6 +3893,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_events_tail";
+            tool.Toolset = "diagnostics";
             tool.Title = "Tail diagnostics events";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3903,6 +3924,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_screenshot";
+            tool.Toolset = "camera";
             tool.Title = "Screenshot viewport";
             // Read-only without a pose, but with a 'camera'/'orbit' pose it moves the
             // editor camera (saving/restoring it) — a transient mutation. Flag it
@@ -3941,6 +3963,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_camera_get";
+            tool.Toolset = "camera";
             tool.Title = "Get camera pose";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -3957,6 +3980,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_camera_set_pose";
+            tool.Toolset = "camera";
             tool.Title = "Set camera pose";
             // Moves the editor camera; same args => same pose (idempotent), destroys nothing.
             tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
@@ -3984,6 +4008,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_camera_orbit";
+            tool.Toolset = "camera";
             tool.Title = "Orbit camera";
             tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
             tool.Description =
@@ -4010,6 +4035,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_camera_frame_entity";
+            tool.Toolset = "camera";
             tool.Title = "Frame entity in view";
             tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
             tool.Description =
@@ -4032,6 +4058,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_viewport_set_size";
+            tool.Toolset = "camera";
             tool.Title = "Set viewport size";
             tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
             tool.Description =
@@ -4057,6 +4084,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_list_targets";
+            tool.Toolset = "render";
             tool.Title = "List render targets";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4074,6 +4102,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_capture_target";
+            tool.Toolset = "render";
             tool.Title = "Capture render target";
             // Reads back one render-graph texture; changes no observable state.
             tool.Annotations = ReadOnlyAnnotations();
@@ -4104,6 +4133,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_toggle_pass";
+            tool.Toolset = "render";
             tool.Title = "Toggle render pass";
             // Edits ephemeral session render settings; flips state when 'enabled' is
             // omitted (so not idempotent), destroys nothing.
@@ -4134,6 +4164,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_set_debug_view";
+            tool.Toolset = "render";
             tool.Title = "Set render debug view";
             // Edits ephemeral session render settings; destroys nothing.
             tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
@@ -4161,6 +4192,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_compare_golden";
+            tool.Toolset = "render";
             tool.Title = "Compare against golden image";
             // Poses the camera (save/restore) and can WRITE/overwrite a golden PNG
             // on create or rebase — a real, potentially destructive filesystem
@@ -4207,6 +4239,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_layer_matrix";
+            tool.Toolset = "physics";
             tool.Title = "Physics layer matrix";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4223,6 +4256,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_list_colliders";
+            tool.Toolset = "physics";
             tool.Title = "List physics colliders";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4245,6 +4279,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_contacts";
+            tool.Toolset = "physics";
             tool.Title = "List physics contacts";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4265,6 +4300,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_raycast";
+            tool.Toolset = "physics";
             tool.Title = "Physics raycast";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4314,6 +4350,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_overlap";
+            tool.Toolset = "physics";
             tool.Title = "Physics overlap query";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4338,6 +4375,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_physics_why_no_collision";
+            tool.Toolset = "physics";
             tool.Title = "Explain missing collision";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4362,6 +4400,7 @@ namespace OloEngine::MCP
         {
             ToolDef tool;
             tool.Name = "olo_render_why_not_visible";
+            tool.Toolset = "render";
             tool.Title = "Explain entity not visible";
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -41,9 +41,25 @@ namespace
         return req;
     }
 
+    // Return the first entry of a JSON tools array whose "name" equals `name`, else
+    // nullptr. Used by the tools/list and tools/search assertions below.
+    const Json* FindToolNamed(const Json& tools, const std::string& name)
+    {
+        for (const auto& tool : tools)
+        {
+            if (tool.contains("name") && tool["name"] == name)
+                return &tool;
+        }
+        return nullptr;
+    }
+
     // Fixture: an McpServer with a stub (empty) editor context plus a handful of
-    // fake registrations, so dispatch can be exercised without the real 19 tools
+    // fake registrations, so dispatch can be exercised without the real 39 tools
     // / 2 resources / 3 prompts and without an editor backing the server.
+    //
+    // Toolsets for the tools/search tests: fake_echo and fake_boom are both in the
+    // "diag" toolset; fake_tool_error is deliberately left uncategorized (empty
+    // Toolset) to exercise the _meta-omission and catalogue-exclusion paths.
     class McpDispatchTest : public ::testing::Test
     {
       protected:
@@ -53,6 +69,7 @@ namespace
             ToolDef echo;
             echo.Name = "fake_echo";
             echo.Description = "Echo back the 'text' argument.";
+            echo.Toolset = "diag";
             echo.InputSchema = Json{ { "type", "object" },
                                      { "properties", { { "text", { { "type", "string" } } } } } };
             echo.Handler = [](McpServer&, const Json& args)
@@ -63,6 +80,7 @@ namespace
             ToolDef boom;
             boom.Name = "fake_boom";
             boom.Description = "Always throws.";
+            boom.Toolset = "diag";
             boom.Handler = [](McpServer&, const Json&) -> ToolResult
             { throw std::runtime_error("kaboom"); };
             m_Server.RegisterTool(std::move(boom));
@@ -70,6 +88,7 @@ namespace
             ToolDef toolError;
             toolError.Name = "fake_tool_error";
             toolError.Description = "Returns a tool-level error (isError=true).";
+            // Intentionally no Toolset (uncategorized).
             toolError.Handler = [](McpServer&, const Json&)
             { return ToolResult::Error("nope"); };
             m_Server.RegisterTool(std::move(toolError));
@@ -167,6 +186,171 @@ TEST_F(McpDispatchTest, ToolsListSurfacesRegisteredToolsWithSchema)
     // A tool with no InputSchema must still advertise a default object schema.
     ASSERT_NE(boom, nullptr);
     EXPECT_EQ((*boom)["inputSchema"], (Json{ { "type", "object" } }));
+}
+
+// A categorized tool surfaces its toolset under `_meta` (the spec extension point)
+// in tools/list; an uncategorized tool omits `_meta` entirely, so tools/list is
+// byte-for-byte unchanged for tools that predate toolsets.
+TEST_F(McpDispatchTest, ToolsListSurfacesToolsetUnderMeta)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(3, "tools/list"));
+    const Json& tools = resp["result"]["tools"];
+
+    const Json* echo = FindToolNamed(tools, "fake_echo");
+    ASSERT_NE(echo, nullptr);
+    ASSERT_TRUE(echo->contains("_meta"));
+    EXPECT_EQ((*echo)["_meta"]["io.oloengine/toolset"], "diag");
+
+    // The uncategorized tool stays clean — no _meta, no toolset.
+    const Json* toolError = FindToolNamed(tools, "fake_tool_error");
+    ASSERT_NE(toolError, nullptr);
+    EXPECT_FALSE(toolError->contains("_meta"));
+    EXPECT_FALSE(toolError->contains("toolset"));
+}
+
+// ---- tools/search (custom discovery method) --------------------------------
+
+// No query / no toolset: returns every tool (uncategorized included) plus a
+// catalogue of toolsets with per-toolset counts. The uncategorized tool is in
+// `tools` but contributes nothing to the catalogue.
+TEST_F(McpDispatchTest, ToolsSearchNoArgsReturnsAllToolsAndCatalogue)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(20, "tools/search"));
+    ASSERT_TRUE(resp.contains("result"));
+    const Json& result = resp["result"];
+
+    ASSERT_TRUE(result["tools"].is_array());
+    EXPECT_EQ(result["tools"].size(), 3u); // all three fakes, including uncategorized
+
+    ASSERT_TRUE(result["toolsets"].is_array());
+    ASSERT_EQ(result["toolsets"].size(), 1u); // only "diag" is categorized
+    EXPECT_EQ(result["toolsets"][0]["name"], "diag");
+    EXPECT_EQ(result["toolsets"][0]["count"], 2); // fake_echo + fake_boom
+}
+
+// A matched, categorized entry carries both the friendly top-level `toolset` field
+// and the `_meta` mirror; an uncategorized matched entry carries neither.
+TEST_F(McpDispatchTest, ToolsSearchEntryCarriesToolsetFieldAndMeta)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(21, "tools/search"));
+    const Json& tools = resp["result"]["tools"];
+
+    const Json* echo = FindToolNamed(tools, "fake_echo");
+    ASSERT_NE(echo, nullptr);
+    EXPECT_EQ((*echo)["toolset"], "diag");
+    EXPECT_EQ((*echo)["_meta"]["io.oloengine/toolset"], "diag");
+
+    const Json* toolError = FindToolNamed(tools, "fake_tool_error");
+    ASSERT_NE(toolError, nullptr);
+    EXPECT_FALSE(toolError->contains("toolset"));
+    EXPECT_FALSE(toolError->contains("_meta"));
+}
+
+// Filtering by toolset returns exactly the tools in that category.
+TEST_F(McpDispatchTest, ToolsSearchFiltersByToolset)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(22, "tools/search", Json{ { "toolset", "diag" } }));
+    const Json& tools = resp["result"]["tools"];
+    ASSERT_EQ(tools.size(), 2u);
+    EXPECT_NE(FindToolNamed(tools, "fake_echo"), nullptr);
+    EXPECT_NE(FindToolNamed(tools, "fake_boom"), nullptr);
+    EXPECT_EQ(FindToolNamed(tools, "fake_tool_error"), nullptr); // uncategorized excluded
+
+    // The catalogue is always the full set, regardless of the active filter.
+    EXPECT_EQ(resp["result"]["toolsets"].size(), 1u);
+}
+
+TEST_F(McpDispatchTest, ToolsSearchToolsetFilterIsCaseInsensitive)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(23, "tools/search", Json{ { "toolset", "DIAG" } }));
+    EXPECT_EQ(resp["result"]["tools"].size(), 2u);
+}
+
+TEST_F(McpDispatchTest, ToolsSearchUnknownToolsetReturnsNoToolsButFullCatalogue)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(24, "tools/search", Json{ { "toolset", "nope" } }));
+    EXPECT_TRUE(resp["result"]["tools"].empty());
+    EXPECT_EQ(resp["result"]["toolsets"].size(), 1u); // catalogue still lists "diag"
+}
+
+// A query matches against name AND description (and title/toolset).
+TEST_F(McpDispatchTest, ToolsSearchQueryMatchesNameAndDescription)
+{
+    const Json byName = m_Server.HandleMessage(MakeRequest(25, "tools/search", Json{ { "query", "echo" } }));
+    ASSERT_EQ(byName["result"]["tools"].size(), 1u);
+    EXPECT_EQ(byName["result"]["tools"][0]["name"], "fake_echo");
+
+    const Json byDesc = m_Server.HandleMessage(MakeRequest(26, "tools/search", Json{ { "query", "throws" } }));
+    ASSERT_EQ(byDesc["result"]["tools"].size(), 1u);
+    EXPECT_EQ(byDesc["result"]["tools"][0]["name"], "fake_boom");
+}
+
+TEST_F(McpDispatchTest, ToolsSearchQueryIsCaseInsensitive)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(27, "tools/search", Json{ { "query", "ECHO" } }));
+    ASSERT_EQ(resp["result"]["tools"].size(), 1u);
+    EXPECT_EQ(resp["result"]["tools"][0]["name"], "fake_echo");
+}
+
+// Multi-term query is AND: every whitespace-separated term must appear somewhere.
+TEST_F(McpDispatchTest, ToolsSearchQueryRequiresAllTerms)
+{
+    // "fake" + "throws" both live in fake_boom (name + description) -> one match.
+    const Json both = m_Server.HandleMessage(MakeRequest(28, "tools/search", Json{ { "query", "fake throws" } }));
+    ASSERT_EQ(both["result"]["tools"].size(), 1u);
+    EXPECT_EQ(both["result"]["tools"][0]["name"], "fake_boom");
+
+    // No single tool has both "echo" and "throws" -> zero matches.
+    const Json none = m_Server.HandleMessage(MakeRequest(29, "tools/search", Json{ { "query", "echo throws" } }));
+    EXPECT_TRUE(none["result"]["tools"].empty());
+}
+
+// A whitespace-only query is treated as "no query" (matches all, toolset filter
+// still applies).
+TEST_F(McpDispatchTest, ToolsSearchBlankQueryMatchesAll)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(30, "tools/search", Json{ { "query", "   " } }));
+    EXPECT_EQ(resp["result"]["tools"].size(), 3u);
+}
+
+// Query and toolset combine with AND.
+TEST_F(McpDispatchTest, ToolsSearchCombinesQueryAndToolset)
+{
+    const Json hit = m_Server.HandleMessage(
+        MakeRequest(31, "tools/search", Json{ { "query", "throws" }, { "toolset", "diag" } }));
+    ASSERT_EQ(hit["result"]["tools"].size(), 1u);
+    EXPECT_EQ(hit["result"]["tools"][0]["name"], "fake_boom");
+
+    // Right query, wrong toolset -> no match.
+    const Json miss = m_Server.HandleMessage(
+        MakeRequest(32, "tools/search", Json{ { "query", "throws" }, { "toolset", "other" } }));
+    EXPECT_TRUE(miss["result"]["tools"].empty());
+}
+
+TEST_F(McpDispatchTest, ToolsSearchRejectsNonStringQuery)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(33, "tools/search", Json{ { "query", 123 } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602); // invalid params
+}
+
+TEST_F(McpDispatchTest, ToolsSearchRejectsNonStringToolset)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(34, "tools/search", Json{ { "toolset", true } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+}
+
+// Matched search entries keep the full tools/list entry shape (name, description,
+// inputSchema) so an agent can call a tool straight from a search result.
+TEST_F(McpDispatchTest, ToolsSearchEntriesKeepToolListShape)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(35, "tools/search", Json{ { "query", "echo" } }));
+    const Json& entry = resp["result"]["tools"][0];
+    EXPECT_EQ(entry["name"], "fake_echo");
+    EXPECT_EQ(entry["description"], "Echo back the 'text' argument.");
+    EXPECT_EQ(entry["inputSchema"]["type"], "object");
+    EXPECT_TRUE(entry["inputSchema"]["properties"].contains("text"));
 }
 
 TEST_F(McpDispatchTest, ResourcesListSurfacesRegisteredResources)

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -353,6 +353,40 @@ TEST_F(McpDispatchTest, ToolsSearchEntriesKeepToolListShape)
     EXPECT_TRUE(entry["inputSchema"]["properties"].contains("text"));
 }
 
+// Regression: the toolset catalogue is keyed on the case-folded toolset and the
+// filter compares case-folded, so a mixed-case Toolset value cannot split the
+// catalogue (two "Render"/"render" entries) while a single case-insensitive filter
+// still matches both — the catalogue count must reconcile with the filtered result.
+// Standalone (own server) so the shared fixture's tool-count assertions are unaffected.
+TEST(McpToolsSearchCaseFold, MixedCaseToolsetCollapsesInCatalogueAndFilter)
+{
+    McpServer server(EditorMcpContext{});
+
+    const auto addTool = [&server](std::string name, std::string toolset)
+    {
+        ToolDef tool;
+        tool.Name = std::move(name);
+        tool.Toolset = std::move(toolset);
+        tool.Description = "fake";
+        tool.Handler = [](McpServer&, const Json&)
+        { return ToolResult::Text("ok"); };
+        server.RegisterTool(std::move(tool));
+    };
+    addTool("fake_a", "Render"); // capitalized
+    addTool("fake_b", "render"); // lowercase — same logical toolset
+
+    // Catalogue collapses to ONE canonical "render" entry covering both tools.
+    const Json all = server.HandleMessage(MakeRequest(1, "tools/search"));
+    const Json& toolsets = all["result"]["toolsets"];
+    ASSERT_EQ(toolsets.size(), 1u);
+    EXPECT_EQ(toolsets[0]["name"], "render");
+    EXPECT_EQ(toolsets[0]["count"], 2);
+
+    // A filter of any case returns BOTH tools, reconciling with the catalogue count.
+    const Json filtered = server.HandleMessage(MakeRequest(2, "tools/search", Json{ { "toolset", "RENDER" } }));
+    EXPECT_EQ(filtered["result"]["tools"].size(), 2u);
+}
+
 TEST_F(McpDispatchTest, ResourcesListSurfacesRegisteredResources)
 {
     const Json resp = m_Server.HandleMessage(MakeRequest(4, "resources/list"));

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -341,6 +341,21 @@ TEST_F(McpDispatchTest, ToolsSearchRejectsNonStringToolset)
     EXPECT_EQ(resp["error"]["code"], -32602);
 }
 
+// A present-but-non-object params (e.g. [] or "x") would otherwise skip both
+// optional filters and silently return the unfiltered catalogue — reject it as a
+// client error instead. (An absent params is dispatched as an empty object and
+// still succeeds; that path is covered by ToolsSearchNoArgsReturnsAllToolsAndCatalogue.)
+TEST_F(McpDispatchTest, ToolsSearchRejectsNonObjectParams)
+{
+    const Json fromArray = m_Server.HandleMessage(MakeRequest(36, "tools/search", Json::array()));
+    ASSERT_TRUE(fromArray.contains("error"));
+    EXPECT_EQ(fromArray["error"]["code"], -32602); // invalid params
+
+    const Json fromString = m_Server.HandleMessage(MakeRequest(37, "tools/search", Json("x")));
+    ASSERT_TRUE(fromString.contains("error"));
+    EXPECT_EQ(fromString["error"]["code"], -32602);
+}
+
 // Matched search entries keep the full tools/list entry shape (name, description,
 // inputSchema) so an agent can call a tool straight from a search result.
 TEST_F(McpDispatchTest, ToolsSearchEntriesKeepToolListShape)

--- a/OloEngine/tests/Rendering/FrameCaptureTest.cpp
+++ b/OloEngine/tests/Rendering/FrameCaptureTest.cpp
@@ -663,7 +663,10 @@ class FrameExportTest : public FrameCapturePipelineTest
         m_TestOutputDir = std::filesystem::temp_directory_path() / "olo_frame_export_test" / (testSuite + "_" + testName);
         std::error_code ec;
         std::filesystem::remove_all(m_TestOutputDir, ec);
+        ASSERT_FALSE(ec) << "Failed to clear test output dir: " << ec.message();
+        ec.clear();
         std::filesystem::create_directories(m_TestOutputDir, ec);
+        ASSERT_FALSE(ec) << "Failed to create test output dir: " << ec.message();
     }
 
     void TearDown() override

--- a/OloEngine/tests/Rendering/FrameCaptureTest.cpp
+++ b/OloEngine/tests/Rendering/FrameCaptureTest.cpp
@@ -652,14 +652,23 @@ class FrameExportTest : public FrameCapturePipelineTest
     {
         FrameCapturePipelineTest::SetUp();
 
-        // Determine a temp directory for test output
-        m_TestOutputDir = std::filesystem::temp_directory_path() / "olo_frame_export_test";
-        std::filesystem::create_directories(m_TestOutputDir);
+        // Per-test subdir so parallel ctest runs (each test is its own process) don't
+        // fight over a shared directory: a sibling FrameExportTest's TearDown
+        // remove_all would otherwise delete the dir mid-write and make an export's
+        // ofstream open fail (the export then returns false). Keyed by suite+test name
+        // so each test owns a unique leaf and only ever removes its own.
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        const std::string testSuite = info ? info->test_suite_name() : "FrameExportTest";
+        const std::string testName = info ? info->name() : "unknown";
+        m_TestOutputDir = std::filesystem::temp_directory_path() / "olo_frame_export_test" / (testSuite + "_" + testName);
+        std::error_code ec;
+        std::filesystem::remove_all(m_TestOutputDir, ec);
+        std::filesystem::create_directories(m_TestOutputDir, ec);
     }
 
     void TearDown() override
     {
-        // Clean up test files
+        // Clean up this test's own files only — never the shared parent dir.
         std::error_code ec;
         std::filesystem::remove_all(m_TestOutputDir, ec);
 

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -145,6 +145,42 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_physics_overlap` | bodies overlapping a sphere (`radius`) or box (`halfExtents`) at `origin`; requires Play mode |
 | `olo_physics_why_no_collision` | explain why two entities (`a`, `b`) are NOT colliding — the "player falls through the floor" debugger: root-cause `reasonCode`, summary, ordered checks, and per-entity facts |
 
+### Toolsets & on-demand tool discovery (`tools/search`)
+
+The tool surface is large enough (39 tools) that paging the whole flat `tools/list`
+to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
+category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
+keyword and/or category instead of pulling the entire list:
+
+| Toolset | Tools |
+|---|---|
+| `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
+| `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
+| `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame` |
+| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
+| `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
+| `assets` | `olo_assets_list`, `olo_assets_problems` |
+| `scripting` | `olo_script_get_api`, `olo_script_get_last_errors` |
+| `camera` | `olo_screenshot`, `olo_camera_get`, `olo_camera_set_pose`, `olo_camera_orbit`, `olo_camera_frame_entity`, `olo_viewport_set_size` |
+| `physics` | `olo_physics_layer_matrix`, `olo_physics_list_colliders`, `olo_physics_contacts`, `olo_physics_raycast`, `olo_physics_overlap`, `olo_physics_why_no_collision` |
+
+`tools/search` params (both optional):
+
+- `query` — free text; whitespace-separated terms are ANDed and matched
+  case-insensitively against each tool's name, title, description, and toolset.
+- `toolset` — restrict to one category (case-insensitive exact match).
+
+It returns `{ "tools": [...], "toolsets": [{ "name", "count" }, ...] }`. The `tools`
+entries are the same shape as `tools/list` (so a tool can be called straight from a
+search hit), plus a convenience top-level `toolset` field. The `toolsets` array is the
+full category catalogue (every toolset + its tool count, regardless of the active
+filter) so an agent can discover categories and refine. With no `query` and no
+`toolset`, it returns every tool plus the catalogue.
+
+This is **additive**: `tools/list` is unchanged (a standard MCP client that never calls
+`tools/search` keeps working) — it now also carries each tool's toolset under the
+spec's `_meta` extension key `io.oloengine/toolset`, which strict clients ignore.
+
 ### Multi-angle visual verification (the CLAUDE.md water pattern)
 
 The camera tools exist so an agent can verify a rendering change from the angles where


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tools/search` to the MCP diagnostics server for on-demand discovery by `query` and/or `toolset` category.
  * Categorized tools now surface toolset metadata in `tools/list` (via `_meta`), and `tools/search` returns a `toolsets` catalogue with counts.
  * Updated MCP diagnostics server documentation with request/response details and examples.

* **Bug Fixes**
  * Improved search behavior to be fully case-insensitive, including toolset filtering and multi-term matching.
  * Fixed frame capture test output handling to avoid interference during parallel test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->