### PR TITLE
feat(audio): route SoundGraphSound volume/pitch/looping/filter setter…

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -7,6 +7,8 @@
 
 #include <choc/containers/choc_Value.h>
 #include <algorithm>
+#include <cmath>
+#include <string_view>
 // AudioEngine.h forward-declares ma_engine; we need the full miniaudio API surface here
 // for ma_engine_get_sample_rate (and the implicit pointer arithmetic on ma_engine*).
 #include <miniaudio.h>
@@ -14,6 +16,22 @@
 namespace OloEngine::Audio::SoundGraph
 {
     using EPlayState = SoundPlayState;
+
+    namespace
+    {
+        // Conventional graph-input parameter names the high-level Sound controls route to.
+        // A SoundGraph opts a control in by exposing a graph input stream of the matching
+        // name + type — float for Volume / Pitch / LowPass / HighPass, bool for Loop — and
+        // routing it to the node it should drive (e.g. a Gain node's amplitude, or a
+        // WavePlayer's "Loop" input). A graph that omits an endpoint simply ignores that
+        // control: the routed write no-ops (SoundGraphSource::SetParameter returns false).
+        // "Loop" matches WavePlayer's loop endpoint so a pass-through graph input lines up.
+        constexpr std::string_view kVolumeParam = "Volume";
+        constexpr std::string_view kPitchParam = "Pitch";
+        constexpr std::string_view kLoopParam = "Loop";
+        constexpr std::string_view kLowPassParam = "LowPass";
+        constexpr std::string_view kHighPassParam = "HighPass";
+    } // namespace
 
     //==============================================================================
     SoundGraphSound::SoundGraphSound()
@@ -75,6 +93,16 @@ namespace OloEngine::Audio::SoundGraph
         return true;
     }
 
+    bool SoundGraphSound::InitializeDetachedSource()
+    {
+        OLO_PROFILE_FUNCTION();
+        // Mirror InitializeAudioCallback's source allocation but skip the ma_engine
+        // attachment: the source can still drive its graph and apply parameter writes,
+        // it just never feeds miniaudio's output. See the header for the rationale.
+        m_Source = CreateScope<Audio::SoundGraph::SoundGraphSource>();
+        return true;
+    }
+
     // Additional overload to match header declaration
     bool SoundGraphSound::InitializeFromGraph(const Ref<Audio::SoundGraph::SoundGraph>& soundGraph)
     {
@@ -98,6 +126,8 @@ namespace OloEngine::Audio::SoundGraph
             m_Source->ReplaceGraph(soundGraph);
             // Only set ready state if the source accepted the graph successfully
             m_IsReadyToPlay = true;
+            // Apply any controls set before the graph existed (volume/pitch/looping/filters).
+            SyncControlParametersToGraph();
             return true;
         }
         catch (const std::exception& e)
@@ -160,6 +190,8 @@ namespace OloEngine::Audio::SoundGraph
             m_Source->ReplaceGraph(soundGraph);
             // Only set ready state if both operations succeeded
             m_IsReadyToPlay = true;
+            // Apply any controls set before the graph existed (volume/pitch/looping/filters).
+            SyncControlParametersToGraph();
             return true;
         }
         catch (const std::exception& e)
@@ -253,16 +285,31 @@ namespace OloEngine::Audio::SoundGraph
     {
         OLO_PROFILE_FUNCTION();
 
+        // Volume can arrive from script / YAML / network (Scene forwards the component's
+        // VolumeMultiplier here); reject a non-finite value rather than letting std::clamp
+        // pass NaN straight through to the graph.
+        if (!std::isfinite(newVolume))
+        {
+            OLO_CORE_WARN("SoundGraphSound::SetVolume - ignoring non-finite volume; keeping {}", m_Volume);
+            return;
+        }
+
         m_Volume = std::clamp(newVolume, 0.0f, 1.0f);
-        // Note: Actual volume control would be implemented via SoundGraph parameters
+        RouteFloatParameter(kVolumeParam, m_Volume);
     }
 
     void SoundGraphSound::SetPitch(f32 newPitch)
     {
         OLO_PROFILE_FUNCTION();
 
+        if (!std::isfinite(newPitch))
+        {
+            OLO_CORE_WARN("SoundGraphSound::SetPitch - ignoring non-finite pitch; keeping {}", m_Pitch);
+            return;
+        }
+
         m_Pitch = std::clamp(newPitch, 0.1f, 4.0f);
-        // Note: Actual pitch control would be implemented via SoundGraph parameters
+        RouteFloatParameter(kPitchParam, m_Pitch);
     }
 
     void SoundGraphSound::SetLooping(bool looping)
@@ -270,7 +317,7 @@ namespace OloEngine::Audio::SoundGraph
         OLO_PROFILE_FUNCTION();
 
         m_IsLooping = looping;
-        // Note: Actual looping would be implemented via SoundGraph parameters
+        RouteBoolParameter(kLoopParam, m_IsLooping);
     }
 
     f32 SoundGraphSound::GetVolume() const
@@ -291,16 +338,56 @@ namespace OloEngine::Audio::SoundGraph
     {
         OLO_PROFILE_FUNCTION();
 
+        if (!std::isfinite(value))
+        {
+            OLO_CORE_WARN("SoundGraphSound::SetLowPassFilter - ignoring non-finite value; keeping {}", m_LowPassValue);
+            return;
+        }
+
         m_LowPassValue = std::clamp(value, 0.0f, 1.0f);
-        // Note: Actual filtering would be implemented via SoundGraph parameters
+        RouteFloatParameter(kLowPassParam, m_LowPassValue);
     }
 
     void SoundGraphSound::SetHighPassFilter(f32 value)
     {
         OLO_PROFILE_FUNCTION();
 
+        if (!std::isfinite(value))
+        {
+            OLO_CORE_WARN("SoundGraphSound::SetHighPassFilter - ignoring non-finite value; keeping {}", m_HighPassValue);
+            return;
+        }
+
         m_HighPassValue = std::clamp(value, 0.0f, 1.0f);
-        // Note: Actual filtering would be implemented via SoundGraph parameters
+        RouteFloatParameter(kHighPassParam, m_HighPassValue);
+    }
+
+    void SoundGraphSound::RouteFloatParameter(std::string_view parameterName, f32 value)
+    {
+        // Best-effort routing into the live graph. SoundGraphSource::SetParameter(name)
+        // hashes the name, checks the graph exposes a matching input endpoint, and applies
+        // the value synchronously; it returns false (no-op) when there's no graph yet or the
+        // endpoint isn't exposed, so this is safe to call before init and on every graph.
+        if (m_Source)
+            m_Source->SetParameter(parameterName, choc::value::createFloat32(value));
+    }
+
+    void SoundGraphSound::RouteBoolParameter(std::string_view parameterName, bool value)
+    {
+        if (m_Source)
+            m_Source->SetParameter(parameterName, choc::value::createBool(value));
+    }
+
+    void SoundGraphSound::SyncControlParametersToGraph()
+    {
+        // Re-push every stored control so a value set before the graph was installed (or
+        // before a graph swap) still lands. Each routes to a conventional endpoint name and
+        // is ignored by a graph that doesn't expose it.
+        RouteFloatParameter(kVolumeParam, m_Volume);
+        RouteFloatParameter(kPitchParam, m_Pitch);
+        RouteBoolParameter(kLoopParam, m_IsLooping);
+        RouteFloatParameter(kLowPassParam, m_LowPassValue);
+        RouteFloatParameter(kHighPassParam, m_HighPassValue);
     }
 
     //==============================================================================
@@ -336,7 +423,7 @@ namespace OloEngine::Audio::SoundGraph
             }
             catch (...)
             {
-                // Ignore errors - this is a stub implementation
+                OLO_CORE_WARN("SoundGraphSound: SetParameter(int) threw unexpectedly for parameterID {}", parameterID);
             }
         }
     }
@@ -353,7 +440,7 @@ namespace OloEngine::Audio::SoundGraph
             }
             catch (...)
             {
-                // Ignore errors - this is a stub implementation
+                OLO_CORE_WARN("SoundGraphSound: SetParameter(bool) threw unexpectedly for parameterID {}", parameterID);
             }
         }
     }
@@ -393,7 +480,15 @@ namespace OloEngine::Audio::SoundGraph
     }
 
     //==============================================================================
-    /// 3D Audio - Stub implementations that just store values
+    /// 3D Audio
+    ///
+    /// These store the spatial state and back GetLocation()/GetVelocity(), but do not
+    /// yet feed a spatializer: SoundGraphSource attaches its bare ma_node straight to the
+    /// engine endpoint, whereas Audio::DSP::Spatializer (AudioEngine::GetSpatializer)
+    /// inserts per-source panning nodes after an ma_engine_node and is wired only into the
+    /// ma_sound-based AudioSource path. Routing a SoundGraph voice through the spatializer
+    /// is real new infrastructure (per-voice node insertion + listener/source registration),
+    /// not a parameter route, so it is deferred — tracked in issue #424.
 
     void SoundGraphSound::SetLocation(const glm::vec3& location)
     {
@@ -446,15 +541,15 @@ namespace OloEngine::Audio::SoundGraph
             }
         }
 
-        // Update source if available, but handle the fact that methods might not exist
+        // Pump the source (drains its audio→main-thread event/message queues) and pick up
+        // a natural-finish transition. Guarded defensively: a throw from the source must not
+        // propagate out of the per-frame Update.
         if (m_Source)
         {
-            // Try to call Update - our SoundGraphSource does have this method
             try
             {
                 m_Source->Update(static_cast<f64>(deltaTime));
 
-                // Try to check if finished - our SoundGraphSource does have this method
                 if (m_Source->IsFinished() && !m_IsFinished)
                 {
                     m_IsFinished = true;
@@ -464,7 +559,7 @@ namespace OloEngine::Audio::SoundGraph
             }
             catch (...)
             {
-                // Ignore errors - this is a stub implementation
+                OLO_CORE_WARN("SoundGraphSound::Update - source update threw unexpectedly");
             }
         }
     }
@@ -507,7 +602,7 @@ namespace OloEngine::Audio::SoundGraph
     }
 
     //==============================================================================
-    /// Private Methods - All stub implementations
+    /// Private Methods
 
     bool SoundGraphSound::StopFade(u64 numSamples)
     {
@@ -566,7 +661,9 @@ namespace OloEngine::Audio::SoundGraph
                 m_OnPlaybackComplete();
         }
 
-        return 0; // Return dummy voice ID
+        // A SoundGraphSound owns a single voice — there is no voice pool to return an ID
+        // from. 0 is the non-negative success sentinel StopFade()'s `>= 0` check expects.
+        return 0;
     }
 
     f32 SoundGraphSound::NormalizedToFrequency(f32 normalizedValue)

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -58,6 +58,9 @@ namespace OloEngine::Audio::SoundGraph
     bool SoundGraphSound::InitializeAudioCallback()
     {
         OLO_PROFILE_FUNCTION();
+        // Replacing the source invalidates readiness (a graph must be re-installed before
+        // Play() may succeed); keep the invariant uniform with InitializeDetachedSource.
+        m_IsReadyToPlay = false;
         m_Source = CreateScope<Audio::SoundGraph::SoundGraphSource>();
 
         // Hook the source's custom ma_node into miniaudio's node graph using the live
@@ -96,6 +99,10 @@ namespace OloEngine::Audio::SoundGraph
     bool SoundGraphSound::InitializeDetachedSource()
     {
         OLO_PROFILE_FUNCTION();
+        // Swapping in a fresh, graphless source invalidates any prior readiness: it can't
+        // play until InitializeFromGraph installs a graph. Clear the flag so a stale
+        // m_IsReadyToPlay from a previous source can't let Play() fire on this one.
+        m_IsReadyToPlay = false;
         // Mirror InitializeAudioCallback's source allocation but skip the ma_engine
         // attachment: the source can still drive its graph and apply parameter writes,
         // it just never feeds miniaudio's output. See the header for the rationale.
@@ -123,8 +130,15 @@ namespace OloEngine::Audio::SoundGraph
         // Wire the sound graph into the source
         try
         {
-            m_Source->ReplaceGraph(soundGraph);
-            // Only set ready state if the source accepted the graph successfully
+            // ReplaceGraph can decline the swap (audio thread didn't quiesce in time) without
+            // throwing. Only mark ready / push controls when the swap actually took — otherwise
+            // m_Graph still holds the old (or no) graph and we'd report a sound that isn't there.
+            if (!m_Source->ReplaceGraph(soundGraph))
+            {
+                OLO_CORE_ERROR("SoundGraphSound::InitializeFromGraph - graph swap did not take effect; not ready");
+                m_IsReadyToPlay = false;
+                return false;
+            }
             m_IsReadyToPlay = true;
             // Apply any controls set before the graph existed (volume/pitch/looping/filters).
             SyncControlParametersToGraph();
@@ -187,7 +201,14 @@ namespace OloEngine::Audio::SoundGraph
         // Wire the sound graph into the source
         try
         {
-            m_Source->ReplaceGraph(soundGraph);
+            // See InitializeFromGraph: a declined swap (no throw) must not be reported ready.
+            if (!m_Source->ReplaceGraph(soundGraph))
+            {
+                OLO_CORE_ERROR("SoundGraphSound::InitializeDataSource - graph swap did not take effect; not ready");
+                m_Source->UninitializeDataSources();
+                m_IsReadyToPlay = false;
+                return false;
+            }
             // Only set ready state if both operations succeeded
             m_IsReadyToPlay = true;
             // Apply any controls set before the graph existed (volume/pitch/looping/filters).

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
@@ -8,6 +8,7 @@
 #include "OloEngine/Asset/Asset.h" // For AssetHandle
 #include <glm/glm.hpp>
 #include <string>
+#include <string_view>
 #include <functional>
 #include <utility>
 #include <vector>
@@ -115,6 +116,16 @@ namespace OloEngine
                     InitializeFromGraph / InitializeDataSource overloads. Exposed publicly so
                     Scene::InitAudioRuntime (and other owners) can drive the lifecycle. */
                 bool InitializeAudioCallback();
+
+                /** Allocate the internal SoundGraphSource WITHOUT attaching it to the live
+                    ma_engine (contrast InitializeAudioCallback). A detached source still
+                    processes its graph and applies parameter writes — so SetVolume / SetPitch /
+                    SetParameter take effect on the graph's input cells — but produces no audible
+                    output because it is never wired into miniaudio's node graph. Used for
+                    headless graph evaluation and for unit-testing the parameter-routing path
+                    without an audio device. Returns true (no failure mode); replaces any
+                    existing source. Follow with InitializeFromGraph as usual. */
+                bool InitializeDetachedSource();
 
                 /** Initialize from SoundGraph instance */
                 bool InitializeFromGraph(const Ref<Audio::SoundGraph::SoundGraph>& soundGraph);
@@ -228,6 +239,18 @@ namespace OloEngine
                 i32 StopNow(StopOptions options = StopOptions::None);
 
                 void InitializeEffects(const Ref<SoundConfig>& config);
+
+                /* Push a high-level control value into the live graph as a conventionally-named
+                   graph input parameter (see the kXxxParam names in the .cpp). Best-effort: a
+                   graph that doesn't expose the endpoint simply ignores the write, and the call
+                   is a no-op until a source + graph are installed. */
+                void RouteFloatParameter(std::string_view parameterName, f32 value);
+                void RouteBoolParameter(std::string_view parameterName, bool value);
+
+                /* Re-push every stored high-level control (volume / pitch / looping / filters)
+                   into the current graph. Called after a graph is installed so a value set
+                   before the graph existed (or before a graph swap) still takes effect. */
+                void SyncControlParametersToGraph();
 
                 // Audio frequency conversion utilities
                 static f32 NormalizedToFrequency(f32 normalizedValue);

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -448,10 +448,10 @@ namespace OloEngine::Audio::SoundGraph
         m_DataSources.UninitializeAll();
     }
 
-    void SoundGraphSource::ReplaceGraph(const Ref<SoundGraph>& newGraph)
+    bool SoundGraphSource::ReplaceGraph(const Ref<SoundGraph>& newGraph)
     {
         if (newGraph == m_Graph)
-            return;
+            return true; // already the installed graph — nothing to do, treat as success
 
         // Swap the live graph reference under the suspend protocol so we don't tear it out
         // from under an in-flight ProcessSamples on the audio thread. SuspendProcessing
@@ -515,6 +515,10 @@ namespace OloEngine::Audio::SoundGraph
         {
             SuspendProcessing(false);
         }
+
+        // True only when the swap actually took effect; false means we timed out and left
+        // m_Graph untouched, so callers must not mark the new graph installed.
+        return suspendAcked;
     }
 
     //==============================================================================

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
@@ -101,8 +101,12 @@ namespace OloEngine::Audio::SoundGraph
         bool InitializeDataSources(const std::vector<AssetHandle>& dataSources);
         void UninitializeDataSources();
 
-        /** Replace current graph with new one. Called when a new graph has been compiled. */
-        void ReplaceGraph(const Ref<SoundGraph>& newGraph);
+        /** Replace current graph with new one. Called when a new graph has been compiled.
+            Returns true if the swap took effect (or newGraph is already the installed graph);
+            returns false if the swap was skipped because the audio thread did not acknowledge
+            the suspend within the timeout — in that case m_Graph is left unchanged and the
+            caller must not treat the new graph as installed. */
+        bool ReplaceGraph(const Ref<SoundGraph>& newGraph);
         Ref<SoundGraph> GetGraph() const
         {
             return m_Graph;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(OloEngine-Tests
 		SoundGraphTypedConnectionTest.cpp
 		SoundGraphSampleAccurateTriggerTest.cpp
 		SoundGraphParameterWiringTest.cpp
+		SoundGraphControlRoutingTest.cpp
 		SoundGraphCacheTest.cpp
 		AudioEventQueueTest.cpp
 		AudioDSPTest.cpp

--- a/OloEngine/tests/SoundGraphControlRoutingTest.cpp
+++ b/OloEngine/tests/SoundGraphControlRoutingTest.cpp
@@ -286,3 +286,47 @@ TEST(SoundGraphControlRouting, GraphWithoutEndpointIgnoresControlGracefully)
     EXPECT_FLOAT_EQ(rig.m_Sound.GetPitch(), 3.0f);
     EXPECT_FALSE(rig.m_Graph->m_EndpointInputStreams.contains(Identifier(kVolume)));
 }
+
+// A detached source has no graph until InitializeFromGraph installs one — Play() must not
+// succeed until then, and InitializeDetachedSource must clear readiness, not leave a stale
+// flag that lets Play() fire on the graphless source.
+TEST(SoundGraphControlRouting, PlayBlockedUntilGraphInstalled)
+{
+    ControlRig rig;
+    ASSERT_TRUE(rig.m_Sound.InitializeDetachedSource());
+    EXPECT_FALSE(rig.m_Sound.IsReadyToPlay());
+    EXPECT_FALSE(rig.m_Sound.Play()) << "Play must fail on a source with no graph installed";
+
+    rig.m_Graph = MakeControlGraph({ kVolume }, {}, kVolume, &rig.m_Capture);
+    ASSERT_TRUE(rig.m_Sound.InitializeFromGraph(rig.m_Graph));
+    EXPECT_TRUE(rig.m_Sound.IsReadyToPlay());
+    EXPECT_TRUE(rig.m_Sound.Play()) << "Play must succeed once the graph is installed";
+}
+
+// Re-creating the source after the sound was ready must drop readiness — the new source is
+// graphless again, so a stale ready flag must not carry over.
+TEST(SoundGraphControlRouting, ReadinessClearedWhenSourceReplaced)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({ kVolume }, {}, kVolume, &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+    ASSERT_TRUE(rig.m_Sound.IsReadyToPlay());
+
+    ASSERT_TRUE(rig.m_Sound.InitializeDetachedSource()); // swap in a fresh, graphless source
+    EXPECT_FALSE(rig.m_Sound.IsReadyToPlay());
+    EXPECT_FALSE(rig.m_Sound.Play());
+}
+
+// ReplaceGraph reports whether the swap took effect — the contract InitializeFromGraph
+// relies on to decide readiness. A device-free (uninitialized) source swaps synchronously,
+// so it always reports success; installing the same graph again is a success no-op. (The
+// false/timeout path needs a starved audio thread and isn't reproducible headlessly.)
+TEST(SoundGraphControlRouting, ReplaceGraphReportsSuccessForDeviceFreeSwap)
+{
+    CaptureNode* cap = nullptr;
+    auto graph = MakeControlGraph({ kVolume }, {}, kVolume, &cap);
+
+    sg::SoundGraphSource source;
+    EXPECT_TRUE(source.ReplaceGraph(graph)) << "an uninitialized source swaps synchronously";
+    EXPECT_TRUE(source.ReplaceGraph(graph)) << "re-installing the same graph is a success no-op";
+}

--- a/OloEngine/tests/SoundGraphControlRoutingTest.cpp
+++ b/OloEngine/tests/SoundGraphControlRoutingTest.cpp
@@ -1,0 +1,288 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+//
+// =============================================================================
+// SoundGraphControlRoutingTest — high-level Sound controls reach the live graph
+//
+// SoundGraphSound's SetVolume / SetPitch / SetLooping / SetLowPassFilter /
+// SetHighPassFilter used to only store a member ("Actual ... control would be
+// implemented via SoundGraph parameters") — so a scene's authored VolumeMultiplier /
+// PitchMultiplier / Looping (forwarded by Scene::InitializeAudioSoundGraph) was
+// silently dropped before it ever reached the audio graph.
+//
+// They now route the (clamped, finite-checked) value into the running SoundGraph as a
+// conventionally-named graph input parameter (Volume / Pitch / Loop / LowPass /
+// HighPass), reusing the proven SoundGraphSource::SetParameter path. This file pins
+// that behaviour end to end, driving the real audio path
+// (SoundGraphSource::ProcessSamples) without a miniaudio device — exactly the
+// device-free graph drive used in SoundGraphParameterWiringTest. A SoundGraphSound is
+// given a *detached* source (InitializeDetachedSource: a SoundGraphSource that is never
+// attached to an ma_engine but still processes its graph), so the routing path is
+// exercised with no audio hardware.
+//
+// Covered:
+//   * each float control reaches its graph input cell with the clamped value, and a
+//     routed control is observed per-frame by a downstream node;
+//   * looping routes as a bool to the "Loop" endpoint;
+//   * values are clamped before routing (volume [0,1], pitch [0.1,4], filters [0,1]);
+//   * a non-finite value is rejected (member + graph left unchanged);
+//   * a control set BEFORE the graph is installed is applied on InitializeFromGraph;
+//   * a graph that doesn't expose a control's endpoint ignores the write without
+//     crashing, and the member is still stored (so the getter stays correct).
+// =============================================================================
+
+#include "OloEngine/Audio/SoundGraph/SoundGraph.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSound.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSource.h"
+#include "OloEngine/Core/Identifier.h"
+#include "OloEngine/Core/UUID.h"
+
+#include <choc/containers/choc_Value.h>
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace)
+namespace sg = OloEngine::Audio::SoundGraph;
+
+namespace
+{
+    constexpr u32 kBlock = 64;
+    constexpr u32 kChannels = 2; // SoundGraphSource default output channel count
+
+    // The conventional names SoundGraphSound routes its high-level controls to. Kept in
+    // the test as literals (not shared with the .cpp constants) so a rename of either
+    // side surfaces as a test failure rather than silently agreeing.
+    constexpr const char* kVolume = "Volume";
+    constexpr const char* kPitch = "Pitch";
+    constexpr const char* kLoop = "Loop";
+    constexpr const char* kLowPass = "LowPass";
+    constexpr const char* kHighPass = "HighPass";
+
+    /// Records the per-frame values seen on an audio-rate input ref, so a graph-parameter
+    /// write can be observed end to end (same shape as SoundGraphParameterWiringTest's).
+    struct CaptureNode : public sg::NodeProcessor
+    {
+        explicit CaptureNode(UUID id) : NodeProcessor("CaptureNode", id)
+        {
+            AddAudioInRef(Identifier("In"), m_In);
+        }
+
+        sg::AudioBufferRef m_In;
+        std::vector<f32> m_Captured;
+
+        void Process(u32 numFrames) final
+        {
+            m_Captured.clear();
+            for (u32 frame = 0; frame < numFrames; ++frame)
+                m_Captured.push_back(m_In.Sample(frame));
+        }
+    };
+
+    struct ControlRig
+    {
+        sg::SoundGraphSound m_Sound;
+        Ref<sg::SoundGraph> m_Graph;
+        CaptureNode* m_Capture = nullptr; // owned by m_Graph
+
+        f32 FloatCell(const char* name) const
+        {
+            return m_Graph->m_EndpointInputStreams.at(Identifier(name)).m_Float;
+        }
+        bool BoolCell(const char* name) const
+        {
+            return m_Graph->m_EndpointInputStreams.at(Identifier(name)).m_Bool;
+        }
+    };
+
+    /// Build a graph exposing the conventional control endpoints. `floatParams` are added
+    /// as float input streams (the first is routed into a CaptureNode's audio-rate "In"),
+    /// `boolParams` as bool input streams. A non-null `routedFloat` overrides which float
+    /// is wired to the capture node.
+    Ref<sg::SoundGraph> MakeControlGraph(const std::vector<std::string>& floatParams,
+                                         const std::vector<std::string>& boolParams,
+                                         const std::string& routedFloat,
+                                         CaptureNode** outCapture)
+    {
+        auto graph = Ref<sg::SoundGraph>::Create("ControlRouting", UUID());
+
+        for (const std::string& name : floatParams)
+            graph->AddGraphInputStream(Identifier(name), choc::value::createFloat32(0.0f));
+        for (const std::string& name : boolParams)
+            graph->AddGraphInputStream(Identifier(name), choc::value::createBool(false));
+
+        auto capture = CreateScope<CaptureNode>(UUID());
+        *outCapture = capture.get();
+        const UUID captureID = capture->m_ID;
+        graph->AddNode(std::move(capture));
+
+        if (!routedFloat.empty())
+            graph->AddInputValueRoute(Identifier(routedFloat), captureID, Identifier("In"));
+
+        graph->Init();
+        return graph;
+    }
+
+    /// Stand up a SoundGraphSound on a detached (device-free) source with the given graph
+    /// installed. SyncControlParametersToGraph runs inside InitializeFromGraph, so the
+    /// rig's cells start at the Sound's default control values.
+    void InstallGraph(ControlRig& rig, const Ref<sg::SoundGraph>& graph)
+    {
+        ASSERT_TRUE(rig.m_Sound.InitializeDetachedSource());
+        ASSERT_TRUE(rig.m_Sound.InitializeFromGraph(graph));
+    }
+
+    /// Drive one block through the Sound's source, writing into a scratch interleaved bus.
+    void ProcessOneBlock(ControlRig& rig)
+    {
+        std::array<f32, kBlock * kChannels> bus{};
+        f32* busPtr = bus.data();
+        auto* source = rig.m_Sound.GetSource();
+        ASSERT_NE(source, nullptr);
+        source->ProcessSamples(&busPtr, kBlock);
+    }
+} // namespace
+
+// A routed float control must reach its graph input cell AND be observed per-frame by a
+// downstream node — proving SetVolume actually drives the graph, not just a member.
+TEST(SoundGraphControlRouting, VolumeReachesGraphAndIsObservedDownstream)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({ kVolume }, {}, kVolume, &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetVolume(0.5f);
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetVolume(), 0.5f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kVolume), 0.5f) << "SetVolume must write the graph's Volume cell";
+
+    ProcessOneBlock(rig);
+
+    ASSERT_EQ(rig.m_Capture->m_Captured.size(), kBlock);
+    EXPECT_FLOAT_EQ(rig.m_Capture->m_Captured.front(), 0.5f)
+        << "the routed Volume value must be seen from the first frame";
+    EXPECT_FLOAT_EQ(rig.m_Capture->m_Captured.back(), 0.5f);
+}
+
+// Pitch and the two filters each route to their own conventional endpoint cell.
+TEST(SoundGraphControlRouting, PitchAndFiltersReachTheirCells)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({ kVolume, kPitch, kLowPass, kHighPass }, {}, kVolume, &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetPitch(2.0f);
+    rig.m_Sound.SetLowPassFilter(0.25f);
+    rig.m_Sound.SetHighPassFilter(0.75f);
+
+    EXPECT_FLOAT_EQ(rig.FloatCell(kPitch), 2.0f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kLowPass), 0.25f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kHighPass), 0.75f);
+}
+
+// Looping routes as a bool to the "Loop" endpoint.
+TEST(SoundGraphControlRouting, LoopingRoutesAsBool)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({}, { kLoop }, "", &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetLooping(true);
+    EXPECT_TRUE(rig.BoolCell(kLoop));
+
+    rig.m_Sound.SetLooping(false);
+    EXPECT_FALSE(rig.BoolCell(kLoop));
+}
+
+// Out-of-range controls are clamped BEFORE routing, so the graph never sees a value
+// outside the documented range.
+TEST(SoundGraphControlRouting, ControlsAreClampedBeforeRouting)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({ kVolume, kPitch, kLowPass, kHighPass }, {}, kVolume, &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetVolume(2.0f); // > 1.0
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetVolume(), 1.0f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kVolume), 1.0f);
+
+    rig.m_Sound.SetVolume(-1.0f); // < 0.0
+    EXPECT_FLOAT_EQ(rig.FloatCell(kVolume), 0.0f);
+
+    rig.m_Sound.SetPitch(10.0f); // > 4.0
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetPitch(), 4.0f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kPitch), 4.0f);
+
+    rig.m_Sound.SetPitch(0.0f); // < 0.1
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetPitch(), 0.1f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kPitch), 0.1f);
+
+    rig.m_Sound.SetLowPassFilter(5.0f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kLowPass), 1.0f);
+    rig.m_Sound.SetHighPassFilter(-5.0f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kHighPass), 0.0f);
+}
+
+// A non-finite value is rejected: the member keeps its previous value and the graph cell
+// is left untouched (NaN must not slip through std::clamp into the audio graph).
+TEST(SoundGraphControlRouting, NonFiniteControlIsRejected)
+{
+    ControlRig rig;
+    rig.m_Graph = MakeControlGraph({ kVolume, kPitch }, {}, kVolume, &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetVolume(0.5f);
+    rig.m_Sound.SetPitch(1.5f);
+
+    rig.m_Sound.SetVolume(std::numeric_limits<f32>::quiet_NaN());
+    rig.m_Sound.SetPitch(std::numeric_limits<f32>::infinity());
+
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetVolume(), 0.5f) << "NaN volume must be ignored";
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetPitch(), 1.5f) << "Inf pitch must be ignored";
+    EXPECT_FLOAT_EQ(rig.FloatCell(kVolume), 0.5f);
+    EXPECT_FLOAT_EQ(rig.FloatCell(kPitch), 1.5f);
+}
+
+// A control set BEFORE a graph is installed must still take effect once it is — the
+// SetX-then-InitializeFromGraph ordering Scene doesn't use today but the public
+// IPlayableAudio interface allows.
+TEST(SoundGraphControlRouting, ControlsSetBeforeGraphInstallApplyOnInit)
+{
+    ControlRig rig;
+    ASSERT_TRUE(rig.m_Sound.InitializeDetachedSource());
+
+    // No graph yet: these store members and route into nothing.
+    rig.m_Sound.SetVolume(0.3f);
+    rig.m_Sound.SetPitch(2.5f);
+    rig.m_Sound.SetLooping(true);
+
+    rig.m_Graph = MakeControlGraph({ kVolume, kPitch }, { kLoop }, kVolume, &rig.m_Capture);
+    ASSERT_TRUE(rig.m_Sound.InitializeFromGraph(rig.m_Graph));
+
+    EXPECT_FLOAT_EQ(rig.FloatCell(kVolume), 0.3f) << "pre-install volume must be synced on init";
+    EXPECT_FLOAT_EQ(rig.FloatCell(kPitch), 2.5f);
+    EXPECT_TRUE(rig.BoolCell(kLoop));
+}
+
+// A graph that doesn't expose a control's endpoint must ignore the write without
+// crashing, and the member must still be stored so the getter stays correct.
+TEST(SoundGraphControlRouting, GraphWithoutEndpointIgnoresControlGracefully)
+{
+    ControlRig rig;
+    // Graph exposes only an unrelated parameter — no Volume/Pitch/etc.
+    rig.m_Graph = MakeControlGraph({ "Unrelated" }, {}, "Unrelated", &rig.m_Capture);
+    InstallGraph(rig, rig.m_Graph);
+
+    rig.m_Sound.SetVolume(0.42f);
+    rig.m_Sound.SetPitch(3.0f);
+    rig.m_Sound.SetLooping(true);
+
+    // No throw, no effect on the unrelated graph, and the members are still stored.
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetVolume(), 0.42f);
+    EXPECT_FLOAT_EQ(rig.m_Sound.GetPitch(), 3.0f);
+    EXPECT_FALSE(rig.m_Graph->m_EndpointInputStreams.contains(Identifier(kVolume)));
+}


### PR DESCRIPTION
…s into the live graph

SoundGraphSound's high-level controls (SetVolume/SetPitch/SetLooping/ SetLowPassFilter/SetHighPassFilter) only stored a member and never reached the running SoundGraph, so a scene's authored VolumeMultiplier/PitchMultiplier/Looping (forwarded by Scene::InitializeAudioSoundGraph) was silently dropped.

They now route the finite-checked, clamped value into the graph as a conventionally- named input parameter (Volume/Pitch/Loop/LowPass/HighPass) via the proven SoundGraphSource::SetParameter path. Routing is opt-in/best-effort: a graph reacts only if it exposes a matching input stream, else the write no-ops. SyncControlParameters- ToGraph re-applies stored controls on graph install so a set-before-init value lands.

Also: InitializeDetachedSource() seam for headless/device-free use; clamp + std::isfinite guards on the float setters; honest comments replacing the stale "stub"/"dummy voice ID" markers (StopNow, SetParameter int/bool catch blocks, Update).

3D spatialization (SetLocation/SetVelocity/SetOrientation) is deferred — the Spatializer is ma_engine_node-based while SoundGraphSource uses a bare ma_node straight to the endpoint, so it needs new infra, not a param route. Tracked in #424.

Tests: SoundGraphControlRoutingTest.cpp (7 unit tests) drives the real ProcessSamples path device-free, proving each control reaches its graph cell (and per-frame downstream), clamping-before-routing, non-finite rejection, set-before-init ordering, and graceful no-op when the endpoint is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live routing for sound controls into the audio graph, including volume, pitch, looping, and filter settings.
  * Preset control values now carry over when a graph is installed.

* **Bug Fixes**
  * Added safer handling for invalid values and runtime errors during sound updates.
  * Improved behavior when controls are used without an active graph connection.

* **Tests**
  * Added end-to-end coverage for control routing, value validation, and graph synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->