### PR TITLE
chore(gameplay): clear SonarQube maintainability smells in Gameplay subsystem

### DIFF
--- a/OloEngine/src/OloEngine/Core/InputActionManager.h
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.h
@@ -2,6 +2,7 @@
 
 #include "OloEngine/Core/IInputProvider.h"
 #include "OloEngine/Core/InputAction.h"
+#include "OloEngine/Core/TransparentStringHash.h"
 
 #include <string>
 #include <string_view>
@@ -9,24 +10,8 @@
 
 namespace OloEngine
 {
-    // Transparent hash/equal for heterogeneous lookup with std::string_view
-    struct StringHash
-    {
-        using is_transparent = void;
-        [[nodiscard]] std::size_t operator()(std::string_view sv) const
-        {
-            return std::hash<std::string_view>{}(sv);
-        }
-    };
-
-    struct StringEqual
-    {
-        using is_transparent = void;
-        [[nodiscard]] bool operator()(std::string_view lhs, std::string_view rhs) const
-        {
-            return lhs == rhs;
-        }
-    };
+    // StringHash / StringEqual (transparent heterogeneous lookup) now live in
+    // Core/TransparentStringHash.h so other subsystems can reuse them.
 
     class InputActionManager
     {

--- a/OloEngine/src/OloEngine/Core/TransparentStringHash.h
+++ b/OloEngine/src/OloEngine/Core/TransparentStringHash.h
@@ -8,10 +8,11 @@
 namespace OloEngine
 {
     // Transparent hash/equal functors for heterogeneous lookup on associative
-    // containers keyed by std::string. Pairing these (plus std::equal_to<>) with
-    // an unordered container lets find/count/contains/erase accept std::string_view
-    // and const char* without materialising a temporary std::string (SonarQube
-    // cpp:S6045). The is_transparent marker is what enables the heterogeneous
+    // containers keyed by std::string. Pairing StringHash + StringEqual with an
+    // unordered container (std::unordered_map<std::string, V, StringHash, StringEqual>)
+    // lets find/count/contains/erase accept std::string_view and const char*
+    // without materialising a temporary std::string (SonarQube cpp:S6045). The
+    // is_transparent marker on both functors is what enables the heterogeneous
     // overloads.
     struct StringHash
     {

--- a/OloEngine/src/OloEngine/Core/TransparentStringHash.h
+++ b/OloEngine/src/OloEngine/Core/TransparentStringHash.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace OloEngine
+{
+    // Transparent hash/equal functors for heterogeneous lookup on associative
+    // containers keyed by std::string. Pairing these (plus std::equal_to<>) with
+    // an unordered container lets find/count/contains/erase accept std::string_view
+    // and const char* without materialising a temporary std::string (SonarQube
+    // cpp:S6045). The is_transparent marker is what enables the heterogeneous
+    // overloads.
+    struct StringHash
+    {
+        using is_transparent = void;
+        [[nodiscard]] std::size_t operator()(std::string_view sv) const
+        {
+            return std::hash<std::string_view>{}(sv);
+        }
+    };
+
+    struct StringEqual
+    {
+        using is_transparent = void;
+        [[nodiscard]] bool operator()(std::string_view lhs, std::string_view rhs) const
+        {
+            return lhs == rhs;
+        }
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Attributes/AttributeSet.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Attributes/AttributeSet.cpp
@@ -158,19 +158,22 @@ namespace OloEngine
         bool hasOverride = false;
         f32 overrideValue = 0.0f;
 
+        using enum AttributeModifier::Operation;
         for (auto const& mod : attr.Modifiers)
         {
             switch (mod.Op)
             {
-                case AttributeModifier::Operation::Add:
+                case Add:
                     additive += mod.Magnitude;
                     break;
-                case AttributeModifier::Operation::Multiply:
+                case Multiply:
                     multiplicative *= mod.Magnitude;
                     break;
-                case AttributeModifier::Operation::Override:
+                case Override:
                     hasOverride = true;
                     overrideValue = mod.Magnitude;
+                    break;
+                default:
                     break;
             }
         }

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Attributes/AttributeSet.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Attributes/AttributeSet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/TransparentStringHash.h"
 #include "OloEngine/Gameplay/Abilities/Attributes/AttributeModifier.h"
 #include "OloEngine/Gameplay/Abilities/Tags/GameplayTag.h"
 
@@ -18,10 +19,10 @@ namespace OloEngine
 
         void DefineAttribute(const std::string& name, f32 baseValue);
 
-        [[nodiscard]] f32 GetBaseValue(const std::string& name) const;
-        [[nodiscard]] f32 GetCurrentValue(const std::string& name) const;
-        [[nodiscard]] bool HasAttribute(const std::string& name) const;
-        [[nodiscard]] std::vector<std::string> GetAttributeNames() const;
+        [[nodiscard("attribute base value must be used")]] f32 GetBaseValue(const std::string& name) const;
+        [[nodiscard("attribute current value must be used")]] f32 GetCurrentValue(const std::string& name) const;
+        [[nodiscard("existence check must be used")]] bool HasAttribute(const std::string& name) const;
+        [[nodiscard("attribute name list must be used")]] std::vector<std::string> GetAttributeNames() const;
 
         void SetBaseValue(const std::string& name, f32 value);
         void AddModifier(const std::string& attribute, const AttributeModifier& modifier);
@@ -29,7 +30,7 @@ namespace OloEngine
         void RemoveAllModifiers(const std::string& attribute);
         void ClearAllModifiers();
 
-        [[nodiscard]] const std::vector<AttributeModifier>& GetModifiers(const std::string& attribute) const;
+        [[nodiscard("modifier list must be used")]] const std::vector<AttributeModifier>& GetModifiers(const std::string& attribute) const;
 
         // For deserialization — restores base values + raw modifier list bypassing
         // ApplyEffect / removal bookkeeping. Caller is responsible for ensuring the
@@ -50,7 +51,7 @@ namespace OloEngine
 
         void RecalculateAttribute(const Attribute& attr) const;
 
-        std::unordered_map<std::string, Attribute> m_Attributes;
+        std::unordered_map<std::string, Attribute, StringHash, StringEqual> m_Attributes;
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/CooldownManager.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/CooldownManager.cpp
@@ -20,18 +20,10 @@ namespace OloEngine
         {
             return;
         }
-        for (auto it = m_Cooldowns.begin(); it != m_Cooldowns.end();)
-        {
-            it->second.Remaining -= dt;
-            if (it->second.Remaining <= 0.0f)
-            {
-                it = m_Cooldowns.erase(it);
-            }
-            else
-            {
-                ++it;
-            }
-        }
+        std::erase_if(m_Cooldowns, [dt](auto& pair)
+                      {
+            pair.second.Remaining -= dt;
+            return pair.second.Remaining <= 0.0f; });
     }
 
     bool CooldownManager::IsOnCooldown(const GameplayTag& abilityTag) const

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/CooldownManager.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/CooldownManager.h
@@ -17,9 +17,9 @@ namespace OloEngine
         void StartCooldown(const GameplayTag& abilityTag, f32 duration);
         void Tick(f32 dt);
 
-        [[nodiscard]] bool IsOnCooldown(const GameplayTag& abilityTag) const;
-        [[nodiscard]] f32 GetRemainingCooldown(const GameplayTag& abilityTag) const;
-        [[nodiscard]] f32 GetCooldownFraction(const GameplayTag& abilityTag) const;
+        [[nodiscard("cooldown state must be checked")]] bool IsOnCooldown(const GameplayTag& abilityTag) const;
+        [[nodiscard("remaining cooldown must be used")]] f32 GetRemainingCooldown(const GameplayTag& abilityTag) const;
+        [[nodiscard("cooldown fraction must be used")]] f32 GetCooldownFraction(const GameplayTag& abilityTag) const;
 
         void ResetCooldown(const GameplayTag& abilityTag);
         void ResetAll();
@@ -38,7 +38,7 @@ namespace OloEngine
                 fn(tag, entry.Duration, entry.Remaining);
             }
         }
-        [[nodiscard]] std::size_t Size() const
+        [[nodiscard("active-cooldown count must be used")]] std::size_t Size() const
         {
             return m_Cooldowns.size();
         }

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Damage/DamageCalculation.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Damage/DamageCalculation.h
@@ -25,8 +25,8 @@ namespace OloEngine
         {
           public:
             explicit ScopedFormula(CustomFormula formula);
-            ~ScopedFormula();
             ScopedFormula(const ScopedFormula&) = delete;
+            ~ScopedFormula();
             ScopedFormula& operator=(const ScopedFormula&) = delete;
 
           private:

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Effects/ActiveEffectsContainer.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Effects/ActiveEffectsContainer.cpp
@@ -203,7 +203,9 @@ namespace OloEngine
     {
         for (auto const& tag : effect.GrantedTags.GetTags())
         {
-            if (++m_TagGrantCounts[tag] == 1)
+            auto& count = m_TagGrantCounts[tag];
+            ++count;
+            if (count == 1)
             {
                 ownerTags.AddTag(tag);
             }
@@ -215,7 +217,12 @@ namespace OloEngine
         for (auto const& tag : effect.GrantedTags.GetTags())
         {
             auto it = m_TagGrantCounts.find(tag);
-            if (it != m_TagGrantCounts.end() && --it->second <= 0)
+            if (it == m_TagGrantCounts.end())
+            {
+                continue;
+            }
+            --it->second;
+            if (it->second <= 0)
             {
                 m_TagGrantCounts.erase(it);
                 ownerTags.RemoveTag(tag);

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Effects/ActiveEffectsContainer.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Effects/ActiveEffectsContainer.h
@@ -38,15 +38,15 @@ namespace OloEngine
 
         void Tick(f32 dt, AttributeSet& attributes, GameplayTagContainer& ownerTags);
 
-        [[nodiscard]] const std::vector<ActiveEffect>& GetActiveEffects() const
+        [[nodiscard("active-effects list must be used")]] const std::vector<ActiveEffect>& GetActiveEffects() const
         {
             return m_ActiveEffects;
         }
-        [[nodiscard]] const std::unordered_map<GameplayTag, i32>& GetTagGrantCounts() const
+        [[nodiscard("tag-grant counts must be used")]] const std::unordered_map<GameplayTag, i32>& GetTagGrantCounts() const
         {
             return m_TagGrantCounts;
         }
-        [[nodiscard]] bool HasAnyEffects() const
+        [[nodiscard("effects-presence check must be used")]] bool HasAnyEffects() const
         {
             return !m_ActiveEffects.empty();
         }

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Tags/GameplayTag.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Tags/GameplayTag.h
@@ -14,18 +14,18 @@ namespace OloEngine
         GameplayTag() = default;
         explicit GameplayTag(std::string tagPath);
 
-        [[nodiscard]] bool MatchesExact(const GameplayTag& other) const;
-        [[nodiscard]] bool MatchesPartial(const GameplayTag& parent) const;
+        [[nodiscard("match result must be used")]] bool MatchesExact(const GameplayTag& other) const;
+        [[nodiscard("match result must be used")]] bool MatchesPartial(const GameplayTag& parent) const;
 
-        [[nodiscard]] const std::string& GetTagString() const
+        [[nodiscard("tag string must be used")]] const std::string& GetTagString() const
         {
             return m_TagPath;
         }
-        [[nodiscard]] u32 GetHash() const
+        [[nodiscard("tag hash must be used")]] u32 GetHash() const
         {
             return m_Hash;
         }
-        [[nodiscard]] bool IsValid() const
+        [[nodiscard("validity check must be used")]] bool IsValid() const
         {
             return !m_TagPath.empty();
         }
@@ -34,10 +34,7 @@ namespace OloEngine
         {
             return m_Hash == other.m_Hash && m_TagPath == other.m_TagPath;
         }
-        auto operator!=(const GameplayTag& other) const -> bool
-        {
-            return !(*this == other);
-        }
+        // operator!= is synthesized from operator== in C++20 (was cpp:S6186).
         auto operator<(const GameplayTag& other) const -> bool
         {
             return m_TagPath < other.m_TagPath;

--- a/OloEngine/src/OloEngine/Gameplay/Abilities/Tags/GameplayTagContainer.h
+++ b/OloEngine/src/OloEngine/Gameplay/Abilities/Tags/GameplayTagContainer.h
@@ -16,19 +16,19 @@ namespace OloEngine
         void RemoveTag(const GameplayTag& tag);
         void Clear();
 
-        [[nodiscard]] bool HasTagExact(const GameplayTag& tag) const;
-        [[nodiscard]] bool HasTagPartial(const GameplayTag& parent) const;
-        [[nodiscard]] bool HasAll(const GameplayTagContainer& required) const;
-        [[nodiscard]] bool HasAny(const GameplayTagContainer& tags) const;
-        [[nodiscard]] bool IsEmpty() const
+        [[nodiscard("tag-presence check must be used")]] bool HasTagExact(const GameplayTag& tag) const;
+        [[nodiscard("tag-presence check must be used")]] bool HasTagPartial(const GameplayTag& parent) const;
+        [[nodiscard("tag-presence check must be used")]] bool HasAll(const GameplayTagContainer& required) const;
+        [[nodiscard("tag-presence check must be used")]] bool HasAny(const GameplayTagContainer& tags) const;
+        [[nodiscard("emptiness check must be used")]] bool IsEmpty() const
         {
             return m_Tags.empty();
         }
-        [[nodiscard]] std::size_t Count() const
+        [[nodiscard("tag count must be used")]] std::size_t Count() const
         {
             return m_Tags.size();
         }
-        [[nodiscard]] const std::vector<GameplayTag>& GetTags() const
+        [[nodiscard("tag list must be used")]] const std::vector<GameplayTag>& GetTags() const
         {
             return m_Tags;
         }

--- a/OloEngine/src/OloEngine/Gameplay/GameplayEventBus.h
+++ b/OloEngine/src/OloEngine/Gameplay/GameplayEventBus.h
@@ -65,7 +65,7 @@ namespace OloEngine
 
         // Number of handlers registered for E (diagnostics / tests).
         template<typename E>
-        [[nodiscard]] sizet HandlerCount() const
+        [[nodiscard("handler count must be used")]] sizet HandlerCount() const
         {
             auto it = m_Handlers.find(std::type_index(typeid(E)));
             return it == m_Handlers.end() ? 0 : it->second.size();

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDatabase.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDatabase.cpp
@@ -4,15 +4,15 @@
 
 namespace OloEngine
 {
-    std::unordered_map<std::string, AffixDefinition>& AffixDatabase::GetDefinitions()
+    std::unordered_map<std::string, AffixDefinition, StringHash, StringEqual>& AffixDatabase::GetDefinitions()
     {
-        static std::unordered_map<std::string, AffixDefinition> s_Definitions;
+        static std::unordered_map<std::string, AffixDefinition, StringHash, StringEqual> s_Definitions;
         return s_Definitions;
     }
 
-    std::unordered_map<std::string, AffixPool>& AffixDatabase::GetPools()
+    std::unordered_map<std::string, AffixPool, StringHash, StringEqual>& AffixDatabase::GetPools()
     {
-        static std::unordered_map<std::string, AffixPool> s_Pools;
+        static std::unordered_map<std::string, AffixPool, StringHash, StringEqual> s_Pools;
         return s_Pools;
     }
 

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDatabase.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDatabase.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "OloEngine/Core/TransparentStringHash.h"
 #include "OloEngine/Gameplay/Inventory/AffixDefinition.h"
 
 #include <string>
@@ -19,8 +20,8 @@ namespace OloEngine
         static void Clear();
 
       private:
-        static std::unordered_map<std::string, AffixDefinition>& GetDefinitions();
-        static std::unordered_map<std::string, AffixPool>& GetPools();
+        [[nodiscard("affix definitions map must be used")]] static std::unordered_map<std::string, AffixDefinition, StringHash, StringEqual>& GetDefinitions();
+        [[nodiscard("affix pools map must be used")]] static std::unordered_map<std::string, AffixPool, StringHash, StringEqual>& GetPools();
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDefinition.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/AffixDefinition.h
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/Base.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OloEngine
@@ -13,7 +14,7 @@ namespace OloEngine
         Suffix
     };
 
-    inline const char* AffixTypeToString(AffixType type)
+    [[nodiscard("affix type string must be used")]] inline const char* AffixTypeToString(AffixType type)
     {
         switch (type)
         {
@@ -21,11 +22,13 @@ namespace OloEngine
                 return "Prefix";
             case AffixType::Suffix:
                 return "Suffix";
+            default:
+                break;
         }
         return "Prefix";
     }
 
-    inline AffixType AffixTypeFromString(const std::string& str)
+    inline AffixType AffixTypeFromString(std::string_view str)
     {
         if (str == "Suffix")
             return AffixType::Suffix;

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/EquipmentSlots.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/EquipmentSlots.cpp
@@ -19,14 +19,11 @@ namespace OloEngine
         }
 
         // If slot is occupied, unequip first
-        if (m_Equipped[slotIdx].has_value())
+        if (m_Equipped[slotIdx].has_value() && !Unequip(slot, sourceInventory))
         {
-            if (!Unequip(slot, sourceInventory))
-            {
-                // Rollback: re-add the removed item
-                sourceInventory.AddItem(item);
-                return false;
-            }
+            // Rollback: re-add the removed item
+            sourceInventory.AddItem(item);
+            return false;
         }
 
         m_Equipped[slotIdx] = item;
@@ -116,73 +113,77 @@ namespace OloEngine
 
     const char* EquipmentSlots::SlotToString(Slot slot)
     {
+        using enum Slot;
         switch (slot)
         {
-            case Slot::Head:
+            case Head:
                 return "Head";
-            case Slot::Chest:
+            case Chest:
                 return "Chest";
-            case Slot::Legs:
+            case Legs:
                 return "Legs";
-            case Slot::Feet:
+            case Feet:
                 return "Feet";
-            case Slot::Hands:
+            case Hands:
                 return "Hands";
-            case Slot::Shoulders:
+            case Shoulders:
                 return "Shoulders";
-            case Slot::Back:
+            case Back:
                 return "Back";
-            case Slot::MainHand:
+            case MainHand:
                 return "MainHand";
-            case Slot::OffHand:
+            case OffHand:
                 return "OffHand";
-            case Slot::Ring1:
+            case Ring1:
                 return "Ring1";
-            case Slot::Ring2:
+            case Ring2:
                 return "Ring2";
-            case Slot::Necklace:
+            case Necklace:
                 return "Necklace";
-            case Slot::Trinket1:
+            case Trinket1:
                 return "Trinket1";
-            case Slot::Trinket2:
+            case Trinket2:
                 return "Trinket2";
-            case Slot::Count:
+            case Count:
                 return "Count";
+            default:
+                break;
         }
         return "Unknown";
     }
 
-    EquipmentSlots::Slot EquipmentSlots::SlotFromString(const std::string& str)
+    EquipmentSlots::Slot EquipmentSlots::SlotFromString(std::string_view str)
     {
+        using enum Slot;
         if (str == "Head")
-            return Slot::Head;
+            return Head;
         if (str == "Chest")
-            return Slot::Chest;
+            return Chest;
         if (str == "Legs")
-            return Slot::Legs;
+            return Legs;
         if (str == "Feet")
-            return Slot::Feet;
+            return Feet;
         if (str == "Hands")
-            return Slot::Hands;
+            return Hands;
         if (str == "Shoulders")
-            return Slot::Shoulders;
+            return Shoulders;
         if (str == "Back")
-            return Slot::Back;
+            return Back;
         if (str == "MainHand")
-            return Slot::MainHand;
+            return MainHand;
         if (str == "OffHand")
-            return Slot::OffHand;
+            return OffHand;
         if (str == "Ring1")
-            return Slot::Ring1;
+            return Ring1;
         if (str == "Ring2")
-            return Slot::Ring2;
+            return Ring2;
         if (str == "Necklace")
-            return Slot::Necklace;
+            return Necklace;
         if (str == "Trinket1")
-            return Slot::Trinket1;
+            return Trinket1;
         if (str == "Trinket2")
-            return Slot::Trinket2;
-        return Slot::Count; // Invalid
+            return Trinket2;
+        return Count; // Invalid
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/EquipmentSlots.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/EquipmentSlots.h
@@ -5,6 +5,8 @@
 
 #include <array>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -35,21 +37,21 @@ namespace OloEngine
         bool Equip(Slot slot, const ItemInstance& item, Inventory& sourceInventory);
         bool DirectEquip(Slot slot, const ItemInstance& item);
         bool Unequip(Slot slot, Inventory& targetInventory);
-        [[nodiscard]] const ItemInstance* GetEquipped(Slot slot) const;
-        [[nodiscard]] bool IsSlotEmpty(Slot slot) const;
+        [[nodiscard("equipped item pointer must be used")]] const ItemInstance* GetEquipped(Slot slot) const;
+        [[nodiscard("slot-empty check must be used")]] bool IsSlotEmpty(Slot slot) const;
 
-        [[nodiscard]] std::vector<std::pair<std::string, f32>> GetAllAttributeModifiers() const;
+        [[nodiscard("attribute modifiers must be used")]] std::vector<std::pair<std::string, f32>> GetAllAttributeModifiers() const;
 
         // Direct access for serialization
-        [[nodiscard]] const auto& GetAllSlots() const
+        [[nodiscard("slot array must be used")]] const auto& GetAllSlots() const
         {
             return m_Equipped;
         }
 
         static constexpr i32 SlotCount = static_cast<i32>(std::to_underlying(Slot::Count));
 
-        static const char* SlotToString(Slot slot);
-        static Slot SlotFromString(const std::string& str);
+        [[nodiscard("slot string must be used")]] static const char* SlotToString(Slot slot);
+        static Slot SlotFromString(std::string_view str);
 
         auto operator==(const EquipmentSlots&) const -> bool = default;
 

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/Inventory.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/Inventory.cpp
@@ -112,13 +112,10 @@ namespace OloEngine
         if (slot.has_value())
         {
             // Try stacking
-            if (slot->IsStackCompatible(item))
+            if (slot->IsStackCompatible(item) && slot->StackCount + item.StackCount <= maxStack)
             {
-                if (slot->StackCount + item.StackCount <= maxStack)
-                {
-                    slot->StackCount += item.StackCount;
-                    return true;
-                }
+                slot->StackCount += item.StackCount;
+                return true;
             }
             return false;
         }
@@ -156,7 +153,7 @@ namespace OloEngine
         return false;
     }
 
-    bool Inventory::RemoveItemByDefinition(const std::string& definitionId, i32 count)
+    bool Inventory::RemoveItemByDefinition(std::string_view definitionId, i32 count)
     {
         if (count <= 0)
         {
@@ -304,7 +301,7 @@ namespace OloEngine
         return s.has_value() ? &s.value() : nullptr;
     }
 
-    i32 Inventory::FindItem(const std::string& definitionId) const
+    i32 Inventory::FindItem(std::string_view definitionId) const
     {
         for (i32 i = 0; i < m_Capacity; ++i)
         {
@@ -317,7 +314,7 @@ namespace OloEngine
         return -1;
     }
 
-    i32 Inventory::CountItem(const std::string& definitionId) const
+    i32 Inventory::CountItem(std::string_view definitionId) const
     {
         i32 total = 0;
         for (auto const& slot : m_Slots)
@@ -330,7 +327,7 @@ namespace OloEngine
         return total;
     }
 
-    bool Inventory::HasItem(const std::string& definitionId, i32 count) const
+    bool Inventory::HasItem(std::string_view definitionId, i32 count) const
     {
         return CountItem(definitionId) >= count;
     }

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/Inventory.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/Inventory.h
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace OloEngine
@@ -17,23 +19,23 @@ namespace OloEngine
         bool AddItem(const ItemInstance& item);
         bool AddItemToSlot(i32 slotIndex, const ItemInstance& item);
         bool RemoveItem(const UUID& instanceId, i32 count = 1);
-        bool RemoveItemByDefinition(const std::string& definitionId, i32 count = 1);
+        bool RemoveItemByDefinition(std::string_view definitionId, i32 count = 1);
         bool MoveItem(i32 fromSlot, i32 toSlot);
         bool SwapItems(i32 slotA, i32 slotB);
         bool TransferItem(i32 fromSlot, Inventory& targetInventory);
 
         // Queries
-        [[nodiscard]] const ItemInstance* GetItemAtSlot(i32 slot) const;
-        [[nodiscard]] ItemInstance* GetMutableItemAtSlot(i32 slot);
-        [[nodiscard]] i32 FindItem(const std::string& definitionId) const;
-        [[nodiscard]] i32 CountItem(const std::string& definitionId) const;
-        [[nodiscard]] bool HasItem(const std::string& definitionId, i32 count = 1) const;
-        [[nodiscard]] i32 GetCapacity() const
+        [[nodiscard("item pointer must be used")]] const ItemInstance* GetItemAtSlot(i32 slot) const;
+        [[nodiscard("item pointer must be used")]] ItemInstance* GetMutableItemAtSlot(i32 slot);
+        [[nodiscard("found slot index must be used")]] i32 FindItem(std::string_view definitionId) const;
+        [[nodiscard("item count must be used")]] i32 CountItem(std::string_view definitionId) const;
+        [[nodiscard("presence check must be used")]] bool HasItem(std::string_view definitionId, i32 count = 1) const;
+        [[nodiscard("capacity must be used")]] i32 GetCapacity() const
         {
             return m_Capacity;
         }
-        [[nodiscard]] i32 GetUsedSlots() const;
-        [[nodiscard]] f32 GetTotalWeight() const;
+        [[nodiscard("used-slot count must be used")]] i32 GetUsedSlots() const;
+        [[nodiscard("total weight must be used")]] f32 GetTotalWeight() const;
 
         // Sorting
         void SortByCategory();
@@ -41,7 +43,7 @@ namespace OloEngine
         void SortByName();
 
         // Direct access for serialization
-        [[nodiscard]] const std::vector<std::optional<ItemInstance>>& GetSlots() const
+        [[nodiscard("slot list must be used")]] const std::vector<std::optional<ItemInstance>>& GetSlots() const
         {
             return m_Slots;
         }

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/InventorySystem.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/InventorySystem.cpp
@@ -20,7 +20,7 @@ namespace OloEngine
 {
     namespace
     {
-        InventoryComponent* ResolveInventory(Scene* scene, Entity entity)
+        InventoryComponent* ResolveInventory(const Scene* scene, Entity entity)
         {
             if (!scene || !entity || !entity.HasComponent<InventoryComponent>())
             {
@@ -29,7 +29,7 @@ namespace OloEngine
             return &entity.GetComponent<InventoryComponent>();
         }
 
-        ItemContainerComponent* ResolveContainer(Scene* scene, Entity entity)
+        ItemContainerComponent* ResolveContainer(const Scene* scene, Entity entity)
         {
             if (!scene || !entity || !entity.HasComponent<ItemContainerComponent>())
             {
@@ -45,12 +45,12 @@ namespace OloEngine
         constexpr i32 kBuybackNumerator = 1;
         constexpr i32 kBuybackDenominator = 2;
 
-        i32 UnitBuyPrice(const ItemDefinition& def)
+        [[nodiscard("unit buy price must be used")]] i32 UnitBuyPrice(const ItemDefinition& def)
         {
             return def.BuyPrice;
         }
 
-        i32 UnitSellPrice(const ItemDefinition& def)
+        [[nodiscard("unit sell price must be used")]] i32 UnitSellPrice(const ItemDefinition& def)
         {
             if (def.SellPrice > 0)
             {
@@ -66,7 +66,7 @@ namespace OloEngine
         // Saturating total = unitPrice * quantity, clamped to i32 range. Used by
         // the GetBuyPrice / GetSellPrice UI helpers; the trade paths compute in
         // i64 and reject overflow rather than clamp.
-        i32 SaturatingTotal(i32 unitPrice, i32 quantity)
+        [[nodiscard("computed total must be used")]] i32 SaturatingTotal(i32 unitPrice, i32 quantity)
         {
             if (unitPrice <= 0 || quantity <= 0)
             {
@@ -113,12 +113,17 @@ namespace OloEngine
             std::vector<Pull> pulls;
             i32 remaining = quantity;
             const auto& slots = source.GetSlots();
-            for (sizet i = 0; i < slots.size() && remaining > 0; ++i)
+            const sizet slotCount = slots.size();
+            for (sizet i = 0; i < slotCount; ++i)
             {
+                if (remaining <= 0)
+                {
+                    break;
+                }
                 if (slots[i].has_value() && slots[i]->ItemDefinitionID == definitionId)
                 {
                     const i32 take = std::min(slots[i]->StackCount, remaining);
-                    pulls.push_back(Pull{ *slots[i], take });
+                    pulls.emplace_back(*slots[i], take);
                     remaining -= take;
                 }
             }
@@ -153,10 +158,11 @@ namespace OloEngine
         // Best-effort slot lookup for an item instance after an add/before a
         // remove. Stacked items merge into an existing slot and drop the new
         // instance's ID, so this can legitimately return -1.
-        i32 FindSlotOfInstance(const Inventory& inventory, const UUID& instanceId)
+        [[nodiscard("slot index must be used")]] i32 FindSlotOfInstance(const Inventory& inventory, const UUID& instanceId)
         {
             const auto& slots = inventory.GetSlots();
-            for (sizet i = 0; i < slots.size(); ++i)
+            const sizet slotCount = slots.size();
+            for (sizet i = 0; i < slotCount; ++i)
             {
                 if (slots[i].has_value() && slots[i]->InstanceID == instanceId)
                 {
@@ -230,14 +236,11 @@ namespace OloEngine
                 f32 distSq = glm::dot(diff, diff);
                 f32 radiusSq = pickupComp.PickupRadius * pickupComp.PickupRadius;
 
-                if (distSq <= radiusSq)
+                if (distSq <= radiusSq && invComp.PlayerInventory.AddItem(pickupComp.Item))
                 {
-                    if (invComp.PlayerInventory.AddItem(pickupComp.Item))
-                    {
-                        const i32 slot = FindSlotOfInstance(invComp.PlayerInventory, pickupComp.Item.InstanceID);
-                        added.push_back(ItemAddedEvent{ invEnt.GetUUID(), pickupComp.Item.InstanceID, pickupComp.Item.ItemDefinitionID, slot });
-                        entitiesToDestroy.insert(pickupEntity);
-                    }
+                    const i32 slot = FindSlotOfInstance(invComp.PlayerInventory, pickupComp.Item.InstanceID);
+                    added.emplace_back(invEnt.GetUUID(), pickupComp.Item.InstanceID, pickupComp.Item.ItemDefinitionID, slot);
+                    entitiesToDestroy.insert(pickupEntity);
                 }
             }
         }

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/InventorySystem.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/InventorySystem.h
@@ -72,14 +72,14 @@ namespace OloEngine
         // Total price (currency) to buy `quantity` of `definitionId`, or 0 if
         // the definition is unknown / not for sale. UI/preview helper — the
         // single source of truth for the buy-side number BuyItem charges.
-        [[nodiscard]] static i32 GetBuyPrice(const std::string& definitionId, i32 quantity = 1);
+        [[nodiscard("buy price must be used")]] static i32 GetBuyPrice(const std::string& definitionId, i32 quantity = 1);
 
         // Total price (currency) a shop pays to buy `quantity` of `definitionId`
         // back, or 0 if unknown. Uses ItemDefinition::SellPrice when set,
         // otherwise falls back to half the BuyPrice (integer division truncates,
         // so a BuyPrice of 1 sells for 0). Single source of truth for the
         // sell-side number SellItem credits.
-        [[nodiscard]] static i32 GetSellPrice(const std::string& definitionId, i32 quantity = 1);
+        [[nodiscard("sell price must be used")]] static i32 GetSellPrice(const std::string& definitionId, i32 quantity = 1);
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/Item.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/Item.h
@@ -55,42 +55,46 @@ namespace OloEngine
     };
 
     // String conversion helpers
-    inline const char* ItemCategoryToString(ItemCategory category)
+    [[nodiscard("category string must be used")]] inline const char* ItemCategoryToString(ItemCategory category)
     {
+        using enum ItemCategory;
         switch (category)
         {
-            case ItemCategory::Weapon:
+            case Weapon:
                 return "Weapon";
-            case ItemCategory::Armor:
+            case Armor:
                 return "Armor";
-            case ItemCategory::Consumable:
+            case Consumable:
                 return "Consumable";
-            case ItemCategory::QuestItem:
+            case QuestItem:
                 return "QuestItem";
-            case ItemCategory::Material:
+            case Material:
                 return "Material";
-            case ItemCategory::Currency:
+            case Currency:
                 return "Currency";
-            case ItemCategory::Misc:
+            case Misc:
                 return "Misc";
+            default:
+                break;
         }
         return "Misc";
     }
 
     inline ItemCategory ItemCategoryFromString(const std::string& str)
     {
+        using enum ItemCategory;
         if (str == "Weapon")
-            return ItemCategory::Weapon;
+            return Weapon;
         if (str == "Armor")
-            return ItemCategory::Armor;
+            return Armor;
         if (str == "Consumable")
-            return ItemCategory::Consumable;
+            return Consumable;
         if (str == "QuestItem")
-            return ItemCategory::QuestItem;
+            return QuestItem;
         if (str == "Material")
-            return ItemCategory::Material;
+            return Material;
         if (str == "Currency")
-            return ItemCategory::Currency;
+            return Currency;
         if (str != "Misc")
         {
             OLO_CORE_WARN("[Item] Unrecognized ItemCategory '{}' \u2014 defaulting to Misc", str);
@@ -98,34 +102,38 @@ namespace OloEngine
         return ItemCategory::Misc;
     }
 
-    inline const char* ItemRarityToString(ItemRarity rarity)
+    [[nodiscard("rarity string must be used")]] inline const char* ItemRarityToString(ItemRarity rarity)
     {
+        using enum ItemRarity;
         switch (rarity)
         {
-            case ItemRarity::Common:
+            case Common:
                 return "Common";
-            case ItemRarity::Uncommon:
+            case Uncommon:
                 return "Uncommon";
-            case ItemRarity::Rare:
+            case Rare:
                 return "Rare";
-            case ItemRarity::Epic:
+            case Epic:
                 return "Epic";
-            case ItemRarity::Legendary:
+            case Legendary:
                 return "Legendary";
+            default:
+                break;
         }
         return "Common";
     }
 
     inline ItemRarity ItemRarityFromString(const std::string& str)
     {
+        using enum ItemRarity;
         if (str == "Uncommon")
-            return ItemRarity::Uncommon;
+            return Uncommon;
         if (str == "Rare")
-            return ItemRarity::Rare;
+            return Rare;
         if (str == "Epic")
-            return ItemRarity::Epic;
+            return Epic;
         if (str == "Legendary")
-            return ItemRarity::Legendary;
+            return Legendary;
         if (str != "Common")
         {
             OLO_CORE_WARN("[Item] Unrecognized ItemRarity '{}' \u2014 defaulting to Common", str);

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/Item.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/Item.h
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/Base.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -80,7 +81,7 @@ namespace OloEngine
         return "Misc";
     }
 
-    inline ItemCategory ItemCategoryFromString(const std::string& str)
+    inline ItemCategory ItemCategoryFromString(std::string_view str)
     {
         using enum ItemCategory;
         if (str == "Weapon")
@@ -99,7 +100,7 @@ namespace OloEngine
         {
             OLO_CORE_WARN("[Item] Unrecognized ItemCategory '{}' \u2014 defaulting to Misc", str);
         }
-        return ItemCategory::Misc;
+        return Misc;
     }
 
     [[nodiscard("rarity string must be used")]] inline const char* ItemRarityToString(ItemRarity rarity)
@@ -123,7 +124,7 @@ namespace OloEngine
         return "Common";
     }
 
-    inline ItemRarity ItemRarityFromString(const std::string& str)
+    inline ItemRarity ItemRarityFromString(std::string_view str)
     {
         using enum ItemRarity;
         if (str == "Uncommon")
@@ -138,7 +139,7 @@ namespace OloEngine
         {
             OLO_CORE_WARN("[Item] Unrecognized ItemRarity '{}' \u2014 defaulting to Common", str);
         }
-        return ItemRarity::Common;
+        return Common;
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <filesystem>
+#include <string_view>
 
 namespace OloEngine
 {
@@ -14,7 +15,7 @@ namespace OloEngine
         // Validate a float read from an .oloitem YAML file (cpp-coding-quality §2b).
         // A corrupt or hand-edited asset can carry NaN/±inf; substitute a safe fallback
         // so it never reaches inventory weight / attribute math.
-        [[nodiscard]] f32 SanitizeFinite(f32 value, f32 fallback, const char* field, const std::string& itemId)
+        [[nodiscard("sanitized value must be used")]] f32 SanitizeFinite(f32 value, f32 fallback, std::string_view field, const std::string& itemId)
         {
             if (!std::isfinite(value))
             {
@@ -25,9 +26,9 @@ namespace OloEngine
         }
     } // namespace
 
-    std::unordered_map<std::string, ItemDefinition>& ItemDatabase::GetItems()
+    std::unordered_map<std::string, ItemDefinition, StringHash, StringEqual>& ItemDatabase::GetItems()
     {
-        static std::unordered_map<std::string, ItemDefinition> s_Items;
+        static std::unordered_map<std::string, ItemDefinition, StringHash, StringEqual> s_Items;
         return s_Items;
     }
 
@@ -146,7 +147,7 @@ namespace OloEngine
         return result;
     }
 
-    std::vector<const ItemDefinition*> ItemDatabase::GetByTag(const std::string& tag)
+    std::vector<const ItemDefinition*> ItemDatabase::GetByTag(std::string_view tag)
     {
         std::vector<const ItemDefinition*> result;
         for (auto const& [id, def] : GetItems())

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/ItemDatabase.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "OloEngine/Core/TransparentStringHash.h"
 #include "OloEngine/Gameplay/Inventory/Item.h"
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -15,12 +17,12 @@ namespace OloEngine
         static void Register(const ItemDefinition& definition);
         static const ItemDefinition* Get(const std::string& itemId);
         static std::vector<const ItemDefinition*> GetByCategory(ItemCategory category);
-        static std::vector<const ItemDefinition*> GetByTag(const std::string& tag);
+        static std::vector<const ItemDefinition*> GetByTag(std::string_view tag);
         static std::vector<const ItemDefinition*> GetAll();
         static void Clear();
 
       private:
-        static std::unordered_map<std::string, ItemDefinition>& GetItems();
+        [[nodiscard("items map must be used")]] static std::unordered_map<std::string, ItemDefinition, StringHash, StringEqual>& GetItems();
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/ItemInstance.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/ItemInstance.h
@@ -2,6 +2,7 @@
 
 #include "OloEngine/Gameplay/Inventory/AffixDefinition.h"
 #include "OloEngine/Gameplay/Inventory/Item.h"
+#include "OloEngine/Core/TransparentStringHash.h"
 #include "OloEngine/Core/UUID.h"
 
 #include <string>
@@ -32,11 +33,11 @@ namespace OloEngine
         f32 MaxDurability = -1.0f;
 
         std::vector<ItemAffix> Affixes;
-        std::unordered_map<std::string, std::string> CustomData;
+        std::unordered_map<std::string, std::string, StringHash, StringEqual> CustomData;
 
         // Returns true when two instances can be merged into one stack
         // (same definition, no per-instance state differences)
-        [[nodiscard]] bool IsStackCompatible(const ItemInstance& other) const
+        [[nodiscard("stack-compatibility result must be used")]] bool IsStackCompatible(const ItemInstance& other) const
         {
             return ItemDefinitionID == other.ItemDefinitionID && Durability == other.Durability && MaxDurability == other.MaxDurability && Affixes == other.Affixes && CustomData == other.CustomData;
         }

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/LootTable.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/LootTable.cpp
@@ -141,12 +141,9 @@ namespace OloEngine
                             const AffixTier* selectedTier = nullptr;
                             for (auto const& tier : affixDef->Tiers)
                             {
-                                if (itemLevel >= tier.MinItemLevel)
+                                if (itemLevel >= tier.MinItemLevel && (!selectedTier || tier.Tier > selectedTier->Tier))
                                 {
-                                    if (!selectedTier || tier.Tier > selectedTier->Tier)
-                                    {
-                                        selectedTier = &tier;
-                                    }
+                                    selectedTier = &tier;
                                 }
                             }
                             if (!selectedTier)

--- a/OloEngine/src/OloEngine/Gameplay/Inventory/LootTable.h
+++ b/OloEngine/src/OloEngine/Gameplay/Inventory/LootTable.h
@@ -31,7 +31,7 @@ namespace OloEngine
         i32 MaxDrops = 3;
         f32 NothingWeight = 0.0f;
 
-        [[nodiscard]] std::vector<ItemInstance> Roll(f32 itemLevel = 1.0f) const;
+        [[nodiscard("rolled loot must be used")]] std::vector<ItemInstance> Roll(f32 itemLevel = 1.0f) const;
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Quest/Quest.h
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/Quest.h
@@ -4,6 +4,7 @@
 #include "OloEngine/Gameplay/Quest/QuestRequirement.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OloEngine
@@ -18,42 +19,44 @@ namespace OloEngine
         TurnedIn     // Completed and acknowledged
     };
 
-    inline const char* QuestStatusToString(QuestStatus status)
+    [[nodiscard("status string must be used")]] inline const char* QuestStatusToString(QuestStatus status)
     {
+        using enum QuestStatus;
         switch (status)
         {
-            case QuestStatus::Unavailable:
+            case Unavailable:
                 return "Unavailable";
-            case QuestStatus::Available:
+            case Available:
                 return "Available";
-            case QuestStatus::Active:
+            case Active:
                 return "Active";
-            case QuestStatus::Completed:
+            case Completed:
                 return "Completed";
-            case QuestStatus::Failed:
+            case Failed:
                 return "Failed";
-            case QuestStatus::TurnedIn:
+            case TurnedIn:
                 return "TurnedIn";
             default:
                 return "Unknown";
         }
     }
 
-    inline QuestStatus QuestStatusFromString(const std::string& str)
+    inline QuestStatus QuestStatusFromString(std::string_view str)
     {
+        using enum QuestStatus;
         if (str == "Unavailable")
-            return QuestStatus::Unavailable;
+            return Unavailable;
         if (str == "Available")
-            return QuestStatus::Available;
+            return Available;
         if (str == "Active")
-            return QuestStatus::Active;
+            return Active;
         if (str == "Completed")
-            return QuestStatus::Completed;
+            return Completed;
         if (str == "Failed")
-            return QuestStatus::Failed;
+            return Failed;
         if (str == "TurnedIn")
-            return QuestStatus::TurnedIn;
-        return QuestStatus::Unavailable;
+            return TurnedIn;
+        return Unavailable;
     }
 
     struct QuestStage

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <filesystem>
+#include <string_view>
 
 namespace OloEngine
 {
@@ -13,7 +14,7 @@ namespace OloEngine
         // Validate a float read from an .oloquest YAML file (cpp-coding-quality §2b).
         // A corrupt or hand-edited asset can carry NaN/±inf; substitute a safe fallback
         // so it never reaches quest timers / cooldowns.
-        [[nodiscard]] f32 SanitizeFinite(f32 value, f32 fallback, const char* field, const std::string& questId)
+        [[nodiscard("sanitized value must be used")]] f32 SanitizeFinite(f32 value, f32 fallback, std::string_view field, const std::string& questId)
         {
             if (!std::isfinite(value))
             {
@@ -70,9 +71,9 @@ namespace OloEngine
         return req;
     }
 
-    std::unordered_map<std::string, QuestDefinition>& QuestDatabase::GetQuests()
+    std::unordered_map<std::string, QuestDefinition, StringHash, StringEqual>& QuestDatabase::GetQuests()
     {
-        static std::unordered_map<std::string, QuestDefinition> s_Quests;
+        static std::unordered_map<std::string, QuestDefinition, StringHash, StringEqual> s_Quests;
         return s_Quests;
     }
 
@@ -247,7 +248,7 @@ namespace OloEngine
         return it != quests.end() ? &it->second : nullptr;
     }
 
-    std::vector<const QuestDefinition*> QuestDatabase::GetByCategory(const std::string& category)
+    std::vector<const QuestDefinition*> QuestDatabase::GetByCategory(std::string_view category)
     {
         std::vector<const QuestDefinition*> result;
         for (auto const& [id, def] : GetQuests())

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.h
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestDatabase.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "OloEngine/Core/TransparentStringHash.h"
 #include "OloEngine/Gameplay/Quest/Quest.h"
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -14,12 +16,12 @@ namespace OloEngine
         static void LoadFromDirectory(const std::string& path);
         static void Register(const QuestDefinition& definition);
         static const QuestDefinition* Get(const std::string& questId);
-        static std::vector<const QuestDefinition*> GetByCategory(const std::string& category);
+        static std::vector<const QuestDefinition*> GetByCategory(std::string_view category);
         static std::vector<const QuestDefinition*> GetAll();
         static void Clear();
 
       private:
-        static std::unordered_map<std::string, QuestDefinition>& GetQuests();
+        [[nodiscard("quests map must be used")]] static std::unordered_map<std::string, QuestDefinition, StringHash, StringEqual>& GetQuests();
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestJournal.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestJournal.cpp
@@ -1,6 +1,8 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Gameplay/Quest/QuestJournal.h"
 
+#include <algorithm>
+
 namespace OloEngine
 {
     namespace
@@ -215,8 +217,7 @@ namespace OloEngine
             {
                 // Overflow-safe: clamp addition to [0, RequiredCount]
                 i32 headroom = obj.RequiredCount - obj.CurrentCount;
-                i32 added = std::min(amount, headroom);
-                if (added > 0)
+                if (i32 added = std::min(amount, headroom); added > 0)
                 {
                     obj.CurrentCount += added;
                     Record(sink, { .Kind = QuestJournalChange::Type::ObjectiveProgress, .QuestID = questId, .ObjectiveID = objectiveId, .CurrentCount = obj.CurrentCount, .RequiredCount = obj.RequiredCount });
@@ -277,7 +278,7 @@ namespace OloEngine
 
         auto const& currentStage = definition.Stages[static_cast<size_t>(state.CurrentStageIndex)];
 
-        bool stageComplete;
+        bool stageComplete = false;
         if (currentStage.RequireAllObjectives)
         {
             stageComplete = true;
@@ -337,22 +338,23 @@ namespace OloEngine
 
     QuestStatus QuestJournal::GetQuestStatus(const std::string& questId) const
     {
+        using enum QuestStatus;
         if (auto it = m_ActiveQuests.find(questId); it != m_ActiveQuests.end())
         {
             return it->second.Status;
         }
         if (m_CompletedQuestIDs.contains(questId))
         {
-            return QuestStatus::Completed;
+            return Completed;
         }
         if (m_FailedQuestIDs.contains(questId))
         {
-            return QuestStatus::Failed;
+            return Failed;
         }
-        return QuestStatus::Unavailable;
+        return Unavailable;
     }
 
-    const QuestObjective* QuestJournal::GetObjective(const std::string& questId, const std::string& objectiveId) const
+    const QuestObjective* QuestJournal::GetObjective(std::string_view questId, std::string_view objectiveId) const
     {
         auto it = m_ActiveQuests.find(questId);
         if (it == m_ActiveQuests.end())
@@ -483,18 +485,10 @@ namespace OloEngine
         }
 
         // Decrement quest cooldowns
-        for (auto it = m_QuestCooldowns.begin(); it != m_QuestCooldowns.end();)
-        {
-            it->second -= dt;
-            if (it->second <= 0.0f)
-            {
-                it = m_QuestCooldowns.erase(it);
-            }
-            else
-            {
-                ++it;
-            }
-        }
+        std::erase_if(m_QuestCooldowns, [dt](auto& pair)
+                      {
+            pair.second -= dt;
+            return pair.second <= 0.0f; });
     }
 
     void QuestJournal::SetActiveQuestState(const std::string& questId, ActiveQuestState state)
@@ -555,12 +549,12 @@ namespace OloEngine
         return it != m_Stats.end() ? it->second : 0;
     }
 
-    void QuestJournal::SetPlayerClass(const std::string& className)
+    void QuestJournal::SetPlayerClass(std::string_view className)
     {
         m_PlayerClass = className;
     }
 
-    void QuestJournal::SetPlayerFaction(const std::string& factionName)
+    void QuestJournal::SetPlayerFaction(std::string_view factionName)
     {
         m_PlayerFaction = factionName;
     }
@@ -623,26 +617,14 @@ namespace OloEngine
 
             case QuestRequirementType::All:
             {
-                for (auto const& child : req.Children)
-                {
-                    if (!CheckRequirement(child))
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return std::ranges::all_of(req.Children, [this](const QuestRequirement& child)
+                                           { return CheckRequirement(child); });
             }
 
             case QuestRequirementType::Any:
             {
-                for (auto const& child : req.Children)
-                {
-                    if (CheckRequirement(child))
-                    {
-                        return true;
-                    }
-                }
-                return false;
+                return std::ranges::any_of(req.Children, [this](const QuestRequirement& child)
+                                           { return CheckRequirement(child); });
             }
 
             case QuestRequirementType::Not:
@@ -661,14 +643,8 @@ namespace OloEngine
 
     bool QuestJournal::CheckRequirements(const std::vector<QuestRequirement>& requirements) const
     {
-        for (auto const& req : requirements)
-        {
-            if (!CheckRequirement(req))
-            {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::all_of(requirements, [this](const QuestRequirement& req)
+                                   { return CheckRequirement(req); });
     }
 
     std::vector<const QuestRequirement*> QuestJournal::GetUnmetRequirements(const std::vector<QuestRequirement>& requirements) const
@@ -684,7 +660,7 @@ namespace OloEngine
         return unmet;
     }
 
-    void QuestJournal::NotifyObjectiveProgress(QuestObjective::Type type, const std::string& targetId, i32 amount, QuestEventSink* sink)
+    void QuestJournal::NotifyObjectiveProgress(QuestObjective::Type type, std::string_view targetId, i32 amount, QuestEventSink* sink)
     {
         if (amount <= 0)
         {

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestJournal.h
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestJournal.h
@@ -2,9 +2,11 @@
 
 #include "OloEngine/Gameplay/Quest/Quest.h"
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Core/TransparentStringHash.h"
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -51,6 +53,13 @@ namespace OloEngine
     class QuestJournal
     {
       public:
+        // Transparent string-keyed containers enable heterogeneous lookup
+        // (std::string_view / const char*) without materialising a temporary
+        // std::string (cpp:S6045).
+        using StringSet = std::unordered_set<std::string, StringHash, StringEqual>;
+        template<typename V>
+        using StringMap = std::unordered_map<std::string, V, StringHash, StringEqual>;
+
         // Accept a quest (moves from Available/Unavailable to Active).
         // When `sink` is non-null, appends a QuestStarted record on success.
         bool AcceptQuest(const std::string& questId, const QuestDefinition& definition, QuestEventSink* sink = nullptr);
@@ -73,13 +82,13 @@ namespace OloEngine
         std::optional<QuestRewards> TryAdvanceStage(const std::string& questId, QuestEventSink* sink = nullptr);
 
         // Queries
-        [[nodiscard]] QuestStatus GetQuestStatus(const std::string& questId) const;
-        [[nodiscard]] const QuestObjective* GetObjective(const std::string& questId, const std::string& objectiveId) const;
-        [[nodiscard]] i32 GetCurrentStageIndex(const std::string& questId) const;
-        [[nodiscard]] std::vector<std::string> GetActiveQuests() const;
-        [[nodiscard]] std::vector<std::string> GetCompletedQuests() const;
-        [[nodiscard]] bool HasCompletedQuest(const std::string& questId) const;
-        [[nodiscard]] bool IsQuestActive(const std::string& questId) const;
+        [[nodiscard("quest status must be used")]] QuestStatus GetQuestStatus(const std::string& questId) const;
+        [[nodiscard("objective pointer must be used")]] const QuestObjective* GetObjective(std::string_view questId, std::string_view objectiveId) const;
+        [[nodiscard("stage index must be used")]] i32 GetCurrentStageIndex(const std::string& questId) const;
+        [[nodiscard("active quest list must be used")]] std::vector<std::string> GetActiveQuests() const;
+        [[nodiscard("completed quest list must be used")]] std::vector<std::string> GetCompletedQuests() const;
+        [[nodiscard("completion check must be used")]] bool HasCompletedQuest(const std::string& questId) const;
+        [[nodiscard("active check must be used")]] bool IsQuestActive(const std::string& questId) const;
 
         // Notify-based progress by objective type. When `sink` is non-null,
         // records the same ObjectiveProgress / ObjectiveCompleted /
@@ -92,56 +101,56 @@ namespace OloEngine
 
         // Tag management (quest-granted tags on the player)
         void AddTag(const std::string& tag);
-        [[nodiscard]] bool HasTag(const std::string& tag) const;
-        [[nodiscard]] const std::unordered_set<std::string>& GetTags() const
+        [[nodiscard("tag-presence check must be used")]] bool HasTag(const std::string& tag) const;
+        [[nodiscard("tag set must be used")]] const StringSet& GetTags() const
         {
             return m_Tags;
         }
 
         // Player state for requirement evaluation (fed by external systems)
         void SetPlayerLevel(i32 level);
-        [[nodiscard]] i32 GetPlayerLevel() const
+        [[nodiscard("player level must be used")]] i32 GetPlayerLevel() const
         {
             return m_PlayerLevel;
         }
 
         void SetReputation(const std::string& factionId, i32 value);
-        [[nodiscard]] i32 GetReputation(const std::string& factionId) const;
-        [[nodiscard]] const std::unordered_map<std::string, i32>& GetReputations() const
+        [[nodiscard("reputation must be used")]] i32 GetReputation(const std::string& factionId) const;
+        [[nodiscard("reputations map must be used")]] const StringMap<i32>& GetReputations() const
         {
             return m_Reputations;
         }
 
         void SetItemCount(const std::string& itemId, i32 count);
-        [[nodiscard]] i32 GetItemCount(const std::string& itemId) const;
-        [[nodiscard]] const std::unordered_map<std::string, i32>& GetItems() const
+        [[nodiscard("item count must be used")]] i32 GetItemCount(const std::string& itemId) const;
+        [[nodiscard("items map must be used")]] const StringMap<i32>& GetItems() const
         {
             return m_Items;
         }
 
         void SetStat(const std::string& statName, i32 value);
-        [[nodiscard]] i32 GetStat(const std::string& statName) const;
-        [[nodiscard]] const std::unordered_map<std::string, i32>& GetStats() const
+        [[nodiscard("stat value must be used")]] i32 GetStat(const std::string& statName) const;
+        [[nodiscard("stats map must be used")]] const StringMap<i32>& GetStats() const
         {
             return m_Stats;
         }
 
-        void SetPlayerClass(const std::string& className);
-        [[nodiscard]] const std::string& GetPlayerClass() const
+        void SetPlayerClass(std::string_view className);
+        [[nodiscard("player class must be used")]] const std::string& GetPlayerClass() const
         {
             return m_PlayerClass;
         }
 
-        void SetPlayerFaction(const std::string& factionName);
-        [[nodiscard]] const std::string& GetPlayerFaction() const
+        void SetPlayerFaction(std::string_view factionName);
+        [[nodiscard("player faction must be used")]] const std::string& GetPlayerFaction() const
         {
             return m_PlayerFaction;
         }
 
         // Requirement evaluation
-        [[nodiscard]] bool CheckRequirement(const QuestRequirement& requirement) const;
-        [[nodiscard]] bool CheckRequirements(const std::vector<QuestRequirement>& requirements) const;
-        [[nodiscard]] std::vector<const QuestRequirement*> GetUnmetRequirements(const std::vector<QuestRequirement>& requirements) const;
+        [[nodiscard("requirement result must be used")]] bool CheckRequirement(const QuestRequirement& requirement) const;
+        [[nodiscard("requirements result must be used")]] bool CheckRequirements(const std::vector<QuestRequirement>& requirements) const;
+        [[nodiscard("unmet requirement list must be used")]] std::vector<const QuestRequirement*> GetUnmetRequirements(const std::vector<QuestRequirement>& requirements) const;
 
         // Time update (called each frame for timed quests). Records QuestFailed
         // into `sink` for any quest that hits its deadline / fail tag this tick.
@@ -160,15 +169,15 @@ namespace OloEngine
             auto operator==(const ActiveQuestState&) const -> bool = default;
         };
 
-        [[nodiscard]] const std::unordered_map<std::string, ActiveQuestState>& GetActiveQuestStates() const
+        [[nodiscard("active quest states must be used")]] const StringMap<ActiveQuestState>& GetActiveQuestStates() const
         {
             return m_ActiveQuests;
         }
-        [[nodiscard]] const std::unordered_set<std::string>& GetCompletedQuestIDs() const
+        [[nodiscard("completed quest IDs must be used")]] const StringSet& GetCompletedQuestIDs() const
         {
             return m_CompletedQuestIDs;
         }
-        [[nodiscard]] const std::unordered_set<std::string>& GetFailedQuestIDs() const
+        [[nodiscard("failed quest IDs must be used")]] const StringSet& GetFailedQuestIDs() const
         {
             return m_FailedQuestIDs;
         }
@@ -179,14 +188,14 @@ namespace OloEngine
         void AddFailedQuestID(const std::string& questId);
 
         // Branch tracking for completed quests
-        [[nodiscard]] const std::string& GetCompletedQuestBranch(const std::string& questId) const;
-        [[nodiscard]] const std::unordered_map<std::string, std::string>& GetCompletedQuestBranches() const
+        [[nodiscard("completed quest branch must be used")]] const std::string& GetCompletedQuestBranch(const std::string& questId) const;
+        [[nodiscard("completed quest branches must be used")]] const StringMap<std::string>& GetCompletedQuestBranches() const
         {
             return m_CompletedQuestBranches;
         }
 
         // Cooldown tracking for repeatable quests
-        [[nodiscard]] const std::unordered_map<std::string, f32>& GetQuestCooldowns() const
+        [[nodiscard("quest cooldowns must be used")]] const StringMap<f32>& GetQuestCooldowns() const
         {
             return m_QuestCooldowns;
         }
@@ -195,20 +204,20 @@ namespace OloEngine
         auto operator==(const QuestJournal&) const -> bool = default;
 
       private:
-        void NotifyObjectiveProgress(QuestObjective::Type type, const std::string& targetId, i32 amount, QuestEventSink* sink = nullptr);
+        void NotifyObjectiveProgress(QuestObjective::Type type, std::string_view targetId, i32 amount, QuestEventSink* sink = nullptr);
 
-        std::unordered_map<std::string, ActiveQuestState> m_ActiveQuests;
-        std::unordered_set<std::string> m_CompletedQuestIDs;
-        std::unordered_set<std::string> m_FailedQuestIDs;
-        std::unordered_set<std::string> m_Tags;
-        std::unordered_map<std::string, std::string> m_CompletedQuestBranches;
-        std::unordered_map<std::string, f32> m_QuestCooldowns;
+        StringMap<ActiveQuestState> m_ActiveQuests;
+        StringSet m_CompletedQuestIDs;
+        StringSet m_FailedQuestIDs;
+        StringSet m_Tags;
+        StringMap<std::string> m_CompletedQuestBranches;
+        StringMap<f32> m_QuestCooldowns;
 
         // External player state for requirement evaluation
         i32 m_PlayerLevel = 0;
-        std::unordered_map<std::string, i32> m_Reputations;
-        std::unordered_map<std::string, i32> m_Items;
-        std::unordered_map<std::string, i32> m_Stats;
+        StringMap<i32> m_Reputations;
+        StringMap<i32> m_Items;
+        StringMap<i32> m_Stats;
         std::string m_PlayerClass;
         std::string m_PlayerFaction;
     };

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestObjective.h
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestObjective.h
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/Base.h"
 
 #include <string>
+#include <string_view>
 
 namespace OloEngine
 {
@@ -33,40 +34,42 @@ namespace OloEngine
         auto operator==(const QuestObjective&) const -> bool = default;
     };
 
-    inline const char* ObjectiveTypeToString(QuestObjective::Type type)
+    [[nodiscard("objective type string must be used")]] inline const char* ObjectiveTypeToString(QuestObjective::Type type)
     {
+        using enum QuestObjective::Type;
         switch (type)
         {
-            case QuestObjective::Type::Kill:
+            case Kill:
                 return "Kill";
-            case QuestObjective::Type::Collect:
+            case Collect:
                 return "Collect";
-            case QuestObjective::Type::Interact:
+            case Interact:
                 return "Interact";
-            case QuestObjective::Type::Reach:
+            case Reach:
                 return "Reach";
-            case QuestObjective::Type::Escort:
+            case Escort:
                 return "Escort";
-            case QuestObjective::Type::Custom:
+            case Custom:
                 return "Custom";
             default:
                 return "Unknown";
         }
     }
 
-    inline QuestObjective::Type ObjectiveTypeFromString(const std::string& str)
+    inline QuestObjective::Type ObjectiveTypeFromString(std::string_view str)
     {
+        using enum QuestObjective::Type;
         if (str == "Kill")
-            return QuestObjective::Type::Kill;
+            return Kill;
         if (str == "Collect")
-            return QuestObjective::Type::Collect;
+            return Collect;
         if (str == "Interact")
-            return QuestObjective::Type::Interact;
+            return Interact;
         if (str == "Reach")
-            return QuestObjective::Type::Reach;
+            return Reach;
         if (str == "Escort")
-            return QuestObjective::Type::Escort;
-        return QuestObjective::Type::Custom;
+            return Escort;
+        return Custom;
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestRequirement.h
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestRequirement.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OloEngine
@@ -48,133 +49,138 @@ namespace OloEngine
         LessThanOrEqual,
     };
 
-    inline const char* RequirementTypeToString(QuestRequirementType type)
+    [[nodiscard("requirement type string must be used")]] inline const char* RequirementTypeToString(QuestRequirementType type)
     {
+        using enum QuestRequirementType;
         switch (type)
         {
-            case QuestRequirementType::QuestCompleted:
+            case QuestCompleted:
                 return "QuestCompleted";
-            case QuestRequirementType::QuestActive:
+            case QuestActive:
                 return "QuestActive";
-            case QuestRequirementType::QuestFailed:
+            case QuestFailed:
                 return "QuestFailed";
-            case QuestRequirementType::QuestNotStarted:
+            case QuestNotStarted:
                 return "QuestNotStarted";
-            case QuestRequirementType::Level:
+            case Level:
                 return "Level";
-            case QuestRequirementType::Reputation:
+            case Reputation:
                 return "Reputation";
-            case QuestRequirementType::HasTag:
+            case HasTag:
                 return "HasTag";
-            case QuestRequirementType::DoesNotHaveTag:
+            case DoesNotHaveTag:
                 return "DoesNotHaveTag";
-            case QuestRequirementType::HasItem:
+            case HasItem:
                 return "HasItem";
-            case QuestRequirementType::Stat:
+            case Stat:
                 return "Stat";
-            case QuestRequirementType::IsClass:
+            case IsClass:
                 return "IsClass";
-            case QuestRequirementType::IsFaction:
+            case IsFaction:
                 return "IsFaction";
-            case QuestRequirementType::All:
+            case All:
                 return "All";
-            case QuestRequirementType::Any:
+            case Any:
                 return "Any";
-            case QuestRequirementType::Not:
+            case Not:
                 return "Not";
             default:
                 return "Unknown";
         }
     }
 
-    inline std::optional<QuestRequirementType> RequirementTypeFromString(const std::string& str)
+    inline std::optional<QuestRequirementType> RequirementTypeFromString(std::string_view str)
     {
+        using enum QuestRequirementType;
         if (str == "QuestCompleted")
-            return QuestRequirementType::QuestCompleted;
+            return QuestCompleted;
         if (str == "QuestActive")
-            return QuestRequirementType::QuestActive;
+            return QuestActive;
         if (str == "QuestFailed")
-            return QuestRequirementType::QuestFailed;
+            return QuestFailed;
         if (str == "QuestNotStarted")
-            return QuestRequirementType::QuestNotStarted;
+            return QuestNotStarted;
         if (str == "Level")
-            return QuestRequirementType::Level;
+            return Level;
         if (str == "Reputation")
-            return QuestRequirementType::Reputation;
+            return Reputation;
         if (str == "HasTag")
-            return QuestRequirementType::HasTag;
+            return HasTag;
         if (str == "DoesNotHaveTag")
-            return QuestRequirementType::DoesNotHaveTag;
+            return DoesNotHaveTag;
         if (str == "HasItem")
-            return QuestRequirementType::HasItem;
+            return HasItem;
         if (str == "Stat")
-            return QuestRequirementType::Stat;
+            return Stat;
         if (str == "IsClass")
-            return QuestRequirementType::IsClass;
+            return IsClass;
         if (str == "IsFaction")
-            return QuestRequirementType::IsFaction;
+            return IsFaction;
         if (str == "All")
-            return QuestRequirementType::All;
+            return All;
         if (str == "Any")
-            return QuestRequirementType::Any;
+            return Any;
         if (str == "Not")
-            return QuestRequirementType::Not;
+            return Not;
         return std::nullopt;
     }
 
-    inline const char* ComparisonOpToString(ComparisonOp op)
+    [[nodiscard("comparison op string must be used")]] inline const char* ComparisonOpToString(ComparisonOp op)
     {
+        using enum ComparisonOp;
         switch (op)
         {
-            case ComparisonOp::Equal:
+            case Equal:
                 return "Equal";
-            case ComparisonOp::NotEqual:
+            case NotEqual:
                 return "NotEqual";
-            case ComparisonOp::GreaterThan:
+            case GreaterThan:
                 return "GreaterThan";
-            case ComparisonOp::GreaterThanOrEqual:
+            case GreaterThanOrEqual:
                 return "GreaterThanOrEqual";
-            case ComparisonOp::LessThan:
+            case LessThan:
                 return "LessThan";
-            case ComparisonOp::LessThanOrEqual:
+            case LessThanOrEqual:
                 return "LessThanOrEqual";
             default:
                 return "GreaterThanOrEqual";
         }
     }
 
-    inline std::optional<ComparisonOp> ComparisonOpFromString(const std::string& str)
+    inline std::optional<ComparisonOp> ComparisonOpFromString(std::string_view str)
     {
+        using enum ComparisonOp;
         if (str == "Equal" || str == "==" || str == "EQ")
-            return ComparisonOp::Equal;
+            return Equal;
         if (str == "NotEqual" || str == "!=" || str == "NE")
-            return ComparisonOp::NotEqual;
+            return NotEqual;
         if (str == "GreaterThan" || str == ">" || str == "GT")
-            return ComparisonOp::GreaterThan;
+            return GreaterThan;
         if (str == "GreaterThanOrEqual" || str == ">=" || str == "GTE")
-            return ComparisonOp::GreaterThanOrEqual;
+            return GreaterThanOrEqual;
         if (str == "LessThan" || str == "<" || str == "LT")
-            return ComparisonOp::LessThan;
+            return LessThan;
         if (str == "LessThanOrEqual" || str == "<=" || str == "LTE")
-            return ComparisonOp::LessThanOrEqual;
+            return LessThanOrEqual;
         return std::nullopt;
     }
 
-    inline bool EvaluateComparison(i32 actual, ComparisonOp op, i32 expected)
+    [[nodiscard("comparison result must be used")]] inline bool EvaluateComparison(i32 actual, ComparisonOp op, i32 expected)
     {
+        using enum ComparisonOp;
         switch (op)
         {
-            case ComparisonOp::Equal:
+            case Equal:
                 return actual == expected;
-            case ComparisonOp::NotEqual:
+            case NotEqual:
                 return actual != expected;
-            case ComparisonOp::GreaterThan:
+            case GreaterThan:
                 return actual > expected;
-            case ComparisonOp::GreaterThanOrEqual:
+            case GreaterThanOrEqual:
                 return actual >= expected;
-            case ComparisonOp::LessThan:
+            case LessThan:
                 return actual < expected;
-            case ComparisonOp::LessThanOrEqual:
+            case LessThanOrEqual:
                 return actual <= expected;
             default:
                 return false;

--- a/OloEngine/src/OloEngine/Gameplay/Quest/QuestSystem.cpp
+++ b/OloEngine/src/OloEngine/Gameplay/Quest/QuestSystem.cpp
@@ -25,37 +25,40 @@ namespace OloEngine
             }
 
             const GameplayEventBus& bus = scene->GetGameplayEvents();
+            using enum QuestJournalChange::Type;
             for (auto const& c : changes)
             {
                 switch (c.Kind)
                 {
-                    case QuestJournalChange::Type::QuestStarted:
+                    case QuestStarted:
                         bus.Publish(QuestStartedEvent{ entityId, c.QuestID });
                         break;
-                    case QuestJournalChange::Type::QuestAbandoned:
+                    case QuestAbandoned:
                         bus.Publish(QuestAbandonedEvent{ entityId, c.QuestID });
                         break;
-                    case QuestJournalChange::Type::QuestFailed:
+                    case QuestFailed:
                         bus.Publish(QuestFailedEvent{ entityId, c.QuestID });
                         break;
-                    case QuestJournalChange::Type::QuestCompleted:
+                    case QuestCompleted:
                         bus.Publish(QuestCompletedEvent{ entityId, c.QuestID, c.BranchChoice });
                         break;
-                    case QuestJournalChange::Type::ObjectiveProgress:
+                    case ObjectiveProgress:
                         bus.Publish(ObjectiveProgressEvent{ entityId, c.QuestID, c.ObjectiveID, c.CurrentCount, c.RequiredCount });
                         break;
-                    case QuestJournalChange::Type::ObjectiveCompleted:
+                    case ObjectiveCompleted:
                         bus.Publish(ObjectiveCompletedEvent{ entityId, c.QuestID, c.ObjectiveID });
                         break;
-                    case QuestJournalChange::Type::StageAdvanced:
+                    case StageAdvanced:
                         bus.Publish(QuestStageAdvancedEvent{ entityId, c.QuestID, c.NewStageIndex });
+                        break;
+                    default:
                         break;
                 }
             }
         }
 
         // Common guard: returns the QuestJournalComponent pointer or nullptr.
-        QuestJournalComponent* ResolveJournal(Scene* scene, Entity entity)
+        QuestJournalComponent* ResolveJournal(const Scene* scene, Entity entity)
         {
             if (!scene || !entity || !entity.HasComponent<QuestJournalComponent>())
             {

--- a/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
+++ b/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
@@ -3032,7 +3032,8 @@ namespace OloEngine
         SerializeQuestDefinition(ar, s.Definition);
     }
 
-    static void SerializeStringSet(FArchive& ar, std::unordered_set<std::string>& set)
+    template<typename Hash, typename Equal>
+    static void SerializeStringSet(FArchive& ar, std::unordered_set<std::string, Hash, Equal>& set)
     {
         if (ar.IsSaving())
         {

--- a/OloEngine/src/OloEngine/Serialization/ArchiveExtensions.h
+++ b/OloEngine/src/OloEngine/Serialization/ArchiveExtensions.h
@@ -180,8 +180,8 @@ namespace OloEngine
         return ar;
     }
 
-    template<std::derived_from<FArchive> Ar, typename K, typename V>
-    Ar& operator<<(Ar& ar, std::unordered_map<K, V>& map)
+    template<std::derived_from<FArchive> Ar, typename K, typename V, typename... Rest>
+    Ar& operator<<(Ar& ar, std::unordered_map<K, V, Rest...>& map)
     {
         if (!ar.IsLoading())
         {
@@ -207,7 +207,7 @@ namespace OloEngine
                 ar.SetError();
                 return ar;
             }
-            std::unordered_map<K, V> temp;
+            std::unordered_map<K, V, Rest...> temp;
             temp.reserve(count);
             for (u32 i = 0; i < count; ++i)
             {

--- a/docs/sonarqube-rule-suggestions.md
+++ b/docs/sonarqube-rule-suggestions.md
@@ -300,6 +300,44 @@ Triaged as **not-a-fix** (left in place, reasoning recorded):
 
 ---
 
+## 9. `cpp:S1771` — "A `struct` should not have member functions" (on defaulted `operator==` PODs)
+
+**Where seen:** ≈10 hits in the `Gameplay/` sweep alone (AttributeModifier, GameplayEffect's nested structs, ItemAffix, QuestStage/QuestBranchChoice/QuestRewards/QuestDefinition, QuestObjective, QuestRequirement, …) plus every ECS `*Component` struct.
+**Status:** False positive on this codebase's idioms — **not fixed**, left in place.
+
+### Why it's a false positive here
+
+The flagged structs are POD aggregates whose *only* member function is a defaulted comparison:
+
+```cpp
+struct QuestRewards
+{
+    i32 ExperiencePoints = 0;
+    i32 Currency = 0;
+    std::vector<std::string> ItemRewards;
+    auto operator==(const QuestRewards&) const -> bool = default;   // ← S1771 fires here
+};
+```
+
+`auto operator==(...) const -> bool = default;` is the **sanctioned house idiom** — [CLAUDE.md §"Editor undo/redo for components"](../CLAUDE.md) and [cpp-coding-quality §7](agent-rules/cpp-coding-quality.md) require it so `SceneHierarchyPanel::DrawComponent<T>` can opt a non-trivially-copyable component into undo via `std::equality_comparable<T>`. The two "compliant" fixes the rule suggests both make the code worse:
+
+- **Remove the member function** — impossible; the comparison is load-bearing for undo / round-trip tests.
+- **Change `struct`→`class`** — flips default access (needs `public:` everywhere), and for the `*Component` structs it risks aggregate-initialisation and must stay a `struct` for the OloHeaderTool `struct *Component` scan to keep generating the `AllComponents` tuple / SaveGame lists.
+
+Same root cause feeds the `cpp:S1067` hits (§3) on those same defaulted `operator==` — you cannot "reduce the conditional operators" of a `= default` comparison without un-defaulting it.
+
+### Action
+
+Scope `cpp:S1771` (and the related `cpp:S1067` on defaulted comparisons) out for `OloEngine/src/OloEngine/**` in `sonar-project.properties`, or deactivate in the Quality Profile. They flag a documented, mandatory idiom.
+
+### Honourable mentions (one-off FPs found in the same sweep, left in place)
+
+- **`cpp:S1706`** ("exceptions should not be used") — the YAML asset-loading `try/catch` in `ItemDatabase`/`QuestDatabase` is the intentional per-file parse-error handler; the project deliberately uses exceptions there. Removing it changes error handling.
+- **`cpp:S5008`** ("replace `void *`") — deliberate type-erasure in `GameplayEventBus` (handlers stored as `std::function<void(const void*)>`, cast back to `const E*`).
+- **`cpp:M23_280`** ("use of a potentially moved-from object") — `optional::reset()` after `std::move(opt)` is well-defined and is exactly how `Inventory::MoveItem` clears the vacated slot.
+
+---
+
 ## High-volume rules to deactivate or scope (full-corpus histogram)
 
 A full-corpus facet query (≈31,800 open issues) surfaced four very high-count rules that are **MISRA / stylistic rules fighting idiomatic modern C++**. These dwarf everything else and are the reason the raw issue count looks alarming. "Fixing" them mechanically would be harmful or pointless; the right move is to deactivate (or tightly scope) them in the C++ Quality Profile.


### PR DESCRIPTION
## What

Batched SonarQube **CODE_SMELL / MAINTAINABILITY** cleanup of the **`Gameplay`** subsystem (`OloEngine/src/OloEngine/Gameplay/`), in the same spirit as the merged Audio (#407) and Animation (#406/#388) sweeps. **No behaviour change** — these are signal-hygiene fixes, not bug fixes.

There is no GitHub issue for this; the source of truth is the SonarQube project `drsnuggles8_OloEngineBase`.

**Before:** 331 OPEN MAINTAINABILITY issues across the 49 `Gameplay/` files. The next SonarQube scan after merge will reflect the reduction (issues stay OPEN until a rescan).

## Rules cleared (mechanical, behaviour-preserving)

| Rule | Count | Fix |
|---|---|---|
| `S6166` | 71 | Added explanation text to every `[[nodiscard]]`. |
| `S6045` | 32 | Transparent `StringHash`/`StringEqual` on `std::string`-keyed unordered containers. |
| `S6177` | 18 | `using enum` in ToString/FromString/switch scopes. |
| `S6007` | 17 | `[[nodiscard("…")]]` on pure getters/helpers. |
| `S131` | 6 | `default:` on exhaustive switches. |
| `S127`/`S6165`/`S886` | 11 | `std::erase_if` for decrement-and-erase loops; hoisted `.size()`; pseudo-counter out of the for-condition. |
| `S1066` | 4 | Merged nested `if` with short-circuit `&&` (side-effect order preserved). |
| `S5566` | 3 | range-for → `std::ranges::all_of` / `any_of`. |
| `S6009`/`S945` | ~13 | `const std::string&` → `std::string_view` where the param is only compared / looked up (lookups now heterogeneous via the transparent maps). |
| `S881`/`S912` | 3 | Lifted increment/decrement-with-side-effect out of `if` conditions. |
| `S6003` | 2 | `push_back` → `emplace_back`. |
| `S6004`,`S5523`,`S4136`,`S6186` | 4 | init-statement; initialize-immediately; group overloads; drop redundant `operator!=` (C++20 synthesizes it). |

### Shared / cross-binding touch-points
- **NEW `Core/TransparentStringHash.h`** — shared `StringHash`/`StringEqual` transparent functors (extracted from the existing `InputActionManager` idiom; that file now includes the header instead of defining its own copies — same names, no behaviour change).
- **`Serialization/ArchiveExtensions.h`** — `operator<<(std::unordered_map<K,V>)` generalized to be variadic over the hash/equal policy (`Rest...`) so the transparent gameplay maps serialize; default maps are unaffected.
- **`SaveGame/SaveGameComponentSerializer.cpp`** — `SerializeStringSet` made a template over the set's hash/equal, for the same reason.

These two serializer generalizations are the necessary cross-binding updates for the `S6045` container-type change (the SaveGame save path consumes `QuestJournal` / `ItemInstance` containers).

## Deliberately skipped (with rationale)

Non-mechanical / behaviour-changing clusters, left in place:

- **`S1142`** (too many returns) — control-flow refactor, risks behaviour.
- **`S1712`** (default params → overloads) — high churn, doubles method count; **already slated for project-wide deactivation** in `docs/sonarqube-rule-suggestions.md`.
- **`S1771`/`S5018`** (struct→class / noexcept move) — every hit is a POD struct whose only member fn is a defaulted `operator==` (the sanctioned undo-tracking idiom, CLAUDE.md §7) or an ECS `*Component` (aggregate-init + the OloHeaderTool `struct *Component` scan). Documented as a false positive in this PR's doc update.
- **`S5536`** (unused function) — all are public API methods; removal is an API change, **also slated for deactivation**.
- **`S925`/`S3776`/`S1448`** — large structural refactors out of scope.
- **`S1706`** (no-exceptions) — the YAML asset-loading `try/catch` is intentional per-file error handling.
- **`S1181`** (catch more specific) — narrowing `catch(std::exception)` would change which exceptions propagate (e.g. `bad_alloc`).
- **`S6010`** (filesystem::path param) — would change fmt log formatting of the path.
- False positives left alone: **`S5008`** (type-erasure `void*` in `GameplayEventBus`), **`S3230`** (move-init from a mutable static), **`M23_279`** (`std::forward` on a loop-invoked callable would be a bug), **`M23_280`** (`optional::reset()` after move is well-defined).

A new `## 9. cpp:S1771` section in `docs/sonarqube-rule-suggestions.md` records the recurring defaulted-`operator==` FP plus the S1706/S5008/M23_280 one-offs.

## Verification
- `OloEngine` and `OloEngine-Tests` build clean (Debug, MSVC).
- All **228** Gameplay/Inventory/Quest/Ability/SaveGame tests pass — including the YAML and save-game round-trip tests that exercise the modified serializer paths.
- Full suite **3607/3612 pass**; the one failure (`FogVisualEvidenceTest`, a GPU visual test untouched by this PR) passes in isolation — a known flaky visual test, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
