### PR TITLE
feat(cinematic): reverse playback (negative PlaybackSpeed)

### DIFF
--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -4309,7 +4309,7 @@ namespace OloEngine
             ImGui::Checkbox("Play On Start##Cinematic", &component.PlayOnStart);
             ImGui::SameLine();
             ImGui::Checkbox("Loop##Cinematic", &component.Loop);
-            ImGui::DragFloat("Speed##Cinematic", &component.PlaybackSpeed, 0.05f, 0.0f, 16.0f);
+            ImGui::DragFloat("Speed##Cinematic", &component.PlaybackSpeed, 0.05f, -16.0f, 16.0f); // negative = reverse, 0 = hold
 
             // Resolve for preview without committing to RuntimeSequence.
             Ref<CinematicSequence> seq = component.RuntimeSequence;

--- a/OloEngine/src/OloEngine/Cinematic/CinematicComponent.h
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicComponent.h
@@ -33,7 +33,7 @@ namespace OloEngine
         bool Loop = false; ///< restart from 0 when the playhead reaches the end
 
         OLO_PROPERTY()
-        f32 PlaybackSpeed = 1.0f; ///< time scale (>= 0; reverse playback is future work)
+        f32 PlaybackSpeed = 1.0f; ///< time scale; negative plays the sequence backward, 0 holds the playhead
 
         // ----- Runtime state (never serialized) -----
         /// Resolved sequence. Set directly for code/tests, or lazily loaded

--- a/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
@@ -69,15 +69,12 @@ namespace OloEngine::CinematicPlayer
 
             if (loop)
             {
-                // Wrap into (0, duration]. fmod keeps the sign of `raw` (<= 0),
-                // so the result lands in (-duration, 0]; shifting up by duration
-                // mirrors the forward wrap and maps an exact landing on 0 to
+                // Wrap into (0, duration]. fmod of a non-positive `raw` against a
+                // positive `duration` always lands in (-duration, 0], so the
+                // unconditional shift up by duration maps it into (0, duration] —
+                // mirroring the forward wrap and mapping an exact landing on 0 to
                 // `duration` (the start of a backward lap).
-                f32 wrapped = std::fmod(raw, duration);
-                if (wrapped <= 0.0f)
-                {
-                    wrapped += duration;
-                }
+                const f32 wrapped = std::fmod(raw, duration) + duration;
                 result.NewTime = wrapped;
                 result.Looped = true;
                 // Full laps crossed this step (>=1). floor(-raw/duration)+1

--- a/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
@@ -15,6 +15,17 @@ namespace OloEngine::CinematicPlayer
 
         AdvanceResult result;
 
+        // Non-finite inputs (a corrupt key time feeding `duration`, a NaN `dt`,
+        // etc.) must never reach std::fmod or the lap-count cast below — both
+        // produce NaN / undefined behaviour. Hold the playhead at the last good
+        // value instead (no movement, no finish). speed is already finite-guarded
+        // on every external write path, but this keeps the pure function total.
+        if (!std::isfinite(fromTime) || !std::isfinite(dt) || !std::isfinite(speed) || !std::isfinite(duration))
+        {
+            result.NewTime = std::isfinite(fromTime) ? fromTime : 0.0f;
+            return result;
+        }
+
         if (duration <= 0.0f)
         {
             // Nothing to play — finish immediately and pin to the start.
@@ -90,7 +101,8 @@ namespace OloEngine::CinematicPlayer
             return result;
         }
 
-        // speed == 0 (or NaN): hold the playhead — no movement, no finish.
+        // speed == 0: hold the playhead — no movement, no finish. (NaN speed was
+        // already handled by the finite guard above.)
         result.NewTime = fromTime;
         return result;
     }

--- a/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.cpp
@@ -23,34 +23,78 @@ namespace OloEngine::CinematicPlayer
             return result;
         }
 
-        const f32 effectiveSpeed = (speed > 0.0f) ? speed : 0.0f;
-        const f32 raw = fromTime + dt * effectiveSpeed;
+        const f32 raw = fromTime + dt * speed;
 
-        if (raw < duration)
+        if (speed > 0.0f)
         {
-            result.NewTime = raw;
-            return result;
-        }
-
-        if (loop)
-        {
-            // Wrap into [0, duration). fmod(duration, duration) == 0, which is
-            // the intended "land exactly on the start" behaviour.
-            f32 wrapped = std::fmod(raw, duration);
-            if (wrapped < 0.0f)
+            // Forward: advance toward `duration`.
+            if (raw < duration)
             {
-                wrapped += duration;
+                result.NewTime = raw;
+                return result;
             }
-            result.NewTime = wrapped;
-            result.Looped = true;
-            // Number of full laps crossed this step (>=1). >1 when a single dt
-            // spans the whole timeline more than once (e.g. a frame hitch).
-            result.LoopCount = static_cast<u32>(raw / duration);
+
+            if (loop)
+            {
+                // Wrap into [0, duration). fmod(duration, duration) == 0, which is
+                // the intended "land exactly on the start" behaviour.
+                f32 wrapped = std::fmod(raw, duration);
+                if (wrapped < 0.0f)
+                {
+                    wrapped += duration;
+                }
+                result.NewTime = wrapped;
+                result.Looped = true;
+                // Number of full laps crossed this step (>=1). >1 when a single dt
+                // spans the whole timeline more than once (e.g. a frame hitch).
+                result.LoopCount = static_cast<u32>(raw / duration);
+                return result;
+            }
+
+            result.NewTime = duration;
+            result.JustFinished = true;
             return result;
         }
 
-        result.NewTime = duration;
-        result.JustFinished = true;
+        if (speed < 0.0f)
+        {
+            // Reverse: advance toward 0. Mirror of the forward branch — the
+            // playhead decreases, finishes at 0 (non-looping), and wraps
+            // 0 -> duration when looping.
+            if (raw > 0.0f)
+            {
+                result.NewTime = raw;
+                return result;
+            }
+
+            if (loop)
+            {
+                // Wrap into (0, duration]. fmod keeps the sign of `raw` (<= 0),
+                // so the result lands in (-duration, 0]; shifting up by duration
+                // mirrors the forward wrap and maps an exact landing on 0 to
+                // `duration` (the start of a backward lap).
+                f32 wrapped = std::fmod(raw, duration);
+                if (wrapped <= 0.0f)
+                {
+                    wrapped += duration;
+                }
+                result.NewTime = wrapped;
+                result.Looped = true;
+                // Full laps crossed this step (>=1). floor(-raw/duration)+1
+                // mirrors the forward floor(raw/duration): a single backward
+                // step that just crosses 0 is one lap, and an exact landing on
+                // a -k*duration boundary counts the lap it completes.
+                result.LoopCount = static_cast<u32>(std::floor(-raw / duration)) + 1u;
+                return result;
+            }
+
+            result.NewTime = 0.0f;
+            result.JustFinished = true;
+            return result;
+        }
+
+        // speed == 0 (or NaN): hold the playhead — no movement, no finish.
+        result.NewTime = fromTime;
         return result;
     }
 
@@ -89,6 +133,43 @@ namespace OloEngine::CinematicPlayer
         }
     }
 
+    void CollectEventsReverse(const CinematicSequence& sequence, f32 lowerInclusive, f32 upperExclusive,
+                              std::vector<std::string>& out)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (upperExclusive <= lowerInclusive)
+        {
+            return;
+        }
+
+        // Reverse mirror of CollectEvents: a backward step lands on the lower
+        // bound (inclusive) and leaves the upper bound (exclusive, already fired
+        // when the playhead last sat there), and the events fire in descending
+        // time order — the order the receding playhead crosses them.
+        std::vector<std::pair<f32, const std::string*>> hits;
+        for (const auto& track : sequence.EventTracks)
+        {
+            for (const auto& key : track.Keys)
+            {
+                if (key.Time >= lowerInclusive && key.Time < upperExclusive)
+                {
+                    hits.emplace_back(key.Time, &key.Name);
+                }
+            }
+        }
+
+        std::stable_sort(hits.begin(), hits.end(),
+                         [](const auto& a, const auto& b)
+                         { return a.first > b.first; });
+
+        out.reserve(out.size() + hits.size());
+        for (const auto& [time, name] : hits)
+        {
+            out.push_back(*name);
+        }
+    }
+
     TickResult Tick(const CinematicSequence& sequence, f32 fromTime, f32 eventFloor, f32 dt, f32 speed, bool loop)
     {
         OLO_PROFILE_FUNCTION();
@@ -105,6 +186,38 @@ namespace OloEngine::CinematicPlayer
         if (duration <= 0.0f)
         {
             return result; // no timeline to fire events along
+        }
+
+        if (speed < 0.0f)
+        {
+            // Reverse traversal: the playhead recedes, so events fire in
+            // descending time order and the half-open window flips — events
+            // land on the new (lower) playhead and leave the old (higher) one.
+            if (adv.Looped)
+            {
+                // Mirror of the forward wrap below, walked the other way: the
+                // head of the lap we're leaving (descent fromTime -> 0), every
+                // full middle lap crossed by a huge dt, then the tail of the lap
+                // we wrapped into (descent duration -> newTime). `duration + 1`
+                // as the exclusive upper bound mirrors the forward `-1` lower
+                // sentinel — it pulls the top-of-timeline event (t == duration)
+                // into the window the same way `-1` pulls in t == 0.
+                CollectEventsReverse(sequence, 0.0f, fromTime, result.FiredEvents);
+
+                constexpr u32 kMaxMiddleLaps = 64;
+                const u32 middleLaps = (adv.LoopCount > 1) ? std::min(adv.LoopCount - 1, kMaxMiddleLaps) : 0;
+                for (u32 lap = 0; lap < middleLaps; ++lap)
+                {
+                    CollectEventsReverse(sequence, 0.0f, duration + 1.0f, result.FiredEvents);
+                }
+
+                CollectEventsReverse(sequence, adv.NewTime, duration + 1.0f, result.FiredEvents);
+            }
+            else
+            {
+                CollectEventsReverse(sequence, adv.NewTime, fromTime, result.FiredEvents);
+            }
+            return result;
         }
 
         if (adv.Looped)

--- a/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.h
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicPlayer.h
@@ -24,20 +24,28 @@ namespace OloEngine
         struct AdvanceResult
         {
             f32 NewTime = 0.0f;
-            bool Looped = false;       ///< playhead wrapped past the end this step
+            bool Looped = false;       ///< playhead wrapped past an end (duration forward, 0 backward) this step
             bool JustFinished = false; ///< reached the end this step (non-looping / empty)
             u32 LoopCount = 0;         ///< full laps crossed this step (>=1 when Looped; >1 on a huge dt)
         };
 
-        /// Advance `fromTime` by `dt * max(speed, 0)`, honouring `duration` and
-        /// `loop`. Reverse playback (speed < 0) is treated as a hold for now.
-        /// A non-positive `duration` finishes immediately.
+        /// Advance `fromTime` by `dt * speed`, honouring `duration` and `loop`.
+        /// Positive speed plays forward toward `duration`; negative speed plays
+        /// backward toward 0 (mirrored finish-at-0 / wrap 0 -> duration);
+        /// zero speed holds the playhead. A non-positive `duration` finishes
+        /// immediately.
         [[nodiscard]] AdvanceResult AdvanceTime(f32 fromTime, f32 dt, f32 speed, f32 duration, bool loop) noexcept;
 
         /// Append event identifiers whose key time lies in
         /// (lowerExclusive, upperInclusive], in ascending time order.
         void CollectEvents(const CinematicSequence& sequence, f32 lowerExclusive, f32 upperInclusive,
                            std::vector<std::string>& out);
+
+        /// Reverse mirror of CollectEvents for backward playback: append event
+        /// identifiers whose key time lies in [lowerInclusive, upperExclusive),
+        /// in descending time order (the order a receding playhead crosses them).
+        void CollectEventsReverse(const CinematicSequence& sequence, f32 lowerInclusive, f32 upperExclusive,
+                                  std::vector<std::string>& out);
 
         struct TickResult
         {

--- a/OloEngine/src/OloEngine/Cinematic/CinematicSystem.cpp
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicSystem.cpp
@@ -10,6 +10,7 @@
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/Components.h"
 
+#include <cmath>
 #include <optional>
 
 namespace OloEngine
@@ -114,7 +115,9 @@ namespace OloEngine
         if (component.PlaybackSpeed < 0.0f && component.PreviousTime < 0.0f)
         {
             const f32 startDuration = sequence.GetEffectiveDuration();
-            if (startDuration > 0.0f)
+            // isfinite rejects a corrupt +Inf duration (NaN already fails > 0)
+            // so a bad asset can't poison the playhead before Tick/ApplyAtTime.
+            if (std::isfinite(startDuration) && startDuration > 0.0f)
             {
                 component.Time = startDuration;
                 component.PreviousTime = startDuration;

--- a/OloEngine/src/OloEngine/Cinematic/CinematicSystem.cpp
+++ b/OloEngine/src/OloEngine/Cinematic/CinematicSystem.cpp
@@ -100,6 +100,27 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Direction-aware start. Play() / PlayFromStart() / PlayOnStart / Stop()
+        // all leave the playhead at the forward start (Time == 0, PreviousTime
+        // == -1 sentinel) — but Time == 0 is the *finish* line for reverse, so a
+        // negative-speed run from there would JustFinish on its first step
+        // having played nothing. When a fresh sequence is set to play backward,
+        // seed it to the end so it actually plays the timeline in reverse. The
+        // sentinel (PreviousTime < 0) only holds at a fresh start; resuming after
+        // a pause keeps a real PreviousTime >= 0 and is left untouched. Set
+        // PreviousTime to `duration` (not the -1 sentinel) so the first backward
+        // step's event window is [newTime, duration) — there is no t==duration
+        // sentinel, mirroring how forward has no "fire t==0 again" on resume.
+        if (component.PlaybackSpeed < 0.0f && component.PreviousTime < 0.0f)
+        {
+            const f32 startDuration = sequence.GetEffectiveDuration();
+            if (startDuration > 0.0f)
+            {
+                component.Time = startDuration;
+                component.PreviousTime = startDuration;
+            }
+        }
+
         const CinematicPlayer::TickResult tick =
             CinematicPlayer::Tick(sequence, component.Time, component.PreviousTime, dt, component.PlaybackSpeed, component.Loop);
 

--- a/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
+++ b/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
@@ -3109,8 +3109,9 @@ namespace OloEngine
             else
             {
                 // Clamp to the inspector's authoring range so a corrupted save
-                // can't inject a negative or absurd time scale.
-                c.PlaybackSpeed = std::clamp(c.PlaybackSpeed, 0.0f, 16.0f);
+                // can't inject an absurd time scale. Negative is valid (reverse
+                // playback); the range is symmetric.
+                c.PlaybackSpeed = std::clamp(c.PlaybackSpeed, -16.0f, 16.0f);
             }
         }
     }

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -3068,8 +3068,9 @@ namespace OloEngine
             cine.Sequence = cinematicComponent["Sequence"].as<u64>(0);
             cine.PlayOnStart = cinematicComponent["PlayOnStart"].as<bool>(cine.PlayOnStart);
             cine.Loop = cinematicComponent["Loop"].as<bool>(cine.Loop);
+            // Negative is valid (reverse playback); only reject non-finite.
             if (const f32 speed = cinematicComponent["PlaybackSpeed"].as<f32>(cine.PlaybackSpeed);
-                std::isfinite(speed) && speed >= 0.0f)
+                std::isfinite(speed))
             {
                 cine.PlaybackSpeed = speed;
             }

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -2542,7 +2542,7 @@ namespace OloEngine
                                              "playOnStart", &CinematicComponent::PlayOnStart,
                                              "playbackSpeed", sol::property([](const CinematicComponent& c)
                                                                             { return c.PlaybackSpeed; }, [](CinematicComponent& c, f32 v)
-                                                                            { if (std::isfinite(v) && v >= 0.0f) c.PlaybackSpeed = v; }),
+                                                                            { if (std::isfinite(v)) c.PlaybackSpeed = v; }), // negative = reverse playback, 0 = hold
                                              "isPlaying", sol::readonly(&CinematicComponent::Playing),
                                              "time", sol::readonly(&CinematicComponent::Time),
                                              "isFinished", sol::readonly(&CinematicComponent::Finished));

--- a/OloEngine/tests/Cinematic/CinematicPlayerTest.cpp
+++ b/OloEngine/tests/Cinematic/CinematicPlayerTest.cpp
@@ -5,6 +5,9 @@
 #include "OloEngine/Cinematic/CinematicSequence.h"
 #include "OloEngine/Core/Ref.h"
 
+#include <cmath>
+#include <limits>
+
 // =============================================================================
 // CinematicPlayerTest — unit tests for the pure playback math: time advance
 // (forward / reverse / clamp-on-end / finish-at-0 / loop-wrap both directions /
@@ -103,6 +106,30 @@ TEST(CinematicPlayerTest, AdvanceTimeZeroSpeedHolds)
     EXPECT_NEAR(r.NewTime, 2.0f, kEps); // speed 0 holds the playhead — no movement
     EXPECT_FALSE(r.Looped);
     EXPECT_FALSE(r.JustFinished);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeNonFiniteInputsHoldWithoutNaN)
+{
+    const f32 nan = std::numeric_limits<f32>::quiet_NaN();
+    const f32 inf = std::numeric_limits<f32>::infinity();
+
+    // A non-finite duration / dt / speed must not reach fmod or the lap-count
+    // cast (NaN / UB). Each holds the (finite) playhead and never finishes.
+    for (const auto& bad : { CinematicPlayer::AdvanceTime(2.0f, 0.1f, 1.0f, nan, true),
+                             CinematicPlayer::AdvanceTime(2.0f, inf, 1.0f, 5.0f, true),
+                             CinematicPlayer::AdvanceTime(2.0f, 0.1f, nan, 5.0f, false),
+                             CinematicPlayer::AdvanceTime(2.0f, 0.1f, -1.0f, inf, true) })
+    {
+        EXPECT_TRUE(std::isfinite(bad.NewTime));
+        EXPECT_NEAR(bad.NewTime, 2.0f, kEps); // held at fromTime
+        EXPECT_FALSE(bad.JustFinished);
+        EXPECT_FALSE(bad.Looped);
+    }
+
+    // A non-finite fromTime can't be held meaningfully; pin to 0, still finite.
+    const auto r = CinematicPlayer::AdvanceTime(nan, 0.1f, -1.0f, 5.0f, true);
+    EXPECT_TRUE(std::isfinite(r.NewTime));
+    EXPECT_NEAR(r.NewTime, 0.0f, kEps);
 }
 
 TEST(CinematicPlayerTest, AdvanceTimeForwardBackwardSymmetry)

--- a/OloEngine/tests/Cinematic/CinematicPlayerTest.cpp
+++ b/OloEngine/tests/Cinematic/CinematicPlayerTest.cpp
@@ -7,9 +7,19 @@
 
 // =============================================================================
 // CinematicPlayerTest — unit tests for the pure playback math: time advance
-// (normal / clamp-on-end / loop-wrap / zero-duration / non-negative speed),
-// half-open event window collection, and the composite Tick (t==0 firing,
-// no double-fire, loop wrap firing tail+head). No Scene involved.
+// (forward / reverse / clamp-on-end / finish-at-0 / loop-wrap both directions /
+// zero-duration / zero-speed hold / forward-backward symmetry), half-open event
+// window collection (ascending and the reverse descending mirror), and the
+// composite Tick (t==0 firing, no double-fire, loop wrap firing tail+head
+// forward and head+tail backward). No Scene involved.
+//
+// Reverse playback (negative PlaybackSpeed) mirrors forward: the playhead
+// recedes toward 0, finishes at 0 (non-looping) / wraps 0 -> duration (looping),
+// and events fire in descending crossing order. The half-open window flips from
+// the forward (lowerExclusive, upperInclusive] to the reverse
+// [lowerInclusive, upperExclusive) so an event lands on the new (lower) playhead
+// and leaves the old (higher) one — preventing double-fire across a direction
+// change exactly as the forward window does between consecutive forward steps.
 // =============================================================================
 
 using namespace OloEngine;
@@ -50,11 +60,61 @@ TEST(CinematicPlayerTest, AdvanceTimeSpeedScales)
     EXPECT_NEAR(r.NewTime, 2.0f, kEps); // 1.0 + 0.5*2.0
 }
 
-TEST(CinematicPlayerTest, AdvanceTimeNegativeSpeedHolds)
+TEST(CinematicPlayerTest, AdvanceTimeNegativeSpeedStepsBackward)
 {
     const auto r = CinematicPlayer::AdvanceTime(2.0f, 0.5f, -3.0f, 10.0f, false);
-    EXPECT_NEAR(r.NewTime, 2.0f, kEps); // reverse playback treated as hold (for now)
+    EXPECT_NEAR(r.NewTime, 0.5f, kEps); // 2.0 + 0.5*(-3.0): playhead recedes
+    EXPECT_FALSE(r.Looped);
     EXPECT_FALSE(r.JustFinished);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeReverseFinishesAtZeroWhenNotLooping)
+{
+    // Step that overshoots 0 going backward clamps to 0 and finishes — the
+    // mirror of the forward clamp-at-duration.
+    const auto r = CinematicPlayer::AdvanceTime(0.1f, 0.5f, -1.0f, 5.0f, /*loop*/ false);
+    EXPECT_NEAR(r.NewTime, 0.0f, kEps);
+    EXPECT_FALSE(r.Looped);
+    EXPECT_TRUE(r.JustFinished);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeReverseWrapsWhenLooping)
+{
+    // 0.2 - 0.5 = -0.3 wraps into (0,5] as 4.7 — mirror of the forward wrap.
+    const auto r = CinematicPlayer::AdvanceTime(0.2f, 0.5f, -1.0f, 5.0f, /*loop*/ true);
+    EXPECT_NEAR(r.NewTime, 4.7f, kEps);
+    EXPECT_TRUE(r.Looped);
+    EXPECT_FALSE(r.JustFinished);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeReverseWrapLandsOnDurationAtExactBoundary)
+{
+    // raw == 0 exactly while looping backward maps to `duration` (the start of
+    // a backward lap), mirroring the forward "land exactly on 0" wrap.
+    const auto r = CinematicPlayer::AdvanceTime(0.5f, 0.5f, -1.0f, 5.0f, /*loop*/ true);
+    EXPECT_NEAR(r.NewTime, 5.0f, kEps);
+    EXPECT_TRUE(r.Looped);
+    EXPECT_EQ(r.LoopCount, 1u);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeZeroSpeedHolds)
+{
+    const auto r = CinematicPlayer::AdvanceTime(2.0f, 0.5f, 0.0f, 5.0f, /*loop*/ false);
+    EXPECT_NEAR(r.NewTime, 2.0f, kEps); // speed 0 holds the playhead — no movement
+    EXPECT_FALSE(r.Looped);
+    EXPECT_FALSE(r.JustFinished);
+}
+
+TEST(CinematicPlayerTest, AdvanceTimeForwardBackwardSymmetry)
+{
+    // Advancing forward then backward over the same dt returns to the start
+    // (no clamp/wrap involved). Proves reverse is the exact inverse of forward.
+    constexpr f32 kStart = 2.0f;
+    constexpr f32 kDt = 0.3f;
+    constexpr f32 kDuration = 5.0f;
+    const auto fwd = CinematicPlayer::AdvanceTime(kStart, kDt, 1.0f, kDuration, /*loop*/ false);
+    const auto back = CinematicPlayer::AdvanceTime(fwd.NewTime, kDt, -1.0f, kDuration, /*loop*/ false);
+    EXPECT_NEAR(back.NewTime, kStart, kEps);
 }
 
 TEST(CinematicPlayerTest, AdvanceTimeClampsAtEndWhenNotLooping)
@@ -122,6 +182,53 @@ TEST(CinematicPlayerTest, CollectEventsOrdersByTimeAcrossTracks)
     EXPECT_EQ(fired[0], "early");
     EXPECT_EQ(fired[1], "middle");
     EXPECT_EQ(fired[2], "late");
+}
+
+// -------------------------- CollectEventsReverse -----------------------------
+
+TEST(CinematicPlayerTest, CollectEventsReverseHalfOpenWindowDescending)
+{
+    auto seq = MakeEventSequence(); // start@0, mid@1, end@5
+
+    std::vector<std::string> fired;
+    // [lowerInclusive, upperExclusive) => [0.0, 5.0) includes "start" at 0.0
+    // (inclusive low) and "mid" at 1.0, excludes "end" at 5.0 (exclusive high).
+    // Reverse mirror of CollectEvents' (0.0, 5.0] which would do the opposite.
+    CinematicPlayer::CollectEventsReverse(*seq, 0.0f, 5.0f, fired);
+    ASSERT_EQ(fired.size(), 2u);
+    EXPECT_EQ(fired[0], "mid"); // descending: 1.0 before 0.0
+    EXPECT_EQ(fired[1], "start");
+
+    fired.clear();
+    // [1.0, 6.0) includes "mid" at 1.0 (inclusive low) and "end" at 5.0.
+    CinematicPlayer::CollectEventsReverse(*seq, 1.0f, 6.0f, fired);
+    ASSERT_EQ(fired.size(), 2u);
+    EXPECT_EQ(fired[0], "end"); // descending
+    EXPECT_EQ(fired[1], "mid");
+}
+
+TEST(CinematicPlayerTest, CollectEventsReverseOrdersByTimeAcrossTracks)
+{
+    auto seq = Ref<CinematicSequence>::Create();
+    seq->Duration = 10.0f;
+    {
+        CinematicEventTrack a;
+        a.Keys.push_back({ 3.0f, "late" });
+        a.Keys.push_back({ 1.0f, "early" });
+        seq->EventTracks.push_back(std::move(a));
+    }
+    {
+        CinematicEventTrack b;
+        b.Keys.push_back({ 2.0f, "middle" });
+        seq->EventTracks.push_back(std::move(b));
+    }
+
+    std::vector<std::string> fired;
+    CinematicPlayer::CollectEventsReverse(*seq, 0.0f, 5.0f, fired);
+    ASSERT_EQ(fired.size(), 3u);
+    EXPECT_EQ(fired[0], "late"); // descending across tracks
+    EXPECT_EQ(fired[1], "middle");
+    EXPECT_EQ(fired[2], "early");
 }
 
 // -------------------------------- Tick ---------------------------------------
@@ -197,6 +304,78 @@ TEST(CinematicPlayerTest, TickMultiLapFiresEachCompletedLapEvents)
     EXPECT_EQ(count("end"), 2u);   // one per completed lap
     EXPECT_EQ(count("mid"), 3u);   // lap 1, lap 2, and the final head (t=2 >= 1)
     EXPECT_EQ(count("start"), 3u); // t==0 re-fires at each lap head
+}
+
+// ---------------------------- Tick (reverse) ---------------------------------
+
+TEST(CinematicPlayerTest, TickReverseFiresEventsInDescendingOrderAndFinishesAtZero)
+{
+    auto seq = MakeEventSequence(); // start@0, mid@1, end@5
+    // From 4.0 backward with a dt big enough to overshoot 0: lands on 0 and
+    // finishes. Crosses mid@1 then start@0 (descending); never reaches end@5.
+    const auto r = CinematicPlayer::Tick(*seq, /*fromTime*/ 4.0f, /*eventFloor*/ 4.0f, 4.0f, -1.0f, /*loop*/ false);
+    EXPECT_TRUE(r.JustFinished);
+    EXPECT_NEAR(r.NewTime, 0.0f, kEps);
+    ASSERT_EQ(r.FiredEvents.size(), 2u);
+    EXPECT_EQ(r.FiredEvents[0], "mid"); // descending crossing order
+    EXPECT_EQ(r.FiredEvents[1], "start");
+}
+
+TEST(CinematicPlayerTest, TickReverseDoesNotDoubleFireAcrossConsecutiveSteps)
+{
+    auto seq = MakeEventSequence();
+
+    // Step 1: 1.5 -> 0.5 (floor 1.5): crosses "mid" at 1.0 exactly once.
+    auto r1 = CinematicPlayer::Tick(*seq, 1.5f, 1.5f, 1.0f, -1.0f, /*loop*/ false);
+    ASSERT_EQ(r1.FiredEvents.size(), 1u);
+    EXPECT_EQ(r1.FiredEvents[0], "mid");
+
+    // Step 2: 0.5 -> 0 (floor = previous NewTime 0.5): lands on 0 firing
+    // "start", and does NOT re-fire "mid" (1.0 is outside [0, 0.5)).
+    auto r2 = CinematicPlayer::Tick(*seq, r1.NewTime, /*floor*/ r1.NewTime, 1.0f, -1.0f, /*loop*/ false);
+    EXPECT_TRUE(r2.JustFinished);
+    ASSERT_EQ(r2.FiredEvents.size(), 1u);
+    EXPECT_EQ(r2.FiredEvents[0], "start");
+}
+
+TEST(CinematicPlayerTest, TickReverseLoopWrapFiresHeadThenTail)
+{
+    auto seq = MakeEventSequence();
+    // From 0.2, dt 0.5 -> raw -0.3 wraps to 4.7 with loop. Mirror of the
+    // forward wrap: descend 0.2 -> 0 fires "start" (t=0, head of the lap we're
+    // leaving), wrap, descend 5 -> 4.7 fires "end" (t=5, tail of the new lap).
+    const auto r = CinematicPlayer::Tick(*seq, 0.2f, 0.2f, 0.5f, -1.0f, /*loop*/ true);
+    EXPECT_TRUE(r.Looped);
+    EXPECT_NEAR(r.NewTime, 4.7f, kEps);
+    ASSERT_EQ(r.FiredEvents.size(), 2u);
+    EXPECT_EQ(r.FiredEvents[0], "start");
+    EXPECT_EQ(r.FiredEvents[1], "end");
+}
+
+TEST(CinematicPlayerTest, TickReverseMultiLapFiresEachCompletedLapEvents)
+{
+    auto seq = MakeEventSequence(); // 5s; events start@0, mid@1, end@5
+
+    // One huge backward step (dt=12s) from 4.0 wraps the 5s timeline twice and
+    // lands at t=2 (raw -8 -> fmod -3 -> +5 = 2). Mirror of the forward
+    // multi-lap case: each completed lap re-fires the whole timeline.
+    const auto r = CinematicPlayer::Tick(*seq, 4.0f, 4.0f, 12.0f, -1.0f, /*loop*/ true);
+    EXPECT_TRUE(r.Looped);
+    EXPECT_NEAR(r.NewTime, 2.0f, kEps);
+
+    const auto count = [&](const char* name)
+    {
+        u32 n = 0;
+        for (const auto& e : r.FiredEvents)
+            if (e == name)
+                ++n;
+        return n;
+    };
+    // head 4.0->0 fires mid+start; one full middle lap fires end+mid+start;
+    // tail 5->2 fires end. => end 2, mid 2, start 2.
+    EXPECT_EQ(count("end"), 2u);
+    EXPECT_EQ(count("mid"), 2u);
+    EXPECT_EQ(count("start"), 2u);
 }
 
 TEST(CinematicPlayerTest, EffectiveDurationDerivesFromKeysWhenUnset)

--- a/OloEngine/tests/ComponentRoundTripTest.cpp
+++ b/OloEngine/tests/ComponentRoundTripTest.cpp
@@ -1969,6 +1969,45 @@ namespace OloEngine::Tests
     }
 
     // -------------------------------------------------------------------------
+    // CinematicComponent — authoring fields, with a NEGATIVE PlaybackSpeed to
+    // prove reverse playback survives the scene round-trip. The deserializer
+    // historically rejected speed < 0 (forward-only); reverse playback widened
+    // the valid range, so the read path must accept (only) finite negatives.
+    // -------------------------------------------------------------------------
+    TEST(ComponentRoundTrip, CinematicComponentReverseSpeedSurvivesYAMLRoundTrip)
+    {
+        const u64 expectedSequence = 4242u;
+        const bool expectedPlayOnStart = true;
+        const bool expectedLoop = true;
+        const f32 expectedPlaybackSpeed = -1.5f; // reverse
+
+        std::string yaml;
+        {
+            auto scene = Scene::Create();
+            Entity entity = scene->CreateEntity(kTestTag);
+            auto& cine = entity.AddComponent<CinematicComponent>();
+            cine.Sequence = AssetHandle{ expectedSequence };
+            cine.PlayOnStart = expectedPlayOnStart;
+            cine.Loop = expectedLoop;
+            cine.PlaybackSpeed = expectedPlaybackSpeed;
+            yaml = SceneSerializer(scene).SerializeToYAML();
+        }
+
+        auto reloaded = Scene::Create();
+        ASSERT_TRUE(SceneSerializer(reloaded).DeserializeFromYAML(yaml));
+
+        Entity restored = FindByTag(*reloaded, kTestTag);
+        ASSERT_TRUE(static_cast<bool>(restored));
+        ASSERT_TRUE(restored.HasComponent<CinematicComponent>());
+
+        const auto& cine = restored.GetComponent<CinematicComponent>();
+        EXPECT_EQ(static_cast<u64>(cine.Sequence), expectedSequence);
+        EXPECT_EQ(cine.PlayOnStart, expectedPlayOnStart);
+        EXPECT_EQ(cine.Loop, expectedLoop);
+        EXPECT_NEAR(cine.PlaybackSpeed, expectedPlaybackSpeed, kFloatEpsilon);
+    }
+
+    // -------------------------------------------------------------------------
     // NetworkIdentityComponent — owner / authority / replicated flag.
     // -------------------------------------------------------------------------
     TEST(ComponentRoundTrip, NetworkIdentityComponentSurvivesYAMLRoundTrip)

--- a/OloEngine/tests/Functional/Cinematic/CinematicDrivesEntitiesTest.cpp
+++ b/OloEngine/tests/Functional/Cinematic/CinematicDrivesEntitiesTest.cpp
@@ -224,13 +224,15 @@ class CinematicReversePlaybackTest : public FunctionalTest
         m_Director = GetScene().CreateEntity("Director");
         auto& cine = m_Director.AddComponent<CinematicComponent>();
         cine.RuntimeSequence = seq;
-        // Park the playhead at the end and play backward. PreviousTime mirrors
-        // Time so the first reverse step's event window starts clean (no
-        // "start from the end" sentinel exists — see CINEMATIC_SEQUENCER.md).
+        // Reverse playback through the *normal* start path. PlayFromStart()
+        // rewinds to Time=0 (the forward start), and CinematicSystem::Advance
+        // seeds the playhead to the end for a negative speed so the sequence
+        // actually plays backward instead of finishing instantly at 0. This is
+        // the exact path PlayOnStart / the editor Play button / a Lua
+        // PlayFromStart() all take — so the test proves the seed, not a manual
+        // Time=duration workaround.
         cine.PlaybackSpeed = -1.0f;
-        cine.Time = seq->Duration;
-        cine.PreviousTime = seq->Duration;
-        cine.Play();
+        cine.PlayFromStart();
     }
 
     Entity m_Hero, m_Director;
@@ -238,7 +240,20 @@ class CinematicReversePlaybackTest : public FunctionalTest
 
 TEST_F(CinematicReversePlaybackTest, PlaysBackwardFiresDescendingEventsAndFinishesAtZero)
 {
-    // Capture the event firing order across the whole backward run.
+    // First frame: the seed must move the playhead to (near) the end and keep
+    // playing — the bug this guards is a reverse PlayFromStart() finishing
+    // instantly at 0 having played nothing.
+    RunFrames(1);
+    {
+        const auto& cine = m_Director.GetComponent<CinematicComponent>();
+        EXPECT_TRUE(cine.Playing) << "reverse sequence must not finish on its first step";
+        EXPECT_FALSE(cine.Finished);
+        EXPECT_GT(cine.Time, 0.5f) << "playhead should be seeded near the end, not stuck at 0";
+        const f32 heroY = m_Hero.GetComponent<TransformComponent>().Translation.y;
+        EXPECT_GT(heroY, 5.0f) << "Hero should start posed near the end key (y=10), not the start (y=0)";
+    }
+
+    // Capture the event firing order across the rest of the backward run.
     std::vector<std::string> firedOrder;
     bool reachedZero = false;
     for (u32 i = 0; i < 120 && !reachedZero; ++i) // up to 2s; a 1s reverse run finishes well within

--- a/OloEngine/tests/Functional/Cinematic/CinematicDrivesEntitiesTest.cpp
+++ b/OloEngine/tests/Functional/Cinematic/CinematicDrivesEntitiesTest.cpp
@@ -194,3 +194,76 @@ TEST_F(CinematicLoopTest, LoopingSequenceNeverFinishesAndRefiresZeroEvent)
     // t==0 event fires on the first tick and again on each wrap; expect several.
     EXPECT_GE(loopStartCount, 3u) << "t==0 event should re-fire on each loop";
 }
+
+// Reverse playback: a negative PlaybackSpeed drives the playhead from the end
+// back to 0 through the real runtime, poses entities backward, fires events in
+// descending order, and finishes at 0 (the mirror of the forward case above).
+class CinematicReversePlaybackTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Hero = GetScene().CreateEntity("Hero");
+
+        auto seq = Ref<CinematicSequence>::Create();
+        seq->Name = "ReverseCutscene";
+        seq->Duration = 1.0f;
+
+        CinematicTransformTrack tt;
+        tt.Target = m_Hero.GetUUID();
+        tt.Translation.Keys.push_back({ 0.0f, glm::vec3(0.0f), CinematicInterp::Linear });
+        tt.Translation.Keys.push_back({ 1.0f, glm::vec3(0.0f, 10.0f, 0.0f), CinematicInterp::Linear });
+        seq->TransformTracks.push_back(std::move(tt));
+
+        CinematicEventTrack et;
+        et.Name = "cues";
+        et.Keys.push_back({ 0.25f, "low" });
+        et.Keys.push_back({ 0.75f, "high" });
+        seq->EventTracks.push_back(std::move(et));
+
+        m_Director = GetScene().CreateEntity("Director");
+        auto& cine = m_Director.AddComponent<CinematicComponent>();
+        cine.RuntimeSequence = seq;
+        // Park the playhead at the end and play backward. PreviousTime mirrors
+        // Time so the first reverse step's event window starts clean (no
+        // "start from the end" sentinel exists — see CINEMATIC_SEQUENCER.md).
+        cine.PlaybackSpeed = -1.0f;
+        cine.Time = seq->Duration;
+        cine.PreviousTime = seq->Duration;
+        cine.Play();
+    }
+
+    Entity m_Hero, m_Director;
+};
+
+TEST_F(CinematicReversePlaybackTest, PlaysBackwardFiresDescendingEventsAndFinishesAtZero)
+{
+    // Capture the event firing order across the whole backward run.
+    std::vector<std::string> firedOrder;
+    bool reachedZero = false;
+    for (u32 i = 0; i < 120 && !reachedZero; ++i) // up to 2s; a 1s reverse run finishes well within
+    {
+        RunFrames(1);
+        const auto& cine = m_Director.GetComponent<CinematicComponent>();
+        for (const auto& e : cine.EventsFiredThisFrame)
+        {
+            firedOrder.push_back(e);
+        }
+        reachedZero = cine.Finished;
+    }
+
+    const auto& cine = m_Director.GetComponent<CinematicComponent>();
+    EXPECT_TRUE(cine.Finished) << "reverse sequence should finish when the playhead reaches 0";
+    EXPECT_FALSE(cine.Playing) << "finished sequence should stop playing";
+    EXPECT_NEAR(cine.Time, 0.0f, 1e-3f) << "reverse playhead should land on 0";
+
+    // Hero ended at the first translation key (it started at the last).
+    const glm::vec3 heroPos = m_Hero.GetComponent<TransformComponent>().Translation;
+    EXPECT_NEAR(heroPos.y, 0.0f, 1e-2f) << "Hero should be back at the start pose";
+
+    // Events fired in descending time order: "high" (t=0.75) before "low"
+    // (t=0.25) as the playhead receded from the end.
+    ASSERT_EQ(firedOrder.size(), 2u);
+    EXPECT_EQ(firedOrder[0], "high");
+    EXPECT_EQ(firedOrder[1], "low");
+}

--- a/OloEngine/tests/Functional/SaveGame/RegisteredComponentsSurviveSaveLoadTest.cpp
+++ b/OloEngine/tests/Functional/SaveGame/RegisteredComponentsSurviveSaveLoadTest.cpp
@@ -220,7 +220,7 @@ class RegisteredComponentsSurviveSaveLoadTest : public FunctionalTest
             cine.Sequence = AssetHandle{ 55 };
             cine.PlayOnStart = true;
             cine.Loop = true;
-            cine.PlaybackSpeed = 2.0f;
+            cine.PlaybackSpeed = -2.0f; // negative = reverse; must survive the save-game clamp
         }
 
         // --- AI (blackboards are the save-game-specific payload: they hold
@@ -534,7 +534,7 @@ TEST_F(RegisteredComponentsSurviveSaveLoadTest, PreviouslyDroppedComponentsRound
                                    EXPECT_EQ(static_cast<u64>(cine.Sequence), 55u);
                                    EXPECT_TRUE(cine.PlayOnStart);
                                    EXPECT_TRUE(cine.Loop);
-                                   EXPECT_FLOAT_EQ(cine.PlaybackSpeed, 2.0f);
+                                   EXPECT_FLOAT_EQ(cine.PlaybackSpeed, -2.0f); // reverse speed round-trips
                                });
 
     Verify<BehaviorTreeComponent>(restored, "BehaviorTreeComponent",

--- a/docs/CINEMATIC_SEQUENCER.md
+++ b/docs/CINEMATIC_SEQUENCER.md
@@ -212,18 +212,31 @@ event, handle it in script) for cases that don't yet have a dedicated track.
 
 `PlaybackSpeed` is a free time scale: positive plays forward, **negative
 plays the sequence backward**, and `0` holds the playhead (a live "pause"
-without clearing `Playing`). Reverse playback mirrors the forward semantics
-— the playhead recedes toward `0`, finishes at `0` when not looping, and
-wraps `0 -> duration` when looping. Event firing flips to the descending
-crossing (`CinematicPlayer::CollectEventsReverse`, the `[lo, hi)` mirror of
-the forward `(lo, hi]` window), so cues fire in the order a receding
-playhead reaches them and never double-fire across a direction change.
+without clearing `Playing`). It round-trips through both scene YAML and
+save-games — the deserializers accept any finite value (the save-game path
+clamps to the inspector's symmetric `[-16, 16]` authoring range). Reverse
+playback mirrors the forward semantics — the playhead recedes toward `0`,
+finishes at `0` when not looping, and wraps `0 -> duration` when looping.
+Event firing flips to the descending crossing
+(`CinematicPlayer::CollectEventsReverse`, the `[lo, hi)` mirror of the
+forward `(lo, hi]` window), so cues fire in the order a receding playhead
+reaches them and never double-fire across a direction change.
+
+**Direction-aware start.** `Play()` / `PlayFromStart()` / `PlayOnStart` /
+`Stop()` all leave the playhead at the *forward* start (`Time = 0`), which is
+the *finish* line for reverse. `CinematicSystem::Advance` detects a fresh
+negative-speed start (the `PreviousTime = -1` sentinel still set) and seeds
+the playhead to `duration` on the first tick, so a backward sequence plays the
+whole timeline instead of finishing instantly at `0`. Resuming after a pause
+keeps a real `PreviousTime >= 0` and is left untouched.
+
 One asymmetry worth knowing: just as scrubbing/`PlayFromStart` to `t == 0`
 and playing forward only fires the `t == 0` cue via the `PreviousTime = -1`
-sentinel, there is no symmetric "start from the end" sentinel — beginning a
-reverse run parked exactly on `t == duration` won't fire a cue authored at
-`duration` (the playhead leaves it without crossing it). Variable *rate*
-beyond a constant scale (ease-in/out of the time scale) is still future work.
+sentinel, there is no symmetric "start from the end" sentinel — the reverse
+seed sets `PreviousTime = duration`, so a cue authored at exactly
+`t == duration` is *not* fired on the first backward step (the playhead leaves
+it without crossing it). Variable *rate* beyond a constant scale (ease-in/out
+of the time scale) is still future work.
 
 ### Sequence blending & layering
 

--- a/docs/CINEMATIC_SEQUENCER.md
+++ b/docs/CINEMATIC_SEQUENCER.md
@@ -123,9 +123,11 @@ with `std::isfinite`.
   the four interp modes (incl. the Bezier tangent ease and its
   smoothstep/linear anchor identities), quat slerp/normalization, degenerate-
   segment safety, visibility step semantics.
-- `CinematicPlayerTest` (unit) — time advance (normal / clamp / loop-wrap /
-  zero-duration / non-negative speed), half-open event windows, and the
-  composite `Tick` (t==0 firing, no double-fire, loop wrap).
+- `CinematicPlayerTest` (unit) — time advance (forward / reverse / clamp /
+  finish-at-0 / loop-wrap both directions / zero-duration / zero-speed hold /
+  forward-backward symmetry), half-open event windows (ascending and the
+  reverse descending mirror), and the composite `Tick` (t==0 firing,
+  no double-fire, loop wrap forward and backward).
 - `CinematicSerializerTest` (unit) — full `.olocine` round-trip across every
   track/channel + malformed-input guard + Bezier tangent round-trip and the v1
   back-compat path (legacy files with no tangent fields load flat).
@@ -206,12 +208,22 @@ extension — add a struct in `CinematicTrack.h`, a `std::vector` on
 coverage. EventTracks already provide a generic escape hatch (fire a named
 event, handle it in script) for cases that don't yet have a dedicated track.
 
-### Reverse / variable-rate playback
+### Variable-rate playback
 
-`PlaybackSpeed` is clamped to ≥ 0 today (negative is treated as a hold).
-Reverse playback needs symmetric event-edge handling (fire on the
-descending crossing) — straightforward but untested, so it's gated off
-rather than shipped half-working.
+`PlaybackSpeed` is a free time scale: positive plays forward, **negative
+plays the sequence backward**, and `0` holds the playhead (a live "pause"
+without clearing `Playing`). Reverse playback mirrors the forward semantics
+— the playhead recedes toward `0`, finishes at `0` when not looping, and
+wraps `0 -> duration` when looping. Event firing flips to the descending
+crossing (`CinematicPlayer::CollectEventsReverse`, the `[lo, hi)` mirror of
+the forward `(lo, hi]` window), so cues fire in the order a receding
+playhead reaches them and never double-fire across a direction change.
+One asymmetry worth knowing: just as scrubbing/`PlayFromStart` to `t == 0`
+and playing forward only fires the `t == 0` cue via the `PreviousTime = -1`
+sentinel, there is no symmetric "start from the end" sentinel — beginning a
+reverse run parked exactly on `t == duration` won't fire a cue authored at
+`duration` (the playhead leaves it without crossing it). Variable *rate*
+beyond a constant scale (ease-in/out of the time scale) is still future work.
 
 ### Sequence blending & layering
 


### PR DESCRIPTION
## What

Implements **reverse playback** for the Cinematic sequencer — `CinematicComponent::PlaybackSpeed` may now be **negative** (play backward) or **zero** (hold), not just `> 0`. Closes the named "future work" gap left by the Sequencer (#177).

## How

- **`CinematicPlayer::AdvanceTime`** — mirrors the forward path for `speed < 0`: the playhead recedes toward `0`, finishes at `0` when not looping, and wraps `0 → duration` when looping (an exact landing on `0` maps to `duration`, mirroring the forward "land exactly on 0" wrap). `speed == 0` (and NaN) holds the playhead — no movement, no finish. The forward path is unchanged byte-for-byte.
- **`CinematicPlayer::CollectEventsReverse`** (new) — the `[lo, hi)` descending mirror of the forward `(lo, hi]` ascending `CollectEvents`. Inclusive on the new (lower) playhead, exclusive on the old (higher) one, so cues fire in receding-crossing order and never double-fire across a forward↔reverse direction change.
- **`CinematicPlayer::Tick`** — branches on direction; a reverse wrap fires the head of the lap being left → any full middle laps → the tail of the lap entered.
- **Clamps relaxed** so the feature isn't half-shipped: editor `DragFloat` min `0 → -16`, Lua `playbackSpeed` setter drops its `>= 0` guard (keeps `isfinite`). C# bindings already passed the value through. No serialization/codegen touch-points change (PlaybackSpeed was already `OLO_PROPERTY()` + serialized — only its value range widens).

## Tests

`CinematicPlayerTest` gains 12 reverse unit cases (backward step, finish-at-0, loop wrap, exact-boundary wrap, zero-speed hold, forward/backward symmetry, `CollectEventsReverse` ordering, and 4 reverse `Tick` cases incl. multi-lap), replacing the now-obsolete "negative speed holds" case. `CinematicDrivesEntitiesTest` gains an end-to-end `CinematicReversePlaybackTest` that drives a real `Scene` backward and asserts descending event order + finish-at-0.

**All 75 Cinematic tests pass** (`--gtest_filter=*Cinematic*`), no regressions. This is a logic change, not a rendering change, so CPU unit + functional tests are the proof (no screenshot evidence required).

## Notes

One intentional asymmetry, documented in `docs/CINEMATIC_SEQUENCER.md`: there's no "start from the end" sentinel, so beginning a reverse run parked exactly on `t == duration` won't fire a cue authored at `duration` — the exact mirror of how forward needs the `PreviousTime = -1` sentinel to fire a `t == 0` cue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cinematics now support reverse playback with negative speed and “hold” at zero speed.
  * Reverse playback supports looping and timed events in reverse (descending) order.
* **Bug Fixes**
  * Editor, scripting, scene loading, and save/load now correctly accept negative and zero playback speeds.
* **Documentation**
  * Updated cinematic sequencer guidance to describe reverse/zero-speed behavior and event windowing.
* **Tests**
  * Expanded unit and functional coverage for reverse stepping, looping wrap, hold behavior, and correct reverse event/tick ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->