### PR TITLE
SoundGraph: sample-accurate external (game-code) triggers

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraph.h
@@ -500,9 +500,18 @@ namespace OloEngine::Audio::SoundGraph
         /// Connect Input Event to Input Event
         void AddRoute(InputEvent& source, InputEvent& destination) const noexcept
         {
+            // Phase 4 (docs/soundgraph-metasounds-refactor.md): forward the sample
+            // offset so a graph-input trigger fired at frame N reaches the destination
+            // node's trigger input at frame N instead of being quantised to the block
+            // boundary. This is the hop an *external* (game-code) trigger takes —
+            // SoundGraphSource enqueues the event with an offset, the audio thread
+            // drains it into SoundGraph::SendInputEvent, and this route carries the
+            // offset the last hop to the consuming node. Binding m_OffsetEvent makes
+            // InputEvent::operator() prefer the offset-aware path; a value-only fire
+            // still arrives with the default offset 0 (block start).
             InputEvent* dest = &destination;
-            source.m_Event = [dest](float v)
-            { (*dest)(v); };
+            source.m_OffsetEvent = [dest](float v, i32 sampleOffset)
+            { (*dest)(v, sampleOffset); };
         }
 
         /// Connect Output Event to Output Event
@@ -514,8 +523,11 @@ namespace OloEngine::Audio::SoundGraph
             sizet currentRouteId = routeCounter.fetch_add(1, std::memory_order_relaxed);
             std::string routeIdStr = "Route_" + std::to_string(currentRouteId);
             Identifier routeId(routeIdStr);
-            AddInEvent(routeId, [dest](float v)
-                       { (*dest)(v); });
+            // Phase 4: forward the sample offset through the output→output hop too, so
+            // a node firing its output trigger mid-block keeps the exact frame as the
+            // event propagates onward (the offset defaults to 0 for value-only fires).
+            AddInEvent(routeId, [dest](float v, i32 sampleOffset)
+                       { (*dest)(v, sampleOffset); });
             // Use the shared_ptr from InEvents for the newly created routeHandler
             if (auto routeHandlerPtr = InEvents.find(routeId); routeHandlerPtr != InEvents.end())
                 source.AddDestination(routeHandlerPtr->second);
@@ -986,15 +998,28 @@ namespace OloEngine::Audio::SoundGraph
             return cell.SetScalarFromValue(value);
         }
 
-        bool SendInputEvent(Identifier endpointID, choc::value::ValueView value)
+        /// Fire a graph input event. `sampleOffset` (Phase 4) is the frame within the
+        /// current block at which the event takes effect; it threads through the
+        /// offset-aware event system to the consuming node's trigger so an externally
+        /// scheduled (game-code) trigger lands on the exact sample instead of being
+        /// quantised to the block start. Defaults to 0 (block boundary) so existing
+        /// callers keep their behaviour.
+        bool SendInputEvent(Identifier endpointID, choc::value::ValueView value, i32 sampleOffset = 0)
         {
             auto endpoint = InEvents.find(endpointID);
 
-            if (endpoint == InEvents.end() || !endpoint->second || !endpoint->second->m_Event)
+            if (endpoint == InEvents.end() || !endpoint->second)
                 return false;
 
-            // Handle float values for events
-            endpoint->second->m_Event(value.isFloat32() ? value.getFloat32() : 1.0f);
+            // A trigger-consuming node (and, after Phase 4, a graph-input route) binds
+            // m_OffsetEvent; a value-only consumer binds m_Event. Dispatch through
+            // operator() so whichever is bound is invoked and the sample offset is
+            // forwarded — the offset is dropped only if the endpoint has no handler.
+            InputEvent& inEvent = *endpoint->second;
+            if (!inEvent.m_Event && !inEvent.m_OffsetEvent)
+                return false;
+
+            inEvent(value.isFloat32() ? value.getFloat32() : 1.0f, sampleOffset);
             return true;
         }
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -491,6 +491,9 @@ namespace OloEngine::Audio::SoundGraph
             // validated against the old graph's endpoints could land on the new graph the
             // next time the audio thread drains.
             m_ParameterUpdateQueue.Clear();
+            // Likewise discard external triggers queued for the previous graph so a footstep
+            // aimed at the old graph's endpoints can't leak onto the new one.
+            m_InputEventQueue.Clear();
 
             if (m_Graph)
             {
@@ -642,6 +645,40 @@ namespace OloEngine::Audio::SoundGraph
         return true;
     }
 
+    i32 SoundGraphSource::ClampInputEventOffset(i32 sampleOffset, u32 blockSize) noexcept
+    {
+        if (blockSize == 0)
+            return 0;
+        if (sampleOffset < 0)
+            return 0; // legacy block-boundary event with no frame info -> frame 0
+        const i32 maxOffset = static_cast<i32>(blockSize) - 1;
+        return sampleOffset > maxOffset ? maxOffset : sampleOffset;
+    }
+
+    bool SoundGraphSource::SendInputEvent(u32 endpointID, f32 value, i32 sampleOffset)
+    {
+        // Main thread (single producer). Hand the event off to the audio thread; it is
+        // applied at its clamped sample offset just before the next Process (see
+        // DrainInputEvents). We deliberately do NOT touch m_Graph here — it may be swapped
+        // by ReplaceGraph on this thread, and InEvents is the audio thread's to read.
+        // Endpoint existence is resolved on the audio thread; an unknown name simply no-ops.
+        InputEventEntry entry;
+        entry.m_EndpointID = endpointID;
+        // Triggers act on the offset, not the value; keep the payload finite regardless.
+        entry.m_Value = std::isfinite(value) ? value : 1.0f;
+        entry.m_SampleOffset = sampleOffset;
+        return m_InputEventQueue.Push(entry);
+    }
+
+    bool SoundGraphSource::SendInputEvent(std::string_view endpointName, f32 value, i32 sampleOffset)
+    {
+        if (endpointName.empty())
+            return false;
+        // FNV hash matches static_cast<u32>(Identifier{name}), the key InEvents is built
+        // from, so the audio thread reconstructs the same Identifier to find the endpoint.
+        return SendInputEvent(OloEngine::Hash::GenerateFNVHash(endpointName), value, sampleOffset);
+    }
+
     void SoundGraphSource::ResetPlayback()
     {
         OLO_PROFILE_FUNCTION();
@@ -719,6 +756,31 @@ namespace OloEngine::Audio::SoundGraph
         while (m_ParameterUpdateQueue.Pop(update))
         {
             if (m_Graph->SendInputValue(update.m_ParameterID, update.m_Value.GetView(), /*interpolate=*/false))
+                ++applied;
+        }
+        return applied;
+    }
+
+    u32 SoundGraphSource::DrainInputEvents(u32 frameCount)
+    {
+        // Audio thread. Wait-free, allocation-free hand-off drain: pop each externally
+        // scheduled trigger/event and fire it into the graph at its block-clamped sample
+        // offset. Must run before SoundGraph::Process for this block so the consuming
+        // node's offset-aware InputEvent handler Fire()s its trigger before Process()
+        // Consume()s and splits the per-frame loop at that frame — that is what makes the
+        // external trigger sample-accurate instead of block-quantised. A zero-length block
+        // has no frame to schedule into, so leave the queue for the next non-empty block.
+        if (!m_Graph || frameCount == 0)
+            return 0;
+
+        u32 applied = 0;
+        InputEventEntry entry;
+        while (m_InputEventQueue.Pop(entry))
+        {
+            const i32 offset = ClampInputEventOffset(entry.m_SampleOffset, frameCount);
+            // createFloat32 here mirrors the existing Play-request fire below; the event
+            // system only reads the float, and trigger consumers ignore even that.
+            if (m_Graph->SendInputEvent(Identifier(entry.m_EndpointID), choc::value::createFloat32(entry.m_Value), offset))
                 ++applied;
         }
         return applied;
@@ -812,6 +874,12 @@ namespace OloEngine::Audio::SoundGraph
             // Apply any parameter writes the main thread queued since the last block,
             // before the graph reads its input cells. Wait-free and allocation-free.
             UpdateChangedParameters();
+
+            // Fire any external (game-code) triggers the main thread queued since the last
+            // block, each at its sample offset within THIS block (clamped to [0, frameCount)).
+            // Must precede Process so the consuming nodes split their per-frame loop at the
+            // exact frame — sample-accurate external triggers, not block-quantised.
+            DrainInputEvents(frameCount);
 
             // Begin processing block (refill wave player buffers)
             m_Graph->BeginProcessBlock();

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
@@ -160,6 +160,31 @@ namespace OloEngine::Audio::SoundGraph
         }
 
         bool SendPlayEvent();
+
+        /** Schedule a sample-accurate external (game-code) trigger/event into the graph.
+            `endpointID` is the hashed graph input-event name (== static_cast<u32>(Identifier{name})
+            == Hash::GenerateFNVHash(name)); the string_view overload hashes for you.
+            `sampleOffset` is the frame within the NEXT processed audio block at which the
+            event fires (e.g. a footstep synced to an animation frame); the audio thread
+            clamps it to [0, blockSize) via ClampInputEventOffset, so an out-of-range or
+            negative offset still lands sanely. `value` is the event's float payload (NaN/Inf
+            sanitised to 1.0f); trigger consumers ignore it and act on the offset only.
+
+            Main thread / single producer (same contract as SetParameter): the event is
+            handed to the audio thread through a lock-free queue and applied just before the
+            graph's Process for that block. Returns false only if the hand-off queue is full
+            (event dropped — preferable to blocking gameplay); it does NOT verify the endpoint
+            exists (unknown names no-op on the audio thread). */
+        bool SendInputEvent(u32 endpointID, f32 value = 1.0f, i32 sampleOffset = 0);
+        bool SendInputEvent(std::string_view endpointName, f32 value = 1.0f, i32 sampleOffset = 0);
+
+        /** Clamp an externally supplied per-event frame offset into the valid range for a
+            block of `blockSize` frames: [0, blockSize). A negative offset (a legacy
+            block-boundary event with no frame info) clamps to 0; an offset at or beyond the
+            block end clamps to the last frame so the event still fires this block. blockSize
+            == 0 yields 0. Static + pure so the validation is unit-testable without a device. */
+        static i32 ClampInputEventOffset(i32 sampleOffset, u32 blockSize) noexcept;
+
         void ResetPlayback();
         u64 GetCurrentFrame() const
         {
@@ -229,6 +254,14 @@ namespace OloEngine::Audio::SoundGraph
 
         /** Called from audio thread each block to push queued parameter changes. */
         void UpdateChangedParameters();
+
+        /** Drain the external input-event hand-off queue, firing each queued trigger/event
+            into the graph at its (block-clamped) sample offset. Audio-thread only: wait-free
+            and allocation-free. Must run before SoundGraph::Process for the same block so the
+            consuming nodes observe the trigger when they process. `frameCount` is the block
+            size used to clamp each event's offset to [0, frameCount). Returns the number of
+            events the graph accepted. */
+        u32 DrainInputEvents(u32 frameCount);
 
         /** SoundGraph event handlers (called from audio thread) */
         static void HandleGraphEvent(void* context, u64 frameIndex, Identifier endpointID, const choc::value::ValueView& eventData);
@@ -301,6 +334,24 @@ namespace OloEngine::Audio::SoundGraph
             Audio::PreAllocatedValue m_Value;
         };
         Audio::LockFreeEventQueue<ParameterUpdate, 256> m_ParameterUpdateQueue;
+
+        // Lock-free hand-off of external (game-code) trigger/event fires from the main
+        // thread (producer: SendInputEvent enqueues) to the audio thread (consumer:
+        // ProcessSamples drains via DrainInputEvents just before SoundGraph::Process).
+        // Each entry carries the target graph input-event hash, the float payload, and
+        // the per-event sample offset within the block. Unlike the Play flag (always
+        // block-quantised to frame 0), this is what makes an externally scheduled
+        // footstep/SFX land on its exact sample — the audio thread clamps the offset to
+        // the block and threads it through SoundGraph::SendInputEvent's offset-aware path.
+        // Events are float-valued (triggers ignore the value), so a plain f32 suffices —
+        // no PreAllocatedValue needed.
+        struct InputEventEntry
+        {
+            u32 m_EndpointID = 0;
+            f32 m_Value = 1.0f;
+            i32 m_SampleOffset = 0;
+        };
+        Audio::LockFreeEventQueue<InputEventEntry, 256> m_InputEventQueue;
 
         AtomicFlag m_PlayRequestFlag;
         bool m_PresetIsInitialized = false;

--- a/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
+++ b/OloEngine/tests/SoundGraphSampleAccurateTriggerTest.cpp
@@ -28,17 +28,33 @@
 //   * WavePlayer: Play/Stop are consumed at their exact frame (observed through
 //     the OnStop / OnFinished output-event offset, since audio output needs a
 //     loaded asset which a unit test does not mount).
+//
+// The follow-on increment (external, game-code triggers) is pinned here too:
+//   * SoundGraph::SendInputEvent forwards a sample offset through a graph-input
+//     route to the consuming node's trigger (the last intra-graph hop).
+//   * SoundGraphSource::ClampInputEventOffset validates an externally supplied
+//     offset into [0, blockSize).
+//   * End-to-end through the real audio path: a trigger handed to
+//     SoundGraphSource::SendInputEvent with a mid-block offset is drained by
+//     ProcessSamples and retriggers a wired envelope at that exact frame —
+//     i.e. an external footstep is sample-accurate, not block-quantised.
 // =============================================================================
 
 #include "OloEngine/Audio/SoundGraph/NodeProcessor.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraph.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSource.h"
 #include "OloEngine/Audio/SoundGraph/StreamRefs.h"
 #include "OloEngine/Audio/SoundGraph/Nodes/EnvelopeNodes.h"
 #include "OloEngine/Audio/SoundGraph/Nodes/TriggerNodes.h"
 #include "OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h"
 #include "OloEngine/Core/Identifier.h"
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Core/Ref.h"
 #include "OloEngine/Core/UUID.h"
 
+#include <choc/containers/choc_Value.h>
+
+#include <array>
 #include <vector>
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace)
@@ -405,4 +421,154 @@ TEST_F(SoundGraphSampleAccurateTriggerTest, WavePlayerWithoutTriggersFiresNoEven
     wp.Process(kBlock);
 
     EXPECT_TRUE(capture.m_Offsets.empty()) << "no trigger fired -> no Play/Stop events";
+}
+
+// -----------------------------------------------------------------------------
+// External (game-code) trigger path: offset survives the graph-input route, the
+// source clamps it, and an externally scheduled trigger lands on the exact frame.
+// -----------------------------------------------------------------------------
+
+namespace
+{
+    /// Build a graph exposing input event `eventName`, routed to the (already
+    /// constructed) `node`'s `nodeEvent` input. The graph takes ownership of `node`;
+    /// the caller keeps a raw pointer (node.get()) for inspection. Sample rate is set
+    /// before Init so node rates compute.
+    Ref<sg::SoundGraph> MakeEventRoutedGraph(Scope<sg::NodeProcessor> node, UUID nodeID,
+                                             Identifier eventName, Identifier nodeEvent)
+    {
+        auto graph = Ref<sg::SoundGraph>::Create("ExternalTrigger", UUID());
+        graph->AddInEvent(eventName); // graph input-event endpoint
+        graph->AddNode(std::move(node));
+
+        EXPECT_TRUE(graph->AddInputEventsRoute(eventName, nodeID, nodeEvent))
+            << "MakeEventRoutedGraph: failed to route the graph input event to the node";
+        graph->SetSampleRate(kSampleRate);
+        graph->Init();
+        return graph;
+    }
+} // namespace
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ClampInputEventOffsetKeepsOffsetsWithinTheBlock)
+{
+    using sg::SoundGraphSource;
+    // Negative (no frame info) clamps to the block start.
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(-1, 480), 0);
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(-1000, 480), 0);
+    // In-range offsets pass through untouched.
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(0, 480), 0);
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(137, 480), 137);
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(479, 480), 479);
+    // At/over the block end clamps to the last frame so the event still fires this block.
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(480, 480), 479);
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(99999, 480), 479);
+    // A zero-length block has no frame to land on.
+    EXPECT_EQ(SoundGraphSource::ClampInputEventOffset(10, 0), 0);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, GraphSendInputEventForwardsSampleOffsetThroughRoute)
+{
+    constexpr i32 kOffset = 271;
+
+    auto capture = CreateScope<OffsetCaptureNode>(UUID());
+    auto* capturePtr = capture.get();
+    const UUID captureID = capture->m_ID;
+    Ref<sg::SoundGraph> graph = MakeEventRoutedGraph(std::move(capture), captureID, Identifier("Footstep"), Identifier("In"));
+
+    // Fire the graph input event with a mid-block offset — the increment under test
+    // is that the offset reaches the consumer instead of being snapped to frame 0.
+    ASSERT_TRUE(graph->SendInputEvent(Identifier("Footstep"), choc::value::createFloat32(1.0f), kOffset));
+
+    ASSERT_EQ(capturePtr->m_Offsets.size(), 1u);
+    EXPECT_EQ(capturePtr->m_Offsets[0], kOffset) << "external trigger offset must survive the graph-input route";
+    EXPECT_FLOAT_EQ(capturePtr->m_Values[0], 1.0f);
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, GraphSendInputEventDefaultsToBlockStart)
+{
+    auto capture = CreateScope<OffsetCaptureNode>(UUID());
+    auto* capturePtr = capture.get();
+    const UUID captureID = capture->m_ID;
+    Ref<sg::SoundGraph> graph = MakeEventRoutedGraph(std::move(capture), captureID, Identifier("Footstep"), Identifier("In"));
+
+    // No offset argument -> legacy block-boundary timing (frame 0).
+    ASSERT_TRUE(graph->SendInputEvent(Identifier("Footstep"), choc::value::createFloat32(1.0f)));
+
+    ASSERT_EQ(capturePtr->m_Offsets.size(), 1u);
+    EXPECT_EQ(capturePtr->m_Offsets[0], 0) << "a value-only external fire must land at the block start";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, GraphSendInputEventOnUnknownEndpointReturnsFalse)
+{
+    auto capture = CreateScope<OffsetCaptureNode>(UUID());
+    auto* capturePtr = capture.get();
+    const UUID captureID = capture->m_ID;
+    Ref<sg::SoundGraph> graph = MakeEventRoutedGraph(std::move(capture), captureID, Identifier("Footstep"), Identifier("In"));
+
+    EXPECT_FALSE(graph->SendInputEvent(Identifier("NoSuchEvent"), choc::value::createFloat32(1.0f), 100));
+    EXPECT_TRUE(capturePtr->m_Offsets.empty()) << "an unknown endpoint must fire nothing";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ExternalTriggerThroughSourceRetriggersEnvelopeAtExactFrame)
+{
+    constexpr i32 kOffset = 222;
+    constexpr u32 kChannels = 2; // SoundGraphSource default output channel count
+
+    // AD envelope wired to a graph input event named "Footstep".
+    auto env = CreateScope<sg::ADEnvelope>("AD", UUID());
+    env->m_AttackTime.SetDefault(0.05f); // ~2400-sample attack, still rising across the block
+    env->m_DecayTime.SetDefault(0.05f);
+    auto* envPtr = env.get();
+    const UUID envID = env->m_ID;
+    Ref<sg::SoundGraph> graph = MakeEventRoutedGraph(std::move(env), envID, Identifier("Footstep"), sg::ADEnvelope::IDs::s_Trigger);
+
+    sg::SoundGraphSource source;
+    source.ReplaceGraph(graph);
+
+    // Game code schedules a footstep at a mid-block sample offset (the external path).
+    ASSERT_TRUE(source.SendInputEvent("Footstep", 1.0f, kOffset));
+
+    // Drive one real audio block through the source; it drains the queue and fires the
+    // trigger at its exact frame before SoundGraph::Process runs (device-free, same as
+    // SoundGraphParameterWiringTest).
+    std::array<f32, kBlock * kChannels> bus{};
+    f32* busPtr = bus.data();
+    source.ProcessSamples(&busPtr, kBlock);
+
+    const f32* out = envPtr->m_OutEnvelope.Data();
+    for (i32 f = 0; f < kOffset; ++f)
+        EXPECT_FLOAT_EQ(out[static_cast<u32>(f)], 0.0f)
+            << "envelope must be silent before the external trigger's frame " << f;
+    EXPECT_GT(out[static_cast<u32>(kOffset)], 0.0f)
+        << "attack must start at the external trigger's exact frame, not the block boundary";
+    EXPECT_GT(out[static_cast<u32>(kOffset) + 50], out[static_cast<u32>(kOffset)])
+        << "attack must be rising after the external trigger";
+}
+
+TEST_F(SoundGraphSampleAccurateTriggerTest, ExternalTriggerThroughSourceClampsOutOfRangeOffsetIntoTheBlock)
+{
+    constexpr u32 kChannels = 2;
+
+    auto env = CreateScope<sg::ADEnvelope>("AD", UUID());
+    env->m_AttackTime.SetDefault(0.05f);
+    env->m_DecayTime.SetDefault(0.05f);
+    auto* envPtr = env.get();
+    const UUID envID = env->m_ID;
+    Ref<sg::SoundGraph> graph = MakeEventRoutedGraph(std::move(env), envID, Identifier("Footstep"), sg::ADEnvelope::IDs::s_Trigger);
+
+    sg::SoundGraphSource source;
+    source.ReplaceGraph(graph);
+
+    // An offset past the block end must clamp to the last frame and still fire this block,
+    // not vanish — so only the final frame shows the attack onset.
+    ASSERT_TRUE(source.SendInputEvent("Footstep", 1.0f, /*sampleOffset=*/100000));
+
+    std::array<f32, kBlock * kChannels> bus{};
+    f32* busPtr = bus.data();
+    source.ProcessSamples(&busPtr, kBlock);
+
+    const f32* out = envPtr->m_OutEnvelope.Data();
+    for (u32 f = 0; f < kBlock - 1; ++f)
+        EXPECT_FLOAT_EQ(out[f], 0.0f) << "clamped trigger must stay silent until the last frame, was at " << f;
+    EXPECT_GT(out[kBlock - 1], 0.0f) << "an out-of-range offset must clamp to the block's last frame";
 }

--- a/docs/soundgraph-metasounds-refactor.md
+++ b/docs/soundgraph-metasounds-refactor.md
@@ -307,13 +307,39 @@ inspect `SampleOffset` and split their `Execute` at that frame index.
 >   producer-fires-mid-block → wired-consumer-reacts case, and WavePlayer Play/Stop
 >   consumed at their exact frame (observed via the output-event offset, since audio
 >   output needs a loaded asset a unit test doesn't mount).
-> - **Out of scope (follow-on).** External triggers from game code still arrive via
->   `SoundGraphSource`'s `SendInputEvent`/lock-free queue, which is drained *before*
->   `Process` and carries no per-event frame index, so an externally-scheduled
->   footstep is still block-quantised until that queue learns to carry offsets. The
->   node-level machinery and the intra-graph producer→consumer path are sample-accurate
->   today; wiring the external scheduler and typed `TriggerRef` connections is the
->   remaining increment.
+> **Status (2026-06-24): external (game-code) triggers now sample-accurate too.**
+> The remaining increment landed. External triggers no longer snap to the block
+> boundary — `SoundGraphSource` carries a per-event sample offset end to end:
+>
+> - **Offset-carrying external queue** (`SoundGraphSource.{h,cpp}`). A new lock-free
+>   `m_InputEventQueue` of `{endpointID, value, sampleOffset}` plus a public
+>   `SendInputEvent(u32 | std::string_view, value, sampleOffset)` (the name overload
+>   FNV-hashes, matching the parameter path). Game code (main thread, single producer)
+>   schedules a trigger at a frame within the next block; the audio thread drains it in
+>   `ProcessSamples` via `DrainInputEvents`, *before* `SoundGraph::Process`, so the
+>   consuming node observes the trigger when it processes. The queue is cleared under
+>   the suspend protocol on `ReplaceGraph` (no stale triggers leak onto a new graph).
+> - **Offset validation.** `SoundGraphSource::ClampInputEventOffset` clamps each
+>   incoming offset to `[0, blockSize)` on the audio thread (negative → frame 0;
+>   at/over the block end → last frame, so the event still fires this block). Static +
+>   pure, so it is unit-tested without a device.
+> - **Offset-threaded `SendInputEvent` + routes** (`SoundGraph.{h,cpp}`).
+>   `SoundGraph::SendInputEvent` gained an `i32 sampleOffset = 0` and now dispatches
+>   through `InputEvent::operator()` (so it reaches an offset-aware *or* a value-only
+>   handler), and **both** `AddRoute` overloads forward the offset — the graph-input →
+>   node-input hop an external trigger takes now preserves the frame instead of
+>   dropping it. Defaults keep every existing caller block-boundary.
+> - **Typed `TriggerRef` connections** stay future work and are **not** needed for the
+>   external path: the offset flows through the offset-aware event system to the node's
+>   `TriggerRef.Fire(offset)`, which is the same proven mechanism the intra-graph path
+>   uses. Direct producer-`Trigger` → consumer-`TriggerRef` binding (bypassing events)
+>   remains the only unused `TriggerRef::Bind` seam.
+> - **Tests.** `SoundGraphSampleAccurateTriggerTest.cpp` adds: the offset clamp; that a
+>   graph `SendInputEvent` offset survives the input route to the consumer (and defaults
+>   to frame 0, and no-ops on an unknown endpoint); and the end-to-end case — a footstep
+>   handed to `SoundGraphSource::SendInputEvent` with a mid-block offset, drained through
+>   the real `ProcessSamples` path, retriggers a wired AD envelope at that exact frame
+>   (and an out-of-range offset clamps into the block instead of vanishing).
 
 ## Decision log
 


### PR DESCRIPTION
Thread a per-event sample offset through SoundGraphSource's input-event queue and SoundGraph::SendInputEvent so externally scheduled triggers land on the exact sample instead of the block boundary.