### PR TITLE
Implement buoyancy sampling from FFT ocean surface in BuoyancySystem

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
@@ -116,13 +116,13 @@ namespace OloEngine
                 // approximation. The proxy is produced by the renderer's water
                 // pass (Scene.cpp); fall back to Gerstner if it hasn't been built
                 // yet (e.g. headless physics with no render pass), so non-rendered
-                // scenes stay backward-compatible. Clamp the height scale exactly
-                // as the render path does so buoyancy and the shader agree.
+                // scenes stay backward-compatible. Clamp the height scale through
+                // the shared helper the render path uses so buoyancy and the
+                // shader agree (single source of truth, can't drift).
                 if (wc.m_UseFFT && wc.m_OceanField && wc.m_OceanField->GetField().IsValid())
                 {
                     w.m_OceanField = wc.m_OceanField;
-                    w.m_FFTHeightScale =
-                        std::isfinite(wc.m_FFTHeightScale) ? std::clamp(wc.m_FFTHeightScale, 0.0f, 20.0f) : 1.0f;
+                    w.m_FFTHeightScale = WaterSurface::ClampFFTHeightScale(wc.m_FFTHeightScale);
                 }
 
                 waters.push_back(w);

--- a/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Physics3D/JoltScene.h"
 #include "OloEngine/Physics3D/JoltBody.h"
 #include "OloEngine/Physics3D/Physics3DTypes.h"
+#include "OloEngine/Renderer/Ocean/OceanFFTField.h"
 #include "OloEngine/Renderer/WaterSurface.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/Entity.h"
@@ -30,6 +31,11 @@ namespace OloEngine
             glm::mat4 m_InvModel{ 1.0f };
             f32 m_HalfX = 0.0f;
             f32 m_HalfZ = 0.0f;
+            // When the tile renders the Tessendorf FFT ocean and its CPU proxy has
+            // been evaluated, sample that surface (the one actually rendered)
+            // instead of the analytic Gerstner field above. Null ⇒ Gerstner.
+            Ref<Ocean::OceanFFTField> m_OceanField;
+            f32 m_FFTHeightScale = 1.0f; ///< artist multiplier (WaterComponent::m_FFTHeightScale, u_FFTParams.z)
         };
 
         [[nodiscard]] bool IsOverFootprint(const WaterVolume& w, const glm::vec3& worldPos)
@@ -103,6 +109,22 @@ namespace OloEngine
                 w.m_InvModel = glm::inverse(model);
                 w.m_HalfX = std::clamp(safeSizeX, 0.1f, 10000.0f) * 0.5f;
                 w.m_HalfZ = std::clamp(safeSizeZ, 0.1f, 10000.0f) * 0.5f;
+
+                // FFT ocean (WATER §5.1): when the entity renders the Tessendorf
+                // spectral surface and its CPU proxy has been evaluated, the
+                // buoyant body should track *that* surface, not the Gerstner
+                // approximation. The proxy is produced by the renderer's water
+                // pass (Scene.cpp); fall back to Gerstner if it hasn't been built
+                // yet (e.g. headless physics with no render pass), so non-rendered
+                // scenes stay backward-compatible. Clamp the height scale exactly
+                // as the render path does so buoyancy and the shader agree.
+                if (wc.m_UseFFT && wc.m_OceanField && wc.m_OceanField->GetField().IsValid())
+                {
+                    w.m_OceanField = wc.m_OceanField;
+                    w.m_FFTHeightScale =
+                        std::isfinite(wc.m_FFTHeightScale) ? std::clamp(wc.m_FFTHeightScale, 0.0f, 20.0f) : 1.0f;
+                }
+
                 waters.push_back(w);
             }
         }
@@ -169,8 +191,16 @@ namespace OloEngine
             for (const glm::vec3& sign : kCornerSigns)
             {
                 const glm::vec3 probeWorld = bodyPos + bodyRot * (sign * ext);
-                const f32 surfaceY = WaterSurface::SampleHeight(water->m_Params,
-                                                                glm::vec2(probeWorld.x, probeWorld.z), rawTime);
+                // FFT ocean if the tile is backed by an evaluated CPU proxy,
+                // otherwise the analytic Gerstner field. Both read the column
+                // height above the probe's world XZ (the FFT path mirrors the
+                // shader's planeHeight + disp.y * heightScale).
+                const glm::vec2 probeXZ(probeWorld.x, probeWorld.z);
+                const f32 surfaceY =
+                    water->m_OceanField
+                        ? WaterSurface::SampleHeightFFT(*water->m_OceanField, probeXZ,
+                                                        water->m_Params.m_PlaneHeight, water->m_FFTHeightScale)
+                        : WaterSurface::SampleHeight(water->m_Params, probeXZ, rawTime);
                 const f32 depth = surfaceY - probeWorld.y;
                 if (!(depth > 0.0f)) // dry (the negation also rejects NaN)
                     continue;

--- a/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
+++ b/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
@@ -1,6 +1,8 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/WaterSurface.h"
 
+#include "OloEngine/Renderer/Ocean/OceanFFTField.h"
+
 #include <glm/glm.hpp>
 
 #include <array>
@@ -171,5 +173,32 @@ namespace OloEngine::WaterSurface
 
         const f32 height = params.m_PlaneHeight + SampleDisplacement(params, base, rawTime).y;
         return std::isfinite(height) ? height : params.m_PlaneHeight;
+    }
+
+    f32 SampleHeightFFT(const Ocean::OceanFFTField& field, glm::vec2 queryXZ, f32 planeHeight, f32 heightScale)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Fail-safe: physics must never see a NaN/Inf surface height. If the
+        // plane height itself is bad we can't recover a sensible value, so fall
+        // back to a flat sea-level 0.
+        if (!std::isfinite(planeHeight))
+            return 0.0f;
+        if (!std::isfinite(heightScale))
+            return planeHeight;
+
+        // OceanFFTField::SampleHeight reads the retained band-limited CPU proxy
+        // and already inverts the choppy horizontal displacement (so the height
+        // belongs to the column above queryXZ). It returns 0 before the first
+        // Update() / when the field is invalid, so an un-built field reads as the
+        // flat plane.
+        const f32 fieldHeight = field.SampleHeight(queryXZ);
+        if (!std::isfinite(fieldHeight))
+            return planeHeight;
+
+        // Water.glsl FFT path: displacedPos.y = worldPos.y + disp.y * u_FFTParams.z
+        // (worldPos.y == the undisplaced plane height; u_FFTParams.z == heightScale).
+        const f32 height = planeHeight + fieldHeight * heightScale;
+        return std::isfinite(height) ? height : planeHeight;
     }
 } // namespace OloEngine::WaterSurface

--- a/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
+++ b/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
@@ -5,6 +5,7 @@
 
 #include <glm/glm.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 
@@ -200,5 +201,13 @@ namespace OloEngine::WaterSurface
         // (worldPos.y == the undisplaced plane height; u_FFTParams.z == heightScale).
         const f32 height = planeHeight + fieldHeight * heightScale;
         return std::isfinite(height) ? height : planeHeight;
+    }
+
+    f32 ClampFFTHeightScale(f32 heightScale)
+    {
+        // Mirror the render path (Scene.cpp's clampF on m_FFTHeightScale): a
+        // non-finite value falls back to the 1.0 default, otherwise clamp to the
+        // [0, 20] authoring range. Keep buoyancy and the shader in lock-step.
+        return std::isfinite(heightScale) ? std::clamp(heightScale, 0.0f, 20.0f) : 1.0f;
     }
 } // namespace OloEngine::WaterSurface

--- a/OloEngine/src/OloEngine/Renderer/WaterSurface.h
+++ b/OloEngine/src/OloEngine/Renderer/WaterSurface.h
@@ -74,4 +74,11 @@ namespace OloEngine::WaterSurface
     /// world-anchored mapping the shader uses (`worldPos.xz * 1/patchSize`).
     [[nodiscard]] f32 SampleHeightFFT(const Ocean::OceanFFTField& field, glm::vec2 queryXZ,
                                       f32 planeHeight, f32 heightScale);
+
+    /// Clamp a raw `WaterComponent::m_FFTHeightScale` (the shader's `u_FFTParams.z`
+    /// artist multiplier) to the authoring range, mapping a non-finite value to
+    /// the 1.0 default. Single source of truth shared by the renderer (Scene.cpp)
+    /// and the buoyancy sampler (BuoyancySystem.cpp) so the rendered FFT crest and
+    /// the physics surface can't silently drift apart.
+    [[nodiscard]] f32 ClampFFTHeightScale(f32 heightScale);
 } // namespace OloEngine::WaterSurface

--- a/OloEngine/src/OloEngine/Renderer/WaterSurface.h
+++ b/OloEngine/src/OloEngine/Renderer/WaterSurface.h
@@ -4,6 +4,11 @@
 
 #include <glm/glm.hpp>
 
+namespace OloEngine::Ocean
+{
+    class OceanFFTField; // FFT ocean cascade (Renderer/Ocean/OceanFFTField.h) — sampled by SampleHeightFFT.
+}
+
 namespace OloEngine::WaterSurface
 {
     // =========================================================================
@@ -43,4 +48,30 @@ namespace OloEngine::WaterSurface
     /// iterations before reading the vertical displacement. Returns the flat
     /// plane height on any non-finite intermediate (fail-safe for physics).
     [[nodiscard]] f32 SampleHeight(const Params& params, glm::vec2 queryXZ, f32 rawTime);
+
+    // =========================================================================
+    // FFT ocean sampling (WATER_FUTURE_IMPROVEMENTS.md §5.1).
+    //
+    // When a WaterComponent renders the Tessendorf FFT ocean instead of summing
+    // Gerstner waves, physics must follow *that* surface. This reads the
+    // OceanFFTField's retained band-limited CPU proxy so a floating body tracks
+    // the rendered FFT crest with no GPU readback — the FFT counterpart to the
+    // Gerstner SampleHeight above. The CPU/GPU mirror (the field's spectrum + FFT
+    // math) is pinned by OceanFFTSpectrumTest; the buoyancy mapping by
+    // WaterSurfaceSamplerTest's FFT cases.
+    // =========================================================================
+
+    /// World-space water height of the FFT ocean surface column directly above
+    /// world `queryXZ`, mirroring Water.glsl's FFT vertex path
+    /// (`displacedPos.y = worldPos.y + disp.y * u_FFTParams.z`):
+    /// `planeHeight + field.SampleHeight(queryXZ) * heightScale`. The field's
+    /// SampleHeight already inverts the choppy horizontal displacement (so the
+    /// height belongs to the column above the query) and returns 0 before its
+    /// first evaluation, so an un-built field reads as the flat plane.
+    /// `heightScale` is the artist multiplier (WaterComponent::m_FFTHeightScale,
+    /// `u_FFTParams.z`). Returns `planeHeight` on any non-finite intermediate
+    /// (fail-safe for physics). The field is sampled at world XZ — the same
+    /// world-anchored mapping the shader uses (`worldPos.xz * 1/patchSize`).
+    [[nodiscard]] f32 SampleHeightFFT(const Ocean::OceanFFTField& field, glm::vec2 queryXZ,
+                                      f32 planeHeight, f32 heightScale);
 } // namespace OloEngine::WaterSurface

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -21,6 +21,7 @@
 #include "OloEngine/Renderer/ProceduralSky.h"
 #include "OloEngine/Renderer/StarNestSky.h"
 #include "OloEngine/Renderer/TextureCubemap.h"
+#include "OloEngine/Renderer/WaterSurface.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
 #include "OloEngine/Scripting/Lua/LuaScriptEngine.h"
 #include "OloEngine/Animation/BoneEntityUtils.h"
@@ -4579,7 +4580,7 @@ namespace OloEngine
                             // w = horizontalScale (choppiness is already baked into the
                             // texture's dx/dz, so keep this at 1).
                             waterParams.fftParams = glm::vec4(
-                                1.0f, invPatch, clampF(water.m_FFTHeightScale, 0.0f, 20.0f, 1.0f), 1.0f);
+                                1.0f, invPatch, WaterSurface::ClampFFTHeightScale(water.m_FFTHeightScale), 1.0f);
                             // FFT crests can exceed the Gerstner-derived TCS cull
                             // margin; disable the per-patch frustum cull so off-screen-
                             // edge crests aren't clipped early.
@@ -4609,7 +4610,7 @@ namespace OloEngine
                     if (water.m_UseFFT)
                     {
                         const f32 fftAmp = clampF(water.m_FFTAmplitude, 0.0f, 100.0f, 2.0f);
-                        const f32 fftHeightScale = clampF(water.m_FFTHeightScale, 0.0f, 20.0f, 1.0f);
+                        const f32 fftHeightScale = WaterSurface::ClampFFTHeightScale(water.m_FFTHeightScale);
                         waveH = std::max(fftAmp * fftHeightScale * 2.0f, 3.0f);
                     }
                     else

--- a/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
@@ -227,34 +227,46 @@ TEST_F(WaterBuoyancyTest, RestsAtTheFFTSurfaceHeight)
     const auto& wc = water.GetComponent<WaterComponent>();
     ASSERT_TRUE(wc.m_OceanField && wc.m_OceanField->GetField().IsValid());
 
-    // Pick a column where the FFT surface is clearly off the plane (deterministic
-    // seed ⇒ reproducible), and predict the rest height from the same sampler the
-    // system uses.
+    // Rest-height tolerance: a band wide enough to absorb box-scale surface
+    // curvature, yet — critically — strictly narrower than the displacement we
+    // pick below. If the tolerance exceeded the displacement, a body that settled
+    // on the flat plane (y=0) would still satisfy the EXPECT_NEAR band and the
+    // FFT-vs-plane discriminator would be vacuous.
+    constexpr f32 kRestTolerance = 0.6f;
+
+    // Scan the whole patch (deterministic seed ⇒ reproducible) for the *most*
+    // displaced column. The extreme |h| keeps the discriminator sound (it must
+    // clear 2× the tolerance, see the assert) and is also where the box tracks
+    // the surface best: a crest/trough is a local gradient zero, so the surface
+    // is ~flat over the 1 m box footprint.
     glm::vec2 sampleXZ(0.0f);
     f32 expectedSurfaceY = 0.0f;
-    for (f32 ox = 1.0f; ox < 70.0f; ox += 2.0f)
-    {
-        const glm::vec2 cand(ox, ox * 0.5f);
-        const f32 h = WaterSurface::SampleHeightFFT(*wc.m_OceanField, cand, 0.0f, wc.m_FFTHeightScale);
-        if (std::abs(h) > 0.3f)
+    for (f32 ox = 0.0f; ox < 80.0f; ox += 2.0f)
+        for (f32 oz = 0.0f; oz < 80.0f; oz += 2.0f)
         {
-            sampleXZ = cand;
-            expectedSurfaceY = h;
-            break;
+            const glm::vec2 cand(ox, oz);
+            const f32 h = WaterSurface::SampleHeightFFT(*wc.m_OceanField, cand, 0.0f, wc.m_FFTHeightScale);
+            if (std::abs(h) > std::abs(expectedSurfaceY))
+            {
+                sampleXZ = cand;
+                expectedSurfaceY = h;
+            }
         }
-    }
-    ASSERT_GT(std::abs(expectedSurfaceY), 0.3f)
-        << "no displaced FFT column found — cannot distinguish FFT surface from a flat plane";
+    // Displacement must clear the tolerance with margin, so the EXPECT_NEAR band
+    // around expectedSurfaceY cannot include y=0 — otherwise a flat-plane rest
+    // (FFT branch never fired) would masquerade as success.
+    ASSERT_GT(std::abs(expectedSurfaceY), 2.0f * kRestTolerance)
+        << "FFT surface not displaced enough to distinguish from a flat plane; max |h|=" << std::abs(expectedSurfaceY);
 
     Entity box = SpawnBuoyantBox({ sampleXZ.x, expectedSurfaceY + 5.0f, sampleXZ.y }, kFloatingMass);
     EnablePhysics3D();
 
     TickFor(15.0f);
 
-    // Settles on the FFT surface (a generous band absorbs box-scale surface
-    // curvature), and crucially NOT at the flat plane (y=0) — that would mean the
-    // FFT branch never fired.
-    EXPECT_NEAR(Y(box), expectedSurfaceY, 0.6f)
+    // Settles on the FFT surface. Because |expectedSurfaceY| > 2·kRestTolerance,
+    // this band excludes y=0 — so passing here proves the body tracked the FFT
+    // surface, not the flat plane (the FFT branch genuinely fired).
+    EXPECT_NEAR(Y(box), expectedSurfaceY, kRestTolerance)
         << "floating body did not rest at the sampled FFT height; y=" << Y(box) << " expected≈" << expectedSurfaceY;
     EXPECT_TRUE(std::isfinite(Y(box)));
 

--- a/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
@@ -21,8 +21,11 @@
 
 #include "Functional/FunctionalTest.h"
 
+#include "OloEngine/Core/Ref.h"
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Components.h"
+#include "OloEngine/Renderer/Ocean/OceanFFTField.h"
+#include "OloEngine/Renderer/Ocean/OceanSpectrum.h"
 #include "OloEngine/Renderer/WaterSurface.h"
 #include "OloEngine/Utils/PlatformUtils.h"
 
@@ -66,6 +69,31 @@ class WaterBuoyancyTest : public FunctionalTest
         wc.m_WorldSizeX = 200.0f;
         wc.m_WorldSizeZ = 200.0f;
         wc.m_WaveAmplitude = amplitude;
+        return water;
+    }
+
+    // FFT-backed water. Gerstner waves are disabled (amplitude 0) so any displaced
+    // rest height can ONLY come from the FFT field — a clean discriminator that
+    // BuoyancySystem really took the FFT path. The CPU proxy is built here (no GPU
+    // upload) exactly as the renderer's water pass would, at the frozen test time.
+    Entity SpawnFFTWater(f32 planeY, f32 fieldTime)
+    {
+        Entity water = GetScene().CreateEntity("FFTWater");
+        water.GetComponent<TransformComponent>().Translation = { 0.0f, planeY, 0.0f };
+        auto& wc = water.AddComponent<WaterComponent>();
+        wc.m_Enabled = true;
+        wc.m_WorldSizeX = 200.0f;
+        wc.m_WorldSizeZ = 200.0f;
+        wc.m_WaveAmplitude = 0.0f; // kill Gerstner: the FFT field is the only wave source
+        wc.m_UseFFT = true;
+        wc.m_FFTHeightScale = 1.0f;
+
+        Ocean::SpectrumParams sp{};
+        sp.m_Resolution = 64u;
+        sp.m_PatchSize = 80.0f;
+        sp.m_Amplitude = 2.0f;
+        wc.m_OceanField = Ref<Ocean::OceanFFTField>::Create();
+        wc.m_OceanField->Update(sp, fieldTime, /*uploadToGpu=*/false);
         return water;
     }
 
@@ -183,6 +211,52 @@ TEST_F(WaterBuoyancyTest, RestsAtTheWaveSurfaceHeight)
     EXPECT_NEAR(Y(box), expectedSurfaceY, 0.35f)
         << "floating body did not rest at the sampled wave height; y=" << Y(box)
         << " expected≈" << expectedSurfaceY;
+
+    Time::ClearMockTime();
+}
+
+TEST_F(WaterBuoyancyTest, RestsAtTheFFTSurfaceHeight)
+{
+    // The §5.1 deliverable: with an FFT-backed water tile, the body must rest on
+    // the FFT surface (the one rendered), sampled via WaterSurface::SampleHeightFFT
+    // — not the Gerstner field and not the flat plane. Gerstner is disabled, so a
+    // displaced rest height proves BuoyancySystem switched to the FFT proxy.
+    Time::SetMockTime(0.0f);
+
+    Entity water = SpawnFFTWater(/*planeY=*/0.0f, /*fieldTime=*/0.0f);
+    const auto& wc = water.GetComponent<WaterComponent>();
+    ASSERT_TRUE(wc.m_OceanField && wc.m_OceanField->GetField().IsValid());
+
+    // Pick a column where the FFT surface is clearly off the plane (deterministic
+    // seed ⇒ reproducible), and predict the rest height from the same sampler the
+    // system uses.
+    glm::vec2 sampleXZ(0.0f);
+    f32 expectedSurfaceY = 0.0f;
+    for (f32 ox = 1.0f; ox < 70.0f; ox += 2.0f)
+    {
+        const glm::vec2 cand(ox, ox * 0.5f);
+        const f32 h = WaterSurface::SampleHeightFFT(*wc.m_OceanField, cand, 0.0f, wc.m_FFTHeightScale);
+        if (std::abs(h) > 0.3f)
+        {
+            sampleXZ = cand;
+            expectedSurfaceY = h;
+            break;
+        }
+    }
+    ASSERT_GT(std::abs(expectedSurfaceY), 0.3f)
+        << "no displaced FFT column found — cannot distinguish FFT surface from a flat plane";
+
+    Entity box = SpawnBuoyantBox({ sampleXZ.x, expectedSurfaceY + 5.0f, sampleXZ.y }, kFloatingMass);
+    EnablePhysics3D();
+
+    TickFor(15.0f);
+
+    // Settles on the FFT surface (a generous band absorbs box-scale surface
+    // curvature), and crucially NOT at the flat plane (y=0) — that would mean the
+    // FFT branch never fired.
+    EXPECT_NEAR(Y(box), expectedSurfaceY, 0.6f)
+        << "floating body did not rest at the sampled FFT height; y=" << Y(box) << " expected≈" << expectedSurfaceY;
+    EXPECT_TRUE(std::isfinite(Y(box)));
 
     Time::ClearMockTime();
 }

--- a/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/WaterBuoyancyTest.cpp
@@ -241,9 +241,14 @@ TEST_F(WaterBuoyancyTest, RestsAtTheFFTSurfaceHeight)
     // is ~flat over the 1 m box footprint.
     glm::vec2 sampleXZ(0.0f);
     f32 expectedSurfaceY = 0.0f;
-    for (f32 ox = 0.0f; ox < 80.0f; ox += 2.0f)
-        for (f32 oz = 0.0f; oz < 80.0f; oz += 2.0f)
+    // Integer counters, float positions derived — scans the 80 m patch on a 2 m
+    // grid without accumulating float-step drift (ox/oz sweep 0,2,…,78).
+    constexpr int kGridSteps = 40; // 80 m patch / 2 m step
+    for (int ix = 0; ix < kGridSteps; ++ix)
+        for (int iz = 0; iz < kGridSteps; ++iz)
         {
+            const f32 ox = static_cast<f32>(ix) * 2.0f;
+            const f32 oz = static_cast<f32>(iz) * 2.0f;
             const glm::vec2 cand(ox, oz);
             const f32 h = WaterSurface::SampleHeightFFT(*wc.m_OceanField, cand, 0.0f, wc.m_FFTHeightScale);
             if (std::abs(h) > std::abs(expectedSurfaceY))

--- a/OloEngine/tests/Rendering/PropertyTests/WaterSurfaceSamplerTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterSurfaceSamplerTest.cpp
@@ -73,7 +73,7 @@ namespace
     // Build the FFT ocean's CPU proxy headlessly (no GPU upload), exactly the
     // surface BuoyancySystem reads for an FFT-backed water tile. Deterministic
     // for a fixed seed/params, so chosen sample points are reproducible.
-    Ref<Ocean::OceanFFTField> MakeFftField(f32 amplitude = 2.0f, f32 time = 2.0f, u32 resolution = 64u,
+    Ref<Ocean::OceanFFTField> MakeFftField(f32 amplitude = 2.0f, f32 evolveTime = 2.0f, u32 resolution = 64u,
                                            f32 patchSize = 80.0f)
     {
         Ocean::SpectrumParams sp{};
@@ -81,7 +81,7 @@ namespace
         sp.m_PatchSize = patchSize;
         sp.m_Amplitude = amplitude;
         auto field = Ref<Ocean::OceanFFTField>::Create();
-        field->Update(sp, time, /*uploadToGpu=*/false);
+        field->Update(sp, evolveTime, /*uploadToGpu=*/false);
         return field;
     }
 
@@ -90,8 +90,11 @@ namespace
     // surface from a flat plane. Returns {0,0} if none found (the caller asserts).
     glm::vec2 FindDisplacedColumn(const Ocean::OceanFFTField& field, f32 minMagnitude = 0.3f)
     {
-        for (f32 ox = 1.0f; ox < 70.0f; ox += 2.0f)
+        // Integer counter, float position derived — avoids float-accumulation
+        // drift (ox sweeps 1,3,…,69 over the 70 m scan on a 2 m grid).
+        for (int ix = 0; ix < 35; ++ix)
         {
+            const f32 ox = 1.0f + static_cast<f32>(ix) * 2.0f;
             const glm::vec2 cand(ox, ox * 0.5f);
             if (std::abs(field.SampleHeight(cand)) > minMagnitude)
                 return cand;
@@ -316,12 +319,12 @@ TEST(WaterSurfaceFFTSampler, NonFinitePlaneOrScaleIsSafe)
     // plane height collapses to sea-level 0.
     auto field = MakeFftField();
     const glm::vec2 xz(6.0f, 6.0f);
-    const f32 nan = std::numeric_limits<f32>::quiet_NaN();
+    const f32 nanValue = std::numeric_limits<f32>::quiet_NaN();
     const f32 inf = std::numeric_limits<f32>::infinity();
 
-    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, 5.0f, nan), 5.0f);
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, 5.0f, nanValue), 5.0f);
     EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, 5.0f, inf), 5.0f);
-    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, nan, 1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, nanValue, 1.0f), 0.0f);
     EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, inf, 1.0f), 0.0f);
 }
 

--- a/OloEngine/tests/Rendering/PropertyTests/WaterSurfaceSamplerTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterSurfaceSamplerTest.cpp
@@ -1,24 +1,35 @@
 #include "OloEnginePCH.h"
 
 // =============================================================================
-// WaterSurfaceSamplerTest — L1 property tests for the CPU Gerstner sampler.
+// WaterSurfaceSamplerTest — L1 property tests for the CPU water samplers.
 //
-// `OloEngine::WaterSurface` (Renderer/WaterSurface.h) is a 1:1 CPU port of
-// WaterCommon.glsl :: sumGerstnerWaves. The BuoyancySystem samples it so a
-// floating body tracks the *rendered* wave surface rather than a flat plane.
-// These tests pin the shared invariants of that port — flatness, plane-height
-// linearity, the displacement bound (shared with the renderer's frustum-cull
-// margin), temporal animation and determinism — so the CPU and GPU copies can't
-// silently drift apart. See docs/agent-rules/testing-architecture.md (the same
-// CPU/GPU-mirror discipline as WaterRenderingTest's ComputeMaxWaveDisplacementCpu).
+// `OloEngine::WaterSurface` (Renderer/WaterSurface.h) is the CPU surface the
+// BuoyancySystem reads so a floating body tracks the *rendered* wave surface
+// rather than a flat plane. Two sampling paths share these tests:
+//   * SampleHeight/SampleDisplacement — a 1:1 CPU port of
+//     WaterCommon.glsl :: sumGerstnerWaves (the analytic Gerstner ocean).
+//   * SampleHeightFFT — reads the OceanFFTField band-limited CPU proxy for the
+//     Tessendorf FFT ocean (WATER_FUTURE_IMPROVEMENTS.md §5.1), mapped exactly
+//     the way Water.glsl's FFT path maps it (planeHeight + disp.y * heightScale).
+// These pin the shared invariants — flatness, plane-height linearity, the
+// Gerstner displacement bound (shared with the renderer's frustum-cull margin),
+// temporal animation, determinism, and the FFT proxy mapping — so the CPU and
+// GPU copies can't silently drift apart. See
+// docs/agent-rules/testing-architecture.md (the same CPU/GPU-mirror discipline
+// as WaterRenderingTest's ComputeMaxWaveDisplacementCpu).
 // =============================================================================
 
+#include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/Ocean/OceanFFTField.h"
+#include "OloEngine/Renderer/Ocean/OceanSpectrum.h"
 #include "OloEngine/Renderer/WaterSurface.h"
 #include "OloEngine/Scene/Components.h"
 
 #include <gtest/gtest.h>
+#include <glm/glm.hpp>
 
 #include <cmath>
+#include <limits>
 
 using namespace OloEngine;
 
@@ -57,6 +68,35 @@ namespace
         const f32 maxOctaveA = avgSt * avgWL / kTwoPi;
         const f32 octaveSum = maxOctaveA * 1.67f; // 0.5+0.4+0.3+0.22+0.15+0.1
         return amp * (a0 * 0.55f + a1 * 0.55f + octaveSum) * 1.5f;
+    }
+
+    // Build the FFT ocean's CPU proxy headlessly (no GPU upload), exactly the
+    // surface BuoyancySystem reads for an FFT-backed water tile. Deterministic
+    // for a fixed seed/params, so chosen sample points are reproducible.
+    Ref<Ocean::OceanFFTField> MakeFftField(f32 amplitude = 2.0f, f32 time = 2.0f, u32 resolution = 64u,
+                                           f32 patchSize = 80.0f)
+    {
+        Ocean::SpectrumParams sp{};
+        sp.m_Resolution = resolution;
+        sp.m_PatchSize = patchSize;
+        sp.m_Amplitude = amplitude;
+        auto field = Ref<Ocean::OceanFFTField>::Create();
+        field->Update(sp, time, /*uploadToGpu=*/false);
+        return field;
+    }
+
+    // First world-XZ from a deterministic scan where the FFT surface is clearly
+    // displaced (|height| > minMagnitude), so a test distinguishes the FFT
+    // surface from a flat plane. Returns {0,0} if none found (the caller asserts).
+    glm::vec2 FindDisplacedColumn(const Ocean::OceanFFTField& field, f32 minMagnitude = 0.3f)
+    {
+        for (f32 ox = 1.0f; ox < 70.0f; ox += 2.0f)
+        {
+            const glm::vec2 cand(ox, ox * 0.5f);
+            if (std::abs(field.SampleHeight(cand)) > minMagnitude)
+                return cand;
+        }
+        return glm::vec2(0.0f);
     }
 } // namespace
 
@@ -189,4 +229,109 @@ TEST(WaterSurfaceSampler, HeightInversionLandsOverTheQueryColumn)
     EXPECT_NEAR(imaged.y, query.y, 1e-2f);
     // The well-converged base reproduces the same height the sampler returned.
     EXPECT_NEAR(p.m_PlaneHeight + dFinal.y, h, 5e-2f);
+}
+
+// ---------------------------------------------------------------------------
+// FFT ocean sampling (WATER_FUTURE_IMPROVEMENTS.md §5.1).
+//
+// When a WaterComponent renders the Tessendorf FFT ocean, BuoyancySystem reads
+// WaterSurface::SampleHeightFFT instead of the Gerstner SampleHeight, so a
+// floating body tracks the *FFT* surface that's actually rendered. These pin
+// the contract that the buoyancy sample equals the field's band-limited CPU
+// proxy height, mapped exactly the way Water.glsl's FFT vertex path maps it
+// (planeHeight + disp.y * heightScale), plus the physics fail-safes.
+// ---------------------------------------------------------------------------
+
+TEST(WaterSurfaceFFTSampler, MatchesFieldProxyAtSameWorldPosition)
+{
+    // The headline contract: the height BuoyancySystem applies is exactly the
+    // FFT proxy's column height, offset by the plane and scaled by heightScale —
+    // i.e. buoyancy sees the same surface the renderer does.
+    auto field = MakeFftField();
+    ASSERT_TRUE(field->GetField().IsValid());
+
+    for (f32 planeHeight : { 0.0f, 3.0f, -2.0f })
+        for (f32 heightScale : { 1.0f, 0.5f, 2.0f })
+            for (glm::vec2 xz : { glm::vec2(0.0f), glm::vec2(17.0f, -23.0f), glm::vec2(123.0f, 45.0f) })
+            {
+                const f32 expected = planeHeight + field->SampleHeight(xz) * heightScale;
+                EXPECT_NEAR(WaterSurface::SampleHeightFFT(*field, xz, planeHeight, heightScale), expected, 1e-5f)
+                    << "plane=" << planeHeight << " scale=" << heightScale << " xz=(" << xz.x << "," << xz.y << ")";
+            }
+}
+
+TEST(WaterSurfaceFFTSampler, PlaneHeightShiftsResultByExactlyDelta)
+{
+    // The FFT field is sampled in world XZ and only offset vertically by the
+    // plane height — raising the plane must raise the surface 1:1.
+    auto field = MakeFftField();
+    const glm::vec2 xz(7.0f, -4.0f);
+    const f32 h0 = WaterSurface::SampleHeightFFT(*field, xz, 0.0f, 1.0f);
+    const f32 h1 = WaterSurface::SampleHeightFFT(*field, xz, 10.0f, 1.0f);
+    EXPECT_NEAR(h1 - h0, 10.0f, 1e-4f);
+}
+
+TEST(WaterSurfaceFFTSampler, HeightScaleScalesTheWaveContributionLinearly)
+{
+    // heightScale multiplies the wave displacement (matching u_FFTParams.z): the
+    // deviation from the plane scales linearly while the plane stays fixed, and
+    // zero heightScale collapses the surface onto the flat plane.
+    auto field = MakeFftField();
+    const glm::vec2 xz = FindDisplacedColumn(*field);
+    ASSERT_GT(std::abs(field->SampleHeight(xz)), 0.0f) << "no displaced FFT column found for scaling test";
+
+    constexpr f32 plane = 4.0f;
+    const f32 baseDev = WaterSurface::SampleHeightFFT(*field, xz, plane, 1.0f) - plane;
+    const f32 doubledDev = WaterSurface::SampleHeightFFT(*field, xz, plane, 2.0f) - plane;
+    ASSERT_GT(std::abs(baseDev), 0.1f) << "chosen column is ~flat; pick another";
+    EXPECT_NEAR(doubledDev, 2.0f * baseDev, 1e-4f);
+    EXPECT_NEAR(WaterSurface::SampleHeightFFT(*field, xz, plane, 0.0f), plane, 1e-5f);
+}
+
+TEST(WaterSurfaceFFTSampler, FlatSeaReturnsPlaneHeight)
+{
+    // Zero spectrum amplitude ⇒ a flat field ⇒ the surface is the plane.
+    auto field = MakeFftField(/*amplitude=*/0.0f);
+    ASSERT_TRUE(field->GetField().IsValid());
+
+    for (f32 plane : { 0.0f, 5.5f, -3.25f })
+        for (glm::vec2 xz : { glm::vec2(0.0f), glm::vec2(10.0f, 20.0f), glm::vec2(-44.0f, 77.0f) })
+            EXPECT_NEAR(WaterSurface::SampleHeightFFT(*field, xz, plane, 1.0f), plane, 1e-3f);
+}
+
+TEST(WaterSurfaceFFTSampler, UnevaluatedFieldReadsAsTheFlatPlane)
+{
+    // A field that was never Update()d (e.g. headless physics before the first
+    // render) is invalid; SampleHeight returns 0, so buoyancy sees the flat
+    // plane rather than a bogus height — and falls back to Gerstner upstream.
+    auto fresh = Ref<Ocean::OceanFFTField>::Create();
+    ASSERT_FALSE(fresh->GetField().IsValid());
+    EXPECT_NEAR(WaterSurface::SampleHeightFFT(*fresh, glm::vec2(1.0f, 2.0f), 4.0f, 3.0f), 4.0f, 1e-5f);
+}
+
+TEST(WaterSurfaceFFTSampler, NonFinitePlaneOrScaleIsSafe)
+{
+    // Defence in depth against bad serialized data: physics must never receive a
+    // NaN/Inf surface height. A bad heightScale collapses to the plane; a bad
+    // plane height collapses to sea-level 0.
+    auto field = MakeFftField();
+    const glm::vec2 xz(6.0f, 6.0f);
+    const f32 nan = std::numeric_limits<f32>::quiet_NaN();
+    const f32 inf = std::numeric_limits<f32>::infinity();
+
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, 5.0f, nan), 5.0f);
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, 5.0f, inf), 5.0f);
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, nan, 1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(WaterSurface::SampleHeightFFT(*field, xz, inf, 1.0f), 0.0f);
+}
+
+TEST(WaterSurfaceFFTSampler, IsFiniteAndDeterministic)
+{
+    auto field = MakeFftField();
+    for (glm::vec2 xz : { glm::vec2(0.0f), glm::vec2(33.0f, -12.0f), glm::vec2(250.0f, 250.0f) })
+    {
+        const f32 h = WaterSurface::SampleHeightFFT(*field, xz, 1.0f, 1.5f);
+        EXPECT_TRUE(std::isfinite(h));
+        EXPECT_FLOAT_EQ(h, WaterSurface::SampleHeightFFT(*field, xz, 1.0f, 1.5f));
+    }
 }

--- a/docs/WATER_FUTURE_IMPROVEMENTS.md
+++ b/docs/WATER_FUTURE_IMPROVEMENTS.md
@@ -73,10 +73,10 @@ fallback. Shipped:
   Pinned by `OceanFFTSpectrumTest` (γ peak enhancement, fetch→peak-frequency
   shift, dispatch routing, metre-scale field) + a `ComponentRoundTrip` YAML test.
 
-Still open (natural follow-ons): **cascaded FFT** (§1.3) and **buoyancy
-sampling from the FFT field** (§5.1 — `WaterSurface` still samples the Gerstner
-sum; once it reads the FFT field, the band-limited physics proxy in
-`OceanFFTField` is the natural source).
+Still open (natural follow-on): **cascaded FFT** (§1.3). **Buoyancy sampling
+from the FFT field** (§5.1) is now **shipped** — `BuoyancySystem` reads
+`OceanFFTField`'s band-limited CPU proxy via `WaterSurface::SampleHeightFFT`
+when a tile uses the FFT ocean, falling back to the Gerstner sum otherwise.
 
 ### 1.1 Tessendorf FFT Pipeline
 
@@ -316,11 +316,24 @@ dense bodies sink, tracks a frozen wave surface) by `WaterBuoyancyTest`
 (Functional). Editor UI, Lua bindings, scene + save-game serialization are all
 wired.
 
+**FFT displacement source — shipped.** When a `WaterComponent` renders the
+Tessendorf FFT ocean (`m_UseFFT`), `BuoyancySystem` samples that surface instead
+of the Gerstner approximation, so a floater tracks the ocean that's actually
+rendered. It reads `OceanFFTField`'s retained **band-limited CPU proxy** via
+`WaterSurface::SampleHeightFFT`, which maps the proxy exactly the way
+`Water.glsl`'s FFT vertex path does (`planeHeight + disp.y * heightScale`); the
+proxy already inverts the choppy horizontal shift, so the height belongs to the
+column above the probe. No GPU readback — the proxy is the same one the renderer
+maintains each frame. The switch is purely runtime-derived (no new serialized
+field): a tile uses the FFT path only when `m_UseFFT` **and** its `m_OceanField`
+proxy has been evaluated; otherwise it falls back to Gerstner (so headless
+physics with no render pass, and all non-FFT water, are unchanged). Pinned by
+`WaterSurfaceSamplerTest`'s FFT cases (the proxy-mapping contract) and
+`WaterBuoyancyTest::RestsAtTheFFTSurfaceHeight` (a body resting on a displaced
+FFT column with Gerstner disabled — proving the branch fired).
+
 Still open:
 
-- **FFT displacement source** — once the §1 FFT pipeline lands, `WaterSurface`
-  should sample its displacement texture (GPU readback or a shared CPU copy)
-  instead of summing Gerstner octaves on the CPU.
 - **GPU readback for many objects** — the current path is CPU per-probe
   (cheap for tens of floaters). A crowd of hundreds wants a batched GPU height
   query.


### PR DESCRIPTION
- Added OceanFFTField support to BuoyancySystem for accurate buoyancy calculations.
- Introduced SampleHeightFFT method in WaterSurface for FFT-based height sampling.
- Updated WaterBuoyancyTest to validate buoyancy behavior with FFT water.
- Enhanced WaterSurfaceSamplerTest to ensure consistency between CPU and GPU height calculations.
- Documented changes in WATER_FUTURE_IMPROVEMENTS.md to reflect new buoyancy sampling capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buoyancy now follows FFT-based ocean surface heights when available, improving object floating behavior on FFT water.
  * Added CPU-side FFT water height sampling for consistent world-space surface queries.

* **Bug Fixes**
  * Improved stability by handling invalid or non-finite water height values safely.
  * Added fallback behavior to keep buoyancy working when FFT sampling is unavailable.

* **Tests**
  * Added coverage for FFT water surface sampling and buoyancy settling at FFT-driven heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->