### PR TITLE
Implement ephemeral sun-direction overrides for lighting iteration

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -3032,6 +3032,13 @@ namespace OloEngine
         // Clear undo history when switching scenes
         m_CommandHistory.Clear();
 
+        // Drop any ephemeral MCP sun-direction override (#316 Part 4) so loading
+        // or creating a scene restores its authored procedural-sky sun. This is the
+        // single choke point for every editor scene swap (NewScene / OpenScene /
+        // auto-save recovery), so clearing here honours the documented "resets on
+        // scene reload" contract; a no-op when no override is active.
+        Renderer3D::ClearSunDirectionOverride();
+
         SyncWindowTitle();
     }
 

--- a/OloEditor/src/MCP/McpRenderOverrides.h
+++ b/OloEditor/src/MCP/McpRenderOverrides.h
@@ -16,6 +16,19 @@
 // server stays read-only with respect to the project — the same boundary the
 // Tier-0 camera/viewport tools respect.
 //
+//   * olo_scene_set_time_of_day — set an ephemeral time-of-day (0-24h) that
+//                                  drives the procedural sky's sun direction.
+//   * olo_scene_set_sun_angle    — set the sun direction directly from a
+//                                  yaw (azimuth) / pitch (elevation) pair.
+//     Both back the lighting inner loop: move the sun -> olo_screenshot ->
+//     move it again. They mutate ONLY a session-global Renderer3D sun-direction
+//     override (read by Scene::LoadAndRenderSkybox when baking the procedural
+//     sky), never the ProceduralSkyComponent's serialized m_SunDirection — so
+//     the change is visible next frame, never saved, and resets on scene reload
+//     / play-stop / server-stop / explicit clear. The sun-direction math lives
+//     here as pure float functions (NO glm) so it unit-tests without a renderer;
+//     the handler converts the result to glm::vec3.
+//
 // The handler in McpTools.cpp does the renderer-bound work on the main thread
 // (resolve the token to the bool field on PostProcessSettings / FogSettings, flip
 // it, read back the new value) and hands the gathered facts here to be turned into
@@ -30,6 +43,8 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
+#include <numbers>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -325,6 +340,108 @@ namespace OloEngine::MCP::RenderOverrides
         j["ssrDebugView"] = r.SSRDebugView;
         j["ssgiDebugView"] = r.SSGIDebugView;
         j["passEnabled"] = r.PassEnabled;
+        if (!r.Note.empty())
+            j["note"] = r.Note;
+        return j;
+    }
+
+    // ---- Sun / time-of-day override ----------------------------------------
+    // Pure sun-direction math for olo_scene_set_time_of_day / olo_scene_set_sun_angle.
+    // A "toward-sun" unit direction in world space (Y up), kept as plain doubles so
+    // this header stays free of glm; the handler converts to glm::vec3 before
+    // handing it to Renderer3D::SetSunDirectionOverride.
+
+    struct SunVec3
+    {
+        double X = 0.0;
+        double Y = 1.0;
+        double Z = 0.0;
+    };
+
+    // Normalise to a unit vector; a (near-)zero vector collapses to straight up so
+    // a degenerate input never yields a NaN direction.
+    [[nodiscard]] inline SunVec3 NormalizeSun(SunVec3 d)
+    {
+        const double len = std::sqrt(d.X * d.X + d.Y * d.Y + d.Z * d.Z);
+        if (len < 1e-9)
+            return SunVec3{ 0.0, 1.0, 0.0 };
+        return SunVec3{ d.X / len, d.Y / len, d.Z / len };
+    }
+
+    // Build a toward-sun unit direction from an azimuth (yaw) and elevation (pitch),
+    // both in degrees. Azimuth is measured from +Z toward +X: 0deg -> +Z, 90deg ->
+    // +X. Elevation is the angle above the horizon: 0deg on the horizon, 90deg
+    // straight up, negative below. This is the shared spherical->cartesian core both
+    // tools resolve to.
+    [[nodiscard]] inline SunVec3 SunDirectionFromAngles(double azimuthDegrees, double elevationDegrees)
+    {
+        constexpr double kDeg2Rad = std::numbers::pi / 180.0;
+        const double az = azimuthDegrees * kDeg2Rad;
+        const double el = elevationDegrees * kDeg2Rad;
+        const double cosE = std::cos(el);
+        return NormalizeSun(SunVec3{ cosE * std::sin(az), std::sin(el), cosE * std::cos(az) });
+    }
+
+    // Map a 24-hour clock time to a toward-sun direction. The sun rises on the east
+    // horizon (+X) at 06:00, climbs to overhead (+Y) at noon, and sets on the west
+    // horizon (-X) at 18:00; before 06:00 / after 18:00 the elevation is negative
+    // (the sun is below the horizon -> night). Elevation follows a smooth
+    // 90*sin(pi*(h-6)/12) arc and the azimuth sweeps east->south->west at 15deg/hr,
+    // so the mapping is monotonic and continuous across the day.
+    [[nodiscard]] inline SunVec3 SunDirectionFromTimeOfDay(double hours)
+    {
+        const double elevationDegrees = 90.0 * std::sin(std::numbers::pi * (hours - 6.0) / 12.0);
+        const double azimuthDegrees = 90.0 + (hours - 6.0) * 15.0;
+        return SunDirectionFromAngles(azimuthDegrees, elevationDegrees);
+    }
+
+    // Elevation (degrees above the horizon) of a toward-sun direction; expects a
+    // roughly-unit vector. Clamped so a slightly-denormalised input can't trip asin.
+    [[nodiscard]] inline double SunElevationDegrees(SunVec3 d)
+    {
+        constexpr double kRad2Deg = 180.0 / std::numbers::pi;
+        return std::asin(std::clamp(d.Y, -1.0, 1.0)) * kRad2Deg;
+    }
+
+    // Azimuth (degrees, measured from +Z toward +X, normalised to [0, 360)) of a
+    // toward-sun direction — the inverse of SunDirectionFromAngles' azimuth.
+    [[nodiscard]] inline double SunAzimuthDegrees(SunVec3 d)
+    {
+        constexpr double kRad2Deg = 180.0 / std::numbers::pi;
+        double az = std::atan2(d.X, d.Z) * kRad2Deg;
+        if (az < 0.0)
+            az += 360.0;
+        return az;
+    }
+
+    // Facts gathered by the handler after a set / clear / introspect call on the
+    // ephemeral sun-direction override.
+    struct SunOverrideResult
+    {
+        bool Active = false;   // an override is in effect after this call
+        bool Cleared = false;  // this call cleared a previously-active override
+        SunVec3 Direction{};   // toward-sun unit direction (meaningful when Active)
+        bool HasHours = false; // Hours is meaningful (the override came from set_time_of_day)
+        double Hours = 0.0;    // 0-24 clock time
+        std::string Source;    // "timeOfDay" | "sunAngle" | "cleared" | "current"
+        std::string Note;      // optional hint (no procedural sky / below-horizon); empty if none
+    };
+
+    [[nodiscard]] inline Json ToJson(const SunOverrideResult& r)
+    {
+        Json j;
+        j["active"] = r.Active;
+        j["source"] = r.Source;
+        if (r.Cleared)
+            j["cleared"] = true;
+        if (r.Active)
+        {
+            j["sunDirection"] = Json::array({ r.Direction.X, r.Direction.Y, r.Direction.Z });
+            j["elevationDegrees"] = SunElevationDegrees(r.Direction);
+            j["azimuthDegrees"] = SunAzimuthDegrees(r.Direction);
+            if (r.HasHours)
+                j["hours"] = r.Hours;
+        }
         if (!r.Note.empty())
             j["note"] = r.Note;
         return j;

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -8,6 +8,7 @@
 #include "MCP/McpServer.h"
 
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Task/NamedThreads.h"
 
 #include <algorithm>
@@ -357,6 +358,13 @@ namespace OloEngine::MCP
             m_Sessions.clear();
         }
         m_Token.clear();
+
+        // Drop any ephemeral sun-direction override an agent left active
+        // (olo_scene_set_time_of_day / olo_scene_set_sun_angle, #316 Part 4) so the
+        // editor returns to the authored procedural-sky sun once its agent is gone.
+        // Stop() runs on the game thread, so touching renderer session state here is
+        // safe; a no-op when no override is active.
+        Renderer3D::ClearSunDirectionOverride();
 
         OLO_CORE_INFO("[MCP] Diagnostics server stopped");
     }

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -2095,6 +2095,155 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_scene_set_time_of_day / olo_scene_set_sun_angle (#316 Part 4) -
+        // Ephemeral sun-direction override for lighting iteration. Like the
+        // toggle/debug-view tools above, these edit ONLY a session-global renderer
+        // override (Renderer3D::SetSunDirectionOverride), never the
+        // ProceduralSkyComponent's serialized m_SunDirection — so the moved sun is
+        // visible next frame, never saved, and resets on scene reload / play-stop /
+        // server-stop / explicit clear. The sun-direction math + result shaping is
+        // the pure RenderOverrides module; the handler does the renderer/scene-bound
+        // work on the main thread inside MarshalRead.
+
+        // (main thread) Finish a sun-override result: annotate it from the active
+        // scene (the override only affects a procedural-sky bake) and the resulting
+        // sun elevation (below the horizon bakes a dark night sky), then shape JSON.
+        Json FinalizeSunOverride(McpServer& server, RenderOverrides::SunOverrideResult& r)
+        {
+            bool skyPresent = false;
+            const Ref<Scene> scene = server.Context().GetActiveScene
+                                         ? server.Context().GetActiveScene()
+                                         : nullptr;
+            if (scene)
+            {
+                auto view = scene->GetAllEntitiesWith<ProceduralSkyComponent>();
+                skyPresent = view.begin() != view.end();
+            }
+
+            if (r.Active && !skyPresent)
+                r.Note = "No ProceduralSkyComponent in the active scene, so this sun override has no visible "
+                         "effect yet. Add a Procedural Sky to the scene to iterate time-of-day lighting.";
+            else if (r.Active && RenderOverrides::SunElevationDegrees(r.Direction) < 0.0)
+                r.Note = "The sun is below the horizon at this setting, so the sky bakes dark (night). Move "
+                         "toward noon (hours ~12) or a positive pitch for daylight.";
+
+            return RenderOverrides::ToJson(r);
+        }
+
+        ToolResult Handle_SceneSetTimeOfDay(McpServer& server, const Json& args)
+        {
+            using namespace RenderOverrides;
+
+            const bool wantClear = args.contains("clear") && args["clear"].is_boolean() && args["clear"].get<bool>();
+            const bool hasHours = !wantClear && args.contains("hours") && args["hours"].is_number();
+            double hours = 0.0;
+            if (hasHours)
+            {
+                hours = args["hours"].get<double>();
+                if (!std::isfinite(hours) || hours < 0.0 || hours > 24.0)
+                    return ToolResult::Error("Invalid 'hours': expected a finite number in [0, 24] "
+                                             "(0 = midnight, 6 = sunrise, 12 = noon, 18 = sunset).");
+            }
+
+            const Json result = server.MarshalRead([&server, wantClear, hasHours, hours]() -> Json
+                                                   {
+                SunOverrideResult r;
+                if (wantClear)
+                {
+                    r.Cleared = Renderer3D::HasSunDirectionOverride();
+                    Renderer3D::ClearSunDirectionOverride();
+                    r.Active = false;
+                    r.Source = "cleared";
+                }
+                else if (hasHours)
+                {
+                    const SunVec3 dir = SunDirectionFromTimeOfDay(hours);
+                    Renderer3D::SetSunDirectionOverride(glm::vec3(
+                        static_cast<f32>(dir.X), static_cast<f32>(dir.Y), static_cast<f32>(dir.Z)));
+                    r.Active = true;
+                    r.Direction = dir;
+                    r.HasHours = true;
+                    r.Hours = hours;
+                    r.Source = "timeOfDay";
+                }
+                else
+                {
+                    // Introspection: report the current override state.
+                    r.Active = Renderer3D::HasSunDirectionOverride();
+                    if (r.Active)
+                    {
+                        const glm::vec3& d = Renderer3D::GetSunDirectionOverride();
+                        r.Direction = SunVec3{ d.x, d.y, d.z };
+                    }
+                    r.Source = "current";
+                }
+                return FinalizeSunOverride(server, r); });
+            return ToolResult::Text(result.dump(2));
+        }
+
+        ToolResult Handle_SceneSetSunAngle(McpServer& server, const Json& args)
+        {
+            using namespace RenderOverrides;
+
+            const bool wantClear = args.contains("clear") && args["clear"].is_boolean() && args["clear"].get<bool>();
+            const bool hasYaw = !wantClear && args.contains("yaw") && args["yaw"].is_number();
+            const bool hasPitch = !wantClear && args.contains("pitch") && args["pitch"].is_number();
+
+            // A set needs BOTH angles — a half-specified direction is ambiguous, so
+            // reject it with guidance rather than silently using a default.
+            if (!wantClear && (hasYaw != hasPitch))
+                return ToolResult::Error("olo_scene_set_sun_angle needs both 'yaw' (azimuth, degrees) and "
+                                         "'pitch' (elevation, degrees). Provide both, pass 'clear':true to "
+                                         "remove the override, or call with no arguments to read the current "
+                                         "state.");
+
+            const bool doSet = !wantClear && hasYaw && hasPitch;
+            double yaw = 0.0;
+            double pitch = 0.0;
+            if (doSet)
+            {
+                yaw = args["yaw"].get<double>();
+                pitch = args["pitch"].get<double>();
+                if (!std::isfinite(yaw) || !std::isfinite(pitch))
+                    return ToolResult::Error("Invalid 'yaw'/'pitch': expected finite numbers in degrees.");
+                if (pitch < -90.0 || pitch > 90.0)
+                    return ToolResult::Error("Invalid 'pitch': expected an elevation in [-90, 90] degrees "
+                                             "(90 = straight up, 0 = horizon, negative = below the horizon).");
+            }
+
+            const Json result = server.MarshalRead([&server, wantClear, doSet, yaw, pitch]() -> Json
+                                                   {
+                SunOverrideResult r;
+                if (wantClear)
+                {
+                    r.Cleared = Renderer3D::HasSunDirectionOverride();
+                    Renderer3D::ClearSunDirectionOverride();
+                    r.Active = false;
+                    r.Source = "cleared";
+                }
+                else if (doSet)
+                {
+                    const SunVec3 dir = SunDirectionFromAngles(yaw, pitch);
+                    Renderer3D::SetSunDirectionOverride(glm::vec3(
+                        static_cast<f32>(dir.X), static_cast<f32>(dir.Y), static_cast<f32>(dir.Z)));
+                    r.Active = true;
+                    r.Direction = dir;
+                    r.Source = "sunAngle";
+                }
+                else
+                {
+                    r.Active = Renderer3D::HasSunDirectionOverride();
+                    if (r.Active)
+                    {
+                        const glm::vec3& d = Renderer3D::GetSunDirectionOverride();
+                        r.Direction = SunVec3{ d.x, d.y, d.z };
+                    }
+                    r.Source = "current";
+                }
+                return FinalizeSunOverride(server, r); });
+            return ToolResult::Text(result.dump(2));
+        }
+
         // ---- olo_render_compare_golden (Part 4 of #316) ------------------------
 
         // Resolve a caller-supplied golden path to a safe, repo-relative location
@@ -4186,6 +4335,69 @@ namespace OloEngine::MCP
             };
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderSetDebugView;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_scene_set_time_of_day";
+            tool.Toolset = "render";
+            tool.Title = "Set time of day (sun)";
+            // Edits an ephemeral session render override; setting the same hours
+            // twice yields the same sun (idempotent), destroys nothing.
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            tool.Description =
+                "Move the procedural sky's sun to a time of day for lighting iteration — the lighting inner "
+                "loop: set the hour, olo_screenshot, set another, compare. 'hours' is a 24-hour clock time "
+                "in [0,24] (0 = midnight, 6 = sunrise, 12 = noon/overhead, 18 = sunset); the sun rises in "
+                "the east, peaks overhead at noon, and sets in the west, dropping below the horizon at night. "
+                "Returns the resulting toward-sun direction with its elevation/azimuth (a 'note' warns when "
+                "the scene has no Procedural Sky to affect, or when the sun is below the horizon). The change "
+                "is EPHEMERAL: it edits a session-global renderer override, NOT the ProceduralSkyComponent, "
+                "so it is never saved and resets on scene reload, play-stop, server-stop, or 'clear':true. "
+                "Pass 'clear':true to restore the authored sun; call with no arguments to read the current "
+                "override state.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "hours", { { "type", "number" }, { "minimum", 0 }, { "maximum", 24 }, { "description", "Time of day on a 24-hour clock (0=midnight, 6=sunrise, 12=noon, 18=sunset). Omit to read current state." } } },
+                    { "clear", { { "type", "boolean" }, { "description", "Set true to remove the override and restore the scene's authored sun direction." } } } } },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_SceneSetTimeOfDay;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_scene_set_sun_angle";
+            tool.Toolset = "render";
+            tool.Title = "Set sun angle (yaw/pitch)";
+            // Edits an ephemeral session render override; same angles -> same sun
+            // (idempotent), destroys nothing.
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            tool.Description =
+                "Aim the procedural sky's sun directly from a yaw/pitch pair — the precise sibling of "
+                "olo_scene_set_time_of_day for lighting iteration. 'yaw' is the azimuth in degrees (measured "
+                "from +Z toward +X: 0=+Z, 90=+X/east, 270=-X/west) and 'pitch' is the elevation in degrees "
+                "in [-90,90] (90=straight up, 0=horizon, negative=below horizon); both are required to set. "
+                "Returns the resulting toward-sun direction with its elevation/azimuth (a 'note' warns when "
+                "the scene has no Procedural Sky to affect, or when the sun is below the horizon). The change "
+                "is EPHEMERAL: it edits a session-global renderer override, NOT the ProceduralSkyComponent, "
+                "so it is never saved and resets on scene reload, play-stop, server-stop, or 'clear':true. "
+                "Pass 'clear':true to restore the authored sun; call with no arguments to read the current "
+                "override state.";
+            tool.InputSchema = Json{
+                { "type", "object" },
+                { "properties",
+                  { { "yaw", { { "type", "number" }, { "description", "Azimuth in degrees (0=+Z, 90=+X/east, 180=-Z, 270=-X/west). Required together with 'pitch' to set." } } },
+                    { "pitch", { { "type", "number" }, { "minimum", -90 }, { "maximum", 90 }, { "description", "Elevation in degrees above the horizon (90=up, 0=horizon, negative=below). Required together with 'yaw' to set." } } },
+                    { "clear", { { "type", "boolean" }, { "description", "Set true to remove the override and restore the scene's authored sun direction." } } } } },
+                { "additionalProperties", false }
+            };
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_SceneSetSunAngle;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -2130,6 +2130,29 @@ namespace OloEngine::MCP
             return RenderOverrides::ToJson(r);
         }
 
+        // (main thread) Clear the ephemeral sun override and record the outcome —
+        // the clear branch shared verbatim by both sun-override handlers.
+        void ApplySunClear(RenderOverrides::SunOverrideResult& r)
+        {
+            r.Cleared = Renderer3D::HasSunDirectionOverride();
+            Renderer3D::ClearSunDirectionOverride();
+            r.Active = false;
+            r.Source = "cleared";
+        }
+
+        // (main thread) Read the current override state into the result — the
+        // no-argument introspection branch shared by both sun-override handlers.
+        void ApplySunIntrospect(RenderOverrides::SunOverrideResult& r)
+        {
+            r.Active = Renderer3D::HasSunDirectionOverride();
+            if (r.Active)
+            {
+                const glm::vec3& d = Renderer3D::GetSunDirectionOverride();
+                r.Direction = RenderOverrides::SunVec3{ d.x, d.y, d.z };
+            }
+            r.Source = "current";
+        }
+
         ToolResult Handle_SceneSetTimeOfDay(McpServer& server, const Json& args)
         {
             using namespace RenderOverrides;
@@ -2150,10 +2173,7 @@ namespace OloEngine::MCP
                 SunOverrideResult r;
                 if (wantClear)
                 {
-                    r.Cleared = Renderer3D::HasSunDirectionOverride();
-                    Renderer3D::ClearSunDirectionOverride();
-                    r.Active = false;
-                    r.Source = "cleared";
+                    ApplySunClear(r);
                 }
                 else if (hasHours)
                 {
@@ -2168,14 +2188,7 @@ namespace OloEngine::MCP
                 }
                 else
                 {
-                    // Introspection: report the current override state.
-                    r.Active = Renderer3D::HasSunDirectionOverride();
-                    if (r.Active)
-                    {
-                        const glm::vec3& d = Renderer3D::GetSunDirectionOverride();
-                        r.Direction = SunVec3{ d.x, d.y, d.z };
-                    }
-                    r.Source = "current";
+                    ApplySunIntrospect(r);
                 }
                 return FinalizeSunOverride(server, r); });
             return ToolResult::Text(result.dump(2));
@@ -2216,10 +2229,7 @@ namespace OloEngine::MCP
                 SunOverrideResult r;
                 if (wantClear)
                 {
-                    r.Cleared = Renderer3D::HasSunDirectionOverride();
-                    Renderer3D::ClearSunDirectionOverride();
-                    r.Active = false;
-                    r.Source = "cleared";
+                    ApplySunClear(r);
                 }
                 else if (doSet)
                 {
@@ -2232,13 +2242,7 @@ namespace OloEngine::MCP
                 }
                 else
                 {
-                    r.Active = Renderer3D::HasSunDirectionOverride();
-                    if (r.Active)
-                    {
-                        const glm::vec3& d = Renderer3D::GetSunDirectionOverride();
-                        r.Direction = SunVec3{ d.x, d.y, d.z };
-                    }
-                    r.Source = "current";
+                    ApplySunIntrospect(r);
                 }
                 return FinalizeSunOverride(server, r); });
             return ToolResult::Text(result.dump(2));

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -594,6 +594,24 @@ namespace OloEngine
             return s_Data.GlobalIBLIntensity;
         }
 
+        // Ephemeral sun-direction override (#316 Part 4). Set by the MCP
+        // olo_scene_set_time_of_day / olo_scene_set_sun_angle tools to drive the
+        // procedural sky's sun from the editor for lighting iteration; consumed by
+        // Scene::LoadAndRenderSkybox, which bakes with this toward-sun direction
+        // instead of the ProceduralSkyComponent's serialized m_SunDirection while it
+        // is Active — without mutating the component, so it is never saved. `dir`
+        // need not be normalised (the bake handles that, like the authored value).
+        static void SetSunDirectionOverride(const glm::vec3& towardSunDirection);
+        static void ClearSunDirectionOverride();
+        [[nodiscard]] static bool HasSunDirectionOverride()
+        {
+            return s_Data.SunDirectionOverrideActive;
+        }
+        [[nodiscard]] static const glm::vec3& GetSunDirectionOverride()
+        {
+            return s_Data.SunDirectionOverride;
+        }
+
         // Culling methods
         static void EnableFrustumCulling(bool enable);
         static bool IsFrustumCullingEnabled();
@@ -1355,6 +1373,17 @@ namespace OloEngine
             Ref<Shader> DecalGBufferEmissiveShader;
             Ref<Mesh> DecalCubeMesh;
             Ref<Texture2D> WhiteTexture; // 1x1 fallback for untextured decals
+
+            // Ephemeral MCP sun-direction override (#316 Part 4 —
+            // olo_scene_set_time_of_day / olo_scene_set_sun_angle). When Active,
+            // Scene::LoadAndRenderSkybox bakes the ProceduralSkyComponent with this
+            // toward-sun direction INSTEAD of the component's serialized
+            // m_SunDirection — without writing the component — so an agent can
+            // iterate lighting from the editor. Session-global like PostProcess /
+            // Fog below, so the change is never saved and a scene reload, play-stop,
+            // server-stop, or explicit clear restores the authored sun.
+            bool SunDirectionOverrideActive = false;
+            glm::vec3 SunDirectionOverride = glm::vec3(0.0f, 1.0f, 0.0f);
 
             // Post-processing
             PostProcessSettings PostProcess;

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DState.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DState.cpp
@@ -74,6 +74,18 @@ namespace OloEngine
         s_Data.PrimaryDirectionalLightDir = direction;
     }
 
+    void Renderer3D::SetSunDirectionOverride(const glm::vec3& towardSunDirection)
+    {
+        s_Data.SunDirectionOverride = towardSunDirection;
+        s_Data.SunDirectionOverrideActive = true;
+    }
+
+    void Renderer3D::ClearSunDirectionOverride()
+    {
+        s_Data.SunDirectionOverrideActive = false;
+        s_Data.SunDirectionOverride = glm::vec3(0.0f, 1.0f, 0.0f);
+    }
+
     void Renderer3D::SetCameraClipPlanes(f32 nearClip, f32 farClip)
     {
         s_Data.CameraNearClip = nearClip;

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -951,6 +951,12 @@ namespace OloEngine
         {
             m_GameplayEventBus->Clear();
         }
+
+        // Drop any ephemeral MCP sun-direction override (#316 Part 4) so leaving
+        // Play mode restores the authored procedural-sky sun. The override is a
+        // diagnostics-server lighting-iteration aid; it must never outlive a
+        // play/stop cycle. A no-op when none is active.
+        Renderer3D::ClearSunDirectionOverride();
     }
 
     void Scene::OnSimulationStart()
@@ -3235,12 +3241,26 @@ namespace OloEngine
                     }
                 }
 
+                // Ephemeral MCP sun-direction override (#316 Part 4): when an
+                // agent has set a time-of-day / sun-angle via the diagnostics
+                // server (olo_scene_set_time_of_day / olo_scene_set_sun_angle),
+                // bake with that toward-sun direction instead of the component's
+                // serialized value — WITHOUT writing m_SunDirection, so the
+                // override stays ephemeral and a scene reload / play-stop /
+                // server-stop / explicit clear restores the authored sun. Applied
+                // after the directional-light link above so it also wins over it.
+                glm::vec3 effectiveSunDirection = sky.m_SunDirection;
+                if (Renderer3D::HasSunDirectionOverride())
+                    effectiveSunDirection = Renderer3D::GetSunDirectionOverride();
+
                 // Detect dirtiness via parameter hash; rebake on change. The
                 // bake is expensive (six cubemap face renders + IBL convolve)
                 // so we deliberately gate on the hash rather than rebake every
-                // frame.
+                // frame. Because the override feeds the same hashed params, a
+                // changed (or cleared) override moves the hash and triggers
+                // exactly one rebake — no per-frame rebake while it is steady.
                 PreethamParameters params;
-                params.SunDirection = sky.m_SunDirection;
+                params.SunDirection = effectiveSunDirection;
                 params.Turbidity = sky.m_Turbidity;
                 params.Exposure = sky.m_Exposure;
                 params.SunIntensity = sky.m_SunIntensity;

--- a/OloEngine/tests/MCP/McpRenderOverridesTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderOverridesTest.cpp
@@ -13,6 +13,7 @@
 // the response shapes the agent reads.
 #include "MCP/McpRenderOverrides.h"
 
+#include <cmath>
 #include <string>
 
 namespace
@@ -229,4 +230,134 @@ TEST(McpRenderOverrides, JoinTokensProducesCommaSeparatedList)
     EXPECT_EQ("a, b, c", RO::JoinTokens({ "a", "b", "c" }));
     // The real error message joins every pass token; sanity-check it mentions one.
     EXPECT_NE(std::string::npos, RO::JoinTokens(RO::PassTokens()).find("bloom"));
+}
+
+// ---- Sun / time-of-day override ------------------------------------------
+// Pure sun-direction math behind olo_scene_set_time_of_day / olo_scene_set_sun_angle.
+// The live bake/override is verified over the MCP attach loop; this pins the
+// time -> direction / angle -> direction mapping and the result JSON shape.
+
+TEST(McpRenderOverridesSun, TimeOfDayNoonIsOverhead)
+{
+    const RO::SunVec3 d = RO::SunDirectionFromTimeOfDay(12.0);
+    EXPECT_NEAR(0.0, d.X, 1e-9);
+    EXPECT_NEAR(1.0, d.Y, 1e-9);
+    EXPECT_NEAR(0.0, d.Z, 1e-9);
+    EXPECT_NEAR(90.0, RO::SunElevationDegrees(d), 1e-6);
+}
+
+TEST(McpRenderOverridesSun, TimeOfDaySunriseAndSunsetSitOnHorizon)
+{
+    const RO::SunVec3 sunrise = RO::SunDirectionFromTimeOfDay(6.0);
+    EXPECT_NEAR(0.0, RO::SunElevationDegrees(sunrise), 1e-6); // on the horizon
+    EXPECT_GT(sunrise.X, 0.5);                                // rises in the east (+X)
+
+    const RO::SunVec3 sunset = RO::SunDirectionFromTimeOfDay(18.0);
+    EXPECT_NEAR(0.0, RO::SunElevationDegrees(sunset), 1e-6);
+    EXPECT_LT(sunset.X, -0.5); // sets in the west (-X)
+}
+
+TEST(McpRenderOverridesSun, TimeOfDayNightIsBelowHorizonAndDayIsAbove)
+{
+    EXPECT_LT(RO::SunElevationDegrees(RO::SunDirectionFromTimeOfDay(0.0)), 0.0);  // midnight
+    EXPECT_LT(RO::SunElevationDegrees(RO::SunDirectionFromTimeOfDay(24.0)), 0.0); // wraps to midnight
+    EXPECT_LT(RO::SunElevationDegrees(RO::SunDirectionFromTimeOfDay(3.0)), 0.0);  // pre-dawn
+    EXPECT_GT(RO::SunElevationDegrees(RO::SunDirectionFromTimeOfDay(9.0)), 0.0);  // mid-morning
+    EXPECT_GT(RO::SunElevationDegrees(RO::SunDirectionFromTimeOfDay(15.0)), 0.0); // mid-afternoon
+}
+
+TEST(McpRenderOverridesSun, EveryDirectionIsUnitLength)
+{
+    for (double h = 0.0; h <= 24.0; h += 1.5)
+    {
+        const RO::SunVec3 d = RO::SunDirectionFromTimeOfDay(h);
+        EXPECT_NEAR(1.0, std::sqrt(d.X * d.X + d.Y * d.Y + d.Z * d.Z), 1e-9) << "hours=" << h;
+    }
+}
+
+TEST(McpRenderOverridesSun, SunAnglesRoundTripThroughDirection)
+{
+    struct Case
+    {
+        double Yaw;
+        double Pitch;
+    };
+    // Avoid pitch == +/-90 where azimuth is degenerate (the pole).
+    const Case cases[] = { { 0.0, 0.0 }, { 90.0, 0.0 }, { 45.0, 30.0 }, { 200.0, -20.0 }, { 270.0, 15.0 } };
+    for (const Case& c : cases)
+    {
+        const RO::SunVec3 d = RO::SunDirectionFromAngles(c.Yaw, c.Pitch);
+        EXPECT_NEAR(c.Pitch, RO::SunElevationDegrees(d), 1e-6) << "yaw=" << c.Yaw;
+        EXPECT_NEAR(c.Yaw, RO::SunAzimuthDegrees(d), 1e-6) << "yaw=" << c.Yaw;
+    }
+}
+
+TEST(McpRenderOverridesSun, SunAnglePitchStraightUpIsOverhead)
+{
+    const RO::SunVec3 d = RO::SunDirectionFromAngles(123.0 /*any yaw*/, 90.0);
+    EXPECT_NEAR(0.0, d.X, 1e-9);
+    EXPECT_NEAR(1.0, d.Y, 1e-9);
+    EXPECT_NEAR(0.0, d.Z, 1e-9);
+}
+
+TEST(McpRenderOverridesSun, NormalizeSunCollapsesZeroToUp)
+{
+    const RO::SunVec3 d = RO::NormalizeSun(RO::SunVec3{ 0.0, 0.0, 0.0 });
+    EXPECT_NEAR(0.0, d.X, 1e-12);
+    EXPECT_NEAR(1.0, d.Y, 1e-12);
+    EXPECT_NEAR(0.0, d.Z, 1e-12);
+}
+
+TEST(McpRenderOverridesSun, OverrideJsonActiveFromTimeOfDay)
+{
+    RO::SunOverrideResult r;
+    r.Active = true;
+    r.Direction = RO::SunDirectionFromTimeOfDay(12.0);
+    r.HasHours = true;
+    r.Hours = 12.0;
+    r.Source = "timeOfDay";
+
+    const Json j = RO::ToJson(r);
+    EXPECT_TRUE(j.at("active").get<bool>());
+    EXPECT_EQ("timeOfDay", j.at("source").get<std::string>());
+    ASSERT_TRUE(j.at("sunDirection").is_array());
+    ASSERT_EQ(3u, j.at("sunDirection").size());
+    EXPECT_NEAR(90.0, j.at("elevationDegrees").get<double>(), 1e-6);
+    EXPECT_TRUE(j.contains("azimuthDegrees"));
+    EXPECT_DOUBLE_EQ(12.0, j.at("hours").get<double>());
+    EXPECT_FALSE(j.contains("cleared")); // only present when a clear happened
+    EXPECT_FALSE(j.contains("note"));
+}
+
+TEST(McpRenderOverridesSun, OverrideJsonClearedOmitsDirection)
+{
+    RO::SunOverrideResult r;
+    r.Active = false;
+    r.Cleared = true;
+    r.Source = "cleared";
+
+    const Json j = RO::ToJson(r);
+    EXPECT_FALSE(j.at("active").get<bool>());
+    EXPECT_TRUE(j.at("cleared").get<bool>());
+    EXPECT_EQ("cleared", j.at("source").get<std::string>());
+    // No direction-derived fields when no override is active.
+    EXPECT_FALSE(j.contains("sunDirection"));
+    EXPECT_FALSE(j.contains("elevationDegrees"));
+    EXPECT_FALSE(j.contains("azimuthDegrees"));
+    EXPECT_FALSE(j.contains("hours"));
+}
+
+TEST(McpRenderOverridesSun, OverrideJsonAngleSourceOmitsHoursAndKeepsNote)
+{
+    RO::SunOverrideResult r;
+    r.Active = true;
+    r.Direction = RO::SunDirectionFromAngles(45.0, 30.0);
+    r.Source = "sunAngle";
+    r.Note = "No ProceduralSkyComponent in the active scene, so this sun override has no visible effect yet.";
+
+    const Json j = RO::ToJson(r);
+    EXPECT_TRUE(j.at("active").get<bool>());
+    EXPECT_FALSE(j.contains("hours")); // HasHours is false for the angle path
+    ASSERT_TRUE(j.contains("note"));
+    EXPECT_NE(std::string::npos, j.at("note").get<std::string>().find("ProceduralSky"));
 }

--- a/OloEngine/tests/MCP/McpRenderOverridesTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderOverridesTest.cpp
@@ -268,8 +268,11 @@ TEST(McpRenderOverridesSun, TimeOfDayNightIsBelowHorizonAndDayIsAbove)
 
 TEST(McpRenderOverridesSun, EveryDirectionIsUnitLength)
 {
-    for (double h = 0.0; h <= 24.0; h += 1.5)
+    // Integer step counter (avoids a floating-point loop counter); samples
+    // h = 0.0, 1.5, ... 24.0 inclusive.
+    for (std::size_t step = 0; step <= 16; ++step)
     {
+        const double h = static_cast<double>(step) * 1.5;
         const RO::SunVec3 d = RO::SunDirectionFromTimeOfDay(h);
         EXPECT_NEAR(1.0, std::sqrt(d.X * d.X + d.Y * d.Y + d.Z * d.Z), 1e-9) << "hours=" << h;
     }

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -137,6 +137,8 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_render_compare_golden` | capture the viewport (optional `camera`/`orbit` pose) and diff it against a golden PNG (`goldenPath`): returns a numeric `similarity`/`rmse`/`ssim` + `pass` verdict; missing golden or `rebase`:true writes the capture as the new baseline (the `OLOENGINE_GOLDEN_REBASE` workflow) |
 | `olo_render_toggle_pass` | flip a post-process / fog feature on/off (`name` + optional `enabled`) — the ephemeral A/B loop: toggle off → `olo_screenshot` → toggle on → `olo_screenshot`. No `name` lists every pass + its live state |
 | `olo_render_set_debug_view` | switch the viewport to a raw AO/SSR/SSGI buffer (`mode`: none/ssao/gtao/ssr/ssgi); reports whether the backing pass is actually running. No `mode` lists the modes + current state |
+| `olo_scene_set_time_of_day` | move the procedural sky's sun to a 24-hour clock time (`hours` 0–24) for lighting iteration — ephemeral session override of the sun direction, never written to the scene. `clear`:true restores the authored sun; no args reports the current override |
+| `olo_scene_set_sun_angle` | aim the procedural sky's sun directly from a `yaw` (azimuth) / `pitch` (elevation) pair — the precise sibling of `olo_scene_set_time_of_day`, same ephemeral session override. `clear`:true restores; no args reports state |
 | `olo_render_why_not_visible` | explain why one entity (`entity`) is NOT on screen — the "why can't I see my mesh?" debugger: root-cause `reasonCode`, summary, ordered checks, and the raw render facts |
 | `olo_physics_layer_matrix` | the collision-layer matrix the sim uses: built-in object layers + user-defined layers, with pairwise collide/no-collide (works in Edit mode) |
 | `olo_physics_list_colliders` | paginated entities with a rigidbody: authored body type / layer / trigger / collider shapes, plus live object layer, position, awake/asleep when playing |
@@ -147,7 +149,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (39 tools) that paging the whole flat `tools/list`
+The tool surface is large enough (41 tools) that paging the whole flat `tools/list`
 to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
 category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
 keyword and/or category instead of pulling the entire list:
@@ -157,7 +159,7 @@ keyword and/or category instead of pulling the entire list:
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame` |
-| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
+| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |
 | `scripting` | `olo_script_get_api`, `olo_script_get_last_errors` |
@@ -350,6 +352,49 @@ when it is not:
 So the usual debug-view flow is two steps: `olo_render_toggle_pass { name: "ssao",
 enabled: true }` then `olo_render_set_debug_view { mode: "ssao" }`. Calling the tool
 with no `mode` lists the modes + the current state.
+
+### Sun / time-of-day override (`olo_scene_set_time_of_day` / `olo_scene_set_sun_angle`)
+
+The **lighting** counterpart of the render-override A/B loop: move the procedural
+sky's sun from the editor so an agent can iterate lighting for any rendering / water
+/ GI / god-ray work, without restarting the editor or touching the user's project.
+
+**Like the toggle/debug-view tools, the change is ephemeral.** Both tools edit only a
+session-global Renderer3D sun-direction override that `Scene::LoadAndRenderSkybox`
+bakes the **`ProceduralSkyComponent`** with — instead of the component's serialized
+`m_SunDirection` — **without ever writing the component**. So a move is visible on the
+next baked frame, is never saved, and the authored sun is restored on **scene reload,
+play-stop, server-stop, or an explicit `clear`**. The sky is hash-gated, so a changed
+(or cleared) sun triggers exactly one re-bake, not a per-frame one.
+
+`olo_scene_set_time_of_day { hours }` maps a 24-hour clock time to the sun direction —
+`0` = midnight, `6` = sunrise (sun on the east horizon, +X), `12` = noon (overhead),
+`18` = sunset (west horizon, −X); before 06:00 / after 18:00 the sun is below the
+horizon (night). The lighting inner loop:
+
+```jsonc
+// 1) olo_scene_set_time_of_day { "hours": 8 }
+{ "active": true, "source": "timeOfDay", "sunDirection": [0.61, 0.71, -0.35],
+  "elevationDegrees": 45.0, "azimuthDegrees": 120.0, "hours": 8 }
+// 2) olo_screenshot { … }                       -> the morning reference
+// 3) olo_scene_set_time_of_day { "hours": 17 }   -> low evening sun
+// 4) olo_screenshot { … }                        -> compare
+// 5) olo_scene_set_time_of_day { "clear": true } -> restore the authored sun
+{ "active": false, "cleared": true, "source": "cleared" }
+```
+
+`olo_scene_set_sun_angle { yaw, pitch }` aims the sun directly: `yaw` is the azimuth in
+degrees (measured from +Z toward +X: `0` = +Z, `90` = +X/east, `270` = −X/west) and
+`pitch` is the elevation in degrees in `[-90, 90]` (`90` = straight up, `0` = horizon,
+negative = below). **Both are required to set** — a half-specified direction is
+rejected with guidance rather than guessed.
+
+Both validate every numeric input with `std::isfinite`, report the resulting
+`sunDirection` with its `elevationDegrees` / `azimuthDegrees`, and surface a **`note`**
+when the override can't be seen — there is **no `ProceduralSkyComponent` in the active
+scene** (nothing to bake), or the **sun is below the horizon** (the sky bakes dark).
+Calling either tool with no arguments reports the current override state; `clear`:true
+removes it.
 
 ### Physics introspection (the `olo_physics_*` family)
 


### PR DESCRIPTION
- Added `olo_scene_set_time_of_day` and `olo_scene_set_sun_angle` tools to adjust the procedural sky's sun direction without modifying the serialized component.
- Introduced methods in `Renderer3D` to set and clear sun direction overrides.
- Updated `Scene` and `McpServer` to handle sun direction overrides during play mode.
- Enhanced unit tests for sun direction calculations and JSON output for overrides.
- Documented new tools and their usage in the diagnostics server documentation.