### PR TITLE
Issue scoring system: WSJF-derived rubric + in-issue olo-score tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,21 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+<!-- olo-score:begin -->
+## Score
+<!-- Rate this issue per docs/process/issue-scoring.md (Fibonacci 1/2/3/5/8/13). Leave the 3s if unsure. -->
+```olo-score
+capability: 3
+craft: 3
+stability: 3
+decay: 1
+effort: 3
+confidence: 0.8
+learning: 3
+fun: 3
+kano: table-stakes
+blocked_by: []
+blocks: []
+```
+<!-- olo-score:end -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,21 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+<!-- olo-score:begin -->
+## Score
+<!-- Rate this issue per docs/process/issue-scoring.md (Fibonacci 1/2/3/5/8/13). Leave the 3s if unsure. -->
+```olo-score
+capability: 3
+craft: 3
+stability: 3
+decay: 1
+effort: 3
+confidence: 0.8
+learning: 3
+fun: 3
+kano: table-stakes
+blocked_by: []
+blocks: []
+```
+<!-- olo-score:end -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ so keep references in sync when moving a file (`git grep "docs/<name>"` before a
 
 > Roadmap docs describe intended/future work — verify "doneness" against the **code**, not these files.
 
+## process/ — how we run the project
+- [process/issue-scoring.md](process/issue-scoring.md) — the rubric for rating issues/tasks (WSJF-derived, engine-tuned: Capability/Craft/Stability/Decay over Effort, plus Learning/Fun). Drives `/start-work` task picking; raw axes live in an `olo-score` block in each issue body, ranked on demand by `scripts/issue_scores.py` (nothing derived is stored).
+
 ## analysis/ — quality & code-health reports
 - [analysis/dead-code.md](analysis/dead-code.md) — dead-code analysis.
 - [analysis/sonarqube-rules.md](analysis/sonarqube-rules.md) — SonarQube rule suggestions & high-volume-rule decisions.

--- a/docs/process/issue-scoring.md
+++ b/docs/process/issue-scoring.md
@@ -1,0 +1,232 @@
+# Issue Scoring
+
+How we decide what to work on next. This replaces gut-feel / "whatever the
+roadmap doc says" backlog ordering with a small, explicit rubric tuned for a
+**personal game-engine project** — where there is no commercial "business
+value," the work is a dependency tree more than a backlog, and rendering
+changes can look done while being wrong.
+
+It is derived from **WSJF / Cost of Delay** (the `value / job-size` model used
+in commercial agile) but with the one axis that doesn't survive the move to a
+hobby engine — *Business Value* — replaced by engine-specific value axes, and
+with two unapologetically personal axes (**Learning**, **Fun**) bolted on the
+side.
+
+> **Source of truth is the axes, not a single number.** We deliberately do
+> *not* store a priority score — only the raw per-axis inputs, which live in an
+> `olo-score` block **in each issue's body** (§5). The score is *derived on
+> read* by the picker; the ranking it produces is just the *default lens*
+> `/start-work` uses to pick the next task. On any given day you can re-sort by a
+> single axis ("today I want a high-Stability cleanup") — the raw axes make that
+> free. **Nothing derived (score, rank, tier) is ever stored** — that only goes
+> stale the moment you edit an axis.
+
+---
+
+## §1 — The axes
+
+Every axis is scored on a **constrained Fibonacci scale** `{1, 2, 3, 5, 8, 13}`.
+Constrained because the gaps are the point: Fibonacci forces "is this *really*
+twice that?" decisions and kills the false precision of a 1–10 scale. Estimate
+**relative to the anchor issues** in §4, never in the abstract.
+
+### Value side — the Cost of Delay (what you lose by *not* doing it)
+
+These four are the only axes that feed the default ranking. They sum into a
+`CoD` (Cost of Delay) numerator.
+
+**Capability / Enablement** — *does it unlock the engine to do things it
+couldn't, including unblocking other queued issues?* This is the
+engine-completeness driver and usually the dominant axis, because the backlog
+is a tech tree.
+
+| 1 | 3 | 5 | 8 | 13 |
+|---|---|---|---|---|
+| pure polish, nothing depends on it | self-contained feature, one subsystem | several workflows use it | a subsystem others build on | unblocks multiple queued features / foundational |
+
+**Craft** — *visible quality + portfolio value + screenshot-ability +
+architectural elegance.* This is our stand-in for "business value": the proxy
+for value-to-an-outside-viewer.
+
+| 1 | 3 | 5 | 8 | 13 |
+|---|---|---|---|---|
+| invisible, no portfolio value | debug view / visible-but-minor | solid visible feature | clearly impressive rendering/gameplay feature | flagship "this is the demo" piece |
+
+**Stability / Correctness** — *does it fix or prevent crashes, data loss,
+silent corruption, footguns?* Weighted to feel heavier than its number suggests,
+because in an engine a bug in a core path (ECS, serialization, memory, the
+cross-binding touch-points) poisons everything built on top of it.
+
+| 1 | 3 | 5 | 8 | 13 |
+|---|---|---|---|---|
+| no stability angle | minor / rare bug | bug that bites occasionally | data loss / silent scene-or-save corruption | crash/corruption in a core path everything depends on |
+
+**Decay** — *does the cost rise if you wait?* WSJF's time-criticality,
+reframed. **Most engine work is a 1** (no external deadline), and that's a
+useful signal: when Decay is flat across the board, raw value-over-effort
+dominates. Decay earns its keep on compounding tech debt (touch-point sprawl
+that gets worse with every new component) and the rare real deadline (a demo).
+
+| 1 | 3 | 5 | 8 | 13 |
+|---|---|---|---|---|
+| flat over time | mild compounding | harder each month / near milestone | actively metastasizing / blocks imminent demo | hard deadline or runaway debt |
+
+### Effort (the denominator)
+
+**Effort** — relative Fibonacci story-size. **Include verification cost**, not
+just authoring cost. For a rendering change the "capture screenshots from
+multiple angles and *actually look at the pixels*" tax (see
+[`CLAUDE.md`](../../CLAUDE.md) → "Rendering changes MUST be visually verified")
+is real and often dwarfs the code change. A logic-only task of the same LOC is
+cheaper here.
+
+| 1 | 2 | 3 | 5 | 8 | 13 |
+|---|---|---|---|---|---|
+| routine single PR — a day or two, ~hundreds of lines (**the common case**) | chunky single PR — ~900 LOC / 15+ files, one sitting | self-contained system — several days / 2–3 PRs | ~a week, multiple PRs | multi-week across subsystems | multi-feature epic — split it |
+
+**Effort is work size, not wall-clock-to-merge.** Calibrated against PR history
+(`gh pr list --state merged`): most features land as a *single* few-hundred-line
+PR — even substantial ones (area-light shadows #422 at +702/15f, ragdoll
+foundation #401 at +931/17f, motion vectors #416). The long pole on the calendar
+is CI + review latency, which is **not** effort. So the typical task is a **1**,
+the scale is deliberately compressed at the bottom, and an 8 or 13 is a genuine
+multi-subsystem epic that should probably be split.
+
+### Confidence (the multiplier)
+
+**Confidence** ∈ `{1.0, 0.8, 0.5}` — how sure are you the approach will work
+*and* that "done" will actually be done?
+
+- `1.0` — known territory, clear approach.
+- `0.8` — some unknowns, but no fundamental risk.
+- `0.5` — **spike first.** This is where "tests green, screen wrong" lives:
+  rendering work where you won't know if it looks right until you try. A `0.5`
+  is a signal to prototype/timebox before committing, not to commit and hope.
+
+### Personal axes — scored, stored, but **never divided by effort**
+
+These are about *you*, not about the artifact, so they stay out of the value
+math. They are tiebreakers and override levers.
+
+- **Learning** (`1` nothing new → `5` a technique you've read but not built →
+  `13` frontier stretch).
+- **Fun** (`1` chore → `5` enjoyable → `13` can't wait).
+
+Keeping them separate means a boring-but-educational task (high Learning, low
+Fun) and a shallow-but-delightful one (low Learning, high Fun) stay
+distinguishable instead of averaging into a meaningless middle.
+
+---
+
+## §2 — Tags (metadata, not scored)
+
+Two things that a number can't express but the picker needs:
+
+- **Kano class** — `table-stakes` / `performance` / `delighter`. This
+  operationalizes the "engine completeness" goal. Without it you systematically
+  starve the unsexy-but-required baseline ("every engine needs working X") in
+  favor of delighters. **Rule: the top of the ranked list must always carry
+  table-stakes coverage** — completeness is a conscious budget, not an accident.
+- **Tech-tree edges** — `blocked_by: [#N, …]` / `blocks: [#N, …]`. The
+  dependency graph WSJF cannot model. **A `blocked_by` that isn't empty
+  excludes the issue from the picker entirely, regardless of score** — you
+  can't pick what you can't start.
+
+---
+
+## §3 — The picker (default lens for `/start-work`)
+
+```
+CoD   = Capability + Craft + Stability + Decay
+Score = Confidence × CoD / Effort          # computed only over UNBLOCKED issues
+```
+
+1. Drop every issue with a non-empty `blocked_by`.
+2. Pick the **max `Score`**.
+3. Break ties with **Learning, then Fun**.
+4. **Pull override:** any issue with `Fun ≥ 8` may be pulled to the front
+   regardless of `Score` — but the override is *logged* (a note in the pick).
+   Motivation is a first-class, deliberate input, not a guilty deviation from
+   "the correct task."
+
+Because the raw axes are stored, the formula is just the default. Re-sorting by
+`Stability` desc (cleanup day), `Learning` desc (study day), or `Craft / Effort`
+(portfolio-screenshot day) is all legitimate and free.
+
+---
+
+## §4 — Anchors (reference issues)
+
+Relative Fibonacci only works if "an 8 looks like *this specific issue*" is
+written down **before** the backlog is scored. The anchors below are the
+canonical reference points per axis; score everything else by comparison to
+them. (A *closed* issue is a valid anchor — it's a reference point, not a task.)
+
+| Axis | anchored rungs |
+|---|---|
+| **Capability** | `3` = #424 (self-contained audio feature) · `8` = #430 (spatial index many subsystems reuse) · `13` = #452 (unblocks dead rollback netcode + replays) |
+| **Effort** | `1` = #424 (routine single PR) · `3` = #430 (multi-day self-contained system) · `13` = #435 (three rendering sub-features — split it) |
+| **Craft** | `3` = #457 (visible-but-minor UI polish) · `8` = #459 (impressive, demo-able gameplay) · `13` = #435, #439 (flagship atmosphere / baked GI) |
+| **Stability** | `3` = #446 (real but test-only) · `8` = #454 (prevents save/scene data loss) · `13` = #325 *(closed)* (silently dropped 28 components from every save — corruption across a core path) |
+
+---
+
+## §5 — Storage: the `olo-score` block
+
+The canonical scores live **in the GitHub issue body** — one source of truth,
+where the work is, born with the issue, can't rot out of sync with a separate
+file. Each scored issue carries a visible `## Score` section whose fenced
+`olo-score` block holds **only the raw inputs** (no derived score/tier):
+
+````markdown
+## Score
+```olo-score
+capability: 8
+craft: 3
+stability: 3
+decay: 1
+effort: 3
+confidence: 0.8
+learning: 3
+fun: 3
+kano: table-stakes
+blocked_by: []
+blocks: []
+```
+<sub>Rated per [issue-scoring](../docs/process/issue-scoring.md) · score = confidence × (capability + craft + stability + decay) / effort, derived by the picker.</sub>
+````
+
+The fenced ` ```olo-score ` info-string is the parse delimiter: visible and
+skimmable on GitHub web (renders as a code block), yet unambiguous to read back.
+The repo is public, so **learning/fun are public too** — that's an accepted
+trade for a single self-contained source of truth.
+
+Tooling lives in [`scripts/issue_scores.py`](../../scripts/issue_scores.py):
+
+- `rank` — pull every open issue, parse its block, print the ranked list (with
+  the Pull-override applied). This is what `/start-work` calls.
+- `lint` — list open issues with **no** `olo-score` block (the "needs-score"
+  nudge).
+- `apply` — one-time / migration helper: write blocks into issue bodies from a
+  local source (used to seed the backlog; not part of the steady state).
+
+There is **no committed scores file** and **no tier label** — ranking is always
+recomputed from the issues on demand.
+
+---
+
+## §6 — Workflow
+
+1. **New issues are born scored.** The feature issue template
+   (`.github/ISSUE_TEMPLATE/`) carries an `olo-score` block pre-seeded to neutral
+   (`3`s, `confidence: 0.8`, `kano: table-stakes`). Fill it in by comparison to
+   the §4 anchors — a rough score beats no score. `issue_scores.py lint` flags
+   any that slipped through unscored.
+2. **Re-score when reality changes** — edit the block in the issue body: a
+   dependency lands (clear `blocked_by`), a spike resolves the unknowns
+   (`Confidence` 0.5 → 1.0), debt compounds (`Decay` climbs), or the work ships
+   (close it).
+3. **Calibration gold:** when the derived rank disagrees with your gut about
+   what to do next, *that's the signal* — either an axis is mis-scored (fix the
+   number) or the rubric is missing something (fix the rubric). Don't silently
+   override; adjust the inputs so the system learns.

--- a/scripts/issue_scores.py
+++ b/scripts/issue_scores.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Issue scoring picker — see docs/process/issue-scoring.md.
+
+Scores live in each GitHub issue body inside an `olo-score` fenced block
+(only the raw inputs; the score is derived here, never stored). Subcommands:
+
+    rank   pull every open issue, parse its block, print the ranked list
+           (default lens; Pull-override applied). This is what /start-work calls.
+    lint   list open issues with no olo-score block (the "needs-score" nudge).
+    apply  one-time/migration: write blocks into issue bodies from a local
+           JSON source (--from issue-scores.json). Supports --dry-run / --only.
+
+Requires the `gh` CLI authenticated against the repo.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO = "drsnuggles8/OloEngineBase"
+VALUE_AXES = ("capability", "craft", "stability", "decay")
+ALL_AXES = VALUE_AXES + ("effort", "confidence", "learning", "fun")
+KANO = ("table-stakes", "performance", "delighter")
+DOC_URL = f"https://github.com/{REPO}/blob/master/docs/process/issue-scoring.md"
+
+BEGIN, END = "<!-- olo-score:begin -->", "<!-- olo-score:end -->"
+SECTION_RE = re.compile(r"\n*" + re.escape(BEGIN) + r".*?" + re.escape(END) + r"\n*", re.DOTALL)
+FENCE_RE = re.compile(r"```olo-score\s*\n(.*?)\n```", re.DOTALL)
+
+
+# ---- gh helpers -------------------------------------------------------------
+def gh_json(args):
+    out = subprocess.run(["gh", *args], capture_output=True, text=True, encoding="utf-8")
+    if out.returncode != 0:
+        sys.exit(f"gh failed: {' '.join(args)}\n{out.stderr}")
+    return json.loads(out.stdout)
+
+
+def open_issues():
+    return gh_json(["issue", "list", "--repo", REPO, "--state", "open",
+                    "--limit", "300", "--json", "number,title,body"])
+
+
+# ---- block parse / render ---------------------------------------------------
+def _coerce(v):
+    v = v.strip()
+    if v.startswith("["):
+        return json.loads(v)
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        return v.strip().strip('"').strip("'")
+
+
+def parse_block(body):
+    """Return the axes dict from an issue body, or None if no block."""
+    if not body:
+        return None
+    m = FENCE_RE.search(body)
+    if not m:
+        return None
+    d = {}
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        d[k.strip()] = _coerce(v)
+    return d
+
+
+def render_section(d):
+    lines = [f"{a}: {d.get(a, 3)}" for a in ALL_AXES]
+    lines.append(f"kano: {d.get('kano', 'table-stakes')}")
+    lines.append(f"blocked_by: {json.dumps(d.get('blocked_by', []))}")
+    lines.append(f"blocks: {json.dumps(d.get('blocks', []))}")
+    block = "\n".join(lines)
+    caption = ("<sub>Rated per [issue-scoring](" + DOC_URL + ") · "
+               "score = confidence × (capability + craft + stability + decay) / effort, "
+               "derived by the picker.</sub>")
+    return f"{BEGIN}\n## Score\n```olo-score\n{block}\n```\n{caption}\n{END}"
+
+
+def splice(body, section):
+    body = body or ""
+    if SECTION_RE.search(body):
+        return SECTION_RE.sub("\n\n" + section + "\n", body).strip() + "\n"
+    return body.rstrip() + "\n\n" + section + "\n"
+
+
+# ---- scoring ----------------------------------------------------------------
+def score(d):
+    eff = d.get("effort", 0) or 0
+    if not eff:
+        return 0.0
+    cod = sum(d.get(a, 0) for a in VALUE_AXES)
+    return round(d.get("confidence", 1.0) * cod / eff, 2)
+
+
+def is_blocked(d):
+    return bool(d.get("blocked_by"))
+
+
+# ---- commands ---------------------------------------------------------------
+def cmd_rank(args):
+    rows = []
+    for it in open_issues():
+        d = parse_block(it.get("body"))
+        if d is None:
+            continue
+        rows.append((it["number"], it["title"], score(d), d))
+    rows.sort(key=lambda r: (not (r[3].get("fun", 0) >= 8 and not is_blocked(r[3])),
+                             is_blocked(r[3]), -r[2], r[0]))
+    print(f"{'#':>5} {'score':>5} {'flags':<14} title")
+    for num, title, s, d in rows:
+        flags = []
+        if d.get("fun", 0) >= 8 and not is_blocked(d):
+            flags.append("PULL")
+        if is_blocked(d):
+            flags.append("blocked:" + ",".join(map(str, d["blocked_by"])))
+        print(f"{num:>5} {s:>5} {' '.join(flags):<14} {title[:64]}")
+    nxt = next((r for r in rows if not is_blocked(r[3])), None)
+    if nxt:
+        why = " (Pull-override: fun>=8)" if nxt[3].get("fun", 0) >= 8 else ""
+        print(f"\nnext: #{nxt[0]} — {nxt[1]}{why}")
+
+
+def cmd_lint(args):
+    missing = [(it["number"], it["title"]) for it in open_issues()
+               if parse_block(it.get("body")) is None]
+    if not missing:
+        print("all open issues have an olo-score block.")
+        return
+    print(f"{len(missing)} open issue(s) need scoring:")
+    for num, title in missing:
+        print(f"  #{num} {title[:70]}")
+    sys.exit(1)
+
+
+def cmd_apply(args):
+    src = json.load(open(args.src, encoding="utf-8"))["scores"]
+    items = sorted(src.items(), key=lambda kv: int(kv[0]))
+    if args.only:
+        items = [(k, v) for k, v in items if k in set(map(str, args.only))]
+    for num, d in items:
+        section = render_section(d)
+        if args.dry_run:
+            cur = gh_json(["issue", "view", num, "--repo", REPO, "--json", "body"])["body"]
+            print(f"\n===== #{num} (spliced body preview) =====\n{splice(cur, section)}")
+            continue
+        cur = gh_json(["issue", "view", num, "--repo", REPO, "--json", "body"])["body"]
+        new_body = splice(cur, section)
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(new_body)
+            path = f.name
+        r = subprocess.run(["gh", "issue", "edit", num, "--repo", REPO, "--body-file", path],
+                           capture_output=True, text=True, encoding="utf-8")
+        print(f"#{num}: {'ok' if r.returncode == 0 else 'FAIL ' + r.stderr.strip()}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("rank").set_defaults(func=cmd_rank)
+    sub.add_parser("lint").set_defaults(func=cmd_lint)
+    ap = sub.add_parser("apply")
+    ap.add_argument("--from", dest="src", default="issue-scores.json")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--only", type=int, nargs="*", help="limit to these issue numbers")
+    ap.set_defaults(func=cmd_apply)
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A lightweight, explicit system for rating issues/tasks, replacing gut-feel backlog ordering. Derived from **WSJF / Cost of Delay**, retuned for a personal game engine (no commercial "business value"; the backlog is a tech tree; rendering can look done while being wrong).

### The rubric — [docs/process/issue-scoring.md](docs/process/issue-scoring.md)
- **Value axes** (Cost of Delay): Capability, Craft, Stability, Decay — Fibonacci `{1,2,3,5,8,13}`.
- **Effort** denominator, calibrated against real PR velocity (typical task = `1`; CI/review latency is *not* effort).
- **Confidence** multiplier (`0.5` = spike-first — the "tests green, screen wrong" guard).
- **Personal axes** (Learning, Fun), kept out of the value math; `Fun ≥ 8` triggers a logged **Pull-override**.
- **Kano** (table-stakes / performance / delighter) + **tech-tree edges** (blocked_by / blocks) as tags.
- `Score = Confidence × (Capability + Craft + Stability + Decay) / Effort`. Anchors locked in §4.

### Storage = the issues themselves
Each issue carries a visible `## Score` section with an `olo-score` fenced block holding **only the raw inputs** — single public source of truth, born with the issue, can't rot out of sync with a side file. **Nothing derived (score/rank/tier) is stored.** All open issues have been seeded.

### Tooling — [scripts/issue_scores.py](scripts/issue_scores.py)
- `rank` — derive scores live from the issues, apply the Pull-override, print the ranked list (what `/start-work` calls).
- `lint` — flag any unscored open issue.
- `apply` — migration helper (seeds blocks from a local source).

### Born-scored
Both issue templates ([feature_request](.github/ISSUE_TEMPLATE/feature_request.md), [bug_report](.github/ISSUE_TEMPLATE/bug_report.md)) now ship a neutral `olo-score` block.

## Note
The `/start-work` and `/pr-status` workflow-loop skills were rewired to select/order by the score, but those live in user-level `~/.claude/commands` (not this repo), so they're not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)