### PR TITLE
feat(mcp): scriptable scene control (olo_scene_open/play/stop) + headless auto-save recovery (#316 Part 5)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -92,6 +92,40 @@ namespace
                                { return static_cast<char>(std::tolower(c)); });
         return ext;
     }
+
+    // How to answer the "Recover Auto-Save?" prompt when OpenScene finds a newer
+    // .auto file. Prompt = show the modal (the interactive default).
+    enum class AutoSaveRecoveryChoice
+    {
+        Prompt,
+        Autosave, // load the .auto (the recovered work)
+        Original, // load the saved scene, leaving the .auto in place
+        Discard,  // delete the .auto, then load the saved scene
+    };
+
+    // A headless / agent session can't click the recovery modal — synthetic Win32
+    // clicks don't reach ImGui — so a newer auto-save would wedge the editor at a
+    // modal it can never dismiss (issue #316 Part 5). OLO_EDITOR_AUTOSAVE_RECOVERY
+    // lets an automated launch pre-answer it: 'autosave'/'recover', 'original'/'keep',
+    // or 'discard'/'delete' (case-insensitive). Unset / empty / unrecognized keeps
+    // the interactive modal, so this never changes a human's editor.
+    [[nodiscard]] AutoSaveRecoveryChoice ResolveAutoSaveRecoveryChoice()
+    {
+        const char* env = std::getenv("OLO_EDITOR_AUTOSAVE_RECOVERY");
+        if (env == nullptr || *env == '\0')
+            return AutoSaveRecoveryChoice::Prompt;
+        std::string value(env);
+        std::ranges::transform(value, value.begin(),
+                               [](unsigned char c)
+                               { return static_cast<char>(std::tolower(c)); });
+        if (value == "autosave" || value == "recover" || value == "auto")
+            return AutoSaveRecoveryChoice::Autosave;
+        if (value == "original" || value == "keep" || value == "saved")
+            return AutoSaveRecoveryChoice::Original;
+        if (value == "discard" || value == "delete")
+            return AutoSaveRecoveryChoice::Discard;
+        return AutoSaveRecoveryChoice::Prompt; // unrecognized -> safe interactive default
+    }
 } // namespace
 
 namespace OloEngine
@@ -405,6 +439,108 @@ namespace OloEngine
 #else
                 result.Message = "C# scripting is disabled in this build (Mono not available on this platform).";
 #endif
+                return result;
+            };
+            // olo_scene_open (#316 Part 5): open/switch the active scene. Resolves the
+            // path against the project asset directory when relative, stops Play mode
+            // if running, and loads the scene DIRECTLY via LoadEditorSceneFile — never
+            // raising the auto-save recovery modal (a remote agent can't click it).
+            // Main-thread-only (EnTT registry / renderer settings), so the MCP server
+            // calls it from a MarshalRead job.
+            mcpContext.OpenSceneFromMcp = [this](const std::string& path) -> MCP::McpSceneOpenResult
+            {
+                MCP::McpSceneOpenResult result;
+                result.Available = true;
+
+                std::filesystem::path scenePath(path);
+                if (scenePath.is_relative() && Project::GetActive())
+                    scenePath = Project::GetAssetFileSystemPath(scenePath);
+                result.Path = scenePath.string();
+
+                if (auto const ext = LowercaseExtension(scenePath); ext != ".olo" && ext != ".scene")
+                {
+                    result.Message = "Not a scene file (expected .olo or .scene): " + scenePath.string();
+                    return result;
+                }
+                std::error_code ec;
+                if (!std::filesystem::exists(scenePath, ec))
+                {
+                    result.Message = "Scene file not found: " + scenePath.string();
+                    return result;
+                }
+
+                // The runtime scene in Play/Simulate is a transient copy; stop first so
+                // the load replaces the authored (Edit-mode) scene cleanly.
+                if (m_SceneState != SceneState::Edit)
+                    OnSceneStop();
+
+                if (!LoadEditorSceneFile(scenePath, scenePath))
+                {
+                    result.Message = "Failed to load scene (deserialize error — see the engine log): " + scenePath.string();
+                    return result;
+                }
+
+                result.Ok = true;
+                result.SceneName = m_ActiveScene ? m_ActiveScene->GetName() : std::string{};
+                result.EntityCount = m_ActiveScene
+                                         ? static_cast<u32>(m_ActiveScene->GetAllEntitiesWith<IDComponent>().size())
+                                         : 0;
+                result.Message = "Opened scene '" + result.SceneName + "' (" +
+                                 std::to_string(result.EntityCount) + " entities).";
+                return result;
+            };
+            // olo_scene_play / olo_scene_stop (#316 Part 5): toggle Play mode — the
+            // same OnScenePlay / OnSceneStop the editor's Play/Stop buttons drive.
+            // Idempotent: a redundant call reports changed:false. Entering Play can
+            // fail when the scene has no primary camera (OnScenePlay reverts to Edit),
+            // reported as ok:false. Main-thread-only (mutates scene state / runs the
+            // runtime start-stop), so it runs inside a MarshalRead job.
+            mcpContext.SetScenePlayState = [this](bool play) -> MCP::McpScenePlayResult
+            {
+                MCP::McpScenePlayResult result;
+                result.Available = true;
+
+                if (play)
+                {
+                    if (m_SceneState == SceneState::Play)
+                    {
+                        result.Ok = true;
+                        result.Playing = true;
+                        result.Message = "Already in Play mode.";
+                    }
+                    else
+                    {
+                        // From Simulate, OnScenePlay stops it first; from Edit it enters
+                        // Play. It reverts to Edit if the scene has no primary camera.
+                        OnScenePlay();
+                        const bool nowPlaying = m_SceneState == SceneState::Play;
+                        result.Ok = nowPlaying;
+                        result.Playing = nowPlaying;
+                        result.Changed = nowPlaying;
+                        result.Message = nowPlaying
+                                             ? "Entered Play mode."
+                                             : "Could not enter Play mode: the scene has no primary CameraComponent "
+                                               "(see the engine log). The editor stayed in Edit mode.";
+                    }
+                }
+                else
+                {
+                    if (m_SceneState == SceneState::Play || m_SceneState == SceneState::Simulate)
+                    {
+                        OnSceneStop();
+                        result.Ok = true;
+                        result.Changed = true;
+                        result.Message = "Stopped Play mode; restored the authored scene.";
+                    }
+                    else
+                    {
+                        result.Ok = true;
+                        result.Message = "Already stopped (Edit mode).";
+                    }
+                    result.Playing = false;
+                }
+
+                result.SceneName = m_ActiveScene ? m_ActiveScene->GetName() : std::string{};
                 return result;
             };
             mcpContext.GetFrameIndex = [this]() -> u64
@@ -2584,19 +2720,53 @@ namespace OloEngine
         autoPath += ".auto";
         if (FileSystem::IsNewer(autoPath, path))
         {
-            m_PendingRecoveryScenePath = path;
-            m_PendingRecoveryAutoPath = autoPath;
-            m_ShowAutoSaveRecovery = true;
-            return true; // The modal will handle loading
+            // A headless / agent session can't click the recovery modal, so an
+            // automated launch can pre-answer it via OLO_EDITOR_AUTOSAVE_RECOVERY
+            // (issue #316 Part 5). Unset -> show the modal as before.
+            switch (ResolveAutoSaveRecoveryChoice())
+            {
+                case AutoSaveRecoveryChoice::Autosave:
+                    OLO_CORE_INFO("Auto-save recovery pre-answered (autosave): loading '{}'", autoPath.string());
+                    return LoadEditorSceneFile(autoPath, path);
+                case AutoSaveRecoveryChoice::Original:
+                    OLO_CORE_INFO("Auto-save recovery pre-answered (original): loading '{}'", path.string());
+                    return LoadEditorSceneFile(path, path);
+                case AutoSaveRecoveryChoice::Discard:
+                {
+                    OLO_CORE_INFO("Auto-save recovery pre-answered (discard): deleting '{}' and loading '{}'",
+                                  autoPath.string(), path.string());
+                    std::error_code ec;
+                    std::filesystem::remove(autoPath, ec);
+                    return LoadEditorSceneFile(path, path);
+                }
+                case AutoSaveRecoveryChoice::Prompt:
+                default:
+                    m_PendingRecoveryScenePath = path;
+                    m_PendingRecoveryAutoPath = autoPath;
+                    m_ShowAutoSaveRecovery = true;
+                    return true; // The modal will handle loading
+            }
         }
 
+        return LoadEditorSceneFile(path, path);
+    }
+
+    // Deserialize `loadPath` and install it as the editor scene, recording `scenePath`
+    // as the scene's on-disk identity (they differ only for auto-save recovery, where
+    // we load the .auto but keep the real scene's path). The full "Open Scene"
+    // finalization: SetEditorScene, camera framing, the unified-timeline SceneLoad
+    // event, and syncing the scene's renderer settings + quality tiering. Shared by
+    // OpenScene (the non-modal path) and the MCP olo_scene_open hook. Returns false
+    // (leaving the current scene untouched) if the deserialize fails.
+    bool EditorLayer::LoadEditorSceneFile(const std::filesystem::path& loadPath, const std::filesystem::path& scenePath)
+    {
         Ref<Scene> const newScene = Ref<Scene>::Create();
-        if (SceneSerializer serializer(newScene); !serializer.Deserialize(path.string()))
+        if (SceneSerializer serializer(newScene); !serializer.Deserialize(loadPath.string()))
         {
             return false;
         }
         SetEditorScene(newScene);
-        m_EditorScenePath = path;
+        m_EditorScenePath = scenePath;
         FrameEditorCameraOnTerrain(newScene);
 
         // One unified-timeline event for the whole load (#306 item B). The per-entity
@@ -2606,7 +2776,7 @@ namespace OloEngine
             DiagnosticEventCategory::SceneLoad,
             "Loaded scene '" + newScene->GetName() + "' (" +
                 std::to_string(static_cast<u64>(newScene->GetAllEntitiesWith<IDComponent>().size())) + " entities)",
-            0, path.filename().string());
+            0, scenePath.filename().string());
 
         Renderer3D::GetPostProcessSettings() = newScene->GetPostProcessSettings();
         Renderer3D::GetSnowSettings() = newScene->GetSnowSettings();

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -85,6 +85,11 @@ namespace OloEngine
         void NewScene();
         void OpenScene();
         bool OpenScene(const std::filesystem::path& path);
+        // Deserialize `loadPath` and install it as the editor scene, recording
+        // `scenePath` as its on-disk identity (they differ only for auto-save
+        // recovery). The shared, modal-free "Open Scene" finalization used by
+        // OpenScene and the MCP olo_scene_open hook. Returns false on a failed load.
+        bool LoadEditorSceneFile(const std::filesystem::path& loadPath, const std::filesystem::path& scenePath);
         // Point the editor camera at a terrain in the scene (terrain spans world
         // [0, worldSize] from its transform, so the default origin-focused camera
         // would otherwise look right past it). No-op when the scene has no terrain.

--- a/OloEditor/src/MCP/McpSceneControl.h
+++ b/OloEditor/src/MCP/McpSceneControl.h
@@ -1,0 +1,135 @@
+#pragma once
+
+// Shared, editor-side schema + result shaping for the consented MCP scene-control
+// write tools (issue #316 Part 5): `olo_scene_open` (open/switch the active scene),
+// `olo_scene_play` and `olo_scene_stop` (toggle Play mode). Together they give an
+// agent scriptable control over which scene is loaded and whether the runtime is
+// simulating — the "scriptable repro setup" the read-only server couldn't drive
+// (previously a manual Sandbox.oloproj StartScene edit + editor relaunch per scene,
+// and an OLO_EDITOR_AUTOPLAY=1 relaunch to reach Play).
+//
+// Like McpReloadScript.h, the ACTIONS cannot live in this header — opening a scene
+// and toggling Play touch the EnTT registry / renderer / runtime, which a unit test
+// must not invoke. So they are routed through the EditorMcpContext hooks
+// (OpenSceneFromMcp / SetScenePlayState): the editor wires them to its Open Scene /
+// OnScenePlay / OnSceneStop paths, a headless host leaves them null ("not
+// available"), and a test injects a fake. What stays here, header-only and
+// engine-free, is the bit the tests pin: the tools' inputSchema, the pure
+// scene-path validation (extension + traversal guard), and the result -> JSON
+// shaping the handlers emit.
+//
+// Engine-free: only McpServer.h (the McpSceneOpenResult / McpScenePlayResult structs
+// + Json) and the schema-builder DSL, so it pulls no extra editor TU into the MCP
+// test binary (which deliberately does NOT link McpTools.cpp) — the same split
+// McpReloadScript.h / McpRendererSettings.h use.
+
+#include "MCP/McpSchemaBuilder.h"
+#include "MCP/McpServer.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace OloEngine::MCP::SceneControl
+{
+    using Json = nlohmann::json;
+
+    // The lowercase extension of `path` including the leading dot ("" if none). Pure
+    // string work — no filesystem access — so it is unit-testable and pulls in no
+    // std::filesystem. Only the final path component's last dot counts.
+    [[nodiscard]] inline std::string LowercaseExtension(std::string_view path)
+    {
+        // Find the start of the final component (after the last '/' or '\\').
+        sizet slash = path.find_last_of("/\\");
+        const std::string_view leaf = (slash == std::string_view::npos) ? path : path.substr(slash + 1);
+        const sizet dot = leaf.find_last_of('.');
+        if (dot == std::string_view::npos || dot == 0) // no dot, or a dotfile like ".gitignore"
+            return {};
+        std::string ext(leaf.substr(dot));
+        for (char& c : ext)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return ext;
+    }
+
+    // Validate a scene path argument for `olo_scene_open`. Pure: it enforces only
+    // what can be checked without the filesystem — a non-empty string with a
+    // recognised scene extension (.olo / .scene) and no parent-directory traversal
+    // (a ".." component would let a consented write escape the project tree). The
+    // editor hook does the rest (resolve relative to the asset directory, check the
+    // file exists, deserialize). Returns a human-readable error, or nullopt on OK.
+    [[nodiscard]] inline std::optional<std::string> ValidateScenePath(std::string_view path)
+    {
+        if (path.empty())
+            return "Missing required argument 'path' (a .olo or .scene scene file, relative to the project asset directory).";
+
+        // Reject a ".." path component (traversal out of the project). Check between
+        // separators so a filename that merely contains ".." (e.g. "a..b.olo") is fine.
+        sizet start = 0;
+        while (start <= path.size())
+        {
+            sizet sep = path.find_first_of("/\\", start);
+            const std::string_view comp = path.substr(start, sep == std::string_view::npos ? std::string_view::npos : sep - start);
+            if (comp == "..")
+                return "Invalid 'path': parent-directory traversal ('..') is not allowed.";
+            if (sep == std::string_view::npos)
+                break;
+            start = sep + 1;
+        }
+
+        if (const std::string ext = LowercaseExtension(path); ext != ".olo" && ext != ".scene")
+            return "Invalid 'path': expected a scene file ending in .olo or .scene.";
+        return std::nullopt;
+    }
+
+    // inputSchema for olo_scene_open: a required `path` string. The value-level
+    // extension / traversal constraints can't be expressed in JSON-Schema, so
+    // ValidateScenePath enforces them and the server's schema check only guarantees
+    // `path` is present and a string.
+    [[nodiscard]] inline Json OpenInputSchema()
+    {
+        return Schema::Object()
+            .Prop("path", Schema::String().Desc("The scene file to open, ending in .olo or .scene. Relative paths resolve "
+                                                "against the project's asset directory (e.g. \"Scenes/Sandbox.olo\"); an absolute "
+                                                "path is also accepted. Parent-directory traversal ('..') is rejected."))
+            .Required({ "path" })
+            .NoAdditional();
+    }
+
+    // inputSchema for olo_scene_play / olo_scene_stop: no arguments (the transition
+    // direction is fixed by which tool you call, mirroring the editor's Play / Stop
+    // buttons).
+    [[nodiscard]] inline Json PlayStopInputSchema()
+    {
+        return Schema::EmptyObject();
+    }
+
+    // Result shaping. Each mirrors the hook's outcome struct into the JSON an agent
+    // sees. `available` distinguishes "no editor in this host" from a real result.
+    [[nodiscard]] inline Json ToJson(const McpSceneOpenResult& result)
+    {
+        return Json{
+            { "available", result.Available },
+            { "ok", result.Ok },
+            { "path", result.Path },
+            { "sceneName", result.SceneName },
+            { "entityCount", result.EntityCount },
+            { "message", result.Message },
+        };
+    }
+
+    [[nodiscard]] inline Json ToJson(const McpScenePlayResult& result)
+    {
+        return Json{
+            { "available", result.Available },
+            { "ok", result.Ok },
+            { "playing", result.Playing },
+            { "changed", result.Changed },
+            { "sceneName", result.SceneName },
+            { "message", result.Message },
+        };
+    }
+} // namespace OloEngine::MCP::SceneControl

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -195,6 +195,40 @@ namespace OloEngine::MCP
         std::string Message;
     };
 
+    // Outcome of a consented scene switch (issue #316 Part 5), returned by
+    // EditorMcpContext::OpenSceneFromMcp. `Available` is false in a host that owns
+    // no editor (the headless attach / dispatch tests) — the tool then reports that
+    // honestly. `Ok` is true only when the scene actually loaded; on failure
+    // `Message` explains why (bad extension, not found, deserialize failed). `Path`
+    // is the resolved scene path, `SceneName` / `EntityCount` describe the scene now
+    // active. The load bypasses the editor's auto-save recovery modal (an agent
+    // can't click it) and loads the requested file directly.
+    struct McpSceneOpenResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        std::string Path;
+        std::string SceneName;
+        u32 EntityCount = 0;
+        std::string Message;
+    };
+
+    // Outcome of a consented play-mode toggle (issue #316 Part 5), returned by
+    // EditorMcpContext::SetScenePlayState. `Available` is false in a host with no
+    // editor. `Ok` is true when the editor is in the requested mode afterwards;
+    // `Changed` is true only when this call actually transitioned (entering Play can
+    // fail — e.g. no primary camera — leaving the editor in Edit with Ok:false).
+    // `Playing` is the resulting play state; `SceneName` is the active scene.
+    struct McpScenePlayResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        bool Playing = false;
+        bool Changed = false;
+        std::string SceneName;
+        std::string Message;
+    };
+
     // Editor state the main-marshaled tools read. EditorLayer fills these in; the
     // std::function bodies are ONLY safe to call on the main (game) thread, i.e.
     // from inside a MarshalRead() job.
@@ -256,6 +290,28 @@ namespace OloEngine::MCP
         // a headless host that owns no script engine — the tool then reports "not
         // available".
         std::function<McpScriptReloadResult()> ReloadScriptAssembly;
+
+        // Open / switch the active scene — the consented-write scene switch
+        // (issue #316 Part 5). Loads the scene at `path` (resolved against the
+        // project asset directory when relative) directly, the same install path
+        // as the editor's Open Scene menu but WITHOUT the auto-save recovery modal
+        // (a remote agent can't click it) and without the file dialog. Stops Play
+        // mode first if running. Main-thread-only (touches the EnTT registry /
+        // renderer settings), so the server calls it from a MarshalRead job. Like
+        // GetCommandHistory this is a consented project-write tool. Null in a
+        // headless host that owns no editor scene — the tool then reports "not
+        // available".
+        std::function<McpSceneOpenResult(const std::string& path)> OpenSceneFromMcp;
+
+        // Toggle Play mode — the consented-write, fully-reversible play/stop switch
+        // (issue #316 Part 5). `play` true enters Play (OnScenePlay: copies the
+        // scene + starts the runtime), false stops it (OnSceneStop: restores the
+        // authored scene). Idempotent — a redundant call is a no-op reported as
+        // Changed:false. Main-thread-only (mutates scene state / runs runtime
+        // start-stop), so the server calls it from a MarshalRead job. A consented
+        // project-write tool (entering Play executes the user's game scripts). Null
+        // in a headless host with no editor.
+        std::function<McpScenePlayResult(bool play)> SetScenePlayState;
     };
 
     // An MCP resource: a passive, addressable blob (vs. an active tool). The reader

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -13,6 +13,7 @@
 #include "MCP/McpRendererSettings.h"
 #include "MCP/McpGenericFieldWrite.h"
 #include "MCP/McpReloadScript.h"
+#include "MCP/McpSceneControl.h"
 #include "MCP/McpSetCollisionLayer.h"
 #include "MCP/McpShaderReload.h"
 #include "MCP/McpEventStream.h"
@@ -3576,6 +3577,83 @@ namespace OloEngine::MCP
             return ToolResult::Text(result.dump(2));
         }
 
+        // ---- olo_scene_open (main-marshaled; PROJECT WRITE) --------------------
+        // Open / switch the active scene over MCP — the consented-write scene switch
+        // (issue #316 Part 5). Loads the requested scene file directly through the
+        // editor's OpenSceneFromMcp hook, which installs it the same way the editor's
+        // Open Scene menu does but WITHOUT the auto-save recovery modal (a remote
+        // agent can't click it) and without the file dialog. Gated at dispatch by the
+        // "Allow writes" session toggle (ToolDef::ProjectWrite): switching scenes
+        // discards the current in-memory scene state, so it crosses the read-only line
+        // by design. The load runs inside the MarshalRead job, i.e. on the main
+        // thread, since it touches the EnTT registry / renderer settings. The shared
+        // schema + path validation + result shaping live in McpSceneControl.h so they
+        // are unit-tested at the dispatch seam without this TU.
+        ToolResult Handle_SceneOpen(McpServer& server, const Json& args)
+        {
+            using namespace SceneControl;
+
+            if (!args.contains("path") || !args["path"].is_string())
+                return ToolResult::Error("Missing required argument 'path' (a .olo or .scene scene file).");
+            const std::string path = args["path"].get<std::string>();
+            if (const auto error = ValidateScenePath(path))
+                return ToolResult::Error(*error);
+
+            if (!server.Context().OpenSceneFromMcp)
+                return ToolResult::Error("Scene open is not available in this editor build.");
+
+            const Json result = server.MarshalRead([&server, &path]() -> Json
+                                                   {
+                if (!server.Context().OpenSceneFromMcp)
+                    return Json{ { "__error", "Scene open is not available in this editor build." } };
+                const McpSceneOpenResult opened = server.Context().OpenSceneFromMcp(path);
+                return ToJson(opened); });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
+        // ---- olo_scene_play / olo_scene_stop (main-marshaled; PROJECT WRITE) ---
+        // Toggle Play mode over MCP — the consented-write, fully-reversible play/stop
+        // switch (issue #316 Part 5). Wraps the editor's OnScenePlay / OnSceneStop
+        // (the same path the editor's Play / Stop toolbar buttons drive) through the
+        // SetScenePlayState hook. Gated at dispatch by the "Allow writes" session
+        // toggle (ToolDef::ProjectWrite): entering Play copies the scene and executes
+        // the user's game scripts, so it crosses the read-only line — but it is
+        // transient (stopping restores the authored scene, exactly like the editor).
+        // olo_scene_summary reports `isPlaying`, so an agent can confirm the
+        // transition took. The transition runs inside the MarshalRead job (main
+        // thread), since it mutates scene state.
+        ToolResult Handle_ScenePlayState(McpServer& server, bool play)
+        {
+            using namespace SceneControl;
+
+            if (!server.Context().SetScenePlayState)
+                return ToolResult::Error("Play-mode control is not available in this editor build.");
+
+            const Json result = server.MarshalRead([&server, play]() -> Json
+                                                   {
+                if (!server.Context().SetScenePlayState)
+                    return Json{ { "__error", "Play-mode control is not available in this editor build." } };
+                const McpScenePlayResult r = server.Context().SetScenePlayState(play);
+                return ToJson(r); });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Text(result.dump(2));
+        }
+
+        ToolResult Handle_ScenePlay(McpServer& server, const Json&)
+        {
+            return Handle_ScenePlayState(server, /*play*/ true);
+        }
+
+        ToolResult Handle_SceneStop(McpServer& server, const Json&)
+        {
+            return Handle_ScenePlayState(server, /*play*/ false);
+        }
+
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
         // entity isn't on screen. Gathers the render-relevant facts off the live
@@ -5094,6 +5172,87 @@ namespace OloEngine::MCP
                                    .NoAdditional();
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderWhyNotVisible;
+            server.RegisterTool(std::move(tool));
+        }
+
+        // ---- olo_scene_open / olo_scene_play / olo_scene_stop (#316 Part 5) ----
+        // The scriptable scene-control write tools: switch the active scene and
+        // toggle Play mode over MCP. All three are ProjectWrite (gated behind the
+        // "Allow writes" session toggle) and MainMarshaled (they touch the registry /
+        // runtime). Registered here as a clean append-only block so they don't
+        // conflict with in-flight branches editing the earlier registrations.
+        {
+            ToolDef tool;
+            tool.Name = "olo_scene_open";
+            tool.Toolset = "scene";
+            tool.Title = "Open / switch scene";
+            // A project-WRITE tool: switching scenes discards the current in-memory
+            // scene, so it is gated behind "Allow writes". readOnlyHint:false; NOT
+            // idempotent (each call reloads from disk, discarding unsaved state); not
+            // destructive to the project files (it never writes — the source scene is
+            // untouched, only the in-editor scene changes).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            tool.Description =
+                "Open / switch the active scene — the scriptable scene-switch that lets an agent set up a repro "
+                "without a manual project StartScene edit + editor relaunch. Give a 'path' to a .olo or .scene file "
+                "(relative paths resolve against the project asset directory, e.g. \"Scenes/Sandbox.olo\"; an absolute "
+                "path also works). Loads the scene directly, the same install path as the editor's File > Open Scene "
+                "but WITHOUT the auto-save recovery modal (a remote agent can't click it). If Play mode is running it "
+                "is stopped first. Returns whether the scene loaded (ok), the resolved path, the new scene name and "
+                "entity count. This is a WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's "
+                "MCP Server panel (off by default).";
+            tool.InputSchema = SceneControl::OpenInputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_SceneOpen;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_scene_play";
+            tool.Toolset = "scene";
+            tool.Title = "Enter Play mode";
+            // A project-WRITE tool: entering Play copies the scene and runs the user's
+            // game scripts, so it is gated behind "Allow writes". readOnlyHint:false;
+            // idempotent (already playing -> no-op, changed:false); not destructive
+            // (fully reversible — olo_scene_stop restores the authored scene).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            tool.Description =
+                "Enter Play mode — start the runtime simulation, the same as the editor's Play button (and the "
+                "OLO_EDITOR_AUTOPLAY workaround, without a relaunch). Needed to verify anything that only runs in "
+                "Play: physics, cloth/soft-body, scripts, animation. Copies the authored scene and starts the "
+                "runtime; already-playing is a no-op (changed:false). Entering Play can fail if the scene has no "
+                "primary camera — then ok:false and the editor stays in Edit (see the message). Confirm with "
+                "olo_scene_summary's isPlaying, then olo_screenshot. Fully reversible via olo_scene_stop. This is a "
+                "WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's MCP Server panel (off by "
+                "default).";
+            tool.InputSchema = SceneControl::PlayStopInputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_ScenePlay;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_scene_stop";
+            tool.Toolset = "scene";
+            tool.Title = "Stop Play mode";
+            // A project-WRITE tool for symmetry with olo_scene_play (it ends the
+            // runtime and restores the authored scene). idempotent (already stopped ->
+            // no-op); not destructive (restores the pre-Play authored scene).
+            tool.ProjectWrite = true;
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            tool.Description =
+                "Stop Play mode — end the runtime simulation and restore the authored (Edit-mode) scene, the same as "
+                "the editor's Stop button. Discards the transient runtime scene copy, so any runtime-only changes are "
+                "dropped (exactly like the editor). Already-stopped is a no-op (changed:false). Confirm with "
+                "olo_scene_summary's isPlaying. This is a WRITE tool: it is refused unless 'Allow writes' is enabled "
+                "in the editor's MCP Server panel (off by default).";
+            tool.InputSchema = SceneControl::PlayStopInputSchema();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_SceneStop;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -436,6 +436,14 @@ add_executable(OloEngine-Tests
 		# structs, restore-prior-value not CommandHistory). Renderer-light header, so
 		# no extra editor TU is pulled in.
 		MCP/McpRendererSettingsTest.cpp
+		# Consented MCP scene-control WRITE tools: olo_scene_open / olo_scene_play /
+		# olo_scene_stop (#316 Part 5) — the scriptable scene switch + play-mode toggle.
+		# Same dispatch seam (session write gate + inputSchema enforcement at
+		# McpServer.cpp) and shared shaping/validation (MCP/McpSceneControl.h: schemas,
+		# ValidateScenePath, result->JSON). The scene ACTIONS are context hooks (the
+		# EnTT registry / runtime in the editor), so the test injects fakes and never
+		# touches a scene. Header-only on the editor side, so no extra editor TU.
+		MCP/McpSceneControlTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).

--- a/OloEngine/tests/MCP/McpSceneControlTest.cpp
+++ b/OloEngine/tests/MCP/McpSceneControlTest.cpp
@@ -1,0 +1,353 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// McpSceneControlTest — unit test (headless, no GL, no live editor, no scene).
+//
+// Pins the consented MCP scene-control write tools olo_scene_open / olo_scene_play /
+// olo_scene_stop (issue #316 Part 5): the scriptable scene switch + play-mode toggle.
+// Two seams, the same shape as McpReloadScriptTest / McpConsentedWriteTest:
+//
+//   1. The dispatch seam (McpServer.cpp, compiled into the test binary): a tool
+//      flagged ToolDef::ProjectWrite is REFUSED with a clean JSON-RPC error while
+//      the session "Allow writes" gate is off, and ACCEPTED once on — and the scene
+//      ACTION does NOT run while the gate is off. The server's inputSchema
+//      enforcement (#423) rejects a malformed call before the handler runs.
+//      McpTools.cpp is deliberately NOT linked here, so the test registers fake
+//      tools wired to the SAME schema + result shaping the real handlers use.
+//
+//   2. The shared shaping + validation (MCP/McpSceneControl.h, header-only): the
+//      inputSchemas, the pure ValidateScenePath / LowercaseExtension helpers, and
+//      the McpSceneOpenResult / McpScenePlayResult -> JSON ToJson the real handlers
+//      emit. The scene ACTIONS themselves are context hooks (the EnTT registry /
+//      runtime in the editor), so the tests inject fakes and never touch a scene —
+//      the same indirection the real handlers delegate to on the main thread.
+//
+// The shared header is renderer/httplib/engine-scene-free, so only McpServer.h + the
+// schema DSL are pulled in — no extra editor TU.
+// =============================================================================
+
+#include "MCP/McpSceneControl.h"
+#include "MCP/McpServer.h"
+
+#include <optional>
+#include <string>
+
+// OLO_TEST_LAYER: unit
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpSceneOpenResult;
+    using OloEngine::MCP::McpScenePlayResult;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+    namespace SceneControl = OloEngine::MCP::SceneControl;
+
+    constexpr int kInvalidParams = -32602;
+
+    Json MakeCallRequest(const Json& id, const std::string& tool, const Json& arguments)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "method", "tools/call" },
+                     { "params", { { "name", tool }, { "arguments", arguments } } } };
+    }
+
+    // Fixture: an McpServer whose tools are fake olo_scene_open / olo_scene_play /
+    // olo_scene_stop, each wired through the SAME schema + ToJson the real handlers
+    // use, but with the scene ACTIONS replaced by test-owned closures that record
+    // their invocations and return canned results — so the dispatch gate, schema
+    // enforcement, and result shaping are exercised without a live scene / game
+    // thread (the real handlers marshal onto the main thread; here they run
+    // synchronously). The handlers mirror the real ones: olo_scene_open validates
+    // the path via ValidateScenePath before invoking, olo_scene_play/stop pass a
+    // fixed bool.
+    class McpSceneControlTest : public ::testing::Test
+    {
+      protected:
+        McpSceneControlTest()
+            : m_Server(EditorMcpContext{})
+        {
+            {
+                ToolDef tool;
+                tool.Name = "olo_scene_open";
+                tool.Description = "Open/switch scene (fake; test wiring).";
+                tool.ProjectWrite = true;
+                tool.InputSchema = SceneControl::OpenInputSchema();
+                tool.Handler = [this](McpServer&, const Json& args) -> ToolResult
+                {
+                    const std::string path = args.value("path", std::string{});
+                    if (const auto error = SceneControl::ValidateScenePath(path))
+                        return ToolResult::Error(*error);
+                    ++m_OpenCount;
+                    m_LastOpenPath = path;
+                    return ToolResult::Text(SceneControl::ToJson(m_FakeOpenResult).dump());
+                };
+                m_Server.RegisterTool(std::move(tool));
+            }
+            {
+                ToolDef tool;
+                tool.Name = "olo_scene_play";
+                tool.Description = "Enter Play mode (fake; test wiring).";
+                tool.ProjectWrite = true;
+                tool.InputSchema = SceneControl::PlayStopInputSchema();
+                tool.Handler = [this](McpServer&, const Json&) -> ToolResult
+                {
+                    ++m_PlayCount;
+                    return ToolResult::Text(SceneControl::ToJson(m_FakePlayResult).dump());
+                };
+                m_Server.RegisterTool(std::move(tool));
+            }
+            {
+                ToolDef tool;
+                tool.Name = "olo_scene_stop";
+                tool.Description = "Stop Play mode (fake; test wiring).";
+                tool.ProjectWrite = true;
+                tool.InputSchema = SceneControl::PlayStopInputSchema();
+                tool.Handler = [this](McpServer&, const Json&) -> ToolResult
+                {
+                    ++m_StopCount;
+                    return ToolResult::Text(SceneControl::ToJson(m_FakeStopResult).dump());
+                };
+                m_Server.RegisterTool(std::move(tool));
+            }
+        }
+
+        McpSceneOpenResult m_FakeOpenResult;
+        McpScenePlayResult m_FakePlayResult;
+        McpScenePlayResult m_FakeStopResult;
+        int m_OpenCount = 0;
+        int m_PlayCount = 0;
+        int m_StopCount = 0;
+        std::string m_LastOpenPath;
+        McpServer m_Server; // declared last → destroyed first (its handlers ref members)
+    };
+} // namespace
+
+// ---- the session write gate (dispatch seam) --------------------------------
+
+// Default state: the gate is OFF, so even well-formed scene-control calls are
+// refused with a JSON-RPC error and the scene action NEVER runs.
+TEST_F(McpSceneControlTest, GateOffRejectsAllAndDoesNotInvoke)
+{
+    ASSERT_FALSE(m_Server.AllowWrites()); // off by default
+
+    const Json openResp = m_Server.HandleMessage(MakeCallRequest(1, "olo_scene_open", Json{ { "path", "Scenes/Sandbox.olo" } }));
+    ASSERT_TRUE(openResp.contains("error"));
+    EXPECT_EQ(openResp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_OpenCount, 0);
+
+    const Json playResp = m_Server.HandleMessage(MakeCallRequest(2, "olo_scene_play", Json::object()));
+    ASSERT_TRUE(playResp.contains("error"));
+    EXPECT_EQ(m_PlayCount, 0);
+
+    const Json stopResp = m_Server.HandleMessage(MakeCallRequest(3, "olo_scene_stop", Json::object()));
+    ASSERT_TRUE(stopResp.contains("error"));
+    EXPECT_EQ(m_StopCount, 0);
+}
+
+// With the gate ON, olo_scene_open runs the action once and returns the hook's
+// shaped result (available/ok/path/sceneName/entityCount).
+TEST_F(McpSceneControlTest, GateOnOpenInvokesAndReturnsResult)
+{
+    m_Server.SetAllowWrites(true);
+    m_FakeOpenResult.Available = true;
+    m_FakeOpenResult.Ok = true;
+    m_FakeOpenResult.Path = "C:/proj/Assets/Scenes/Sandbox.olo";
+    m_FakeOpenResult.SceneName = "Sandbox";
+    m_FakeOpenResult.EntityCount = 42;
+    m_FakeOpenResult.Message = "Opened scene 'Sandbox' (42 entities).";
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(4, "olo_scene_open", Json{ { "path", "Scenes/Sandbox.olo" } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(m_OpenCount, 1);
+    EXPECT_EQ(m_LastOpenPath, "Scenes/Sandbox.olo");
+
+    const Json payload = Json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["available"].get<bool>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_EQ(payload["sceneName"], "Sandbox");
+    EXPECT_EQ(payload["entityCount"], 42);
+}
+
+// With the gate ON, olo_scene_play / olo_scene_stop each run once and carry the
+// resulting play state through.
+TEST_F(McpSceneControlTest, GateOnPlayStopInvokeAndReturnResult)
+{
+    m_Server.SetAllowWrites(true);
+
+    m_FakePlayResult.Available = true;
+    m_FakePlayResult.Ok = true;
+    m_FakePlayResult.Playing = true;
+    m_FakePlayResult.Changed = true;
+    const Json playResp = m_Server.HandleMessage(MakeCallRequest(5, "olo_scene_play", Json::object()));
+    ASSERT_TRUE(playResp.contains("result"));
+    EXPECT_EQ(m_PlayCount, 1);
+    const Json playPayload = Json::parse(playResp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(playPayload["playing"].get<bool>());
+    EXPECT_TRUE(playPayload["changed"].get<bool>());
+
+    m_FakeStopResult.Available = true;
+    m_FakeStopResult.Ok = true;
+    m_FakeStopResult.Playing = false;
+    m_FakeStopResult.Changed = true;
+    const Json stopResp = m_Server.HandleMessage(MakeCallRequest(6, "olo_scene_stop", Json::object()));
+    ASSERT_TRUE(stopResp.contains("result"));
+    EXPECT_EQ(m_StopCount, 1);
+    const Json stopPayload = Json::parse(stopResp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_FALSE(stopPayload["playing"].get<bool>());
+}
+
+// Entering Play when the scene has no primary camera is a clean result — the call
+// SUCCEEDS at the protocol level but ok:false / changed:false report the real
+// outcome, so an agent isn't told a failed transition worked.
+TEST_F(McpSceneControlTest, PlayFailureReportsOkFalse)
+{
+    m_Server.SetAllowWrites(true);
+    m_FakePlayResult.Available = true;
+    m_FakePlayResult.Ok = false;
+    m_FakePlayResult.Playing = false;
+    m_FakePlayResult.Changed = false;
+    m_FakePlayResult.Message = "Could not enter Play mode: the scene has no primary CameraComponent.";
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(7, "olo_scene_play", Json::object()));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    const Json payload = Json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_FALSE(payload["ok"].get<bool>());
+    EXPECT_FALSE(payload["playing"].get<bool>());
+}
+
+// ---- server-side inputSchema enforcement (#423), gate ON -------------------
+
+// olo_scene_open's schema requires `path`; omitting it is rejected at the schema
+// layer before the handler runs.
+TEST_F(McpSceneControlTest, OpenSchemaRejectsMissingPath)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(8, "olo_scene_open", Json::object()));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_OpenCount, 0);
+}
+
+// olo_scene_play/stop take no arguments — an unexpected property is rejected before
+// the handler runs.
+TEST_F(McpSceneControlTest, PlaySchemaRejectsUnknownProperty)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(9, "olo_scene_play", Json{ { "speed", 2 } }));
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kInvalidParams);
+    EXPECT_EQ(m_PlayCount, 0);
+}
+
+// A valid `path` string passes the schema but a bad EXTENSION is caught by the
+// handler's ValidateScenePath (a value-level constraint JSON-Schema can't express),
+// so the scene action never runs and the call is a tool error.
+TEST_F(McpSceneControlTest, OpenHandlerRejectsBadExtension)
+{
+    m_Server.SetAllowWrites(true);
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(10, "olo_scene_open", Json{ { "path", "notes.txt" } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_TRUE(resp["result"]["isError"]);
+    EXPECT_EQ(m_OpenCount, 0);
+}
+
+// ---- the shared shaping + validation core (MCP/McpSceneControl.h) ----------
+
+TEST(McpSceneControlShaping, OpenToJsonCarriesEveryField)
+{
+    McpSceneOpenResult r;
+    r.Available = true;
+    r.Ok = true;
+    r.Path = "C:/proj/Scenes/A.olo";
+    r.SceneName = "A";
+    r.EntityCount = 3;
+    r.Message = "ok";
+
+    const Json j = SceneControl::ToJson(r);
+    EXPECT_TRUE(j["available"].get<bool>());
+    EXPECT_TRUE(j["ok"].get<bool>());
+    EXPECT_EQ(j["path"], "C:/proj/Scenes/A.olo");
+    EXPECT_EQ(j["sceneName"], "A");
+    EXPECT_EQ(j["entityCount"], 3);
+    EXPECT_EQ(j["message"], "ok");
+}
+
+TEST(McpSceneControlShaping, PlayToJsonCarriesEveryField)
+{
+    McpScenePlayResult r;
+    r.Available = true;
+    r.Ok = true;
+    r.Playing = true;
+    r.Changed = true;
+    r.SceneName = "A";
+    r.Message = "Entered Play mode.";
+
+    const Json j = SceneControl::ToJson(r);
+    EXPECT_TRUE(j["available"].get<bool>());
+    EXPECT_TRUE(j["ok"].get<bool>());
+    EXPECT_TRUE(j["playing"].get<bool>());
+    EXPECT_TRUE(j["changed"].get<bool>());
+    EXPECT_EQ(j["sceneName"], "A");
+}
+
+TEST(McpSceneControlShaping, OpenInputSchemaRequiresPath)
+{
+    const Json schema = SceneControl::OpenInputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    ASSERT_TRUE(schema.contains("required"));
+    ASSERT_TRUE(schema["required"].is_array());
+    EXPECT_EQ(schema["required"][0], "path");
+    ASSERT_TRUE(schema.contains("additionalProperties"));
+    EXPECT_FALSE(schema["additionalProperties"].get<bool>());
+}
+
+TEST(McpSceneControlShaping, PlayStopSchemaIsClosedEmptyObject)
+{
+    const Json schema = SceneControl::PlayStopInputSchema();
+    EXPECT_EQ(schema["type"], "object");
+    ASSERT_TRUE(schema.contains("additionalProperties"));
+    EXPECT_FALSE(schema["additionalProperties"].get<bool>());
+}
+
+// ValidateScenePath: accepts .olo / .scene (case-insensitive), rejects empty, a bad
+// extension, and parent-directory traversal.
+TEST(McpSceneControlValidation, ValidateScenePathAcceptsSceneFiles)
+{
+    EXPECT_FALSE(SceneControl::ValidateScenePath("Scenes/Sandbox.olo").has_value());
+    EXPECT_FALSE(SceneControl::ValidateScenePath("A.scene").has_value());
+    EXPECT_FALSE(SceneControl::ValidateScenePath("Deep/Nested/Path/level.OLO").has_value()); // case-insensitive
+    EXPECT_FALSE(SceneControl::ValidateScenePath("C:/abs/path/level.olo").has_value());      // absolute allowed
+}
+
+TEST(McpSceneControlValidation, ValidateScenePathRejectsBadInputs)
+{
+    EXPECT_TRUE(SceneControl::ValidateScenePath("").has_value());                   // empty
+    EXPECT_TRUE(SceneControl::ValidateScenePath("notes.txt").has_value());          // bad extension
+    EXPECT_TRUE(SceneControl::ValidateScenePath("Scenes").has_value());             // no extension
+    EXPECT_TRUE(SceneControl::ValidateScenePath("../secrets/x.olo").has_value());   // traversal
+    EXPECT_TRUE(SceneControl::ValidateScenePath("Scenes/../../x.olo").has_value()); // traversal mid-path
+    EXPECT_TRUE(SceneControl::ValidateScenePath("Scenes\\..\\x.olo").has_value());  // traversal, backslash
+    // A filename that merely CONTAINS ".." between dots is fine (not a "." component).
+    EXPECT_FALSE(SceneControl::ValidateScenePath("weird..name.olo").has_value());
+}
+
+TEST(McpSceneControlValidation, LowercaseExtensionHandlesEdgeCases)
+{
+    EXPECT_EQ(SceneControl::LowercaseExtension("a/b/c.OLO"), ".olo");
+    EXPECT_EQ(SceneControl::LowercaseExtension("Scene.Scene"), ".scene");
+    EXPECT_EQ(SceneControl::LowercaseExtension("noext"), "");
+    EXPECT_EQ(SceneControl::LowercaseExtension("dir.with.dot/file"), ""); // dot in dir, not leaf
+    EXPECT_EQ(SceneControl::LowercaseExtension(".gitignore"), "");        // dotfile → no extension
+}

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -252,7 +252,7 @@ keyword and/or category instead of pulling the entire list:
 | Toolset | Tools |
 |---|---|
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
-| `scene` | `olo_scene_summary`, `olo_scene_open`, `olo_scene_play`, `olo_scene_stop`, `olo_scene_list_entities`, `olo_scene_get_entity` |
+| `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity`, `olo_entity_list_fields`, `olo_entity_set_field`, `olo_scene_open`, `olo_scene_play`, `olo_scene_stop` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings` |
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -164,6 +164,8 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_log_tail` | recent engine log lines, filterable by `minLevel` and `tag` |
 | `olo_events_tail` | unified "what just happened?" timeline — scene load, play/stop, entity spawn/destroy, asset reload, script error — newest last with a monotonic `id`; incremental polling via `sinceId`, plus a `categories` filter |
 | `olo_scene_summary` | active scene name, play state, entity count |
+| `olo_scene_open` | **(consented write)** open / switch the active scene by `path` (a `.olo`/`.scene` file, relative paths resolve against the project asset directory) — the scriptable scene switch. Loads directly, bypassing the auto-save recovery modal a remote agent can't click; stops Play mode first. Reports the loaded scene name + entity count. Gated behind **Agent writes** |
+| `olo_scene_play` / `olo_scene_stop` | **(consented write)** enter / leave Play mode — the same as the editor's Play/Stop buttons, so an agent can verify anything that only runs in Play (physics, cloth, scripts). Transient + fully reversible (stop restores the authored scene); idempotent (`changed:false` when already in that state); `olo_scene_summary` reports `isPlaying` to confirm. Gated behind **Agent writes** |
 | `olo_scene_list_entities` | paginated entity list (id, name, parent, child count) + name filter |
 | `olo_scene_get_entity` | one entity's full component data (YAML) by UUID |
 | `olo_perf_snapshot` | fps, frame/CPU/GPU time (real whole-frame GPU timer), `gpuWaitMs` (CPU blocked on the GPU fence — the direct GPU-bound signal), draw calls, instancing, triangles |
@@ -208,8 +210,9 @@ the server, so update the config (or re-copy from the panel) accordingly.
 ### Write consent — Disabled / Prompt / Allow all (issue #306 item C)
 
 Every project-mutating tool (`olo_set_collision_layer`, `olo_entity_set_field`,
-`olo_reload_script`, `olo_renderer_settings_set` — anything marked **(consented
-write)** above) is gated in the MCP panel by a three-way **Agent writes** control.
+`olo_reload_script`, `olo_renderer_settings_set`, `olo_scene_open`,
+`olo_scene_play`, `olo_scene_stop` — anything marked **(consented write)** above)
+is gated in the MCP panel by a three-way **Agent writes** control.
 It is **off by default and never persisted**, so every editor launch starts read-only
 and the human at the editor opts in for the session:
 
@@ -241,7 +244,7 @@ blocks on an agent.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (48 tools) that paging the whole flat `tools/list`
+The tool surface is large enough (51 tools) that paging the whole flat `tools/list`
 to find the right one is wasteful. Every tool is tagged with a **toolset** (grouping
 category), and a custom `tools/search` JSON-RPC method lets an agent discover tools by
 keyword and/or category instead of pulling the entire list:
@@ -249,7 +252,7 @@ keyword and/or category instead of pulling the entire list:
 | Toolset | Tools |
 |---|---|
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
-| `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity` |
+| `scene` | `olo_scene_summary`, `olo_scene_open`, `olo_scene_play`, `olo_scene_stop`, `olo_scene_list_entities`, `olo_scene_get_entity` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings` |
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
@@ -423,6 +426,76 @@ component bindings.
   don't trust `scriptClassCount` on a failed reload. Rebuild the game assembly and retry.
 - **Lua is not reloaded here.** This tool targets the C# (Mono) app assembly; Lua scripts
   re-execute per entity on play and have no single global reload entry point.
+
+### Scriptable scene control (`olo_scene_open` / `olo_scene_play` / `olo_scene_stop`)
+
+The **scriptable repro setup** (issue #316 Part 5): switch which scene is loaded and
+toggle the runtime, so an agent can set up and drive a repro over MCP instead of the
+old manual dance — editing `Sandbox.oloproj`'s `StartScene` + relaunching the editor
+per target scene, and `OLO_EDITOR_AUTOPLAY=1` + a relaunch to reach Play.
+
+- **`olo_scene_open { path }`** opens / switches the active scene. `path` is a
+  `.olo` / `.scene` file; a relative path resolves against the project's asset
+  directory (e.g. `"Scenes/Sandbox.olo"`), an absolute path also works, and `..`
+  traversal is rejected. It loads the scene **directly** — the same install path as
+  the editor's *File ▸ Open Scene*, but **without the auto-save recovery modal** (a
+  remote agent can't click it; see below) and without a file dialog. If Play mode is
+  running it is stopped first. The response reports whether the scene loaded (`ok`),
+  the resolved `path`, and the new `sceneName` + `entityCount`.
+- **`olo_scene_play {}` / `olo_scene_stop {}`** enter / leave Play mode — the same
+  `OnScenePlay` / `OnSceneStop` the editor's Play / Stop toolbar buttons drive. This
+  is what lets an agent verify anything that **only runs in Play**: physics,
+  cloth/soft-body, scripts, animation (an edit-mode `olo_screenshot` shows none of
+  it). Entering Play copies the authored scene and starts the runtime; **stopping
+  restores the authored scene**, so the toggle is transient and fully reversible.
+  Both are **idempotent** — a redundant call is a no-op reported as `changed:false`.
+  Entering Play can fail if the scene has no primary `CameraComponent`; then
+  `ok:false` and the editor stays in Edit (see the `message`).
+
+All three are **consented WRITE tools** (issue #306 item C): refused while **Agent
+writes** is *Disabled* in the MCP panel (the default), prompted per-action in
+*Prompt* mode, applied directly in *Allow all*. They cross the read-only line
+because `olo_scene_open` discards the current in-memory scene and `olo_scene_play`
+executes the user's game scripts — but neither writes a project file (the scene
+`.olo` on disk is never modified).
+
+```jsonc
+// 1) olo_scene_open { "path": "Scenes/Sandbox.olo" }
+{ "available": true, "ok": true, "path": ".../Assets/Scenes/Sandbox.olo",
+  "sceneName": "Sandbox", "entityCount": 42, "message": "Opened scene 'Sandbox' (42 entities)." }
+// 2) olo_scene_play {}
+{ "available": true, "ok": true, "playing": true, "changed": true,
+  "sceneName": "Sandbox", "message": "Entered Play mode." }
+// 3) olo_scene_summary {}          -> confirm "isPlaying": true
+// 4) olo_screenshot { … }          -> see the simulating frame (cloth settling, physics, …)
+// 5) olo_scene_stop {}
+{ "available": true, "ok": true, "playing": false, "changed": true,
+  "sceneName": "Sandbox", "message": "Stopped Play mode; restored the authored scene." }
+```
+
+The scene-control actions run on the editor's main thread (marshaled at a frame
+boundary, like the other scene tools); a headless test host that owns no editor
+scene reports a clean *"not available"*.
+
+#### The auto-save recovery modal — headless dismissal (`OLO_EDITOR_AUTOSAVE_RECOVERY`)
+
+When the editor opens a scene whose `.olo.auto` auto-save is newer than the saved
+scene, it raises a **"Recover Auto-Save?"** modal. That modal is un-dismissible
+remotely — synthetic Win32 clicks don't reach ImGui — so a headless / agent launch
+with a stray `.auto` file would wedge at a popup it can never answer, blocking
+`olo_scene_open` (and everything else) from ever reaching a usable state.
+
+Set **`OLO_EDITOR_AUTOSAVE_RECOVERY`** before launching the editor to pre-answer it:
+
+- `autosave` (aliases `recover` / `auto`) — load the newer `.auto` (the recovered work).
+- `original` (aliases `keep` / `saved`) — load the saved scene, leaving the `.auto`.
+- `discard` (aliases `delete`) — delete the `.auto`, then load the saved scene.
+
+Unset / empty / unrecognized keeps the interactive modal, so this never changes a
+human's editor. The `run-oloengine` skill's `attach` action sets it (typically
+`original`) so an agent session always boots straight to a usable editor.
+`olo_scene_open` itself never raises the modal — it loads the requested file
+directly, since an agent explicitly asked for that scene.
 
 ### Render override A/B (`olo_render_toggle_pass` / `olo_render_set_debug_view`)
 


### PR DESCRIPTION
Closes the last open checklist of the **#316** umbrella (Part 5 — scriptable repro setup). Gives an agent scriptable control over *which scene is loaded* and *whether the runtime is simulating* over MCP — the "scriptable repro" the read-only server couldn't drive (previously a manual `Sandbox.oloproj` `StartScene` edit + relaunch per scene, and `OLO_EDITOR_AUTOPLAY=1` + relaunch to reach Play).

### What's new

Three consented-write MCP tools + a headless auto-save fix, following the established `olo_reload_script` / `olo_renderer_settings_set` consented-write pattern (session **Agent writes** gate, main-thread-marshaled, engine-free shared header so the MCP test binary exercises the real schema/parse/shape without linking `McpTools.cpp`):

- **`olo_scene_open({path})`** — open / switch the active scene. Resolves a relative `path` against the project asset dir, validates `.olo`/`.scene` extension, rejects `..` traversal, stops Play mode, and loads **directly** (never raising the recovery modal). Reports `ok` / resolved `path` / `sceneName` / `entityCount`.
- **`olo_scene_play` / `olo_scene_stop`** — enter / leave Play mode (the same `OnScenePlay`/`OnSceneStop` the toolbar buttons drive). Transient + fully reversible (stop restores the authored scene), idempotent (`changed:false` when already in that state), honest `ok:false` when Play can't start (no primary camera). `olo_scene_summary`'s `isPlaying` confirms the transition.
- **Auto-save modal fix** — `OLO_EDITOR_AUTOSAVE_RECOVERY` env var (`autosave`/`original`/`discard` + aliases) pre-answers the "Recover Auto-Save?" modal, which is un-clickable remotely (synthetic Win32 clicks don't reach ImGui) and otherwise wedges a headless launch at startup (`OpenScene(startScenePath)`). Unset keeps the interactive modal for humans.

### Implementation notes

- New engine-free header `OloEditor/src/MCP/McpSceneControl.h` (schemas + pure `ValidateScenePath`/`LowercaseExtension` + result→JSON shaping).
- New context hooks `OpenSceneFromMcp` / `SetScenePlayState` + result structs in `McpServer.h`; wired in `EditorLayer.cpp`. `OpenScene`'s load body extracted into a shared `LoadEditorSceneFile(loadPath, scenePath)` used by both `OpenScene` and the MCP hook.
- Tool registrations added as a **clean append-only block** in `McpTools.cpp` (per the in-flight-branch caution in the handover — no existing registration lines touched).
- Headless host leaves the new hooks null, so they report a clean "not available" (honesty boundary unchanged).

### Verification

- New unit test `OloEngine/tests/MCP/McpSceneControlTest.cpp` — **14/14 pass** (dispatch write-gate, inputSchema enforcement, path validation, result shaping). Full MCP suite **327/327 green**. OloEditor builds clean.
- **Live over MCP** (writes enabled in the panel): opened `ClothTest.olo` → Play (cloth soft-body simulating, 400 particles, screenshot confirmed) → idempotent replay → stop restored the authored scene; bad-path / bad-extension / `..` traversal all rejected honestly. Panel shows **51 tools** (was 48).
- **Autosave fix**: with a newer `.auto` + `OLO_EDITOR_AUTOSAVE_RECOVERY=original`, the log shows *"Auto-save recovery pre-answered (original)"* and the editor boots to a usable frame instead of wedging.

### Follow-up noted

MCP consented-write tools can currently only be unlocked by a human in the editor panel — there's no headless `OLO_MCP_ALLOW_WRITES` override — so an agent session (the primary consumer of Part 5) can't self-enable writes. Left the security design untouched here; a follow-up env override for #306 would make the whole consented-write family usable headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scriptable scene controls for opening scenes and toggling Play mode from the MCP diagnostics server.
  * Headless runs can now resolve auto-save recovery automatically instead of waiting on a modal prompt.

* **Bug Fixes**
  * Improved scene-loading behavior and reporting so the active scene name and load details are tracked more accurately.
  * Strengthened scene path validation to reject invalid paths and unsupported file types.

* **Documentation**
  * Updated MCP diagnostics docs to cover the new scene tools, consent flow, and auto-save recovery options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->