### PR TITLE
feat(mcp): real GPU timings end-to-end — whole-frame timer, gpuWaitMs…

### DIFF
--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -153,6 +153,7 @@ Show-Tool 'olo_perf_snapshot' @{} | Out-Null
 Show-Tool 'olo_perf_bottlenecks' @{} | Out-Null
 Show-Tool 'olo_perf_frame_history' @{ points = 8 } | Out-Null
 Show-Tool 'olo_perf_capture_frame' @{ topK = 5 } | Out-Null
+Show-Tool 'olo_perf_pass_timings' @{} | Out-Null
 
 # 19-20. Shader tools (olo_shader_list discovers a real name for olo_shader_get)
 Show-Tool 'olo_shader_errors' @{} | Out-Null

--- a/OloEditor/src/MCP/McpPassTimings.h
+++ b/OloEditor/src/MCP/McpPassTimings.h
@@ -1,0 +1,119 @@
+#pragma once
+
+// Pure JSON shaping for the olo_perf_pass_timings MCP tool (issue #316: split
+// whole-frame GPU time by render-graph pass — Shadow vs Scene vs GTAO vs Bloom
+// vs ToneMap...). The MCP handler in McpTools.cpp gathers, inside a MarshalRead:
+//   - per-pass GPU times from GPUPassTimerPool (always-on GL_TIMESTAMP pairs,
+//     resolved 1-3 frames after issue),
+//   - per-pass CPU times from the live RenderGraph's last execution timings,
+//   - frame totals from RendererProfiler,
+// pre-resolves them into the plain input structs below, and hands them here.
+//
+// Keeping the shaping in free functions over engine-free inputs means it
+// unit-tests directly against synthetic data — the test binary compiles this
+// header but deliberately NOT McpTools.cpp. Mirrors the sibling pattern of
+// McpFrameBreakdown.h / McpRenderExplain.h.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace OloEngine::MCP::PassTimings
+{
+    using Json = nlohmann::json;
+
+    // One render-graph pass's GPU time (execution order preserved).
+    struct GpuPassEntry
+    {
+        std::string Name;
+        f64 GpuMs = 0.0;
+    };
+
+    // One render-graph pass's CPU (submission/dispatch) time.
+    struct CpuPassEntry
+    {
+        std::string Name;
+        f64 CpuMs = 0.0;
+    };
+
+    struct FrameTotals
+    {
+        f64 FrameTimeMs = 0.0;
+        f64 CpuMs = 0.0;
+        f64 GpuMs = 0.0;     // whole-frame GPU time (timestamp span)
+        f64 GpuWaitMs = 0.0; // CPU time blocked on the frame fence
+        // How many frames old the resolved GPU numbers are (0 = nothing
+        // resolved yet). GPU results always lag 1-3 frames behind the CPU
+        // numbers; transient name mismatches between the two lists are normal.
+        u64 GpuResultsAgeFrames = 0;
+    };
+
+    // Millisecond values are sub-ms for many passes — keep 3 decimals.
+    [[nodiscard]] inline f64 Round3(f64 v)
+    {
+        return std::round(v * 1000.0) / 1000.0;
+    }
+
+    // Join the GPU list (primary, execution order) with CPU times by pass name;
+    // CPU-only passes (not GPU-timed this frame — pool overflow or transient
+    // topology change between the resolved GPU frame and the current CPU frame)
+    // are appended with gpuMs 0.
+    [[nodiscard]] inline Json BuildPassTimings(const std::vector<GpuPassEntry>& gpuPasses,
+                                               const std::vector<CpuPassEntry>& cpuPasses,
+                                               const FrameTotals& totals)
+    {
+        Json passes = Json::array();
+        f64 passGpuTotal = 0.0;
+
+        std::vector<bool> cpuUsed(cpuPasses.size(), false);
+        const auto findCpuMs = [&](const std::string& name) -> f64
+        {
+            for (sizet i = 0; i < cpuPasses.size(); ++i)
+            {
+                if (!cpuUsed[i] && cpuPasses[i].Name == name)
+                {
+                    cpuUsed[i] = true;
+                    return cpuPasses[i].CpuMs;
+                }
+            }
+            return 0.0;
+        };
+
+        for (const auto& gpuPass : gpuPasses)
+        {
+            passGpuTotal += gpuPass.GpuMs;
+            passes.push_back(Json{ { "pass", gpuPass.Name },
+                                   { "gpuMs", Round3(gpuPass.GpuMs) },
+                                   { "cpuMs", Round3(findCpuMs(gpuPass.Name)) } });
+        }
+
+        for (sizet i = 0; i < cpuPasses.size(); ++i)
+        {
+            if (cpuUsed[i])
+                continue;
+            passes.push_back(Json{ { "pass", cpuPasses[i].Name },
+                                   { "gpuMs", 0.0 },
+                                   { "cpuMs", Round3(cpuPasses[i].CpuMs) } });
+        }
+
+        Json o;
+        o["frame"] = Json{ { "frameTimeMs", Round3(totals.FrameTimeMs) },
+                           { "cpuMs", Round3(totals.CpuMs) },
+                           { "gpuMs", Round3(totals.GpuMs) },
+                           { "gpuWaitMs", Round3(totals.GpuWaitMs) } };
+        o["passes"] = std::move(passes);
+        o["passGpuTotalMs"] = Round3(passGpuTotal);
+        // GPU time inside the frame span but between/outside timed passes
+        // (barriers, transient materialization, HZB rebuild, capture readbacks).
+        // Negative values are clamped: pass spans can overlap the frame span's
+        // edges by a timestamp tick.
+        o["unattributedGpuMs"] = Round3(totals.GpuMs > passGpuTotal ? totals.GpuMs - passGpuTotal : 0.0);
+        o["gpuResultsAgeFrames"] = totals.GpuResultsAgeFrames;
+        return o;
+    }
+} // namespace OloEngine::MCP::PassTimings

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -5,6 +5,7 @@
 #include "MCP/McpScriptApi.h"
 #include "MCP/McpFrameBreakdown.h"
 #include "MCP/McpGoldenCompare.h"
+#include "MCP/McpPassTimings.h"
 #include "MCP/McpPhysicsExplain.h"
 #include "MCP/McpRenderExplain.h"
 #include "MCP/McpRenderGraphTopology.h"
@@ -26,6 +27,7 @@
 #include "OloEngine/Renderer/Debug/CapturedFrameData.h"
 #include "OloEngine/Renderer/Debug/CommandPacketDebugger.h"
 #include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
 #include "OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h"
 #include "OloEngine/Renderer/Debug/RendererMemoryTracker.h"
@@ -466,6 +468,7 @@ namespace OloEngine::MCP
                 o["frameTimeMs"] = Round2(f.m_FrameTime);
                 o["cpuMs"] = Round2(f.m_CPUTime);
                 o["gpuMs"] = Round2(f.m_GPUTime);
+                o["gpuWaitMs"] = Round2(f.m_GPUWaitTime);
                 o["drawCalls"] = f.m_DrawCalls;
                 o["instancedDrawCalls"] = f.m_InstancedDrawCalls;
                 o["instancesRendered"] = f.m_InstancesRendered;
@@ -601,6 +604,43 @@ namespace OloEngine::MCP
                         "renderer's timer-query pool. For the per-command / per-stage structural breakdown "
                         "(command list, draw keys, sort/batch analysis), use olo_render_frame_breakdown.";
             return ToolResult::Text(o.dump(2));
+        }
+
+        // ---- olo_perf_pass_timings (main-marshaled) -----------------------------
+        // Per-render-graph-pass GPU/CPU times: GPU from the always-on
+        // GPUPassTimerPool (GL_TIMESTAMP pairs around each executed pass, resolved
+        // 1-3 frames after issue), CPU from the live graph's last execution
+        // timings, frame totals from the profiler. Shaping lives in the pure
+        // McpPassTimings.h so it unit-tests without this TU.
+        ToolResult Handle_PerfPassTimings(McpServer& server, const Json& /*args*/)
+        {
+            Json j = server.MarshalRead([]() -> Json
+                                        {
+                const auto& pool = GPUPassTimerPool::GetInstance();
+
+                std::vector<PassTimings::GpuPassEntry> gpuPasses;
+                for (const auto& timing : pool.GetLastPassTimingsCopy())
+                    gpuPasses.push_back(PassTimings::GpuPassEntry{ timing.Name, timing.GpuMs });
+
+                std::vector<PassTimings::CpuPassEntry> cpuPasses;
+                if (const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph())
+                {
+                    for (const auto& timing : graph->GetLastExecutionTimings())
+                        cpuPasses.push_back(PassTimings::CpuPassEntry{ timing.NodeName, timing.CpuMs });
+                }
+
+                const RendererProfiler::FrameData& f = RendererProfiler::GetInstance().GetCurrentFrameData();
+                PassTimings::FrameTotals totals;
+                totals.FrameTimeMs = f.m_FrameTime;
+                totals.CpuMs = f.m_CPUTime;
+                totals.GpuMs = f.m_GPUTime;
+                totals.GpuWaitMs = f.m_GPUWaitTime;
+                totals.GpuResultsAgeFrames =
+                    (pool.GetLastResolvedFrameNumber() > 0 && pool.GetCurrentFrameNumber() >= pool.GetLastResolvedFrameNumber())
+                        ? pool.GetCurrentFrameNumber() - pool.GetLastResolvedFrameNumber()
+                        : 0;
+                return PassTimings::BuildPassTimings(gpuPasses, cpuPasses, totals); });
+            return ToolResult::Structured(j);
         }
 
         // Defined further down (next to the topology export handler that shares it);
@@ -4026,6 +4066,7 @@ namespace OloEngine::MCP
                                     .Prop("commandPackets", Schema::Int().Min(0))
                                     .Prop("sortingMs", Schema::Number())
                                     .Prop("cullingMs", Schema::Number())
+                                    .Prop("gpuWaitMs", Schema::Number().Desc("CPU ms spent blocked on the GPU frame fence — high values mean GPU-bound."))
                                     .Required({ "fps", "frameTimeMs", "cpuMs", "gpuMs", "drawCalls", "triangles" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfSnapshot;
@@ -4081,6 +4122,38 @@ namespace OloEngine::MCP
                                    .NoAdditional();
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfCaptureFrame;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_perf_pass_timings";
+            tool.Toolset = "perf";
+            tool.Title = "Per-pass GPU timings";
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "Whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs "
+                "ToneMap...). Each pass carries its GPU time (always-on timestamp queries, resolved a few "
+                "frames after issue) and its CPU dispatch time from the live graph. Frame totals include "
+                "gpuWaitMs (CPU blocked on the GPU fence — the direct GPU-bound signal); unattributedGpuMs "
+                "is frame GPU time spent between/outside the timed passes.";
+            tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("frame", Schema::Object()
+                                                       .Prop("frameTimeMs", Schema::Number())
+                                                       .Prop("cpuMs", Schema::Number())
+                                                       .Prop("gpuMs", Schema::Number())
+                                                       .Prop("gpuWaitMs", Schema::Number()))
+                                    .Prop("passes", Schema::Array(Schema::Object()
+                                                                      .Prop("pass", Schema::String())
+                                                                      .Prop("gpuMs", Schema::Number())
+                                                                      .Prop("cpuMs", Schema::Number())))
+                                    .Prop("passGpuTotalMs", Schema::Number())
+                                    .Prop("unattributedGpuMs", Schema::Number())
+                                    .Prop("gpuResultsAgeFrames", Schema::Int().Min(0).Desc("How many frames old the GPU numbers are (results resolve 1-3 frames after issue)."))
+                                    .Required({ "frame", "passes", "passGpuTotalMs" });
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_PerfPassTimings;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -682,6 +682,8 @@
 		"OloEngine/Renderer/Debug/FrameCaptureManager.cpp"
 		"OloEngine/Renderer/Debug/GPUTimerQueryPool.h"
 		"OloEngine/Renderer/Debug/GPUTimerQueryPool.cpp"
+		"OloEngine/Renderer/Debug/GPUPassTimerPool.h"
+		"OloEngine/Renderer/Debug/GPUPassTimerPool.cpp"
 		"OloEngine/Renderer/Debug/RendererMemoryTracker.h"
 		"OloEngine/Renderer/Debug/RendererMemoryTracker.cpp"
 		"OloEngine/Renderer/Debug/RendererProfiler.h"

--- a/OloEngine/src/OloEngine/Renderer/Commands/FrameResourceManager.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/FrameResourceManager.cpp
@@ -3,6 +3,8 @@
 
 #include <glad/gl.h>
 
+#include <chrono>
+
 namespace OloEngine
 {
     FrameResourceManager& FrameResourceManager::Get()
@@ -80,11 +82,14 @@ namespace OloEngine
         }
 
         u32 currentIndex = m_CurrentFrameIndex.load(std::memory_order_acquire);
+        m_LastBeginFrameWaitMs = 0.0;
 
         // When double-buffering, we need to wait for the frame we're about to reuse
         if (m_DoubleBufferingEnabled && m_TotalFrameCount >= NUM_BUFFERED_FRAMES)
         {
+            const auto waitStart = std::chrono::steady_clock::now();
             WaitForFrame(currentIndex);
+            m_LastBeginFrameWaitMs = std::chrono::duration<f64, std::milli>(std::chrono::steady_clock::now() - waitStart).count();
 
             // Only reset allocators if the GPU fence was actually signaled;
             // otherwise the GPU may still be reading this frame's data.

--- a/OloEngine/src/OloEngine/Renderer/Commands/FrameResourceManager.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/FrameResourceManager.h
@@ -102,6 +102,15 @@ namespace OloEngine
             return m_TotalFrameCount;
         }
 
+        // CPU time (ms) the most recent BeginFrame() spent blocked on the GPU
+        // fence (glClientWaitSync). 0.0 when the fence was already signaled.
+        // This is the direct "CPU waited for the GPU" measure — feed it to
+        // RendererProfiler::AddGPUWaitTime so cpu/gpuWait metrics stay honest.
+        f64 GetLastBeginFrameWaitMs() const
+        {
+            return m_LastBeginFrameWaitMs;
+        }
+
         // Check if GPU has finished a specific frame
         bool IsFrameComplete(u32 frameIndex) const;
 
@@ -141,6 +150,7 @@ namespace OloEngine
         // Atomic frame index: main thread writes with release, worker threads read with acquire
         std::atomic<u32> m_CurrentFrameIndex{ 0 };
         u64 m_TotalFrameCount = 0;
+        f64 m_LastBeginFrameWaitMs = 0.0;
         bool m_DoubleBufferingEnabled = true;
         bool m_Initialized = false;
     };

--- a/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
@@ -48,7 +48,18 @@ namespace OloEngine
 
         // Also stop from CaptureNextFrame state
         expected = CaptureState::CaptureNextFrame;
-        m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel);
+        if (m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel))
+        {
+            return;
+        }
+
+        // And from AwaitingGpuResults — the parked one-shot frame is dropped.
+        expected = CaptureState::AwaitingGpuResults;
+        if (m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel))
+        {
+            m_PendingFrame = CapturedFrameData{};
+            m_CurrentPassIndex = -1;
+        }
     }
 
     std::optional<CapturedFrameData> FrameCaptureManager::GetSelectedFrame() const
@@ -156,13 +167,92 @@ namespace OloEngine
         pass.Stats.TotalFrameTimeMs = sortTimeMs + batchTimeMs + executeTimeMs;
     }
 
+    CapturedPassData* FrameCaptureManager::FindSourcePass()
+    {
+        if (!m_PendingFrame.SourcePassName.empty())
+        {
+            for (auto& pass : m_PendingFrame.Passes)
+            {
+                if (pass.PassName == m_PendingFrame.SourcePassName)
+                    return &pass;
+            }
+        }
+        return m_PendingFrame.Passes.empty() ? nullptr : &m_PendingFrame.Passes.front();
+    }
+
+    void FrameCaptureManager::ApplyGpuTimingsToSource(const std::vector<f64>& resultsMs)
+    {
+        if (resultsMs.empty())
+            return;
+
+        CapturedPassData* source = FindSourcePass();
+        if (!source)
+            return;
+
+        // The query index is the command's execution-order position in the
+        // bucket ExecuteWithGPUTiming ran, so apply positionally onto the
+        // final (executed) list.
+        auto& timedCommands = source->HasPostBatch
+                                  ? source->PostBatchCommands
+                                  : (source->HasPostSort ? source->PostSortCommands : source->PreSortCommands);
+        const u32 count = std::min(static_cast<u32>(timedCommands.size()), static_cast<u32>(resultsMs.size()));
+        for (u32 i = 0; i < count; ++i)
+            timedCommands[i].SetGpuTimeMs(resultsMs[i]);
+    }
+
     void FrameCaptureManager::CommitFrame()
     {
         OLO_PROFILE_FUNCTION();
-        if (!IsCapturing())
-            return;
 
-        CommitPendingFrame(++m_CommittedFrameCounter);
+        switch (m_State.load(std::memory_order_acquire))
+        {
+            case CaptureState::CaptureNextFrame:
+            {
+                // The per-draw GL_TIME_ELAPSED queries this frame just issued
+                // are not readable yet (the GPU is still executing the frame).
+                // Park the pending frame and resolve+commit on a later
+                // CommitFrame call instead of committing all-zero timings.
+                m_GpuResolveWaitFrames = 0;
+                m_State.store(CaptureState::AwaitingGpuResults, std::memory_order_release);
+                break;
+            }
+            case CaptureState::AwaitingGpuResults:
+            {
+                std::vector<f64> resultsMs;
+                const bool resolved = GPUTimerQueryPool::GetInstance().TryGetIssuedQueryResultsMs(resultsMs);
+                ++m_GpuResolveWaitFrames;
+                if (!resolved && m_GpuResolveWaitFrames < kMaxGpuResolveWaitFrames)
+                    return; // try again next frame
+
+                if (resolved)
+                    ApplyGpuTimingsToSource(resultsMs);
+                else
+                    OLO_CORE_WARN("FrameCaptureManager: GPU timer results not readable after {} frames — committing capture without per-draw GPU times", kMaxGpuResolveWaitFrames);
+
+                CommitPendingFrame(++m_CommittedFrameCounter);
+                break;
+            }
+            case CaptureState::Recording:
+            {
+                // Continuous recording: ExecuteWithGPUTiming ticks the query pool
+                // every frame, so the pool's readable results (from the PREVIOUS
+                // frame's near-identical command list) are the best available
+                // approximation without holding every frame back.
+                const auto& gpuTimer = GPUTimerQueryPool::GetInstance();
+                if (gpuTimer.IsInitialized() && gpuTimer.GetReadableQueryCount() > 0)
+                {
+                    std::vector<f64> resultsMs(gpuTimer.GetReadableQueryCount());
+                    for (u32 i = 0; i < gpuTimer.GetReadableQueryCount(); ++i)
+                        resultsMs[i] = gpuTimer.GetQueryResultMs(i);
+                    ApplyGpuTimingsToSource(resultsMs);
+                }
+                CommitPendingFrame(++m_CommittedFrameCounter);
+                break;
+            }
+            case CaptureState::Idle:
+            default:
+                break;
+        }
     }
 
     void FrameCaptureManager::OnFrameEnd(u32 frameNumber, f64 sortTimeMs, f64 batchTimeMs, f64 executeTimeMs)
@@ -172,8 +262,16 @@ namespace OloEngine
             return;
 
         // Legacy single-pass entrypoint: stash the timings on the current/implicit
-        // pass, then commit with the caller-supplied frame number.
+        // pass, then commit with the caller-supplied frame number. GPU timings use
+        // the pool's readable (previous-tick) results, matching the old behaviour.
         RecordPassTimings(sortTimeMs, batchTimeMs, executeTimeMs);
+        if (const auto& gpuTimer = GPUTimerQueryPool::GetInstance(); gpuTimer.IsInitialized() && gpuTimer.GetReadableQueryCount() > 0)
+        {
+            std::vector<f64> resultsMs(gpuTimer.GetReadableQueryCount());
+            for (u32 i = 0; i < gpuTimer.GetReadableQueryCount(); ++i)
+                resultsMs[i] = gpuTimer.GetQueryResultMs(i);
+            ApplyGpuTimingsToSource(resultsMs);
+        }
         CommitPendingFrame(frameNumber);
     }
 
@@ -185,38 +283,17 @@ namespace OloEngine
         // (legacy) view consumed by the markdown report, olo_perf_capture_frame and
         // the single-pass tests. Prefer the recorded SourcePassName; fall back to
         // the first captured pass (the implicit entry the direct-API hooks create
-        // when no BeginPass() was issued).
-        CapturedPassData* source = nullptr;
-        if (!m_PendingFrame.SourcePassName.empty())
-        {
-            for (auto& pass : m_PendingFrame.Passes)
-            {
-                if (pass.PassName == m_PendingFrame.SourcePassName)
-                {
-                    source = &pass;
-                    break;
-                }
-            }
-        }
-        if (!source && !m_PendingFrame.Passes.empty())
-            source = &m_PendingFrame.Passes.front();
+        // when no BeginPass() was issued). Per-command GPU timings have already
+        // been applied by ApplyGpuTimingsToSource (deferred one-shot resolve, or
+        // previous-tick results for Recording / the legacy OnFrameEnd path), so
+        // the copies below carry them into the top-level view.
+        CapturedPassData* source = FindSourcePass();
 
         bool hasPostSort = false;
         bool hasPostBatch = false;
         FrameCaptureStats sourceStats;
         if (source)
         {
-            // Apply GPU timing to the source pass's execution-order list FIRST, so
-            // both the per-pass entry and the derived top-level list carry GPU times.
-            if (const auto& gpuTimer = GPUTimerQueryPool::GetInstance(); gpuTimer.IsInitialized() && gpuTimer.GetReadableQueryCount() > 0)
-            {
-                auto& timedCommands = source->HasPostBatch
-                                          ? source->PostBatchCommands
-                                          : (source->HasPostSort ? source->PostSortCommands : source->PreSortCommands);
-                for (u32 i = 0; i < static_cast<u32>(timedCommands.size()) && i < gpuTimer.GetReadableQueryCount(); ++i)
-                    timedCommands[i].SetGpuTimeMs(gpuTimer.GetQueryResultMs(i));
-            }
-
             m_PendingFrame.PreSortCommands = source->PreSortCommands;
             m_PendingFrame.PostSortCommands = source->PostSortCommands;
             m_PendingFrame.PostBatchCommands = source->PostBatchCommands;
@@ -306,10 +383,15 @@ namespace OloEngine
             m_CaptureGeneration.fetch_add(1, std::memory_order_release);
         }
 
-        // State machine transition (single-frame capture returns to Idle; recording
-        // stays in Recording for the next frame).
+        // State machine transition (a one-shot capture — committed either directly
+        // via the legacy OnFrameEnd path or from the deferred AwaitingGpuResults
+        // hold — returns to Idle; recording stays in Recording for the next frame).
         auto expected = CaptureState::CaptureNextFrame;
-        m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel);
+        if (!m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel))
+        {
+            expected = CaptureState::AwaitingGpuResults;
+            m_State.compare_exchange_strong(expected, CaptureState::Idle, std::memory_order_acq_rel);
+        }
 
         // Re-init pending frame for the next capture
         m_PendingFrame = CapturedFrameData{};

--- a/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.cpp
@@ -212,22 +212,33 @@ namespace OloEngine
                 // are not readable yet (the GPU is still executing the frame).
                 // Park the pending frame and resolve+commit on a later
                 // CommitFrame call instead of committing all-zero timings.
+                // CAS rather than store: a concurrent StopRecording() may have
+                // cancelled the capture since the switch loaded the state — an
+                // unconditional store would resurrect it.
                 m_GpuResolveWaitFrames = 0;
-                m_State.store(CaptureState::AwaitingGpuResults, std::memory_order_release);
+                auto expected = CaptureState::CaptureNextFrame;
+                m_State.compare_exchange_strong(expected, CaptureState::AwaitingGpuResults, std::memory_order_acq_rel);
                 break;
             }
             case CaptureState::AwaitingGpuResults:
             {
+                const auto& gpuTimer = GPUTimerQueryPool::GetInstance();
                 std::vector<f64> resultsMs;
-                const bool resolved = GPUTimerQueryPool::GetInstance().TryGetIssuedQueryResultsMs(resultsMs);
-                ++m_GpuResolveWaitFrames;
-                if (!resolved && m_GpuResolveWaitFrames < kMaxGpuResolveWaitFrames)
-                    return; // try again next frame
+                bool resolved = false;
+                if (gpuTimer.IsInitialized())
+                {
+                    resolved = gpuTimer.TryGetIssuedQueryResultsMs(resultsMs);
+                    ++m_GpuResolveWaitFrames;
+                    if (!resolved && m_GpuResolveWaitFrames < kMaxGpuResolveWaitFrames)
+                        return; // try again next frame
+                }
+                // Pool never initialized (the capture frame issued no queries):
+                // nothing will ever resolve — commit immediately without timings.
 
                 if (resolved)
                     ApplyGpuTimingsToSource(resultsMs);
                 else
-                    OLO_CORE_WARN("FrameCaptureManager: GPU timer results not readable after {} frames — committing capture without per-draw GPU times", kMaxGpuResolveWaitFrames);
+                    OLO_CORE_WARN("FrameCaptureManager: GPU timer results not available — committing capture without per-draw GPU times");
 
                 CommitPendingFrame(++m_CommittedFrameCounter);
                 break;

--- a/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/FrameCaptureManager.h
@@ -16,9 +16,13 @@ namespace OloEngine
     // Recording state machine
     enum class CaptureState : u8
     {
-        Idle = 0,         // Not capturing
-        CaptureNextFrame, // Will capture the next frame, then return to Idle
-        Recording         // Continuously capturing until stopped
+        Idle = 0,          // Not capturing
+        CaptureNextFrame,  // Will capture the next frame, then await GPU results
+        Recording,         // Continuously capturing until stopped
+        AwaitingGpuResults // One-shot frame captured; holding the commit until the
+                           // GPU timer queries issued during the capture frame are
+                           // readable (they resolve one-plus frames later). No new
+                           // recording happens in this state.
     };
 
     // Manages frame capture/recording for the command bucket visualization tool
@@ -37,7 +41,8 @@ namespace OloEngine
         }
         bool IsCapturing() const
         {
-            return m_State.load(std::memory_order_acquire) != CaptureState::Idle;
+            const CaptureState state = m_State.load(std::memory_order_acquire);
+            return state == CaptureState::CaptureNextFrame || state == CaptureState::Recording;
         }
 
         // Configuration
@@ -84,7 +89,14 @@ namespace OloEngine
         // pending frame has accumulated every command-bucket pass. Finalises the
         // frame (derives the top-level source-pass view, computes stats, snapshots
         // render state, pushes it to the captured-frame ring) and advances the
-        // state machine. No-op when not capturing. Frame numbers auto-increment.
+        // state machine. No-op when idle. Frame numbers auto-increment.
+        //
+        // One-shot captures are committed DEFERRED (issue #316 Part 4 follow-up):
+        // the capture frame's per-draw GL_TIME_ELAPSED queries only become
+        // readable a frame-plus later, so the first CommitFrame after the capture
+        // parks the pending frame in AwaitingGpuResults and a subsequent
+        // CommitFrame resolves the queries into it before pushing it to the ring.
+        // Continuous Recording keeps the immediate previous-frame-results commit.
         void CommitFrame();
 
         // Legacy single-pass commit. Records the current pass's timings and commits
@@ -122,6 +134,15 @@ namespace OloEngine
         // Deep-copy all commands from a bucket into a vector
         void DeepCopyCommands(const CommandBucket& bucket, std::vector<CapturedCommandData>& outCommands, bool useSortedOrder) const;
 
+        // Locate the pending frame's source pass (SourcePassName match, else the
+        // first captured pass). Null when nothing was captured.
+        CapturedPassData* FindSourcePass();
+
+        // Write per-command GPU times (execution order) onto the source pass's
+        // final command list. Must run BEFORE CommitPendingFrame copies the
+        // source lists into the top-level view.
+        void ApplyGpuTimingsToSource(const std::vector<f64>& resultsMs);
+
         // Return the current per-pass entry being built, creating an implicit one
         // when no BeginPass() has run yet (the legacy single-pass direct-API path).
         CapturedPassData& EnsureCurrentPass();
@@ -143,6 +164,12 @@ namespace OloEngine
         CapturedFrameData m_PendingFrame;
         i32 m_CurrentPassIndex = -1;
         u32 m_CommittedFrameCounter = 0;
+
+        // Frames spent in AwaitingGpuResults. If the queries still aren't
+        // readable after kMaxGpuResolveWaitFrames the capture commits with
+        // whatever is available rather than hanging the ring forever.
+        static constexpr u32 kMaxGpuResolveWaitFrames = 8;
+        u32 m_GpuResolveWaitFrames = 0;
 
         std::deque<CapturedFrameData> m_CapturedFrames;
 

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.cpp
@@ -1,0 +1,190 @@
+#include "OloEnginePCH.h"
+#include "GPUPassTimerPool.h"
+#include "OloEngine/Core/Log.h"
+
+#include <glad/gl.h>
+
+namespace OloEngine
+{
+    GPUPassTimerPool& GPUPassTimerPool::GetInstance()
+    {
+        static GPUPassTimerPool instance;
+        return instance;
+    }
+
+    GPUPassTimerPool::~GPUPassTimerPool()
+    {
+        OLO_CORE_ASSERT(!m_Initialized, "GPUPassTimerPool::~GPUPassTimerPool: Shutdown() was not called before destruction!");
+    }
+
+    void GPUPassTimerPool::Initialize(u32 maxPassesPerFrame)
+    {
+        OLO_PROFILE_FUNCTION();
+        if (m_Initialized)
+            return;
+
+        m_MaxPasses = maxPassesPerFrame;
+
+        const u32 queriesPerSlot = 2 + (2 * maxPassesPerFrame);
+        for (auto& slot : m_Slots)
+        {
+            slot.Queries.resize(queriesPerSlot, 0);
+            glCreateQueries(GL_TIMESTAMP, static_cast<GLsizei>(queriesPerSlot), slot.Queries.data());
+            slot.PassNames.resize(maxPassesPerFrame);
+            slot.PassCount = 0;
+            slot.FrameNumber = 0;
+            slot.Pending = false;
+        }
+
+        m_WriteSlot = 0;
+        m_FrameCounter = 0;
+        m_Active = false;
+        m_PassOpen = false;
+        m_LastFrameGpuMs = 0.0;
+        m_LastResolvedFrame = 0;
+        m_LastPassTimings.clear();
+        m_Initialized = true;
+
+        OLO_CORE_INFO("GPUPassTimerPool: Initialized with {} pass slots x {} frames in flight", maxPassesPerFrame, kSlotCount);
+    }
+
+    void GPUPassTimerPool::Shutdown()
+    {
+        OLO_PROFILE_FUNCTION();
+        if (!m_Initialized)
+            return;
+
+        for (auto& slot : m_Slots)
+        {
+            if (!slot.Queries.empty())
+            {
+                glDeleteQueries(static_cast<GLsizei>(slot.Queries.size()), slot.Queries.data());
+                slot.Queries.clear();
+            }
+            slot.PassNames.clear();
+            slot.Pending = false;
+        }
+
+        m_LastPassTimings.clear();
+        m_Initialized = false;
+        m_Active = false;
+        m_PassOpen = false;
+
+        OLO_CORE_INFO("GPUPassTimerPool: Shutdown");
+    }
+
+    void GPUPassTimerPool::BeginFrame()
+    {
+        OLO_PROFILE_FUNCTION();
+        if (!m_Initialized)
+            return;
+
+        // Resolve pending slots oldest-first so the published results always end
+        // on the newest fully-completed frame. Walking (m_WriteSlot + i) visits
+        // slots in ascending write age.
+        for (u32 i = 1; i <= kSlotCount; ++i)
+        {
+            FrameSlot& slot = m_Slots[(m_WriteSlot + i) % kSlotCount];
+            if (slot.Pending)
+                TryResolveSlot(slot, false);
+        }
+
+        m_WriteSlot = (m_WriteSlot + 1) % kSlotCount;
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+
+        // About to overwrite: if the GPU is somehow >kSlotCount-1 frames behind,
+        // drop the stale slot rather than stalling on it.
+        if (slot.Pending)
+            TryResolveSlot(slot, true);
+
+        ++m_FrameCounter;
+        slot.FrameNumber = m_FrameCounter;
+        slot.PassCount = 0;
+        slot.Pending = false;
+
+        glQueryCounter(slot.Queries[0], GL_TIMESTAMP);
+        m_Active = true;
+        m_PassOpen = false;
+    }
+
+    void GPUPassTimerPool::EndFrame()
+    {
+        if (!m_Initialized || !m_Active)
+            return;
+
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+        glQueryCounter(slot.Queries[1], GL_TIMESTAMP);
+        slot.Pending = true;
+        m_Active = false;
+        m_PassOpen = false;
+    }
+
+    void GPUPassTimerPool::BeginPass(const std::string& name)
+    {
+        if (!m_Active || m_PassOpen)
+            return;
+
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+        if (slot.PassCount >= m_MaxPasses)
+            return;
+
+        slot.PassNames[slot.PassCount] = name;
+        glQueryCounter(slot.Queries[2 + (2 * slot.PassCount)], GL_TIMESTAMP);
+        m_PassOpen = true;
+    }
+
+    void GPUPassTimerPool::EndPass()
+    {
+        if (!m_Active || !m_PassOpen)
+            return;
+
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+        glQueryCounter(slot.Queries[3 + (2 * slot.PassCount)], GL_TIMESTAMP);
+        ++slot.PassCount;
+        m_PassOpen = false;
+    }
+
+    void GPUPassTimerPool::TryResolveSlot(FrameSlot& slot, bool dropIfUnavailable)
+    {
+        // The frame-end timestamp is the last query stamped in the slot; queries
+        // complete in submission order, so its availability implies every earlier
+        // timestamp in the slot is readable too.
+        GLint available = GL_FALSE;
+        glGetQueryObjectiv(slot.Queries[1], GL_QUERY_RESULT_AVAILABLE, &available);
+        if (!available)
+        {
+            if (dropIfUnavailable)
+                slot.Pending = false;
+            return;
+        }
+
+        GLuint64 frameBegin = 0;
+        GLuint64 frameEnd = 0;
+        glGetQueryObjectui64v(slot.Queries[0], GL_QUERY_RESULT, &frameBegin);
+        glGetQueryObjectui64v(slot.Queries[1], GL_QUERY_RESULT, &frameEnd);
+
+        m_LastFrameGpuMs = (frameEnd > frameBegin)
+                               ? static_cast<f64>(frameEnd - frameBegin) / 1'000'000.0
+                               : 0.0;
+
+        m_LastPassTimings.clear();
+        m_LastPassTimings.reserve(slot.PassCount);
+        for (u32 i = 0; i < slot.PassCount; ++i)
+        {
+            GLuint64 passBegin = 0;
+            GLuint64 passEnd = 0;
+            glGetQueryObjectui64v(slot.Queries[2 + (2 * i)], GL_QUERY_RESULT, &passBegin);
+            glGetQueryObjectui64v(slot.Queries[3 + (2 * i)], GL_QUERY_RESULT, &passEnd);
+
+            m_LastPassTimings.push_back(PassTiming{
+                .Name = slot.PassNames[i],
+                .GpuMs = (passEnd > passBegin)
+                             ? static_cast<f64>(passEnd - passBegin) / 1'000'000.0
+                             : 0.0,
+            });
+        }
+
+        m_LastResolvedFrame = slot.FrameNumber;
+        slot.Pending = false;
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace OloEngine
+{
+    /// @brief Always-on GPU timing for the whole frame and each render-graph pass.
+    ///
+    /// Ring-buffered GL_TIMESTAMP query pairs: frame N stamps begin/end timestamps
+    /// around the frame's render and around every executed pass; the results are
+    /// resolved a few frames later via a non-blocking availability check, so the
+    /// published numbers always describe the most recent fully-completed frame.
+    ///
+    /// Deliberately uses GL_TIMESTAMP (glQueryCounter) instead of GL_TIME_ELAPSED:
+    /// TIME_ELAPSED query scopes must not nest, and the frame-capture path
+    /// (GPUTimerQueryPool) already owns per-draw TIME_ELAPSED scopes *inside* the
+    /// pass brackets this pool times. Timestamps are scope-free and coexist.
+    class GPUPassTimerPool
+    {
+      public:
+        struct PassTiming
+        {
+            std::string Name;
+            f64 GpuMs = 0.0;
+        };
+
+        static GPUPassTimerPool& GetInstance();
+
+        /// @brief Allocate query objects. Call once after the GL context is valid.
+        void Initialize(u32 maxPassesPerFrame = 96);
+
+        /// @brief Delete all query objects.
+        void Shutdown();
+
+        /// @brief Advance to the next ring slot, resolve any completed older
+        /// slots (non-blocking), and stamp the frame-begin timestamp.
+        void BeginFrame();
+
+        /// @brief Stamp the frame-end timestamp and mark the slot for readback.
+        void EndFrame();
+
+        /// @brief Stamp the begin timestamp for the named pass. Passes must not
+        /// overlap; a Begin without a matching End is dropped.
+        void BeginPass(const std::string& name);
+
+        /// @brief Stamp the end timestamp for the pass opened by BeginPass.
+        void EndPass();
+
+        [[nodiscard]] bool IsInitialized() const
+        {
+            return m_Initialized;
+        }
+
+        /// @brief Whole-frame GPU time of the most recently resolved frame in ms
+        /// (frame-begin to frame-end timestamp span on the GPU timeline).
+        [[nodiscard]] f64 GetLastFrameGpuMs() const
+        {
+            return m_LastFrameGpuMs;
+        }
+
+        /// @brief Per-pass GPU times of the most recently resolved frame, in
+        /// execution order. Returns a copy so callers reading via a main-thread
+        /// marshal (e.g. the MCP diagnostics server) get a stable snapshot.
+        [[nodiscard]] std::vector<PassTiming> GetLastPassTimingsCopy() const
+        {
+            return m_LastPassTimings;
+        }
+
+        /// @brief Frame counter value of the most recently resolved frame (0 when
+        /// nothing has resolved yet). Compare against GetCurrentFrameNumber() to
+        /// see how many frames the published results lag.
+        [[nodiscard]] u64 GetLastResolvedFrameNumber() const
+        {
+            return m_LastResolvedFrame;
+        }
+
+        [[nodiscard]] u64 GetCurrentFrameNumber() const
+        {
+            return m_FrameCounter;
+        }
+
+      private:
+        GPUPassTimerPool() = default;
+        ~GPUPassTimerPool();
+        GPUPassTimerPool(const GPUPassTimerPool&) = delete;
+        GPUPassTimerPool& operator=(const GPUPassTimerPool&) = delete;
+
+        // 4 slots: results are read back 1-3 frames after issue without ever
+        // blocking; a slot still pending when its turn comes again (GPU >3
+        // frames behind — pathological) is dropped instead of waited on.
+        static constexpr u32 kSlotCount = 4;
+
+        struct FrameSlot
+        {
+            // [0] = frame begin, [1] = frame end, then per-pass begin/end pairs
+            // at [2 + 2*i] / [3 + 2*i].
+            std::vector<u32> Queries;
+            std::vector<std::string> PassNames;
+            u32 PassCount = 0;
+            u64 FrameNumber = 0;
+            bool Pending = false; // stamped and awaiting readback
+        };
+
+        // Reads the slot's results if the GPU has finished them (checked via the
+        // frame-end query — the last one stamped) and publishes them. When
+        // `dropIfUnavailable` is set the slot is cleared even if unresolvable,
+        // so it can be rewritten.
+        void TryResolveSlot(FrameSlot& slot, bool dropIfUnavailable);
+
+        std::array<FrameSlot, kSlotCount> m_Slots;
+        u32 m_WriteSlot = 0;
+        u32 m_MaxPasses = 0;
+        u64 m_FrameCounter = 0;
+        bool m_Initialized = false;
+        bool m_Active = false;   // between BeginFrame/EndFrame
+        bool m_PassOpen = false; // between BeginPass/EndPass
+
+        // Published results (most recently resolved frame).
+        std::vector<PassTiming> m_LastPassTimings;
+        f64 m_LastFrameGpuMs = 0.0;
+        u64 m_LastResolvedFrame = 0;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUTimerQueryPool.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUTimerQueryPool.cpp
@@ -132,4 +132,28 @@ namespace OloEngine
             return m_Results[commandIndex];
         return 0.0;
     }
+
+    bool GPUTimerQueryPool::TryGetIssuedQueryResultsMs(std::vector<f64>& outResultsMs) const
+    {
+        if (!m_Initialized || m_WriteQueryCount == 0)
+            return false;
+
+        const auto& queries = m_QueryObjects[m_WriteBuffer];
+
+        // Queries complete in submission order, so the last issued query being
+        // available implies every earlier one is readable too.
+        GLint available = GL_FALSE;
+        glGetQueryObjectiv(queries[m_WriteQueryCount - 1], GL_QUERY_RESULT_AVAILABLE, &available);
+        if (!available)
+            return false;
+
+        outResultsMs.resize(m_WriteQueryCount);
+        for (u32 i = 0; i < m_WriteQueryCount; ++i)
+        {
+            GLuint64 timeNs = 0;
+            glGetQueryObjectui64v(queries[i], GL_QUERY_RESULT, &timeNs);
+            outResultsMs[i] = static_cast<f64>(timeNs) / 1'000'000.0;
+        }
+        return true;
+    }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUTimerQueryPool.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUTimerQueryPool.h
@@ -39,6 +39,14 @@ namespace OloEngine
         /// @return Time in milliseconds, or 0.0 if not available.
         f64 GetQueryResultMs(u32 commandIndex) const;
 
+        /// @brief Non-blocking readback of the queries issued in the most recent
+        /// BeginFrame/EndFrame cycle, WITHOUT swapping buffers. Used by
+        /// FrameCaptureManager's deferred one-shot commit: the capture frame
+        /// issues the queries, then a later frame (when the GPU has caught up)
+        /// resolves them straight out of the write buffer before the capture is
+        /// committed. Returns false while the results are still pending.
+        bool TryGetIssuedQueryResultsMs(std::vector<f64>& outResultsMs) const;
+
         /// @brief Number of queries issued in the previous (now-readable) frame.
         u32 GetReadableQueryCount() const
         {

--- a/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.cpp
@@ -81,6 +81,7 @@ namespace OloEngine
         m_LastFrameTime = m_FrameStartTime;
 
         // Reset frame counters
+        m_CurrentFrame.m_GPUWaitTime = 0.0;
         m_CurrentFrame.m_DrawCalls = 0;
         m_CurrentFrame.m_StateChanges = 0;
         m_CurrentFrame.m_ShaderBinds = 0;
@@ -106,9 +107,13 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        // Calculate CPU frame time
+        // Calculate CPU frame time. The BeginFrame->EndFrame bracket is wall
+        // time and includes any glClientWaitSync fence waits (accumulated into
+        // m_GPUWaitTime via AddGPUWaitTime); subtract them so m_CPUTime reflects
+        // actual CPU work — the wait is GPU-bound stall time, not CPU cost.
         auto frameEndTime = std::chrono::high_resolution_clock::now();
-        m_CurrentFrame.m_CPUTime = std::chrono::duration<f64, std::milli>(frameEndTime - m_FrameStartTime).count();
+        const f64 wallMs = std::chrono::duration<f64, std::milli>(frameEndTime - m_FrameStartTime).count();
+        m_CurrentFrame.m_CPUTime = std::max(0.0, wallMs - m_CurrentFrame.m_GPUWaitTime);
 
         // Store frame data in history
         m_FrameHistory[m_HistoryIndex] = m_CurrentFrame;
@@ -118,6 +123,7 @@ namespace OloEngine
         m_Counters[MetricType::FrameTime].AddSample(m_CurrentFrame.m_FrameTime);
         m_Counters[MetricType::CPUTime].AddSample(m_CurrentFrame.m_CPUTime);
         m_Counters[MetricType::GPUTime].AddSample(m_CurrentFrame.m_GPUTime);
+        m_Counters[MetricType::GPUWaitTime].AddSample(m_CurrentFrame.m_GPUWaitTime);
         m_Counters[MetricType::DrawCalls].AddSample(m_CurrentFrame.m_DrawCalls);
         m_Counters[MetricType::StateChanges].AddSample(m_CurrentFrame.m_StateChanges);
         m_Counters[MetricType::ShaderBinds].AddSample(m_CurrentFrame.m_ShaderBinds);
@@ -203,6 +209,9 @@ namespace OloEngine
         {
             case MetricType::GPUTime:
                 m_CurrentFrame.m_GPUTime = value;
+                break;
+            case MetricType::GPUWaitTime:
+                m_CurrentFrame.m_GPUWaitTime = value;
                 break;
             default:
                 break;
@@ -566,10 +575,10 @@ namespace OloEngine
     {
         BottleneckInfo info;
 
-        // Simple heuristic-based analysis
-        f64 frameTime = m_CurrentFrame.m_FrameTime;
-        f64 cpuTime = m_CurrentFrame.m_CPUTime;
-        f64 gpuTime = m_CurrentFrame.m_GPUTime;
+        const f64 frameTime = m_CurrentFrame.m_FrameTime;
+        const f64 cpuTime = m_CurrentFrame.m_CPUTime; // fence waits already subtracted (EndFrame)
+        const f64 gpuTime = m_CurrentFrame.m_GPUTime; // measured by GPUPassTimerPool, lags 1-3 frames
+        const f64 gpuWait = m_CurrentFrame.m_GPUWaitTime;
 
         if (frameTime <= 0.0)
         {
@@ -579,58 +588,77 @@ namespace OloEngine
             return info;
         }
 
-        f64 cpuUtilization = cpuTime / frameTime;
-        f64 gpuUtilization = gpuTime / frameTime;
+        const f64 cpuUtilization = cpuTime / frameTime;
+        const f64 gpuUtilization = gpuTime / frameTime;
+        const f64 waitShare = gpuWait / frameTime;
 
-        // Determine primary bottleneck
-        if (!m_EnableGPUTiming || gpuTime <= 0.0)
+        const auto formatShares = [&]
         {
-            // Can't determine GPU usage, assume CPU bound if frame time is high
-            if (frameTime > (1000.0 / m_TargetFrameRate))
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(1)
+                << " (cpu " << cpuTime << " ms, gpu " << gpuTime
+                << " ms, gpuWait " << gpuWait << " ms, frame " << frameTime << " ms)";
+            return oss.str();
+        };
+
+        // The explicit fence wait (glClientWaitSync on the frame-resource fence)
+        // is the most direct signal: the CPU finished its work and sat blocked
+        // until the GPU caught up.
+        const bool significantWait = waitShare > 0.15;
+
+        if (gpuTime <= 0.0)
+        {
+            // No GPU timer results yet (first frames, or timer unavailable).
+            if (significantWait)
+            {
+                info.m_Type = BottleneckInfo::GPU_Bound;
+                info.m_Confidence = (f32)std::min(0.6 + waitShare, 1.0);
+                info.m_Description = "CPU spends a large share of the frame blocked on GPU fences." + formatShares();
+            }
+            else if (frameTime > (1000.0 / m_TargetFrameRate) && cpuUtilization > 0.8)
             {
                 info.m_Type = BottleneckInfo::CPU_Bound;
-                info.m_Confidence = 0.7f;
-                info.m_Description = "Frame time exceeds target. Enable GPU timing for better analysis.";
+                info.m_Confidence = 0.6f;
+                info.m_Description = "Frame time exceeds target and CPU accounts for most of it; no GPU timing data yet." + formatShares();
             }
             else
             {
                 info.m_Type = BottleneckInfo::Balanced;
-                info.m_Confidence = 0.8f;
-                info.m_Description = "Performance appears balanced.";
+                info.m_Confidence = 0.3f;
+                info.m_Description = "No GPU timing data yet; nothing indicates a bottleneck." + formatShares();
             }
+            return info;
+        }
+
+        if (significantWait || (gpuUtilization > 0.8 && gpuTime > cpuTime))
+        {
+            info.m_Type = BottleneckInfo::GPU_Bound;
+            info.m_Confidence = (f32)std::min(std::max(gpuUtilization, 0.6 + waitShare), 1.0);
+            info.m_Description = "GPU is the primary bottleneck." + formatShares();
+            info.m_Recommendations = {
+                "Optimize shader performance (fragment cost scales with resolution)",
+                "Reduce texture resolution or use compression",
+                "Implement level-of-detail (LOD) systems",
+                "Use occlusion culling"
+            };
+        }
+        else if (cpuUtilization > 0.8 && cpuTime > gpuTime)
+        {
+            info.m_Type = BottleneckInfo::CPU_Bound;
+            info.m_Confidence = (f32)std::min(cpuUtilization, 1.0);
+            info.m_Description = "CPU is the primary bottleneck." + formatShares();
+            info.m_Recommendations = {
+                "Reduce draw calls through batching",
+                "Optimize culling algorithms",
+                "Minimize state changes",
+                "Use instanced rendering for similar objects"
+            };
         }
         else
         {
-            if (cpuUtilization > 0.8 && cpuUtilization > gpuUtilization)
-            {
-                info.m_Type = BottleneckInfo::CPU_Bound;
-                info.m_Confidence = (f32)std::min(cpuUtilization, 1.0);
-                info.m_Description = "CPU is the primary bottleneck. Consider optimizing CPU-side rendering logic.";
-                info.m_Recommendations = {
-                    "Reduce draw calls through batching",
-                    "Optimize culling algorithms",
-                    "Minimize state changes",
-                    "Use instanced rendering for similar objects"
-                };
-            }
-            else if (gpuUtilization > 0.8 && gpuUtilization > cpuUtilization)
-            {
-                info.m_Type = BottleneckInfo::GPU_Bound;
-                info.m_Confidence = (f32)std::min(gpuUtilization, 1.0);
-                info.m_Description = "GPU is the primary bottleneck. Consider optimizing shaders or reducing scene complexity.";
-                info.m_Recommendations = {
-                    "Optimize shader performance",
-                    "Reduce texture resolution or compression",
-                    "Implement level-of-detail (LOD) systems",
-                    "Use occlusion culling"
-                };
-            }
-            else
-            {
-                info.m_Type = BottleneckInfo::Balanced;
-                info.m_Confidence = 0.8f;
-                info.m_Description = "CPU and GPU utilization appears balanced.";
-            }
+            info.m_Type = BottleneckInfo::Balanced;
+            info.m_Confidence = 0.8f;
+            info.m_Description = "CPU and GPU utilization appears balanced." + formatShares();
         }
 
         return info;
@@ -658,6 +686,8 @@ namespace OloEngine
                 return "CPU Time";
             case MetricType::GPUTime:
                 return "GPU Time";
+            case MetricType::GPUWaitTime:
+                return "GPU Wait";
             case MetricType::DrawCalls:
                 return "Draw Calls";
             case MetricType::StateChanges:
@@ -696,6 +726,7 @@ namespace OloEngine
             case MetricType::FrameTime:
             case MetricType::CPUTime:
             case MetricType::GPUTime:
+            case MetricType::GPUWaitTime:
             case MetricType::SortingTime:
             case MetricType::CullingTime:
                 return "ms";
@@ -714,6 +745,8 @@ namespace OloEngine
                 return ImVec4(0.2f, 0.8f, 0.2f, 1.0f);
             case MetricType::GPUTime:
                 return ImVec4(0.8f, 0.2f, 0.2f, 1.0f);
+            case MetricType::GPUWaitTime:
+                return ImVec4(0.9f, 0.4f, 0.1f, 1.0f);
             case MetricType::DrawCalls:
                 return ImVec4(0.2f, 0.6f, 0.8f, 1.0f);
             case MetricType::StateChanges:
@@ -750,7 +783,7 @@ namespace OloEngine
                 return false;
 
             // CSV header
-            file << "Frame,FrameTime,CPUTime,GPUTime,DrawCalls,StateChanges,ShaderBinds,TextureBinds,BufferBinds,Vertices,Triangles,CommandPackets,SortingTime,CullingTime\n";
+            file << "Frame,FrameTime,CPUTime,GPUTime,GPUWaitTime,DrawCalls,StateChanges,ShaderBinds,TextureBinds,BufferBinds,Vertices,Triangles,CommandPackets,SortingTime,CullingTime\n";
 
             // Export frame history
             for (u32 i = 0; i < OLO_FRAME_HISTORY_SIZE; ++i)
@@ -762,6 +795,7 @@ namespace OloEngine
                      << frame.m_FrameTime << ","
                      << frame.m_CPUTime << ","
                      << frame.m_GPUTime << ","
+                     << frame.m_GPUWaitTime << ","
                      << frame.m_DrawCalls << ","
                      << frame.m_StateChanges << ","
                      << frame.m_ShaderBinds << ","

--- a/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.h
@@ -22,6 +22,7 @@ namespace OloEngine
             FrameTime = 0,
             CPUTime,
             GPUTime,
+            GPUWaitTime, // CPU time spent blocked on GPU fences (glClientWaitSync) — the direct "GPU-bound" signal
             DrawCalls,
             StateChanges,
             ShaderBinds,
@@ -79,6 +80,7 @@ namespace OloEngine
             f64 m_FrameTime = 0.0;
             f64 m_CPUTime = 0.0;
             f64 m_GPUTime = 0.0;
+            f64 m_GPUWaitTime = 0.0;
             u32 m_DrawCalls = 0;
             u32 m_StateChanges = 0;
             u32 m_ShaderBinds = 0;
@@ -195,6 +197,14 @@ namespace OloEngine
 
         // @brief Set a value metric
         void SetValue(MetricType type, f64 value);
+
+        // @brief Accumulate CPU time spent blocked on a GPU fence this frame.
+        // EndFrame() subtracts the total from m_CPUTime so cpu time reflects
+        // actual CPU work, and publishes it as the GPUWaitTime metric.
+        void AddGPUWaitTime(f64 timeMs)
+        {
+            m_CurrentFrame.m_GPUWaitTime += timeMs;
+        }
 
         // @brief Render the profiler UI
         void RenderUI(bool* open = nullptr);
@@ -368,7 +378,7 @@ namespace OloEngine
 
         // Configuration
         f32 m_TargetFrameRate = 60.0f;
-        bool m_EnableGPUTiming = false; // Requires GPU timing queries
+        bool m_EnableGPUTiming = true; // GPUPassTimerPool feeds GPUTime every frame; toggle only hides the UI plot
         bool m_ShowAdvancedMetrics = false;
         bool m_AutoAnalyzeBottlenecks = true;
         // UI state

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.cpp
@@ -2,6 +2,7 @@
 #include "OloEngine/Renderer/RenderGraphPlanExecutor.h"
 
 #include "OloEngine/Debug/Profiler.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 
 #include <chrono>
 
@@ -53,9 +54,17 @@ namespace OloEngine::RenderGraphPlanExecutor
                         break;
 
                     input.Context.BeginPass(cmd.NodeName);
+                    // Always-on per-pass GPU timestamps (GL_TIMESTAMP pairs, so
+                    // they coexist with the capture path's per-draw
+                    // GL_TIME_ELAPSED scopes inside the pass). Resolved a few
+                    // frames later by GPUPassTimerPool::BeginFrame; surfaced via
+                    // the olo_perf_pass_timings MCP tool.
+                    auto& gpuTimers = GPUPassTimerPool::GetInstance();
+                    gpuTimers.BeginPass(cmd.NodeName);
                     const auto executeStart = std::chrono::steady_clock::now();
                     cmd.NodePointer->Execute(input.Context);
                     const auto executeEnd = std::chrono::steady_clock::now();
+                    gpuTimers.EndPass();
                     input.Context.EndPass();
 
                     const auto elapsedMs = std::chrono::duration<f64, std::milli>(executeEnd - executeStart).count();

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -7,6 +7,7 @@
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
 #include "OloEngine/Renderer/Commands/FrameDataBuffer.h"
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/GBuffer.h"
@@ -132,6 +133,14 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Open the profiler bracket before any per-frame work so the wall
+        // bracket covers the whole render section, including the fence wait
+        // inside FrameResourceManager::BeginFrame below. The wait itself is
+        // measured and handed to AddGPUWaitTime, and EndFrame subtracts it so
+        // the CPUTime metric reflects actual CPU work.
+        auto& profiler = RendererProfiler::GetInstance();
+        profiler.BeginFrame();
+
         // Process any pending GPU resource creation commands from async loaders.
         GPUResourceQueue::ProcessAll();
 
@@ -147,10 +156,18 @@ namespace OloEngine
             }
         }
 
-        // Begin new frame for double-buffered resources.
+        // Begin new frame for double-buffered resources. May block on the
+        // frame fence when the GPU is behind — that wait IS the gpuWait metric.
         FrameResourceManager::Get().BeginFrame();
+        profiler.AddGPUWaitTime(FrameResourceManager::Get().GetLastBeginFrameWaitMs());
 
-        RendererProfiler::GetInstance().BeginFrame();
+        // Advance the always-on GPU frame/pass timers: resolve a completed
+        // earlier frame's timestamps (non-blocking) and stamp this frame's
+        // begin. Feed the resolved whole-frame GPU time to the profiler — it
+        // lags 1-3 frames, which is fine for steady-state metrics.
+        auto& gpuTimers = GPUPassTimerPool::GetInstance();
+        gpuTimers.BeginFrame();
+        profiler.SetValue(RendererProfiler::MetricType::GPUTime, gpuTimers.GetLastFrameGpuMs());
 
         if (!FrameCorePasses.Scene)
         {

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Core/PerformanceProfiler.h"
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
 #include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Occlusion/OcclusionQueryPool.h"
 #include "OloEngine/Renderer/Passes/SceneRenderPass.h"
@@ -268,6 +269,10 @@ namespace OloEngine
                 node->SetCommandAllocator(nullptr);
         };
         pipeline.ForEachRenderStreamNode(clearRenderStreamAllocator);
+
+        // Stamp the whole-frame GPU end timestamp after all of this frame's GPU
+        // work has been submitted (graph execute, HZB rebuild, capture commit).
+        GPUPassTimerPool::GetInstance().EndFrame();
 
         RendererProfiler::GetInstance().EndFrame();
 

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -34,6 +34,7 @@
 
 #include <chrono>
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Occlusion/OcclusionQueryPool.h"
@@ -100,6 +101,7 @@ namespace OloEngine
         OLO_CORE_INFO("Initializing Renderer3D.");
 
         RendererProfiler::GetInstance().Initialize();
+        GPUPassTimerPool::GetInstance().Initialize();
 
         // Query driver MSAA caps once so the settings panel and the
         // ApplyRendererSettings clamp logic have the true max the GPU
@@ -529,6 +531,7 @@ namespace OloEngine
         // Boot/fallback shader shutdown is handled by Renderer::Shutdown()
         // (both are idempotent, but no need to call them twice).
 
+        GPUPassTimerPool::GetInstance().Shutdown();
         RendererProfiler::GetInstance().Shutdown();
 
         s_Data.CoreInitialized = false;

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
@@ -25,6 +25,32 @@
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Stable per-draw debug label for frame capture / olo_perf_capture_frame:
+        // the submesh's node (or mesh) name. Returns a pointer into the
+        // MeshSource's own strings — valid for the mesh's lifetime, which spans
+        // the frame the packet lives in (PacketMetadata::m_DebugName is a
+        // non-owning const char*).
+        const char* GetMeshDebugName(const Ref<Mesh>& mesh)
+        {
+            if (!mesh || !mesh->GetMeshSource())
+                return nullptr;
+
+            const auto& submeshes = mesh->GetMeshSource()->GetSubmeshes();
+            const u32 submeshIndex = mesh->GetSubmeshIndex();
+            if (submeshIndex >= static_cast<u32>(submeshes.Num()))
+                return nullptr;
+
+            const Submesh& submesh = submeshes[submeshIndex];
+            if (!submesh.m_NodeName.empty())
+                return submesh.m_NodeName.c_str();
+            if (!submesh.m_MeshName.empty())
+                return submesh.m_MeshName.c_str();
+            return nullptr;
+        }
+    } // namespace
+
     auto Renderer3D::ValidateDrawMeshRendererIDs(const char* context, const u32 vaoID, const u32 shaderID) -> bool
     {
         if (vaoID != 0 && shaderID != 0)
@@ -339,6 +365,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depth);
         metadata.m_IsStatic = isStatic;
+        metadata.m_DebugName = GetMeshDebugName(meshToUse);
         packet->SetMetadata(metadata);
 
         if (overlayRoute)
@@ -513,6 +540,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depth);
         metadata.m_IsStatic = isStatic;
+        metadata.m_DebugName = GetMeshDebugName(mesh);
         packet->SetMetadata(metadata);
 
         return packet;
@@ -700,6 +728,7 @@ namespace OloEngine
             else
                 metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, sortDepth);
             metadata.m_IsStatic = isStatic;
+            metadata.m_DebugName = GetMeshDebugName(mesh);
             packet->SetMetadata(metadata);
             return packet;
         };
@@ -969,6 +998,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depth);
         metadata.m_IsStatic = isStatic;
+        metadata.m_DebugName = GetMeshDebugName(mesh);
         packet->SetMetadata(metadata);
 
         if (overlayRoute)
@@ -1405,6 +1435,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depthKey);
         metadata.m_IsStatic = isStatic;
+        metadata.m_DebugName = GetMeshDebugName(mesh);
         packet->SetMetadata(metadata);
 
         if (overlayReroute)
@@ -1606,6 +1637,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depthKey);
         metadata.m_IsStatic = isStatic;
+        metadata.m_DebugName = GetMeshDebugName(mesh);
         packet->SetMetadata(metadata);
 
         return packet;

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
@@ -1435,7 +1435,7 @@ namespace OloEngine
         else
             metadata.m_SortKey = DrawKey::CreateOpaque(0, ViewLayerType::ThreeD, shaderID, materialID, depthKey);
         metadata.m_IsStatic = isStatic;
-        metadata.m_DebugName = GetMeshDebugName(mesh);
+        metadata.m_DebugName = GetMeshDebugName(meshToUse);
         packet->SetMetadata(metadata);
 
         if (overlayReroute)

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -358,6 +358,10 @@ add_executable(OloEngine-Tests
 		# olo_render_frame_breakdown (#306 item D, bullet 2). Header-only
 		# (MCP/McpFrameBreakdown.h), no extra editor TU pulled in.
 		MCP/McpFrameBreakdownTest.cpp
+		# Pure per-pass GPU/CPU timings shaping behind olo_perf_pass_timings
+		# (#316: split whole-frame GPU time by render-graph pass). Header-only
+		# (MCP/McpPassTimings.h), no extra editor TU pulled in.
+		MCP/McpPassTimingsTest.cpp
 		# Pure JSON / Mermaid topology shaping behind olo_render_graph_topology_export
 		# (#316 Part 4, LLM-analysis exports). Header-only (MCP/McpRenderGraphTopology.h),
 		# no extra editor TU pulled in.

--- a/OloEngine/tests/MCP/McpPassTimingsTest.cpp
+++ b/OloEngine/tests/MCP/McpPassTimingsTest.cpp
@@ -1,0 +1,151 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Unit tests for the pure JSON shaping behind olo_perf_pass_timings (issue #316:
+// split whole-frame GPU time by render-graph pass). The shaping lives in a header
+// over engine-free input structs (MCP/McpPassTimings.h), so it is exercised here
+// against synthetic pass/frame data — the test binary deliberately does NOT
+// compile McpTools.cpp (the editor-backed handler). The live tool's
+// GPUPassTimerPool -> JSON path is verified over the MCP attach loop; this pins
+// the join/rounding/totals shape.
+#include "MCP/McpPassTimings.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::PassTimings::BuildPassTimings;
+    using OloEngine::MCP::PassTimings::CpuPassEntry;
+    using OloEngine::MCP::PassTimings::FrameTotals;
+    using OloEngine::MCP::PassTimings::GpuPassEntry;
+    using OloEngine::MCP::PassTimings::Round3;
+    using Json = OloEngine::MCP::PassTimings::Json;
+
+    FrameTotals MakeTotals()
+    {
+        FrameTotals totals;
+        totals.FrameTimeMs = 12.65;
+        totals.CpuMs = 4.2;
+        totals.GpuMs = 8.1;
+        totals.GpuWaitMs = 3.4;
+        totals.GpuResultsAgeFrames = 2;
+        return totals;
+    }
+} // namespace
+
+TEST(McpPassTimingsTest, JoinsGpuAndCpuByPassName)
+{
+    const std::vector<GpuPassEntry> gpu = {
+        { "ShadowPass", 1.25 },
+        { "ScenePass", 5.5 },
+        { "GTAOPass", 0.7 },
+    };
+    const std::vector<CpuPassEntry> cpu = {
+        { "ScenePass", 2.0 },
+        { "ShadowPass", 0.5 },
+        { "GTAOPass", 0.1 },
+    };
+
+    const Json o = BuildPassTimings(gpu, cpu, MakeTotals());
+
+    ASSERT_TRUE(o.contains("passes"));
+    ASSERT_EQ(o["passes"].size(), 3u);
+
+    // GPU execution order is preserved as the primary ordering.
+    EXPECT_EQ(o["passes"][0]["pass"], "ShadowPass");
+    EXPECT_DOUBLE_EQ(o["passes"][0]["gpuMs"].get<double>(), 1.25);
+    EXPECT_DOUBLE_EQ(o["passes"][0]["cpuMs"].get<double>(), 0.5);
+
+    EXPECT_EQ(o["passes"][1]["pass"], "ScenePass");
+    EXPECT_DOUBLE_EQ(o["passes"][1]["gpuMs"].get<double>(), 5.5);
+    EXPECT_DOUBLE_EQ(o["passes"][1]["cpuMs"].get<double>(), 2.0);
+
+    EXPECT_DOUBLE_EQ(o["passGpuTotalMs"].get<double>(), 7.45);
+}
+
+TEST(McpPassTimingsTest, AppendsCpuOnlyPassesWithZeroGpu)
+{
+    const std::vector<GpuPassEntry> gpu = { { "ScenePass", 5.0 } };
+    const std::vector<CpuPassEntry> cpu = {
+        { "ScenePass", 2.0 },
+        { "BloomPass", 0.3 }, // ran on CPU this frame, not in the resolved GPU frame
+    };
+
+    const Json o = BuildPassTimings(gpu, cpu, MakeTotals());
+
+    ASSERT_EQ(o["passes"].size(), 2u);
+    EXPECT_EQ(o["passes"][1]["pass"], "BloomPass");
+    EXPECT_DOUBLE_EQ(o["passes"][1]["gpuMs"].get<double>(), 0.0);
+    EXPECT_DOUBLE_EQ(o["passes"][1]["cpuMs"].get<double>(), 0.3);
+}
+
+TEST(McpPassTimingsTest, DuplicatePassNamesJoinPositionally)
+{
+    // Two passes with the same name (e.g. a pass that runs twice): each GPU
+    // entry consumes a distinct CPU entry instead of double-counting the first.
+    const std::vector<GpuPassEntry> gpu = {
+        { "BlurPass", 1.0 },
+        { "BlurPass", 2.0 },
+    };
+    const std::vector<CpuPassEntry> cpu = {
+        { "BlurPass", 0.25 },
+        { "BlurPass", 0.75 },
+    };
+
+    const Json o = BuildPassTimings(gpu, cpu, MakeTotals());
+
+    ASSERT_EQ(o["passes"].size(), 2u);
+    EXPECT_DOUBLE_EQ(o["passes"][0]["cpuMs"].get<double>(), 0.25);
+    EXPECT_DOUBLE_EQ(o["passes"][1]["cpuMs"].get<double>(), 0.75);
+}
+
+TEST(McpPassTimingsTest, FrameTotalsAndUnattributedGpu)
+{
+    const std::vector<GpuPassEntry> gpu = {
+        { "ScenePass", 5.0 },
+        { "ToneMapPass", 1.0 },
+    };
+
+    const Json o = BuildPassTimings(gpu, {}, MakeTotals());
+
+    EXPECT_DOUBLE_EQ(o["frame"]["frameTimeMs"].get<double>(), 12.65);
+    EXPECT_DOUBLE_EQ(o["frame"]["cpuMs"].get<double>(), 4.2);
+    EXPECT_DOUBLE_EQ(o["frame"]["gpuMs"].get<double>(), 8.1);
+    EXPECT_DOUBLE_EQ(o["frame"]["gpuWaitMs"].get<double>(), 3.4);
+    EXPECT_EQ(o["gpuResultsAgeFrames"].get<std::uint64_t>(), 2u);
+
+    // 8.1 total - 6.0 attributed = 2.1 unattributed (barriers, HZB rebuild, ...).
+    EXPECT_NEAR(o["unattributedGpuMs"].get<double>(), 2.1, 1e-9);
+}
+
+TEST(McpPassTimingsTest, UnattributedGpuClampsToZeroWhenPassesExceedFrameSpan)
+{
+    FrameTotals totals = MakeTotals();
+    totals.GpuMs = 4.0;
+    const std::vector<GpuPassEntry> gpu = { { "ScenePass", 5.0 } }; // overlap artifact
+
+    const Json o = BuildPassTimings(gpu, {}, totals);
+
+    EXPECT_DOUBLE_EQ(o["unattributedGpuMs"].get<double>(), 0.0);
+}
+
+TEST(McpPassTimingsTest, EmptyInputsProduceEmptyPassListAndZeroTotals)
+{
+    FrameTotals totals; // all zeros
+    const Json o = BuildPassTimings({}, {}, totals);
+
+    EXPECT_TRUE(o["passes"].empty());
+    EXPECT_DOUBLE_EQ(o["passGpuTotalMs"].get<double>(), 0.0);
+    EXPECT_DOUBLE_EQ(o["unattributedGpuMs"].get<double>(), 0.0);
+    EXPECT_EQ(o["gpuResultsAgeFrames"].get<std::uint64_t>(), 0u);
+}
+
+TEST(McpPassTimingsTest, RoundsToThreeDecimals)
+{
+    EXPECT_DOUBLE_EQ(Round3(0.0004999), 0.0);
+    EXPECT_DOUBLE_EQ(Round3(0.0005001), 0.001);
+    EXPECT_DOUBLE_EQ(Round3(1.23456), 1.235);
+}

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -166,10 +166,11 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_scene_summary` | active scene name, play state, entity count |
 | `olo_scene_list_entities` | paginated entity list (id, name, parent, child count) + name filter |
 | `olo_scene_get_entity` | one entity's full component data (YAML) by UUID |
-| `olo_perf_snapshot` | fps, frame/CPU/GPU time, draw calls, instancing, triangles |
-| `olo_perf_bottlenecks` | CPU/GPU/Memory/IO bottleneck + confidence + recommendations |
+| `olo_perf_snapshot` | fps, frame/CPU/GPU time (real whole-frame GPU timer), `gpuWaitMs` (CPU blocked on the GPU fence — the direct GPU-bound signal), draw calls, instancing, triangles |
+| `olo_perf_bottlenecks` | CPU/GPU/Memory/IO bottleneck + confidence + recommendations (uses real cpu/gpu/gpuWait numbers) |
 | `olo_perf_frame_history` | downsampled recent-frame time series |
-| `olo_perf_capture_frame` | triggers a real frame capture: stats + top-K draw commands by GPU time |
+| `olo_perf_capture_frame` | triggers a real frame capture: stats + top-K draw commands by GPU time (per-draw times resolve via a deferred commit one-plus frames after the capture; draws carry their submesh debug names) |
+| `olo_perf_pass_timings` | whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs ToneMap…): per-pass GPU (always-on timestamp queries) + CPU dispatch ms, frame totals incl. `gpuWaitMs`, and `unattributedGpuMs` |
 | `olo_render_frame_breakdown` | triggers a real frame capture and returns its **per-command / per-pipeline-stage** structural breakdown (the granularity `olo_perf_capture_frame` omits): pipeline stats + the ordered command list (type, debug-name pass label, draw key shader/material/depth, group, execution order, static flag, GPU time) + a command-type histogram, at the chosen `viewMode` (`presort`/`postsort`/`postbatch`); `format:"markdown"` returns the Command Bucket Inspector's LLM-analysis report (sort/state-change/batching analysis + optimization hints) |
 | `olo_memory_report` | GPU/CPU memory total + per-type breakdown + suspected leaks |
 | `olo_shader_list` | inventory of all registered shaders (id, name, hasErrors) |
@@ -206,7 +207,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (47 tools) that paging the whole flat `tools/list`
+The tool surface is large enough (48 tools) that paging the whole flat `tools/list`
 to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
 category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
 keyword and/or category instead of pulling the entire list:
@@ -215,7 +216,7 @@ keyword and/or category instead of pulling the entire list:
 |---|---|
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
-| `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame` |
+| `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings` |
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |


### PR DESCRIPTION
…, olo_perf_pass_timings, capture-frame per-draw fix (#316, #306)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new performance diagnostics view that breaks down whole-frame timing by render pass, including GPU and CPU timing details.
  * Expanded the MCP diagnostics toolset with additional pass-timing output and updated smoke coverage.
  * Enabled more detailed frame and GPU wait metrics in the renderer profiler.

* **Bug Fixes**
  * Improved capture handling so one-shot timing results can resolve more reliably without stalling.
  * Better tracks GPU wait time during frame starts and includes it in reported performance data.

* **Documentation**
  * Updated the MCP diagnostics guide to reflect the expanded performance tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->