### PR TITLE
feat(asset): validate references + placeholder fallback at runtime (#…

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1022,6 +1022,13 @@ namespace OloEngine
 
             ImGui::Separator();
 
+            if (ImGui::MenuItem("Validate Asset References"))
+            {
+                ValidateAssetReferences();
+            }
+
+            ImGui::Separator();
+
             if (ImGui::MenuItem("Asset Pack Builder", nullptr, &m_ShowAssetPackBuilder))
             {
                 // Toggle panel visibility
@@ -3833,6 +3840,48 @@ namespace OloEngine
         else
         {
             OLO_CORE_ERROR("Shader Pack build failed");
+        }
+    }
+
+    void EditorLayer::ValidateAssetReferences() const
+    {
+        OLO_PROFILE_FUNCTION();
+
+        auto project = Project::GetActive();
+        if (!project)
+        {
+            OLO_CORE_WARN("Validate Asset References: no active project");
+            return;
+        }
+
+        Ref<AssetManagerBase> assetManager = project->GetAssetManager();
+        if (!assetManager)
+        {
+            OLO_CORE_WARN("Validate Asset References: no active asset manager");
+            return;
+        }
+
+        const AssetReferenceValidationReport report = assetManager->ValidateReferences();
+
+        if (report.IsValid())
+        {
+            OLO_CORE_INFO("Validate Asset References: checked {} reference(s); no dangling references found.",
+                          report.CheckedReferenceCount);
+            return;
+        }
+
+        OLO_CORE_WARN("Validate Asset References: checked {} reference(s); found {} dangling reference(s):",
+                      report.CheckedReferenceCount, report.DanglingCount());
+        for (const auto& dangling : report.DanglingReferences)
+        {
+            const AssetMetadata referencerMeta = assetManager->GetAssetMetadata(dangling.Referencer);
+            const std::string referencerLabel = referencerMeta.FilePath.empty()
+                                                    ? std::to_string(static_cast<u64>(dangling.Referencer))
+                                                    : referencerMeta.FilePath.string();
+            OLO_CORE_WARN("  - '{}' references missing asset {} ({})",
+                          referencerLabel,
+                          static_cast<u64>(dangling.Reference),
+                          AssetUtils::AssetTypeToString(dangling.ReferenceType));
         }
     }
 

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -120,6 +120,11 @@ namespace OloEngine
         // Bundles all compiled SPIR-V into a single binary file for distribution builds
         void BuildShaderPack() const;
 
+        // Asset reference validation (issue #455)
+        // Sweeps the active asset manager's dependency registry for dangling
+        // (missing/moved/deleted) references and logs a report to the console.
+        void ValidateAssetReferences() const;
+
         // Build status and progress queries
         bool IsBuildInProgress() const
         {

--- a/OloEngine/src/OloEngine/Asset/AssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager.cpp
@@ -8,12 +8,75 @@
 #include "OloEngine/Asset/AssetImporter.h"
 #include "OloEngine/Asset/AssetTypes.h"
 #include "OloEngine/Asset/PlaceholderAsset.h"
+#include "OloEngine/Threading/Mutex.h"
+#include "OloEngine/Threading/UniqueLock.h"
+
+#include <unordered_set>
 
 namespace OloEngine
 {
     Ref<Asset> AssetManager::GetPlaceholderAsset(AssetType type)
     {
         return PlaceholderAssetManager::GetPlaceholderAsset(type);
+    }
+
+    Ref<Asset> AssetManager::UnwrapPlaceholder(const Ref<Asset>& asset)
+    {
+        if (!asset)
+            return nullptr;
+
+        // Placeholders wrap a concrete renderable; hand back that inner asset so the
+        // typed GetAsset<T>() can cast it to the requested type.
+        if (auto texture = asset.As<PlaceholderTexture>())
+            return texture->GetTexture();
+        if (auto material = asset.As<PlaceholderMaterial>())
+            return material->GetMaterial();
+        if (auto mesh = asset.As<PlaceholderMesh>())
+            return mesh->GetMesh();
+
+        // GenericPlaceholder / PlaceholderAudio / non-placeholder assets have no
+        // castable inner renderable.
+        return nullptr;
+    }
+
+    Ref<Asset> AssetManager::ResolveAssetOrPlaceholder(AssetHandle assetHandle, const Ref<Asset>& resolved, AssetType type)
+    {
+        if (resolved)
+        {
+            // A manager already substituted a placeholder on load (missing file /
+            // corrupt payload). Unwrap it to its visible inner asset; generic
+            // placeholders have none, so the caller gets null without a cast warning
+            // (the substituting manager already warned once).
+            if (PlaceholderAssetManager::IsPlaceholderAsset(resolved))
+                return UnwrapPlaceholder(resolved);
+
+            // A genuine asset whose type doesn't match the request — a real bug at the
+            // call site, so keep surfacing it.
+            OLO_CORE_WARN("AssetManager::GetAsset - Failed to cast asset {} from type {} to requested type {}",
+                          assetHandle, AssetUtils::AssetTypeToString(resolved->GetAssetType()), AssetUtils::AssetTypeToString(type));
+            return nullptr;
+        }
+
+        // resolved == null with a non-zero handle (the template already short-circuits
+        // handle 0): a dangling/unresolvable reference. Warn once per handle so a broken
+        // reference touched every frame doesn't flood the log, then substitute.
+        {
+            static FMutex s_WarnedMutex;
+            static std::unordered_set<AssetHandle> s_WarnedHandles;
+            TUniqueLock<FMutex> lock(s_WarnedMutex);
+            if (s_WarnedHandles.insert(assetHandle).second)
+            {
+                OLO_CORE_WARN("AssetManager::GetAsset - Asset {} ({}) is missing/unresolvable; "
+                              "substituting a placeholder. Check the scene/asset references.",
+                              assetHandle, AssetUtils::AssetTypeToString(type));
+            }
+        }
+
+        Ref<Asset> placeholder = PlaceholderAssetManager::GetPlaceholderAsset(type);
+        Ref<Asset> inner = UnwrapPlaceholder(placeholder);
+        // Renderable types unwrap to a visible stand-in; generic types have none, so
+        // return the wrapper itself (non-null, won't cast to T but never crashes).
+        return inner ? inner : placeholder;
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/AssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager.h
@@ -202,7 +202,12 @@ namespace OloEngine
             // dangling non-zero reference. ResolveAssetOrPlaceholder() unwraps a
             // placeholder to a visible stand-in, substitutes one for a dangling handle
             // (warning once), or surfaces a genuine wrong-type cast warning.
-            return ResolveAssetOrPlaceholder(assetHandle, asset, T::GetStaticType()).As<T>();
+            //
+            // Bind to a concrete Ref<Asset> first: a T::GetStaticType() argument makes the
+            // call expression type-dependent, so calling .As<T>() directly on it would need
+            // the `template` keyword under Clang (MSVC is lenient). The local sidesteps that.
+            Ref<Asset> resolved = ResolveAssetOrPlaceholder(assetHandle, asset, T::GetStaticType());
+            return resolved.As<T>();
         }
 
         /**

--- a/OloEngine/src/OloEngine/Asset/AssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager.h
@@ -169,7 +169,16 @@ namespace OloEngine
          * @brief Get an asset synchronously with type safety
          * @tparam T Asset type to retrieve
          * @param assetHandle Handle of the asset
-         * @return Typed reference to the asset, or nullptr if not found/invalid
+         * @return Typed reference to the asset; a visible placeholder for a
+         *         dangling/unresolvable reference; nullptr for an empty (0) handle
+         *
+         * Robustness contract (issue #455): a broken/moved/deleted reference must not
+         * fail silently with null (which downstream code dereferences and crashes).
+         * - A zero handle is a legitimate unset slot and stays null.
+         * - A non-zero handle that resolves to nothing, or to a placeholder a manager
+         *   substituted on load (missing file / corrupt payload), yields the matching
+         *   PlaceholderAsset unwrapped to T (e.g. a magenta texture / cube mesh) and a
+         *   one-time warning, so the frame shows a stand-in instead of null/crash.
          */
         template<typename T>
         static Ref<T> GetAsset(AssetHandle assetHandle)
@@ -178,16 +187,22 @@ namespace OloEngine
                           "GetAsset only works for types derived from Asset");
 
             Ref<Asset> asset = GetActiveManager()->GetAsset(assetHandle);
-            if (!asset)
-                return nullptr;
-
-            Ref<T> castedAsset = asset.As<T>();
-            if (!castedAsset)
+            if (asset)
             {
-                OLO_CORE_WARN("AssetManager::GetAsset - Failed to cast asset {} from type {} to requested type {}",
-                              assetHandle, AssetUtils::AssetTypeToString(asset->GetAssetType()), typeid(T).name());
+                if (Ref<T> castedAsset = asset.As<T>())
+                    return castedAsset;
             }
-            return castedAsset;
+            else if (assetHandle == 0)
+            {
+                // A zero handle is a legitimate unset slot, not a dangling reference.
+                return nullptr;
+            }
+
+            // Either the handle resolved to a placeholder / wrong-type asset, or it is a
+            // dangling non-zero reference. ResolveAssetOrPlaceholder() unwraps a
+            // placeholder to a visible stand-in, substitutes one for a dangling handle
+            // (warning once), or surfaces a genuine wrong-type cast warning.
+            return ResolveAssetOrPlaceholder(assetHandle, asset, T::GetStaticType()).As<T>();
         }
 
         /**
@@ -328,6 +343,37 @@ namespace OloEngine
             OLO_CORE_ASSERT(manager, "Asset manager not initialized");
             return manager;
         }
+
+        /**
+         * @brief Return the inner usable asset wrapped by a PlaceholderAsset
+         * @param asset Candidate asset (may be a placeholder wrapper or anything else)
+         * @return The wrapped Texture2D/MaterialAsset/Mesh as Ref<Asset>, or nullptr
+         *
+         * Placeholders wrap a real renderable (PlaceholderTexture -> Texture2D, ...);
+         * this unwraps that inner asset so GetAsset<T>() can hand back a usable T.
+         * Returns nullptr for non-placeholders and for placeholders with no inner
+         * asset (generic / audio). Defined in the .cpp to keep the heavy
+         * placeholder/renderer includes out of this widely-included header.
+         */
+        static Ref<Asset> UnwrapPlaceholder(const Ref<Asset>& asset);
+
+        /**
+         * @brief Resolve a non-direct-cast GetAsset<T>() outcome to a usable asset
+         * @param assetHandle The requested handle (used to warn once per dangling handle)
+         * @param resolved What the active manager returned (null, a placeholder, or a wrong-type asset)
+         * @param type The statically-requested asset type
+         * @return An asset to cast to T: an unwrapped placeholder, a freshly substituted
+         *         placeholder for a dangling handle, or nullptr
+         *
+         * Centralises the placeholder-fallback policy so the template stays thin and the
+         * heavy placeholder/renderer includes stay in the .cpp:
+         * - @p resolved is a placeholder a manager substituted on load -> unwrap to a
+         *   visible inner asset (nullptr for generic placeholders; no log spam).
+         * - @p resolved is a genuine wrong-type asset -> warn about the cast, return null.
+         * - @p resolved is null and @p assetHandle is non-zero -> dangling reference:
+         *   substitute the type-correct placeholder and warn once.
+         */
+        static Ref<Asset> ResolveAssetOrPlaceholder(AssetHandle assetHandle, const Ref<Asset>& resolved, AssetType type);
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Asset/AssetManager/AssetManagerBase.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/AssetManagerBase.h
@@ -12,12 +12,47 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <functional>
+#include <vector>
 
 namespace OloEngine
 {
     // Forward declarations
     template<typename T>
     struct AsyncAssetResult;
+
+    /**
+     * @brief One unresolvable asset reference discovered by a validation sweep
+     *
+     * A reference is "dangling" when the referenced handle has no resolvable
+     * backing (file missing / not present in any loaded pack / handle unknown).
+     */
+    struct DanglingAssetReference
+    {
+        AssetHandle Referencer = 0;                ///< Asset holding the reference (0 when checked from an explicit handle set)
+        AssetHandle Reference = 0;                 ///< The unresolvable handle being referenced
+        AssetType ReferenceType = AssetType::None; ///< Best-effort type of the reference (None if no longer known)
+    };
+
+    /**
+     * @brief Result of an asset-reference validation sweep
+     *
+     * Produced by AssetManagerBase::ValidateReferences(). Lists every dangling
+     * reference found and how many references were checked.
+     */
+    struct AssetReferenceValidationReport
+    {
+        std::vector<DanglingAssetReference> DanglingReferences;
+        u32 CheckedReferenceCount = 0;
+
+        [[nodiscard]] bool IsValid() const noexcept
+        {
+            return DanglingReferences.empty();
+        }
+        [[nodiscard]] sizet DanglingCount() const noexcept
+        {
+            return DanglingReferences.size();
+        }
+    };
     /**
      * @brief Abstract base class for asset management implementations
      *
@@ -195,6 +230,68 @@ namespace OloEngine
          * @return Set of handles that this asset depends on
          */
         virtual std::unordered_set<AssetHandle> GetDependencies(AssetHandle handle) const = 0;
+
+        /**
+         * @brief Get a snapshot of every registered dependency edge
+         * @return Copy of the dependency registry: referencer handle -> the handles it references
+         *
+         * Used by ValidateReferences() to sweep the whole dependency graph. The base
+         * returns an empty map; file-/pack-backed managers override it with their
+         * tracked dependencies. Returns a copy so callers can iterate lock-free.
+         */
+        virtual std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> GetAllDependencies() const
+        {
+            return {};
+        }
+
+        /**
+         * @brief Validate every registered asset reference and report the dangling ones
+         * @return Report listing each unresolvable reference and how many were checked
+         *
+         * Walks the dependency registry (GetAllDependencies()) and flags any referenced
+         * handle whose backing is gone (IsAssetMissing()). This is the runtime
+         * asset-reference validation sweep: a broken/moved/deleted reference surfaces
+         * here as a dangling entry instead of failing silently at load time.
+         */
+        [[nodiscard]] AssetReferenceValidationReport ValidateReferences() const
+        {
+            AssetReferenceValidationReport report;
+            const auto dependencies = GetAllDependencies();
+            for (const auto& [referencer, references] : dependencies)
+            {
+                for (AssetHandle reference : references)
+                {
+                    if (reference == 0)
+                        continue;
+                    ++report.CheckedReferenceCount;
+                    if (IsAssetMissing(reference))
+                        report.DanglingReferences.push_back({ referencer, reference, GetAssetType(reference) });
+                }
+            }
+            return report;
+        }
+
+        /**
+         * @brief Validate an explicit set of referenced handles
+         * @param handles Handles to check (e.g. every asset a freshly loaded scene refers to)
+         * @return Report listing the unresolvable handles among @p handles
+         *
+         * Complements the registry sweep for callers that know which handles a given
+         * artifact references but haven't registered them as dependencies.
+         */
+        [[nodiscard]] AssetReferenceValidationReport ValidateReferences(const std::unordered_set<AssetHandle>& handles) const
+        {
+            AssetReferenceValidationReport report;
+            for (AssetHandle reference : handles)
+            {
+                if (reference == 0)
+                    continue;
+                ++report.CheckedReferenceCount;
+                if (IsAssetMissing(reference))
+                    report.DanglingReferences.push_back({ 0, reference, GetAssetType(reference) });
+            }
+            return report;
+        }
 
         /**
          * @brief Synchronize with the asset loading thread

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -662,6 +662,12 @@ namespace OloEngine
         return (it != m_AssetDependencies.end()) ? it->second : std::unordered_set<AssetHandle>{};
     }
 
+    std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> EditorAssetManager::GetAllDependencies() const
+    {
+        TSharedLock<FSharedMutex> lock(m_DependenciesMutex);
+        return m_AssetDependencies; // copy under lock for lock-free iteration by the caller
+    }
+
     std::unordered_set<AssetHandle> EditorAssetManager::GetAllAssetsWithType(AssetType type) const
     {
         std::unordered_set<AssetHandle> result;

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -83,6 +83,7 @@ namespace OloEngine
         void DeregisterDependency(AssetHandle handle, AssetHandle dependency) override;
         void DeregisterDependencies(AssetHandle handle) override;
         std::unordered_set<AssetHandle> GetDependencies(AssetHandle handle) const override;
+        std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> GetAllDependencies() const override;
 
         void SyncWithAssetThread() noexcept override;
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Asset/AssetImporter.h"
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Asset/AssetPack.h"
+#include "OloEngine/Asset/PlaceholderAsset.h"
 #include "OloEngine/Containers/Array.h"
 #include "OloEngine/Core/Events/EditorEvents.h"
 #include "OloEngine/Scene/Scene.h"
@@ -27,6 +28,10 @@ namespace OloEngine
 #endif
 
         AssetImporter::Init();
+        // Shipping builds need the same placeholder set as the editor so a
+        // broken/moved/deleted reference resolves to a visible stand-in instead of
+        // null (issue #455). Reference-counted, so overlapping manager lifetimes are safe.
+        PlaceholderAssetManager::Initialize();
         OLO_CORE_INFO("RuntimeAssetManager initialized");
 
         if (!autoLoadDefaultPack)
@@ -78,9 +83,14 @@ namespace OloEngine
         m_LoadedPacks.clear();
         m_AssetMetadata.clear();
         m_AssetDependencies.clear();
+        m_WarnedUnresolvableHandles.clear();
 
         // Shutdown AssetImporter to release serializer resources
         AssetImporter::Shutdown();
+
+        // Release this manager's reference to the shared placeholder set (ref-counted;
+        // the last live manager tears it down).
+        PlaceholderAssetManager::Shutdown();
     }
 
     AssetType RuntimeAssetManager::GetAssetType(AssetHandle assetHandle) const noexcept
@@ -155,21 +165,43 @@ namespace OloEngine
             lock.Unlock();
             Ref<Asset> asset = LoadAssetFromPack(assetHandle);
 
+            // Re-acquire the lock to publish either the loaded asset or a placeholder fallback.
+            lock.Lock();
+
+            // Final check: another thread may have loaded (or substituted) it meanwhile.
+            if (auto finalIt = m_LoadedAssets.find(assetHandle); finalIt != m_LoadedAssets.end())
+                return finalIt->second;
+
             if (asset)
             {
-                // Re-acquire lock to insert the loaded asset
-                lock.Lock();
-
-                // Final check: ensure no other thread loaded it while we were loading
-                if (auto finalIt = m_LoadedAssets.find(assetHandle); finalIt != m_LoadedAssets.end())
-                {
-                    // Another thread loaded it, return that instance
-                    return finalIt->second;
-                }
-
                 // Safe to insert our loaded asset
                 m_LoadedAssets[assetHandle] = asset;
                 return asset;
+            }
+
+            // Load failed. If the handle is valid-but-unresolvable (the pack indexes it,
+            // so its type is known, but its payload could not be deserialized), substitute
+            // the matching placeholder + warn once so a corrupt/partial asset shows a
+            // visible stand-in instead of null (issue #455) and is not re-deserialized every
+            // call. A handle with no pack metadata is a truly-dangling reference whose type
+            // we cannot know here; leave it null and let the typed AssetManager::GetAsset<T>()
+            // facade substitute a placeholder by the requested type T.
+            // AssetExistsInPacks()/GetAssetTypeFromPacks() take m_PacksMutex (shared); the
+            // m_AssetsMutex -> m_PacksMutex order matches Shutdown()/UnloadAssetPack().
+            if (AssetExistsInPacks(assetHandle))
+            {
+                const AssetType type = GetAssetTypeFromPacks(assetHandle);
+                if (Ref<Asset> placeholder = PlaceholderAssetManager::GetPlaceholderAsset(type))
+                {
+                    m_LoadedAssets[assetHandle] = placeholder;
+                    if (m_WarnedUnresolvableHandles.insert(assetHandle).second)
+                    {
+                        OLO_CORE_WARN("RuntimeAssetManager::GetAsset - Asset {} ({}) is indexed but could not be "
+                                      "loaded from any pack; substituting a placeholder.",
+                                      assetHandle, AssetUtils::AssetTypeToString(type));
+                    }
+                    return placeholder;
+                }
             }
         }
 
@@ -358,6 +390,12 @@ namespace OloEngine
         TSharedLock<FSharedMutex> lock(m_DependenciesMutex);
         auto it = m_AssetDependencies.find(handle);
         return (it != m_AssetDependencies.end()) ? it->second : std::unordered_set<AssetHandle>{};
+    }
+
+    std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> RuntimeAssetManager::GetAllDependencies() const
+    {
+        TSharedLock<FSharedMutex> lock(m_DependenciesMutex);
+        return m_AssetDependencies; // copy under lock for lock-free iteration by the caller
     }
 
     void RuntimeAssetManager::SyncWithAssetThread() noexcept

--- a/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/RuntimeAssetManager.h
@@ -74,6 +74,7 @@ namespace OloEngine
         void DeregisterDependency(AssetHandle handle, AssetHandle dependency) override;
         void DeregisterDependencies(AssetHandle handle) override;
         std::unordered_set<AssetHandle> GetDependencies(AssetHandle handle) const override;
+        std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> GetAllDependencies() const override;
 
         void SyncWithAssetThread() noexcept override;
 
@@ -159,6 +160,11 @@ namespace OloEngine
 
         // Simplified dependency tracking for runtime
         std::unordered_map<AssetHandle, std::unordered_set<AssetHandle>> m_AssetDependencies;
+
+        // Handles for which a valid-but-unresolvable warning has already been logged,
+        // so a corrupt asset substituted with a placeholder warns once, not per call.
+        // Guarded by m_AssetsMutex (only touched while it is held exclusively).
+        std::unordered_set<AssetHandle> m_WarnedUnresolvableHandles;
 
         // Async asset loading system
         Ref<RuntimeAssetSystem> m_AssetThread;

--- a/OloEngine/src/OloEngine/Renderer/EnvironmentMap.h
+++ b/OloEngine/src/OloEngine/Renderer/EnvironmentMap.h
@@ -136,7 +136,9 @@ namespace OloEngine
 
         Ref<TextureCubemap> ConvertEquirectangularToCubemap(const std::string& filePath);
 
-        // Asset interface
+      public:
+        // Asset interface — must be public so AssetManager::GetAsset<EnvironmentMap>() /
+        // GetAllAssetsWithType<T>() can read the static type tag.
         static AssetType GetStaticType()
         {
             return AssetType::EnvMap;

--- a/OloEngine/src/OloEngine/Renderer/Model.h
+++ b/OloEngine/src/OloEngine/Renderer/Model.h
@@ -130,7 +130,9 @@ namespace OloEngine
             return nullMaterial;
         }
 
-        // Asset interface
+      public:
+        // Asset interface — must be public so AssetManager::GetAsset<Model>() /
+        // GetAllAssetsWithType<T>() can read the static type tag.
         constexpr static AssetType GetStaticType()
         {
             return AssetType::Model;

--- a/OloEngine/tests/RuntimeAssetManagerTest.cpp
+++ b/OloEngine/tests/RuntimeAssetManagerTest.cpp
@@ -4,11 +4,13 @@
 #include "OloEngine/Asset/AssetManager/RuntimeAssetManager.h"
 #include "OloEngine/Asset/AssetMetadata.h"
 #include "OloEngine/Asset/AssetTypes.h"
+#include "OloEngine/Asset/PlaceholderAsset.h"
 #include "OloEngine/Serialization/AssetPackFile.h"
 #include "OloEngine/Serialization/FileStream.h"
 
 #include <filesystem>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -209,4 +211,107 @@ TEST_F(RuntimeAssetManagerTest, MetadataSurvivesUntilExplicitUnload)
 
     EXPECT_TRUE(manager.IsAssetHandleValid(handle));
     EXPECT_EQ(manager.GetAssetType(handle), AssetType::Texture2D);
+}
+
+// ============================================================================
+// Asset-reference validation + placeholder fallback (issue #455)
+//
+// These use AssetType::Terrain, which has no registered asset-pack serializer:
+// the pack indexes the handle (so it is "valid"), but LoadAssetFromPack fails to
+// deserialize it cleanly (returns null), and the matching placeholder is a
+// GenericPlaceholder that needs no GL context. That makes the valid-but-
+// unresolvable path exercisable headless without a GPU.
+// ============================================================================
+
+TEST_F(RuntimeAssetManagerTest, ValidButUnresolvableHandleReturnsPlaceholderNotNull)
+{
+    const AssetHandle handle = 303;
+    WritePack({ { handle, AssetType::Terrain } });
+
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    ASSERT_TRUE(manager.LoadAssetPack(m_TempPath));
+
+    // The handle is indexed (so AssetExistsInPacks is true) but its payload can't be
+    // deserialized. Before #455 this returned null; now it returns a placeholder.
+    Ref<Asset> asset = manager.GetAsset(handle);
+    ASSERT_TRUE(asset);
+    EXPECT_TRUE(PlaceholderAssetManager::IsPlaceholderAsset(asset));
+
+    // The substituted placeholder is cached, so a second call returns the same one
+    // (no repeated deserialize attempt, no log spam).
+    EXPECT_EQ(manager.GetAsset(handle).Raw(), asset.Raw());
+}
+
+TEST_F(RuntimeAssetManagerTest, ZeroHandleReturnsNullNotPlaceholder)
+{
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    // A zero handle is a legitimate empty reference, never a placeholder.
+    EXPECT_FALSE(manager.GetAsset(0));
+}
+
+TEST_F(RuntimeAssetManagerTest, AbsentHandleReturnsNullForFacadeToSubstitute)
+{
+    const AssetHandle known = 11;
+    WritePack({ { known, AssetType::Terrain } });
+
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    ASSERT_TRUE(manager.LoadAssetPack(m_TempPath));
+
+    // A handle with no pack metadata has unknown type here, so the manager leaves it
+    // null; the typed AssetManager::GetAsset<T>() facade substitutes by T.
+    EXPECT_FALSE(manager.GetAsset(404));
+}
+
+TEST_F(RuntimeAssetManagerTest, ValidateReferencesReportsDanglingDependency)
+{
+    const AssetHandle a = 1;
+    const AssetHandle b = 2;
+    const AssetHandle missing = 999;
+    WritePack({ { a, AssetType::Terrain }, { b, AssetType::Terrain } });
+
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    ASSERT_TRUE(manager.LoadAssetPack(m_TempPath));
+
+    manager.RegisterDependency(a, b);       // a -> b (resolvable)
+    manager.RegisterDependency(a, missing); // a -> missing (dangling)
+
+    const AssetReferenceValidationReport report = manager.ValidateReferences();
+    EXPECT_FALSE(report.IsValid());
+    EXPECT_EQ(report.CheckedReferenceCount, 2u);
+    ASSERT_EQ(report.DanglingCount(), 1u);
+    EXPECT_EQ(report.DanglingReferences[0].Reference, missing);
+    EXPECT_EQ(report.DanglingReferences[0].Referencer, a);
+}
+
+TEST_F(RuntimeAssetManagerTest, ValidateReferencesCleanWhenAllResolvable)
+{
+    const AssetHandle a = 1;
+    const AssetHandle b = 2;
+    WritePack({ { a, AssetType::Terrain }, { b, AssetType::Terrain } });
+
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    ASSERT_TRUE(manager.LoadAssetPack(m_TempPath));
+
+    manager.RegisterDependency(a, b);
+
+    const AssetReferenceValidationReport report = manager.ValidateReferences();
+    EXPECT_TRUE(report.IsValid());
+    EXPECT_EQ(report.DanglingCount(), 0u);
+    EXPECT_EQ(report.CheckedReferenceCount, 1u);
+}
+
+TEST_F(RuntimeAssetManagerTest, ValidateExplicitHandleSetReportsMissingAndSkipsZero)
+{
+    const AssetHandle present = 1;
+    WritePack({ { present, AssetType::Terrain } });
+
+    RuntimeAssetManager manager(/*autoLoadDefaultPack=*/false);
+    ASSERT_TRUE(manager.LoadAssetPack(m_TempPath));
+
+    const std::unordered_set<AssetHandle> refs = { present, AssetHandle(777), AssetHandle(0) };
+    const AssetReferenceValidationReport report = manager.ValidateReferences(refs);
+
+    EXPECT_EQ(report.CheckedReferenceCount, 2u); // the zero handle is skipped
+    ASSERT_EQ(report.DanglingCount(), 1u);
+    EXPECT_EQ(report.DanglingReferences[0].Reference, AssetHandle(777));
 }


### PR DESCRIPTION
…455)

A broken/moved/deleted asset reference previously failed silently (null asset) or crashed. Now a dangling reference resolves to a visible placeholder + a one-time warning, and a validation sweep reports dangling references.

- AssetManager::GetAsset<T>() (typed facade): a non-zero handle that resolves to nothing, or to a placeholder a manager substituted on load, yields the matching PlaceholderAsset unwrapped to T (magenta texture / cube mesh) + warn-once. Zero handle stays null. This also makes the editor's pre-existing missing-file placeholder usable - the As<T>() cast on the wrapper returned null before.
- RuntimeAssetManager: valid-but-unresolvable handle (indexed but payload won't deserialize) -> cached placeholder + warn-once; now initializes/shuts down PlaceholderAssetManager (it never did, so shipped builds had no placeholders).
- AssetManagerBase::ValidateReferences(): sweeps the dependency registry (plus an explicit-handle-set overload) and reports dangling references via IsAssetMissing.
- OloEditor: "Validate Asset References" item in the Build menu logs the report.
- EnvironmentMap/Model: GetStaticType()/GetAssetType() moved private->public (the facade now needs T::GetStaticType(); both were latently private).
- Tests: 6 headless cases in RuntimeAssetManagerTest.cpp.

Layered at the Asset/ AssetManager layer (not SceneSerializer.cpp) to stay disjoint from the parallel codegen-serializer work (#451).