### PR TITLE
Renderer: frame pacing — frame-rate limiter + frame-time smoothing (#456)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1826,6 +1826,10 @@ namespace OloEngine
         m_ThrottlePlayMode = m_Prefs.ThrottlePlayMode;
         m_RenderBudgetMs = m_Prefs.RenderBudgetMs;
 
+        // Push frame pacing to the main loop (#456).
+        Application::Get().SetFrameRateCap(m_Prefs.FrameRateCap);
+        Application::Get().SetFrameTimeSmoothing(m_Prefs.FrameTimeSmoothing);
+
         auto& physicsSettings = Physics3DSystem::GetSettings();
         physicsSettings.m_CaptureOnPlay = m_Prefs.CapturePhysicsOnPlay;
 
@@ -1870,6 +1874,10 @@ namespace OloEngine
         m_Prefs.ThrottleEditMode = m_ThrottleEditMode;
         m_Prefs.ThrottlePlayMode = m_ThrottlePlayMode;
         m_Prefs.RenderBudgetMs = m_RenderBudgetMs;
+
+        // Frame pacing lives on the Application; read the live values back (#456).
+        m_Prefs.FrameRateCap = Application::Get().GetFrameRateCap();
+        m_Prefs.FrameTimeSmoothing = Application::Get().GetFrameTimeSmoothing();
 
         // MCP: port + auto-start are edited in place by the panel; sync redaction
         // (which lives on the server) back so it persists. (#285)

--- a/OloEditor/src/Panels/EditorPreferencesPanel.cpp
+++ b/OloEditor/src/Panels/EditorPreferencesPanel.cpp
@@ -221,6 +221,65 @@ namespace OloEngine
         {
             ImGui::SetTooltip("Rendering is skipped when the previous frame\nexceeded this duration. Lower values throttle more\naggressively. 33.3 ms = ~30 FPS threshold.");
         }
+
+        ImGui::Spacing();
+        ImGui::Text("Frame-Rate Limiter");
+        ImGui::Separator();
+        ImGui::TextWrapped("Cap the windowed main loop to a target frame rate (sleep + short spin). "
+                           "Composes with vsync — the limiter only sleeps for time vsync didn't "
+                           "already consume, so it never double-throttles.");
+        ImGui::Spacing();
+
+        static const char* const kCapLabels[] = { "Off", "60 FPS", "120 FPS", "144 FPS", "Custom" };
+        static constexpr u32 kCapValues[] = { 0u, 60u, 120u, 144u };
+        constexpr int kCustomIndex = 4;
+
+        int capIndex = kCustomIndex; // any non-preset value shows as "Custom"
+        for (int i = 0; i < kCustomIndex; ++i)
+        {
+            if (m_Draft.FrameRateCap == kCapValues[i])
+            {
+                capIndex = i;
+                break;
+            }
+        }
+
+        if (ImGui::Combo("Frame Cap", &capIndex, kCapLabels, IM_ARRAYSIZE(kCapLabels)))
+        {
+            // Seed Custom with a non-preset value so the selection sticks.
+            m_Draft.FrameRateCap = (capIndex < kCustomIndex) ? kCapValues[capIndex] : 90u;
+        }
+        if (capIndex == kCustomIndex)
+        {
+            int customFps = static_cast<int>(m_Draft.FrameRateCap);
+            if (ImGui::DragInt("Custom FPS", &customFps, 1.0f, 1, 1000, "%d FPS"))
+            {
+                m_Draft.FrameRateCap = static_cast<u32>(std::clamp(customFps, 1, 1000));
+            }
+        }
+
+        ImGui::Spacing();
+        ImGui::Text("Frame-Time Smoothing");
+        ImGui::Separator();
+        ImGui::TextWrapped("Damp frame-time jitter with an exponential moving average on the "
+                           "delta handed to gameplay/camera. Off by default.");
+        ImGui::Spacing();
+
+        bool smoothingOn = m_Draft.FrameTimeSmoothing < 1.0f;
+        if (ImGui::Checkbox("Smooth frame delta (EMA)", &smoothingOn))
+        {
+            m_Draft.FrameTimeSmoothing = smoothingOn ? 0.2f : 1.0f;
+        }
+        if (smoothingOn)
+        {
+            ImGui::DragFloat("Smoothing (alpha)", &m_Draft.FrameTimeSmoothing, 0.01f, 0.01f, 0.99f, "%.2f");
+            ImGui::SameLine();
+            ImGui::TextDisabled("(?)");
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("EMA weight for the newest frame's delta.\nLower = smoother but laggier. 1.0 disables smoothing.");
+            }
+        }
     }
 
     std::filesystem::path EditorPreferencesPanel::GetPrefsPath(const std::filesystem::path& projectDir)
@@ -248,6 +307,8 @@ namespace OloEngine
         out << YAML::Key << "ThrottleEditMode" << YAML::Value << prefs.ThrottleEditMode;
         out << YAML::Key << "ThrottlePlayMode" << YAML::Value << prefs.ThrottlePlayMode;
         out << YAML::Key << "RenderBudgetMs" << YAML::Value << prefs.RenderBudgetMs;
+        out << YAML::Key << "FrameRateCap" << YAML::Value << prefs.FrameRateCap;
+        out << YAML::Key << "FrameTimeSmoothing" << YAML::Value << prefs.FrameTimeSmoothing;
         out << YAML::Key << "EnableAutoSave" << YAML::Value << prefs.EnableAutoSave;
         out << YAML::Key << "AutoSaveIntervalSeconds" << YAML::Value << prefs.AutoSaveIntervalSeconds;
         out << YAML::Key << "McpAutoStart" << YAML::Value << prefs.McpAutoStart;
@@ -353,6 +414,11 @@ namespace OloEngine
             if (node["RenderBudgetMs"])
                 if (f32 v = node["RenderBudgetMs"].as<f32>(); std::isfinite(v))
                     prefs.RenderBudgetMs = std::clamp(v, 8.0f, 100.0f);
+            if (node["FrameRateCap"])
+                prefs.FrameRateCap = std::min(node["FrameRateCap"].as<u32>(), 1000u);
+            if (node["FrameTimeSmoothing"])
+                if (f32 v = node["FrameTimeSmoothing"].as<f32>(); std::isfinite(v))
+                    prefs.FrameTimeSmoothing = std::clamp(v, 0.01f, 1.0f);
             if (node["EnableAutoSave"])
                 prefs.EnableAutoSave = node["EnableAutoSave"].as<bool>();
             if (node["AutoSaveIntervalSeconds"])

--- a/OloEditor/src/Panels/EditorPreferencesPanel.h
+++ b/OloEditor/src/Panels/EditorPreferencesPanel.h
@@ -47,6 +47,13 @@ namespace OloEngine
         bool ThrottlePlayMode = false;
         f32 RenderBudgetMs = 33.3f;
 
+        // Frame pacing (#456). FrameRateCap: 0 = uncapped, else the target FPS
+        // the windowed main loop paces itself to (off / 60 / 120 / 144 / custom).
+        // FrameTimeSmoothing: EMA weight for the delta handed to layers, in
+        // (0, 1]; 1.0 disables smoothing.
+        u32 FrameRateCap = 0;
+        f32 FrameTimeSmoothing = 1.0f;
+
         // Physics debug
         bool CapturePhysicsOnPlay = false;
 

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -298,6 +298,8 @@
 		"OloEngine/Core/FileSystem.cpp"
 		"OloEngine/Core/FileSystem.h"
 		"OloEngine/Core/FilesystemUtils.h"
+		"OloEngine/Core/FramePacer.cpp"
+		"OloEngine/Core/FramePacer.h"
 		"OloEngine/Core/IInputProvider.h"
 		"OloEngine/Core/Input.h"
 		"OloEngine/Core/InputAction.h"

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -278,7 +278,11 @@ namespace OloEngine
             const auto timeNow = Time::GetTime();
             const f32 rawDelta = timeNow - m_LastFrameTime;
             m_UnscaledDeltaTime = rawDelta;
-            const Timestep timestep = std::min(rawDelta, s_MaxTimestep) * m_TimeScale;
+            // EMA-smooth the delta handed to layers to damp frame-time jitter
+            // (issue #456). With smoothing disabled (default) this returns the
+            // raw delta unchanged, so behaviour is identical until opted in.
+            const f32 smoothedDelta = m_FramePacer.SmoothDelta(rawDelta);
+            const Timestep timestep = std::min(smoothedDelta, s_MaxTimestep) * m_TimeScale;
             m_LastFrameTime = timeNow;
 
             // Poll OS events first so GLFW key state is fresh for this frame
@@ -334,6 +338,13 @@ namespace OloEngine
             OLO_PROFILE_FRAMEMARK_START("Window SwapBuffers");
             m_Window->SwapBuffers();
             OLO_PROFILE_FRAMEMARK_END("Window SwapBuffers");
+
+            // Frame-rate cap (issue #456). Placed AFTER SwapBuffers so it only
+            // sleeps for the budget vsync (if on) didn't already consume — no
+            // double-throttle. Measured from this frame's start (timeNow).
+            OLO_PROFILE_FRAMEMARK_START("FramePacer LimitFrameRate");
+            m_FramePacer.LimitFrameRate(timeNow);
+            OLO_PROFILE_FRAMEMARK_END("FramePacer LimitFrameRate");
 
             // Snapshot per-function performance data for this frame
             m_PerformanceProfiler.EndFrame();

--- a/OloEngine/src/OloEngine/Core/Application.h
+++ b/OloEngine/src/OloEngine/Core/Application.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/FramePacer.h"
 #include "OloEngine/Core/LayerStack.h"
 #include "OloEngine/Core/PerformanceProfiler.h"
 #include "OloEngine/Core/Timestep.h"
@@ -182,6 +183,38 @@ namespace OloEngine
             return m_UnscaledDeltaTime;
         }
 
+        // Frame-rate limiter (issue #456). 0 disables the cap; any positive value
+        // is the target FPS the windowed loop paces itself to (off / 60 / 120 /
+        // 144 / custom). Composes with vsync — the limiter only sleeps for time
+        // vsync didn't already consume, so it never double-throttles.
+        void SetFrameRateCap(u32 fps)
+        {
+            m_FramePacer.SetTargetFPS(fps);
+        }
+        [[nodiscard("Store this!")]] u32 GetFrameRateCap() const
+        {
+            return m_FramePacer.GetTargetFPS();
+        }
+
+        // EMA smoothing weight for the frame delta handed to layers, in (0, 1].
+        // 1.0 (default) disables smoothing; smaller values smooth more heavily.
+        void SetFrameTimeSmoothing(f32 alpha)
+        {
+            m_FramePacer.SetSmoothingFactor(alpha);
+        }
+        [[nodiscard("Store this!")]] f32 GetFrameTimeSmoothing() const
+        {
+            return m_FramePacer.GetSmoothingFactor();
+        }
+
+        // The EMA-smoothed frame delta (seconds), unscaled by time scale. Equals
+        // the raw delta when smoothing is disabled. This is the value the loop
+        // feeds to Layer::OnUpdate (after clamping + time scale).
+        [[nodiscard("Store this!")]] f32 GetSmoothedDeltaTime() const
+        {
+            return m_FramePacer.GetSmoothedDelta();
+        }
+
         [[nodiscard("Store this!")]] PerformanceProfiler* GetPerformanceProfiler()
         {
             return &m_PerformanceProfiler;
@@ -230,6 +263,7 @@ namespace OloEngine
         f32 m_FixedTimeStep = 1.0f / 60.0f;
         u64 m_RandomSeed = kDefaultRandomSeed;
         u32 m_SmokeTestTicksCompleted = 0; // see SmokeTestTickLimit / IsSmokeTest
+        FramePacer m_FramePacer;           // frame-rate cap + delta smoothing (#456)
         PerformanceProfiler m_PerformanceProfiler;
 
       private:

--- a/OloEngine/src/OloEngine/Core/FramePacer.cpp
+++ b/OloEngine/src/OloEngine/Core/FramePacer.cpp
@@ -1,0 +1,142 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Core/FramePacer.h"
+
+#include "OloEngine/Utils/PlatformUtils.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <thread>
+
+#ifdef OLO_PLATFORM_WINDOWS
+#include <Windows.h>
+#include <timeapi.h> // timeBeginPeriod / timeEndPeriod (winmm)
+#endif
+
+namespace OloEngine
+{
+    FramePacer::~FramePacer()
+    {
+        // Release the OS timer-resolution request if we still hold it.
+        m_TargetFPS = kUncapped;
+        UpdateTimerResolution();
+    }
+
+    void FramePacer::SetTargetFPS(u32 fps)
+    {
+        m_TargetFPS = fps;
+        UpdateTimerResolution();
+    }
+
+    void FramePacer::UpdateTimerResolution()
+    {
+        const bool wantHigh = (m_TargetFPS != kUncapped);
+        if (wantHigh == m_TimerResolutionRaised)
+        {
+            return;
+        }
+
+#ifdef OLO_PLATFORM_WINDOWS
+        if (wantHigh)
+        {
+            ::timeBeginPeriod(1);
+        }
+        else
+        {
+            ::timeEndPeriod(1);
+        }
+#endif
+
+        m_TimerResolutionRaised = wantHigh;
+    }
+
+    void FramePacer::SetSmoothingFactor(f32 alpha)
+    {
+        if (!std::isfinite(alpha))
+        {
+            alpha = 1.0f;
+        }
+        m_SmoothingAlpha = std::clamp(alpha, kMinSmoothingAlpha, 1.0f);
+    }
+
+    f32 FramePacer::SmoothDelta(f32 rawDelta)
+    {
+        if (!m_HasSmoothedDelta)
+        {
+            m_SmoothedDelta = std::isfinite(rawDelta) ? rawDelta : 0.0f;
+            m_HasSmoothedDelta = true;
+            return m_SmoothedDelta;
+        }
+
+        m_SmoothedDelta = SmoothFrameTime(m_SmoothedDelta, rawDelta, m_SmoothingAlpha);
+        return m_SmoothedDelta;
+    }
+
+    void FramePacer::LimitFrameRate(f32 frameStartTime)
+    {
+        const f32 targetFrameTime = GetTargetFrameTime();
+        if (targetFrameTime <= 0.0f)
+        {
+            return; // uncapped
+        }
+
+        // A frozen clock (deterministic capture/test) never advances — spinning
+        // on it would hang the loop forever, so leave the pacing to real time.
+        if (Time::HasMockTime())
+        {
+            return;
+        }
+
+        for (;;)
+        {
+            const f32 elapsed = Time::GetTime() - frameStartTime;
+            const f32 remaining = targetFrameTime - elapsed;
+            if (!std::isfinite(remaining) || remaining <= 0.0f)
+            {
+                break;
+            }
+
+            if (const f32 sleepSeconds = ComputeSleepSeconds(remaining, kSpinMarginSeconds); sleepSeconds > 0.0f)
+            {
+                std::this_thread::sleep_for(std::chrono::duration<f32>(sleepSeconds));
+            }
+            else
+            {
+                // Busy-spin the final sub-millisecond for accuracy the OS sleep
+                // can't deliver; yield so a hyperthread sibling can progress.
+                std::this_thread::yield();
+            }
+        }
+    }
+
+    f32 FramePacer::ComputeSleepSeconds(f32 remaining, f32 spinMargin)
+    {
+        if (!std::isfinite(spinMargin) || spinMargin < 0.0f)
+        {
+            spinMargin = 0.0f;
+        }
+        if (!std::isfinite(remaining) || remaining <= spinMargin)
+        {
+            return 0.0f;
+        }
+        return remaining - spinMargin;
+    }
+
+    f32 FramePacer::SmoothFrameTime(f32 previous, f32 sample, f32 alpha)
+    {
+        if (!std::isfinite(sample))
+        {
+            return previous;
+        }
+        if (!std::isfinite(previous))
+        {
+            return sample;
+        }
+        if (!std::isfinite(alpha))
+        {
+            alpha = 1.0f;
+        }
+        alpha = std::clamp(alpha, 0.0f, 1.0f);
+        return previous + alpha * (sample - previous);
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Core/FramePacer.h
+++ b/OloEngine/src/OloEngine/Core/FramePacer.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+namespace OloEngine
+{
+    // Frame pacing for the windowed main loop (issue #456): an optional
+    // frame-rate cap (coarse sleep + short busy-spin to hit a target frame time)
+    // plus exponential-moving-average smoothing of the per-frame delta handed to
+    // consumers.
+    //
+    // The cap is designed to COMPOSE with vsync rather than fight it: the loop
+    // calls LimitFrameRate AFTER SwapBuffers, so when vsync has already consumed
+    // the frame budget the remaining wait is <= 0 and nothing sleeps (no
+    // double-throttle). A cap slower than the vsync rate throttles the extra
+    // time; a cap faster than vsync is simply dominated by vsync.
+    //
+    // The precision-sensitive parts live behind PURE, wall-clock-free static
+    // helpers (ComputeSleepSeconds / SmoothFrameTime) so the math can be unit
+    // tested without any timing flakiness. The blocking wait (LimitFrameRate)
+    // reads the real clock through Utils::Time and is intentionally not unit
+    // tested — it is validated by feel in the running editor.
+    //
+    // On Windows the default scheduler tick (~15.6 ms) is far too coarse for a
+    // frame limiter, so while a cap is active the pacer raises the process timer
+    // resolution to 1 ms (timeBeginPeriod, winmm) and releases it when the cap is
+    // turned off or the pacer is destroyed.
+    class FramePacer
+    {
+      public:
+        // Sentinel target FPS meaning "no cap" (the limiter is a no-op).
+        static constexpr u32 kUncapped = 0;
+
+        FramePacer() = default;
+        ~FramePacer();
+
+        // Owns a process-wide timer-resolution request on Windows — copying would
+        // double-release it. The pacer lives as a single Application member.
+        FramePacer(const FramePacer&) = delete;
+        FramePacer& operator=(const FramePacer&) = delete;
+
+        // 0 (kUncapped) disables the cap. Any positive value is the target
+        // frames-per-second. Toggling the cap raises/releases the OS timer
+        // resolution on Windows, so this is defined out-of-line.
+        void SetTargetFPS(u32 fps);
+        [[nodiscard]] u32 GetTargetFPS() const
+        {
+            return m_TargetFPS;
+        }
+        [[nodiscard]] bool IsCapEnabled() const
+        {
+            return m_TargetFPS != kUncapped;
+        }
+
+        // Target frame time in seconds for the current cap, or 0 when uncapped.
+        [[nodiscard]] f32 GetTargetFrameTime() const
+        {
+            return m_TargetFPS == kUncapped ? 0.0f : 1.0f / static_cast<f32>(m_TargetFPS);
+        }
+
+        // EMA weight for the newest sample, in [kMinSmoothingAlpha, 1]. 1.0 is
+        // the default and disables smoothing (the returned delta equals the raw
+        // delta bit-for-bit); smaller values smooth more heavily. Non-finite or
+        // out-of-range inputs are sanitized.
+        void SetSmoothingFactor(f32 alpha);
+        [[nodiscard]] f32 GetSmoothingFactor() const
+        {
+            return m_SmoothingAlpha;
+        }
+        [[nodiscard]] bool IsSmoothingEnabled() const
+        {
+            return m_SmoothingAlpha < 1.0f;
+        }
+
+        // Feed the raw per-frame delta (seconds); returns the EMA-smoothed delta
+        // and stores it. The first call (or first after Reset) seeds the average
+        // with rawDelta. A non-finite rawDelta is ignored (the previous smoothed
+        // value is returned unchanged).
+        f32 SmoothDelta(f32 rawDelta);
+        [[nodiscard]] f32 GetSmoothedDelta() const
+        {
+            return m_SmoothedDelta;
+        }
+
+        // Forget the smoothing history so the next SmoothDelta re-seeds. Call
+        // after a long stall (level load, breakpoint) so a huge stale delta
+        // doesn't bleed into subsequent frames.
+        void Reset()
+        {
+            m_HasSmoothedDelta = false;
+        }
+
+        // Block (coarse sleep + short busy-spin) until GetTargetFrameTime()
+        // seconds have elapsed since frameStartTime (both from Utils::Time). A
+        // no-op when uncapped, when the budget is already spent, or when the
+        // clock is frozen (deterministic capture/test via Time::SetMockTime).
+        void LimitFrameRate(f32 frameStartTime);
+
+        // ---- Pure, wall-clock-free math (unit tested) --------------------------
+
+        // How long to coarse-sleep given the time still remaining in the frame
+        // budget and a busy-spin safety margin. Returns 0 when the remaining time
+        // is within the margin (spin-only) or already spent, so the caller spins
+        // the final margin for accuracy instead of trusting the OS sleep.
+        [[nodiscard]] static f32 ComputeSleepSeconds(f32 remaining, f32 spinMargin);
+
+        // One EMA step: previous + alpha * (sample - previous). Sanitizes
+        // non-finite inputs (a bad sample keeps previous; a bad previous adopts
+        // the sample; a bad alpha is treated as 1.0) and clamps alpha to [0, 1].
+        [[nodiscard]] static f32 SmoothFrameTime(f32 previous, f32 sample, f32 alpha);
+
+      private:
+        void UpdateTimerResolution();
+
+        u32 m_TargetFPS = kUncapped;
+        f32 m_SmoothingAlpha = 1.0f; // 1.0 == smoothing disabled
+        f32 m_SmoothedDelta = 0.0f;
+        bool m_HasSmoothedDelta = false;
+        bool m_TimerResolutionRaised = false;
+
+        // Coarse-sleep until this much of the budget remains, then busy-spin the
+        // rest. ~1 ms comfortably covers 1 ms-timer-resolution wake-up jitter on
+        // Windows without a system-wide power-hungrier resolution bump.
+        static constexpr f32 kSpinMarginSeconds = 0.001f;
+        // Never let alpha reach 0 — a 0 weight would freeze the average forever.
+        static constexpr f32 kMinSmoothingAlpha = 0.001f;
+    };
+} // namespace OloEngine

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -513,6 +513,8 @@ add_executable(OloEngine-Tests
 		Functional/SaveGame/HierarchyPreservedAcrossSaveLoadTest.cpp
 		Functional/Scene/EntityNameMapStaysConsistentTest.cpp
 		Functional/Diagnostics/EmptyTickReproTest.cpp
+		# FramePacer: frame-rate cap sleep/spin math + EMA delta smoothing (#456)
+		FramePacerTest.cpp
 )
 target_link_libraries(OloEngine-Tests
 	OloEngine

--- a/OloEngine/tests/FramePacerTest.cpp
+++ b/OloEngine/tests/FramePacerTest.cpp
@@ -1,0 +1,218 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Core/FramePacer.h"
+#include "OloEngine/Utils/PlatformUtils.h"
+
+#include <cmath>
+#include <limits>
+
+namespace
+{
+    using namespace OloEngine;
+
+    constexpr f32 kInf = std::numeric_limits<f32>::infinity();
+    const f32 kNaN = std::numeric_limits<f32>::quiet_NaN();
+
+    // =========================================================================
+    // ComputeSleepSeconds — pure sleep/spin split math
+    // =========================================================================
+
+    TEST(FramePacerComputeSleep, LeavesTheSpinMarginToBusyWait)
+    {
+        // 5 ms remaining, 1 ms spin margin -> coarse-sleep 4 ms, spin the rest.
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.005f, 0.001f), 0.004f);
+    }
+
+    TEST(FramePacerComputeSleep, ReturnsZeroWhenWithinTheMargin)
+    {
+        // Remaining <= margin -> spin only, no coarse sleep.
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.001f, 0.001f), 0.0f);
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.0005f, 0.001f), 0.0f);
+    }
+
+    TEST(FramePacerComputeSleep, ReturnsZeroWhenBudgetAlreadySpent)
+    {
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.0f, 0.001f), 0.0f);
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(-0.010f, 0.001f), 0.0f);
+    }
+
+    TEST(FramePacerComputeSleep, TreatsNonFiniteAsZero)
+    {
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(kNaN, 0.001f), 0.0f);
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(kInf, 0.001f), 0.0f); // non-finite remaining -> no sleep
+        // A bad margin is treated as 0 -> sleep the whole remaining time.
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.005f, kNaN), 0.005f);
+        EXPECT_FLOAT_EQ(FramePacer::ComputeSleepSeconds(0.005f, -1.0f), 0.005f);
+    }
+
+    // =========================================================================
+    // SmoothFrameTime — pure single EMA step
+    // =========================================================================
+
+    TEST(FramePacerSmoothStep, AlphaOneAdoptsTheSample)
+    {
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(0.010f, 0.020f, 1.0f), 0.020f);
+    }
+
+    TEST(FramePacerSmoothStep, AlphaZeroKeepsThePrevious)
+    {
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(0.010f, 0.020f, 0.0f), 0.010f);
+    }
+
+    TEST(FramePacerSmoothStep, BlendsProportionally)
+    {
+        // previous + alpha*(sample - previous) = 0.010 + 0.25*0.010 = 0.0125
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(0.010f, 0.020f, 0.25f), 0.0125f);
+    }
+
+    TEST(FramePacerSmoothStep, SanitizesNonFiniteInputs)
+    {
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(0.010f, kNaN, 0.5f), 0.010f);   // bad sample -> keep prev
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(kInf, 0.020f, 0.5f), 0.020f);   // bad prev -> adopt sample
+        EXPECT_FLOAT_EQ(FramePacer::SmoothFrameTime(0.010f, 0.020f, kNaN), 0.020f); // bad alpha -> treat as 1.0
+    }
+
+    TEST(FramePacerSmoothStep, ConvergesTowardAConstantSample)
+    {
+        f32 value = 0.0f;
+        for (int i = 0; i < 200; ++i)
+        {
+            value = FramePacer::SmoothFrameTime(value, 0.016f, 0.2f);
+        }
+        EXPECT_NEAR(value, 0.016f, 1e-4f);
+    }
+
+    // =========================================================================
+    // Frame-rate cap accessors
+    // =========================================================================
+
+    TEST(FramePacerCap, UncappedByDefault)
+    {
+        FramePacer pacer;
+        EXPECT_EQ(pacer.GetTargetFPS(), FramePacer::kUncapped);
+        EXPECT_FALSE(pacer.IsCapEnabled());
+        EXPECT_FLOAT_EQ(pacer.GetTargetFrameTime(), 0.0f);
+    }
+
+    TEST(FramePacerCap, TargetFrameTimeIsReciprocalOfFPS)
+    {
+        FramePacer pacer;
+        pacer.SetTargetFPS(60);
+        EXPECT_TRUE(pacer.IsCapEnabled());
+        EXPECT_FLOAT_EQ(pacer.GetTargetFrameTime(), 1.0f / 60.0f);
+
+        pacer.SetTargetFPS(144);
+        EXPECT_FLOAT_EQ(pacer.GetTargetFrameTime(), 1.0f / 144.0f);
+
+        pacer.SetTargetFPS(FramePacer::kUncapped);
+        EXPECT_FALSE(pacer.IsCapEnabled());
+        EXPECT_FLOAT_EQ(pacer.GetTargetFrameTime(), 0.0f);
+    }
+
+    // =========================================================================
+    // Smoothing factor + stateful SmoothDelta
+    // =========================================================================
+
+    TEST(FramePacerSmoothing, DisabledByDefault)
+    {
+        FramePacer pacer;
+        EXPECT_FLOAT_EQ(pacer.GetSmoothingFactor(), 1.0f);
+        EXPECT_FALSE(pacer.IsSmoothingEnabled());
+    }
+
+    TEST(FramePacerSmoothing, SetterClampsToValidRange)
+    {
+        FramePacer pacer;
+        pacer.SetSmoothingFactor(0.3f);
+        EXPECT_FLOAT_EQ(pacer.GetSmoothingFactor(), 0.3f);
+        EXPECT_TRUE(pacer.IsSmoothingEnabled());
+
+        pacer.SetSmoothingFactor(5.0f); // above 1 -> clamps to 1
+        EXPECT_FLOAT_EQ(pacer.GetSmoothingFactor(), 1.0f);
+
+        pacer.SetSmoothingFactor(0.0f); // 0 would freeze the average -> floored
+        EXPECT_GT(pacer.GetSmoothingFactor(), 0.0f);
+
+        pacer.SetSmoothingFactor(kNaN); // non-finite -> disabled (1.0)
+        EXPECT_FLOAT_EQ(pacer.GetSmoothingFactor(), 1.0f);
+    }
+
+    TEST(FramePacerSmoothing, FirstCallSeedsWithTheRawDelta)
+    {
+        FramePacer pacer;
+        pacer.SetSmoothingFactor(0.1f);
+        EXPECT_FLOAT_EQ(pacer.SmoothDelta(0.02f), 0.02f);
+        EXPECT_FLOAT_EQ(pacer.GetSmoothedDelta(), 0.02f);
+    }
+
+    TEST(FramePacerSmoothing, DisabledSmoothingIsAnIdentityPassThrough)
+    {
+        FramePacer pacer; // alpha == 1.0
+        EXPECT_FLOAT_EQ(pacer.SmoothDelta(0.016f), 0.016f);
+        EXPECT_FLOAT_EQ(pacer.SmoothDelta(0.033f), 0.033f);
+        EXPECT_FLOAT_EQ(pacer.SmoothDelta(0.008f), 0.008f);
+    }
+
+    TEST(FramePacerSmoothing, DampsAJitterSpike)
+    {
+        FramePacer pacer;
+        pacer.SetSmoothingFactor(0.2f);
+        pacer.SmoothDelta(0.016f); // seed at 16 ms
+
+        // A single doubled frame should barely move the smoothed value.
+        const f32 afterSpike = pacer.SmoothDelta(0.032f);
+        EXPECT_GT(afterSpike, 0.016f);
+        EXPECT_LT(afterSpike, 0.020f); // far below the raw 32 ms spike
+    }
+
+    TEST(FramePacerSmoothing, IgnoresNonFiniteSamples)
+    {
+        FramePacer pacer;
+        pacer.SetSmoothingFactor(0.5f);
+        pacer.SmoothDelta(0.016f);
+        const f32 kept = pacer.SmoothDelta(kNaN);
+        EXPECT_FLOAT_EQ(kept, 0.016f);
+        EXPECT_FLOAT_EQ(pacer.GetSmoothedDelta(), 0.016f);
+    }
+
+    TEST(FramePacerSmoothing, ResetReseedsOnNextSample)
+    {
+        FramePacer pacer;
+        pacer.SetSmoothingFactor(0.2f);
+        pacer.SmoothDelta(0.016f);
+        pacer.SmoothDelta(0.016f);
+
+        pacer.Reset();
+        // After a reset the next sample seeds directly instead of blending.
+        EXPECT_FLOAT_EQ(pacer.SmoothDelta(0.100f), 0.100f);
+    }
+
+    // =========================================================================
+    // LimitFrameRate — no-op paths (never block the deterministic test run)
+    // =========================================================================
+
+    TEST(FramePacerLimit, UncappedReturnsImmediately)
+    {
+        FramePacer pacer; // uncapped
+        const f32 before = Time::GetTime();
+        pacer.LimitFrameRate(before);
+        // No cap -> should not have paced anything meaningfully.
+        EXPECT_LT(Time::GetTime() - before, 0.05f);
+    }
+
+    TEST(FramePacerLimit, FrozenClockDoesNotHang)
+    {
+        // A mock (frozen) clock never advances; the limiter must bail instead of
+        // spinning forever waiting for elapsed time that can't accrue.
+        Time::SetMockTime(123.0f);
+        {
+            FramePacer pacer;
+            pacer.SetTargetFPS(60);
+            pacer.LimitFrameRate(123.0f); // returns immediately by contract
+            SUCCEED();
+        }
+        Time::ClearMockTime();
+    }
+} // namespace

--- a/scripts/build-ffmpeg.sh
+++ b/scripts/build-ffmpeg.sh
@@ -108,8 +108,16 @@ if [ -f ffbuild/config.mak ] && [ "$MODE" != "configure-only" ] && [ "${OLO_FFMP
     echo "=== already configured (ffbuild/config.mak present) — skipping configure ==="
 else
     if [ "$OLO_OS" = windows ]; then
+        # --disable-inline-asm is mandatory for the MSVC toolchain: cl.exe cannot
+        # compile FFmpeg's GNU (AT&T) inline asm at all. FFmpeg's configure is
+        # *supposed* to reach the same conclusion via its runtime check_inline_asm
+        # probe, but the msvc branch never hard-disables it, and on newer cl
+        # versions that probe can flake and leave HAVE_INLINE_ASM=1 — which then
+        # fails the build with C2143 in libavcodec/x86/mathops.h on a fresh tree.
+        # Forcing it off makes the Windows build deterministic (matches every
+        # correctly-configured tree, which all have HAVE_INLINE_ASM=0).
         # shellcheck disable=SC2086
-        ./configure --prefix="$(cygpath -w "$PREFIX")" --toolchain=msvc --target-os=win64 --arch=x86_64 $CODEC_FLAGS 2>&1 | tail -40
+        ./configure --prefix="$(cygpath -w "$PREFIX")" --toolchain=msvc --target-os=win64 --arch=x86_64 --disable-inline-asm $CODEC_FLAGS 2>&1 | tail -40
     else
         # shellcheck disable=SC2086
         ./configure --prefix="$PREFIX" $CODEC_FLAGS 2>&1 | tail -40


### PR DESCRIPTION
## Summary

First slice of #456 (frame pacing). Adds a `FramePacer` to the windowed main loop:

- **Configurable frame-rate cap** — off / 60 / 120 / 144 / custom. Hits a target frame time with a coarse `sleep` + short busy-spin. Called **after** `SwapBuffers` so it **composes with vsync** instead of double-throttling (if vsync already consumed the budget, the remaining wait is ≤ 0 and nothing sleeps). On Windows it raises the process timer resolution to 1 ms (`timeBeginPeriod`, winmm) while a cap is active and releases it when uncapped/destroyed.
- **EMA frame-time smoothing** — damps jitter on the per-frame delta handed to layers. Default `alpha = 1.0` = **disabled** (identity pass-through), so behaviour is unchanged until opted in. Guards non-finite samples and a frozen clock.
- **Public API** on `Application` (`SetFrameRateCap` / `SetFrameTimeSmoothing` / `GetSmoothedDeltaTime`) + an editor **Performance-tab UI** (cap combo + smoothing), persisted to `EditorPreferences.yaml`.

The precision-sensitive parts sit behind pure, wall-clock-free static helpers (`ComputeSleepSeconds` / `SmoothFrameTime`) so the math is unit-testable without timing flakiness.

### Deferred to a follow-up
Slice 3 of the issue — **update/render decoupling with interpolation** — is the large architectural piece (pairs with the #484 fixed tick and relates to the #453 system-scheduler). Not in this PR; will be filed as a scored follow-up.

## Also: ffmpeg build hardening
`scripts/build-ffmpeg.sh` now forces `--disable-inline-asm` for the MSVC toolchain. `cl.exe` can't compile FFmpeg's GNU inline asm; ffmpeg's `configure` is meant to disable it via a runtime probe, but the msvc branch never hard-disables it and the probe can flake on newer `cl`, leaving `HAVE_INLINE_ASM=1` and breaking a **fresh-tree** build with `C2143` in `libavcodec/x86/mathops.h`. Forcing it off makes the Windows ffmpeg build deterministic (matches every correctly-configured tree, which all have `HAVE_INLINE_ASM=0`).

## Testing
- `OloEngine-Tests` + `OloEditor` build clean (VS18 2026 / cl 19.51).
- **20 new unit tests pass** (`FramePacerTest.cpp`, layer `unit`): sleep/spin split, EMA convergence + jitter damping, non-finite handling, cap accessors, no-hang paths.
- ffmpeg hardening validated: configure now yields `HAVE_INLINE_ASM 0` deterministically.
- Remaining manual check: eyeball the cap feel in the live editor (Preferences → Performance → Frame Cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)