### PR TITLE
feat(mcp): olo_renderer_settings_set — consented renderer/post-process settings write (#306)

### DIFF
--- a/OloEditor/src/MCP/McpRendererSettings.h
+++ b/OloEditor/src/MCP/McpRendererSettings.h
@@ -43,6 +43,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <optional>
@@ -293,29 +294,57 @@ namespace OloEngine::MCP::RendererSettings
         bool PathChanged = false;
     };
 
+    // Read the current engine-enum integer of `setting` from the live settings. The
+    // single per-setting READ mapping, shared by Apply (the prior value) and Describe
+    // (the current value) so the mapping lives in one place and can't drift when a
+    // setting is added. NOTE: `OloEngine::RendererSettings` is spelled fully qualified
+    // — unqualified `RendererSettings` names THIS namespace, not the engine struct.
+    [[nodiscard]] inline i32 CurrentValue(Setting setting, const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs)
+    {
+        switch (setting)
+        {
+            case Setting::Upscale:
+                return static_cast<i32>(pp.Upscale);
+            case Setting::Tonemap:
+                return static_cast<i32>(pp.Tonemap);
+            case Setting::RenderPath:
+                return static_cast<i32>(rs.Path);
+        }
+        return 0;
+    }
+
     // Apply `value` (an engine enum integer) to `setting`, mutating the matching
     // field of `pp` / `rs` and reporting the prior value so the change can be
     // restored by setting it back (restore-prior-value, no undo stack). MUST run on
     // the main (game) thread — the caller passes the live Renderer3D settings.
-    // NOTE: the engine struct `OloEngine::RendererSettings` must be spelled fully
-    // qualified here — unqualified `RendererSettings` would name THIS namespace
-    // (OloEngine::MCP::RendererSettings), not the type.
     [[nodiscard]] inline ApplyResult Apply(Setting setting, i32 value, PostProcessSettings& pp, ::OloEngine::RendererSettings& rs)
     {
         ApplyResult result;
-        i32 previous = 0;
+
+        // Validate the value against the setting's allowed set BEFORE mutating. Apply
+        // is a public seam callable independently of ParseArgs (e.g. from tests / a
+        // future caller), so it must not blindly cast an arbitrary integer into an
+        // engine enum — reject an out-of-range value and leave pp / rs untouched.
+        const auto allowed = SettingValues(setting);
+        if (std::none_of(allowed.begin(), allowed.end(),
+                         [value](const EnumValue& v)
+                         { return v.Value == value; }))
+        {
+            result.Error = "Invalid value " + std::to_string(value) + " for setting '" +
+                           std::string(SettingToken(setting)) + "'. Valid values: " + JoinValueTokens(setting) + ".";
+            return result;
+        }
+
+        const i32 previous = CurrentValue(setting, pp, rs);
         switch (setting)
         {
             case Setting::Upscale:
-                previous = static_cast<i32>(pp.Upscale);
                 pp.Upscale = static_cast<UpscaleMode>(value);
                 break;
             case Setting::Tonemap:
-                previous = static_cast<i32>(pp.Tonemap);
                 pp.Tonemap = static_cast<TonemapOperator>(value);
                 break;
             case Setting::RenderPath:
-                previous = static_cast<i32>(rs.Path);
                 rs.Path = static_cast<RenderingPath>(static_cast<u8>(value));
                 break;
         }
@@ -346,19 +375,7 @@ namespace OloEngine::MCP::RendererSettings
         Json arr = Json::array();
         for (const auto& info : kSettings)
         {
-            i32 current = 0;
-            switch (info.Id)
-            {
-                case Setting::Upscale:
-                    current = static_cast<i32>(pp.Upscale);
-                    break;
-                case Setting::Tonemap:
-                    current = static_cast<i32>(pp.Tonemap);
-                    break;
-                case Setting::RenderPath:
-                    current = static_cast<i32>(rs.Path);
-                    break;
-            }
+            const i32 current = CurrentValue(info.Id, pp, rs);
 
             Json values = Json::array();
             for (const auto& v : SettingValues(info.Id))

--- a/OloEditor/src/MCP/McpRendererSettings.h
+++ b/OloEditor/src/MCP/McpRendererSettings.h
@@ -1,0 +1,376 @@
+#pragma once
+
+// Shared, editor-side logic behind the consented MCP write tool
+// `olo_renderer_settings_set` (issue #306 item C): set a multi-valued, session-
+// global renderer / post-process setting — the FSR1 spatial-upscale mode, the
+// tone-map operator, or the rendering path — so an agent can verify a rendering
+// feature LIVE at each setting over MCP (the motivating case is #480's FSR1
+// EASU/RCAS "Spatial Upscale" dropdown, which the read-only server couldn't drive).
+//
+// It is the ENUM-valued sibling of the boolean `olo_render_toggle_pass`: the
+// toggle tool flips on/off fields, this one selects one of several named values
+// the toggle shape can't express (upscale quality preset, tone-map operator,
+// forward/forward+/deferred path).
+//
+// Restore semantics — restore-PRIOR-VALUE, NOT CommandHistory. Unlike the entity
+// field writes (olo_set_collision_layer / olo_entity_set_field), which push an
+// undoable ComponentChangeCommand onto the editor's undo stack, these are GLOBAL
+// renderer settings, not scene/ECS data — an undo-stack entry would be wrong. So
+// the tool snapshots the prior value and reports it as `previousValue`; to restore,
+// the agent calls again with that token (the change is reverted by setting it back).
+// The settings are session-global and never written to the project, so a scene
+// reload also restores them — the same ephemeral boundary the render-override /
+// sun tools respect.
+//
+// Everything here is httplib/editor/McpServer-free: it mutates the plain POD
+// settings structs (PostProcessSettings / RendererSettings) by reference + the
+// schema-builder DSL + nlohmann::json, so the MCP test binary (which deliberately
+// does NOT link McpTools.cpp) exercises the real schema + parse + apply code, the
+// same split McpSetCollisionLayer.h / McpRenderOverrides.h use. The renderer-bound
+// side effect a render-path switch needs (rebuild the render-graph topology via
+// Renderer3D::ApplyRendererSettings) stays in the McpTools.cpp handler — this
+// header only signals it via ApplyResult::PathChanged.
+//
+// The enum value tables reference the engine enums directly (UpscaleMode /
+// TonemapOperator / RenderingPath), so the token->int mapping can never drift out
+// of sync with the renderer — a reordered enum is a compile-time change here.
+
+#include "MCP/McpSchemaBuilder.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/PostProcessSettings.h"
+#include "OloEngine/Renderer/RenderingPath.h"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <cctype>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace OloEngine::MCP::RendererSettings
+{
+    using Json = nlohmann::json;
+
+    // The multi-valued renderer settings this tool can set. Each maps to exactly one
+    // enum field; the field binding lives in Apply()/Describe() below (still header-
+    // only — the structs are plain POD).
+    enum class Setting
+    {
+        Upscale,    // PostProcessSettings::Upscale  (FSR1 spatial-upscale quality preset)
+        Tonemap,    // PostProcessSettings::Tonemap  (tone-map operator)
+        RenderPath, // RendererSettings::Path        (forward / forward+ / deferred)
+    };
+
+    // One allowed value of an enum-valued setting: the stable, user-facing token the
+    // agent passes, the underlying engine enum integer, and a human description.
+    struct EnumValue
+    {
+        std::string_view Token;
+        i32 Value;
+        std::string_view Description;
+    };
+
+    // Value tables. Each references the engine enum directly, so the token->int
+    // mapping is pinned to the renderer at compile time (a reordered/renumbered enum
+    // fails to compile here rather than silently mis-mapping).
+    inline constexpr std::array<EnumValue, 5> kUpscaleValues = { {
+        { "off", static_cast<i32>(UpscaleMode::Off), "Native resolution — no FSR1 upscale (render scale 1.0)" },
+        { "quality", static_cast<i32>(UpscaleMode::Quality), "FSR1 Quality (0.667x linear render scale)" },
+        { "balanced", static_cast<i32>(UpscaleMode::Balanced), "FSR1 Balanced (0.59x linear render scale)" },
+        { "performance", static_cast<i32>(UpscaleMode::Performance), "FSR1 Performance (0.5x linear render scale)" },
+        { "ultraperformance", static_cast<i32>(UpscaleMode::UltraPerformance), "FSR1 Ultra Performance (0.333x linear render scale)" },
+    } };
+
+    inline constexpr std::array<EnumValue, 4> kTonemapValues = { {
+        { "none", static_cast<i32>(TonemapOperator::None), "No tone mapping (raw HDR clamp)" },
+        { "reinhard", static_cast<i32>(TonemapOperator::Reinhard), "Reinhard" },
+        { "aces", static_cast<i32>(TonemapOperator::ACES), "ACES filmic" },
+        { "uncharted2", static_cast<i32>(TonemapOperator::Uncharted2), "Uncharted 2 filmic" },
+    } };
+
+    inline constexpr std::array<EnumValue, 3> kRenderPathValues = { {
+        { "forward", static_cast<i32>(RenderingPath::Forward), "Classic forward (all lights via UBO loop; low overhead)" },
+        { "forwardplus", static_cast<i32>(RenderingPath::ForwardPlus), "Tiled Forward+ (compute-culled per-tile light lists)" },
+        { "deferred", static_cast<i32>(RenderingPath::Deferred), "G-buffer + tiled deferred lighting (enables SSR/SSGI)" },
+    } };
+
+    // Setting token + description + which struct field it targets (documented only).
+    struct SettingInfo
+    {
+        std::string_view Token;
+        Setting Id;
+        std::string_view Description;
+    };
+
+    inline constexpr std::array<SettingInfo, 3> kSettings = { {
+        { "upscale", Setting::Upscale,
+          "FSR1 spatial-upscale quality preset (PostProcess.Upscale). Off is native resolution; the other presets render "
+          "below display resolution and EASU-upscale the HDR scene colour back to display res (#480)." },
+        { "tonemap", Setting::Tonemap, "Tone-mapping operator applied to the HDR scene colour (PostProcess.Tonemap)." },
+        { "renderpath", Setting::RenderPath,
+          "High-level rendering path (RendererSettings.Path). Switching rebuilds the render-graph topology; Deferred is "
+          "required for SSR / SSGI." },
+    } };
+
+    // Lowercase + drop every non-alphanumeric character so "Ultra Performance",
+    // "ultra_performance" and "ultra-performance" all collapse to one key. Pure;
+    // makes token matching forgiving, mirroring RenderOverrides::Normalize.
+    [[nodiscard]] inline std::string Normalize(std::string_view s)
+    {
+        std::string out;
+        out.reserve(s.size());
+        for (const char c : s)
+        {
+            const auto uc = static_cast<unsigned char>(c);
+            if (std::isalnum(uc) != 0)
+                out.push_back(static_cast<char>(std::tolower(uc)));
+        }
+        return out;
+    }
+
+    // The allowed values of a setting.
+    [[nodiscard]] inline std::span<const EnumValue> SettingValues(Setting setting)
+    {
+        switch (setting)
+        {
+            case Setting::Upscale:
+                return kUpscaleValues;
+            case Setting::Tonemap:
+                return kTonemapValues;
+            case Setting::RenderPath:
+                return kRenderPathValues;
+        }
+        return {};
+    }
+
+    // Canonical token for a Setting (reported back in the tool JSON).
+    [[nodiscard]] inline std::string_view SettingToken(Setting setting)
+    {
+        for (const auto& info : kSettings)
+        {
+            if (info.Id == setting)
+                return info.Token;
+        }
+        return "unknown";
+    }
+
+    // Resolve a setting token (case / separator insensitive). Returns false for an
+    // unknown token.
+    [[nodiscard]] inline bool ParseSetting(std::string_view token, Setting& out)
+    {
+        const std::string key = Normalize(token);
+        if (key.empty())
+            return false;
+        for (const auto& info : kSettings)
+        {
+            if (Normalize(info.Token) == key)
+            {
+                out = info.Id;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Resolve a value token within one setting's allowed values (case / separator
+    // insensitive) to its engine enum integer. Returns false for an unknown token.
+    [[nodiscard]] inline bool ParseValue(Setting setting, std::string_view token, i32& out)
+    {
+        const std::string key = Normalize(token);
+        if (key.empty())
+            return false;
+        for (const auto& value : SettingValues(setting))
+        {
+            if (Normalize(value.Token) == key)
+            {
+                out = value.Value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Canonical token for a setting's current integer value ("unknown" if the live
+    // value is outside the known set — never expected, but reported honestly).
+    [[nodiscard]] inline std::string ValueToken(Setting setting, i32 value)
+    {
+        for (const auto& v : SettingValues(setting))
+        {
+            if (v.Value == value)
+                return std::string(v.Token);
+        }
+        return "unknown";
+    }
+
+    // ", "-joined token lists for error / help text.
+    [[nodiscard]] inline std::string JoinSettingTokens()
+    {
+        std::string out;
+        for (const auto& info : kSettings)
+        {
+            if (!out.empty())
+                out += ", ";
+            out += std::string(info.Token);
+        }
+        return out;
+    }
+
+    [[nodiscard]] inline std::string JoinValueTokens(Setting setting)
+    {
+        std::string out;
+        for (const auto& v : SettingValues(setting))
+        {
+            if (!out.empty())
+                out += ", ";
+            out += std::string(v.Token);
+        }
+        return out;
+    }
+
+    // The tool's inputSchema. Both properties are optional at the schema level: no
+    // arguments = introspection (list every setting + its current value + allowed
+    // values). The value-token-for-this-setting constraint can't be expressed in
+    // JSON-Schema (it is conditional on `setting`), so ParseArgs enforces it and the
+    // server's schema check only guarantees `setting` is one of the known tokens.
+    [[nodiscard]] inline Json InputSchema()
+    {
+        return Schema::Object()
+            .Prop("setting", Schema::String().Enum({ "upscale", "tonemap", "renderpath" }).Desc("Which renderer / post-process setting to set. Omit both arguments to list every setting with its current value and allowed values."))
+            .Prop("value", Schema::String().Desc("The new value token for the chosen setting — upscale: off|quality|balanced|performance|ultraperformance; tonemap: none|reinhard|aces|uncharted2; renderpath: forward|forwardplus|deferred. Call with no arguments to discover the valid tokens for each setting."))
+            .NoAdditional();
+    }
+
+    // Parse the tool arguments. On success, `isIntrospect` true means "list all"
+    // (no `setting` given); otherwise `setting` + `value` are filled. The server
+    // validates against InputSchema() first (#423), but this stays defensive (it is
+    // also reached directly from tests). Returns a human-readable error, or nullopt.
+    [[nodiscard]] inline std::optional<std::string> ParseArgs(const Json& args, bool& isIntrospect, Setting& setting, i32& value)
+    {
+        const bool hasSetting = args.contains("setting") && !args["setting"].is_null();
+        if (!hasSetting)
+        {
+            isIntrospect = true;
+            // A value without a setting is a mistake — reject it rather than silently
+            // listing everything and ignoring the value.
+            if (args.contains("value") && !args["value"].is_null())
+                return "Provide 'setting' when providing 'value' (omit both to list every setting).";
+            return std::nullopt;
+        }
+
+        isIntrospect = false;
+        if (!args["setting"].is_string())
+            return "Invalid 'setting': expected a string.";
+        const std::string settingStr = args["setting"].get<std::string>();
+        if (!ParseSetting(settingStr, setting))
+            return "Unknown setting '" + settingStr + "'. Valid settings: " + JoinSettingTokens() + ".";
+
+        if (!args.contains("value") || args["value"].is_null())
+            return "Missing required argument 'value' for setting '" + std::string(SettingToken(setting)) +
+                   "'. Valid values: " + JoinValueTokens(setting) + ".";
+        if (!args["value"].is_string())
+            return "Invalid 'value': expected a string token.";
+        const std::string valueStr = args["value"].get<std::string>();
+        if (!ParseValue(setting, valueStr, value))
+            return "Invalid value '" + valueStr + "' for setting '" + std::string(SettingToken(setting)) +
+                   "'. Valid values: " + JoinValueTokens(setting) + ".";
+        return std::nullopt;
+    }
+
+    // Outcome of applying a settings write. On success `Data` is the structured
+    // result payload; `PathChanged` is true only when a RenderPath write actually
+    // changed the path, signalling the handler to rebuild the render-graph topology
+    // (Renderer3D::ApplyRendererSettings) — that renderer-bound call stays out of
+    // this header.
+    struct ApplyResult
+    {
+        bool Ok = false;
+        std::string Error;
+        Json Data;
+        bool PathChanged = false;
+    };
+
+    // Apply `value` (an engine enum integer) to `setting`, mutating the matching
+    // field of `pp` / `rs` and reporting the prior value so the change can be
+    // restored by setting it back (restore-prior-value, no undo stack). MUST run on
+    // the main (game) thread — the caller passes the live Renderer3D settings.
+    // NOTE: the engine struct `OloEngine::RendererSettings` must be spelled fully
+    // qualified here — unqualified `RendererSettings` would name THIS namespace
+    // (OloEngine::MCP::RendererSettings), not the type.
+    [[nodiscard]] inline ApplyResult Apply(Setting setting, i32 value, PostProcessSettings& pp, ::OloEngine::RendererSettings& rs)
+    {
+        ApplyResult result;
+        i32 previous = 0;
+        switch (setting)
+        {
+            case Setting::Upscale:
+                previous = static_cast<i32>(pp.Upscale);
+                pp.Upscale = static_cast<UpscaleMode>(value);
+                break;
+            case Setting::Tonemap:
+                previous = static_cast<i32>(pp.Tonemap);
+                pp.Tonemap = static_cast<TonemapOperator>(value);
+                break;
+            case Setting::RenderPath:
+                previous = static_cast<i32>(rs.Path);
+                rs.Path = static_cast<RenderingPath>(static_cast<u8>(value));
+                break;
+        }
+
+        const bool changed = previous != value;
+        if (setting == Setting::RenderPath)
+            result.PathChanged = changed;
+
+        result.Ok = true;
+        result.Data = Json{
+            { "setting", std::string(SettingToken(setting)) },
+            { "previousValue", ValueToken(setting, previous) },
+            { "value", ValueToken(setting, value) },
+            { "changed", changed },
+            // Restore hint: these are session-global settings, so a revert is just
+            // this same tool with `value` = previousValue (no CommandHistory / Ctrl-Z
+            // entry, unlike the entity field writes).
+            { "restoreWith", ValueToken(setting, previous) },
+        };
+        return result;
+    }
+
+    // Introspection payload: every setting with its live current value and the full
+    // allowed-value catalogue. The handler reads the live Renderer3D settings and
+    // hands them here.
+    [[nodiscard]] inline Json Describe(const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs)
+    {
+        Json arr = Json::array();
+        for (const auto& info : kSettings)
+        {
+            i32 current = 0;
+            switch (info.Id)
+            {
+                case Setting::Upscale:
+                    current = static_cast<i32>(pp.Upscale);
+                    break;
+                case Setting::Tonemap:
+                    current = static_cast<i32>(pp.Tonemap);
+                    break;
+                case Setting::RenderPath:
+                    current = static_cast<i32>(rs.Path);
+                    break;
+            }
+
+            Json values = Json::array();
+            for (const auto& v : SettingValues(info.Id))
+                values.push_back(Json{ { "token", std::string(v.Token) }, { "description", std::string(v.Description) } });
+
+            arr.push_back(Json{
+                { "setting", std::string(info.Token) },
+                { "description", std::string(info.Description) },
+                { "currentValue", ValueToken(info.Id, current) },
+                { "values", std::move(values) },
+            });
+        }
+        return Json{ { "settings", std::move(arr) } };
+    }
+} // namespace OloEngine::MCP::RendererSettings

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -9,6 +9,7 @@
 #include "MCP/McpRenderExplain.h"
 #include "MCP/McpRenderGraphTopology.h"
 #include "MCP/McpRenderOverrides.h"
+#include "MCP/McpRendererSettings.h"
 #include "MCP/McpGenericFieldWrite.h"
 #include "MCP/McpReloadScript.h"
 #include "MCP/McpSetCollisionLayer.h"
@@ -3479,6 +3480,62 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_renderer_settings_set (main-marshaled; PROJECT WRITE) ---------
+        // Set a multi-valued, session-global renderer / post-process setting — the
+        // FSR1 spatial-upscale mode, the tone-map operator, or the rendering path —
+        // so an agent can verify a rendering feature LIVE at each setting over MCP
+        // (the motivating case is #480's FSR1 "Spatial Upscale" dropdown, which the
+        // read-only server couldn't drive). It is the ENUM-valued sibling of the
+        // boolean olo_render_toggle_pass. Gated at dispatch by the "Allow writes"
+        // session toggle (ToolDef::ProjectWrite): a settings write crosses the
+        // read-only line, though it is session-scoped and restorable, never a
+        // project mutation. Restore is restore-PRIOR-VALUE, NOT CommandHistory —
+        // these are global renderer settings, not scene/ECS data, so the tool
+        // reports `previousValue` and the agent reverts by setting it back (a scene
+        // reload also restores them). The shared schema + parse + apply core lives
+        // in McpRendererSettings.h so it is unit-tested at the dispatch seam without
+        // this TU; the render-path switch's render-graph rebuild
+        // (Renderer3D::ApplyRendererSettings) stays here, on the main thread.
+        ToolResult Handle_RendererSettingsSet(McpServer& server, const Json& args)
+        {
+            using namespace RendererSettings;
+
+            bool introspect = false;
+            Setting setting{};
+            i32 value = 0;
+            if (const auto error = ParseArgs(args, introspect, setting, value))
+                return ToolResult::Error(*error);
+
+            // Introspection: no `setting` -> list every setting with its live current
+            // value and the allowed-value catalogue.
+            if (introspect)
+            {
+                const Json result = server.MarshalRead([]() -> Json
+                                                       { return Describe(Renderer3D::GetPostProcessSettings(), Renderer3D::GetRendererSettings()); });
+                return ToolResult::Text(result.dump(2));
+            }
+
+            const Json result = server.MarshalRead([setting, value]() -> Json
+                                                   {
+                PostProcessSettings& pp = Renderer3D::GetPostProcessSettings();
+                // Fully qualified: `using namespace RendererSettings` is in scope, so
+                // unqualified `RendererSettings` would name that MCP namespace, not the
+                // engine struct.
+                ::OloEngine::RendererSettings& rs = Renderer3D::GetRendererSettings();
+                const ApplyResult applied = Apply(setting, value, pp, rs);
+                if (!applied.Ok)
+                    return Json{ { "__error", applied.Error } };
+                // A render-path switch changes the registered pass list, so the
+                // render-graph topology must be rebuilt for the new value to render.
+                if (applied.PathChanged)
+                    Renderer3D::ApplyRendererSettings();
+                return applied.Data; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
         // entity isn't on screen. Gathers the render-relevant facts off the live
@@ -4911,6 +4968,35 @@ namespace OloEngine::MCP
             tool.InputSchema = ReloadScript::InputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_ReloadScript;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_renderer_settings_set";
+            tool.Toolset = "render";
+            tool.Title = "Set renderer / post-process setting";
+            // A project-WRITE tool (#306 item C): it mutates the session-global
+            // renderer settings, which crosses the read-only line, so it is gated
+            // behind the "Allow writes" session toggle like the other writes.
+            // readOnlyHint:false; idempotent (setting a value twice leaves the same
+            // state — the enum-valued sibling of the flip-based toggle_pass); not
+            // destructive (fully reversible by setting the reported previousValue).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            tool.Description =
+                "Set a multi-valued renderer / post-process setting to verify a rendering feature LIVE at each value — "
+                "the enum-valued sibling of the on/off olo_render_toggle_pass. Settings: 'upscale' (FSR1 spatial-upscale "
+                "mode: off|quality|balanced|performance|ultraperformance — the #480 case), 'tonemap' (none|reinhard|aces|"
+                "uncharted2), 'renderpath' (forward|forwardplus|deferred; switching rebuilds the render graph, and "
+                "Deferred is required for SSR/SSGI). Call with NO arguments to list every setting with its current value "
+                "and allowed values. The change is session-global and ephemeral (a scene reload restores it); the "
+                "response reports 'previousValue' so you can restore by calling again with that token — this is "
+                "restore-prior-value, NOT an undo-stack entry (unlike olo_entity_set_field). This is a WRITE tool: it is "
+                "refused unless 'Allow writes' is enabled in the editor's MCP Server panel (off by default).";
+            tool.InputSchema = RendererSettings::InputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_RendererSettingsSet;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -408,6 +408,14 @@ add_executable(OloEngine-Tests
 		# (ScriptEngine/Mono in the editor), so the test injects a fake hook and never
 		# touches Mono. Header-only on the editor side, so no extra editor TU.
 		MCP/McpReloadScriptTest.cpp
+		# Consented MCP WRITE tool: olo_renderer_settings_set (#306 item C) — set a
+		# multi-valued, session-global renderer / post-process setting (FSR1 upscale
+		# mode, tone-map operator, rendering path). Same dispatch seam (session write
+		# gate + inputSchema enforcement at McpServer.cpp) and shared core
+		# (MCP/McpRendererSettings.h: schema + parse + apply against the POD settings
+		# structs, restore-prior-value not CommandHistory). Renderer-light header, so
+		# no extra editor TU is pulled in.
+		MCP/McpRendererSettingsTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
+++ b/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
@@ -269,6 +269,22 @@ TEST(McpRendererSettingsApply, NoOpWhenValueUnchanged)
     EXPECT_FALSE(result.PathChanged);
 }
 
+// Apply is a public seam callable independently of ParseArgs, so it must reject an
+// out-of-range integer rather than casting it blindly into the engine enum: it
+// returns a failure ApplyResult and leaves the settings untouched.
+TEST(McpRendererSettingsApply, RejectsOutOfRangeValueAndMutatesNothing)
+{
+    PostProcessSettings pp;
+    pp.Upscale = UpscaleMode::Quality;
+    RendererSettings rs;
+
+    const auto result = RS::Apply(RS::Setting::Upscale, 999, pp, rs);
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(result.Error.empty());
+    EXPECT_TRUE(result.Data.is_null());
+    EXPECT_EQ(pp.Upscale, UpscaleMode::Quality); // unchanged
+}
+
 // ---- the shared arg parser + token resolution ------------------------------
 
 TEST(McpRendererSettingsParse, ResolvesSettingAndValueCaseAndSeparatorInsensitive)

--- a/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
+++ b/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
@@ -1,0 +1,347 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// McpRendererSettingsTest — unit test (headless, no GL, no live editor).
+//
+// Pins the consented MCP WRITE tool olo_renderer_settings_set (issue #306 item C):
+// set a multi-valued, session-global renderer / post-process setting (FSR1 upscale
+// mode, tone-map operator, rendering path) so an agent can verify a rendering
+// feature LIVE at each value over MCP — the enum-valued sibling of the boolean
+// olo_render_toggle_pass. Two seams are exercised:
+//
+//   1. The dispatch seam (McpServer.cpp, compiled into the test binary): a tool
+//      flagged ToolDef::ProjectWrite is REFUSED with a clean JSON-RPC error while
+//      the session "Allow writes" gate is off, and ACCEPTED once it is on. The
+//      server's inputSchema enforcement (#423) rejects an unknown setting token /
+//      unexpected property before the handler runs. McpTools.cpp (the real tool
+//      registrations) is deliberately NOT linked here, so the test registers a fake
+//      tool wired to the SAME shared apply code the real handler uses.
+//
+//   2. The shared core (MCP/McpRendererSettings.h, header-only): schema, ParseArgs,
+//      ParseSetting/ParseValue, and Apply against the plain POD settings structs —
+//      assert the field changed AND that the prior value is reported so the change
+//      can be restored by setting it back (restore-prior-value, no undo stack).
+//
+// The shared header is renderer-light (the POD PostProcessSettings / RendererSettings
+// structs) and httplib/editor-free, so no extra editor TU is pulled in.
+// =============================================================================
+
+#include "MCP/McpRendererSettings.h"
+#include "MCP/McpServer.h"
+
+#include "OloEngine/Renderer/PostProcessSettings.h"
+#include "OloEngine/Renderer/RenderingPath.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+
+// OLO_TEST_LAYER: unit
+
+namespace
+{
+    namespace RS = OloEngine::MCP::RendererSettings;
+    using OloEngine::PostProcessSettings;
+    using OloEngine::RendererSettings;
+    using OloEngine::RenderingPath;
+    using OloEngine::TonemapOperator;
+    using OloEngine::UpscaleMode;
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+
+    constexpr int kInvalidParams = -32602;
+
+    Json MakeCallRequest(const Json& id, const Json& arguments)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "method", "tools/call" },
+                     { "params", { { "name", "olo_renderer_settings_set" }, { "arguments", arguments } } } };
+    }
+
+    // Fixture: an McpServer whose only tool is a fake olo_renderer_settings_set wired
+    // to test-owned PostProcessSettings + RendererSettings through the SAME schema +
+    // ParseArgs + Apply code the real handler uses. The fake handler runs
+    // synchronously (no MarshalRead — there is no game thread here), which is exactly
+    // what the real handler delegates to once on the main thread.
+    class McpRendererSettingsWriteTest : public ::testing::Test
+    {
+      protected:
+        McpRendererSettingsWriteTest()
+            : m_Server(EditorMcpContext{})
+        {
+            ToolDef tool;
+            tool.Name = "olo_renderer_settings_set";
+            tool.Description = "Set a renderer / post-process setting (fake; test wiring).";
+            tool.ProjectWrite = true;
+            tool.InputSchema = RS::InputSchema();
+            tool.Handler = [this](McpServer&, const Json& args) -> ToolResult
+            {
+                bool introspect = false;
+                RS::Setting setting{};
+                i32 value = 0;
+                if (const auto error = RS::ParseArgs(args, introspect, setting, value))
+                    return ToolResult::Error(*error);
+                if (introspect)
+                    return ToolResult::Text(RS::Describe(m_PP, m_RS).dump());
+                const RS::ApplyResult applied = RS::Apply(setting, value, m_PP, m_RS);
+                if (!applied.Ok)
+                    return ToolResult::Error(applied.Error);
+                return ToolResult::Text(applied.Data.dump());
+            };
+            m_Server.RegisterTool(std::move(tool));
+        }
+
+        PostProcessSettings m_PP;
+        RendererSettings m_RS;
+        McpServer m_Server; // declared last → destroyed first (its handler refs m_PP/m_RS)
+    };
+} // namespace
+
+// ---- the session write gate (dispatch seam) --------------------------------
+
+// Default state: the gate is OFF, so even a well-formed write call is refused with a
+// JSON-RPC error and NOTHING is mutated.
+TEST_F(McpRendererSettingsWriteTest, GateOffRejectsWriteAndMutatesNothing)
+{
+    ASSERT_FALSE(m_Server.AllowWrites()); // off by default
+    ASSERT_EQ(m_PP.Upscale, UpscaleMode::Off);
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(1, Json{ { "setting", "upscale" }, { "value", "performance" } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+
+    // The setting is untouched — the gate stopped the handler from ever running.
+    EXPECT_EQ(m_PP.Upscale, UpscaleMode::Off);
+}
+
+// With the gate ON the same call succeeds and the field changes; the response reports
+// the prior value so the change can be reverted by setting it back.
+TEST_F(McpRendererSettingsWriteTest, GateOnAppliesWriteAndReportsPrior)
+{
+    m_Server.SetAllowWrites(true);
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(2, Json{ { "setting", "upscale" }, { "value", "performance" } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(m_PP.Upscale, UpscaleMode::Performance);
+
+    // The result payload carries the restore hint (previousValue == "off").
+    const Json payload = Json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_EQ(payload["setting"], "upscale");
+    EXPECT_EQ(payload["previousValue"], "off");
+    EXPECT_EQ(payload["value"], "performance");
+    EXPECT_TRUE(payload["changed"].get<bool>());
+    EXPECT_EQ(payload["restoreWith"], "off");
+
+    // Restore by setting it back to the reported prior value.
+    const Json restore = m_Server.HandleMessage(MakeCallRequest(3, Json{ { "setting", "upscale" }, { "value", "off" } }));
+    ASSERT_TRUE(restore.contains("result"));
+    EXPECT_EQ(m_PP.Upscale, UpscaleMode::Off);
+}
+
+// Introspection (no arguments) still requires the gate (the whole tool is a write
+// tool), and once on it lists every setting with its live current value.
+TEST_F(McpRendererSettingsWriteTest, IntrospectionListsSettingsWhenGateOn)
+{
+    m_Server.SetAllowWrites(true);
+    m_PP.Tonemap = TonemapOperator::ACES;
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, Json::object()));
+    ASSERT_TRUE(resp.contains("result"));
+    const Json payload = Json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+    ASSERT_TRUE(payload["settings"].is_array());
+    EXPECT_EQ(payload["settings"].size(), RS::kSettings.size());
+
+    bool sawTonemap = false;
+    for (const auto& entry : payload["settings"])
+    {
+        if (entry["setting"] == "tonemap")
+        {
+            sawTonemap = true;
+            EXPECT_EQ(entry["currentValue"], "aces");
+        }
+    }
+    EXPECT_TRUE(sawTonemap);
+}
+
+// ---- server-side inputSchema enforcement (#423), gate ON -------------------
+
+TEST_F(McpRendererSettingsWriteTest, SchemaRejectsUnknownSetting)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(5, Json{ { "setting", "bogus" }, { "value", "off" } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_PP.Upscale, UpscaleMode::Off); // never applied
+}
+
+TEST_F(McpRendererSettingsWriteTest, SchemaRejectsUnknownProperty)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(
+        MakeCallRequest(6, Json{ { "setting", "upscale" }, { "value", "off" }, { "extra", true } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+}
+
+// ---- handler-level (tool) errors, gate ON ----------------------------------
+
+// A schema-valid setting with a value token that doesn't belong to it is a TOOL-level
+// error (isError) — the call reached the handler (setting is a valid enum), the
+// handler's ParseArgs rejected the value.
+TEST_F(McpRendererSettingsWriteTest, MismatchedValueIsToolError)
+{
+    m_Server.SetAllowWrites(true);
+    // "reinhard" is a tonemap value, not an upscale value.
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(7, Json{ { "setting", "upscale" }, { "value", "reinhard" } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+    EXPECT_EQ(m_PP.Upscale, UpscaleMode::Off);
+}
+
+// A setting without a value is a tool error naming the valid values.
+TEST_F(McpRendererSettingsWriteTest, MissingValueIsToolError)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(8, Json{ { "setting", "tonemap" } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+}
+
+// ---- the shared apply core (MCP/McpRendererSettings.h), no server ----------
+
+TEST(McpRendererSettingsApply, SetsUpscaleAndReportsPrior)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    const auto result = RS::Apply(RS::Setting::Upscale, static_cast<i32>(UpscaleMode::Balanced), pp, rs);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_EQ(pp.Upscale, UpscaleMode::Balanced);
+    EXPECT_EQ(result.Data["previousValue"], "off");
+    EXPECT_EQ(result.Data["value"], "balanced");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.PathChanged); // not a render-path write
+}
+
+TEST(McpRendererSettingsApply, SetsTonemap)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    const auto result = RS::Apply(RS::Setting::Tonemap, static_cast<i32>(TonemapOperator::ACES), pp, rs);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_EQ(pp.Tonemap, TonemapOperator::ACES);
+    EXPECT_EQ(result.Data["previousValue"], "reinhard"); // struct default
+    EXPECT_EQ(result.Data["value"], "aces");
+}
+
+// A render-path write flags PathChanged so the handler rebuilds the render graph.
+TEST(McpRendererSettingsApply, RenderPathChangeFlagsRebuild)
+{
+    PostProcessSettings pp;
+    RendererSettings rs; // default Forward
+    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Deferred), pp, rs);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_EQ(rs.Path, RenderingPath::Deferred);
+    EXPECT_TRUE(result.PathChanged);
+    EXPECT_EQ(result.Data["previousValue"], "forward");
+    EXPECT_EQ(result.Data["value"], "deferred");
+}
+
+// Setting a value it already has changes nothing and (for render path) does not
+// request a rebuild.
+TEST(McpRendererSettingsApply, NoOpWhenValueUnchanged)
+{
+    PostProcessSettings pp;
+    RendererSettings rs; // default Forward
+    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Forward), pp, rs);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_FALSE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.PathChanged);
+}
+
+// ---- the shared arg parser + token resolution ------------------------------
+
+TEST(McpRendererSettingsParse, ResolvesSettingAndValueCaseAndSeparatorInsensitive)
+{
+    RS::Setting setting{};
+    EXPECT_TRUE(RS::ParseSetting("RenderPath", setting));
+    EXPECT_EQ(setting, RS::Setting::RenderPath);
+    EXPECT_TRUE(RS::ParseSetting("render_path", setting));
+    EXPECT_EQ(setting, RS::Setting::RenderPath);
+
+    i32 value = -1;
+    EXPECT_TRUE(RS::ParseValue(RS::Setting::Upscale, "Ultra Performance", value));
+    EXPECT_EQ(value, static_cast<i32>(UpscaleMode::UltraPerformance));
+    EXPECT_TRUE(RS::ParseValue(RS::Setting::Upscale, "ultra-performance", value));
+    EXPECT_EQ(value, static_cast<i32>(UpscaleMode::UltraPerformance));
+}
+
+TEST(McpRendererSettingsParse, NoArgsIsIntrospection)
+{
+    bool introspect = false;
+    RS::Setting setting{};
+    i32 value = 0;
+    EXPECT_FALSE(RS::ParseArgs(Json::object(), introspect, setting, value).has_value());
+    EXPECT_TRUE(introspect);
+}
+
+TEST(McpRendererSettingsParse, ValueWithoutSettingIsRejected)
+{
+    bool introspect = false;
+    RS::Setting setting{};
+    i32 value = 0;
+    EXPECT_TRUE(RS::ParseArgs(Json{ { "value", "off" } }, introspect, setting, value).has_value());
+}
+
+TEST(McpRendererSettingsParse, RejectsUnknownSettingAndMismatchedValue)
+{
+    bool introspect = false;
+    RS::Setting setting{};
+    i32 value = 0;
+    EXPECT_TRUE(RS::ParseArgs(Json{ { "setting", "nope" }, { "value", "off" } }, introspect, setting, value).has_value());
+    EXPECT_TRUE(RS::ParseArgs(Json{ { "setting", "upscale" }, { "value", "aces" } }, introspect, setting, value).has_value());
+    EXPECT_TRUE(RS::ParseArgs(Json{ { "setting", "upscale" } }, introspect, setting, value).has_value());
+}
+
+TEST(McpRendererSettingsParse, RoundTripsEveryValueTokenForEverySetting)
+{
+    for (const auto& info : RS::kSettings)
+    {
+        for (const auto& v : RS::SettingValues(info.Id))
+        {
+            i32 parsed = -12345;
+            EXPECT_TRUE(RS::ParseValue(info.Id, v.Token, parsed)) << "token: " << v.Token;
+            EXPECT_EQ(parsed, v.Value);
+            EXPECT_EQ(RS::ValueToken(info.Id, v.Value), std::string(v.Token));
+        }
+    }
+}
+
+// ---- the shared inputSchema -------------------------------------------------
+
+TEST(McpRendererSettingsSchema, DeclaresSettingEnumAndIsClosed)
+{
+    const Json schema = RS::InputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    EXPECT_EQ(schema["additionalProperties"], false);
+    EXPECT_EQ(schema["properties"]["setting"]["type"], "string");
+    EXPECT_EQ(schema["properties"]["value"]["type"], "string");
+
+    ASSERT_TRUE(schema["properties"]["setting"]["enum"].is_array());
+    const auto& settingEnum = schema["properties"]["setting"]["enum"];
+    // The schema enum lists exactly the known setting tokens.
+    EXPECT_EQ(settingEnum.size(), RS::kSettings.size());
+    for (const auto& info : RS::kSettings)
+        EXPECT_NE(std::find(settingEnum.begin(), settingEnum.end(), std::string(info.Token)), settingEnum.end())
+            << "setting token: " << info.Token;
+}

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -206,7 +206,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (42 tools) that paging the whole flat `tools/list`
+The tool surface is large enough (47 tools) that paging the whole flat `tools/list`
 to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
 category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
 keyword and/or category instead of pulling the entire list:
@@ -216,7 +216,7 @@ keyword and/or category instead of pulling the entire list:
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame` |
-| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
+| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |
 | `scripting` | `olo_script_get_api`, `olo_script_get_last_errors`, `olo_reload_script` |

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -193,6 +193,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_render_compare_golden` | capture the viewport (optional `camera`/`orbit` pose) and diff it against a golden PNG (`goldenPath`): returns a numeric `similarity`/`rmse`/`ssim` + `pass` verdict; missing golden or `rebase`:true writes the capture as the new baseline (the `OLOENGINE_GOLDEN_REBASE` workflow) |
 | `olo_render_toggle_pass` | flip a post-process / fog feature on/off (`name` + optional `enabled`) — the ephemeral A/B loop: toggle off → `olo_screenshot` → toggle on → `olo_screenshot`. No `name` lists every pass + its live state |
 | `olo_render_set_debug_view` | switch the viewport to a raw AO/SSR/SSGI buffer (`mode`: none/ssao/gtao/ssr/ssgi); reports whether the backing pass is actually running. No `mode` lists the modes + current state |
+| `olo_renderer_settings_set` | **(consented write)** set a multi-valued, session-global renderer / post-process setting — `upscale` (FSR1 spatial-upscale mode), `tonemap` (operator), `renderpath` (forward/forward+/deferred) — to verify a rendering feature live at each value. The enum-valued sibling of `olo_render_toggle_pass`; reports `previousValue` for restore-prior-value (no undo stack). No args lists every setting + current value + allowed values. Gated behind "Allow writes" |
 | `olo_scene_set_time_of_day` | move the procedural sky's sun to a 24-hour clock time (`hours` 0–24) for lighting iteration — ephemeral session override of the sun direction, never written to the scene. `clear`:true restores the authored sun; no args reports the current override |
 | `olo_scene_set_sun_angle` | aim the procedural sky's sun directly from a `yaw` (azimuth) / `pitch` (elevation) pair — the precise sibling of `olo_scene_set_time_of_day`, same ephemeral session override. `clear`:true restores; no args reports state |
 | `olo_render_why_not_visible` | explain why one entity (`entity`) is NOT on screen — the "why can't I see my mesh?" debugger: root-cause `reasonCode`, summary, ordered checks, and the raw render facts |
@@ -205,7 +206,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (41 tools) that paging the whole flat `tools/list`
+The tool surface is large enough (42 tools) that paging the whole flat `tools/list`
 to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
 category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
 keyword and/or category instead of pulling the entire list:
@@ -215,7 +216,7 @@ keyword and/or category instead of pulling the entire list:
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame` |
-| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
+| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |
 | `scripting` | `olo_script_get_api`, `olo_script_get_last_errors`, `olo_reload_script` |
@@ -445,6 +446,53 @@ when it is not:
 So the usual debug-view flow is two steps: `olo_render_toggle_pass { name: "ssao",
 enabled: true }` then `olo_render_set_debug_view { mode: "ssao" }`. Calling the tool
 with no `mode` lists the modes + the current state.
+
+### Multi-valued renderer settings (`olo_renderer_settings_set`)
+
+The **enum-valued** counterpart of `olo_render_toggle_pass`: where the toggle flips
+an on/off pass, this selects one of several named values a boolean can't express, so
+an agent can verify a rendering feature **live at each setting** over MCP. It exists
+because the read-only server couldn't drive #480's FSR1 "Spatial Upscale" dropdown —
+so multi-setting / multi-angle rendering verification of a new feature wasn't
+possible from a session.
+
+It is a **consented WRITE tool** (issue #306 item C): like the other writes it is
+refused unless **"Allow writes"** is enabled in the MCP panel (off by default). A
+settings change crosses the read-only line — but it is **session-scoped and
+restorable, never a project mutation**: the tool mutates only the renderer's
+session-global `PostProcessSettings` / `RendererSettings` (the same structs
+`olo_render_toggle_pass` edits), so the change is visible next frame, is never
+written to disk, and a **scene reload restores it**.
+
+The settings:
+
+- **`upscale`** — FSR1 spatial-upscale mode: `off` | `quality` | `balanced` |
+  `performance` | `ultraperformance` (the #480 motivating case).
+- **`tonemap`** — tone-map operator: `none` | `reinhard` | `aces` | `uncharted2`.
+- **`renderpath`** — rendering path: `forward` | `forwardplus` | `deferred`.
+  Switching **rebuilds the render-graph topology**, and `deferred` is required for
+  SSR / SSGI.
+
+**Restore is restore-PRIOR-VALUE, not CommandHistory.** Unlike the entity field
+writes (`olo_set_collision_layer` / `olo_entity_set_field`), which push an undoable
+`ComponentChangeCommand` onto the editor's undo stack, these are **global renderer
+settings, not scene/ECS data** — an undo-stack entry would be wrong. So the response
+reports `previousValue` (and a convenience `restoreWith`) and you revert by calling
+again with that token. The A/B loop:
+
+```jsonc
+// 1) olo_renderer_settings_set { "setting": "upscale", "value": "performance" }
+{ "setting": "upscale", "previousValue": "off", "value": "performance",
+  "changed": true, "restoreWith": "off" }
+// 2) olo_screenshot { … }                          -> the upscaled frame
+// 3) olo_renderer_settings_set { "setting": "upscale", "value": "off" }
+{ "setting": "upscale", "previousValue": "performance", "value": "off", … }
+// 4) olo_screenshot { … }                          -> the native-res reference
+```
+
+Calling the tool with **no arguments** lists every setting with its live
+`currentValue` and the full allowed-value catalogue (still behind the write gate,
+since the whole tool is a write tool).
 
 ### Sun / time-of-day override (`olo_scene_set_time_of_day` / `olo_scene_set_sun_angle`)
 


### PR DESCRIPTION
## What

Adds **`olo_renderer_settings_set`** — a consented MCP write tool (issue **#306** item C) that sets multi-valued, session-global renderer settings over MCP, so a rendering feature can be **verified live at each value** from an agent session. It is the enum-valued sibling of the boolean `olo_render_toggle_pass`.

Settings covered (the ones the issue names / that made #480 hard to verify):
- **`upscale`** — FSR1 spatial-upscale mode (`off`/`quality`/`balanced`/`performance`/`ultraperformance`) — the #480 motivating case.
- **`tonemap`** — tone-map operator (`none`/`reinhard`/`aces`/`uncharted2`).
- **`renderpath`** — rendering path (`forward`/`forwardplus`/`deferred`; switching rebuilds the render-graph topology).

Call with **no arguments** to list every setting + current value + allowed values.

## Design

- **Gated** behind the existing session write gate (`ToolDef::ProjectWrite` / "Allow writes", default OFF, not persisted). `readOnlyHint:false`, `idempotentHint:true`. Schema-enforced (#423) + payload cap.
- **Restore-prior-value, NOT `CommandHistory`.** These are global renderer settings, not scene/ECS data, so an undo-stack entry would be wrong (unlike `olo_set_collision_layer` / `olo_entity_set_field`). The response reports `previousValue`/`restoreWith`; the agent reverts by setting it back. The settings are never written to disk (a scene reload restores them) — the same ephemeral boundary the render-override / sun tools respect.
- **Testable seam split:** the httplib/editor-free apply core lives in `OloEditor/src/MCP/McpRendererSettings.h` (mutates the POD `PostProcessSettings`/`RendererSettings` by reference), mirroring `McpSetCollisionLayer.h` / `McpRenderOverrides.h`. The enum value tables reference the engine enums directly, so the token↔int mapping can't drift. A render-path switch signals `ApplyResult::PathChanged` so the handler calls `Renderer3D::ApplyRendererSettings()` (render-graph rebuild) — the only renderer-bound bit, kept in `McpTools.cpp`.

## Tests

- **17 new seam tests** (`OloEngine/tests/MCP/McpRendererSettingsTest.cpp`): gate off/on, schema enforcement, `Apply`, parse + token round-trip. **300 total MCP tests green**, clean compile.

## Live verification (attached editor over MCP)

- Tool registered live with correct schema/annotations (render toolset 10→11).
- **Gate OFF** refuses `set` + introspection + malformed call (gate runs before schema check).
- **Gate ON** applies: tonemap `reinhard→aces` showed a clear visible change (more saturated greens / higher contrast), and **restore was byte-identical to the baseline frame**.

## Note — a pre-existing #480 bug this surfaces

Setting `upscale` non-off **at runtime in the editor viewport** renders a **black frame** + a flood of `GL_INVALID_VALUE: y values exceeds the boundaries of the corresponding image object`. The editor's own "Spatial Upscale (FSR1)" dropdown (`PostProcessSettingsPanel::DrawUpscaleSection`) applies `Upscale` identically, so this is a **pre-existing #480/#491 EASU render-scale bug**, not introduced here — the new tool just makes it observable live, which is exactly #306-C's purpose. Tracked separately.

## Docs

`docs/guides/mcp-diagnostics-server.md` — tool table, `render` toolset, tool count (41→42), and a new "Multi-valued renderer settings" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MCP tool for viewing and updating renderer session settings.
  * Supports introspection of current renderer/post-process values and allowed options.
  * Lets users change settings like upscale, tonemap, and render path, with restore-friendly responses.

* **Bug Fixes**
  * Improved validation so invalid or incomplete tool inputs are rejected clearly.
  * Changes that affect render path now trigger the needed renderer refresh.

* **Documentation**
  * Updated MCP diagnostics documentation to cover the new renderer settings tool and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->