### PR TITLE
feat(audio): route SoundGraph voices through the 3D spatializer (#424)

### DIFF
--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
@@ -510,6 +510,12 @@ namespace OloEngine::Audio::DSP
 
         VBAP::ClearVBAP(source.SpatializerNode.vbap.get());
 
+        // Free the VBAP channel converter's internal heap. InitSourceInternal builds it with
+        // ma_channel_converter_init (default allocator → pass nullptr to match); without this it
+        // leaks ~72 bytes per source (caught by LSan once a source is actually released). Safe on
+        // a never-initialized (zeroed) converter — uninit no-ops when it owns no heap.
+        ::ma_channel_converter_uninit(&source.Converter, nullptr);
+
         source.bInitialPositionSet = false;
         source.bInitialized = false;
 

--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
@@ -131,7 +131,12 @@ namespace OloEngine::Audio::DSP
                 }
             }
 
-            pEngineNode->spatializer.dopplerPitch = node->DopplerPitch;
+            // Doppler is hosted by the upstream ma_engine_node's built-in spatializer; a bare
+            // node (SoundGraphSource) has none, so skip the write when there's no engine node.
+            if (pEngineNode != nullptr)
+            {
+                pEngineNode->spatializer.dopplerPitch = node->DopplerPitch;
+            }
         }
 
         // Apply panning to output
@@ -305,8 +310,9 @@ namespace OloEngine::Audio::DSP
 
         glm::vec3 listenerVel = listenerVelocity;
 
-        // Doppler effect
-        if (source.DopplerFactor > 0.0f && listener != nullptr)
+        // Doppler effect — only meaningful when an upstream ma_engine_node hosts the built-in
+        // spatializer that consumes the pitch (the bare-node SoundGraph path has no engine node).
+        if (source.DopplerFactor > 0.0f && listener != nullptr && pEngineNode != nullptr)
         {
             ma_vec3f lpos = ::ma_spatializer_listener_get_position(listener);
             glm::vec3 lp(lpos.x, lpos.y, lpos.z);
@@ -315,6 +321,7 @@ namespace OloEngine::Audio::DSP
         }
         else
         {
+            // No engine node (bare custom node) or Doppler disabled — leave pitch neutral.
             source.SpatializerNode.DopplerPitch = 1.0f;
         }
     }
@@ -337,6 +344,23 @@ namespace OloEngine::Audio::DSP
 
     bool Spatializer::InitSource(u32 sourceID, ma_engine_node* nodeToInsertAfter, const AudioSourceConfig& config)
     {
+        // ma_sound path: insert after the engine node's base, and drive its built-in
+        // spatializer for Doppler. resampler.channels is the engine node's source channel count.
+        return InitSourceInternal(sourceID, &nodeToInsertAfter->baseNode,
+                                  nodeToInsertAfter->resampler.channels, nodeToInsertAfter, config);
+    }
+
+    bool Spatializer::InitSource(u32 sourceID, ma_node_base* nodeToInsertAfter, const AudioSourceConfig& config)
+    {
+        // Bare-node path (SoundGraphSource): no engine node, so no Doppler sink. The source
+        // channel count is the node's output channel count.
+        const u32 sourceChannels = ::ma_node_get_output_channels(nodeToInsertAfter, 0);
+        return InitSourceInternal(sourceID, nodeToInsertAfter, sourceChannels, /*dopplerSink=*/nullptr, config);
+    }
+
+    bool Spatializer::InitSourceInternal(u32 sourceID, ma_node_base* sourceNode, u32 sourceChannels,
+                                         ma_engine_node* dopplerSink, const AudioSourceConfig& config)
+    {
         OLO_CORE_ASSERT(m_Sources.find(sourceID) == m_Sources.end());
 
         auto [it, success] = m_Sources.try_emplace(sourceID);
@@ -358,8 +382,7 @@ namespace OloEngine::Audio::DSP
         // Base node setup
         source.InternalChannelCount = 4; // Quad virtual speaker layout
 
-        const u32 sourceChannels = nodeToInsertAfter->resampler.channels;
-        const u32 sourceNodeChannels = ::ma_node_get_output_channels(nodeToInsertAfter, 0);
+        const u32 sourceNodeChannels = ::ma_node_get_output_channels(sourceNode, 0);
 
         const u32 numInputChannels[1]{ sourceNodeChannels };
         const u32 numOutputChannels[1]{ sourceNodeChannels };
@@ -379,7 +402,8 @@ namespace OloEngine::Audio::DSP
 
         source.SpatializerNode.channelsIn = numInputChannels[0];
         source.SpatializerNode.channelsOut = numOutputChannels[0];
-        source.SpatializerNode.targetEngineNode = nodeToInsertAfter;
+        source.SpatializerNode.attachedNode = sourceNode;
+        source.SpatializerNode.targetEngineNode = dopplerSink;
 
         // VBAP channel converter
         ::ma_channel_map_init_standard(ma_standard_channel_map_default, source.InternalChannelMap,
@@ -423,9 +447,9 @@ namespace OloEngine::Audio::DSP
             return false;
         }
 
-        // Routing: insert spatializer between nodeToInsertAfter and its current output
-        auto* output = nodeToInsertAfter->baseNode.pOutputBuses->pInputNode;
-        ma_uint8 downstreamInputBus = nodeToInsertAfter->baseNode.pOutputBuses->inputNodeInputBusIndex;
+        // Routing: insert spatializer between sourceNode and its current output
+        auto* output = sourceNode->pOutputBuses->pInputNode;
+        ma_uint8 downstreamInputBus = sourceNode->pOutputBuses->inputNodeInputBusIndex;
 
         result = ::ma_node_attach_output_bus(&source.SpatializerNode, 0, output, downstreamInputBus);
         if (abortIfFailed(result, "Spatializer output attach failed"))
@@ -433,7 +457,7 @@ namespace OloEngine::Audio::DSP
             return false;
         }
 
-        result = ::ma_node_attach_output_bus(nodeToInsertAfter, 0, &source.SpatializerNode, 0);
+        result = ::ma_node_attach_output_bus(sourceNode, 0, &source.SpatializerNode, 0);
         if (abortIfFailed(result, "Spatializer input attach failed"))
         {
             return false;
@@ -460,7 +484,7 @@ namespace OloEngine::Audio::DSP
         if (source.bInitialized)
         {
             auto* output = source.SpatializerNode.base.pOutputBuses->pInputNode;
-            auto* input = source.SpatializerNode.targetEngineNode;
+            auto* input = source.SpatializerNode.attachedNode;
 
             ma_result result = ::ma_node_attach_output_bus(input, 0, output, source.DownstreamInputBus);
             if (result != MA_SUCCESS)
@@ -480,6 +504,7 @@ namespace OloEngine::Audio::DSP
                 allocationCallbacks = nullptr;
             }
             ::ma_node_uninit(&source.SpatializerNode, allocationCallbacks);
+            source.SpatializerNode.attachedNode = nullptr;
             source.SpatializerNode.targetEngineNode = nullptr;
         }
 

--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.h
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.h
@@ -36,8 +36,18 @@ namespace OloEngine::Audio::DSP
         [[nodiscard("attenuation value must be used")]] float GetCurrentConeAngleAttenuation(u32 sourceID) const;
         [[nodiscard("distance must be used")]] float GetCurrentDistance(u32 sourceID) const;
 
-        // Spatialized Sources
+        // Spatialized Sources.
+        //
+        // Two flavours of upstream node can host a per-source spatializer node:
+        //   * ma_engine_node — the ma_sound path (AudioSource). Carries a built-in
+        //     ma_spatializer whose dopplerPitch we drive for the Doppler effect.
+        //   * ma_node_base   — a bare custom node (e.g. SoundGraphSource's node, which
+        //     attaches straight to the engine endpoint). There is no engine node to host
+        //     Doppler, so Doppler is skipped for this flavour; VBAP panning + distance /
+        //     cone attenuation are computed entirely inside the spatializer node and behave
+        //     identically for both. See issue #424.
         bool InitSource(u32 sourceID, ma_engine_node* nodeToInsertAfter, const AudioSourceConfig& config);
+        bool InitSource(u32 sourceID, ma_node_base* nodeToInsertAfter, const AudioSourceConfig& config);
         bool ReleaseSource(u32 sourceID);
         void UpdateSourcePosition(u32 sourceID, const Audio::Transform& position,
                                   glm::vec3 velocity = { 0.0f, 0.0f, 0.0f });
@@ -48,6 +58,14 @@ namespace OloEngine::Audio::DSP
 
       private:
         struct Source;
+
+        // Shared core for both InitSource overloads. `sourceNode` is the upstream node the
+        // spatializer is inserted after (for the engine overload this is &engineNode->baseNode);
+        // `sourceChannels` is the source's channel count for the VBAP source channel map;
+        // `dopplerSink` is the ma_engine_node whose built-in spatializer receives the Doppler
+        // pitch, or nullptr for a bare node (Doppler disabled).
+        bool InitSourceInternal(u32 sourceID, ma_node_base* sourceNode, u32 sourceChannels,
+                                ma_engine_node* dopplerSink, const AudioSourceConfig& config);
 
         static float GetSpreadFromSourceSize(float sourceSize, float distance);
         static void UpdatePositionalData(Source& source, const ma_spatializer_listener* listener, glm::vec3 listenerVelocity);
@@ -66,6 +84,12 @@ namespace OloEngine::Audio::DSP
             ma_node_base base{};
             u32 channelsIn = 0;
             u32 channelsOut = 0;
+            // Upstream node the spatializer was inserted after — used to re-route on release.
+            // Stored as the generic node base so a bare custom node (SoundGraphSource) works
+            // alongside an ma_engine_node.
+            ma_node_base* attachedNode = nullptr;
+            // ma_engine_node hosting the built-in spatializer we drive for Doppler pitch, or
+            // nullptr for a bare node (no Doppler). See InitSource.
             ma_engine_node* targetEngineNode = nullptr;
 
             Scope<VBAPData> vbap;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -3,6 +3,8 @@
 #include "SoundGraphSource.h"
 #include "SoundGraph.h"
 #include "OloEngine/Audio/AudioEngine.h"
+#include "OloEngine/Audio/AudioSource.h"    // AudioSourceConfig
+#include "OloEngine/Audio/AudioTransform.h" // Audio::Transform
 #include "OloEngine/Asset/AssetManager.h"
 
 #include <choc/containers/choc_Value.h>
@@ -92,6 +94,24 @@ namespace OloEngine::Audio::SoundGraph
             OLO_CORE_ERROR("SoundGraphSound::InitializeAudioCallback - SoundGraphSource::Initialize failed");
             m_Source.reset();
             return false;
+        }
+
+        // Insert a per-voice 3D spatializer node between the SoundGraph node and the engine
+        // endpoint (issue #424). Best-effort: if spatialization is disabled, or the engine has
+        // no spatializer, the voice simply plays non-positional. A previously-set position is
+        // pushed straight away so the spatializer starts at the right place (its node otherwise
+        // stays muted until the first UpdateSourcePosition).
+        if (m_SpatializationEnabled)
+        {
+            if (auto* spatializer = AudioEngine::GetSpatializer())
+            {
+                AudioSourceConfig spatialConfig;
+                spatialConfig.Spatialization = true;
+                if (m_Source->RegisterSpatializer(spatializer, spatialConfig))
+                {
+                    SyncSpatialPositionToSource();
+                }
+            }
         }
         return true;
     }
@@ -503,31 +523,56 @@ namespace OloEngine::Audio::SoundGraph
     //==============================================================================
     /// 3D Audio
     ///
-    /// These store the spatial state and back GetLocation()/GetVelocity(), but do not
-    /// yet feed a spatializer: SoundGraphSource attaches its bare ma_node straight to the
-    /// engine endpoint, whereas Audio::DSP::Spatializer (AudioEngine::GetSpatializer)
-    /// inserts per-source panning nodes after an ma_engine_node and is wired only into the
-    /// ma_sound-based AudioSource path. Routing a SoundGraph voice through the spatializer
-    /// is real new infrastructure (per-voice node insertion + listener/source registration),
-    /// not a parameter route, so it is deferred — tracked in issue #424.
+    /// Each setter stores the spatial state (backing GetLocation()/GetVelocity()) and routes
+    /// it into the source's per-voice spatializer node via Spatializer::UpdateSourcePosition
+    /// (issue #424). The push no-ops until the source hosts a spatializer node (disabled, a
+    /// detached source, or no engine spatializer), so the stored value is what a later
+    /// registration / the getters observe.
 
     void SoundGraphSound::SetLocation(const glm::vec3& location)
     {
         OLO_PROFILE_FUNCTION();
         m_Position = location;
+        SyncSpatialPositionToSource();
     }
 
     void SoundGraphSound::SetVelocity(const glm::vec3& velocity)
     {
         OLO_PROFILE_FUNCTION();
         m_Velocity = velocity;
+        SyncSpatialPositionToSource();
     }
 
     void SoundGraphSound::SetOrientation(const glm::vec3& forward, const glm::vec3& up)
     {
         OLO_PROFILE_FUNCTION();
-        (void)up;
         m_Orientation = forward;
+        m_Up = up;
+        SyncSpatialPositionToSource();
+    }
+
+    void SoundGraphSound::SyncSpatialPositionToSource()
+    {
+        if (!m_Source)
+            return;
+
+        // The spatializer expects a position, a look direction (orientation), and an up
+        // vector; we keep all three so cone-angle attenuation has a meaningful source facing.
+        Audio::Transform transform;
+        transform.Position = m_Position;
+        transform.Orientation = m_Orientation;
+        transform.Up = m_Up;
+        m_Source->UpdateSpatialPosition(transform, m_Velocity);
+    }
+
+    bool SoundGraphSound::IsSpatialized() const
+    {
+        return m_Source && m_Source->IsSpatialized();
+    }
+
+    u32 SoundGraphSound::GetSpatializerSourceID() const
+    {
+        return m_Source ? m_Source->GetSpatializerSourceID() : 0;
     }
 
     //==============================================================================

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -6,6 +6,7 @@
 #include "OloEngine/Audio/AudioSource.h"    // AudioSourceConfig
 #include "OloEngine/Audio/AudioTransform.h" // Audio::Transform
 #include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Math/Math.h" // Math::IsFinite
 
 #include <choc/containers/choc_Value.h>
 #include <algorithm>
@@ -532,6 +533,11 @@ namespace OloEngine::Audio::SoundGraph
     void SoundGraphSound::SetLocation(const glm::vec3& location)
     {
         OLO_PROFILE_FUNCTION();
+        // Reject non-finite positions before they reach the cache (the getters / a later
+        // registration observe it) or the spatializer's lookAt/length math, where a NaN
+        // silently corrupts panning for the voice (issue #424).
+        if (!Math::IsFinite(location))
+            return;
         m_Position = location;
         SyncSpatialPositionToSource();
     }
@@ -539,6 +545,8 @@ namespace OloEngine::Audio::SoundGraph
     void SoundGraphSound::SetVelocity(const glm::vec3& velocity)
     {
         OLO_PROFILE_FUNCTION();
+        if (!Math::IsFinite(velocity))
+            return;
         m_Velocity = velocity;
         SyncSpatialPositionToSource();
     }
@@ -546,6 +554,13 @@ namespace OloEngine::Audio::SoundGraph
     void SoundGraphSound::SetOrientation(const glm::vec3& forward, const glm::vec3& up)
     {
         OLO_PROFILE_FUNCTION();
+        // The forward/up basis feeds glm::lookAt inside the spatializer; a non-finite or
+        // degenerate (zero-length) vector makes lookAt produce NaN, so cache only a valid
+        // facing (issue #424).
+        if (!Math::IsFinite(forward) || !Math::IsFinite(up))
+            return;
+        if (glm::length(forward) < 1e-4f || glm::length(up) < 1e-4f)
+            return;
         m_Orientation = forward;
         m_Up = up;
         SyncSpatialPositionToSource();

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
@@ -137,6 +137,13 @@ namespace OloEngine
 
                 //==============================================================================
                 /// 3D Audio
+                ///
+                /// These now drive the per-voice 3D spatializer (issue #424): each setter
+                /// stores the spatial state AND, once a spatializer node is hosted by the
+                /// source, pushes the combined transform/velocity into
+                /// Audio::DSP::Spatializer::UpdateSourcePosition. They no-op gracefully before
+                /// the source/spatializer exists (the value is still stored, so the getters and
+                /// a later registration stay correct).
                 void SetLocation(const glm::vec3& location);
                 void SetVelocity(const glm::vec3& velocity);
                 void SetOrientation(const glm::vec3& forward, const glm::vec3& up);
@@ -149,6 +156,28 @@ namespace OloEngine
                 {
                     return m_Velocity;
                 }
+
+                /// Whether this voice is routed through the 3D spatializer. Owned here at
+                /// runtime (the AudioSoundGraphComponent has no serialized spatialization flag
+                /// yet — see issue #424); defaults to enabled so a SoundGraph voice on an entity
+                /// is positioned. Must be set BEFORE InitializeAudioCallback to take effect, as
+                /// that is where the spatializer node is registered.
+                void SetSpatializationEnabled(bool enabled)
+                {
+                    m_SpatializationEnabled = enabled;
+                }
+                bool IsSpatializationEnabled() const
+                {
+                    return m_SpatializationEnabled;
+                }
+
+                /// True once the source actually hosts a spatializer node (false if disabled,
+                /// the source is detached, or the engine spatializer was unavailable).
+                bool IsSpatialized() const;
+
+                /// The spatializer sourceID for this voice (0 when not spatialized). Lets
+                /// callers/tests query Audio::DSP::Spatializer's per-source getters.
+                u32 GetSpatializerSourceID() const;
 
                 //==============================================================================
                 /// Status
@@ -256,6 +285,11 @@ namespace OloEngine
                 static f32 NormalizedToFrequency(f32 normalizedValue);
                 static f32 FrequencyToNormalized(f32 frequency);
 
+                /* Push the current spatial state (position/orientation/up + velocity) into the
+                   source's spatializer node. No-op until the source hosts one. Called from each
+                   3D setter. */
+                void SyncSpatialPositionToSource();
+
               private:
                 friend class AudioEngine;
                 friend class SourceManager;
@@ -291,8 +325,10 @@ namespace OloEngine
 
                 // Spatial audio properties
                 glm::vec3 m_Position{ 0.0f };
-                glm::vec3 m_Orientation{ 0.0f, 0.0f, 1.0f };
+                glm::vec3 m_Orientation{ 0.0f, 0.0f, -1.0f }; // forward; matches Audio::Transform default
+                glm::vec3 m_Up{ 0.0f, 1.0f, 0.0f };
                 glm::vec3 m_Velocity{ 0.0f };
+                bool m_SpatializationEnabled = true; // 3D spatializer routing on by default (issue #424)
 
                 // Status flags
                 bool m_IsReadyToPlay = false;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Audio/AudioLoader.h"
 #include "OloEngine/Audio/DSP/Spatializer/Spatializer.h"
 #include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Math/Math.h" // Math::IsFinite
 #include "OloEngine/Core/Hash.h"
 #include "OloEngine/Project/Project.h"
 #include <atomic>
@@ -387,8 +388,20 @@ namespace OloEngine::Audio::SoundGraph
 
     void SoundGraphSource::UpdateSpatialPosition(const Audio::Transform& transform, glm::vec3 velocity)
     {
-        if (m_SpatializerRegistered && m_Spatializer)
-            m_Spatializer->UpdateSourcePosition(m_SpatializerSourceID, transform, velocity);
+        if (!m_SpatializerRegistered || !m_Spatializer)
+            return;
+
+        // Guard the spatializer boundary: a non-finite position/velocity, or a non-finite or
+        // degenerate (zero-length) orientation/up basis, would feed NaN into the lookAt and
+        // length math in Spatializer::UpdateSourcePosition and corrupt panning (issue #424).
+        if (!Math::IsFinite(transform.Position) || !Math::IsFinite(velocity))
+            return;
+        if (!Math::IsFinite(transform.Orientation) || !Math::IsFinite(transform.Up))
+            return;
+        if (glm::length(transform.Orientation) < 1e-4f || glm::length(transform.Up) < 1e-4f)
+            return;
+
+        m_Spatializer->UpdateSourcePosition(m_SpatializerSourceID, transform, velocity);
     }
 
     void SoundGraphSource::SuspendProcessing(bool shouldBeSuspended)

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -1,9 +1,11 @@
 #include "OloEnginePCH.h"
 #include "SoundGraphSource.h"
 #include "OloEngine/Audio/AudioLoader.h"
+#include "OloEngine/Audio/DSP/Spatializer/Spatializer.h"
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Core/Hash.h"
 #include "OloEngine/Project/Project.h"
+#include <atomic>
 #include <chrono>
 #include <thread>
 #include <variant>
@@ -58,6 +60,11 @@ namespace OloEngine::Audio::SoundGraph
             1,       // 1 output bus
             0        // flags
         };
+
+        // Process-wide monotonic source-ID allocator for the shared Audio::DSP::Spatializer
+        // (AudioEngine::GetSpatializer()): every SoundGraph voice registers under a unique key
+        // in the spatializer's source map. Starts at 1 so 0 stays a "not registered" sentinel.
+        std::atomic<u32> s_NextSpatializerSourceID{ 1 };
     } // namespace
 
     //==============================================================================
@@ -317,6 +324,11 @@ namespace OloEngine::Audio::SoundGraph
 
         UninitializeDataSources();
 
+        // Tear the spatializer node out (re-routes m_Node straight back to the endpoint and
+        // frees the inserted node) BEFORE we uninit m_Node — ReleaseSource reads m_Node's
+        // output bus to find the downstream it should reattach to.
+        UnregisterSpatializer();
+
         ::ma_node_uninit(&m_Node.m_Base, nullptr);
         m_Node.m_Owner = nullptr;
 
@@ -326,6 +338,57 @@ namespace OloEngine::Audio::SoundGraph
         m_PresetIsInitialized = false;
 
         OLO_CORE_INFO("[SoundGraphSource] Shutdown complete");
+    }
+
+    //==============================================================================
+    /// 3D Spatialization (issue #424)
+
+    bool SoundGraphSource::RegisterSpatializer(Audio::DSP::Spatializer* spatializer, const AudioSourceConfig& config)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (!m_IsInitialized)
+        {
+            // The spatializer node inserts itself between m_Node and m_Node's current
+            // downstream (the endpoint), so m_Node must already be attached. A detached
+            // source (InitializeDetachedSource) never attaches and so can't be spatialized.
+            OLO_CORE_WARN("[SoundGraphSource] RegisterSpatializer called before Initialize; ignoring");
+            return false;
+        }
+        if (!spatializer)
+            return false;
+        if (m_SpatializerRegistered)
+            return true; // idempotent
+
+        const u32 sourceID = s_NextSpatializerSourceID.fetch_add(1, std::memory_order_relaxed);
+        if (!spatializer->InitSource(sourceID, &m_Node.m_Base, config))
+        {
+            OLO_CORE_WARN("[SoundGraphSource] Spatializer::InitSource failed for sourceID {}", sourceID);
+            return false;
+        }
+
+        m_Spatializer = spatializer;
+        m_SpatializerSourceID = sourceID;
+        m_SpatializerRegistered = true;
+        OLO_CORE_TRACE("[SoundGraphSource] Registered spatializer source {}", sourceID);
+        return true;
+    }
+
+    void SoundGraphSource::UnregisterSpatializer()
+    {
+        if (!m_SpatializerRegistered || !m_Spatializer)
+            return;
+
+        m_Spatializer->ReleaseSource(m_SpatializerSourceID);
+        m_Spatializer = nullptr;
+        m_SpatializerSourceID = 0;
+        m_SpatializerRegistered = false;
+    }
+
+    void SoundGraphSource::UpdateSpatialPosition(const Audio::Transform& transform, glm::vec3 velocity)
+    {
+        if (m_SpatializerRegistered && m_Spatializer)
+            m_Spatializer->UpdateSourcePosition(m_SpatializerSourceID, transform, velocity);
     }
 
     void SoundGraphSource::SuspendProcessing(bool shouldBeSuspended)

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
@@ -3,10 +3,13 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Asset/Asset.h"
+#include "OloEngine/Audio/AudioSource.h"    // AudioSourceConfig + Audio::DSP::Spatializer fwd-decl
+#include "OloEngine/Audio/AudioTransform.h" // Audio::Transform
 #include "OloEngine/Audio/SoundGraph/SoundGraph.h"
 #include "OloEngine/Audio/SoundGraph/SoundGraphPatchPreset.h"
 #include "OloEngine/Audio/LockFreeEventQueue.h"
 #include <choc/containers/choc_Value.h>
+#include <glm/vec3.hpp>
 #include "WaveSource.h"
 
 #include <miniaudio.h>
@@ -214,6 +217,43 @@ namespace OloEngine::Audio::SoundGraph
         }
 
         //==============================================================================
+        /// 3D Spatialization
+        ///
+        /// The source can host a per-voice spatializer node inserted between its SoundGraph
+        /// node and the engine endpoint (issue #424). The owner (SoundGraphSound) wires this
+        /// to AudioEngine::GetSpatializer(); the Spatializer pointer is injected so a test can
+        /// drive a device-free spatializer. Requires Initialize() to have attached the node
+        /// first (a detached source has nothing to insert before).
+
+        /** Insert and register a spatializer node for this source's output, assigning a
+            process-wide unique sourceID. Idempotent (a second call while registered is a
+            no-op success). Returns false if the source isn't initialized, `spatializer` is
+            null, or the spatializer's InitSource failed. */
+        bool RegisterSpatializer(Audio::DSP::Spatializer* spatializer, const AudioSourceConfig& config);
+
+        /** Release the spatializer node (re-routing the SoundGraph node straight to its prior
+            output) and drop the registration. Safe to call when not registered. Called from
+            Shutdown so cleanup is guaranteed even if the owner forgets. */
+        void UnregisterSpatializer();
+
+        /** Push a new world position/orientation (+ velocity) for this voice into the
+            spatializer. No-op when not registered. */
+        void UpdateSpatialPosition(const Audio::Transform& transform, glm::vec3 velocity = glm::vec3(0.0f));
+
+        /** True if a spatializer node is currently hosted for this source. */
+        bool IsSpatialized() const
+        {
+            return m_SpatializerRegistered;
+        }
+
+        /** The spatializer sourceID assigned at RegisterSpatializer (0 when not registered).
+            Exposed so callers/tests can query the Spatializer's per-source getters. */
+        u32 GetSpatializerSourceID() const
+        {
+            return m_SpatializerSourceID;
+        }
+
+        //==============================================================================
         /// Event Callbacks (set by SoundGraphPlayer or other managers)
 
         using OnGraphMessageCallback = std::function<void(u64 frameIndex, const char* message)>;
@@ -291,6 +331,14 @@ namespace OloEngine::Audio::SoundGraph
         u32 m_SampleRate = 0;
         u32 m_BlockSize = 0;
         u32 m_ChannelCount = 2;
+
+        //============================================
+        /// 3D spatialization (issue #424). The spatializer node lives between m_Node and the
+        /// engine endpoint. m_Spatializer is non-owning (the global AudioEngine spatializer, or
+        /// a test-injected one). sourceID is assigned by RegisterSpatializer.
+        Audio::DSP::Spatializer* m_Spatializer = nullptr;
+        u32 m_SpatializerSourceID = 0;
+        bool m_SpatializerRegistered = false;
 
         //============================================
         /// Playback state

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -90,6 +90,9 @@
 #include "OloEngine/Audio/AudioEvents/AudioEventsManager.h"
 #include "OloEngine/Audio/AudioEvents/AudioCommandRegistry.h"
 #include "OloEngine/Audio/AudioEvents/AudioPlayback.h"
+#include "OloEngine/Audio/AudioEngine.h"
+#include "OloEngine/Audio/AudioTransform.h"
+#include "OloEngine/Audio/DSP/Spatializer/Spatializer.h"
 #include "OloEngine/Project/Project.h"
 
 #include <glm/glm.hpp>
@@ -583,6 +586,17 @@ namespace OloEngine
                 ac.Listener->SetConfig(ac.Config);
                 ac.Listener->SetPosition(tc.Translation);
                 ac.Listener->SetDirection(-forward);
+                // Seed the 3D spatializer's listener pose so SoundGraph voices registered just
+                // below (InitializeAudioSoundGraph) compute their initial relative position
+                // against the real listener, not the default origin (issue #424).
+                if (auto* spatializer = AudioEngine::GetSpatializer())
+                {
+                    Audio::Transform listenerTransform;
+                    listenerTransform.Position = tc.Translation;
+                    listenerTransform.Orientation = -forward;
+                    listenerTransform.Up = normalize(glm::vec3(inverted[1]));
+                    spatializer->UpdateListener(listenerTransform);
+                }
                 break;
             }
         }
@@ -1553,6 +1567,16 @@ namespace OloEngine
                     const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
                     ac.Listener->SetPosition(tc.Translation);
                     ac.Listener->SetDirection(-forward);
+                    // Keep the 3D spatializer's listener in sync each frame so SoundGraph voices
+                    // pan/attenuate relative to the live listener pose (issue #424).
+                    if (auto* spatializer = AudioEngine::GetSpatializer())
+                    {
+                        Audio::Transform listenerTransform;
+                        listenerTransform.Position = tc.Translation;
+                        listenerTransform.Orientation = -forward;
+                        listenerTransform.Up = normalize(glm::vec3(inverted[1]));
+                        spatializer->UpdateListener(listenerTransform);
+                    }
                     break;
                 }
             }
@@ -1567,6 +1591,21 @@ namespace OloEngine
                     const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
                     ac.Source->SetPosition(tc.Translation);
                     ac.Source->SetDirection(forward);
+                }
+            }
+
+            // Drive 3D position/orientation for SoundGraph voices (issue #424). Mirrors the
+            // AudioSource loop above; SetLocation/SetOrientation route into the per-voice
+            // spatializer node, which no-ops until the voice actually hosts one.
+            for (auto sgView = m_Registry.view<AudioSoundGraphComponent, TransformComponent>(); auto&& [e, sgc, tc] : sgView.each())
+            {
+                if (sgc.Sound)
+                {
+                    const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
+                    const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
+                    const glm::vec3 up = normalize(glm::vec3(inverted[1]));
+                    sgc.Sound->SetLocation(tc.Translation);
+                    sgc.Sound->SetOrientation(forward, up);
                 }
             }
 

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -136,6 +136,18 @@ namespace OloEngine
         return true;
     }
 
+    // Audio listener/source orientation comes from columns of an entity's inverse local
+    // transform. A singular (zero-scale) or non-finite transform makes glm::inverse emit
+    // NaN/Inf, and normalizing a zero/NaN vector yields NaN — which would poison the 3D
+    // spatializer's lookAt/length math (issue #424). Fall back to the canonical axis (what
+    // an identity transform yields) when the basis vector is degenerate.
+    static glm::vec3 SafeAudioBasis(const glm::vec3& basis, const glm::vec3& fallback)
+    {
+        if (std::isfinite(basis.x) && std::isfinite(basis.y) && std::isfinite(basis.z) && glm::length(basis) > 1e-4f)
+            return glm::normalize(basis);
+        return fallback;
+    }
+
     static void DrawTextWithShadow(const TextComponent& text, const TransformComponent& transform, int entityID)
     {
         if (text.DropShadow)
@@ -582,7 +594,7 @@ namespace OloEngine
             if (ac.Active)
             {
                 const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
-                const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
+                const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
                 ac.Listener->SetConfig(ac.Config);
                 ac.Listener->SetPosition(tc.Translation);
                 ac.Listener->SetDirection(-forward);
@@ -594,7 +606,7 @@ namespace OloEngine
                     Audio::Transform listenerTransform;
                     listenerTransform.Position = tc.Translation;
                     listenerTransform.Orientation = -forward;
-                    listenerTransform.Up = normalize(glm::vec3(inverted[1]));
+                    listenerTransform.Up = SafeAudioBasis(glm::vec3(inverted[1]), glm::vec3(0.0f, 1.0f, 0.0f));
                     spatializer->UpdateListener(listenerTransform);
                 }
                 break;
@@ -623,7 +635,7 @@ namespace OloEngine
             if (ac.Source)
             {
                 const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
-                const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
+                const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
                 ac.Source->SetConfig(ac.Config);
                 ac.Source->SetPosition(tc.Translation);
                 ac.Source->SetDirection(forward);
@@ -1564,7 +1576,7 @@ namespace OloEngine
                 if (ac.Active)
                 {
                     const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
-                    const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
+                    const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
                     ac.Listener->SetPosition(tc.Translation);
                     ac.Listener->SetDirection(-forward);
                     // Keep the 3D spatializer's listener in sync each frame so SoundGraph voices
@@ -1574,7 +1586,7 @@ namespace OloEngine
                         Audio::Transform listenerTransform;
                         listenerTransform.Position = tc.Translation;
                         listenerTransform.Orientation = -forward;
-                        listenerTransform.Up = normalize(glm::vec3(inverted[1]));
+                        listenerTransform.Up = SafeAudioBasis(glm::vec3(inverted[1]), glm::vec3(0.0f, 1.0f, 0.0f));
                         spatializer->UpdateListener(listenerTransform);
                     }
                     break;
@@ -1588,7 +1600,7 @@ namespace OloEngine
                 {
                     Entity entity = { e, this };
                     const glm::mat4 inverted = glm::inverse(entity.GetLocalTransform());
-                    const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
+                    const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
                     ac.Source->SetPosition(tc.Translation);
                     ac.Source->SetDirection(forward);
                 }
@@ -1602,8 +1614,8 @@ namespace OloEngine
                 if (sgc.Sound)
                 {
                     const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
-                    const glm::vec3 forward = normalize(glm::vec3(inverted[2]));
-                    const glm::vec3 up = normalize(glm::vec3(inverted[1]));
+                    const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
+                    const glm::vec3 up = SafeAudioBasis(glm::vec3(inverted[1]), glm::vec3(0.0f, 1.0f, 0.0f));
                     sgc.Sound->SetLocation(tc.Translation);
                     sgc.Sound->SetOrientation(forward, up);
                 }

--- a/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
+++ b/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
@@ -1,0 +1,205 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+//
+// =============================================================================
+// AudioSoundGraphSpatializerTest — SoundGraph voices route through the 3D spatializer
+//
+// Issue #424: a SoundGraphSource attaches a *bare* ma_node straight to the engine
+// endpoint, but Audio::DSP::Spatializer::InitSource was built around an ma_engine_node
+// (it reads `resampler.channels` and writes the engine node's built-in
+// `spatializer.dopplerPitch`). This pins the new bare-node path end to end:
+//
+//   * SoundGraphSource::RegisterSpatializer inserts a per-voice spatializer node
+//     between its SoundGraph node and the endpoint (the crux — a bare ma_node, not an
+//     ma_engine_node), assigning a unique sourceID;
+//   * UpdateSpatialPosition drives Spatializer::UpdateSourcePosition so the source's
+//     distance / distance-attenuation track its world position relative to the listener;
+//   * UnregisterSpatializer / Shutdown release the source cleanly (re-routing the
+//     SoundGraph node straight back to the endpoint).
+//
+// Everything runs against a device-free ma_engine (config.noDevice = MA_TRUE): the node
+// graph + resource manager exist (so node insertion + the VBAP / distance math run), but
+// no audio hardware is opened — so this gates a normal headless CI run. The assertions
+// use the spatializer's CPU-side getters (GetCurrentDistance / GetCurrentDistanceAttenuation
+// / GetCurrentConeAngleAttenuation), which are pure functions of the geometry.
+// =============================================================================
+
+#include "OloEngine/Audio/AudioSource.h"
+#include "OloEngine/Audio/AudioTransform.h"
+#include "OloEngine/Audio/DSP/Spatializer/Spatializer.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSource.h"
+
+#include <glm/glm.hpp>
+#include <miniaudio.h>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace)
+namespace sg = OloEngine::Audio::SoundGraph;
+namespace dsp = OloEngine::Audio::DSP;
+
+namespace
+{
+    constexpr u32 kSampleRate = 48000;
+    constexpr u32 kBlockSize = 1024;
+    constexpr u32 kChannels = 2;
+
+    // Brings up a device-free ma_engine + a Spatializer + a real SoundGraphSource whose node
+    // is attached to the engine endpoint — i.e. exactly the topology a SoundGraph voice has,
+    // minus the audio device. Skips cleanly if the engine cannot be created (it has no device
+    // dependency, so this should always succeed, but be defensive like the GL visual tests).
+    class SoundGraphSpatializerTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            ma_engine_config config = ::ma_engine_config_init();
+            config.noDevice = MA_TRUE;   // offline / manual processing — no hardware opened
+            config.channels = kChannels; // required when noDevice (nothing to infer from)
+            config.sampleRate = kSampleRate;
+            config.listenerCount = 1;
+
+            if (::ma_engine_init(&config, &m_Engine) != MA_SUCCESS)
+            {
+                GTEST_SKIP() << "Device-free ma_engine could not be created on this host";
+            }
+            m_EngineReady = true;
+
+            ASSERT_TRUE(m_Spatializer.Initialize(&m_Engine));
+            ASSERT_TRUE(m_Source.Initialize(&m_Engine, kSampleRate, kBlockSize, kChannels));
+        }
+
+        void TearDown() override
+        {
+            if (m_EngineReady)
+            {
+                // Source first: Shutdown unregisters its spatializer node (re-routing the
+                // SoundGraph node back to the endpoint), then the spatializer, then the engine.
+                m_Source.Shutdown();
+                m_Spatializer.Uninitialize();
+                ::ma_engine_uninit(&m_Engine);
+            }
+        }
+
+        ma_engine m_Engine{};
+        bool m_EngineReady = false;
+        dsp::Spatializer m_Spatializer;
+        sg::SoundGraphSource m_Source;
+    };
+} // namespace
+
+// The bare SoundGraph node can host a spatializer node and gets a valid, unique sourceID.
+TEST_F(SoundGraphSpatializerTest, RegisterInsertsSpatializerNodeAndAssignsSourceID)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+
+    EXPECT_FALSE(m_Source.IsSpatialized());
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config))
+        << "InitSource must accept a bare ma_node (SoundGraphSource), not just an ma_engine_node";
+
+    EXPECT_TRUE(m_Source.IsSpatialized());
+    const u32 id = m_Source.GetSpatializerSourceID();
+    EXPECT_NE(id, 0u) << "a registered voice gets a non-zero (allocated) sourceID";
+    EXPECT_TRUE(m_Spatializer.IsInitialized(id));
+
+    // Idempotent: a second register while already registered is a success no-op (same ID).
+    EXPECT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    EXPECT_EQ(m_Source.GetSpatializerSourceID(), id);
+}
+
+// Distance reported by the spatializer matches the geometric distance to the listener, and
+// distance-attenuation is monotonic: a nearer source is louder than a farther one.
+TEST_F(SoundGraphSpatializerTest, PositionDrivesDistanceAndAttenuation)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true; // default Inverse model, MinDistance 0.3, MaxDistance 1000
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+
+    // Listener at the origin, looking down -Z (Audio::Transform defaults).
+    m_Spatializer.UpdateListener(Audio::Transform{});
+
+    // A source 2 units directly in front of the listener.
+    Audio::Transform nearPose;
+    nearPose.Position = { 0.0f, 0.0f, -2.0f };
+    m_Source.UpdateSpatialPosition(nearPose);
+    EXPECT_NEAR(m_Spatializer.GetCurrentDistance(id), 2.0f, 1e-3f);
+    const float nearAtten = m_Spatializer.GetCurrentDistanceAttenuation(id);
+
+    // The same source moved far away.
+    Audio::Transform farPose;
+    farPose.Position = { 0.0f, 0.0f, -50.0f };
+    m_Source.UpdateSpatialPosition(farPose);
+    EXPECT_NEAR(m_Spatializer.GetCurrentDistance(id), 50.0f, 1e-3f);
+    const float farAtten = m_Spatializer.GetCurrentDistanceAttenuation(id);
+
+    EXPECT_GT(nearAtten, farAtten) << "a nearer source must attenuate less (be louder)";
+    EXPECT_GT(nearAtten, 0.0f);
+    EXPECT_LE(nearAtten, 1.0f);
+    EXPECT_GT(farAtten, 0.0f);
+
+    // With the default omnidirectional (360°) cone, there is no angular attenuation: the cone
+    // factor is neutral (the spatializer folds any cone gain into the distance factor).
+    EXPECT_NEAR(m_Spatializer.GetCurrentConeAngleAttenuation(id), 1.0f, 1e-4f);
+}
+
+// A source at (clamped to) the listener position is at full gain; moving it out attenuates.
+TEST_F(SoundGraphSpatializerTest, AtListenerIsFullGain)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+
+    m_Spatializer.UpdateListener(Audio::Transform{});
+
+    // Co-located with the listener: distance clamps to MinDistance, so attenuation is ~1.0.
+    Audio::Transform atListener; // position {0,0,0}
+    m_Source.UpdateSpatialPosition(atListener);
+    EXPECT_NEAR(m_Spatializer.GetCurrentDistanceAttenuation(id), 1.0f, 1e-3f);
+}
+
+// Moving the listener (not the source) also recomputes the source's relative distance —
+// proving the listener-update path feeds the same math.
+TEST_F(SoundGraphSpatializerTest, MovingListenerRecomputesDistance)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+
+    m_Spatializer.UpdateListener(Audio::Transform{});
+
+    Audio::Transform sourcePose;
+    sourcePose.Position = { 0.0f, 0.0f, -10.0f };
+    m_Source.UpdateSpatialPosition(sourcePose);
+    EXPECT_NEAR(m_Spatializer.GetCurrentDistance(id), 10.0f, 1e-3f);
+
+    // Move the listener 6 units toward the source (down -Z): distance should drop to ~4.
+    Audio::Transform listenerPose;
+    listenerPose.Position = { 0.0f, 0.0f, -6.0f };
+    m_Spatializer.UpdateListener(listenerPose);
+    EXPECT_NEAR(m_Spatializer.GetCurrentDistance(id), 4.0f, 1e-3f);
+}
+
+// Unregistering releases the spatializer source and re-routes the node — the sourceID is
+// freed and IsSpatialized goes false. (Shutdown does the same; this exercises the explicit path.)
+TEST_F(SoundGraphSpatializerTest, UnregisterReleasesSource)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+    ASSERT_TRUE(m_Spatializer.IsInitialized(id));
+
+    m_Source.UnregisterSpatializer();
+
+    EXPECT_FALSE(m_Source.IsSpatialized());
+    EXPECT_EQ(m_Source.GetSpatializerSourceID(), 0u);
+    EXPECT_FALSE(m_Spatializer.IsInitialized(id)) << "the released sourceID is gone from the map";
+
+    // Re-registering after release works and yields a fresh (different) sourceID.
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    EXPECT_NE(m_Source.GetSpatializerSourceID(), 0u);
+}

--- a/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
+++ b/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
@@ -199,7 +199,10 @@ TEST_F(SoundGraphSpatializerTest, UnregisterReleasesSource)
     EXPECT_EQ(m_Source.GetSpatializerSourceID(), 0u);
     EXPECT_FALSE(m_Spatializer.IsInitialized(id)) << "the released sourceID is gone from the map";
 
-    // Re-registering after release works and yields a fresh (different) sourceID.
+    // Re-registering after release works and yields a fresh sourceID — distinct from the
+    // one we just released (id), so the allocator can't silently recycle it.
     ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
-    EXPECT_NE(m_Source.GetSpatializerSourceID(), 0u);
+    const u32 reusedID = m_Source.GetSpatializerSourceID();
+    EXPECT_NE(reusedID, 0u);
+    EXPECT_NE(reusedID, id) << "the re-registered source must not reuse the released sourceID";
 }

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(OloEngine-Tests
 		AudioEventQueueTest.cpp
 		AudioDSPTest.cpp
 		AudioSpatializerTest.cpp
+		AudioSoundGraphSpatializerTest.cpp
 		VideoPlaybackTest.cpp
 		Audio/CommandIDTest.cpp
 		Audio/AudioCommandRegistryTest.cpp


### PR DESCRIPTION
## What & why

Closes the gap in #424: a SoundGraph voice was **not 3D-positioned at all**. `SoundGraphSound::SetLocation` / `SetVelocity` / `SetOrientation` only stored the value — nothing reached a spatializer.

`Audio::DSP::Spatializer` already did VBAP panning + distance/cone attenuation, but its `InitSource` was built around an `ma_engine_node` (it reads `resampler.channels` and drives the engine node's built-in `spatializer.dopplerPitch`) and was wired to **nothing** in production. A `SoundGraphSource`, by contrast, attaches a **bare `ma_node`** straight to the engine endpoint — the crux mismatch this PR resolves.

## Changes

- **Spatializer** — add `InitSource(ma_node_base*)` beside the existing `InitSource(ma_engine_node*)`; both delegate to a shared `InitSourceInternal`. The Doppler sink (`ma_engine_node*`) is now **nullable** and the doppler-pitch writes (audio callback + `UpdatePositionalData`) are null-guarded, so a bare node still gets full VBAP panning + distance/cone attenuation (computed inside the spatializer node) while Doppler — which needs the engine node's resampler — is skipped. `ReleaseSource` re-routes via a new `attachedNode` field. The engine-node path is unchanged.
- **SoundGraphSource** — hosts a per-voice spatializer node: `RegisterSpatializer` (inserts between the SoundGraph node and the endpoint, allocates a process-unique sourceID), `UpdateSpatialPosition`, `UnregisterSpatializer` (also from `Shutdown`, before `ma_node_uninit`).
- **SoundGraphSound** — routes the three 3D setters through `Spatializer::UpdateSourcePosition`; registers the spatializer in `InitializeAudioCallback`; removes the deferral comment.
- **Scene** — feeds the active listener pose into `Spatializer::UpdateListener` (init + per-frame) and drives per-frame SoundGraph voice positions in `OnUpdateRuntime`.

### Spatialization-enabled ownership (scope item 3)

Owned at runtime by `SoundGraphSound::m_SpatializationEnabled` (default **on**), **not** a serialized `AudioSoundGraphComponent` field — deliberately, to avoid a `SceneSerializer.cpp` change that would collide with the in-flight #451 codegen work. A serialized per-voice toggle (to allow 2D SoundGraph voices) is the natural follow-up once #451 lands.

## Tests

`AudioSoundGraphSpatializerTest` (classified `unit`, device-free `ma_engine` via `config.noDevice`): pins that the bare SoundGraph node hosts a spatializer node, and that position drives `GetCurrentDistance` / `GetCurrentDistanceAttenuation` correctly (geometry-exact distance, monotonic attenuation, full gain at the listener, listener-move recompute, clean release). All 5 pass; the surrounding 155 audio/SoundGraph/VBAP tests and the `AudioRuntimeTicksViaScene` Functional test still pass.

> Note: audio spatialization can't be visually/audibly inspected — the deterministic distance/attenuation math (CPU-side, via the spatializer getters) is the strongest available evidence, plus the no-crash Scene-tick path.

Refs #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-voice 3D spatial audio for sound graph voices, with controls to enable/disable spatialization and query spatialized status/source ID.
  * Spatial audio now initializes and tracks the listener pose from scene transforms, and voices sync position/velocity/orientation (including up) when changed.
* **Bug Fixes**
  * Improved safety for Doppler and pitch updates when required graph nodes aren’t present.
  * Hardened spatial updates against invalid inputs and fixed spatializer registration/release behavior to avoid leaks and stale routing.
* **Tests**
  * Added coverage for spatializer routing, distance/cone attenuation behavior, listener-relative updates, and correct unregister/register semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->