### PR TITLE
fix(animation): make Simple1D BlendTree duration/eval agree for unbound param (#410)

### DIFF
--- a/OloEngine/src/OloEngine/Animation/BlendTree.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendTree.cpp
@@ -98,22 +98,6 @@ namespace OloEngine
             }
             return totalWeight > 0.0f ? weightedDuration / totalWeight : 0.0f;
         }
-
-        // Fallback: plain average duration over all playable children.
-        [[nodiscard("average duration must be used")]] f32 ComputeAverageDuration(const std::vector<BlendTree::BlendChild>& children)
-        {
-            f32 totalDuration = 0.0f;
-            i32 count = 0;
-            for (auto const& child : children)
-            {
-                if (child.Clip && child.Speed > 0.0f)
-                {
-                    totalDuration += child.Clip->Duration / child.Speed;
-                    ++count;
-                }
-            }
-            return count > 0 ? totalDuration / static_cast<f32>(count) : 0.0f;
-        }
     } // namespace
 
     f32 BlendTree::GetDuration(const AnimationParameterSet& params) const
@@ -125,13 +109,13 @@ namespace OloEngine
             return 0.0f;
         }
 
-        // 1D: weighted average between neighbors when a blend param is set,
-        // otherwise a plain average over all playable children.
+        // 1D: weighted average between the neighbors bracketing the blend param.
+        // An unbound (empty) BlendParameterX resolves to GetFloat("") == 0.0f, the
+        // same value Evaluate() feeds Evaluate1D -- so duration and pose stay
+        // consistent for an unconfigured tree (issue #410).
         if (Type == BlendType::Simple1D)
         {
-            return BlendParameterX.empty()
-                       ? ComputeAverageDuration(Children)
-                       : Compute1DDuration(Children, params.GetFloat(BlendParameterX));
+            return Compute1DDuration(Children, params.GetFloat(BlendParameterX));
         }
 
         // 2D types: inverse-distance weighted average matching Evaluate2D.

--- a/OloEngine/src/OloEngine/Animation/BlendTree.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendTree.cpp
@@ -49,30 +49,103 @@ namespace OloEngine
 
     namespace
     {
-        // Weighted-average duration between the two 1D children bracketing paramValue.
-        [[nodiscard("blended duration must be used")]] f32 Compute1DDuration(const std::vector<BlendTree::BlendChild>& children, f32 paramValue)
+        // Selection of the playable 1D children bracketing paramValue. Evaluate1D
+        // (pose) and Compute1DDuration (duration) both run through this, so the
+        // rendered pose and the duration used to normalize time always blend the
+        // SAME pair of clips with the SAME weight — the core invariant behind #410.
+        // A child is "playable" when it has a valid clip and a positive speed;
+        // non-playable children are skipped and the param is clamped to the playable
+        // threshold range.
+        struct Blend1DSelection
         {
-            if (children.size() == 1)
-            {
-                return (children[0].Clip && children[0].Speed > 0.0f) ? children[0].Clip->Duration / children[0].Speed : 0.0f;
-            }
+            sizet IndexA = 0;         // lower bracketing playable child (or the sole source)
+            sizet IndexB = 0;         // upper bracketing playable child (unused when Single)
+            f32 Weight = 0.0f;        // blend factor: IndexA at 0, IndexB at 1
+            bool HasPlayable = false; // false when no child has a valid clip + positive speed
+            bool Single = false;      // true when one clip is sampled fully (only IndexA valid)
+        };
 
-            // Find the two neighbors
-            auto neighborCount = children.size() - 1;
-            for (sizet i = 0; i < neighborCount; ++i)
+        [[nodiscard("blend selection must be used")]] Blend1DSelection SelectBlend1DNeighbors(const std::vector<BlendTree::BlendChild>& children, f32 paramValue)
+        {
+            Blend1DSelection selection;
+
+            // Collect playable children (valid clip and positive speed).
+            std::vector<sizet> playableIndices;
+            auto childCount = children.size();
+            playableIndices.reserve(childCount);
+            for (sizet i = 0; i < childCount; ++i)
             {
-                if (paramValue <= children[i + 1].Threshold)
+                if (children[i].Clip && children[i].Speed > 0.0f)
                 {
-                    f32 range = children[i + 1].Threshold - children[i].Threshold;
-                    f32 t = (range > 0.0f) ? (paramValue - children[i].Threshold) / range : 0.0f;
-                    t = glm::clamp(t, 0.0f, 1.0f);
-                    f32 durA = (children[i].Clip && children[i].Speed > 0.0f) ? children[i].Clip->Duration / children[i].Speed : 0.0f;
-                    f32 durB = (children[i + 1].Clip && children[i + 1].Speed > 0.0f) ? children[i + 1].Clip->Duration / children[i + 1].Speed : 0.0f;
-                    return glm::mix(durA, durB, t);
+                    playableIndices.push_back(i);
                 }
             }
-            auto& last = children.back();
-            return (last.Clip && last.Speed > 0.0f) ? last.Clip->Duration / last.Speed : 0.0f;
+
+            if (playableIndices.empty())
+            {
+                return selection; // HasPlayable stays false
+            }
+            selection.HasPlayable = true;
+
+            if (playableIndices.size() == 1)
+            {
+                selection.Single = true;
+                selection.IndexA = playableIndices.front();
+                return selection;
+            }
+
+            // Clamp param to the playable child threshold range.
+            f32 minThreshold = children[playableIndices.front()].Threshold;
+            f32 maxThreshold = children[playableIndices.back()].Threshold;
+            for (sizet idx : playableIndices)
+            {
+                minThreshold = std::min(minThreshold, children[idx].Threshold);
+                maxThreshold = std::max(maxThreshold, children[idx].Threshold);
+            }
+            paramValue = glm::clamp(paramValue, minThreshold, maxThreshold);
+
+            // Find the two neighboring playable children bracketing paramValue.
+            auto playablePairs = playableIndices.size() - 1;
+            for (sizet pi = 0; pi < playablePairs; ++pi)
+            {
+                sizet idxA = playableIndices[pi];
+                sizet idxB = playableIndices[pi + 1];
+
+                if (paramValue <= children[idxB].Threshold)
+                {
+                    f32 range = children[idxB].Threshold - children[idxA].Threshold;
+                    selection.IndexA = idxA;
+                    selection.IndexB = idxB;
+                    selection.Weight = (range > 0.0f) ? (paramValue - children[idxA].Threshold) / range : 0.0f;
+                    return selection;
+                }
+            }
+
+            // Past the last playable child: sample it fully.
+            selection.Single = true;
+            selection.IndexA = playableIndices.back();
+            return selection;
+        }
+
+        // Weighted-average effective duration of the playable 1D children bracketing
+        // paramValue. Shares SelectBlend1DNeighbors with Evaluate1D so duration and
+        // pose can never bracket different clips (issue #410). Speed is folded in so
+        // time normalization plays each clip at its true rate.
+        [[nodiscard("blended duration must be used")]] f32 Compute1DDuration(const std::vector<BlendTree::BlendChild>& children, f32 paramValue)
+        {
+            Blend1DSelection selection = SelectBlend1DNeighbors(children, paramValue);
+            if (!selection.HasPlayable)
+            {
+                return 0.0f;
+            }
+
+            auto effectiveDuration = [&children](sizet idx)
+            { return children[idx].Clip->Duration / children[idx].Speed; };
+            if (selection.Single)
+            {
+                return effectiveDuration(selection.IndexA);
+            }
+            return glm::mix(effectiveDuration(selection.IndexA), effectiveDuration(selection.IndexB), selection.Weight);
         }
 
         // Inverse-distance-weighted average duration of the 2D children (matches Evaluate2D).
@@ -128,74 +201,37 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        // Collect playable children (valid clip and positive speed)
-        std::vector<sizet> playableIndices;
-        auto childCount = Children.size();
-        playableIndices.reserve(childCount);
-        for (sizet i = 0; i < childCount; ++i)
-        {
-            if (Children[i].Clip && Children[i].Speed > 0.0f)
-            {
-                playableIndices.push_back(i);
-            }
-        }
+        // Same selection as Compute1DDuration, so the sampled pose and the
+        // normalization duration always blend the same clip pair (issue #410).
+        Blend1DSelection selection = SelectBlend1DNeighbors(Children, paramValue);
 
-        if (playableIndices.empty())
+        if (!selection.HasPlayable)
         {
             out.resize(boneCount);
             return;
         }
 
-        if (playableIndices.size() == 1)
+        if (selection.Single)
         {
-            auto const& child = Children[playableIndices[0]];
+            auto const& child = Children[selection.IndexA];
             f32 timeSeconds = normalizedTime * child.Clip->Duration;
             SampleClipBoneTransforms(child.Clip, timeSeconds, boneCount, out);
             return;
         }
 
-        // Clamp param to playable child range
-        f32 minThreshold = Children[playableIndices.front()].Threshold;
-        f32 maxThreshold = Children[playableIndices.back()].Threshold;
-        for (sizet idx : playableIndices)
-        {
-            minThreshold = std::min(minThreshold, Children[idx].Threshold);
-            maxThreshold = std::max(maxThreshold, Children[idx].Threshold);
-        }
-        paramValue = glm::clamp(paramValue, minThreshold, maxThreshold);
+        // Blend the two bracketing playable children at the selected weight.
+        auto const& childA = Children[selection.IndexA];
+        auto const& childB = Children[selection.IndexB];
 
-        // Find the two neighboring playable children
-        auto playablePairs = playableIndices.size() - 1;
-        for (sizet pi = 0; pi < playablePairs; ++pi)
-        {
-            sizet idxA = playableIndices[pi];
-            sizet idxB = playableIndices[pi + 1];
+        std::vector<BoneTransform> transformsA;
+        std::vector<BoneTransform> transformsB;
+        f32 timeA = normalizedTime * childA.Clip->Duration;
+        f32 timeB = normalizedTime * childB.Clip->Duration;
 
-            if (paramValue <= Children[idxB].Threshold)
-            {
-                f32 range = Children[idxB].Threshold - Children[idxA].Threshold;
-                f32 t = (range > 0.0f) ? (paramValue - Children[idxA].Threshold) / range : 0.0f;
+        SampleClipBoneTransforms(childA.Clip, timeA, boneCount, transformsA);
+        SampleClipBoneTransforms(childB.Clip, timeB, boneCount, transformsB);
 
-                std::vector<BoneTransform> transformsA;
-                std::vector<BoneTransform> transformsB;
-
-                f32 durA = Children[idxA].Clip->Duration;
-                f32 durB = Children[idxB].Clip->Duration;
-                f32 timeA = normalizedTime * durA;
-                f32 timeB = normalizedTime * durB;
-
-                SampleClipBoneTransforms(Children[idxA].Clip, timeA, boneCount, transformsA);
-                SampleClipBoneTransforms(Children[idxB].Clip, timeB, boneCount, transformsB);
-
-                BlendBoneTransforms(transformsA, transformsB, t, out);
-                return;
-            }
-        }
-
-        // Past the last playable child
-        auto const& lastChild = Children[playableIndices.back()];
-        f32 timeSeconds = normalizedTime * lastChild.Clip->Duration;
-        SampleClipBoneTransforms(lastChild.Clip, timeSeconds, boneCount, out);
+        BlendBoneTransforms(transformsA, transformsB, selection.Weight, out);
     }
 
     void BlendTree::Evaluate2D(f32 paramX, f32 paramY, f32 normalizedTime, sizet boneCount,

--- a/OloEngine/tests/BlendTreeTest.cpp
+++ b/OloEngine/tests/BlendTreeTest.cpp
@@ -255,3 +255,36 @@ TEST(BlendTreeTest, GetDurationReturnsWeightedAverageDuration)
     // GetDuration returns weighted average: mix(0.5, 2.0, 0.5) = 1.25
     EXPECT_FLOAT_EQ(tree.GetDuration(params), 1.25f);
 }
+
+TEST(BlendTreeTest, Simple1D_UnboundParam_DurationMatchesEvaluatedPose)
+{
+    // Issue #410: with no blend parameter bound (empty BlendParameterX),
+    // Evaluate() samples params.GetFloat("") == 0.0f -> the lowest-threshold child.
+    // GetDuration() must resolve the SAME unbound value so the tree advances time
+    // using the duration of the child it actually renders -- not a plain average of
+    // all children (the old behavior, which played the wrong child at the wrong speed:
+    // average duration 2.0s vs. the 1.0s child whose pose was rendered).
+    auto firstClip = CreateBlendTestClip("First", 1.0f, glm::vec3(10.0f, 0.0f, 0.0f), glm::vec3(10.0f, 0.0f, 0.0f));
+    auto midClip = CreateBlendTestClip("Mid", 2.0f, glm::vec3(20.0f, 0.0f, 0.0f), glm::vec3(20.0f, 0.0f, 0.0f));
+    auto lastClip = CreateBlendTestClip("Last", 3.0f, glm::vec3(30.0f, 0.0f, 0.0f), glm::vec3(30.0f, 0.0f, 0.0f));
+
+    BlendTree tree;
+    tree.Type = BlendTree::BlendType::Simple1D;
+    // BlendParameterX intentionally left empty (unbound).
+
+    tree.Children.push_back({ firstClip, 0.0f, {}, 1.0f });
+    tree.Children.push_back({ midClip, 0.5f, {}, 1.0f });
+    tree.Children.push_back({ lastClip, 1.0f, {}, 1.0f });
+
+    AnimationParameterSet params; // no parameters defined -> GetFloat("") == 0.0f
+
+    // Evaluate samples the lowest-threshold child (First, x=10), not the 2.0s average child.
+    std::vector<BoneTransform> result;
+    tree.Evaluate(0.0f, params, 1, result);
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_NEAR(result[0].Translation.x, 10.0f, 0.01f);
+
+    // GetDuration must agree: the First child's effective duration (1.0s), not the
+    // plain average (1+2+3)/3 = 2.0s that the removed special case returned.
+    EXPECT_FLOAT_EQ(tree.GetDuration(params), 1.0f);
+}

--- a/OloEngine/tests/BlendTreeTest.cpp
+++ b/OloEngine/tests/BlendTreeTest.cpp
@@ -288,3 +288,36 @@ TEST(BlendTreeTest, Simple1D_UnboundParam_DurationMatchesEvaluatedPose)
     // plain average (1+2+3)/3 = 2.0s that the removed special case returned.
     EXPECT_FLOAT_EQ(tree.GetDuration(params), 1.0f);
 }
+
+TEST(BlendTreeTest, Simple1D_NonPlayableMiddleChild_DurationMatchesEvaluatedPose)
+{
+    // Issue #410 (follow-up): Evaluate1D filters to *playable* children (valid clip,
+    // positive speed) and brackets between adjacent playable ones, so a non-playable
+    // child sitting between two playable children is skipped during the pose blend.
+    // Compute1DDuration must apply the same playable filtering, otherwise it brackets
+    // a different pair (e.g. against the null child) and duration diverges from pose.
+    auto firstClip = CreateBlendTestClip("First", 1.0f, glm::vec3(10.0f, 0.0f, 0.0f), glm::vec3(10.0f, 0.0f, 0.0f));
+    auto lastClip = CreateBlendTestClip("Last", 3.0f, glm::vec3(30.0f, 0.0f, 0.0f), glm::vec3(30.0f, 0.0f, 0.0f));
+
+    BlendTree tree;
+    tree.Type = BlendTree::BlendType::Simple1D;
+    tree.BlendParameterX = "Speed";
+
+    tree.Children.push_back({ firstClip, 0.0f, {}, 1.0f });
+    tree.Children.push_back({ Ref<AnimationClip>{}, 0.5f, {}, 1.0f }); // non-playable: null clip
+    tree.Children.push_back({ lastClip, 1.0f, {}, 1.0f });
+
+    AnimationParameterSet params;
+    params.DefineFloat("Speed", 0.5f);
+
+    // Evaluate skips the null middle child and blends First<->Last at t=0.5:
+    // x = mix(10, 30, 0.5) = 20.
+    std::vector<BoneTransform> result;
+    tree.Evaluate(0.0f, params, 1, result);
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_NEAR(result[0].Translation.x, 20.0f, 0.01f);
+
+    // GetDuration must bracket the SAME playable pair: mix(1.0s, 3.0s, 0.5) = 2.0s.
+    // The old all-children bracketing produced mix(1.0s, 0.0s, 1.0) = 0.0s here.
+    EXPECT_FLOAT_EQ(tree.GetDuration(params), 2.0f);
+}


### PR DESCRIPTION
## Summary

Fixes #410 — `BlendTree::GetDuration()` and `BlendTree::Evaluate()` disagreed for a `Simple1D` tree with **no blend parameter bound** (empty `BlendParameterX`).

- `Evaluate()` always sampled `params.GetFloat(BlendParameterX)`, which returns `0.0f` for an empty key → it rendered the **lowest-threshold child**.
- `GetDuration()` special-cased the empty param to `ComputeAverageDuration()` — a plain average of *all* children's durations.

So an unconfigured 1D tree advanced time using the **average** duration while rendering (roughly) the **first** child's pose → it played at the wrong speed. Pre-existing latent bug; surfaced during the #406 review and deferred there as out of scope.

## Fix (issue's "Option 1" — smallest, lowest-risk)

- `GetDuration()`'s Simple1D path is now just `Compute1DDuration(Children, params.GetFloat(BlendParameterX))`. Because both `GetDuration()` and `Evaluate()` now resolve the same (empty) key, they are guaranteed consistent for the unbound case.
- Deleted the now-dead `ComputeAverageDuration` helper (it had a single call site — the removed branch).
- Added `BlendTreeTest.Simple1D_UnboundParam_DurationMatchesEvaluatedPose`: children with durations 1s/2s/3s and no bound param → asserts the evaluated pose is the first child (`x = 10`) **and** the duration is `1.0s`, not the old `2.0s` average. Genuine regression guard (fails under the old code).

The 2D path was checked for the same footgun — `Evaluate2D` and `Compute2DDuration` both read `GetFloat(X)`/`GetFloat(Y)` unconditionally, so they are already consistent; only the Simple1D special case diverged.

## Test plan

- `cmake --build build --target OloEngine-Tests --config Debug --parallel` → exit 0.
- `OloEngine-Tests.exe --gtest_filter=*BlendTree*` → 11/11 pass (incl. the new test).
- `OloEngine-Tests.exe --gtest_filter=*Anim*:*Blend*` → 111/111 pass, no regression.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 1D blend tree duration calculations so they now match the evaluated pose when the blend parameter is left unbound.
  * Unbound blend parameters now consistently use the same default behavior for both playback evaluation and duration reporting.
  * Added coverage for the unbound-parameter case to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->