### PR TITLE
feat(mcp): live diagnostics push over GET /mcp SSE stream (#306 item B)

### DIFF
--- a/OloEditor/src/MCP/McpEventStream.h
+++ b/OloEditor/src/MCP/McpEventStream.h
@@ -1,0 +1,139 @@
+#pragma once
+
+// Pure, transport-agnostic serialization for the MCP server-push event stream
+// (issue #306 item B — the "live push" half of olo_events_tail).
+//
+// `GET /mcp` opens a persistent `text/event-stream` (Server-Sent Events) and the
+// engine's diagnostics ring buffer (Debug/DiagnosticsEventLog.h) is bridged onto it:
+// every newly-recorded DiagnosticEvent is pushed to connected agents as an MCP
+// JSON-RPC notification (`notifications/message`), framed per the SSE wire format.
+//
+// This header holds ONLY the serialization — turning a DiagnosticEvent into its
+// JSON-RPC notification object and into the SSE frame bytes. It is deliberately
+// httplib-free and editor-free so:
+//   * the OloEditor SSE transport (MCP/McpServer.cpp) and the poll-based
+//     olo_events_tail tool (MCP/McpTools.cpp) share ONE event-JSON shape — a push
+//     consumer and a poll consumer see byte-identical event fields, and
+//   * the logic is unit-testable in OloEngine/tests/MCP without binding a socket or
+//     constructing httplib types (mirrors the McpDispatch / McpGoldenCompare seams).
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace OloEngine::MCP
+{
+    using Json = nlohmann::json;
+
+    // Format an epoch-seconds timestamp as a UTC "HH:MM:SS.mmm" wall-clock string.
+    // Computed with modular arithmetic to dodge the non-thread-safe / platform-split
+    // gmtime APIs — the date is irrelevant for a "what just happened" timeline. Empty
+    // for a non-finite / non-positive timestamp. (Shared with olo_events_tail so the
+    // stream and the poll tool stamp time identically.)
+    [[nodiscard]] inline std::string FormatEventUtcTime(f64 epochSeconds)
+    {
+        if (!std::isfinite(epochSeconds) || epochSeconds <= 0.0)
+            return std::string{};
+        const auto total = static_cast<std::int64_t>(epochSeconds);
+        const auto secOfDay = static_cast<int>(((total % 86400) + 86400) % 86400);
+        int milliseconds = static_cast<int>((epochSeconds - static_cast<f64>(total)) * 1000.0);
+        if (milliseconds < 0)
+            milliseconds = 0;
+        else if (milliseconds > 999)
+            milliseconds = 999;
+        char buffer[16];
+        std::snprintf(buffer, sizeof(buffer), "%02d:%02d:%02d.%03d",
+                      secOfDay / 3600, (secOfDay % 3600) / 60, secOfDay % 60, milliseconds);
+        return std::string(buffer);
+    }
+
+    // One diagnostics event as a JSON object — the SAME shape olo_events_tail emits
+    // per array entry (id, category, time, message, entity, context), so a push
+    // subscriber and an incremental poller see identical records. Optional fields
+    // (time / entity / context) are omitted when absent, exactly like the poll path.
+    [[nodiscard]] inline Json EventToJson(const DiagnosticEvent& event)
+    {
+        Json j;
+        j["id"] = event.Id;
+        j["category"] = DiagnosticEvent::CategoryToString(event.Category);
+        if (std::string time = FormatEventUtcTime(event.Timestamp); !time.empty())
+            j["time"] = std::move(time);
+        j["message"] = event.Message;
+        if (event.Entity != 0)
+            j["entity"] = std::to_string(event.Entity);
+        if (!event.Context.empty())
+            j["context"] = event.Context;
+        return j;
+    }
+
+    // Map an event category to an MCP logging severity (RFC-5424 token, the
+    // `notifications/message` `level` field): a script error is an "error", the
+    // chatty per-entity spawn/destroy are "debug", and the rest are "info". Lets a
+    // generic MCP client filter / colour the pushed events by severity.
+    [[nodiscard]] inline const char* EventLogLevel(DiagnosticEventCategory category)
+    {
+        switch (category)
+        {
+            case DiagnosticEventCategory::ScriptError:
+                return "error";
+            case DiagnosticEventCategory::EntitySpawn:
+            case DiagnosticEventCategory::EntityDestroy:
+                return "debug";
+            case DiagnosticEventCategory::SceneLoad:
+            case DiagnosticEventCategory::Play:
+            case DiagnosticEventCategory::Stop:
+            case DiagnosticEventCategory::AssetReload:
+                return "info";
+        }
+        return "info";
+    }
+
+    // The full MCP JSON-RPC notification for one event: the spec's logging
+    // notification (`notifications/message`) carrying the structured event under
+    // `params.data`, with a severity `level` and a `logger` namespace. It is a
+    // notification (no `id`), so the client never replies. Spec-compliant means a
+    // generic MCP client surfaces it without bespoke handling; clients that ignore
+    // logging simply drop it.
+    [[nodiscard]] inline Json MakeEventNotification(const DiagnosticEvent& event)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "method", "notifications/message" },
+                     { "params", { { "level", EventLogLevel(event.Category) }, { "logger", "olo.events" }, { "data", EventToJson(event) } } } };
+    }
+
+    // Frame a payload as one SSE event block: an `id:` line carrying the monotonic
+    // event id (so a reconnecting client can resume via the `Last-Event-ID` header)
+    // and a single `data:` line, terminated by the mandatory blank line. The payload
+    // is dumped compact so it never contains a newline that would split the data
+    // field across SSE lines.
+    [[nodiscard]] inline std::string FormatSseEvent(u64 eventId, const Json& payload)
+    {
+        std::string out;
+        out += "id: ";
+        out += std::to_string(eventId);
+        out += '\n';
+        out += "data: ";
+        out += payload.dump();
+        out += "\n\n";
+        return out;
+    }
+
+    // An SSE comment line (a line starting with ':'). Clients ignore it; used as a
+    // keep-alive heartbeat that also probes whether the socket is still writable.
+    [[nodiscard]] inline std::string FormatSseComment(std::string_view text)
+    {
+        std::string out;
+        out += ": ";
+        out += text;
+        out += "\n\n";
+        return out;
+    }
+} // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -569,14 +570,16 @@ namespace OloEngine::MCP
         u64 startCursor = DiagnosticsEventLog::Get().LastId();
         if (req.has_header("Last-Event-ID"))
         {
-            try
-            {
-                startCursor = std::stoull(req.get_header_value("Last-Event-ID"));
-            }
-            catch (...)
-            {
-                // Malformed cursor — ignore it and start at the head.
-            }
+            // Resume only on a cleanly-parsed cursor. from_chars rejects a leading sign
+            // and trailing junk, unlike std::stoull which would accept "123abc" as 123
+            // or "-1" as a wrapped ULLONG_MAX (silently starving the stream). Requiring
+            // full-string consumption means a malformed header falls back to the head.
+            const std::string lastEventId = req.get_header_value("Last-Event-ID");
+            u64 parsed = 0;
+            const char* const first = lastEventId.data();
+            const char* const last = first + lastEventId.size();
+            if (const auto [ptr, ec] = std::from_chars(first, last, parsed); ec == std::errc{} && ptr == last)
+                startCursor = parsed;
         }
 
         res.set_header("Cache-Control", "no-cache");

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -6,8 +6,10 @@
 #include <httplib.h>
 
 #include "MCP/McpServer.h"
+#include "MCP/McpEventStream.h"
 
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Task/NamedThreads.h"
 
@@ -29,6 +31,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -206,6 +209,53 @@ namespace OloEngine::MCP
             }
         }
 
+        // ---- SSE server-push stream (issue #306 item B) -------------------------
+
+        // Worst-case push latency: the content provider is invoked back-to-back by
+        // httplib, so the stream loop sleeps this long each cycle to avoid busy-spin.
+        // Imperceptible for a live-watch loop, and bounds how long after Stop() a
+        // stream takes to notice the server is gone.
+        constexpr std::chrono::milliseconds kStreamPollInterval{ 250 };
+        // Idle keep-alive cadence: emit an SSE comment after this long with no event,
+        // so intermediaries see traffic and a dead client is detected via a failed write.
+        constexpr std::chrono::seconds kStreamHeartbeat{ 15 };
+
+        // One service cycle of a GET /mcp push stream, run on an httplib worker
+        // thread. Drains every diagnostics event newer than `cursor` from the
+        // (mutex-guarded, lock-safe) ring buffer and writes each as an MCP
+        // notification SSE frame, advances the cursor, then emits a keep-alive
+        // heartbeat once the stream has been idle. Returns false when a write fails
+        // (client gone) so the caller ends the stream. Reads only the lock-safe event
+        // log — no main-thread marshal needed (mirrors olo_events_tail).
+        [[nodiscard]] bool ServiceEventStream(httplib::DataSink& sink, u64& cursor,
+                                              std::chrono::steady_clock::time_point& lastWrite)
+        {
+            DiagnosticEventQuery query;
+            query.SinceId = cursor;
+            query.MaxCount = 0; // deliver every new event — no newest-N cap on a live stream.
+            const DiagnosticEventQueryResult snap = DiagnosticsEventLog::Get().QueryWithCursor(query);
+            for (const auto& event : snap.Events)
+            {
+                const std::string frame = FormatSseEvent(event.Id, MakeEventNotification(event));
+                if (!sink.write(frame.data(), frame.size()))
+                    return false;
+                lastWrite = std::chrono::steady_clock::now();
+            }
+            // Advance to the buffer head (past events that were filtered or none) so a
+            // later cycle never rescans the same ids — same cursor semantics as
+            // olo_events_tail's lastId.
+            cursor = snap.LastId;
+
+            if (std::chrono::steady_clock::now() - lastWrite >= kStreamHeartbeat)
+            {
+                const std::string hb = FormatSseComment("keep-alive");
+                if (!sink.write(hb.data(), hb.size()))
+                    return false;
+                lastWrite = std::chrono::steady_clock::now();
+            }
+            return true;
+        }
+
     } // namespace
 
     // ---- ToolResult ------------------------------------------------------------
@@ -298,10 +348,10 @@ namespace OloEngine::MCP
         m_Http->Post("/mcp", [this](const httplib::Request& req, httplib::Response& res)
                      { HandlePost(req, res); });
 
-        // We never push server-initiated messages, so the Streamable-HTTP GET
-        // stream is unsupported — 405 is the spec-sanctioned response.
-        m_Http->Get("/mcp", [](const httplib::Request&, httplib::Response& res)
-                    { res.status = 405; });
+        // Streamable-HTTP GET opens a persistent server-push SSE stream: new
+        // diagnostics events are pushed as MCP notifications (issue #306 item B).
+        m_Http->Get("/mcp", [this](const httplib::Request& req, httplib::Response& res)
+                    { HandleGetStream(req, res); });
 
         // Explicit session teardown.
         m_Http->Delete("/mcp", [this](const httplib::Request& req, httplib::Response& res)
@@ -486,6 +536,95 @@ namespace OloEngine::MCP
         sendJson(framed.Body, framed.Status);
     }
 
+    void McpServer::HandleGetStream(const httplib::Request& req, httplib::Response& res)
+    {
+        // Same gates as HandlePost: Origin (DNS-rebinding defence), bearer auth, and
+        // session validation when the client presents an Mcp-Session-Id.
+        if (req.has_header("Origin") && !IsOriginAllowed(req.get_header_value("Origin")))
+        {
+            res.status = 403;
+            return;
+        }
+        if (!CheckAuth(req))
+        {
+            res.set_header("WWW-Authenticate", "Bearer");
+            res.status = 401;
+            return;
+        }
+        if (req.has_header("Mcp-Session-Id"))
+        {
+            const std::string sid = req.get_header_value("Mcp-Session-Id");
+            std::lock_guard lock(m_SessionMutex);
+            if (!m_Sessions.contains(sid))
+            {
+                res.status = 404;
+                return;
+            }
+        }
+
+        // Where to resume: SSE reconnection replays the last id via Last-Event-ID, so
+        // honour it to resume without gaps. Otherwise start at the current head so a
+        // fresh subscriber receives only NEW events — not a backlog flood (the ring
+        // holds 512). This is the per-connection cursor the plan calls for.
+        u64 startCursor = DiagnosticsEventLog::Get().LastId();
+        if (req.has_header("Last-Event-ID"))
+        {
+            try
+            {
+                startCursor = std::stoull(req.get_header_value("Last-Event-ID"));
+            }
+            catch (...)
+            {
+                // Malformed cursor — ignore it and start at the head.
+            }
+        }
+
+        res.set_header("Cache-Control", "no-cache");
+        // Conventional SSE hint: tell any intermediary not to buffer the stream.
+        res.set_header("X-Accel-Buffering", "no");
+
+        // Balanced by the resource-releaser below, which httplib calls once the
+        // provider finishes (client disconnect, server stop, or write failure).
+        m_ActiveStreams.fetch_add(1, std::memory_order_relaxed);
+        res.set_chunked_content_provider(
+            "text/event-stream",
+            [this, cursor = startCursor, lastWrite = std::chrono::steady_clock::now(), greeted = false](
+                std::size_t /*offset*/, httplib::DataSink& sink) mutable -> bool
+            {
+                // Server tearing down: end the stream gracefully so the worker thread
+                // is free to be joined by Stop().
+                if (!m_Running.load(std::memory_order_acquire))
+                {
+                    sink.done();
+                    return true;
+                }
+                if (!sink.is_writable())
+                    return false; // client gone
+
+                // One-time greeting comment so the client sees the stream is open
+                // before the first event, and as an immediate disconnect probe.
+                if (!greeted)
+                {
+                    const std::string hello = FormatSseComment("olo-mcp event stream connected");
+                    if (!sink.write(hello.data(), hello.size()))
+                        return false;
+                    greeted = true;
+                    lastWrite = std::chrono::steady_clock::now();
+                }
+
+                if (!ServiceEventStream(sink, cursor, lastWrite))
+                    return false;
+
+                // Pace the loop (httplib calls the provider back-to-back).
+                std::this_thread::sleep_for(kStreamPollInterval);
+                return true;
+            },
+            [this](bool /*success*/)
+            {
+                m_ActiveStreams.fetch_sub(1, std::memory_order_relaxed);
+            });
+    }
+
     Json McpServer::HandleMessage(const Json& message)
     {
         return DispatchRpc(message);
@@ -624,9 +763,12 @@ namespace OloEngine::MCP
 
         Json result;
         result["protocolVersion"] = version;
+        // `logging` is advertised because the GET /mcp SSE stream pushes diagnostics
+        // events as `notifications/message` log notifications (issue #306 item B).
         result["capabilities"] = Json{ { "tools", { { "listChanged", false } } },
                                        { "resources", { { "subscribe", false }, { "listChanged", false } } },
-                                       { "prompts", { { "listChanged", false } } } };
+                                       { "prompts", { { "listChanged", false } } },
+                                       { "logging", Json::object() } };
         result["serverInfo"] = Json{ { "name", "OloEditor" },
                                      { "title", "OloEngine Editor Diagnostics" },
                                      { "version", "0.0.1" } };

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -583,9 +583,6 @@ namespace OloEngine::MCP
         // Conventional SSE hint: tell any intermediary not to buffer the stream.
         res.set_header("X-Accel-Buffering", "no");
 
-        // Balanced by the resource-releaser below, which httplib calls once the
-        // provider finishes (client disconnect, server stop, or write failure).
-        m_ActiveStreams.fetch_add(1, std::memory_order_relaxed);
         res.set_chunked_content_provider(
             "text/event-stream",
             [this, cursor = startCursor, lastWrite = std::chrono::steady_clock::now(), greeted = false](
@@ -623,6 +620,12 @@ namespace OloEngine::MCP
             {
                 m_ActiveStreams.fetch_sub(1, std::memory_order_relaxed);
             });
+        // Count the stream only once the provider + its releaser are registered: if
+        // set_chunked_content_provider had thrown, the releaser would never run, so an
+        // increment before it could leak. The provider/releaser run later (during
+        // response writing, after this handler returns), so the matching decrement
+        // can't race ahead of this increment.
+        m_ActiveStreams.fetch_add(1, std::memory_order_relaxed);
     }
 
     Json McpServer::HandleMessage(const Json& message)

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -236,6 +236,13 @@ namespace OloEngine::MCP
         {
             return m_Token;
         }
+        // Number of live server-push SSE streams currently connected on GET /mcp
+        // (issue #306 item B). Surfaced in the panel so the user can see an agent is
+        // watching; lock-free, safe to read from any thread.
+        [[nodiscard]] int ActiveStreamCount() const
+        {
+            return m_ActiveStreams.load(std::memory_order_relaxed);
+        }
 
         // Optional redaction: when on, absolute filesystem paths are scrubbed from
         // text output before it leaves the process (off by default).
@@ -354,6 +361,13 @@ namespace OloEngine::MCP
         // JSON-RPC parse, dispatch. Defined in McpServer.cpp.
         void HandlePost(const httplib::Request& req, httplib::Response& res);
 
+        // GET /mcp handler: opens a persistent text/event-stream (SSE) and pushes
+        // newly-recorded diagnostics events to the agent as MCP JSON-RPC
+        // notifications (issue #306 item B). Same origin + bearer + session gates as
+        // HandlePost; then it streams on the worker thread until the client
+        // disconnects or the server stops. Defined in McpServer.cpp.
+        void HandleGetStream(const httplib::Request& req, httplib::Response& res);
+
         // Dispatch one JSON-RPC message. Returns the response object, or a null Json
         // for notifications (no response is sent).
         [[nodiscard]] Json DispatchRpc(const Json& request);
@@ -390,6 +404,10 @@ namespace OloEngine::MCP
         std::string m_Token;
 
         std::atomic<bool> m_RedactPaths{ false };
+
+        // Count of live GET /mcp SSE push streams (issue #306 item B). Bumped while a
+        // stream's content provider runs; surfaced via ActiveStreamCount().
+        std::atomic<int> m_ActiveStreams{ 0 };
 
         mutable std::mutex m_SessionMutex;
         std::unordered_set<std::string> m_Sessions;

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -66,6 +66,13 @@ namespace OloEngine::MCP
             if (ImGui::Button("Copy command"))
                 ImGui::SetClipboardText(command.c_str());
 
+            ImGui::Spacing();
+            if (const int streams = server.ActiveStreamCount(); streams > 0)
+                ImGui::TextColored(ImVec4(0.30f, 0.85f, 0.30f, 1.0f),
+                                   "Live event push: %d stream(s) connected (GET /mcp SSE)", streams);
+            else
+                ImGui::TextDisabled("Live event push: idle (an agent's GET /mcp opens a live event stream)");
+
             ImGui::Separator();
             if (ImGui::Button("Stop server"))
                 server.Stop();

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -8,6 +8,7 @@
 #include "MCP/McpRenderExplain.h"
 #include "MCP/McpRenderOverrides.h"
 #include "MCP/McpShaderReload.h"
+#include "MCP/McpEventStream.h"
 
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Asset/AssetMetadata.h"
@@ -1142,22 +1143,6 @@ namespace OloEngine::MCP
 
         // ---- olo_events_tail (lock-safe; unified diagnostics event ring buffer) -
 
-        // Format an epoch-seconds timestamp as a UTC "HH:MM:SS.mmm" wall-clock string.
-        // Computed with modular arithmetic to dodge the non-thread-safe / platform-split
-        // gmtime APIs — the date is irrelevant for a "what just happened" timeline.
-        std::string FormatEpochUtcTime(f64 epochSeconds)
-        {
-            if (!std::isfinite(epochSeconds) || epochSeconds <= 0.0)
-                return std::string{};
-            const auto total = static_cast<std::int64_t>(epochSeconds);
-            const auto secOfDay = static_cast<int>(((total % 86400) + 86400) % 86400);
-            const int milliseconds = static_cast<int>((epochSeconds - static_cast<f64>(total)) * 1000.0);
-            char buffer[16];
-            std::snprintf(buffer, sizeof(buffer), "%02d:%02d:%02d.%03d",
-                          secOfDay / 3600, (secOfDay % 3600) / 60, secOfDay % 60, std::clamp(milliseconds, 0, 999));
-            return std::string(buffer);
-        }
-
         // A unified "what just happened?" timeline backed by the engine's diagnostics
         // event ring buffer (Debug/DiagnosticsEventLog.h, mutex-guarded — safe from the
         // handler thread). Supports incremental polling via sinceId: pass back the
@@ -1209,19 +1194,7 @@ namespace OloEngine::MCP
 
             Json arr = Json::array();
             for (const auto& event : result.Events)
-            {
-                Json j;
-                j["id"] = event.Id;
-                j["category"] = DiagnosticEvent::CategoryToString(event.Category);
-                if (std::string time = FormatEpochUtcTime(event.Timestamp); !time.empty())
-                    j["time"] = std::move(time);
-                j["message"] = event.Message;
-                if (event.Entity != 0)
-                    j["entity"] = std::to_string(event.Entity);
-                if (!event.Context.empty())
-                    j["context"] = event.Context;
-                arr.push_back(std::move(j));
-            }
+                arr.push_back(EventToJson(event)); // shared with the SSE push path (McpEventStream.h)
 
             Json out;
             out["count"] = static_cast<int>(arr.size());

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -322,6 +322,10 @@ add_executable(OloEngine-Tests
 		# Header-only engine facility (Debug/DiagnosticsEventLog.h, compiled into
 		# OloEngine), so no extra editor TU is pulled in.
 		MCP/McpEventsTailTest.cpp
+		# Event -> MCP-notification -> SSE-frame serialization behind the GET /mcp
+		# server-push stream (#306 item B). Header-only (MCP/McpEventStream.h,
+		# DiagnosticsEventLog + nlohmann::json only), so no extra editor TU is pulled in.
+		MCP/McpEventStreamTest.cpp
 		# Pure result-shaping behind olo_shader_reload (#316 Part 4). Header-only
 		# (MCP/McpShaderReload.h, depends only on the engine's ShaderCompilationStatus
 		# enum), so no extra editor TU is pulled in.

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -135,6 +135,9 @@ TEST_F(McpDispatchTest, InitializeReturnsHandshakeShape)
     EXPECT_TRUE(caps.contains("tools"));
     EXPECT_TRUE(caps.contains("resources"));
     EXPECT_TRUE(caps.contains("prompts"));
+    // `logging` is advertised because GET /mcp pushes diagnostics events as
+    // notifications/message log notifications (#306 item B server-push stream).
+    EXPECT_TRUE(caps.contains("logging"));
 }
 
 TEST_F(McpDispatchTest, InitializeEchoesSupportedProtocolVersion)

--- a/OloEngine/tests/MCP/McpEventStreamTest.cpp
+++ b/OloEngine/tests/MCP/McpEventStreamTest.cpp
@@ -1,0 +1,192 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Unit tests for the MCP server-push serialization seam (issue #306 item B). The
+// SSE transport (GET /mcp) lives in OloEditor and needs a live socket, but the pure
+// event -> MCP-notification -> SSE-frame serialization is header-only
+// (MCP/McpEventStream.h), so it is exercised here directly with no editor / socket /
+// agent — the same pattern as McpGoldenCompare / McpRenderExplain. We pin: the event
+// JSON shape (must match olo_events_tail), the category -> log-level map, the
+// JSON-RPC notification envelope, and the text/event-stream wire framing.
+#include "MCP/McpEventStream.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::DiagnosticEvent;
+    using OloEngine::DiagnosticEventCategory;
+    using Json = nlohmann::json;
+
+    namespace MCP = OloEngine::MCP;
+
+    // Build a fully-populated event with a fixed timestamp (2000-01-01 12:34:56.789
+    // UTC = 946730096.789 epoch seconds) so the formatted time is deterministic.
+    DiagnosticEvent MakeEvent(DiagnosticEventCategory category, std::string message,
+                              u64 entity = 0, std::string context = {})
+    {
+        DiagnosticEvent e;
+        e.Id = 7;
+        e.Timestamp = 946730096.789;
+        e.Category = category;
+        e.Message = std::move(message);
+        e.Entity = entity;
+        e.Context = std::move(context);
+        return e;
+    }
+} // namespace
+
+// ---- FormatEventUtcTime ----------------------------------------------------
+
+TEST(McpEventStreamTime, FormatsEpochAsUtcWallClock)
+{
+    // 946730096.789 -> 12:34:56.789 UTC (date is intentionally discarded).
+    EXPECT_EQ(MCP::FormatEventUtcTime(946730096.789), "12:34:56.789");
+}
+
+TEST(McpEventStreamTime, RejectsNonFiniteAndNonPositive)
+{
+    EXPECT_TRUE(MCP::FormatEventUtcTime(0.0).empty());
+    EXPECT_TRUE(MCP::FormatEventUtcTime(-1.0).empty());
+    EXPECT_TRUE(MCP::FormatEventUtcTime(std::nan("")).empty());
+    EXPECT_TRUE(MCP::FormatEventUtcTime(std::numeric_limits<f64>::infinity()).empty());
+}
+
+// ---- EventToJson (must mirror olo_events_tail's per-entry shape) ------------
+
+TEST(McpEventStreamJson, FullEventCarriesEveryField)
+{
+    const Json j = MCP::EventToJson(
+        MakeEvent(DiagnosticEventCategory::EntitySpawn, "Spawned entity 'Hero'", 4242u, "MyScene"));
+
+    EXPECT_EQ(j["id"], 7u);
+    EXPECT_EQ(j["category"], "entity_spawn");
+    EXPECT_EQ(j["time"], "12:34:56.789");
+    EXPECT_EQ(j["message"], "Spawned entity 'Hero'");
+    // Entity is serialized as a STRING (UUIDs exceed JSON integer precision), exactly
+    // like the poll path.
+    EXPECT_EQ(j["entity"], "4242");
+    EXPECT_EQ(j["context"], "MyScene");
+}
+
+TEST(McpEventStreamJson, OptionalFieldsOmittedWhenAbsent)
+{
+    const Json j = MCP::EventToJson(MakeEvent(DiagnosticEventCategory::Play, "Entered Play mode"));
+
+    EXPECT_TRUE(j.contains("id"));
+    EXPECT_TRUE(j.contains("category"));
+    EXPECT_TRUE(j.contains("message"));
+    // Entity 0 and an empty context are omitted, not emitted as 0 / "".
+    EXPECT_FALSE(j.contains("entity"));
+    EXPECT_FALSE(j.contains("context"));
+}
+
+TEST(McpEventStreamJson, OmitsTimeForNonFiniteTimestamp)
+{
+    DiagnosticEvent e = MakeEvent(DiagnosticEventCategory::Stop, "Left Play mode");
+    e.Timestamp = 0.0; // unset / invalid
+    const Json j = MCP::EventToJson(e);
+    EXPECT_FALSE(j.contains("time"));
+}
+
+// ---- EventLogLevel ---------------------------------------------------------
+
+TEST(McpEventStreamLevel, MapsCategoryToSeverity)
+{
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::ScriptError), "error");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::EntitySpawn), "debug");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::EntityDestroy), "debug");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::SceneLoad), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::Play), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::Stop), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::AssetReload), "info");
+}
+
+// Every category must map to a recognised RFC-5424 severity token (no "unknown" or
+// empty), so a new category can't silently ship an invalid notification level.
+TEST(McpEventStreamLevel, EveryCategoryHasAKnownLevel)
+{
+    constexpr DiagnosticEventCategory all[] = {
+        DiagnosticEventCategory::SceneLoad,
+        DiagnosticEventCategory::Play,
+        DiagnosticEventCategory::Stop,
+        DiagnosticEventCategory::EntitySpawn,
+        DiagnosticEventCategory::EntityDestroy,
+        DiagnosticEventCategory::AssetReload,
+        DiagnosticEventCategory::ScriptError,
+    };
+    static_assert(std::size(all) == OloEngine::kDiagnosticEventCategoryCount,
+                  "update this list when DiagnosticEventCategory changes");
+    const std::vector<std::string> valid = { "debug", "info", "notice", "warning",
+                                             "error", "critical", "alert", "emergency" };
+    for (const DiagnosticEventCategory c : all)
+    {
+        const std::string level = MCP::EventLogLevel(c);
+        EXPECT_NE(std::find(valid.begin(), valid.end(), level), valid.end()) << "level: " << level;
+    }
+}
+
+// ---- MakeEventNotification (JSON-RPC envelope) -----------------------------
+
+TEST(McpEventStreamNotification, IsAJsonRpcMessageNotification)
+{
+    const Json n = MCP::MakeEventNotification(
+        MakeEvent(DiagnosticEventCategory::ScriptError, "NullReferenceException", 99u, "Player.cs"));
+
+    EXPECT_EQ(n["jsonrpc"], "2.0");
+    EXPECT_EQ(n["method"], "notifications/message");
+    // A notification carries NO id — the client never replies.
+    EXPECT_FALSE(n.contains("id"));
+
+    const Json& params = n["params"];
+    EXPECT_EQ(params["level"], "error");
+    EXPECT_EQ(params["logger"], "olo.events");
+    // The structured event rides under params.data and matches EventToJson exactly.
+    EXPECT_EQ(params["data"], MCP::EventToJson(
+                                  MakeEvent(DiagnosticEventCategory::ScriptError, "NullReferenceException", 99u, "Player.cs")));
+}
+
+// ---- FormatSseEvent (text/event-stream wire framing) -----------------------
+
+TEST(McpEventStreamSse, FramesIdAndSingleLineData)
+{
+    const Json n = MCP::MakeEventNotification(MakeEvent(DiagnosticEventCategory::Play, "Entered Play mode"));
+    const std::string frame = MCP::FormatSseEvent(312u, n);
+
+    // id line carries the monotonic event id (for Last-Event-ID resume).
+    EXPECT_TRUE(frame.starts_with("id: 312\n")) << frame;
+    // terminated by the mandatory blank line.
+    EXPECT_TRUE(frame.ends_with("\n\n")) << frame;
+
+    // Extract the data payload and confirm it is a SINGLE line (compact dump) — a raw
+    // newline inside would split the SSE data field and corrupt the frame.
+    const std::string marker = "data: ";
+    const auto dataStart = frame.find(marker);
+    ASSERT_NE(dataStart, std::string::npos);
+    const auto payloadStart = dataStart + marker.size();
+    const auto payloadEnd = frame.find("\n\n", payloadStart);
+    ASSERT_NE(payloadEnd, std::string::npos);
+    const std::string payload = frame.substr(payloadStart, payloadEnd - payloadStart);
+    EXPECT_EQ(payload.find('\n'), std::string::npos) << "data field must be a single line";
+
+    // The payload round-trips back to the original notification.
+    EXPECT_EQ(Json::parse(payload), n);
+}
+
+TEST(McpEventStreamSse, CommentLineIsIgnorableHeartbeat)
+{
+    const std::string hb = MCP::FormatSseComment("keep-alive");
+    EXPECT_EQ(hb, ": keep-alive\n\n");
+    // An SSE comment starts with ':' so clients ignore it.
+    EXPECT_TRUE(hb.starts_with(":"));
+    EXPECT_TRUE(hb.ends_with("\n\n"));
+}

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -534,9 +534,54 @@ deserialization on load would otherwise flood the ring with hundreds of
 512 events; older ones are evicted, but `sinceId` polling means an agent that checks
 in regularly never misses anything between checks.
 
-> **Follow-up (still open under issue #306 item B):** this is the *poll-based* half.
-> Server-*initiated* push (MCP notifications / `resources/subscribe` / SSE — `GET /mcp`
-> currently returns 405) is a larger transport change and remains open.
+> **Companion (issue #306 item B, server-push half — done):** `olo_events_tail` is the
+> *poll-based* read of the ring buffer; the same buffer is now also **pushed live** over a
+> persistent SSE stream on `GET /mcp` (previously `405`). See **Live event push** below.
+> `resources/subscribe` remains the one unimplemented sub-item.
+
+### Live event push (server-initiated SSE stream)
+
+`GET /mcp` opens a persistent **`text/event-stream`** (Server-Sent Events) — the
+server-*initiated* counterpart of `olo_events_tail`. Instead of polling, an agent
+holds the stream open and is **pushed** each new diagnostics event the instant it is
+recorded, so a session watching a playtest sees script errors, scene loads, asset
+hot-reloads, and play/stop transitions arrive on their own. It is the same ring buffer
+(`Debug/DiagnosticsEventLog.h`) behind `olo_events_tail`, so the push and the poll
+surface byte-identical event records.
+
+- **Same gate as everything else.** The stream is behind the identical
+  `127.0.0.1`-bind + `Origin` check + **bearer token** (+ `Mcp-Session-Id` validation
+  when presented) as `POST /mcp`. It stays read-only: it only *reads* the event log.
+- **Each event is an MCP `notifications/message`** — the spec's logging notification —
+  carrying the structured event (the same `id` / `category` / `time` / `message` /
+  `entity` / `context` fields `olo_events_tail` returns) under `params.data`, with a
+  severity `level` (a script error is `error`, entity spawn/destroy are `debug`, the
+  rest `info`) and `logger: "olo.events"`. Each SSE frame's `id:` line is the event's
+  monotonic id. The server advertises the `logging` capability in `initialize`.
+- **No backlog flood.** A fresh subscriber starts at the *current* head of the ring, so
+  it receives only events recorded *after* it connects — not a 512-event dump. A
+  reconnecting client that sends the standard SSE **`Last-Event-ID`** header resumes
+  from exactly that id, with no gap and no duplicates (it maps straight onto the ring's
+  `sinceId` cursor).
+- **Keep-alive.** When idle the stream emits an SSE comment (`: keep-alive`) every ~15 s,
+  which also detects a vanished client. New events carry a worst-case latency of ~250 ms
+  (the stream's internal poll cadence). The MCP panel shows how many push streams are
+  connected.
+
+```jsonc
+// Wire format (one frame per event), pushed over GET /mcp:
+// id: 313
+// data: {"jsonrpc":"2.0","method":"notifications/message","params":{
+//          "level":"info","logger":"olo.events",
+//          "data":{"id":313,"category":"play","time":"14:02:11.418",
+//                  "message":"Entered Play mode","context":"MyScene"}}}
+```
+
+Attach with a streaming-capable client (the same `claude mcp add` line works — Claude
+Code opens the GET stream automatically alongside the POST channel). The threading is
+the same lock-safe path as `olo_events_tail`: the stream runs on an httplib worker
+thread and only touches the mutex-guarded event log, so it never marshals to or blocks
+the editor's main thread.
 
 ### Resources
 

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -543,9 +543,10 @@ in regularly never misses anything between checks.
 
 `GET /mcp` opens a persistent **`text/event-stream`** (Server-Sent Events) — the
 server-*initiated* counterpart of `olo_events_tail`. Instead of polling, an agent
-holds the stream open and is **pushed** each new diagnostics event the instant it is
-recorded, so a session watching a playtest sees script errors, scene loads, asset
-hot-reloads, and play/stop transitions arrive on their own. It is the same ring buffer
+holds the stream open and is **pushed** each new diagnostics event shortly after it is
+recorded (within ~250 ms — see the keep-alive note below), so a session watching a
+playtest sees script errors, scene loads, asset hot-reloads, and play/stop transitions
+arrive on their own. It is the same ring buffer
 (`Debug/DiagnosticsEventLog.h`) behind `olo_events_tail`, so the push and the poll
 surface byte-identical event records.
 

--- a/docs/mcp-diagnostics-server.md
+++ b/docs/mcp-diagnostics-server.md
@@ -561,8 +561,10 @@ surface byte-identical event records.
 - **No backlog flood.** A fresh subscriber starts at the *current* head of the ring, so
   it receives only events recorded *after* it connects — not a 512-event dump. A
   reconnecting client that sends the standard SSE **`Last-Event-ID`** header resumes
-  from exactly that id, with no gap and no duplicates (it maps straight onto the ring's
-  `sinceId` cursor).
+  from that id while the requested history is still retained in the ring (it maps
+  straight onto the ring's `sinceId` cursor). If more than 512 events arrive while the
+  client is away, the oldest may already have been evicted, so a long gap can still drop
+  the events in between.
 - **Keep-alive.** When idle the stream emits an SSE comment (`: keep-alive`) every ~15 s,
   which also detects a vanished client. New events carry a worst-case latency of ~250 ms
   (the stream's internal poll cadence). The MCP panel shows how many push streams are


### PR DESCRIPTION
## What

`GET /mcp` previously returned **405**; it now opens a persistent **`text/event-stream`** (Server-Sent Events) that pushes each new diagnostics event to a connected agent as an MCP JSON-RPC notification. This turns the existing `olo_events_tail` ring buffer (PR #343) into a **live stream** — an agent watching a playtest is *pushed* script errors, scene loads, asset hot-reloads, and play/stop transitions instead of polling.

Implements **#306 item B** (the server-initiated push channel) and the "live push" frontier flagged in #357. Stays fully **read-only** — it only reads the event log; it does not cross the write line (that's item C).

## How

- **`OloEditor/src/MCP/McpEventStream.h`** (new) — a pure, httplib-free serialization seam: `EventToJson` (shared with `olo_events_tail` so push and poll produce byte-identical records), `EventLogLevel` (category → RFC-5424 severity), `MakeEventNotification` (`notifications/message` envelope), and `FormatSseEvent`/`FormatSseComment` wire framing. Header-only so it is unit-testable without a socket (mirrors the McpGoldenCompare / McpRenderExplain seams).
- **`McpServer.{h,cpp}`** — `HandleGetStream` behind the **same Origin + bearer-token + session gates** as `POST /mcp`. A worker-thread chunked-content-provider loop drains the lock-safe ring every 250 ms and pushes new events, honours the SSE **`Last-Event-ID`** header for gap-free resume, starts a fresh subscriber at the ring head (no backlog flood), emits a 15 s keep-alive comment, and exits cleanly on `Stop()`. Advertises the `logging` capability in `initialize`. Adds a live-stream counter.
- **`McpTools.cpp`** — `olo_events_tail` refactored onto the shared `EventToJson`.
- **`McpServerPanel.cpp`** — shows the number of connected push streams.
- **`docs/mcp-diagnostics-server.md`** — replaced the "still open / 405" note with a "Live event push (server-initiated SSE stream)" section.

## Threading

The stream runs on an httplib worker thread and only touches the mutex-guarded `DiagnosticsEventLog` — the same lock-safe path as `olo_events_tail`, so it never marshals to or blocks the editor's main thread. `Stop()` flips `m_Running` then joins the worker pool; the provider notices within one ~250 ms cycle and ends gracefully.

## Testing

- **27/27 MCP unit tests pass** — 10 new in `OloEngine/tests/MCP/McpEventStreamTest.cpp` (`// OLO_TEST_LAYER: unit`) pinning the event-JSON shape, category→level map, notification envelope, and SSE framing, plus a `logging`-capability assertion in `McpDispatchTest`.
- **OloEditor + OloEngine-Tests build clean** (Debug).
- **Live-verified against the running editor** (via the `run-oloengine` attach loop): `GET` without a token → `401`; the stream opens with a greeting; a real engine `scene_load` event was pushed as a correctly-framed MCP `notifications/message` (via `Last-Event-ID: 0` replay — the same drain loop used for live appends); the 15 s keep-alive fired on a held-open connection.

## Scope

Ticks **#306 item B**; does **not** close #306 (item C "consented writes" remains). `resources/subscribe` is the one unimplemented sub-item, deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time diagnostics streaming over `GET /mcp` via SSE (`text/event-stream`), including MCP `notifications/message` event payloads.
  * Updated MCP `initialize` capabilities to advertise `logging` support; MCP panel now shows the number of active live push connections.
* **Bug Fixes**
  * Improved reconnection continuity using `Last-Event-ID` and added periodic keep-alive comments when idle.
  * Standardized `olo_events_tail` event serialization to match the new notification format.
* **Documentation**
  * Updated MCP diagnostics server docs with the new SSE streaming behavior and connection semantics.
* **Tests**
  * Added unit tests for event-to-notification serialization and SSE frame formatting; extended handshake capability assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->