### PR TITLE
feat(asset): auto-import new asset files on filewatch

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1882,6 +1882,7 @@ namespace OloEngine
         dispatcher.Dispatch<MouseButtonPressedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnMouseButtonPressed));
         dispatcher.Dispatch<AssetLoadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetLoaded));
         dispatcher.Dispatch<AssetReloadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetReloaded));
+        dispatcher.Dispatch<AssetImportedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetImported));
         dispatcher.Dispatch<WindowCloseEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnWindowClose));
     }
 
@@ -3483,6 +3484,35 @@ namespace OloEngine
         }
 
         OLO_TRACE("📦 Asset Loaded Event Received!");
+        OLO_TRACE("   Handle: {}", static_cast<u64>(e.GetHandle()));
+        OLO_TRACE("   Type: {}", (int)e.GetAssetType());
+        OLO_TRACE("   Path: {}", e.GetPath().string());
+
+        return false; // Don't consume — other listeners may want this too.
+    }
+
+    bool EditorLayer::OnAssetImported(AssetImportedEvent const& e)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // A brand-new file was auto-imported from disk by the asset manager's
+        // filesystem watcher. Surface it in the Content Browser so it appears
+        // without a manual import or F5: mark the directory that now contains it
+        // dirty so the panel rescans it on the next paint. (The Content Browser
+        // grid is built from a cached filesystem tree, not the asset registry,
+        // so the registry import alone wouldn't make it show up.)
+        if (m_ContentBrowserPanel)
+        {
+            m_ContentBrowserPanel->OnAssetImported(e.GetPath());
+        }
+
+        DiagnosticsEventLog::Get().Record(
+            DiagnosticEventCategory::AssetReload,
+            std::string("Auto-imported ") + AssetUtils::AssetTypeToString(e.GetAssetType()) + " '" +
+                e.GetPath().filename().string() + "'",
+            static_cast<u64>(e.GetHandle()), e.GetPath().string());
+
+        OLO_TRACE("✨ Asset Imported Event Received!");
         OLO_TRACE("   Handle: {}", static_cast<u64>(e.GetHandle()));
         OLO_TRACE("   Type: {}", (int)e.GetAssetType());
         OLO_TRACE("   Path: {}", e.GetPath().string());

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -50,6 +50,7 @@ namespace OloEngine
 
     class AssetLoadedEvent;
     class AssetReloadedEvent;
+    class AssetImportedEvent;
     class AssetPackBuilderPanel;
     class BuildGamePanel;
 
@@ -71,6 +72,7 @@ namespace OloEngine
         bool OnMouseButtonPressed(MouseButtonPressedEvent const& e);
         bool OnAssetLoaded(AssetLoadedEvent const& e);
         bool OnAssetReloaded(AssetReloadedEvent const& e);
+        bool OnAssetImported(AssetImportedEvent const& e);
 
         void OnOverlayRender() const;
         void OnOverlayRender3D() const;

--- a/OloEditor/src/Panels/ContentBrowserPanel.cpp
+++ b/OloEditor/src/Panels/ContentBrowserPanel.cpp
@@ -1069,6 +1069,34 @@ namespace OloEngine
         m_PendingVisibleItemsRefresh = true;
     }
 
+    void ContentBrowserPanel::OnAssetImported(const std::filesystem::path& absoluteAssetPath)
+    {
+        const auto& assetRoot = m_DirectoryTree.GetAssetRoot();
+        if (assetRoot.empty() || absoluteAssetPath.empty())
+            return;
+
+        // Map the absolute file path to a directory relative to our asset root.
+        // The new file lives in its parent directory, so that's what must rescan.
+        std::error_code ec;
+        std::filesystem::path relativeDir =
+            std::filesystem::relative(absoluteAssetPath.parent_path(), assetRoot, ec);
+        if (ec)
+            return;
+
+        // A leading ".." means the path is outside the content browser's asset
+        // tree (e.g. a project-config file under the project root but not Assets/).
+        // Nothing for this panel to show.
+        if (relativeDir.empty())
+            relativeDir = ".";
+        else if (relativeDir.begin() != relativeDir.end() && *relativeDir.begin() == "..")
+            return;
+
+        // Mark the containing directory (and its ancestors) dirty. RefreshIfDirty
+        // at the top of OnImGuiRender then rescans the current directory if it is
+        // the one that changed, so the file appears on the next paint.
+        m_DirectoryTree.MarkDirty(relativeDir);
+    }
+
     // =========================================================================
     // Create Menu (preserved from original)
     // =========================================================================

--- a/OloEditor/src/Panels/ContentBrowserPanel.h
+++ b/OloEditor/src/Panels/ContentBrowserPanel.h
@@ -33,6 +33,15 @@ namespace OloEngine
         // etc.) propagate visually without restarting the editor.
         void InvalidateThumbnail(AssetHandle handle, const std::filesystem::path& path);
 
+        // React to a brand-new asset auto-imported from disk by the editor's
+        // filesystem watcher (EditorAssetManager::AutoImportNewAsset →
+        // AssetImportedEvent → EditorLayer). Marks the directory that should
+        // now contain `absoluteAssetPath` as needing a rescan, so the file
+        // shows up on the next paint without a manual import or F5. The path is
+        // absolute and resolved against this panel's asset root; paths outside
+        // the asset tree are ignored.
+        void OnAssetImported(const std::filesystem::path& absoluteAssetPath);
+
         // Drop every preview thumbnail — both the handle-keyed cache
         // and the path-keyed fast path. Called when a *texture* changes
         // because we don't track which materials reference which

--- a/OloEngine/src/OloEngine/Asset/AssetFileWatchPolicy.h
+++ b/OloEngine/src/OloEngine/Asset/AssetFileWatchPolicy.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Asset/AssetTypes.h"
+
+namespace OloEngine
+{
+    /**
+     * @brief What the editor file watcher should do with a single filesystem event.
+     *
+     * Decoupled from the watcher library so the decision is a pure function that
+     * can be unit-tested without a live filewatch thread or asset registry.
+     */
+    enum class FileWatchAction : u8
+    {
+        Ignore = 0, ///< Not actionable: drop event, non-asset, vanished file, or unloaded tracked asset.
+        Import,     ///< Untracked importable file that exists on disk -> register it in the registry.
+        Reload,     ///< Already-tracked asset that is currently loaded changed -> hot-reload it.
+    };
+
+    /**
+     * @brief Inputs the auto-import / hot-reload decision needs, gathered by the caller.
+     *
+     * Keeping these as plain booleans (rather than the filewatch enum or live
+     * registry handles) is what makes DecideFileWatchAction a pure function.
+     */
+    struct FileWatchDecisionInput
+    {
+        /// added / modified / renamed_new — i.e. "the file now exists at this path".
+        /// removed / renamed_old are drops and never set this.
+        bool IsPresenceEvent = false;
+        /// AssetType resolved from the extension; None means "not an importable file".
+        AssetType Type = AssetType::None;
+        /// The path resolves to a real, regular file on disk right now.
+        bool ExistsAsRegularFile = false;
+        /// The path already has a handle in the asset registry.
+        bool AlreadyTracked = false;
+        /// The tracked asset is currently in the loaded-asset cache.
+        bool CurrentlyLoaded = false;
+    };
+
+    /**
+     * @brief Decide how to react to a filesystem event for a path under the project.
+     *
+     * Rules (in order):
+     *  - A non-presence event (removed / renamed_old) or a path that maps to no
+     *    AssetType is ignored — this also covers the registry's own AssetRegistry.oar,
+     *    .meta sidecars, and partial-download / temp extensions, none of which are
+     *    in the extension map, so persisting the registry can't re-trigger an import.
+     *  - An already-tracked asset is hot-reloaded only when it is currently loaded.
+     *    Reloading an asset nobody has loaded is wasted work, and — critically —
+     *    suppresses the burst of partial-content reloads that a large new file
+     *    would otherwise generate as it streams onto disk during a copy (the file
+     *    is auto-imported on the first event, then every subsequent write event
+     *    would hit this branch). An unloaded asset just loads current on first use.
+     *  - An untracked path is imported only if it is a real file on disk now (the
+     *    event may describe a file that was already deleted, or a directory that
+     *    coincidentally shares an asset extension).
+     */
+    [[nodiscard]] constexpr FileWatchAction DecideFileWatchAction(const FileWatchDecisionInput& in) noexcept
+    {
+        if (!in.IsPresenceEvent || in.Type == AssetType::None)
+            return FileWatchAction::Ignore;
+
+        if (in.AlreadyTracked)
+            return in.CurrentlyLoaded ? FileWatchAction::Reload : FileWatchAction::Ignore;
+
+        return in.ExistsAsRegularFile ? FileWatchAction::Import : FileWatchAction::Ignore;
+    }
+
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -1083,8 +1083,16 @@ namespace OloEngine
         // Convert to filesystem path for easier manipulation
         std::filesystem::path filePath(file);
 
-        // Only handle modification events (ignoring added/removed for now)
-        if (change_type != filewatch::Event::modified)
+        // Accept events that mean "this file now exists / changed at this path":
+        // added (new file), modified (edited), and renamed_new (the common
+        // write-temp-then-rename save pattern). removed / renamed_old are drops —
+        // we neither reload nor import those. Handling added/renamed_new (not just
+        // modified) is what lets brand-new files be auto-imported: a freshly
+        // copied or moved-in file usually surfaces first as `added`.
+        const bool isPresenceEvent = (change_type == filewatch::Event::added) ||
+                                     (change_type == filewatch::Event::modified) ||
+                                     (change_type == filewatch::Event::renamed_new);
+        if (!isPresenceEvent)
             return;
 
         // Filter by asset extensions to avoid processing non-asset files
@@ -1152,24 +1160,84 @@ namespace OloEngine
                 }
             }
 
-            // If we found the asset, reload it
-            if (assetHandle != 0)
+            const bool alreadyTracked = (assetHandle != 0);
+
+            // Resolve the absolute path once for the existence check and import.
+            const std::filesystem::path absolutePath =
+                filePath.is_absolute() ? filePath : (m_ProjectPath / filePath);
+
+            // Gather the pure decision inputs (see AssetFileWatchPolicy.h).
+            // Existence is a single stat; loaded-status is a cheap shared lock.
+            FileWatchDecisionInput decision;
+            decision.IsPresenceEvent = true; // already filtered above
+            decision.Type = assetType;
+            decision.AlreadyTracked = alreadyTracked;
+            decision.CurrentlyLoaded = alreadyTracked && IsAssetLoaded(assetHandle);
             {
-                OLO_CORE_INFO("🔄 Hot-reload triggered for asset: {} (Handle: {}, Type: {})",
-                              pathStr, (u64)assetHandle, (int)assetType);
-                ReloadDataAsync(assetHandle);
+                std::error_code statEc;
+                decision.ExistsAsRegularFile = std::filesystem::is_regular_file(absolutePath, statEc) && !statEc;
             }
-            else
+
+            switch (DecideFileWatchAction(decision))
             {
-                // Check if this might be a new asset file
-                OLO_CORE_TRACE("File change detected for untracked file: {} (Type: {})",
-                               pathStr, (int)assetType);
-                // TODO: In the future, we could auto-import new assets here
+                case FileWatchAction::Reload:
+                    OLO_CORE_INFO("🔄 Hot-reload triggered for asset: {} (Handle: {}, Type: {})",
+                                  pathStr, (u64)assetHandle, (int)assetType);
+                    ReloadDataAsync(assetHandle);
+                    break;
+
+                case FileWatchAction::Import:
+                    AutoImportNewAsset(absolutePath, assetType);
+                    break;
+
+                case FileWatchAction::Ignore:
+                    OLO_CORE_TRACE("File change ignored: {} (tracked={}, loaded={}, exists={}, type={})",
+                                   pathStr, alreadyTracked, decision.CurrentlyLoaded,
+                                   decision.ExistsAsRegularFile, (int)assetType);
+                    break;
             }
         }
         catch (const std::exception& e)
         {
             OLO_CORE_ERROR("Error handling file system event for {}: {}", file, e.what());
+        }
+    }
+
+    void EditorAssetManager::AutoImportNewAsset(const std::filesystem::path& absolutePath, AssetType assetType)
+    {
+        OLO_PROFILER_SCOPE("EditorAssetManager::AutoImportNewAsset");
+
+        // ImportAsset is idempotent (returns the existing handle if the path is
+        // already registered) and writes *metadata only* — it does not read the
+        // file's contents, so registering a file that is still being flushed to
+        // disk is safe; the bytes are parsed lazily on first GetAsset. A burst of
+        // create/modify events for one new file therefore imports exactly once;
+        // later events fall through to the (loaded-only) reload branch.
+        const AssetHandle handle = ImportAsset(absolutePath);
+        if (handle == 0)
+        {
+            OLO_CORE_WARN("Auto-import failed for new file: {}", absolutePath.string());
+            return;
+        }
+
+        OLO_CORE_INFO("✨ Auto-imported new asset: {} (Handle: {}, Type: {})",
+                      absolutePath.string(), (u64)handle, (int)assetType);
+
+        // Persist immediately so the new handle survives an editor restart even
+        // before the next explicit save. The registry file (AssetRegistry.oar)
+        // lives under the watched project dir, but its extension maps to no
+        // AssetType, so writing it can't re-enter this handler — no import loop.
+        SerializeAssetRegistry();
+
+        // Surface it: notify the editor (Content Browser) that a new asset
+        // appeared so it refreshes without a manual import. We are already on the
+        // game thread (OnFileSystemEvent is dispatched via EnqueueGameThreadTask),
+        // so dispatch inline. The event carries the absolute path so listeners can
+        // resolve it against their own root without the project base.
+        if (Application* app = Application::TryGet())
+        {
+            AssetImportedEvent evt(handle, assetType, absolutePath);
+            app->OnEvent(evt);
         }
     }
 #endif

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -756,6 +756,17 @@ namespace OloEngine
     void EditorAssetManager::SyncWithAssetThread() noexcept
     {
 #if OLO_ASYNC_ASSETS
+        // Centralized, once-per-frame registry flush. Auto-import marks the
+        // registry dirty (m_RegistryFlushPending) instead of writing per file;
+        // here we coalesce a frame's worth of imports into a single disk write.
+        // Done before the m_AssetThread early-return so a pending flush can't be
+        // dropped, and exchange()d so an import that arrives after this point just
+        // flushes next frame. SerializeAssetRegistry() is internally noexcept.
+        if (m_RegistryFlushPending.exchange(false, std::memory_order_acq_rel))
+        {
+            SerializeAssetRegistry();
+        }
+
         if (!m_AssetThread)
             return;
 
@@ -1223,11 +1234,15 @@ namespace OloEngine
         OLO_CORE_INFO("✨ Auto-imported new asset: {} (Handle: {}, Type: {})",
                       absolutePath.string(), (u64)handle, (int)assetType);
 
-        // Persist immediately so the new handle survives an editor restart even
-        // before the next explicit save. The registry file (AssetRegistry.oar)
-        // lives under the watched project dir, but its extension maps to no
-        // AssetType, so writing it can't re-enter this handler — no import loop.
-        SerializeAssetRegistry();
+        // Mark the registry dirty rather than writing it here: dropping a folder
+        // of N files fires N separate game-thread import tasks, and a per-file
+        // SerializeAssetRegistry() would rewrite the whole registry N times. The
+        // single per-frame flush in SyncWithAssetThread() coalesces the burst
+        // into one write. (AssetRegistry.oar's extension maps to no AssetType, so
+        // writing it can't re-enter this handler — no import loop.) The handle is
+        // already live in the in-memory registry; only the disk write is deferred
+        // (by at most a frame), and Shutdown() serializes unconditionally.
+        m_RegistryFlushPending.store(true, std::memory_order_relaxed);
 
         // Surface it: notify the editor (Content Browser) that a new asset
         // appeared so it refreshes without a manual import. We are already on the

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -400,6 +400,14 @@ namespace OloEngine
         // Async reload tracking
         std::atomic<u32> m_ActiveReloadTasks{ 0 };
 
+        // Coalesced registry persistence. Auto-import (and any other game-thread
+        // path that wants the registry persisted) sets this instead of calling
+        // SerializeAssetRegistry() directly; SyncWithAssetThread() flushes it once
+        // per frame. A burst of N new files dropped at once therefore produces a
+        // single full-registry rewrite, not N. Game-thread-only in practice, but
+        // atomic to match the other watcher flags and stay defensive.
+        std::atomic<bool> m_RegistryFlushPending{ false };
+
         // Real-time file watching using filewatch library
         std::unique_ptr<filewatch::FileWatch<std::string>> m_ProjectFileWatcher;
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -3,6 +3,7 @@
 #include "AssetManagerBase.h"
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Asset/AssetFileWatchPolicy.h"
 #include "OloEngine/Asset/AssetRegistry.h"
 #include "OloEngine/Asset/AssetImporter.h"
 #include "OloEngine/Asset/AssetSystem/EditorAssetSystem.h"
@@ -352,6 +353,21 @@ namespace OloEngine
          * @param directory Directory to scan
          */
         void ScanDirectoryForAssets(const std::filesystem::path& directory);
+
+#if OLO_ASYNC_ASSETS
+        /**
+         * @brief Auto-import a newly discovered, untracked asset file (filewatch path)
+         *
+         * Registers metadata for a file the watcher saw appear under the project,
+         * persists the registry, and fires an AssetImportedEvent so the editor can
+         * surface it live. Called only from OnFileSystemEvent (game thread) after
+         * the decision policy resolves to FileWatchAction::Import.
+         *
+         * @param absolutePath Absolute path of the new file on disk (already verified to exist)
+         * @param assetType    Asset type resolved from the file extension
+         */
+        void AutoImportNewAsset(const std::filesystem::path& absolutePath, AssetType assetType);
+#endif
 
       private:
         // Asset registry for metadata management

--- a/OloEngine/src/OloEngine/Core/Events/EditorEvents.h
+++ b/OloEngine/src/OloEngine/Core/Events/EditorEvents.h
@@ -156,4 +156,57 @@ namespace OloEngine
         std::filesystem::path m_Path;
     };
 
+    /**
+     * @brief Engine event fired when a brand-new asset file is auto-imported from disk.
+     *
+     * Unlike `AssetLoadedEvent` (which fires for every async load completion) this
+     * fires only when the editor's filesystem watcher discovers a previously
+     * untracked file under the project assets dir and registers it in the asset
+     * registry. Editor layers listen for it to surface the new asset live — e.g.
+     * the Content Browser refreshes the containing directory so the file appears
+     * without a manual import or F5.
+     *
+     * The carried path is **absolute**, so listeners can resolve it against their
+     * own root (the Content Browser's asset root differs from the project root)
+     * without needing the project base.
+     *
+     * Dispatched on the game thread by `EditorAssetManager::AutoImportNewAsset`.
+     */
+    class AssetImportedEvent : public Event
+    {
+      public:
+        AssetImportedEvent(AssetHandle handle, AssetType type, const std::filesystem::path& absolutePath)
+            : m_Handle(handle), m_Type(type), m_Path(absolutePath) {}
+
+        EVENT_CLASS_TYPE(AssetImported)
+        EVENT_CLASS_CATEGORY(EventCategory::Application)
+
+        AssetHandle GetHandle() const
+        {
+            return m_Handle;
+        }
+        AssetType GetAssetType() const
+        {
+            return m_Type;
+        }
+        /// Absolute filesystem path of the newly imported asset.
+        const std::filesystem::path& GetPath() const
+        {
+            return m_Path;
+        }
+
+        std::string ToString() const override
+        {
+            return std::format("AssetImportedEvent: handle={}, type={}, path={}",
+                               static_cast<u64>(m_Handle),
+                               static_cast<int>(std::to_underlying(m_Type)),
+                               m_Path.string());
+        }
+
+      private:
+        AssetHandle m_Handle = 0;
+        AssetType m_Type = AssetType::None;
+        std::filesystem::path m_Path;
+    };
+
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Events/Event.h
+++ b/OloEngine/src/OloEngine/Events/Event.h
@@ -40,6 +40,7 @@ namespace OloEngine
         // Editor/Engine custom events
         AssetLoaded,
         AssetReloaded,
+        AssetImported,
         LocaleChanged,
     };
 

--- a/OloEngine/tests/AssetFileWatchPolicyTest.cpp
+++ b/OloEngine/tests/AssetFileWatchPolicyTest.cpp
@@ -1,0 +1,127 @@
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// AssetFileWatchPolicyTest.cpp
+//
+// Unit test for DecideFileWatchAction (OloEngine/Asset/AssetFileWatchPolicy.h),
+// the pure decision the editor's filesystem watcher uses to choose between
+// importing a new asset, hot-reloading a changed one, or ignoring the event.
+//
+// This is the auto-import feature's control-flow core, factored out of
+// EditorAssetManager::OnFileSystemEvent specifically so it can be exercised
+// without a live filewatch thread, asset registry, or GL context. The live
+// editor wiring (event broadening, registry persist, Content Browser refresh)
+// is verified by running the editor; here we pin the branch logic that decides
+// *whether* to act so a future refactor can't silently regress it — e.g.
+// re-introducing the "reload an unloaded asset" behavior that would spam
+// partial-content loads while a large new file is still copying onto disk.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Asset/AssetFileWatchPolicy.h"
+#include "OloEngine/Asset/AssetTypes.h"
+
+using namespace OloEngine;
+
+namespace
+{
+    // Baseline: a present, importable, untracked file that exists on disk —
+    // the canonical "new asset dropped in" case. Individual tests flip one
+    // field to isolate each branch.
+    FileWatchDecisionInput NewImportableFile()
+    {
+        FileWatchDecisionInput in;
+        in.IsPresenceEvent = true;
+        in.Type = AssetType::Texture2D;
+        in.ExistsAsRegularFile = true;
+        in.AlreadyTracked = false;
+        in.CurrentlyLoaded = false;
+        return in;
+    }
+} // namespace
+
+// ----------------------------------------------------------------------------
+// Import branch
+// ----------------------------------------------------------------------------
+
+TEST(AssetFileWatchPolicyTest, UntrackedExistingImportableFileIsImported)
+{
+    EXPECT_EQ(DecideFileWatchAction(NewImportableFile()), FileWatchAction::Import);
+}
+
+TEST(AssetFileWatchPolicyTest, UntrackedFileThatVanishedIsIgnored)
+{
+    // The event may describe a file already deleted, or a directory that merely
+    // shares an asset extension — only import a real, existing regular file.
+    auto in = NewImportableFile();
+    in.ExistsAsRegularFile = false;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Ignore);
+}
+
+// ----------------------------------------------------------------------------
+// Reload branch — only for already-loaded tracked assets
+// ----------------------------------------------------------------------------
+
+TEST(AssetFileWatchPolicyTest, TrackedLoadedAssetIsReloaded)
+{
+    auto in = NewImportableFile();
+    in.AlreadyTracked = true;
+    in.CurrentlyLoaded = true;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Reload);
+}
+
+TEST(AssetFileWatchPolicyTest, TrackedButUnloadedAssetIsIgnored)
+{
+    // Hot-reloading an asset nobody has loaded is wasted work, and suppresses
+    // the burst of partial-content reloads a large new file would otherwise
+    // trigger as it streams onto disk (imported on the first event, then every
+    // subsequent write event would land here). It loads current on first use.
+    auto in = NewImportableFile();
+    in.AlreadyTracked = true;
+    in.CurrentlyLoaded = false;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Ignore);
+}
+
+TEST(AssetFileWatchPolicyTest, ExistenceIsIrrelevantOnceTracked)
+{
+    // The existence stat is only consulted on the untracked import path; a
+    // tracked-loaded asset reloads regardless (ReloadData handles a missing
+    // file by substituting a placeholder).
+    auto in = NewImportableFile();
+    in.AlreadyTracked = true;
+    in.CurrentlyLoaded = true;
+    in.ExistsAsRegularFile = false;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Reload);
+}
+
+// ----------------------------------------------------------------------------
+// Ignore branch — non-actionable events / non-assets
+// ----------------------------------------------------------------------------
+
+TEST(AssetFileWatchPolicyTest, NonPresenceEventIsAlwaysIgnored)
+{
+    // removed / renamed_old map to IsPresenceEvent == false; never act on a drop,
+    // even for a tracked-loaded asset.
+    auto in = NewImportableFile();
+    in.AlreadyTracked = true;
+    in.CurrentlyLoaded = true;
+    in.IsPresenceEvent = false;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Ignore);
+}
+
+TEST(AssetFileWatchPolicyTest, NonAssetTypeIsIgnored)
+{
+    // AssetType::None covers extensions outside the map: temp/partial-download
+    // files, .meta sidecars, and the registry's own AssetRegistry.oar — so
+    // persisting the registry after an import can't re-trigger an import loop.
+    auto in = NewImportableFile();
+    in.Type = AssetType::None;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Ignore);
+
+    // ...even if it happens to be a tracked, loaded, existing path.
+    in.AlreadyTracked = true;
+    in.CurrentlyLoaded = true;
+    EXPECT_EQ(DecideFileWatchAction(in), FileWatchAction::Ignore);
+}

--- a/OloEngine/tests/AssetLoadedEventTest.cpp
+++ b/OloEngine/tests/AssetLoadedEventTest.cpp
@@ -98,3 +98,59 @@ TEST(AssetLoadedEventTest, DispatcherSkipsMismatchedHandler)
     EXPECT_FALSE(reloadedHandlerRan);
     EXPECT_FALSE(evt.Handled);
 }
+
+// ----------------------------------------------------------------------------
+// AssetImportedEvent — fired only when the filewatch auto-imports a new file.
+// Must be a distinct EventType so its Content Browser-refresh listener never
+// fires for the much more frequent AssetLoaded / AssetReloaded events.
+// ----------------------------------------------------------------------------
+
+TEST(AssetImportedEventTest, ExposesPayload)
+{
+    const AssetHandle handle = 9876543ULL;
+    const AssetType type = AssetType::Texture2D;
+    const std::filesystem::path path = "C:/proj/Assets/textures/new.png";
+
+    AssetImportedEvent evt(handle, type, path);
+
+    EXPECT_EQ(evt.GetHandle(), handle);
+    EXPECT_EQ(evt.GetAssetType(), type);
+    EXPECT_EQ(evt.GetPath(), path);
+}
+
+TEST(AssetImportedEventTest, IdentifiesItselfAsAssetImported)
+{
+    AssetImportedEvent evt(1ULL, AssetType::Mesh, "Assets/m.olomesh");
+
+    EXPECT_EQ(AssetImportedEvent::GetStaticType(), EventType::AssetImported);
+    EXPECT_EQ(evt.GetEventType(), EventType::AssetImported);
+    EXPECT_STREQ(evt.GetName(), "AssetImported");
+    EXPECT_TRUE(evt.IsInCategory(EventCategory::Application));
+}
+
+TEST(AssetImportedEventTest, IsDistinctFromLoadedAndReloaded)
+{
+    // A listener wired for AssetImported (Content Browser refresh) must not also
+    // fire for AssetLoaded (every async load) or AssetReloaded (every hot-reload).
+    EXPECT_NE(AssetImportedEvent::GetStaticType(), AssetLoadedEvent::GetStaticType());
+    EXPECT_NE(AssetImportedEvent::GetStaticType(), AssetReloadedEvent::GetStaticType());
+}
+
+TEST(AssetImportedEventTest, DispatcherInvokesMatchingHandler)
+{
+    AssetImportedEvent evt(55ULL, AssetType::Audio, "Assets/sfx/blip.wav");
+
+    bool handlerRan = false;
+    EventDispatcher dispatcher(evt);
+    const bool dispatched = dispatcher.Dispatch<AssetImportedEvent>(
+        [&](AssetImportedEvent& e)
+        {
+            handlerRan = true;
+            EXPECT_EQ(e.GetHandle(), 55ULL);
+            return true;
+        });
+
+    EXPECT_TRUE(dispatched);
+    EXPECT_TRUE(handlerRan);
+    EXPECT_TRUE(evt.Handled);
+}

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(OloEngine-Tests
 		AssetBinaryIntegrityTest.cpp
 		AssetContentValidityTest.cpp
 		AssetExtensionsCoverageTest.cpp
+		AssetFileWatchPolicyTest.cpp
 		SRGBTextureSupportTest.cpp
 		AssetSceneLoadTest.cpp
 		AssetGenerationTest.cpp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic processing of newly imported assets detected from filesystem changes.
  * Updated the content browser to refresh the affected directories when new assets are imported.
  * Introduced an editor “asset imported” notification event for listeners.

* **Bug Fixes**
  * Improved file-watcher handling to correctly decide between ignoring, importing, or reloading assets based on state and file existence.
  * Ensured registry updates are coalesced to prevent excessive persistence work.

* **Tests**
  * Added unit tests for the new file-watch decision logic and the asset imported event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->