### PR TITLE
chore(physics3d): SonarQube CODE_SMELL cleanup (no behaviour change)

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/BuoyancySystem.cpp
@@ -38,7 +38,7 @@ namespace OloEngine
             f32 m_FFTHeightScale = 1.0f; ///< artist multiplier (WaterComponent::m_FFTHeightScale, u_FFTParams.z)
         };
 
-        [[nodiscard]] bool IsOverFootprint(const WaterVolume& w, const glm::vec3& worldPos)
+        [[nodiscard("footprint test result must be used")]] bool IsOverFootprint(const WaterVolume& w, const glm::vec3& worldPos)
         {
             const glm::vec4 local = w.m_InvModel * glm::vec4(worldPos, 1.0f);
             if (!std::isfinite(local.x) || !std::isfinite(local.z))
@@ -46,7 +46,7 @@ namespace OloEngine
             return local.x >= -w.m_HalfX && local.x <= w.m_HalfX && local.z >= -w.m_HalfZ && local.z <= w.m_HalfZ;
         }
 
-        [[nodiscard]] WaterSurface::Params MakeParams(const WaterComponent& wc, f32 planeHeight)
+        [[nodiscard("constructed water-surface params must be used")]] WaterSurface::Params MakeParams(const WaterComponent& wc, f32 planeHeight)
         {
             WaterSurface::Params p;
             p.m_WaveDir0 = wc.PackWaveDir0();

--- a/OloEngine/src/OloEngine/Physics3D/JoltContactListener.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltContactListener.cpp
@@ -171,13 +171,13 @@ namespace OloEngine
         }
     }
 
-    [[nodiscard]] UUID JoltContactListener::GetEntityIDFromBody(const JPH::Body& body) const noexcept
+    [[nodiscard("entity UUID lookup result must be used")]] UUID JoltContactListener::GetEntityIDFromBody(const JPH::Body& body) const noexcept
     {
         // The entity ID is stored in the body's user data
         return static_cast<UUID>(body.GetUserData());
     }
 
-    [[nodiscard]] u32 JoltContactListener::GetPhysicsLayerFromBody(const JPH::Body& body) const noexcept
+    [[nodiscard("physics layer lookup result must be used")]] u32 JoltContactListener::GetPhysicsLayerFromBody(const JPH::Body& body) const noexcept
     {
         // Check if this is a custom physics layer (offset by NUM_LAYERS)
         if (JPH::ObjectLayer objectLayer = body.GetObjectLayer(); objectLayer >= ObjectLayers::NUM_LAYERS)

--- a/OloEngine/src/OloEngine/Physics3D/JoltContactListener.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltContactListener.h
@@ -54,7 +54,7 @@ namespace OloEngine
         // they collapse to one entry). Each pair is ordered so (A,B) and (B,A) are
         // the same entry. Used by the read-only MCP diagnostics server's
         // olo_physics_contacts tool; safe to call from any thread (mutex-guarded).
-        [[nodiscard]] std::vector<std::pair<UUID, UUID>> GetActiveContactPairs() const;
+        [[nodiscard("contact-pair snapshot must be used")]] std::vector<std::pair<UUID, UUID>> GetActiveContactPairs() const;
 
       private:
         struct ContactEvent
@@ -92,10 +92,10 @@ namespace OloEngine
         }
 
         // Retrieves entity UUID from JPH::Body::GetUserData (expects u64 UUID); returns 0 when no valid UUID is present
-        [[nodiscard]] UUID GetEntityIDFromBody(const JPH::Body& body) const noexcept;
+        [[nodiscard("entity UUID lookup result must be used")]] UUID GetEntityIDFromBody(const JPH::Body& body) const noexcept;
 
         // Retrieves physics layer ID from JPH::Body::GetObjectLayer; returns INVALID_LAYER_ID for built-in layers
-        [[nodiscard]] u32 GetPhysicsLayerFromBody(const JPH::Body& body) const noexcept;
+        [[nodiscard("physics layer lookup result must be used")]] u32 GetPhysicsLayerFromBody(const JPH::Body& body) const noexcept;
 
         // Helper method to process contact manifolds and avoid duplicate logic
         void ProcessContactManifold(const JPH::Body& inBody1, const JPH::Body& inBody2, const JPH::ContactManifold& inManifold, ContactType type);

--- a/OloEngine/src/OloEngine/Physics3D/JoltJobSystemAdapter.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltJobSystemAdapter.cpp
@@ -53,7 +53,7 @@ namespace OloEngine
         constexpr auto kTimeout = 5s;
         try
         {
-            std::unique_lock<std::mutex> lock(m_DrainMutex);
+            std::unique_lock lock(m_DrainMutex);
             const bool drained = m_DrainCv.wait_for(lock, kTimeout, [this]() noexcept
                                                     { return m_OutstandingTasks.load(std::memory_order_acquire) == 0; });
             if (!drained)
@@ -110,12 +110,12 @@ namespace OloEngine
         u32 index = m_Jobs.ConstructObject(inName, inColor, this, inJobFunction, inNumDependencies);
         if (index == FAvailableJobs::cInvalidObjectIndex)
         {
-            using clock = std::chrono::steady_clock;
+            using Clock = std::chrono::steady_clock;
             constexpr auto kTimeout = std::chrono::seconds(5);
-            const auto deadline = clock::now() + kTimeout;
+            const auto deadline = Clock::now() + kTimeout;
             do
             {
-                if (clock::now() > deadline)
+                if (Clock::now() > deadline)
                 {
                     OLO_CORE_ERROR("JoltJobSystemAdapter::CreateJob: physics job free-list exhausted for {}s "
                                    "(likely a job leak or wedged scheduler); returning an empty handle",
@@ -181,7 +181,7 @@ namespace OloEngine
                 // brief lock is uncontended in the common case — the game thread only holds
                 // it while actually draining.
                 {
-                    std::lock_guard<std::mutex> lock(m_DrainMutex);
+                    std::lock_guard lock(m_DrainMutex);
                     m_OutstandingTasks.fetch_sub(1, std::memory_order_release);
                     m_DrainCv.notify_one();
                 }

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -408,11 +408,8 @@ namespace OloEngine
         DestroyAllVehicles();
         DestroyAllConstraints();
 
-        // Destroy all bodies
-        for (const auto& [entityID, body] : m_Bodies)
-        {
-            // Body destructor will handle cleanup
-        }
+        // Destroy all bodies — the JoltBody destructors run as clear() releases
+        // each Ref; the reverse-lookup and sync sets are dropped with them.
         m_Bodies.clear();
         m_BodyIDToEntity.clear(); // Clear reverse lookup map
         m_BodiesToSync.clear();
@@ -1051,7 +1048,7 @@ namespace OloEngine
         // Map the authored path-rotation mode onto Jolt's enum. The values match
         // 1:1 (JointPathRotationMode mirrors EPathRotationConstraintType); an
         // out-of-range value falls back to Free (rotation unconstrained).
-        JPH::EPathRotationConstraintType ToJoltPathRotation(JointPathRotationMode mode)
+        [[nodiscard("mapped Jolt path-rotation enum must be used")]] JPH::EPathRotationConstraintType ToJoltPathRotation(JointPathRotationMode mode)
         {
             switch (mode)
             {
@@ -1244,9 +1241,8 @@ namespace OloEngine
             if (static_cast<u64>(otherID) == 0 || otherID == ownerID)
                 continue; // world anchor / self-joint: no second body to filter
 
-            Ref<JoltBody> bodyA = GetBodyByEntityID(ownerID);
-            Ref<JoltBody> bodyB = GetBodyByEntityID(otherID);
-            if (!bodyA || !bodyA->IsValid() || !bodyB || !bodyB->IsValid())
+            if (Ref<JoltBody> bodyA = GetBodyByEntityID(ownerID), bodyB = GetBodyByEntityID(otherID);
+                !bodyA || !bodyA->IsValid() || !bodyB || !bodyB->IsValid())
                 continue; // an endpoint has no live body — nothing to filter
 
             // Assign each participating body a stable sub-group id the first time
@@ -1295,7 +1291,7 @@ namespace OloEngine
         UUID entityID = entity.GetUUID();
 
         // Idempotent — already built for this entity.
-        if (m_Constraints.find(entityID) != m_Constraints.end())
+        if (m_Constraints.contains(entityID))
             return true;
 
         // The joint owner must have a physics body to be a constraint endpoint.
@@ -1419,8 +1415,10 @@ namespace OloEngine
                     s.mSpace = JPH::EConstraintSpace::WorldSpace;
                     s.mPoint1 = p1;
                     s.mPoint2 = p2;
-                    s.mHingeAxis1 = s.mHingeAxis2 = jAxis;
-                    s.mNormalAxis1 = s.mNormalAxis2 = jNormal;
+                    s.mHingeAxis1 = jAxis;
+                    s.mHingeAxis2 = jAxis;
+                    s.mNormalAxis1 = jNormal;
+                    s.mNormalAxis2 = jNormal;
                     s.mLimitsMin = std::clamp(JoltUtils::DegreesToRadians(joint.m_HingeMinAngleDeg), -glm::pi<f32>(), 0.0f);
                     s.mLimitsMax = std::clamp(JoltUtils::DegreesToRadians(joint.m_HingeMaxAngleDeg), 0.0f, glm::pi<f32>());
                     // Friction torque (used only when the motor is Off) and the
@@ -1441,8 +1439,10 @@ namespace OloEngine
                     s.mAutoDetectPoint = false;
                     s.mPoint1 = p1;
                     s.mPoint2 = p2;
-                    s.mSliderAxis1 = s.mSliderAxis2 = jAxis;
-                    s.mNormalAxis1 = s.mNormalAxis2 = jNormal;
+                    s.mSliderAxis1 = jAxis;
+                    s.mSliderAxis2 = jAxis;
+                    s.mNormalAxis1 = jNormal;
+                    s.mNormalAxis2 = jNormal;
                     s.mLimitsMin = joint.m_SliderMinLimit;
                     s.mLimitsMax = joint.m_SliderMaxLimit;
                     // Friction force (used only when the motor is Off) and the
@@ -1462,7 +1462,8 @@ namespace OloEngine
                     s.mSpace = JPH::EConstraintSpace::WorldSpace;
                     s.mPoint1 = p1;
                     s.mPoint2 = p2;
-                    s.mTwistAxis1 = s.mTwistAxis2 = jAxis;
+                    s.mTwistAxis1 = jAxis;
+                    s.mTwistAxis2 = jAxis;
                     s.mHalfConeAngle = std::clamp(JoltUtils::DegreesToRadians(joint.m_ConeHalfAngleDeg), 0.0f, glm::pi<f32>());
                     return s.Create(body1, body2);
                 }
@@ -1476,8 +1477,10 @@ namespace OloEngine
                     s.mSpace = JPH::EConstraintSpace::WorldSpace;
                     s.mPosition1 = p1;
                     s.mPosition2 = p2;
-                    s.mTwistAxis1 = s.mTwistAxis2 = jAxis;
-                    s.mPlaneAxis1 = s.mPlaneAxis2 = jNormal;
+                    s.mTwistAxis1 = jAxis;
+                    s.mTwistAxis2 = jAxis;
+                    s.mPlaneAxis1 = jNormal;
+                    s.mPlaneAxis2 = jNormal;
                     s.mNormalHalfConeAngle = SanitizeJointAngleDeg(joint.m_SwingNormalHalfAngleDeg, 0.0f, glm::pi<f32>(), 45.0f);
                     s.mPlaneHalfConeAngle = SanitizeJointAngleDeg(joint.m_SwingPlaneHalfAngleDeg, 0.0f, glm::pi<f32>(), 45.0f);
                     f32 twistMin = SanitizeJointAngleDeg(joint.m_TwistMinAngleDeg, -glm::pi<f32>(), glm::pi<f32>(), -45.0f);
@@ -1503,8 +1506,10 @@ namespace OloEngine
                     s.mSpace = JPH::EConstraintSpace::WorldSpace;
                     s.mPosition1 = p1;
                     s.mPosition2 = p2;
-                    s.mAxisX1 = s.mAxisX2 = jAxis;
-                    s.mAxisY1 = s.mAxisY2 = jNormal;
+                    s.mAxisX1 = jAxis;
+                    s.mAxisX2 = jAxis;
+                    s.mAxisY1 = jNormal;
+                    s.mAxisY2 = jNormal;
                     s.mSwingType = JPH::ESwingType::Pyramid;
 
                     const auto applyAxis = [&s](ESix ax, JointAxisMode mode, f32 lo, f32 hi)
@@ -1703,7 +1708,7 @@ namespace OloEngine
         // they connect are destroyed.
         if (m_JoltSystem)
         {
-            for (auto& [entityID, constraint] : m_Constraints)
+            for (const auto& [entityID, constraint] : m_Constraints)
             {
                 if (constraint != nullptr)
                     m_JoltSystem->RemoveConstraint(constraint);
@@ -1743,7 +1748,7 @@ namespace OloEngine
         const UUID entityID = entity.GetUUID();
 
         // Idempotent — already built for this entity.
-        if (m_Vehicles.find(entityID) != m_Vehicles.end())
+        if (m_Vehicles.contains(entityID))
             return true;
 
         // The chassis IS this entity's rigidbody; it must exist and be dynamic to
@@ -1789,7 +1794,7 @@ namespace OloEngine
         // mMaxPitchRollAngle left at its JPH_PI default (anti-topple off).
 
         // Standard four-wheel layout: 0=FL, 1=FR (steerable), 2=RL, 3=RR (driven).
-        const auto makeWheel = [&](f32 localX, f32 localZ, f32 steerRad) -> JPH::WheelSettingsWV*
+        const auto makeWheel = [&](f32 localX, f32 localZ, f32 steerRad)
         {
             auto* wheel = new JPH::WheelSettingsWV();
             wheel->mPosition = JPH::Vec3(localX, attachHeight, localZ);
@@ -1883,7 +1888,7 @@ namespace OloEngine
         // be removed before the bodies they drive are destroyed.
         if (m_JoltSystem)
         {
-            for (auto& [entityID, constraint] : m_Vehicles)
+            for (const auto& [entityID, constraint] : m_Vehicles)
             {
                 if (constraint != nullptr)
                 {
@@ -2141,7 +2146,7 @@ namespace OloEngine
             return;
 
         JPH::BodyInterface& bodyInterface = m_JoltSystem->GetBodyInterface();
-        for (auto& [entityID, constraint] : m_Vehicles)
+        for (const auto& [entityID, constraint] : m_Vehicles)
         {
             if (constraint == nullptr)
                 continue;
@@ -2167,7 +2172,7 @@ namespace OloEngine
 
             // A settled vehicle sleeps; without this it would ignore throttle /
             // steering / brake input until something else woke it.
-            if (JPH::Body* body = constraint->GetVehicleBody();
+            if (const JPH::Body* body = constraint->GetVehicleBody();
                 body != nullptr && (std::abs(forward) > 1.0e-4f || std::abs(right) > 1.0e-4f || brake > 1.0e-4f))
             {
                 bodyInterface.ActivateBody(body->GetID());

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -76,7 +76,7 @@ namespace OloEngine
         // second pass and from the runtime-add hook. DestroyConstraint releases it.
         bool CreateConstraint(Entity entity);
         void DestroyConstraint(Entity entity);
-        u32 GetConstraintCount() const
+        [[nodiscard("constraint count query result must be used")]] u32 GetConstraintCount() const
         {
             return static_cast<u32>(m_Constraints.size());
         }
@@ -100,7 +100,7 @@ namespace OloEngine
         // releases the constraint, and clears the token. Both are idempotent.
         bool CreateVehicle(Entity entity);
         void DestroyVehicle(Entity entity);
-        u32 GetVehicleCount() const
+        [[nodiscard("vehicle count query result must be used")]] u32 GetVehicleCount() const
         {
             return static_cast<u32>(m_Vehicles.size());
         }
@@ -122,7 +122,7 @@ namespace OloEngine
         void CreateRagdolls();
         // Remove every generated ragdoll component (restoring the authored scene).
         void DestroyAllRagdolls();
-        u32 GetRagdollCount() const
+        [[nodiscard("ragdoll count query result must be used")]] u32 GetRagdollCount() const
         {
             return static_cast<u32>(m_Ragdolls.size());
         }
@@ -223,7 +223,7 @@ namespace OloEngine
         // contact, deduplicated per entity pair. Empty when the contact listener
         // is absent (physics not initialized). Backs the read-only MCP
         // olo_physics_contacts diagnostics tool. Thread-safe (listener-locked).
-        [[nodiscard]] std::vector<std::pair<UUID, UUID>> GetActiveContactPairs() const;
+        [[nodiscard("contact-pair snapshot must be used")]] std::vector<std::pair<UUID, UUID>> GetActiveContactPairs() const;
 
       private:
         void CreateRigidBodies();

--- a/OloEngine/src/OloEngine/Physics3D/JoltShapes.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltShapes.cpp
@@ -130,7 +130,7 @@ namespace OloEngine
     std::filesystem::path JoltShapes::GetDefaultCacheDirectory()
     {
         // Check environment variable first
-        if (const char* envCacheDir = std::getenv("OLO_PHYSICS_CACHE_DIR"); envCacheDir && strlen(envCacheDir) > 0)
+        if (const char* envCacheDir = std::getenv("OLO_PHYSICS_CACHE_DIR"); envCacheDir && ::strlen(envCacheDir) > 0)
         {
             return std::filesystem::path(envCacheDir);
         }
@@ -1055,7 +1055,7 @@ namespace OloEngine
                 bool syncSuccess = false;
 #ifdef _WIN32
                 // On Windows, use _open and _commit for guaranteed persistence
-                if (int fd = _open(tempFilePath.string().c_str(), _O_WRONLY); fd != -1)
+                if (int fd = ::_open(tempFilePath.string().c_str(), _O_WRONLY); fd != -1)
                 {
                     if (_commit(fd) == 0)
                     {

--- a/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/MeshCookingFactory.cpp
@@ -501,7 +501,7 @@ namespace OloEngine
             JPH::ConvexHullBuilder builder(joltVertices);
 
             const char* error = nullptr;
-            if (JPH::ConvexHullBuilder::EResult result = builder.Initialize(i32_max, 1e-5f, error); result != JPH::ConvexHullBuilder::EResult::Success)
+            if (JPH::ConvexHullBuilder::EResult result = builder.Initialize(::i32_max, 1e-5f, error); result != JPH::ConvexHullBuilder::EResult::Success)
             {
                 std::string errorMsg = error ? error : "Unknown error";
                 LogCookingError("GenerateConvexHull", "Convex hull generation failed: " + errorMsg);
@@ -679,7 +679,7 @@ namespace OloEngine
             std::set<sizet> selectedIndices;
 
             // Always include the 6 axis-aligned extremes (min/max X, Y, Z)
-            auto findExtreme = [&inputVertices, &center](const glm::vec3& direction) -> sizet
+            auto findExtreme = [&inputVertices, &center](const glm::vec3& direction)
             {
                 f32 maxDot = -std::numeric_limits<f32>::max();
                 sizet bestIndex = 0;


### PR DESCRIPTION

Mechanical SonarQube MAINTAINABILITY cleanup confined to
`OloEngine/src/OloEngine/Physics3D/**`. Same kind of work as the merged
per-subsystem sweeps #406 (Animation) and #407 (Audio): query SonarQube, fix a
coherent batch of smells, change no behaviour, keep physics tests green.

35 issues cleared across 8 files, 11 distinct rules:

- **S6166** (6): added explanation strings to existing `[[nodiscard]]`
  attributes (BuoyancySystem, JoltContactListener.{h,cpp}, JoltScene.h). No new
  bare attributes, so no new S6166 warnings.
- **S6007** (4): declared non-mutating const getters / pure mapping function
  `[[nodiscard(...)]]` (JoltScene.h count getters, JoltScene.cpp
  `ToJoltPathRotation`) — with a message to pre-empt S6166.
- **S6012** (2): CTAD on `std::unique_lock` / `std::lock_guard`
  (JoltJobSystemAdapter).
- **S6936** (1): renamed the local `clock` type alias → `Clock` (collides with
  libc `clock`) in JoltJobSystemAdapter.
- **S1271** (3): `::`-qualified global C-API / global constants — `::strlen`,
  `::_open` (JoltShapes), `::i32_max` (MeshCookingFactory).
- **S3574** (2): removed redundant lambda return types (`makeWheel`,
  `findExtreme`).
- **S1481** (1): removed a dead empty range-for over `m_Bodies` whose only effect
  was the unused binding; `m_Bodies.clear()` already runs the destructors.
- **S6004** (1): folded two `Ref<JoltBody>` locals into the `if` init-statement.
- **S6171** (2): `map.find(k) != end()` → `map.contains(k)` (constraints,
  vehicles).
- **S1121** (9): split chained `a1 = a2 = v;` constraint-axis assignments into
  independent statements.
- **S5350** (4): made vehicle/constraint range-for bindings `const auto&` and a
  `JPH::Body*` a `const JPH::Body*`.

No behaviour change. OloEngine + OloEngine-Tests build green; physics tests pass.
SonarQube auto-resolves the cleared rules on its next scan; no GitHub issue.

### Deliberately left (judgement / behaviour-risk / precedent)
- **S8417** (atomics memory-order, ~7) — changing the carefully-chosen
  acquire/release/relaxed orders to seq_cst is a behaviour change; deferred as
  "noise" exactly as in #407.
- **S5981** (`dynamic_cast` downcasts, ~13) — Jolt disables `std` RTTI and uses
  `static_cast` for constraint/controller downcasts by design; `dynamic_cast`
  would not compile / is wrong. Judgement rule, deferred as in #407.
- **S5025 / M23_329** (raw `new` / advanced allocation, ~12) — Jolt's
  `Ref<T>` / settings APIs take ownership of `new`-allocated objects; not a
  free-standing `make_unique` swap.
- **S1142** (too-many-returns, 11), **S3776** (cognitive complexity, 3),
  **S1188** (long lambda, 2), **S1151** (long switch case, 2) — branchy
  validation / converter flow; structural refactors out of scope for a
  behaviour-preserving sweep (matches #406's "clean guard merges only").
- **S131** (1) — the `JointType3D` switch already covers every enumerator with a
  post-switch fallback `return nullptr`; adding a `default` would trip clang's
  `-Wcovered-switch-default`.
- **S5945** (1) — a bounded `const JPH::BodyID[2]` feeding a pointer+count Jolt
  API; the C array is the idiomatic form and a swap would pull in `<array>` for
  one site.
- **S799** (2), **S1712** (1), **S5419** (3), **S1706 / S2486** (try/catch),
  **M23_235** (explicit lambda capture) — public-API renames / overload &
  parameter restructuring / try-catch reshaping; left as in #406/#407.
- **S6022** (3) — false positive: `ECollisionFlags` bitwise-OR via
  `std::to_underlying`; `std::byte` would be semantically wrong for a typed enum.
- **S5421** (1) — false positive: `s_JoltGlobalRefCount` is a mutable atomic
  ref-count and cannot be `const`.

`sonar-project.properties` is owned by the sibling `chore/sonarqube-analysis-setup`
branch and was **not** touched — all findings were addressed in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
