### PR TITLE
feat(asset): enhance file dialog with initial directory and output pa…

### DIFF
--- a/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/FileSystem.h"
 #include "OloEngine/Project/Project.h"
+#include "OloEngine/Utils/PlatformUtils.h"
 
 #include <imgui.h>
 #include <cstring>
@@ -146,14 +147,44 @@ namespace OloEngine
             ImGui::SameLine();
             if (ImGui::Button("Browse"))
             {
-                // For now, just use default extension
-                std::string defaultPath = m_OutputPathBuffer.data();
-                if (defaultPath.empty())
+                // Default the dialog to the active project's asset directory, falling
+                // back to the directory of whatever path is already in the buffer.
+                std::string initialDir;
+                if (Project::GetActive())
                 {
-                    defaultPath = "Assets/AssetPack.olopack";
+                    initialDir = Project::GetAssetDirectory().string();
                 }
-                // Could implement file dialog here in the future
-                OLO_CORE_INFO("File dialog not implemented yet, using: {}", defaultPath);
+                else if (std::filesystem::path current(m_OutputPathBuffer.data()); current.has_parent_path())
+                {
+                    initialDir = current.parent_path().string();
+                }
+
+                // Win32 commdlg double-NUL-terminated filter; the Linux backend parses
+                // the same format (see LinuxPlatformUtils::ParseWin32Filter).
+                std::string selected = FileDialogs::SaveFile(
+                    "Asset Pack (*.olopack)\0*.olopack\0",
+                    initialDir.empty() ? nullptr : initialDir.c_str());
+
+                // Empty result == user cancelled — leave the current path untouched.
+                if (!selected.empty())
+                {
+                    // Mirror the manual-entry normalisation: append .olopack if missing.
+                    if (std::filesystem::path fsPath(selected); fsPath.extension() != ".olopack")
+                    {
+                        selected += ".olopack";
+                    }
+
+                    // Write the chosen path into the buffer and run it through the same
+                    // validation the text field uses, so the error UX is identical.
+                    sizet len = std::min(selected.length(), m_OutputPathBuffer.size() - 1);
+                    std::memcpy(m_OutputPathBuffer.data(), selected.c_str(), len);
+                    m_OutputPathBuffer[len] = '\0';
+
+                    if (ValidateOutputPath(selected, m_OutputPathError))
+                    {
+                        m_BuildSettings.m_OutputPath = std::filesystem::path(selected);
+                    }
+                }
             }
 
             // Basic settings
@@ -268,7 +299,8 @@ namespace OloEngine
 
                 // Show file size if file exists
                 std::error_code ec;
-                if (std::filesystem::exists(m_LastBuildResult.m_OutputPath, ec) && !ec)
+                bool outputExists = std::filesystem::exists(m_LastBuildResult.m_OutputPath, ec) && !ec;
+                if (outputExists)
                 {
                     auto fileSize = std::filesystem::file_size(m_LastBuildResult.m_OutputPath, ec);
                     if (!ec)
@@ -278,8 +310,22 @@ namespace OloEngine
                     }
                 }
 
-                // Note: Explorer functionality not yet implemented in OloEngine
-                // TODO: Add platform-specific directory opening functionality
+                // Reveal the built pack in the OS file manager. Only meaningful once
+                // the file actually exists on disk, so disable it otherwise.
+                if (!outputExists)
+                {
+                    ImGui::BeginDisabled();
+                }
+                if (ImGui::Button("Open Output Folder"))
+                {
+                    FileDialogs::ShowInFileManager(m_LastBuildResult.m_OutputPath);
+                }
+                if (!outputExists)
+                {
+                    ImGui::EndDisabled();
+                }
+
+                ImGui::SameLine();
                 if (ImGui::Button("Copy Output Path"))
                 {
                     ImGui::SetClipboardText(m_LastBuildResult.m_OutputPath.string().c_str());

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.cpp
@@ -116,25 +116,7 @@ namespace OloEngine
             // Validate path on change
             if (bool pathChanged = ImGui::InputText("##OutputPath", m_OutputPathBuffer.data(), m_OutputPathBuffer.size()); pathChanged)
             {
-                std::string inputPath = m_OutputPathBuffer.data();
-
-                // Automatically append .olopack extension if missing
-                if (std::filesystem::path fsPath(inputPath); fsPath.extension() != ".olopack")
-                {
-                    inputPath += ".olopack";
-                    // Update buffer with corrected path
-                    sizet len = std::min(inputPath.length(), m_OutputPathBuffer.size() - 1);
-                    std::memcpy(m_OutputPathBuffer.data(), inputPath.c_str(), len);
-                    m_OutputPathBuffer[len] = '\0';
-                }
-
-                // Validate the path
-                if (ValidateOutputPath(inputPath, m_OutputPathError))
-                {
-                    // Path is valid, update settings
-                    m_BuildSettings.m_OutputPath = std::filesystem::path(inputPath);
-                }
-                // If invalid, don't update m_OutputPath but keep the error message for display
+                ApplyOutputPath(m_OutputPathBuffer.data());
             }
 
             // Display validation error if any
@@ -166,24 +148,11 @@ namespace OloEngine
                     initialDir.empty() ? nullptr : initialDir.c_str());
 
                 // Empty result == user cancelled — leave the current path untouched.
+                // Otherwise route through the shared helper so normalisation, the
+                // buffer write and validation match the manual-entry path exactly.
                 if (!selected.empty())
                 {
-                    // Mirror the manual-entry normalisation: append .olopack if missing.
-                    if (std::filesystem::path fsPath(selected); fsPath.extension() != ".olopack")
-                    {
-                        selected += ".olopack";
-                    }
-
-                    // Write the chosen path into the buffer and run it through the same
-                    // validation the text field uses, so the error UX is identical.
-                    sizet len = std::min(selected.length(), m_OutputPathBuffer.size() - 1);
-                    std::memcpy(m_OutputPathBuffer.data(), selected.c_str(), len);
-                    m_OutputPathBuffer[len] = '\0';
-
-                    if (ValidateOutputPath(selected, m_OutputPathError))
-                    {
-                        m_BuildSettings.m_OutputPath = std::filesystem::path(selected);
-                    }
+                    ApplyOutputPath(std::move(selected));
                 }
             }
 
@@ -420,6 +389,36 @@ namespace OloEngine
         // sets m_IsBuildInProgress=false; OnImGuiRender (or the destructor) joins.
     }
 
+    void AssetPackBuilderPanel::ApplyOutputPath(std::string path)
+    {
+        // Normalise the extension identically for manual entry and the Browse dialog.
+        if (std::filesystem::path fsPath(path); fsPath.extension() != ".olopack")
+        {
+            path += ".olopack";
+        }
+
+        // Reject anything that wouldn't fit the fixed UI buffer rather than silently
+        // truncating it: a truncated buffer would desync from the string that
+        // ValidateOutputPath checked and from what StartBuild() later reads back out
+        // of m_OutputPathBuffer.
+        if (path.length() >= m_OutputPathBuffer.size())
+        {
+            m_OutputPathError = "Output path is too long";
+            return;
+        }
+
+        std::memcpy(m_OutputPathBuffer.data(), path.c_str(), path.length());
+        m_OutputPathBuffer[path.length()] = '\0';
+
+        // Validate; only commit to the build settings when the path is accepted.
+        if (ValidateOutputPath(path, m_OutputPathError))
+        {
+            m_BuildSettings.m_OutputPath = std::filesystem::path(path);
+        }
+        // If invalid, keep the buffer (so the user sees what they entered) and the
+        // error message for display, but don't update m_BuildSettings.m_OutputPath.
+    }
+
     bool AssetPackBuilderPanel::ValidateOutputPath(const std::string& path, std::string& errorMessage) const
     {
         if (path.empty())
@@ -428,24 +427,32 @@ namespace OloEngine
             return false;
         }
 
-        // Check for invalid filename characters (Windows and Unix common restrictions)
-        if (std::regex invalidChars(R"([<>:"|?*\x00-\x1f])"); std::regex_search(path, invalidChars))
+        const std::filesystem::path fsPath(path);
+
+        // Check for invalid filename characters (Windows and Unix common restrictions).
+        // The drive-letter colon (e.g. "C:") is the only legal ':' on Windows, so strip
+        // the root-name before scanning — otherwise every absolute path the Save dialog
+        // returns ("X:\...") would be rejected and the Build button would stay disabled.
+        const sizet rootLen = std::min(path.size(), fsPath.root_name().string().size());
+        const std::string scanText = path.substr(rootLen);
+        if (std::regex invalidChars(R"([<>:"|?*\x00-\x1f])"); std::regex_search(scanText, invalidChars))
         {
             errorMessage = "Path contains invalid characters (< > : \" | ? * or control characters)";
             return false;
         }
 
         // Ensure .olopack extension
-        std::filesystem::path fsPath(path);
         if (fsPath.extension() != ".olopack")
         {
             errorMessage = "Path must end with .olopack extension";
             return false;
         }
 
-        // Check if parent directory exists
-        std::filesystem::path parentDir = fsPath.parent_path();
-        if (!parentDir.empty() && !std::filesystem::exists(parentDir))
+        // Check if parent directory exists. The error_code overload keeps a transient
+        // filesystem error from throwing out of the ImGui render loop.
+        std::error_code existsEc;
+        const std::filesystem::path parentDir = fsPath.parent_path();
+        if (!parentDir.empty() && !std::filesystem::exists(parentDir, existsEc))
         {
             errorMessage = "Parent directory does not exist: " + parentDir.string();
             return false;

--- a/OloEditor/src/Panels/AssetPackBuilderPanel.h
+++ b/OloEditor/src/Panels/AssetPackBuilderPanel.h
@@ -82,6 +82,16 @@ namespace OloEngine
          */
         bool ValidateOutputPath(const std::string& path, std::string& errorMessage) const;
 
+        /**
+         * @brief Normalise, store, validate and (if valid) commit an output path.
+         *
+         * Shared by the manual text-entry handler and the Browse dialog so both
+         * apply identical .olopack normalisation, buffer writes and validation.
+         * Rejects paths that don't fit m_OutputPathBuffer rather than truncating.
+         * @param path Candidate output path (taken by value; mutated internally).
+         */
+        void ApplyOutputPath(std::string path);
+
       private:
         // Build settings
         AssetPackBuilder::BuildSettings m_BuildSettings;

--- a/OloEngine/src/OloEngine/Utils/PlatformUtils.h
+++ b/OloEngine/src/OloEngine/Utils/PlatformUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <optional>
 
@@ -12,6 +13,14 @@ namespace OloEngine
         // initialDir overrides the OS-remembered last-used directory when provided
         static std::string OpenFile(const char* filter, const char* initialDir = nullptr);
         static std::string SaveFile(const char* filter, const char* initialDir = nullptr);
+
+        // Reveal a path in the OS file manager (Explorer on Windows, the default
+        // file manager via xdg-open on Linux). When `path` is a regular file it is
+        // selected inside its parent folder on platforms that support selection
+        // (Windows); otherwise the containing / target directory is opened. No-op
+        // with a warning when the path does not exist or no file manager is
+        // available. Non-blocking — returns as soon as the launch is dispatched.
+        static void ShowInFileManager(const std::filesystem::path& path);
     };
 
     enum class MessagePromptResult

--- a/OloEngine/src/Platform/Linux/LinuxPlatformUtils.cpp
+++ b/OloEngine/src/Platform/Linux/LinuxPlatformUtils.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstdlib> // getenv
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -264,6 +265,54 @@ namespace OloEngine
             return false;
         }
 
+        // Fire-and-forget launch of argv[0] (resolved via PATH) with no shell — no
+        // quoting/escaping pitfalls. Used to open the OS file manager without
+        // blocking the editor UI thread. Double-forks so the grandchild that runs
+        // the file manager is reparented to init and never lingers as a zombie.
+        bool LaunchDetached(const std::vector<std::string>& argv)
+        {
+            if (argv.empty())
+                return false;
+
+            // Build the char* vector in the parent — after fork() only async-signal-safe
+            // calls are allowed in the child, so keep its path malloc-free.
+            std::vector<char*> cargv;
+            cargv.reserve(argv.size() + 1);
+            for (const std::string& arg : argv)
+                cargv.push_back(const_cast<char*>(arg.c_str()));
+            cargv.push_back(nullptr);
+
+            const pid_t pid = ::fork();
+            if (pid < 0)
+            {
+                OLO_CORE_ERROR("ShowInFileManager: fork() failed (errno={})", errno);
+                return false;
+            }
+
+            if (pid == 0)
+            {
+                // Intermediate child: fork again and exit immediately so the grandchild
+                // is orphaned onto init (PID 1), which reaps it — the parent never has
+                // to wait on the file manager itself.
+                const pid_t grandchild = ::fork();
+                if (grandchild == 0)
+                {
+                    ::execvp(cargv[0], cargv.data());
+                    _exit(127); // only reached if exec failed
+                }
+                _exit(grandchild < 0 ? 127 : 0);
+            }
+
+            // Parent: reap the intermediate child, which exits right away.
+            int status = 0;
+            while (::waitpid(pid, &status, 0) == -1)
+            {
+                if (errno != EINTR)
+                    break;
+            }
+            return true;
+        }
+
         std::vector<std::string> BuildZenityArgs(const std::vector<FileFilter>& filters, const std::string& startDir, bool save)
         {
             std::vector<std::string> argv;
@@ -415,6 +464,33 @@ namespace OloEngine
     std::string FileDialogs::SaveFile(const char* const filter, const char* const initialDir)
     {
         return RunFileDialog(filter, initialDir, /*save=*/true);
+    }
+
+    void FileDialogs::ShowInFileManager(const std::filesystem::path& path)
+    {
+        std::error_code ec;
+        if (!std::filesystem::exists(path, ec) || ec)
+        {
+            OLO_CORE_WARN("ShowInFileManager: path does not exist: '{}'", path.string());
+            return;
+        }
+
+        // xdg-open has no "select this file" mode, so when handed a file we open its
+        // containing directory — which is what the caller wants (reveal where it lives).
+        std::filesystem::path target = (std::filesystem::is_directory(path, ec) && !ec)
+                                           ? path
+                                           : path.parent_path();
+        if (target.empty())
+            target = std::filesystem::path(".");
+
+        if (!IsExecutableInPath("xdg-open"))
+        {
+            OLO_CORE_ERROR("ShowInFileManager: 'xdg-open' not found on PATH; cannot reveal '{}'.", target.string());
+            return;
+        }
+
+        if (!LaunchDetached({ "xdg-open", target.string() }))
+            OLO_CORE_ERROR("ShowInFileManager: failed to launch xdg-open for '{}'.", target.string());
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/OloEngine/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -3,6 +3,8 @@
 #include "OloEngine/Core/Application.h"
 
 #include <commdlg.h>
+#include <shellapi.h>
+#include <filesystem>
 #include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
@@ -84,6 +86,33 @@ namespace OloEngine
         }
         return {};
     }
+
+    void FileDialogs::ShowInFileManager(const std::filesystem::path& path)
+    {
+        // canonical() resolves the path relative to the process cwd and fails (sets
+        // ec) when it does not exist — so it doubles as the existence check.
+        std::error_code ec;
+        const std::filesystem::path canonical = std::filesystem::canonical(path, ec);
+        if (ec)
+        {
+            OLO_CORE_WARN("ShowInFileManager: cannot resolve path '{}': {}", path.string(), ec.message());
+            return;
+        }
+
+        if (std::filesystem::is_directory(canonical, ec) && !ec)
+        {
+            // Open the directory itself in a new Explorer window.
+            ::ShellExecuteW(nullptr, L"explore", canonical.wstring().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+        }
+        else
+        {
+            // Select the file inside its parent folder. The path is quoted because
+            // /select treats everything after the comma as the (possibly spaced) path.
+            const std::wstring args = L"/select,\"" + canonical.wstring() + L"\"";
+            ::ShellExecuteW(nullptr, L"open", L"explorer.exe", args.c_str(), nullptr, SW_SHOWNORMAL);
+        }
+    }
+
     MessagePromptResult MessagePrompt::YesNoCancel(const char* const title, const char* const message)
     {
         OLO_PROFILE_FUNCTION();

--- a/OloEngine/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/OloEngine/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -99,17 +99,24 @@ namespace OloEngine
             return;
         }
 
+        // ShellExecuteW returns an HINSTANCE whose value <= 32 indicates failure;
+        // surface it as a warning so a failed launch isn't silent (matching the
+        // header contract and the Linux backend's logging).
         if (std::filesystem::is_directory(canonical, ec) && !ec)
         {
             // Open the directory itself in a new Explorer window.
-            ::ShellExecuteW(nullptr, L"explore", canonical.wstring().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+            const HINSTANCE rc = ::ShellExecuteW(nullptr, L"explore", canonical.wstring().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+            if (reinterpret_cast<INT_PTR>(rc) <= 32)
+                OLO_CORE_WARN("ShowInFileManager: failed to open '{}' (ShellExecute code {})", canonical.string(), reinterpret_cast<INT_PTR>(rc));
         }
         else
         {
             // Select the file inside its parent folder. The path is quoted because
             // /select treats everything after the comma as the (possibly spaced) path.
             const std::wstring args = L"/select,\"" + canonical.wstring() + L"\"";
-            ::ShellExecuteW(nullptr, L"open", L"explorer.exe", args.c_str(), nullptr, SW_SHOWNORMAL);
+            const HINSTANCE rc = ::ShellExecuteW(nullptr, L"open", L"explorer.exe", args.c_str(), nullptr, SW_SHOWNORMAL);
+            if (reinterpret_cast<INT_PTR>(rc) <= 32)
+                OLO_CORE_WARN("ShowInFileManager: failed to reveal '{}' (ShellExecute code {})", canonical.string(), reinterpret_cast<INT_PTR>(rc));
         }
     }
 


### PR DESCRIPTION
…th validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app file picker for choosing the asset pack output path, with smarter default folder selection and path validation.
  * Added a new “Open Output Folder” action that opens the built output location in the system file manager.
* **Bug Fixes**
  * The output folder action is now disabled when no built pack exists, preventing dead-end clicks.
  * Canceling the file picker now leaves the current output path unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->