### PR TITLE
chore(animation): SonarQube CODE_SMELL cleanup (excl. Retargeting/)

### DIFF
--- a/OloEngine/src/OloEngine/Animation/AnimatedMeshComponents.h
+++ b/OloEngine/src/OloEngine/Animation/AnimatedMeshComponents.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <utility>
 #include "OloEngine/Threading/Mutex.h"
 #include "OloEngine/Threading/UniqueLock.h"
 
@@ -41,7 +42,9 @@ namespace OloEngine
 
         SubmeshComponent() = default;
         SubmeshComponent(const SubmeshComponent& other) = default;
-        explicit SubmeshComponent(const Ref<OloEngine::Mesh>& mesh, u32 submeshIndex = 0)
+        explicit SubmeshComponent(const Ref<OloEngine::Mesh>& mesh)
+            : SubmeshComponent(mesh, 0) {}
+        explicit SubmeshComponent(const Ref<OloEngine::Mesh>& mesh, u32 submeshIndex)
             : m_Mesh(mesh), m_SubmeshIndex(submeshIndex)
         {
             // Validate mesh reference
@@ -55,11 +58,10 @@ namespace OloEngine
         // default vector== implementation. Compare UUIDs via u64.
         auto operator==(const SubmeshComponent& other) const -> bool
         {
-            if (m_Mesh != other.m_Mesh || m_SubmeshIndex != other.m_SubmeshIndex || m_Visible != other.m_Visible)
+            auto boneCount = m_BoneEntityIds.size();
+            if (m_Mesh != other.m_Mesh || m_SubmeshIndex != other.m_SubmeshIndex || m_Visible != other.m_Visible || boneCount != other.m_BoneEntityIds.size())
                 return false;
-            if (m_BoneEntityIds.size() != other.m_BoneEntityIds.size())
-                return false;
-            for (sizet i = 0; i < m_BoneEntityIds.size(); ++i)
+            for (sizet i = 0; i < boneCount; ++i)
             {
                 if (static_cast<u64>(m_BoneEntityIds[i]) != static_cast<u64>(other.m_BoneEntityIds[i]))
                     return false;
@@ -214,7 +216,7 @@ namespace OloEngine
             : m_Skeleton(other.m_Skeleton)
         {
             // Thread-safe copy of cache data
-            TUniqueLock<FMutex> lock(other.m_CacheMutex);
+            TUniqueLock lock(other.m_CacheMutex);
             m_TagEntityCache = other.m_TagEntityCache;
             m_CacheValid = other.m_CacheValid;
             // Each component gets its own mutex
@@ -233,8 +235,8 @@ namespace OloEngine
                 {
                     std::swap(first, second);
                 }
-                TUniqueLock<FMutex> lock1(*first);
-                TUniqueLock<FMutex> lock2(*second);
+                TUniqueLock lock1(*first);
+                TUniqueLock lock2(*second);
                 m_Skeleton = other.m_Skeleton;
                 m_TagEntityCache = other.m_TagEntityCache;
                 m_CacheValid = other.m_CacheValid;
@@ -248,7 +250,7 @@ namespace OloEngine
             : m_Skeleton(std::move(other.m_Skeleton))
         {
             // Transfer cache data under lock from the source
-            TUniqueLock<FMutex> lock(other.m_CacheMutex);
+            TUniqueLock lock(other.m_CacheMutex);
             m_TagEntityCache = std::move(other.m_TagEntityCache);
             m_CacheValid = other.m_CacheValid;
             other.m_CacheValid = false; // Invalidate source cache
@@ -268,8 +270,8 @@ namespace OloEngine
                 {
                     std::swap(first, second);
                 }
-                TUniqueLock<FMutex> lock1(*first);
-                TUniqueLock<FMutex> lock2(*second);
+                TUniqueLock lock1(*first);
+                TUniqueLock lock2(*second);
                 m_Skeleton = std::move(other.m_Skeleton);
                 m_TagEntityCache = std::move(other.m_TagEntityCache);
                 m_CacheValid = other.m_CacheValid;
@@ -281,7 +283,7 @@ namespace OloEngine
         // Invalidate cache when skeleton changes
         void InvalidateCache() const noexcept
         {
-            TUniqueLock<FMutex> lock(m_CacheMutex);
+            TUniqueLock lock(m_CacheMutex);
             m_CacheValid = false;
             m_TagEntityCache.clear();
         }
@@ -289,7 +291,7 @@ namespace OloEngine
         // Thread-safe setter for skeleton that automatically invalidates cache
         void SetSkeleton(const Ref<Skeleton>& skeleton) noexcept
         {
-            TUniqueLock<FMutex> lock(m_CacheMutex);
+            TUniqueLock lock(m_CacheMutex);
             m_Skeleton = skeleton;
             m_CacheValid = false;
             m_TagEntityCache.clear();
@@ -301,7 +303,7 @@ namespace OloEngine
         // to repopulate it. Encapsulating the access here lets the mutable cache
         // members stay private and guarded by m_CacheMutex.
         template<typename RebuildFn>
-        [[nodiscard]] std::vector<UUID> ResolveBoneEntities(
+        [[nodiscard("resolved bone entity IDs must be used")]] std::vector<UUID> ResolveBoneEntities(
             const std::vector<std::string>& boneNames, RebuildFn&& rebuildCache) const
         {
             std::vector<UUID> boneEntityIds;
@@ -309,11 +311,11 @@ namespace OloEngine
 
             bool foundAtLeastOne = false;
             {
-                TUniqueLock<FMutex> lock(m_CacheMutex);
+                TUniqueLock lock(m_CacheMutex);
                 if (!m_CacheValid)
                 {
                     m_TagEntityCache.clear();
-                    rebuildCache(m_TagEntityCache);
+                    std::forward<RebuildFn>(rebuildCache)(m_TagEntityCache);
                     m_CacheValid = true;
                 }
 

--- a/OloEngine/src/OloEngine/Animation/AnimationAsset.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationAsset.h
@@ -4,6 +4,7 @@
 #include "OloEngine/Animation/AnimationClip.h"
 #include "OloEngine/Core/Base.h"
 #include <string>
+#include <utility>
 #include <glm/glm.hpp>
 
 namespace OloEngine
@@ -35,7 +36,9 @@ namespace OloEngine
       public:
         AnimationAsset() = default;
         explicit AnimationAsset(AssetHandle animationSource, AssetHandle mesh, std::string animationName,
-                                const AnimationRootMotionSettings& rootMotion = {});
+                                const AnimationRootMotionSettings& rootMotion);
+        explicit AnimationAsset(AssetHandle animationSource, AssetHandle mesh, std::string animationName)
+            : AnimationAsset(animationSource, mesh, std::move(animationName), {}) {}
 
         static AssetType GetStaticType()
         {

--- a/OloEngine/src/OloEngine/Animation/AnimationGraph.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraph.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Animation/AnimationState.h"
 #include "OloEngine/Animation/AnimationStateMachine.h"
 #include "OloEngine/Core/Log.h"
+#include <algorithm>
 #include <unordered_set>
 
 namespace OloEngine
@@ -215,12 +216,9 @@ namespace OloEngine
     const std::string& AnimationGraph::GetCurrentStateName(i32 layerIndex) const
     {
         OLO_PROFILE_FUNCTION();
-        if (layerIndex >= 0 && layerIndex < static_cast<i32>(Layers.size()))
+        if (layerIndex >= 0 && layerIndex < static_cast<i32>(Layers.size()) && Layers[static_cast<sizet>(layerIndex)].StateMachine)
         {
-            if (Layers[layerIndex].StateMachine)
-            {
-                return Layers[layerIndex].StateMachine->GetCurrentStateName();
-            }
+            return Layers[static_cast<sizet>(layerIndex)].StateMachine->GetCurrentStateName();
         }
         return s_EmptyString;
     }
@@ -228,12 +226,9 @@ namespace OloEngine
     bool AnimationGraph::IsInTransition(i32 layerIndex) const
     {
         OLO_PROFILE_FUNCTION();
-        if (layerIndex >= 0 && layerIndex < static_cast<i32>(Layers.size()))
+        if (layerIndex >= 0 && layerIndex < static_cast<i32>(Layers.size()) && Layers[static_cast<sizet>(layerIndex)].StateMachine)
         {
-            if (Layers[layerIndex].StateMachine)
-            {
-                return Layers[layerIndex].StateMachine->IsInTransition();
-            }
+            return Layers[static_cast<sizet>(layerIndex)].StateMachine->IsInTransition();
         }
         return false;
     }
@@ -283,13 +278,15 @@ namespace OloEngine
         std::unordered_set<std::string> affectedBoneSet(layer.AffectedBones.begin(), layer.AffectedBones.end());
         bool hasMask = !affectedBoneSet.empty();
 
-        for (sizet i = 0; i < accumulatedTransforms.size() && i < layerTransforms.size(); ++i)
+        auto accumulatedCount = accumulatedTransforms.size();
+        auto layerCount = layerTransforms.size();
+        for (sizet i = 0; i < accumulatedCount && i < layerCount; ++i)
         {
             // Check bone mask using cached set
             if (hasMask)
             {
                 std::string boneName = (i < boneNames.size()) ? boneNames[i] : "";
-                if (boneName.empty() || affectedBoneSet.find(boneName) == affectedBoneSet.end())
+                if (boneName.empty() || !affectedBoneSet.contains(boneName))
                 {
                     continue;
                 }
@@ -340,14 +337,7 @@ namespace OloEngine
             return false;
         }
 
-        for (auto const& affectedBone : layer.AffectedBones)
-        {
-            if (affectedBone == boneName)
-            {
-                return true;
-            }
-        }
-        return false;
+        return std::ranges::contains(layer.AffectedBones, boneName);
     }
 
     glm::mat4 AnimationGraph::BoneTransformToMatrix(const BoneTransform& transform)

--- a/OloEngine/src/OloEngine/Animation/AnimationGraph.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraph.h
@@ -28,8 +28,16 @@ namespace OloEngine
         [[nodiscard("cloned graph must be assigned")]] Ref<AnimationGraph> Clone() const;
         void ResolveClips(const std::vector<Ref<AnimationClip>>& availableClips);
         [[nodiscard("check needed to avoid sampling missing clips")]] bool HasUnresolvedClips() const;
-        [[nodiscard("state name needed for UI or logic")]] const std::string& GetCurrentStateName(i32 layerIndex = 0) const;
-        [[nodiscard("transition check needed for blend decisions")]] bool IsInTransition(i32 layerIndex = 0) const;
+        [[nodiscard("state name needed for UI or logic")]] const std::string& GetCurrentStateName(i32 layerIndex) const;
+        [[nodiscard("state name needed for UI or logic")]] const std::string& GetCurrentStateName() const
+        {
+            return GetCurrentStateName(0);
+        }
+        [[nodiscard("transition check needed for blend decisions")]] bool IsInTransition(i32 layerIndex) const;
+        [[nodiscard("transition check needed for blend decisions")]] bool IsInTransition() const
+        {
+            return IsInTransition(0);
+        }
 
         // Morph-target (blend-shape) sampling support: the active single clip on
         // a layer plus the clip-space time (seconds) at which to sample its

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphComponent.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphComponent.h
@@ -26,6 +26,7 @@ namespace OloEngine
             : AnimationGraphAssetHandle(other.AnimationGraphAssetHandle), Parameters(other.Parameters)
         {
         }
+        AnimationGraphComponent(AnimationGraphComponent&&) noexcept = default;
         AnimationGraphComponent& operator=(const AnimationGraphComponent& other)
         {
             if (this != &other)
@@ -36,7 +37,6 @@ namespace OloEngine
             }
             return *this;
         }
-        AnimationGraphComponent(AnimationGraphComponent&&) noexcept = default;
         AnimationGraphComponent& operator=(AnimationGraphComponent&&) noexcept = default;
 
         // Rule of five: a user-managed copy/move set should also declare the

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphSerializer.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphSerializer.cpp
@@ -10,20 +10,22 @@
 #include <yaml-cpp/yaml.h>
 #include <fstream>
 #include <sstream>
+#include <string_view>
 
 namespace OloEngine
 {
     static std::string ParameterTypeToString(AnimationParameterType type)
     {
+        using enum AnimationParameterType;
         switch (type)
         {
-            case AnimationParameterType::Float:
+            case Float:
                 return "Float";
-            case AnimationParameterType::Int:
+            case Int:
                 return "Int";
-            case AnimationParameterType::Bool:
+            case Bool:
                 return "Bool";
-            case AnimationParameterType::Trigger:
+            case Trigger:
                 return "Trigger";
             default:
                 break;
@@ -31,30 +33,32 @@ namespace OloEngine
         return "Float";
     }
 
-    static AnimationParameterType StringToParameterType(const std::string& str)
+    static AnimationParameterType StringToParameterType(std::string_view str)
     {
+        using enum AnimationParameterType;
         if (str == "Int")
-            return AnimationParameterType::Int;
+            return Int;
         if (str == "Bool")
-            return AnimationParameterType::Bool;
+            return Bool;
         if (str == "Trigger")
-            return AnimationParameterType::Trigger;
-        return AnimationParameterType::Float;
+            return Trigger;
+        return Float;
     }
 
     static std::string ComparisonToString(TransitionCondition::Comparison op)
     {
+        using enum TransitionCondition::Comparison;
         switch (op)
         {
-            case TransitionCondition::Comparison::Greater:
+            case Greater:
                 return "Greater";
-            case TransitionCondition::Comparison::Less:
+            case Less:
                 return "Less";
-            case TransitionCondition::Comparison::Equal:
+            case Equal:
                 return "Equal";
-            case TransitionCondition::Comparison::NotEqual:
+            case NotEqual:
                 return "NotEqual";
-            case TransitionCondition::Comparison::TriggerSet:
+            case TriggerSet:
                 return "TriggerSet";
             default:
                 break;
@@ -62,30 +66,32 @@ namespace OloEngine
         return "Greater";
     }
 
-    static TransitionCondition::Comparison StringToComparison(const std::string& str)
+    static TransitionCondition::Comparison StringToComparison(std::string_view str)
     {
+        using enum TransitionCondition::Comparison;
         if (str == "Less")
-            return TransitionCondition::Comparison::Less;
+            return Less;
         if (str == "Equal")
-            return TransitionCondition::Comparison::Equal;
+            return Equal;
         if (str == "NotEqual")
-            return TransitionCondition::Comparison::NotEqual;
+            return NotEqual;
         if (str == "TriggerSet")
-            return TransitionCondition::Comparison::TriggerSet;
-        return TransitionCondition::Comparison::Greater;
+            return TriggerSet;
+        return Greater;
     }
 
     static std::string BlendTypeToString(BlendTree::BlendType type)
     {
+        using enum BlendTree::BlendType;
         switch (type)
         {
-            case BlendTree::BlendType::Simple1D:
+            case Simple1D:
                 return "Simple1D";
-            case BlendTree::BlendType::SimpleDirectional2D:
+            case SimpleDirectional2D:
                 return "SimpleDirectional2D";
-            case BlendTree::BlendType::FreeformDirectional2D:
+            case FreeformDirectional2D:
                 return "FreeformDirectional2D";
-            case BlendTree::BlendType::FreeformCartesian2D:
+            case FreeformCartesian2D:
                 return "FreeformCartesian2D";
             default:
                 break;
@@ -93,15 +99,16 @@ namespace OloEngine
         return "Simple1D";
     }
 
-    static BlendTree::BlendType StringToBlendType(const std::string& str)
+    static BlendTree::BlendType StringToBlendType(std::string_view str)
     {
+        using enum BlendTree::BlendType;
         if (str == "SimpleDirectional2D")
-            return BlendTree::BlendType::SimpleDirectional2D;
+            return SimpleDirectional2D;
         if (str == "FreeformDirectional2D")
-            return BlendTree::BlendType::FreeformDirectional2D;
+            return FreeformDirectional2D;
         if (str == "FreeformCartesian2D")
-            return BlendTree::BlendType::FreeformCartesian2D;
-        return BlendTree::BlendType::Simple1D;
+            return FreeformCartesian2D;
+        return Simple1D;
     }
 
     static std::string BlendModeToString(AnimationLayer::BlendMode mode)
@@ -118,7 +125,7 @@ namespace OloEngine
         return "Override";
     }
 
-    static AnimationLayer::BlendMode StringToBlendMode(const std::string& str)
+    static AnimationLayer::BlendMode StringToBlendMode(std::string_view str)
     {
         if (str == "Additive")
             return AnimationLayer::BlendMode::Additive;
@@ -258,18 +265,19 @@ namespace OloEngine
             out << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << param.Name;
             out << YAML::Key << "type" << YAML::Value << ParameterTypeToString(param.ParamType);
+            using enum AnimationParameterType;
             switch (param.ParamType)
             {
-                case AnimationParameterType::Float:
+                case Float:
                     out << YAML::Key << "default" << YAML::Value << param.FloatValue;
                     break;
-                case AnimationParameterType::Int:
+                case Int:
                     out << YAML::Key << "default" << YAML::Value << param.IntValue;
                     break;
-                case AnimationParameterType::Bool:
+                case Bool:
                     out << YAML::Key << "default" << YAML::Value << param.BoolValue;
                     break;
-                case AnimationParameterType::Trigger:
+                case Trigger:
                     break;
                 default:
                     break;
@@ -469,18 +477,19 @@ namespace OloEngine
         {
             std::string name = paramNode["name"].as<std::string>("");
             auto type = StringToParameterType(paramNode["type"].as<std::string>("Float"));
+            using enum AnimationParameterType;
             switch (type)
             {
-                case AnimationParameterType::Float:
+                case Float:
                     parameters.DefineFloat(name, paramNode["default"].as<f32>(0.0f));
                     break;
-                case AnimationParameterType::Int:
+                case Int:
                     parameters.DefineInt(name, paramNode["default"].as<i32>(0));
                     break;
-                case AnimationParameterType::Bool:
+                case Bool:
                     parameters.DefineBool(name, paramNode["default"].as<bool>(false));
                     break;
-                case AnimationParameterType::Trigger:
+                case Trigger:
                     parameters.DefineTrigger(name);
                     break;
                 default:

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
@@ -95,7 +95,8 @@ namespace OloEngine::Animation
 
         // Compute global transforms (forward kinematics)
         // Pre-transforms account for non-bone intermediate nodes in the hierarchy
-        for (sizet i = 0; i < skeleton.m_LocalTransforms.size(); ++i)
+        auto localTransformCount = skeleton.m_LocalTransforms.size();
+        for (sizet i = 0; i < localTransformCount; ++i)
         {
             const glm::mat4& preTransform = (i < skeleton.m_BonePreTransforms.size())
                                                 ? skeleton.m_BonePreTransforms[i]
@@ -103,7 +104,7 @@ namespace OloEngine::Animation
             i32 parent = skeleton.m_ParentIndices[i];
             if (parent >= 0)
             {
-                skeleton.m_GlobalTransforms[i] = skeleton.m_GlobalTransforms[parent] * preTransform * skeleton.m_LocalTransforms[i];
+                skeleton.m_GlobalTransforms[i] = skeleton.m_GlobalTransforms[static_cast<sizet>(parent)] * preTransform * skeleton.m_LocalTransforms[i];
             }
             else
             {
@@ -112,7 +113,8 @@ namespace OloEngine::Animation
         }
 
         // Compute final bone matrices for GPU skinning (GlobalTransform * InverseBindPose)
-        for (sizet i = 0; i < skeleton.m_GlobalTransforms.size(); ++i)
+        auto globalTransformCount = skeleton.m_GlobalTransforms.size();
+        for (sizet i = 0; i < globalTransformCount; ++i)
         {
             if (i < skeleton.m_InverseBindPoses.size())
             {

--- a/OloEngine/src/OloEngine/Animation/AnimationParameter.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationParameter.h
@@ -34,13 +34,25 @@ namespace OloEngine
         // AnimationLayer) — moves without throwing (S5018).
         AnimationParameterSet() = default;
         AnimationParameterSet(const AnimationParameterSet&) = default;
-        AnimationParameterSet& operator=(const AnimationParameterSet&) = default;
         AnimationParameterSet(AnimationParameterSet&&) noexcept = default;
+        AnimationParameterSet& operator=(const AnimationParameterSet&) = default;
         AnimationParameterSet& operator=(AnimationParameterSet&&) noexcept = default;
 
-        void DefineFloat(const std::string& name, f32 defaultValue = 0.0f);
-        void DefineBool(const std::string& name, bool defaultValue = false);
-        void DefineInt(const std::string& name, i32 defaultValue = 0);
+        void DefineFloat(const std::string& name, f32 defaultValue);
+        void DefineFloat(const std::string& name)
+        {
+            DefineFloat(name, 0.0f);
+        }
+        void DefineBool(const std::string& name, bool defaultValue);
+        void DefineBool(const std::string& name)
+        {
+            DefineBool(name, false);
+        }
+        void DefineInt(const std::string& name, i32 defaultValue);
+        void DefineInt(const std::string& name)
+        {
+            DefineInt(name, 0);
+        }
         void DefineTrigger(const std::string& name);
         void RemoveParameter(const std::string& name);
 

--- a/OloEngine/src/OloEngine/Animation/AnimationState.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationState.cpp
@@ -4,6 +4,29 @@
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Sample a single clip into the output pose: clear to bind pose, then
+        // per-bone TRS for every bone that has an animation channel.
+        void SampleClipIntoPose(const AnimationClip& clip, f32 normalizedTime, sizet boneCount,
+                                std::vector<BoneTransform>& out)
+        {
+            f32 timeSeconds = normalizedTime * clip.Duration;
+            out.assign(boneCount, BoneTransform{});
+            auto boneAnimCount = clip.BoneAnimations.size();
+            for (sizet i = 0; i < boneCount; ++i)
+            {
+                if (i < boneAnimCount)
+                {
+                    auto const& boneAnim = clip.BoneAnimations[i];
+                    out[i].Translation = AnimatedModel::SampleBonePosition(boneAnim.PositionKeys, timeSeconds);
+                    out[i].Rotation = AnimatedModel::SampleBoneRotation(boneAnim.RotationKeys, timeSeconds);
+                    out[i].Scale = AnimatedModel::SampleBoneScale(boneAnim.ScaleKeys, timeSeconds);
+                }
+            }
+        }
+    } // namespace
+
     void AnimationState::Evaluate(f32 normalizedTime, const AnimationParameterSet& params,
                                   sizet boneCount,
                                   std::vector<BoneTransform>& outBoneTransforms) const
@@ -19,18 +42,7 @@ namespace OloEngine
                     outBoneTransforms.assign(boneCount, BoneTransform{});
                     return;
                 }
-                f32 timeSeconds = normalizedTime * Clip->Duration;
-                outBoneTransforms.assign(boneCount, BoneTransform{});
-                for (sizet i = 0; i < boneCount; ++i)
-                {
-                    if (i < Clip->BoneAnimations.size())
-                    {
-                        auto const& boneAnim = Clip->BoneAnimations[i];
-                        outBoneTransforms[i].Translation = AnimatedModel::SampleBonePosition(boneAnim.PositionKeys, timeSeconds);
-                        outBoneTransforms[i].Rotation = AnimatedModel::SampleBoneRotation(boneAnim.RotationKeys, timeSeconds);
-                        outBoneTransforms[i].Scale = AnimatedModel::SampleBoneScale(boneAnim.ScaleKeys, timeSeconds);
-                    }
-                }
+                SampleClipIntoPose(*Clip, normalizedTime, boneCount, outBoneTransforms);
                 break;
             }
             case MotionType::BlendTree:

--- a/OloEngine/src/OloEngine/Animation/AnimationSystem.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationSystem.cpp
@@ -28,7 +28,7 @@ namespace OloEngine::Animation
         // Sample a clip at a given time and return the bone's TRS. A cached
         // BoneAnimation pointer skips the per-bone lookup when the caller has it.
         TRSFrame SampleClipTRS(const Ref<AnimationClip>& clip, f32 timeSeconds, const std::string& boneName,
-                               const BoneAnimation* cachedBoneAnim = nullptr)
+                               const BoneAnimation* cachedBoneAnim)
         {
             TRSFrame result = { glm::vec3(0.0f), glm::quat(1.0f, 0.0f, 0.0f, 0.0f), glm::vec3(1.0f) };
             if (!clip)
@@ -42,7 +42,7 @@ namespace OloEngine::Animation
             return result;
         }
 
-        glm::mat4 TRSToMatrix(const TRSFrame& trs)
+        [[nodiscard("composed matrix must be used")]] glm::mat4 TRSToMatrix(const TRSFrame& trs)
         {
             return glm::translate(glm::mat4(1.0f), trs.translation) *
                    glm::mat4_cast(trs.rotation) *
@@ -116,7 +116,7 @@ namespace OloEngine::Animation
         skeleton.RotateBoneHistory();
 
         // Advance and loop animation time for current and next clips
-        auto LoopTime = [](f32 t, const Ref<AnimationClip>& clip) -> f32
+        auto LoopTime = [](f32 t, const Ref<AnimationClip>& clip)
         {
             if (clip && clip->Duration > 0.0f)
             {
@@ -162,7 +162,8 @@ namespace OloEngine::Animation
         // channels in the active clip(s) keep their bind-pose local transform
         // (e.g. b_Root_00 carries a -90° X rotation in the fox.gltf model but has
         // no keyframes in the animation).
-        for (sizet i = 0; i < skeleton.m_BoneNames.size(); ++i)
+        auto boneNameCount = skeleton.m_BoneNames.size();
+        for (sizet i = 0; i < boneNameCount; ++i)
         {
             if (auto animatedLocal = EvaluateBoneLocalTransform(animState, skeleton.m_BoneNames[i]); animatedLocal)
             {
@@ -194,20 +195,22 @@ namespace OloEngine::Animation
 
         // Compute global transforms, applying pre-transforms for non-bone ancestor nodes
         static const glm::mat4 identityTransform(1.0f);
-        for (sizet i = 0; i < skeleton.m_LocalTransforms.size(); ++i)
+        auto localTransformCount = skeleton.m_LocalTransforms.size();
+        for (sizet i = 0; i < localTransformCount; ++i)
         {
             const glm::mat4& preTransform = (i < skeleton.m_BonePreTransforms.size())
                                                 ? skeleton.m_BonePreTransforms[i]
                                                 : identityTransform;
             i32 parent = skeleton.m_ParentIndices[i];
             if (parent >= 0)
-                skeleton.m_GlobalTransforms[i] = skeleton.m_GlobalTransforms[parent] * preTransform * skeleton.m_LocalTransforms[i];
+                skeleton.m_GlobalTransforms[i] = skeleton.m_GlobalTransforms[static_cast<sizet>(parent)] * preTransform * skeleton.m_LocalTransforms[i];
             else
                 skeleton.m_GlobalTransforms[i] = preTransform * skeleton.m_LocalTransforms[i];
         }
 
         // Compute final bone matrices for GPU skinning (GlobalTransform * InverseBindPose)
-        for (sizet i = 0; i < skeleton.m_GlobalTransforms.size(); ++i)
+        auto globalTransformCount = skeleton.m_GlobalTransforms.size();
+        for (sizet i = 0; i < globalTransformCount; ++i)
         {
             if (i < skeleton.m_InverseBindPoses.size())
             {

--- a/OloEngine/src/OloEngine/Animation/AnimationTransition.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationTransition.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Animation/AnimationTransition.h"
+#include <algorithm>
 #include <cmath>
 
 namespace OloEngine
@@ -8,6 +9,7 @@ namespace OloEngine
 
     bool TransitionCondition::Evaluate(const AnimationParameterSet& params) const
     {
+        using enum AnimationParameterType;
         const AnimationParameter* param = params.GetParameter(ParameterName);
         if (!param)
         {
@@ -20,34 +22,34 @@ namespace OloEngine
                 return params.IsTriggerSet(ParameterName);
 
             case Comparison::Greater:
-                if (param->ParamType == AnimationParameterType::Float)
+                if (param->ParamType == Float)
                     return param->FloatValue > FloatThreshold;
-                if (param->ParamType == AnimationParameterType::Int)
+                if (param->ParamType == Int)
                     return param->IntValue > IntThreshold;
                 return false;
 
             case Comparison::Less:
-                if (param->ParamType == AnimationParameterType::Float)
+                if (param->ParamType == Float)
                     return param->FloatValue < FloatThreshold;
-                if (param->ParamType == AnimationParameterType::Int)
+                if (param->ParamType == Int)
                     return param->IntValue < IntThreshold;
                 return false;
 
             case Comparison::Equal:
-                if (param->ParamType == AnimationParameterType::Float)
+                if (param->ParamType == Float)
                     return std::abs(param->FloatValue - FloatThreshold) < kFloatEpsilon;
-                if (param->ParamType == AnimationParameterType::Int)
+                if (param->ParamType == Int)
                     return param->IntValue == IntThreshold;
-                if (param->ParamType == AnimationParameterType::Bool)
+                if (param->ParamType == Bool)
                     return param->BoolValue == BoolValue;
                 return false;
 
             case Comparison::NotEqual:
-                if (param->ParamType == AnimationParameterType::Float)
+                if (param->ParamType == Float)
                     return std::abs(param->FloatValue - FloatThreshold) >= kFloatEpsilon;
-                if (param->ParamType == AnimationParameterType::Int)
+                if (param->ParamType == Int)
                     return param->IntValue != IntThreshold;
-                if (param->ParamType == AnimationParameterType::Bool)
+                if (param->ParamType == Bool)
                     return param->BoolValue != BoolValue;
                 return false;
 
@@ -60,13 +62,7 @@ namespace OloEngine
 
     bool AnimationTransition::Evaluate(const AnimationParameterSet& params) const
     {
-        for (const auto& condition : Conditions)
-        {
-            if (!condition.Evaluate(params))
-            {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::all_of(Conditions, [&params](const auto& condition)
+                                   { return condition.Evaluate(params); });
     }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Animation/BlendTree.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendTree.cpp
@@ -19,17 +19,18 @@ namespace OloEngine
             return;
         }
 
+        using enum BlendType;
         switch (Type)
         {
-            case BlendType::Simple1D:
+            case Simple1D:
             {
                 f32 paramValue = params.GetFloat(BlendParameterX);
                 Evaluate1D(paramValue, normalizedTime, boneCount, outBoneTransforms);
                 break;
             }
-            case BlendType::SimpleDirectional2D:
-            case BlendType::FreeformDirectional2D:
-            case BlendType::FreeformCartesian2D:
+            case SimpleDirectional2D:
+            case FreeformDirectional2D:
+            case FreeformCartesian2D:
             {
                 f32 paramX = params.GetFloat(BlendParameterX);
                 f32 paramY = params.GetFloat(BlendParameterY);
@@ -49,7 +50,7 @@ namespace OloEngine
     namespace
     {
         // Weighted-average duration between the two 1D children bracketing paramValue.
-        f32 Compute1DDuration(const std::vector<BlendTree::BlendChild>& children, f32 paramValue)
+        [[nodiscard("blended duration must be used")]] f32 Compute1DDuration(const std::vector<BlendTree::BlendChild>& children, f32 paramValue)
         {
             if (children.size() == 1)
             {
@@ -57,7 +58,8 @@ namespace OloEngine
             }
 
             // Find the two neighbors
-            for (sizet i = 0; i < children.size() - 1; ++i)
+            auto neighborCount = children.size() - 1;
+            for (sizet i = 0; i < neighborCount; ++i)
             {
                 if (paramValue <= children[i + 1].Threshold)
                 {
@@ -98,7 +100,7 @@ namespace OloEngine
         }
 
         // Fallback: plain average duration over all playable children.
-        f32 ComputeAverageDuration(const std::vector<BlendTree::BlendChild>& children)
+        [[nodiscard("average duration must be used")]] f32 ComputeAverageDuration(const std::vector<BlendTree::BlendChild>& children)
         {
             f32 totalDuration = 0.0f;
             i32 count = 0;
@@ -123,21 +125,18 @@ namespace OloEngine
             return 0.0f;
         }
 
-        // For 1D: weighted average of durations between two neighboring children
-        if (Type == BlendType::Simple1D && !BlendParameterX.empty())
+        // 1D: weighted average between neighbors when a blend param is set,
+        // otherwise a plain average over all playable children.
+        if (Type == BlendType::Simple1D)
         {
-            return Compute1DDuration(Children, params.GetFloat(BlendParameterX));
+            return BlendParameterX.empty()
+                       ? ComputeAverageDuration(Children)
+                       : Compute1DDuration(Children, params.GetFloat(BlendParameterX));
         }
 
-        // For 2D types: inverse-distance weighted average matching Evaluate2D
-        if (Type != BlendType::Simple1D)
-        {
-            glm::vec2 paramPos(params.GetFloat(BlendParameterX), params.GetFloat(BlendParameterY));
-            return Compute2DDuration(Children, paramPos);
-        }
-
-        // Fallback: average duration
-        return ComputeAverageDuration(Children);
+        // 2D types: inverse-distance weighted average matching Evaluate2D.
+        glm::vec2 paramPos(params.GetFloat(BlendParameterX), params.GetFloat(BlendParameterY));
+        return Compute2DDuration(Children, paramPos);
     }
 
     void BlendTree::Evaluate1D(f32 paramValue, f32 normalizedTime, sizet boneCount,
@@ -147,8 +146,9 @@ namespace OloEngine
 
         // Collect playable children (valid clip and positive speed)
         std::vector<sizet> playableIndices;
-        playableIndices.reserve(Children.size());
-        for (sizet i = 0; i < Children.size(); ++i)
+        auto childCount = Children.size();
+        playableIndices.reserve(childCount);
+        for (sizet i = 0; i < childCount; ++i)
         {
             if (Children[i].Clip && Children[i].Speed > 0.0f)
             {
@@ -181,7 +181,8 @@ namespace OloEngine
         paramValue = glm::clamp(paramValue, minThreshold, maxThreshold);
 
         // Find the two neighboring playable children
-        for (sizet pi = 0; pi < playableIndices.size() - 1; ++pi)
+        auto playablePairs = playableIndices.size() - 1;
+        for (sizet pi = 0; pi < playablePairs; ++pi)
         {
             sizet idxA = playableIndices[pi];
             sizet idxB = playableIndices[pi + 1];
@@ -221,10 +222,11 @@ namespace OloEngine
         // Inverse distance weighting for 2D blend
         glm::vec2 paramPos(paramX, paramY);
 
-        std::vector<f32> weights(Children.size(), 0.0f);
+        auto childCount = Children.size();
+        std::vector<f32> weights(childCount, 0.0f);
         f32 totalWeight = 0.0f;
 
-        for (sizet i = 0; i < Children.size(); ++i)
+        for (sizet i = 0; i < childCount; ++i)
         {
             if (!Children[i].Clip || Children[i].Speed <= 0.0f)
             {
@@ -255,7 +257,7 @@ namespace OloEngine
         out.resize(boneCount);
         f32 accumulatedWeight = 0.0f;
         bool first = true;
-        for (sizet i = 0; i < Children.size(); ++i)
+        for (sizet i = 0; i < childCount; ++i)
         {
             if (weights[i] < 1e-6f)
             {
@@ -306,7 +308,8 @@ namespace OloEngine
             return;
         }
 
-        for (sizet i = 0; i < boneCount && i < clip->BoneAnimations.size(); ++i)
+        auto boneAnimCount = clip->BoneAnimations.size();
+        for (sizet i = 0; i < boneCount && i < boneAnimCount; ++i)
         {
             auto const& boneAnim = clip->BoneAnimations[i];
             out[i].Translation = AnimatedModel::SampleBonePosition(boneAnim.PositionKeys, timeSeconds);

--- a/OloEngine/src/OloEngine/Animation/BlendUtils.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendUtils.cpp
@@ -60,8 +60,7 @@ namespace OloEngine::Animation::BlendUtils
         glm::vec3 translation;
         glm::quat rotation;
         glm::vec3 skew;
-        glm::vec4 perspective;
-        if (!glm::decompose(m, scale, rotation, translation, skew, perspective))
+        if (glm::vec4 perspective; !glm::decompose(m, scale, rotation, translation, skew, perspective))
         {
             return { glm::vec3(0.0f), glm::identity<glm::quat>(), glm::vec3(1.0f) };
         }
@@ -115,7 +114,7 @@ namespace OloEngine::Animation::BlendUtils
         }
 
         // Build effective local transform: preTransform[i] * localPose[i]
-        auto effectiveLocal = [&preTransforms, &localPose](u32 idx) -> BoneTransform
+        auto effectiveLocal = [&preTransforms, &localPose](u32 idx)
         {
             if (idx < preTransforms.size())
             {
@@ -132,10 +131,13 @@ namespace OloEngine::Animation::BlendUtils
         // Build the chain from root to boneIndex
         std::vector<u32> chain;
         chain.reserve(16);
-        for (auto idx = static_cast<int>(boneIndex); idx >= 0 && static_cast<sizet>(idx) < localPose.size() && static_cast<sizet>(idx) < parentIndices.size();)
+        auto localPoseSize = localPose.size();
+        auto parentSize = parentIndices.size();
+        auto idx = static_cast<int>(boneIndex);
+        while (idx >= 0 && static_cast<sizet>(idx) < localPoseSize && static_cast<sizet>(idx) < parentSize)
         {
             chain.push_back(static_cast<u32>(idx));
-            if (chain.size() > localPose.size())
+            if (chain.size() > localPoseSize)
             {
                 return {}; // cycle guard — return identity
             }
@@ -144,7 +146,8 @@ namespace OloEngine::Animation::BlendUtils
 
         BoneTransform result;
         // Process from root (back of chain) to leaf (front of chain)
-        for (auto it = chain.rbegin(); it != chain.rend(); ++it)
+        auto chainEnd = chain.rend();
+        for (auto it = chain.rbegin(); it != chainEnd; ++it)
         {
             result = MultiplyTransforms(result, effectiveLocal(*it));
         }

--- a/OloEngine/src/OloEngine/Animation/BlendUtils.h
+++ b/OloEngine/src/OloEngine/Animation/BlendUtils.h
@@ -45,7 +45,14 @@ namespace OloEngine::Animation::BlendUtils
         std::span<const BoneTransform> localPose,
         std::span<const int> parentIndices,
         std::vector<BoneTransform>& outModelSpacePose,
-        std::span<const glm::mat4> preTransforms = {});
+        std::span<const glm::mat4> preTransforms);
+    inline void ComputeModelSpacePose(
+        std::span<const BoneTransform> localPose,
+        std::span<const int> parentIndices,
+        std::vector<BoneTransform>& outModelSpacePose)
+    {
+        ComputeModelSpacePose(localPose, parentIndices, outModelSpacePose, {});
+    }
 
     // Compute a single bone's model-space transform by walking up the parent chain.
     // When preTransforms is non-empty, each bone's effective local transform is
@@ -54,7 +61,14 @@ namespace OloEngine::Animation::BlendUtils
         u32 boneIndex,
         std::span<const BoneTransform> localPose,
         std::span<const int> parentIndices,
-        std::span<const glm::mat4> preTransforms = {});
+        std::span<const glm::mat4> preTransforms);
+    [[nodiscard("computed model-space transform must be used")]] inline BoneTransform ComputeModelSpaceTransform(
+        u32 boneIndex,
+        std::span<const BoneTransform> localPose,
+        std::span<const int> parentIndices)
+    {
+        return ComputeModelSpaceTransform(boneIndex, localPose, parentIndices, {});
+    }
 
     // --- Standard blending ---
 

--- a/OloEngine/src/OloEngine/Animation/BoneEntityUtils.cpp
+++ b/OloEngine/src/OloEngine/Animation/BoneEntityUtils.cpp
@@ -6,12 +6,43 @@
 #include "OloEngine/Renderer/MeshSource.h"
 #include <algorithm>
 #include <functional>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include "OloEngine/Threading/UniqueLock.h"
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Recursively maps each TagComponent's tag to its entity UUID, walking
+        // the hierarchy from `entity`. `visited` guards against cycles.
+        void BuildTagEntityMap(Entity entity, const Scene* scene,
+                               std::unordered_set<UUID>& visited,
+                               std::unordered_map<std::string, UUID>& out)
+        {
+            if (!entity || !scene)
+                return;
+
+            UUID entityUUID = entity.GetUUID();
+            if (visited.contains(entityUUID))
+                return;
+            visited.insert(entityUUID);
+
+            if (entity.HasComponent<TagComponent>())
+            {
+                const auto& tagComponent = entity.GetComponent<TagComponent>();
+                out[tagComponent.Tag] = entity.GetUUID();
+            }
+
+            for (const auto& childId : entity.Children())
+            {
+                if (auto childOpt = scene->TryGetEntityWithUUID(childId))
+                    BuildTagEntityMap(*childOpt, scene, visited, out);
+            }
+        }
+    } // namespace
+
     std::vector<glm::mat4> BoneEntityUtils::GetModelSpaceBoneTransforms(
         const std::vector<UUID>& boneEntityIds,
         const MeshSource* meshSource,
@@ -83,36 +114,7 @@ namespace OloEngine
         // Build tag-to-entity map once for O(1) lookups
         std::unordered_map<std::string, UUID> tagEntityMap;
         std::unordered_set<UUID> visited;
-
-        // Build tag map with cycle detection
-        std::function<void(Entity)> buildTagMap = [&scene, &visited, &tagEntityMap, &buildTagMap](Entity entity)
-        {
-            if (!entity || !scene)
-                return;
-
-            UUID entityUUID = entity.GetUUID();
-            if (visited.find(entityUUID) != visited.end())
-                return;
-
-            visited.insert(entityUUID);
-
-            if (entity.HasComponent<TagComponent>())
-            {
-                const auto& tagComponent = entity.GetComponent<TagComponent>();
-                tagEntityMap[tagComponent.Tag] = entity.GetUUID();
-            }
-
-            for (const auto& childId : entity.Children())
-            {
-                auto childOpt = scene->TryGetEntityWithUUID(childId);
-                if (childOpt)
-                {
-                    buildTagMap(*childOpt);
-                }
-            }
-        };
-
-        buildTagMap(rootEntity);
+        BuildTagEntityMap(rootEntity, scene, visited, tagEntityMap);
 
         bool foundAtLeastOne = false;
         for (const auto& boneName : boneNames)
@@ -156,36 +158,7 @@ namespace OloEngine
             [&scene, rootEntity](std::unordered_map<std::string, UUID>& tagEntityCache)
             {
                 std::unordered_set<UUID> visited;
-
-                // Build tag map with cycle detection
-                std::function<void(Entity)> buildTagMap = [&scene, &visited, &tagEntityCache, &buildTagMap](Entity entity)
-                {
-                    if (!entity || !scene)
-                        return;
-
-                    UUID entityUUID = entity.GetUUID();
-                    if (visited.find(entityUUID) != visited.end())
-                        return;
-
-                    visited.insert(entityUUID);
-
-                    if (entity.HasComponent<TagComponent>())
-                    {
-                        const auto& tagComponent = entity.GetComponent<TagComponent>();
-                        tagEntityCache[tagComponent.Tag] = entity.GetUUID();
-                    }
-
-                    for (const auto& childId : entity.Children())
-                    {
-                        auto childOpt = scene->TryGetEntityWithUUID(childId);
-                        if (childOpt)
-                        {
-                            buildTagMap(*childOpt);
-                        }
-                    }
-                };
-
-                buildTagMap(rootEntity);
+                BuildTagEntityMap(rootEntity, scene, visited, tagEntityCache);
             });
     }
 
@@ -207,7 +180,7 @@ namespace OloEngine
             {
                 // Check for cycles - if this parent was already visited, break to prevent infinite loop
                 UUID parentUUID = parentEntity.GetUUID();
-                if (visitedParents.find(parentUUID) != visitedParents.end())
+                if (visitedParents.contains(parentUUID))
                     break;
 
                 // Mark this parent as visited
@@ -261,7 +234,8 @@ namespace OloEngine
 
             // Queue children in reverse so the first child is processed next — preserves pre-order DFS
             const auto& children = current.Children();
-            for (auto it = children.rbegin(); it != children.rend(); ++it)
+            auto childrenEnd = children.rend();
+            for (auto it = children.rbegin(); it != childrenEnd; ++it)
             {
                 auto childOpt = scene->TryGetEntityWithUUID(*it);
                 if (childOpt)
@@ -314,7 +288,8 @@ namespace OloEngine
 
             // Queue children in reverse so the first child is processed next — preserves pre-order DFS
             const auto& children = current.Children();
-            for (auto it = children.rbegin(); it != children.rend(); ++it)
+            auto childrenEnd = children.rend();
+            for (auto it = children.rbegin(); it != childrenEnd; ++it)
             {
                 auto childOpt = scene->TryGetEntityWithUUID(*it);
                 if (childOpt)
@@ -332,7 +307,7 @@ namespace OloEngine
     }
 
     // Internal helper with cycle detection (iterative pre-order DFS to avoid recursion)
-    static Entity FindEntityWithTagImpl(Entity entity, const std::string& tag, const Scene* scene, std::unordered_set<UUID>& visited)
+    static Entity FindEntityWithTagImpl(Entity entity, std::string_view tag, const Scene* scene, std::unordered_set<UUID>& visited)
     {
         if (!entity || !scene)
             return Entity();
@@ -355,13 +330,14 @@ namespace OloEngine
             if (current.HasComponent<TagComponent>())
             {
                 const auto& tagComponent = current.GetComponent<TagComponent>();
-                if (tagComponent.Tag == tag)
+                if (tag == tagComponent.Tag)
                     return current;
             }
 
             // Queue children in reverse so the first child is searched next — preserves pre-order DFS
             const auto& children = current.Children();
-            for (auto it = children.rbegin(); it != children.rend(); ++it)
+            auto childrenEnd = children.rend();
+            for (auto it = children.rbegin(); it != childrenEnd; ++it)
             {
                 auto childOpt = scene->TryGetEntityWithUUID(*it);
                 if (childOpt)

--- a/OloEngine/src/OloEngine/Animation/BoneEntityUtils.cpp
+++ b/OloEngine/src/OloEngine/Animation/BoneEntityUtils.cpp
@@ -5,7 +5,6 @@
 #include "OloEngine/Animation/AnimatedMeshComponents.h"
 #include "OloEngine/Renderer/MeshSource.h"
 #include <algorithm>
-#include <functional>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>

--- a/OloEngine/src/OloEngine/Animation/BoneEntityUtils.h
+++ b/OloEngine/src/OloEngine/Animation/BoneEntityUtils.h
@@ -27,8 +27,8 @@ namespace OloEngine
         // Delete constructor and copy operations to prevent instantiation
         BoneEntityUtils() = delete;
         BoneEntityUtils(const BoneEntityUtils&) = delete;
-        BoneEntityUtils& operator=(const BoneEntityUtils&) = delete;
         BoneEntityUtils(BoneEntityUtils&&) = delete;
+        BoneEntityUtils& operator=(const BoneEntityUtils&) = delete;
         BoneEntityUtils& operator=(BoneEntityUtils&&) = delete;
 
         /**
@@ -115,33 +115,6 @@ namespace OloEngine
         static void BuildAnimationBoneEntityIds(
             Entity entity,
             Entity rootEntity,
-            Scene* scene);
-
-        /**
-         * @brief Find the entity with a specific bone name and index
-         *
-         * @param rootEntity The root entity to search from
-         * @param boneName The name of the bone to find
-         * @param boneIndex The index of the bone to find
-         * @param scene The scene containing the entities
-         * @return The entity containing the bone, or null entity if not found
-         */
-        static Entity FindBoneEntity(
-            Entity rootEntity,
-            const std::string& boneName,
-            sizet boneIndex,
-            const Scene* scene);
-
-        /**
-         * @brief Create bone entities for a skeleton hierarchy
-         *
-         * @param rootEntity The root entity to create bone entities under
-         * @param skeleton The skeleton data to create entities from
-         * @param scene The scene to create entities in
-         */
-        static void CreateBoneEntities(
-            Entity rootEntity,
-            const Skeleton* skeleton,
             Scene* scene);
 
         /**

--- a/OloEngine/src/OloEngine/Animation/IK/AimIKSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/AimIKSolver.cpp
@@ -81,8 +81,7 @@ namespace OloEngine::Animation
         glm::vec3 offsettedForward;
         glm::quat correction = glm::identity<glm::quat>();
 
-        constexpr f32 kEpsilon = 1e-7f;
-        if (boneToTargetLen2 > kEpsilon && ComputeOffsettedForward(forward, offset, boneToTarget, offsettedForward))
+        if (constexpr f32 kEpsilon = 1e-7f; boneToTargetLen2 > kEpsilon && ComputeOffsettedForward(forward, offset, boneToTarget, offsettedForward))
         {
             // Quaternion that rotates offsetted forward onto target direction
             glm::quat boneToTargetRotation(offsettedForward, boneToTarget);
@@ -164,8 +163,9 @@ namespace OloEngine::Animation
                 }
                 idx = static_cast<u32>(parent);
             }
-            originalRotations.resize(chainIndices.size());
-            for (sizet i = 0; i < chainIndices.size(); ++i)
+            auto chainSize = chainIndices.size();
+            originalRotations.resize(chainSize);
+            for (sizet i = 0; i < chainSize; ++i)
             {
                 originalRotations[i] = pose[chainIndices[i]].Rotation;
             }
@@ -247,7 +247,8 @@ namespace OloEngine::Animation
         // Apply global weight: blend between original and IK result (chain bones only)
         if (needWeightBlend)
         {
-            for (sizet i = 0; i < chainIndices.size(); ++i)
+            auto blendCount = chainIndices.size();
+            for (sizet i = 0; i < blendCount; ++i)
             {
                 auto bi = chainIndices[i];
                 pose[bi].Rotation = glm::slerp(originalRotations[i], pose[bi].Rotation, params.Weight);

--- a/OloEngine/src/OloEngine/Animation/IK/AimIKSolver.h
+++ b/OloEngine/src/OloEngine/Animation/IK/AimIKSolver.h
@@ -29,6 +29,13 @@ namespace OloEngine::Animation
             std::span<BoneTransform> pose,
             std::span<const int> parentIndices,
             const AimIKParams& params,
-            std::span<const glm::mat4> preTransforms = {});
+            std::span<const glm::mat4> preTransforms);
+        static void Solve(
+            std::span<BoneTransform> pose,
+            std::span<const int> parentIndices,
+            const AimIKParams& params)
+        {
+            Solve(pose, parentIndices, params, {});
+        }
     };
 } // namespace OloEngine::Animation

--- a/OloEngine/src/OloEngine/Animation/IK/FABRIKSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/FABRIKSolver.cpp
@@ -208,8 +208,9 @@ namespace OloEngine::Animation
         bool needWeightBlend = (weight < 1.0f - 1e-6f);
         if (needWeightBlend)
         {
-            originalRotations.resize(boneIndices.size());
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto chainSize = boneIndices.size();
+            originalRotations.resize(chainSize);
+            for (sizet i = 0; i < chainSize; ++i)
             {
                 originalRotations[i] = pose[boneIndices[i]].Rotation;
             }
@@ -236,15 +237,13 @@ namespace OloEngine::Animation
             totalLength += boneLengths[i];
         }
 
-        constexpr f32 kDirectionEpsilon = 1e-6f;
-        if (totalLength < kDirectionEpsilon)
+        if (constexpr f32 kDirectionEpsilon = 1e-6f; totalLength < kDirectionEpsilon)
         {
             return; // All joints coincident — no usable chain geometry
         }
 
-        auto basePosition = jointPositions[0];
-
-        if (!SolveFabrikPositions(jointPositions, boneLengths, basePosition, params.TargetPosition,
+        if (auto basePosition = jointPositions[0];
+            !SolveFabrikPositions(jointPositions, boneLengths, basePosition, params.TargetPosition,
                                   jointCount, totalLength, params.MaxIterations, tolerance))
         {
             return;
@@ -297,9 +296,9 @@ namespace OloEngine::Animation
             // Compute rotation in bone's local frame
             auto invRot = glm::conjugate(thisBoneMS.Rotation);
             auto toOriginal = SafeNormalize(invRot * originalDir);
-            auto toTarget = SafeNormalize(invRot * targetDir);
 
-            if (glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
+            if (auto toTarget = SafeNormalize(invRot * targetDir);
+                glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
             {
                 pose[thisIdx].Rotation *= glm::rotation(toOriginal, toTarget);
             }
@@ -311,7 +310,8 @@ namespace OloEngine::Animation
         // Apply global weight: blend between original and IK result (chain bones only)
         if (needWeightBlend)
         {
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto blendCount = boneIndices.size();
+            for (sizet i = 0; i < blendCount; ++i)
             {
                 auto bi = boneIndices[i];
                 pose[bi].Rotation = glm::slerp(originalRotations[i], pose[bi].Rotation, weight);

--- a/OloEngine/src/OloEngine/Animation/IK/FABRIKSolver.h
+++ b/OloEngine/src/OloEngine/Animation/IK/FABRIKSolver.h
@@ -34,6 +34,13 @@ namespace OloEngine::Animation
             std::span<BoneTransform> pose,
             std::span<const int> parentIndices,
             const FABRIKParams& params,
-            std::span<const glm::mat4> preTransforms = {});
+            std::span<const glm::mat4> preTransforms);
+        static void Solve(
+            std::span<BoneTransform> pose,
+            std::span<const int> parentIndices,
+            const FABRIKParams& params)
+        {
+            Solve(pose, parentIndices, params, {});
+        }
     };
 } // namespace OloEngine::Animation

--- a/OloEngine/src/OloEngine/Animation/IK/IKPostPass.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/IKPostPass.cpp
@@ -27,7 +27,10 @@ namespace OloEngine::Animation
         auto bone = startBone;
         for (u32 j = 0; j < chainLength; ++j)
         {
-            if (bone >= static_cast<u32>(boneCount))
+            // boneCount comes from the caller's LocalTransforms; parentIndices is a
+            // separate span only asserted (not enforced) to match it, so bound the
+            // read against both to stay safe on a malformed skeleton in release.
+            if (bone >= static_cast<u32>(boneCount) || bone >= parentIndices.size())
             {
                 break;
             }

--- a/OloEngine/src/OloEngine/Animation/IK/IKPostPass.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/IKPostPass.cpp
@@ -25,17 +25,17 @@ namespace OloEngine::Animation
         std::vector<bool>& ikModified)
     {
         auto bone = startBone;
-        for (u32 j = 0; j < chainLength && bone < static_cast<u32>(boneCount); ++j)
+        for (u32 j = 0; j < chainLength; ++j)
         {
-            ikModified[bone] = true;
-            if (auto parent = parentIndices[bone]; parent < 0)
+            if (bone >= static_cast<u32>(boneCount))
             {
                 break;
             }
-            else
-            {
-                bone = static_cast<u32>(parent);
-            }
+            ikModified[bone] = true;
+            // Walk to the parent; a missing parent (< 0) ends the chain via the
+            // out-of-range guard on the next iteration (keeps a single break).
+            const int parent = parentIndices[bone];
+            bone = (parent < 0) ? static_cast<u32>(boneCount) : static_cast<u32>(parent);
         }
     }
 
@@ -50,8 +50,7 @@ namespace OloEngine::Animation
             glm::vec3 translation;
             glm::quat rotation;
             glm::vec3 skew;
-            glm::vec4 perspective;
-            if (!glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
+            if (glm::vec4 perspective; !glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
             {
                 localPose[i] = { glm::vec3(0.0f), glm::identity<glm::quat>(), glm::vec3(1.0f) };
                 continue;

--- a/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.cpp
@@ -141,8 +141,9 @@ namespace OloEngine::Animation
         bool needWeightBlend = (weight < 1.0f - 1e-6f);
         if (needWeightBlend)
         {
-            originalRotations.resize(boneIndices.size());
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto chainSize = boneIndices.size();
+            originalRotations.resize(chainSize);
+            for (sizet i = 0; i < chainSize; ++i)
             {
                 originalRotations[i] = pose[boneIndices[i]].Rotation;
             }
@@ -218,9 +219,9 @@ namespace OloEngine::Animation
             // Compute rotation in bone's local frame
             auto invRot = glm::conjugate(thisBoneMS.Rotation);
             auto toOriginal = SafeNormalize(invRot * originalDir);
-            auto toTarget = SafeNormalize(invRot * targetDir);
 
-            if (glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
+            if (auto toTarget = SafeNormalize(invRot * targetDir);
+                glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
             {
                 pose[thisIdx].Rotation *= glm::rotation(toOriginal, toTarget);
             }
@@ -232,7 +233,8 @@ namespace OloEngine::Animation
         // Apply global weight: blend between original and IK result (chain bones only)
         if (needWeightBlend)
         {
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto blendCount = boneIndices.size();
+            for (sizet i = 0; i < blendCount; ++i)
             {
                 auto bi = boneIndices[i];
                 pose[bi].Rotation = glm::slerp(originalRotations[i], pose[bi].Rotation, weight);

--- a/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.h
+++ b/OloEngine/src/OloEngine/Animation/IK/LimbIKSolver.h
@@ -28,6 +28,13 @@ namespace OloEngine::Animation
             std::span<BoneTransform> pose,
             std::span<const int> parentIndices,
             const LimbIKParams& params,
-            std::span<const glm::mat4> preTransforms = {});
+            std::span<const glm::mat4> preTransforms);
+        static void Solve(
+            std::span<BoneTransform> pose,
+            std::span<const int> parentIndices,
+            const LimbIKParams& params)
+        {
+            Solve(pose, parentIndices, params, {});
+        }
     };
 } // namespace OloEngine::Animation

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/FacialExpressionLibrary.cpp
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/FacialExpressionLibrary.cpp
@@ -79,7 +79,8 @@ namespace OloEngine
 
         if (auto weightsNode = exprNode["TargetWeights"]; weightsNode && weightsNode.IsMap())
         {
-            for (auto it = weightsNode.begin(); it != weightsNode.end(); ++it)
+            auto weightsEnd = weightsNode.end();
+            for (auto it = weightsNode.begin(); it != weightsEnd; ++it)
             {
                 expr.TargetWeights[it->first.as<std::string>()] = it->second.as<f32>(0.0f);
             }

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/FacialExpressionLibrary.h
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/FacialExpressionLibrary.h
@@ -25,7 +25,11 @@ namespace OloEngine
             GetExpressions()[expr.Name] = expr;
         }
 
-        static void ApplyExpression(MorphTargetComponent& morphComp, const std::string& exprName, f32 blend = 1.0f)
+        static void ApplyExpression(MorphTargetComponent& morphComp, const std::string& exprName)
+        {
+            ApplyExpression(morphComp, exprName, 1.0f);
+        }
+        static void ApplyExpression(MorphTargetComponent& morphComp, const std::string& exprName, f32 blend)
         {
             OLO_PROFILE_FUNCTION();
 
@@ -106,7 +110,7 @@ namespace OloEngine
         static bool LoadExpression(const std::string& filePath);
 
       private:
-        static std::unordered_map<std::string, FacialExpression>& GetExpressions()
+        [[nodiscard("expression registry reference must be used")]] static std::unordered_map<std::string, FacialExpression>& GetExpressions()
         {
             static std::unordered_map<std::string, FacialExpression> s_Expressions;
             return s_Expressions;

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTarget.h
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTarget.h
@@ -39,20 +39,25 @@ namespace OloEngine
         }
 
         // Convert dense representation to sparse (only non-zero deltas)
-        void ConvertToSparse(f32 epsilon = 1e-6f)
+        void ConvertToSparse()
+        {
+            ConvertToSparse(1e-6f);
+        }
+        void ConvertToSparse(f32 epsilon)
         {
             if (IsSparse)
                 return;
 
             SparseVertices.clear();
-            for (u32 i = 0; i < static_cast<u32>(Vertices.size()); ++i)
+            auto vertexCount = static_cast<u32>(Vertices.size());
+            for (u32 i = 0; i < vertexCount; ++i)
             {
                 const auto& v = Vertices[i];
                 if (glm::length(v.DeltaPosition) > epsilon ||
                     glm::length(v.DeltaNormal) > epsilon ||
                     glm::length(v.DeltaTangent) > epsilon)
                 {
-                    SparseVertices.push_back({ i, v });
+                    SparseVertices.emplace_back(i, v);
                 }
             }
             IsSparse = true;

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetComponents.h
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetComponents.h
@@ -52,12 +52,8 @@ namespace OloEngine
         // Check if any morph target has a non-zero weight
         [[nodiscard("active weight check drives morph target updates")]] bool HasActiveWeights() const
         {
-            for (const auto& [name, weight] : Weights)
-            {
-                if (weight > 1e-4f)
-                    return true;
-            }
-            return false;
+            return std::ranges::any_of(Weights, [](const auto& kv)
+                                       { return kv.second > 1e-4f; });
         }
 
         // Build a flat weight vector matching the MorphTargetSet order
@@ -70,7 +66,7 @@ namespace OloEngine
             for (const auto& [name, weight] : Weights)
             {
                 if (auto idx = MorphTargets->FindTargetCached(name); idx >= 0)
-                    ordered[idx] = weight;
+                    ordered[static_cast<sizet>(idx)] = weight;
             }
             return ordered;
         }

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetSet.h
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetSet.h
@@ -7,6 +7,7 @@
 #include "OloEngine/Threading/UniqueLock.h"
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -20,12 +21,12 @@ namespace OloEngine
 
         MorphTargetSet() = default;
 
-        [[nodiscard("target index needed for weight mapping")]] i32 FindTarget(const std::string& name) const
+        [[nodiscard("target index needed for weight mapping")]] i32 FindTarget(std::string_view name) const
         {
             auto count = static_cast<i32>(Targets.size());
             for (i32 i = 0; i < count; ++i)
             {
-                if (Targets[i].Name == name)
+                if (name == Targets[static_cast<sizet>(i)].Name)
                     return i;
             }
             return -1;
@@ -58,7 +59,7 @@ namespace OloEngine
                 return false;
             }
             {
-                TUniqueLock<FMutex> lock(m_CacheMutex);
+                TUniqueLock lock(m_CacheMutex);
                 m_NameIndexCache.clear(); // Invalidate cache
             }
             Targets.push_back(std::move(target));
@@ -68,7 +69,7 @@ namespace OloEngine
         // O(1) name-to-index lookup via cached map
         [[nodiscard("cached target index needed for weight mapping")]] i32 FindTargetCached(const std::string& name) const
         {
-            TUniqueLock<FMutex> lock(m_CacheMutex);
+            TUniqueLock lock(m_CacheMutex);
             BuildNameIndexCacheLocked();
             auto it = m_NameIndexCache.find(name);
             return (it != m_NameIndexCache.end()) ? it->second : -1;
@@ -80,8 +81,9 @@ namespace OloEngine
         {
             if (!m_NameIndexCache.empty() || Targets.empty())
                 return;
-            for (i32 i = 0; i < static_cast<i32>(Targets.size()); ++i)
-                m_NameIndexCache[Targets[i].Name] = i;
+            auto targetCount = static_cast<i32>(Targets.size());
+            for (i32 i = 0; i < targetCount; ++i)
+                m_NameIndexCache[Targets[static_cast<sizet>(i)].Name] = i;
         }
 
         // Guards the mutable cache so const lookups can rebuild it from multiple

--- a/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetSystem.cpp
+++ b/OloEngine/src/OloEngine/Animation/MorphTargets/MorphTargetSystem.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/Log.h"
 
 #include <algorithm>
+#include <functional>
 
 namespace OloEngine
 {
@@ -24,9 +25,8 @@ namespace OloEngine
                 continue;
 
             // Binary search for the first key with time >= 'timeSeconds'
-            auto it = std::lower_bound(keys.begin(), keys.end(), timeSeconds,
-                                       [](const std::pair<f64, f32>& key, f64 t)
-                                       { return key.first < t; });
+            auto it = std::ranges::lower_bound(keys, timeSeconds, std::ranges::less{},
+                                               &std::pair<f64, f32>::first);
 
             f32 weight = 0.0f;
             if (it == keys.end())

--- a/OloEngine/src/OloEngine/Animation/OneShotBlend.cpp
+++ b/OloEngine/src/OloEngine/Animation/OneShotBlend.cpp
@@ -31,6 +31,7 @@ namespace OloEngine::Animation
 
     bool OneShotBlend::AdvancePhase()
     {
+        using enum Phase;
         // Loop to handle instant transitions (e.g., zero-duration blend-in/out can
         // skip multiple phases in one frame).
         bool transitioned = true;
@@ -39,28 +40,28 @@ namespace OloEngine::Animation
             transitioned = false;
             switch (m_Phase)
             {
-                case Phase::BlendIn:
+                case BlendIn:
                     if (BlendInDuration <= 0.0f || m_PhaseTime >= BlendInDuration)
                     {
-                        m_Phase = Phase::Playing;
+                        m_Phase = Playing;
                         m_PhaseTime = (BlendInDuration > 0.0f) ? (m_PhaseTime - BlendInDuration) : 0.0f;
                         transitioned = true;
                     }
                     break;
-                case Phase::Playing:
+                case Playing:
                 {
                     if (f32 blendOutStart = Clip->Duration - BlendOutDuration; m_PlaybackTime >= blendOutStart)
                     {
-                        m_Phase = Phase::BlendOut;
+                        m_Phase = BlendOut;
                         m_PhaseTime = m_PlaybackTime - blendOutStart;
                         transitioned = true;
                     }
                     break;
                 }
-                case Phase::BlendOut:
+                case BlendOut:
                     if (BlendOutDuration <= 0.0f || m_PhaseTime >= BlendOutDuration || m_PlaybackTime >= Clip->Duration)
                     {
-                        m_Phase = Phase::Idle;
+                        m_Phase = Idle;
                         m_PlaybackTime = 0.0f;
                         m_PhaseTime = 0.0f;
                         if (OnFinished)
@@ -70,7 +71,7 @@ namespace OloEngine::Animation
                         return false;
                     }
                     break;
-                case Phase::Idle:
+                case Idle:
                     return false;
                 default:
                     break;
@@ -151,7 +152,8 @@ namespace OloEngine::Animation
         if (m_CachedBoneCount != boneCount || m_CachedBoneNamesHash != nameHash)
         {
             m_BoneNameToIndex.clear();
-            for (sizet i = 0; i < boneCount && i < boneNames.size(); ++i)
+            auto boneNameCount = boneNames.size();
+            for (sizet i = 0; i < boneCount && i < boneNameCount; ++i)
             {
                 m_BoneNameToIndex[boneNames[i]] = i;
             }

--- a/OloEngine/src/OloEngine/Animation/OneShotBlend.h
+++ b/OloEngine/src/OloEngine/Animation/OneShotBlend.h
@@ -32,8 +32,8 @@ namespace OloEngine::Animation
         // and AnimationLayer, which embeds it — moves without throwing (S5018).
         OneShotBlend() = default;
         OneShotBlend(const OneShotBlend&) = default;
-        OneShotBlend& operator=(const OneShotBlend&) = default;
         OneShotBlend(OneShotBlend&&) noexcept = default;
+        OneShotBlend& operator=(const OneShotBlend&) = default;
         OneShotBlend& operator=(OneShotBlend&&) noexcept = default;
 
         void Trigger();

--- a/OloEngine/src/OloEngine/Animation/Procedural/NoisePostPass.cpp
+++ b/OloEngine/src/OloEngine/Animation/Procedural/NoisePostPass.cpp
@@ -48,8 +48,7 @@ namespace OloEngine::Animation
         // float-precision danger zone by wrapping; simplex noise is aperiodic so
         // a large wrap point is visually seamless.
         state.Time += deltaTime;
-        constexpr f32 kPhaseWrap = 100000.0f;
-        if (!std::isfinite(state.Time) || std::abs(state.Time) > kPhaseWrap)
+        if (constexpr f32 kPhaseWrap = 100000.0f; !std::isfinite(state.Time) || std::abs(state.Time) > kPhaseWrap)
         {
             state.Time = std::fmod(state.Time, kPhaseWrap);
             if (!std::isfinite(state.Time))
@@ -97,8 +96,7 @@ namespace OloEngine::Animation
             glm::vec3 translation;
             glm::quat rotation;
             glm::vec3 skew;
-            glm::vec4 perspective;
-            if (!glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
+            if (glm::vec4 perspective; !glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
             {
                 // Degenerate/non-affine local transform — drop this bone from the
                 // write-back so we preserve its original matrix instead of

--- a/OloEngine/src/OloEngine/Animation/Procedural/NoiseSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/Procedural/NoiseSolver.cpp
@@ -80,7 +80,7 @@ namespace OloEngine::Animation
         f32 seedOffset = static_cast<f32>(params.Seed) * 19.19f;
         f32 boneDecorr = static_cast<f32>(chainIndex) * 5.31f + static_cast<f32>(boneIndex) * 0.733f + seedOffset;
 
-        auto sample = [&params, phase, boneDecorr, lacunarity, gain](f32 lane) -> f32
+        auto sample = [&params, phase, boneDecorr, lacunarity, gain](f32 lane)
         {
             return Fbm(phase, boneDecorr + lane, lane * 1.7f, params.Octaves, lacunarity, gain);
         };
@@ -142,12 +142,10 @@ namespace OloEngine::Animation
             pose[bone].Rotation = glm::normalize(pose[bone].Rotation * noiseRot);
             pose[bone].Translation += bo.Translation;
 
+            // Walk to the parent; a missing parent (< 0) ends the chain via the
+            // out-of-range guard on the next iteration (keeps a single break).
             const int parent = parentIndices[bone];
-            if (parent < 0)
-            {
-                break;
-            }
-            bone = static_cast<u32>(parent);
+            bone = (parent < 0) ? static_cast<u32>(boneCount) : static_cast<u32>(parent);
         }
     }
 } // namespace OloEngine::Animation

--- a/OloEngine/src/OloEngine/Animation/Procedural/NoiseSolver.h
+++ b/OloEngine/src/OloEngine/Animation/Procedural/NoiseSolver.h
@@ -50,7 +50,7 @@ namespace OloEngine::Animation
         //   |EulerRadians[a]| <= |RotationAmplitude[a]| * clamp(Weight, 0, 1)
         //   |Translation[a]|  <= |TranslationAmplitude[a]| * clamp(Weight, 0, 1)
         // Returns a zero offset for a non-finite or zero-weight configuration.
-        [[nodiscard]] static NoiseBoneOffset SampleBoneOffset(
+        [[nodiscard("sampled bone offset must be applied to the pose")]] static NoiseBoneOffset SampleBoneOffset(
             const NoiseParams& params, u32 chainIndex, u32 boneIndex, f32 timeSeconds);
 
         // Adds noise offsets to the local-space pose of the bone chain in place.

--- a/OloEngine/src/OloEngine/Animation/Procedural/SpringBonePostPass.cpp
+++ b/OloEngine/src/OloEngine/Animation/Procedural/SpringBonePostPass.cpp
@@ -87,8 +87,7 @@ namespace OloEngine::Animation
             glm::vec3 translation;
             glm::quat rotation;
             glm::vec3 skew;
-            glm::vec4 perspective;
-            if (!glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
+            if (glm::vec4 perspective; !glm::decompose(skeleton.m_LocalTransforms[i], scale, rotation, translation, skew, perspective))
             {
                 localPose[i] = { glm::vec3(0.0f), glm::identity<glm::quat>(), glm::vec3(1.0f) };
                 continue;
@@ -109,8 +108,7 @@ namespace OloEngine::Animation
         // world-space sag stays consistent regardless of entity scale. Falls
         // back to the raw vector when the transform is degenerate (zero scale).
         auto entityRotScale = glm::mat3(entityWorldTransform);
-        constexpr f32 kDeterminantEpsilon = 1e-12f;
-        if (std::abs(glm::determinant(entityRotScale)) > kDeterminantEpsilon)
+        if (constexpr f32 kDeterminantEpsilon = 1e-12f; std::abs(glm::determinant(entityRotScale)) > kDeterminantEpsilon)
         {
             params.Gravity = glm::inverse(entityRotScale) * springBone.Gravity;
             if (!isFiniteVec3(params.Gravity))

--- a/OloEngine/src/OloEngine/Animation/Procedural/SpringBoneSolver.cpp
+++ b/OloEngine/src/OloEngine/Animation/Procedural/SpringBoneSolver.cpp
@@ -34,6 +34,24 @@ namespace OloEngine::Animation
         {
             return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
         }
+
+        // True when the cached simulation state matches the current chain size
+        // and contains only finite positions (so it can be reused this frame).
+        bool IsSpringStateValid(const SpringBoneState& state, sizet simCount)
+        {
+            if (!state.Initialized || state.CurrPositions.size() != simCount || state.PrevPositions.size() != simCount)
+            {
+                return false;
+            }
+            for (sizet i = 0; i < simCount; ++i)
+            {
+                if (!IsFiniteVec3(state.CurrPositions[i]) || !IsFiniteVec3(state.PrevPositions[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     } // namespace
 
     void SpringBoneSolver::Solve(
@@ -123,16 +141,7 @@ namespace OloEngine::Animation
         // position is driven by the parent hierarchy, not the simulation.
         auto simCount = static_cast<sizet>(jointCount) - 1;
 
-        auto stateValid = state.Initialized && state.CurrPositions.size() == simCount && state.PrevPositions.size() == simCount;
-        if (stateValid)
-        {
-            for (sizet i = 0; i < simCount && stateValid; ++i)
-            {
-                stateValid = IsFiniteVec3(state.CurrPositions[i]) && IsFiniteVec3(state.PrevPositions[i]);
-            }
-        }
-
-        if (!stateValid)
+        if (!IsSpringStateValid(state, simCount))
         {
             // (Re-)initialize to the animated pose: the chain starts at rest,
             // so the first solved frame leaves the pose untouched.
@@ -187,8 +196,9 @@ namespace OloEngine::Animation
         bool needWeightBlend = (weight < 1.0f - 1e-6f);
         if (needWeightBlend)
         {
-            originalRotations.resize(boneIndices.size());
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto chainSize = boneIndices.size();
+            originalRotations.resize(chainSize);
+            for (sizet i = 0; i < chainSize; ++i)
             {
                 originalRotations[i] = pose[boneIndices[i]].Rotation;
             }
@@ -232,9 +242,9 @@ namespace OloEngine::Animation
             // Compute the correction in the bone's local frame
             auto invRot = glm::conjugate(thisBoneMS.Rotation);
             auto toOriginal = SafeNormalize(invRot * originalDir);
-            auto toTarget = SafeNormalize(invRot * targetDir);
 
-            if (glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
+            if (auto toTarget = SafeNormalize(invRot * targetDir);
+                glm::length2(toOriginal) > 1e-10f && glm::length2(toTarget) > 1e-10f)
             {
                 pose[thisIdx].Rotation *= glm::rotation(toOriginal, toTarget);
             }
@@ -246,7 +256,8 @@ namespace OloEngine::Animation
         // Apply global weight: blend between the animated and simulated result
         if (needWeightBlend)
         {
-            for (sizet i = 0; i < boneIndices.size(); ++i)
+            auto blendCount = boneIndices.size();
+            for (sizet i = 0; i < blendCount; ++i)
             {
                 auto bi = boneIndices[i];
                 pose[bi].Rotation = glm::slerp(originalRotations[i], pose[bi].Rotation, weight);

--- a/OloEngine/src/OloEngine/Animation/Procedural/SpringBoneSolver.h
+++ b/OloEngine/src/OloEngine/Animation/Procedural/SpringBoneSolver.h
@@ -46,6 +46,15 @@ namespace OloEngine::Animation
             const SpringBoneParams& params,
             SpringBoneState& state,
             f32 deltaTime,
-            std::span<const glm::mat4> preTransforms = {});
+            std::span<const glm::mat4> preTransforms);
+        static void Solve(
+            std::span<BoneTransform> pose,
+            std::span<const int> parentIndices,
+            const SpringBoneParams& params,
+            SpringBoneState& state,
+            f32 deltaTime)
+        {
+            Solve(pose, parentIndices, params, state, deltaTime, {});
+        }
     };
 } // namespace OloEngine::Animation


### PR DESCRIPTION
## Summary
Batched SonarQube **CODE_SMELL** (maintainability) cleanup across `OloEngine/src/OloEngine/Animation/**`, **excluding `Animation/Retargeting/`** (carved out for active retargeting feature work). **~138 of 271** in-scope issues cleared; the rest are deliberate, documented leaves.

**No behaviour changes.** All edits are value-preserving (signed/unsigned casts guarded by non-negativity, loop hoists where the container isn't mutated, additive overloads, helper extractions that copy logic verbatim).

## Verification
- `cmake --build build --target OloEngine --config Debug` → clean (EXIT=0)
- `OloEngine-Tests` animation subset (`*Anim*:*IK*:*Blend*:*Morph*:*Spring*:*Bone*:*Noise*:*Transition*:*OneShot*:*Skeleton*`) → **238 passed**

## Cleared rules
`S127` ×31 (loop stop-condition hoists / `for`→`while` parent-walks), `S6004` ×12 (if-init), `S6012` ×11 (CTAD), `S6177` ×11 (`using enum`), `S845` ×9 (index casts), `S4136` ×8 (group special-member overloads), `S1712` ×16 (default-arg → forwarding overload), `S6009` ×6 (`string_view`), `S6171` ×4 (`.contains`), `S6007`/`S6166` ×6 (`nodiscard`), `S3574` ×3, `S5566` ×3 (ranges algos), `S1188` ×3 (deduped two recursive `buildTagMap` lambdas into one helper), `S1142` ×3 (clean guard merges), `S1066` ×2, `S886` ×2, `S924`, `S3776`, `S6197`, `S6003`, `S1151`, `M23_279`, and 2 dead declarations (`S5536`).

## Deliberately left (by design / deferred)
- **S6045 ×24** — transparent-hasher migration changes public string-keyed container *types* across headers; a separate, more invasive change. Main follow-up.
- **S5536 ×20** — public API / pure-virtual interfaces (`BlendNode`) / symmetric pairs (`ModelToWorldSpace`) / unwired feature paths (`EvaluateGPU`, `IsBoneAffected`); kept per the "when unsure, leave it" caution.
- **S1712 ×13** on `AnimationSystem`/`AnimationGraphSystem::Update` — a 7-pointer hot path driven by `Scene::OnUpdateRuntime`; overload/context-struct refactor where a silent arg transposition would still compile (out of scope for a mechanical pass).
- **S1771 ×12** — `struct *Component` is the OloHeaderTool `AllComponents` codegen marker; struct→class would drop them from the generated tuple.
- **S1917 ×7** (file-level "no mixed comment styles" vs the Doxygen `/** */` + `//` convention), **S5419/S107 ×11** (param-struct restructuring), **S1706/S1181/S2738/S1141 ×9** (try/catch around exception-throwing yaml-cpp / asset reload — S1706 is literally "don't use exceptions"), **S1142 ×16** (branchy / validation / converter flow), plus FP/by-design **S5414/S3230/S3624/S995/S1820**.

`Retargeting/` was intentionally **not** touched. SonarQube auto-resolves the cleared rules on its next scan — no GitHub issue to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety and edge-case handling in animation graph state/transition queries, bone-mask membership checks, and transform application loops.
  * Hardened bone-entity/tag traversal to better prevent cycles and handle missing/invalid hierarchy links.
  * Strengthened IK/procedural solvers’ validity checks and parent-chain handling.

* **New Features**
  * Added convenience overloads to omit optional transform inputs (including multiple IK solvers), plus no-argument access for layer-0 state/transition.
  * Added expression/morph helper overloads for simpler calls (e.g., default blend handling).
  * Improved lookup APIs to accept `std::string_view` where applicable.

* **Chores**
  * Updated diagnostics/`nodiscard` messaging and modernized internal cache locking/parameter passing patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->