### PR TITLE
feat(mcp): implement per-action write consent modal and update consen…

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1625,6 +1625,14 @@ namespace OloEngine
             MCP::RenderMcpServerPanel(*m_McpServer, m_Prefs.McpPort, m_Prefs.McpAutoStart, &m_ShowMcpPanel);
         }
 
+        // MCP per-action write-consent modal (issue #306 item C). Rendered every frame
+        // regardless of the panel's visibility so an agent's write in Prompt mode is
+        // never left blocked because the user closed the panel. A no-op when idle.
+        if (m_McpServer)
+        {
+            MCP::RenderMcpConsentModal(*m_McpServer);
+        }
+
         // Thread Inspector Panel
         if (m_ShowThreadInspector)
         {

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -597,6 +597,13 @@ namespace OloEngine::MCP
         if (m_Running.load(std::memory_order_acquire))
             return false;
 
+        // Clear any consent-abort latch left by a prior Stop() so this fresh session
+        // can prompt again (the queue was already drained as the old workers unblocked).
+        {
+            std::lock_guard lock(m_ConsentMutex);
+            m_ConsentAborting = false;
+        }
+
         m_Token = GenerateHexToken(16);
 
         m_Http = CreateScope<httplib::Server>();
@@ -665,6 +672,15 @@ namespace OloEngine::MCP
         // Signal first so any handler blocked in MarshalRead aborts promptly
         // instead of deadlocking against this thread (Stop runs on the game thread).
         m_Running.store(false, std::memory_order_release);
+
+        // Release any worker blocked in RequestConsent as a Deny BEFORE joining the
+        // http worker pool below — otherwise the join would wait forever on a thread
+        // parked on a consent that the (now-gone) editor UI can never resolve.
+        {
+            std::lock_guard lock(m_ConsentMutex);
+            m_ConsentAborting = true;
+        }
+        m_ConsentCv.notify_all();
 
         m_Http->stop();
         if (m_ListenThread.joinable())
@@ -749,6 +765,150 @@ namespace OloEngine::MCP
 
             if (std::chrono::steady_clock::now() >= deadline)
                 throw std::runtime_error("Timed out waiting for the editor main thread (is the editor responsive?)");
+        }
+    }
+
+    namespace
+    {
+        // A compact, human-readable rendering of a tool's arguments for the consent
+        // modal: one "key = value" per line (strings unquoted, everything else via a
+        // compact JSON dump). Generic over any ProjectWrite tool's argument shape, so
+        // the dialog needs no per-tool knowledge.
+        std::string BuildConsentSummary(const Json& arguments)
+        {
+            if (!arguments.is_object() || arguments.empty())
+                return "(no arguments)";
+
+            std::string out;
+            for (auto it = arguments.begin(); it != arguments.end(); ++it)
+            {
+                out += it.key();
+                out += " = ";
+                const Json& value = it.value();
+                out += value.is_string() ? value.get<std::string>() : value.dump();
+                out += '\n';
+            }
+            if (!out.empty() && out.back() == '\n')
+                out.pop_back();
+            return out;
+        }
+    } // namespace
+
+    void McpServer::SetWriteConsentMode(WriteConsentMode mode)
+    {
+        m_ConsentMode.store(mode, std::memory_order_relaxed);
+
+        // Drain any in-flight prompts to match the new mode: AllowSession approves
+        // them (the human just said "allow everything"), Disabled denies them. Prompt
+        // leaves them awaiting a per-action decision. Either way, wake the waiters.
+        if (mode == WriteConsentMode::Prompt)
+            return;
+
+        const ConsentDecision resolution =
+            (mode == WriteConsentMode::AllowSession) ? ConsentDecision::Approve : ConsentDecision::Deny;
+        {
+            std::lock_guard lock(m_ConsentMutex);
+            for (ConsentEntry& entry : m_ConsentQueue)
+            {
+                if (entry.Decision == ConsentDecision::Pending)
+                    entry.Decision = resolution;
+            }
+        }
+        m_ConsentCv.notify_all();
+    }
+
+    std::vector<McpServer::PendingConsent> McpServer::PendingConsents() const
+    {
+        std::vector<PendingConsent> pending;
+        std::lock_guard lock(m_ConsentMutex);
+        for (const ConsentEntry& entry : m_ConsentQueue)
+        {
+            if (entry.Decision != ConsentDecision::Pending)
+                continue; // already resolved, waiting to be reaped by its handler thread
+            pending.push_back(PendingConsent{ entry.Id, entry.ToolName, entry.ToolTitle, entry.Summary });
+        }
+        return pending;
+    }
+
+    void McpServer::ResolveConsent(u64 id, ConsentDecision decision)
+    {
+        // ApproveAll flips the whole session to auto-approve, which also resolves this
+        // prompt and every other pending one — route it through SetWriteConsentMode so
+        // the mode change and the drain happen atomically together.
+        if (decision == ConsentDecision::ApproveAll)
+        {
+            SetWriteConsentMode(WriteConsentMode::AllowSession);
+            return;
+        }
+
+        {
+            std::lock_guard lock(m_ConsentMutex);
+            for (ConsentEntry& entry : m_ConsentQueue)
+            {
+                if (entry.Id == id && entry.Decision == ConsentDecision::Pending)
+                {
+                    entry.Decision = decision;
+                    break;
+                }
+            }
+        }
+        m_ConsentCv.notify_all();
+    }
+
+    ConsentDecision McpServer::RequestConsent(const ToolDef& tool, const Json& arguments)
+    {
+        const auto timeout = std::chrono::milliseconds(m_ConsentTimeoutMs.load(std::memory_order_relaxed));
+
+        u64 myId = 0;
+        {
+            std::unique_lock lock(m_ConsentMutex);
+            if (m_ConsentAborting)
+                return ConsentDecision::Deny;
+            // A concurrent mode change may have already settled the outcome before we
+            // enqueue anything — honour it without prompting.
+            const WriteConsentMode mode = m_ConsentMode.load(std::memory_order_relaxed);
+            if (mode == WriteConsentMode::AllowSession)
+                return ConsentDecision::Approve;
+            if (mode == WriteConsentMode::Disabled)
+                return ConsentDecision::Deny;
+
+            myId = m_NextConsentId++;
+            ConsentEntry entry;
+            entry.Id = myId;
+            entry.ToolName = tool.Name;
+            entry.ToolTitle = tool.Title.empty() ? tool.Name : tool.Title;
+            entry.Summary = BuildConsentSummary(arguments);
+            m_ConsentQueue.push_back(std::move(entry));
+
+            const bool resolved = m_ConsentCv.wait_for(lock, timeout, [this, myId]
+                                                       {
+                                                           if (m_ConsentAborting)
+                                                               return true;
+                                                           for (const ConsentEntry& e : m_ConsentQueue)
+                                                           {
+                                                               if (e.Id == myId)
+                                                                   return e.Decision != ConsentDecision::Pending;
+                                                           }
+                                                           return true; // entry vanished => treat as resolved
+                                                       });
+
+            // Reap our entry and read its decision under the same lock.
+            ConsentDecision decision = ConsentDecision::Pending;
+            for (auto it = m_ConsentQueue.begin(); it != m_ConsentQueue.end(); ++it)
+            {
+                if (it->Id == myId)
+                {
+                    decision = it->Decision;
+                    m_ConsentQueue.erase(it);
+                    break;
+                }
+            }
+
+            if (m_ConsentAborting)
+                return ConsentDecision::Deny;
+            if (!resolved || decision == ConsentDecision::Pending)
+                return ConsentDecision::Timeout;
+            return decision;
         }
     }
 
@@ -1165,17 +1325,44 @@ namespace OloEngine::MCP
             return MakeError(id, kInvalidParams, "Invalid params: 'arguments' must be an object");
         const Json arguments = params.contains("arguments") ? params["arguments"] : Json::object();
 
-        // Session write gate (issue #306 item C): a project-mutating tool is refused
-        // unless the user has turned on "Allow writes" in the MCP panel (default off,
-        // never persisted). This is distinct from — and stacks on top of — the
-        // enabled + bearer-token gate: even an authenticated agent stays read-only
-        // w.r.t. the project until the user opts in for the session. Read-only and
-        // ephemeral editor-state tools (camera / viewport / render overrides) are not
-        // ProjectWrite, so they are unaffected.
-        if (tool->ProjectWrite && !AllowWrites())
-            return MakeError(id, kInvalidParams,
-                             "Write tools are disabled. Enable \"Allow writes\" in the editor's MCP "
-                             "Server panel to permit this mutation (it is off by default).");
+        // Session write consent (issue #306 item C): a project-mutating tool is gated
+        // by the WriteConsentMode the user set in the MCP panel (default Disabled,
+        // never persisted). This stacks on top of the enabled + bearer-token gate:
+        // even an authenticated agent stays read-only w.r.t. the project until the
+        // human opts in for the session. Read-only / ephemeral editor-state tools
+        // (camera / viewport / render overrides) are not ProjectWrite, so no mode
+        // affects them.
+        //
+        //   Disabled     -> refuse outright.
+        //   Prompt       -> block this worker thread on RequestConsent until the human
+        //                   approves/denies the per-action modal (or it times out).
+        //   AllowSession -> proceed (the human already approved everything).
+        if (tool->ProjectWrite)
+        {
+            const WriteConsentMode mode = m_ConsentMode.load(std::memory_order_relaxed);
+            if (mode == WriteConsentMode::Disabled)
+                return MakeError(id, kInvalidParams,
+                                 "Write tools are disabled. Set writes to \"Prompt\" or \"Allow all\" in the "
+                                 "editor's MCP Server panel to permit this mutation (they are off by default).");
+            if (mode == WriteConsentMode::Prompt)
+            {
+                switch (RequestConsent(*tool, arguments))
+                {
+                    case ConsentDecision::Approve:
+                    case ConsentDecision::ApproveAll:
+                        break; // human approved — fall through to the handler.
+                    case ConsentDecision::Timeout:
+                        return MakeError(id, kInvalidParams,
+                                         "Write consent request timed out with no response from the editor user.");
+                    case ConsentDecision::Deny:
+                    case ConsentDecision::Pending:
+                    default:
+                        return MakeError(id, kInvalidParams,
+                                         "The editor user denied this write. Ask them to Approve it (or switch writes "
+                                         "to \"Allow all\") in the editor's MCP Server panel.");
+                }
+            }
+        }
 
         // Enforce the tool's declared inputSchema before the handler runs, so a
         // malformed call fails with a clean, field-naming kInvalidParams instead of

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -796,7 +796,7 @@ namespace OloEngine::MCP
 
     void McpServer::SetWriteConsentMode(WriteConsentMode mode)
     {
-        m_ConsentMode.store(mode, std::memory_order_relaxed);
+        m_ConsentMode.store(mode);
 
         // Drain any in-flight prompts to match the new mode: AllowSession approves
         // them (the human just said "allow everything"), Disabled denies them. Prompt
@@ -834,9 +834,20 @@ namespace OloEngine::MCP
     {
         // ApproveAll flips the whole session to auto-approve, which also resolves this
         // prompt and every other pending one — route it through SetWriteConsentMode so
-        // the mode change and the drain happen atomically together.
+        // the mode change and the drain happen atomically together. But only when `id`
+        // still names a live pending prompt: a stale/missing id is a no-op (same
+        // contract as the Approve/Deny path), so a late click on an already-reaped
+        // request can't silently disable consent for the rest of the session.
         if (decision == ConsentDecision::ApproveAll)
         {
+            {
+                std::lock_guard lock(m_ConsentMutex);
+                const bool present = std::any_of(m_ConsentQueue.begin(), m_ConsentQueue.end(),
+                                                 [id](const ConsentEntry& entry)
+                                                 { return entry.Id == id && entry.Decision == ConsentDecision::Pending; });
+                if (!present)
+                    return;
+            }
             SetWriteConsentMode(WriteConsentMode::AllowSession);
             return;
         }
@@ -857,7 +868,7 @@ namespace OloEngine::MCP
 
     ConsentDecision McpServer::RequestConsent(const ToolDef& tool, const Json& arguments)
     {
-        const auto timeout = std::chrono::milliseconds(m_ConsentTimeoutMs.load(std::memory_order_relaxed));
+        const auto timeout = std::chrono::milliseconds(m_ConsentTimeoutMs.load());
 
         u64 myId = 0;
         {
@@ -866,7 +877,7 @@ namespace OloEngine::MCP
                 return ConsentDecision::Deny;
             // A concurrent mode change may have already settled the outcome before we
             // enqueue anything — honour it without prompting.
-            const WriteConsentMode mode = m_ConsentMode.load(std::memory_order_relaxed);
+            const WriteConsentMode mode = m_ConsentMode.load();
             if (mode == WriteConsentMode::AllowSession)
                 return ConsentDecision::Approve;
             if (mode == WriteConsentMode::Disabled)
@@ -1325,6 +1336,17 @@ namespace OloEngine::MCP
             return MakeError(id, kInvalidParams, "Invalid params: 'arguments' must be an object");
         const Json arguments = params.contains("arguments") ? params["arguments"] : Json::object();
 
+        // Enforce the tool's declared inputSchema BEFORE anything else user-visible, so
+        // a malformed call fails with a clean, field-naming kInvalidParams instead of
+        // depending on whatever ad-hoc checks that one handler happens to do (issue
+        // #357 conformance / #306 item D hardening). A permissive (empty / non-object)
+        // schema validates nothing. This must precede the consent gate below: a
+        // malformed write should never raise the per-action consent modal (the human
+        // would be asked to approve a call that can't run) — validate first, prompt only
+        // for a well-formed mutation.
+        if (const auto error = ValidateArguments(tool->InputSchema, arguments))
+            return MakeError(id, kInvalidParams, "Invalid arguments for tool '" + name + "': " + *error);
+
         // Session write consent (issue #306 item C): a project-mutating tool is gated
         // by the WriteConsentMode the user set in the MCP panel (default Disabled,
         // never persisted). This stacks on top of the enabled + bearer-token gate:
@@ -1339,7 +1361,7 @@ namespace OloEngine::MCP
         //   AllowSession -> proceed (the human already approved everything).
         if (tool->ProjectWrite)
         {
-            const WriteConsentMode mode = m_ConsentMode.load(std::memory_order_relaxed);
+            const WriteConsentMode mode = m_ConsentMode.load();
             if (mode == WriteConsentMode::Disabled)
                 return MakeError(id, kInvalidParams,
                                  "Write tools are disabled. Set writes to \"Prompt\" or \"Allow all\" in the "
@@ -1363,14 +1385,6 @@ namespace OloEngine::MCP
                 }
             }
         }
-
-        // Enforce the tool's declared inputSchema before the handler runs, so a
-        // malformed call fails with a clean, field-naming kInvalidParams instead of
-        // depending on whatever ad-hoc checks that one handler happens to do (issue
-        // #357 conformance / #306 item D hardening). A permissive (empty / non-object)
-        // schema validates nothing.
-        if (const auto error = ValidateArguments(tool->InputSchema, arguments))
-            return MakeError(id, kInvalidParams, "Invalid arguments for tool '" + name + "': " + *error);
 
         ToolResult result;
         try

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -346,7 +346,7 @@ namespace OloEngine::MCP
         void SetWriteConsentMode(WriteConsentMode mode);
         [[nodiscard]] WriteConsentMode GetWriteConsentMode() const
         {
-            return m_ConsentMode.load(std::memory_order_relaxed);
+            return m_ConsentMode.load();
         }
 
         // Back-compat binary gate over the mode: true maps to AllowSession (writes go
@@ -359,7 +359,7 @@ namespace OloEngine::MCP
         }
         [[nodiscard]] bool AllowWrites() const
         {
-            return m_ConsentMode.load(std::memory_order_relaxed) != WriteConsentMode::Disabled;
+            return m_ConsentMode.load() != WriteConsentMode::Disabled;
         }
 
         // A consent prompt awaiting a human decision, as a snapshot for the panel to
@@ -388,7 +388,7 @@ namespace OloEngine::MCP
         // dispatch returns a clean error). Default 120s; exposed for tests.
         void SetConsentTimeout(std::chrono::milliseconds timeout)
         {
-            m_ConsentTimeoutMs.store(timeout.count(), std::memory_order_relaxed);
+            m_ConsentTimeoutMs.store(timeout.count());
         }
         [[nodiscard]] const EditorMcpContext& Context() const
         {

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -33,6 +33,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -66,6 +67,30 @@ namespace OloEngine::MCP
 
     // Default localhost port the MCP server binds to. Configurable in the panel.
     inline constexpr u16 DefaultPort = 7345;
+
+    // How a project-mutating (ToolDef::ProjectWrite) tool call is authorized at
+    // dispatch (issue #306 item C). Supersedes the old binary "Allow writes" gate,
+    // which maps onto the two extremes (Disabled / AllowSession); the middle mode
+    // adds the per-action consent DIALOG. OFF by default and never persisted, so
+    // every editor launch starts read-only and the human opts in for the session.
+    enum class WriteConsentMode : u8
+    {
+        Disabled = 0,     // writes refused outright (default) — the read-only posture.
+        Prompt = 1,       // each write pops a consent dialog the human approves/denies.
+        AllowSession = 2, // writes auto-approved for the rest of the session (no prompt).
+    };
+
+    // The resolution of one consent prompt. Pending until the human (or a mode
+    // change / server shutdown) resolves it. Approve/Deny/ApproveAll are the three
+    // buttons the panel offers; Timeout is set internally when no answer arrives.
+    enum class ConsentDecision : u8
+    {
+        Pending = 0,
+        Approve = 1,
+        Deny = 2,
+        ApproveAll = 3, // approve THIS one and flip the session to AllowSession.
+        Timeout = 4,
+    };
 
     // Result of a tool invocation. `Content` is the MCP content array
     // (e.g. [{ "type": "text", "text": "..." }]); `IsError` maps to the
@@ -305,20 +330,65 @@ namespace OloEngine::MCP
             return m_RedactPaths.load(std::memory_order_relaxed);
         }
 
-        // Session-level write gate (issue #306 item C). OFF by default and NOT
-        // persisted, so every editor launch starts read-only and the user opts in
-        // for the session via the MCP panel. Distinct from the enabled + bearer-token
-        // gate: even an authenticated agent cannot mutate the project until this is
-        // on. When off, HandleToolsCall rejects any tool flagged ToolDef::ProjectWrite
-        // with a clean JSON-RPC error. The read-only / ephemeral-editor-state tools
-        // are unaffected.
+        // Session-level write consent (issue #306 item C). OFF by default (Disabled)
+        // and NOT persisted, so every editor launch starts read-only and the user
+        // opts in for the session via the MCP panel. Distinct from the enabled +
+        // bearer-token gate: even an authenticated agent cannot mutate the project
+        // until the human raises this. Read-only / ephemeral-editor-state tools
+        // (camera / viewport / render overrides) are never ProjectWrite, so they are
+        // unaffected by any mode.
+        //
+        // In Prompt mode a ProjectWrite dispatch calls RequestConsent, which BLOCKS
+        // the handler (worker) thread until the human resolves the modal the panel
+        // renders on the main thread — see ResolveConsent / PendingConsents. Setting
+        // the mode drains any in-flight prompts: AllowSession approves them, Disabled
+        // denies them. Defined in the .cpp (touches the consent queue).
+        void SetWriteConsentMode(WriteConsentMode mode);
+        [[nodiscard]] WriteConsentMode GetWriteConsentMode() const
+        {
+            return m_ConsentMode.load(std::memory_order_relaxed);
+        }
+
+        // Back-compat binary gate over the mode: true maps to AllowSession (writes go
+        // straight through, no prompt), false to Disabled. `AllowWrites()` is "any
+        // mode that permits a write" (Prompt or AllowSession). Kept so the existing
+        // dispatch tests and any external caller need not learn the tri-state.
         void SetAllowWrites(bool enabled)
         {
-            m_AllowWrites.store(enabled, std::memory_order_relaxed);
+            SetWriteConsentMode(enabled ? WriteConsentMode::AllowSession : WriteConsentMode::Disabled);
         }
         [[nodiscard]] bool AllowWrites() const
         {
-            return m_AllowWrites.load(std::memory_order_relaxed);
+            return m_ConsentMode.load(std::memory_order_relaxed) != WriteConsentMode::Disabled;
+        }
+
+        // A consent prompt awaiting a human decision, as a snapshot for the panel to
+        // render. The panel polls PendingConsents() each frame; when non-empty it
+        // shows the modal and calls ResolveConsent() on a button press. Main-thread
+        // (UI) side of the RequestConsent handshake.
+        struct PendingConsent
+        {
+            u64 Id = 0;
+            std::string ToolName;  // e.g. "olo_entity_set_field"
+            std::string ToolTitle; // display title (falls back to ToolName)
+            std::string Summary;   // human-readable arguments (one "key = value" per line)
+        };
+
+        // Snapshot of every prompt currently awaiting a decision, oldest first.
+        // Cheap + lock-guarded; safe to call every frame from the main thread.
+        [[nodiscard]] std::vector<PendingConsent> PendingConsents() const;
+
+        // Resolve one pending prompt by id (main thread, from the panel). Approve /
+        // Deny apply to that prompt only; ApproveAll additionally flips the session
+        // to AllowSession and approves every currently-pending prompt. Wakes the
+        // blocked handler thread(s). A no-op if the id is already gone.
+        void ResolveConsent(u64 id, ConsentDecision decision);
+
+        // How long RequestConsent waits for a human before giving up (Timeout ->
+        // dispatch returns a clean error). Default 120s; exposed for tests.
+        void SetConsentTimeout(std::chrono::milliseconds timeout)
+        {
+            m_ConsentTimeoutMs.store(timeout.count(), std::memory_order_relaxed);
         }
         [[nodiscard]] const EditorMcpContext& Context() const
         {
@@ -470,6 +540,14 @@ namespace OloEngine::MCP
         [[nodiscard]] Json HandlePromptsList(const Json& id) const;
         [[nodiscard]] Json HandlePromptsGet(const Json& id, const Json& params) const;
 
+        // Prompt-mode consent handshake (issue #306 item C). Called from
+        // HandleToolsCall on a worker thread for a ProjectWrite tool when the mode is
+        // Prompt: enqueue a prompt, block until the panel resolves it (or the timeout
+        // / a mode change / shutdown intervenes), and return the decision. MUST run on
+        // a handler thread — it blocks on the main thread rendering the modal, so
+        // calling it from the game thread would deadlock.
+        [[nodiscard]] ConsentDecision RequestConsent(const ToolDef& tool, const Json& arguments);
+
         [[nodiscard]] const ToolDef* FindTool(const std::string& name) const;
         [[nodiscard]] const ResourceDef* FindResource(const std::string& uri) const;
         [[nodiscard]] const PromptDef* FindPrompt(const std::string& name) const;
@@ -488,9 +566,30 @@ namespace OloEngine::MCP
 
         std::atomic<bool> m_RedactPaths{ false };
 
-        // Session write gate (issue #306 item C); see SetAllowWrites. Default OFF,
-        // never persisted — every launch starts read-only.
-        std::atomic<bool> m_AllowWrites{ false };
+        // Session write consent mode (issue #306 item C); see SetWriteConsentMode.
+        // Default Disabled (read-only), never persisted — every launch starts safe.
+        std::atomic<WriteConsentMode> m_ConsentMode{ WriteConsentMode::Disabled };
+
+        // Prompt-mode consent handshake state. RequestConsent (worker thread) pushes
+        // an entry and waits on m_ConsentCv; the panel (main thread) mutates the
+        // entry's Decision via ResolveConsent and notifies. m_ConsentAborting is
+        // raised by Stop()/the destructor to release any blocked worker as a Deny —
+        // distinct from m_Running so the dispatch tests (which never Start the server)
+        // can still exercise the handshake.
+        mutable std::mutex m_ConsentMutex;
+        std::condition_variable m_ConsentCv;
+        struct ConsentEntry
+        {
+            u64 Id = 0;
+            std::string ToolName;
+            std::string ToolTitle;
+            std::string Summary;
+            ConsentDecision Decision = ConsentDecision::Pending;
+        };
+        std::vector<ConsentEntry> m_ConsentQueue;      // guarded by m_ConsentMutex
+        u64 m_NextConsentId = 1;                       // guarded by m_ConsentMutex
+        bool m_ConsentAborting = false;                // guarded by m_ConsentMutex
+        std::atomic<i64> m_ConsentTimeoutMs{ 120000 }; // human-response deadline
 
         // Count of live GET /mcp SSE push streams (issue #306 item B). Bumped while a
         // stream's content provider runs; surfaced via ActiveStreamCount().

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -137,6 +137,11 @@ namespace OloEngine::MCP
                 ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f),
                                    "(agents may MUTATE the scene WITHOUT asking — Ctrl-Z to revert)");
                 break;
+            default:
+                // Unknown / future mode: fail safe to a neutral note rather than an
+                // unlabeled state (also satisfies -Wswitch-default / SonarQube S131).
+                ImGui::TextDisabled("(unknown write-consent mode)");
+                break;
         }
 
         ImGui::Checkbox("Start automatically when the editor launches", &autoStart);
@@ -183,9 +188,20 @@ namespace OloEngine::MCP
 
             ImGui::Spacing();
             ImGui::TextUnformatted("Requested change:");
-            ImGui::Indent();
+            // Bound the (agent-supplied) summary: a long field value or many-line
+            // argument list would otherwise widen/lengthen the AlwaysAutoResize popup
+            // until the Approve/Deny buttons are pushed off-screen. Wrap it in a
+            // fixed-width, height-capped scrolling child so the modal always fits.
+            constexpr float kSummaryWidth = 440.0f;
+            const float maxSummaryHeight = ImGui::GetTextLineHeightWithSpacing() * 10.0f;
+            const ImVec2 summarySize =
+                ImGui::CalcTextSize(request.Summary.c_str(), nullptr, false, kSummaryWidth);
+            const float summaryHeight = std::min(summarySize.y, maxSummaryHeight) + ImGui::GetStyle().FramePadding.y * 2.0f;
+            ImGui::BeginChild("##mcp_consent_summary", ImVec2(kSummaryWidth, summaryHeight), ImGuiChildFlags_Borders);
+            ImGui::PushTextWrapPos(0.0f);
             ImGui::TextUnformatted(request.Summary.c_str());
-            ImGui::Unindent();
+            ImGui::PopTextWrapPos();
+            ImGui::EndChild();
 
             ImGui::Spacing();
             ImGui::TextDisabled("Approving applies the change through the undo stack (Ctrl-Z to revert).");

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -105,19 +105,39 @@ namespace OloEngine::MCP
         ImGui::SameLine();
         ImGui::TextDisabled("(scrubs absolute paths before they leave the process)");
 
-        // Session write gate (issue #306 item C). OFF by default and not persisted, so
-        // every launch starts read-only; the user opts in here for the session. While
-        // off, any project-mutating tool (e.g. olo_set_collision_layer) is refused with
-        // a clean JSON-RPC error even for an authenticated agent. Writes route through
-        // the editor undo stack, so an agent's change is a single Ctrl-Z.
-        if (bool allowWrites = server.AllowWrites(); ImGui::Checkbox("Allow writes (undoable)", &allowWrites))
-            server.SetAllowWrites(allowWrites);
+        // Session write consent (issue #306 item C). Disabled by default and not
+        // persisted, so every launch starts read-only; the user opts in here for the
+        // session. Three modes compose the session gate with the per-action dialog:
+        //   Disabled  — project-mutating tools are refused with a clean JSON-RPC error.
+        //   Prompt    — each write pops a modal the user Approves/Denies (see below).
+        //   Allow all — writes auto-apply for the session, no prompt.
+        // Writes route through the editor undo stack, so an agent's change is a Ctrl-Z.
+        ImGui::TextUnformatted("Agent writes:");
         ImGui::SameLine();
-        if (server.AllowWrites())
-            ImGui::TextColored(ImVec4(0.85f, 0.60f, 0.30f, 1.0f),
-                               "(agents may MUTATE the scene via the undo stack — Ctrl-Z to revert)");
-        else
-            ImGui::TextDisabled("(off: write tools are refused; read-only. Not persisted — resets each launch)");
+        const WriteConsentMode mode = server.GetWriteConsentMode();
+        if (ImGui::RadioButton("Disabled", mode == WriteConsentMode::Disabled))
+            server.SetWriteConsentMode(WriteConsentMode::Disabled);
+        ImGui::SameLine();
+        if (ImGui::RadioButton("Prompt", mode == WriteConsentMode::Prompt))
+            server.SetWriteConsentMode(WriteConsentMode::Prompt);
+        ImGui::SameLine();
+        if (ImGui::RadioButton("Allow all", mode == WriteConsentMode::AllowSession))
+            server.SetWriteConsentMode(WriteConsentMode::AllowSession);
+
+        switch (mode)
+        {
+            case WriteConsentMode::Disabled:
+                ImGui::TextDisabled("(read-only: write tools are refused. Not persisted — resets each launch)");
+                break;
+            case WriteConsentMode::Prompt:
+                ImGui::TextColored(ImVec4(0.85f, 0.60f, 0.30f, 1.0f),
+                                   "(each agent write asks you to Approve/Deny — Ctrl-Z reverts an approved one)");
+                break;
+            case WriteConsentMode::AllowSession:
+                ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f),
+                                   "(agents may MUTATE the scene WITHOUT asking — Ctrl-Z to revert)");
+                break;
+        }
 
         ImGui::Checkbox("Start automatically when the editor launches", &autoStart);
         ImGui::SameLine();
@@ -130,5 +150,68 @@ namespace OloEngine::MCP
                     static_cast<int>(server.Prompts().size()));
 
         ImGui::End();
+    }
+
+    void RenderMcpConsentModal(McpServer& server)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // One prompt at a time (oldest first): a second concurrent write parks in the
+        // queue and surfaces on the next frame once this one is resolved.
+        const std::vector<McpServer::PendingConsent> pending = server.PendingConsents();
+        if (pending.empty())
+            return;
+        const McpServer::PendingConsent& request = pending.front();
+
+        constexpr const char* kPopupId = "MCP write request##mcp_consent";
+        if (!ImGui::IsPopupOpen(kPopupId))
+            ImGui::OpenPopup(kPopupId);
+
+        // Center on first appearance; let the user drag it afterwards.
+        const ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+        if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f),
+                               "An MCP agent wants to MODIFY your scene.");
+            ImGui::Separator();
+
+            ImGui::Text("Tool: %s", request.ToolTitle.c_str());
+            if (request.ToolName != request.ToolTitle)
+                ImGui::TextDisabled("(%s)", request.ToolName.c_str());
+
+            ImGui::Spacing();
+            ImGui::TextUnformatted("Requested change:");
+            ImGui::Indent();
+            ImGui::TextUnformatted(request.Summary.c_str());
+            ImGui::Unindent();
+
+            ImGui::Spacing();
+            ImGui::TextDisabled("Approving applies the change through the undo stack (Ctrl-Z to revert).");
+            if (const int extra = static_cast<int>(pending.size()) - 1; extra > 0)
+                ImGui::TextDisabled("(%d more request%s waiting)", extra, extra == 1 ? "" : "s");
+            ImGui::Separator();
+
+            if (ImGui::Button("Approve"))
+            {
+                server.ResolveConsent(request.Id, ConsentDecision::Approve);
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Deny"))
+            {
+                server.ResolveConsent(request.Id, ConsentDecision::Deny);
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Approve all this session"))
+            {
+                server.ResolveConsent(request.Id, ConsentDecision::ApproveAll);
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        }
     }
 } // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpServerPanel.h
+++ b/OloEditor/src/MCP/McpServerPanel.h
@@ -9,4 +9,10 @@ namespace OloEngine::MCP
     // `port` and `autoStart` are edited in place and persisted by the caller
     // (EditorPreferences). `p_open` drives the window's visibility.
     void RenderMcpServerPanel(McpServer& server, int& port, bool& autoStart, bool* p_open);
+
+    // Renders the per-action write-consent modal (issue #306 item C). Call this every
+    // frame, UNCONDITIONALLY — independent of whether the MCP panel window above is
+    // open — so an agent's write in Prompt mode is never left blocked because the user
+    // closed the panel. A no-op when nothing is awaiting consent (the common case).
+    void RenderMcpConsentModal(McpServer& server);
 } // namespace OloEngine::MCP

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -33,8 +33,11 @@
 #include "OloEngine/Scene/Scene.h"
 
 #include <algorithm>
+#include <chrono>
+#include <future>
 #include <optional>
 #include <string>
+#include <thread>
 
 // OLO_TEST_LAYER: unit
 
@@ -47,10 +50,12 @@ namespace
     using OloEngine::Ref;
     using OloEngine::Rigidbody3DComponent;
     using OloEngine::Scene;
+    using OloEngine::MCP::ConsentDecision;
     using OloEngine::MCP::EditorMcpContext;
     using OloEngine::MCP::McpServer;
     using OloEngine::MCP::ToolDef;
     using OloEngine::MCP::ToolResult;
+    using OloEngine::MCP::WriteConsentMode;
     using Json = OloEngine::MCP::Json;
     namespace SetCollisionLayer = OloEngine::MCP::SetCollisionLayer;
 
@@ -109,6 +114,21 @@ namespace
                 .m_LayerID;
         }
 
+        // Spin (main test thread) until a worker thread has parked a consent prompt,
+        // then return its id — or 0 if none appears within the budget. Mirrors what
+        // the editor's main-thread panel poll does each frame.
+        [[nodiscard]] u64 WaitForPendingConsent()
+        {
+            for (int i = 0; i < 400; ++i)
+            {
+                const auto pending = m_Server.PendingConsents();
+                if (!pending.empty())
+                    return pending.front().Id;
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            return 0;
+        }
+
         static constexpr u32 kInitialLayer = 0;
 
         Ref<Scene> m_Scene;
@@ -160,6 +180,108 @@ TEST_F(McpConsentedWriteTest, GateOnAppliesUndoableWrite)
     EXPECT_FALSE(m_History.CanUndo());
 
     m_History.Redo();
+    EXPECT_EQ(CurrentLayer(), 3u);
+}
+
+// ---- the per-action consent dialog (Prompt mode) ---------------------------
+// The write reaches HandleToolsCall on a "worker" thread that BLOCKS in
+// RequestConsent until the main test thread resolves the prompt — the same
+// handshake the editor's panel drives on its UI thread. AllowSession (== the old
+// gate-on) still applies straight through with no prompt (asserted separately).
+
+// Prompt mode surfaces a pending request; Approve applies the undoable write.
+TEST_F(McpConsentedWriteTest, PromptModeApproveAppliesWrite)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(10, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u) << "no consent prompt surfaced";
+    // The write must NOT have applied while the prompt is unresolved.
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    m_Server.ResolveConsent(id, ConsentDecision::Approve);
+
+    const Json resp = call.get();
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(CurrentLayer(), 3u);
+    EXPECT_TRUE(m_History.CanUndo());
+}
+
+// Deny rejects the call with a JSON-RPC error and mutates nothing.
+TEST_F(McpConsentedWriteTest, PromptModeDenyRejectsWrite)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(11, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u);
+    m_Server.ResolveConsent(id, ConsentDecision::Deny);
+
+    const Json resp = call.get();
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+}
+
+// "Approve all this session" applies the current write AND flips the mode to
+// AllowSession, so a subsequent write applies with no prompt.
+TEST_F(McpConsentedWriteTest, ApproveAllFlipsToAllowSession)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+
+    std::future<Json> first = std::async(std::launch::async, [this]
+                                         { return m_Server.HandleMessage(
+                                               MakeCallRequest(12, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u);
+    m_Server.ResolveConsent(id, ConsentDecision::ApproveAll);
+
+    ASSERT_TRUE(first.get()["result"].is_object());
+    EXPECT_EQ(CurrentLayer(), 3u);
+    EXPECT_EQ(m_Server.GetWriteConsentMode(), WriteConsentMode::AllowSession);
+
+    // The next write runs with no prompt outstanding (synchronous — no waiter needed).
+    const Json second = m_Server.HandleMessage(
+        MakeCallRequest(13, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 7 } }));
+    ASSERT_TRUE(second.contains("result"));
+    EXPECT_FALSE(second["result"]["isError"]);
+    EXPECT_TRUE(m_Server.PendingConsents().empty());
+    EXPECT_EQ(CurrentLayer(), 7u);
+}
+
+// No answer within the deadline is a clean timeout error, and nothing is mutated.
+TEST_F(McpConsentedWriteTest, PromptModeTimesOutWhenUnanswered)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    m_Server.SetConsentTimeout(std::chrono::milliseconds(40));
+
+    // Runs on this thread: RequestConsent blocks ~40ms, then returns Timeout.
+    const Json resp = m_Server.HandleMessage(
+        MakeCallRequest(14, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+}
+
+// AllowSession (== the legacy gate-on) never prompts — the queue stays empty.
+TEST_F(McpConsentedWriteTest, AllowSessionAppliesWithoutPrompt)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::AllowSession);
+    const Json resp = m_Server.HandleMessage(
+        MakeCallRequest(15, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } }));
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_TRUE(m_Server.PendingConsents().empty());
     EXPECT_EQ(CurrentLayer(), 3u);
 }
 

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -116,15 +116,20 @@ namespace
 
         // Spin (main test thread) until a worker thread has parked a consent prompt,
         // then return its id — or 0 if none appears within the budget. Mirrors what
-        // the editor's main-thread panel poll does each frame.
-        [[nodiscard]] u64 WaitForPendingConsent()
+        // the editor's main-thread panel poll does each frame. The budget is generous
+        // (default ~30 s) so a heavily-loaded CI box that is slow to schedule the
+        // worker onto RequestConsent doesn't spuriously fail ASSERT_NE(id, 0u); callers
+        // resolve the prompt the instant it appears, so the ceiling is never reached in
+        // the happy path.
+        [[nodiscard]] u64 WaitForPendingConsent(std::chrono::milliseconds budget = std::chrono::seconds(30))
         {
-            for (int i = 0; i < 400; ++i)
+            constexpr auto step = std::chrono::milliseconds(5);
+            for (auto waited = std::chrono::milliseconds(0); waited < budget; waited += step)
             {
                 const auto pending = m_Server.PendingConsents();
                 if (!pending.empty())
                     return pending.front().Id;
-                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                std::this_thread::sleep_for(step);
             }
             return 0;
         }

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -180,7 +180,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_assets_problems` | assets that failed to load or are missing/invalid |
 | `olo_script_get_api` | C# / Lua scripting API digest (types + members), with a type filter |
 | `olo_script_get_last_errors` | recent C# (Mono) / Lua (Sol2) script exceptions |
-| `olo_reload_script` | **(consented write)** reload the C# script assembly — the editor's *Script ▸ Reload assembly* (Ctrl+R) path — so a rebuilt game assembly is picked up without restarting the editor; reports whether scripting is available, whether the reload ran, and the post-reload script-class count. Gated behind "Allow writes" |
+| `olo_reload_script` | **(consented write)** reload the C# script assembly — the editor's *Script ▸ Reload assembly* (Ctrl+R) path — so a rebuilt game assembly is picked up without restarting the editor; reports whether scripting is available, whether the reload ran, and the post-reload script-class count. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
 | `olo_crash_list` / `olo_crash_get` | crash reports under `CrashReports/` |
 | `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera |
 | `olo_camera_get` | the editor camera's pose (position, focal point, yaw/pitch, FOV, clips, viewport size) |
@@ -193,7 +193,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_render_compare_golden` | capture the viewport (optional `camera`/`orbit` pose) and diff it against a golden PNG (`goldenPath`): returns a numeric `similarity`/`rmse`/`ssim` + `pass` verdict; missing golden or `rebase`:true writes the capture as the new baseline (the `OLOENGINE_GOLDEN_REBASE` workflow) |
 | `olo_render_toggle_pass` | flip a post-process / fog feature on/off (`name` + optional `enabled`) — the ephemeral A/B loop: toggle off → `olo_screenshot` → toggle on → `olo_screenshot`. No `name` lists every pass + its live state |
 | `olo_render_set_debug_view` | switch the viewport to a raw AO/SSR/SSGI buffer (`mode`: none/ssao/gtao/ssr/ssgi); reports whether the backing pass is actually running. No `mode` lists the modes + current state |
-| `olo_renderer_settings_set` | **(consented write)** set a multi-valued, session-global renderer / post-process setting — `upscale` (FSR1 spatial-upscale mode), `tonemap` (operator), `renderpath` (forward/forward+/deferred) — to verify a rendering feature live at each value. The enum-valued sibling of `olo_render_toggle_pass`; reports `previousValue` for restore-prior-value (no undo stack). No args lists every setting + current value + allowed values. Gated behind "Allow writes" |
+| `olo_renderer_settings_set` | **(consented write)** set a multi-valued, session-global renderer / post-process setting — `upscale` (FSR1 spatial-upscale mode), `tonemap` (operator), `renderpath` (forward/forward+/deferred) — to verify a rendering feature live at each value. The enum-valued sibling of `olo_render_toggle_pass`; reports `previousValue` for restore-prior-value (no undo stack). No args lists every setting + current value + allowed values. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
 | `olo_scene_set_time_of_day` | move the procedural sky's sun to a 24-hour clock time (`hours` 0–24) for lighting iteration — ephemeral session override of the sun direction, never written to the scene. `clear`:true restores the authored sun; no args reports the current override |
 | `olo_scene_set_sun_angle` | aim the procedural sky's sun directly from a `yaw` (azimuth) / `pitch` (elevation) pair — the precise sibling of `olo_scene_set_time_of_day`, same ephemeral session override. `clear`:true restores; no args reports state |
 | `olo_render_why_not_visible` | explain why one entity (`entity`) is NOT on screen — the "why can't I see my mesh?" debugger: root-cause `reasonCode`, summary, ordered checks, and the raw render facts |
@@ -203,6 +203,40 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_physics_raycast` | cast a ray (`origin` + `direction`\|`to`) through the live physics world: closest hit, or up to `maxHits` ordered hits (entity, position, normal, distance) |
 | `olo_physics_overlap` | bodies overlapping a sphere (`radius`) or box (`halfExtents`) at `origin`; requires Play mode |
 | `olo_physics_why_no_collision` | explain why two entities (`a`, `b`) are NOT colliding — the "player falls through the floor" debugger: root-cause `reasonCode`, summary, ordered checks, and per-entity facts |
+
+### Write consent — Disabled / Prompt / Allow all (issue #306 item C)
+
+Every project-mutating tool (`olo_set_collision_layer`, `olo_entity_set_field`,
+`olo_reload_script`, `olo_renderer_settings_set` — anything marked **(consented
+write)** above) is gated in the MCP panel by a three-way **Agent writes** control.
+It is **off by default and never persisted**, so every editor launch starts read-only
+and the human at the editor opts in for the session:
+
+- **Disabled** (default) — a write tool is refused at dispatch with a clean JSON-RPC
+  error; the server is read-only with respect to your project. The read-only
+  diagnostics and the ephemeral editor-only tools (camera / viewport / render
+  overrides) are unaffected by this control.
+- **Prompt** — each write pops a **per-action consent modal** in the editor showing the
+  tool and the exact arguments the agent wants to apply. The agent's `tools/call`
+  **blocks** until you click **Approve** (apply this one), **Deny** (reject it — the
+  call returns a "denied by the editor user" error), or **Approve all this session**
+  (apply it and switch to *Allow all* for the rest of the session). An unanswered
+  prompt times out (120 s) and the call returns a timeout error. The modal renders even
+  when the MCP panel window is closed, so a write is never left silently blocked.
+- **Allow all** — writes auto-apply for the session with no prompt (the legacy
+  "Allow writes" behaviour). Use it when you're actively driving a batch of edits and
+  don't want to click through each one.
+
+Every entity/component write still routes through the editor's **undo stack** — an
+approved change is a single **Ctrl-Z** — so *Prompt* and *Allow all* differ only in
+whether you confirm each action up front, not in reversibility. (The renderer-settings
+and sun/time-of-day writes are session-global and restore-prior-value instead; see
+those sections.)
+
+Threading: the write handler runs on a cpp-httplib worker thread and blocks there
+while the main (UI) thread renders the modal and records your decision — the same
+main-thread-marshal discipline the read tools use, so the editor's render loop never
+blocks on an agent.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
@@ -368,9 +402,11 @@ component bindings.
 ```
 
 - **It is a consented WRITE tool** (issue #306 item C): like the other writes it is
-  refused unless **"Allow writes"** is enabled in the editor's MCP panel (off by
-  default). Reloading runs the user's freshly-built assembly code, so it deliberately
-  crosses the read-only line — hence the gate.
+  refused while **Agent writes** is *Disabled* in the editor's MCP panel (the default),
+  prompts for per-action consent in *Prompt* mode, and applies directly in *Allow all*
+  — see [Write consent](#write-consent--disabled--prompt--allow-all-issue-306-item-c).
+  Reloading runs the user's freshly-built assembly code, so it deliberately crosses the
+  read-only line — hence the gate.
 - **Whole-assembly, no arguments.** C# reload has no per-script granularity (the editor
   reloads the entire app assembly), so the tool takes no parameters — exactly mirroring
   the parameterless Ctrl+R.
@@ -457,7 +493,8 @@ so multi-setting / multi-angle rendering verification of a new feature wasn't
 possible from a session.
 
 It is a **consented WRITE tool** (issue #306 item C): like the other writes it is
-refused unless **"Allow writes"** is enabled in the MCP panel (off by default). A
+refused while **Agent writes** is *Disabled* in the MCP panel (the default), prompts
+per-action in *Prompt* mode, and applies directly in *Allow all*. A
 settings change crosses the read-only line — but it is **session-scoped and
 restorable, never a project mutation**: the tool mutates only the renderer's
 session-global `PostProcessSettings` / `RendererSettings` (the same structs


### PR DESCRIPTION
…t handling

- Introduced a new consent modal that renders every frame to ensure user actions are not blocked.
- Added consent management logic in McpServer for handling write permissions based on user decisions.
- Updated MCP panel to allow users to set write consent modes: Disabled, Prompt, and Allow all.
- Enhanced tests to validate the new consent flow and its integration with project-mutating tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a three-mode write permission control for MCP actions: disabled, prompt for each write, or allow for the session.
  * Added a per-action consent dialog so users can approve, deny, or allow all writes for the session.
  * Expanded diagnostics docs to explain the new write-consent behavior.

* **Bug Fixes**
  * Improved consent handling so prompts no longer get stuck after stopping and restarting the server.
  * Ensured pending write requests time out or resolve cleanly without leaving actions blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->