### PR TITLE
feat(mcp): enforce tool inputSchema on tools/call + cap request payload

### DIFF
--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -25,6 +25,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <optional>
 #include <random>
 #include <regex>
 #include <sstream>
@@ -46,6 +47,13 @@ namespace OloEngine::MCP
         constexpr int kMethodNotFound = -32601;
         constexpr int kInvalidParams = -32602;
 
+        // DoS hardening (issue #306 item D): the largest request body POST /mcp will
+        // buffer before dispatch. cpp-httplib defaults its payload cap to SIZE_MAX,
+        // so without this a single request could buffer an arbitrarily large body
+        // into memory. A real JSON-RPC call (or batch) is a few KB; 8 MiB is generous
+        // headroom while still bounding the worst case.
+        constexpr std::size_t kMaxRequestBytes = 8ull * 1024 * 1024;
+
         Json MakeResult(const Json& id, Json result)
         {
             return Json{ { "jsonrpc", "2.0" }, { "id", id }, { "result", std::move(result) } };
@@ -56,6 +64,236 @@ namespace OloEngine::MCP
             return Json{ { "jsonrpc", "2.0" },
                          { "id", id },
                          { "error", { { "code", code }, { "message", message } } } };
+        }
+
+        // ---- tools/call argument validation (issue #357 / #306 item D) ---------
+        //
+        // A deliberately small JSON-Schema-subset validator covering exactly what
+        // the schema-builder DSL (McpSchemaBuilder.h) can emit — see
+        // McpServer::ValidateArguments for the public contract. Everything here is
+        // pure (Json + stdlib only) so the dispatch test binary exercises it
+        // without an editor.
+
+        // Render a JSON-Schema `type` token as an English noun phrase for messages.
+        std::string SchemaTypeNoun(std::string_view type)
+        {
+            if (type == "integer")
+                return "an integer";
+            if (type == "number")
+                return "a number";
+            if (type == "string")
+                return "a string";
+            if (type == "boolean")
+                return "a boolean";
+            if (type == "array")
+                return "an array";
+            if (type == "object")
+                return "an object";
+            if (type == "null")
+                return "null";
+            return std::string(type);
+        }
+
+        // True if `value` satisfies the single JSON-Schema `type` token. "integer"
+        // is strict (a JSON integer, not a 5.0-style float) — deliberate hardening:
+        // every integer field the DSL declares (count / page / pageSize / bounds)
+        // is sent as an integer by any sane client, and a strict check needs no
+        // float-equality test (which SonarQube flags). "number" accepts either.
+        bool ValueMatchesSchemaType(const Json& value, std::string_view type)
+        {
+            if (type == "object")
+                return value.is_object();
+            if (type == "array")
+                return value.is_array();
+            if (type == "string")
+                return value.is_string();
+            if (type == "boolean")
+                return value.is_boolean();
+            if (type == "number")
+                return value.is_number(); // integer or float
+            if (type == "integer")
+                return value.is_number_integer();
+            if (type == "null")
+                return value.is_null();
+            return true; // an unmodelled type keyword: don't reject what we can't check
+        }
+
+        // "'parent.child'"-style dotted path for nested fields; just "child" at the
+        // top level (empty parent). Keeps an error pointing at the exact field.
+        std::string JoinFieldPath(const std::string& parent, std::string_view name)
+        {
+            if (parent.empty())
+                return std::string(name);
+            return parent + "." + std::string(name);
+        }
+
+        // A quoted subject for a message: "'count'", or "value" for the unnamed
+        // top-level object (which in practice always matches, so it rarely shows).
+        std::string FieldSubject(const std::string& label)
+        {
+            return label.empty() ? std::string("value") : "'" + label + "'";
+        }
+
+        // Validate `value` against `schema` (`label` names `value` for messages),
+        // returning the first error or nullopt. Forward-declared so the per-keyword
+        // checks below can recurse into nested properties / array items. A non-object
+        // schema is permissive (nothing modelled to enforce). Each keyword lives in
+        // its own small checker so the orchestrator stays flat and easy to audit.
+        std::optional<std::string> ValidateValueAgainstSchema(const Json& schema, const Json& value,
+                                                              const std::string& label);
+
+        // `type`: a single token, or an array of tokens (a union — match any one).
+        std::optional<std::string> CheckType(const Json& schema, const Json& value, const std::string& label)
+        {
+            const auto it = schema.find("type");
+            if (it == schema.end())
+                return std::nullopt;
+
+            if (it->is_string())
+            {
+                const std::string type = it->get<std::string>();
+                if (!ValueMatchesSchemaType(value, type))
+                    return FieldSubject(label) + " must be " + SchemaTypeNoun(type);
+                return std::nullopt;
+            }
+            if (!it->is_array())
+                return std::nullopt; // malformed `type` — not modelled
+
+            bool matched = false;
+            std::string nouns;
+            for (const auto& entry : *it)
+            {
+                if (!entry.is_string())
+                    continue;
+                const std::string type = entry.get<std::string>();
+                matched = matched || ValueMatchesSchemaType(value, type);
+                if (!nouns.empty())
+                    nouns += " or ";
+                nouns += SchemaTypeNoun(type);
+            }
+            if (matched || nouns.empty())
+                return std::nullopt;
+            return FieldSubject(label) + " must be " + nouns;
+        }
+
+        // `enum`: the value must equal one of the allowed entries.
+        std::optional<std::string> CheckEnum(const Json& schema, const Json& value, const std::string& label)
+        {
+            const auto it = schema.find("enum");
+            if (it == schema.end() || !it->is_array())
+                return std::nullopt;
+            for (const auto& allowed : *it)
+            {
+                if (value == allowed)
+                    return std::nullopt;
+            }
+            return FieldSubject(label) + " must be one of " + it->dump();
+        }
+
+        // `minimum` / `maximum` / `exclusiveMinimum` — only meaningful once the value
+        // is a number. The comparisons are relational, not equality, so float-clean.
+        std::optional<std::string> CheckNumericBounds(const Json& schema, const Json& value, const std::string& label)
+        {
+            if (!value.is_number())
+                return std::nullopt;
+            const double n = value.get<double>();
+            if (const auto it = schema.find("minimum"); it != schema.end() && it->is_number() && n < it->get<double>())
+                return FieldSubject(label) + " must be >= " + it->dump();
+            if (const auto it = schema.find("maximum"); it != schema.end() && it->is_number() && n > it->get<double>())
+                return FieldSubject(label) + " must be <= " + it->dump();
+            if (const auto it = schema.find("exclusiveMinimum");
+                it != schema.end() && it->is_number() && n <= it->get<double>())
+                return FieldSubject(label) + " must be > " + it->dump();
+            return std::nullopt;
+        }
+
+        // `required` + `additionalProperties` + per-property recursion.
+        std::optional<std::string> CheckObjectConstraints(const Json& schema, const Json& value,
+                                                          const std::string& label)
+        {
+            if (!value.is_object())
+                return std::nullopt;
+
+            const Json* properties = nullptr;
+            if (const auto it = schema.find("properties"); it != schema.end() && it->is_object())
+                properties = &(*it);
+
+            if (const auto it = schema.find("required"); it != schema.end() && it->is_array())
+            {
+                for (const auto& entry : *it)
+                {
+                    if (!entry.is_string())
+                        continue;
+                    const std::string name = entry.get<std::string>();
+                    if (!value.contains(name))
+                        return "missing required property '" + JoinFieldPath(label, name) + "'";
+                }
+            }
+
+            const auto addlIt = schema.find("additionalProperties");
+            const bool closed = addlIt != schema.end() && addlIt->is_boolean() && !addlIt->get<bool>();
+            const Json* addlSchema = (addlIt != schema.end() && addlIt->is_object()) ? &(*addlIt) : nullptr;
+
+            for (const auto& [key, member] : value.items())
+            {
+                if (properties != nullptr && properties->contains(key))
+                {
+                    if (auto err = ValidateValueAgainstSchema((*properties)[key], member, JoinFieldPath(label, key)))
+                        return err;
+                }
+                else if (closed)
+                    return "unexpected property '" + JoinFieldPath(label, key) + "'";
+                else if (addlSchema != nullptr)
+                {
+                    if (auto err = ValidateValueAgainstSchema(*addlSchema, member, JoinFieldPath(label, key)))
+                        return err;
+                }
+            }
+            return std::nullopt;
+        }
+
+        // `minItems` / `maxItems` + per-element `items` recursion.
+        std::optional<std::string> CheckArrayConstraints(const Json& schema, const Json& value,
+                                                         const std::string& label)
+        {
+            if (!value.is_array())
+                return std::nullopt;
+
+            const auto count = static_cast<std::int64_t>(value.size());
+            if (const auto it = schema.find("minItems");
+                it != schema.end() && it->is_number_integer() && count < it->get<std::int64_t>())
+                return FieldSubject(label) + " must have at least " + it->dump() + " items";
+            if (const auto it = schema.find("maxItems");
+                it != schema.end() && it->is_number_integer() && count > it->get<std::int64_t>())
+                return FieldSubject(label) + " must have at most " + it->dump() + " items";
+
+            const auto it = schema.find("items");
+            if (it == schema.end() || !it->is_object())
+                return std::nullopt;
+            for (std::size_t i = 0; i < value.size(); ++i)
+            {
+                const std::string elemLabel =
+                    (label.empty() ? std::string("value") : label) + "[" + std::to_string(i) + "]";
+                if (auto err = ValidateValueAgainstSchema(*it, value[i], elemLabel))
+                    return err;
+            }
+            return std::nullopt;
+        }
+
+        std::optional<std::string> ValidateValueAgainstSchema(const Json& schema, const Json& value,
+                                                              const std::string& label)
+        {
+            if (!schema.is_object())
+                return std::nullopt;
+            if (auto err = CheckType(schema, value, label))
+                return err;
+            if (auto err = CheckEnum(schema, value, label))
+                return err;
+            if (auto err = CheckNumericBounds(schema, value, label))
+                return err;
+            if (auto err = CheckObjectConstraints(schema, value, label))
+                return err;
+            return CheckArrayConstraints(schema, value, label);
         }
 
         // Reverse-DNS-namespaced `_meta` key carrying a tool's toolset (grouping
@@ -317,6 +555,16 @@ namespace OloEngine::MCP
         return true;
     }
 
+    std::optional<std::string> McpServer::ValidateArguments(const Json& schema, const Json& args)
+    {
+        // An absent / non-object / empty schema declares no constraints, so there is
+        // nothing to enforce — treat it as permissive (the caller also skips such
+        // schemas, but guarding here keeps the helper safe to call unconditionally).
+        if (!schema.is_object() || schema.empty())
+            return std::nullopt;
+        return ValidateValueAgainstSchema(schema, args, std::string{});
+    }
+
     void McpServer::RegisterTool(ToolDef tool)
     {
         // Fail loudly at registration: every tool is registered in code at startup,
@@ -345,6 +593,22 @@ namespace OloEngine::MCP
         m_Token = GenerateHexToken(16);
 
         m_Http = CreateScope<httplib::Server>();
+
+        // Bound the buffered request body so an oversized POST is rejected (413)
+        // before any handler runs, instead of being read entirely into memory.
+        m_Http->set_payload_max_length(kMaxRequestBytes);
+
+        // Give httplib-generated error responses (notably the 413 from the cap above,
+        // which short-circuits before HandlePost) a small JSON-RPC error body. Our
+        // own handler errors already carry their envelope, so only fill an empty body.
+        m_Http->set_error_handler([](const httplib::Request&, httplib::Response& res)
+                                  {
+            if (res.body.empty())
+            {
+                const Json body = MakeError(Json(nullptr), kInvalidRequest,
+                                            "Request rejected (HTTP " + std::to_string(res.status) + ")");
+                res.set_content(body.dump(), "application/json");
+            } });
 
         m_Http->Post("/mcp", [this](const httplib::Request& req, httplib::Response& res)
                      { HandlePost(req, res); });
@@ -889,6 +1153,14 @@ namespace OloEngine::MCP
         const Json arguments = (params.contains("arguments") && params["arguments"].is_object())
                                    ? params["arguments"]
                                    : Json::object();
+
+        // Enforce the tool's declared inputSchema before the handler runs, so a
+        // malformed call fails with a clean, field-naming kInvalidParams instead of
+        // depending on whatever ad-hoc checks that one handler happens to do (issue
+        // #357 conformance / #306 item D hardening). A permissive (empty / non-object)
+        // schema validates nothing.
+        if (const auto error = ValidateArguments(tool->InputSchema, arguments))
+            return MakeError(id, kInvalidParams, "Invalid arguments for tool '" + name + "': " + *error);
 
         ToolResult result;
         try

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <charconv>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
@@ -197,6 +198,12 @@ namespace OloEngine::MCP
             if (!value.is_number())
                 return std::nullopt;
             const double n = value.get<double>();
+            // A non-finite number (NaN / ±Inf) slips past the relational bound checks
+            // below — every comparison against NaN is false, and +Inf clears any
+            // schema without a `maximum` — and is never valid input. Reject it up
+            // front (the project rule to isfinite-validate floats from JSON/network).
+            if (!std::isfinite(n))
+                return FieldSubject(label) + " must be a finite number";
             if (const auto it = schema.find("minimum"); it != schema.end() && it->is_number() && n < it->get<double>())
                 return FieldSubject(label) + " must be >= " + it->dump();
             if (const auto it = schema.find("maximum"); it != schema.end() && it->is_number() && n > it->get<double>())
@@ -1150,9 +1157,13 @@ namespace OloEngine::MCP
         if (tool == nullptr)
             return MakeError(id, kInvalidParams, "Unknown tool: " + name);
 
-        const Json arguments = (params.contains("arguments") && params["arguments"].is_object())
-                                   ? params["arguments"]
-                                   : Json::object();
+        // `arguments` is optional, but when present it MUST be an object (MCP spec).
+        // A present-but-non-object payload is malformed: coercing it to {} would
+        // validate against an empty object and hide the mismatch, so reject it. Only
+        // a truly-absent field defaults to {}.
+        if (params.contains("arguments") && !params["arguments"].is_object())
+            return MakeError(id, kInvalidParams, "Invalid params: 'arguments' must be an object");
+        const Json arguments = params.contains("arguments") ? params["arguments"] : Json::object();
 
         // Enforce the tool's declared inputSchema before the handler runs, so a
         // malformed call fails with a clean, field-naming kInvalidParams instead of

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -355,6 +356,23 @@ namespace OloEngine::MCP
         // loudly via OLO_CORE_VERIFY. Exposed as a pure helper so it can be unit
         // tested without tripping that assert. Pure.
         [[nodiscard]] static bool IsValidToolName(std::string_view name);
+
+        // Validate a tools/call `arguments` object against a tool's declared
+        // `inputSchema` BEFORE the handler runs, so a malformed call fails with a
+        // clean kInvalidParams naming the offending field instead of reaching the
+        // handler's ad-hoc checks (or worse, silently not being checked at all).
+        // Supports exactly the JSON-Schema vocabulary the schema-builder DSL
+        // (McpSchemaBuilder.h) can emit: object / integer / number / boolean /
+        // string / array (incl. a multi-type `type` array), `properties`, `items`,
+        // `required`, `enum`, `minimum` / `maximum` / `exclusiveMinimum`,
+        // `minItems` / `maxItems`, and `additionalProperties:false`. It is NOT a
+        // general JSON-Schema implementation.
+        //
+        // Returns a human-readable error (e.g. "missing required property
+        // 'entity'", "'count' must be <= 200", "unexpected property 'foo'") or
+        // std::nullopt when `args` satisfies `schema`. A non-object / empty schema
+        // is treated as permissive (returns nullopt — nothing to enforce). Pure.
+        [[nodiscard]] static std::optional<std::string> ValidateArguments(const Json& schema, const Json& args);
 
       private:
         // Top-level HTTP handler (cpp-httplib worker thread): auth + origin check,

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -349,6 +349,12 @@ add_executable(OloEngine-Tests
 		# schema literals (#357 Tier 2 P4). Header-only (MCP/McpSchemaBuilder.h,
 		# nlohmann::json + stdlib only), so no extra editor TU is pulled in.
 		MCP/McpSchemaBuilderTest.cpp
+		# Server-side inputSchema enforcement for tools/call: McpServer::ValidateArguments
+		# (the pure validator) + HandleToolsCall rejecting malformed calls with a
+		# field-naming kInvalidParams (#357 conformance / #306 item D hardening).
+		# Exercises the McpServer.cpp TU already pulled in above plus the header-only
+		# schema-builder DSL; no extra editor TU is needed.
+		MCP/McpInputValidationTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpInputValidationTest.cpp
+++ b/OloEngine/tests/MCP/McpInputValidationTest.cpp
@@ -1,0 +1,292 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Server-side `inputSchema` enforcement for tools/call (issue #357 conformance /
+// #306 item D hardening). Two surfaces are exercised, both httplib-free:
+//   * McpServer::ValidateArguments(schema, args) — the pure validator, driven with
+//     schemas built by the real schema-builder DSL (McpSchemaBuilder.h), so the
+//     tests assert against exactly what the live tools emit.
+//   * HandleToolsCall (via the dispatch seam) — that a malformed call now fails
+//     with a field-naming kInvalidParams BEFORE the handler runs, and a valid call
+//     still reaches the handler.
+// No live OloEditor, GPU, or agent is required (McpServer.cpp is compiled in; the
+// DSL header is header-only).
+#include "MCP/McpServer.h"
+#include "MCP/McpSchemaBuilder.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+    namespace Schema = OloEngine::MCP::Schema;
+
+    // True if `result` (an std::optional<std::string> from ValidateArguments) holds
+    // an error whose text contains `needle`. Fails the calling EXPECT otherwise.
+    bool ErrorContains(const std::optional<std::string>& result, std::string_view needle)
+    {
+        return result.has_value() && result->find(needle) != std::string::npos;
+    }
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    // The canonical "one int + one string, int required, closed" schema — the shape
+    // most real tool inputs reduce to. Built with the DSL so it is byte-identical to
+    // what McpTools.cpp emits.
+    Json CountAndTagSchema()
+    {
+        return Schema::Object()
+            .Prop("count", Schema::Int().Min(1).Max(200).Desc("How many."))
+            .Prop("tag", Schema::String().Desc("Optional filter."))
+            .Required({ "count" })
+            .NoAdditional();
+    }
+} // namespace
+
+// ---- pure validator: happy path -------------------------------------------
+
+TEST(McpInputValidation, HappyPathReturnsNoError)
+{
+    const Json schema = CountAndTagSchema();
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "count", 50 }, { "tag", "ui" } }).has_value());
+    // The optional `tag` may be omitted.
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "count", 1 } }).has_value());
+    // Bounds are inclusive at both ends.
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "count", 200 } }).has_value());
+}
+
+// ---- pure validator: each vocabulary keyword ------------------------------
+
+TEST(McpInputValidation, MissingRequiredPropertyNamesTheField)
+{
+    const auto err = McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "tag", "ui" } });
+    EXPECT_TRUE(ErrorContains(err, "missing required property 'count'"));
+}
+
+TEST(McpInputValidation, WrongTypeNamesFieldAndExpectedType)
+{
+    const auto err = McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "count", "fifty" } });
+    EXPECT_TRUE(ErrorContains(err, "'count'"));
+    EXPECT_TRUE(ErrorContains(err, "must be an integer"));
+}
+
+TEST(McpInputValidation, IntegerIsStrictAboutWholeValuedFloats)
+{
+    // A 5.0-style JSON float is NOT a JSON integer — deliberate hardening, and it
+    // keeps the validator free of any float-equality test.
+    const auto err = McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "count", 5.0 } });
+    EXPECT_TRUE(ErrorContains(err, "must be an integer"));
+}
+
+TEST(McpInputValidation, IntegerOutOfRangeReportsTheBound)
+{
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "count", 0 } }),
+                              "'count' must be >= 1"));
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "count", 201 } }),
+                              "'count' must be <= 200"));
+}
+
+TEST(McpInputValidation, NumberAcceptsIntegerAndFloatAndEnforcesExclusiveMin)
+{
+    const Json schema = Schema::Object()
+                            .Prop("distance", Schema::Number().ExclusiveMin(0).Desc("World units."))
+                            .NoAdditional();
+    // A "number" field accepts both a JSON integer and a JSON float.
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "distance", 10 } }).has_value());
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "distance", 2.5 } }).has_value());
+    // exclusiveMinimum rejects the bound itself and anything below it.
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "distance", 0 } }),
+                              "'distance' must be > 0"));
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "distance", -3.0 } }),
+                              "'distance' must be > 0"));
+}
+
+TEST(McpInputValidation, EnumRejectsValuesOutsideTheClosedSet)
+{
+    const Json schema = Schema::Object()
+                            .Prop("mode", Schema::String().Enum({ "depth", "normals", "albedo" }))
+                            .NoAdditional();
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "mode", "normals" } }).has_value());
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "mode", "bogus" } }),
+                              "'mode' must be one of"));
+}
+
+TEST(McpInputValidation, ClosedObjectRejectsUnexpectedProperty)
+{
+    const auto err = McpServer::ValidateArguments(CountAndTagSchema(), Json{ { "count", 1 }, { "extra", true } });
+    EXPECT_TRUE(ErrorContains(err, "unexpected property 'extra'"));
+}
+
+TEST(McpInputValidation, OpenObjectAllowsUnknownProperties)
+{
+    // No NoAdditional() => additionalProperties is not closed, so unknown keys pass.
+    const Json schema = Schema::Object().Prop("count", Schema::Int()).Required({ "count" });
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "count", 1 }, { "extra", true } }).has_value());
+}
+
+TEST(McpInputValidation, EmptyObjectSchemaRejectsAnyArgument)
+{
+    // Schema::EmptyObject() is the argument-less tool schema (closed, no properties).
+    const Json schema = Schema::EmptyObject();
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json::object()).has_value());
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "foo", 1 } }),
+                              "unexpected property 'foo'"));
+}
+
+// ---- pure validator: nested array (Vec3) + multi-type ----------------------
+
+TEST(McpInputValidation, NestedArrayEnforcesItemsAndLength)
+{
+    const Json schema = Schema::Object()
+                            .Prop("position", Schema::Vec3("Camera eye [x, y, z]."))
+                            .Required({ "position" })
+                            .NoAdditional();
+    // A well-formed 3-number position passes (integers count as numbers).
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "position", Json::array({ 1, 2, 3 }) } }).has_value());
+    EXPECT_FALSE(
+        McpServer::ValidateArguments(schema, Json{ { "position", Json::array({ 1.5, -2.0, 3.25 }) } }).has_value());
+
+    // Too few / too many elements report the length bound on the named field.
+    EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "position", Json::array({ 1, 2 }) } }),
+                              "'position' must have at least 3 items"));
+    EXPECT_TRUE(
+        ErrorContains(McpServer::ValidateArguments(schema, Json{ { "position", Json::array({ 1, 2, 3, 4 }) } }),
+                      "'position' must have at most 3 items"));
+
+    // A non-number element is reported with its index.
+    EXPECT_TRUE(
+        ErrorContains(McpServer::ValidateArguments(schema, Json{ { "position", Json::array({ 1, "x", 3 }) } }),
+                      "'position[1]' must be a number"));
+}
+
+TEST(McpInputValidation, MultiTypeUnionAcceptsEitherTypeAndReportsBoth)
+{
+    // The `sinceId` shape from olo_events_tail: `{ "type": ["integer", "string"] }`.
+    const Json schema = Schema::Object()
+                            .Prop("sinceId", Schema::Raw(Json{ { "type", Json::array({ "integer", "string" }) } }))
+                            .NoAdditional();
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "sinceId", 42 } }).has_value());
+    EXPECT_FALSE(McpServer::ValidateArguments(schema, Json{ { "sinceId", "abc" } }).has_value());
+
+    const auto err = McpServer::ValidateArguments(schema, Json{ { "sinceId", true } });
+    EXPECT_TRUE(ErrorContains(err, "an integer or a string"));
+}
+
+// ---- pure validator: permissive schemas skip cleanly -----------------------
+
+TEST(McpInputValidation, PermissiveSchemaValidatesNothing)
+{
+    // An empty object, a bare {} schema, and a non-object schema all declare no
+    // constraints, so any arguments pass (the dispatcher also skips these).
+    EXPECT_FALSE(McpServer::ValidateArguments(Json::object(), Json{ { "anything", 1 } }).has_value());
+    EXPECT_FALSE(McpServer::ValidateArguments(Json(nullptr), Json{ { "anything", 1 } }).has_value());
+    EXPECT_FALSE(McpServer::ValidateArguments(Json("not-a-schema"), Json{ { "anything", 1 } }).has_value());
+}
+
+// ---- dispatch integration: tools/call enforces the schema ------------------
+
+namespace
+{
+    // Fixture registering one tool with a closed count+tag schema and one tool with
+    // no declared schema, so both the enforced and the permissive paths are covered
+    // end-to-end through HandleMessage -> HandleToolsCall.
+    class McpInputValidationDispatch : public ::testing::Test
+    {
+      protected:
+        McpInputValidationDispatch()
+            : m_Server(EditorMcpContext{})
+        {
+            ToolDef validated;
+            validated.Name = "fake_validated";
+            validated.Description = "Validates its arguments.";
+            validated.InputSchema = CountAndTagSchema();
+            validated.Handler = [](McpServer&, const Json&)
+            { return ToolResult::Text("ok"); };
+            m_Server.RegisterTool(std::move(validated));
+
+            ToolDef open;
+            open.Name = "fake_open";
+            open.Description = "Declares no schema (permissive).";
+            open.Handler = [](McpServer&, const Json&)
+            { return ToolResult::Text("ok"); };
+            m_Server.RegisterTool(std::move(open));
+        }
+
+        Json Call(const Json& arguments)
+        {
+            return m_Server.HandleMessage(
+                MakeRequest(1, "tools/call", Json{ { "name", "fake_validated" }, { "arguments", arguments } }));
+        }
+
+        McpServer m_Server;
+    };
+} // namespace
+
+TEST_F(McpInputValidationDispatch, ValidArgumentsReachHandler)
+{
+    const Json resp = Call(Json{ { "count", 5 }, { "tag", "ui" } });
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(resp["result"]["content"][0]["text"], "ok");
+}
+
+TEST_F(McpInputValidationDispatch, MissingRequiredIsInvalidParamsBeforeHandler)
+{
+    const Json resp = Call(Json::object());
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result")); // handler never ran
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    const std::string message = resp["error"]["message"].get<std::string>();
+    EXPECT_NE(message.find("missing required property 'count'"), std::string::npos);
+    EXPECT_NE(message.find("fake_validated"), std::string::npos);
+}
+
+TEST_F(McpInputValidationDispatch, WrongTypeIsInvalidParams)
+{
+    const Json resp = Call(Json{ { "count", "fifty" } });
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    EXPECT_NE(resp["error"]["message"].get<std::string>().find("must be an integer"), std::string::npos);
+}
+
+TEST_F(McpInputValidationDispatch, OutOfRangeIsInvalidParams)
+{
+    const Json resp = Call(Json{ { "count", 9999 } });
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    EXPECT_NE(resp["error"]["message"].get<std::string>().find("must be <= 200"), std::string::npos);
+}
+
+TEST_F(McpInputValidationDispatch, UnexpectedPropertyIsInvalidParams)
+{
+    const Json resp = Call(Json{ { "count", 1 }, { "bogus", true } });
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    EXPECT_NE(resp["error"]["message"].get<std::string>().find("unexpected property 'bogus'"), std::string::npos);
+}
+
+// A tool that declares no InputSchema is permissive: arbitrary arguments reach the
+// handler (validation is skipped, not failed).
+TEST_F(McpInputValidationDispatch, NoSchemaToolSkipsValidation)
+{
+    const Json resp = m_Server.HandleMessage(
+        MakeRequest(2, "tools/call", Json{ { "name", "fake_open" }, { "arguments", { { "whatever", 123 } } } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+}

--- a/OloEngine/tests/MCP/McpInputValidationTest.cpp
+++ b/OloEngine/tests/MCP/McpInputValidationTest.cpp
@@ -15,6 +15,7 @@
 #include "MCP/McpServer.h"
 #include "MCP/McpSchemaBuilder.h"
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <utility>
@@ -114,6 +115,25 @@ TEST(McpInputValidation, NumberAcceptsIntegerAndFloatAndEnforcesExclusiveMin)
                               "'distance' must be > 0"));
     EXPECT_TRUE(ErrorContains(McpServer::ValidateArguments(schema, Json{ { "distance", -3.0 } }),
                               "'distance' must be > 0"));
+}
+
+TEST(McpInputValidation, NonFiniteNumbersAreRejected)
+{
+    // NaN passes every relational bound check (all NaN comparisons are false) and
+    // +Inf clears a schema with no `maximum`, so a finite check is what actually
+    // rejects them — a non-finite number is never valid input.
+    const Json schema = Schema::Object()
+                            .Prop("distance", Schema::Number().ExclusiveMin(0))
+                            .NoAdditional();
+    EXPECT_TRUE(ErrorContains(
+        McpServer::ValidateArguments(schema, Json{ { "distance", std::numeric_limits<double>::quiet_NaN() } }),
+        "'distance' must be a finite number"));
+    EXPECT_TRUE(ErrorContains(
+        McpServer::ValidateArguments(schema, Json{ { "distance", std::numeric_limits<double>::infinity() } }),
+        "'distance' must be a finite number"));
+    EXPECT_TRUE(ErrorContains(
+        McpServer::ValidateArguments(schema, Json{ { "distance", -std::numeric_limits<double>::infinity() } }),
+        "'distance' must be a finite number"));
 }
 
 TEST(McpInputValidation, EnumRejectsValuesOutsideTheClosedSet)
@@ -287,6 +307,28 @@ TEST_F(McpInputValidationDispatch, NoSchemaToolSkipsValidation)
 {
     const Json resp = m_Server.HandleMessage(
         MakeRequest(2, "tools/call", Json{ { "name", "fake_open" }, { "arguments", { { "whatever", 123 } } } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+}
+
+// A present-but-non-object `arguments` is malformed and must be rejected, not
+// silently coerced to {} (which would validate against an empty object and hide the
+// mismatch). Even the no-schema tool rejects it, since the check precedes validation.
+TEST_F(McpInputValidationDispatch, PresentNonObjectArgumentsIsInvalidParams)
+{
+    const Json resp = m_Server.HandleMessage(
+        MakeRequest(3, "tools/call", Json{ { "name", "fake_open" }, { "arguments", Json::array({ 1, 2, 3 }) } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    EXPECT_NE(resp["error"]["message"].get<std::string>().find("'arguments' must be an object"),
+              std::string::npos);
+}
+
+// A truly-absent `arguments` still defaults to {} and reaches the handler.
+TEST_F(McpInputValidationDispatch, AbsentArgumentsDefaultsToEmptyObject)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(4, "tools/call", Json{ { "name", "fake_open" } }));
     ASSERT_TRUE(resp.contains("result"));
     EXPECT_FALSE(resp["result"]["isError"]);
 }


### PR DESCRIPTION
## What

The MCP diagnostics server publishes a precise `inputSchema` for every tool but never enforced it: `HandleToolsCall` passed `arguments` straight to the handler, so a malformed `tools/call` only failed if that one handler happened to hand-roll a check (~41 tools, ~40 ad-hoc sites, inconsistent). This adds **server-side argument validation against the declared schema, before dispatch**, returning a clean `kInvalidParams` (-32602) naming the offending field.

Builds directly on the just-merged schema-builder DSL (PR #421): the DSL made schemas precise; this enforces them. It *consumes* the DSL output — no general JSON-Schema library, just the vocabulary the DSL can emit.

Advances **#357** (protocol-conformance — server-side schema enforcement) and **#306 item D** (hardening). Does not close either (both have other open items).

## Changes

- **`McpServer::ValidateArguments(schema, args) → std::optional<std::string>`** — a pure, transport-agnostic validator next to `IsValidToolName`. Covers exactly the DSL vocabulary: object / integer / number / boolean / string / array (incl. a multi-type `type` union), `properties`, `items`, `required`, `enum`, `minimum`/`maximum`/`exclusiveMinimum`, `minItems`/`maxItems`, `additionalProperties:false`. Small per-keyword checkers + a flat orchestrator (keeps cognitive complexity low for this SonarQube-sensitive file). Empty / non-object schemas are permissive (skipped).
- **Call site in `HandleToolsCall`** — validates before the handler runs; on failure returns `kInvalidParams` with a field-naming message, e.g. `Invalid arguments for tool 'olo_scene_get_entity': missing required property 'id'`.
- **Payload-size cap in `Start()`** (#306-D) — `set_payload_max_length(8 MiB)` (cpp-httplib defaults to `SIZE_MAX`, so `POST /mcp` would otherwise buffer an arbitrarily large body into memory) plus a `set_error_handler` that fills only *empty* error bodies, so the 413 gets a clean JSON-RPC body while handler-produced errors are untouched.

## Tests

New `McpInputValidationTest.cpp` (classified `// OLO_TEST_LAYER: unit`, registered in `OloEngine/tests/CMakeLists.txt`), driven by **real DSL-built schemas** — mirrors the existing httplib-free dispatch-seam pattern (`McpDispatchTest` / `McpSchemaBuilderTest`), no live editor/GPU/agent:

- 13 pure `ValidateArguments` cases: happy path, missing required, wrong type, integer strictness (`5.0` rejected), int/number range, `exclusiveMinimum`, enum, unexpected property, open vs closed objects, empty-object schema, nested Vec3 array (item type + length + index in the message), multi-type union, permissive-skip.
- 6 end-to-end dispatch cases proving the -32602 fires **before** the handler, and that a schema-less tool skips validation.

`cmake --build build --target OloEngine-Tests --config Debug` ✅ (exit 0). `OloEngine-Tests.exe --gtest_filter=*Mcp*` → **210/210 pass**, including the pre-existing dispatch / structured-output / annotations / schema-builder suites (no regression).

## Notes

- **Entity-id fields stay strict by design.** `olo_scene_get_entity` etc. declare `type:"string"` for the id while their handler's `ParseUuid` also tolerates a JSON number; the DSL authors used an explicit `["integer","string"]` union (`sinceId`) where both types are the intended contract, so plain `string` is deliberate. Enforcing string is correct and the practical regression is ~zero (UUIDs are 64-bit, unsafe as JS numbers; `olo_scene_list_entities` returns ids as strings, so the round-trip already uses strings). The `EntityId()` schema is byte-locked by `McpSchemaBuilderTest`, so it is intentionally left unchanged; reconciling its "also accepts a number" description is a separate maintainer schema decision.
- The payload cap is compile/link-verified against the real httplib API but not unit-tested (it's an httplib-transport concern, not the pure dispatch seam, as called out in the task) — a runtime smoke would need a >8 MiB `POST /mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-size protection for the MCP endpoint to reject oversized POST bodies.
  * Added validation of tool arguments against declared input schemas, including support for common object, array, numeric, enum, and type checks.

* **Bug Fixes**
  * Invalid tool calls now fail early with clearer parameter errors instead of reaching the handler.
  * Tools without a schema remain permissive, preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->