### PR TITLE
feat(mcp): consented, undoable write tools — olo_set_collision_layer …

### DIFF
--- a/OloEditor/SandboxProject/Assets/Scenes/FoliageGenerationTest.olo.auto
+++ b/OloEditor/SandboxProject/Assets/Scenes/FoliageGenerationTest.olo.auto
@@ -1,0 +1,417 @@
+Scene: FoliageGenerationTest.olo
+PostProcessSettings:
+  TonemapOperator: 1
+  Exposure: 1
+  Gamma: 2.2
+  BloomEnabled: false
+  BloomThreshold: 1
+  BloomIntensity: 0.5
+  BloomIterations: 5
+  VignetteEnabled: false
+  VignetteIntensity: 0.3
+  VignetteSmoothness: 0.5
+  ChromaticAberrationEnabled: false
+  ChromaticAberrationIntensity: 0.005
+  FXAAEnabled: false
+  DOFEnabled: false
+  DOFFocusDistance: 10
+  DOFFocusRange: 5
+  DOFBokehRadius: 3
+  MotionBlurEnabled: false
+  MotionBlurStrength: 0.5
+  MotionBlurSamples: 8
+  ColorGradingEnabled: false
+  SSAOEnabled: true
+  SSAORadius: 0.5
+  SSAOBias: 0.025
+  SSAOIntensity: 1
+  SSAOSamples: 32
+  SSAODebugView: false
+  SSREnabled: false
+  SSRMaxDistance: 40
+  SSRThickness: 0.8
+  SSRStride: 0.25
+  SSRMaxSteps: 64
+  SSRBinarySearchSteps: 6
+  SSRIntensity: 1
+  SSRMaxRoughness: 0.6
+  SSREdgeFade: 0.1
+  SSRDebugView: false
+  SSGIEnabled: false
+  SSGIIntensity: 1
+  SSGIMaxDistance: 8
+  SSGIThickness: 0.5
+  SSGIStride: 0.25
+  SSGIMaxSteps: 24
+  SSGIRayCount: 8
+  SSGIEdgeFade: 0.1
+  SSGIDebugView: false
+  ContactShadowEnabled: false
+  ContactShadowIntensity: 1
+  ContactShadowMaxDistance: 1
+  ContactShadowThickness: 0.3
+  ContactShadowStride: 0.04
+  ContactShadowMaxSteps: 24
+  ContactShadowBias: 0.02
+  ContactShadowEdgeFade: 0.1
+  ContactShadowDebugView: false
+  AutoExposureEnabled: false
+  AutoExposureMinLogLuminance: -8
+  AutoExposureMaxLogLuminance: 3.5
+  AutoExposureSpeedUp: 3
+  AutoExposureSpeedDown: 1
+  AutoExposureCompensation: 0
+  AutoExposureMinExposure: 0.05
+  AutoExposureMaxExposure: 16
+SnowSettings:
+  Enabled: false
+  HeightStart: -5
+  HeightFull: 5
+  SlopeStart: 0.7
+  SlopeFull: 0.3
+  Albedo: [0.92, 0.93, 0.98]
+  Roughness: 0.65
+  SSSColor: [0.4, 0.6, 0.9]
+  SSSIntensity: 0.6
+  SparkleIntensity: 0.8
+  SparkleDensity: 80
+  SparkleScale: 1
+  NormalPerturbStrength: 0.25
+  WindDriftFactor: 0
+  SSSBlurEnabled: false
+  SSSBlurRadius: 2
+  SSSBlurFalloff: 1
+FogSettings:
+  Enabled: false
+  Mode: 2
+  Color: [0.5, 0.6, 0.7]
+  Density: 0.02
+  Start: 10
+  End: 300
+  HeightFalloff: 0.1
+  HeightOffset: 0
+  MaxOpacity: 1
+  EnableScattering: false
+  RayleighStrength: 1
+  MieStrength: 0.005
+  MieDirectionality: 0.76
+  RayleighColor: [0.27, 0.51, 0.83]
+  SunIntensity: 22
+  EnableVolumetric: false
+  VolumetricSamples: 32
+  AbsorptionCoefficient: 0.02
+  EnableNoise: false
+  NoiseScale: 0.01
+  NoiseSpeed: 0.1
+  NoiseIntensity: 0.3
+  EnableLightShafts: false
+  LightShaftIntensity: 1
+WindSettings:
+  Enabled: false
+  Direction: [1, 0, 0]
+  Speed: 5
+  GustStrength: 0.3
+  GustFrequency: 0.5
+  TurbulenceIntensity: 0.5
+  TurbulenceScale: 0.1
+  GridWorldSize: 200
+  GridResolution: 128
+SnowAccumulationSettings:
+  Enabled: false
+  AccumulationRate: 0.02
+  MaxDepth: 0.5
+  MeltRate: 0.005
+  RestorationRate: 0.01
+  DisplacementScale: 1
+  ClipmapResolution: 2048
+  ClipmapExtent: 128
+  NumClipmapRings: 3
+  SnowDensity: 0.3
+SnowEjectaSettings:
+  Enabled: false
+  ParticlesPerDeform: 8
+  EjectaSpeed: 2.5
+  SpeedVariance: 0.8
+  UpwardBias: 0.6
+  LifetimeMin: 0.4
+  LifetimeMax: 1.2
+  InitialSize: 0.04
+  SizeVariance: 0.02
+  GravityScale: 0.3
+  DragCoefficient: 2
+  Color: [0.95, 0.97, 1, 0.7]
+  VelocityThreshold: 0.1
+  MaxParticles: 8192
+  WindInfluence: 0.5
+  NoiseStrength: 0.3
+  NoiseFrequency: 2
+  GroundY: 0
+  CollisionBounce: 0
+  CollisionFriction: 1
+PrecipitationSettings:
+  Enabled: false
+  Type: 0
+  Intensity: 0.5
+  TransitionSpeed: 1
+  BaseEmissionRate: 4000
+  MaxParticlesNearField: 100000
+  MaxParticlesFarField: 200000
+  NearFieldExtent: [15, 20, 15]
+  NearFieldParticleSize: 0.04
+  NearFieldSizeVariance: 0.02
+  NearFieldSpeedMin: 0.8
+  NearFieldSpeedMax: 2
+  NearFieldLifetime: 10
+  FarFieldExtent: [60, 30, 60]
+  FarFieldParticleSize: 0.025
+  FarFieldSpeedMin: 0.5
+  FarFieldSpeedMax: 1.5
+  FarFieldLifetime: 15
+  FarFieldAlphaMultiplier: 0.5
+  GravityScale: 0.8
+  WindInfluence: 1
+  DragCoefficient: 0.3
+  TurbulenceStrength: 0.8
+  TurbulenceFrequency: 0.5
+  GroundCollisionEnabled: true
+  GroundY: 0
+  CollisionBounce: 0
+  CollisionFriction: 1
+  FeedAccumulation: true
+  AccumulationFeedRate: 0.0001
+  ScreenStreaksEnabled: true
+  ScreenStreakIntensity: 0.3
+  ScreenStreakLength: 0.15
+  LensImpactsEnabled: true
+  LensImpactRate: 3
+  LensImpactLifetime: 1.5
+  LensImpactSize: 0.03
+  LODNearDistance: 30
+  LODFarDistance: 120
+  FrameBudgetMs: 1
+  ParticleColor: [0.95, 0.97, 1, 0.85]
+  ColorVariance: 0.05
+  RotationSpeed: 30
+StreamingSettings:
+  Enabled: false
+  DefaultLoadRadius: 200
+  DefaultUnloadRadius: 250
+  MaxLoadedRegions: 16
+  RegionDirectory: ""
+Entities:
+  - Entity: 100000000000040
+    TagComponent:
+      Tag: Grassland Terrain
+    TransformComponent:
+      Translation: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    TerrainComponent:
+      HeightmapPath: ""
+      WorldSizeX: 256
+      WorldSizeZ: 256
+      HeightScale: 30
+      ProceduralEnabled: true
+      ProceduralSeed: 7
+      ProceduralResolution: 256
+      ProceduralOctaves: 5
+      ProceduralFrequency: 2
+      ProceduralLacunarity: 2
+      ProceduralPersistence: 0.45
+      ProceduralErosionIterations: 0
+      ShapingRidgeBlend: 0
+      ShapingWarpStrength: 0.12
+      ShapingWarpFrequency: 2
+      ShapingTerraceSteps: 0
+      ShapingTerraceSharpness: 0.6
+      ShapingHeightExponent: 1.3
+      AutoMaterial: true
+      SplatmapGenResolution: 256
+      LayerRules:
+        - LayerIndex: 0
+          MinHeight: 0
+          MaxHeight: 0.1
+          HeightBlend: 0.05
+          MinSlopeDeg: 0
+          MaxSlopeDeg: 35
+          SlopeBlend: 8
+          Strength: 1
+        - LayerIndex: 1
+          MinHeight: 0.06
+          MaxHeight: 0.7
+          HeightBlend: 0.16
+          MinSlopeDeg: 0
+          MaxSlopeDeg: 30
+          SlopeBlend: 8
+          Strength: 1
+        - LayerIndex: 2
+          MinHeight: 0
+          MaxHeight: 1
+          HeightBlend: 0
+          MinSlopeDeg: 34
+          MaxSlopeDeg: 90
+          SlopeBlend: 10
+          Strength: 1
+        - LayerIndex: 3
+          MinHeight: 0.82
+          MaxHeight: 1
+          HeightBlend: 0.12
+          MinSlopeDeg: 0
+          MaxSlopeDeg: 50
+          SlopeBlend: 10
+          Strength: 1
+      TessellationEnabled: false
+      TargetTriangleSize: 8
+      MorphRegion: 0.3
+      StreamingEnabled: false
+      TileDirectory: ""
+      TileFilePattern: tile_%d_%d.raw
+      TileWorldSize: 256
+      TileResolution: 513
+      StreamingLoadRadius: 3
+      StreamingMaxTiles: 25
+      VoxelEnabled: false
+      VoxelSize: 1
+      SplatmapPath0: ""
+      SplatmapPath1: ""
+      Layers:
+        - Name: Sand
+          AlbedoPath: ""
+          NormalPath: ""
+          ARMPath: ""
+          TilingScale: 16
+          HeightBlendSharpness: 4
+          TriplanarSharpness: 8
+          BaseColor: [0.76, 0.7, 0.5]
+          Roughness: 0.95
+          Metallic: 0
+        - Name: Grass
+          AlbedoPath: ""
+          NormalPath: ""
+          ARMPath: ""
+          TilingScale: 20
+          HeightBlendSharpness: 4
+          TriplanarSharpness: 8
+          BaseColor: [0.28, 0.45, 0.17]
+          Roughness: 0.9
+          Metallic: 0
+        - Name: Rock
+          AlbedoPath: ""
+          NormalPath: ""
+          ARMPath: ""
+          TilingScale: 12
+          HeightBlendSharpness: 4
+          TriplanarSharpness: 8
+          BaseColor: [0.42, 0.4, 0.38]
+          Roughness: 0.8
+          Metallic: 0
+        - Name: Snow
+          AlbedoPath: ""
+          NormalPath: ""
+          ARMPath: ""
+          TilingScale: 18
+          HeightBlendSharpness: 4
+          TriplanarSharpness: 8
+          BaseColor: [0.92, 0.93, 0.96]
+          Roughness: 0.6
+          Metallic: 0
+    FoliageComponent:
+      Enabled: true
+      Layers:
+        - Name: Grass
+          MeshPath: ""
+          AlbedoPath: assets/textures/grass.png
+          Density: 6
+          SplatmapChannel: 1
+          MinSlopeAngle: 0
+          MaxSlopeAngle: 30
+          MinScale: 0.9
+          MaxScale: 1.9
+          MinHeight: 1.2
+          MaxHeight: 2.6
+          RandomRotation: true
+          ViewDistance: 180
+          FadeStartDistance: 144
+          WindStrength: 0.35
+          WindSpeed: 1.6
+          BaseColor: [0.3, 0.46, 0.16]
+          Roughness: 0.8
+          AlphaCutoff: 0.5
+          Enabled: true
+        - Name: Wildflowers
+          MeshPath: ""
+          AlbedoPath: assets/textures/grass.png
+          Density: 1.5
+          SplatmapChannel: 1
+          MinSlopeAngle: 0
+          MaxSlopeAngle: 22
+          MinScale: 0.7
+          MaxScale: 1.3
+          MinHeight: 0.8
+          MaxHeight: 1.6
+          RandomRotation: true
+          ViewDistance: 140
+          FadeStartDistance: 112
+          WindStrength: 0.25
+          WindSpeed: 1.2
+          BaseColor: [0.66, 0.56, 0.24]
+          Roughness: 0.8
+          AlphaCutoff: 0.5
+          Enabled: true
+        - Name: Dune Grass
+          MeshPath: ""
+          AlbedoPath: assets/textures/grass.png
+          Density: 1
+          SplatmapChannel: 0
+          MinSlopeAngle: 0
+          MaxSlopeAngle: 18
+          MinScale: 0.8
+          MaxScale: 1.4
+          MinHeight: 0.9
+          MaxHeight: 1.8
+          RandomRotation: true
+          ViewDistance: 140
+          FadeStartDistance: 112
+          WindStrength: 0.4
+          WindSpeed: 1.4
+          BaseColor: [0.62, 0.6, 0.32]
+          Roughness: 0.8
+          AlphaCutoff: 0.5
+          Enabled: true
+  - Entity: 100000000000041
+    TagComponent:
+      Tag: Directional Light
+    TransformComponent:
+      Translation: [21.055992, 25.520258, 26.569588]
+      Rotation: [-0.78539824, 0.39269903, 0]
+      Scale: [1, 1, 1]
+    DirectionalLightComponent:
+      Direction: [-0.4, -0.8, -0.3]
+      Color: [1, 0.9607843, 0.8980392]
+      Intensity: 2.5
+      CastShadows: true
+      ShadowBias: 0.005
+      ShadowNormalBias: 0.01
+      MaxShadowDistance: 500
+      CascadeSplitLambda: 0.5
+      CascadeDebugVisualization: false
+  - Entity: 9977033210160945020
+    TagComponent:
+      Tag: camera
+    TransformComponent:
+      Translation: [128, 30, 235]
+      Rotation: [-0.18, 0, 0]
+      Scale: [1, 1, 1]
+    CameraComponent:
+      Camera:
+        ProjectionType: 0
+        PerspectiveFOV: 0.7853982
+        PerspectiveNear: 0.1
+        PerspectiveFar: 2000
+        OrthographicSize: 10
+        OrthographicNear: -1
+        OrthographicFar: 1
+      Primary: true
+      FixedAspectRatio: false
+      RuntimeControl: true
+      FlySpeed: 20

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -361,6 +361,12 @@ namespace OloEngine
                 }
                 m_McpViewportSizeOverride = { width, height };
             };
+            // Consented, undoable project writes (#306 item C). The write tools run
+            // their mutation through the same undo stack as the editor's own edits,
+            // so an agent's change is a single Ctrl-Z. Main-thread-only, like the
+            // readers above (the MCP server calls it from a MarshalRead job).
+            mcpContext.GetCommandHistory = [this]() -> CommandHistory*
+            { return &m_CommandHistory; };
             mcpContext.GetFrameIndex = [this]() -> u64
             { return m_FrameIndex; };
             mcpContext.IsCaptureUnready = [this]() -> bool

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -366,7 +366,14 @@ namespace OloEngine
             // so an agent's change is a single Ctrl-Z. Main-thread-only, like the
             // readers above (the MCP server calls it from a MarshalRead job).
             mcpContext.GetCommandHistory = [this]() -> CommandHistory*
-            { return &m_CommandHistory; };
+            {
+                // Only expose the undo stack in Edit mode. In Play / Simulate the
+                // runtime scene is a transient copy the editor undo stack does not
+                // track, so a write there would be unsound (and discarded on stop) —
+                // hand out nullptr so the write handler refuses ("no editor command
+                // history available") rather than mutating the runtime scene.
+                return m_SceneState == SceneState::Edit ? &m_CommandHistory : nullptr;
+            };
             mcpContext.GetFrameIndex = [this]() -> u64
             { return m_FrameIndex; };
             mcpContext.IsCaptureUnready = [this]() -> bool

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -1165,6 +1165,18 @@ namespace OloEngine::MCP
             return MakeError(id, kInvalidParams, "Invalid params: 'arguments' must be an object");
         const Json arguments = params.contains("arguments") ? params["arguments"] : Json::object();
 
+        // Session write gate (issue #306 item C): a project-mutating tool is refused
+        // unless the user has turned on "Allow writes" in the MCP panel (default off,
+        // never persisted). This is distinct from — and stacks on top of — the
+        // enabled + bearer-token gate: even an authenticated agent stays read-only
+        // w.r.t. the project until the user opts in for the session. Read-only and
+        // ephemeral editor-state tools (camera / viewport / render overrides) are not
+        // ProjectWrite, so they are unaffected.
+        if (tool->ProjectWrite && !AllowWrites())
+            return MakeError(id, kInvalidParams,
+                             "Write tools are disabled. Enable \"Allow writes\" in the editor's MCP "
+                             "Server panel to permit this mutation (it is off by default).");
+
         // Enforce the tool's declared inputSchema before the handler runs, so a
         // malformed call fails with a clean, field-naming kInvalidParams instead of
         // depending on whatever ad-hoc checks that one handler happens to do (issue

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -51,6 +51,15 @@ namespace httplib
     struct Response;
 } // namespace httplib
 
+namespace OloEngine
+{
+    // The editor's undo/redo stack (OloEditor/src/UndoRedo/EditorCommand.h). Only
+    // forward-declared here: EditorMcpContext exposes a pointer to it so consented
+    // write tools (issue #306 item C) can route their mutation through a single
+    // undoable command, without this header pulling in the editor command classes.
+    class CommandHistory;
+} // namespace OloEngine
+
 namespace OloEngine::MCP
 {
     using Json = nlohmann::json;
@@ -119,6 +128,13 @@ namespace OloEngine::MCP
         std::string Toolset;
         ToolHandler Handler;
         bool MainMarshaled = false;
+        // True for a tool that MUTATES the user's project (scene / ECS components /
+        // assets) — as opposed to the read-only diagnostics and the ephemeral
+        // editor-only camera/viewport/render-override tools. A project-write tool is
+        // gated behind the session "Allow writes" toggle: HandleToolsCall rejects it
+        // with a clean JSON-RPC error when writes are disabled (the default). Issue
+        // #306 item C; should be paired with `readOnlyHint:false` annotations.
+        bool ProjectWrite = false;
     };
 
     // Snapshot of the editor camera's full pose, returned by GetCameraPose and
@@ -182,6 +198,14 @@ namespace OloEngine::MCP
         // rendered before capturing.
         std::function<u64()> GetFrameIndex;
         std::function<bool()> IsCaptureUnready;
+
+        // ---- Consented, undoable project writes (issue #306 item C) ------------
+        // The editor's undo/redo stack, so a write tool can apply its mutation as a
+        // single undoable command (a Ctrl-Z). Main-thread-only, like the readers
+        // above — call it from inside a MarshalRead job, alongside GetActiveScene.
+        // Null in a build that does not back the server with an editor (the dispatch
+        // tests), and gated at dispatch by the "Allow writes" session toggle.
+        std::function<CommandHistory*()> GetCommandHistory;
     };
 
     // An MCP resource: a passive, addressable blob (vs. an active tool). The reader
@@ -254,6 +278,22 @@ namespace OloEngine::MCP
         [[nodiscard]] bool RedactPaths() const
         {
             return m_RedactPaths.load(std::memory_order_relaxed);
+        }
+
+        // Session-level write gate (issue #306 item C). OFF by default and NOT
+        // persisted, so every editor launch starts read-only and the user opts in
+        // for the session via the MCP panel. Distinct from the enabled + bearer-token
+        // gate: even an authenticated agent cannot mutate the project until this is
+        // on. When off, HandleToolsCall rejects any tool flagged ToolDef::ProjectWrite
+        // with a clean JSON-RPC error. The read-only / ephemeral-editor-state tools
+        // are unaffected.
+        void SetAllowWrites(bool enabled)
+        {
+            m_AllowWrites.store(enabled, std::memory_order_relaxed);
+        }
+        [[nodiscard]] bool AllowWrites() const
+        {
+            return m_AllowWrites.load(std::memory_order_relaxed);
         }
         [[nodiscard]] const EditorMcpContext& Context() const
         {
@@ -422,6 +462,10 @@ namespace OloEngine::MCP
         std::string m_Token;
 
         std::atomic<bool> m_RedactPaths{ false };
+
+        // Session write gate (issue #306 item C); see SetAllowWrites. Default OFF,
+        // never persisted — every launch starts read-only.
+        std::atomic<bool> m_AllowWrites{ false };
 
         // Count of live GET /mcp SSE push streams (issue #306 item B). Bumped while a
         // stream's content provider runs; surfaced via ActiveStreamCount().

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -105,11 +105,26 @@ namespace OloEngine::MCP
         ImGui::SameLine();
         ImGui::TextDisabled("(scrubs absolute paths before they leave the process)");
 
+        // Session write gate (issue #306 item C). OFF by default and not persisted, so
+        // every launch starts read-only; the user opts in here for the session. While
+        // off, any project-mutating tool (e.g. olo_set_collision_layer) is refused with
+        // a clean JSON-RPC error even for an authenticated agent. Writes route through
+        // the editor undo stack, so an agent's change is a single Ctrl-Z.
+        if (bool allowWrites = server.AllowWrites(); ImGui::Checkbox("Allow writes (undoable)", &allowWrites))
+            server.SetAllowWrites(allowWrites);
+        ImGui::SameLine();
+        if (server.AllowWrites())
+            ImGui::TextColored(ImVec4(0.85f, 0.60f, 0.30f, 1.0f),
+                               "(agents may MUTATE the scene via the undo stack — Ctrl-Z to revert)");
+        else
+            ImGui::TextDisabled("(off: write tools are refused; read-only. Not persisted — resets each launch)");
+
         ImGui::Checkbox("Start automatically when the editor launches", &autoStart);
         ImGui::SameLine();
         ImGui::TextDisabled("(persisted; default off)");
 
-        ImGui::Text("Exposed (read-only): %d tools, %d resources, %d prompts",
+        ImGui::Text("Exposed (%s): %d tools, %d resources, %d prompts",
+                    server.AllowWrites() ? "writes ON" : "read-only",
                     static_cast<int>(server.Tools().size()),
                     static_cast<int>(server.Resources().size()),
                     static_cast<int>(server.Prompts().size()));

--- a/OloEditor/src/MCP/McpSetCollisionLayer.h
+++ b/OloEditor/src/MCP/McpSetCollisionLayer.h
@@ -1,0 +1,195 @@
+#pragma once
+
+// Shared, editor-side logic behind the first consented, undoable MCP write tool
+// `olo_set_collision_layer` (issue #306 item C, first slice). Split out of
+// McpTools.cpp into this header so it can be unit-tested without the httplib /
+// real-tool translation unit — the same "extract the reusable core into a header"
+// pattern McpPhysicsExplain.h / McpRenderOverrides.h / McpSchemaBuilder.h use, so
+// the MCP test binary (which deliberately does NOT link McpTools.cpp) can exercise
+// the real schema + parse + apply code rather than a re-implementation.
+//
+// The write is applied through the editor's `CommandHistory` undo stack, so an
+// agent's fix is a single Ctrl-Z: it builds a `ComponentChangeCommand<T>` keyed by
+// UUID (relocation-safe) and runs it through the history, exactly like the editor's
+// own component edits (SceneHierarchyPanel::DrawComponent).
+//
+// Everything here is renderer/httplib/McpServer-free (engine Scene/ECS types + the
+// header-only UndoRedo + nlohmann::json + the schema-builder DSL), so it pulls no
+// extra editor TU into the test binary.
+
+#include "MCP/McpSchemaBuilder.h"
+#include "UndoRedo/ComponentCommands.h"
+#include "UndoRedo/EditorCommand.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/UUID.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Scene.h"
+
+#include <nlohmann/json.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace OloEngine::MCP::SetCollisionLayer
+{
+    using Json = nlohmann::json;
+
+    // Upper bound on a user-defined physics layer id. The engine maps a layer id to
+    // the Jolt object layer `ObjectLayers::NUM_LAYERS + id`, capped at
+    // Physics3DSystem::sMaxLayers (32) total layers; 31 is a generous, overflow-safe
+    // ceiling for the authored `m_LayerID` field (a u32). The actual set of *valid*
+    // layers is project-defined — an agent discovers them via olo_physics_layer_matrix;
+    // we don't cross-check the live registry here (its contents depend on the loaded
+    // project, and layer 0 is the always-present default), so this is a sanity bound,
+    // not a validity guarantee.
+    inline constexpr u32 kMaxLayerId = 31;
+
+    // The tool's inputSchema, authored with the schema-builder DSL. Shared by the real
+    // registration (McpTools.cpp) and the dispatch-seam test so the test validates the
+    // exact schema the server enforces (the server runs ValidateArguments before the
+    // handler — issue #423).
+    [[nodiscard]] inline Json InputSchema()
+    {
+        return Schema::Object()
+            .Prop("entity", Schema::EntityId("UUID of the entity whose physics body collision layer to set (string; also accepts a number)."))
+            .Prop("layer", Schema::Int().Min(0).Max(static_cast<std::int64_t>(kMaxLayerId)).Desc("Collision layer id to assign to the body (a user-defined physics layer; 0 is the default. Use olo_physics_layer_matrix to discover valid ids)."))
+            .Required({ "entity", "layer" })
+            .NoAdditional();
+    }
+
+    // Parse + validate the tool arguments into native values. The server validates
+    // `args` against InputSchema() before the handler runs, but this stays defensive
+    // (it is also reached directly from tests) and converts the UUID string — which
+    // exceeds JSON's safe-integer range — exactly like McpTools::ParseUuid. Returns a
+    // human-readable error, or std::nullopt on success.
+    [[nodiscard]] inline std::optional<std::string> ParseArgs(const Json& args, u64& entityUuid, u32& layer)
+    {
+        if (!args.contains("entity"))
+            return "Missing required argument 'entity' (entity UUID).";
+        const Json& entityValue = args["entity"];
+        if (entityValue.is_string())
+        {
+            try
+            {
+                entityUuid = std::stoull(entityValue.get<std::string>());
+            }
+            catch (...)
+            {
+                return "Invalid 'entity': expected a UUID as a string or number.";
+            }
+        }
+        else if (entityValue.is_number_unsigned())
+        {
+            entityUuid = entityValue.get<u64>();
+        }
+        else if (entityValue.is_number_integer())
+        {
+            const long long signedId = entityValue.get<long long>();
+            if (signedId < 0)
+                return "Invalid 'entity': expected a non-negative UUID.";
+            entityUuid = static_cast<u64>(signedId);
+        }
+        else
+        {
+            return "Invalid 'entity': expected a UUID as a string or number.";
+        }
+
+        if (!args.contains("layer"))
+            return "Missing required argument 'layer'.";
+        const Json& layerValue = args["layer"];
+        if (!layerValue.is_number_integer())
+            return "Invalid 'layer': expected an integer.";
+        const long long signedLayer = layerValue.get<long long>();
+        if (signedLayer < 0 || signedLayer > static_cast<long long>(kMaxLayerId))
+            return "Invalid 'layer': expected an integer in [0, " + std::to_string(kMaxLayerId) + "].";
+        layer = static_cast<u32>(signedLayer);
+        return std::nullopt;
+    }
+
+    // Outcome of applying a collision-layer write. On success `Data` is the structured
+    // result payload; on failure `Error` is a tool-level error message.
+    struct ApplyResult
+    {
+        bool Ok = false;
+        std::string Error;
+        Json Data;
+    };
+
+    // Set the entity's physics-body collision layer (Rigidbody3DComponent::m_LayerID,
+    // or CharacterController3DComponent::m_LayerID for a character controller) through
+    // `history`, so the change is a single undoable command. A no-op change (the body
+    // already on that layer) pushes nothing onto the undo stack and reports
+    // changed=false. MUST run on the main (game) thread — it touches the EnTT registry
+    // and the editor command stack.
+    [[nodiscard]] inline ApplyResult Apply(const Ref<Scene>& scene, CommandHistory& history, u64 entityUuid, u32 layer)
+    {
+        ApplyResult result;
+        if (!scene)
+        {
+            result.Error = "No active scene.";
+            return result;
+        }
+
+        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+        if (!entityOpt)
+        {
+            result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+            return result;
+        }
+        Entity entity = *entityOpt;
+
+        std::string componentName;
+        u32 previousLayer = 0;
+
+        if (entity.HasComponent<Rigidbody3DComponent>())
+        {
+            componentName = "Rigidbody3DComponent";
+            const auto& component = entity.GetComponent<Rigidbody3DComponent>();
+            previousLayer = component.m_LayerID;
+            if (previousLayer != layer)
+            {
+                Rigidbody3DComponent newData = component;
+                newData.m_LayerID = layer;
+                history.Execute(std::make_unique<ComponentChangeCommand<Rigidbody3DComponent>>(
+                    scene, UUID(entityUuid), component, newData, "Set Collision Layer"));
+            }
+        }
+        else if (entity.HasComponent<CharacterController3DComponent>())
+        {
+            componentName = "CharacterController3DComponent";
+            const auto& component = entity.GetComponent<CharacterController3DComponent>();
+            previousLayer = component.m_LayerID;
+            if (previousLayer != layer)
+            {
+                CharacterController3DComponent newData = component;
+                newData.m_LayerID = layer;
+                history.Execute(std::make_unique<ComponentChangeCommand<CharacterController3DComponent>>(
+                    scene, UUID(entityUuid), component, newData, "Set Collision Layer"));
+            }
+        }
+        else
+        {
+            result.Error = "Entity has no physics body with a collision layer "
+                           "(needs a Rigidbody3DComponent or CharacterController3DComponent).";
+            return result;
+        }
+
+        const bool changed = previousLayer != layer;
+        result.Ok = true;
+        result.Data = Json{
+            { "entity", std::to_string(entityUuid) },
+            { "component", componentName },
+            { "previousLayer", previousLayer },
+            { "layer", layer },
+            { "changed", changed },
+            // `undoable` reflects whether a command was actually pushed (a no-op change
+            // pushes nothing): an agent that wants to revert knows a single Ctrl-Z / undo
+            // applies only when something changed.
+            { "undoable", changed },
+        };
+        return result;
+    }
+} // namespace OloEngine::MCP::SetCollisionLayer

--- a/OloEditor/src/MCP/McpSetCollisionLayer.h
+++ b/OloEditor/src/MCP/McpSetCollisionLayer.h
@@ -29,6 +29,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
@@ -37,15 +38,19 @@ namespace OloEngine::MCP::SetCollisionLayer
 {
     using Json = nlohmann::json;
 
-    // Upper bound on a user-defined physics layer id. The engine maps a layer id to
-    // the Jolt object layer `ObjectLayers::NUM_LAYERS + id`, capped at
-    // Physics3DSystem::sMaxLayers (32) total layers; 31 is a generous, overflow-safe
-    // ceiling for the authored `m_LayerID` field (a u32). The actual set of *valid*
+    // Upper bound on a user-defined physics layer id. The engine maps a user layer id
+    // to the Jolt object layer `ObjectLayers::NUM_LAYERS + id`, and the whole
+    // object-layer budget is `JoltUtils::kMaxJoltLayers` (32). So the largest authored
+    // `m_LayerID` (a u32) that still maps to a valid object-layer slot is
+    // `kMaxJoltLayers - ObjectLayers::NUM_LAYERS - 1` = 32 - 5 - 1 = 26 — anything above
+    // would overflow the object-layer arrays. This header stays Jolt-free (it compiles
+    // into the test binary), so the value is written out here and McpTools.cpp
+    // `static_assert`s it against the live engine constants: if the budget changes, that
+    // fails the build instead of silently over-permitting. The actual set of *valid*
     // layers is project-defined — an agent discovers them via olo_physics_layer_matrix;
-    // we don't cross-check the live registry here (its contents depend on the loaded
-    // project, and layer 0 is the always-present default), so this is a sanity bound,
-    // not a validity guarantee.
-    inline constexpr u32 kMaxLayerId = 31;
+    // we don't cross-check the live registry here (layer 0 is the always-present
+    // default), so this is the budget ceiling, not a per-project validity guarantee.
+    inline constexpr u32 kMaxLayerId = 26;
 
     // The tool's inputSchema, authored with the schema-builder DSL. Shared by the real
     // registration (McpTools.cpp) and the dispatch-seam test so the test validates the
@@ -54,7 +59,7 @@ namespace OloEngine::MCP::SetCollisionLayer
     [[nodiscard]] inline Json InputSchema()
     {
         return Schema::Object()
-            .Prop("entity", Schema::EntityId("UUID of the entity whose physics body collision layer to set (string; also accepts a number)."))
+            .Prop("entity", Schema::EntityId("UUID of the entity whose physics body collision layer to set (a decimal-digit string)."))
             .Prop("layer", Schema::Int().Min(0).Max(static_cast<std::int64_t>(kMaxLayerId)).Desc("Collision layer id to assign to the body (a user-defined physics layer; 0 is the default. Use olo_physics_layer_matrix to discover valid ids)."))
             .Required({ "entity", "layer" })
             .NoAdditional();
@@ -62,39 +67,31 @@ namespace OloEngine::MCP::SetCollisionLayer
 
     // Parse + validate the tool arguments into native values. The server validates
     // `args` against InputSchema() before the handler runs, but this stays defensive
-    // (it is also reached directly from tests) and converts the UUID string — which
-    // exceeds JSON's safe-integer range — exactly like McpTools::ParseUuid. Returns a
-    // human-readable error, or std::nullopt on success.
+    // (it is also reached directly from tests). Returns a human-readable error, or
+    // std::nullopt on success.
     [[nodiscard]] inline std::optional<std::string> ParseArgs(const Json& args, u64& entityUuid, u32& layer)
     {
         if (!args.contains("entity"))
             return "Missing required argument 'entity' (entity UUID).";
         const Json& entityValue = args["entity"];
-        if (entityValue.is_string())
+        // UUIDs exceed JSON's safe-integer range, so they travel as a decimal string
+        // (the inputSchema declares `entity` a string). Require the WHOLE string to be
+        // decimal digits before converting: std::stoull would otherwise accept a leading
+        // '-' (wrapping to a huge u64) or stop at the first non-digit ("42abc" -> 42).
+        if (!entityValue.is_string())
+            return "Invalid 'entity': expected a UUID as a decimal-digit string.";
+        const std::string entityStr = entityValue.get<std::string>();
+        if (entityStr.empty() ||
+            !std::all_of(entityStr.begin(), entityStr.end(), [](unsigned char c)
+                         { return c >= '0' && c <= '9'; }))
+            return "Invalid 'entity': expected a UUID as a decimal-digit string.";
+        try
         {
-            try
-            {
-                entityUuid = std::stoull(entityValue.get<std::string>());
-            }
-            catch (...)
-            {
-                return "Invalid 'entity': expected a UUID as a string or number.";
-            }
+            entityUuid = std::stoull(entityStr);
         }
-        else if (entityValue.is_number_unsigned())
+        catch (...) // std::out_of_range — value exceeds u64
         {
-            entityUuid = entityValue.get<u64>();
-        }
-        else if (entityValue.is_number_integer())
-        {
-            const long long signedId = entityValue.get<long long>();
-            if (signedId < 0)
-                return "Invalid 'entity': expected a non-negative UUID.";
-            entityUuid = static_cast<u64>(signedId);
-        }
-        else
-        {
-            return "Invalid 'entity': expected a UUID as a string or number.";
+            return "Invalid 'entity': UUID value is out of range.";
         }
 
         if (!args.contains("layer"))

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -8,6 +8,7 @@
 #include "MCP/McpPhysicsExplain.h"
 #include "MCP/McpRenderExplain.h"
 #include "MCP/McpRenderOverrides.h"
+#include "MCP/McpSetCollisionLayer.h"
 #include "MCP/McpShaderReload.h"
 #include "MCP/McpEventStream.h"
 
@@ -3179,6 +3180,48 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_set_collision_layer (main-marshaled; PROJECT WRITE) -----------
+        // The first consented, undoable write tool (#306 item C, first slice): set an
+        // entity's physics-body collision layer through the editor's undo stack, so an
+        // agent can try a fix the user can Ctrl-Z. The mutation is gated at dispatch by
+        // the "Allow writes" session toggle (ToolDef::ProjectWrite); the shared apply
+        // logic lives in McpSetCollisionLayer.h so it is unit-tested at the dispatch
+        // seam without this TU. The command is built + executed inside the MarshalRead
+        // job, i.e. on the main thread, since it touches the EnTT registry and the
+        // editor command stack.
+        ToolResult Handle_SetCollisionLayer(McpServer& server, const Json& args)
+        {
+            if (!server.Context().GetActiveScene || !server.Context().GetCommandHistory)
+                return ToolResult::Error("Project writes are not available in this editor build.");
+
+            u64 entityUuid = 0;
+            u32 layer = 0;
+            if (const auto error = SetCollisionLayer::ParseArgs(args, entityUuid, layer))
+                return ToolResult::Error(*error);
+
+            const Json result = server.MarshalRead([&server, entityUuid, layer]() -> Json
+                                                   {
+                const Ref<Scene> scene = server.Context().GetActiveScene
+                                             ? server.Context().GetActiveScene()
+                                             : nullptr;
+                CommandHistory* history = server.Context().GetCommandHistory
+                                              ? server.Context().GetCommandHistory()
+                                              : nullptr;
+                if (!scene)
+                    return Json{ { "__error", "No active scene." } };
+                if (!history)
+                    return Json{ { "__error", "No editor command history available." } };
+
+                const SetCollisionLayer::ApplyResult applied = SetCollisionLayer::Apply(scene, *history, entityUuid, layer);
+                if (!applied.Ok)
+                    return Json{ { "__error", applied.Error } };
+                return applied.Data; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
         // entity isn't on screen. Gathers the render-relevant facts off the live
@@ -4444,6 +4487,31 @@ namespace OloEngine::MCP
                                    .NoAdditional();
             tool.MainMarshaled = true;
             tool.Handler = Handle_PhysicsWhyNoCollision;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_set_collision_layer";
+            tool.Toolset = "physics";
+            tool.Title = "Set collision layer (undoable)";
+            // The first project-WRITE tool: gated behind the session "Allow writes"
+            // toggle and routed through the editor undo stack. readOnlyHint:false (not
+            // idempotent — each call snapshots the prior layer into a distinct undo
+            // command; not destructive — fully reversible via Ctrl-Z / undo).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            tool.Description =
+                "Set the collision layer of an entity's physics body — the undoable fix half of the "
+                "olo_physics_* debugging story (e.g. after olo_physics_why_no_collision blames the layer "
+                "filter). Targets the entity's Rigidbody3DComponent (or CharacterController3DComponent) "
+                "'m_LayerID'. The change is applied through the editor's undo stack, so it is a single "
+                "Ctrl-Z. This is a WRITE tool: it is refused unless 'Allow writes' is enabled in the "
+                "editor's MCP Server panel (off by default). Discover valid layer ids with "
+                "olo_physics_layer_matrix.";
+            tool.InputSchema = SetCollisionLayer::InputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_SetCollisionLayer;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -3180,6 +3180,16 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // Keep the schema's layer cap aligned with the engine's object-layer budget.
+        // A user layer id maps to the Jolt object layer ObjectLayers::NUM_LAYERS + id,
+        // and the whole budget is JoltUtils::kMaxJoltLayers; the largest authored id
+        // that still fits a valid slot is kMaxJoltLayers - NUM_LAYERS - 1. The shared
+        // header keeps kMaxLayerId Jolt-free (it compiles into the test binary), so pin
+        // it here — where the engine constants are in scope — and fail the build if the
+        // budget ever changes rather than silently letting an out-of-budget layer through.
+        static_assert(SetCollisionLayer::kMaxLayerId == JoltUtils::kMaxJoltLayers - ObjectLayers::NUM_LAYERS - 1,
+                      "olo_set_collision_layer layer cap is out of sync with the Jolt object-layer budget");
+
         // ---- olo_set_collision_layer (main-marshaled; PROJECT WRITE) -----------
         // The first consented, undoable write tool (#306 item C, first slice): set an
         // entity's physics-body collision layer through the editor's undo stack, so an

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -355,6 +355,13 @@ add_executable(OloEngine-Tests
 		# Exercises the McpServer.cpp TU already pulled in above plus the header-only
 		# schema-builder DSL; no extra editor TU is needed.
 		MCP/McpInputValidationTest.cpp
+		# First consented, undoable MCP WRITE tool: olo_set_collision_layer (#306
+		# item C, first slice). Exercises the session write gate + inputSchema
+		# enforcement at the McpServer.cpp dispatch seam, and the shared apply core
+		# (MCP/McpSetCollisionLayer.h). Header-only on the editor side (the schema
+		# DSL + the header-only UndoRedo CommandHistory), so no extra editor TU is
+		# pulled in — it links the engine Scene/ECS already in the test binary.
+		MCP/McpConsentedWriteTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -177,7 +177,9 @@ TEST_F(McpConsentedWriteTest, SchemaRejectsLayerBelowMinimum)
 TEST_F(McpConsentedWriteTest, SchemaRejectsLayerAboveMaximum)
 {
     m_Server.SetAllowWrites(true);
-    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 999 } }));
+    // Derive the over-limit value from the shared cap so this stays valid if it changes.
+    const int overMax = static_cast<int>(SetCollisionLayer::kMaxLayerId) + 1;
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", overMax } }));
     ASSERT_TRUE(resp.contains("error"));
     EXPECT_EQ(resp["error"]["code"], kInvalidParams);
 }
@@ -315,21 +317,34 @@ TEST(McpSetCollisionLayerParse, AcceptsStringUuidAndLayer)
     EXPECT_EQ(layer, 7u);
 }
 
-TEST(McpSetCollisionLayerParse, AcceptsNumericUuid)
+// The entity contract is a decimal-digit STRING (matching the inputSchema, which the
+// server enforces before the handler runs). A numeric entity is rejected — passing a
+// u64 UUID as a JSON number would also lose precision above 2^53.
+TEST(McpSetCollisionLayerParse, RejectsNumericUuid)
 {
     u64 entity = 0;
     u32 layer = 0;
-    const auto error = SetCollisionLayer::ParseArgs(Json{ { "entity", 42 }, { "layer", 0 } }, entity, layer);
-    EXPECT_FALSE(error.has_value());
-    EXPECT_EQ(entity, 42u);
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", 42 }, { "layer", 0 } }, entity, layer).has_value());
+}
+
+// std::stoull would otherwise silently accept these; require the whole string to be digits.
+TEST(McpSetCollisionLayerParse, RejectsPartialOrSignedUuidString)
+{
+    u64 entity = 0;
+    u32 layer = 0;
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "42abc" }, { "layer", 1 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "-1" }, { "layer", 1 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "" }, { "layer", 1 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", " 42" }, { "layer", 1 } }, entity, layer).has_value());
 }
 
 TEST(McpSetCollisionLayerParse, RejectsOutOfRangeAndMissing)
 {
     u64 entity = 0;
     u32 layer = 0;
+    const int overMax = static_cast<int>(SetCollisionLayer::kMaxLayerId) + 1;
     EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" }, { "layer", -1 } }, entity, layer).has_value());
-    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" }, { "layer", 9999 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" }, { "layer", overMax } }, entity, layer).has_value());
     EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "layer", 1 } }, entity, layer).has_value());
     EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" } }, entity, layer).has_value());
     EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "not-a-number" }, { "layer", 1 } }, entity, layer).has_value());

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -1,0 +1,355 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// McpConsentedWriteTest — unit test (headless, no GL, no live editor).
+//
+// Pins the first consented, undoable MCP WRITE tool: olo_set_collision_layer
+// (issue #306 item C, first slice). Two seams are exercised:
+//
+//   1. The dispatch seam (McpServer.cpp, compiled into the test binary): a tool
+//      flagged ToolDef::ProjectWrite is REFUSED with a clean JSON-RPC error while
+//      the session "Allow writes" gate is off, and ACCEPTED once it is on. The
+//      server's inputSchema enforcement (#423) rejects a bad layer / missing
+//      entity before the handler runs. McpTools.cpp (the real tool registrations)
+//      is deliberately NOT linked here, so the test registers a fake tool wired to
+//      the SAME shared apply code the real handler uses.
+//
+//   2. The shared apply core (MCP/McpSetCollisionLayer.h, header-only): it sets
+//      the physics body's m_LayerID through a real CommandHistory so the change is
+//      a single undoable command — assert the field changed AND that an undo
+//      reverts it. This is the half the real handler delegates to.
+//
+// The shared header is renderer/httplib-free, so only engine Scene/ECS types and
+// the header-only UndoRedo stack are pulled in — no extra editor TU.
+// =============================================================================
+
+#include "MCP/McpServer.h"
+#include "MCP/McpSetCollisionLayer.h"
+#include "UndoRedo/EditorCommand.h"
+
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Scene.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+
+// OLO_TEST_LAYER: unit
+
+// u32 / u64 are global typedefs (Core/Base.h), so they need no using-declaration.
+namespace
+{
+    using OloEngine::CharacterController3DComponent;
+    using OloEngine::CommandHistory;
+    using OloEngine::Entity;
+    using OloEngine::Ref;
+    using OloEngine::Rigidbody3DComponent;
+    using OloEngine::Scene;
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+    namespace SetCollisionLayer = OloEngine::MCP::SetCollisionLayer;
+
+    constexpr int kInvalidParams = -32602;
+
+    Json MakeCallRequest(const Json& id, const Json& arguments)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "method", "tools/call" },
+                     { "params", { { "name", "olo_set_collision_layer" }, { "arguments", arguments } } } };
+    }
+
+    // Fixture: an McpServer whose only tool is a fake olo_set_collision_layer wired
+    // to a test-owned Scene + CommandHistory through the SAME schema + ParseArgs +
+    // Apply code the real handler uses. The fake handler runs synchronously (no
+    // MarshalRead — there is no game thread to service it here), which is exactly
+    // what the real handler delegates to once on the main thread.
+    class McpConsentedWriteTest : public ::testing::Test
+    {
+      protected:
+        McpConsentedWriteTest()
+            : m_Server(EditorMcpContext{})
+        {
+            m_Scene = Ref<Scene>::Create();
+            Entity entity = m_Scene->CreateEntity("Body");
+            Rigidbody3DComponent rb;
+            rb.m_LayerID = kInitialLayer;
+            entity.AddComponent<Rigidbody3DComponent>(rb);
+            m_EntityUuid = static_cast<u64>(entity.GetUUID());
+
+            ToolDef tool;
+            tool.Name = "olo_set_collision_layer";
+            tool.Description = "Set the collision layer of an entity's physics body (fake; test wiring).";
+            tool.ProjectWrite = true;
+            tool.InputSchema = SetCollisionLayer::InputSchema();
+            tool.Handler = [this](McpServer&, const Json& args) -> ToolResult
+            {
+                u64 entityUuid = 0;
+                u32 layer = 0;
+                if (const auto error = SetCollisionLayer::ParseArgs(args, entityUuid, layer))
+                    return ToolResult::Error(*error);
+                const SetCollisionLayer::ApplyResult applied =
+                    SetCollisionLayer::Apply(m_Scene, m_History, entityUuid, layer);
+                if (!applied.Ok)
+                    return ToolResult::Error(applied.Error);
+                return ToolResult::Text(applied.Data.dump());
+            };
+            m_Server.RegisterTool(std::move(tool));
+        }
+
+        [[nodiscard]] u32 CurrentLayer() const
+        {
+            return m_Scene->TryGetEntityWithUUID(OloEngine::UUID(m_EntityUuid))
+                ->GetComponent<Rigidbody3DComponent>()
+                .m_LayerID;
+        }
+
+        static constexpr u32 kInitialLayer = 0;
+
+        Ref<Scene> m_Scene;
+        CommandHistory m_History;
+        u64 m_EntityUuid = 0;
+        McpServer m_Server; // declared last → destroyed first (its handler refs m_Scene/m_History)
+    };
+} // namespace
+
+// ---- the session write gate (dispatch seam) --------------------------------
+
+// Default state: the gate is OFF, so even a well-formed write call is refused with
+// a JSON-RPC error and NOTHING is mutated / pushed onto the undo stack.
+TEST_F(McpConsentedWriteTest, GateOffRejectsWriteAndMutatesNothing)
+{
+    ASSERT_FALSE(m_Server.AllowWrites()); // off by default
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(1, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+
+    // The body is untouched and the undo stack is empty — the gate stopped the
+    // handler from ever running.
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+}
+
+// With the gate ON the same call succeeds, the field changes, and the change is a
+// single undoable command — an undo reverts it, a redo re-applies it.
+TEST_F(McpConsentedWriteTest, GateOnAppliesUndoableWrite)
+{
+    m_Server.SetAllowWrites(true);
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(2, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+
+    EXPECT_EQ(CurrentLayer(), 3u);
+    ASSERT_TRUE(m_History.CanUndo());
+    EXPECT_EQ(m_History.GetUndoDescription(), "Set Collision Layer");
+
+    // The defining property of a consented write: it is a single Ctrl-Z.
+    m_History.Undo();
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+
+    m_History.Redo();
+    EXPECT_EQ(CurrentLayer(), 3u);
+}
+
+// ---- server-side inputSchema enforcement (#423), gate ON -------------------
+
+TEST_F(McpConsentedWriteTest, SchemaRejectsLayerBelowMinimum)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(3, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", -1 } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(CurrentLayer(), kInitialLayer); // never applied
+}
+
+TEST_F(McpConsentedWriteTest, SchemaRejectsLayerAboveMaximum)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 999 } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+TEST_F(McpConsentedWriteTest, SchemaRejectsMissingEntity)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(5, Json{ { "layer", 2 } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+TEST_F(McpConsentedWriteTest, SchemaRejectsNonIntegerLayer)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(6, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", "3" } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+TEST_F(McpConsentedWriteTest, SchemaRejectsUnknownProperty)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(
+        MakeCallRequest(7, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 2 }, { "extra", true } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+// ---- handler-level (tool) errors, gate ON ----------------------------------
+
+// A schema-valid call for a non-existent entity is a TOOL-level error (isError),
+// not a JSON-RPC protocol error — the call reached the handler, the handler failed.
+TEST_F(McpConsentedWriteTest, UnknownEntityIsToolError)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(8, Json{ { "entity", "99999999" }, { "layer", 2 } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+}
+
+// ---- the shared apply core (MCP/McpSetCollisionLayer.h), no server ----------
+
+TEST(McpSetCollisionLayerApply, ChangesRigidbodyLayerAndUndoReverts)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Body");
+    entity.AddComponent<Rigidbody3DComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = SetCollisionLayer::Apply(scene, history, uuid, 5);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_EQ(result.Data["component"], "Rigidbody3DComponent");
+    EXPECT_EQ(result.Data["previousLayer"], 0u);
+    EXPECT_EQ(result.Data["layer"], 5u);
+    EXPECT_EQ(entity.GetComponent<Rigidbody3DComponent>().m_LayerID, 5u);
+
+    ASSERT_TRUE(history.CanUndo());
+    history.Undo();
+    EXPECT_EQ(entity.GetComponent<Rigidbody3DComponent>().m_LayerID, 0u);
+}
+
+// Setting the layer to the value it already has changes nothing and pushes no undo
+// command (no spurious dirty / undo-stack entry).
+TEST(McpSetCollisionLayerApply, NoOpWhenLayerUnchanged)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Body");
+    Rigidbody3DComponent rb;
+    rb.m_LayerID = 4;
+    entity.AddComponent<Rigidbody3DComponent>(rb);
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = SetCollisionLayer::Apply(scene, history, uuid, 4);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_FALSE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_FALSE(history.CanUndo());
+    EXPECT_EQ(entity.GetComponent<Rigidbody3DComponent>().m_LayerID, 4u);
+}
+
+// A character controller carries its own m_LayerID and is the secondary write target.
+TEST(McpSetCollisionLayerApply, ChangesCharacterControllerLayer)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Player");
+    entity.AddComponent<CharacterController3DComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = SetCollisionLayer::Apply(scene, history, uuid, 2);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_EQ(result.Data["component"], "CharacterController3DComponent");
+    EXPECT_EQ(entity.GetComponent<CharacterController3DComponent>().m_LayerID, 2u);
+    ASSERT_TRUE(history.CanUndo());
+    history.Undo();
+    EXPECT_EQ(entity.GetComponent<CharacterController3DComponent>().m_LayerID, 0u);
+}
+
+TEST(McpSetCollisionLayerApply, RejectsEntityWithoutPhysicsBody)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("NoBody");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = SetCollisionLayer::Apply(scene, history, uuid, 1);
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(result.Error.empty());
+    EXPECT_FALSE(history.CanUndo());
+}
+
+TEST(McpSetCollisionLayerApply, RejectsMissingEntity)
+{
+    auto scene = Ref<Scene>::Create();
+    CommandHistory history;
+    const auto result = SetCollisionLayer::Apply(scene, history, /*entityUuid*/ 12345, 1);
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(result.Error.empty());
+}
+
+// ---- the shared arg parser --------------------------------------------------
+
+TEST(McpSetCollisionLayerParse, AcceptsStringUuidAndLayer)
+{
+    u64 entity = 0;
+    u32 layer = 0;
+    const auto error = SetCollisionLayer::ParseArgs(Json{ { "entity", "42" }, { "layer", 7 } }, entity, layer);
+    EXPECT_FALSE(error.has_value());
+    EXPECT_EQ(entity, 42u);
+    EXPECT_EQ(layer, 7u);
+}
+
+TEST(McpSetCollisionLayerParse, AcceptsNumericUuid)
+{
+    u64 entity = 0;
+    u32 layer = 0;
+    const auto error = SetCollisionLayer::ParseArgs(Json{ { "entity", 42 }, { "layer", 0 } }, entity, layer);
+    EXPECT_FALSE(error.has_value());
+    EXPECT_EQ(entity, 42u);
+}
+
+TEST(McpSetCollisionLayerParse, RejectsOutOfRangeAndMissing)
+{
+    u64 entity = 0;
+    u32 layer = 0;
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" }, { "layer", -1 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" }, { "layer", 9999 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "layer", 1 } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "1" } }, entity, layer).has_value());
+    EXPECT_TRUE(SetCollisionLayer::ParseArgs(Json{ { "entity", "not-a-number" }, { "layer", 1 } }, entity, layer).has_value());
+}
+
+// ---- the shared inputSchema -------------------------------------------------
+
+TEST(McpSetCollisionLayerSchema, DeclaresRequiredFieldsAndLayerBounds)
+{
+    const Json schema = SetCollisionLayer::InputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    EXPECT_EQ(schema["additionalProperties"], false);
+
+    ASSERT_TRUE(schema["required"].is_array());
+    const auto& required = schema["required"];
+    EXPECT_NE(std::find(required.begin(), required.end(), "entity"), required.end());
+    EXPECT_NE(std::find(required.begin(), required.end(), "layer"), required.end());
+
+    EXPECT_EQ(schema["properties"]["entity"]["type"], "string");
+    EXPECT_EQ(schema["properties"]["layer"]["type"], "integer");
+    EXPECT_EQ(schema["properties"]["layer"]["minimum"], 0);
+    EXPECT_EQ(schema["properties"]["layer"]["maximum"], static_cast<int>(SetCollisionLayer::kMaxLayerId));
+}


### PR DESCRIPTION
…+ session write gate (#306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new foliage test scene with terrain, lighting, camera, weather, snow, fog, wind, precipitation, and streaming setup.
  * Introduced a new collision-layer editing tool that can update entity physics layers through the editor.

* **Bug Fixes**
  * Project-changing editor actions made through MCP can now be undone with the editor’s undo stack.
  * Added a session-level “Allow writes” toggle so write tools are blocked by default and clearly reported in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->