### PR TITLE
feat(mcp): olo_reload_script — consented C# assembly reload (#306)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -374,6 +374,32 @@ namespace OloEngine
                 // history available") rather than mutating the runtime scene.
                 return m_SceneState == SceneState::Edit ? &m_CommandHistory : nullptr;
             };
+            // olo_reload_script: reload the C# app assembly — the same path as the
+            // Script ▸ Reload assembly menu (Ctrl+R). Main-thread-only (Mono domain),
+            // so the MCP server calls it from a MarshalRead job. Reports honestly when
+            // C# scripting is disabled in this build or not yet initialized, rather
+            // than pretending a reload happened.
+            mcpContext.ReloadScriptAssembly = []() -> MCP::McpScriptReloadResult
+            {
+                MCP::McpScriptReloadResult result;
+                result.Language = "csharp";
+#if OLO_ENABLE_CSHARP_SCRIPTING
+                if (ScriptEngine::GetCoreAssemblyImage() == nullptr)
+                {
+                    result.Message = "C# scripting is not initialized (no core assembly loaded).";
+                    return result;
+                }
+                ScriptEngine::ReloadAssembly();
+                result.Available = true;
+                result.Ok = true;
+                result.ScriptClassCount = static_cast<u32>(ScriptEngine::GetEntityClasses().size());
+                result.Message = "Reloaded the C# app assembly (" +
+                                 std::to_string(result.ScriptClassCount) + " script class(es) registered).";
+#else
+                result.Message = "C# scripting is disabled in this build (Mono not available on this platform).";
+#endif
+                return result;
+            };
             mcpContext.GetFrameIndex = [this]() -> u64
             { return m_FrameIndex; };
             mcpContext.IsCaptureUnready = [this]() -> bool

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -389,12 +389,19 @@ namespace OloEngine
                     result.Message = "C# scripting is not initialized (no core assembly loaded).";
                     return result;
                 }
-                ScriptEngine::ReloadAssembly();
+                // Available: scripting is initialized so a reload could be attempted.
+                // Ok: whether the assembly actually loaded (false when the freshly-built
+                // app assembly fails to load — e.g. a compile error — leaving the entity
+                // classes stale). Report both distinctly rather than always claiming success.
+                const bool reloaded = ScriptEngine::ReloadAssembly();
                 result.Available = true;
-                result.Ok = true;
+                result.Ok = reloaded;
                 result.ScriptClassCount = static_cast<u32>(ScriptEngine::GetEntityClasses().size());
-                result.Message = "Reloaded the C# app assembly (" +
-                                 std::to_string(result.ScriptClassCount) + " script class(es) registered).";
+                result.Message = reloaded
+                                     ? "Reloaded the C# app assembly (" + std::to_string(result.ScriptClassCount) +
+                                           " script class(es) registered)."
+                                     : "Reload failed: the C# app assembly did not load (see the engine log). "
+                                       "Rebuild the game assembly and retry.";
 #else
                 result.Message = "C# scripting is disabled in this build (Mono not available on this platform).";
 #endif

--- a/OloEditor/src/MCP/McpReloadScript.h
+++ b/OloEditor/src/MCP/McpReloadScript.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// Shared, editor-side schema + result shaping for the consented MCP write tool
+// `olo_reload_script` (issue #306 item C): reload the C# script assembly — the
+// editor's Script ▸ Reload assembly (Ctrl+R) path, ScriptEngine::ReloadAssembly()
+// — so an agent can iterate on freshly-built C# scripts over MCP without
+// restarting the editor (the scripting counterpart of `olo_shader_reload`'s inner
+// loop for shaders).
+//
+// Unlike the field-write tools (McpSetCollisionLayer.h / McpGenericFieldWrite.h),
+// the reload ACTION cannot live in this header: it calls into ScriptEngine /Mono,
+// which a unit test must not actually invoke. So the action is routed through the
+// EditorMcpContext::ReloadScriptAssembly hook (the same indirection as
+// GetCommandHistory) — the editor wires it to ScriptEngine::ReloadAssembly(), a
+// headless host leaves it null ("not available"), and a test injects a fake. What
+// stays here, header-only and engine-script-free, is the bit the test pins: the
+// tool's inputSchema and the McpScriptReloadResult -> JSON shaping the handler
+// emits.
+//
+// The reload is whole-assembly (C# reloads the entire app assembly; there is no
+// per-script granularity in ScriptEngine), so the tool takes NO arguments — an
+// empty-object schema, exactly mirroring the editor's parameterless Ctrl+R.
+//
+// Engine-script-free: only McpServer.h (the McpScriptReloadResult struct + Json)
+// and the schema-builder DSL, so it pulls no extra editor TU into the MCP test
+// binary (which deliberately does NOT link McpTools.cpp).
+
+#include "MCP/McpSchemaBuilder.h"
+#include "MCP/McpServer.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+namespace OloEngine::MCP::ReloadScript
+{
+    using Json = nlohmann::json;
+
+    // The tool's inputSchema: no arguments (the C# reload is whole-assembly, like the
+    // editor's parameterless Ctrl+R). The server validates against it before dispatch
+    // (#423), so an unexpected property is rejected up front.
+    [[nodiscard]] inline Json InputSchema()
+    {
+        return Schema::EmptyObject();
+    }
+
+    // The structured result payload an agent sees, shaped from the hook's outcome.
+    // `available` distinguishes "C# scripting is off in this build / not initialized"
+    // (a clean, honest result) from a real reload; `ok` reports whether the reload
+    // ran; `scriptClassCount` is a non-zero signal the app assembly loaded.
+    [[nodiscard]] inline Json ToJson(const McpScriptReloadResult& result)
+    {
+        return Json{
+            { "language", result.Language },
+            { "available", result.Available },
+            { "ok", result.Ok },
+            { "scriptClassCount", result.ScriptClassCount },
+            { "message", result.Message },
+        };
+    }
+} // namespace OloEngine::MCP::ReloadScript

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -155,6 +155,21 @@ namespace OloEngine::MCP
         u32 ViewportHeight = 0;
     };
 
+    // Outcome of a consented script reload (issue #306 item C), returned by
+    // EditorMcpContext::ReloadScriptAssembly. `Available` is false when C# scripting
+    // is not compiled into this build or the engine has no core assembly loaded — the
+    // tool then reports that honestly instead of pretending it reloaded. `Ok` is true
+    // only when the reload actually ran; `ScriptClassCount` is how many entity-script
+    // classes are registered afterwards (a non-zero signal the app assembly loaded).
+    struct McpScriptReloadResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        std::string Language = "csharp";
+        u32 ScriptClassCount = 0;
+        std::string Message;
+    };
+
     // Editor state the main-marshaled tools read. EditorLayer fills these in; the
     // std::function bodies are ONLY safe to call on the main (game) thread, i.e.
     // from inside a MarshalRead() job.
@@ -206,6 +221,16 @@ namespace OloEngine::MCP
         // Null in a build that does not back the server with an editor (the dispatch
         // tests), and gated at dispatch by the "Allow writes" session toggle.
         std::function<CommandHistory*()> GetCommandHistory;
+
+        // Reload the C# script assembly — the editor's Script ▸ Reload assembly
+        // (Ctrl+R) path, ScriptEngine::ReloadAssembly(), so an agent can iterate on
+        // C# scripts over MCP without restarting the editor. Like GetCommandHistory
+        // this is a consented project-write tool: gated at dispatch by "Allow writes"
+        // (reloading runs the user's freshly-built assembly code). Main-thread-only
+        // (touches the Mono domain), so call it from inside a MarshalRead job. Null in
+        // a headless host that owns no script engine — the tool then reports "not
+        // available".
+        std::function<McpScriptReloadResult()> ReloadScriptAssembly;
     };
 
     // An MCP resource: a passive, addressable blob (vs. an active tool). The reader

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -4902,8 +4902,9 @@ namespace OloEngine::MCP
                 "here, and the editor runs the new script code without restarting. Drives the same "
                 "ScriptEngine::ReloadAssembly() path as the editor's Script menu Reload assembly (Ctrl+R), so "
                 "the reload is whole-assembly (C# has no per-script granularity) and the tool takes no "
-                "arguments. Returns whether scripting is available in this build, whether the reload ran, and "
-                "how many entity-script classes are registered afterwards. This is a WRITE tool: it is refused "
+                "arguments. Returns whether scripting is available in this build, whether the reload SUCCEEDED "
+                "(ok:false when the freshly-built app assembly fails to load — e.g. a compile error — see the "
+                "engine log), and how many entity-script classes are registered afterwards. This is a WRITE tool: it is refused "
                 "unless 'Allow writes' is enabled in the editor's MCP Server panel (off by default), because "
                 "reloading executes the freshly-built assembly. If C# scripting is disabled or uninitialized "
                 "the call still succeeds but reports available:false.";

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -10,6 +10,7 @@
 #include "MCP/McpRenderGraphTopology.h"
 #include "MCP/McpRenderOverrides.h"
 #include "MCP/McpGenericFieldWrite.h"
+#include "MCP/McpReloadScript.h"
 #include "MCP/McpSetCollisionLayer.h"
 #include "MCP/McpShaderReload.h"
 #include "MCP/McpEventStream.h"
@@ -3450,6 +3451,34 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_reload_script (main-marshaled; PROJECT WRITE) -----------------
+        // Reload the C# script assembly — the scripting counterpart of
+        // olo_shader_reload's inner loop: build the game assembly, reload it over MCP,
+        // and the editor picks up the new script code without a restart. Drives the
+        // exact ScriptEngine::ReloadAssembly() path the editor's Script ▸ Reload
+        // assembly (Ctrl+R) uses, via the ReloadScriptAssembly context hook (so the
+        // engine/Mono call stays out of the test binary and a headless host can leave
+        // it null). Gated at dispatch by the "Allow writes" session toggle
+        // (ToolDef::ProjectWrite): reloading runs the user's freshly-built assembly
+        // code, so it crosses the read-only line by design. The reload runs inside the
+        // MarshalRead job, i.e. on the main thread, since it touches the Mono domain.
+        ToolResult Handle_ReloadScript(McpServer& server, const Json&)
+        {
+            if (!server.Context().ReloadScriptAssembly)
+                return ToolResult::Error("Script reload is not available in this editor build.");
+
+            const Json result = server.MarshalRead([&server]() -> Json
+                                                   {
+                if (!server.Context().ReloadScriptAssembly)
+                    return Json{ { "__error", "Script reload is not available in this editor build." } };
+                const McpScriptReloadResult reloaded = server.Context().ReloadScriptAssembly();
+                return ReloadScript::ToJson(reloaded); });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
         // entity isn't on screen. Gathers the render-relevant facts off the live
@@ -4852,6 +4881,35 @@ namespace OloEngine::MCP
             tool.InputSchema = GenericFieldWrite::InputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_EntitySetField;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_reload_script";
+            tool.Toolset = "scripting";
+            tool.Title = "Reload script assembly";
+            // A project-WRITE tool (#306 item C): reloading swaps in the user's
+            // freshly-built C# assembly and runs its code, so it is gated behind the
+            // session "Allow writes" toggle, like the other writes. readOnlyHint:false
+            // (not idempotent — each reload re-reads from disk into a fresh app domain;
+            // not destructive — it overwrites no project data, the source files are
+            // untouched).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            tool.Description =
+                "Reload the C# script assembly — the scripting inner loop: build the game assembly, reload it "
+                "here, and the editor runs the new script code without restarting. Drives the same "
+                "ScriptEngine::ReloadAssembly() path as the editor's Script menu Reload assembly (Ctrl+R), so "
+                "the reload is whole-assembly (C# has no per-script granularity) and the tool takes no "
+                "arguments. Returns whether scripting is available in this build, whether the reload ran, and "
+                "how many entity-script classes are registered afterwards. This is a WRITE tool: it is refused "
+                "unless 'Allow writes' is enabled in the editor's MCP Server panel (off by default), because "
+                "reloading executes the freshly-built assembly. If C# scripting is disabled or uninitialized "
+                "the call still succeeds but reports available:false.";
+            tool.InputSchema = ReloadScript::InputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_ReloadScript;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
@@ -336,7 +336,7 @@ namespace OloEngine
         return true;
     }
 
-    void ScriptEngine::ReloadAssembly()
+    bool ScriptEngine::ReloadAssembly()
     {
         ::mono_domain_set(::mono_get_root_domain(), false);
 
@@ -350,8 +350,11 @@ namespace OloEngine
         LoadAssembly(s_Data->CoreAssemblyFilepath);
         if (!LoadAppAssembly(s_Data->AppAssemblyFilepath))
         {
+            // The app assembly did not load: the entity-class registry keeps its stale
+            // pre-reload contents (LoadAssemblyClasses ran only on the success path), so
+            // report the failure to the caller rather than pretending the reload worked.
             OLO_CORE_ERROR("[ScriptEngine] Failed to reload app assembly: {}", s_Data->AppAssemblyFilepath.string());
-            return;
+            return false;
         }
         LoadAssemblyClasses();
 
@@ -359,6 +362,7 @@ namespace OloEngine
 
         // Retrieve and instantiate class
         s_Data->EntityClass = Ref<ScriptClass>::Create("OloEngine", "Entity", true);
+        return true;
     }
 
     void ScriptEngine::OnRuntimeStart(Scene* scene)
@@ -704,7 +708,10 @@ namespace OloEngine
     {
         return false;
     }
-    void ScriptEngine::ReloadAssembly() {}
+    bool ScriptEngine::ReloadAssembly()
+    {
+        return false;
+    }
     void ScriptEngine::OnRuntimeStart(Scene* scene)
     {
         s_SceneContext = scene;

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.h
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.h
@@ -187,7 +187,11 @@ namespace OloEngine
         static bool LoadAssembly(const std::filesystem::path& filepath);
         static bool LoadAppAssembly(const std::filesystem::path& filepath);
 
-        static void ReloadAssembly();
+        // Reload the app (and core) assemblies into a fresh app domain. Returns true
+        // on a clean reload, false if an assembly failed to load (the app domain is
+        // then left without a usable app assembly — see the engine log). The editor's
+        // Ctrl+R menu discards the result; olo_reload_script surfaces it.
+        static bool ReloadAssembly();
 
         static void OnRuntimeStart(Scene* scene);
         static void OnRuntimeStop();

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -394,6 +394,13 @@ add_executable(OloEngine-Tests
 		# (MCP/McpGenericFieldWrite.h). Header-only on the editor side, so no extra
 		# editor TU is pulled in.
 		MCP/McpGenericFieldWriteTest.cpp
+		# Consented MCP WRITE tool: olo_reload_script (#306 item C) — reload the C#
+		# script assembly. Same dispatch seam (session write gate + inputSchema
+		# enforcement at McpServer.cpp) and shared shaping (MCP/McpReloadScript.h:
+		# schema + McpScriptReloadResult->JSON). The reload ACTION is a context hook
+		# (ScriptEngine/Mono in the editor), so the test injects a fake hook and never
+		# touches Mono. Header-only on the editor side, so no extra editor TU.
+		MCP/McpReloadScriptTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpReloadScriptTest.cpp
+++ b/OloEngine/tests/MCP/McpReloadScriptTest.cpp
@@ -1,0 +1,192 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// McpReloadScriptTest — unit test (headless, no GL, no live editor, no Mono).
+//
+// Pins the consented MCP write tool olo_reload_script (issue #306 item C): reload
+// the C# script assembly — the scripting counterpart of olo_shader_reload's inner
+// loop. Two seams, the same shape as McpConsentedWriteTest / McpGenericFieldWrite:
+//
+//   1. The dispatch seam (McpServer.cpp, compiled into the test binary): a tool
+//      flagged ToolDef::ProjectWrite is REFUSED with a clean JSON-RPC error while
+//      the session "Allow writes" gate is off, and ACCEPTED once on — and the
+//      reload action does NOT run while the gate is off. The server's inputSchema
+//      enforcement (#423) rejects an unexpected property before the handler runs.
+//      McpTools.cpp is deliberately NOT linked here, so the test registers a fake
+//      tool wired to the SAME schema + result shaping the real handler uses.
+//
+//   2. The shared shaping (MCP/McpReloadScript.h, header-only): the empty-object
+//      inputSchema + the McpScriptReloadResult -> JSON ToJson the real handler
+//      emits. The reload ACTION itself is a context hook (ScriptEngine /Mono in
+//      the editor), so the test injects a fake hook and never touches Mono — the
+//      same indirection the real handler delegates to once on the main thread.
+//
+// The shared header is renderer/httplib/Mono-free, so only McpServer.h + the schema
+// DSL are pulled in — no extra editor TU.
+// =============================================================================
+
+#include "MCP/McpReloadScript.h"
+#include "MCP/McpServer.h"
+
+#include <string>
+
+// OLO_TEST_LAYER: unit
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpScriptReloadResult;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+    namespace ReloadScript = OloEngine::MCP::ReloadScript;
+
+    constexpr int kInvalidParams = -32602;
+
+    Json MakeCallRequest(const Json& id, const Json& arguments)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "method", "tools/call" },
+                     { "params", { { "name", "olo_reload_script" }, { "arguments", arguments } } } };
+    }
+
+    // Fixture: an McpServer whose only tool is a fake olo_reload_script wired through
+    // the SAME schema + ToJson the real handler uses, but with the reload ACTION
+    // replaced by a test-owned closure that records its invocations and returns a
+    // canned McpScriptReloadResult — so the dispatch gate, schema enforcement, and
+    // result shaping are exercised without Mono / a game thread (the real handler
+    // marshals onto the main thread; here it runs synchronously).
+    class McpReloadScriptTest : public ::testing::Test
+    {
+      protected:
+        McpReloadScriptTest()
+            : m_Server(EditorMcpContext{})
+        {
+            ToolDef tool;
+            tool.Name = "olo_reload_script";
+            tool.Description = "Reload the C# script assembly (fake; test wiring).";
+            tool.ProjectWrite = true;
+            tool.InputSchema = ReloadScript::InputSchema();
+            tool.Handler = [this](McpServer&, const Json&) -> ToolResult
+            {
+                ++m_ReloadCount;
+                return ToolResult::Text(ReloadScript::ToJson(m_FakeResult).dump());
+            };
+            m_Server.RegisterTool(std::move(tool));
+        }
+
+        McpScriptReloadResult m_FakeResult;
+        int m_ReloadCount = 0;
+        McpServer m_Server; // declared last → destroyed first (its handler refs members)
+    };
+} // namespace
+
+// ---- the session write gate (dispatch seam) --------------------------------
+
+// Default state: the gate is OFF, so even a well-formed (argument-less) reload call
+// is refused with a JSON-RPC error and the reload action NEVER runs.
+TEST_F(McpReloadScriptTest, GateOffRejectsReloadAndDoesNotInvoke)
+{
+    ASSERT_FALSE(m_Server.AllowWrites()); // off by default
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(1, Json::object()));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_ReloadCount, 0); // the reload action must not have run
+}
+
+// With the gate ON the same call succeeds, the reload action runs exactly once, and
+// the structured result carries the hook's outcome (available/ok/scriptClassCount).
+TEST_F(McpReloadScriptTest, GateOnInvokesReloadAndReturnsResult)
+{
+    m_Server.SetAllowWrites(true);
+    m_FakeResult.Available = true;
+    m_FakeResult.Ok = true;
+    m_FakeResult.ScriptClassCount = 7;
+    m_FakeResult.Message = "Reloaded the C# app assembly (7 script class(es) registered).";
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(2, Json::object()));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(m_ReloadCount, 1);
+
+    // The handler returns the ToJson payload as the result text — parse + verify shape.
+    const std::string text = resp["result"]["content"][0]["text"].get<std::string>();
+    const Json payload = Json::parse(text);
+    EXPECT_EQ(payload["language"], "csharp");
+    EXPECT_TRUE(payload["available"].get<bool>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_EQ(payload["scriptClassCount"], 7);
+}
+
+// When C# scripting is unavailable (disabled in the build / not initialized) the
+// call still SUCCEEDS — it is a clean, honest result reporting available:false, not
+// a tool error. The agent learns scripting is off rather than getting a generic fail.
+TEST_F(McpReloadScriptTest, UnavailableScriptingIsCleanResult)
+{
+    m_Server.SetAllowWrites(true);
+    m_FakeResult.Available = false;
+    m_FakeResult.Ok = false;
+    m_FakeResult.Message = "C# scripting is disabled in this build (Mono not available on this platform).";
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(3, Json::object()));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(m_ReloadCount, 1);
+
+    const std::string text = resp["result"]["content"][0]["text"].get<std::string>();
+    const Json payload = Json::parse(text);
+    EXPECT_FALSE(payload["available"].get<bool>());
+    EXPECT_FALSE(payload["ok"].get<bool>());
+}
+
+// ---- server-side inputSchema enforcement (#423), gate ON -------------------
+
+// The schema is an empty object with no additional properties allowed, so an
+// unexpected argument is rejected at the schema layer before the handler runs (and
+// the reload action never fires).
+TEST_F(McpReloadScriptTest, SchemaRejectsUnknownProperty)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, Json{ { "name", "Player" } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_ReloadCount, 0);
+}
+
+// ---- the shared shaping core (MCP/McpReloadScript.h), no server -------------
+
+TEST(McpReloadScriptShaping, ToJsonCarriesEveryField)
+{
+    McpScriptReloadResult r;
+    r.Language = "csharp";
+    r.Available = true;
+    r.Ok = true;
+    r.ScriptClassCount = 3;
+    r.Message = "ok";
+
+    const Json j = ReloadScript::ToJson(r);
+    EXPECT_EQ(j["language"], "csharp");
+    EXPECT_TRUE(j["available"].get<bool>());
+    EXPECT_TRUE(j["ok"].get<bool>());
+    EXPECT_EQ(j["scriptClassCount"], 3);
+    EXPECT_EQ(j["message"], "ok");
+}
+
+TEST(McpReloadScriptShaping, InputSchemaIsClosedEmptyObject)
+{
+    const Json schema = ReloadScript::InputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    // No additional properties allowed — an empty, closed object schema.
+    ASSERT_TRUE(schema.contains("additionalProperties"));
+    EXPECT_FALSE(schema["additionalProperties"].get<bool>());
+}

--- a/OloEngine/tests/MCP/McpReloadScriptTest.cpp
+++ b/OloEngine/tests/MCP/McpReloadScriptTest.cpp
@@ -126,6 +126,29 @@ TEST_F(McpReloadScriptTest, GateOnInvokesReloadAndReturnsResult)
     EXPECT_EQ(payload["scriptClassCount"], 7);
 }
 
+// A failed reload (scripting available, but the freshly-built app assembly did not
+// load) is reported as available:true, ok:false — the call SUCCEEDS at the protocol
+// level (it is not a tool error), but ok distinguishes the real outcome so an agent
+// isn't told a broken reload worked.
+TEST_F(McpReloadScriptTest, FailedReloadReportsOkFalse)
+{
+    m_Server.SetAllowWrites(true);
+    m_FakeResult.Available = true;
+    m_FakeResult.Ok = false;
+    m_FakeResult.Message = "Reload failed: the C# app assembly did not load (see the engine log).";
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(9, Json::object()));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(m_ReloadCount, 1);
+
+    const std::string text = resp["result"]["content"][0]["text"].get<std::string>();
+    const Json payload = Json::parse(text);
+    EXPECT_TRUE(payload["available"].get<bool>());
+    EXPECT_FALSE(payload["ok"].get<bool>());
+}
+
 // When C# scripting is unavailable (disabled in the build / not initialized) the
 // call still SUCCEEDS — it is a clean, honest result reporting available:false, not
 // a tool error. The agent learns scripting is off rather than getting a generic fail.

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -378,6 +378,11 @@ component bindings.
   *succeeds* but reports `available: false` with an explanatory `message`, rather than
   pretending a reload happened. `scriptClassCount` is the number of entity-script classes
   registered after the reload — a non-zero value confirms the app assembly loaded.
+- **Honest about failure.** `ok` reports whether the reload actually **succeeded**: if the
+  freshly-built app assembly fails to load (e.g. a C# compile error, or a missing/locked
+  `.dll`), the tool returns `available: true, ok: false` with a `message` pointing you at
+  the engine log — the entity-class registry then keeps its stale pre-reload contents, so
+  don't trust `scriptClassCount` on a failed reload. Rebuild the game assembly and retry.
 - **Lua is not reloaded here.** This tool targets the C# (Mono) app assembly; Lua scripts
   re-execute per entity on play and have no single global reload entry point.
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -180,6 +180,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_assets_problems` | assets that failed to load or are missing/invalid |
 | `olo_script_get_api` | C# / Lua scripting API digest (types + members), with a type filter |
 | `olo_script_get_last_errors` | recent C# (Mono) / Lua (Sol2) script exceptions |
+| `olo_reload_script` | **(consented write)** reload the C# script assembly — the editor's *Script ▸ Reload assembly* (Ctrl+R) path — so a rebuilt game assembly is picked up without restarting the editor; reports whether scripting is available, whether the reload ran, and the post-reload script-class count. Gated behind "Allow writes" |
 | `olo_crash_list` / `olo_crash_get` | crash reports under `CrashReports/` |
 | `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera |
 | `olo_camera_get` | the editor camera's pose (position, focal point, yaw/pitch, FOV, clips, viewport size) |
@@ -217,7 +218,7 @@ keyword and/or category instead of pulling the entire list:
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |
-| `scripting` | `olo_script_get_api`, `olo_script_get_last_errors` |
+| `scripting` | `olo_script_get_api`, `olo_script_get_last_errors`, `olo_reload_script` |
 | `camera` | `olo_screenshot`, `olo_camera_get`, `olo_camera_set_pose`, `olo_camera_orbit`, `olo_camera_frame_entity`, `olo_viewport_set_size` |
 | `physics` | `olo_physics_layer_matrix`, `olo_physics_list_colliders`, `olo_physics_contacts`, `olo_physics_raycast`, `olo_physics_overlap`, `olo_physics_why_no_collision` |
 
@@ -347,6 +348,38 @@ editor can crash. So reserve `olo_shader_reload` for applying an edit you **expe
 compile** (the normal inner-loop case — confirm the result `status` is `ready`, then
 screenshot); to inspect a shader that you know is broken, read `olo_shader_errors` /
 `olo_shader_get` rather than recompiling it.
+
+### The scripting inner loop (`olo_reload_script`)
+
+The scripting counterpart of `olo_shader_reload`: reload the **C# script assembly**
+without restarting the editor, so an agent can run the tight scripting loop — **edit a
+C# script → rebuild the game assembly → `olo_reload_script` → observe the new behaviour
+→ repeat.** It drives the exact `ScriptEngine::ReloadAssembly()` path the editor's
+*Script ▸ Reload assembly* (Ctrl+R) menu uses: it unloads the app domain and re-loads
+the core + app assemblies, rediscovers the entity-script classes, and re-registers the
+component bindings.
+
+```jsonc
+// 1) … edit your C# script + rebuild the game assembly (the .dll the editor loads) …
+// 2) olo_reload_script {}
+{ "language": "csharp", "available": true, "ok": true,
+  "scriptClassCount": 7, "message": "Reloaded the C# app assembly (7 script class(es) registered)." }
+```
+
+- **It is a consented WRITE tool** (issue #306 item C): like the other writes it is
+  refused unless **"Allow writes"** is enabled in the editor's MCP panel (off by
+  default). Reloading runs the user's freshly-built assembly code, so it deliberately
+  crosses the read-only line — hence the gate.
+- **Whole-assembly, no arguments.** C# reload has no per-script granularity (the editor
+  reloads the entire app assembly), so the tool takes no parameters — exactly mirroring
+  the parameterless Ctrl+R.
+- **Honest about availability.** When C# scripting is **disabled in the build** (no Mono
+  on this platform) or **not yet initialized** (no core assembly loaded), the call still
+  *succeeds* but reports `available: false` with an explanatory `message`, rather than
+  pretending a reload happened. `scriptClassCount` is the number of entity-script classes
+  registered after the reload — a non-zero value confirms the app assembly loaded.
+- **Lua is not reloaded here.** This tool targets the C# (Mono) app assembly; Lua scripts
+  re-execute per entity on play and have no single global reload entry point.
 
 ### Render override A/B (`olo_render_toggle_pass` / `olo_render_set_debug_view`)
 


### PR DESCRIPTION
Add the olo_reload_script MCP write tool (issue #306 item C): reload the C# script assembly over MCP — the scripting counterpart of olo_shader_reload's inner loop — driving the same ScriptEngine::ReloadAssembly() path as the editor's Script > Reload assembly (Ctrl+R). Whole-assembly (C# has no per-script granularity), so the tool takes no arguments.

Gated behind the existing #427 session write gate (ProjectWrite): reloading runs the user's freshly-built assembly, so it crosses the read-only line by design. The reload action is routed through a new EditorMcpContext hook (ReloadScriptAssembly), keeping the engine/Mono call out of the shared header and the test binary; a headless host leaves it null ("not available"). Reports available:false honestly when C# scripting is disabled in the build or not yet initialized, rather than faking a reload.

- McpServer.h: McpScriptReloadResult struct + ReloadScriptAssembly hook
- McpReloadScript.h: Mono-free schema + result shaping (testable core)
- McpTools.cpp: Handle_ReloadScript (main-marshaled) + registration
- EditorLayer.cpp: wire the hook to ScriptEngine::ReloadAssembly()
- McpReloadScriptTest.cpp: gate + schema + shaping unit tests (6, all pass)
- docs: tools table, scripting toolset, scripting-inner-loop section