### PR TITLE
Add offline texture compression support with BC7 and BC5 formats

### DIFF
--- a/OloEditor/assets/shaders/include/PBRCommon.glsl
+++ b/OloEditor/assets/shaders/include/PBRCommon.glsl
@@ -264,8 +264,16 @@ vec3 cookTorranceBRDFEnhanced(vec3 N, vec3 V, vec3 L, vec3 albedo, float metalli
 // Get normal from normal map using derivative method
 vec3 getNormalFromMap(sampler2D normalMap, vec2 texCoords, vec3 worldPos, vec3 normal, float normalScale)
 {
-    vec3 tangentNormal = texture(normalMap, texCoords).xyz * 2.0 - 1.0;
-    tangentNormal.xy *= normalScale;
+    // Reconstruct z from xy rather than sampling the blue channel. A tangent-space
+    // unit normal always has z = sqrt(1 - x^2 - y^2), so this is correct for ordinary
+    // 3-channel (RGB) normal maps AND required for 2-channel BC5/RGTC2 normal maps,
+    // whose blue channel is 0 on the GPU (sampling it would give z = -1 and invert the
+    // normal). Reconstruction is done after the xy intensity scale so the result stays
+    // unit length. (#440)
+    vec2 nxy = texture(normalMap, texCoords).xy * 2.0 - 1.0;
+    nxy *= normalScale;
+    float nz = sqrt(max(0.0, 1.0 - min(1.0, dot(nxy, nxy))));
+    vec3 tangentNormal = vec3(nxy, nz);
 
     vec3 Q1 = dFdx(worldPos);
     vec3 Q2 = dFdy(worldPos);

--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -148,6 +148,7 @@ target_include_directories(OloEngine PRIVATE
 # Cross-platform link libraries
 target_link_libraries(OloEngine
 	assimp
+	bc7enc
 	box2d
 	choc
 	Detour

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -583,6 +583,8 @@
 		"OloEngine/Renderer/ShaderWarmup.h"
 		"OloEngine/Renderer/Texture.cpp"
 		"OloEngine/Renderer/Texture.h"
+		"OloEngine/Renderer/TextureCompression.cpp"
+		"OloEngine/Renderer/TextureCompression.h"
 		"OloEngine/Renderer/TextureCubemap.cpp"
 		"OloEngine/Renderer/TextureCubemap.h"
 		"OloEngine/Renderer/EnvironmentMap.cpp"

--- a/OloEngine/src/OloEngine/Asset/AssetExtensions.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetExtensions.cpp
@@ -114,6 +114,9 @@ namespace OloEngine
         s_ExtensionMap["jpeg"] = AssetType::Texture2D;
         s_ExtensionMap["tga"] = AssetType::Texture2D;
         s_ExtensionMap["bmp"] = AssetType::Texture2D;
+        // Offline block-compressed (BC7/BC5) texture container (#440). Loaded straight
+        // into a GPU-compressed texture by TextureSerializer.
+        s_ExtensionMap["olotex"] = AssetType::Texture2D;
         s_ExtensionMap["hdr"] = AssetType::EnvMap;
         s_ExtensionMap["exr"] = AssetType::EnvMap;
 

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -76,79 +76,9 @@ namespace OloEngine
 
     bool TextureSerializer::IsLikelyColorTextureByName(std::string_view filename)
     {
-        std::string lower(filename);
-        std::ranges::transform(lower, lower.begin(),
-                               [](unsigned char c)
-                               { return static_cast<char>(std::tolower(c)); });
-
-        // Data-texture keywords trump colour keywords — e.g. "Diffuse_AO.png"
-        // is an AO map even though it carries "Diffuse" in the name, because
-        // the explicit "_AO" suffix is the meaningful tag.
-        constexpr std::string_view dataKeywords[] = {
-            "normal",
-            "_n.",
-            "_n_",
-            "norm",
-            "metal",
-            "_m.",
-            "_m_",
-            "metallic",
-            "rough",
-            "_r.",
-            "_r_",
-            "roughness",
-            "_ao.",
-            "_ao_",
-            "ambient_occlusion",
-            "ambientocclusion",
-            "occlusion",
-            "height",
-            "_h.",
-            "_h_",
-            "displace",
-            "disp",
-            "spec",
-            "_s.",
-            "bump",
-            "_orm.",
-            "_arm.",
-            "_orm_",
-            "_arm_",
-        };
-        for (const auto& kw : dataKeywords)
-        {
-            if (lower.find(kw) != std::string::npos)
-                return false;
-        }
-
-        constexpr std::string_view colorKeywords[] = {
-            "albedo",
-            "_a.",
-            "_a_",
-            "basecolor",
-            "base_color",
-            "diffuse",
-            "_d.",
-            "_d_",
-            "color",
-            "colour",
-            "emissive",
-            "emission",
-            "_e.",
-            "_e_",
-        };
-        for (const auto& kw : colorKeywords)
-        {
-            if (lower.find(kw) != std::string::npos)
-                return true;
-        }
-
-        // Ambiguous filename: be conservative and treat as linear. The model
-        // loader's per-aiTextureType path already tags colour textures
-        // explicitly, so the asset-pipeline path only kicks in for standalone
-        // .png drag-drops where the safer default is "do not double-decode
-        // gamma."
-        return false;
+        // Single source of truth for the colour/linear heuristic, shared with the
+        // offline cook (Renderer/TextureCompression) so the two can't diverge (#440).
+        return TextureCompression::IsLikelyColorTexture(filename);
     }
 
     bool TextureSerializer::TryLoadData(const AssetMetadata& metadata, Ref<Asset>& asset) const
@@ -163,6 +93,7 @@ namespace OloEngine
                 OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to read .olotex: {}", metadata.FilePath.string());
                 return false;
             }
+            image.SourcePath = metadata.FilePath.string(); // so GetPath() -> pack re-read works
             Ref<Texture2D> texture = Texture2D::Create(image);
             if (!texture || !texture->IsLoaded())
             {
@@ -211,6 +142,7 @@ namespace OloEngine
                 OLO_CORE_ERROR("TextureSerializer::TryLoadRawData - Failed to read .olotex: {}", metadata.FilePath.string());
                 return false;
             }
+            image.SourcePath = metadata.FilePath.string(); // so GetPath() -> pack re-read works
             outRawData = std::move(image);
             return true;
         }
@@ -391,6 +323,41 @@ namespace OloEngine
         // GL_SRGB8_ALPHA8 conversion.
         stream.WriteRaw<bool>(spec.SRGB);
 
+        // Block-compressed textures (#440) cannot be re-created from the path via
+        // stb_image, and the spec-only path produces empty storage — so embed the whole
+        // .olotex container blob here, making the pack self-contained. The bytes are the
+        // exact on-disk container; re-read them from the source path (set as GetPath()
+        // by the .olotex loader). Appended AFTER srgb so the legacy record layout for
+        // uncompressed textures is byte-identical.
+        if (IsCompressedFormat(spec.Format))
+        {
+            const std::string& oloTexPath = texture->GetPath();
+            std::vector<u8> blob;
+            if (!oloTexPath.empty())
+            {
+                std::ifstream file(oloTexPath, std::ios::binary | std::ios::ate);
+                if (file)
+                {
+                    const std::streamsize sz = file.tellg();
+                    if (sz > 0)
+                    {
+                        blob.resize(static_cast<sizet>(sz));
+                        file.seekg(0);
+                        file.read(reinterpret_cast<char*>(blob.data()), sz);
+                        if (!file)
+                            blob.clear();
+                    }
+                }
+            }
+            if (blob.empty())
+            {
+                OLO_CORE_ERROR("TextureSerializer::SerializeToAssetPack - could not read .olotex blob for '{}'; packed texture would be empty", oloTexPath);
+                return false;
+            }
+            stream.WriteRaw<u64>(static_cast<u64>(blob.size()));
+            stream.WriteData(reinterpret_cast<const char*>(blob.data()), blob.size());
+        }
+
         outInfo.Size = stream.GetStreamPosition() - outInfo.Offset;
         return true;
     }
@@ -447,6 +414,39 @@ namespace OloEngine
         else
         {
             // No additional handling required.
+        }
+
+        // Block-compressed textures (#440) embed the whole .olotex container blob after
+        // the srgb byte (see SerializeToAssetPack). Reconstruct the GPU texture straight
+        // from the embedded blob — self-contained, no dependency on the loose file.
+        if (IsCompressedFormat(format))
+        {
+            u64 blobSize = 0;
+            stream.ReadRaw(blobSize);
+            const u64 recordEnd = packedEndOverflows ? std::numeric_limits<u64>::max()
+                                                     : assetInfo.PackedOffset + assetInfo.PackedSize;
+            if (blobSize == 0 || stream.GetStreamPosition() + blobSize > recordEnd)
+            {
+                OLO_CORE_ERROR("TextureSerializer::DeserializeFromAssetPack - compressed blob size {} out of record bounds", blobSize);
+                return nullptr;
+            }
+            std::vector<u8> blob(static_cast<sizet>(blobSize));
+            stream.ReadData(reinterpret_cast<char*>(blob.data()), blob.size());
+
+            CompressedTextureImage image;
+            if (!TextureCompression::DeserializeFromBlob(blob, image))
+            {
+                OLO_CORE_ERROR("TextureSerializer::DeserializeFromAssetPack - failed to parse embedded .olotex blob");
+                return nullptr;
+            }
+            Ref<Texture2D> compressed = Texture2D::Create(image);
+            if (!compressed || !compressed->IsLoaded())
+            {
+                OLO_CORE_ERROR("TextureSerializer::DeserializeFromAssetPack - failed to create compressed texture");
+                return nullptr;
+            }
+            compressed->SetHandle(assetInfo.Handle);
+            return compressed;
         }
 
         // Create texture specification

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -9,6 +9,7 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Debug/Instrumentor.h"
 #include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Renderer/TextureCompression.h"
 #include "OloEngine/Renderer/Font.h"
 #include "OloEngine/Renderer/Material.h"
 #include "OloEngine/Renderer/MaterialAsset.h"
@@ -50,11 +51,25 @@
 #include <cctype>
 #include <cmath>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 
 namespace OloEngine
 {
+    namespace
+    {
+        // True for the offline block-compressed container (.olotex, #440), matched
+        // case-insensitively on the extension.
+        bool IsOloTexPath(const std::filesystem::path& path)
+        {
+            std::string ext = path.extension().string();
+            std::ranges::transform(ext, ext.begin(), [](unsigned char c)
+                                   { return static_cast<char>(std::tolower(c)); });
+            return ext == ".olotex";
+        }
+    } // namespace
+
     //////////////////////////////////////////////////////////////////////////////////
     // TextureSerializer
     //////////////////////////////////////////////////////////////////////////////////
@@ -138,6 +153,27 @@ namespace OloEngine
 
     bool TextureSerializer::TryLoadData(const AssetMetadata& metadata, Ref<Asset>& asset) const
     {
+        // Offline block-compressed container (#440): read the BCn mip chain and upload
+        // it straight into a GPU-compressed texture.
+        if (IsOloTexPath(metadata.FilePath))
+        {
+            CompressedTextureImage image;
+            if (!TextureCompression::ReadFile(metadata.FilePath.string(), image))
+            {
+                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to read .olotex: {}", metadata.FilePath.string());
+                return false;
+            }
+            Ref<Texture2D> texture = Texture2D::Create(image);
+            if (!texture || !texture->IsLoaded())
+            {
+                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to create compressed texture: {}", metadata.FilePath.string());
+                return false;
+            }
+            texture->m_Handle = metadata.Handle;
+            asset = texture;
+            return true;
+        }
+
         const std::string filename = metadata.FilePath.filename().string();
         const bool srgb = IsLikelyColorTextureByName(filename);
         Ref<Texture2D> texture = Texture2D::Create(metadata.FilePath.string(), srgb);
@@ -164,6 +200,20 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
 
         // This method is safe to call from any thread - no GPU/GL calls here
+
+        // Offline block-compressed container (#440): reading the .olotex blob is pure
+        // CPU work, so it belongs on the worker thread; GPU upload happens in Finalize.
+        if (IsOloTexPath(metadata.FilePath))
+        {
+            CompressedTextureImage image;
+            if (!TextureCompression::ReadFile(metadata.FilePath.string(), image))
+            {
+                OLO_CORE_ERROR("TextureSerializer::TryLoadRawData - Failed to read .olotex: {}", metadata.FilePath.string());
+                return false;
+            }
+            outRawData = std::move(image);
+            return true;
+        }
 
         std::string path = metadata.FilePath.string();
 
@@ -223,6 +273,20 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
 
         // This method MUST be called from the main thread - creates GPU resources
+
+        // Offline block-compressed container (#440): upload the BCn mip chain.
+        if (std::holds_alternative<CompressedTextureImage>(rawData))
+        {
+            const auto& image = std::get<CompressedTextureImage>(rawData);
+            Ref<Texture2D> texture = Texture2D::Create(image);
+            if (!texture || !texture->IsLoaded())
+            {
+                OLO_CORE_ERROR("TextureSerializer::FinalizeFromRawData - Failed to create compressed texture");
+                return false;
+            }
+            asset = texture;
+            return true;
+        }
 
         if (!std::holds_alternative<RawTextureData>(rawData))
         {

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.h
@@ -9,7 +9,8 @@
 
 #include "OloEngine/Serialization/FileStream.h"
 #include "OloEngine/Serialization/AssetPackFile.h"
-#include "OloEngine/Renderer/GPUResourceQueue.h" // For RawTextureData, RawShaderData
+#include "OloEngine/Renderer/GPUResourceQueue.h"   // For RawTextureData, RawShaderData
+#include "OloEngine/Renderer/TextureCompression.h" // For CompressedTextureImage (.olotex)
 
 // Forward declarations
 namespace YAML
@@ -50,9 +51,10 @@ namespace OloEngine
      * and main thread finalizes GPU resources.
      */
     using RawAssetData = std::variant<
-        std::monostate, // Empty/invalid
-        RawTextureData, // Decoded pixel data
-        RawShaderData   // Shader source code
+        std::monostate,        // Empty/invalid
+        RawTextureData,        // Decoded pixel data
+        RawShaderData,         // Shader source code
+        CompressedTextureImage // Offline BCn mip chain (.olotex, #440)
         // Add more types as needed (RawMeshData, etc.)
         >;
 

--- a/OloEngine/src/OloEngine/Renderer/Texture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Texture.cpp
@@ -25,6 +25,25 @@ namespace OloEngine
         return nullptr;
     }
 
+    Ref<Texture2D> Texture2D::Create(const CompressedTextureImage& compressedImage)
+    {
+        switch (Renderer::GetAPI())
+        {
+            case RendererAPI::API::None:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::OpenGL:
+            {
+                return Ref<OpenGLTexture2D>::Create(compressedImage);
+            }
+        }
+
+        OLO_CORE_ASSERT(false, "Unknown RendererAPI!");
+        return nullptr;
+    }
+
     Ref<Texture2D> Texture2D::Create(const std::string& path, bool srgb)
     {
         switch (Renderer::GetAPI())

--- a/OloEngine/src/OloEngine/Renderer/Texture.h
+++ b/OloEngine/src/OloEngine/Renderer/Texture.h
@@ -10,6 +10,9 @@
 
 namespace OloEngine
 {
+    // Defined in Renderer/TextureCompression.h — a mip chain of BCn block bytes.
+    struct CompressedTextureImage;
+
     enum class ImageFormat
     {
         None = 0,
@@ -27,9 +30,21 @@ namespace OloEngine
         DEPTH24STENCIL8,
         RG16F, // Keep appended to preserve legacy serialized enum values
         R32I,
-        RG8 // 2-channel 8-bit (normal-map xy, two-channel masks). Appended to
-            // preserve legacy serialised enum integer values used in asset packs.
+        RG8, // 2-channel 8-bit (normal-map xy, two-channel masks). Appended to
+             // preserve legacy serialised enum integer values used in asset packs.
+        // Block-compressed formats (#440). Uploaded via glCompressedTextureSubImage2D
+        // rather than a client pixel format; the sRGB variant of BC7 is selected from
+        // TextureSpecification::SRGB. Appended to preserve legacy serialised values.
+        BC7, // BPTC RGBA — base color / albedo / emissive
+        BC5  // RGTC2 two-channel — tangent-space normal xy
     };
+
+    // True for the block-compressed ImageFormat values, which take the
+    // glCompressedTextureSubImage2D upload path instead of a client pixel format.
+    [[nodiscard]] constexpr bool IsCompressedFormat(ImageFormat format) noexcept
+    {
+        return format == ImageFormat::BC7 || format == ImageFormat::BC5;
+    }
 
     struct TextureSpecification
     {
@@ -111,6 +126,11 @@ namespace OloEngine
         virtual void Resize(u32 width, u32 height) = 0;
 
         static Ref<Texture2D> Create(const TextureSpecification& specification);
+        // Create a GPU texture from an offline block-compressed (BC7/BC5) mip chain,
+        // uploaded via glCompressedTextureSubImage2D. On hardware lacking the required
+        // BPTC/RGTC support the blocks are decompressed on the CPU and uploaded as an
+        // uncompressed RGBA8 texture so nothing breaks (#440).
+        static Ref<Texture2D> Create(const CompressedTextureImage& compressedImage);
         // Load a texture from disk. Pass srgb=true for color textures (albedo,
         // emissive, UI) so the GPU converts samples from sRGB to linear on
         // read. Leave srgb=false (default) for data textures (normal map,

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -177,28 +177,66 @@ namespace OloEngine
         constexpr std::array<u8, 4> kOloTexMagic = { 'O', 'T', 'E', 'X' };
         constexpr u32 kOloTexVersion = 1;
 
-        // Minimal filename heuristic mirroring TextureSerializer::IsLikelyColorTextureByName,
-        // duplicated here so the Renderer-layer cook stays independent of the Asset layer.
-        // Colour textures (albedo / diffuse / basecolor / emissive) want sRGB BC7.
-        bool IsLikelyColorTextureByName(std::string_view filename)
+        // Container header flag bits (persisted in the .olotex blob).
+        constexpr u32 kFlagSRGB = 0x1u;
+        constexpr u32 kFlagHasAlpha = 0x2u;
+
+        // Hard ceiling for a deserialized .olotex header — a malformed/hostile file must
+        // not drive an unbounded allocation or an illegal GL level count. 16384 is well
+        // above any real shipped texture and keeps block math inside u32.
+        constexpr u32 kMaxTextureDimension = 16384;
+
+        // Highest legitimate mip level count for the given dimensions: floor(log2(max))+1.
+        u32 MaxMipLevels(u32 width, u32 height)
         {
-            std::string lower(filename);
-            std::ranges::transform(lower, lower.begin(), [](unsigned char c)
-                                   { return static_cast<char>(std::tolower(c)); });
-            constexpr std::array<std::string_view, 6> kColorKeywords = {
-                "albedo", "diffuse", "basecolor", "base_color", "emissive", "_col"
-            };
-            for (auto keyword : kColorKeywords)
+            u32 dim = std::max(width, height);
+            u32 levels = 1;
+            while (dim > 1)
             {
-                if (lower.find(keyword) != std::string::npos)
-                    return true;
+                dim >>= 1;
+                ++levels;
             }
-            return false;
+            return levels;
         }
     } // namespace
 
     namespace TextureCompression
     {
+        bool IsLikelyColorTexture(std::string_view filename)
+        {
+            std::string lower(filename);
+            std::ranges::transform(lower, lower.begin(), [](unsigned char c)
+                                   { return static_cast<char>(std::tolower(c)); });
+
+            // Data-texture keywords trump colour keywords — e.g. "Diffuse_AO.png" is an
+            // AO map even though it carries "Diffuse", because the "_AO" suffix is the
+            // meaningful tag. (Kept in sync with the tests in SRGBTextureSupportTest.)
+            constexpr std::string_view dataKeywords[] = {
+                "normal", "_n.", "_n_", "norm", "metal", "_m.", "_m_", "metallic",
+                "rough", "_r.", "_r_", "roughness", "_ao.", "_ao_", "ambient_occlusion",
+                "ambientocclusion", "occlusion", "height", "_h.", "_h_", "displace",
+                "disp", "spec", "_s.", "bump", "_orm.", "_arm.", "_orm_", "_arm_"
+            };
+            for (std::string_view kw : dataKeywords)
+            {
+                if (lower.find(kw) != std::string::npos)
+                    return false;
+            }
+
+            constexpr std::string_view colorKeywords[] = {
+                "albedo", "_a.", "_a_", "basecolor", "base_color", "diffuse", "_d.",
+                "_d_", "color", "colour", "emissive", "emission", "_e.", "_e_"
+            };
+            for (std::string_view kw : colorKeywords)
+            {
+                if (lower.find(kw) != std::string::npos)
+                    return true;
+            }
+
+            // Ambiguous: be conservative and treat as linear (avoid double gamma decode).
+            return false;
+        }
+
         u32 BlockSizeBytes(TextureCompressionFormat format)
         {
             switch (format)
@@ -256,6 +294,10 @@ namespace OloEngine
             image.Width = width;
             image.Height = height;
             image.SRGB = srgb;
+            // A 4-channel source carries alpha; 1/3-channel sources get a constant
+            // alpha=255 from ExpandToRGBA8, which is opaque — so don't report alpha for
+            // those (keeps opaque BC7 albedo out of the transparent render pass).
+            image.HasAlpha = (channels == 4);
 
             std::vector<u8> level = ExpandToRGBA8(pixels, width, height, channels);
             u32 mw = width;
@@ -279,9 +321,11 @@ namespace OloEngine
             OLO_PROFILE_FUNCTION();
 
             CompressedTextureImage image;
-            if (!pixels || width == 0 || height == 0 || channels == 0 || channels > 4)
+            // BC5 encodes two channels (R,G) — a single-channel source would silently
+            // duplicate R into G and produce a meaningless "normal" map, so require >= 2.
+            if (!pixels || width == 0 || height == 0 || channels < 2 || channels > 4)
             {
-                OLO_CORE_ERROR("TextureCompression::EncodeBC5 - invalid input ({}x{}, {} ch)", width, height, channels);
+                OLO_CORE_ERROR("TextureCompression::EncodeBC5 - invalid input ({}x{}, {} ch; needs 2-4 channels)", width, height, channels);
                 return image;
             }
 
@@ -386,12 +430,25 @@ namespace OloEngine
             if (!image.IsValid())
                 return blob;
 
+            // Total size is fully known up front (28-byte header + per-mip 4-byte length
+            // + block bytes); reserve once so the appends don't repeatedly realloc.
+            sizet total = 4 + 6 * sizeof(u32);
+            for (const std::vector<u8>& mip : image.Mips)
+                total += sizeof(u32) + mip.size();
+            blob.reserve(total);
+
+            u32 flags = 0;
+            if (image.SRGB)
+                flags |= kFlagSRGB;
+            if (image.HasAlpha)
+                flags |= kFlagHasAlpha;
+
             blob.insert(blob.end(), kOloTexMagic.begin(), kOloTexMagic.end());
             AppendU32(blob, kOloTexVersion);
             AppendU32(blob, static_cast<u32>(image.Format));
             AppendU32(blob, image.Width);
             AppendU32(blob, image.Height);
-            AppendU32(blob, image.SRGB ? 1u : 0u);
+            AppendU32(blob, flags);
             AppendU32(blob, image.MipLevels());
             for (const std::vector<u8>& mip : image.Mips)
             {
@@ -440,13 +497,29 @@ namespace OloEngine
                 OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - degenerate dimensions/mips");
                 return false;
             }
+            // Bound header fields BEFORE any allocation: a hostile/corrupt .olotex must
+            // not drive an OOM (unbounded Mips.reserve) or an over-long mip chain that
+            // later trips glTextureStorage2D. width/height are capped, and mipCount can't
+            // exceed the chain length the dimensions allow.
+            if (width > kMaxTextureDimension || height > kMaxTextureDimension)
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - dimensions {}x{} exceed max {}", width, height, kMaxTextureDimension);
+                return false;
+            }
+            if (mipCount > MaxMipLevels(width, height))
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - mipCount {} exceeds max {} for {}x{}",
+                               mipCount, MaxMipLevels(width, height), width, height);
+                return false;
+            }
 
             CompressedTextureImage image;
             image.Format = static_cast<TextureCompressionFormat>(formatInt);
             image.Width = width;
             image.Height = height;
-            image.SRGB = (flags & 0x1u) != 0;
-            image.Mips.reserve(mipCount);
+            image.SRGB = (flags & kFlagSRGB) != 0;
+            image.HasAlpha = (flags & kFlagHasAlpha) != 0;
+            image.Mips.reserve(mipCount); // now bounded by MaxMipLevels above
 
             for (u32 i = 0; i < mipCount; ++i)
             {
@@ -533,7 +606,7 @@ namespace OloEngine
             if (options.AutoSRGBFromName && format == TextureCompressionFormat::BC7)
             {
                 const std::string filename = std::filesystem::path(srcImagePath).filename().string();
-                srgb = IsLikelyColorTextureByName(filename);
+                srgb = IsLikelyColorTexture(filename);
             }
 
             // Match the runtime texture loader's vertical flip so the stored blocks

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -186,6 +186,13 @@ namespace OloEngine
         // above any real shipped texture and keeps block math inside u32.
         constexpr u32 kMaxTextureDimension = 16384;
 
+        // Upper bound on a legitimate serialized .olotex payload, used to reject an
+        // oversized/corrupt file before allocating a read buffer from its reported size.
+        // Worst case is BC7/BC5 (1 byte/texel) at the max dimension with a full mip chain
+        // (<4/3 x the base level); 2 x W x H plus a small header slop covers it generously.
+        constexpr sizet kMaxSerializedBlobSize =
+            2ull * kMaxTextureDimension * kMaxTextureDimension + 4096ull;
+
         // Highest legitimate mip level count for the given dimensions: floor(log2(max))+1.
         u32 MaxMipLevels(u32 width, u32 height)
         {
@@ -497,6 +504,20 @@ namespace OloEngine
                 OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - degenerate dimensions/mips");
                 return false;
             }
+            // Reject non-canonical metadata: only the two defined flag bits may be set,
+            // and BC5 (two-channel normal data) can carry neither sRGB nor alpha — a blob
+            // claiming otherwise is corrupt or version-skewed, not something we produced.
+            if ((flags & ~(kFlagSRGB | kFlagHasAlpha)) != 0)
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - unknown flag bits set ({:#x})", flags);
+                return false;
+            }
+            if (static_cast<TextureCompressionFormat>(formatInt) == TextureCompressionFormat::BC5 &&
+                (flags & (kFlagSRGB | kFlagHasAlpha)) != 0)
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - BC5 must not set sRGB/alpha flags ({:#x})", flags);
+                return false;
+            }
             // Bound header fields BEFORE any allocation: a hostile/corrupt .olotex must
             // not drive an OOM (unbounded Mips.reserve) or an over-long mip chain that
             // later trips glTextureStorage2D. width/height are capped, and mipCount can't
@@ -546,6 +567,14 @@ namespace OloEngine
                 cursor += mipSize;
             }
 
+            // The blob must be fully consumed: trailing bytes mean a malformed or
+            // version-skewed payload that merely happened to parse up to the last mip.
+            if (cursor != blob.size())
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - {} trailing byte(s) after final mip", blob.size() - cursor);
+                return false;
+            }
+
             out = std::move(image);
             return true;
         }
@@ -580,6 +609,14 @@ namespace OloEngine
             if (size <= 0)
             {
                 OLO_CORE_ERROR("TextureCompression::ReadFile - empty file '{}'", path);
+                return false;
+            }
+            // Reject an implausibly large file BEFORE allocating from its size — a corrupt
+            // or hostile .olotex must not drive a multi-gigabyte allocation off tellg().
+            if (static_cast<u64>(size) > kMaxSerializedBlobSize)
+            {
+                OLO_CORE_ERROR("TextureCompression::ReadFile - file '{}' size {} exceeds max serialized size {}",
+                               path, static_cast<u64>(size), kMaxSerializedBlobSize);
                 return false;
             }
             std::vector<u8> blob(static_cast<sizet>(size));

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -1,0 +1,571 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/TextureCompression.h"
+
+#include "OloEngine/Core/Log.h"
+#include "OloEngine/Debug/Instrumentor.h"
+
+// Vendored encoders/decoders (bc7enc_rdo, MIT / public domain). Only this TU pulls
+// them in, keeping the header renderer-agnostic. bc7enc: BC7 encode; rgbcx: BC5
+// encode + decode; bc7decomp: BC7 decode.
+#include <bc7enc.h>
+#include <bc7decomp.h>
+#include <rgbcx.h>
+
+// stb_image is only *declared* here — STB_IMAGE_IMPLEMENTATION lives in
+// Platform/OpenGL/OpenGLTexture.cpp, which provides the definitions at link time.
+#include <stb_image/stb_image.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+
+namespace OloEngine
+{
+    namespace
+    {
+        // One-time init for both encoders. bc7enc builds its mode tables; rgbcx builds
+        // its BC1/4/5 tables. Both are process-global and idempotent behind call_once.
+        void EnsureEncodersInitialized()
+        {
+            static std::once_flag s_InitFlag;
+            std::call_once(s_InitFlag, []()
+                           {
+                               ::bc7enc_compress_block_init();
+                               ::rgbcx::init(); });
+        }
+
+        // Expand tightly-packed `channels`-per-texel source to RGBA8 (4 bytes/texel).
+        // 1ch -> R,R,R,255 (greyscale); 2ch -> R,G,0,255; 3ch -> R,G,B,255; 4ch -> as-is.
+        std::vector<u8> ExpandToRGBA8(const u8* pixels, u32 width, u32 height, u32 channels)
+        {
+            const sizet texelCount = static_cast<sizet>(width) * height;
+            std::vector<u8> rgba(texelCount * 4);
+            for (sizet i = 0; i < texelCount; ++i)
+            {
+                const u8* src = pixels + i * channels;
+                u8* dst = rgba.data() + i * 4;
+                switch (channels)
+                {
+                    case 1:
+                        dst[0] = src[0];
+                        dst[1] = src[0];
+                        dst[2] = src[0];
+                        dst[3] = 255;
+                        break;
+                    case 2:
+                        dst[0] = src[0];
+                        dst[1] = src[1];
+                        dst[2] = 0;
+                        dst[3] = 255;
+                        break;
+                    case 3:
+                        dst[0] = src[0];
+                        dst[1] = src[1];
+                        dst[2] = src[2];
+                        dst[3] = 255;
+                        break;
+                    default: // 4
+                        dst[0] = src[0];
+                        dst[1] = src[1];
+                        dst[2] = src[2];
+                        dst[3] = src[3];
+                        break;
+                }
+            }
+            return rgba;
+        }
+
+        // Box-filter downsample an RGBA8 image to half size (each dim halved, min 1).
+        // NOTE: filtering is done in the stored 8-bit space (gamma-naive for sRGB) —
+        // matches glGenerateMipmap's default behaviour; a linear-space mip build is a
+        // deliberate follow-up. `outW`/`outH` receive the reduced dimensions.
+        std::vector<u8> DownsampleRGBA8(const std::vector<u8>& src, u32 width, u32 height, u32& outW, u32& outH)
+        {
+            outW = std::max(1u, width / 2);
+            outH = std::max(1u, height / 2);
+            std::vector<u8> dst(static_cast<sizet>(outW) * outH * 4);
+
+            for (u32 y = 0; y < outH; ++y)
+            {
+                const u32 sy0 = std::min(y * 2, height - 1);
+                const u32 sy1 = std::min(y * 2 + 1, height - 1);
+                for (u32 x = 0; x < outW; ++x)
+                {
+                    const u32 sx0 = std::min(x * 2, width - 1);
+                    const u32 sx1 = std::min(x * 2 + 1, width - 1);
+                    const u8* p00 = &src[(static_cast<sizet>(sy0) * width + sx0) * 4];
+                    const u8* p01 = &src[(static_cast<sizet>(sy0) * width + sx1) * 4];
+                    const u8* p10 = &src[(static_cast<sizet>(sy1) * width + sx0) * 4];
+                    const u8* p11 = &src[(static_cast<sizet>(sy1) * width + sx1) * 4];
+                    u8* d = &dst[(static_cast<sizet>(y) * outW + x) * 4];
+                    for (u32 c = 0; c < 4; ++c)
+                    {
+                        const u32 sum = static_cast<u32>(p00[c]) + p01[c] + p10[c] + p11[c];
+                        d[c] = static_cast<u8>((sum + 2) / 4);
+                    }
+                }
+            }
+            return dst;
+        }
+
+        // Gather the 4x4 block at (blockX, blockY) from an RGBA8 image into a 64-byte
+        // (16 texel x RGBA) contiguous buffer, clamping to the edge for partial blocks.
+        void GatherBlockRGBA(const std::vector<u8>& rgba, u32 width, u32 height, u32 blockX, u32 blockY,
+                             std::array<u8, 64>& outBlock)
+        {
+            for (u32 ry = 0; ry < 4; ++ry)
+            {
+                const u32 sy = std::min(blockY * 4 + ry, height - 1);
+                for (u32 rx = 0; rx < 4; ++rx)
+                {
+                    const u32 sx = std::min(blockX * 4 + rx, width - 1);
+                    const u8* src = &rgba[(static_cast<sizet>(sy) * width + sx) * 4];
+                    u8* dst = &outBlock[(static_cast<sizet>(ry) * 4 + rx) * 4];
+                    dst[0] = src[0];
+                    dst[1] = src[1];
+                    dst[2] = src[2];
+                    dst[3] = src[3];
+                }
+            }
+        }
+
+        // Encode a single RGBA8 mip level's blocks with the given per-block encoder.
+        // `encodeBlock(dst16, block64)` fills 16 output bytes from a 64-byte RGBA block.
+        template<typename EncodeBlockFn>
+        std::vector<u8> EncodeLevel(const std::vector<u8>& rgba, u32 width, u32 height, EncodeBlockFn&& encodeBlock)
+        {
+            const u32 bx = TextureCompression::BlockCount(width);
+            const u32 by = TextureCompression::BlockCount(height);
+            std::vector<u8> out(static_cast<sizet>(bx) * by * 16);
+
+            std::array<u8, 64> block{};
+            for (u32 y = 0; y < by; ++y)
+            {
+                for (u32 x = 0; x < bx; ++x)
+                {
+                    GatherBlockRGBA(rgba, width, height, x, y, block);
+                    u8* dst = out.data() + (static_cast<sizet>(y) * bx + x) * 16;
+                    encodeBlock(dst, block.data());
+                }
+            }
+            return out;
+        }
+
+        // Little-endian POD append/read helpers for the .olotex blob.
+        void AppendU32(std::vector<u8>& out, u32 value)
+        {
+            out.push_back(static_cast<u8>(value & 0xFF));
+            out.push_back(static_cast<u8>((value >> 8) & 0xFF));
+            out.push_back(static_cast<u8>((value >> 16) & 0xFF));
+            out.push_back(static_cast<u8>((value >> 24) & 0xFF));
+        }
+
+        bool ReadU32(std::span<const u8> blob, sizet& cursor, u32& outValue)
+        {
+            if (cursor + 4 > blob.size())
+                return false;
+            outValue = static_cast<u32>(blob[cursor]) | (static_cast<u32>(blob[cursor + 1]) << 8) |
+                       (static_cast<u32>(blob[cursor + 2]) << 16) | (static_cast<u32>(blob[cursor + 3]) << 24);
+            cursor += 4;
+            return true;
+        }
+
+        constexpr std::array<u8, 4> kOloTexMagic = { 'O', 'T', 'E', 'X' };
+        constexpr u32 kOloTexVersion = 1;
+
+        // Minimal filename heuristic mirroring TextureSerializer::IsLikelyColorTextureByName,
+        // duplicated here so the Renderer-layer cook stays independent of the Asset layer.
+        // Colour textures (albedo / diffuse / basecolor / emissive) want sRGB BC7.
+        bool IsLikelyColorTextureByName(std::string_view filename)
+        {
+            std::string lower(filename);
+            std::ranges::transform(lower, lower.begin(), [](unsigned char c)
+                                   { return static_cast<char>(std::tolower(c)); });
+            constexpr std::array<std::string_view, 6> kColorKeywords = {
+                "albedo", "diffuse", "basecolor", "base_color", "emissive", "_col"
+            };
+            for (auto keyword : kColorKeywords)
+            {
+                if (lower.find(keyword) != std::string::npos)
+                    return true;
+            }
+            return false;
+        }
+    } // namespace
+
+    namespace TextureCompression
+    {
+        u32 BlockSizeBytes(TextureCompressionFormat format)
+        {
+            switch (format)
+            {
+                case TextureCompressionFormat::BC7:
+                case TextureCompressionFormat::BC5:
+                    return 16;
+                case TextureCompressionFormat::None:
+                    return 0;
+            }
+            return 0;
+        }
+
+        u32 BlockCount(u32 dimension)
+        {
+            return std::max(1u, (dimension + 3) / 4);
+        }
+
+        sizet MipByteSize(TextureCompressionFormat format, u32 width, u32 height)
+        {
+            return static_cast<sizet>(BlockCount(width)) * BlockCount(height) * BlockSizeBytes(format);
+        }
+
+        CompressedTextureImage EncodeBC7(const u8* pixels, u32 width, u32 height, u32 channels, bool srgb, bool generateMips)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            CompressedTextureImage image;
+            if (!pixels || width == 0 || height == 0 || channels == 0 || channels > 4)
+            {
+                OLO_CORE_ERROR("TextureCompression::EncodeBC7 - invalid input ({}x{}, {} ch)", width, height, channels);
+                return image;
+            }
+
+            EnsureEncodersInitialized();
+
+            // Full init first: the *_weights helpers below only set m_perceptual +
+            // m_weights[] and leave mode_mask / max_partitions / uber_level etc.
+            // uninitialized, so calling one WITHOUT the base init encodes from garbage
+            // params. bc7enc_compress_block_params_init sets every field (and defaults
+            // to perceptual weights).
+            ::bc7enc_compress_block_params params;
+            ::bc7enc_compress_block_params_init(&params);
+            // Perceptual (YCbCr-weighted) error suits sRGB albedo; linear weights are
+            // correct for non-colour data packed as BC7.
+            if (!srgb)
+                ::bc7enc_compress_block_params_init_linear_weights(&params);
+
+            const auto encodeBlock = [&params](u8* dst, const u8* block64)
+            {
+                ::bc7enc_compress_block(dst, block64, &params);
+            };
+
+            image.Format = TextureCompressionFormat::BC7;
+            image.Width = width;
+            image.Height = height;
+            image.SRGB = srgb;
+
+            std::vector<u8> level = ExpandToRGBA8(pixels, width, height, channels);
+            u32 mw = width;
+            u32 mh = height;
+            while (true)
+            {
+                image.Mips.push_back(EncodeLevel(level, mw, mh, encodeBlock));
+                if (!generateMips || (mw == 1 && mh == 1))
+                    break;
+                u32 nw = 0;
+                u32 nh = 0;
+                level = DownsampleRGBA8(level, mw, mh, nw, nh);
+                mw = nw;
+                mh = nh;
+            }
+            return image;
+        }
+
+        CompressedTextureImage EncodeBC5(const u8* pixels, u32 width, u32 height, u32 channels, bool generateMips)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            CompressedTextureImage image;
+            if (!pixels || width == 0 || height == 0 || channels == 0 || channels > 4)
+            {
+                OLO_CORE_ERROR("TextureCompression::EncodeBC5 - invalid input ({}x{}, {} ch)", width, height, channels);
+                return image;
+            }
+
+            EnsureEncodersInitialized();
+
+            // rgbcx::encode_bc5 reads channels 0 and 1 (R,G) from a 4-byte-stride buffer.
+            const auto encodeBlock = [](u8* dst, const u8* block64)
+            {
+                ::rgbcx::encode_bc5(dst, block64, 0, 1, 4);
+            };
+
+            image.Format = TextureCompressionFormat::BC5;
+            image.Width = width;
+            image.Height = height;
+            image.SRGB = false; // BC5 is always linear (normal xy / two-channel data)
+
+            std::vector<u8> level = ExpandToRGBA8(pixels, width, height, channels);
+            u32 mw = width;
+            u32 mh = height;
+            while (true)
+            {
+                image.Mips.push_back(EncodeLevel(level, mw, mh, encodeBlock));
+                if (!generateMips || (mw == 1 && mh == 1))
+                    break;
+                u32 nw = 0;
+                u32 nh = 0;
+                level = DownsampleRGBA8(level, mw, mh, nw, nh);
+                mw = nw;
+                mh = nh;
+            }
+            return image;
+        }
+
+        bool DecodeToRGBA8(const CompressedTextureImage& image, u32 mipLevel,
+                           std::vector<u8>& outRGBA8, u32& outWidth, u32& outHeight)
+        {
+            if (!image.IsValid() || mipLevel >= image.MipLevels())
+                return false;
+
+            const u32 mw = std::max(1u, image.Width >> mipLevel);
+            const u32 mh = std::max(1u, image.Height >> mipLevel);
+            outWidth = mw;
+            outHeight = mh;
+            outRGBA8.assign(static_cast<sizet>(mw) * mh * 4, 0);
+
+            const std::vector<u8>& blocks = image.Mips[mipLevel];
+            const u32 bxCount = BlockCount(mw);
+            const u32 byCount = BlockCount(mh);
+            if (blocks.size() < static_cast<sizet>(bxCount) * byCount * 16)
+            {
+                OLO_CORE_ERROR("TextureCompression::DecodeToRGBA8 - mip {} block data truncated", mipLevel);
+                return false;
+            }
+
+            std::array<u8, 64> decoded{};
+            for (u32 by = 0; by < byCount; ++by)
+            {
+                for (u32 bx = 0; bx < bxCount; ++bx)
+                {
+                    const u8* blockPtr = blocks.data() + (static_cast<sizet>(by) * bxCount + bx) * 16;
+                    if (image.Format == TextureCompressionFormat::BC7)
+                    {
+                        // bc7decomp writes 16 color_rgba (RGBA) contiguously.
+                        static_assert(sizeof(::bc7decomp::color_rgba) == 4, "color_rgba must be 4 bytes");
+                        ::bc7decomp::unpack_bc7(blockPtr, reinterpret_cast<::bc7decomp::color_rgba*>(decoded.data()));
+                    }
+                    else // BC5
+                    {
+                        decoded.fill(0);
+                        ::rgbcx::unpack_bc5(blockPtr, decoded.data(), 0, 1, 4);
+                        for (u32 i = 0; i < 16; ++i)
+                            decoded[i * 4 + 3] = 255; // opaque alpha; b stays 0
+                    }
+
+                    // Scatter the 4x4 block into the output, cropping partial edge blocks.
+                    for (u32 ry = 0; ry < 4; ++ry)
+                    {
+                        const u32 dy = by * 4 + ry;
+                        if (dy >= mh)
+                            break;
+                        for (u32 rx = 0; rx < 4; ++rx)
+                        {
+                            const u32 dx = bx * 4 + rx;
+                            if (dx >= mw)
+                                break;
+                            const u8* s = &decoded[(static_cast<sizet>(ry) * 4 + rx) * 4];
+                            u8* d = &outRGBA8[(static_cast<sizet>(dy) * mw + dx) * 4];
+                            d[0] = s[0];
+                            d[1] = s[1];
+                            d[2] = s[2];
+                            d[3] = s[3];
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        std::vector<u8> SerializeToBlob(const CompressedTextureImage& image)
+        {
+            std::vector<u8> blob;
+            if (!image.IsValid())
+                return blob;
+
+            blob.insert(blob.end(), kOloTexMagic.begin(), kOloTexMagic.end());
+            AppendU32(blob, kOloTexVersion);
+            AppendU32(blob, static_cast<u32>(image.Format));
+            AppendU32(blob, image.Width);
+            AppendU32(blob, image.Height);
+            AppendU32(blob, image.SRGB ? 1u : 0u);
+            AppendU32(blob, image.MipLevels());
+            for (const std::vector<u8>& mip : image.Mips)
+            {
+                AppendU32(blob, static_cast<u32>(mip.size()));
+                blob.insert(blob.end(), mip.begin(), mip.end());
+            }
+            return blob;
+        }
+
+        bool DeserializeFromBlob(std::span<const u8> blob, CompressedTextureImage& out)
+        {
+            if (blob.size() < 4 || !std::equal(kOloTexMagic.begin(), kOloTexMagic.end(), blob.begin()))
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - bad magic / too small");
+                return false;
+            }
+
+            sizet cursor = 4;
+            u32 version = 0;
+            u32 formatInt = 0;
+            u32 width = 0;
+            u32 height = 0;
+            u32 flags = 0;
+            u32 mipCount = 0;
+            if (!ReadU32(blob, cursor, version) || !ReadU32(blob, cursor, formatInt) ||
+                !ReadU32(blob, cursor, width) || !ReadU32(blob, cursor, height) ||
+                !ReadU32(blob, cursor, flags) || !ReadU32(blob, cursor, mipCount))
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - header truncated");
+                return false;
+            }
+
+            if (version != kOloTexVersion)
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - unsupported version {}", version);
+                return false;
+            }
+            if (formatInt != static_cast<u32>(TextureCompressionFormat::BC7) &&
+                formatInt != static_cast<u32>(TextureCompressionFormat::BC5))
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - unknown format {}", formatInt);
+                return false;
+            }
+            if (width == 0 || height == 0 || mipCount == 0)
+            {
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - degenerate dimensions/mips");
+                return false;
+            }
+
+            CompressedTextureImage image;
+            image.Format = static_cast<TextureCompressionFormat>(formatInt);
+            image.Width = width;
+            image.Height = height;
+            image.SRGB = (flags & 0x1u) != 0;
+            image.Mips.reserve(mipCount);
+
+            for (u32 i = 0; i < mipCount; ++i)
+            {
+                u32 mipSize = 0;
+                if (!ReadU32(blob, cursor, mipSize))
+                {
+                    OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - mip {} size truncated", i);
+                    return false;
+                }
+                if (cursor + mipSize > blob.size())
+                {
+                    OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - mip {} data truncated", i);
+                    return false;
+                }
+                const u32 mw = std::max(1u, width >> i);
+                const u32 mh = std::max(1u, height >> i);
+                if (mipSize != MipByteSize(image.Format, mw, mh))
+                {
+                    OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - mip {} size mismatch (got {}, expected {})",
+                                   i, mipSize, MipByteSize(image.Format, mw, mh));
+                    return false;
+                }
+                image.Mips.emplace_back(blob.begin() + cursor, blob.begin() + cursor + mipSize);
+                cursor += mipSize;
+            }
+
+            out = std::move(image);
+            return true;
+        }
+
+        bool WriteFile(const std::string& path, const CompressedTextureImage& image)
+        {
+            const std::vector<u8> blob = SerializeToBlob(image);
+            if (blob.empty())
+            {
+                OLO_CORE_ERROR("TextureCompression::WriteFile - nothing to write for '{}'", path);
+                return false;
+            }
+            std::ofstream file(path, std::ios::binary | std::ios::trunc);
+            if (!file)
+            {
+                OLO_CORE_ERROR("TextureCompression::WriteFile - cannot open '{}'", path);
+                return false;
+            }
+            file.write(reinterpret_cast<const char*>(blob.data()), static_cast<std::streamsize>(blob.size()));
+            return static_cast<bool>(file);
+        }
+
+        bool ReadFile(const std::string& path, CompressedTextureImage& out)
+        {
+            std::ifstream file(path, std::ios::binary | std::ios::ate);
+            if (!file)
+            {
+                OLO_CORE_ERROR("TextureCompression::ReadFile - cannot open '{}'", path);
+                return false;
+            }
+            const std::streamsize size = file.tellg();
+            if (size <= 0)
+            {
+                OLO_CORE_ERROR("TextureCompression::ReadFile - empty file '{}'", path);
+                return false;
+            }
+            std::vector<u8> blob(static_cast<sizet>(size));
+            file.seekg(0);
+            file.read(reinterpret_cast<char*>(blob.data()), size);
+            if (!file)
+            {
+                OLO_CORE_ERROR("TextureCompression::ReadFile - short read '{}'", path);
+                return false;
+            }
+            return DeserializeFromBlob(blob, out);
+        }
+
+        bool CompressTextureFile(const std::string& srcImagePath, const std::string& dstOlotexPath,
+                                 const CompressOptions& options)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            TextureCompressionFormat format = options.Format;
+            if (format == TextureCompressionFormat::None)
+                format = TextureCompressionFormat::BC7;
+
+            bool srgb = options.SRGB;
+            if (options.AutoSRGBFromName && format == TextureCompressionFormat::BC7)
+            {
+                const std::string filename = std::filesystem::path(srcImagePath).filename().string();
+                srgb = IsLikelyColorTextureByName(filename);
+            }
+
+            // Match the runtime texture loader's vertical flip so the stored blocks
+            // upload without re-flipping (see OpenGLTexture2D path-load ctor).
+            ::stbi_set_flip_vertically_on_load_thread(1);
+            int width = 0;
+            int height = 0;
+            int channels = 0;
+            stbi_uc* data = ::stbi_load(srcImagePath.c_str(), &width, &height, &channels, 0);
+            ::stbi_set_flip_vertically_on_load_thread(0);
+
+            if (!data)
+            {
+                OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load '{}'", srcImagePath);
+                return false;
+            }
+
+            CompressedTextureImage image;
+            if (format == TextureCompressionFormat::BC5)
+                image = EncodeBC5(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), options.GenerateMips);
+            else
+                image = EncodeBC7(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), srgb, options.GenerateMips);
+
+            ::stbi_image_free(data);
+
+            if (!image.IsValid())
+            {
+                OLO_CORE_ERROR("TextureCompression::CompressTextureFile - encode failed for '{}'", srcImagePath);
+                return false;
+            }
+
+            return WriteFile(dstOlotexPath, image);
+        }
+    } // namespace TextureCompression
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.h
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.h
@@ -34,12 +34,19 @@ namespace OloEngine
     struct CompressedTextureImage
     {
         TextureCompressionFormat Format = TextureCompressionFormat::None;
-        u32 Width = 0;     // base-level width in texels
-        u32 Height = 0;    // base-level height in texels
-        bool SRGB = false; // source colour space; selects the sRGB GL internal format on upload
+        u32 Width = 0;         // base-level width in texels
+        u32 Height = 0;        // base-level height in texels
+        bool SRGB = false;     // source colour space; selects the sRGB GL internal format on upload
+        bool HasAlpha = false; // true if the source carried a meaningful alpha channel (BC7 from
+                               // 4-channel input); drives Texture::HasAlphaChannel() so an opaque
+                               // BC7 albedo isn't mis-sorted into the transparent pass.
         // One entry per mip level (mip 0 = full resolution). Each holds the tightly
         // packed BCn blocks for that level: ceil(w/4) * ceil(h/4) * BlockSizeBytes.
         std::vector<std::vector<u8>> Mips;
+        // Runtime-only: the source .olotex path, set by the asset loader (NOT persisted
+        // by SerializeToBlob). Lets the GPU texture report GetPath() so the asset-pack
+        // serializer can re-read + embed the container. Empty for test/procedural images.
+        std::string SourcePath;
 
         [[nodiscard]] bool IsValid() const
         {
@@ -51,6 +58,17 @@ namespace OloEngine
             return static_cast<u32>(Mips.size());
         }
     };
+
+    namespace TextureCompression
+    {
+        // Filename -> "is this a colour (sRGB) texture?" heuristic. Single source of
+        // truth shared by the offline cook and the asset loader
+        // (TextureSerializer::IsLikelyColorTextureByName delegates here) so the two can
+        // never disagree on the same filename. Data-texture keywords (normal / metallic /
+        // roughness / AO / height / ...) veto colour keywords (albedo / diffuse / base
+        // color / emissive). Returns true for colour.
+        [[nodiscard]] bool IsLikelyColorTexture(std::string_view filename);
+    } // namespace TextureCompression
 
     namespace TextureCompression
     {

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.h
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.h
@@ -68,10 +68,7 @@ namespace OloEngine
         // roughness / AO / height / ...) veto colour keywords (albedo / diffuse / base
         // color / emissive). Returns true for colour.
         [[nodiscard]] bool IsLikelyColorTexture(std::string_view filename);
-    } // namespace TextureCompression
 
-    namespace TextureCompression
-    {
         // ---- Block geometry ---------------------------------------------------
         // Bytes per 4x4 block (BC5 and BC7 are both 16). 0 for None.
         [[nodiscard]] u32 BlockSizeBytes(TextureCompressionFormat format);

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.h
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Offline block-texture compression (#440).
+//
+// This is the CPU / cook-time side of the texture-compression pipeline: it turns
+// decoded 8-bit pixels into a GPU-ready BCn mip chain, (de)serializes that chain to
+// a self-contained ".olotex" container, and offers a one-call file cook. The GL
+// upload of the resulting blocks lives in the OpenGL backend
+// (Platform/OpenGL/OpenGLTexture.cpp); this header intentionally has no GL / renderer
+// dependency so it can be unit-tested without a graphics context.
+//
+// Encoders come from the vendored bc7enc_rdo library (BC7 via bc7enc, BC5 via rgbcx);
+// they are pulled in only by TextureCompression.cpp so this header stays lightweight.
+
+namespace OloEngine
+{
+    // BCn formats produced by the cook. Values are persisted in the .olotex container
+    // header, so only ever append new entries — never renumber.
+    enum class TextureCompressionFormat : u32
+    {
+        None = 0,
+        BC7 = 1, // RGBA, high quality, 16 bytes / 4x4 block. Base color / albedo / emissive.
+        BC5 = 2, // Two-channel (R,G), 16 bytes / 4x4 block. Tangent-space normal xy.
+    };
+
+    // A GPU-ready block-compressed image: a mip chain of raw BCn block bytes (mip 0 first).
+    struct CompressedTextureImage
+    {
+        TextureCompressionFormat Format = TextureCompressionFormat::None;
+        u32 Width = 0;     // base-level width in texels
+        u32 Height = 0;    // base-level height in texels
+        bool SRGB = false; // source colour space; selects the sRGB GL internal format on upload
+        // One entry per mip level (mip 0 = full resolution). Each holds the tightly
+        // packed BCn blocks for that level: ceil(w/4) * ceil(h/4) * BlockSizeBytes.
+        std::vector<std::vector<u8>> Mips;
+
+        [[nodiscard]] bool IsValid() const
+        {
+            return Format != TextureCompressionFormat::None && Width > 0 && Height > 0 && !Mips.empty();
+        }
+
+        [[nodiscard]] u32 MipLevels() const
+        {
+            return static_cast<u32>(Mips.size());
+        }
+    };
+
+    namespace TextureCompression
+    {
+        // ---- Block geometry ---------------------------------------------------
+        // Bytes per 4x4 block (BC5 and BC7 are both 16). 0 for None.
+        [[nodiscard]] u32 BlockSizeBytes(TextureCompressionFormat format);
+        // Number of 4x4 blocks spanning a mip dimension: ceil(dim / 4), at least 1.
+        [[nodiscard]] u32 BlockCount(u32 dimension);
+        // Byte size of one mip level's block data for the given texel dimensions.
+        [[nodiscard]] sizet MipByteSize(TextureCompressionFormat format, u32 width, u32 height);
+
+        // ---- Encode -----------------------------------------------------------
+        // Source pixels are tightly packed, `channels` bytes/texel, row-major.
+        // `generateMips` builds the full box-filtered chain; otherwise mip 0 only.
+        //
+        // EncodeBC7 expands the source to RGBA (missing channels: G/B copy R for 1-ch,
+        // A defaults to 255) before encoding all four channels.
+        // EncodeBC5 encodes source channels 0 and 1 (R,G) — intended for normal xy.
+        [[nodiscard]] CompressedTextureImage EncodeBC7(const u8* pixels, u32 width, u32 height, u32 channels, bool srgb, bool generateMips);
+        [[nodiscard]] CompressedTextureImage EncodeBC5(const u8* pixels, u32 width, u32 height, u32 channels, bool generateMips);
+
+        // ---- Decode (CPU) -----------------------------------------------------
+        // Decompress one mip level to RGBA8 (4 bytes/texel). BC5 fills b=0, a=255.
+        // Used by tests and the no-BPTC-hardware fallback upload path.
+        [[nodiscard]] bool DecodeToRGBA8(const CompressedTextureImage& image, u32 mipLevel,
+                                         std::vector<u8>& outRGBA8, u32& outWidth, u32& outHeight);
+
+        // ---- Container (.olotex) ---------------------------------------------
+        [[nodiscard]] std::vector<u8> SerializeToBlob(const CompressedTextureImage& image);
+        [[nodiscard]] bool DeserializeFromBlob(std::span<const u8> blob, CompressedTextureImage& out);
+        [[nodiscard]] bool WriteFile(const std::string& path, const CompressedTextureImage& image);
+        [[nodiscard]] bool ReadFile(const std::string& path, CompressedTextureImage& out);
+
+        // ---- Offline cook -----------------------------------------------------
+        struct CompressOptions
+        {
+            // None => auto-pick from the filename: color textures (albedo/emissive/...)
+            // become sRGB BC7, everything else linear BC5 is NOT auto-chosen (BC5 is a
+            // deliberate opt-in for two-channel normal data); auto defaults to BC7.
+            TextureCompressionFormat Format = TextureCompressionFormat::None;
+            bool SRGB = false;            // color-space hint for BC7 (ignored for BC5)
+            bool AutoSRGBFromName = true; // when true, override SRGB using the filename heuristic
+            bool GenerateMips = true;
+        };
+
+        // Load `srcImagePath` (any stb-supported image), encode per `options`, and write
+        // the `.olotex` container to `dstOlotexPath`. Returns false on load/encode/write
+        // failure (details logged). Pixels are loaded with the same vertical flip the
+        // runtime texture loader uses, so the stored blocks upload without re-flipping.
+        [[nodiscard]] bool CompressTextureFile(const std::string& srcImagePath, const std::string& dstOlotexPath,
+                                               const CompressOptions& options);
+    } // namespace TextureCompression
+} // namespace OloEngine

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
 #include "Platform/OpenGL/OpenGLUtilities.h"
+#include "OloEngine/Renderer/TextureCompression.h"
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
 #include "OloEngine/Renderer/Debug/RendererMemoryTracker.h"
@@ -54,6 +55,11 @@ namespace OloEngine
                     return GL_RGBA;
                 case ImageFormat::DEPTH24STENCIL8:
                     return GL_DEPTH_STENCIL;
+                case ImageFormat::BC7:
+                case ImageFormat::BC5:
+                    // Compressed formats upload via glCompressedTextureSubImage2D with no
+                    // client pixel format; this value is unused for those paths.
+                    return 0;
             }
 
             OLO_CORE_ASSERT(false, "Unknown ImageFormat!");
@@ -97,10 +103,49 @@ namespace OloEngine
                     return GL_RGBA32F;
                 case ImageFormat::DEPTH24STENCIL8:
                     return GL_DEPTH24_STENCIL8;
+                case ImageFormat::BC7:
+                    // BPTC. sRGB variant for colour data; UNORM for linear.
+                    return srgb ? GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM : GL_COMPRESSED_RGBA_BPTC_UNORM;
+                case ImageFormat::BC5:
+                    // RGTC2 two-channel; always linear.
+                    return GL_COMPRESSED_RG_RGTC2;
             }
 
             OLO_CORE_ASSERT(false, "Unknown ImageFormat!");
             return 0;
+        }
+
+        // GL internal format for a block-compressed cook format.
+        [[nodiscard("Store this!")]] static GLenum CompressionFormatToGLInternalFormat(TextureCompressionFormat format, bool srgb)
+        {
+            switch (format)
+            {
+                case TextureCompressionFormat::BC7:
+                    return srgb ? GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM : GL_COMPRESSED_RGBA_BPTC_UNORM;
+                case TextureCompressionFormat::BC5:
+                    return GL_COMPRESSED_RG_RGTC2;
+                case TextureCompressionFormat::None:
+                    return 0;
+            }
+            return 0;
+        }
+
+        // Whether the current GL context can accept the given compressed format.
+        // BPTC (BC7) is core since GL 4.2, RGTC (BC5) since GL 3.0 — both guaranteed on
+        // the engine's required 4.6 context. Still queried so a degraded context (or a
+        // future lower-GL backend) falls back to uncompressed instead of erroring.
+        [[nodiscard("Store this!")]] static bool IsCompressionSupported(TextureCompressionFormat format)
+        {
+            switch (format)
+            {
+                case TextureCompressionFormat::BC7:
+                    return (GLAD_GL_VERSION_4_2 != 0) || (GLAD_GL_ARB_texture_compression_bptc != 0);
+                case TextureCompressionFormat::BC5:
+                    return (GLAD_GL_VERSION_3_0 != 0) || (GLAD_GL_ARB_texture_compression_rgtc != 0);
+                case TextureCompressionFormat::None:
+                    return false;
+            }
+            return false;
         }
 
     } // namespace Utils
@@ -213,6 +258,13 @@ namespace OloEngine
             case ImageFormat::DEPTH24STENCIL8:
                 bytesPerPixel = 4;
                 break;
+            case ImageFormat::BC7:
+            case ImageFormat::BC5:
+                // Block-compressed textures are not created through the spec ctor (use
+                // the CompressedTextureImage ctor, which tracks block bytes exactly).
+                // ~1 byte/texel is a coarse placeholder purely for this tracking line.
+                bytesPerPixel = 1;
+                break;
         }
         auto textureMemory = static_cast<sizet>(m_Width) * static_cast<sizet>(m_Height) *
                              static_cast<sizet>(bytesPerPixel) * static_cast<sizet>(m_Specification.Samples);
@@ -277,6 +329,114 @@ namespace OloEngine
 
         ::stbi_image_free(data);
     }
+
+    OpenGLTexture2D::OpenGLTexture2D(const CompressedTextureImage& image)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (!image.IsValid())
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D: invalid CompressedTextureImage");
+            return;
+        }
+
+        m_Width = image.Width;
+        m_Height = image.Height;
+        m_Specification.Width = image.Width;
+        m_Specification.Height = image.Height;
+        m_Specification.SRGB = image.SRGB;
+        m_Specification.Format = (image.Format == TextureCompressionFormat::BC5) ? ImageFormat::BC5 : ImageFormat::BC7;
+        m_MipLevels = image.MipLevels();
+        m_Specification.MipLevels = m_MipLevels;
+        m_Specification.GenerateMips = m_MipLevels > 1u;
+
+        // Fallback: on a context without the required compressed-format support, decode
+        // the mip chain on the CPU and upload uncompressed so rendering still works.
+        if (!Utils::IsCompressionSupported(image.Format))
+        {
+            OLO_CORE_WARN("OpenGLTexture2D: driver lacks {} support — falling back to uncompressed RGBA8",
+                          image.Format == TextureCompressionFormat::BC5 ? "BC5/RGTC" : "BC7/BPTC");
+            UploadDecompressedFallback(image);
+            return;
+        }
+
+        m_InternalFormat = Utils::CompressionFormatToGLInternalFormat(image.Format, image.SRGB);
+        m_DataFormat = 0; // compressed: no client pixel format
+
+        glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
+        glTextureStorage2D(m_RendererID, static_cast<GLsizei>(m_MipLevels), m_InternalFormat,
+                           static_cast<GLsizei>(m_Width), static_cast<GLsizei>(m_Height));
+
+        sizet totalBytes = 0;
+        for (u32 level = 0; level < m_MipLevels; ++level)
+        {
+            const u32 mipWidth = std::max(1u, m_Width >> level);
+            const u32 mipHeight = std::max(1u, m_Height >> level);
+            const std::vector<u8>& blocks = image.Mips[level];
+
+            const sizet expected = TextureCompression::MipByteSize(image.Format, mipWidth, mipHeight);
+            if (blocks.size() != expected)
+            {
+                OLO_CORE_ERROR("OpenGLTexture2D: mip {} size {} != expected {} — skipping upload", level, blocks.size(), expected);
+                continue;
+            }
+
+            glCompressedTextureSubImage2D(m_RendererID, static_cast<GLint>(level), 0, 0,
+                                          static_cast<GLsizei>(mipWidth), static_cast<GLsizei>(mipHeight),
+                                          m_InternalFormat, static_cast<GLsizei>(blocks.size()), blocks.data());
+            totalBytes += blocks.size();
+        }
+
+        OLO_TRACK_GPU_ALLOC(this, totalBytes, RendererMemoryTracker::ResourceType::Texture2D, "OpenGL Texture2D (compressed)");
+        GPUResourceInspector::GetInstance().RegisterTexture(m_RendererID, "Texture2D (compressed)", "Texture2D");
+
+        glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER, m_MipLevels > 1u ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+        m_IsLoaded = true;
+    }
+
+    void OpenGLTexture2D::UploadDecompressedFallback(const CompressedTextureImage& image)
+    {
+        // Decode base mip to RGBA8 and upload as a normal texture; regenerate mips on GPU.
+        std::vector<u8> rgba;
+        u32 w = 0;
+        u32 h = 0;
+        if (!TextureCompression::DecodeToRGBA8(image, 0, rgba, w, h) || rgba.empty())
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D: fallback decode failed");
+            return;
+        }
+
+        const bool wantMips = image.MipLevels() > 1u;
+        m_MipLevels = wantMips ? CalculateFullMipCount(w, h) : 1u;
+        m_Specification.Format = ImageFormat::RGBA8;
+        m_Specification.MipLevels = m_MipLevels;
+        m_Specification.GenerateMips = wantMips;
+        m_InternalFormat = image.SRGB ? GL_SRGB8_ALPHA8 : GL_RGBA8;
+        m_DataFormat = GL_RGBA;
+
+        glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
+        glTextureStorage2D(m_RendererID, static_cast<GLsizei>(m_MipLevels), m_InternalFormat,
+                           static_cast<GLsizei>(w), static_cast<GLsizei>(h));
+        glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<GLsizei>(w), static_cast<GLsizei>(h),
+                            GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
+        if (m_MipLevels > 1u)
+            glGenerateTextureMipmap(m_RendererID);
+
+        OLO_TRACK_GPU_ALLOC(this, rgba.size(), RendererMemoryTracker::ResourceType::Texture2D, "OpenGL Texture2D (compressed-fallback)");
+        GPUResourceInspector::GetInstance().RegisterTexture(m_RendererID, "Texture2D (compressed-fallback)", "Texture2D");
+
+        glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER, m_MipLevels > 1u ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+        m_IsLoaded = true;
+    }
+
     OpenGLTexture2D::~OpenGLTexture2D()
     {
         OLO_PROFILE_FUNCTION();

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -171,6 +171,18 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Block-compressed formats have no population path through the spec ctor: it would
+        // allocate empty compressed storage and report IsLoaded, producing a garbage
+        // texture. They MUST be created via the CompressedTextureImage overload.
+        if (IsCompressedFormat(m_Specification.Format))
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D: block-compressed format {} cannot be created from a TextureSpecification — use the CompressedTextureImage overload",
+                           static_cast<u32>(m_Specification.Format));
+            m_RendererID = 0;
+            m_IsLoaded = false;
+            return;
+        }
+
         m_Specification.Samples = std::max(m_Specification.Samples, 1u);
         m_InternalFormat = Utils::OloEngineImageFormatToGLInternalFormat(m_Specification.Format, m_Specification.SRGB);
         m_DataFormat = Utils::OloEngineImageFormatToGLDataFormat(m_Specification.Format);
@@ -357,7 +369,7 @@ namespace OloEngine
                            static_cast<GLsizei>(m_Width), static_cast<GLsizei>(m_Height));
 
         sizet totalBytes = 0;
-        u32 uploadedLevels = 0;
+        bool baseLevelUploaded = false;
         for (u32 level = 0; level < m_MipLevels; ++level)
         {
             const u32 mipWidth = std::max(1u, m_Width >> level);
@@ -375,7 +387,8 @@ namespace OloEngine
                                           static_cast<GLsizei>(mipWidth), static_cast<GLsizei>(mipHeight),
                                           m_InternalFormat, static_cast<GLsizei>(blocks.size()), blocks.data());
             totalBytes += blocks.size();
-            ++uploadedLevels;
+            if (level == 0)
+                baseLevelUploaded = true;
         }
 
         OLO_TRACK_GPU_ALLOC(this, totalBytes, RendererMemoryTracker::ResourceType::Texture2D, "OpenGL Texture2D (compressed)");
@@ -386,11 +399,12 @@ namespace OloEngine
         glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
         glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-        // Only report loaded if at least one mip actually reached the GPU — otherwise a
-        // truncated/mismatched blob would masquerade as a successfully loaded texture.
-        m_IsLoaded = (uploadedLevels > 0);
+        // Require the base level (mip 0) specifically — a texture whose full-resolution
+        // level never uploaded is unusable even if a smaller mip happened to succeed, so a
+        // truncated/mismatched blob must not masquerade as a successfully loaded texture.
+        m_IsLoaded = baseLevelUploaded;
         if (!m_IsLoaded)
-            OLO_CORE_ERROR("OpenGLTexture2D: compressed upload produced no valid mip levels");
+            OLO_CORE_ERROR("OpenGLTexture2D: compressed upload did not produce a valid base mip level");
     }
 
     void OpenGLTexture2D::UploadDecompressedFallback(const CompressedTextureImage& image)
@@ -407,7 +421,11 @@ namespace OloEngine
 
         const bool wantMips = image.MipLevels() > 1u;
         m_MipLevels = wantMips ? CalculateFullMipCount(w, h) : 1u;
-        m_Specification.Format = ImageFormat::RGBA8;
+        // Keep m_Specification.Format as the compressed (BC7/BC5) identity — the physical
+        // GL upload format lives in m_InternalFormat/m_DataFormat below. Overwriting it
+        // with RGBA8 would defeat HasAlphaChannel() (an opaque BC7 / BC5 normal would then
+        // report alpha and mis-sort into the transparent pass), unguard Resize/SetData/
+        // SubImage, and make the asset-pack serializer treat the texture as uncompressed.
         m_Specification.MipLevels = m_MipLevels;
         m_Specification.GenerateMips = wantMips;
         m_InternalFormat = image.SRGB ? GL_SRGB8_ALPHA8 : GL_RGBA8;

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -115,21 +115,6 @@ namespace OloEngine
             return 0;
         }
 
-        // GL internal format for a block-compressed cook format.
-        [[nodiscard("Store this!")]] static GLenum CompressionFormatToGLInternalFormat(TextureCompressionFormat format, bool srgb)
-        {
-            switch (format)
-            {
-                case TextureCompressionFormat::BC7:
-                    return srgb ? GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM : GL_COMPRESSED_RGBA_BPTC_UNORM;
-                case TextureCompressionFormat::BC5:
-                    return GL_COMPRESSED_RG_RGTC2;
-                case TextureCompressionFormat::None:
-                    return 0;
-            }
-            return 0;
-        }
-
         // Whether the current GL context can accept the given compressed format.
         // BPTC (BC7) is core since GL 4.2, RGTC (BC5) since GL 3.0 — both guaranteed on
         // the engine's required 4.6 context. Still queried so a degraded context (or a
@@ -342,10 +327,12 @@ namespace OloEngine
 
         m_Width = image.Width;
         m_Height = image.Height;
+        m_Path = image.SourcePath; // so GetPath() works (pack serializer re-reads the .olotex)
         m_Specification.Width = image.Width;
         m_Specification.Height = image.Height;
         m_Specification.SRGB = image.SRGB;
         m_Specification.Format = (image.Format == TextureCompressionFormat::BC5) ? ImageFormat::BC5 : ImageFormat::BC7;
+        m_CompressedHasAlpha = image.HasAlpha;
         m_MipLevels = image.MipLevels();
         m_Specification.MipLevels = m_MipLevels;
         m_Specification.GenerateMips = m_MipLevels > 1u;
@@ -360,7 +347,9 @@ namespace OloEngine
             return;
         }
 
-        m_InternalFormat = Utils::CompressionFormatToGLInternalFormat(image.Format, image.SRGB);
+        // Reuse the single ImageFormat->GL internal-format mapping (m_Specification.Format
+        // is already BC7/BC5) rather than a second parallel switch.
+        m_InternalFormat = Utils::OloEngineImageFormatToGLInternalFormat(m_Specification.Format, image.SRGB);
         m_DataFormat = 0; // compressed: no client pixel format
 
         glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
@@ -368,6 +357,7 @@ namespace OloEngine
                            static_cast<GLsizei>(m_Width), static_cast<GLsizei>(m_Height));
 
         sizet totalBytes = 0;
+        u32 uploadedLevels = 0;
         for (u32 level = 0; level < m_MipLevels; ++level)
         {
             const u32 mipWidth = std::max(1u, m_Width >> level);
@@ -385,6 +375,7 @@ namespace OloEngine
                                           static_cast<GLsizei>(mipWidth), static_cast<GLsizei>(mipHeight),
                                           m_InternalFormat, static_cast<GLsizei>(blocks.size()), blocks.data());
             totalBytes += blocks.size();
+            ++uploadedLevels;
         }
 
         OLO_TRACK_GPU_ALLOC(this, totalBytes, RendererMemoryTracker::ResourceType::Texture2D, "OpenGL Texture2D (compressed)");
@@ -395,7 +386,11 @@ namespace OloEngine
         glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
         glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-        m_IsLoaded = true;
+        // Only report loaded if at least one mip actually reached the GPU — otherwise a
+        // truncated/mismatched blob would masquerade as a successfully loaded texture.
+        m_IsLoaded = (uploadedLevels > 0);
+        if (!m_IsLoaded)
+            OLO_CORE_ERROR("OpenGLTexture2D: compressed upload produced no valid mip levels");
     }
 
     void OpenGLTexture2D::UploadDecompressedFallback(const CompressedTextureImage& image)
@@ -466,6 +461,14 @@ namespace OloEngine
     void OpenGLTexture2D::Resize(u32 width, u32 height)
     {
         OLO_PROFILE_FUNCTION();
+
+        // Block-compressed textures carry no re-uploadable client data — a resize would
+        // recreate empty compressed storage (undefined mips). Reject rather than corrupt.
+        if (IsCompressedFormat(m_Specification.Format))
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D::Resize: not supported for block-compressed textures");
+            return;
+        }
 
         if (width == 0 || height == 0)
         {
@@ -576,6 +579,12 @@ namespace OloEngine
     void OpenGLTexture2D::SetData(void* const data, const u32 size)
     {
         OLO_PROFILE_FUNCTION();
+
+        if (IsCompressedFormat(m_Specification.Format))
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D::SetData: not supported for block-compressed textures (upload via the CompressedTextureImage ctor)");
+            return;
+        }
 
         if (m_Specification.Samples > 1u)
         {
@@ -688,6 +697,12 @@ namespace OloEngine
     void OpenGLTexture2D::SubImage(u32 x, u32 y, u32 width, u32 height, const void* data, [[maybe_unused]] u32 dataSize)
     {
         OLO_PROFILE_FUNCTION();
+
+        if (IsCompressedFormat(m_Specification.Format))
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D::SubImage: not supported for block-compressed textures");
+            return;
+        }
 
         if (m_Specification.Samples > 1u)
         {

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
@@ -11,6 +11,9 @@ namespace OloEngine
       public:
         explicit OpenGLTexture2D(const TextureSpecification& specification);
         explicit OpenGLTexture2D(const std::string& path, bool srgb = false);
+        // Upload an offline block-compressed (BC7/BC5) mip chain (#440). Falls back to
+        // CPU-decompressed RGBA8 when the driver lacks BPTC/RGTC support.
+        explicit OpenGLTexture2D(const CompressedTextureImage& compressedImage);
         ~OpenGLTexture2D() override;
 
         const TextureSpecification& GetSpecification() const override
@@ -48,7 +51,8 @@ namespace OloEngine
 
         [[nodiscard("Use for transparency")]] bool HasAlphaChannel() const override
         {
-            return m_DataFormat == GL_RGBA || m_Specification.Format == ImageFormat::RGBA8 || m_Specification.Format == ImageFormat::RGBA32F;
+            return m_DataFormat == GL_RGBA || m_Specification.Format == ImageFormat::RGBA8 ||
+                   m_Specification.Format == ImageFormat::RGBA32F || m_Specification.Format == ImageFormat::BC7;
         }
 
         bool GetData(std::vector<u8>& outData, u32 mipLevel = 0) const override;
@@ -62,6 +66,9 @@ namespace OloEngine
 
       private:
         void InvalidateImpl(std::string_view path, u32 width, u32 height, const void* data, u32 channels);
+        // CPU-decompress a block-compressed image and upload it as an uncompressed
+        // RGBA8 texture (used when the driver lacks BPTC/RGTC support).
+        void UploadDecompressedFallback(const CompressedTextureImage& image);
         void CreateStorage();
         [[nodiscard]] static u32 CalculateFullMipCount(u32 width, u32 height);
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
@@ -51,8 +51,13 @@ namespace OloEngine
 
         [[nodiscard("Use for transparency")]] bool HasAlphaChannel() const override
         {
+            // For compressed textures the source's alpha presence is recorded at cook
+            // time (m_CompressedHasAlpha) rather than inferred from the GL data format,
+            // so an opaque BC7 albedo isn't mis-reported as alpha-bearing.
+            if (IsCompressedFormat(m_Specification.Format))
+                return m_CompressedHasAlpha;
             return m_DataFormat == GL_RGBA || m_Specification.Format == ImageFormat::RGBA8 ||
-                   m_Specification.Format == ImageFormat::RGBA32F || m_Specification.Format == ImageFormat::BC7;
+                   m_Specification.Format == ImageFormat::RGBA32F;
         }
 
         bool GetData(std::vector<u8>& outData, u32 mipLevel = 0) const override;
@@ -83,6 +88,9 @@ namespace OloEngine
         u32 m_RendererID{};
         GLenum m_InternalFormat{};
         GLenum m_DataFormat{};
+        // For block-compressed textures only: whether the source carried a meaningful
+        // alpha channel (see HasAlphaChannel()). Ignored for uncompressed formats.
+        bool m_CompressedHasAlpha = false;
 
         // Double-buffered Pixel Buffer Objects for streaming uploads (see
         // TextureSpecification::Streaming). Created lazily on the first SetData and

--- a/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
@@ -32,6 +32,14 @@ namespace OloEngine
                     return GL_RGBA;
                 case ImageFormat::DEPTH24STENCIL8:
                     return GL_DEPTH_STENCIL;
+                case ImageFormat::BC7:
+                case ImageFormat::BC5:
+                    // Block-compressed cubemaps aren't produced by the cook path; a
+                    // compressed face would need glCompressedTextureSubImage3D. Return 0
+                    // (unsupported) explicitly so a stray value is a defined error, not an
+                    // out-of-range assert fall-through.
+                    OLO_CORE_ASSERT(false, "Block-compressed cubemaps are not supported");
+                    return 0;
             }
 
             OLO_CORE_ASSERT(false, "Unknown ImageFormat!");
@@ -58,6 +66,11 @@ namespace OloEngine
                     return GL_RGBA32F;
                 case ImageFormat::DEPTH24STENCIL8:
                     return GL_DEPTH24_STENCIL8;
+                case ImageFormat::BC7:
+                case ImageFormat::BC5:
+                    // Block-compressed cubemaps aren't produced by the cook path.
+                    OLO_CORE_ASSERT(false, "Block-compressed cubemaps are not supported");
+                    return 0;
             }
 
             OLO_CORE_ASSERT(false, "Unknown ImageFormat!");

--- a/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
@@ -142,6 +142,19 @@ namespace OloEngine
         m_Specification.Format = m_CubemapSpecification.Format;
         m_Specification.GenerateMips = m_CubemapSpecification.GenerateMips;
 
+        // Block-compressed cubemaps aren't produced by the cook path; the format->GL
+        // helpers below return 0 for them (an assert in debug, but silently in release).
+        // Bail before any GL call so glTextureStorage2D never sees an invalid internal
+        // format — GetFormatInfo() further down would otherwise be the only line to catch it.
+        if (IsCompressedFormat(m_CubemapSpecification.Format))
+        {
+            OLO_CORE_ERROR("OpenGLTextureCubemap: block-compressed format {} is not supported for cubemaps",
+                           static_cast<u32>(m_CubemapSpecification.Format));
+            m_RendererID = 0;
+            m_IsLoaded = false;
+            return;
+        }
+
         m_InternalFormat = Utils::OloEngineImageFormatToGLInternalFormat(m_CubemapSpecification.Format);
         m_DataFormat = Utils::OloEngineImageFormatToGLDataFormat(m_CubemapSpecification.Format);
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(OloEngine-Tests
 
 		# Rendering subsystem tests (Tiers 1-5)
 		Rendering/DrawKeyTest.cpp
+		Rendering/TextureCompressionTest.cpp
 		Rendering/BoundingVolumeTest.cpp
 		Rendering/FrustumCullingTest.cpp
 		Rendering/ReflectionProbeSelectionTest.cpp
@@ -160,6 +161,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/StarNestSkyVisualTest.cpp
 		Rendering/PropertyTests/StarNestReflectionEvidenceTest.cpp
 		Rendering/PropertyTests/WaterVisualEvidenceTest.cpp
+		Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
 		Rendering/PropertyTests/OceanFFTVisualEvidenceTest.cpp
 		Rendering/PropertyTests/UnderwaterCausticsVisualTest.cpp
 		Rendering/PropertyTests/SSRVisualEvidenceTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
@@ -1,0 +1,203 @@
+// OLO_TEST_LAYER: L3
+//
+// GPU round-trip + pixel evidence for the BC7/BC5 compressed-texture upload path
+// (#440). Runs on a real GL 4.6 context (SKIPs cleanly on CI without a GPU).
+//
+// Two independent proofs that the glCompressedTextureSubImage2D upload is correct:
+//   1. glGetCompressedTextureImage reads the stored blocks back and they are
+//      BIT-EXACT with the CPU-encoded blocks we uploaded — proves storage + layout.
+//   2. glGetTextureImage(GL_RGBA) asks the driver to DECOMPRESS the texture; the
+//      result matches the source within a PSNR tolerance — proves the GPU samples
+//      the format we think it does. That decompressed frame is written to a PNG and
+//      read back, so there is a human-inspectable pixel artifact per the project's
+//      visual-verification rule.
+
+#include "RenderPropertyTest.h"
+
+#include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Renderer/TextureCompression.h"
+
+#include <glad/gl.h>
+#include <gtest/gtest.h>
+#include <stb_image/stb_image.h>
+#include <stb_image/stb_image_write.h>
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace OloEngine;
+using namespace OloEngine::Tests;
+
+namespace
+{
+    std::vector<u8> MakeGradientRGBA(u32 width, u32 height)
+    {
+        std::vector<u8> pixels(static_cast<sizet>(width) * height * 4);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                u8* p = &pixels[(static_cast<sizet>(y) * width + x) * 4];
+                p[0] = static_cast<u8>((x * 255) / (width - 1));
+                p[1] = static_cast<u8>((y * 255) / (height - 1));
+                p[2] = static_cast<u8>(128);
+                p[3] = 255;
+            }
+        }
+        return pixels;
+    }
+
+    double ComputePSNR(const std::vector<u8>& a, const std::vector<u8>& b, u32 compareChannels)
+    {
+        if (a.size() != b.size() || a.empty())
+            return 0.0;
+        double mse = 0.0;
+        sizet samples = 0;
+        for (sizet texel = 0; texel + 4 <= a.size(); texel += 4)
+        {
+            for (u32 c = 0; c < compareChannels; ++c)
+            {
+                const double d = static_cast<double>(a[texel + c]) - static_cast<double>(b[texel + c]);
+                mse += d * d;
+                ++samples;
+            }
+        }
+        if (samples == 0)
+            return 0.0;
+        mse /= static_cast<double>(samples);
+        if (mse < 1e-9)
+            return 99.0;
+        return 10.0 * std::log10((255.0 * 255.0) / mse);
+    }
+
+    std::filesystem::path CaseKeyedTempPng()
+    {
+        const testing::TestInfo* info = testing::UnitTest::GetInstance()->current_test_info();
+        std::string name = std::string(info->test_suite_name()) + "." + info->name() + ".png";
+        return std::filesystem::temp_directory_path() / name;
+    }
+} // namespace
+
+TEST(CompressedTextureVisualEvidence, BC7UploadStoresBlocksAndDecompressesOnGPU)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    // Encode base color -> BC7 (sRGB colour), base mip only for a clean 1:1 comparison.
+    const CompressedTextureImage image = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, /*srgb*/ true, /*mips*/ false);
+    ASSERT_TRUE(image.IsValid());
+
+    Ref<Texture2D> texture = Texture2D::Create(image);
+    ASSERT_TRUE(texture);
+    EXPECT_TRUE(texture->IsLoaded());
+    EXPECT_EQ(texture->GetWidth(), kW);
+    EXPECT_EQ(texture->GetHeight(), kH);
+    EXPECT_NE(texture->GetRendererID(), 0u);
+
+    while (glGetError() != GL_NO_ERROR)
+    {
+    } // drain any leaked errors
+
+    const GLuint id = texture->GetRendererID();
+
+    // (1) Read the stored compressed blocks back — must be bit-exact with upload.
+    {
+        GLint compressedSize = 0;
+        glGetTextureLevelParameteriv(id, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressedSize);
+        ASSERT_EQ(static_cast<sizet>(compressedSize), image.Mips[0].size())
+            << "GPU-reported compressed size != uploaded block bytes";
+
+        std::vector<u8> readback(static_cast<sizet>(compressedSize));
+        glGetCompressedTextureImage(id, 0, compressedSize, readback.data());
+        ASSERT_EQ(glGetError(), GL_NO_ERROR) << "glGetCompressedTextureImage failed";
+        EXPECT_EQ(readback, image.Mips[0]) << "stored BC7 blocks differ from uploaded blocks";
+    }
+
+    // (2) Ask the driver to decompress the texture and compare to the source.
+    std::vector<u8> decompressed(static_cast<sizet>(kW) * kH * 4);
+    glGetTextureImage(id, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                      static_cast<GLsizei>(decompressed.size()), decompressed.data());
+    ASSERT_EQ(glGetError(), GL_NO_ERROR) << "glGetTextureImage (decompress) failed";
+
+    const double psnr = ComputePSNR(source, decompressed, 3);
+    EXPECT_GT(psnr, 30.0) << "GPU-decompressed BC7 PSNR too low: " << psnr << " dB";
+
+    // Pixel evidence: write the decompressed frame and read it back to confirm.
+    const std::filesystem::path pngPath = CaseKeyedTempPng();
+    const int wrote = ::stbi_write_png(pngPath.string().c_str(), static_cast<int>(kW), static_cast<int>(kH), 4,
+                                       decompressed.data(), static_cast<int>(kW) * 4);
+    EXPECT_NE(wrote, 0) << "failed to write evidence PNG";
+    if (wrote != 0)
+    {
+        int rw = 0;
+        int rh = 0;
+        int rc = 0;
+        stbi_uc* reread = ::stbi_load(pngPath.string().c_str(), &rw, &rh, &rc, 4);
+        EXPECT_NE(reread, nullptr);
+        EXPECT_EQ(rw, static_cast<int>(kW));
+        EXPECT_EQ(rh, static_cast<int>(kH));
+        if (reread)
+            ::stbi_image_free(reread);
+        OLO_CORE_INFO("CompressedTextureVisualEvidence: wrote BC7 decompressed evidence to {}", pngPath.string());
+        std::error_code ec;
+        std::filesystem::remove(pngPath, ec);
+    }
+}
+
+TEST(CompressedTextureVisualEvidence, BC5UploadStoresBlocksAndDecompressesOnGPU)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 32;
+    // Normal-map-like RG data expanded to RGBA (B=0, A=255) for the encoder.
+    std::vector<u8> source(static_cast<sizet>(kW) * kH * 4, 0);
+    for (u32 y = 0; y < kH; ++y)
+    {
+        for (u32 x = 0; x < kW; ++x)
+        {
+            u8* p = &source[(static_cast<sizet>(y) * kW + x) * 4];
+            p[0] = static_cast<u8>((x * 255) / (kW - 1));
+            p[1] = static_cast<u8>((y * 255) / (kH - 1));
+            p[3] = 255;
+        }
+    }
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC5(source.data(), kW, kH, 4, /*mips*/ false);
+    ASSERT_TRUE(image.IsValid());
+
+    Ref<Texture2D> texture = Texture2D::Create(image);
+    ASSERT_TRUE(texture);
+    EXPECT_TRUE(texture->IsLoaded());
+    EXPECT_NE(texture->GetRendererID(), 0u);
+
+    while (glGetError() != GL_NO_ERROR)
+    {
+    }
+
+    const GLuint id = texture->GetRendererID();
+
+    GLint compressedSize = 0;
+    glGetTextureLevelParameteriv(id, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressedSize);
+    ASSERT_EQ(static_cast<sizet>(compressedSize), image.Mips[0].size());
+    std::vector<u8> readback(static_cast<sizet>(compressedSize));
+    glGetCompressedTextureImage(id, 0, compressedSize, readback.data());
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+    EXPECT_EQ(readback, image.Mips[0]) << "stored BC5 blocks differ from uploaded blocks";
+
+    // Decompress and compare the two carried channels (R,G). BC5 leaves B undefined
+    // on the GPU (reconstructed by shaders), so only compare R,G here.
+    std::vector<u8> decompressed(static_cast<sizet>(kW) * kH * 4);
+    glGetTextureImage(id, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                      static_cast<GLsizei>(decompressed.size()), decompressed.data());
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+
+    const double psnr = ComputePSNR(source, decompressed, 2);
+    EXPECT_GT(psnr, 30.0) << "GPU-decompressed BC5 PSNR too low: " << psnr << " dB";
+}

--- a/OloEngine/tests/Rendering/TextureCompressionTest.cpp
+++ b/OloEngine/tests/Rendering/TextureCompressionTest.cpp
@@ -1,0 +1,314 @@
+// OLO_TEST_LAYER: L3
+//
+// Data round-trip contract for the offline BC7/BC5 texture-compression cook (#440).
+// Pure CPU — no GL context required, so these run in CI. They pin: block geometry
+// math, encode->decode fidelity (via PSNR, since BCn is lossy — never bit-exact),
+// mip-chain generation, the .olotex container round-trip (bit-exact block bytes),
+// and non-multiple-of-4 (partial block) handling. The GPU upload path is verified
+// separately by the GL evidence test.
+
+#include "OloEngine/Renderer/TextureCompression.h"
+
+#include <gtest/gtest.h>
+#include <stb_image/stb_image_write.h>
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace OloEngine;
+
+namespace
+{
+    // Peak signal-to-noise ratio (dB) between two equal-length 8-bit buffers over the
+    // given channel count, sampling only `compareChannels` of each `stride`-byte texel.
+    // Returns a large finite value when the buffers are identical.
+    double ComputePSNR(const std::vector<u8>& a, const std::vector<u8>& b, u32 stride, u32 compareChannels)
+    {
+        EXPECT_EQ(a.size(), b.size());
+        if (a.size() != b.size() || a.empty())
+            return 0.0;
+
+        double mse = 0.0;
+        sizet samples = 0;
+        for (sizet texel = 0; texel + stride <= a.size(); texel += stride)
+        {
+            for (u32 c = 0; c < compareChannels; ++c)
+            {
+                const double diff = static_cast<double>(a[texel + c]) - static_cast<double>(b[texel + c]);
+                mse += diff * diff;
+                ++samples;
+            }
+        }
+        if (samples == 0)
+            return 0.0;
+        mse /= static_cast<double>(samples);
+        if (mse < 1e-9)
+            return 99.0; // effectively lossless
+        return 10.0 * std::log10((255.0 * 255.0) / mse);
+    }
+
+    // A smooth RGBA gradient — BCn compresses smooth data very well, so a healthy
+    // encoder should clear a comfortable PSNR margin.
+    std::vector<u8> MakeGradientRGBA(u32 width, u32 height)
+    {
+        std::vector<u8> pixels(static_cast<sizet>(width) * height * 4);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                u8* p = &pixels[(static_cast<sizet>(y) * width + x) * 4];
+                p[0] = static_cast<u8>((x * 255) / std::max(1u, width - 1));
+                p[1] = static_cast<u8>((y * 255) / std::max(1u, height - 1));
+                p[2] = static_cast<u8>(((x + y) * 255) / std::max(1u, (width + height) - 2));
+                p[3] = 255;
+            }
+        }
+        return pixels;
+    }
+
+    // A tangent-space-normal-like RG field: xy sweep, packed into R,G (B,A unused here).
+    std::vector<u8> MakeNormalRG(u32 width, u32 height)
+    {
+        std::vector<u8> pixels(static_cast<sizet>(width) * height * 2);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                u8* p = &pixels[(static_cast<sizet>(y) * width + x) * 2];
+                p[0] = static_cast<u8>((x * 255) / std::max(1u, width - 1));
+                p[1] = static_cast<u8>((y * 255) / std::max(1u, height - 1));
+            }
+        }
+        return pixels;
+    }
+
+    std::filesystem::path CaseKeyedTempFile(const char* suffix)
+    {
+        const testing::TestInfo* info = testing::UnitTest::GetInstance()->current_test_info();
+        std::string name = std::string(info->test_suite_name()) + "." + info->name() + suffix;
+        return std::filesystem::temp_directory_path() / name;
+    }
+} // namespace
+
+TEST(TextureCompression, BlockGeometry)
+{
+    EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::BC7), 16u);
+    EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::BC5), 16u);
+    EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::None), 0u);
+
+    // ceil(dim/4), at least one block.
+    EXPECT_EQ(TextureCompression::BlockCount(1), 1u);
+    EXPECT_EQ(TextureCompression::BlockCount(4), 1u);
+    EXPECT_EQ(TextureCompression::BlockCount(5), 2u);
+    EXPECT_EQ(TextureCompression::BlockCount(16), 4u);
+    EXPECT_EQ(TextureCompression::BlockCount(17), 5u);
+
+    // 16x16 -> 4x4 blocks -> 16 blocks * 16 bytes = 256.
+    EXPECT_EQ(TextureCompression::MipByteSize(TextureCompressionFormat::BC7, 16, 16), 256u);
+    // 13x7 -> ceil(13/4)=4, ceil(7/4)=2 -> 8 blocks * 16 = 128.
+    EXPECT_EQ(TextureCompression::MipByteSize(TextureCompressionFormat::BC5, 13, 7), 128u);
+}
+
+TEST(TextureCompression, EncodeBC7RoundTripWithinTolerance)
+{
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, false, false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Format, TextureCompressionFormat::BC7);
+    EXPECT_EQ(image.MipLevels(), 1u); // generateMips=false
+    EXPECT_EQ(image.Mips[0].size(), TextureCompression::MipByteSize(TextureCompressionFormat::BC7, kW, kH));
+
+    std::vector<u8> decoded;
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBA8(image, 0, decoded, dw, dh));
+    EXPECT_EQ(dw, kW);
+    EXPECT_EQ(dh, kH);
+
+    // Compare RGB (BC7 encodes A too, but the source A is a constant 255).
+    const double psnr = ComputePSNR(source, decoded, 4, 3);
+    EXPECT_GT(psnr, 35.0) << "BC7 gradient round-trip PSNR too low: " << psnr << " dB";
+}
+
+TEST(TextureCompression, EncodeBC5RoundTripWithinTolerance)
+{
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    const std::vector<u8> source = MakeNormalRG(kW, kH); // 2 channels
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC5(source.data(), kW, kH, 2, false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Format, TextureCompressionFormat::BC5);
+
+    std::vector<u8> decoded; // RGBA8: R,G carry the two channels, B=0, A=255
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBA8(image, 0, decoded, dw, dh));
+
+    // Re-pack the source RG as RGBA to reuse the PSNR helper on channels 0..1.
+    std::vector<u8> sourceRGBA(static_cast<sizet>(kW) * kH * 4, 0);
+    for (sizet i = 0; i < static_cast<sizet>(kW) * kH; ++i)
+    {
+        sourceRGBA[i * 4 + 0] = source[i * 2 + 0];
+        sourceRGBA[i * 4 + 1] = source[i * 2 + 1];
+        sourceRGBA[i * 4 + 3] = 255;
+    }
+    const double psnr = ComputePSNR(sourceRGBA, decoded, 4, 2);
+    EXPECT_GT(psnr, 35.0) << "BC5 normal round-trip PSNR too low: " << psnr << " dB";
+}
+
+TEST(TextureCompression, GeneratesFullMipChain)
+{
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, true, true);
+    ASSERT_TRUE(image.IsValid());
+    // 64 -> 32 -> 16 -> 8 -> 4 -> 2 -> 1  == 7 levels (floor(log2(64)) + 1).
+    EXPECT_EQ(image.MipLevels(), 7u);
+
+    for (u32 level = 0; level < image.MipLevels(); ++level)
+    {
+        const u32 mw = std::max(1u, kW >> level);
+        const u32 mh = std::max(1u, kH >> level);
+        EXPECT_EQ(image.Mips[level].size(), TextureCompression::MipByteSize(TextureCompressionFormat::BC7, mw, mh))
+            << "mip " << level << " byte size mismatch";
+    }
+}
+
+TEST(TextureCompression, HandlesNonMultipleOf4Dimensions)
+{
+    constexpr u32 kW = 13; // deliberately not a multiple of 4
+    constexpr u32 kH = 7;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, false, false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Width, kW);
+    EXPECT_EQ(image.Height, kH);
+
+    std::vector<u8> decoded;
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBA8(image, 0, decoded, dw, dh));
+    EXPECT_EQ(dw, kW);
+    EXPECT_EQ(dh, kH);
+    EXPECT_EQ(decoded.size(), static_cast<sizet>(kW) * kH * 4);
+
+    const double psnr = ComputePSNR(source, decoded, 4, 3);
+    EXPECT_GT(psnr, 30.0) << "partial-block PSNR too low: " << psnr << " dB";
+}
+
+TEST(TextureCompression, ContainerBlobRoundTripIsBitExact)
+{
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 16;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const CompressedTextureImage original = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, true, true);
+    ASSERT_TRUE(original.IsValid());
+
+    const std::vector<u8> blob = TextureCompression::SerializeToBlob(original);
+    ASSERT_FALSE(blob.empty());
+
+    CompressedTextureImage restored;
+    ASSERT_TRUE(TextureCompression::DeserializeFromBlob(blob, restored));
+
+    EXPECT_EQ(restored.Format, original.Format);
+    EXPECT_EQ(restored.Width, original.Width);
+    EXPECT_EQ(restored.Height, original.Height);
+    EXPECT_EQ(restored.SRGB, original.SRGB);
+    ASSERT_EQ(restored.MipLevels(), original.MipLevels());
+    for (u32 level = 0; level < original.MipLevels(); ++level)
+        EXPECT_EQ(restored.Mips[level], original.Mips[level]) << "mip " << level << " block bytes differ";
+}
+
+TEST(TextureCompression, SRGBFlagSurvivesContainerRoundTrip)
+{
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const CompressedTextureImage srgbImage = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, /*srgb*/ true, false);
+    ASSERT_TRUE(srgbImage.SRGB);
+
+    CompressedTextureImage restored;
+    ASSERT_TRUE(TextureCompression::DeserializeFromBlob(TextureCompression::SerializeToBlob(srgbImage), restored));
+    EXPECT_TRUE(restored.SRGB);
+}
+
+TEST(TextureCompression, RejectsCorruptBlob)
+{
+    // Empty and bad-magic blobs must be rejected, not crash.
+    CompressedTextureImage out;
+    EXPECT_FALSE(TextureCompression::DeserializeFromBlob({}, out));
+
+    std::vector<u8> garbage = { 'N', 'O', 'P', 'E', 1, 2, 3, 4 };
+    EXPECT_FALSE(TextureCompression::DeserializeFromBlob(garbage, out));
+}
+
+TEST(TextureCompression, OfflineCookFromPngProducesLoadableOloTex)
+{
+    // Full offline-cook primitive: write a source PNG, CompressTextureFile it to a
+    // .olotex, then read the container back and confirm a valid BC7 mip chain.
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 24;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+
+    const std::filesystem::path pngPath = CaseKeyedTempFile(".png");
+    const std::filesystem::path oloTexPath = CaseKeyedTempFile(".olotex");
+    ASSERT_NE(::stbi_write_png(pngPath.string().c_str(), static_cast<int>(kW), static_cast<int>(kH), 4,
+                               source.data(), static_cast<int>(kW) * 4),
+              0);
+
+    TextureCompression::CompressOptions options;
+    options.Format = TextureCompressionFormat::BC7;
+    options.GenerateMips = true;
+    ASSERT_TRUE(TextureCompression::CompressTextureFile(pngPath.string(), oloTexPath.string(), options));
+
+    CompressedTextureImage loaded;
+    ASSERT_TRUE(TextureCompression::ReadFile(oloTexPath.string(), loaded));
+    EXPECT_EQ(loaded.Format, TextureCompressionFormat::BC7);
+    EXPECT_EQ(loaded.Width, kW);
+    EXPECT_EQ(loaded.Height, kH);
+    EXPECT_GT(loaded.MipLevels(), 1u);
+
+    // The .olotex should be materially smaller than the raw RGBA8 source it came from.
+    sizet compressedBytes = 0;
+    for (const auto& mip : loaded.Mips)
+        compressedBytes += mip.size();
+    EXPECT_LT(compressedBytes, source.size()) << "compressed size should be below raw RGBA8";
+
+    std::error_code ec;
+    std::filesystem::remove(pngPath, ec);
+    std::filesystem::remove(oloTexPath, ec);
+}
+
+TEST(TextureCompression, WriteThenReadFileRoundTrip)
+{
+    constexpr u32 kW = 16;
+    constexpr u32 kH = 16;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+    const CompressedTextureImage original = TextureCompression::EncodeBC7(source.data(), kW, kH, 4, false, true);
+    ASSERT_TRUE(original.IsValid());
+
+    const std::filesystem::path path = CaseKeyedTempFile(".olotex");
+    ASSERT_TRUE(TextureCompression::WriteFile(path.string(), original));
+
+    CompressedTextureImage restored;
+    ASSERT_TRUE(TextureCompression::ReadFile(path.string(), restored));
+    EXPECT_EQ(restored.Width, original.Width);
+    EXPECT_EQ(restored.Height, original.Height);
+    ASSERT_EQ(restored.MipLevels(), original.MipLevels());
+    EXPECT_EQ(restored.Mips[0], original.Mips[0]);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}

--- a/OloEngine/tests/Rendering/TextureCompressionTest.cpp
+++ b/OloEngine/tests/Rendering/TextureCompressionTest.cpp
@@ -225,9 +225,71 @@ TEST(TextureCompression, ContainerBlobRoundTripIsBitExact)
     EXPECT_EQ(restored.Width, original.Width);
     EXPECT_EQ(restored.Height, original.Height);
     EXPECT_EQ(restored.SRGB, original.SRGB);
+    EXPECT_EQ(restored.HasAlpha, original.HasAlpha);
     ASSERT_EQ(restored.MipLevels(), original.MipLevels());
     for (u32 level = 0; level < original.MipLevels(); ++level)
         EXPECT_EQ(restored.Mips[level], original.Mips[level]) << "mip " << level << " block bytes differ";
+}
+
+TEST(TextureCompression, BC7RecordsAlphaFromSourceChannelCount)
+{
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    // 4-channel source -> alpha present.
+    const std::vector<u8> rgba = MakeGradientRGBA(kW, kH);
+    const CompressedTextureImage withAlpha = TextureCompression::EncodeBC7(rgba.data(), kW, kH, 4, false, false);
+    EXPECT_TRUE(withAlpha.HasAlpha);
+
+    // 3-channel source -> opaque, must NOT report alpha (else opaque albedo is
+    // mis-sorted into the transparent pass).
+    std::vector<u8> rgb(static_cast<sizet>(kW) * kH * 3);
+    for (sizet i = 0; i < rgb.size(); ++i)
+        rgb[i] = static_cast<u8>(i);
+    const CompressedTextureImage noAlpha = TextureCompression::EncodeBC7(rgb.data(), kW, kH, 3, false, false);
+    EXPECT_FALSE(noAlpha.HasAlpha);
+}
+
+TEST(TextureCompression, BC5RejectsSingleChannelSource)
+{
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    std::vector<u8> gray(static_cast<sizet>(kW) * kH, 128);
+    // 1 channel is meaningless for a two-channel (R,G) format — must be rejected.
+    const CompressedTextureImage image = TextureCompression::EncodeBC5(gray.data(), kW, kH, 1, false);
+    EXPECT_FALSE(image.IsValid());
+}
+
+TEST(TextureCompression, DeserializeRejectsHostileHeaderFields)
+{
+    // Build a valid blob, then corrupt the header fields to hostile values and confirm
+    // deserialize rejects them BEFORE any large allocation (mipCount / dimensions).
+    const std::vector<u8> source = MakeGradientRGBA(16, 16);
+    const CompressedTextureImage good = TextureCompression::EncodeBC7(source.data(), 16, 16, 4, false, false);
+    std::vector<u8> blob = TextureCompression::SerializeToBlob(good);
+    ASSERT_GE(blob.size(), 28u);
+
+    // Header layout (little-endian u32 after the 4-byte magic):
+    // [4]=version [8]=format [12]=width [16]=height [20]=flags [24]=mipCount
+    const auto patchU32 = [](std::vector<u8>& b, sizet off, u32 v)
+    {
+        b[off + 0] = static_cast<u8>(v & 0xFF);
+        b[off + 1] = static_cast<u8>((v >> 8) & 0xFF);
+        b[off + 2] = static_cast<u8>((v >> 16) & 0xFF);
+        b[off + 3] = static_cast<u8>((v >> 24) & 0xFF);
+    };
+
+    {
+        std::vector<u8> hostile = blob;
+        patchU32(hostile, 24, 0xFFFFFFFFu); // absurd mipCount -> must not reserve ~100GB
+        CompressedTextureImage out;
+        EXPECT_FALSE(TextureCompression::DeserializeFromBlob(hostile, out));
+    }
+    {
+        std::vector<u8> hostile = blob;
+        patchU32(hostile, 12, 0xFFFFFFFEu); // absurd width
+        CompressedTextureImage out;
+        EXPECT_FALSE(TextureCompression::DeserializeFromBlob(hostile, out));
+    }
 }
 
 TEST(TextureCompression, SRGBFlagSurvivesContainerRoundTrip)

--- a/OloEngine/tests/Rendering/TextureCompressionTest.cpp
+++ b/OloEngine/tests/Rendering/TextureCompressionTest.cpp
@@ -290,6 +290,38 @@ TEST(TextureCompression, DeserializeRejectsHostileHeaderFields)
         CompressedTextureImage out;
         EXPECT_FALSE(TextureCompression::DeserializeFromBlob(hostile, out));
     }
+    {
+        std::vector<u8> hostile = blob;
+        patchU32(hostile, 20, 0x4u); // flags: an undefined bit set -> non-canonical
+        CompressedTextureImage out;
+        EXPECT_FALSE(TextureCompression::DeserializeFromBlob(hostile, out));
+    }
+    {
+        std::vector<u8> trailing = blob;
+        trailing.push_back(0x00); // extra byte after the final mip -> not fully consumed
+        CompressedTextureImage out;
+        EXPECT_FALSE(TextureCompression::DeserializeFromBlob(trailing, out));
+    }
+}
+
+TEST(TextureCompression, DeserializeRejectsBC5WithColorFlags)
+{
+    // BC5 (two-channel normal data) must carry neither sRGB nor alpha. A blob that
+    // claims otherwise is corrupt/version-skewed and must be rejected.
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    std::vector<u8> rg(static_cast<sizet>(kW) * kH * 2);
+    for (sizet i = 0; i < rg.size(); ++i)
+        rg[i] = static_cast<u8>(i * 3);
+    const CompressedTextureImage bc5 = TextureCompression::EncodeBC5(rg.data(), kW, kH, 2, false);
+    ASSERT_TRUE(bc5.IsValid());
+    std::vector<u8> blob = TextureCompression::SerializeToBlob(bc5);
+    ASSERT_GE(blob.size(), 28u);
+
+    // Patch the flags field (offset 20) to set the sRGB bit — illegal for BC5.
+    blob[20] = 0x1u;
+    CompressedTextureImage out;
+    EXPECT_FALSE(TextureCompression::DeserializeFromBlob(blob, out));
 }
 
 TEST(TextureCompression, SRGBFlagSurvivesContainerRoundTrip)

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -366,6 +366,39 @@ if(cpp_httplib_ADDED)
 	target_include_directories(cpp_httplib SYSTEM INTERFACE ${cpp_httplib_SOURCE_DIR})
 endif()
 
+# bc7enc_rdo: Rich Geldreich's BC1-7 / BC6H block-compression encoders + decoders.
+# Used by the offline texture-compression cook (Renderer/TextureCompression.cpp) to
+# encode base-color -> BC7 and normal maps -> BC5 (#440). Dual MIT / public-domain
+# licensed for the core sources we use (bc7enc / rgbcx / bc7decomp); we deliberately
+# skip bc7e.ispc (Apache + needs the ISPC compiler), lodepng, miniz, and the RDO
+# post-processor — none are needed for a straight CPU encode. DOWNLOAD_ONLY because
+# the repo's own CMakeLists builds a test exe that requires ISPC; we compile just the
+# three self-contained TUs into our own static lib, mirroring the imgui / lua pattern.
+# Pinned to a fixed commit SHA for reproducible builds (#294 convention).
+CPMAddPackage(NAME bc7enc_rdo
+  GIT_REPOSITORY https://github.com/richgel999/bc7enc_rdo.git
+  GIT_TAG dbe416d28a5530b4e8cc45b14bf034dc6b96bbde  # master @ 2026-02-27
+  GIT_SHALLOW FALSE
+  DOWNLOAD_ONLY YES)
+if(bc7enc_rdo_ADDED)
+	add_library(bc7enc STATIC
+		"${bc7enc_rdo_SOURCE_DIR}/bc7enc.cpp"
+		"${bc7enc_rdo_SOURCE_DIR}/bc7decomp.cpp"
+		"${bc7enc_rdo_SOURCE_DIR}/rgbcx.cpp")
+	# SYSTEM so the encoder's own warnings don't count against OloEngine's /W4-ish flags.
+	target_include_directories(bc7enc SYSTEM PUBLIC "${bc7enc_rdo_SOURCE_DIR}")
+	set_target_properties(bc7enc PROPERTIES FOLDER "Utilities/bc7enc"
+		ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/vendor/bc7enc-build"
+		LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/vendor/bc7enc-build"
+		RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/vendor/bc7enc-build")
+	# clang-cl maps our /WX onto -Werror; the vendored encoder trips a raft of
+	# Clang-only warnings (unused, sign-compare, ...). Suppress -Werror on it only,
+	# same treatment already applied to Jolt / assimp / box2d below.
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		target_compile_options(bc7enc PRIVATE -Wno-error -Wno-everything)
+	endif()
+endif()
+
 set_target_properties(assimp PROPERTIES FOLDER "Utilities/assimp")
 if(TARGET UpdateAssimpLibsDebugSymbolsAndDLLs)
 	set_target_properties(UpdateAssimpLibsDebugSymbolsAndDLLs PROPERTIES FOLDER "Utilities/assimp")


### PR DESCRIPTION
- Introduced TextureCompression.h for handling texture compression logic, including encoding and decoding for BC7 and BC5 formats.
- Implemented OpenGLTexture2D constructor to support uploading compressed textures, with fallback to uncompressed RGBA8 if necessary.
- Added tests for texture compression, including round-trip fidelity checks for BC7 and BC5 formats, mip chain generation, and blob serialization.
- Integrated bc7enc_rdo library for texture compression algorithms, ensuring reproducible builds with a pinned commit.
- Updated CMake configuration to include the new compression library and its dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline block-compressed texture support (BC7/BC5) with a new `.olotex` asset type and texture pipeline integration for rendering.
  * Compressed textures can now be loaded/saved and uploaded for supported GPUs; on unsupported hardware, a CPU fallback path is used.
  * Added tooling plus CPU and GPU automated tests to validate encoding/decoding and container round-trips.
* **Bug Fixes**
  * Improved robustness with stricter validation and error handling for malformed or incompatible compressed texture data.
  * Prevented invalid compressed-texture operations (e.g., unsupported cubemap formats).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->