### PR TITLE
feat(renderer): consume per-object velocity buffer in motion blur

### DIFF
--- a/OloEditor/assets/shaders/PostProcess_MotionBlur.glsl
+++ b/OloEditor/assets/shaders/PostProcess_MotionBlur.glsl
@@ -20,6 +20,7 @@ layout(location = 0) out vec4 o_Color;
 layout(location = 0) in vec2 v_TexCoord;
 
 layout(binding = 0) uniform sampler2D u_Texture;      // Scene color (HDR)
+layout(binding = 2) uniform sampler2D u_Velocity;     // Per-pixel screen-space velocity (RG16F, curr-prev in UV) — Deferred G-Buffer RT3 / Forward scene attachment 3
 layout(binding = 19) uniform sampler2D u_DepthTexture;  // Scene depth
 
 layout(std140, binding = 7) uniform PostProcessUBO
@@ -50,31 +51,55 @@ layout(std140, binding = 7) uniform PostProcessUBO
     float u_Far;
 };
 
-// Motion blur matrices (UBO binding 8)
+// Motion blur matrices (UBO binding 8) — camera-only velocity reconstruction
+// for background pixels and the no-velocity-buffer fallback.
 layout(std140, binding = 8) uniform MotionBlurUBO
 {
     mat4 u_InverseViewProjection;
     mat4 u_PrevViewProjection;
 };
 
-void main()
+// Motion-blur per-pass flags (UBO binding 42). x = hasVelocityTexture (0/1):
+// when 1, geometry pixels read full per-object+camera motion from u_Velocity;
+// when 0 (no velocity buffer for this path), every pixel falls back to the
+// camera-only reconstruction below.
+layout(std140, binding = 42) uniform MotionBlurParams
 {
-    // Reconstruct world position from depth
-    float depth = texture(u_DepthTexture, v_TexCoord).r;
+    vec4 u_MB_Params;
+};
+#define u_HasVelocityTexture (int(u_MB_Params.x))
 
-    // NDC position
-    vec4 ndcPos = vec4(v_TexCoord * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
-
-    // World position
+// Camera-only velocity from depth + previous view-projection. Covers
+// background/sky pixels (which geometry never writes into the velocity
+// buffer) and the Forward fallback when no velocity buffer exists.
+vec2 ReconstructCameraVelocity(vec2 uv, float depth)
+{
+    vec4 ndcPos = vec4(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
     vec4 worldPos = u_InverseViewProjection * ndcPos;
     worldPos /= worldPos.w;
-
-    // Project to previous frame's screen position
     vec4 prevClipPos = u_PrevViewProjection * worldPos;
+    if (prevClipPos.w <= 0.0001)
+        return vec2(0.0);
     vec2 prevUV = (prevClipPos.xy / prevClipPos.w) * 0.5 + 0.5;
+    return uv - prevUV; // current - prev (matches the sign convention of the velocity buffer)
+}
 
-    // Velocity = current UV - previous UV
-    vec2 velocity = (v_TexCoord - prevUV) * u_MotionBlurStrength;
+void main()
+{
+    float depth = texture(u_DepthTexture, v_TexCoord).r;
+
+    // Per-pixel velocity (curr.xy/w - prev.xy/w, halved to UV units) already
+    // encodes full camera + object motion, so geometry pixels need no extra
+    // reconstruction. Background pixels (depth == far) are never written into
+    // the velocity buffer, so reconstruct camera motion there to keep the sky
+    // streaking under camera movement just like the legacy camera-only path.
+    vec2 velocity;
+    if (u_HasVelocityTexture != 0 && depth < 1.0)
+        velocity = texture(u_Velocity, v_TexCoord).rg;
+    else
+        velocity = ReconstructCameraVelocity(v_TexCoord, depth);
+
+    velocity *= u_MotionBlurStrength;
 
     // Clamp velocity to prevent excessive blur
     float speed = length(velocity / vec2(u_InverseScreenWidth, u_InverseScreenHeight));

--- a/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.cpp
@@ -27,7 +27,6 @@ namespace OloEngine
         m_SelectedSceneDepthTexture = {};
         m_SelectedVelocityTexture = {};
 
-        (void)blackboard;
         [[maybe_unused]] const auto input = RenderPipelineBuilderInternal::ReadFirstValidVersionedInputForPass(
             builder,
             this,

--- a/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.cpp
@@ -3,6 +3,7 @@
 
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
+#include "OloEngine/Renderer/PostProcessSettings.h"
 #include "OloEngine/Renderer/RGCommandContext.h"
 #include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/RenderPipelineBuilderInternal.h"
@@ -24,6 +25,7 @@ namespace OloEngine
     {
         RenderGraphNode::Setup(builder, blackboard);
         m_SelectedSceneDepthTexture = {};
+        m_SelectedVelocityTexture = {};
 
         (void)blackboard;
         [[maybe_unused]] const auto input = RenderPipelineBuilderInternal::ReadFirstValidVersionedInputForPass(
@@ -42,6 +44,13 @@ namespace OloEngine
         {
             m_SelectedSceneDepthTexture = blackboard.Scene.SceneDepth;
             [[maybe_unused]] const auto sceneDepthRead = builder.Read(blackboard.Scene.SceneDepth, RGReadUsage::ShaderSample);
+        }
+        // Per-pixel velocity (Deferred G-Buffer RT3 / Forward attachment 3). Optional:
+        // when absent the shader reconstructs camera-only motion for every pixel.
+        if (blackboard.GBuffer.Velocity.IsValid())
+        {
+            m_SelectedVelocityTexture = blackboard.GBuffer.Velocity;
+            [[maybe_unused]] const auto velocityRead = builder.Read(blackboard.GBuffer.Velocity, RGReadUsage::ShaderSample);
         }
         if (blackboard.Post.MotionBlurColor.IsValid())
         {
@@ -68,6 +77,7 @@ namespace OloEngine
         CreateFramebuffer(spec.Width, spec.Height);
 
         m_MotionBlurShader = Shader::Create("assets/shaders/PostProcess_MotionBlur.glsl");
+        m_MotionBlurParamsUBO = UniformBuffer::Create(MotionBlurParamsUBOData::GetSize(), ShaderBindingLayout::UBO_MOTION_BLUR_PARAMS);
 
         OLO_CORE_INFO("MotionBlurRenderPass: Initialized with viewport {}x{}", spec.Width, spec.Height);
     }
@@ -122,12 +132,23 @@ namespace OloEngine
             return;
         }
 
+        const u32 velocityTextureID = m_SelectedVelocityTexture.IsValid()
+                                          ? context.ResolveTexture(m_SelectedVelocityTexture)
+                                          : 0u;
+
         m_Target = outputFramebuffer;
 
         if (m_PostProcessUBO)
             m_PostProcessUBO->Bind();
         if (m_MotionBlurUBO)
             m_MotionBlurUBO->Bind();
+        if (m_MotionBlurParamsUBO)
+        {
+            MotionBlurParamsUBOData params;
+            params.Params.x = (velocityTextureID != 0) ? 1.0f : 0.0f;
+            m_MotionBlurParamsUBO->SetData(&params, MotionBlurParamsUBOData::GetSize());
+            m_MotionBlurParamsUBO->Bind();
+        }
 
         outputFramebuffer->Bind();
 
@@ -152,6 +173,11 @@ namespace OloEngine
 
         context.BindTexture(0, inputColorTextureID);
         m_MotionBlurShader->SetInt("u_Texture", 0);
+
+        // Velocity slot mirrors TAA (slot 2 = u_Velocity). Bound even when 0
+        // (the params UBO's hasVelocity flag gates whether the shader reads it).
+        context.BindTexture(2, velocityTextureID);
+        m_MotionBlurShader->SetInt("u_Velocity", 2);
 
         context.BindTexture(ShaderBindingLayout::TEX_POSTPROCESS_DEPTH, sceneDepthTextureID);
         m_MotionBlurShader->SetInt("u_DepthTexture", ShaderBindingLayout::TEX_POSTPROCESS_DEPTH);
@@ -184,5 +210,6 @@ namespace OloEngine
     {
         m_Target = nullptr;
         m_SelectedSceneDepthTexture = {};
+        m_SelectedVelocityTexture = {};
     }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.h
+++ b/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.h
@@ -61,7 +61,8 @@ namespace OloEngine
 
         [[nodiscard]] bool IsReadyForExecution() const noexcept override
         {
-            return m_MotionBlurShader && m_MotionBlurShader->IsReady() && m_MotionBlurUBO && m_MotionBlurParamsUBO;
+            return m_MotionBlurShader && m_MotionBlurShader->IsReady() &&
+                   m_MotionBlurUBO && m_PostProcessUBO && m_MotionBlurParamsUBO;
         }
 
       private:

--- a/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.h
+++ b/OloEngine/src/OloEngine/Renderer/Passes/MotionBlurRenderPass.h
@@ -61,7 +61,7 @@ namespace OloEngine
 
         [[nodiscard]] bool IsReadyForExecution() const noexcept override
         {
-            return m_MotionBlurShader && m_MotionBlurShader->IsReady() && m_MotionBlurUBO;
+            return m_MotionBlurShader && m_MotionBlurShader->IsReady() && m_MotionBlurUBO && m_MotionBlurParamsUBO;
         }
 
       private:
@@ -73,6 +73,11 @@ namespace OloEngine
         Ref<Shader> m_MotionBlurShader;
         Ref<UniformBuffer> m_MotionBlurUBO;
         Ref<UniformBuffer> m_PostProcessUBO;
+        // Pass-owned UBO (binding 42) carrying the per-pass hasVelocity flag.
+        Ref<UniformBuffer> m_MotionBlurParamsUBO;
         RGTextureHandle m_SelectedSceneDepthTexture{};
+        // Per-pixel velocity buffer (G-Buffer RT3 / Forward attachment 3);
+        // 0/invalid → shader uses camera-only reconstruction for every pixel.
+        RGTextureHandle m_SelectedVelocityTexture{};
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/PostProcessSettings.h
+++ b/OloEngine/src/OloEngine/Renderer/PostProcessSettings.h
@@ -337,6 +337,22 @@ namespace OloEngine
         }
     };
 
+    // GPU-side UBO layout for motion-blur per-pass flags (std140, binding 42).
+    // Set by MotionBlurRenderPass each frame from whether a per-pixel velocity
+    // texture resolved for this path. x = hasVelocityTexture (0/1): when 1 the
+    // shader reads full camera+object motion from the velocity buffer on
+    // geometry pixels; when 0 every pixel falls back to camera-only
+    // reconstruction from depth.
+    struct MotionBlurParamsUBOData
+    {
+        glm::vec4 Params = glm::vec4(0.0f); // x = hasVelocityTexture, yzw reserved
+
+        static constexpr u32 GetSize()
+        {
+            return sizeof(MotionBlurParamsUBOData);
+        }
+    };
+
     // GPU-side UBO layout for TAA (std140, binding 32)
     struct TAAUBOData
     {

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -649,6 +649,7 @@ namespace OloEngine
         static constexpr u32 UBO_STAR_NEST_SKY = 39;        // Star Nest raymarched nebula sky parameters (StarNestSkyUBO, 4 vec4)
         static constexpr u32 UBO_SSGI = 40;                 // Screen-space global illumination parameters (camera matrices + hemisphere ray-march settings)
         static constexpr u32 UBO_CONTACT_SHADOW = 41;       // Screen-space contact shadows parameters (camera matrices + toward-light dir + ray-march settings)
+        static constexpr u32 UBO_MOTION_BLUR_PARAMS = 42;   // Motion-blur per-pass flags (hasVelocity gate: per-pixel velocity vs camera-only reconstruction)
 
         // =============================================================================
         // TEXTURE SAMPLER BINDINGS
@@ -889,6 +890,8 @@ namespace OloEngine
                     return name.contains("SSGI") || name.contains("ssgi");
                 case UBO_CONTACT_SHADOW:
                     return name.contains("ContactShadow") || name.contains("contactShadow");
+                case UBO_MOTION_BLUR_PARAMS:
+                    return name.contains("MotionBlur") || name.contains("motionBlur");
                 default:
                     return false;
             }

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(OloEngine-Tests
 		Rendering/SSAOMathTest.cpp
 		Rendering/BloomMathTest.cpp
 		Rendering/FogMathTest.cpp
+		Rendering/MotionVectorMathTest.cpp
 		Rendering/SSRHiZTraversalTest.cpp
 		Rendering/RenderGraphFingerprintTest.cpp
 		Rendering/CommandPacketTest.cpp

--- a/OloEngine/tests/Rendering/MotionVectorMathTest.cpp
+++ b/OloEngine/tests/Rendering/MotionVectorMathTest.cpp
@@ -37,6 +37,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <algorithm>
 #include <cmath>
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace) — test brevity
@@ -54,8 +55,11 @@ namespace
     {
         const glm::vec4 clipCurr = viewProjection * model * glm::vec4(localPos, 1.0f);
         const glm::vec4 clipPrev = prevViewProjection * prevModel * glm::vec4(localPos, 1.0f);
-        const glm::vec2 ndcCurr = glm::vec2(clipCurr) / clipCurr.w;
-        const glm::vec2 ndcPrev = glm::vec2(clipPrev) / clipPrev.w;
+        // Mirror the G-buffer shader's guarded divide (max(w, 1e-6)) so the
+        // contract validates the same near-zero/invalid clip-W behaviour.
+        constexpr f32 kClipWEpsilon = 1.0e-6f;
+        const glm::vec2 ndcCurr = glm::vec2(clipCurr) / std::max(clipCurr.w, kClipWEpsilon);
+        const glm::vec2 ndcPrev = glm::vec2(clipPrev) / std::max(clipPrev.w, kClipWEpsilon);
         return (ndcCurr - ndcPrev) * 0.5f;
     }
 

--- a/OloEngine/tests/Rendering/MotionVectorMathTest.cpp
+++ b/OloEngine/tests/Rendering/MotionVectorMathTest.cpp
@@ -1,0 +1,147 @@
+// OLO_TEST_LAYER: shaderpipe
+// =============================================================================
+// MotionVectorMathTest.cpp
+//
+// CPU contract tests for the per-object screen-space velocity (motion vector)
+// math implemented in the deferred / forward G-Buffer shaders
+// (PBR_GBuffer.glsl, PBR_GBuffer_Skinned.glsl, PBR_MultiLight.glsl). These pin
+// the formula WITHOUT a GL context (headless CI), mirroring the *MathTest.cpp
+// style of ScreenSpaceReflectionMathTest / ContactShadowMathTest.
+//
+// The shaders compute, per vertex/fragment:
+//     ndcCurr  = (u_ViewProjection     * u_Model     * pos).xy / w
+//     ndcPrev  = (u_PrevViewProjection * u_PrevModel * pos).xy / w
+//     velocity = (ndcCurr - ndcPrev) * 0.5            // → UV-space delta
+//
+// The 0.5 converts the [-2,2] NDC difference into the [0,1] UV delta that TAA
+// and motion blur consume as `prevUV = uv - velocity`. So velocity is exactly
+// `uvCurr - uvPrev`: it points from where the surface WAS to where it is now.
+//
+// What this file proves (sign + magnitude, the two failure modes that silently
+// break TAA reprojection and motion-blur direction):
+//   * A perfectly static object under a static camera produces zero velocity.
+//   * An object translating +X (world) under a static camera produces +X
+//     screen velocity (and ~0 in Y).
+//   * A static object under a camera panning +X produces -X screen velocity
+//     (the world appears to slide left) — the opposite sign of object motion.
+//   * Velocity magnitude scales ~linearly with object displacement.
+//
+// Complementary GPU coverage (PostProcessPropertyTests.cpp) proves the motion
+// blur shader actually consumes this buffer and smears along the velocity
+// vector; this file proves the buffer's contents are correct in the first place.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <cmath>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test brevity
+
+namespace
+{
+    // Mirror of the velocity computation in the G-Buffer shaders. `localPos` is
+    // the object-space vertex position; the model matrices place it in the world
+    // and the view-projection matrices project current vs previous frame.
+    glm::vec2 ComputeMotionVector(const glm::mat4& viewProjection,
+                                  const glm::mat4& model,
+                                  const glm::mat4& prevViewProjection,
+                                  const glm::mat4& prevModel,
+                                  const glm::vec3& localPos)
+    {
+        const glm::vec4 clipCurr = viewProjection * model * glm::vec4(localPos, 1.0f);
+        const glm::vec4 clipPrev = prevViewProjection * prevModel * glm::vec4(localPos, 1.0f);
+        const glm::vec2 ndcCurr = glm::vec2(clipCurr) / clipCurr.w;
+        const glm::vec2 ndcPrev = glm::vec2(clipPrev) / clipPrev.w;
+        return (ndcCurr - ndcPrev) * 0.5f;
+    }
+
+    // A camera at `eye` looking down -Z (world +X maps to screen +X, +Y up).
+    glm::mat4 MakeViewProjection(const glm::vec3& eye)
+    {
+        const glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.0f, 0.1f, 100.0f);
+        const glm::mat4 view = glm::lookAt(eye, eye + glm::vec3(0.0f, 0.0f, -1.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+        return proj * view;
+    }
+} // namespace
+
+// A stationary object viewed by a stationary camera must produce exactly zero
+// motion — otherwise TAA reprojects history off the static surface (ghosting)
+// and motion blur smears a still frame.
+TEST(MotionVectorMath, StaticObjectStaticCameraIsZero)
+{
+    const glm::mat4 vp = MakeViewProjection(glm::vec3(0.0f));
+    const glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -5.0f));
+
+    const glm::vec2 velocity = ComputeMotionVector(vp, model, vp, model, glm::vec3(0.0f));
+
+    EXPECT_NEAR(velocity.x, 0.0f, 1e-6f);
+    EXPECT_NEAR(velocity.y, 0.0f, 1e-6f);
+}
+
+// An object translating +X in world space (static camera) moves rightward on
+// screen, so the velocity's X component is positive and Y is ~zero.
+TEST(MotionVectorMath, ObjectMovingRightYieldsPositiveXVelocity)
+{
+    const glm::mat4 vp = MakeViewProjection(glm::vec3(0.0f));
+    const glm::mat4 prevModel = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -5.0f));
+    const glm::mat4 currModel = glm::translate(glm::mat4(1.0f), glm::vec3(0.1f, 0.0f, -5.0f));
+
+    const glm::vec2 velocity = ComputeMotionVector(vp, currModel, vp, prevModel, glm::vec3(0.0f));
+
+    EXPECT_GT(velocity.x, 1e-4f) << "object moving +X should give +X screen velocity";
+    EXPECT_NEAR(velocity.y, 0.0f, 1e-5f) << "pure horizontal motion has no vertical velocity";
+}
+
+// A static object viewed by a camera panning +X appears to slide left, so the
+// velocity's X component is negative — the opposite sign of object motion. This
+// is the case camera-only reprojection already handled; the per-object buffer
+// must reproduce it for stationary geometry.
+TEST(MotionVectorMath, CameraPanningRightYieldsNegativeXVelocity)
+{
+    const glm::mat4 prevVP = MakeViewProjection(glm::vec3(0.0f));
+    const glm::mat4 currVP = MakeViewProjection(glm::vec3(0.1f, 0.0f, 0.0f));
+    const glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -5.0f));
+
+    const glm::vec2 velocity = ComputeMotionVector(currVP, model, prevVP, model, glm::vec3(0.0f));
+
+    EXPECT_LT(velocity.x, -1e-4f) << "camera panning +X makes the static world slide -X on screen";
+    EXPECT_NEAR(velocity.y, 0.0f, 1e-5f);
+}
+
+// Object and camera motion of equal-and-opposite world displacement cancel:
+// tracking the object with the camera leaves it stationary on screen.
+TEST(MotionVectorMath, ObjectAndCameraMovingTogetherCancel)
+{
+    const glm::mat4 prevVP = MakeViewProjection(glm::vec3(0.0f));
+    const glm::mat4 currVP = MakeViewProjection(glm::vec3(0.1f, 0.0f, 0.0f));
+    const glm::mat4 prevModel = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -5.0f));
+    const glm::mat4 currModel = glm::translate(glm::mat4(1.0f), glm::vec3(0.1f, 0.0f, -5.0f));
+
+    const glm::vec2 velocity = ComputeMotionVector(currVP, currModel, prevVP, prevModel, glm::vec3(0.0f));
+
+    // The object sits at the same screen position both frames (camera follows
+    // it exactly), so the residual velocity is negligible.
+    EXPECT_NEAR(velocity.x, 0.0f, 1e-4f);
+    EXPECT_NEAR(velocity.y, 0.0f, 1e-4f);
+}
+
+// Velocity magnitude scales ~linearly with object displacement for small steps
+// (constant w at fixed depth), so doubling the move roughly doubles velocity.
+TEST(MotionVectorMath, VelocityScalesWithDisplacement)
+{
+    const glm::mat4 vp = MakeViewProjection(glm::vec3(0.0f));
+    const glm::mat4 prevModel = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -5.0f));
+    const glm::mat4 model1 = glm::translate(glm::mat4(1.0f), glm::vec3(0.05f, 0.0f, -5.0f));
+    const glm::mat4 model2 = glm::translate(glm::mat4(1.0f), glm::vec3(0.10f, 0.0f, -5.0f));
+
+    const f32 v1 = ComputeMotionVector(vp, model1, vp, prevModel, glm::vec3(0.0f)).x;
+    const f32 v2 = ComputeMotionVector(vp, model2, vp, prevModel, glm::vec3(0.0f)).x;
+
+    EXPECT_GT(v1, 0.0f);
+    EXPECT_GT(v2, v1) << "larger displacement → larger velocity";
+    EXPECT_NEAR(v2 / v1, 2.0f, 0.02f) << "doubling the world displacement should ~double the velocity";
+}

--- a/OloEngine/tests/Rendering/PropertyTests/PostProcessPropertyTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PostProcessPropertyTests.cpp
@@ -38,7 +38,10 @@
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/PostProcessSettings.h"
 #include "OloEngine/Renderer/Shader.h"
+#include "OloEngine/Renderer/ShaderBindingLayout.h"
 #include "OloEngine/Renderer/UniformBuffer.h"
+
+#include <glm/glm.hpp>
 
 #include <cmath>
 #include <vector>
@@ -74,6 +77,35 @@ namespace OloEngine::Tests
             ubo.TexelSizeX = ubo.InverseScreenWidth;
             ubo.TexelSizeY = ubo.InverseScreenHeight;
             return ubo;
+        }
+
+        // Holds the motion-blur auxiliary UBOs alive for the duration of a draw.
+        // PostProcess_MotionBlur reads binding 8 (camera matrices, for the
+        // camera-only fallback) and binding 42 (the hasVelocity flag). Both must
+        // be bound or the shader reads undefined UBO memory.
+        struct MotionBlurAuxUBOs
+        {
+            Ref<UniformBuffer> Matrices;
+            Ref<UniformBuffer> Params;
+        };
+
+        MotionBlurAuxUBOs BindMotionBlurAuxUBOs(bool hasVelocity,
+                                                const glm::mat4& inverseViewProjection = glm::mat4(1.0f),
+                                                const glm::mat4& prevViewProjection = glm::mat4(1.0f))
+        {
+            MotionBlurUBOData matricesData{};
+            matricesData.InverseViewProjection = inverseViewProjection;
+            matricesData.PrevViewProjection = prevViewProjection;
+            Ref<UniformBuffer> matrices = UniformBuffer::Create(MotionBlurUBOData::GetSize(), ShaderBindingLayout::UBO_USER_1);
+            matrices->SetData(&matricesData, MotionBlurUBOData::GetSize());
+
+            MotionBlurParamsUBOData paramsData{};
+            paramsData.Params.x = hasVelocity ? 1.0f : 0.0f;
+            Ref<UniformBuffer> params =
+                UniformBuffer::Create(MotionBlurParamsUBOData::GetSize(), ShaderBindingLayout::UBO_MOTION_BLUR_PARAMS);
+            params->SetData(&paramsData, MotionBlurParamsUBOData::GetSize());
+
+            return { matrices, params };
         }
 
         // Common setup: input texture + output framebuffer + UBO binding 7 +
@@ -577,11 +609,10 @@ namespace OloEngine::Tests
         const u32 depthTex = CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f);
         ::glBindTextureUnit(19, static_cast<GLuint>(depthTex));
 
-        // MotionBlur UBO at binding 8: identity matrices.
-        MotionBlurUBOData mbUbo{};
-        // (default-initialized matrices are already identity)
-        Ref<UniformBuffer> mbBuffer = UniformBuffer::Create(MotionBlurUBOData::GetSize(), 8);
-        mbBuffer->SetData(&mbUbo, MotionBlurUBOData::GetSize());
+        // MotionBlur UBO (binding 8, identity matrices) + params UBO (binding 42,
+        // hasVelocity = 0). With no velocity buffer the shader reconstructs
+        // camera-only motion, and identity matrices make that zero everywhere.
+        [[maybe_unused]] auto aux = BindMotionBlurAuxUBOs(/*hasVelocity*/ false);
 
         harness.Draw();
 
@@ -598,6 +629,133 @@ namespace OloEngine::Tests
             EXPECT_NEAR(static_cast<int>(rgba[i * 4 + 1]), static_cast<int>(expected), 2);
             EXPECT_NEAR(static_cast<int>(rgba[i * 4 + 2]), static_cast<int>(expected), 2);
         }
+    }
+
+    // =========================================================================
+    // Motion blur — per-pixel velocity path (the feature this PR wires up).
+    //
+    // With hasVelocity = 1 the shader reads the per-object velocity buffer
+    // (slot 2) on geometry pixels (depth < 1) instead of reconstructing
+    // camera-only motion from depth. A zero velocity buffer must therefore
+    // still reduce to an identity pass — proving the new sampling path does not
+    // introduce spurious blur on stationary geometry.
+    //
+    // Catches: a wrong sign/scale on the velocity sample, or the geometry
+    // branch firing with a non-zero default when the buffer reads zero.
+    // =========================================================================
+    TEST(MotionBlurVelocityTest, ZeroVelocityBufferIsIdentity)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        constexpr u32 kSize = 32;
+        PostProcessUBOData ubo = MakeDefaultPostProcessUBO(kSize, kSize);
+        ubo.MotionBlurStrength = 1.0f;
+        ubo.MotionBlurSamples = 8;
+
+        PostProcessHarness harness(kSize, kSize, "assets/shaders/PostProcess_MotionBlur.glsl", ubo);
+        harness.SetInputTexture(CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f));
+
+        // Depth < 1 everywhere → the geometry branch reads the velocity buffer.
+        const u32 depthTex = CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f);
+        ::glBindTextureUnit(19, static_cast<GLuint>(depthTex));
+        // Velocity buffer (slot 2) holds zero motion for every pixel.
+        const u32 velTex = CreateUniformFloatTexture2D(kSize, kSize, 0.0f, 0.0f, 0.0f, 0.0f);
+        ::glBindTextureUnit(2, static_cast<GLuint>(velTex));
+
+        [[maybe_unused]] auto aux = BindMotionBlurAuxUBOs(/*hasVelocity*/ true);
+
+        harness.Draw();
+
+        std::vector<u8> rgba;
+        harness.ReadOutputRgba8(rgba);
+        ::glDeleteTextures(1, &depthTex);
+        ::glDeleteTextures(1, &velTex);
+
+        const u8 expected = static_cast<u8>(std::lround(0.5f * 255.0f));
+        for (std::size_t i = 0; i < static_cast<std::size_t>(kSize) * kSize; ++i)
+        {
+            EXPECT_NEAR(static_cast<int>(rgba[i * 4 + 0]), static_cast<int>(expected), 2)
+                << "pixel " << i << " drifted (velocity-path blur activated at zero velocity)";
+            EXPECT_NEAR(static_cast<int>(rgba[i * 4 + 1]), static_cast<int>(expected), 2);
+            EXPECT_NEAR(static_cast<int>(rgba[i * 4 + 2]), static_cast<int>(expected), 2);
+        }
+    }
+
+    // The blur must follow the per-pixel velocity *vector*, not just its
+    // magnitude. Feed a vertical white→black edge and the same velocity
+    // magnitude in two directions: a horizontal velocity bleeds the edge
+    // sideways into the black region, while a vertical velocity leaves a
+    // vertical edge untouched (it is invariant under vertical smearing). This
+    // is the core behaviour the PR adds — motion blur consuming the per-object
+    // velocity buffer rather than camera-only depth reprojection.
+    TEST(MotionBlurVelocityTest, VelocityDirectionDrivesBlur)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        constexpr u32 kSize = 32;
+        PostProcessUBOData ubo = MakeDefaultPostProcessUBO(kSize, kSize);
+        ubo.MotionBlurStrength = 1.0f;
+        ubo.MotionBlurSamples = 16;
+
+        PostProcessHarness harness(kSize, kSize, "assets/shaders/PostProcess_MotionBlur.glsl", ubo);
+
+        // Input: left half white, right half black, full height → a vertical edge
+        // at the x = kSize/2 boundary.
+        std::vector<f32> edge(static_cast<std::size_t>(kSize) * kSize * 4, 0.0f);
+        for (u32 y = 0; y < kSize; ++y)
+        {
+            for (u32 x = 0; x < kSize; ++x)
+            {
+                const f32 v = (x < kSize / 2) ? 1.0f : 0.0f;
+                const std::size_t i = (static_cast<std::size_t>(y) * kSize + x) * 4;
+                edge[i + 0] = v;
+                edge[i + 1] = v;
+                edge[i + 2] = v;
+                edge[i + 3] = 1.0f;
+            }
+        }
+        harness.SetInputTexture(CreateFloatTexture2D(kSize, kSize, edge.data()));
+
+        const u32 depthTex = CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f);
+        ::glBindTextureUnit(19, static_cast<GLuint>(depthTex));
+
+        [[maybe_unused]] auto aux = BindMotionBlurAuxUBOs(/*hasVelocity*/ true);
+
+        const auto sampleR = [kSize](const std::vector<u8>& px, u32 x, u32 y)
+        {
+            return static_cast<int>(px[(static_cast<std::size_t>(y) * kSize + x) * 4 + 0]);
+        };
+
+        // Horizontal velocity (0.25 UV ≈ 8 px) — smears the edge left↔right.
+        const u32 horizontalVel = CreateUniformFloatTexture2D(kSize, kSize, 0.25f, 0.0f, 0.0f, 0.0f);
+        ::glBindTextureUnit(2, static_cast<GLuint>(horizontalVel));
+        harness.Draw();
+        std::vector<u8> horizontal;
+        harness.ReadOutputRgba8(horizontal);
+
+        // Same magnitude, vertical — a vertical edge is invariant under it.
+        const u32 verticalVel = CreateUniformFloatTexture2D(kSize, kSize, 0.0f, 0.25f, 0.0f, 0.0f);
+        ::glBindTextureUnit(2, static_cast<GLuint>(verticalVel));
+        harness.Draw();
+        std::vector<u8> vertical;
+        harness.ReadOutputRgba8(vertical);
+
+        ::glDeleteTextures(1, &depthTex);
+        ::glDeleteTextures(1, &horizontalVel);
+        ::glDeleteTextures(1, &verticalVel);
+
+        const u32 row = kSize / 2;
+        // Column 18 sits in the black region but within horizontal blur reach of
+        // the edge at column 16 → horizontal blur bleeds white in; vertical cannot.
+        EXPECT_GT(sampleR(horizontal, 18, row), 25)
+            << "horizontal velocity should smear the vertical edge rightward into the black region";
+        EXPECT_LT(sampleR(vertical, 18, row), 15)
+            << "vertical velocity must not smear a vertical edge horizontally";
+        // Deep white / deep black regions stay put under either direction.
+        EXPECT_GT(sampleR(horizontal, 4, row), 230);
+        EXPECT_GT(sampleR(vertical, 4, row), 230);
+        EXPECT_LT(sampleR(horizontal, 28, row), 15);
+        EXPECT_LT(sampleR(vertical, 28, row), 15);
     }
 
     // =========================================================================

--- a/OloEngine/tests/Rendering/PropertyTests/PostProcessPropertyTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PostProcessPropertyTests.cpp
@@ -657,7 +657,7 @@ namespace OloEngine::Tests
 
         // Depth < 1 everywhere → the geometry branch reads the velocity buffer.
         const u32 depthTex = CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f);
-        ::glBindTextureUnit(19, static_cast<GLuint>(depthTex));
+        ::glBindTextureUnit(ShaderBindingLayout::TEX_POSTPROCESS_DEPTH, static_cast<GLuint>(depthTex));
         // Velocity buffer (slot 2) holds zero motion for every pixel.
         const u32 velTex = CreateUniformFloatTexture2D(kSize, kSize, 0.0f, 0.0f, 0.0f, 0.0f);
         ::glBindTextureUnit(2, static_cast<GLuint>(velTex));
@@ -717,7 +717,7 @@ namespace OloEngine::Tests
         harness.SetInputTexture(CreateFloatTexture2D(kSize, kSize, edge.data()));
 
         const u32 depthTex = CreateUniformFloatTexture2D(kSize, kSize, 0.5f, 0.5f, 0.5f, 1.0f);
-        ::glBindTextureUnit(19, static_cast<GLuint>(depthTex));
+        ::glBindTextureUnit(ShaderBindingLayout::TEX_POSTPROCESS_DEPTH, static_cast<GLuint>(depthTex));
 
         [[maybe_unused]] auto aux = BindMotionBlurAuxUBOs(/*hasVelocity*/ true);
 

--- a/docs/agent-rules/glsl-shaders.md
+++ b/docs/agent-rules/glsl-shaders.md
@@ -81,15 +81,17 @@ All UBO blocks use `layout(std140, binding = N)`. Block names and members follow
 
 ## 4. MRT output (forward pass)
 
-All forward-rendered geometry outputs **three render targets**:
+All forward-rendered geometry outputs **four render targets**:
 
 ```glsl
 layout(location = 0) out vec4 o_Color;       // RGBA16F — final shaded color
 layout(location = 1) out int  o_EntityID;    // R32I   — entity ID for editor picking
 layout(location = 2) out vec2 o_ViewNormal;  // RG16F  — octahedral view-space normal (SSAO input)
+layout(location = 3) out vec2 o_Velocity;    // RG16F  — screen-space motion vector (TAA / motion blur)
 ```
 
 Omitting `o_EntityID` breaks editor selection. Omitting `o_ViewNormal` breaks SSAO.
+Omitting `o_Velocity` ghosts moving objects under TAA and drops per-object motion blur.
 
 Octahedral encoding for normals:
 
@@ -102,6 +104,47 @@ vec2 octEncode(vec3 n)
     return n.xy * 0.5 + 0.5;
 }
 ```
+
+---
+
+## 4a. Motion vectors / velocity buffer (G-Buffer RT3 / forward attachment 3)
+
+Per-object screen-space velocity is written by every opaque geometry shader
+(`PBR_GBuffer*.glsl` deferred, `PBR_MultiLight*.glsl` forward) and consumed by
+TAA (`PostProcess_TAA.glsl`) and motion blur (`PostProcess_MotionBlur.glsl`).
+
+Convention — the velocity stored is a **UV-space delta**, current minus previous:
+
+```glsl
+vec2 ndcCurr = v_ClipPosCurr.xy / v_ClipPosCurr.w;   // u_ViewProjection     * u_Model     * pos
+vec2 ndcPrev = v_ClipPosPrev.xy / v_ClipPosPrev.w;   // u_PrevViewProjection * u_PrevModel * pos
+o_Velocity   = (ndcCurr - ndcPrev) * 0.5;            // = uvCurr - uvPrev  → consumers do prevUV = uv - velocity
+```
+
+Per-frame previous data comes from the renderer: `u_PrevModel` (per-entity
+prev transform, `ModelMatrices` tail), `u_PrevViewProjection` (`MotionBlurMatrices`,
+binding 8), and `u_PrevBoneTransforms` (`PrevBoneMatrices`, binding 31) for skinned
+meshes. All alias their current value on the first frame, so velocity is zero for
+newly-spawned geometry — never undefined.
+
+Three gotchas for any **consumer** of this buffer:
+
+- **It is geometry-only.** Background / sky pixels are never written, so they keep
+  the buffer's clear value (zero). A consumer that wants *camera* motion on the
+  background (e.g. motion blur streaking the sky as the camera turns) must
+  depth-gate: where `depth == 1.0` (far plane), fall back to camera-only
+  reconstruction (`InverseViewProjection` + `PrevViewProjection` from binding 8)
+  instead of sampling the velocity buffer.
+- **It carries TAA jitter.** Both `u_ViewProjection` and `u_PrevViewProjection`
+  bake in their frame's Halton jitter (so TAA history reprojection stays
+  self-consistent). Consumers inherit a sub-pixel (~1 px) jitter velocity on
+  static geometry — harmless for motion blur, deliberately kept for TAA; don't
+  "unjitter" it in one consumer without accounting for the other.
+- **Gate optional velocity with a flag, don't assume it exists.** Forward and
+  deferred both produce it today, but pass a `hasVelocity` flag (TAA's
+  `TAAParams`, motion blur's `MotionBlurParams` at binding 42) so a path without
+  a velocity buffer degrades to camera-only reconstruction rather than reading an
+  unbound sampler.
 
 ---
 


### PR DESCRIPTION
## What

Wire the renderer's **per-object velocity (motion-vector) buffer** into **motion blur**.

Most of the per-object motion-vector pipeline already shipped on `master`: the deferred G-Buffer writes a per-pixel velocity RT (RT3, `RG16F`) for static *and* skinned meshes, the forward path writes the same into scene attachment 3, the renderer caches per-entity previous-model matrices + previous view-projection + previous bone matrices, jitter is handled, and **TAA already consumes the velocity buffer**.

The one remaining gap was **motion blur**: it reconstructed *camera-only* motion from depth + inverse-VP and ignored the per-pixel velocity buffer, so moving/animated objects only got approximate (camera-induced) blur. This PR closes that gap.

## How

- **`PostProcess_MotionBlur.glsl`** — sample the per-pixel velocity buffer (slot 2, `u_Velocity`) on geometry pixels, which already encodes full camera + object motion. Background/sky pixels (depth == far) are never written into the velocity buffer, so they keep a **depth-gated camera-only reconstruction** — the sky still streaks under camera motion, no regression. A `hasVelocity` flag falls the whole frame back to camera-only when no velocity buffer exists.
- **`MotionBlurRenderPass`** — select/`Read` `blackboard.GBuffer.Velocity`, bind it at slot 2, and upload the `hasVelocity` flag through a small pass-owned UBO. This mirrors `TAARenderPass` exactly.
- **`UBO_MOTION_BLUR_PARAMS = 42`** + `MotionBlurParamsUBOData` carry that flag (the GLSL "no bare non-opaque uniforms" rule requires a UBO). Slot 2 was already reserved in `ShaderBindingLayout` "for TAA / motion-blur passes".

Path-agnostic: motion blur reads the same `GBuffer.Velocity` handle whether deferred (RT3) or forward (attachment 3).

## Tests

- **CPU contract** (`MotionVectorMathTest.cpp`, 5 tests, headless): velocity = `(ndcCurr − ndcPrev)·0.5` sign/magnitude — static→zero, object +X→+X velocity, camera-pan +X→−X velocity, object+camera cancel, linear scaling.
- **GPU property** (`PostProcessPropertyTests.cpp`, renders the real shader + reads pixels back): zero-velocity → identity, and **`VelocityDirectionDrivesBlur`** — horizontal velocity smears a vertical edge sideways while vertical velocity leaves it sharp (proves the blur follows the velocity *vector*).
- Full suite: **3614 pass / 4 skip**. The one failure, `FogVisualEvidenceTest.DistantGeometryFogsNearStaysClear`, is a **pre-existing, deterministic test-ordering GL-state contamination** unrelated to this change: it fails identically *with and without* the new tests, passes in isolation, predates this branch's base, and the failure is "fog not applied" (nothing to do with motion vectors).

## Verification

Math pinned by CPU/contract tests; the velocity-consumption behaviour proven by GPU pixel-readback tests; live editor over MCP shows **0 shader errors** and a populated `Velocity` render target with correct per-pixel motion vectors under camera motion (geometry colored, background black — confirming the geometry-only behaviour the depth-gate handles). Docs lesson added in `docs/agent-rules/glsl-shaders.md` §4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-pixel motion blur support using velocity information for more accurate blur on moving objects.
  * Expanded renderer output to include motion vectors, improving motion blur and temporal stability.

* **Bug Fixes**
  * Reduced ghosting and incorrect blur when velocity data is unavailable or zeroed.
  * Improved blur direction handling so motion follows object movement more naturally.

* **Tests**
  * Added coverage for motion-vector calculations and motion blur behavior across static, moving, and mixed-motion cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->