### PR TITLE
perf(scene): cache TransformComponent local world matrix (#442, slice 1)

### DIFF
--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -1161,6 +1161,15 @@ namespace OloEngine
     {
     };
 
+    // TransformComponent carries a mutable runtime-only local-matrix cache that a
+    // render pass can repopulate between the undo snapshot and the compare. Its
+    // operator== deliberately ignores those cache fields, so use value-comparison
+    // to avoid spurious undo entries from stale cache bytes in the memcmp path.
+    template<>
+    struct PreferValueComparison<TransformComponent> : std::true_type
+    {
+    };
+
     template<typename T, typename UIFunction>
     static void DrawComponent(const std::string& name, Entity entity, UIFunction uiFunction)
     {

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -195,6 +195,18 @@ namespace OloEngine
         glm::vec3 RotationEuler = { 0.0f, 0.0f, 0.0f };
         glm::quat Rotation = { 1.0f, 0.0f, 0.0f, 0.0f };
 
+        // Runtime-only cache of the local TRS matrix. NOT serialized and excluded
+        // from operator== (see below): purely a perf accelerator for GetTransform().
+        // Because Translation/Scale are public and mutated in-place across the code
+        // base, a setter-invalidated dirty flag would miss those writes; instead the
+        // cache validates itself by bit-comparing the current TRS inputs against the
+        // inputs it was built from, so any mutation path invalidates it correctly.
+        mutable glm::mat4 m_CachedTransform{ 1.0f };
+        mutable glm::vec3 m_CachedTranslation{ 0.0f, 0.0f, 0.0f };
+        mutable glm::quat m_CachedRotation{ 1.0f, 0.0f, 0.0f, 0.0f };
+        mutable glm::vec3 m_CachedScale{ 1.0f, 1.0f, 1.0f };
+        mutable bool m_CacheValid = false;
+
       public:
         TransformComponent() = default;
         TransformComponent(const TransformComponent& other) = default;
@@ -288,10 +300,30 @@ namespace OloEngine
 
         [[nodiscard("Store this!")]] glm::mat4 GetTransform() const
         {
-            return glm::translate(glm::mat4(1.0f), Translation) * glm::toMat4(Rotation) * glm::scale(glm::mat4(1.0f), Scale);
+            // O(1) cache hit when the local TRS inputs are bit-identical to the last
+            // build; otherwise rebuild once and remember the inputs. Bit-exact compare
+            // is intentional (cpp-coding-quality §2b): identical bits reproduce an
+            // identical matrix, and any real edit differs in at least one bit.
+            if (m_CacheValid && Math::BitwiseEqual(m_CachedTranslation, Translation) && Math::BitwiseEqual(m_CachedRotation, Rotation) && Math::BitwiseEqual(m_CachedScale, Scale))
+            {
+                return m_CachedTransform;
+            }
+
+            m_CachedTransform = glm::translate(glm::mat4(1.0f), Translation) * glm::toMat4(Rotation) * glm::scale(glm::mat4(1.0f), Scale);
+            m_CachedTranslation = Translation;
+            m_CachedRotation = Rotation;
+            m_CachedScale = Scale;
+            m_CacheValid = true;
+            return m_CachedTransform;
         }
 
-        auto operator==(const TransformComponent&) const -> bool = default;
+        // Excludes the runtime-only cache fields from equality: two transforms with
+        // identical authored TRS must compare equal regardless of cache state (undo
+        // change-detection and round-trip tests rely on this). Bit-exact per §2a/§7.
+        auto operator==(const TransformComponent& other) const -> bool
+        {
+            return Math::BitwiseEqual(Translation, other.Translation) && Math::BitwiseEqual(Scale, other.Scale) && Math::BitwiseEqual(RotationEuler, other.RotationEuler) && Math::BitwiseEqual(Rotation, other.Rotation);
+        }
     };
 
     struct SpriteRendererComponent

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -317,12 +317,17 @@ namespace OloEngine
             return m_CachedTransform;
         }
 
-        // Excludes the runtime-only cache fields from equality: two transforms with
-        // identical authored TRS must compare equal regardless of cache state (undo
+        // Compares only the fields that actually define the transform: Translation,
+        // Scale, and the Rotation quat used by GetTransform(). RotationEuler is a
+        // history-dependent display representation (SetRotation() picks among
+        // equivalent Euler angles for gizmo continuity), so two identical rotations
+        // can hold different Euler values — including it would report false
+        // inequality on SetRotation() paths. The runtime-only cache fields are
+        // likewise excluded so cache state never affects equality (undo
         // change-detection and round-trip tests rely on this). Bit-exact per §2a/§7.
         auto operator==(const TransformComponent& other) const -> bool
         {
-            return Math::BitwiseEqual(Translation, other.Translation) && Math::BitwiseEqual(Scale, other.Scale) && Math::BitwiseEqual(RotationEuler, other.RotationEuler) && Math::BitwiseEqual(Rotation, other.Rotation);
+            return Math::BitwiseEqual(Translation, other.Translation) && Math::BitwiseEqual(Scale, other.Scale) && Math::BitwiseEqual(Rotation, other.Rotation);
         }
     };
 

--- a/OloEngine/tests/TransformComponentTest.cpp
+++ b/OloEngine/tests/TransformComponentTest.cpp
@@ -282,6 +282,29 @@ TEST(TransformComponentCache, OperatorEqualsIgnoresCacheState)
     EXPECT_FALSE(primed == fresh);
 }
 
+TEST(TransformComponentCache, OperatorEqualsIgnoresEulerRepresentationWhenQuatMatches)
+{
+    // Reach the same quaternion via two different Euler histories: SetRotation()
+    // picks among equivalent Euler angles for gizmo continuity, so RotationEuler
+    // can differ while the Rotation quat (and thus GetTransform()) is identical.
+    const glm::quat q = glm::quat(glm::vec3(glm::pi<float>() + 0.05f, 0.0f, 0.0f));
+
+    TransformComponent fromZero;
+    fromZero.SetRotation(q); // continuity relative to euler (0,0,0)
+
+    TransformComponent fromNearPi;
+    fromNearPi.SetRotationEuler({ glm::pi<float>() - 0.05f, 0.0f, 0.0f });
+    fromNearPi.SetRotation(q); // continuity relative to euler near +pi
+
+    // Quats are bit-identical (both glm::normalize of the same q)...
+    ASSERT_TRUE(OloEngine::Math::BitwiseEqual(fromZero.GetRotation(), fromNearPi.GetRotation()));
+    // ...but the continuity-adjusted Euler representations differ.
+    ASSERT_FALSE(OloEngine::Math::BitwiseEqual(fromZero.GetRotationEuler(), fromNearPi.GetRotationEuler()));
+
+    // Equality must follow the authored transform (the quat), not the display Euler.
+    EXPECT_TRUE(fromZero == fromNearPi) << "differing RotationEuler must not cause false inequality when Rotation matches";
+}
+
 // =============================================================================
 // Copy semantics
 // =============================================================================

--- a/OloEngine/tests/TransformComponentTest.cpp
+++ b/OloEngine/tests/TransformComponentTest.cpp
@@ -163,6 +163,126 @@ TEST(TransformComponent, SetTransformRoundTrip)
 }
 
 // =============================================================================
+// World-matrix cache (issue #442) -- cached path must equal a fresh recompute,
+// and any TRS mutation (via setter OR direct public-field write) must invalidate.
+// =============================================================================
+
+namespace
+{
+    // Reference recompute, matching GetTransform()'s formula exactly.
+    glm::mat4 FreshTransform(const TransformComponent& tc)
+    {
+        return glm::translate(glm::mat4(1.0f), tc.Translation) * glm::toMat4(tc.GetRotation()) * glm::scale(glm::mat4(1.0f), tc.Scale);
+    }
+
+    void ExpectMatNear(const glm::mat4& a, const glm::mat4& b, f32 eps = 1e-5f)
+    {
+        for (int col = 0; col < 4; ++col)
+            for (int row = 0; row < 4; ++row)
+                EXPECT_NEAR(a[col][row], b[col][row], eps) << "mismatch at [" << col << "][" << row << "]";
+    }
+} // namespace
+
+TEST(TransformComponentCache, RepeatedCallsAreBitIdenticalAndMatchFreshRecompute)
+{
+    TransformComponent tc;
+    tc.Translation = { 1.5f, -2.0f, 3.25f };
+    tc.SetRotationEuler({ 0.3f, -0.7f, 0.9f });
+    tc.Scale = { 2.0f, 0.5f, 1.25f };
+
+    const glm::mat4 first = tc.GetTransform();
+    // The reference recompute must agree with the (now cached) first result.
+    ExpectMatNear(first, FreshTransform(tc));
+
+    // Subsequent reads without any mutation must return the byte-identical cache.
+    for (int i = 0; i < 5; ++i)
+        EXPECT_TRUE(OloEngine::Math::BitwiseEqual(tc.GetTransform(), first));
+}
+
+TEST(TransformComponentCache, DirectTranslationWriteInvalidatesCache)
+{
+    TransformComponent tc;
+    tc.Translation = { 1.0f, 0.0f, 0.0f };
+    (void)tc.GetTransform(); // prime the cache
+
+    tc.Translation = { 9.0f, -4.0f, 2.0f }; // direct public-field mutation
+    ExpectMatNear(tc.GetTransform(), FreshTransform(tc));
+    EXPECT_NEAR(tc.GetTransform()[3][0], 9.0f, 1e-5f);
+    EXPECT_NEAR(tc.GetTransform()[3][1], -4.0f, 1e-5f);
+    EXPECT_NEAR(tc.GetTransform()[3][2], 2.0f, 1e-5f);
+}
+
+TEST(TransformComponentCache, DirectScaleWriteInvalidatesCache)
+{
+    TransformComponent tc;
+    (void)tc.GetTransform(); // prime with identity scale
+
+    tc.Scale = { 3.0f, 4.0f, 5.0f }; // direct public-field mutation
+    ExpectMatNear(tc.GetTransform(), FreshTransform(tc));
+    EXPECT_NEAR(glm::length(glm::vec3(tc.GetTransform()[0])), 3.0f, 1e-5f);
+    EXPECT_NEAR(glm::length(glm::vec3(tc.GetTransform()[1])), 4.0f, 1e-5f);
+    EXPECT_NEAR(glm::length(glm::vec3(tc.GetTransform()[2])), 5.0f, 1e-5f);
+}
+
+TEST(TransformComponentCache, RotationSettersInvalidateCache)
+{
+    TransformComponent tc;
+    (void)tc.GetTransform(); // prime with identity rotation
+
+    tc.SetRotationEuler({ 0.4f, 0.5f, -0.6f });
+    ExpectMatNear(tc.GetTransform(), FreshTransform(tc));
+
+    (void)tc.GetTransform();
+    tc.SetRotation(glm::quat(glm::vec3(-0.2f, 0.8f, 0.1f)));
+    ExpectMatNear(tc.GetTransform(), FreshTransform(tc));
+}
+
+TEST(TransformComponentCache, SetTransformInvalidatesCache)
+{
+    TransformComponent tc;
+    tc.Translation = { 1.0f, 1.0f, 1.0f };
+    (void)tc.GetTransform(); // prime
+
+    const glm::mat4 target = glm::translate(glm::mat4(1.0f), glm::vec3(4.0f, -2.0f, 6.0f)) * glm::toMat4(glm::quat(glm::vec3(0.1f, 0.2f, 0.3f))) * glm::scale(glm::mat4(1.0f), glm::vec3(2.0f));
+    tc.SetTransform(target);
+    ExpectMatNear(tc.GetTransform(), FreshTransform(tc), 1e-4f);
+}
+
+TEST(TransformComponentCache, CopyCarriesValidCache)
+{
+    TransformComponent src;
+    src.Translation = { 2.0f, 3.0f, 4.0f };
+    src.SetRotationEuler({ 0.2f, 0.4f, 0.6f });
+    src.Scale = { 1.5f, 2.5f, 0.5f };
+    const glm::mat4 srcMat = src.GetTransform(); // prime src cache
+
+    TransformComponent dst = src; // copy includes the cache
+    ExpectMatNear(dst.GetTransform(), srcMat);
+
+    // Mutating the copy must not affect the source and must invalidate dst's cache.
+    dst.Translation = { -1.0f, -1.0f, -1.0f };
+    ExpectMatNear(dst.GetTransform(), FreshTransform(dst));
+    ExpectMatNear(src.GetTransform(), srcMat);
+}
+
+TEST(TransformComponentCache, OperatorEqualsIgnoresCacheState)
+{
+    TransformComponent primed;
+    primed.Translation = { 1.0f, 2.0f, 3.0f };
+    primed.SetRotationEuler({ 0.1f, 0.2f, 0.3f });
+    (void)primed.GetTransform(); // primed has a valid cache
+
+    TransformComponent fresh;
+    fresh.Translation = { 1.0f, 2.0f, 3.0f };
+    fresh.SetRotationEuler({ 0.1f, 0.2f, 0.3f }); // identical TRS, cache never built
+
+    EXPECT_TRUE(primed == fresh) << "equality must depend only on authored TRS, not cache state";
+
+    fresh.Translation.x += 1.0f;
+    EXPECT_FALSE(primed == fresh);
+}
+
+// =============================================================================
 // Copy semantics
 // =============================================================================
 

--- a/docs/agent-rules/cpp-coding-quality.md
+++ b/docs/agent-rules/cpp-coding-quality.md
@@ -177,6 +177,28 @@ When the component contains a type without `operator==` (e.g., `Material`), writ
 
 `UUID` has implicit `operator u64()`. That causes **C2666 ambiguity** with any member `operator==`. In a manual `operator==`, compare UUIDs via `static_cast<u64>()` to disambiguate.
 
+### Mutable caches must be excluded from `operator==` (and routed off the memcmp undo path)
+
+If a component holds a `mutable` runtime-only cache (e.g. `TransformComponent`'s local-matrix
+cache from issue #442), do **not** leave `operator==` as `= default`: the defaulted comparison
+includes the cache fields, so two components with identical authored data compare **unequal**
+when one has a populated cache and the other doesn't — breaking round-trip tests and undo
+change-detection. Write a manual `operator==` (trailing-return form) that compares only the
+authored fields via `Math::BitwiseEqual`. Additionally, because the cache is `mutable`, a render
+pass can repopulate it between the editor undo snapshot and the compare — so the whole-struct
+`memcmp` path in `SceneHierarchyPanel::DrawComponent` would see spurious byte diffs. Opt the
+component into the value-comparison path with `PreferValueComparison<T> : std::true_type` so undo
+uses the cache-agnostic `operator==` instead.
+
+### Prefer input-snapshot validation over a setter dirty-flag when the inputs are public
+
+A dirty flag only works if **every** mutation goes through a setter. `TransformComponent.Translation`
+/`.Scale` are public and mutated in-place in hundreds of call sites, so a setter-invalidated flag
+would silently miss direct writes. Instead cache the computed result **plus** a bit-copy of the
+inputs it was built from, and on read compare the current inputs (`Math::BitwiseEqual`) against the
+cached inputs — any mutation path (setter or raw field write) invalidates correctly, with no
+call-site changes. Seed a `bool m_CacheValid = false` so the first read always computes.
+
 ---
 
 ## 8. Prefer structured bindings and range-for


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transform edits and undo/redo so cached transform data no longer causes false “changed” states.
  * Improved transform updates so repeated reads stay consistent while still refreshing correctly after position, rotation, or scale changes.

* **Documentation**
  * Updated coding guidance for safer handling of runtime-only cached values and reliable change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->