### PR TITLE
feat(mcp): ScenePass sub-pass GPU timings, depthprepass/softshadows p…

### DIFF
--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -153,7 +153,20 @@ Show-Tool 'olo_perf_snapshot' @{} | Out-Null
 Show-Tool 'olo_perf_bottlenecks' @{} | Out-Null
 Show-Tool 'olo_perf_frame_history' @{ points = 8 } | Out-Null
 Show-Tool 'olo_perf_capture_frame' @{ topK = 5 } | Out-Null
-Show-Tool 'olo_perf_pass_timings' @{} | Out-Null
+$passTimings = Show-Tool 'olo_perf_pass_timings' @{}
+# ScenePass sub-pass split (#316): ScenePass should carry subPasses
+# (DepthPrepass and/or Color) once GPU results have resolved. Soft check — the
+# first frames after attach may not have resolved timings yet.
+if ($passTimings.result -and -not $passTimings.result.isError) {
+    $ptObj = $passTimings.result.content[0].text | ConvertFrom-Json
+    $scenePass = $ptObj.passes | Where-Object { $_.pass -eq 'ScenePass' } | Select-Object -First 1
+    if ($scenePass -and $scenePass.subPasses) {
+        $subNames = ($scenePass.subPasses | ForEach-Object { "$($_.name)=$($_.gpuMs)ms" }) -join ', '
+        Write-Host "  ScenePass subPasses: $subNames" -ForegroundColor Green
+    } else {
+        Write-Host '  (no ScenePass subPasses yet — GPU timings unresolved or 2D mode)' -ForegroundColor Yellow
+    }
+}
 
 # 19-20. Shader tools (olo_shader_list discovers a real name for olo_shader_get)
 Show-Tool 'olo_shader_errors' @{} | Out-Null
@@ -193,9 +206,41 @@ if ($camObj.distance -gt 0) {
     Show-Tool 'olo_camera_set_pose' @{ position = @($camObj.position[0], $camObj.position[1], $camObj.position[2]); yaw = $camObj.yawDegrees; pitch = $camObj.pitchDegrees; fov = $camObj.fovDegrees } | Out-Null
 }
 
-# viewport override + reset
+# viewport override + reset. While the override is active, olo_perf_snapshot's
+# renderWidth/renderHeight must match it (#316: the render graph once silently
+# stayed at window size, inflating override readings ~6x on a 4K monitor).
 Show-Tool 'olo_viewport_set_size' @{ width = 1280; height = 720 } | Out-Null
+Start-Sleep -Milliseconds 250 # let a couple of frames apply the override
+$snapAtOverride = Show-Tool 'olo_perf_snapshot' @{}
+if ($snapAtOverride.result -and -not $snapAtOverride.result.isError) {
+    $snapObj = $snapAtOverride.result.content[0].text | ConvertFrom-Json
+    if ($snapObj.renderWidth) {
+        if ([int]$snapObj.renderWidth -eq 1280 -and [int]$snapObj.renderHeight -eq 720) {
+            Write-Host "  renderWidth/Height match the 1280x720 override" -ForegroundColor Green
+        } else {
+            # Note: the framebuffer is viewport x HiDPI scale, so e.g. 1920x1080 at
+            # 150% display scaling is expected — only a WILD mismatch (window-sized
+            # target while an override is active) indicates the #316 resize fight.
+            Write-Warning "renderWidth/Height ($($snapObj.renderWidth)x$($snapObj.renderHeight)) differ from the 1280x720 viewport override (HiDPI scale? resize fight?)"
+        }
+    } else {
+        Write-Host '  (no renderWidth in snapshot — render graph not live?)' -ForegroundColor Yellow
+    }
+}
 Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
+
+# olo_renderer_settings_set is a consented WRITE tool: with the editor's
+# "Allow writes" gate off (the default) the call must be REFUSED cleanly; with
+# it on, the no-arg form lists every setting (upscale/tonemap/renderpath +
+# the #316 perf levers depthprepass/softshadows). Either outcome is a pass here.
+$settingsList = Invoke-Rpc 'tools/call' @{ name = 'olo_renderer_settings_set'; arguments = @{} }
+if ($settingsList.error) {
+    Write-Host "tools/call olo_renderer_settings_set -> refused (writes gate off): $($settingsList.error.message)" -ForegroundColor Yellow
+} else {
+    $settingsObj = $settingsList.result.content[0].text | ConvertFrom-Json
+    $tokens = ($settingsObj.settings | ForEach-Object { "$($_.setting)=$($_.currentValue)" }) -join ', '
+    Write-Host "tools/call olo_renderer_settings_set (introspect) -> $tokens" -ForegroundColor Green
+}
 
 # 30. olo_screenshot with a one-shot camera pose (save/restore path).
 # Orbit the sandbox terrain's centre (terrain spans [0,256]^2) — orbiting the

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1965,7 +1965,7 @@ namespace OloEngine
         dispatcher.Dispatch<WindowCloseEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnWindowClose));
     }
 
-    bool EditorLayer::OnWindowResized([[maybe_unused]] WindowResizeEvent const& e)
+    bool EditorLayer::OnWindowResized(WindowResizeEvent const& e)
     {
         // Application::OnWindowResize already ran (it dispatches before the layer
         // stack) and resized the Renderer3D render graph to the OS window's
@@ -1973,8 +1973,12 @@ namespace OloEngine
         // panel (or the MCP olo_viewport_set_size override), not the window, so
         // mark the viewport-derived size for one reassert on the next OnUpdate —
         // the resize guard there won't fire on its own when the viewport size is
-        // unchanged (see m_ViewportSizeReassertNeeded).
-        m_ViewportSizeReassertNeeded = true;
+        // unchanged (see m_ViewportSizeReassertNeeded). Ignore minimize-sized
+        // events (width/height == 0) since there's no real render-graph work.
+        if (e.GetWidth() > 0 && e.GetHeight() > 0)
+        {
+            m_ViewportSizeReassertNeeded = true;
+        }
         return false; // other layers may care about the resize too
     }
 

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -525,11 +525,18 @@ namespace OloEngine
         const u32 fbWidth = std::max(1u, static_cast<u32>(m_ViewportSize.x * dpiScale));
         const u32 fbHeight = std::max(1u, static_cast<u32>(m_ViewportSize.y * dpiScale));
 
-        // Resize
+        // Resize. Also fires when a window-resize event was seen
+        // (m_ViewportSizeReassertNeeded): Application::OnWindowResize resized the
+        // render graph to the OS window size behind our back, and with an
+        // unchanged viewport size (e.g. an active MCP viewport override) the
+        // spec comparison alone would never correct it — the scene would keep
+        // rendering at window resolution (#316: ~6x inflated frame times with a
+        // maximized window on a 4K monitor).
         if (FramebufferSpecification const spec = m_Framebuffer->GetSpecification();
             (m_ViewportSize.x > 0.0f) && (m_ViewportSize.y > 0.0f) && // zero sized framebuffer is invalid
-            ((std::abs(static_cast<f32>(spec.Width) - static_cast<f32>(fbWidth)) > epsilon) || (std::abs(static_cast<f32>(spec.Height) - static_cast<f32>(fbHeight)) > epsilon)))
+            ((std::abs(static_cast<f32>(spec.Width) - static_cast<f32>(fbWidth)) > epsilon) || (std::abs(static_cast<f32>(spec.Height) - static_cast<f32>(fbHeight)) > epsilon) || m_ViewportSizeReassertNeeded))
         {
+            m_ViewportSizeReassertNeeded = false;
             m_Framebuffer->Resize(fbWidth, fbHeight);
             m_LastViewportResizeFrame = m_FrameIndex; // MCP captures must wait out the resize transient
             m_CameraController.OnResize(m_ViewportSize.x, m_ViewportSize.y);
@@ -1951,10 +1958,24 @@ namespace OloEngine
         EventDispatcher dispatcher(e);
         dispatcher.Dispatch<KeyPressedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnKeyPressed));
         dispatcher.Dispatch<MouseButtonPressedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnMouseButtonPressed));
+        dispatcher.Dispatch<WindowResizeEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnWindowResized));
         dispatcher.Dispatch<AssetLoadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetLoaded));
         dispatcher.Dispatch<AssetReloadedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetReloaded));
         dispatcher.Dispatch<AssetImportedEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnAssetImported));
         dispatcher.Dispatch<WindowCloseEvent>(OLO_BIND_EVENT_FN(EditorLayer::OnWindowClose));
+    }
+
+    bool EditorLayer::OnWindowResized([[maybe_unused]] WindowResizeEvent const& e)
+    {
+        // Application::OnWindowResize already ran (it dispatches before the layer
+        // stack) and resized the Renderer3D render graph to the OS window's
+        // framebuffer size. In the editor the scene renders into the viewport
+        // panel (or the MCP olo_viewport_set_size override), not the window, so
+        // mark the viewport-derived size for one reassert on the next OnUpdate —
+        // the resize guard there won't fire on its own when the viewport size is
+        // unchanged (see m_ViewportSizeReassertNeeded).
+        m_ViewportSizeReassertNeeded = true;
+        return false; // other layers may care about the resize too
     }
 
     bool EditorLayer::OnKeyPressed(KeyPressedEvent const& e)

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -70,6 +70,7 @@ namespace OloEngine
       private:
         bool OnKeyPressed(KeyPressedEvent const& e);
         bool OnMouseButtonPressed(MouseButtonPressedEvent const& e);
+        bool OnWindowResized(WindowResizeEvent const& e);
         bool OnAssetLoaded(AssetLoadedEvent const& e);
         bool OnAssetReloaded(AssetReloadedEvent const& e);
         bool OnAssetImported(AssetImportedEvent const& e);
@@ -303,6 +304,16 @@ namespace OloEngine
         // resized render-graph framebuffers render black for a couple of
         // frames, so captures must not trust the first frames after a resize.
         u64 m_LastViewportResizeFrame = 0;
+        // Set by OnWindowResized: Application::OnWindowResize (which runs before
+        // layers see the event) resizes the Renderer3D render graph to the OS
+        // window's framebuffer size, but in the editor the graph must track the
+        // viewport panel / MCP override size. When the viewport-derived size
+        // didn't change (typical with an olo_viewport_set_size override active),
+        // the OnUpdate resize guard wouldn't fire and the graph would silently
+        // keep rendering at window resolution — e.g. maximizing on a 4K monitor
+        // inflated a "1920x1080" override's frame times ~6x (#316). This flag
+        // forces one reassert of the viewport-derived size on the next update.
+        bool m_ViewportSizeReassertNeeded = false;
 
         // Undo/Redo
         CommandHistory m_CommandHistory;

--- a/OloEditor/src/MCP/McpPassTimings.h
+++ b/OloEditor/src/MCP/McpPassTimings.h
@@ -19,6 +19,7 @@
 #include <nlohmann/json.hpp>
 
 #include <cmath>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -63,6 +64,15 @@ namespace OloEngine::MCP::PassTimings
     // CPU-only passes (not GPU-timed this frame — pool overflow or transient
     // topology change between the resolved GPU frame and the current CPU frame)
     // are appended with gpuMs 0.
+    //
+    // A GPU entry named "Parent/Sub" is a SUB-PASS bracket stamped inside the
+    // pass named "Parent" (GPUPassTimerPool::BeginSubPass — e.g. the ScenePass
+    // DepthPrepass/Color split, #316): it is attached to the most recent
+    // top-level entry named "Parent" as subPasses[{name, gpuMs}] and does NOT
+    // count toward passGpuTotalMs (its time is already inside the parent's
+    // bracket). An orphan sub-entry (parent not GPU-timed this frame — pool
+    // overflow) is kept as a top-level entry under its full name rather than
+    // dropped.
     [[nodiscard]] inline Json BuildPassTimings(const std::vector<GpuPassEntry>& gpuPasses,
                                                const std::vector<CpuPassEntry>& cpuPasses,
                                                const FrameTotals& totals)
@@ -84,8 +94,35 @@ namespace OloEngine::MCP::PassTimings
             return 0.0;
         };
 
+        // Index of the last top-level entry per pass name, for sub-pass
+        // attachment (the pool allocates parent-before-sub, so a forward walk
+        // always sees the parent first).
+        const auto findParentIndex = [&passes](const std::string& parentName) -> std::optional<sizet>
+        {
+            for (sizet i = passes.size(); i > 0; --i)
+            {
+                if (passes[i - 1]["pass"].get<std::string>() == parentName)
+                    return i - 1;
+            }
+            return std::nullopt;
+        };
+
         for (const auto& gpuPass : gpuPasses)
         {
+            if (const auto slash = gpuPass.Name.find('/'); slash != std::string::npos)
+            {
+                if (const auto parentIdx = findParentIndex(gpuPass.Name.substr(0, slash)))
+                {
+                    Json& parent = passes[*parentIdx];
+                    if (!parent.contains("subPasses"))
+                        parent["subPasses"] = Json::array();
+                    parent["subPasses"].push_back(Json{ { "name", gpuPass.Name.substr(slash + 1) },
+                                                        { "gpuMs", Round3(gpuPass.GpuMs) } });
+                    continue;
+                }
+                // Orphan sub-entry: fall through and publish under the full name
+                // (counted in passGpuTotal — its parent bracket is absent).
+            }
             passGpuTotal += gpuPass.GpuMs;
             passes.push_back(Json{ { "pass", gpuPass.Name },
                                    { "gpuMs", Round3(gpuPass.GpuMs) },

--- a/OloEditor/src/MCP/McpRendererSettings.h
+++ b/OloEditor/src/MCP/McpRendererSettings.h
@@ -12,6 +12,14 @@
 // the toggle shape can't express (upscale quality preset, tone-map operator,
 // forward/forward+/deferred path).
 //
+// Issue #316 added the two big perf LEVERS the live perf sessions had to A/B via
+// shader-source edits: `depthprepass` (off|on|auto — Renderer3D's live toggle;
+// 'auto' restores the settings-derived value) and `softshadows` (pcf|pcss —
+// ShadowSettings::SoftShadows). Neither lives in the PostProcessSettings /
+// RendererSettings PODs, so the handler snapshots them into a LeverState POD
+// before Apply()/Describe() and pushes mutated fields back to the renderer
+// afterwards (Renderer3D::EnableDepthPrepass / ShadowMap::SetSettings).
+//
 // Restore semantics — restore-PRIOR-VALUE, NOT CommandHistory. Unlike the entity
 // field writes (olo_set_collision_layer / olo_entity_set_field), which push an
 // undoable ComponentChangeCommand onto the editor's undo stack, these are GLOBAL
@@ -61,10 +69,36 @@ namespace OloEngine::MCP::RendererSettings
     // only — the structs are plain POD).
     enum class Setting
     {
-        Upscale,    // PostProcessSettings::Upscale  (FSR1 spatial-upscale quality preset)
-        Tonemap,    // PostProcessSettings::Tonemap  (tone-map operator)
-        RenderPath, // RendererSettings::Path        (forward / forward+ / deferred)
+        Upscale,      // PostProcessSettings::Upscale  (FSR1 spatial-upscale quality preset)
+        Tonemap,      // PostProcessSettings::Tonemap  (tone-map operator)
+        RenderPath,   // RendererSettings::Path        (forward / forward+ / deferred)
+        DepthPrepass, // LeverState::DepthPrepassEnabled (Renderer3D live toggle; 'auto' = settings-derived)
+        SoftShadows,  // LeverState::SoftShadows       (ShadowSettings::SoftShadows: PCSS vs PCF)
     };
+
+    // Live renderer state the perf-lever settings (#316) read/write. These are NOT
+    // fields of PostProcessSettings / RendererSettings: the depth prepass is
+    // Renderer3D's live toggle (EnableDepthPrepass) and soft shadows live in
+    // ShadowSettings. The handler snapshots the live values into this POD before
+    // Apply()/Describe() and pushes mutated fields back to the renderer afterwards
+    // (EnableDepthPrepass / ShadowMap::SetSettings) — keeping this header
+    // renderer-free and unit-testable, same seam as the pp/rs structs.
+    struct LeverState
+    {
+        bool DepthPrepassEnabled = false; // live effective value (Renderer3D::IsDepthPrepassEnabled)
+        bool DepthPrepassAuto = false;    // what 'auto' resolves to (Renderer3D::ComputeSettingsDerivedDepthPrepass)
+        bool SoftShadows = false;         // live ShadowSettings::SoftShadows
+    };
+
+    // Engine integers of the depthprepass tri-token. 'off'/'on' mirror the live
+    // bool; 'auto' (2) is a WRITE-ONLY token that resolves to LeverState::
+    // DepthPrepassAuto on apply — the current value always reads back as off/on.
+    inline constexpr i32 kDepthPrepassOff = 0;
+    inline constexpr i32 kDepthPrepassOn = 1;
+    inline constexpr i32 kDepthPrepassAuto = 2;
+
+    inline constexpr i32 kSoftShadowsPcf = 0;
+    inline constexpr i32 kSoftShadowsPcss = 1;
 
     // One allowed value of an enum-valued setting: the stable, user-facing token the
     // agent passes, the underlying engine enum integer, and a human description.
@@ -99,6 +133,17 @@ namespace OloEngine::MCP::RendererSettings
         { "deferred", static_cast<i32>(RenderingPath::Deferred), "G-buffer + tiled deferred lighting (enables SSR/SSGI)" },
     } };
 
+    inline constexpr std::array<EnumValue, 3> kDepthPrepassValues = { {
+        { "off", kDepthPrepassOff, "Force the depth prepass off for this session (single geometry pass; full overdraw cost)" },
+        { "on", kDepthPrepassOn, "Force the depth prepass on for this session (depth-only pass first, then color with GL_EQUAL)" },
+        { "auto", kDepthPrepassAuto, "Restore the settings-derived value (on when the user toggle or the Forward+/Deferred path requires it)" },
+    } };
+
+    inline constexpr std::array<EnumValue, 2> kSoftShadowValues = { {
+        { "pcf", kSoftShadowsPcf, "Fixed 3x3 hardware PCF (cheap, hard-edged shadows)" },
+        { "pcss", kSoftShadowsPcss, "Percentage-Closer Soft Shadows (contact-hardening variable penumbra; expensive blocker search)" },
+    } };
+
     // Setting token + description + which struct field it targets (documented only).
     struct SettingInfo
     {
@@ -107,7 +152,7 @@ namespace OloEngine::MCP::RendererSettings
         std::string_view Description;
     };
 
-    inline constexpr std::array<SettingInfo, 3> kSettings = { {
+    inline constexpr std::array<SettingInfo, 5> kSettings = { {
         { "upscale", Setting::Upscale,
           "FSR1 spatial-upscale quality preset (PostProcess.Upscale). Off is native resolution; the other presets render "
           "below display resolution and EASU-upscale the HDR scene colour back to display res (#480)." },
@@ -115,6 +160,15 @@ namespace OloEngine::MCP::RendererSettings
         { "renderpath", Setting::RenderPath,
           "High-level rendering path (RendererSettings.Path). Switching rebuilds the render-graph topology; Deferred is "
           "required for SSR / SSGI." },
+        { "depthprepass", Setting::DepthPrepass,
+          "Depth-prepass perf lever (Renderer3D live toggle, #316). 'on'/'off' force the live state for this session; "
+          "'auto' restores the settings-derived value. Forward+/Deferred derive it ON because their tile culling reads "
+          "the prepass depth — forcing 'off' there is a valid perf experiment but degrades tiled lighting until restored. "
+          "A later settings apply (e.g. a renderpath switch) re-derives it." },
+        { "softshadows", Setting::SoftShadows,
+          "Directional-shadow filtering (ShadowSettings.SoftShadows): 'pcss' = contact-hardening soft shadows, 'pcf' = "
+          "fixed 3x3 hardware PCF. THE dominant ScenePass perf lever in shadowed scenes (#316: PCSS was ~93% of "
+          "ScenePass at 1080p Sponza)." },
     } };
 
     // Lowercase + drop every non-alphanumeric character so "Ultra Performance",
@@ -144,6 +198,10 @@ namespace OloEngine::MCP::RendererSettings
                 return kTonemapValues;
             case Setting::RenderPath:
                 return kRenderPathValues;
+            case Setting::DepthPrepass:
+                return kDepthPrepassValues;
+            case Setting::SoftShadows:
+                return kSoftShadowValues;
         }
         return {};
     }
@@ -240,8 +298,8 @@ namespace OloEngine::MCP::RendererSettings
     [[nodiscard]] inline Json InputSchema()
     {
         return Schema::Object()
-            .Prop("setting", Schema::String().Enum({ "upscale", "tonemap", "renderpath" }).Desc("Which renderer / post-process setting to set. Omit both arguments to list every setting with its current value and allowed values."))
-            .Prop("value", Schema::String().Desc("The new value token for the chosen setting — upscale: off|quality|balanced|performance|ultraperformance; tonemap: none|reinhard|aces|uncharted2; renderpath: forward|forwardplus|deferred. Call with no arguments to discover the valid tokens for each setting."))
+            .Prop("setting", Schema::String().Enum({ "upscale", "tonemap", "renderpath", "depthprepass", "softshadows" }).Desc("Which renderer / post-process setting to set. Omit both arguments to list every setting with its current value and allowed values."))
+            .Prop("value", Schema::String().Desc("The new value token for the chosen setting — upscale: off|quality|balanced|performance|ultraperformance; tonemap: none|reinhard|aces|uncharted2; renderpath: forward|forwardplus|deferred; depthprepass: off|on|auto; softshadows: pcf|pcss. Call with no arguments to discover the valid tokens for each setting."))
             .NoAdditional();
     }
 
@@ -299,7 +357,7 @@ namespace OloEngine::MCP::RendererSettings
     // (the current value) so the mapping lives in one place and can't drift when a
     // setting is added. NOTE: `OloEngine::RendererSettings` is spelled fully qualified
     // — unqualified `RendererSettings` names THIS namespace, not the engine struct.
-    [[nodiscard]] inline i32 CurrentValue(Setting setting, const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs)
+    [[nodiscard]] inline i32 CurrentValue(Setting setting, const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs, const LeverState& lever)
     {
         switch (setting)
         {
@@ -309,15 +367,23 @@ namespace OloEngine::MCP::RendererSettings
                 return static_cast<i32>(pp.Tonemap);
             case Setting::RenderPath:
                 return static_cast<i32>(rs.Path);
+            case Setting::DepthPrepass:
+                // Always reads back as off/on — 'auto' is a write-only token.
+                return lever.DepthPrepassEnabled ? kDepthPrepassOn : kDepthPrepassOff;
+            case Setting::SoftShadows:
+                return lever.SoftShadows ? kSoftShadowsPcss : kSoftShadowsPcf;
         }
         return 0;
     }
 
     // Apply `value` (an engine enum integer) to `setting`, mutating the matching
-    // field of `pp` / `rs` and reporting the prior value so the change can be
-    // restored by setting it back (restore-prior-value, no undo stack). MUST run on
-    // the main (game) thread — the caller passes the live Renderer3D settings.
-    [[nodiscard]] inline ApplyResult Apply(Setting setting, i32 value, PostProcessSettings& pp, ::OloEngine::RendererSettings& rs)
+    // field of `pp` / `rs` / `lever` and reporting the prior value so the change can
+    // be restored by setting it back (restore-prior-value, no undo stack). MUST run
+    // on the main (game) thread — the caller passes the live Renderer3D settings and
+    // a LeverState snapshot of the live renderer toggles, and pushes any mutated
+    // lever field back to the renderer afterwards (the renderer-bound side effect
+    // stays out of this header, like PathChanged).
+    [[nodiscard]] inline ApplyResult Apply(Setting setting, i32 value, PostProcessSettings& pp, ::OloEngine::RendererSettings& rs, LeverState& lever)
     {
         ApplyResult result;
 
@@ -335,7 +401,15 @@ namespace OloEngine::MCP::RendererSettings
             return result;
         }
 
-        const i32 previous = CurrentValue(setting, pp, rs);
+        const i32 previous = CurrentValue(setting, pp, rs, lever);
+
+        // 'auto' resolves to the settings-derived bool before the write, so the
+        // reported value / changed flag describe the actual resulting state (the
+        // response carries "requested": "auto" for transparency).
+        const bool requestedAuto = setting == Setting::DepthPrepass && value == kDepthPrepassAuto;
+        if (requestedAuto)
+            value = lever.DepthPrepassAuto ? kDepthPrepassOn : kDepthPrepassOff;
+
         switch (setting)
         {
             case Setting::Upscale:
@@ -346,6 +420,12 @@ namespace OloEngine::MCP::RendererSettings
                 break;
             case Setting::RenderPath:
                 rs.Path = static_cast<RenderingPath>(static_cast<u8>(value));
+                break;
+            case Setting::DepthPrepass:
+                lever.DepthPrepassEnabled = value == kDepthPrepassOn;
+                break;
+            case Setting::SoftShadows:
+                lever.SoftShadows = value == kSoftShadowsPcss;
                 break;
         }
 
@@ -364,18 +444,20 @@ namespace OloEngine::MCP::RendererSettings
             // entry, unlike the entity field writes).
             { "restoreWith", ValueToken(setting, previous) },
         };
+        if (requestedAuto)
+            result.Data["requested"] = "auto";
         return result;
     }
 
     // Introspection payload: every setting with its live current value and the full
     // allowed-value catalogue. The handler reads the live Renderer3D settings and
     // hands them here.
-    [[nodiscard]] inline Json Describe(const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs)
+    [[nodiscard]] inline Json Describe(const PostProcessSettings& pp, const ::OloEngine::RendererSettings& rs, const LeverState& lever)
     {
         Json arr = Json::array();
         for (const auto& info : kSettings)
         {
-            const i32 current = CurrentValue(info.Id, pp, rs);
+            const i32 current = CurrentValue(info.Id, pp, rs, lever);
 
             Json values = Json::array();
             for (const auto& v : SettingValues(info.Id))

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -481,6 +481,17 @@ namespace OloEngine::MCP
                 o["commandPackets"] = f.m_CommandPackets;
                 o["sortingMs"] = Round2(f.m_SortingTime);
                 o["cullingMs"] = Round2(f.m_CullingTime);
+                // The ACTUAL scene render resolution (SceneColor target size), so a
+                // reading taken at the wrong resolution is self-evident — e.g. the
+                // render graph silently left at window size while a viewport
+                // override claims 1920x1080 (#316), or FSR rendering below display
+                // res. Omitted when no render graph is live (2D mode / no frame).
+                if (const Ref<Framebuffer> sceneFB = Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::SceneColor))
+                {
+                    const auto& spec = sceneFB->GetSpecification();
+                    o["renderWidth"] = spec.Width;
+                    o["renderHeight"] = spec.Height;
+                }
                 return o; });
             return ToolResult::Structured(j);
         }
@@ -3546,29 +3557,53 @@ namespace OloEngine::MCP
             if (const auto error = ParseArgs(args, introspect, setting, value))
                 return ToolResult::Error(*error);
 
+            // Snapshot the live renderer toggles the perf-lever settings read/write
+            // (#316). Main-thread only — always called inside a MarshalRead.
+            const auto snapshotLever = []() -> LeverState
+            {
+                LeverState lever;
+                lever.DepthPrepassEnabled = Renderer3D::IsDepthPrepassEnabled();
+                lever.DepthPrepassAuto = Renderer3D::ComputeSettingsDerivedDepthPrepass();
+                lever.SoftShadows = Renderer3D::GetShadowMap().GetSettings().SoftShadows;
+                return lever;
+            };
+
             // Introspection: no `setting` -> list every setting with its live current
             // value and the allowed-value catalogue.
             if (introspect)
             {
-                const Json result = server.MarshalRead([]() -> Json
-                                                       { return Describe(Renderer3D::GetPostProcessSettings(), Renderer3D::GetRendererSettings()); });
+                const Json result = server.MarshalRead([&snapshotLever]() -> Json
+                                                       { return Describe(Renderer3D::GetPostProcessSettings(), Renderer3D::GetRendererSettings(), snapshotLever()); });
                 return ToolResult::Text(result.dump(2));
             }
 
-            const Json result = server.MarshalRead([setting, value]() -> Json
+            const Json result = server.MarshalRead([setting, value, &snapshotLever]() -> Json
                                                    {
                 PostProcessSettings& pp = Renderer3D::GetPostProcessSettings();
                 // Fully qualified: `using namespace RendererSettings` is in scope, so
                 // unqualified `RendererSettings` would name that MCP namespace, not the
                 // engine struct.
                 ::OloEngine::RendererSettings& rs = Renderer3D::GetRendererSettings();
-                const ApplyResult applied = Apply(setting, value, pp, rs);
+                LeverState lever = snapshotLever();
+                const ApplyResult applied = Apply(setting, value, pp, rs, lever);
                 if (!applied.Ok)
                     return Json{ { "__error", applied.Error } };
                 // A render-path switch changes the registered pass list, so the
                 // render-graph topology must be rebuilt for the new value to render.
                 if (applied.PathChanged)
                     Renderer3D::ApplyRendererSettings();
+                // Push mutated lever fields back to the renderer — Apply only wrote
+                // the POD snapshot (the header stays renderer-free).
+                if (setting == Setting::DepthPrepass)
+                {
+                    Renderer3D::EnableDepthPrepass(lever.DepthPrepassEnabled);
+                }
+                else if (setting == Setting::SoftShadows)
+                {
+                    ShadowSettings shadow = Renderer3D::GetShadowMap().GetSettings();
+                    shadow.SoftShadows = lever.SoftShadows;
+                    Renderer3D::GetShadowMap().SetSettings(shadow);
+                }
                 return applied.Data; });
 
             if (result.is_object() && result.contains("__error"))
@@ -4046,8 +4081,10 @@ namespace OloEngine::MCP
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Current-frame renderer performance: fps, frame/CPU/GPU time (ms), draw calls, instanced "
-                "draw calls, triangles, state/shader/texture binds. Server-computed snapshot from the live "
-                "profiler. Map a low fps back to draw calls / lack of instancing.";
+                "draw calls, triangles, state/shader/texture binds, and the ACTUAL scene render resolution "
+                "(renderWidth/renderHeight — cross-check it against any olo_viewport_set_size override "
+                "before trusting timings). Server-computed snapshot from the live profiler. Map a low fps "
+                "back to draw calls / lack of instancing.";
             tool.InputSchema = Schema::EmptyObject();
             tool.OutputSchema = Schema::Object()
                                     .Prop("fps", Schema::Number())
@@ -4067,6 +4104,8 @@ namespace OloEngine::MCP
                                     .Prop("sortingMs", Schema::Number())
                                     .Prop("cullingMs", Schema::Number())
                                     .Prop("gpuWaitMs", Schema::Number().Desc("CPU ms spent blocked on the GPU frame fence — high values mean GPU-bound."))
+                                    .Prop("renderWidth", Schema::Int().Min(0).Desc("Actual SceneColor render-target width in pixels. Compare against your viewport override to detect a stale/incorrect render size. Omitted when no render graph is live."))
+                                    .Prop("renderHeight", Schema::Int().Min(0).Desc("Actual SceneColor render-target height in pixels."))
                                     .Required({ "fps", "frameTimeMs", "cpuMs", "gpuMs", "drawCalls", "triangles" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfSnapshot;
@@ -4134,9 +4173,11 @@ namespace OloEngine::MCP
             tool.Description =
                 "Whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs "
                 "ToneMap...). Each pass carries its GPU time (always-on timestamp queries, resolved a few "
-                "frames after issue) and its CPU dispatch time from the live graph. Frame totals include "
-                "gpuWaitMs (CPU blocked on the GPU fence — the direct GPU-bound signal); unattributedGpuMs "
-                "is frame GPU time spent between/outside the timed passes.";
+                "frames after issue) and its CPU dispatch time from the live graph. ScenePass "
+                "additionally reports subPasses splitting its GPU time into DepthPrepass vs Color (no "
+                "DepthPrepass sub-entry = depth prepass off; sub-pass times are inside the parent's gpuMs, "
+                "not additional). Frame totals include gpuWaitMs (CPU blocked on the GPU fence — the direct "
+                "GPU-bound signal); unattributedGpuMs is frame GPU time spent between/outside the timed passes.";
             tool.InputSchema = Schema::EmptyObject();
             tool.OutputSchema = Schema::Object()
                                     .Prop("frame", Schema::Object()
@@ -4147,7 +4188,11 @@ namespace OloEngine::MCP
                                     .Prop("passes", Schema::Array(Schema::Object()
                                                                       .Prop("pass", Schema::String())
                                                                       .Prop("gpuMs", Schema::Number())
-                                                                      .Prop("cpuMs", Schema::Number())))
+                                                                      .Prop("cpuMs", Schema::Number())
+                                                                      .Prop("subPasses", Schema::Array(Schema::Object()
+                                                                                                           .Prop("name", Schema::String())
+                                                                                                           .Prop("gpuMs", Schema::Number()))
+                                                                                             .Desc("GPU sub-pass brackets stamped inside this pass (e.g. ScenePass DepthPrepass/Color). Contained in the parent's gpuMs; absent when the pass has no sub-brackets."))))
                                     .Prop("passGpuTotalMs", Schema::Number())
                                     .Prop("unattributedGpuMs", Schema::Number())
                                     .Prop("gpuResultsAgeFrames", Schema::Int().Min(0).Desc("How many frames old the GPU numbers are (results resolve 1-3 frames after issue)."))
@@ -5062,11 +5107,15 @@ namespace OloEngine::MCP
                 "the enum-valued sibling of the on/off olo_render_toggle_pass. Settings: 'upscale' (FSR1 spatial-upscale "
                 "mode: off|quality|balanced|performance|ultraperformance — the #480 case), 'tonemap' (none|reinhard|aces|"
                 "uncharted2), 'renderpath' (forward|forwardplus|deferred; switching rebuilds the render graph, and "
-                "Deferred is required for SSR/SSGI). Call with NO arguments to list every setting with its current value "
-                "and allowed values. The change is session-global and ephemeral (a scene reload restores it); the "
-                "response reports 'previousValue' so you can restore by calling again with that token — this is "
-                "restore-prior-value, NOT an undo-stack entry (unlike olo_entity_set_field). This is a WRITE tool: it is "
-                "refused unless 'Allow writes' is enabled in the editor's MCP Server panel (off by default).";
+                "Deferred is required for SSR/SSGI), plus the two big perf levers (#316): 'depthprepass' (off|on|auto — "
+                "forces the live depth-prepass state; 'auto' restores the settings-derived value; Forward+/Deferred "
+                "derive it on for tile culling) and 'softshadows' (pcf|pcss — PCSS is the dominant ScenePass cost in "
+                "shadowed scenes; A/B it in one call instead of editing shader source). Call with NO arguments to list "
+                "every setting with its current value and allowed values. The change is session-global and ephemeral (a "
+                "scene reload restores it); the response reports 'previousValue' so you can restore by calling again "
+                "with that token — this is restore-prior-value, NOT an undo-stack entry (unlike olo_entity_set_field). "
+                "This is a WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's MCP Server panel "
+                "(off by default).";
             tool.InputSchema = RendererSettings::InputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_RendererSettingsSet;

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.cpp
@@ -40,6 +40,7 @@ namespace OloEngine
         m_FrameCounter = 0;
         m_Active = false;
         m_PassOpen = false;
+        m_SubPassOpen = false;
         m_LastFrameGpuMs = 0.0;
         m_LastResolvedFrame = 0;
         m_LastPassTimings.clear();
@@ -69,6 +70,7 @@ namespace OloEngine
         m_Initialized = false;
         m_Active = false;
         m_PassOpen = false;
+        m_SubPassOpen = false;
 
         OLO_CORE_INFO("GPUPassTimerPool: Shutdown");
     }
@@ -105,6 +107,7 @@ namespace OloEngine
         glQueryCounter(slot.Queries[0], GL_TIMESTAMP);
         m_Active = true;
         m_PassOpen = false;
+        m_SubPassOpen = false;
     }
 
     void GPUPassTimerPool::EndFrame()
@@ -112,11 +115,17 @@ namespace OloEngine
         if (!m_Initialized || !m_Active)
             return;
 
+        // Close any bracket left open (a Begin without its End). Every
+        // allocated pair MUST have both timestamps stamped before the slot is
+        // marked pending — resolving a never-stamped end query would publish
+        // garbage.
+        EndSubPass();
+        EndPass();
+
         FrameSlot& slot = m_Slots[m_WriteSlot];
         glQueryCounter(slot.Queries[1], GL_TIMESTAMP);
         slot.Pending = true;
         m_Active = false;
-        m_PassOpen = false;
     }
 
     void GPUPassTimerPool::BeginPass(const std::string& name)
@@ -128,8 +137,11 @@ namespace OloEngine
         if (slot.PassCount >= m_MaxPasses)
             return;
 
-        slot.PassNames[slot.PassCount] = name;
-        glQueryCounter(slot.Queries[2 + (2 * slot.PassCount)], GL_TIMESTAMP);
+        // Allocate the pair up front (rather than on EndPass) so a sub-pass
+        // opened inside this bracket gets its own pair without colliding.
+        m_CurrentPassIndex = slot.PassCount++;
+        slot.PassNames[m_CurrentPassIndex] = name;
+        glQueryCounter(slot.Queries[2 + (2 * m_CurrentPassIndex)], GL_TIMESTAMP);
         m_PassOpen = true;
     }
 
@@ -138,10 +150,37 @@ namespace OloEngine
         if (!m_Active || !m_PassOpen)
             return;
 
+        // A sub-pass left open must not outlive its parent bracket.
+        EndSubPass();
+
         FrameSlot& slot = m_Slots[m_WriteSlot];
-        glQueryCounter(slot.Queries[3 + (2 * slot.PassCount)], GL_TIMESTAMP);
-        ++slot.PassCount;
+        glQueryCounter(slot.Queries[3 + (2 * m_CurrentPassIndex)], GL_TIMESTAMP);
         m_PassOpen = false;
+    }
+
+    void GPUPassTimerPool::BeginSubPass(const std::string& name)
+    {
+        if (!m_Active || !m_PassOpen || m_SubPassOpen)
+            return;
+
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+        if (slot.PassCount >= m_MaxPasses)
+            return;
+
+        m_CurrentSubPassIndex = slot.PassCount++;
+        slot.PassNames[m_CurrentSubPassIndex] = slot.PassNames[m_CurrentPassIndex] + "/" + name;
+        glQueryCounter(slot.Queries[2 + (2 * m_CurrentSubPassIndex)], GL_TIMESTAMP);
+        m_SubPassOpen = true;
+    }
+
+    void GPUPassTimerPool::EndSubPass()
+    {
+        if (!m_Active || !m_SubPassOpen)
+            return;
+
+        FrameSlot& slot = m_Slots[m_WriteSlot];
+        glQueryCounter(slot.Queries[3 + (2 * m_CurrentSubPassIndex)], GL_TIMESTAMP);
+        m_SubPassOpen = false;
     }
 
     void GPUPassTimerPool::TryResolveSlot(FrameSlot& slot, bool dropIfUnavailable)

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
@@ -43,12 +43,23 @@ namespace OloEngine
         /// @brief Stamp the frame-end timestamp and mark the slot for readback.
         void EndFrame();
 
-        /// @brief Stamp the begin timestamp for the named pass. Passes must not
-        /// overlap; a Begin without a matching End is dropped.
+        /// @brief Stamp the begin timestamp for the named pass. Top-level passes
+        /// must not overlap; a Begin without a matching End is closed at EndFrame.
         void BeginPass(const std::string& name);
 
         /// @brief Stamp the end timestamp for the pass opened by BeginPass.
         void EndPass();
+
+        /// @brief Stamp the begin timestamp for a sub-pass INSIDE the currently
+        /// open pass (e.g. the ScenePass depth-prepass vs color split, #316).
+        /// The sub-pass is published as "<ParentName>/<name>"; timestamps are
+        /// scope-free so the pair coexists with (and overlaps) the parent's
+        /// bracket. One level only: a sub-pass inside a sub-pass is dropped, as
+        /// is a sub-pass with no pass open.
+        void BeginSubPass(const std::string& name);
+
+        /// @brief Stamp the end timestamp for the sub-pass opened by BeginSubPass.
+        void EndSubPass();
 
         [[nodiscard]] bool IsInitialized() const
         {
@@ -97,7 +108,11 @@ namespace OloEngine
         struct FrameSlot
         {
             // [0] = frame begin, [1] = frame end, then per-pass begin/end pairs
-            // at [2 + 2*i] / [3 + 2*i].
+            // at [2 + 2*i] / [3 + 2*i]. Pass and sub-pass brackets share the
+            // pair array: each Begin{Sub,}Pass allocates the next pair, so a
+            // sub-pass pair sits between its parent's begin and end stamps
+            // (parent-first allocation order is what the MCP shaping relies on
+            // to attach "Parent/Sub" entries to their parent).
             std::vector<u32> Queries;
             std::vector<std::string> PassNames;
             u32 PassCount = 0;
@@ -116,8 +131,11 @@ namespace OloEngine
         u32 m_MaxPasses = 0;
         u64 m_FrameCounter = 0;
         bool m_Initialized = false;
-        bool m_Active = false;   // between BeginFrame/EndFrame
-        bool m_PassOpen = false; // between BeginPass/EndPass
+        bool m_Active = false;      // between BeginFrame/EndFrame
+        bool m_PassOpen = false;    // between BeginPass/EndPass
+        bool m_SubPassOpen = false; // between BeginSubPass/EndSubPass
+        u32 m_CurrentPassIndex = 0; // pair index of the open pass
+        u32 m_CurrentSubPassIndex = 0;
 
         // Published results (most recently resolved frame).
         std::vector<PassTiming> m_LastPassTimings;

--- a/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
@@ -9,6 +9,7 @@
 #include "OloEngine/Renderer/Commands/RenderCommand.h"
 #include "OloEngine/Renderer/Debug/FrameCaptureManager.h"
 #include "OloEngine/Renderer/Debug/GLStateGuard.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
 #include "OloEngine/Renderer/Occlusion/OcclusionCuller.h"
 #include "OloEngine/Renderer/Passes/DecalRenderPass.h"
@@ -238,12 +239,22 @@ namespace OloEngine
         // with GL_EQUAL and no depth writes for the color pass. This eliminates
         // overdraw from fragment shading of occluded pixels.
         const bool depthPrepass = Renderer3D::IsDepthPrepassEnabled();
+        // Sub-pass GPU timestamp brackets (#316): split this pass's GPU time
+        // into DepthPrepass vs Color inside the render-graph executor's pass
+        // bracket. The pool prefixes the open pass's registered node name
+        // (RenderPipeline names this node "ScenePass"), so these publish as
+        // "ScenePass/DepthPrepass" and "ScenePass/Color"; surfaced as
+        // subPasses in olo_perf_pass_timings. Strictly additive around the
+        // existing Execute calls.
+        auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
         if (depthPrepass)
         {
             // Pass 1: depth only — CommandDispatch overrides per-command state
+            gpuSubTimers.BeginSubPass("DepthPrepass");
             CommandDispatch::SetDepthPrepassActive(true);
             m_CommandBucket.Execute(rendererAPI);
             CommandDispatch::SetDepthPrepassActive(false);
+            gpuSubTimers.EndSubPass();
         }
 
         // Flush deferred occlusion query proxy draws. When a depth prepass ran,
@@ -285,10 +296,15 @@ namespace OloEngine
             rendererAPI.SetPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         }
 
+        // "Color" is emitted even without a depth prepass, so a missing
+        // DepthPrepass sub-entry in olo_perf_pass_timings reads as "prepass
+        // off" rather than "sub-pass timing broken".
+        gpuSubTimers.BeginSubPass("Color");
         if (capturing)
             m_CommandBucket.ExecuteWithGPUTiming(rendererAPI);
         else
             m_CommandBucket.Execute(rendererAPI);
+        gpuSubTimers.EndSubPass();
 
         // Restore depth state after prepass
         if (depthPrepass)

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -668,6 +668,12 @@ namespace OloEngine
         // Depth prepass control
         static void EnableDepthPrepass(bool enable);
         static bool IsDepthPrepassEnabled();
+        // The depth-prepass value ApplyRendererSettings derives from the current
+        // RendererSettings (the "auto" state): the user toggle OR'd with the
+        // paths that require the prepass depth for tile culling (Forward+,
+        // Deferred, Forward with auto-switch). Exposed so the MCP depthprepass
+        // lever's 'auto' token resolves through the same single derivation.
+        static bool ComputeSettingsDerivedDepthPrepass();
 
         // Occlusion culling control (legacy CPU hardware-query path).
         static void EnableOcclusionCulling(bool enable);

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DState.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DState.cpp
@@ -228,6 +228,19 @@ namespace OloEngine
         return s_Data.DepthPrepassEnabled;
     }
 
+    bool Renderer3D::ComputeSettingsDerivedDepthPrepass()
+    {
+        // Forward+ compute culling requires the depth pre-pass.
+        // Include the Auto case: when Forward+ can dynamically activate,
+        // the depth buffer must already be available for the culling dispatch.
+        // Deferred likewise needs the depth buffer before the lighting pass —
+        // the G-Buffer depth attachment is populated by the scene pass MRT
+        // writes, and the depth-prepass additionally supports Forward+ tile
+        // culling reused by DeferredLightingPass.
+        const auto& settings = s_Data.Settings;
+        return settings.DepthPrepassEnabled || (settings.Path == RenderingPath::ForwardPlus) || (settings.Path == RenderingPath::Deferred) || (settings.Path == RenderingPath::Forward && settings.ForwardPlusAutoSwitch);
+    }
+
     void Renderer3D::EnableOcclusionCulling(bool enable)
     {
         OLO_PROFILE_FUNCTION();
@@ -359,15 +372,10 @@ namespace OloEngine
                 break;
         }
 
-        // Forward+ compute culling requires the depth pre-pass.
-        // Include the Auto case: when Forward+ can dynamically activate,
-        // the depth buffer must already be available for the culling dispatch.
-        // Deferred likewise needs the depth buffer before the lighting pass —
-        // the G-Buffer depth attachment is populated by the scene pass MRT
-        // writes, and the depth-prepass additionally supports Forward+ tile
-        // culling reused by DeferredLightingPass.
-        const bool effectiveDepthPrepass = settings.DepthPrepassEnabled || (settings.Path == RenderingPath::ForwardPlus) || (settings.Path == RenderingPath::Deferred) || (settings.Path == RenderingPath::Forward && settings.ForwardPlusAutoSwitch);
-        EnableDepthPrepass(effectiveDepthPrepass);
+        // Depth prepass: settings-derived (see ComputeSettingsDerivedDepthPrepass
+        // for why Forward+/Deferred force it on). Shared with the MCP
+        // depthprepass lever's 'auto' token, so the two can't drift.
+        EnableDepthPrepass(ComputeSettingsDerivedDepthPrepass());
 
         fplus.SetTileSize(settings.ForwardPlusTileSize);
         fplus.SetDebugVisualization(settings.ForwardPlusDebugHeatmap);

--- a/OloEngine/tests/MCP/McpPassTimingsTest.cpp
+++ b/OloEngine/tests/MCP/McpPassTimingsTest.cpp
@@ -149,3 +149,77 @@ TEST(McpPassTimingsTest, RoundsToThreeDecimals)
     EXPECT_DOUBLE_EQ(Round3(0.0005001), 0.001);
     EXPECT_DOUBLE_EQ(Round3(1.23456), 1.235);
 }
+
+// ---- sub-pass grouping ("Parent/Sub" GPU entries, #316) ---------------------
+
+// A "Parent/Sub" GPU entry attaches to its parent's subPasses instead of the
+// top-level list, and does NOT count toward passGpuTotalMs (its time is inside
+// the parent's bracket).
+TEST(McpPassTimingsTest, GroupsSubPassEntriesUnderParent)
+{
+    const std::vector<GpuPassEntry> gpu = {
+        { "ShadowPass", 1.0 },
+        { "ScenePass", 46.6 },
+        { "ScenePass/DepthPrepass", 21.9 },
+        { "ScenePass/Color", 24.2 },
+        { "GTAOPass", 0.7 },
+    };
+    const std::vector<CpuPassEntry> cpu = { { "ScenePass", 2.0 } };
+
+    const Json o = BuildPassTimings(gpu, cpu, MakeTotals());
+
+    // Sub entries are folded into the parent: 3 top-level passes remain.
+    ASSERT_EQ(o["passes"].size(), 3u);
+    const Json& scene = o["passes"][1];
+    EXPECT_EQ(scene["pass"], "ScenePass");
+    EXPECT_DOUBLE_EQ(scene["cpuMs"].get<double>(), 2.0);
+
+    ASSERT_TRUE(scene.contains("subPasses"));
+    ASSERT_EQ(scene["subPasses"].size(), 2u);
+    EXPECT_EQ(scene["subPasses"][0]["name"], "DepthPrepass");
+    EXPECT_DOUBLE_EQ(scene["subPasses"][0]["gpuMs"].get<double>(), 21.9);
+    EXPECT_EQ(scene["subPasses"][1]["name"], "Color");
+    EXPECT_DOUBLE_EQ(scene["subPasses"][1]["gpuMs"].get<double>(), 24.2);
+
+    // Passes without sub brackets carry no subPasses key at all.
+    EXPECT_FALSE(o["passes"][0].contains("subPasses"));
+
+    // Total counts each top-level pass once — sub times are already inside.
+    EXPECT_NEAR(o["passGpuTotalMs"].get<double>(), 1.0 + 46.6 + 0.7, 1e-9);
+}
+
+// An orphan sub entry (parent not GPU-timed this frame — pool overflow) stays
+// a top-level entry under its full name and counts toward the total, rather
+// than being dropped silently.
+TEST(McpPassTimingsTest, OrphanSubPassEntryStaysTopLevel)
+{
+    const std::vector<GpuPassEntry> gpu = {
+        { "ScenePass/Color", 24.2 },
+    };
+
+    const Json o = BuildPassTimings(gpu, {}, MakeTotals());
+
+    ASSERT_EQ(o["passes"].size(), 1u);
+    EXPECT_EQ(o["passes"][0]["pass"], "ScenePass/Color");
+    EXPECT_DOUBLE_EQ(o["passes"][0]["gpuMs"].get<double>(), 24.2);
+    EXPECT_NEAR(o["passGpuTotalMs"].get<double>(), 24.2, 1e-9);
+}
+
+// With duplicate parent names (a pass that runs twice), a sub entry attaches to
+// the MOST RECENT parent — the pool allocates parent-before-sub in execution
+// order, so the nearest preceding entry is the owning bracket.
+TEST(McpPassTimingsTest, SubPassAttachesToMostRecentParent)
+{
+    const std::vector<GpuPassEntry> gpu = {
+        { "BlurPass", 1.0 },
+        { "BlurPass", 2.0 },
+        { "BlurPass/Horizontal", 0.9 },
+    };
+
+    const Json o = BuildPassTimings(gpu, {}, MakeTotals());
+
+    ASSERT_EQ(o["passes"].size(), 2u);
+    EXPECT_FALSE(o["passes"][0].contains("subPasses"));
+    ASSERT_TRUE(o["passes"][1].contains("subPasses"));
+    EXPECT_EQ(o["passes"][1]["subPasses"][0]["name"], "Horizontal");
+}

--- a/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
+++ b/OloEngine/tests/MCP/McpRendererSettingsTest.cpp
@@ -87,8 +87,8 @@ namespace
                 if (const auto error = RS::ParseArgs(args, introspect, setting, value))
                     return ToolResult::Error(*error);
                 if (introspect)
-                    return ToolResult::Text(RS::Describe(m_PP, m_RS).dump());
-                const RS::ApplyResult applied = RS::Apply(setting, value, m_PP, m_RS);
+                    return ToolResult::Text(RS::Describe(m_PP, m_RS, m_Lever).dump());
+                const RS::ApplyResult applied = RS::Apply(setting, value, m_PP, m_RS, m_Lever);
                 if (!applied.Ok)
                     return ToolResult::Error(applied.Error);
                 return ToolResult::Text(applied.Data.dump());
@@ -98,7 +98,8 @@ namespace
 
         PostProcessSettings m_PP;
         RendererSettings m_RS;
-        McpServer m_Server; // declared last → destroyed first (its handler refs m_PP/m_RS)
+        RS::LeverState m_Lever;
+        McpServer m_Server; // declared last → destroyed first (its handler refs m_PP/m_RS/m_Lever)
     };
 } // namespace
 
@@ -224,7 +225,8 @@ TEST(McpRendererSettingsApply, SetsUpscaleAndReportsPrior)
 {
     PostProcessSettings pp;
     RendererSettings rs;
-    const auto result = RS::Apply(RS::Setting::Upscale, static_cast<i32>(UpscaleMode::Balanced), pp, rs);
+    RS::LeverState lever;
+    const auto result = RS::Apply(RS::Setting::Upscale, static_cast<i32>(UpscaleMode::Balanced), pp, rs, lever);
     ASSERT_TRUE(result.Ok);
     EXPECT_EQ(pp.Upscale, UpscaleMode::Balanced);
     EXPECT_EQ(result.Data["previousValue"], "off");
@@ -237,7 +239,8 @@ TEST(McpRendererSettingsApply, SetsTonemap)
 {
     PostProcessSettings pp;
     RendererSettings rs;
-    const auto result = RS::Apply(RS::Setting::Tonemap, static_cast<i32>(TonemapOperator::ACES), pp, rs);
+    RS::LeverState lever;
+    const auto result = RS::Apply(RS::Setting::Tonemap, static_cast<i32>(TonemapOperator::ACES), pp, rs, lever);
     ASSERT_TRUE(result.Ok);
     EXPECT_EQ(pp.Tonemap, TonemapOperator::ACES);
     EXPECT_EQ(result.Data["previousValue"], "reinhard"); // struct default
@@ -249,7 +252,8 @@ TEST(McpRendererSettingsApply, RenderPathChangeFlagsRebuild)
 {
     PostProcessSettings pp;
     RendererSettings rs; // default Forward
-    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Deferred), pp, rs);
+    RS::LeverState lever;
+    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Deferred), pp, rs, lever);
     ASSERT_TRUE(result.Ok);
     EXPECT_EQ(rs.Path, RenderingPath::Deferred);
     EXPECT_TRUE(result.PathChanged);
@@ -263,7 +267,8 @@ TEST(McpRendererSettingsApply, NoOpWhenValueUnchanged)
 {
     PostProcessSettings pp;
     RendererSettings rs; // default Forward
-    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Forward), pp, rs);
+    RS::LeverState lever;
+    const auto result = RS::Apply(RS::Setting::RenderPath, static_cast<i32>(RenderingPath::Forward), pp, rs, lever);
     ASSERT_TRUE(result.Ok);
     EXPECT_FALSE(result.Data["changed"].get<bool>());
     EXPECT_FALSE(result.PathChanged);
@@ -277,12 +282,120 @@ TEST(McpRendererSettingsApply, RejectsOutOfRangeValueAndMutatesNothing)
     PostProcessSettings pp;
     pp.Upscale = UpscaleMode::Quality;
     RendererSettings rs;
+    RS::LeverState lever;
 
-    const auto result = RS::Apply(RS::Setting::Upscale, 999, pp, rs);
+    const auto result = RS::Apply(RS::Setting::Upscale, 999, pp, rs, lever);
     EXPECT_FALSE(result.Ok);
     EXPECT_FALSE(result.Error.empty());
     EXPECT_TRUE(result.Data.is_null());
     EXPECT_EQ(pp.Upscale, UpscaleMode::Quality); // unchanged
+}
+
+// ---- the perf-lever settings (#316: depthprepass / softshadows) ------------
+
+// The depthprepass lever writes the LeverState snapshot (the handler pushes it
+// to Renderer3D::EnableDepthPrepass afterwards) and never touches pp / rs.
+TEST(McpRendererSettingsApply, DepthPrepassOffWritesLeverOnly)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    RS::LeverState lever;
+    lever.DepthPrepassEnabled = true;
+
+    const auto result = RS::Apply(RS::Setting::DepthPrepass, RS::kDepthPrepassOff, pp, rs, lever);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_FALSE(lever.DepthPrepassEnabled);
+    EXPECT_EQ(result.Data["previousValue"], "on");
+    EXPECT_EQ(result.Data["value"], "off");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data.contains("requested"));
+    EXPECT_FALSE(result.PathChanged);
+}
+
+// 'auto' resolves to the settings-derived value BEFORE the write, so the
+// response reports the actual resulting state (plus requested:"auto") and the
+// restore hint still round-trips through off/on.
+TEST(McpRendererSettingsApply, DepthPrepassAutoResolvesToDerivedValue)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    RS::LeverState lever;
+    lever.DepthPrepassEnabled = false; // forced off by a prior 'off' write
+    lever.DepthPrepassAuto = true;     // settings say it should be on
+
+    const auto result = RS::Apply(RS::Setting::DepthPrepass, RS::kDepthPrepassAuto, pp, rs, lever);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_TRUE(lever.DepthPrepassEnabled);
+    EXPECT_EQ(result.Data["previousValue"], "off");
+    EXPECT_EQ(result.Data["value"], "on"); // the resolved state, not "auto"
+    EXPECT_EQ(result.Data["requested"], "auto");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+}
+
+// 'auto' that resolves to the current state is honestly reported unchanged.
+TEST(McpRendererSettingsApply, DepthPrepassAutoNoOpWhenAlreadyDerived)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    RS::LeverState lever;
+    lever.DepthPrepassEnabled = true;
+    lever.DepthPrepassAuto = true;
+
+    const auto result = RS::Apply(RS::Setting::DepthPrepass, RS::kDepthPrepassAuto, pp, rs, lever);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_FALSE(result.Data["changed"].get<bool>());
+    EXPECT_EQ(result.Data["requested"], "auto");
+}
+
+TEST(McpRendererSettingsApply, SoftShadowsPcfDisablesPcssAndReportsPrior)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    RS::LeverState lever;
+    lever.SoftShadows = true; // engine default: PCSS on
+
+    const auto result = RS::Apply(RS::Setting::SoftShadows, RS::kSoftShadowsPcf, pp, rs, lever);
+    ASSERT_TRUE(result.Ok);
+    EXPECT_FALSE(lever.SoftShadows);
+    EXPECT_EQ(result.Data["previousValue"], "pcss");
+    EXPECT_EQ(result.Data["value"], "pcf");
+    EXPECT_EQ(result.Data["restoreWith"], "pcss");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+
+    // Restore by setting the reported prior value back.
+    const auto restored = RS::Apply(RS::Setting::SoftShadows, RS::kSoftShadowsPcss, pp, rs, lever);
+    ASSERT_TRUE(restored.Ok);
+    EXPECT_TRUE(lever.SoftShadows);
+}
+
+// Describe reads the lever state for the two new settings — 'auto' is
+// write-only, so the current value is always off/on.
+TEST(McpRendererSettingsApply, DescribeReportsLeverCurrentValues)
+{
+    PostProcessSettings pp;
+    RendererSettings rs;
+    RS::LeverState lever;
+    lever.DepthPrepassEnabled = true;
+    lever.SoftShadows = false;
+
+    const Json described = RS::Describe(pp, rs, lever);
+    bool sawPrepass = false;
+    bool sawShadows = false;
+    for (const auto& entry : described["settings"])
+    {
+        if (entry["setting"] == "depthprepass")
+        {
+            sawPrepass = true;
+            EXPECT_EQ(entry["currentValue"], "on");
+        }
+        if (entry["setting"] == "softshadows")
+        {
+            sawShadows = true;
+            EXPECT_EQ(entry["currentValue"], "pcf");
+        }
+    }
+    EXPECT_TRUE(sawPrepass);
+    EXPECT_TRUE(sawShadows);
 }
 
 // ---- the shared arg parser + token resolution ------------------------------

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -166,11 +166,11 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_scene_summary` | active scene name, play state, entity count |
 | `olo_scene_list_entities` | paginated entity list (id, name, parent, child count) + name filter |
 | `olo_scene_get_entity` | one entity's full component data (YAML) by UUID |
-| `olo_perf_snapshot` | fps, frame/CPU/GPU time (real whole-frame GPU timer), `gpuWaitMs` (CPU blocked on the GPU fence — the direct GPU-bound signal), draw calls, instancing, triangles |
+| `olo_perf_snapshot` | fps, frame/CPU/GPU time (real whole-frame GPU timer), `gpuWaitMs` (CPU blocked on the GPU fence — the direct GPU-bound signal), draw calls, instancing, triangles, plus `renderWidth`/`renderHeight` — the ACTUAL SceneColor render resolution; cross-check it against any `olo_viewport_set_size` override before trusting timings |
 | `olo_perf_bottlenecks` | CPU/GPU/Memory/IO bottleneck + confidence + recommendations (uses real cpu/gpu/gpuWait numbers) |
 | `olo_perf_frame_history` | downsampled recent-frame time series |
 | `olo_perf_capture_frame` | triggers a real frame capture: stats + top-K draw commands by GPU time (per-draw times resolve via a deferred commit one-plus frames after the capture; draws carry their submesh debug names) |
-| `olo_perf_pass_timings` | whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs ToneMap…): per-pass GPU (always-on timestamp queries) + CPU dispatch ms, frame totals incl. `gpuWaitMs`, and `unattributedGpuMs` |
+| `olo_perf_pass_timings` | whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs ToneMap…): per-pass GPU (always-on timestamp queries) + CPU dispatch ms, frame totals incl. `gpuWaitMs`, and `unattributedGpuMs`. `ScenePass` carries `subPasses` splitting its GPU time into `DepthPrepass` vs `Color` (no DepthPrepass entry = prepass off; sub times are inside the parent's `gpuMs`, not additional) |
 | `olo_render_frame_breakdown` | triggers a real frame capture and returns its **per-command / per-pipeline-stage** structural breakdown (the granularity `olo_perf_capture_frame` omits): pipeline stats + the ordered command list (type, debug-name pass label, draw key shader/material/depth, group, execution order, static flag, GPU time) + a command-type histogram, at the chosen `viewMode` (`presort`/`postsort`/`postbatch`); `format:"markdown"` returns the Command Bucket Inspector's LLM-analysis report (sort/state-change/batching analysis + optimization hints) |
 | `olo_memory_report` | GPU/CPU memory total + per-type breakdown + suspected leaks |
 | `olo_shader_list` | inventory of all registered shaders (id, name, hasErrors) |
@@ -188,13 +188,13 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_camera_set_pose` | move the editor camera: `position` + (`target` \| `yaw`/`pitch`), optional `fov` |
 | `olo_camera_orbit` | orbit-frame the camera around a world point: `target`, `yaw`, `pitch`, `distance` |
 | `olo_camera_frame_entity` | point the camera at an entity (by UUID) and fit it in view |
-| `olo_viewport_set_size` | override the viewport's logical render size for deterministic captures (`reset` to clear) |
+| `olo_viewport_set_size` | override the viewport's logical render size for deterministic captures (`reset` to clear). The override wins over window/panel resizes (the editor reasserts it after any OS window-resize event); verify with `olo_perf_snapshot`'s `renderWidth`/`renderHeight` before perf measurements |
 | `olo_render_list_targets` | the render graph's live texture/framebuffer resources (name, kind, format, size, producers) |
 | `olo_render_capture_target` | read back one intermediate render target (depth, normals, G-buffer, shadow map, AO, post-process stages, …) as a PNG image block; depth is min-max normalised by default |
 | `olo_render_compare_golden` | capture the viewport (optional `camera`/`orbit` pose) and diff it against a golden PNG (`goldenPath`): returns a numeric `similarity`/`rmse`/`ssim` + `pass` verdict; missing golden or `rebase`:true writes the capture as the new baseline (the `OLOENGINE_GOLDEN_REBASE` workflow) |
 | `olo_render_toggle_pass` | flip a post-process / fog feature on/off (`name` + optional `enabled`) — the ephemeral A/B loop: toggle off → `olo_screenshot` → toggle on → `olo_screenshot`. No `name` lists every pass + its live state |
 | `olo_render_set_debug_view` | switch the viewport to a raw AO/SSR/SSGI buffer (`mode`: none/ssao/gtao/ssr/ssgi); reports whether the backing pass is actually running. No `mode` lists the modes + current state |
-| `olo_renderer_settings_set` | **(consented write)** set a multi-valued, session-global renderer / post-process setting — `upscale` (FSR1 spatial-upscale mode), `tonemap` (operator), `renderpath` (forward/forward+/deferred) — to verify a rendering feature live at each value. The enum-valued sibling of `olo_render_toggle_pass`; reports `previousValue` for restore-prior-value (no undo stack). No args lists every setting + current value + allowed values. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
+| `olo_renderer_settings_set` | **(consented write)** set a multi-valued, session-global renderer / post-process setting — `upscale` (FSR1 spatial-upscale mode), `tonemap` (operator), `renderpath` (forward/forward+/deferred), `depthprepass` (off/on/auto — the #316 perf lever), `softshadows` (pcf/pcss — THE ScenePass shadow-cost lever) — to verify a rendering feature live at each value. The enum-valued sibling of `olo_render_toggle_pass`; reports `previousValue` for restore-prior-value (no undo stack). No args lists every setting + current value + allowed values. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
 | `olo_scene_set_time_of_day` | move the procedural sky's sun to a 24-hour clock time (`hours` 0–24) for lighting iteration — ephemeral session override of the sun direction, never written to the scene. `clear`:true restores the authored sun; no args reports the current override |
 | `olo_scene_set_sun_angle` | aim the procedural sky's sun directly from a `yaw` (azimuth) / `pitch` (elevation) pair — the precise sibling of `olo_scene_set_time_of_day`, same ephemeral session override. `clear`:true restores; no args reports state |
 | `olo_render_why_not_visible` | explain why one entity (`entity`) is NOT on screen — the "why can't I see my mesh?" debugger: root-cause `reasonCode`, summary, ordered checks, and the raw render facts |
@@ -510,6 +510,18 @@ The settings:
 - **`renderpath`** — rendering path: `forward` | `forwardplus` | `deferred`.
   Switching **rebuilds the render-graph topology**, and `deferred` is required for
   SSR / SSGI.
+- **`depthprepass`** — the depth-prepass perf lever (#316): `off` | `on` | `auto`.
+  `on`/`off` force the **live** Renderer3D toggle for this session; `auto` restores
+  the settings-derived value (the response then carries `"requested": "auto"` plus
+  the resolved `off`/`on` it landed on). Forward+/Deferred derive it **on** because
+  their tile culling reads the prepass depth — forcing `off` there is a legitimate
+  perf experiment but degrades tiled lighting until restored. Note a later settings
+  apply (e.g. a `renderpath` switch) re-derives it.
+- **`softshadows`** — directional-shadow filtering (#316): `pcf` | `pcss`. PCSS
+  (contact-hardening penumbra) is **the** dominant ScenePass cost in shadowed scenes
+  — the second live perf session measured it at ~93 % of a 46.6 ms ScenePass at
+  1080p Sponza. This lever turns that A/B into one call instead of a shader-source
+  edit + `olo_shader_reload`.
 
 **Restore is restore-PRIOR-VALUE, not CommandHistory.** Unlike the entity field
 writes (`olo_set_collision_layer` / `olo_entity_set_field`), which push an undoable


### PR DESCRIPTION
…erf levers, viewport-override resize fix (#316)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer GPU timing output with nested sub-pass breakdowns for scene rendering.
  * Added support for more renderer settings, including depth prepass and soft shadows.
  * Added viewport-aware performance snapshots that report actual render resolution.

* **Bug Fixes**
  * Improved resize handling so viewport and framebuffer sizes stay in sync after window resizes.
  * Fixed timing and snapshot validation to better reflect actual rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->