### PR TITLE
ci: fix sccache backend, switch Windows ASan to clang-cl, speed up So…

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -48,26 +48,41 @@ jobs:
       - name: Setup Vulkan SDK
         uses: ./.github/actions/setup-vulkan
       
+      # cl.exe + Windows SDK include/lib paths on the job env for the Ninja
+      # generator used by the build-wrapper step below. No sccache here (see that
+      # step) — this is only to make Ninja + cl.exe work.
+      - name: Setup MSVC dev environment
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: x64
+
       - name: Install Build Wrapper
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
 
       - name: Run build-wrapper
-        # NO sccache here, on purpose (issue #304). Two independent blockers:
-        #   1. This uses CMake's default Visual Studio (MSBuild) generator, which
-        #      IGNORES CMAKE_<LANG>_COMPILER_LAUNCHER — sccache would never engage
-        #      (cmake/CompilerCache.cmake even warns in that case). Windows.yml had
-        #      to switch to Ninja Multi-Config for the launcher to take effect.
-        #   2. More fundamentally, sccache is INCOMPATIBLE with SonarQube's
-        #      build-wrapper even on Ninja: build-wrapper analyses C/C++ by
-        #      capturing each real compiler invocation. A warm sccache cache
-        #      serves objects WITHOUT invoking the compiler, so those translation
-        #      units would silently vanish from the analysis — a worse outcome
-        #      than a slow build. Caching is therefore deliberately omitted; the
-        #      cold build is the correct behaviour for this job.
+        # NO sccache here, on purpose (issue #304): sccache is INCOMPATIBLE with
+        # SonarQube's build-wrapper. build-wrapper analyses C/C++ by capturing each
+        # real compiler invocation; a warm cache serves objects WITHOUT invoking
+        # the compiler, so those TUs would silently vanish from the analysis — a
+        # worse outcome than a slow build. The cold build is correct for this job.
+        #
+        # We DO use Ninja + `--parallel` (not the default VS/MSBuild generator):
+        # build-wrapper wraps whatever build command it's given, so it captures a
+        # Ninja build just fine, and a parallel Ninja clean build is faster than
+        # MSBuild here. cl.exe comes from the msvc-dev-cmd step above. (Trade-off,
+        # same as Windows.yml: Ninja doesn't build the C# ScriptCore project, but
+        # the C-family analyzer doesn't analyse C# anyway.)
+        #
+        # -DBUILD_TESTS=OFF: the 398 test TUs are ~43% of the build and are
+        # declared as test sources (sonar.tests), so production rules don't run on
+        # them — building + parsing them was ~40% of this job's cost for near-zero
+        # production-analysis value. Dropping them shrinks BOTH the build and the
+        # C-family scan. (Test code is no longer analysed; it was already heavily
+        # rule-excluded — see sonar-project.properties tst_* ignores.)
         run: |
           New-Item -ItemType directory -Path build
-          cmake -S . -B build -DPython_EXECUTABLE="${{ env.pythonLocation }}/python.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOLO_VIDEO_FFMPEG=OFF
-          build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release
+          cmake -S . -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DPython_EXECUTABLE="${{ env.pythonLocation }}/python.exe" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOLO_VIDEO_FFMPEG=OFF -DBUILD_TESTS=OFF
+          build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release --parallel
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
@@ -82,5 +97,10 @@ jobs:
           # sonar-scanner-cli >= 6.0 (older releases used SONAR_SCANNER_OPTS).
           SONAR_SCANNER_JAVA_OPTS: "-Xmx6g"
         with:
+          # sonar.cfamily.threads=4: parallelise the C-family analysis across the
+          # runner's 4 vCPUs (windows-latest). The analyzer is the ~51-min half of
+          # this job; threading it is the biggest single scan-time lever. The
+          # -Xmx6g heap above has headroom for the parallel workers.
           args: >
             --define sonar.cfamily.build-wrapper-output=${{ env.BUILD_WRAPPER_OUT_DIR }}
+            --define sonar.cfamily.threads=4

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -22,10 +22,19 @@ concurrency:
 
 env:
   BUILD_TYPE: Release
-  # Route sccache at its GitHub Actions cache backend (set up by the
-  # mozilla-actions/sccache-action step below). Object files are then reused
-  # across CI runs, so a push only recompiles the TUs that actually changed.
-  SCCACHE_GHA_ENABLED: "true"
+  # sccache uses a LOCAL-DISK cache (SCCACHE_DIR), persisted across runs as a
+  # SINGLE actions/cache entry (see the "Cache sccache storage" step below).
+  # We deliberately do NOT use sccache's GitHub Actions cache backend
+  # (SCCACHE_GHA_ENABLED): it stores one cache entry PER OBJECT FILE, which
+  # flooded the repo's 10 GB Actions-cache cap with 20k+ tiny entries and made
+  # EVERY write fail (observed 0% hit rate, write-errors == misses on every
+  # job). One bounded local-disk dir wrapped in actions/cache stays under the
+  # cap and actually warms between runs.
+  SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  # Bound the on-disk cache so the saved actions/cache entry stays small — every
+  # cache (this, Vulkan, FFmpeg, the sanitizer jobs' sccache dirs) shares the
+  # repo's single 10 GB Actions-cache cap.
+  SCCACHE_CACHE_SIZE: "2G"
 
 jobs:
   build:
@@ -99,6 +108,18 @@ jobs:
       uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
+
+    # Persist sccache's local-disk cache (SCCACHE_DIR) as a single actions/cache
+    # entry. The key is unique per run (run_id) so the post-job save always
+    # writes a fresh, updated snapshot; restore-keys falls back to the most
+    # recent prior snapshot, so each run starts warm and saves the superset.
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-windows-release-${{ github.run_id }}
+        restore-keys: |
+          sccache-windows-release-
 
     - name: Configure CMake
       # On a cache hit, point CMake at the prebuilt FFmpeg (ffmpeg.cmake's OLO_FFMPEG_PREFIX

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -19,15 +19,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
-  # Route sccache at its GitHub Actions cache backend (provisioned by the
-  # mozilla-actions/sccache-action step in each job below). Object files are
-  # then reused across CI runs, so a per-PR push only recompiles the TUs that
-  # actually changed instead of building OloEngine-Tests cold every run.
-  # Mirrors the Windows.yml pattern landed in #319. The -fsanitize=address|
-  # undefined|thread flag is part of each compile command line (and so part of
-  # sccache's hash), so the per-sanitizer object sets are distinct cache
-  # entries — a single shared backend cannot collide across jobs.
-  SCCACHE_GHA_ENABLED: "true"
+  # sccache uses a LOCAL-DISK cache (SCCACHE_DIR), persisted across runs as a
+  # SINGLE actions/cache entry PER JOB (see each job's "Cache sccache storage"
+  # step). We deliberately do NOT use sccache's GitHub Actions cache backend
+  # (SCCACHE_GHA_ENABLED): it stores one cache entry PER OBJECT FILE, which
+  # flooded the repo's 10 GB Actions-cache cap with 20k+ tiny entries and made
+  # EVERY write fail (observed write-errors == misses on all four jobs, hit rate
+  # then frozen/decaying). One bounded local-disk dir per job stays under the
+  # cap. The -fsanitize=address|undefined|thread flag is part of each compile
+  # command line (and so part of sccache's hash), so the per-sanitizer object
+  # sets stay distinct; the actions/cache KEY below is also per-sanitizer so the
+  # four jobs never clobber each other's snapshot.
+  SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  # Bound the on-disk cache so each saved actions/cache entry stays small — all
+  # caches (the four sccache dirs here, Windows.yml's, Vulkan, FFmpeg) share the
+  # repo's single 10 GB Actions-cache cap.
+  SCCACHE_CACHE_SIZE: "1500M"
 
 permissions:
   contents: read
@@ -71,7 +78,7 @@ jobs:
             - '.github/sanitizer-suppressions/**'
 
   asan-windows:
-    name: ASan (Windows/MSVC)
+    name: ASan (Windows/clang-cl)
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.native == 'true' }}
     runs-on: windows-latest
@@ -99,15 +106,20 @@ jobs:
     - name: Setup Vulkan SDK
       uses: ./.github/actions/setup-vulkan
 
-    # We build with the Ninja generator (not the default Visual Studio
-    # generator) so CMAKE_<LANG>_COMPILER_LAUNCHER engages — the VS/MSBuild
-    # generator IGNORES it, so sccache would never run there
-    # (cmake/CompilerCache.cmake even emits a warning in that case). Ninja needs
-    # cl.exe + the Windows SDK include/lib paths on the job env; ilammy/msvc-dev-cmd
-    # runs vcvars and exports them to every subsequent step. Mirrors Windows.yml.
+    # This job builds with clang-cl (Clang front-end, MSVC ABI) via the
+    # cmake/ClangCLToolchain.cmake toolchain — the same one the local
+    # `clangcl-asan` preset uses. clang-cl gives the genuinely Windows-specific
+    # coverage that justifies a Windows ASan job (MSVC ABI + MSVC STL + the
+    # Windows-only Platform/* code) but runs Clang's more complete ASan runtime
+    # instead of MSVC's, and its /Z7 objects cache under sccache (MSVC cl.exe ASan
+    # objects did not — see issue #304). clang-cl still needs the MSVC headers,
+    # libs, and Windows SDK on the env; ilammy/msvc-dev-cmd runs vcvars and
+    # exports them, and also puts the VS-bundled LLVM (clang-cl, lld-link) on PATH.
+    # We build with Ninja (not the VS generator) so the sccache compiler launcher
+    # engages — the VS/MSBuild generator IGNORES CMAKE_<LANG>_COMPILER_LAUNCHER.
     # (Trade-off, same as Windows.yml: the Ninja path does not build the C#
-    # OloEngine-ScriptCore project — it is gated on the VS generator — but the
-    # OloEngine-Tests build never links that assembly, so ASan coverage is intact.)
+    # OloEngine-ScriptCore project, but OloEngine-Tests never links that
+    # assembly, so ASan coverage is intact.)
     - name: Setup MSVC dev environment
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
@@ -122,21 +134,34 @@ jobs:
       with:
         version: "v0.15.0"
 
+    # Persist sccache's local-disk cache as one actions/cache entry (unique key
+    # per run so the post-job save always writes a fresh snapshot; restore-keys
+    # warms from the most recent prior one). Key is per-sanitizer.
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-windows-${{ github.run_id }}
+        restore-keys: |
+          sccache-asan-windows-
+
     - name: Configure CMake (ASan enabled)
+      # --toolchain cmake/ClangCLToolchain.cmake: build with clang-cl + lld-link
+      #   (Clang front-end, MSVC ABI) — same toolchain as the local clangcl-asan
+      #   preset. CMake reports clang-cl as MSVC, so cmake/Sanitizers.cmake takes
+      #   the /fsanitize=address + /MD + /INCREMENTAL:NO path automatically.
       # -G "Ninja Multi-Config": required for the sccache compiler launcher to
-      #   engage (see the MSVC dev-env step above). The build/ctest steps still
-      #   select Release via --config / -C Release, exactly as the VS generator did.
-      # -DCMAKE_*_COMPILER=cl: force MSVC cl.exe (msvc-dev-cmd put it on PATH) so
-      #   Ninja doesn't auto-pick a clang/gcc that may also be on the runner.
+      #   engage. The build/ctest steps still select Release via --config / -C.
       # -DOLO_ENABLE_COMPILER_CACHE=ON: wires sccache as the launcher and switches
-      #   MSVC debug info to /Z7 (Embedded) so objects are cacheable.
-      # -DOLO_ENABLE_LTO=OFF: this is a Release build, where LTO is on by default;
-      #   its /GL flag makes objects non-cacheable (and /GL + ASan is unsupported).
-      #   CI binaries are for testing, not shipping, so dropping LTO is free here.
+      #   debug info to /Z7 (Embedded) so clang-cl objects are cacheable (unlike
+      #   the old MSVC cl.exe ASan objects, which never cached — issue #304).
+      # -DOLO_ENABLE_LTO=OFF: Release defaults LTO on; its /GL makes objects
+      #   non-cacheable (and /GL + ASan is unsupported). CI binaries are for
+      #   testing, not shipping, so dropping LTO is free here.
       run: >
         cmake -S . -B build
         -G "Ninja Multi-Config"
-        -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+        --toolchain "${{ github.workspace }}/cmake/ClangCLToolchain.cmake"
         -DOLO_VIDEO_FFMPEG=OFF
         -DOLO_ENABLE_COMPILER_CACHE=ON
         -DOLO_ENABLE_LTO=OFF
@@ -158,14 +183,21 @@ jobs:
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"
       shell: pwsh
 
-    - name: Add MSVC ASan runtime to PATH
+    - name: Add clang-cl ASan runtime to PATH
       shell: pwsh
+      # clang-cl links the dynamic ASan runtime, so the test exe needs
+      # clang_rt.asan_dynamic-x86_64.dll on PATH at run time. It ships next to
+      # the clang-cl used for the build; `clang-cl -print-runtime-dir` (LLVM >= 16)
+      # reports that directory. Use the same clang-cl that PATH resolves to (the
+      # one CMake built with) so the DLL version matches the instrumented objects.
       run: |
-        $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-        $msvcDir = Get-ChildItem "$vsPath\VC\Tools\MSVC" -Directory | Sort-Object Name -Descending | Select-Object -First 1
-        $binDir = "$($msvcDir.FullName)\bin\Hostx64\x64"
-        Write-Host "Adding MSVC bin to PATH: $binDir"
-        echo "$binDir" >> $env:GITHUB_PATH
+        $rtDir = (& clang-cl -print-runtime-dir).Trim()
+        Write-Host "clang-cl runtime dir: $rtDir"
+        if (-not (Test-Path (Join-Path $rtDir 'clang_rt.asan_dynamic-x86_64.dll'))) {
+          Write-Error "ASan runtime DLL not found in $rtDir"
+          exit 1
+        }
+        echo "$rtDir" >> $env:GITHUB_PATH
 
     - name: Run tests under ASan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
@@ -176,7 +208,9 @@ jobs:
       # `pugi::xpath_*`). That is now fixed at the source: NetworkManager::Init
       # skips the live GameNetworkingSockets_Init under ASan (OLO_ASAN_ENABLED),
       # so every suite that merely constructs/uses NetworkManager runs clean.
-      # (Upstream GNS bug: ValveSoftware/GameNetworkingSockets#418.)
+      # (Upstream GNS bug: ValveSoftware/GameNetworkingSockets#418.) The gate is
+      # keyed on OLO_ASAN_ENABLED, not the compiler, so it applies identically
+      # now that this job builds with clang-cl ASan instead of MSVC cl.exe ASan.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
       # task system starts the Steam service thread" theory — they never touched
@@ -196,7 +230,7 @@ jobs:
       # The suite is parallel-safe by construction: tests key their temp paths by
       # PID / gtest case name, and the handful that share the engine's repo-relative
       # mesh cache are serialized against each other with a ctest RESOURCE_LOCK
-      # (OloEngine/tests/CMakeLists.txt). Capped at 2 (not 4) because MSVC ASan
+      # (OloEngine/tests/CMakeLists.txt). Capped at 2 (not 4) because ASan
       # shadow memory inflates each test process's resident footprint; 2-wide stays
       # comfortably inside the windows-latest ~16 GB budget.
       run: ctest --parallel 2 -C Release --output-on-failure --timeout 120 --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
@@ -285,6 +319,17 @@ jobs:
       uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
+
+    # Persist sccache's local-disk cache as one actions/cache entry (unique key
+    # per run so the post-job save always writes a fresh snapshot; restore-keys
+    # warms from the most recent prior one). Key is per-sanitizer.
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-lsan-linux-${{ github.run_id }}
+        restore-keys: |
+          sccache-asan-lsan-linux-
 
     - name: Configure CMake (ASan + LSan)
       # -fuse-ld=lld: the default GNU BFD ld holds the entire Debug +
@@ -434,6 +479,17 @@ jobs:
       with:
         version: "v0.15.0"
 
+    # Persist sccache's local-disk cache as one actions/cache entry (unique key
+    # per run so the post-job save always writes a fresh snapshot; restore-keys
+    # warms from the most recent prior one). Key is per-sanitizer.
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-ubsan-linux-${{ github.run_id }}
+        restore-keys: |
+          sccache-ubsan-linux-
+
     - name: Configure CMake (UBSan)
       # -fuse-ld=lld: see the ASan + LSan configure step above — BFD ld can
       # OOM the runner during the final OloEngine-Tests link.
@@ -558,6 +614,17 @@ jobs:
       uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
+
+    # Persist sccache's local-disk cache as one actions/cache entry (unique key
+    # per run so the post-job save always writes a fresh snapshot; restore-keys
+    # warms from the most recent prior one). Key is per-sanitizer.
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsan-linux-${{ github.run_id }}
+        restore-keys: |
+          sccache-tsan-linux-
 
     - name: Configure CMake (TSan)
       # -fuse-ld=lld: see the ASan + LSan configure step above — BFD ld can

--- a/.github/workflows/flaky-repro-281.yml
+++ b/.github/workflows/flaky-repro-281.yml
@@ -50,7 +50,12 @@ concurrency:
 
 env:
   BUILD_TYPE: Release
-  SCCACHE_GHA_ENABLED: "true"
+  # Local-disk sccache cache persisted as a single actions/cache entry (NOT the
+  # per-object GHA backend, which saturated the repo's 10 GB cap). This is a
+  # manual repro job, so it gets its own small budget and warms from its own
+  # prior runs only. See Windows.yml for the full rationale.
+  SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  SCCACHE_CACHE_SIZE: "2G"
 
 jobs:
   hunt:
@@ -93,6 +98,14 @@ jobs:
       uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         version: "v0.15.0"
+
+    - name: Cache sccache storage
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-flaky-281-${{ github.run_id }}
+        restore-keys: |
+          sccache-flaky-281-
 
     # Mirror Windows.yml's fast Ninja+sccache build. /Z7 (embedded debug info,
     # via the compiler-cache path) keeps objects cacheable AND lets the linker


### PR DESCRIPTION
…narQube

The sccache addition was not helping CI: the repo's GitHub Actions cache was pegged at the 10 GB per-repo hard cap with 21,711 entries, because sccache's GHA backend stores one cache entry PER OBJECT FILE. At the cap, every write errored (observed write-errors == misses on every job), so the Windows jobs ran at 0% hit rate and the Linux jobs decayed from a frozen snapshot. Net effect: sccache was pure overhead on Windows (it also forces PCH + unity off), while SonarQube — which correctly can't use sccache — was the real long pole at ~2.5 h.

Cache backend (Windows.yml, asan.yml x4, flaky-repro-281.yml):
- Replace the per-object GHA backend (SCCACHE_GHA_ENABLED) with a bounded local-disk cache (SCCACHE_DIR + SCCACHE_CACHE_SIZE) wrapped in a single actions/cache entry per job, keyed per-flavor with run_id (always-save) + restore-keys (warm restore). One entry per job instead of ~thousands keeps the shared 10 GB cap from re-saturating.

Windows ASan -> clang-cl (asan.yml):
- Build the asan-windows job with clang-cl via cmake/ClangCLToolchain.cmake (the local clangcl-asan preset's toolchain) instead of MSVC cl.exe. Keeps the Windows-specific coverage (MSVC ABI + STL + Platform/* code) but runs Clang's more complete ASan runtime, and its /Z7 objects actually cache under sccache (MSVC cl.exe ASan objects never did). LeakSanitizer stays Linux-only (unavailable on Windows for either compiler). Runtime-DLL PATH step now uses `clang-cl -print-runtime-dir`.

SonarQube speedups (SonarCloud.yml):
- -DBUILD_TESTS=OFF for the build-wrapper build: the 398 test TUs are ~43% of the build and are declared as test sources (sonar.tests), so production rules never ran on them — dropping them shrinks both the build and the C-family scan for near-zero production-analysis loss.
- Build with Ninja + --parallel (via msvc-dev-cmd) instead of the VS/MSBuild generator; build-wrapper captures a Ninja build fine and it's faster. sccache remains deliberately absent (build-wrapper needs real compiles).
- sonar.cfamily.threads=4 to parallelise the analyzer across the runner's 4 vCPUs — the biggest lever on the ~51-min scan.

Also purged the 21,711 stale Actions-cache entries so the new bounded caches have room immediately (done out-of-band via `gh cache delete`).