### PR TITLE
ci: track vendored C++ deps with Renovate; group Dependabot Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot config. See:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+# Scope note: Dependabot only covers the GitHub Actions used by our workflows
+# (and the composite action under .github/actions/, which `directory: "/"`
+# scans too). It CANNOT read the C++ vendored deps, which are fetched via CMake
+# FetchContent / CPM in OloEngine/vendor/CMakeLists.txt — there is no CMake
+# ecosystem in Dependabot. Those are tracked by Renovate instead; see
+# .github/renovate.json5. The two bots are kept strictly non-overlapping:
+# Dependabot owns Actions, Renovate owns the vendored C++ deps only.
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "monthly"
+    # One combined PR per run instead of up to ~11 — each PR otherwise triggers
+    # the full CI matrix (SonarCloud Scan alone is a ~1.5-2h long pole).
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    labels:
+      - "github_actions"
+    commit-message:
+      prefix: "ci"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,7 +36,7 @@
       //   and the CPMAddPackage GITHUB_REPOSITORY form (imgui "docking", etc.).
       // Bump the pinned digest to the current tip of that branch.
       customType: "regex",
-      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      managerFilePatterns: ["/^OloEngine/vendor/CMakeLists\\.txt$/"],
       datasourceTemplate: "git-refs",
       packageNameTemplate: "https://github.com/{{{depName}}}",
       matchStrings: [
@@ -51,7 +51,7 @@
       // cleanly separates the two styles (and skips bare-SHA pins like Jolt,
       // which carry no branch hint and can't be auto-tracked — left manual).
       customType: "regex",
-      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      managerFilePatterns: ["/^OloEngine/vendor/CMakeLists\\.txt$/"],
       datasourceTemplate: "github-tags",
       versioningTemplate: "loose",
       matchStrings: [
@@ -66,7 +66,7 @@
       // (Renovate re-pins it to the new tag's commit). The "# v<num>" comment
       // distinguishes this from the "# <branch> @ <date>" digest pins above.
       customType: "regex",
-      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      managerFilePatterns: ["/^OloEngine/vendor/CMakeLists\\.txt$/"],
       datasourceTemplate: "github-tags",
       versioningTemplate: "loose",
       matchStrings: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,78 @@
+{
+  // Renovate config — tracks ONLY the C++ vendored dependencies that Dependabot
+  // cannot read (CMake FetchContent / CPM in OloEngine/vendor/CMakeLists.txt).
+  //
+  // Requires the Mend Renovate GitHub App installed on the repo (free for this
+  // project). On first install Renovate opens an onboarding PR + a "Dependency
+  // Dashboard" issue listing exactly what these custom managers detected — use
+  // that to validate the regexes below before relying on them, since regex
+  // managers are fiddly and can't be dry-run locally.
+  //
+  // Division of labour: Dependabot owns GitHub Actions (.github/dependabot.yml);
+  // Renovate runs ONLY the custom managers here, so the two never double-PR.
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+  enabledManagers: ["custom.regex"],
+
+  // The vendored deps move as a batch (note the shared "# <branch> @ <date>"
+  // stamps in the CMakeLists). Keep them in ONE PR on a weekly cadence so each
+  // bump isn't a separate ~2h SonarCloud run.
+  schedule: ["before 6am on monday"],
+  labels: ["dependencies"],
+
+  packageRules: [
+    {
+      matchManagers: ["custom.regex"],
+      groupName: "vendored C++ deps",
+    },
+  ],
+
+  customManagers: [
+    {
+      // Style 1 — pinned to a moving branch by full commit SHA, with a
+      //   "# <branch> @ <date>" comment, e.g.:
+      //     GIT_REPOSITORY https://github.com/assimp/assimp.git
+      //     GIT_TAG        ace8c31...ccd07  # master @ 2026-06-05
+      //   and the CPMAddPackage GITHUB_REPOSITORY form (imgui "docking", etc.).
+      // Bump the pinned digest to the current tip of that branch.
+      customType: "regex",
+      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      datasourceTemplate: "git-refs",
+      packageNameTemplate: "https://github.com/{{{depName}}}",
+      matchStrings: [
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{40})\\s+#\\s*(?<currentValue>[\\w./-]+)\\s+@",
+        "GITHUB_REPOSITORY\\s+(?<depName>[\\w.-]+/[\\w.-]+)\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{40})\\s+#\\s*(?<currentValue>[\\w./-]+)\\s+@",
+      ],
+    },
+    {
+      // Style 2 — pinned to a release tag, e.g. "GIT_TAG v3.0.0".
+      // Tags here always contain a "." (v3.0.0, 3.4, 1.0.20-RELEASE, ...) while
+      // the digest pins above are dot-free hex, so requiring a "." in the value
+      // cleanly separates the two styles (and skips bare-SHA pins like Jolt,
+      // which carry no branch hint and can't be auto-tracked — left manual).
+      customType: "regex",
+      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      datasourceTemplate: "github-tags",
+      versioningTemplate: "loose",
+      matchStrings: [
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentValue>v?\\d[\\w-]*\\.[\\w.-]*)",
+      ],
+    },
+    {
+      // Style 3 — SHA pinned to a *release tag*, with the tag in the comment:
+      //     GIT_TAG 5304464...c91e3  # v0.29.0   (cpp_httplib)
+      // The gold-standard pin (same shape as our SHA-pinned GitHub Actions).
+      // currentValue = the tag (drives version bumps), currentDigest = the SHA
+      // (Renovate re-pins it to the new tag's commit). The "# v<num>" comment
+      // distinguishes this from the "# <branch> @ <date>" digest pins above.
+      customType: "regex",
+      fileMatch: ["^OloEngine/vendor/CMakeLists\\.txt$"],
+      datasourceTemplate: "github-tags",
+      versioningTemplate: "loose",
+      matchStrings: [
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{40})\\s+#\\s*(?<currentValue>v?\\d[\\w.-]*)",
+        "GITHUB_REPOSITORY\\s+(?<depName>[\\w.-]+/[\\w.-]+)\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{40})\\s+#\\s*(?<currentValue>v?\\d[\\w.-]*)",
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
## Why

Dependabot can't read CMake `FetchContent` / `CPM` deps — there's no CMake ecosystem in Dependabot — so the ~26 vendored C++ dependencies in `OloEngine/vendor/CMakeLists.txt` were going untracked. This adds **Renovate** (the right tool for that) alongside Dependabot, with a strict division of labour so the two never double-PR.

## What

**`.github/renovate.json5`** (new) — three custom managers covering every pinning style in the vendor file, grouped into **one weekly PR** so each bump isn't a separate ~1.5–2h SonarCloud run:

| Style | Example | Datasource | Deps |
|---|---|---|--:|
| SHA pinned to a branch | `GIT_TAG <sha>  # master @ 2026-06-05` | `git-refs` (digest) | 13 |
| Release tag | `GIT_TAG v3.0.0` | `github-tags` | 10 |
| SHA pinned to a tag | `GIT_TAG <sha>  # v0.29.0` | `github-tags` + digest | 1 |

→ **24 of 26 deps auto-tracked, no overlaps.** `enabledManagers: ["custom.regex"]` keeps Renovate off everything else, so Dependabot still solely owns GitHub Actions. **Jolt** (bare SHA, no branch hint) and **lua** (`VERSION` keyword, not `GIT_TAG`) are left manual by design — neither bot can resolve them — and that's noted inline.

**`.github/dependabot.yml`** (tuned) — group all GitHub Actions updates into one PR (instead of up to ~11, each triggering the full CI matrix), plus an open-PR limit, the existing `github_actions` label, and a `ci` commit prefix.

## Validation

- `dependabot.yml` parses as YAML; `renovate.json5` parses as JSON5.
- Ran all three manager regexes against the real `CMakeLists.txt`: correct split (13 / 10 / 1), **zero overlaps**, Jolt correctly excluded.

## Action required to activate

`renovate.json5` is inert until the **Mend Renovate GitHub App** is installed on this repo (free for OSS). On install, Renovate opens an onboarding PR + a "Dependency Dashboard" issue showing exactly what it detected — that's the live validation of the regexes (verified here with Python `re`; Renovate uses JS regex + live digest resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Renovate support for tracking and updating vendored C++ dependencies.
  * Grouped GitHub Actions updates into a single pull request, with clearer labels and commit messages.
  * Added scheduled update handling and limits to keep dependency update activity more predictable.
* **Documentation**
  * Expanded configuration notes to clarify the scope of automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->