### PR TITLE
fix(content): isfinite-guard float reads in Quest/Item/Dialogue deser…

### DIFF
--- a/OloEngine/src/OloEngine/Dialogue/DialogueTreeSerializer.cpp
+++ b/OloEngine/src/OloEngine/Dialogue/DialogueTreeSerializer.cpp
@@ -5,6 +5,7 @@
 #include "OloEngine/Project/Project.h"
 #include "OloEngine/Scene/Scene.h"
 
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <unordered_set>
@@ -49,6 +50,19 @@ namespace OloEngine
                     return "unknown"; }, value);
         }
 
+        // Validate a float read from a content YAML file (cpp-coding-quality §2b): a
+        // hand-edited ".nan"/".inf" value parses cleanly but must not enter graph/condition
+        // logic. Returns 0 on non-finite input.
+        [[nodiscard]] f32 SanitizeFinite(f32 value, const char* context)
+        {
+            if (!std::isfinite(value))
+            {
+                OLO_CORE_WARN("DialogueTreeSerializer - Non-finite {} (NaN/inf); using 0", context);
+                return 0.0f;
+            }
+            return value;
+        }
+
         // Contract: typeStr must be one of "bool", "int", "float", or treated as "string".
         // Both parameters are const std::string& — callers must not swap them.
         DialoguePropertyValue ParsePropertyValue(const std::string& typeStr, const std::string& valueStr)
@@ -60,7 +74,18 @@ namespace OloEngine
                 if (typeStr == "int")
                     return static_cast<i32>(std::stoi(valueStr));
                 if (typeStr == "float")
-                    return std::stof(valueStr);
+                {
+                    // std::stof accepts "nan"/"inf"; reject those so a non-finite value never
+                    // enters dialogue condition/branch logic. Fall through to the raw string
+                    // (the same fallback the parse-failure path already uses).
+                    f32 parsed = std::stof(valueStr);
+                    if (!std::isfinite(parsed))
+                    {
+                        OLO_CORE_WARN("DialogueTreeSerializer - Non-finite float property value '{}'; storing as string", valueStr);
+                        return valueStr;
+                    }
+                    return parsed;
+                }
             }
             catch (const std::exception& e)
             {
@@ -309,8 +334,9 @@ namespace OloEngine
                 {
                     try
                     {
-                        node.EditorPosition.x = editorPos[0].as<f32>();
-                        node.EditorPosition.y = editorPos[1].as<f32>();
+                        // A non-finite editor position breaks graph-UI layout; clamp to origin.
+                        node.EditorPosition.x = SanitizeFinite(editorPos[0].as<f32>(), "EditorPosition.x");
+                        node.EditorPosition.y = SanitizeFinite(editorPos[1].as<f32>(), "EditorPosition.y");
                     }
                     catch (const YAML::Exception& e)
                     {

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.cpp
@@ -3,10 +3,28 @@
 #include "OloEngine/Core/Log.h"
 
 #include <yaml-cpp/yaml.h>
+
+#include <cmath>
 #include <filesystem>
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Validate a float read from an .oloitem YAML file (cpp-coding-quality §2b).
+        // A corrupt or hand-edited asset can carry NaN/±inf; substitute a safe fallback
+        // so it never reaches inventory weight / attribute math.
+        [[nodiscard]] f32 SanitizeFinite(f32 value, f32 fallback, const char* field, const std::string& itemId)
+        {
+            if (!std::isfinite(value))
+            {
+                OLO_CORE_WARN("[ItemDatabase] Item '{}' has non-finite {} ({}); using {}", itemId, field, value, fallback);
+                return fallback;
+            }
+            return value;
+        }
+    } // namespace
+
     std::unordered_map<std::string, ItemDefinition>& ItemDatabase::GetItems()
     {
         static std::unordered_map<std::string, ItemDefinition> s_Items;
@@ -51,7 +69,13 @@ namespace OloEngine
                     def.Rarity = ItemRarityFromString(itemNode["Rarity"].as<std::string>("Common"));
 
                     def.MaxStackSize = itemNode["MaxStackSize"].as<i32>(1);
-                    def.Weight = itemNode["Weight"].as<f32>(0.0f);
+                    // Weight feeds carry-capacity math (Inventory::GetTotalWeight); reject NaN/±inf and negatives.
+                    def.Weight = SanitizeFinite(itemNode["Weight"].as<f32>(0.0f), 0.0f, "Weight", def.ItemID);
+                    if (def.Weight < 0.0f)
+                    {
+                        OLO_CORE_WARN("[ItemDatabase] Item '{}' has negative Weight ({}); using 0", def.ItemID, def.Weight);
+                        def.Weight = 0.0f;
+                    }
                     def.BuyPrice = itemNode["BuyPrice"].as<i32>(0);
                     def.SellPrice = itemNode["SellPrice"].as<i32>(0);
 
@@ -62,9 +86,10 @@ namespace OloEngine
                     {
                         for (auto const& mod : modifiers)
                         {
+                            // Negative modifiers are legitimate (debuffs); only reject NaN/±inf.
                             def.AttributeModifiers.emplace_back(
                                 mod["Attribute"].as<std::string>(),
-                                mod["Value"].as<f32>(0.0f));
+                                SanitizeFinite(mod["Value"].as<f32>(0.0f), 0.0f, "AttributeModifier Value", def.ItemID));
                         }
                     }
 

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.cpp
@@ -2,10 +2,28 @@
 #include "OloEngine/Gameplay/Quest/QuestDatabase.h"
 
 #include <yaml-cpp/yaml.h>
+
+#include <cmath>
 #include <filesystem>
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Validate a float read from an .oloquest YAML file (cpp-coding-quality §2b).
+        // A corrupt or hand-edited asset can carry NaN/±inf; substitute a safe fallback
+        // so it never reaches quest timers / cooldowns.
+        [[nodiscard]] f32 SanitizeFinite(f32 value, f32 fallback, const char* field, const std::string& questId)
+        {
+            if (!std::isfinite(value))
+            {
+                OLO_CORE_WARN("[QuestDatabase] Quest '{}' has non-finite {} ({}); using {}", questId, field, value, fallback);
+                return fallback;
+            }
+            return value;
+        }
+    } // namespace
+
     static std::optional<QuestRequirement> ParseRequirementNode(const YAML::Node& node)
     {
         QuestRequirement req;
@@ -90,9 +108,17 @@ namespace OloEngine
                     def.Description = root["Description"].as<std::string>("");
                     def.Category = root["Category"].as<std::string>("Side");
                     def.CanFail = root["CanFail"].as<bool>(false);
-                    def.TimeLimit = root["TimeLimit"].as<f32>(-1.0f);
+                    // TimeLimit: -1 (or any value <= 0) means "no time limit"; reject NaN/±inf.
+                    def.TimeLimit = SanitizeFinite(root["TimeLimit"].as<f32>(-1.0f), -1.0f, "TimeLimit", def.QuestID);
                     def.IsRepeatable = root["IsRepeatable"].as<bool>(false);
-                    def.RepeatCooldownSeconds = root["RepeatCooldownSeconds"].as<f32>(0.0f);
+                    // RepeatCooldownSeconds: reject NaN/±inf and negative cooldowns; fall back to 0 (no cooldown).
+                    f32 cooldown = SanitizeFinite(root["RepeatCooldownSeconds"].as<f32>(0.0f), 0.0f, "RepeatCooldownSeconds", def.QuestID);
+                    if (cooldown < 0.0f)
+                    {
+                        OLO_CORE_WARN("[QuestDatabase] Quest '{}' has negative RepeatCooldownSeconds ({}); using 0", def.QuestID, cooldown);
+                        cooldown = 0.0f;
+                    }
+                    def.RepeatCooldownSeconds = cooldown;
 
                     if (auto failTags = root["FailOnTags"]; failTags && failTags.IsSequence())
                     {

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -208,6 +208,7 @@ add_executable(OloEngine-Tests
 		# Dialogue system tests
 		DialogueVariablesTest.cpp
 		DialogueTreeSerializationTest.cpp
+		DialogueTreeFloatValidationTest.cpp
 		DialogueSystemTest.cpp
 		# Shader Graph Tests
 		ShaderGraph/ShaderGraphTest.cpp
@@ -261,8 +262,10 @@ add_executable(OloEngine-Tests
 		AI/PerceptionMathTest.cpp
 		# Inventory Tests
 		InventoryTest.cpp
+		ItemDatabaseFloatValidationTest.cpp
 		# Quest Tests
 		QuestSystemTest.cpp
+		QuestDatabaseFloatValidationTest.cpp
 		# Gameplay event bus
 		GameplayEventBusTest.cpp
 		# Auto-Save Tests

--- a/OloEngine/tests/DialogueTreeFloatValidationTest.cpp
+++ b/OloEngine/tests/DialogueTreeFloatValidationTest.cpp
@@ -1,0 +1,111 @@
+// OLO_TEST_LAYER: unit
+//
+// Guards DialogueTreeSerializer's YAML float reads against non-finite values in a
+// hand-edited or corrupt .olodiag file. A ".nan"/".inf" EditorPosition breaks graph-UI
+// layout, and a "nan"/"inf" float property (parsed via std::stof, which accepts both)
+// would inject a non-finite value into dialogue condition/branch logic. See
+// cpp-coding-quality.md §2b.
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+#include "OloEngine/Scene/Scene.h" // Required: AssetSerializer.h uses Ref<Scene> inline
+#include "OloEngine/Dialogue/DialogueTreeAsset.h"
+#include "OloEngine/Dialogue/DialogueTreeSerializer.h"
+
+#include <cmath>
+#include <string>
+#include <variant>
+
+using namespace OloEngine;
+
+namespace
+{
+    class DialogueTreeFloatValidationTest : public ::testing::Test
+    {
+      protected:
+        DialogueTreeSerializer serializer;
+    };
+
+    TEST_F(DialogueTreeFloatValidationTest, NonFiniteEditorPositionIsClampedToOrigin)
+    {
+        const std::string yaml =
+            "DialogueTree:\n"
+            "  RootNodeID: 1001\n"
+            "  Nodes:\n"
+            "    - ID: 1001\n"
+            "      Type: dialogue\n"
+            "      Name: Root\n"
+            "      EditorPosition: [.nan, .inf]\n"
+            "  Connections: []\n";
+
+        auto asset = Ref<DialogueTreeAsset>::Create();
+        ASSERT_TRUE(serializer.TestDeserializeFromYAML(yaml, asset));
+
+        const auto* node = asset->FindNode(UUID(1001));
+        ASSERT_NE(node, nullptr);
+        EXPECT_TRUE(std::isfinite(node->EditorPosition.x));
+        EXPECT_TRUE(std::isfinite(node->EditorPosition.y));
+        EXPECT_FLOAT_EQ(node->EditorPosition.x, 0.0f);
+        EXPECT_FLOAT_EQ(node->EditorPosition.y, 0.0f);
+    }
+
+    TEST_F(DialogueTreeFloatValidationTest, NonFiniteFloatPropertyFallsThroughToString)
+    {
+        const std::string yaml =
+            "DialogueTree:\n"
+            "  RootNodeID: 1001\n"
+            "  Nodes:\n"
+            "    - ID: 1001\n"
+            "      Type: condition\n"
+            "      Name: Gate\n"
+            "      EditorPosition: [0.0, 0.0]\n"
+            "      Properties:\n"
+            "        threshold:\n"
+            "          type: float\n"
+            "          value: \"nan\"\n"
+            "  Connections: []\n";
+
+        auto asset = Ref<DialogueTreeAsset>::Create();
+        ASSERT_TRUE(serializer.TestDeserializeFromYAML(yaml, asset));
+
+        const auto* node = asset->FindNode(UUID(1001));
+        ASSERT_NE(node, nullptr);
+        auto it = node->Properties.find("threshold");
+        ASSERT_NE(it, node->Properties.end());
+        // Non-finite float must NOT be stored as an f32 — it falls through to the raw string.
+        EXPECT_FALSE(std::holds_alternative<f32>(it->second));
+        const auto* asString = std::get_if<std::string>(&it->second);
+        ASSERT_NE(asString, nullptr);
+        EXPECT_EQ(*asString, "nan");
+    }
+
+    TEST_F(DialogueTreeFloatValidationTest, ValidFloatsAreParsedAndKept)
+    {
+        const std::string yaml =
+            "DialogueTree:\n"
+            "  RootNodeID: 2001\n"
+            "  Nodes:\n"
+            "    - ID: 2001\n"
+            "      Type: condition\n"
+            "      Name: Gate\n"
+            "      EditorPosition: [100.0, 200.0]\n"
+            "      Properties:\n"
+            "        threshold:\n"
+            "          type: float\n"
+            "          value: \"1.5\"\n"
+            "  Connections: []\n";
+
+        auto asset = Ref<DialogueTreeAsset>::Create();
+        ASSERT_TRUE(serializer.TestDeserializeFromYAML(yaml, asset));
+
+        const auto* node = asset->FindNode(UUID(2001));
+        ASSERT_NE(node, nullptr);
+        EXPECT_FLOAT_EQ(node->EditorPosition.x, 100.0f);
+        EXPECT_FLOAT_EQ(node->EditorPosition.y, 200.0f);
+
+        auto it = node->Properties.find("threshold");
+        ASSERT_NE(it, node->Properties.end());
+        const auto* asFloat = std::get_if<f32>(&it->second);
+        ASSERT_NE(asFloat, nullptr);
+        EXPECT_FLOAT_EQ(*asFloat, 1.5f);
+    }
+} // namespace

--- a/OloEngine/tests/ItemDatabaseFloatValidationTest.cpp
+++ b/OloEngine/tests/ItemDatabaseFloatValidationTest.cpp
@@ -1,0 +1,111 @@
+// OLO_TEST_LAYER: unit
+//
+// Guards ItemDatabase::LoadFromDirectory against non-finite floats in hand-edited or
+// corrupt .oloitem files. A NaN/inf Weight poisons Inventory::GetTotalWeight (def->Weight
+// * StackCount), breaking carry-capacity checks; a NaN attribute modifier corrupts stat
+// math. The loader must substitute safe fallbacks. See cpp-coding-quality.md §2b.
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Gameplay/Inventory/Item.h"
+#include "OloEngine/Gameplay/Inventory/ItemDatabase.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace OloEngine;
+
+namespace
+{
+    class ItemDatabaseFloatValidationTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            ItemDatabase::Clear();
+            m_Dir = std::filesystem::temp_directory_path() / "olo_item_floatval_test";
+            std::error_code ec;
+            std::filesystem::remove_all(m_Dir, ec);
+            std::filesystem::create_directories(m_Dir, ec);
+        }
+
+        void TearDown() override
+        {
+            ItemDatabase::Clear();
+            std::error_code ec;
+            std::filesystem::remove_all(m_Dir, ec);
+        }
+
+        void WriteItem(const std::string& fileName, const std::string& body)
+        {
+            std::ofstream out(m_Dir / fileName);
+            out << body;
+            out.close();
+            ItemDatabase::LoadFromDirectory(m_Dir.string());
+        }
+
+        std::filesystem::path m_Dir;
+    };
+
+    TEST_F(ItemDatabaseFloatValidationTest, NaNWeightFallsBackToZero)
+    {
+        WriteItem("nan_weight.oloitem",
+                  "ItemDefinition:\n"
+                  "  ItemID: i_nan_weight\n"
+                  "  Weight: .nan\n");
+
+        const auto* def = ItemDatabase::Get("i_nan_weight");
+        ASSERT_NE(def, nullptr);
+        EXPECT_TRUE(std::isfinite(def->Weight));
+        EXPECT_FLOAT_EQ(def->Weight, 0.0f);
+    }
+
+    TEST_F(ItemDatabaseFloatValidationTest, NegativeWeightIsClampedToZero)
+    {
+        WriteItem("neg_weight.oloitem",
+                  "ItemDefinition:\n"
+                  "  ItemID: i_neg_weight\n"
+                  "  Weight: -2.5\n");
+
+        const auto* def = ItemDatabase::Get("i_neg_weight");
+        ASSERT_NE(def, nullptr);
+        EXPECT_FLOAT_EQ(def->Weight, 0.0f);
+    }
+
+    TEST_F(ItemDatabaseFloatValidationTest, InfAttributeModifierFallsBackToZero)
+    {
+        WriteItem("inf_modifier.oloitem",
+                  "ItemDefinition:\n"
+                  "  ItemID: i_inf_mod\n"
+                  "  Weight: 1.0\n"
+                  "  AttributeModifiers:\n"
+                  "    - Attribute: AttackPower\n"
+                  "      Value: .inf\n");
+
+        const auto* def = ItemDatabase::Get("i_inf_mod");
+        ASSERT_NE(def, nullptr);
+        ASSERT_EQ(def->AttributeModifiers.size(), 1u);
+        EXPECT_EQ(def->AttributeModifiers[0].first, "AttackPower");
+        EXPECT_TRUE(std::isfinite(def->AttributeModifiers[0].second));
+        EXPECT_FLOAT_EQ(def->AttributeModifiers[0].second, 0.0f);
+    }
+
+    TEST_F(ItemDatabaseFloatValidationTest, ValidValuesIncludingNegativeModifierAreKept)
+    {
+        WriteItem("valid.oloitem",
+                  "ItemDefinition:\n"
+                  "  ItemID: i_valid\n"
+                  "  Weight: 3.5\n"
+                  "  AttributeModifiers:\n"
+                  "    - Attribute: Defense\n"
+                  "      Value: -10.0\n"); // negative modifiers (debuffs) are legitimate
+
+        const auto* def = ItemDatabase::Get("i_valid");
+        ASSERT_NE(def, nullptr);
+        EXPECT_FLOAT_EQ(def->Weight, 3.5f);
+        ASSERT_EQ(def->AttributeModifiers.size(), 1u);
+        EXPECT_FLOAT_EQ(def->AttributeModifiers[0].second, -10.0f);
+    }
+} // namespace

--- a/OloEngine/tests/QuestDatabaseFloatValidationTest.cpp
+++ b/OloEngine/tests/QuestDatabaseFloatValidationTest.cpp
@@ -1,0 +1,102 @@
+// OLO_TEST_LAYER: unit
+//
+// Guards QuestDatabase::LoadFromDirectory against non-finite floats in hand-edited or
+// corrupt .oloquest files. A NaN/inf TimeLimit or RepeatCooldownSeconds would silently
+// corrupt quest timing (QuestJournal compares TimeLimit/cooldown against 0), so the
+// loader must substitute the documented sentinels. See cpp-coding-quality.md §2b.
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Gameplay/Quest/QuestDatabase.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace OloEngine;
+
+namespace
+{
+    class QuestDatabaseFloatValidationTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            QuestDatabase::Clear();
+            m_Dir = std::filesystem::temp_directory_path() / "olo_quest_floatval_test";
+            std::error_code ec;
+            std::filesystem::remove_all(m_Dir, ec);
+            std::filesystem::create_directories(m_Dir, ec);
+        }
+
+        void TearDown() override
+        {
+            QuestDatabase::Clear();
+            std::error_code ec;
+            std::filesystem::remove_all(m_Dir, ec);
+        }
+
+        // Writes a single .oloquest file with the given body and loads the directory.
+        void WriteQuest(const std::string& fileName, const std::string& body)
+        {
+            std::ofstream out(m_Dir / fileName);
+            out << body;
+            out.close();
+            QuestDatabase::LoadFromDirectory(m_Dir.string());
+        }
+
+        std::filesystem::path m_Dir;
+    };
+
+    TEST_F(QuestDatabaseFloatValidationTest, NaNTimeLimitFallsBackToNoLimitSentinel)
+    {
+        WriteQuest("nan_timelimit.oloquest",
+                   "QuestID: q_nan_time\n"
+                   "TimeLimit: .nan\n");
+
+        const auto* def = QuestDatabase::Get("q_nan_time");
+        ASSERT_NE(def, nullptr);
+        EXPECT_TRUE(std::isfinite(def->TimeLimit));
+        EXPECT_FLOAT_EQ(def->TimeLimit, -1.0f); // -1 == "no time limit"
+    }
+
+    TEST_F(QuestDatabaseFloatValidationTest, InfCooldownFallsBackToZero)
+    {
+        WriteQuest("inf_cooldown.oloquest",
+                   "QuestID: q_inf_cd\n"
+                   "IsRepeatable: true\n"
+                   "RepeatCooldownSeconds: .inf\n");
+
+        const auto* def = QuestDatabase::Get("q_inf_cd");
+        ASSERT_NE(def, nullptr);
+        EXPECT_TRUE(std::isfinite(def->RepeatCooldownSeconds));
+        EXPECT_FLOAT_EQ(def->RepeatCooldownSeconds, 0.0f);
+    }
+
+    TEST_F(QuestDatabaseFloatValidationTest, NegativeCooldownIsClampedToZero)
+    {
+        WriteQuest("neg_cooldown.oloquest",
+                   "QuestID: q_neg_cd\n"
+                   "IsRepeatable: true\n"
+                   "RepeatCooldownSeconds: -5.0\n");
+
+        const auto* def = QuestDatabase::Get("q_neg_cd");
+        ASSERT_NE(def, nullptr);
+        EXPECT_FLOAT_EQ(def->RepeatCooldownSeconds, 0.0f);
+    }
+
+    TEST_F(QuestDatabaseFloatValidationTest, ValidFloatsAreLeftUntouched)
+    {
+        WriteQuest("valid.oloquest",
+                   "QuestID: q_valid\n"
+                   "TimeLimit: 120.0\n"
+                   "IsRepeatable: true\n"
+                   "RepeatCooldownSeconds: 30.0\n");
+
+        const auto* def = QuestDatabase::Get("q_valid");
+        ASSERT_NE(def, nullptr);
+        EXPECT_FLOAT_EQ(def->TimeLimit, 120.0f);
+        EXPECT_FLOAT_EQ(def->RepeatCooldownSeconds, 30.0f);
+    }
+} // namespace


### PR DESCRIPTION
…ializers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed numeric values in dialogue, item, and quest data so invalid values no longer break loading or create bad in-game/editor behavior.
  * Added safeguards for editor positions, item weights, attribute modifiers, quest time limits, and cooldowns, with sensible fallback values when needed.
  * Prevented negative or non-finite values from causing unstable or unexpected results in loaded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->