### PR TITLE
chore(video): SonarQube CODE_SMELL cleanup (no behaviour change)

### DIFF
--- a/OloEngine/src/OloEngine/Video/FFmpegBackend.cpp
+++ b/OloEngine/src/OloEngine/Video/FFmpegBackend.cpp
@@ -29,10 +29,18 @@ namespace OloEngine
         class FFmpegBackend final : public IVideoDecoderBackend
         {
           public:
+            FFmpegBackend() = default;
             ~FFmpegBackend() override
             {
                 Cleanup();
             }
+
+            // Owns raw libav contexts/packets/frames — non-copyable and non-movable
+            // (it is only ever held by a Scope).
+            FFmpegBackend(const FFmpegBackend&) = delete;
+            FFmpegBackend& operator=(const FFmpegBackend&) = delete;
+            FFmpegBackend(FFmpegBackend&&) = delete;
+            FFmpegBackend& operator=(FFmpegBackend&&) = delete;
 
             bool Open(const std::string& filePath, bool decodeAudio) override
             {

--- a/OloEngine/src/OloEngine/Video/PlMpegBackend.cpp
+++ b/OloEngine/src/OloEngine/Video/PlMpegBackend.cpp
@@ -12,11 +12,18 @@ namespace OloEngine
         class PlMpegBackend final : public IVideoDecoderBackend
         {
           public:
+            PlMpegBackend() = default;
             ~PlMpegBackend() override
             {
                 if (m_Plm)
                     plm_destroy(m_Plm);
             }
+
+            // Owns a raw plm_t* — non-copyable and non-movable (it is only ever held by a Scope).
+            PlMpegBackend(const PlMpegBackend&) = delete;
+            PlMpegBackend& operator=(const PlMpegBackend&) = delete;
+            PlMpegBackend(PlMpegBackend&&) = delete;
+            PlMpegBackend& operator=(PlMpegBackend&&) = delete;
 
             bool Open(const std::string& filePath, bool decodeAudio) override
             {
@@ -111,8 +118,7 @@ namespace OloEngine
 
                 const u32 w = frame->width;
                 const u32 h = frame->height;
-                const sizet byteCount = static_cast<sizet>(w) * h * 4u;
-                if (outRGBA.size() != byteCount)
+                if (const sizet byteCount = static_cast<sizet>(w) * h * 4u; outRGBA.size() != byteCount)
                     outRGBA.resize(byteCount);
 
                 plm_frame_to_rgba(frame, outRGBA.data(), static_cast<int>(w * 4u));
@@ -143,7 +149,8 @@ namespace OloEngine
             {
                 if (!m_Plm)
                     return false;
-                const int ok = plm_seek(m_Plm, timeSeconds, 1 /*seek_exact*/);
+                constexpr int seekExact = 1;
+                const int ok = plm_seek(m_Plm, timeSeconds, seekExact);
                 if (ok)
                     m_EndOfStream = false;
                 return ok != 0;

--- a/OloEngine/src/OloEngine/Video/VideoAudioStream.cpp
+++ b/OloEngine/src/OloEngine/Video/VideoAudioStream.cpp
@@ -11,7 +11,7 @@
 namespace OloEngine
 {
     // The ma_data_source_base MUST be the first member so a ma_data_source* handed to the
-    // vtable callbacks can be reinterpret_cast straight back to this struct.
+    // vtable callbacks (it is really a void*) can be static_cast straight back to this struct.
     struct VideoAudioStream::Impl
     {
         ma_data_source_base DataSource{};
@@ -29,7 +29,7 @@ namespace OloEngine
     {
         VideoAudioStream::Impl* ImplFrom(ma_data_source* pDataSource)
         {
-            return reinterpret_cast<VideoAudioStream::Impl*>(pDataSource);
+            return static_cast<VideoAudioStream::Impl*>(pDataSource);
         }
 
         ma_result VideoDS_OnRead(ma_data_source* pDataSource, void* pFramesOut, ma_uint64 frameCount, ma_uint64* pFramesRead)
@@ -72,7 +72,7 @@ namespace OloEngine
 
         ma_result VideoDS_OnGetDataFormat(ma_data_source* pDataSource, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap)
         {
-            auto* impl = ImplFrom(pDataSource);
+            const auto* impl = ImplFrom(pDataSource);
             if (pFormat)
                 *pFormat = ma_format_f32;
             if (pChannels)
@@ -86,20 +86,20 @@ namespace OloEngine
 
         ma_result VideoDS_OnGetCursor(ma_data_source* pDataSource, ma_uint64* pCursor)
         {
-            auto* impl = ImplFrom(pDataSource);
+            const auto* impl = ImplFrom(pDataSource);
             if (pCursor)
                 *pCursor = impl->FramesConsumed.load(std::memory_order_relaxed);
             return MA_SUCCESS;
         }
 
-        ma_data_source_vtable g_VideoDataSourceVtable = {
+        const ma_data_source_vtable g_VideoDataSourceVtable = {
             VideoDS_OnRead,
             VideoDS_OnSeek,
             VideoDS_OnGetDataFormat,
             VideoDS_OnGetCursor,
-            /*onGetLength*/ nullptr, // unknown / infinite
-            /*onSetLooping*/ nullptr,
-            /*flags*/ 0
+            nullptr, // onGetLength: unknown / infinite
+            nullptr, // onSetLooping
+            0        // flags
         };
     } // namespace
 
@@ -215,7 +215,8 @@ namespace OloEngine
 
     sizet VideoAudioStream::Write(const f32* interleaved, sizet frameCount)
     {
-        if (!m_Active || !m_Impl || !m_Impl->RingInit || !interleaved || frameCount == 0)
+        const bool ready = m_Active && m_Impl && m_Impl->RingInit;
+        if (!ready || !interleaved || frameCount == 0)
             return 0;
 
         sizet written = 0;

--- a/OloEngine/src/OloEngine/Video/VideoAudioStream.h
+++ b/OloEngine/src/OloEngine/Video/VideoAudioStream.h
@@ -39,16 +39,16 @@ namespace OloEngine
         sizet Write(const f32* interleaved, sizet frameCount);
 
         /// Free space available to Write right now, in frames.
-        [[nodiscard]] sizet WritableFrames() const;
+        [[nodiscard("writable frame count must be used")]] sizet WritableFrames() const;
 
         /// Master clock: seconds of audio the device has consumed (+ last seek base).
-        [[nodiscard]] f64 ClockSeconds() const;
+        [[nodiscard("clock value must be used")]] f64 ClockSeconds() const;
 
-        [[nodiscard]] bool IsActive() const
+        [[nodiscard("active state must be used")]] bool IsActive() const
         {
             return m_Active;
         }
-        [[nodiscard]] u32 GetSampleRate() const
+        [[nodiscard("sample rate must be used")]] u32 GetSampleRate() const
         {
             return m_SampleRate;
         }

--- a/OloEngine/src/OloEngine/Video/VideoDecoder.cpp
+++ b/OloEngine/src/OloEngine/Video/VideoDecoder.cpp
@@ -2,8 +2,6 @@
 #include "OloEngine/Video/VideoDecoder.h"
 #include "OloEngine/Video/VideoDecoderBackend.h"
 
-#include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <utility>
 
@@ -28,8 +26,13 @@ namespace OloEngine
         bool IsMpeg1Extension(const std::string& filePath)
         {
             std::string ext = std::filesystem::path(filePath).extension().string();
-            std::ranges::transform(ext, ext.begin(), [](unsigned char c)
-                                   { return static_cast<char>(std::tolower(c)); });
+            // ASCII-lowercase in place; file extensions are ASCII, so this avoids the
+            // locale-dependent <cctype> functions (and their narrow-char UB pitfalls).
+            for (char& ch : ext)
+            {
+                if (ch >= 'A' && ch <= 'Z')
+                    ch = static_cast<char>(ch - 'A' + 'a');
+            }
             return ext == ".mpg" || ext == ".mpeg" || ext == ".m1v" || ext == ".mpg1";
         }
     } // namespace

--- a/OloEngine/src/OloEngine/Video/VideoDecoder.h
+++ b/OloEngine/src/OloEngine/Video/VideoDecoder.h
@@ -33,8 +33,8 @@ namespace OloEngine
 
         VideoDecoder(const VideoDecoder&) = delete;
         VideoDecoder& operator=(const VideoDecoder&) = delete;
-        VideoDecoder(VideoDecoder&&) noexcept;
-        VideoDecoder& operator=(VideoDecoder&&) noexcept;
+        VideoDecoder(VideoDecoder&& other) noexcept;
+        VideoDecoder& operator=(VideoDecoder&& other) noexcept;
 
         /// Open a media file for decoding.
         /// @param filePath  Absolute or working-directory-relative path to the file.
@@ -45,14 +45,14 @@ namespace OloEngine
         bool Open(const std::string& filePath, bool decodeAudio = false);
         void Close();
 
-        [[nodiscard]] bool IsOpen() const;
-        [[nodiscard]] f64 GetDuration() const; // Total seconds (0 if unknown).
-        [[nodiscard]] u32 GetWidth() const;
-        [[nodiscard]] u32 GetHeight() const;
-        [[nodiscard]] f64 GetFrameRate() const;       // Frames per second.
-        [[nodiscard]] bool HasAudio() const;          // True if the file carries an audio stream.
-        [[nodiscard]] u32 GetAudioSampleRate() const; // Hz (0 if no audio).
-        [[nodiscard]] u32 GetAudioChannels() const;   // Output channel count (backends output stereo: 2).
+        [[nodiscard("open state must be used")]] bool IsOpen() const;
+        [[nodiscard("duration must be used")]] f64 GetDuration() const; // Total seconds (0 if unknown).
+        [[nodiscard("width must be used")]] u32 GetWidth() const;
+        [[nodiscard("height must be used")]] u32 GetHeight() const;
+        [[nodiscard("frame rate must be used")]] f64 GetFrameRate() const;        // Frames per second.
+        [[nodiscard("audio-presence flag must be used")]] bool HasAudio() const;  // True if the file carries an audio stream.
+        [[nodiscard("sample rate must be used")]] u32 GetAudioSampleRate() const; // Hz (0 if no audio).
+        [[nodiscard("channel count must be used")]] u32 GetAudioChannels() const; // Output channel count (backends output stereo: 2).
 
         /// Decode the next video frame into @p outRGBA (resized to width*height*4).
         /// @return false at end-of-stream or when no decoder is open.
@@ -69,7 +69,7 @@ namespace OloEngine
         bool Seek(f64 timeSeconds);
 
         /// True once the end of the video stream has been reached.
-        [[nodiscard]] bool IsEndOfStream() const;
+        [[nodiscard("end-of-stream flag must be used")]] bool IsEndOfStream() const;
 
       private:
         struct Impl;

--- a/OloEngine/src/OloEngine/Video/VideoDecoderBackend.h
+++ b/OloEngine/src/OloEngine/Video/VideoDecoderBackend.h
@@ -19,26 +19,26 @@ namespace OloEngine
 
         virtual bool Open(const std::string& filePath, bool decodeAudio) = 0;
 
-        [[nodiscard]] virtual u32 GetWidth() const = 0;
-        [[nodiscard]] virtual u32 GetHeight() const = 0;
-        [[nodiscard]] virtual f64 GetDuration() const = 0;
-        [[nodiscard]] virtual f64 GetFrameRate() const = 0;
-        [[nodiscard]] virtual bool HasAudio() const = 0;
-        [[nodiscard]] virtual u32 GetAudioSampleRate() const = 0;
-        [[nodiscard]] virtual u32 GetAudioChannels() const = 0; // output channels (always 2)
+        [[nodiscard("width must be used")]] virtual u32 GetWidth() const = 0;
+        [[nodiscard("height must be used")]] virtual u32 GetHeight() const = 0;
+        [[nodiscard("duration must be used")]] virtual f64 GetDuration() const = 0;
+        [[nodiscard("frame rate must be used")]] virtual f64 GetFrameRate() const = 0;
+        [[nodiscard("audio-presence flag must be used")]] virtual bool HasAudio() const = 0;
+        [[nodiscard("sample rate must be used")]] virtual u32 GetAudioSampleRate() const = 0;
+        [[nodiscard("channel count must be used")]] virtual u32 GetAudioChannels() const = 0; // output channels (always 2)
 
         virtual bool DecodeNextFrame(std::vector<u8>& outRGBA, VideoFrameInfo& outInfo) = 0;
         virtual bool DecodeAudioSamples(std::vector<f32>& outSamples, f64& outTimestamp) = 0;
         virtual bool Seek(f64 timeSeconds) = 0;
-        [[nodiscard]] virtual bool IsEndOfStream() const = 0;
+        [[nodiscard("end-of-stream flag must be used")]] virtual bool IsEndOfStream() const = 0;
     };
 
     /// pl_mpeg backend (MPEG-1 video + MP2 audio). Always available.
-    [[nodiscard]] Scope<IVideoDecoderBackend> CreatePlMpegBackend();
+    [[nodiscard("created backend must be used")]] Scope<IVideoDecoderBackend> CreatePlMpegBackend();
 
 #if defined(OLO_VIDEO_FFMPEG)
     /// FFmpeg/libav backend (H.264/HEVC/VP9/… in MP4/MOV/MKV/…). Built from source when the
     /// OLO_VIDEO_FFMPEG CMake option is on.
-    [[nodiscard]] Scope<IVideoDecoderBackend> CreateFFmpegBackend();
+    [[nodiscard("created backend must be used")]] Scope<IVideoDecoderBackend> CreateFFmpegBackend();
 #endif
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Video/VideoPlayer.cpp
+++ b/OloEngine/src/OloEngine/Video/VideoPlayer.cpp
@@ -21,7 +21,8 @@ namespace OloEngine
 
         // Request audio decoding so we can drive A/V sync; the decoder reports whether the
         // file actually carries an audio stream.
-        if (!m_Decoder.Open(filePath, /*decodeAudio=*/true))
+        constexpr bool decodeAudio = true;
+        if (!m_Decoder.Open(filePath, decodeAudio))
             return false;
 
         m_Width = m_Decoder.GetWidth();
@@ -183,6 +184,10 @@ namespace OloEngine
             m_CurrentTime = m_AudioStream->ClockSeconds();
         else if (std::isfinite(dt) && dt > 0.0f)
             m_CurrentTime = m_CurrentTime.load() + static_cast<f64>(dt) * static_cast<f64>(m_PlaybackSpeed);
+        else
+        {
+            // Paused or a non-finite/zero dt: hold the clock at its current value.
+        }
 
         const f64 now = m_CurrentTime.load();
 
@@ -207,11 +212,11 @@ namespace OloEngine
         }
 
         // End-of-stream handling: decoder exhausted and every decoded frame consumed.
-        bool queueEmpty;
+        const bool queueEmpty = [this]
         {
             std::scoped_lock lock(m_QueueMutex);
-            queueEmpty = m_FrameQueue.empty();
-        }
+            return m_FrameQueue.empty();
+        }();
 
         if (m_DecoderAtEnd.load() && queueEmpty)
         {
@@ -233,6 +238,10 @@ namespace OloEngine
                         m_AudioStream->Stop();
                     if (OnFinished)
                         OnFinished();
+                }
+                else
+                {
+                    // Already finished and not looping: nothing more to do.
                 }
             }
         }
@@ -310,11 +319,11 @@ namespace OloEngine
             }
 
             // 3. Keep the video frame queue topped up.
-            bool videoRoom;
+            const bool videoRoom = [this]
             {
                 std::scoped_lock lock(m_QueueMutex);
-                videoRoom = m_FrameQueue.size() < s_MaxQueuedFrames;
-            }
+                return m_FrameQueue.size() < s_MaxQueuedFrames;
+            }();
             if (!m_DecoderAtEnd.load() && videoRoom)
             {
                 if (m_Decoder.DecodeNextFrame(scratch.Data, info))

--- a/OloEngine/src/OloEngine/Video/VideoPlayer.h
+++ b/OloEngine/src/OloEngine/Video/VideoPlayer.h
@@ -83,69 +83,69 @@ namespace OloEngine
         /// frame shown via the same overlay path as video. Replaces any loaded video.
         void PresentImage(const u8* rgba, u32 width, u32 height);
 
-        [[nodiscard]] bool IsLoaded() const
+        [[nodiscard("loaded state must be used")]] bool IsLoaded() const
         {
             return m_Loaded;
         }
-        [[nodiscard]] bool IsPlaying() const
+        [[nodiscard("playing state must be used")]] bool IsPlaying() const
         {
             return m_State == VideoPlaybackState::Playing;
         }
-        [[nodiscard]] bool IsPaused() const
+        [[nodiscard("paused state must be used")]] bool IsPaused() const
         {
             return m_State == VideoPlaybackState::Paused;
         }
-        [[nodiscard]] bool IsStopped() const
+        [[nodiscard("stopped state must be used")]] bool IsStopped() const
         {
             return m_State == VideoPlaybackState::Stopped;
         }
-        [[nodiscard]] bool IsFinished() const
+        [[nodiscard("finished state must be used")]] bool IsFinished() const
         {
             return m_Finished;
         }
-        [[nodiscard]] VideoPlaybackState GetState() const
+        [[nodiscard("playback state must be used")]] VideoPlaybackState GetState() const
         {
             return m_State;
         }
 
-        [[nodiscard]] f64 GetCurrentTime() const
+        [[nodiscard("current time must be used")]] f64 GetCurrentTime() const
         {
             return m_CurrentTime.load();
         }
-        [[nodiscard]] f64 GetDuration() const
+        [[nodiscard("duration must be used")]] f64 GetDuration() const
         {
             return m_Duration;
         }
-        [[nodiscard]] f32 GetPlaybackSpeed() const
+        [[nodiscard("playback speed must be used")]] f32 GetPlaybackSpeed() const
         {
             return m_PlaybackSpeed;
         }
-        [[nodiscard]] f32 GetVolume() const
+        [[nodiscard("volume must be used")]] f32 GetVolume() const
         {
             return m_Volume;
         }
-        [[nodiscard]] bool IsLooping() const
+        [[nodiscard("looping state must be used")]] bool IsLooping() const
         {
             return m_Looping;
         }
-        [[nodiscard]] u32 GetWidth() const
+        [[nodiscard("width must be used")]] u32 GetWidth() const
         {
             return m_Width;
         }
-        [[nodiscard]] u32 GetHeight() const
+        [[nodiscard("height must be used")]] u32 GetHeight() const
         {
             return m_Height;
         }
-        [[nodiscard]] f64 GetFrameRate() const
+        [[nodiscard("frame rate must be used")]] f64 GetFrameRate() const
         {
             return m_FrameRate;
         }
 
-        [[nodiscard]] const VideoTexture& GetTexture() const
+        [[nodiscard("texture must be used")]] const VideoTexture& GetTexture() const
         {
             return m_Texture;
         }
-        [[nodiscard]] VideoTexture& GetTexture()
+        [[nodiscard("texture must be used")]] VideoTexture& GetTexture()
         {
             return m_Texture;
         }

--- a/OloEngine/src/OloEngine/Video/VideoSystem.h
+++ b/OloEngine/src/OloEngine/Video/VideoSystem.h
@@ -31,15 +31,15 @@ namespace OloEngine
         /// the same overlay path as video. Width*height*4 bytes; the buffer is copied.
         static void ShowFullscreenImage(const u8* rgba, u32 width, u32 height);
         static void StopFullscreen();
-        [[nodiscard]] static bool IsFullscreenPlaying();
-        [[nodiscard]] static Ref<VideoPlayer> GetFullscreenPlayer();
+        [[nodiscard("playing state must be used")]] static bool IsFullscreenPlaying();
+        [[nodiscard("fullscreen player must be used")]] static Ref<VideoPlayer> GetFullscreenPlayer();
         /// Stop a skippable fullscreen video early (fires its OnFinished). No-op otherwise.
         static void SkipFullscreen();
         static void SetFullscreenSkippable(bool skippable);
-        [[nodiscard]] static bool IsFullscreenSkippable();
+        [[nodiscard("skippable state must be used")]] static bool IsFullscreenSkippable();
 
         // --- World-space ---
         /// Create a standalone player for binding to a mesh material. Returns null on failure.
-        [[nodiscard]] static Ref<VideoPlayer> CreateWorldPlayer(const std::string& filePath);
+        [[nodiscard("created player must be used")]] static Ref<VideoPlayer> CreateWorldPlayer(const std::string& filePath);
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Video/VideoTexture.h
+++ b/OloEngine/src/OloEngine/Video/VideoTexture.h
@@ -37,20 +37,20 @@ namespace OloEngine
 
         void Bind(u32 slot = 0) const;
 
-        [[nodiscard]] bool IsInitialized() const
+        [[nodiscard("initialized state must be used")]] bool IsInitialized() const
         {
             return m_Texture != nullptr;
         }
-        [[nodiscard]] u32 GetRendererID() const;
-        [[nodiscard]] u32 GetWidth() const
+        [[nodiscard("renderer ID must be used")]] u32 GetRendererID() const;
+        [[nodiscard("width must be used")]] u32 GetWidth() const
         {
             return m_Width;
         }
-        [[nodiscard]] u32 GetHeight() const
+        [[nodiscard("height must be used")]] u32 GetHeight() const
         {
             return m_Height;
         }
-        [[nodiscard]] const Ref<Texture2D>& GetTexture() const
+        [[nodiscard("texture must be used")]] const Ref<Texture2D>& GetTexture() const
         {
             return m_Texture;
         }

--- a/docs/agent-rules/sonarqube-review-alignment.md
+++ b/docs/agent-rules/sonarqube-review-alignment.md
@@ -115,3 +115,58 @@ before assuming a finding is new.
    manual buffer/pointer work). Pin genuine ones with a code fix.
 4. For anything ambiguous, the rationale and prior triage are in
    [../sonarqube-rule-suggestions.md](../sonarqube-rule-suggestions.md).
+
+---
+
+## 5. Per-subsystem MAINTAINABILITY cleanups — fix patterns & recurring false-positives
+
+The merged per-subsystem code-smell sweeps (#406 Animation, #407 Audio, #415 Gameplay,
+#418 Physics3D, Video) converged on a consistent bar. Reuse it for the next subsystem.
+
+**The scan can be stale relative to HEAD.** Issues carry the line numbers from the scan
+that created them; a later commit shifts them. **Verify every finding against the *current*
+file** — don't trust the reported line. Some findings are already fixed (e.g. a rule-of-5
+added after the scan); some moved.
+
+**Fix these (mechanical, semantics-preserving):**
+- `S6166` add `[[nodiscard]]` message → `[[nodiscard("<thing> must be used")]]` (only on
+  *existing* attributes — adding new `[[nodiscard]]` creates *new* findings).
+- `S6004` / `S5523` declare-then-assign → if/for **init-statement**, or an immediately-invoked
+  lambda when a lock scopes the assignment: `const bool x = [this]{ std::scoped_lock l(m_M); return …; }();`.
+- `S126` if/else-if with no trailing `else` → add a **commented** empty `else { /* … */ }`
+  (the comment keeps `S108` "empty block" quiet).
+- `S5421` global → `const` **only when never mutated** (a vtable/table, yes; mutable module
+  state, no — see below).
+- `S1067` >3 `&&`/`||`/`?:` in one expression → hoist a sub-predicate into a named `const bool`.
+- `S3630` `reinterpret_cast` → `static_cast` when the source is genuinely a `void*` (e.g. a C
+  handle `typedef`'d to `void`, like miniaudio's `ma_data_source`).
+- `S3624` rule-of-5 → for a class with a **custom destructor that frees a raw resource**, declare
+  the copy/move members (delete them for a `Scope`/`unique_ptr`-held, never-copied object). This
+  is a genuine double-free guard, not noise.
+- `S926` name unnamed prototype params; `S5350` read-only local pointer → pointer-to-const.
+
+**Deliberately defer / don't fight (note in the PR, leave the code):**
+- `S8417` explicit `std::memory_order_*` — usually a *deliberate* `relaxed` on a counter/flag;
+  "fixing" to `seq_cst` is a behaviour/perf change and a real risk. Deferred as noise in Audio + Video.
+- `S4136` group overloaded members — judgement/format churn; deferred in Audio + Video.
+- `S6168` `std::thread` → `std::jthread` — changes join/stop semantics ⇒ **behaviour change**.
+- `S1142` (>3 returns), `S1820` (>20 fields), `S5414` (mixed public/private members) — invasive
+  structural refactors, not mechanical; leave for a dedicated change.
+
+**Recurring false-positives in C-ABI / pImpl / interop code (don't "fix", optionally mark won't-fix):**
+- `S5008` `void*` → meaningful type — false when the `void*` is mandated by a C callback
+  signature (e.g. a miniaudio `ma_data_source_vtable` callback) or a `void**` C API
+  (`ma_pcm_rb_acquire_read/write`). Can't change without breaking the ABI.
+- `S5421` global → const — false for genuinely **mutable** module state (e.g. Video's
+  `s_FullscreenPlayer` / `s_FullscreenSkippable`, reassigned at runtime).
+- `S3624` rule-of-5 — false for a **pImpl** class that already declares move-only semantics with
+  an out-of-line `= default` destructor (the idiom *requires* defaulted-but-out-of-line specials;
+  SonarCpp wants a non-defaulted body it can't have).
+- `S859` / `M23_090` `const_cast` removing const — often forced by a **downstream API that isn't
+  const-correct** (e.g. `Texture2D::SetData(void*)` called with a `const u8*` frame). The real fix
+  is const-correcting that API; out of scope for a one-subsystem sweep.
+- `S988` remove a libc include — **false on a vendored single-header amalgam wrapper.**
+  `OloEngine/src/OloEngine/Video/PlMpeg.cpp` is the pl_mpeg TU (`#define PL_MPEG_IMPLEMENTATION`);
+  its `#include <stdio.h>` is **required and documented** (pl_mpeg's `FILE*` API needs it before the
+  impl, and the no-PCH cacheable build can't force-include it). Treat that file like `vendor/` — don't
+  clean it; only its first-party wrapper `PlMpegBackend.cpp` and the rest of `Video/` are fair game.


### PR DESCRIPTION
Per-subsystem SonarQube **MAINTAINABILITY** cleanup confined to `OloEngine/src/OloEngine/Video/**`, same pattern as #406 (Animation), #407 (Audio), #415 (Gameplay), #418 (Physics3D). **No behaviour change.** Pulled the full Video list via the SonarQube MCP (95 open maintainability issues) and cleared the genuine, mechanically-verifiable smells; deliberate suppressions and risky/behaviour-changing rules were left and are listed below.

## Fixed (semantics-preserving)

- **`S6166`** (add explanation to existing `[[nodiscard]]`) across all 6 Video headers → `[[nodiscard("<thing> must be used")]]` (no new attributes, so no new findings).
- **`S3624`** rule-of-5 — `PlMpegBackend`/`FFmpegBackend` own raw decoder resources (`plm_t*` / libav contexts) via a custom destructor but declared no copy/move; deleted both (they are only ever held by a `Scope`). Genuine accidental-double-free guard. *(`FFmpegBackend` is built under `OLO_VIDEO_FFMPEG`, which is ON in this build/CI — it compiled.)*
- **`S3630`** `reinterpret_cast`→`static_cast` in the `ma_data_source` pImpl recovery (miniaudio's `ma_data_source` is `typedef void`, so this is exactly equivalent).
- **`S5421`** `const` on the never-mutated `ma_data_source_vtable` global.
- **`S5350`** two read-only `impl` locals → pointer-to-const.
- **`S1067`** hoisted a `const bool ready` sub-predicate (>3 conditional operators → ≤3).
- **`S126`** added commented trailing `else` to two if/else-if chains.
- **`S5523`** declare-then-assign-under-lock → immediate-init lambda (×2).
- **`S1917`** inline `/*…*/` argument comments → named `constexpr` / trailing `//` (×3 files).
- **`M23_404` + `S810`** dropped `<cctype>` (+ now-unused `<algorithm>`); ASCII-fold the extension instead of `std::tolower`.
- **`S926`** named the `VideoDecoder` move-ctor/assignment parameters.
- **`S6004`** moved `byteCount` into an `if` init-statement.

## Deliberately NOT changed (noted, would be wrong or out-of-scope)

- **`S8417`** memory-order ×6 — the `relaxed` ordering on the clock/seek atomics is intentional; switching to `seq_cst` is a real behaviour/perf change. Same call as #407.
- **`S5008`** `void*` ×6 — mandated by the miniaudio C ABI (vtable callback signatures + the `void**` ring-buffer API).
- **`S5421`** ×2 in `VideoSystem.cpp` — `s_FullscreenPlayer`/`s_FullscreenSkippable` are *mutable* module state; cannot be `const` (false positive).
- **`S859`/`M23_090`** `const_cast` in `VideoTexture.cpp` — forced by `Texture2D::SetData(void*)` not being const-correct; the real fix is a Renderer API change, out of scope here.
- **`S988`** `<stdio.h>` in `PlMpeg.cpp` — that file is the **vendored pl_mpeg amalgam TU**; the include is required and documented (false positive). Treated like `vendor/`.
- **`S3624`** on `VideoDecoder` (pImpl) — already declares move-only rule-of-5; the flag is a pImpl false positive (out-of-line `= default` dtor).
- **`S6168`** `std::thread`→`std::jthread`, **`S1142`** (returns), **`S1820`** (fields), **`S5414`** (mixed access), **`S4136`** (overload grouping) — behaviour change or invasive structural refactor; deferred.

## Verification

- `OLO_VIDEO_FFMPEG=ON` → all 12 files compile; `OloEngine-Tests` and `OloEditor` build green (Debug).
- Video tests: **15 passed, 1 skipped** (`VideoDecoderFixture.DecodesFrameWhenFixtureAvailable` skips cleanly when no fixture video is present).

## Docs

Added §5 to `docs/agent-rules/sonarqube-review-alignment.md` recording the per-subsystem fix patterns + recurring C-ABI/pImpl false-positives (incl. the pl_mpeg-vendored note) for the next sweep.

Relates to umbrella #411 (SonarQube setup) — not closing it (setup-level items remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback and decoding stability with several internal cleanups.
  * Made return-value warnings more explicit across video-related APIs, helping catch missed results earlier.
  * Refined media type detection to use consistent character handling.

* **Chores**
  * Tightened ownership rules for video backends to prevent accidental copying or moving.
  * Simplified and clarified several playback and audio-stream code paths without changing behavior.

* **Documentation**
  * Expanded internal guidance for review and maintenance consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->