### PR TITLE
feat(mcp): generic undoable olo_entity_set_field + olo_entity_list_fi…

### DIFF
--- a/OloEditor/src/MCP/McpGenericFieldWrite.h
+++ b/OloEditor/src/MCP/McpGenericFieldWrite.h
@@ -1,0 +1,647 @@
+#pragma once
+
+// Shared, editor-side core behind the GENERIC consented, undoable MCP write tool
+// `olo_entity_set_field` (issue #306 item C, second slice) and its read companion
+// `olo_entity_list_fields`. The first write slice (`olo_set_collision_layer`,
+// McpSetCollisionLayer.h) shipped one tool per field; this is the catch-all that
+// mutates ANY registered component field through one tool, so an agent can apply
+// a fix to a transform, a light, a sprite, a camera, ... without a bespoke tool
+// for each.
+//
+// Like McpSetCollisionLayer.h, the write is applied through the editor's
+// `CommandHistory` undo stack (a UUID-keyed `ComponentChangeCommand<T>`,
+// relocation-safe) so an agent's edit is a single Ctrl-Z, and the whole core is
+// split into this header — renderer/httplib/McpServer-free (engine Scene/ECS
+// types + the header-only UndoRedo + nlohmann::json + the schema-builder DSL) — so
+// the MCP test binary (which deliberately does NOT link McpTools.cpp) exercises
+// the real schema + parse + coerce + apply code, not a re-implementation.
+//
+// Why a hand-built field registry (and not OloHeaderTool codegen)
+//   C++ has no runtime reflection, and `OLO_PROPERTY` is a pure compile-time
+//   marker consumed by OloHeaderTool to emit *static* C#/Lua glue — there is no
+//   runtime (component-name, field-name) -> typed-setter table to borrow. So the
+//   registry below is type-safe codegen-free reflection: each entry pairs a script
+//   facing name with a real pointer-to-member, and a templated closure does the
+//   JSON->field coercion, the no-op detection, and the undoable command build. The
+//   field NAMES match the m_-stripped keys an agent already sees in
+//   `olo_scene_get_entity`'s YAML (and the OLO_PROPERTY convention), so the write
+//   contract lines up with the read contract.
+//
+//   Adding a field is one `MakeField<Component>(...)` line in BuildRegistry(); a
+//   future slice could repopulate the same registry from an OloHeaderTool-generated
+//   list once codegen for it exists. Until then this is a curated set, not every
+//   field — by design, not omission (an agent discovers exactly what's writable via
+//   `olo_entity_list_fields`).
+
+#include "MCP/McpSchemaBuilder.h"
+#include "UndoRedo/ComponentCommands.h"
+#include "UndoRedo/EditorCommand.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/UUID.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Scene.h"
+
+#include <glm/glm.hpp>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace OloEngine::MCP::GenericFieldWrite
+{
+    using Json = nlohmann::json;
+
+    // ---- type-name reporting -------------------------------------------------
+
+    // The agent-facing type token for a field type, used in discovery output and
+    // coercion error messages. Drives nothing in C++ — coercion dispatches on the
+    // type itself via `if constexpr`, not on this string.
+    template<typename F>
+    [[nodiscard]] constexpr std::string_view FieldTypeName()
+    {
+        if constexpr (std::is_same_v<F, bool>)
+            return "bool";
+        else if constexpr (std::is_same_v<F, std::string>)
+            return "string";
+        else if constexpr (std::is_same_v<F, UUID>) // == AssetHandle
+            return "handle";
+        else if constexpr (std::is_same_v<F, glm::vec2>)
+            return "vec2";
+        else if constexpr (std::is_same_v<F, glm::vec3>)
+            return "vec3";
+        else if constexpr (std::is_same_v<F, glm::vec4>)
+            return "vec4";
+        else if constexpr (std::is_enum_v<F>)
+            return "int"; // enums travel as their integer value
+        else if constexpr (std::is_integral_v<F>)
+            return "int";
+        else if constexpr (std::is_floating_point_v<F>)
+            return "float";
+        else
+        {
+            static_assert(sizeof(F) == 0, "FieldTypeName: unsupported field type");
+            return "";
+        }
+    }
+
+    // ---- JSON -> field coercion ----------------------------------------------
+
+    // Read exactly N finite JSON numbers into a glm vector. Validates length and
+    // finiteness (the project rule: every float from JSON/network is isfinite-checked).
+    template<int N, typename V>
+    [[nodiscard]] inline std::optional<std::string> CoerceVec(const Json& v, V& out)
+    {
+        if (!v.is_array())
+            return "expected an array of " + std::to_string(N) + " numbers";
+        if (v.size() != static_cast<std::size_t>(N))
+            return "expected " + std::to_string(N) + " elements, got " + std::to_string(v.size());
+        for (int i = 0; i < N; ++i)
+        {
+            const Json& element = v[static_cast<std::size_t>(i)];
+            if (!element.is_number())
+                return "element " + std::to_string(i) + " is not a number";
+            const double d = element.get<double>();
+            if (!std::isfinite(d))
+                return "element " + std::to_string(i) + " is not finite";
+            out[static_cast<glm::length_t>(i)] = static_cast<float>(d);
+        }
+        return std::nullopt;
+    }
+
+    // Coerce a JSON value into the field's declared type. Returns a human-readable
+    // reason on mismatch, or std::nullopt + the coerced value on success. Strict:
+    // a boolean must be a JSON boolean, an integer a JSON integer (not 3.0), and a
+    // UUID/AssetHandle a decimal-digit string (a u64 exceeds JSON's safe-integer
+    // range, so it travels as a string — same contract as the entity UUID).
+    template<typename F>
+    [[nodiscard]] inline std::optional<std::string> CoerceJson(const Json& v, F& out)
+    {
+        if constexpr (std::is_same_v<F, bool>)
+        {
+            if (!v.is_boolean())
+                return "expected a boolean";
+            out = v.get<bool>();
+            return std::nullopt;
+        }
+        else if constexpr (std::is_same_v<F, std::string>)
+        {
+            if (!v.is_string())
+                return "expected a string";
+            out = v.get<std::string>();
+            return std::nullopt;
+        }
+        else if constexpr (std::is_same_v<F, UUID>) // == AssetHandle
+        {
+            if (!v.is_string())
+                return "expected a decimal-digit string (u64 handle)";
+            const std::string s = v.get<std::string>();
+            if (s.empty() || !std::all_of(s.begin(), s.end(), [](unsigned char c)
+                                          { return c >= '0' && c <= '9'; }))
+                return "expected a decimal-digit string (u64 handle)";
+            try
+            {
+                out = UUID(std::stoull(s));
+            }
+            catch (...) // std::out_of_range — exceeds u64
+            {
+                return "handle value is out of range";
+            }
+            return std::nullopt;
+        }
+        else if constexpr (std::is_same_v<F, glm::vec2>)
+            return CoerceVec<2>(v, out);
+        else if constexpr (std::is_same_v<F, glm::vec3>)
+            return CoerceVec<3>(v, out);
+        else if constexpr (std::is_same_v<F, glm::vec4>)
+            return CoerceVec<4>(v, out);
+        else if constexpr (std::is_enum_v<F>)
+        {
+            using U = std::underlying_type_t<F>;
+            if (!v.is_number_integer())
+                return "expected an integer (enum value)";
+            const std::int64_t n = v.get<std::int64_t>();
+            if (n < static_cast<std::int64_t>(std::numeric_limits<U>::min()) ||
+                n > static_cast<std::int64_t>(std::numeric_limits<U>::max()))
+                return "enum value is out of range";
+            out = static_cast<F>(static_cast<U>(n));
+            return std::nullopt;
+        }
+        else if constexpr (std::is_integral_v<F>)
+        {
+            // sizeof<=4 keeps numeric_limits<F> within int64 for the bound check;
+            // 64-bit integral fields would be UUID/AssetHandle, handled above.
+            static_assert(sizeof(F) <= 4, "CoerceJson: 64-bit integral fields go through the handle path");
+            if (!v.is_number_integer())
+                return "expected an integer";
+            const std::int64_t n = v.get<std::int64_t>();
+            if (n < static_cast<std::int64_t>(std::numeric_limits<F>::min()) ||
+                n > static_cast<std::int64_t>(std::numeric_limits<F>::max()))
+                return "value is out of range for the field";
+            out = static_cast<F>(n);
+            return std::nullopt;
+        }
+        else if constexpr (std::is_floating_point_v<F>)
+        {
+            if (!v.is_number())
+                return "expected a number";
+            const double d = v.get<double>();
+            if (!std::isfinite(d))
+                return "must be a finite number";
+            out = static_cast<F>(d);
+            return std::nullopt;
+        }
+        else
+        {
+            static_assert(sizeof(F) == 0, "CoerceJson: unsupported field type");
+            return "unsupported field type";
+        }
+    }
+
+    // The field's current value as JSON, the inverse of CoerceJson — used for the
+    // write result's previousValue/value and the read tool's reported value. A
+    // u64-wrapper (UUID/AssetHandle) is emitted as a decimal string to match its
+    // input contract and stay in JSON's safe-integer range.
+    template<typename F>
+    [[nodiscard]] inline Json FieldToJson(const F& v)
+    {
+        if constexpr (std::is_same_v<F, bool>)
+            return Json(v);
+        else if constexpr (std::is_same_v<F, std::string>)
+            return Json(v);
+        else if constexpr (std::is_same_v<F, UUID>) // == AssetHandle
+            return Json(std::to_string(static_cast<u64>(v)));
+        else if constexpr (std::is_same_v<F, glm::vec2>)
+            return Json::array({ v.x, v.y });
+        else if constexpr (std::is_same_v<F, glm::vec3>)
+            return Json::array({ v.x, v.y, v.z });
+        else if constexpr (std::is_same_v<F, glm::vec4>)
+            return Json::array({ v.x, v.y, v.z, v.w });
+        else if constexpr (std::is_enum_v<F>)
+            return Json(static_cast<std::int64_t>(v));
+        else if constexpr (std::is_integral_v<F>)
+            return Json(v);
+        else if constexpr (std::is_floating_point_v<F>)
+            return Json(v);
+        else
+        {
+            static_assert(sizeof(F) == 0, "FieldToJson: unsupported field type");
+            return Json();
+        }
+    }
+
+    // Whether the coerced new value differs from the current one — gates whether a
+    // command is pushed at all (a no-op write must not pollute the undo stack). For
+    // trivially-copyable field types (primitives, glm::vec*, UUID, enums) this is a
+    // byte compare — the exact change-detection the editor's own undo uses for
+    // trivially-copyable components (SceneHierarchyPanel::DrawComponent tier 1) — so
+    // it needs no float `==` (which the project lint/SonarQube flags). std::string
+    // is the one non-trivial type, compared with !=.
+    template<typename F>
+    [[nodiscard]] inline bool FieldChanged(const F& a, const F& b)
+    {
+        if constexpr (std::is_same_v<F, std::string>)
+            return a != b;
+        else
+        {
+            static_assert(std::is_trivially_copyable_v<F>, "FieldChanged: type must be trivially copyable or std::string");
+            return std::memcmp(&a, &b, sizeof(F)) != 0;
+        }
+    }
+
+    // ---- the field registry --------------------------------------------------
+
+    // Outcome of applying a field write. On success `Data` is the structured result
+    // payload; on failure `Error` is a tool-level error message.
+    struct ApplyResult
+    {
+        bool Ok = false;
+        std::string Error;
+        Json Data;
+    };
+
+    // One writable (component, field) pair, type-erased over the field type. The
+    // closures bake in the component type C and a pointer-to-member, so dispatch on
+    // a runtime string lands on real typed code with no per-type branching at the
+    // call site.
+    struct FieldEntry
+    {
+        std::string Component;
+        std::string Field;
+        std::string Type; // FieldTypeName<F>()
+
+        // Coerce `value`, no-op-detect, and (when changed) push a single undoable
+        // ComponentChangeCommand<C>. The entity is already resolved + known to exist.
+        std::function<ApplyResult(const Ref<Scene>&, CommandHistory&, Entity, u64, const Json&)> Apply;
+        // The field's current value as JSON, or nullopt when the entity lacks C.
+        std::function<std::optional<Json>(Entity)> Read;
+    };
+
+    // Build one registry entry from a component type + a script-facing field name +
+    // a pointer-to-member. The field type F is deduced, which selects the coercion /
+    // serialization / change-detection specializations above.
+    template<typename C, typename F>
+    [[nodiscard]] inline FieldEntry MakeField(std::string component, std::string field, F C::* member)
+    {
+        FieldEntry entry;
+        entry.Component = component;
+        entry.Field = field;
+        entry.Type = std::string(FieldTypeName<F>());
+
+        entry.Apply = [member, component, field](const Ref<Scene>& scene, CommandHistory& history,
+                                                 Entity entity, u64 uuid, const Json& value) -> ApplyResult
+        {
+            ApplyResult result;
+            if (!entity.HasComponent<C>())
+            {
+                result.Error = "Entity has no " + component + ".";
+                return result;
+            }
+
+            F coerced{};
+            if (const auto error = CoerceJson<F>(value, coerced))
+            {
+                result.Error = "Invalid 'value' for " + component + "." + field +
+                               " (expects " + std::string(FieldTypeName<F>()) + "): " + *error + ".";
+                return result;
+            }
+
+            const C& current = entity.GetComponent<C>();
+            const Json previousValue = FieldToJson<F>(current.*member);
+            const bool changed = FieldChanged<F>(current.*member, coerced);
+            if (changed)
+            {
+                C newData = current;
+                newData.*member = coerced;
+                history.Execute(std::make_unique<ComponentChangeCommand<C>>(
+                    scene, UUID(uuid), current, newData, "Set " + component + "." + field));
+            }
+
+            result.Ok = true;
+            result.Data = Json{
+                { "entity", std::to_string(uuid) },
+                { "component", component },
+                { "field", field },
+                { "type", std::string(FieldTypeName<F>()) },
+                { "previousValue", previousValue },
+                { "value", FieldToJson<F>(coerced) },
+                { "changed", changed },
+                // `undoable` reflects whether a command was actually pushed (a no-op
+                // change pushes nothing): a single Ctrl-Z reverts only when changed.
+                { "undoable", changed },
+            };
+            return result;
+        };
+
+        entry.Read = [member](Entity entity) -> std::optional<Json>
+        {
+            if (!entity.HasComponent<C>())
+                return std::nullopt;
+            return FieldToJson<F>(entity.GetComponent<C>().*member);
+        };
+
+        return entry;
+    }
+
+    // The curated set of writable fields. Field names are the m_-stripped keys an
+    // agent already sees in olo_scene_get_entity's YAML; the component name is the
+    // struct's name (also its serializer key), stringized from the type by the
+    // helper macro so the two can't drift. Extend by adding an OLO_GFW_FIELD line
+    // (and confirming the member exists in Components.h).
+    //
+    // OLO_GFW_FIELD(Comp, "FieldName", Member) registers Comp::Member under the
+    // component name "Comp" and the script-facing field name "FieldName". Scoped to
+    // this function and #undef'd at the end so it never leaks out of the header.
+#define OLO_GFW_FIELD(Comp, FieldName, Member) MakeField<Comp>(#Comp, FieldName, &Comp::Member)
+    [[nodiscard]] inline std::vector<FieldEntry> BuildRegistry()
+    {
+        std::vector<FieldEntry> registry;
+
+        // Transform (rotation is a derived euler/quat pair behind setters, not a
+        // plain member, so it is intentionally not here — translation + scale are).
+        registry.push_back(OLO_GFW_FIELD(TransformComponent, "Translation", Translation));
+        registry.push_back(OLO_GFW_FIELD(TransformComponent, "Scale", Scale));
+
+        // Identity / labels.
+        registry.push_back(OLO_GFW_FIELD(TagComponent, "Tag", Tag));
+
+        // 2D renderers.
+        registry.push_back(OLO_GFW_FIELD(SpriteRendererComponent, "Color", Color));
+        registry.push_back(OLO_GFW_FIELD(SpriteRendererComponent, "TilingFactor", TilingFactor));
+        registry.push_back(OLO_GFW_FIELD(CircleRendererComponent, "Color", Color));
+        registry.push_back(OLO_GFW_FIELD(CircleRendererComponent, "Thickness", Thickness));
+        registry.push_back(OLO_GFW_FIELD(CircleRendererComponent, "Fade", Fade));
+
+        // Camera flags (projection/FOV live behind SceneCamera setters).
+        registry.push_back(OLO_GFW_FIELD(CameraComponent, "Primary", Primary));
+        registry.push_back(OLO_GFW_FIELD(CameraComponent, "FixedAspectRatio", FixedAspectRatio));
+
+        // Lights — the highest-value iteration knobs for a rendering agent.
+        registry.push_back(OLO_GFW_FIELD(DirectionalLightComponent, "Color", m_Color));
+        registry.push_back(OLO_GFW_FIELD(DirectionalLightComponent, "Intensity", m_Intensity));
+        registry.push_back(OLO_GFW_FIELD(DirectionalLightComponent, "CastShadows", m_CastShadows));
+
+        registry.push_back(OLO_GFW_FIELD(PointLightComponent, "Color", m_Color));
+        registry.push_back(OLO_GFW_FIELD(PointLightComponent, "Intensity", m_Intensity));
+        registry.push_back(OLO_GFW_FIELD(PointLightComponent, "Range", m_Range));
+        registry.push_back(OLO_GFW_FIELD(PointLightComponent, "CastShadows", m_CastShadows));
+
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "Color", m_Color));
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "Intensity", m_Intensity));
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "Range", m_Range));
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "InnerCutoff", m_InnerCutoff));
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "OuterCutoff", m_OuterCutoff));
+        registry.push_back(OLO_GFW_FIELD(SpotLightComponent, "CastShadows", m_CastShadows));
+
+        registry.push_back(OLO_GFW_FIELD(SphereAreaLightComponent, "Color", m_Color));
+        registry.push_back(OLO_GFW_FIELD(SphereAreaLightComponent, "Intensity", m_Intensity));
+        registry.push_back(OLO_GFW_FIELD(SphereAreaLightComponent, "Radius", m_Radius));
+        registry.push_back(OLO_GFW_FIELD(SphereAreaLightComponent, "Range", m_Range));
+        registry.push_back(OLO_GFW_FIELD(SphereAreaLightComponent, "CastShadows", m_CastShadows));
+
+        return registry;
+    }
+#undef OLO_GFW_FIELD
+
+    // The process-wide registry, built once. `inline` => one shared instance across
+    // every TU that includes this header (McpTools.cpp + the test binary).
+    [[nodiscard]] inline const std::vector<FieldEntry>& Registry()
+    {
+        static const std::vector<FieldEntry> registry = BuildRegistry();
+        return registry;
+    }
+
+    // Look up the entry for (component, field), or nullptr. Pointers into the static
+    // registry are stable for the process lifetime.
+    [[nodiscard]] inline const FieldEntry* Find(std::string_view component, std::string_view field)
+    {
+        for (const FieldEntry& entry : Registry())
+        {
+            if (entry.Component == component && entry.Field == field)
+                return &entry;
+        }
+        return nullptr;
+    }
+
+    // The distinct editable component type names, in first-seen order.
+    [[nodiscard]] inline std::vector<std::string> EditableComponents()
+    {
+        std::vector<std::string> names;
+        for (const FieldEntry& entry : Registry())
+        {
+            if (std::find(names.begin(), names.end(), entry.Component) == names.end())
+                names.push_back(entry.Component);
+        }
+        return names;
+    }
+
+    // The editable field names for one component (empty if the component is unknown).
+    [[nodiscard]] inline std::vector<std::string> EditableFieldsFor(std::string_view component)
+    {
+        std::vector<std::string> fields;
+        for (const FieldEntry& entry : Registry())
+        {
+            if (entry.Component == component)
+                fields.push_back(entry.Field);
+        }
+        return fields;
+    }
+
+    // ---- schema + arg parsing (write tool) -----------------------------------
+
+    namespace Detail
+    {
+        [[nodiscard]] inline std::string Join(const std::vector<std::string>& items)
+        {
+            std::string out;
+            for (std::size_t i = 0; i < items.size(); ++i)
+            {
+                if (i != 0)
+                    out += ", ";
+                out += items[i];
+            }
+            return out;
+        }
+    } // namespace Detail
+
+    // A precise error for an unresolved (component, field): distinguishes an unknown
+    // component from a known component lacking that field, and lists the valid
+    // alternatives so an agent can self-correct without a round-trip.
+    [[nodiscard]] inline std::string DescribeUnknownField(const std::string& component, const std::string& field)
+    {
+        const std::vector<std::string> fields = EditableFieldsFor(component);
+        if (fields.empty())
+            return "Unknown or non-editable component '" + component +
+                   "'. Editable components: " + Detail::Join(EditableComponents()) + ".";
+        return "Component '" + component + "' has no editable field '" + field +
+               "'. Editable fields: " + Detail::Join(fields) + ".";
+    }
+
+    // The write tool's inputSchema. `value` is intentionally typed as a union of the
+    // shapes a field can take (boolean / number / string / array) so the server's
+    // pre-handler validation (#423) rejects an object/null up front, while the exact
+    // per-field type is enforced by CoerceJson in the handler.
+    [[nodiscard]] inline Json InputSchema()
+    {
+        return Schema::Object()
+            .Prop("entity", Schema::EntityId("UUID of the entity to modify (a decimal-digit string)."))
+            .Prop("component", Schema::String().Desc("Component type name, e.g. 'TransformComponent' or 'PointLightComponent'. Discover writable components/fields with olo_entity_list_fields."))
+            .Prop("field", Schema::String().Desc("Field name to set, e.g. 'Translation' or 'Intensity' — the m_-stripped name shown in olo_scene_get_entity's YAML."))
+            .Prop("value", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
+                               .Desc("New value, typed to match the field: a boolean, a number, a string, or an array of numbers for a vector (e.g. [x, y, z] for a vec3)."))
+            .Required({ "entity", "component", "field", "value" })
+            .NoAdditional();
+    }
+
+    // The read companion (olo_entity_list_fields) inputSchema.
+    [[nodiscard]] inline Json ListInputSchema()
+    {
+        return Schema::Object()
+            .Prop("entity", Schema::EntityId("UUID of the entity whose writable fields to list (a decimal-digit string)."))
+            .Prop("component", Schema::String().Desc("Optional: restrict the listing to one component type name."))
+            .Required({ "entity" })
+            .NoAdditional();
+    }
+
+    // Parse the write tool's arguments. The server validates against InputSchema()
+    // before the handler runs; this stays defensive (it is also reached from tests).
+    // `value` is left as raw Json (its type depends on the target field).
+    [[nodiscard]] inline std::optional<std::string> ParseArgs(const Json& args, u64& entityUuid,
+                                                              std::string& component, std::string& field, Json& value)
+    {
+        if (!args.contains("entity"))
+            return "Missing required argument 'entity' (entity UUID).";
+        const Json& entityValue = args["entity"];
+        if (!entityValue.is_string())
+            return "Invalid 'entity': expected a UUID as a decimal-digit string.";
+        const std::string entityStr = entityValue.get<std::string>();
+        if (entityStr.empty() ||
+            !std::all_of(entityStr.begin(), entityStr.end(), [](unsigned char c)
+                         { return c >= '0' && c <= '9'; }))
+            return "Invalid 'entity': expected a UUID as a decimal-digit string.";
+        try
+        {
+            entityUuid = std::stoull(entityStr);
+        }
+        catch (...) // std::out_of_range — value exceeds u64
+        {
+            return "Invalid 'entity': UUID value is out of range.";
+        }
+
+        if (!args.contains("component") || !args["component"].is_string())
+            return "Missing or invalid required argument 'component' (a component type name).";
+        component = args["component"].get<std::string>();
+        if (component.empty())
+            return "Invalid 'component': must be a non-empty component type name.";
+
+        if (!args.contains("field") || !args["field"].is_string())
+            return "Missing or invalid required argument 'field' (a field name).";
+        field = args["field"].get<std::string>();
+        if (field.empty())
+            return "Invalid 'field': must be a non-empty field name.";
+
+        if (!args.contains("value"))
+            return "Missing required argument 'value'.";
+        value = args["value"];
+        return std::nullopt;
+    }
+
+    // ---- apply / list --------------------------------------------------------
+
+    // Set one component field through `history` (a single undoable command). MUST run
+    // on the main (game) thread — it touches the EnTT registry and the editor command
+    // stack. Resolves the entry + entity centrally so the type-specific work in the
+    // entry's closure only handles the component it was built for.
+    [[nodiscard]] inline ApplyResult Apply(const Ref<Scene>& scene, CommandHistory& history, u64 entityUuid,
+                                           const std::string& component, const std::string& field, const Json& value)
+    {
+        ApplyResult result;
+        if (!scene)
+        {
+            result.Error = "No active scene.";
+            return result;
+        }
+
+        const FieldEntry* entry = Find(component, field);
+        if (entry == nullptr)
+        {
+            result.Error = DescribeUnknownField(component, field);
+            return result;
+        }
+
+        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+        if (!entityOpt)
+        {
+            result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+            return result;
+        }
+
+        return entry->Apply(scene, history, *entityOpt, entityUuid, value);
+    }
+
+    // List the writable fields of one entity, with their current values, restricted
+    // to `componentFilter` when non-empty. Only components the entity actually HAS
+    // (and that have registered fields) are reported, so the output is exactly what
+    // an agent can write right now. `*entityFound` reports whether the UUID resolved.
+    [[nodiscard]] inline Json ListFields(const Ref<Scene>& scene, u64 entityUuid,
+                                         const std::string& componentFilter, bool& entityFound)
+    {
+        entityFound = false;
+        Json out;
+        out["entity"] = std::to_string(entityUuid);
+
+        if (!scene)
+        {
+            out["found"] = false;
+            out["components"] = Json::array();
+            return out;
+        }
+        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+        if (!entityOpt)
+        {
+            out["found"] = false;
+            out["components"] = Json::array();
+            return out;
+        }
+        entityFound = true;
+        out["found"] = true;
+
+        Entity entity = *entityOpt;
+        Json components = Json::array();
+        // Walk the editable component names in order; for each (optionally matching
+        // the filter), collect the fields the entity currently exposes.
+        for (const std::string& componentName : EditableComponents())
+        {
+            if (!componentFilter.empty() && componentFilter != componentName)
+                continue;
+
+            Json fields = Json::array();
+            for (const FieldEntry& entry : Registry())
+            {
+                if (entry.Component != componentName)
+                    continue;
+                const std::optional<Json> current = entry.Read(entity);
+                if (!current) // entity lacks this component
+                    break;
+                fields.push_back(Json{ { "field", entry.Field },
+                                       { "type", entry.Type },
+                                       { "value", *current } });
+            }
+            if (!fields.empty())
+                components.push_back(Json{ { "component", componentName }, { "fields", std::move(fields) } });
+        }
+        out["components"] = std::move(components);
+        return out;
+    }
+} // namespace OloEngine::MCP::GenericFieldWrite

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -9,6 +9,7 @@
 #include "MCP/McpRenderExplain.h"
 #include "MCP/McpRenderGraphTopology.h"
 #include "MCP/McpRenderOverrides.h"
+#include "MCP/McpGenericFieldWrite.h"
 #include "MCP/McpSetCollisionLayer.h"
 #include "MCP/McpShaderReload.h"
 #include "MCP/McpEventStream.h"
@@ -3375,6 +3376,80 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_entity_set_field (main-marshaled; PROJECT WRITE) --------------
+        // The GENERIC consented, undoable write tool (#306 item C, second slice):
+        // set ANY registered component field by (component, field, value) through the
+        // editor's undo stack — the catch-all successor to olo_set_collision_layer's
+        // one-tool-per-field shape. Gated at dispatch by the "Allow writes" session
+        // toggle (ToolDef::ProjectWrite); the shared reflect+coerce+apply core lives
+        // in McpGenericFieldWrite.h so it is unit-tested at the dispatch seam without
+        // this TU. The command is built + executed inside the MarshalRead job, i.e.
+        // on the main thread, since it touches the EnTT registry and command stack.
+        ToolResult Handle_EntitySetField(McpServer& server, const Json& args)
+        {
+            if (!server.Context().GetActiveScene || !server.Context().GetCommandHistory)
+                return ToolResult::Error("Project writes are not available in this editor build.");
+
+            u64 entityUuid = 0;
+            std::string component;
+            std::string field;
+            Json value;
+            if (const auto error = GenericFieldWrite::ParseArgs(args, entityUuid, component, field, value))
+                return ToolResult::Error(*error);
+
+            const Json result = server.MarshalRead([&server, entityUuid, component, field, value]() -> Json
+                                                   {
+                const Ref<Scene> scene = server.Context().GetActiveScene
+                                             ? server.Context().GetActiveScene()
+                                             : nullptr;
+                CommandHistory* history = server.Context().GetCommandHistory
+                                              ? server.Context().GetCommandHistory()
+                                              : nullptr;
+                if (!scene)
+                    return Json{ { "__error", "No active scene." } };
+                if (!history)
+                    return Json{ { "__error", "No editor command history available." } };
+
+                const GenericFieldWrite::ApplyResult applied =
+                    GenericFieldWrite::Apply(scene, *history, entityUuid, component, field, value);
+                if (!applied.Ok)
+                    return Json{ { "__error", applied.Error } };
+                return applied.Data; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
+        // ---- olo_entity_list_fields (main-marshaled; read-only) ----------------
+        // The discovery half of olo_entity_set_field: for one entity, list the
+        // writable component fields (those the entity actually has) with their type
+        // and current value, so an agent learns the exact (component, field) names +
+        // value shapes before issuing a write. Read-only (not ProjectWrite).
+        ToolResult Handle_EntityListFields(McpServer& server, const Json& args)
+        {
+            if (!server.Context().GetActiveScene)
+                return ToolResult::Error("Scene reads are not available in this editor build.");
+
+            if (!args.contains("entity"))
+                return ToolResult::Error("Missing required argument 'entity' (entity UUID).");
+            u64 entityUuid = 0;
+            if (!ParseUuid(args["entity"], entityUuid))
+                return ToolResult::Error("Invalid 'entity': expected a UUID as a string or number.");
+            const std::string componentFilter =
+                (args.contains("component") && args["component"].is_string()) ? args["component"].get<std::string>() : std::string();
+
+            const Json result = server.MarshalRead([&server, entityUuid, componentFilter]() -> Json
+                                                   {
+                const Ref<Scene> scene = server.Context().GetActiveScene
+                                             ? server.Context().GetActiveScene()
+                                             : nullptr;
+                bool entityFound = false;
+                return GenericFieldWrite::ListFields(scene, entityUuid, componentFilter, entityFound); });
+
+            return ToolResult::Text(result.dump(2));
+        }
+
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
         // entity isn't on screen. Gathers the render-relevant facts off the live
@@ -4732,6 +4807,51 @@ namespace OloEngine::MCP
             tool.InputSchema = SetCollisionLayer::InputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_SetCollisionLayer;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_entity_list_fields";
+            tool.Toolset = "scene";
+            tool.Title = "List entity writable fields";
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "List the writable component fields of one entity, with each field's type and current value — "
+                "the read-only discovery half of olo_entity_set_field. Only components the entity actually has "
+                "(and that expose writable fields) are returned, so the result is exactly what you can write "
+                "right now. Pass an optional 'component' to restrict the listing. Field names match the keys "
+                "shown in olo_scene_get_entity's YAML.";
+            tool.InputSchema = GenericFieldWrite::ListInputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_EntityListFields;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_entity_set_field";
+            tool.Toolset = "scene";
+            tool.Title = "Set component field (undoable)";
+            // The generic project-WRITE tool (#306 item C, second slice): gated behind
+            // the session "Allow writes" toggle and routed through the editor undo
+            // stack. readOnlyHint:false (not idempotent — each call snapshots the prior
+            // value into a distinct undo command; not destructive — fully reversible
+            // via Ctrl-Z / undo).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            tool.Description =
+                "Set a single component field on an entity by (component, field, value) — the generic, "
+                "undoable successor to olo_set_collision_layer that mutates ANY registered field (transform "
+                "translation/scale, light color/intensity/range/shadows, sprite/circle color, camera flags, "
+                "tag, ...). The value type must match the field: a boolean, a number, a string, or an array "
+                "of numbers for a vector (e.g. [r,g,b] for a vec3 color). The change is applied through the "
+                "editor's undo stack, so it is a single Ctrl-Z. This is a WRITE tool: it is refused unless "
+                "'Allow writes' is enabled in the editor's MCP Server panel (off by default). Discover the "
+                "exact writable (component, field) names + value shapes for an entity with olo_entity_list_fields.";
+            tool.InputSchema = GenericFieldWrite::InputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_EntitySetField;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -370,6 +370,13 @@ add_executable(OloEngine-Tests
 		# DSL + the header-only UndoRedo CommandHistory), so no extra editor TU is
 		# pulled in — it links the engine Scene/ECS already in the test binary.
 		MCP/McpConsentedWriteTest.cpp
+		# Generic consented, undoable MCP WRITE tool: olo_entity_set_field + its read
+		# companion olo_entity_list_fields (#306 item C, second slice). Same seams as
+		# McpConsentedWriteTest.cpp — the session write gate + inputSchema enforcement
+		# at the McpServer.cpp dispatch seam, and the shared reflect+coerce+apply core
+		# (MCP/McpGenericFieldWrite.h). Header-only on the editor side, so no extra
+		# editor TU is pulled in.
+		MCP/McpGenericFieldWriteTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
@@ -1,0 +1,616 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// McpGenericFieldWriteTest — unit test (headless, no GL, no live editor).
+//
+// Pins the GENERIC consented, undoable MCP write tool olo_entity_set_field and
+// its read companion olo_entity_list_fields (issue #306 item C, second slice —
+// the catch-all successor to olo_set_collision_layer). Same two seams as
+// McpConsentedWriteTest.cpp:
+//
+//   1. The dispatch seam (McpServer.cpp, compiled into the test binary): a tool
+//      flagged ToolDef::ProjectWrite is REFUSED with a clean JSON-RPC error while
+//      the session "Allow writes" gate is off, and ACCEPTED once on. The server's
+//      inputSchema enforcement (#423) rejects a malformed call before the handler
+//      runs. McpTools.cpp is deliberately NOT linked here, so the test registers a
+//      fake tool wired to the SAME shared parse + apply code the real handler uses.
+//
+//   2. The shared core (MCP/McpGenericFieldWrite.h, header-only): the field
+//      registry + JSON->field coercion + FieldToJson + the undoable
+//      ComponentChangeCommand<T> apply, plus the read/list helper. These are the
+//      halves the real handlers delegate to.
+//
+// The shared header is renderer/httplib-free, so only engine Scene/ECS types and
+// the header-only UndoRedo stack are pulled in — no extra editor TU.
+// =============================================================================
+
+#include "MCP/McpGenericFieldWrite.h"
+#include "MCP/McpServer.h"
+#include "UndoRedo/EditorCommand.h"
+
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Scene.h"
+
+#include <glm/glm.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <string>
+
+// OLO_TEST_LAYER: unit
+
+namespace
+{
+    using OloEngine::CommandHistory;
+    using OloEngine::DirectionalLightComponent;
+    using OloEngine::Entity;
+    using OloEngine::Ref;
+    using OloEngine::Scene;
+    using OloEngine::SpriteRendererComponent;
+    using OloEngine::TagComponent;
+    using OloEngine::TransformComponent;
+    using OloEngine::UUID;
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+    namespace GFW = OloEngine::MCP::GenericFieldWrite;
+
+    constexpr int kInvalidParams = -32602;
+
+    // Component-wise float comparison (gtest ULP-based) — never `==` on glm::vec*,
+    // which SonarQube flags (cpp-coding-quality §2a). Values asserted here are
+    // exactly representable, so EXPECT_FLOAT_EQ is exact in practice.
+    void ExpectVec3(const glm::vec3& v, float x, float y, float z)
+    {
+        EXPECT_FLOAT_EQ(v.x, x);
+        EXPECT_FLOAT_EQ(v.y, y);
+        EXPECT_FLOAT_EQ(v.z, z);
+    }
+    void ExpectVec4(const glm::vec4& v, float x, float y, float z, float w)
+    {
+        EXPECT_FLOAT_EQ(v.x, x);
+        EXPECT_FLOAT_EQ(v.y, y);
+        EXPECT_FLOAT_EQ(v.z, z);
+        EXPECT_FLOAT_EQ(v.w, w);
+    }
+
+    Json MakeCallRequest(const Json& id, const Json& arguments)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "method", "tools/call" },
+                     { "params", { { "name", "olo_entity_set_field" }, { "arguments", arguments } } } };
+    }
+
+    // Fixture: an McpServer whose only tool is a fake olo_entity_set_field wired to a
+    // test-owned Scene + CommandHistory through the SAME schema + ParseArgs + Apply
+    // code the real handler uses. The fake handler runs synchronously (no MarshalRead
+    // — there is no game thread to service it here), exactly what the real handler
+    // delegates to once on the main thread.
+    class McpGenericFieldWriteTest : public ::testing::Test
+    {
+      protected:
+        McpGenericFieldWriteTest()
+            : m_Server(EditorMcpContext{})
+        {
+            m_Scene = Ref<Scene>::Create();
+            Entity entity = m_Scene->CreateEntity("Thing"); // gets Transform + Tag
+            entity.AddComponent<SpriteRendererComponent>();
+            entity.AddComponent<DirectionalLightComponent>();
+            m_EntityUuid = static_cast<u64>(entity.GetUUID());
+
+            ToolDef tool;
+            tool.Name = "olo_entity_set_field";
+            tool.Description = "Set any registered component field (fake; test wiring).";
+            tool.ProjectWrite = true;
+            tool.InputSchema = GFW::InputSchema();
+            tool.Handler = [this](McpServer&, const Json& args) -> ToolResult
+            {
+                u64 entityUuid = 0;
+                std::string component;
+                std::string field;
+                Json value;
+                if (const auto error = GFW::ParseArgs(args, entityUuid, component, field, value))
+                    return ToolResult::Error(*error);
+                const GFW::ApplyResult applied = GFW::Apply(m_Scene, m_History, entityUuid, component, field, value);
+                if (!applied.Ok)
+                    return ToolResult::Error(applied.Error);
+                return ToolResult::Text(applied.Data.dump());
+            };
+            m_Server.RegisterTool(std::move(tool));
+        }
+
+        [[nodiscard]] Entity TheEntity() const
+        {
+            return *m_Scene->TryGetEntityWithUUID(UUID(m_EntityUuid));
+        }
+        [[nodiscard]] glm::vec3 CurrentTranslation() const
+        {
+            return TheEntity().GetComponent<TransformComponent>().Translation;
+        }
+
+        Ref<Scene> m_Scene;
+        CommandHistory m_History;
+        u64 m_EntityUuid = 0;
+        McpServer m_Server; // declared last → destroyed first (its handler refs m_Scene/m_History)
+    };
+} // namespace
+
+// ---- the session write gate (dispatch seam) --------------------------------
+
+// Default state: the gate is OFF, so even a well-formed write call is refused with
+// a JSON-RPC error and NOTHING is mutated / pushed onto the undo stack.
+TEST_F(McpGenericFieldWriteTest, GateOffRejectsWriteAndMutatesNothing)
+{
+    ASSERT_FALSE(m_Server.AllowWrites()); // off by default
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        1, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+
+    ExpectVec3(CurrentTranslation(), 0.0f, 0.0f, 0.0f);
+    EXPECT_FALSE(m_History.CanUndo());
+}
+
+// With the gate ON the same call succeeds, the field changes, and the change is a
+// single undoable command — an undo reverts it, a redo re-applies it.
+TEST_F(McpGenericFieldWriteTest, GateOnAppliesUndoableWrite)
+{
+    m_Server.SetAllowWrites(true);
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        2, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+
+    ExpectVec3(CurrentTranslation(), 1.0f, 2.0f, 3.0f);
+    ASSERT_TRUE(m_History.CanUndo());
+    EXPECT_EQ(m_History.GetUndoDescription(), "Set TransformComponent.Translation");
+
+    m_History.Undo();
+    ExpectVec3(CurrentTranslation(), 0.0f, 0.0f, 0.0f);
+    EXPECT_FALSE(m_History.CanUndo());
+
+    m_History.Redo();
+    ExpectVec3(CurrentTranslation(), 1.0f, 2.0f, 3.0f);
+}
+
+// ---- server-side inputSchema enforcement (#423), gate ON -------------------
+
+TEST_F(McpGenericFieldWriteTest, SchemaRejectsMissingEntity)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        3, Json{ { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+TEST_F(McpGenericFieldWriteTest, SchemaRejectsMissingComponentFieldOrValue)
+{
+    m_Server.SetAllowWrites(true);
+    const Json base = Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) } };
+    for (const char* missing : { "component", "field", "value" })
+    {
+        Json args = base;
+        args.erase(missing);
+        const Json resp = m_Server.HandleMessage(MakeCallRequest(4, args));
+        ASSERT_TRUE(resp.contains("error")) << "should reject missing '" << missing << "'";
+        EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    }
+}
+
+// `value` is a union of boolean/number/string/array, so an object/null is rejected
+// at the schema layer before the handler runs.
+TEST_F(McpGenericFieldWriteTest, SchemaRejectsObjectValue)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        5, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::object({ { "x", 1 } }) } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+TEST_F(McpGenericFieldWriteTest, SchemaRejectsUnknownProperty)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        6, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) }, { "extra", true } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+// ---- handler-level (tool) errors, gate ON ----------------------------------
+
+// A schema-valid call for a non-existent entity is a TOOL-level error (isError),
+// not a JSON-RPC protocol error — the call reached the handler, the handler failed.
+TEST_F(McpGenericFieldWriteTest, UnknownEntityIsToolError)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        7, Json{ { "entity", "99999999" }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", Json::array({ 1.0, 2.0, 3.0 }) } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+}
+
+// A wrong value type for the field (string into a vec3) reaches the handler (schema
+// allows a string) and is a tool-level coercion error.
+TEST_F(McpGenericFieldWriteTest, WrongValueTypeIsToolError)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        8, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "TransformComponent" }, { "field", "Translation" }, { "value", "not-a-vector" } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+    ExpectVec3(CurrentTranslation(), 0.0f, 0.0f, 0.0f); // never applied
+}
+
+// ---- the shared apply core (MCP/McpGenericFieldWrite.h), no server ----------
+
+TEST(McpGenericFieldWriteApply, ChangesVec3AndUndoReverts)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "TransformComponent", "Scale", Json::array({ 2.0, 3.0, 4.0 }));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_TRUE(result.Data["undoable"].get<bool>());
+    EXPECT_EQ(result.Data["type"], "vec3");
+    EXPECT_EQ(result.Data["previousValue"], Json::array({ 1.0, 1.0, 1.0 }));
+    ExpectVec3(entity.GetComponent<TransformComponent>().Scale, 2.0f, 3.0f, 4.0f);
+
+    ASSERT_TRUE(history.CanUndo());
+    history.Undo();
+    ExpectVec3(entity.GetComponent<TransformComponent>().Scale, 1.0f, 1.0f, 1.0f);
+}
+
+TEST(McpGenericFieldWriteApply, ChangesVec4Color)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    entity.AddComponent<SpriteRendererComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "SpriteRendererComponent", "Color", Json::array({ 0.1, 0.2, 0.3, 0.4 }));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "vec4");
+    ExpectVec4(entity.GetComponent<SpriteRendererComponent>().Color, 0.1f, 0.2f, 0.3f, 0.4f);
+}
+
+TEST(McpGenericFieldWriteApply, ChangesFloatField)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    entity.AddComponent<DirectionalLightComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "DirectionalLightComponent", "Intensity", Json(2.5));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "float");
+    EXPECT_FLOAT_EQ(entity.GetComponent<DirectionalLightComponent>().m_Intensity, 2.5f);
+    history.Undo();
+    EXPECT_FLOAT_EQ(entity.GetComponent<DirectionalLightComponent>().m_Intensity, 1.0f);
+}
+
+TEST(McpGenericFieldWriteApply, ChangesBoolField)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    entity.AddComponent<DirectionalLightComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "DirectionalLightComponent", "CastShadows", Json(false));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "bool");
+    EXPECT_FALSE(entity.GetComponent<DirectionalLightComponent>().m_CastShadows);
+}
+
+TEST(McpGenericFieldWriteApply, ChangesStringTag)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Old");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "TagComponent", "Tag", Json("New"));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "string");
+    EXPECT_EQ(result.Data["previousValue"], "Old");
+    EXPECT_EQ(entity.GetComponent<TagComponent>().Tag, "New");
+    history.Undo();
+    EXPECT_EQ(entity.GetComponent<TagComponent>().Tag, "Old");
+}
+
+// Setting a field to the value it already has changes nothing and pushes no undo
+// command (no spurious dirty / undo-stack entry).
+TEST(McpGenericFieldWriteApply, NoOpWhenUnchanged)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    // Scale defaults to (1,1,1).
+    const auto result = GFW::Apply(scene, history, uuid, "TransformComponent", "Scale", Json::array({ 1.0, 1.0, 1.0 }));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_FALSE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_FALSE(history.CanUndo());
+}
+
+TEST(McpGenericFieldWriteApply, UnknownComponentListsEditableComponents)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "NotAComponent", "Field", Json(1));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("Editable components"), std::string::npos);
+    EXPECT_FALSE(history.CanUndo());
+}
+
+TEST(McpGenericFieldWriteApply, UnknownFieldListsEditableFields)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "TransformComponent", "Nope", Json::array({ 1.0, 2.0, 3.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("Editable fields"), std::string::npos);
+    EXPECT_NE(result.Error.find("Translation"), std::string::npos);
+}
+
+TEST(McpGenericFieldWriteApply, EntityLackingComponentIsError)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E"); // no SpriteRendererComponent
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const auto result = GFW::Apply(scene, history, uuid, "SpriteRendererComponent", "Color", Json::array({ 1.0, 1.0, 1.0, 1.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("has no SpriteRendererComponent"), std::string::npos);
+    EXPECT_FALSE(history.CanUndo());
+}
+
+TEST(McpGenericFieldWriteApply, MissingEntityIsError)
+{
+    auto scene = Ref<Scene>::Create();
+    CommandHistory history;
+    const auto result = GFW::Apply(scene, history, /*uuid*/ 424242, "TransformComponent", "Scale", Json::array({ 1.0, 1.0, 1.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(result.Error.empty());
+}
+
+// Non-finite vector components are rejected (the isfinite-from-JSON rule).
+TEST(McpGenericFieldWriteApply, RejectsNonFiniteVector)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history;
+
+    const double inf = std::numeric_limits<double>::infinity();
+    const auto result = GFW::Apply(scene, history, uuid, "TransformComponent", "Translation", Json::array({ 0.0, inf, 0.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(history.CanUndo());
+}
+
+// ---- the shared coercion (CoerceJson<F>) -----------------------------------
+
+TEST(McpGenericFieldWriteCoerce, Primitives)
+{
+    bool b = false;
+    EXPECT_FALSE(GFW::CoerceJson<bool>(Json(true), b).has_value());
+    EXPECT_TRUE(b);
+    EXPECT_TRUE(GFW::CoerceJson<bool>(Json(1), b).has_value()); // 1 is not a JSON boolean
+
+    f32 f = 0.0f;
+    EXPECT_FALSE(GFW::CoerceJson<f32>(Json(3), f).has_value()); // integer accepted as number
+    EXPECT_FLOAT_EQ(f, 3.0f);
+    EXPECT_TRUE(GFW::CoerceJson<f32>(Json(std::numeric_limits<double>::quiet_NaN()), f).has_value());
+    EXPECT_TRUE(GFW::CoerceJson<f32>(Json("x"), f).has_value());
+
+    int i = 0;
+    EXPECT_FALSE(GFW::CoerceJson<int>(Json(-5), i).has_value());
+    EXPECT_EQ(i, -5);
+    EXPECT_TRUE(GFW::CoerceJson<int>(Json(2.5), i).has_value()); // not an integer
+
+    u32 u = 0;
+    EXPECT_FALSE(GFW::CoerceJson<u32>(Json(7), u).has_value());
+    EXPECT_EQ(u, 7u);
+    EXPECT_TRUE(GFW::CoerceJson<u32>(Json(-1), u).has_value()); // out of range for u32
+
+    std::string s;
+    EXPECT_FALSE(GFW::CoerceJson<std::string>(Json("hi"), s).has_value());
+    EXPECT_EQ(s, "hi");
+    EXPECT_TRUE(GFW::CoerceJson<std::string>(Json(3), s).has_value());
+}
+
+TEST(McpGenericFieldWriteCoerce, Vectors)
+{
+    glm::vec3 v{};
+    EXPECT_FALSE(GFW::CoerceJson<glm::vec3>(Json::array({ 1.0, 2.0, 3.0 }), v).has_value());
+    ExpectVec3(v, 1.0f, 2.0f, 3.0f);
+
+    EXPECT_TRUE(GFW::CoerceJson<glm::vec3>(Json::array({ 1.0, 2.0 }), v).has_value());           // too short
+    EXPECT_TRUE(GFW::CoerceJson<glm::vec3>(Json::array({ 1.0, 2.0, 3.0, 4.0 }), v).has_value()); // too long
+    EXPECT_TRUE(GFW::CoerceJson<glm::vec3>(Json::array({ 1.0, "x", 3.0 }), v).has_value());      // non-number
+    EXPECT_TRUE(GFW::CoerceJson<glm::vec3>(Json(5), v).has_value());                             // not an array
+}
+
+TEST(McpGenericFieldWriteCoerce, Handle)
+{
+    UUID h(0);
+    EXPECT_FALSE(GFW::CoerceJson<UUID>(Json("123456789"), h).has_value());
+    EXPECT_EQ(static_cast<u64>(h), 123456789ull);
+
+    EXPECT_TRUE(GFW::CoerceJson<UUID>(Json(123), h).has_value());    // must be a string
+    EXPECT_TRUE(GFW::CoerceJson<UUID>(Json("12ab"), h).has_value()); // non-digit
+    EXPECT_TRUE(GFW::CoerceJson<UUID>(Json("-1"), h).has_value());   // signed
+    EXPECT_TRUE(GFW::CoerceJson<UUID>(Json(""), h).has_value());     // empty
+}
+
+TEST(McpGenericFieldWriteSerialize, FieldToJsonRoundTrips)
+{
+    EXPECT_EQ(GFW::FieldToJson<bool>(true), Json(true));
+    EXPECT_EQ(GFW::FieldToJson<glm::vec3>(glm::vec3(1.0f, 2.0f, 3.0f)), Json::array({ 1.0, 2.0, 3.0 }));
+    EXPECT_EQ(GFW::FieldToJson<glm::vec4>(glm::vec4(1.0f, 2.0f, 3.0f, 4.0f)), Json::array({ 1.0, 2.0, 3.0, 4.0 }));
+    EXPECT_EQ(GFW::FieldToJson<UUID>(UUID(42)), Json("42")); // handle as decimal string
+    EXPECT_EQ(GFW::FieldToJson<std::string>(std::string("t")), Json("t"));
+}
+
+// ---- the read companion (ListFields) ---------------------------------------
+
+TEST(McpGenericFieldWriteList, ListsFieldsTheEntityHasWithValues)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Listed"); // Transform + Tag
+    entity.AddComponent<DirectionalLightComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    bool found = false;
+    const Json out = GFW::ListFields(scene, uuid, /*filter*/ "", found);
+    ASSERT_TRUE(found);
+    EXPECT_TRUE(out["found"].get<bool>());
+    ASSERT_TRUE(out["components"].is_array());
+
+    // It should include the components the entity actually has, and NOT one it lacks.
+    bool hasTransform = false;
+    bool hasTag = false;
+    bool hasLight = false;
+    bool hasSprite = false;
+    for (const auto& comp : out["components"])
+    {
+        const std::string name = comp["component"].get<std::string>();
+        hasTransform = hasTransform || name == "TransformComponent";
+        hasTag = hasTag || name == "TagComponent";
+        hasLight = hasLight || name == "DirectionalLightComponent";
+        hasSprite = hasSprite || name == "SpriteRendererComponent";
+    }
+    EXPECT_TRUE(hasTransform);
+    EXPECT_TRUE(hasTag);
+    EXPECT_TRUE(hasLight);
+    EXPECT_FALSE(hasSprite); // entity has no SpriteRendererComponent
+}
+
+TEST(McpGenericFieldWriteList, ComponentFilterRestrictsListing)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("Listed");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    bool found = false;
+    const Json out = GFW::ListFields(scene, uuid, "TagComponent", found);
+    ASSERT_TRUE(found);
+    ASSERT_EQ(out["components"].size(), 1u);
+    EXPECT_EQ(out["components"][0]["component"], "TagComponent");
+    EXPECT_EQ(out["components"][0]["fields"][0]["field"], "Tag");
+    EXPECT_EQ(out["components"][0]["fields"][0]["value"], "Listed");
+}
+
+TEST(McpGenericFieldWriteList, MissingEntityReportsNotFound)
+{
+    auto scene = Ref<Scene>::Create();
+    bool found = false;
+    const Json out = GFW::ListFields(scene, /*uuid*/ 7777, "", found);
+    EXPECT_FALSE(found);
+    EXPECT_FALSE(out["found"].get<bool>());
+    EXPECT_TRUE(out["components"].is_array());
+    EXPECT_TRUE(out["components"].empty());
+}
+
+// ---- the shared arg parser --------------------------------------------------
+
+TEST(McpGenericFieldWriteParse, AcceptsValidArgs)
+{
+    u64 entity = 0;
+    std::string component;
+    std::string field;
+    Json value;
+    const auto error = GFW::ParseArgs(
+        Json{ { "entity", "42" }, { "component", "TransformComponent" }, { "field", "Scale" }, { "value", Json::array({ 1.0, 1.0, 1.0 }) } },
+        entity, component, field, value);
+    EXPECT_FALSE(error.has_value());
+    EXPECT_EQ(entity, 42u);
+    EXPECT_EQ(component, "TransformComponent");
+    EXPECT_EQ(field, "Scale");
+    EXPECT_TRUE(value.is_array());
+}
+
+TEST(McpGenericFieldWriteParse, RejectsNumericOrPartialUuid)
+{
+    u64 entity = 0;
+    std::string component;
+    std::string field;
+    Json value;
+    const Json good = Json{ { "component", "C" }, { "field", "F" }, { "value", 1 } };
+    auto with = [&](const Json& e)
+    {
+        Json a = good;
+        a["entity"] = e;
+        return GFW::ParseArgs(a, entity, component, field, value);
+    };
+    EXPECT_TRUE(with(Json(42)).has_value());      // numeric UUID rejected
+    EXPECT_TRUE(with(Json("42abc")).has_value()); // partial
+    EXPECT_TRUE(with(Json("-1")).has_value());    // signed
+    EXPECT_TRUE(with(Json("")).has_value());      // empty
+}
+
+TEST(McpGenericFieldWriteParse, RejectsMissingFields)
+{
+    u64 entity = 0;
+    std::string component;
+    std::string field;
+    Json value;
+    EXPECT_TRUE(GFW::ParseArgs(Json{ { "component", "C" }, { "field", "F" }, { "value", 1 } }, entity, component, field, value).has_value());
+    EXPECT_TRUE(GFW::ParseArgs(Json{ { "entity", "1" }, { "field", "F" }, { "value", 1 } }, entity, component, field, value).has_value());
+    EXPECT_TRUE(GFW::ParseArgs(Json{ { "entity", "1" }, { "component", "C" }, { "value", 1 } }, entity, component, field, value).has_value());
+    EXPECT_TRUE(GFW::ParseArgs(Json{ { "entity", "1" }, { "component", "C" }, { "field", "F" } }, entity, component, field, value).has_value());
+}
+
+// ---- the shared inputSchema -------------------------------------------------
+
+TEST(McpGenericFieldWriteSchema, DeclaresRequiredFieldsAndValueUnion)
+{
+    const Json schema = GFW::InputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    EXPECT_EQ(schema["additionalProperties"], false);
+
+    ASSERT_TRUE(schema["required"].is_array());
+    const auto& required = schema["required"];
+    for (const char* name : { "entity", "component", "field", "value" })
+        EXPECT_NE(std::find(required.begin(), required.end(), name), required.end()) << "required should contain " << name;
+
+    EXPECT_EQ(schema["properties"]["entity"]["type"], "string");
+    EXPECT_EQ(schema["properties"]["component"]["type"], "string");
+    EXPECT_EQ(schema["properties"]["field"]["type"], "string");
+
+    // `value` is a type union accepting boolean/number/string/array (so the server
+    // rejects an object/null up front; the exact per-field type is coerced later).
+    const auto& valueType = schema["properties"]["value"]["type"];
+    ASSERT_TRUE(valueType.is_array());
+    for (const char* t : { "boolean", "number", "string", "array" })
+        EXPECT_NE(std::find(valueType.begin(), valueType.end(), t), valueType.end()) << "value type union should contain " << t;
+}


### PR DESCRIPTION
…elds (#306)

Add the catch-all consented write tool olo_entity_set_field and its read companion olo_entity_list_fields (issue #306 item C, second slice) — the generic successor to olo_set_collision_layer's one-tool-per-field shape.

- Mutates any registered component field by (component, field, value) through the editor undo stack as a single ComponentChangeCommand<T> (one Ctrl-Z), gated behind the session "Allow writes" toggle (ToolDef::ProjectWrite, default off).
- Shared core in header-only McpGenericFieldWrite.h: a type-safe member-pointer field registry (OLO_PROPERTY is compile-time only, so there is no runtime reflection to borrow), JSON<->field coercion (bool/int/float/glm::vec2-4/string/UUID-handle/enum, all finite-checked), memcmp no-op detection, and a JSON value reader for discovery.
- Field names are the m_-stripped serializer keys an agent already sees in olo_scene_get_entity's YAML, so the write contract matches the read.
- 30 unit tests at the dispatch seam (gate on/off, schema enforcement, coercion, undo/redo round-trip, discovery). Zero engine changes.