### PR TITLE
feat(mcp): full per-pass command-bucket capture for olo_render_frame_breakdown (#463)

### DIFF
--- a/OloEditor/src/MCP/McpFrameBreakdown.h
+++ b/OloEditor/src/MCP/McpFrameBreakdown.h
@@ -15,21 +15,22 @@
 // CommandPacketDebugger.h (which pulls in ImGui). This mirrors the sibling pattern
 // of McpRenderExplain.h / McpGoldenCompare.h.
 //
-// Graph attribution (issue #316 Part 4, "graph-wide command-bucket attribution").
-// Every command FrameCaptureManager captures still comes from a SINGLE pass's
-// command bucket — SceneRenderPass's — because that pass alone drives the capture
-// state machine (it both begins the pending frame at OnPreSort and commits it at
-// OnFrameEnd, before the other command-bucket passes run). The frame records which
-// pass that was (CapturedFrameData::SourcePassName), so BuildBreakdown attributes
-// every captured command to a real render-graph pass rather than a hard-coded
-// label. To place that single bucket in the whole-graph picture, the MCP handler
-// also gathers a GraphAttribution off the live RenderGraph (every pass, which ones
-// own a command bucket, which is the capture source, culled/final/work-type) and
-// passes it here. Per-command capture of the OTHER command-bucket passes (water /
-// foliage / decal / forward-overlay) requires relocating the capture commit out of
-// SceneRenderPass into a central frame-end hook — the unbounded alternative this
-// slice defers (tracked as a follow-up); those passes are enumerated here so the
-// gap is visible, not silently scoped away.
+// Graph attribution + full per-pass capture (issue #316 Part 4 / issue #463).
+// FrameCaptureManager now captures EVERY command-bucket pass that runs in the
+// frame, not just SceneRenderPass's: each pass (Scene, Water, Foliage, Decal,
+// ForwardOverlay) registers itself and snapshots its own bucket, and the commit
+// is a single central hook in Renderer3D::EndScene AFTER the whole graph executes
+// (relocated out of SceneRenderPass::OnFrameEnd, which used to commit mid-graph
+// before the other passes ran). The captured frame therefore carries one
+// CapturedPassData per command-bucket pass (CapturedFrameData::Passes); the
+// top-level lists remain the SOURCE pass (SourcePassName, the scene pass) for
+// backward compatibility. BuildBreakdown emits a `passBreakdowns` array — one
+// per-command list per pass, each tagged with its graph pass name. To place those
+// buckets in the whole-graph picture, the MCP handler also gathers a
+// GraphAttribution off the live RenderGraph (every pass, which own a command
+// bucket, which is the capture source, culled/final/work-type) and passes it here;
+// when capture covered every command-bucket pass that ran,
+// graphAttribution.capturedPassCount == graphAttribution.commandBucketPassCount.
 //
 // GraphAttribution is a plain, engine-free input struct (the handler pre-resolves
 // every graph enum to a string / bool), so this header still unit-tests against a
@@ -44,6 +45,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -87,42 +89,54 @@ namespace OloEngine::MCP::FrameBreakdown
         }
     }
 
-    // Pick the command vector for the requested stage, falling back to an earlier,
-    // populated stage when the requested one is empty (PostBatch -> PostSort ->
-    // PreSort; PostSort -> PreSort). This matches CommandPacketDebugger's own
-    // "use post-batch if not empty else post-sort" behaviour so the tool never
-    // silently reports an empty list when an earlier stage has the commands. The
-    // stage actually returned is written to `usedMode`.
-    [[nodiscard]] inline const std::vector<CapturedCommandData>& SelectCommands(const CapturedFrameData& frame, ViewMode requested, ViewMode& usedMode)
+    // Pick the command vector for the requested stage out of one bucket's three
+    // stage lists, falling back to an earlier, populated stage when the requested
+    // one is empty (PostBatch -> PostSort -> PreSort; PostSort -> PreSort). This
+    // matches CommandPacketDebugger's own "use post-batch if not empty else
+    // post-sort" behaviour so the tool never silently reports an empty list when an
+    // earlier stage has the commands. The stage actually returned is written to
+    // `usedMode`. Used by both the top-level (source-pass) breakdown and each
+    // per-pass entry (CapturedPassData has the same three stage lists).
+    [[nodiscard]] inline const std::vector<CapturedCommandData>& SelectStage(
+        const std::vector<CapturedCommandData>& preSort,
+        const std::vector<CapturedCommandData>& postSort,
+        const std::vector<CapturedCommandData>& postBatch,
+        ViewMode requested, ViewMode& usedMode)
     {
         switch (requested)
         {
             case ViewMode::PreSort:
                 usedMode = ViewMode::PreSort;
-                return frame.PreSortCommands;
+                return preSort;
             case ViewMode::PostSort:
-                if (!frame.PostSortCommands.empty())
+                if (!postSort.empty())
                 {
                     usedMode = ViewMode::PostSort;
-                    return frame.PostSortCommands;
+                    return postSort;
                 }
                 usedMode = ViewMode::PreSort;
-                return frame.PreSortCommands;
+                return preSort;
             case ViewMode::PostBatch:
             default:
-                if (!frame.PostBatchCommands.empty())
+                if (!postBatch.empty())
                 {
                     usedMode = ViewMode::PostBatch;
-                    return frame.PostBatchCommands;
+                    return postBatch;
                 }
-                if (!frame.PostSortCommands.empty())
+                if (!postSort.empty())
                 {
                     usedMode = ViewMode::PostSort;
-                    return frame.PostSortCommands;
+                    return postSort;
                 }
                 usedMode = ViewMode::PreSort;
-                return frame.PreSortCommands;
+                return preSort;
         }
+    }
+
+    // Convenience overload selecting from a frame's top-level (source-pass) lists.
+    [[nodiscard]] inline const std::vector<CapturedCommandData>& SelectCommands(const CapturedFrameData& frame, ViewMode requested, ViewMode& usedMode)
+    {
+        return SelectStage(frame.PreSortCommands, frame.PostSortCommands, frame.PostBatchCommands, requested, usedMode);
     }
 
     // One render-graph pass as seen by the command-attribution view. The MCP
@@ -138,14 +152,16 @@ namespace OloEngine::MCP::FrameBreakdown
         int ExecutionIndex = -1;           // 0-based position in the topological run order; -1 if not scheduled
     };
 
-    // The whole-graph command-bucket landscape joined to a captured frame. The
-    // capture today covers exactly one pass's bucket (CaptureSourcePass); the other
-    // command-bucket passes are enumerated so an agent sees which passes emit draw
-    // commands and which are not yet per-command attributed.
+    // The whole-graph command-bucket landscape joined to a captured frame. Every
+    // command-bucket pass that ran is now captured per-command (see
+    // CapturedFrameData::Passes / `passBreakdowns`); CaptureSourcePass names the one
+    // whose bucket is ALSO the top-level view. The full pass list lets the breakdown
+    // flag which graph passes were captured and compute capturedPassCount /
+    // commandBucketPassCount.
     struct GraphAttribution
     {
         std::vector<GraphPassInfo> Passes;
-        std::string CaptureSourcePass; // graph pass whose bucket the per-command breakdown describes
+        std::string CaptureSourcePass; // graph pass whose bucket is the top-level (source) per-command breakdown
     };
 
     namespace Detail
@@ -185,27 +201,25 @@ namespace OloEngine::MCP::FrameBreakdown
         }
     } // namespace Detail
 
-    // Build the structured per-command / per-stage breakdown for one captured
-    // frame. `requested` is the stage the caller asked for; `maxCommands` (>= 1)
-    // caps the returned command array — the full count and a `truncated` flag are
-    // ALWAYS reported, so the cap is never a silent truncation.
-    //
-    // `attribution` (optional) is the live-graph command-bucket landscape gathered
-    // by the MCP handler. When supplied, a `graphAttribution` block enumerates every
-    // graph pass and flags the capture source; when null (e.g. unit tests, or no
-    // active graph), only the frame-recorded `sourcePass` is reported.
-    [[nodiscard]] inline Json BuildBreakdown(const CapturedFrameData& frame, ViewMode requested, int maxCommands,
-                                             const GraphAttribution* attribution = nullptr)
+    // Shape one command bucket's three stage lists into the common per-bucket JSON
+    // fields (requestedViewMode, viewMode, stageCounts, commandTypeHistogram,
+    // commandCount, returnedCommands, truncated, commands). Shared by the top-level
+    // (source-pass) breakdown and every per-pass entry so both views are identical
+    // in shape. The histogram covers the FULL selected stage (not just the returned
+    // slice) so it stays accurate under truncation; `commandCount` is always the
+    // full count and `truncated` flags the cap, so the maxCommands limit is never a
+    // silent truncation.
+    [[nodiscard]] inline Json ShapeBucket(const std::vector<CapturedCommandData>& preSort,
+                                          const std::vector<CapturedCommandData>& postSort,
+                                          const std::vector<CapturedCommandData>& postBatch,
+                                          ViewMode requested, int maxCommands)
     {
         ViewMode usedMode = requested;
-        const std::vector<CapturedCommandData>& commands = SelectCommands(frame, requested, usedMode);
+        const std::vector<CapturedCommandData>& commands = SelectStage(preSort, postSort, postBatch, requested, usedMode);
 
         const sizet total = commands.size();
         const sizet limit = maxCommands < 1 ? total : std::min<sizet>(total, static_cast<sizet>(maxCommands));
 
-        // Histogram of command types over the FULL selected stage (not just the
-        // returned slice), so it stays accurate under truncation. std::map keeps
-        // the keys ordered for stable output.
         std::map<std::string, u32> histogram;
         for (const auto& cmd : commands)
             ++histogram[cmd.GetCommandTypeString()];
@@ -218,26 +232,51 @@ namespace OloEngine::MCP::FrameBreakdown
         for (sizet i = 0; i < limit; ++i)
             cmdArray.push_back(Detail::CommandToJson(i, commands[i]));
 
+        Json out;
+        out["requestedViewMode"] = ViewModeName(requested);
+        out["viewMode"] = ViewModeName(usedMode);
+        out["stageCounts"] = Json{ { "preSort", preSort.size() },
+                                   { "postSort", postSort.size() },
+                                   { "postBatch", postBatch.size() } };
+        out["commandTypeHistogram"] = std::move(typeHistogram);
+        out["commandCount"] = total;
+        out["returnedCommands"] = limit;
+        out["truncated"] = limit < total;
+        out["commands"] = std::move(cmdArray);
+        return out;
+    }
+
+    // Build the structured per-command / per-stage breakdown for one captured
+    // frame. `requested` is the stage the caller asked for; `maxCommands` (>= 1)
+    // caps the returned command array — the full count and a `truncated` flag are
+    // ALWAYS reported, so the cap is never a silent truncation.
+    //
+    // `attribution` (optional) is the live-graph command-bucket landscape gathered
+    // by the MCP handler. When supplied, a `graphAttribution` block enumerates every
+    // graph pass and flags the capture source; when null (e.g. unit tests, or no
+    // active graph), only the frame-recorded `sourcePass` is reported.
+    [[nodiscard]] inline Json BuildBreakdown(const CapturedFrameData& frame, ViewMode requested, int maxCommands,
+                                             const GraphAttribution* attribution = nullptr)
+    {
+        // Shape the top-level (source / scene pass) bucket — backward-compatible
+        // with the single-pass breakdown.
+        Json out = ShapeBucket(frame.PreSortCommands, frame.PostSortCommands, frame.PostBatchCommands,
+                               requested, maxCommands);
+
         const FrameCaptureStats& stats = frame.Stats;
 
-        // The pass these captured commands were emitted by. Prefer the name the
+        // The pass these top-level commands were emitted by. Prefer the name the
         // capture recorded on the frame; fall back to the attribution's source
         // (same value, kept for callers that only populate the attribution).
         std::string sourcePass = frame.SourcePassName;
         if (sourcePass.empty() && attribution != nullptr)
             sourcePass = attribution->CaptureSourcePass;
 
-        Json out;
         out["frameNumber"] = frame.FrameNumber;
         out["timestampSeconds"] = Detail::Round(frame.TimestampSeconds, 3);
         out["sourcePass"] = sourcePass;
         out["bucket"] = sourcePass.empty() ? std::string("scene render command bucket")
                                            : sourcePass + " command bucket";
-        out["requestedViewMode"] = ViewModeName(requested);
-        out["viewMode"] = ViewModeName(usedMode);
-        out["stageCounts"] = Json{ { "preSort", frame.PreSortCommands.size() },
-                                   { "postSort", frame.PostSortCommands.size() },
-                                   { "postBatch", frame.PostBatchCommands.size() } };
         out["stats"] = Json{ { "totalCommands", stats.TotalCommands },
                              { "drawCalls", stats.DrawCalls },
                              { "batchedCommands", stats.BatchedCommands },
@@ -248,26 +287,59 @@ namespace OloEngine::MCP::FrameBreakdown
                              { "batchMs", Detail::Round(stats.BatchTimeMs, 3) },
                              { "executeMs", Detail::Round(stats.ExecuteTimeMs, 3) },
                              { "totalMs", Detail::Round(stats.TotalFrameTimeMs, 3) } };
-        out["commandTypeHistogram"] = std::move(typeHistogram);
-        out["commandCount"] = total;
-        out["returnedCommands"] = limit;
-        out["truncated"] = limit < total;
-        out["commands"] = std::move(cmdArray);
 
-        // Graph-wide command-bucket attribution: place the captured single-pass
-        // bucket in the context of the whole render graph (issue #316 Part 4).
+        // Per-pass command breakdown (issue #463 / #316 Part 4). One entry per
+        // command-bucket pass that executed this frame (Scene, Water, Foliage,
+        // Decal, ForwardOverlay), each tagged with its graph pass name and shaped
+        // identically to the top-level bucket. The capture is no longer limited to
+        // the single scene-pass bucket. Empty for a legacy single-pass capture.
+        if (!frame.Passes.empty())
+        {
+            Json passBreakdowns = Json::array();
+            for (const auto& pass : frame.Passes)
+            {
+                Json entry = ShapeBucket(pass.PreSortCommands, pass.PostSortCommands, pass.PostBatchCommands,
+                                         requested, maxCommands);
+                entry["name"] = pass.PassName;
+                entry["isCaptureSource"] = !sourcePass.empty() && pass.PassName == sourcePass;
+                passBreakdowns.push_back(std::move(entry));
+            }
+            out["passBreakdowns"] = std::move(passBreakdowns);
+        }
+
+        // Names of the passes actually captured this frame — used to flag each
+        // graph pass below as captured / not, and to size capturedPassCount.
+        std::set<std::string> capturedPassNames;
+        for (const auto& pass : frame.Passes)
+            capturedPassNames.insert(pass.PassName);
+
+        // capturedPassCount is the number of per-pass command captures this frame.
+        // Falls back to the legacy single-pass count (0/1) for an old-style frame
+        // that has no per-pass entries.
+        const u32 capturedPassCount = frame.Passes.empty()
+                                          ? (sourcePass.empty() ? 0u : 1u)
+                                          : static_cast<u32>(frame.Passes.size());
+
+        // Graph-wide command-bucket attribution: place the captured per-pass
+        // buckets in the context of the whole render graph (issue #316 Part 4).
         if (attribution != nullptr)
         {
+            // Command-bucket passes that RAN this frame (non-culled). This is the
+            // denominator the capture is expected to cover: with full per-pass
+            // capture, capturedPassCount == commandBucketPassCount for a frame in
+            // which every command-bucket pass executed. Culled passes own a bucket
+            // but emit nothing, so they are excluded from the running count.
             u32 bucketPassCount = 0;
             Json passes = Json::array();
             for (const auto& p : attribution->Passes)
             {
-                if (p.UsesCommandBucket)
+                if (p.UsesCommandBucket && !p.Culled)
                     ++bucketPassCount;
                 passes.push_back(Json{ { "name", p.Name },
                                        { "workType", p.WorkType },
                                        { "usesCommandBucket", p.UsesCommandBucket },
                                        { "isCaptureSource", !sourcePass.empty() && p.Name == sourcePass },
+                                       { "captured", capturedPassNames.contains(p.Name) },
                                        { "culled", p.Culled },
                                        { "isFinalPass", p.IsFinalPass },
                                        { "executionIndex", p.ExecutionIndex } });
@@ -277,23 +349,25 @@ namespace OloEngine::MCP::FrameBreakdown
             graph["captureSourcePass"] = sourcePass;
             graph["passCount"] = static_cast<u32>(attribution->Passes.size());
             graph["commandBucketPassCount"] = bucketPassCount;
-            graph["capturedPassCount"] = sourcePass.empty() ? 0u : 1u;
+            graph["capturedPassCount"] = capturedPassCount;
             graph["passes"] = std::move(passes);
             graph["note"] = "Every pass in the live render graph. 'usesCommandBucket' passes emit sortable draw "
-                            "commands; exactly one of them ('isCaptureSource' / captureSourcePass) had its bucket "
-                            "captured and broken down per-command above. The other command-bucket passes are "
-                            "listed but not yet per-command attributed — full per-pass capture is deferred "
-                            "(it needs the capture commit moved out of SceneRenderPass into a frame-end hook). "
+                            "commands; each that ran this frame had its bucket captured and broken down per-command "
+                            "in 'passBreakdowns' (flagged here with 'captured'). 'isCaptureSource' marks the pass "
+                            "whose bucket is ALSO the top-level 'commands'/'stats' view (the scene pass). "
+                            "'commandBucketPassCount' counts command-bucket passes that RAN (non-culled); when "
+                            "capture covered them all, capturedPassCount == commandBucketPassCount. "
                             "'executionIndex' is the topological run order; 'culled' passes were skipped this frame.";
             out["graphAttribution"] = std::move(graph);
         }
 
-        out["note"] = "Per-command breakdown of one render-graph pass's command bucket ('sourcePass'). GPU times "
-                      "come from the renderer's double-buffered timer-query pool (previous-frame readback, "
-                      "approximate). 'debugName' is the per-command label within that bucket. See "
-                      "'graphAttribution' for where this bucket sits in the whole graph and which other passes "
-                      "emit commands. Use format:\"markdown\" for the Command Bucket Inspector's full "
-                      "sort/state-change/batching analysis.";
+        out["note"] = "Top-level 'commands'/'stats' describe the source pass's bucket ('sourcePass', the scene "
+                      "pass). 'passBreakdowns' lists EVERY command-bucket pass that ran this frame (Scene, Water, "
+                      "Foliage, Decal, ForwardOverlay) with its own per-command list, each tagged by pass name. "
+                      "GPU times come from the renderer's double-buffered timer-query pool (previous-frame "
+                      "readback, approximate) and are populated for the source pass only. See 'graphAttribution' "
+                      "for where these buckets sit in the whole graph. Use format:\"markdown\" for the Command "
+                      "Bucket Inspector's full sort/state-change/batching analysis.";
         return out;
     }
 } // namespace OloEngine::MCP::FrameBreakdown

--- a/OloEngine/src/OloEngine/Renderer/Debug/CapturedFrameData.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/CapturedFrameData.h
@@ -185,6 +185,34 @@ namespace OloEngine
         f64 m_GpuTimeMs = 0.0;
     };
 
+    // One render-graph pass's captured command bucket. The whole-frame capture
+    // accumulates one of these per command-bucket pass that executed this frame
+    // (SceneRenderPass, WaterRenderPass, FoliageRenderPass, DecalRenderPass,
+    // ForwardOverlayPass), so olo_render_frame_breakdown can list every pass's
+    // commands rather than only the scene pass's (issue #463 / #316 Part 4).
+    //
+    // PassName is the graph node's GetName(); the three stage lists mirror
+    // CapturedFrameData's own top-level lists (which remain the *source* / scene
+    // pass for backward compatibility). The Has* flags distinguish "stage
+    // captured, zero commands" from "stage not captured" — an empty PostBatch can
+    // mean either, and the stats derivation at commit needs to tell them apart.
+    // Stats carries this pass's own sort/batch/execute timings (zero when the
+    // pass did not record them — only the scene pass does today).
+    struct CapturedPassData
+    {
+        std::string PassName;
+
+        std::vector<CapturedCommandData> PreSortCommands;   // Submission order
+        std::vector<CapturedCommandData> PostSortCommands;  // After radix sort
+        std::vector<CapturedCommandData> PostBatchCommands; // After batching
+
+        bool HasPreSort = false;
+        bool HasPostSort = false;
+        bool HasPostBatch = false;
+
+        FrameCaptureStats Stats;
+    };
+
     // A fully captured frame with commands at different pipeline stages
     struct CapturedFrameData
     {
@@ -192,18 +220,26 @@ namespace OloEngine
         f64 TimestampSeconds = 0.0;
 
         // Name of the render-graph pass that drove this capture — i.e. the pass
-        // whose command bucket the PreSort/PostSort/PostBatch lists were copied
-        // from (SceneRenderPass today; recorded rather than hard-coded so the
+        // whose command bucket the top-level PreSort/PostSort/PostBatch lists were
+        // copied from (SceneRenderPass today; recorded rather than hard-coded so the
         // olo_render_frame_breakdown MCP tool can attribute every captured command
-        // to a real graph pass, and so a future per-pass capture can stamp each
-        // pass's own name). Empty when the capture was produced outside a named
-        // pass (e.g. a synthetic test frame).
+        // to a real graph pass). Empty when the capture was produced outside a named
+        // pass (e.g. a synthetic test frame). The top-level lists describe THIS
+        // (source) pass; `Passes` below holds every captured pass including this one.
         std::string SourcePassName;
 
-        // Commands at different pipeline stages
+        // Commands at different pipeline stages (the SOURCE / scene pass — kept as
+        // the top-level view for backward compatibility with olo_perf_capture_frame,
+        // the Command Bucket Inspector markdown report, and the single-pass tests).
         std::vector<CapturedCommandData> PreSortCommands;   // Submission order
         std::vector<CapturedCommandData> PostSortCommands;  // After radix sort
         std::vector<CapturedCommandData> PostBatchCommands; // After batching
+
+        // Per-pass captured command buckets for the whole render graph (issue
+        // #463 / #316 Part 4). One entry per command-bucket pass that executed
+        // this frame, in execution order. Empty for a legacy single-pass capture
+        // (the top-level lists above are then the only view).
+        std::vector<CapturedPassData> Passes;
 
         // Deep-copied snapshots of per-frame render state and material data tables.
         // These are captured at frame-end so that the debugger can inspect the exact

--- a/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
@@ -23,9 +23,7 @@ namespace OloEngine
         if (m_State.compare_exchange_strong(expected, CaptureState::CaptureNextFrame, std::memory_order_acq_rel))
         {
             m_PendingFrame = CapturedFrameData{};
-            m_HasPendingPreSort = false;
-            m_HasPendingPostSort = false;
-            m_HasPendingPostBatch = false;
+            m_CurrentPassIndex = -1;
         }
     }
 
@@ -35,9 +33,7 @@ namespace OloEngine
         if (m_State.compare_exchange_strong(expected, CaptureState::Recording, std::memory_order_acq_rel))
         {
             m_PendingFrame = CapturedFrameData{};
-            m_HasPendingPreSort = false;
-            m_HasPendingPostSort = false;
-            m_HasPendingPostBatch = false;
+            m_CurrentPassIndex = -1;
         }
     }
 
@@ -92,15 +88,36 @@ namespace OloEngine
         m_PendingFrame.SourcePassName = passName;
     }
 
+    CapturedPassData& FrameCaptureManager::EnsureCurrentPass()
+    {
+        if (m_CurrentPassIndex < 0 || m_CurrentPassIndex >= static_cast<i32>(m_PendingFrame.Passes.size()))
+        {
+            m_PendingFrame.Passes.emplace_back();
+            m_CurrentPassIndex = static_cast<i32>(m_PendingFrame.Passes.size()) - 1;
+        }
+        return m_PendingFrame.Passes[static_cast<sizet>(m_CurrentPassIndex)];
+    }
+
+    void FrameCaptureManager::BeginPass(std::string_view passName)
+    {
+        if (!IsCapturing())
+            return;
+
+        m_PendingFrame.Passes.emplace_back();
+        m_CurrentPassIndex = static_cast<i32>(m_PendingFrame.Passes.size()) - 1;
+        m_PendingFrame.Passes[static_cast<sizet>(m_CurrentPassIndex)].PassName = passName;
+    }
+
     void FrameCaptureManager::OnPreSort(const CommandBucket& bucket)
     {
         OLO_PROFILE_FUNCTION();
         if (!IsCapturing())
             return;
 
-        m_PendingFrame.PreSortCommands.clear();
-        DeepCopyCommands(bucket, m_PendingFrame.PreSortCommands, false);
-        m_HasPendingPreSort = true;
+        CapturedPassData& pass = EnsureCurrentPass();
+        pass.PreSortCommands.clear();
+        DeepCopyCommands(bucket, pass.PreSortCommands, false);
+        pass.HasPreSort = true;
     }
 
     void FrameCaptureManager::OnPostSort(const CommandBucket& bucket)
@@ -109,9 +126,10 @@ namespace OloEngine
         if (!IsCapturing())
             return;
 
-        m_PendingFrame.PostSortCommands.clear();
-        DeepCopyCommands(bucket, m_PendingFrame.PostSortCommands, true);
-        m_HasPendingPostSort = true;
+        CapturedPassData& pass = EnsureCurrentPass();
+        pass.PostSortCommands.clear();
+        DeepCopyCommands(bucket, pass.PostSortCommands, true);
+        pass.HasPostSort = true;
     }
 
     void FrameCaptureManager::OnPostBatch(const CommandBucket& bucket)
@@ -120,9 +138,31 @@ namespace OloEngine
         if (!IsCapturing())
             return;
 
-        m_PendingFrame.PostBatchCommands.clear();
-        DeepCopyCommands(bucket, m_PendingFrame.PostBatchCommands, true);
-        m_HasPendingPostBatch = true;
+        CapturedPassData& pass = EnsureCurrentPass();
+        pass.PostBatchCommands.clear();
+        DeepCopyCommands(bucket, pass.PostBatchCommands, true);
+        pass.HasPostBatch = true;
+    }
+
+    void FrameCaptureManager::RecordPassTimings(f64 sortTimeMs, f64 batchTimeMs, f64 executeTimeMs)
+    {
+        if (!IsCapturing())
+            return;
+
+        CapturedPassData& pass = EnsureCurrentPass();
+        pass.Stats.SortTimeMs = sortTimeMs;
+        pass.Stats.BatchTimeMs = batchTimeMs;
+        pass.Stats.ExecuteTimeMs = executeTimeMs;
+        pass.Stats.TotalFrameTimeMs = sortTimeMs + batchTimeMs + executeTimeMs;
+    }
+
+    void FrameCaptureManager::CommitFrame()
+    {
+        OLO_PROFILE_FUNCTION();
+        if (!IsCapturing())
+            return;
+
+        CommitPendingFrame(++m_CommittedFrameCounter);
     }
 
     void FrameCaptureManager::OnFrameEnd(u32 frameNumber, f64 sortTimeMs, f64 batchTimeMs, f64 executeTimeMs)
@@ -131,20 +171,79 @@ namespace OloEngine
         if (!IsCapturing())
             return;
 
+        // Legacy single-pass entrypoint: stash the timings on the current/implicit
+        // pass, then commit with the caller-supplied frame number.
+        RecordPassTimings(sortTimeMs, batchTimeMs, executeTimeMs);
+        CommitPendingFrame(frameNumber);
+    }
+
+    void FrameCaptureManager::CommitPendingFrame(u32 frameNumber)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Pick the source / primary pass whose stage lists become the top-level
+        // (legacy) view consumed by the markdown report, olo_perf_capture_frame and
+        // the single-pass tests. Prefer the recorded SourcePassName; fall back to
+        // the first captured pass (the implicit entry the direct-API hooks create
+        // when no BeginPass() was issued).
+        CapturedPassData* source = nullptr;
+        if (!m_PendingFrame.SourcePassName.empty())
+        {
+            for (auto& pass : m_PendingFrame.Passes)
+            {
+                if (pass.PassName == m_PendingFrame.SourcePassName)
+                {
+                    source = &pass;
+                    break;
+                }
+            }
+        }
+        if (!source && !m_PendingFrame.Passes.empty())
+            source = &m_PendingFrame.Passes.front();
+
+        bool hasPostSort = false;
+        bool hasPostBatch = false;
+        FrameCaptureStats sourceStats;
+        if (source)
+        {
+            // Apply GPU timing to the source pass's execution-order list FIRST, so
+            // both the per-pass entry and the derived top-level list carry GPU times.
+            if (const auto& gpuTimer = GPUTimerQueryPool::GetInstance(); gpuTimer.IsInitialized() && gpuTimer.GetReadableQueryCount() > 0)
+            {
+                auto& timedCommands = source->HasPostBatch
+                                          ? source->PostBatchCommands
+                                          : (source->HasPostSort ? source->PostSortCommands : source->PreSortCommands);
+                for (u32 i = 0; i < static_cast<u32>(timedCommands.size()) && i < gpuTimer.GetReadableQueryCount(); ++i)
+                    timedCommands[i].SetGpuTimeMs(gpuTimer.GetQueryResultMs(i));
+            }
+
+            m_PendingFrame.PreSortCommands = source->PreSortCommands;
+            m_PendingFrame.PostSortCommands = source->PostSortCommands;
+            m_PendingFrame.PostBatchCommands = source->PostBatchCommands;
+            hasPostSort = source->HasPostSort;
+            hasPostBatch = source->HasPostBatch;
+            sourceStats = source->Stats;
+
+            // Legacy implicit pass (no BeginPass/SetSourcePass): adopt its name so
+            // the breakdown still labels the bucket.
+            if (m_PendingFrame.SourcePassName.empty())
+                m_PendingFrame.SourcePassName = source->PassName;
+        }
+
         m_PendingFrame.FrameNumber = frameNumber;
         m_PendingFrame.TimestampSeconds =
             std::chrono::duration<f64>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 
         m_PendingFrame.Stats.TotalCommands = static_cast<u32>(m_PendingFrame.PreSortCommands.size());
-        m_PendingFrame.Stats.SortTimeMs = sortTimeMs;
-        m_PendingFrame.Stats.BatchTimeMs = batchTimeMs;
-        m_PendingFrame.Stats.ExecuteTimeMs = executeTimeMs;
-        m_PendingFrame.Stats.TotalFrameTimeMs = sortTimeMs + batchTimeMs + executeTimeMs;
+        m_PendingFrame.Stats.SortTimeMs = sourceStats.SortTimeMs;
+        m_PendingFrame.Stats.BatchTimeMs = sourceStats.BatchTimeMs;
+        m_PendingFrame.Stats.ExecuteTimeMs = sourceStats.ExecuteTimeMs;
+        m_PendingFrame.Stats.TotalFrameTimeMs = sourceStats.SortTimeMs + sourceStats.BatchTimeMs + sourceStats.ExecuteTimeMs;
 
         // Count draw calls and state changes from post-batch (or post-sort) commands
-        const auto& finalCommands = m_HasPendingPostBatch
+        const auto& finalCommands = hasPostBatch
                                         ? m_PendingFrame.PostBatchCommands
-                                        : (m_HasPendingPostSort ? m_PendingFrame.PostSortCommands : m_PendingFrame.PreSortCommands);
+                                        : (hasPostSort ? m_PendingFrame.PostSortCommands : m_PendingFrame.PreSortCommands);
 
         u32 drawCalls = 0;
         u32 stateChanges = 0;
@@ -162,23 +261,8 @@ namespace OloEngine
         m_PendingFrame.Stats.DrawCalls = drawCalls;
         m_PendingFrame.Stats.StateChanges = stateChanges;
 
-        // Populate GPU timing from the previous frame's readback
-        // (GPU timer uses double-buffered queries; results lag by one frame)
-        if (const auto& gpuTimer = GPUTimerQueryPool::GetInstance(); gpuTimer.IsInitialized() && gpuTimer.GetReadableQueryCount() > 0)
-        {
-            // Apply to post-sort commands (the execution order)
-            auto& timedCommands = m_HasPendingPostBatch
-                                      ? m_PendingFrame.PostBatchCommands
-                                      : (m_HasPendingPostSort ? m_PendingFrame.PostSortCommands : m_PendingFrame.PreSortCommands);
-
-            for (u32 i = 0; i < static_cast<u32>(timedCommands.size()) && i < gpuTimer.GetReadableQueryCount(); ++i)
-            {
-                timedCommands[i].SetGpuTimeMs(gpuTimer.GetQueryResultMs(i));
-            }
-        }
-
         // Count batched commands (difference between post-sort and post-batch)
-        if (m_HasPendingPostSort && m_HasPendingPostBatch)
+        if (hasPostSort && hasPostBatch)
         {
             i32 diff = static_cast<i32>(m_PendingFrame.PostSortCommands.size()) - static_cast<i32>(m_PendingFrame.PostBatchCommands.size());
             m_PendingFrame.Stats.BatchedCommands = diff > 0 ? static_cast<u32>(diff) : 0;
@@ -222,15 +306,14 @@ namespace OloEngine
             m_CaptureGeneration.fetch_add(1, std::memory_order_release);
         }
 
-        // State machine transition
+        // State machine transition (single-frame capture returns to Idle; recording
+        // stays in Recording for the next frame).
         auto expected = CaptureState::CaptureNextFrame;
         m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel);
 
         // Re-init pending frame for the next capture
         m_PendingFrame = CapturedFrameData{};
-        m_HasPendingPreSort = false;
-        m_HasPendingPostSort = false;
-        m_HasPendingPostBatch = false;
+        m_CurrentPassIndex = -1;
     }
 
     void FrameCaptureManager::DeepCopyCommands(const CommandBucket& bucket,

--- a/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.h
@@ -50,16 +50,47 @@ namespace OloEngine
             return m_MaxCapturedFrames.load(std::memory_order_acquire);
         }
 
-        // Records the name of the render-graph pass driving the in-progress
-        // capture (the pass whose command bucket feeds OnPreSort/OnPostSort/
-        // OnPostBatch). No-op when not capturing. Lets the breakdown attribute
-        // captured commands to a real graph pass instead of a hard-coded label.
+        // Records the name of the SOURCE render-graph pass — the pass whose
+        // command bucket becomes CapturedFrameData's top-level PreSort/PostSort/
+        // PostBatch lists (SceneRenderPass today). No-op when not capturing. Lets
+        // the breakdown attribute the top-level bucket to a real graph pass instead
+        // of a hard-coded label.
         void SetSourcePass(std::string_view passName);
 
-        // Capture hooks — called from SceneRenderPass::Execute()
+        // Per-pass capture (issue #463 / #316 Part 4) ------------------------
+        // Each command-bucket pass (Scene, Water, Foliage, Decal, ForwardOverlay)
+        // calls BeginPass(GetName()) at the top of its Execute() before any early
+        // return, so even a pass with an empty bucket registers itself. The
+        // subsequent OnPreSort/OnPostSort/OnPostBatch hooks then fill THIS pass's
+        // per-pass entry (CapturedFrameData::Passes), not a single shared list, so
+        // the whole graph's buckets accumulate across passes before the frame is
+        // committed. No-op when not capturing.
+        void BeginPass(std::string_view passName);
+
+        // Capture hooks — called by each command-bucket pass's Execute(). They
+        // target the CURRENT per-pass entry (created by BeginPass, or implicitly
+        // created on first use for the legacy single-pass direct-API path).
         void OnPreSort(const CommandBucket& bucket);
         void OnPostSort(const CommandBucket& bucket);
         void OnPostBatch(const CommandBucket& bucket);
+
+        // Record the current pass's sort/batch/execute timings (the scene pass
+        // calls this at the end of its Execute()). These feed the committed
+        // frame's top-level Stats for the source pass. No-op when not capturing.
+        void RecordPassTimings(f64 sortTimeMs, f64 batchTimeMs, f64 executeTimeMs);
+
+        // Central post-graph commit (issue #463). Called once from
+        // Renderer3D::EndScene AFTER the whole render graph has executed, so the
+        // pending frame has accumulated every command-bucket pass. Finalises the
+        // frame (derives the top-level source-pass view, computes stats, snapshots
+        // render state, pushes it to the captured-frame ring) and advances the
+        // state machine. No-op when not capturing. Frame numbers auto-increment.
+        void CommitFrame();
+
+        // Legacy single-pass commit. Records the current pass's timings and commits
+        // with an explicit frame number in one call. Retained for the direct-API
+        // unit tests (FrameCaptureTest) and any single-pass driver; the production
+        // multi-pass path uses RecordPassTimings + CommitFrame instead.
         void OnFrameEnd(u32 frameNumber, f64 sortTimeMs, f64 batchTimeMs, f64 executeTimeMs);
 
         // Access captured data (thread-safe copies for UI consumption)
@@ -91,16 +122,27 @@ namespace OloEngine
         // Deep-copy all commands from a bucket into a vector
         void DeepCopyCommands(const CommandBucket& bucket, std::vector<CapturedCommandData>& outCommands, bool useSortedOrder) const;
 
+        // Return the current per-pass entry being built, creating an implicit one
+        // when no BeginPass() has run yet (the legacy single-pass direct-API path).
+        CapturedPassData& EnsureCurrentPass();
+
+        // Finalise m_PendingFrame and push it to the captured-frame ring. Shared
+        // by CommitFrame() (central, auto frame number) and OnFrameEnd() (legacy,
+        // explicit frame number). Resets the pending frame afterwards.
+        void CommitPendingFrame(u32 frameNumber);
+
         std::atomic<CaptureState> m_State = CaptureState::Idle;
         std::atomic<u32> m_MaxCapturedFrames = 60;
         std::atomic<i32> m_SelectedFrameIndex = -1;
         std::atomic<u64> m_CaptureGeneration = 0;
 
-        // In-progress frame being built during capture hooks
+        // In-progress frame being built during capture hooks. The per-pass entries
+        // accumulate in m_PendingFrame.Passes; m_CurrentPassIndex points at the
+        // entry the OnPreSort/OnPostSort/OnPostBatch hooks currently fill (-1 = none
+        // yet). m_CommittedFrameCounter feeds CommitFrame()'s auto frame numbers.
         CapturedFrameData m_PendingFrame;
-        bool m_HasPendingPreSort = false;
-        bool m_HasPendingPostSort = false;
-        bool m_HasPendingPostBatch = false;
+        i32 m_CurrentPassIndex = -1;
+        u32 m_CommittedFrameCounter = 0;
 
         std::deque<CapturedFrameData> m_CapturedFrames;
 

--- a/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Passes/DecalRenderPass.h"
+#include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/Debug/GLStateGuard.h"
 #include "OloEngine/Renderer/GBuffer.h"
 #include "OloEngine/Renderer/RGBuilder.h"
@@ -102,6 +103,21 @@ namespace OloEngine
     void DecalRenderPass::Execute(RGCommandContext& context)
     {
         OLO_PROFILE_FUNCTION();
+
+        // Per-pass command capture (issue #463): register this pass and snapshot its
+        // submission-order bucket BEFORE any early-return below, so the decal pass
+        // always appears in the frame breakdown's per-pass list. In the deferred
+        // path the opaque decals were already drained into the G-Buffer by the
+        // separate DeferredOpaqueDecalPass node (which resets the bucket when no
+        // transparent decals remain), so this capture sees only the still-queued
+        // (transparent) decals — captured under this pass's single name.
+        auto& captureManager = FrameCaptureManager::GetInstance();
+        const bool capturing = captureManager.IsCapturing();
+        if (capturing)
+        {
+            captureManager.BeginPass(GetName());
+            captureManager.OnPreSort(m_CommandBucket);
+        }
 
         // Resolve the setup-selected scene framebuffer instead of replaying
         // a blackboard lookup ladder at execute time.
@@ -219,6 +235,8 @@ namespace OloEngine
             context.BindTexture(ShaderBindingLayout::TEX_POSTPROCESS_DEPTH, depthTextureID);
 
             m_CommandBucket.SortCommands();
+            if (capturing)
+                captureManager.OnPostSort(m_CommandBucket);
             auto& rendererAPI = RenderCommand::GetRendererAPI();
             for (const auto* packet : m_CommandBucket.GetPackets())
             {
@@ -249,6 +267,9 @@ namespace OloEngine
 
         // Sort and dispatch decal commands through the command bucket
         m_CommandBucket.SortCommands();
+
+        if (capturing)
+            captureManager.OnPostSort(m_CommandBucket);
 
         auto& rendererAPI = RenderCommand::GetRendererAPI();
         for (const auto* packet : m_CommandBucket.GetPackets())

--- a/OloEngine/src/OloEngine/Renderer/Passes/FoliageRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/FoliageRenderPass.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Passes/FoliageRenderPass.h"
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
+#include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/RGBuilder.h"
 #include "OloEngine/Renderer/RGCommandContext.h"
 #include "OloEngine/Renderer/Renderer.h"
@@ -41,6 +42,17 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Per-pass command capture (issue #463): register this pass and snapshot its
+        // submission-order bucket BEFORE any early-return below, so even an empty
+        // foliage frame appears in the frame breakdown's per-pass list.
+        auto& captureManager = FrameCaptureManager::GetInstance();
+        const bool capturing = captureManager.IsCapturing();
+        if (capturing)
+        {
+            captureManager.BeginPass(GetName());
+            captureManager.OnPreSort(m_CommandBucket);
+        }
+
         // Resolve the setup-selected scene framebuffer instead of replaying
         // a blackboard lookup ladder at execute time.
         if (const auto sceneHandle = GetPrimaryInputFramebufferHandle(); sceneHandle.IsValid())
@@ -66,6 +78,9 @@ namespace OloEngine
 
         // Sort and dispatch foliage commands through the command bucket
         m_CommandBucket.SortCommands();
+
+        if (capturing)
+            captureManager.OnPostSort(m_CommandBucket);
 
         auto& rendererAPI = RenderCommand::GetRendererAPI();
         m_CommandBucket.Execute(rendererAPI);

--- a/OloEngine/src/OloEngine/Renderer/Passes/ForwardOverlayRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/ForwardOverlayRenderPass.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Passes/ForwardOverlayRenderPass.h"
+#include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/Debug/GLStateGuard.h"
 #include "OloEngine/Renderer/RGBuilder.h"
 #include "OloEngine/Renderer/RGCommandContext.h"
@@ -50,6 +51,17 @@ namespace OloEngine
     void ForwardOverlayRenderPass::Execute(RGCommandContext& context)
     {
         OLO_PROFILE_FUNCTION();
+
+        // Per-pass command capture (issue #463): register this pass and snapshot its
+        // submission-order bucket BEFORE any early-return below, so even an empty
+        // overlay frame appears in the frame breakdown's per-pass list.
+        auto& captureManager = FrameCaptureManager::GetInstance();
+        const bool capturing = captureManager.IsCapturing();
+        if (capturing)
+        {
+            captureManager.BeginPass(GetName());
+            captureManager.OnPreSort(m_CommandBucket);
+        }
 
         // Resolve the setup-selected scene framebuffer instead of replaying
         // a blackboard lookup ladder at execute time.
@@ -128,6 +140,8 @@ namespace OloEngine
         if (m_CommandBucket.GetCommandCount() > 0)
         {
             m_CommandBucket.SortCommands();
+            if (capturing)
+                captureManager.OnPostSort(m_CommandBucket);
             m_CommandBucket.Execute(rendererAPI);
         }
 

--- a/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
@@ -200,8 +200,12 @@ namespace OloEngine
 
         if (capturing)
         {
-            // Stamp the capture with this pass's graph name so the breakdown can
-            // attribute every captured command to a real render-graph pass.
+            // Open this pass's per-pass capture entry, and mark it the SOURCE pass
+            // (its bucket becomes the frame's top-level / legacy view). The frame
+            // is no longer committed here — Renderer3D::EndScene commits it after
+            // the whole graph runs, so Water / Foliage / Decal / ForwardOverlay can
+            // accumulate their own per-pass buckets first (issue #463).
+            captureManager.BeginPass(GetName());
             captureManager.SetSourcePass(GetName());
             captureManager.OnPreSort(m_CommandBucket);
         }
@@ -322,8 +326,10 @@ namespace OloEngine
 
         if (capturing)
         {
-            captureManager.OnFrameEnd(
-                m_FrameCounter,
+            // Record this (source) pass's timings into its per-pass entry; they
+            // become the committed frame's top-level Stats. The commit itself runs
+            // centrally in Renderer3D::EndScene after the whole graph executes.
+            captureManager.RecordPassTimings(
                 m_CommandBucket.GetLastSortTimeMs(),
                 m_CommandBucket.GetLastBatchTimeMs(),
                 m_CommandBucket.GetLastExecuteTimeMs());

--- a/OloEngine/src/OloEngine/Renderer/Passes/WaterRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/WaterRenderPass.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Renderer/Passes/WaterRenderPass.h"
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
 #include "OloEngine/Renderer/Commands/RenderCommand.h"
+#include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/Debug/GLStateGuard.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "OloEngine/Renderer/Renderer3D.h"
@@ -84,6 +85,17 @@ namespace OloEngine
     void WaterRenderPass::Execute(RGCommandContext& context)
     {
         OLO_PROFILE_FUNCTION();
+
+        // Per-pass command capture (issue #463): register this pass and snapshot its
+        // submission-order bucket BEFORE any early-return below, so even an empty
+        // water frame appears in the frame breakdown's per-pass list.
+        auto& captureManager = FrameCaptureManager::GetInstance();
+        const bool capturing = captureManager.IsCapturing();
+        if (capturing)
+        {
+            captureManager.BeginPass(GetName());
+            captureManager.OnPreSort(m_CommandBucket);
+        }
 
         // Clear any previously-published water-surface depth up front so the
         // underwater fog never samples a stale texture if this pass early-exits
@@ -178,6 +190,9 @@ namespace OloEngine
 
         // Sort and dispatch water commands through the command bucket
         m_CommandBucket.SortCommands();
+
+        if (capturing)
+            captureManager.OnPostSort(m_CommandBucket);
 
         auto& rendererAPI = RenderCommand::GetRendererAPI();
 

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Renderer/Renderer3DInternal.h"
 #include "OloEngine/Core/PerformanceProfiler.h"
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
+#include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Occlusion/OcclusionQueryPool.h"
 
@@ -134,6 +135,15 @@ namespace OloEngine
         }
 
         s_Data.RGraph->Execute();
+
+        // Central frame-capture commit (issue #463 / #316 Part 4). The whole render
+        // graph has now executed, so every command-bucket pass (Scene, Water,
+        // Foliage, Decal, ForwardOverlay) has accumulated its own per-pass bucket
+        // into the pending capture. Commit it here — relocated out of
+        // SceneRenderPass::OnFrameEnd, which used to commit mid-graph (before the
+        // other passes ran) and thus only ever captured the scene pass's bucket.
+        // No-op when not capturing.
+        FrameCaptureManager::GetInstance().CommitFrame();
 
         // End occlusion query frame after render graph execution
         if (s_Data.OcclusionCullingEnabled)

--- a/OloEngine/tests/MCP/McpFrameBreakdownTest.cpp
+++ b/OloEngine/tests/MCP/McpFrameBreakdownTest.cpp
@@ -11,12 +11,14 @@
 // attach loop; this pins the per-command / per-stage breakdown shape.
 #include "MCP/McpFrameBreakdown.h"
 
+#include <initializer_list>
 #include <string>
 
 namespace
 {
     using OloEngine::CapturedCommandData;
     using OloEngine::CapturedFrameData;
+    using OloEngine::CapturedPassData;
     using OloEngine::CommandType;
     using OloEngine::DrawKey;
     using OloEngine::RenderMode;
@@ -269,8 +271,12 @@ TEST(McpFrameBreakdown, GraphAttributionEnumeratesPassesAndFlagsCaptureSource)
     const Json& g = j["graphAttribution"];
     EXPECT_EQ("SceneRenderPass", g["captureSourcePass"].get<std::string>());
     EXPECT_EQ(6u, g["passCount"].get<u32>());
-    // ShadowPass + Composite lack buckets -> 4 command-bucket passes.
-    EXPECT_EQ(4u, g["commandBucketPassCount"].get<u32>());
+    // ShadowPass + Composite lack buckets; DisabledFogPass owns a bucket but is
+    // culled. commandBucketPassCount counts only command-bucket passes that RAN
+    // (non-culled) -> Scene + Water + ForwardOverlay = 3.
+    EXPECT_EQ(3u, g["commandBucketPassCount"].get<u32>());
+    // This frame has no per-pass captures (legacy single-pass MakeFrame), so the
+    // captured count falls back to the source-pass-only count of 1.
     EXPECT_EQ(1u, g["capturedPassCount"].get<u32>());
 
     const Json& passes = g["passes"];
@@ -317,4 +323,171 @@ TEST(McpFrameBreakdown, CaptureSourceFallsBackToAttributionWhenFrameUnset)
     const Json& passes = j["graphAttribution"]["passes"];
     EXPECT_TRUE(passes[1]["isCaptureSource"].get<bool>());
     EXPECT_FALSE(passes[2]["isCaptureSource"].get<bool>());
+}
+
+// ---- full per-pass command capture (#463 / #316 Part 4) ---------------------
+
+namespace
+{
+    // One captured per-pass entry with `drawNames.size()` DrawMesh commands in
+    // both submission (presort) and sorted (postsort) order — mirrors what the
+    // secondary command-bucket passes (Water / Foliage / Decal / ForwardOverlay)
+    // accumulate: sorted but not batched.
+    CapturedPassData MakePassEntry(const char* name, std::initializer_list<const char*> drawNames)
+    {
+        CapturedPassData pass;
+        pass.PassName = name;
+        u32 idx = 0;
+        for (const char* dn : drawNames)
+        {
+            pass.PreSortCommands.push_back(MakeCmd(CommandType::DrawMesh, dn, 1, idx, idx * 10, idx, idx, false, idx));
+            pass.PostSortCommands.push_back(MakeCmd(CommandType::DrawMesh, dn, 1, idx, idx * 10, idx, idx, false, idx));
+            ++idx;
+        }
+        pass.HasPreSort = true;
+        pass.HasPostSort = true;
+        return pass;
+    }
+
+    // A multi-pass captured frame: the scene pass (also the source, with a batched
+    // post-batch stage) plus the four secondary command-bucket passes, each with
+    // its own commands. The top-level lists mirror the scene/source pass.
+    CapturedFrameData MakeMultiPassFrame()
+    {
+        CapturedFrameData frame;
+        frame.FrameNumber = 7;
+        frame.SourcePassName = "SceneRenderPass";
+
+        CapturedPassData scene = MakePassEntry("SceneRenderPass", { "cube", "sphere", "plane" });
+        scene.PostBatchCommands = scene.PostSortCommands; // pretend batching collapsed nothing
+        scene.HasPostBatch = true;
+        frame.Passes.push_back(scene);
+        frame.Passes.push_back(MakePassEntry("FoliageRenderPass", { "grass" }));
+        frame.Passes.push_back(MakePassEntry("WaterRenderPass", { "waterA", "waterB" }));
+        frame.Passes.push_back(MakePassEntry("DecalRenderPass", { "decal" }));
+        frame.Passes.push_back(MakePassEntry("ForwardOverlayPass", { "skybox", "grid" }));
+
+        // Top-level (legacy) view = the source/scene pass's lists.
+        frame.PreSortCommands = frame.Passes[0].PreSortCommands;
+        frame.PostSortCommands = frame.Passes[0].PostSortCommands;
+        frame.PostBatchCommands = frame.Passes[0].PostBatchCommands;
+        return frame;
+    }
+
+    // Attribution for the multi-pass frame: a shadow pass (no bucket), the five
+    // command-bucket passes (all non-culled, so all RAN), and a final composite
+    // (no bucket). Mirrors a frame where every command-bucket pass executed.
+    GraphAttribution MakeMultiPassAttribution()
+    {
+        GraphAttribution attr;
+        attr.CaptureSourcePass = "SceneRenderPass";
+        attr.Passes.push_back(GraphPassInfo{ "ShadowPass", "Graphics", false, false, false, 0 });
+        attr.Passes.push_back(GraphPassInfo{ "SceneRenderPass", "Graphics", true, false, false, 1 });
+        attr.Passes.push_back(GraphPassInfo{ "FoliageRenderPass", "Graphics", true, false, false, 2 });
+        attr.Passes.push_back(GraphPassInfo{ "WaterRenderPass", "Graphics", true, false, false, 3 });
+        attr.Passes.push_back(GraphPassInfo{ "DecalRenderPass", "Graphics", true, false, false, 4 });
+        attr.Passes.push_back(GraphPassInfo{ "ForwardOverlayPass", "Graphics", true, false, false, 5 });
+        attr.Passes.push_back(GraphPassInfo{ "CompositePass", "Graphics", false, false, true, 6 });
+        return attr;
+    }
+} // namespace
+
+TEST(McpFrameBreakdown, PerPassBreakdownListsEveryCapturedPassWithCommands)
+{
+    const CapturedFrameData frame = MakeMultiPassFrame();
+
+    // No attribution needed: passBreakdowns is driven purely by the captured frame.
+    const Json j = BuildBreakdown(frame, ViewMode::PostBatch, 200);
+
+    ASSERT_TRUE(j.contains("passBreakdowns"));
+    const Json& passes = j["passBreakdowns"];
+    ASSERT_EQ(5u, passes.size());
+
+    // Order preserved (execution order); each tagged with its pass name + commands.
+    EXPECT_EQ("SceneRenderPass", passes[0]["name"].get<std::string>());
+    EXPECT_TRUE(passes[0]["isCaptureSource"].get<bool>());
+    EXPECT_EQ(3u, passes[0]["commandCount"].get<sizet>());
+    // Scene batched -> the post-batch stage is what's listed.
+    EXPECT_EQ("postbatch", passes[0]["viewMode"].get<std::string>());
+
+    EXPECT_EQ("FoliageRenderPass", passes[1]["name"].get<std::string>());
+    EXPECT_FALSE(passes[1]["isCaptureSource"].get<bool>());
+    EXPECT_EQ(1u, passes[1]["commandCount"].get<sizet>());
+    // Secondary passes only sort (no batch) -> post-batch empty, falls back to post-sort.
+    EXPECT_EQ("postsort", passes[1]["viewMode"].get<std::string>());
+
+    EXPECT_EQ("WaterRenderPass", passes[2]["name"].get<std::string>());
+    EXPECT_EQ(2u, passes[2]["commandCount"].get<sizet>());
+    EXPECT_EQ("waterA", passes[2]["commands"][0]["debugName"].get<std::string>());
+    EXPECT_EQ("waterB", passes[2]["commands"][1]["debugName"].get<std::string>());
+
+    EXPECT_EQ("DecalRenderPass", passes[3]["name"].get<std::string>());
+    EXPECT_EQ(1u, passes[3]["commandCount"].get<sizet>());
+
+    EXPECT_EQ("ForwardOverlayPass", passes[4]["name"].get<std::string>());
+    EXPECT_EQ(2u, passes[4]["commandCount"].get<sizet>());
+
+    // Top-level view is unchanged (the scene/source pass's bucket).
+    EXPECT_EQ("SceneRenderPass", j["sourcePass"].get<std::string>());
+    EXPECT_EQ(3u, j["commandCount"].get<sizet>());
+}
+
+TEST(McpFrameBreakdown, CapturedPassCountEqualsCommandBucketPassCountForFullFrame)
+{
+    const CapturedFrameData frame = MakeMultiPassFrame();
+    const GraphAttribution attr = MakeMultiPassAttribution();
+
+    const Json j = BuildBreakdown(frame, ViewMode::PostBatch, 200, &attr);
+
+    ASSERT_TRUE(j.contains("graphAttribution"));
+    const Json& g = j["graphAttribution"];
+
+    // Every command-bucket pass ran and was captured — the headline invariant.
+    EXPECT_EQ(5u, g["commandBucketPassCount"].get<u32>());
+    EXPECT_EQ(5u, g["capturedPassCount"].get<u32>());
+    EXPECT_EQ(g["commandBucketPassCount"].get<u32>(), g["capturedPassCount"].get<u32>());
+
+    // Each graph pass is flagged captured iff it has a per-pass capture entry.
+    const Json& passes = g["passes"];
+    ASSERT_EQ(7u, passes.size());
+    for (const auto& p : passes)
+    {
+        const bool usesBucket = p["usesCommandBucket"].get<bool>();
+        EXPECT_EQ(usesBucket, p["captured"].get<bool>())
+            << "pass " << p["name"].get<std::string>() << " captured flag should match bucket ownership";
+    }
+
+    // The shadow/composite passes own no bucket and aren't captured.
+    EXPECT_FALSE(passes[0]["captured"].get<bool>()); // ShadowPass
+    EXPECT_FALSE(passes[6]["captured"].get<bool>()); // CompositePass
+}
+
+TEST(McpFrameBreakdown, CulledCommandBucketPassIsExcludedFromRunningCount)
+{
+    // A frame that captured Scene + Water (2 passes), with a graph where a third
+    // bucket pass (Foliage) was culled. The running command-bucket count excludes
+    // the culled pass, so it still matches the captured count.
+    CapturedFrameData frame;
+    frame.SourcePassName = "SceneRenderPass";
+    frame.Passes.push_back(MakePassEntry("SceneRenderPass", { "cube" }));
+    frame.Passes.push_back(MakePassEntry("WaterRenderPass", { "waterA" }));
+    frame.PreSortCommands = frame.Passes[0].PreSortCommands;
+    frame.PostSortCommands = frame.Passes[0].PostSortCommands;
+
+    GraphAttribution attr;
+    attr.CaptureSourcePass = "SceneRenderPass";
+    attr.Passes.push_back(GraphPassInfo{ "SceneRenderPass", "Graphics", true, false, false, 0 });
+    attr.Passes.push_back(GraphPassInfo{ "WaterRenderPass", "Graphics", true, false, false, 1 });
+    attr.Passes.push_back(GraphPassInfo{ "FoliageRenderPass", "Graphics", true, /*culled*/ true, false, -1 });
+
+    const Json j = BuildBreakdown(frame, ViewMode::PostSort, 200, &attr);
+    const Json& g = j["graphAttribution"];
+
+    EXPECT_EQ(2u, g["commandBucketPassCount"].get<u32>()); // Foliage culled -> excluded
+    EXPECT_EQ(2u, g["capturedPassCount"].get<u32>());
+
+    // The culled foliage pass is listed but flagged not-captured.
+    const Json& passes = g["passes"];
+    EXPECT_TRUE(passes[2]["culled"].get<bool>());
+    EXPECT_FALSE(passes[2]["captured"].get<bool>());
 }


### PR DESCRIPTION
Closes the still-deferred half of #316 Part 4 (tracked as #463): per-command **capture** of every render-graph command-bucket pass, not just the scene pass.

## The gap
`olo_render_frame_breakdown` previously captured exactly one pass's bucket — the scene pass — because `SceneRenderPass` drove the `FrameCaptureManager` state machine and committed the pending frame at its own `OnFrameEnd`, *before* Water / Foliage / Decal / ForwardOverlay ran (each resets its bucket at the end of its `Execute`, so a post-frame walk found them empty).

## Fix
- **Relocate the commit point** out of `SceneRenderPass::OnFrameEnd` into a single central hook, `FrameCaptureManager::CommitFrame()`, called from `Renderer3D::EndScene` **after** `RGraph->Execute()` — so the pending frame accumulates per-pass buckets across the whole graph before commit.
- **Per-pass capture hook**: each command-bucket pass calls `BeginPass(GetName())` + presort snapshot at the top of its `Execute` (before any early-return on an empty bucket, so even an empty pass registers), and post-sort after its `SortCommands()`. Entries accumulate in `CapturedFrameData::Passes`; the top-level lists stay the source/scene pass for backward compatibility.
- All capture calls are `if (capturing)`-guarded and `CommitFrame()` is a no-op when not capturing, so the live render path is unchanged when no capture is in flight.

## Producer (`McpFrameBreakdown.h`)
- New top-level `passBreakdowns` array — one per-command list per pass, each tagged with its graph pass name, shaped identically to the top-level bucket (shared `ShapeBucket` helper).
- `graphAttribution.capturedPassCount` = number of per-pass captures; `commandBucketPassCount` = command-bucket passes that **ran** (non-culled). For a frame where every command-bucket pass executed, `capturedPassCount == commandBucketPassCount`. Each graph pass also carries a `captured` flag.

## Acceptance criteria — met
- ✅ Multi-pass breakdown returns per-command lists for each command-bucket pass, tagged by name.
- ✅ `capturedPassCount == commandBucketPassCount` for such a frame (culled bucket passes excluded from the running count so the invariant holds on real frames).
- ✅ Producer unit-tested against a synthetic multi-pass capture.

## Verification
- **29/29** unit tests pass — 7 `FrameCaptureManager` + 7 `FrameCapturePipeline` (backward-compat) + 15 `McpFrameBreakdown` (incl. 3 new multi-pass tests).
- **Visual-evidence suite passes with a real GL context** (`SceneRenderEvidence`, `WaterVisualEvidence` ×6 angles, `FogVisualEvidence`) — rendering undisturbed.
- **Live editor over MCP**: `passBreakdowns` returned `ScenePass` (24 cmds) + `FoliagePass` (3 cmds); `capturedPassCount=2 == commandBucketPassCount=2`; culled `WaterPass`/`DecalPass` flagged `captured=false, culled=true` and excluded from the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)