### PR TITLE
feat(mcp): headless attach to the test-harness offscreen framebuffer …

### DIFF
--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -177,6 +177,12 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/RendererAttachedTest.cpp
 		Rendering/PropertyTests/RendererAttachedSmokeTest.cpp
 		Rendering/PropertyTests/SceneRenderEvidenceTest.cpp
+		# Headless-attach stretch of issue #316: hosts the read-only MCP server
+		# inside the test binary against the offscreen render-graph FB so
+		# olo_screenshot / olo_shader_errors work in the headless visual-verify
+		# loop. Header-only host helper (McpHeadlessHost.h); pulls in the real MCP
+		# tools (McpTools.cpp + McpScriptApi.cpp) added to the source list below.
+		Rendering/PropertyTests/McpHeadlessAttachTest.cpp
 		Rendering/PropertyTests/VideoOverlayVisualEvidenceTest.cpp
 		Rendering/PropertyTests/AutoExposureEvidenceTest.cpp
 		Rendering/PropertyTests/TestFailureCapture.cpp
@@ -307,10 +313,17 @@ add_executable(OloEngine-Tests
 		# MCP JSON-RPC dispatch / framing tests (issue #306 item D). The dispatch
 		# core lives in the OloEditor target, so pull its single httplib-free-at-
 		# the-seam translation unit into the test binary (cpp_httplib is linked
-		# below). McpServerPanel.* (ImGui) and McpTools.* (real tools) are NOT
-		# needed — the test registers fake tools/resources/prompts.
+		# below). McpServerPanel.* (ImGui) is NOT needed.
 		MCP/McpDispatchTest.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpServer.cpp
+		# Headless-attach stretch (issue #316): McpHeadlessAttachTest hosts the
+		# REAL tool surface (RegisterBuiltinTools) against the offscreen FB, so it
+		# needs the actual tool TUs too. These are editor-decoupled — they include
+		# only OloEngine headers + the header-only MCP/* helpers — so they compile
+		# cleanly into the test binary (which links OloEngine). McpScriptApi.cpp
+		# supplies BuildScriptApiDigest, referenced by McpTools.cpp.
+		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpTools.cpp
+		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpScriptApi.cpp
 		# Pure reasoning behind olo_physics_why_no_collision (#306 item A). Header-
 		# only (MCP/McpPhysicsExplain.h), so no extra editor TU is pulled in.
 		MCP/McpPhysicsExplainTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
@@ -95,19 +95,24 @@ namespace OloEngine::Tests
                 return -1; // padding '=' or whitespace
             };
             std::vector<u8> out;
-            int buffer = 0;
+            // Unsigned accumulator: signed left-shift overflows after a few sextets
+            // (>32 bits) and that is UB. After each emitted byte, mask off the
+            // consumed high bits so `buffer` only ever retains the `bits` leftover
+            // low bits of base64 state.
+            u32 buffer = 0;
             int bits = 0;
             for (const char c : in)
             {
                 const int v = value(c);
                 if (v < 0)
                     continue;
-                buffer = (buffer << 6) | v;
+                buffer = (buffer << 6) | static_cast<u32>(v);
                 bits += 6;
                 if (bits >= 8)
                 {
                     bits -= 8;
-                    out.push_back(static_cast<u8>((buffer >> bits) & 0xFF));
+                    out.push_back(static_cast<u8>((buffer >> bits) & 0xFFu));
+                    buffer &= (1u << bits) - 1u;
                 }
             }
             return out;

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
@@ -1,0 +1,422 @@
+// =============================================================================
+// McpHeadlessAttachTest.cpp
+//
+// Headless-attach stretch of issue #316: prove the read-only MCP diagnostics
+// tools (olo_screenshot, olo_shader_errors, olo_render_capture_target) work
+// against the TEST harness's OFFSCREEN render-graph framebuffer — the same
+// RunEditorFrames / visual-evidence path renderer worktrees verify in — rather
+// than only a live editor viewport.
+//
+// Why this matters
+// ----------------
+// CLAUDE.md mandates "Rendering changes MUST be visually verified". That loop
+// lives in the editor today (the MCP server reads the live viewport). But the
+// real renderer verification happens HEADLESS (WaterVisualEvidenceTest et al.
+// render into an offscreen FB and read it back). McpHeadlessHost stands the
+// read-only MCP server up inside this test binary, pointed at that offscreen FB,
+// so an agent gets olo_screenshot / olo_shader_errors against exactly what the
+// headless pipeline drew — closing the visual-verify loop where renderer work
+// actually lives.
+//
+// The two tests
+// -------------
+//   * ScreenshotAndShaderErrorsOverMcp — the CI regression guard. Renders a lit
+//     cube into the offscreen FB, hosts the MCP server in-process, issues real
+//     JSON-RPC tools/call dispatches through the httplib-free seam (on a worker
+//     thread while this thread pumps the GameThread queue, preserving the
+//     MarshalRead contract), and asserts olo_screenshot returns a decodable PNG
+//     of the offscreen frame + olo_shader_errors returns a well-formed report.
+//     SKIPs cleanly (not fails) when no GL 4.6 context — same gate as the other
+//     visual-evidence tests.
+//   * HostUntilDetached — the INTERACTIVE headless-attach entry point. SKIPs
+//     unless OLO_MCP_HEADLESS_ATTACH=1; when set, it renders + hosts the server
+//     (honouring OLO_MCP_PORT / OLO_MCP_DISCOVERY_FILE) and pumps live until a
+//     stop signal, so an external agent attached via `claude mcp add` can
+//     screenshot the offscreen FB from a renderer worktree's headless loop.
+//
+// Classification: integration (full Renderer3D bring-up + RGBA8 readback +
+// in-process MCP dispatch). Sibling of RendererAttachedSmokeTest.
+// =============================================================================
+
+// OLO_TEST_LAYER: integration
+
+#include "OloEnginePCH.h"
+
+#include "McpHeadlessHost.h"
+#include "RenderPropertyTest.h"
+#include "RendererAttachedTest.h"
+
+#include "MCP/McpServer.h"
+
+#include "OloEngine/Renderer/Camera/EditorCamera.h"
+#include "OloEngine/Renderer/Framebuffer.h"
+#include "OloEngine/Renderer/Mesh.h"
+#include "OloEngine/Renderer/MeshPrimitives.h"
+#include "OloEngine/Renderer/Renderer3D.h"
+#include "OloEngine/Renderer/ResourceHandle.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+
+#include <gtest/gtest.h>
+#include <stb_image/stb_image.h>
+
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        using Json = OloEngine::MCP::Json;
+
+        constexpr u32 kWidth = 640;
+        constexpr u32 kHeight = 360;
+
+        // Minimal base64 decoder (RFC 4648) so the test can hand the PNG bytes to
+        // stb_image and confirm the screenshot is a real, decodable image of the
+        // requested size — not just a non-empty string.
+        [[nodiscard]] std::vector<u8> Base64Decode(const std::string& in)
+        {
+            auto value = [](char c) -> int
+            {
+                if (c >= 'A' && c <= 'Z')
+                    return c - 'A';
+                if (c >= 'a' && c <= 'z')
+                    return c - 'a' + 26;
+                if (c >= '0' && c <= '9')
+                    return c - '0' + 52;
+                if (c == '+')
+                    return 62;
+                if (c == '/')
+                    return 63;
+                return -1; // padding '=' or whitespace
+            };
+            std::vector<u8> out;
+            int buffer = 0;
+            int bits = 0;
+            for (const char c : in)
+            {
+                const int v = value(c);
+                if (v < 0)
+                    continue;
+                buffer = (buffer << 6) | v;
+                bits += 6;
+                if (bits >= 8)
+                {
+                    bits -= 8;
+                    out.push_back(static_cast<u8>((buffer >> bits) & 0xFF));
+                }
+            }
+            return out;
+        }
+
+        // Pull the first image content block (type:"image") out of a tools/call
+        // JSON-RPC response, returning its base64 data, or "" if none.
+        [[nodiscard]] std::string FindImageData(const Json& response)
+        {
+            if (!response.contains("result") || !response["result"].contains("content"))
+                return {};
+            for (const auto& block : response["result"]["content"])
+            {
+                if (block.value("type", std::string{}) == "image" && block.contains("data"))
+                    return block["data"].get<std::string>();
+            }
+            return {};
+        }
+
+        // Find the first text content block of a tools/call response.
+        [[nodiscard]] std::string FindTextData(const Json& response)
+        {
+            if (!response.contains("result") || !response["result"].contains("content"))
+                return {};
+            for (const auto& block : response["result"]["content"])
+            {
+                if (block.value("type", std::string{}) == "text" && block.contains("text"))
+                    return block["text"].get<std::string>();
+            }
+            return {};
+        }
+
+        [[nodiscard]] bool EnvFlagSet(const char* name)
+        {
+            const char* v = std::getenv(name);
+            return v != nullptr && v[0] != '\0' && v[0] != '0';
+        }
+    } // namespace
+
+    // A minimal lit scene rendered through the full editor render path into the
+    // fixture's offscreen render-graph FB — the surface the headless MCP host
+    // screenshots.
+    class McpHeadlessAttachTest : public RendererAttachedTest
+    {
+      protected:
+        void BuildScene() override
+        {
+            Scene& scene = GetScene();
+            EnableRendering(kWidth, kHeight);
+
+            // A directional light so the cube is actually shaded (a black frame
+            // would make the screenshot evidence meaningless).
+            {
+                Entity light = scene.CreateEntity("Sun");
+                auto& tc = light.GetComponent<TransformComponent>();
+                tc.Translation = { 2.0f, 4.0f, 3.0f };
+                auto& dl = light.AddComponent<DirectionalLightComponent>();
+                dl.m_Direction = glm::normalize(glm::vec3(-0.4f, -0.8f, -0.45f));
+                dl.m_Color = glm::vec3(1.0f, 0.97f, 0.9f);
+                dl.m_Intensity = 3.0f;
+            }
+
+            // A unit cube at the origin with a bright, unmistakably non-grey
+            // material so the captured PNG is obviously a rendered object.
+            {
+                Entity cube = scene.CreateEntity("Cube");
+                auto& tc = cube.GetComponent<TransformComponent>();
+                tc.Translation = { 0.0f, 0.0f, 0.0f };
+                tc.Scale = { 1.5f, 1.5f, 1.5f };
+                auto& mc = cube.AddComponent<MeshComponent>();
+                mc.m_Primitive = MeshPrimitive::Cube;
+                if (Ref<Mesh> mesh = MeshPrimitives::CreateCube())
+                    mc.m_MeshSource = mesh->GetMeshSource();
+                auto& mat = cube.AddComponent<MaterialComponent>();
+                mat.m_Material.SetBaseColorFactor(glm::vec4(0.15f, 0.65f, 0.95f, 1.0f));
+            }
+        }
+
+        // Pose an EditorCamera so the cube fills the frame.
+        [[nodiscard]] EditorCamera MakeCamera() const
+        {
+            EditorCamera camera(45.0f, static_cast<f32>(kWidth) / static_cast<f32>(kHeight), 0.1f, 1000.0f);
+            camera.SetViewportSize(static_cast<f32>(kWidth), static_cast<f32>(kHeight));
+            camera.SetPose(glm::vec3(0.0f, 1.2f, 4.5f), /*yaw=*/0.0f, /*pitch=*/0.18f);
+            return camera;
+        }
+    };
+
+    // The CI regression guard: olo_screenshot + olo_shader_errors against the
+    // offscreen FB, end to end through real JSON-RPC dispatch. SKIPs without GL.
+    TEST_F(McpHeadlessAttachTest, ScreenshotAndShaderErrorsOverMcp)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        EditorCamera camera = MakeCamera();
+
+        // Render a couple of frames so the offscreen composite FB has content
+        // before the host comes up.
+        RunEditorFrames(camera, 2);
+
+        // Independent sanity check that the offscreen frame is NOT black — so a
+        // passing screenshot can't be a captured black buffer.
+        {
+            std::vector<u8> pixels;
+            u32 w = 0, h = 0;
+            ASSERT_TRUE(ReadbackComposite(pixels, w, h)) << "offscreen composite FB unavailable";
+            ASSERT_EQ(w, kWidth);
+            ASSERT_EQ(h, kHeight);
+            u64 lumaSum = 0;
+            for (std::size_t i = 0; i + 3 < pixels.size(); i += 4)
+                lumaSum += pixels[i] + pixels[i + 1] + pixels[i + 2];
+            const f64 meanChannel = static_cast<f64>(lumaSum) / (static_cast<f64>(kWidth) * kHeight * 3.0);
+            ASSERT_GT(meanChannel, 2.0) << "offscreen frame rendered (near-)black; screenshot evidence would be meaningless";
+        }
+
+        McpHeadlessHost host(McpHeadlessHost::Hooks{
+            .GetScene = [this]() -> Ref<Scene>
+            { return GetSceneRef(); },
+            .GetCompositeFramebuffer = []() -> Ref<Framebuffer>
+            { return Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::UIComposite); },
+            .Camera = &camera,
+            .RenderWidth = kWidth,
+            .RenderHeight = kHeight,
+            .RenderOneFrame = [this, &camera]()
+            { RunEditorFrames(camera, 1); },
+        });
+
+        const u16 port = host.Start();
+        ASSERT_NE(port, 0) << "McpHeadlessHost failed to bind any port for the MCP server";
+
+        // ---- olo_screenshot (no pose): capture the current offscreen frame -----
+        {
+            const Json resp = host.CallTool("olo_screenshot", Json{ { "maxWidth", 256 } });
+            ASSERT_TRUE(resp.contains("result")) << "olo_screenshot returned an error: " << resp.dump(2);
+            EXPECT_FALSE(resp["result"].value("isError", false)) << resp.dump(2);
+
+            const std::string b64 = FindImageData(resp);
+            ASSERT_FALSE(b64.empty()) << "olo_screenshot returned no image block: " << resp.dump(2);
+
+            const std::vector<u8> png = Base64Decode(b64);
+            ASSERT_GT(png.size(), 8u);
+            // PNG signature.
+            const std::array<u8, 8> sig = { 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A };
+            for (std::size_t i = 0; i < sig.size(); ++i)
+                ASSERT_EQ(png[i], sig[i]) << "screenshot is not a PNG (byte " << i << ")";
+
+            int dw = 0, dh = 0, dch = 0;
+            stbi_uc* decoded = ::stbi_load_from_memory(png.data(), static_cast<int>(png.size()), &dw, &dh, &dch, 4);
+            ASSERT_NE(decoded, nullptr) << "screenshot PNG did not decode";
+            ::stbi_image_free(decoded);
+            EXPECT_GT(dw, 0);
+            EXPECT_GT(dh, 0);
+            EXPECT_LE(dw, 256) << "screenshot was not downscaled to maxWidth";
+            // Aspect ratio of the offscreen FB is preserved on downscale.
+            EXPECT_EQ(dh, std::max(1, (256 * static_cast<int>(kHeight)) / static_cast<int>(kWidth)));
+        }
+
+        // ---- olo_screenshot (posed): exercises camera control + frame-await ----
+        {
+            const Json resp = host.CallTool(
+                "olo_screenshot",
+                Json{ { "maxWidth", 200 },
+                      { "camera", { { "position", { 3.0, 2.0, 3.0 } }, { "target", { 0.0, 0.0, 0.0 } } } },
+                      { "settleFrames", 2 } });
+            ASSERT_TRUE(resp.contains("result")) << "posed olo_screenshot errored: " << resp.dump(2);
+            EXPECT_FALSE(resp["result"].value("isError", false)) << resp.dump(2);
+            const std::string b64 = FindImageData(resp);
+            ASSERT_FALSE(b64.empty()) << "posed olo_screenshot returned no image: " << resp.dump(2);
+            const std::vector<u8> png = Base64Decode(b64);
+            int dw = 0, dh = 0, dch = 0;
+            stbi_uc* decoded = ::stbi_load_from_memory(png.data(), static_cast<int>(png.size()), &dw, &dh, &dch, 4);
+            ASSERT_NE(decoded, nullptr) << "posed screenshot PNG did not decode";
+            ::stbi_image_free(decoded);
+            EXPECT_GT(dw, 0);
+            EXPECT_LE(dw, 200);
+
+            // The camera must be restored to the pre-call pose (the host wired the
+            // save/restore contract). The MakeCamera pose sits on +Z; the posed
+            // capture moved it to (3,2,3). After the call it should be back.
+            EXPECT_NEAR(camera.GetPosition().z, 4.5f, 1.0f)
+                << "posed screenshot did not restore the prior camera";
+        }
+
+        // ---- olo_shader_errors: queries the live ShaderDebugger ----------------
+        {
+            const Json resp = host.CallTool("olo_shader_errors");
+            ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+            EXPECT_FALSE(resp["result"].value("isError", false)) << resp.dump(2);
+
+            const std::string text = FindTextData(resp);
+            ASSERT_FALSE(text.empty()) << "olo_shader_errors returned no text: " << resp.dump(2);
+            const Json report = Json::parse(text, nullptr, /*allow_exceptions=*/false);
+            ASSERT_TRUE(report.is_object()) << "olo_shader_errors text was not JSON: " << text;
+            ASSERT_TRUE(report.contains("count") && report["count"].is_number_integer()) << text;
+            ASSERT_TRUE(report.contains("errors") && report["errors"].is_array()) << text;
+            EXPECT_EQ(static_cast<std::size_t>(report["count"].get<int>()), report["errors"].size());
+            // The production shader set compiled during Renderer::Init; any error
+            // here is a real shader regression, not an MCP-plumbing failure.
+            EXPECT_EQ(report["count"].get<int>(), 0)
+                << "olo_shader_errors reported broken shaders: " << text;
+        }
+
+        // ---- olo_render_capture_target: best-effort intermediate-buffer read ---
+        // A nice-to-have for the slice (the handover says don't block on it). We
+        // discover a live target via olo_render_list_targets, then capture it and
+        // assert the dispatch produced a well-formed result (image or a clean tool
+        // error) — never a crash. Skips quietly if the graph exposed no targets.
+        {
+            const Json listResp = host.CallTool("olo_render_list_targets");
+            ASSERT_TRUE(listResp.contains("result")) << listResp.dump(2);
+            const std::string listText = FindTextData(listResp);
+            const Json targets = Json::parse(listText, nullptr, false);
+            std::string targetName;
+            if (targets.is_object() && targets.contains("targets") && targets["targets"].is_array())
+            {
+                for (const auto& t : targets["targets"])
+                {
+                    if (t.contains("name") && t["name"].is_string())
+                    {
+                        targetName = t["name"].get<std::string>();
+                        break;
+                    }
+                }
+            }
+            if (!targetName.empty())
+            {
+                const Json capResp = host.CallTool("olo_render_capture_target",
+                                                   Json{ { "name", targetName }, { "maxWidth", 128 } });
+                ASSERT_TRUE(capResp.contains("result")) << capResp.dump(2);
+                // Either a real image came back, or a clean tool-level error — both
+                // prove the tool ran end-to-end against the headless graph.
+                const bool isError = capResp["result"].value("isError", false);
+                const std::string capImg = FindImageData(capResp);
+                EXPECT_TRUE(isError || !capImg.empty())
+                    << "olo_render_capture_target('" << targetName << "') produced neither image nor error: "
+                    << capResp.dump(2);
+            }
+        }
+
+        host.Stop();
+    }
+
+    // Interactive headless-attach: render + host the MCP server live so an
+    // external agent (attached over the bound socket) can screenshot the
+    // offscreen FB. SKIPs in normal CI; opt in with OLO_MCP_HEADLESS_ATTACH=1.
+    // The run-oloengine driver sets OLO_MCP_PORT / OLO_MCP_DISCOVERY_FILE so the
+    // bound server + discovery file land where `claude mcp add` expects them.
+    TEST_F(McpHeadlessAttachTest, HostUntilDetached)
+    {
+        if (!EnvFlagSet("OLO_MCP_HEADLESS_ATTACH"))
+            GTEST_SKIP() << "Set OLO_MCP_HEADLESS_ATTACH=1 to host the offscreen FB over MCP for an external agent "
+                            "(interactive headless-attach mode).";
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        EditorCamera camera = MakeCamera();
+        RunEditorFrames(camera, 2);
+
+        McpHeadlessHost host(McpHeadlessHost::Hooks{
+            .GetScene = [this]() -> Ref<Scene>
+            { return GetSceneRef(); },
+            .GetCompositeFramebuffer = []() -> Ref<Framebuffer>
+            { return Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::UIComposite); },
+            .Camera = &camera,
+            .RenderWidth = kWidth,
+            .RenderHeight = kHeight,
+            .RenderOneFrame = [this, &camera]()
+            { RunEditorFrames(camera, 1); },
+        });
+
+        // Honour the per-worktree port the driver picked (OLO_MCP_PORT); the
+        // discovery file path comes from OLO_MCP_DISCOVERY_FILE inside Start().
+        u16 basePort = 0;
+        if (const char* portEnv = std::getenv("OLO_MCP_PORT"); portEnv != nullptr)
+        {
+            if (const unsigned long parsed = std::strtoul(portEnv, nullptr, 10); parsed >= 1024 && parsed <= 65535)
+                basePort = static_cast<u16>(parsed);
+        }
+        const u16 port = host.Start(basePort);
+        ASSERT_NE(port, 0) << "McpHeadlessHost failed to bind a port for the MCP server";
+
+        // How long to stay up (seconds); generous default for an interactive
+        // session, capped so a forgotten run can't wedge a CI machine forever.
+        int seconds = 600;
+        if (const char* secEnv = std::getenv("OLO_MCP_ATTACH_SECONDS"); secEnv != nullptr)
+        {
+            if (const long parsed = std::strtol(secEnv, nullptr, 10); parsed > 0 && parsed <= 7200)
+                seconds = static_cast<int>(parsed);
+        }
+
+        // A stop sentinel: delete this file (or let the timeout fire) to detach.
+        const std::string stopFile = MCP::McpServer::DiscoveryFilePath(port) + ".stop";
+        OLO_CORE_INFO("[MCP headless attach] hosting offscreen FB on http://127.0.0.1:{}/mcp for up to {}s. "
+                      "Touch '{}' then delete it to stop early.",
+                      port, seconds, stopFile);
+
+        bool sawSentinel = false;
+        host.HostUntil(
+            [&]() -> bool
+            {
+                // Stop once the sentinel has appeared and then been removed, so an
+                // operator can deterministically end the session.
+                const bool exists = std::filesystem::exists(stopFile);
+                if (exists)
+                    sawSentinel = true;
+                return sawSentinel && !exists;
+            },
+            std::chrono::seconds(seconds));
+
+        host.Stop();
+        SUCCEED() << "headless MCP attach session ended (port " << port << ").";
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
@@ -222,10 +222,12 @@ namespace OloEngine::Tests
             }
         }
 
-        // ---- PNG capture (mirrors EditorLayer::CaptureFramebufferPng) -----------
+        // ---- PNG capture (after EditorLayer::CaptureFramebufferPng) -------------
         // Read back colour attachment 0 of `framebuffer` (RGBA8), flip to PNG
-        // top-down orientation, optionally downscale so the width is <= maxWidth,
-        // and encode a PNG in memory. MUST run on the GL thread. Empty on failure.
+        // top-down orientation, optionally downscale so the LONG EDGE is <= maxWidth
+        // (the EditorMcpContext::CaptureViewportPng contract — clamps the longer of
+        // width/height, not width alone, so a portrait target is bounded too), and
+        // encode a PNG in memory. MUST run on the GL thread. Empty on failure.
         [[nodiscard]] static std::vector<u8> CaptureFramebufferPng(const Ref<Framebuffer>& framebuffer, int maxWidth)
         {
             if (!framebuffer)
@@ -254,10 +256,22 @@ namespace OloEngine::Tests
             u32 outH = height;
             const std::vector<u8>* src = &flipped;
             std::vector<u8> scaled;
-            if (maxWidth > 0 && width > static_cast<u32>(maxWidth))
+            const u32 longEdge = std::max(width, height);
+            if (maxWidth > 0 && longEdge > static_cast<u32>(maxWidth))
             {
-                outW = static_cast<u32>(maxWidth);
-                outH = std::max<u32>(1, static_cast<u32>((static_cast<u64>(height) * outW) / width));
+                // Clamp the LONGER edge to maxWidth, preserving aspect ratio, so a
+                // portrait target is bounded too (not just width).
+                const u32 cap = static_cast<u32>(maxWidth);
+                if (width >= height)
+                {
+                    outW = cap;
+                    outH = std::max<u32>(1, static_cast<u32>((static_cast<u64>(height) * cap) / width));
+                }
+                else
+                {
+                    outH = cap;
+                    outW = std::max<u32>(1, static_cast<u32>((static_cast<u64>(width) * cap) / height));
+                }
                 scaled.assign(static_cast<sizet>(outW) * outH * 4, 0);
                 for (u32 y = 0; y < outH; ++y)
                 {

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
@@ -1,0 +1,374 @@
+#pragma once
+
+// =============================================================================
+// McpHeadlessHost — stand up the read-only MCP diagnostics server inside the
+// TEST binary, pointed at the test fixture's OFFSCREEN render-graph framebuffer
+// (the RunEditorFrames / visual-evidence path) instead of a live editor
+// viewport.
+//
+// This is the "headless attach" stretch of issue #316. The visual-verify loop
+// CLAUDE.md mandates ("Rendering changes MUST be visually verified") lives in
+// the editor today: the MCP server reads the editor's live viewport. Renderer
+// worktrees, though, do their real verification in the HEADLESS test loop
+// (WaterVisualEvidenceTest / SceneRenderEvidenceTest render into an offscreen
+// FB). This host makes olo_screenshot / olo_shader_errors / olo_render_capture_target
+// work against that offscreen FB, so a renderer agent can verify visually
+// without a running editor.
+//
+// The seam
+// --------
+// McpServer is already decoupled from the editor: it only reads an
+// EditorMcpContext (a struct of std::function hooks) and marshals main-thread
+// work onto the engine GameThread queue via EnqueueGameThreadTask. In the
+// editor, Application::Run drains that queue every frame; a test has no such
+// loop, so this host pumps the GameThread queue ITSELF
+// (FNamedThreadManager::ProcessTasks(GameThread)) from the GL-context thread
+// while an MCP tools/call runs on a worker thread.
+//
+// The MarshalRead contract is preserved exactly: tool handlers run on a NON-game
+// thread (the worker) and block on a job the pumping (GL-context) thread
+// services — never a deadlock, because the pumping thread is not the one calling
+// MarshalRead. Every context hook (CaptureViewportPng, camera get/set, frame
+// index) therefore runs on the GL-context thread, where readback / EditorCamera
+// access is valid.
+//
+// Usage
+// -----
+//   McpHeadlessHost host(McpHeadlessHost::Hooks{
+//       .GetScene              = [&]{ return GetSceneRef(); },
+//       .GetCompositeFramebuffer = [&]{ return Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::UIComposite); },
+//       .Camera                = &camera,
+//       .RenderWidth = w, .RenderHeight = h,
+//       .RenderOneFrame        = [&]{ RunEditorFrames(camera, 1); },
+//   });
+//   const u16 port = host.Start(/*basePort=*/0);   // 0 => derive a free port
+//   const Json result = host.CallTool("olo_screenshot", { {"maxWidth", 256} });
+//   ...
+//   host.Stop();
+//
+// All of Start/Stop/PumpOnce/CallTool/HostUntil MUST be called from the
+// GL-context thread (the test's main thread). CallTool dispatches on a worker
+// thread internally and pumps this thread until the call completes.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "MCP/McpServer.h"
+#include "MCP/McpTools.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/Camera/EditorCamera.h"
+#include "OloEngine/Renderer/Framebuffer.h"
+#include "OloEngine/Scene/Scene.h"
+#include "OloEngine/Task/NamedThreads.h"
+
+#include <glad/gl.h>
+#include <nlohmann/json.hpp>
+#include <stb_image/stb_image_write.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <future>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace OloEngine::Tests
+{
+    class McpHeadlessHost
+    {
+      public:
+        using Json = OloEngine::MCP::Json;
+
+        // Hooks the host needs from the test. Every callback runs on the pumping
+        // (GL-context) thread inside a MarshalRead job, so GL readback / EnTT /
+        // EditorCamera access is valid there.
+        struct Hooks
+        {
+            // The active scene the diagnostics tools (olo_scene_*) read.
+            std::function<Ref<Scene>()> GetScene;
+            // Resolve the offscreen composite framebuffer olo_screenshot reads
+            // back — the same UIComposite RT0 the editor viewport samples and the
+            // visual-evidence tests read via ReadbackComposite.
+            std::function<Ref<Framebuffer>()> GetCompositeFramebuffer;
+            // The EditorCamera the olo_camera_* / posed-olo_screenshot tools drive.
+            // RenderOneFrame must render THIS camera so a pose change is visible in
+            // the next captured frame.
+            EditorCamera* Camera = nullptr;
+            u32 RenderWidth = 0;
+            u32 RenderHeight = 0;
+            // Render one frame at the current camera pose into the offscreen FB.
+            // Called by PumpOnce before draining the GameThread queue, so a capture
+            // job always sees a fresh frame and AwaitRenderedFrames sees the frame
+            // counter advance.
+            std::function<void()> RenderOneFrame;
+        };
+
+        explicit McpHeadlessHost(Hooks hooks)
+            : m_Hooks(std::move(hooks))
+        {
+            m_Server = CreateScope<MCP::McpServer>(BuildContext());
+            MCP::RegisterBuiltinTools(*m_Server);
+        }
+
+        ~McpHeadlessHost()
+        {
+            Stop();
+        }
+
+        McpHeadlessHost(const McpHeadlessHost&) = delete;
+        McpHeadlessHost& operator=(const McpHeadlessHost&) = delete;
+
+        // Start the server, binding the first free port at or after `basePort`.
+        // basePort == 0 derives a per-process base (from the PID) so parallel
+        // ctest processes don't collide. Returns the bound port, or 0 on failure.
+        [[nodiscard]] u16 Start(u16 basePort = 0, int attempts = 24)
+        {
+            u16 port = basePort != 0 ? basePort : DerivePidPort();
+            for (int i = 0; i < attempts; ++i)
+            {
+                const u16 candidate = static_cast<u16>(port + static_cast<u16>(i));
+                if (candidate < 1024)
+                    continue;
+                if (m_Server->Start(candidate))
+                    return candidate;
+            }
+            return 0;
+        }
+
+        void Stop()
+        {
+            if (m_Server && m_Server->IsRunning())
+                m_Server->Stop();
+        }
+
+        [[nodiscard]] MCP::McpServer& Server()
+        {
+            return *m_Server;
+        }
+        [[nodiscard]] u64 FrameIndex() const
+        {
+            return m_FrameIndex.load(std::memory_order_relaxed);
+        }
+
+        // Pump one iteration on the CALLING (GL-context) thread: render one frame
+        // (advancing the frame counter the capture/await tools observe) then drain
+        // the GameThread queue so any pending MarshalRead job runs to completion.
+        void PumpOnce()
+        {
+            if (m_Hooks.RenderOneFrame)
+                m_Hooks.RenderOneFrame();
+            m_FrameIndex.fetch_add(1, std::memory_order_relaxed);
+            // Explicit-thread overload: drains the GameThread queue regardless of
+            // named-thread attachment (we don't AttachToThread — the pumping thread
+            // already holds the GL context the jobs need).
+            Tasks::FNamedThreadManager::Get().ProcessTasks(Tasks::ENamedThread::GameThread, /*bIncludeLocalQueue=*/true);
+        }
+
+        // Run a JSON-RPC tools/call and return the raw JSON-RPC response object.
+        // The handler runs on a worker thread (so its MarshalRead is legal); this
+        // thread pumps until it completes. MUST be called from the GL-context
+        // thread. Returns the full { jsonrpc, id, result|error } envelope.
+        [[nodiscard]] Json CallTool(const std::string& name, const Json& arguments = Json::object(),
+                                    std::chrono::milliseconds timeout = std::chrono::seconds(30))
+        {
+            const Json message = { { "jsonrpc", "2.0" },
+                                   { "id", ++m_NextId },
+                                   { "method", "tools/call" },
+                                   { "params", { { "name", name }, { "arguments", arguments } } } };
+            return CallRaw(message, timeout);
+        }
+
+        // Run any JSON-RPC message (tools/list, initialize, …) with the same
+        // pump-while-dispatching machinery.
+        [[nodiscard]] Json CallRaw(const Json& message, std::chrono::milliseconds timeout = std::chrono::seconds(30))
+        {
+            std::future<Json> future =
+                std::async(std::launch::async, [this, message]() -> Json
+                           { return m_Server->HandleMessage(message); });
+
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            while (future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+            {
+                PumpOnce();
+                if (std::chrono::steady_clock::now() >= deadline)
+                    break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+            // Even on the deadline path the worker self-bounds: MarshalRead times
+            // out (~5 s) and the handler returns a tool error, so get() completes.
+            return future.get();
+        }
+
+        // Interactive headless-attach mode: render + pump continuously so an
+        // EXTERNAL agent (attached over the bound socket via `claude mcp add`) can
+        // screenshot the offscreen FB live. Returns when `shouldStop` reports true
+        // or `maxDuration` elapses. The discovery file was already written by
+        // Start() (honouring OLO_MCP_DISCOVERY_FILE / OLO_MCP_PORT).
+        void HostUntil(const std::function<bool()>& shouldStop, std::chrono::seconds maxDuration)
+        {
+            const auto deadline = std::chrono::steady_clock::now() + maxDuration;
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                if (shouldStop && shouldStop())
+                    break;
+                PumpOnce();
+                std::this_thread::sleep_for(std::chrono::milliseconds(8));
+            }
+        }
+
+        // ---- PNG capture (mirrors EditorLayer::CaptureFramebufferPng) -----------
+        // Read back colour attachment 0 of `framebuffer` (RGBA8), flip to PNG
+        // top-down orientation, optionally downscale so the width is <= maxWidth,
+        // and encode a PNG in memory. MUST run on the GL thread. Empty on failure.
+        [[nodiscard]] static std::vector<u8> CaptureFramebufferPng(const Ref<Framebuffer>& framebuffer, int maxWidth)
+        {
+            if (!framebuffer)
+                return {};
+            const auto& spec = framebuffer->GetSpecification();
+            const u32 width = spec.Width;
+            const u32 height = spec.Height;
+            if (width == 0 || height == 0)
+                return {};
+            const u32 textureId = framebuffer->GetColorAttachmentRendererID(0);
+            if (textureId == 0)
+                return {};
+
+            std::vector<u8> pixels(static_cast<sizet>(width) * height * 4);
+            ::glGetTextureImage(textureId, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                                static_cast<GLsizei>(pixels.size()), pixels.data());
+
+            // glGetTextureImage returns rows bottom-up; flip for PNG (top-down).
+            const u32 rowBytes = width * 4;
+            std::vector<u8> flipped(pixels.size());
+            for (u32 y = 0; y < height; ++y)
+                std::memcpy(flipped.data() + static_cast<sizet>(y) * rowBytes,
+                            pixels.data() + static_cast<sizet>(height - 1 - y) * rowBytes, rowBytes);
+
+            u32 outW = width;
+            u32 outH = height;
+            const std::vector<u8>* src = &flipped;
+            std::vector<u8> scaled;
+            if (maxWidth > 0 && width > static_cast<u32>(maxWidth))
+            {
+                outW = static_cast<u32>(maxWidth);
+                outH = std::max<u32>(1, static_cast<u32>((static_cast<u64>(height) * outW) / width));
+                scaled.assign(static_cast<sizet>(outW) * outH * 4, 0);
+                for (u32 y = 0; y < outH; ++y)
+                {
+                    const u32 sy = std::min(height - 1, static_cast<u32>((static_cast<u64>(y) * height) / outH));
+                    for (u32 x = 0; x < outW; ++x)
+                    {
+                        const u32 sx = std::min(width - 1, static_cast<u32>((static_cast<u64>(x) * width) / outW));
+                        std::memcpy(&scaled[(static_cast<sizet>(y) * outW + x) * 4],
+                                    &flipped[(static_cast<sizet>(sy) * width + sx) * 4], 4);
+                    }
+                }
+                src = &scaled;
+            }
+
+            std::vector<u8> png;
+            const auto append = [](void* context, void* data, int size)
+            {
+                auto* out = static_cast<std::vector<u8>*>(context);
+                const auto* bytes = static_cast<const u8*>(data);
+                out->insert(out->end(), bytes, bytes + size);
+            };
+            if (::stbi_write_png_to_func(append, &png, static_cast<int>(outW), static_cast<int>(outH),
+                                         4, src->data(), static_cast<int>(outW * 4)) == 0)
+                return {};
+            return png;
+        }
+
+      private:
+        // Build the EditorMcpContext that backs the server with the OFFSCREEN FB
+        // and the test's EditorCamera. Mirrors EditorLayer's wiring (#316) but
+        // sources its frame from the fixture's render-graph composite rather than
+        // a live viewport. GetCommandHistory / FrameEntity / SetViewportSizeOverride
+        // are intentionally null (no project writes in the headless host; the
+        // remaining two degrade to a clean "not available" from their tools).
+        MCP::EditorMcpContext BuildContext()
+        {
+            MCP::EditorMcpContext ctx;
+            ctx.GetActiveScene = [this]() -> Ref<Scene>
+            { return m_Hooks.GetScene ? m_Hooks.GetScene() : nullptr; };
+            ctx.IsPlaying = []() -> bool
+            { return false; };
+            ctx.CaptureViewportPng = [this](int maxWidth) -> std::vector<u8>
+            {
+                const Ref<Framebuffer> fb = m_Hooks.GetCompositeFramebuffer ? m_Hooks.GetCompositeFramebuffer() : nullptr;
+                return CaptureFramebufferPng(fb, maxWidth);
+            };
+
+            ctx.GetCameraPose = [this]() -> MCP::McpCameraPose
+            {
+                MCP::McpCameraPose pose;
+                if (m_Hooks.Camera)
+                {
+                    EditorCamera& cam = *m_Hooks.Camera;
+                    pose.Position = cam.GetPosition();
+                    pose.FocalPoint = cam.GetFocalPoint();
+                    pose.Forward = cam.GetForwardDirection();
+                    pose.Distance = cam.GetDistance();
+                    pose.YawRadians = cam.GetYaw();
+                    pose.PitchRadians = cam.GetPitch();
+                    pose.FovDegrees = cam.GetFOV();
+                    pose.NearClip = cam.GetNearClip();
+                    pose.FarClip = cam.GetFarClip();
+                }
+                pose.ViewportWidth = m_Hooks.RenderWidth;
+                pose.ViewportHeight = m_Hooks.RenderHeight;
+                return pose;
+            };
+            ctx.SetCameraPose = [this](const glm::vec3& eye, f32 yaw, f32 pitch, f32 fovDegrees)
+            {
+                if (!m_Hooks.Camera)
+                    return;
+                if (fovDegrees > 0.0f)
+                    m_Hooks.Camera->SetFOV(fovDegrees);
+                m_Hooks.Camera->SetPose(eye, yaw, pitch);
+            };
+            ctx.OrbitCamera = [this](const glm::vec3& target, f32 yaw, f32 pitch, f32 distance)
+            {
+                if (m_Hooks.Camera)
+                    m_Hooks.Camera->Focus(target, distance, yaw, pitch);
+            };
+            ctx.RestoreCameraPose = [this](const MCP::McpCameraPose& pose)
+            {
+                if (!m_Hooks.Camera)
+                    return;
+                m_Hooks.Camera->SetFOV(pose.FovDegrees);
+                m_Hooks.Camera->Focus(pose.FocalPoint, pose.Distance, pose.YawRadians, pose.PitchRadians);
+            };
+
+            ctx.GetFrameIndex = [this]() -> u64
+            { return m_FrameIndex.load(std::memory_order_relaxed); };
+            ctx.IsCaptureUnready = [this]() -> bool
+            { return m_FrameIndex.load(std::memory_order_relaxed) == 0; };
+            return ctx;
+        }
+
+        // A per-process base port in [20000, 60000) so two MCP-hosting test
+        // processes under `ctest --parallel` start their bind sweep at different
+        // ports. The address of a static varies across processes (ASLR) and is
+        // header-free; even if two processes collide, Start()'s ascending bind
+        // sweep moves the loser forward (bind is atomic), so this only shortens
+        // the sweep, it isn't relied on for correctness.
+        [[nodiscard]] static u16 DerivePidPort()
+        {
+            static int anchor = 0;
+            const auto bits = reinterpret_cast<std::uintptr_t>(&anchor);
+            return static_cast<u16>(20000 + static_cast<u32>(bits % 40000u));
+        }
+
+        Hooks m_Hooks;
+        Scope<MCP::McpServer> m_Server;
+        std::atomic<u64> m_FrameIndex{ 0 };
+        std::atomic<int> m_NextId{ 0 };
+    };
+} // namespace OloEngine::Tests

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -53,6 +53,61 @@ The `run-oloengine` skill's `attach` action automates this end-to-end: it picks 
 per-worktree port + `OLO_MCP_DISCOVERY_FILE`, launches the editor with the server
 auto-started, then runs `claude mcp add` so the `olo_*` tools attach to the session.
 
+## Headless attach — the offscreen framebuffer (issue #316)
+
+The editor host above reads a **live viewport**. But the renderer's real verification
+happens **headless**: the test harness renders into an *offscreen* render-graph
+framebuffer (`RendererAttachedTest::RunEditorFrames` → the `UIComposite` RT the visual
+evidence tests read back — `WaterVisualEvidenceTest`, `SceneRenderEvidenceTest`). CLAUDE.md
+requires every rendering change to be *visually* verified, and a renderer worktree often has
+no editor running — just the test binary. The **headless attach** path makes the read-only
+visual tools (`olo_screenshot`, `olo_shader_errors`, and `olo_render_capture_target`) work
+against that offscreen framebuffer, so an agent can screenshot exactly what the headless
+pipeline drew.
+
+The seam is that `McpServer` is already decoupled from the editor — it only reads an
+`EditorMcpContext` (a struct of hooks) and marshals main-thread work onto the engine
+**GameThread** task queue. The test-side host
+([`OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h`](../../OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h))
+wires that context to the offscreen composite framebuffer + an `EditorCamera`, starts the
+server, and **pumps the GameThread queue itself** (`FNamedThreadManager::ProcessTasks`) from
+the GL-context thread while a tool call runs on a worker thread — preserving the
+`MarshalRead` contract (handlers run on a non-game thread; the pumping thread services their
+jobs). It captures the same `UIComposite` RT0 the editor viewport samples, so the screenshot
+is byte-for-byte the headless frame.
+
+Two entry points, both in
+[`McpHeadlessAttachTest.cpp`](../../OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp):
+
+- **`ScreenshotAndShaderErrorsOverMcp`** — the CI regression guard. Renders a lit cube into
+  the offscreen FB, hosts the server in-process, issues real JSON-RPC `tools/call`
+  dispatches, and asserts `olo_screenshot` returns a decodable PNG of the offscreen frame
+  and `olo_shader_errors` a well-formed report. It **SKIPs** (not fails) without a GL 4.6
+  context, exactly like the other visual-evidence tests.
+- **`HostUntilDetached`** — the interactive headless-attach mode. It **SKIPs** in normal CI;
+  set `OLO_MCP_HEADLESS_ATTACH=1` (plus the usual `OLO_MCP_PORT` / `OLO_MCP_DISCOVERY_FILE`)
+  and it renders + hosts the server live, pumping until a stop signal, so an external agent
+  attached over the bound socket can screenshot the offscreen FB from a renderer worktree's
+  headless loop:
+
+  ```bash
+  # Host the offscreen frame over MCP from the test binary (port + discovery file
+  # land where `claude mcp add` expects them):
+  OLO_MCP_HEADLESS_ATTACH=1 OLO_MCP_PORT=21000 \
+  OLO_MCP_DISCOVERY_FILE="$TMPDIR/oloengine-mcp-21000.json" \
+    build/OloEngine/tests/Debug/OloEngine-Tests.exe \
+    --gtest_filter='McpHeadlessAttachTest.HostUntilDetached'
+  # …then `claude mcp add` with the token from the discovery file (see "Attaching an agent").
+  ```
+
+  The session runs for `OLO_MCP_ATTACH_SECONDS` (default 600, capped 7200), or stops early
+  when the sentinel file `<discovery-file>.stop` is created and then removed.
+
+Honesty boundary: the headless host wires the read-only/inspection hooks only —
+`olo_camera_frame_entity`, `olo_viewport_set_size`, and the consented project-write tools
+return a clean "not available" because the test owns no editor undo stack / panel viewport.
+The screenshot, shader, scene, perf, physics, and render-capture/override tools all work.
+
 ## Attaching an agent
 
 ### Claude Code


### PR DESCRIPTION
…(#316)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a headless attach mode for MCP diagnostics, enabling offscreen rendering and tool access without a live editor viewport.
  * Introduced a new regression test that verifies screenshots, shader error reporting, and render-capture behavior through MCP.
* **Documentation**
  * Expanded the MCP diagnostics guide with setup steps, environment variables, detach workflow, and supported/unsupported tool behavior in headless mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->