### PR TITLE
fix(renderer): make Renderer3D::Init idempotent to prevent double-init crash on 0x0 framebuffer

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1784,7 +1784,7 @@ namespace OloEngine
 
     void EditorLayer::TryInitialize3DMode()
     {
-        if (!m_Is3DMode || Renderer3D::IsInitialized())
+        if (!m_Is3DMode || Renderer3D::HasInitialized())
         {
             return;
         }
@@ -1851,7 +1851,7 @@ namespace OloEngine
             Renderer3D::GetShadowMap().SetSettings(shadowCopy);
         }
 
-        if (m_Is3DMode && !Renderer3D::IsInitialized())
+        if (m_Is3DMode && !Renderer3D::HasInitialized())
         {
             TryInitialize3DMode();
         }

--- a/OloEngine/src/OloEngine/Renderer/Renderer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer.cpp
@@ -44,8 +44,12 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
 
         // Renderer3D may have been lazily initialized (e.g. EditorLayer 3D mode)
-        // regardless of the preferred renderer type — always shut it down if active.
-        if (Renderer3D::IsInitialized())
+        // regardless of the preferred renderer type — always shut it down if init
+        // ran. Guard on HasInitialized() ("Init ran"), not IsInitialized()
+        // ("render graph ready"): a renderer that initialized at a 0x0 size (never
+        // completed its graph build) still allocated one-shot singletons that must
+        // be torn down, or FrameDataBufferManager leaks and asserts on next launch.
+        if (Renderer3D::HasInitialized())
             Renderer3D::Shutdown();
 
         // Renderer2D is always initialized (either as the preferred renderer, or

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -185,7 +185,17 @@ namespace OloEngine
         //                       flushed synchronously without UI.
         static void Init(Window* loadingWindow = nullptr);
         static void Shutdown();
+        // True once the render graph is fully built (Scene pass exists) and the
+        // renderer is ready to draw. May be false immediately after Init() when
+        // Init ran against a 0x0 framebuffer — see HasInitialized() for the
+        // "Init() has run at all" query that init/shutdown guards want.
         static bool IsInitialized();
+        // True once Init() has run (and allocated its one-shot singletons),
+        // regardless of whether the deferred render-graph build has completed.
+        // Use this — not IsInitialized() — to guard against double-Init and to
+        // decide whether Shutdown() must run; IsInitialized() is for "ready to
+        // render" gates only.
+        static bool HasInitialized();
 
         // Asset hot-reload handler — ensures next frame picks up new RendererIDs
         static void OnAssetReloaded(const AssetReloadedEvent& e);
@@ -1429,6 +1439,18 @@ namespace OloEngine
 
             Ref<RenderGraph> RGraph;
             std::unique_ptr<RenderPipeline> Pipeline;
+
+            // True once Init() has allocated the renderer's one-shot singletons
+            // (FrameDataBufferManager, FrameResourceManager, command dispatch, …).
+            // Distinct from IsInitialized(): Init() can legitimately run with a
+            // 0x0 framebuffer (window not yet sized on the editor's OnAttach path),
+            // in which case SetupRenderGraph early-outs and the Scene pass — and
+            // therefore IsInitialized() — stays false until the first real
+            // OnWindowResize completes the deferred graph build. This flag guards
+            // Init() against being re-entered in that window, which would otherwise
+            // re-run FrameDataBufferManager::Init() and trip its "already
+            // initialized" assert. Reset in Shutdown().
+            bool CoreInitialized = false;
 
             // Shadow mapping
             ShadowMap Shadow;

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -81,6 +81,22 @@ namespace OloEngine
     void Renderer3D::Init(Window* loadingWindow)
     {
         OLO_PROFILE_FUNCTION();
+
+        // Idempotency guard. Init() may be reached twice on the editor's
+        // OnAttach path: once from OpenProject()->ApplyPreferences() (with a
+        // still-0x0 window framebuffer, so the render graph is only partially
+        // built and IsInitialized() stays false) and once directly from
+        // OnAttach(). Without this guard the second call re-runs
+        // FrameDataBufferManager::Init() and trips its "already initialized"
+        // assert. The deferred SetupRenderGraph in OnWindowResize() finishes the
+        // graph build once a real framebuffer size arrives.
+        if (s_Data.CoreInitialized)
+        {
+            OLO_CORE_TRACE("Renderer3D::Init called while already initialized — ignoring re-entry.");
+            return;
+        }
+        s_Data.CoreInitialized = true;
+
         OLO_CORE_INFO("Initializing Renderer3D.");
 
         RendererProfiler::GetInstance().Initialize();
@@ -423,7 +439,12 @@ namespace OloEngine
 
     bool Renderer3D::IsInitialized()
     {
-        return s_Data.RGraph != nullptr && s_Data.Pipeline->FrameCorePasses.Scene != nullptr;
+        return s_Data.RGraph != nullptr && s_Data.Pipeline && s_Data.Pipeline->FrameCorePasses.Scene != nullptr;
+    }
+
+    bool Renderer3D::HasInitialized()
+    {
+        return s_Data.CoreInitialized;
     }
 
     void Renderer3D::Shutdown()
@@ -509,6 +530,8 @@ namespace OloEngine
         // (both are idempotent, but no need to call them twice).
 
         RendererProfiler::GetInstance().Shutdown();
+
+        s_Data.CoreInitialized = false;
 
         OLO_CORE_INFO("Renderer3D shutdown complete.");
     }

--- a/OloRuntime/src/OloRuntimeApp.cpp
+++ b/OloRuntime/src/OloRuntimeApp.cpp
@@ -97,7 +97,11 @@ namespace OloEngine
             if (m_Is3DMode)
             {
                 // Initialize 3D rendering systems (render graph, UBOs, IBL, etc.)
-                if (!Renderer3D::IsInitialized())
+                // Guard on HasInitialized() ("Init ran"), not IsInitialized()
+                // ("render graph ready"): if Init already ran at a 0x0 size the
+                // graph isn't built yet, but re-running Init would double-init the
+                // one-shot singletons. The OnWindowResize below completes the build.
+                if (!Renderer3D::HasInitialized())
                 {
                     Renderer3D::Init(&Application::Get().GetWindow());
                 }


### PR DESCRIPTION
## Problem

OloEditor crashes on launch with `FrameDataBufferManager already initialized!` when `Renderer3D::Init` runs once against a **0×0 window framebuffer**.

`Init()` allocates `FrameDataBufferManager` (and other one-shot singletons) **early**, but the guard callers used — `IsInitialized()` — only reports true once the render graph's Scene pass exists. `SetupRenderGraph` early-returns before creating that pass when the framebuffer is 0×0 (the window isn't sized yet during `OnAttach → OpenProject → ApplyPreferences`). So the first init leaves `s_Buffer` allocated while `IsInitialized()` stays `false`, and the second `TryInitialize3DMode()` re-runs `Init()` → the assert.

The crash is timing-dependent on whether GLFW has reported a framebuffer size by `OnAttach` time.

## Fix

Decouple *"Init has run"* from *"ready to render"*:

- Add `Renderer3DData::CoreInitialized` + a top-of-`Init()` idempotency guard, so `Init()` is safe to call twice regardless of caller; reset it in `Shutdown()`.
- Add `Renderer3D::HasInitialized()` (*"Init ran"*) alongside `IsInitialized()` (*"render graph ready"*), and repoint the init/shutdown guards (`EditorLayer`, `OloRuntimeApp`, `Renderer::Shutdown`) to it. Keying `Shutdown` on `HasInitialized()` also ensures a renderer that inited at 0×0 gets torn down instead of leaking `FrameDataBufferManager`.
- Harden `IsInitialized()` against a null `Pipeline`.

The existing deferred `SetupRenderGraph` in `OnWindowResize` completes the graph build (and re-inits ForwardPlus at the real size) once a valid framebuffer size arrives.

## Verification

- OloEditor builds clean and launches to a fully-rendered frame with **no assert** in the log.
- 69 tests pass across the `FrameDataBuffer` / `RendererAttached` / `CommandBucket` / `FrameCapture` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D mode startup and shutdown reliability when initialization happens before a valid window size is available.
  * Prevented repeated or skipped initialization in edge cases, reducing next-launch assertions and resource leaks.
  * Ensured the app correctly finishes 3D setup after window resizing when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->