### PR TITLE
feat(input): action-map contexts with switching + nesting stack (#461)

### DIFF
--- a/OloEngine-ScriptCore/src/OloEngine/Input.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/Input.cs
@@ -1,5 +1,16 @@
 namespace OloEngine
 {
+	// Named input contexts. Only one is active at a time; switching contexts swaps
+	// which action map drives IsActionPressed/GetActionAxisValue. Mirrors the C++
+	// OloEngine::InputContextType enum — keep the values in sync.
+	public enum InputContext
+	{
+		Gameplay = 0,
+		Menu = 1,
+		Vehicle = 2,
+		Custom = 3
+	}
+
 	public class Input
 	{
 		public static bool IsKeyDown(KeyCode keycode)
@@ -52,6 +63,36 @@ namespace OloEngine
 		public static float GetActionAxisValue(string actionName)
 		{
 			return InternalCalls.Input_GetActionAxisValue(actionName);
+		}
+
+		// Hard switch of the active action-map context. A key held across the switch
+		// does not register as "just pressed" in the newly-activated context.
+		public static void SetInputContext(InputContext context)
+		{
+			InternalCalls.Input_SetInputContext((int)context);
+		}
+
+		public static InputContext GetInputContext()
+		{
+			return (InputContext)InternalCalls.Input_GetInputContext();
+		}
+
+		// Push a context onto the stack (e.g. a menu over gameplay), making it active.
+		public static void PushInputContext(InputContext context)
+		{
+			InternalCalls.Input_PushInputContext((int)context);
+		}
+
+		// Pop the active context, restoring the one beneath. Returns false if only the
+		// base context remains (it is never popped).
+		public static bool PopInputContext()
+		{
+			return InternalCalls.Input_PopInputContext();
+		}
+
+		public static int GetInputContextDepth()
+		{
+			return InternalCalls.Input_GetInputContextDepth();
 		}
 
 		// --- Gamepad ---

--- a/OloEngine-ScriptCore/src/OloEngine/InternalCalls.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/InternalCalls.cs
@@ -78,6 +78,16 @@ namespace OloEngine
         internal static extern bool Input_IsActionJustReleased(string actionName);
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern float Input_GetActionAxisValue(string actionName);
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern void Input_SetInputContext(int context);
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern int Input_GetInputContext();
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern void Input_PushInputContext(int context);
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern bool Input_PopInputContext();
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern int Input_GetInputContextDepth();
         #endregion
 
         #region AudioSourceComponent (hand-written action methods only)

--- a/OloEngine/src/OloEngine/Core/InputActionManager.cpp
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.cpp
@@ -156,32 +156,38 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        s_ActiveMap = {};
+        s_ContextStack.assign(1, InputContextType::Gameplay);
+        s_ContextMaps.clear();
         s_CurrentState.clear();
         s_PreviousState.clear();
         s_AxisValues.clear();
+        s_SuppressTransientOnNextUpdate = false;
     }
 
     void InputActionManager::Shutdown()
     {
         OLO_PROFILE_FUNCTION();
 
-        s_ActiveMap = {};
+        s_ContextStack.assign(1, InputContextType::Gameplay);
+        s_ContextMaps.clear();
         s_CurrentState.clear();
         s_PreviousState.clear();
         s_AxisValues.clear();
+        s_SuppressTransientOnNextUpdate = false;
     }
 
     void InputActionManager::Update()
     {
         OLO_PROFILE_FUNCTION();
 
+        const InputActionMap& activeMap = ActiveMap();
+
         s_PreviousState = s_CurrentState;
 
         // Prune stale entries for actions that no longer exist in the map
         for (auto it = s_CurrentState.begin(); it != s_CurrentState.end();)
         {
-            if (!s_ActiveMap.Actions.contains(it->first))
+            if (!activeMap.Actions.contains(it->first))
             {
                 it = s_CurrentState.erase(it);
             }
@@ -192,7 +198,7 @@ namespace OloEngine
         }
         for (auto it = s_PreviousState.begin(); it != s_PreviousState.end();)
         {
-            if (!s_ActiveMap.Actions.contains(it->first))
+            if (!activeMap.Actions.contains(it->first))
             {
                 it = s_PreviousState.erase(it);
             }
@@ -202,7 +208,7 @@ namespace OloEngine
             }
         }
 
-        for (const auto& [actionName, action] : s_ActiveMap.Actions)
+        for (const auto& [actionName, action] : activeMap.Actions)
         {
             bool pressed = false;
             for (const auto& binding : action.Bindings)
@@ -282,6 +288,15 @@ namespace OloEngine
             }
             s_AxisValues[actionName] = bestAxisValue;
         }
+
+        // First frame after a context switch: align previous to current so no action
+        // reports just-pressed/just-released from input that was already held. From the
+        // next frame on, transitions are detected normally.
+        if (s_SuppressTransientOnNextUpdate)
+        {
+            s_PreviousState = s_CurrentState;
+            s_SuppressTransientOnNextUpdate = false;
+        }
     }
 
     bool InputActionManager::IsActionPressed(std::string_view actionName)
@@ -315,12 +330,86 @@ namespace OloEngine
         return prevIt != s_PreviousState.end() && prevIt->second;
     }
 
-    void InputActionManager::SetActionMap(const InputActionMap& map)
+    void InputActionManager::ResetStateForContextChange()
     {
-        s_ActiveMap = map;
+        // Clear cached press/axis state and suppress just-pressed/just-released on the
+        // next Update(), so a key still held from the previous context doesn't fire a
+        // same-key action in the newly-activated context (e.g. Escape opening a menu
+        // shouldn't instantly trigger the menu's Escape-bound "Back").
         s_CurrentState.clear();
         s_PreviousState.clear();
         s_AxisValues.clear();
+        s_SuppressTransientOnNextUpdate = true;
+    }
+
+    void InputActionManager::SetActionMap(const InputActionMap& map)
+    {
+        ActiveMap() = map;
+        s_CurrentState.clear();
+        s_PreviousState.clear();
+        s_AxisValues.clear();
+    }
+
+    void InputActionManager::SetActionMap(InputContextType ctx, const InputActionMap& map)
+    {
+        const bool isActive = (ctx == s_ContextStack.back());
+        s_ContextMaps[ctx] = map;
+        if (isActive)
+        {
+            s_CurrentState.clear();
+            s_PreviousState.clear();
+            s_AxisValues.clear();
+        }
+    }
+
+    void InputActionManager::SetInputContext(InputContextType ctx)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Hard switch: collapse the stack to a single entry. No-op when ctx is
+        // already the sole active context, so cached state is preserved.
+        if (s_ContextStack.size() == 1 && s_ContextStack.back() == ctx)
+        {
+            return;
+        }
+
+        const bool activeChanged = (s_ContextStack.back() != ctx);
+        s_ContextStack.assign(1, ctx);
+        if (activeChanged)
+        {
+            ResetStateForContextChange();
+        }
+    }
+
+    void InputActionManager::PushContext(InputContextType ctx)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        const bool activeChanged = (s_ContextStack.back() != ctx);
+        s_ContextStack.push_back(ctx);
+        if (activeChanged)
+        {
+            ResetStateForContextChange();
+        }
+    }
+
+    bool InputActionManager::PopContext()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Never pop the base context — there must always be an active context.
+        if (s_ContextStack.size() <= 1)
+        {
+            return false;
+        }
+
+        const InputContextType popped = s_ContextStack.back();
+        s_ContextStack.pop_back();
+        if (s_ContextStack.back() != popped)
+        {
+            ResetStateForContextChange();
+        }
+        return true;
     }
 
     void InputActionManager::SetInputProvider(IInputProvider* provider)

--- a/OloEngine/src/OloEngine/Core/InputActionManager.h
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.h
@@ -7,11 +7,29 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 namespace OloEngine
 {
     // StringHash / StringEqual (transparent heterogeneous lookup) now live in
     // Core/TransparentStringHash.h so other subsystems can reuse them.
+
+    // Named input contexts. Exactly one is active at a time — the top of the
+    // context stack. Each context owns its own InputActionMap, so switching
+    // contexts changes which actions drive IsActionPressed / GetActionAxisValue
+    // without manual unbinding. Use SetInputContext for a hard switch, or
+    // PushContext / PopContext to nest (e.g. push Menu over Gameplay, pop to
+    // restore). The first Update() after the active context changes suppresses
+    // just-pressed/just-released, so a key still held from the previous context
+    // (e.g. the Escape that opened a menu) doesn't immediately fire a same-key
+    // action in the new context.
+    enum class InputContextType : u8
+    {
+        Gameplay,
+        Menu,
+        Vehicle,
+        Custom
+    };
 
     class InputActionManager
     {
@@ -22,7 +40,7 @@ namespace OloEngine
         // Call once per frame before layer updates to refresh action states.
         static void Update();
 
-        // Query methods — return false for unknown action names.
+        // Query methods — operate on the active context's map. Return false for unknown action names.
         [[nodiscard]] static bool IsActionPressed(std::string_view actionName);
         [[nodiscard]] static bool IsActionJustPressed(std::string_view actionName);
         [[nodiscard]] static bool IsActionJustReleased(std::string_view actionName);
@@ -31,24 +49,78 @@ namespace OloEngine
         // Keyboard/mouse bindings return 0/1; gamepad axis bindings return the raw axis value.
         [[nodiscard]] static f32 GetActionAxisValue(std::string_view actionName);
 
-        // Replace the active action map and reset all cached state.
+        // --- Action-map contexts (gameplay / menu / vehicle / custom) ---
+
+        // Hard switch: collapse the context stack to a single entry and activate ctx.
+        // A no-op (preserving cached state) when ctx is already the sole active context.
+        static void SetInputContext(InputContextType ctx);
+
+        // Push ctx onto the context stack, making it active. The context beneath
+        // stays in place and its map is restored on the matching PopContext.
+        static void PushContext(InputContextType ctx);
+
+        // Pop the active context, restoring the one beneath. Never pops the base
+        // context (returns false and leaves the stack untouched when at depth 1).
+        static bool PopContext();
+
+        [[nodiscard]] static InputContextType GetInputContext()
+        {
+            return s_ContextStack.back();
+        }
+
+        // Number of contexts currently on the stack (always >= 1 after Init).
+        [[nodiscard]] static sizet GetContextDepth()
+        {
+            return s_ContextStack.size();
+        }
+
+        // Replace the active context's action map and reset all cached state.
         static void SetActionMap(const InputActionMap& map);
+
+        // Replace a specific context's action map. If ctx is the active context this
+        // also resets cached state; otherwise the map is stored until ctx is activated.
+        static void SetActionMap(InputContextType ctx, const InputActionMap& map);
 
         // Inject a custom input provider (for testing). Passing nullptr restores the default.
         static void SetInputProvider(IInputProvider* provider);
 
-        // Mutable access for editor panel mutation. Stale state is pruned in Update().
+        // Mutable access to the active context's map for editor panel mutation.
+        // Stale state is pruned in Update().
         [[nodiscard]] static InputActionMap& GetActionMap()
         {
-            return s_ActiveMap;
+            return ActiveMap();
         }
         [[nodiscard]] static const InputActionMap& GetActionMapConst()
         {
-            return s_ActiveMap;
+            return ActiveMap();
+        }
+
+        // Read/author access to any context's map (the active context returns the live map).
+        // A context that was never set is created empty.
+        [[nodiscard]] static const InputActionMap& GetActionMap(InputContextType ctx)
+        {
+            return s_ContextMaps[ctx];
         }
 
       private:
-        inline static InputActionMap s_ActiveMap;
+        // The active context is always the top of the stack; its map lives in s_ContextMaps.
+        [[nodiscard]] static InputActionMap& ActiveMap()
+        {
+            return s_ContextMaps[s_ContextStack.back()];
+        }
+
+        // Clear cached press/axis state and suppress just-pressed/just-released on the
+        // next Update() — used whenever the active context (and thus its map) changes.
+        static void ResetStateForContextChange();
+
+        // Stack of active contexts; back() is active. Seeded with Gameplay so queries
+        // are valid even before Init(). Never emptied (PopContext keeps the base).
+        inline static std::vector<InputContextType> s_ContextStack{ InputContextType::Gameplay };
+        // One action map per context, keyed by the enum — stack duplicates share one map.
+        inline static std::unordered_map<InputContextType, InputActionMap> s_ContextMaps;
+        // Set on a context change; the next Update() forces previous == current so no
+        // action fires just-pressed/just-released on the first frame of the new context.
+        inline static bool s_SuppressTransientOnNextUpdate = false;
         inline static std::unordered_map<std::string, bool, StringHash, StringEqual> s_CurrentState;
         inline static std::unordered_map<std::string, bool, StringHash, StringEqual> s_PreviousState;
         inline static std::unordered_map<std::string, f32, StringHash, StringEqual> s_AxisValues;

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
@@ -2060,6 +2060,41 @@ namespace OloEngine
         return result;
     }
 
+    static void Input_SetInputContext(i32 context)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        InputActionManager::SetInputContext(static_cast<InputContextType>(context));
+    }
+
+    static i32 Input_GetInputContext()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        return static_cast<i32>(InputActionManager::GetInputContext());
+    }
+
+    static void Input_PushInputContext(i32 context)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        InputActionManager::PushContext(static_cast<InputContextType>(context));
+    }
+
+    static bool Input_PopInputContext()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        return InputActionManager::PopContext();
+    }
+
+    static i32 Input_GetInputContextDepth()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        return static_cast<i32>(InputActionManager::GetContextDepth());
+    }
+
     template<typename... Component>
     static void RegisterComponent()
     {
@@ -3298,6 +3333,11 @@ namespace OloEngine
         OLO_ADD_INTERNAL_CALL(Input_IsActionJustPressed);
         OLO_ADD_INTERNAL_CALL(Input_IsActionJustReleased);
         OLO_ADD_INTERNAL_CALL(Input_GetActionAxisValue);
+        OLO_ADD_INTERNAL_CALL(Input_SetInputContext);
+        OLO_ADD_INTERNAL_CALL(Input_GetInputContext);
+        OLO_ADD_INTERNAL_CALL(Input_PushInputContext);
+        OLO_ADD_INTERNAL_CALL(Input_PopInputContext);
+        OLO_ADD_INTERNAL_CALL(Input_GetInputContextDepth);
 
         ///////////////////////////////////////////////////////////////
         // Audio Source ///////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -2367,6 +2367,29 @@ namespace OloEngine
         {
             return InputActionManager::GetActionAxisValue(name);
         };
+        // Action-map contexts (gameplay/menu/vehicle). Pass an InputContext.* constant.
+        // Switching contexts swaps the active action map and resets transient press state.
+        // SetInputContext is a hard switch; Push/Pop nest (e.g. push Menu over Gameplay).
+        inputTable["SetInputContext"] = [](i32 context)
+        {
+            InputActionManager::SetInputContext(static_cast<InputContextType>(context));
+        };
+        inputTable["GetInputContext"] = []() -> i32
+        {
+            return static_cast<i32>(InputActionManager::GetInputContext());
+        };
+        inputTable["PushInputContext"] = [](i32 context)
+        {
+            InputActionManager::PushContext(static_cast<InputContextType>(context));
+        };
+        inputTable["PopInputContext"] = []() -> bool
+        {
+            return InputActionManager::PopContext();
+        };
+        inputTable["GetInputContextDepth"] = []() -> i32
+        {
+            return static_cast<i32>(InputActionManager::GetContextDepth());
+        };
         inputTable["GetMousePosition"] = []() -> std::tuple<f32, f32>
         {
             auto pos = Input::GetMousePosition();
@@ -2506,6 +2529,15 @@ namespace OloEngine
             cursorTable["Normal"] = static_cast<i32>(CursorMode::Normal);
             cursorTable["Hidden"] = static_cast<i32>(CursorMode::Hidden);
             cursorTable["Locked"] = static_cast<i32>(CursorMode::Locked);
+        }
+
+        // --- InputContext constants (for Input.SetInputContext — action-map contexts) ---
+        {
+            auto inputContextTable = lua.create_named_table("InputContext");
+            inputContextTable["Gameplay"] = static_cast<i32>(InputContextType::Gameplay);
+            inputContextTable["Menu"] = static_cast<i32>(InputContextType::Menu);
+            inputContextTable["Vehicle"] = static_cast<i32>(InputContextType::Vehicle);
+            inputContextTable["Custom"] = static_cast<i32>(InputContextType::Custom);
         }
 
         // --- DialogueComponent ---

--- a/OloEngine/tests/InputActionTest.cpp
+++ b/OloEngine/tests/InputActionTest.cpp
@@ -744,3 +744,242 @@ TEST_F(InputStateTransitionTest, StaleStateCleanedAfterActionRemoval)
     EXPECT_FALSE(InputActionManager::IsActionPressed("Jump"));
     EXPECT_FALSE(InputActionManager::IsActionJustReleased("Jump"));
 }
+
+// ============================================================================
+// Input context (action-map) tests — multiple named contexts, single-active
+// switching, and held-key carry-over suppression on switch.
+// ============================================================================
+
+class InputContextTest : public ::testing::Test
+{
+  protected:
+    MockInputProvider m_Mock;
+
+    static InputActionMap MakeGameplayMap()
+    {
+        InputActionMap map;
+        map.Name = "Gameplay";
+        map.AddAction({ "Fire", { InputBinding::Key(Key::Space) } });
+        map.AddAction({ "Reload", { InputBinding::Key(Key::R) } });
+        return map;
+    }
+
+    static InputActionMap MakeMenuMap()
+    {
+        InputActionMap map;
+        map.Name = "Menu";
+        map.AddAction({ "Confirm", { InputBinding::Key(Key::Enter) } });
+        // Deliberately reuse Space (Gameplay's "Fire" key) so the carry-over
+        // suppression test can prove a held key doesn't leak across the switch.
+        map.AddAction({ "Back", { InputBinding::Key(Key::Space) } });
+        return map;
+    }
+
+    void SetUp() override
+    {
+        InputActionManager::Init();
+        InputActionManager::SetInputProvider(&m_Mock);
+    }
+
+    void TearDown() override
+    {
+        InputActionManager::SetInputProvider(nullptr); // restore default
+        InputActionManager::Shutdown();
+    }
+};
+
+TEST_F(InputContextTest, DefaultContextIsGameplay)
+{
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+}
+
+TEST_F(InputContextTest, SetInputContextChangesActiveContext)
+{
+    InputActionManager::SetInputContext(InputContextType::Menu);
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Menu);
+
+    InputActionManager::SetInputContext(InputContextType::Vehicle);
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Vehicle);
+}
+
+TEST_F(InputContextTest, SwitchingContextActivatesDifferentMap)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    // Active context is Gameplay: Space drives "Fire"; "Confirm" is unknown here.
+    m_Mock.PressKey(Key::Space);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Fire"));
+    EXPECT_FALSE(InputActionManager::IsActionPressed("Confirm"));
+
+    // Switch to Menu: Enter drives "Confirm"; "Fire" no longer exists.
+    m_Mock.ReleaseAll();
+    InputActionManager::SetInputContext(InputContextType::Menu);
+    m_Mock.PressKey(Key::Enter);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Confirm"));
+    EXPECT_FALSE(InputActionManager::IsActionPressed("Fire"));
+}
+
+TEST_F(InputContextTest, MapsArePreservedAcrossContextRoundTrip)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    EXPECT_EQ(InputActionManager::GetActionMap().Name, "Gameplay");
+    EXPECT_TRUE(InputActionManager::GetActionMap().HasAction("Fire"));
+
+    InputActionManager::SetInputContext(InputContextType::Menu);
+    EXPECT_EQ(InputActionManager::GetActionMap().Name, "Menu");
+    EXPECT_TRUE(InputActionManager::GetActionMap().HasAction("Confirm"));
+
+    InputActionManager::SetInputContext(InputContextType::Gameplay);
+    EXPECT_EQ(InputActionManager::GetActionMap().Name, "Gameplay");
+    EXPECT_TRUE(InputActionManager::GetActionMap().HasAction("Reload"));
+}
+
+TEST_F(InputContextTest, GetActionMapByContextReadsInactiveContext)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    // Gameplay is active; read the inactive Menu map without switching to it.
+    const auto& menu = InputActionManager::GetActionMap(InputContextType::Menu);
+    EXPECT_EQ(menu.Name, "Menu");
+    EXPECT_TRUE(menu.HasAction("Confirm"));
+
+    // The active-context overload routes back to the live map.
+    const auto& gameplay = InputActionManager::GetActionMap(InputContextType::Gameplay);
+    EXPECT_EQ(gameplay.Name, "Gameplay");
+}
+
+TEST_F(InputContextTest, HeldKeyDoesNotFireSameKeyActionAfterSwitch)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    // Hold Space in Gameplay — "Fire" fires.
+    m_Mock.PressKey(Key::Space);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionJustPressed("Fire"));
+
+    // Switch to Menu while Space is still held. Menu's "Back" is also bound to Space.
+    InputActionManager::SetInputContext(InputContextType::Menu);
+    InputActionManager::Update();
+
+    // "Back" is pressed (the key is down) but must NOT be just-pressed — the press
+    // carried over from the previous context and should be ignored for one frame.
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Back"));
+    EXPECT_FALSE(InputActionManager::IsActionJustPressed("Back"));
+
+    // Release then re-press → now it registers as a fresh just-pressed.
+    m_Mock.ReleaseKey(Key::Space);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionJustReleased("Back"));
+
+    m_Mock.PressKey(Key::Space);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionJustPressed("Back"));
+}
+
+TEST_F(InputContextTest, SwitchingToSameContextIsNoOp)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+
+    m_Mock.PressKey(Key::Space);
+    InputActionManager::Update();
+    InputActionManager::Update(); // held across two frames → no longer "just" pressed
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Fire"));
+    EXPECT_FALSE(InputActionManager::IsActionJustPressed("Fire"));
+
+    // Switching to the already-active context must not reset cached state.
+    InputActionManager::SetInputContext(InputContextType::Gameplay);
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Fire"));
+}
+
+TEST_F(InputContextTest, DefaultContextDepthIsOne)
+{
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+}
+
+TEST_F(InputContextTest, PushContextActivatesAndPopRestores)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+
+    // Push Menu over Gameplay — Menu becomes active, depth grows.
+    InputActionManager::PushContext(InputContextType::Menu);
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Menu);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 2 });
+    EXPECT_TRUE(InputActionManager::GetActionMap().HasAction("Confirm"));
+
+    // Pop — Gameplay is restored, including its (still-present) map.
+    EXPECT_TRUE(InputActionManager::PopContext());
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+    EXPECT_TRUE(InputActionManager::GetActionMap().HasAction("Fire"));
+}
+
+TEST_F(InputContextTest, PopContextNeverPopsBaseContext)
+{
+    // At depth 1, PopContext is a no-op that reports failure.
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+    EXPECT_FALSE(InputActionManager::PopContext());
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+}
+
+TEST_F(InputContextTest, PushContextNestsMultipleLevels)
+{
+    InputActionManager::PushContext(InputContextType::Menu);
+    InputActionManager::PushContext(InputContextType::Vehicle);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 3 });
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Vehicle);
+
+    EXPECT_TRUE(InputActionManager::PopContext());
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Menu);
+
+    EXPECT_TRUE(InputActionManager::PopContext());
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+}
+
+TEST_F(InputContextTest, SetInputContextCollapsesTheStack)
+{
+    InputActionManager::PushContext(InputContextType::Menu);
+    InputActionManager::PushContext(InputContextType::Vehicle);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 3 });
+
+    // A hard switch flattens any nesting back to a single active context.
+    InputActionManager::SetInputContext(InputContextType::Gameplay);
+    EXPECT_EQ(InputActionManager::GetContextDepth(), sizet{ 1 });
+    EXPECT_EQ(InputActionManager::GetInputContext(), InputContextType::Gameplay);
+}
+
+TEST_F(InputContextTest, PushAndPopSuppressHeldKeyCarryOver)
+{
+    InputActionManager::SetActionMap(InputContextType::Gameplay, MakeGameplayMap());
+    InputActionManager::SetActionMap(InputContextType::Menu, MakeMenuMap());
+
+    // Hold Space in Gameplay — "Fire" fires.
+    m_Mock.PressKey(Key::Space);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionJustPressed("Fire"));
+
+    // Push Menu while Space is still held. Menu's "Back" shares the Space binding,
+    // but the carried-over press must not register as a fresh just-pressed.
+    InputActionManager::PushContext(InputContextType::Menu);
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Back"));
+    EXPECT_FALSE(InputActionManager::IsActionJustPressed("Back"));
+
+    // Pop back to Gameplay with Space still held — same suppression on the way back.
+    EXPECT_TRUE(InputActionManager::PopContext());
+    InputActionManager::Update();
+    EXPECT_TRUE(InputActionManager::IsActionPressed("Fire"));
+    EXPECT_FALSE(InputActionManager::IsActionJustPressed("Fire"));
+}


### PR DESCRIPTION
Add named input contexts (Gameplay/Menu/Vehicle/Custom) to the input action system. Each context owns its own InputActionMap; a context stack decides which one is active, so switching to a menu changes which actions are live without manual unbinding.

- SetInputContext (hard switch — collapses the stack), PushContext/ PopContext (nest/restore; base context never popped), GetInputContext, GetContextDepth, SetActionMap(ctx,map), GetActionMap(ctx).
- Existing GetActionMap()/GetActionMapConst()/SetActionMap(map) preserved (route through the active context) — the editor panel is untouched.
- The first Update() after an active-context change aligns previous==current so a key still held from the old context (e.g. the Escape that opened a menu) doesn't fire a same-key action in the new context.
- Lua + C# bindings for the new context API.
- 13 InputContextTest cases in InputActionTest.cpp (classified unit; no CMakeLists.txt change).

Deferred to #461 follow-ups: in-game rebinding UI and multi-context serialization.