### PR TITLE
fix(renderer): reset water-depth/planar-reflection texture publications per frame (#505)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Debug/GLStateGuard.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GLStateGuard.cpp
@@ -266,11 +266,19 @@ namespace OloEngine
         // FBO bindings FIRST — subsequent state-setting calls are global so
         // their order doesn't matter, but `glNamedFramebuffer*` DSA calls
         // (not used here) would still target the snapshot's FBO regardless.
-        ::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_FboDraw);
-        ::glBindFramebuffer(GL_READ_FRAMEBUFFER, m_FboRead);
+        //
+        // Each container-object name is validated before the rebind: the guarded
+        // scope may legitimately delete an object that was bound at entry (a
+        // render-graph resize destroys framebuffers/VAOs), and rebinding a
+        // deleted name is itself a GL_INVALID_OPERATION — the guard would then
+        // manufacture the very GL-error pollution it exists to contain (#505).
+        // Restoring 0 for a dead name matches what the driver did to the
+        // binding when the object was deleted.
+        ::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, ::glIsFramebuffer(m_FboDraw) ? m_FboDraw : 0u);
+        ::glBindFramebuffer(GL_READ_FRAMEBUFFER, ::glIsFramebuffer(m_FboRead) ? m_FboRead : 0u);
 
-        ::glUseProgram(m_ActiveProgram);
-        ::glBindVertexArray(m_Vao);
+        ::glUseProgram(::glIsProgram(m_ActiveProgram) ? m_ActiveProgram : 0u);
+        ::glBindVertexArray(::glIsVertexArray(m_Vao) ? m_Vao : 0u);
 
         // Depth
         if (m_DepthTest)

--- a/OloEngine/src/OloEngine/Renderer/Debug/GLStateGuard.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GLStateGuard.cpp
@@ -259,6 +259,24 @@ namespace OloEngine
         return diffs;
     }
 
+    namespace
+    {
+        // A snapshotted container-object name is validated before the rebind:
+        // the guarded scope may legitimately delete an object that was bound at
+        // entry (a render-graph resize destroys framebuffers/VAOs), and
+        // rebinding a deleted name is itself a GL_INVALID_OPERATION — the guard
+        // would then manufacture the very GL-error pollution it exists to
+        // contain (#505). Restoring 0 for a dead name matches what the driver
+        // did to the binding when the object was deleted.
+        // The parameter type is glad's shared `GLboolean (GLAD_API_PTR*)(GLuint)`
+        // pointer signature (all glIs* typedefs alias it) so the calling
+        // convention matches on every target, not just x64 where it's moot.
+        u32 ValidOrZero(u32 name, PFNGLISFRAMEBUFFERPROC isAlive)
+        {
+            return (name != 0u && isAlive(name)) ? name : 0u;
+        }
+    } // namespace
+
     void GLStateSnapshot::ApplyCore() const
     {
         OLO_PROFILE_FUNCTION();
@@ -266,19 +284,11 @@ namespace OloEngine
         // FBO bindings FIRST — subsequent state-setting calls are global so
         // their order doesn't matter, but `glNamedFramebuffer*` DSA calls
         // (not used here) would still target the snapshot's FBO regardless.
-        //
-        // Each container-object name is validated before the rebind: the guarded
-        // scope may legitimately delete an object that was bound at entry (a
-        // render-graph resize destroys framebuffers/VAOs), and rebinding a
-        // deleted name is itself a GL_INVALID_OPERATION — the guard would then
-        // manufacture the very GL-error pollution it exists to contain (#505).
-        // Restoring 0 for a dead name matches what the driver did to the
-        // binding when the object was deleted.
-        ::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, ::glIsFramebuffer(m_FboDraw) ? m_FboDraw : 0u);
-        ::glBindFramebuffer(GL_READ_FRAMEBUFFER, ::glIsFramebuffer(m_FboRead) ? m_FboRead : 0u);
+        ::glBindFramebuffer(GL_DRAW_FRAMEBUFFER, ValidOrZero(m_FboDraw, ::glIsFramebuffer));
+        ::glBindFramebuffer(GL_READ_FRAMEBUFFER, ValidOrZero(m_FboRead, ::glIsFramebuffer));
 
-        ::glUseProgram(::glIsProgram(m_ActiveProgram) ? m_ActiveProgram : 0u);
-        ::glBindVertexArray(::glIsVertexArray(m_Vao) ? m_Vao : 0u);
+        ::glUseProgram(ValidOrZero(m_ActiveProgram, ::glIsProgram));
+        ::glBindVertexArray(ValidOrZero(m_Vao, ::glIsVertexArray));
 
         // Depth
         if (m_DepthTest)

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -187,6 +187,17 @@ namespace OloEngine
         data.PrevInstanceTransforms = std::move(data.CurrInstanceTransforms);
         data.CurrInstanceTransforms.clear();
 
+        // The water-surface-depth and planar-reflection texture publications are
+        // strictly per-frame: the owning pass re-publishes when it executes.
+        // Clear them HERE rather than trusting the passes' own Execute-entry
+        // clears — when the render graph culls the publisher entirely (any
+        // no-water frame), Execute never runs, and a consumer that binds
+        // unconditionally (ToneMap's underwater-fog water-depth slot) would
+        // bind a texture name whose owning framebuffer died in an earlier graph
+        // resize/rebuild — the #505 stale-texture GL_INVALID_OPERATION.
+        data.WaterSurfaceDepthTextureID = 0;
+        data.PlanarReflectionTextureID = 0;
+
         // GPU frustum-cull pool reset — slot cursor recycles from 0 each
         // frame. Buffers stay allocated (lifetime = engine, not frame) so
         // steady-state scatter scenes don't re-allocate on every frame.

--- a/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
@@ -4,9 +4,40 @@
 #include <glad/gl.h>
 
 #include <cstring>
+#include <sstream>
+
+// Stack trace support - available when <stacktrace> header is present (C++23).
+// MSVC reports __cplusplus as 199711L unless /Zc:__cplusplus is set, so check
+// _MSVC_LANG as well — without it this path silently compiles out on MSVC.
+#if __has_include(<stacktrace>) && (__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))
+#include <stacktrace>
+#define OLO_HAS_STACKTRACE 1
+#else
+#define OLO_HAS_STACKTRACE 0
+#endif
 
 namespace OloEngine
 {
+    // Log the native call stack that produced a GL ERROR-type debug message.
+    // The debug context is synchronous (GL_DEBUG_OUTPUT_SYNCHRONOUS, see
+    // OpenGLRendererAPI::Init), so the callback runs on the thread that issued
+    // the offending GL call and the capture pins the exact bind/draw site —
+    // this is what turns a "some earlier test corrupted shared renderer state"
+    // hunt (issue #505) into a file:line answer. Errors are rare and already
+    // log at ERROR/CRITICAL, so the symbolization cost only hits broken runs.
+    static void LogGLErrorCallStack()
+    {
+#if OLO_HAS_STACKTRACE
+        const auto stack = std::stacktrace::current(2, 24); // skip this fn + the driver callback thunk
+        std::ostringstream oss;
+        for (const auto& frame : stack)
+        {
+            oss << "\n    " << std::to_string(frame);
+        }
+        OLO_CORE_ERROR("GL error call stack (synchronous debug context):{0}", oss.str());
+#endif
+    }
+
     void OpenGLMessageCallback(
         const unsigned int source,
         const unsigned int type,
@@ -133,9 +164,17 @@ namespace OloEngine
             {
                 case GL_DEBUG_SEVERITY_HIGH:
                     OLO_CORE_CRITICAL("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
+                    if (type == GL_DEBUG_TYPE_ERROR)
+                    {
+                        LogGLErrorCallStack();
+                    }
                     return;
                 case GL_DEBUG_SEVERITY_MEDIUM:
                     OLO_CORE_ERROR("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
+                    if (type == GL_DEBUG_TYPE_ERROR)
+                    {
+                        LogGLErrorCallStack();
+                    }
                     return;
                 case GL_DEBUG_SEVERITY_LOW:
                     OLO_CORE_WARN("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);

--- a/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
@@ -164,25 +164,29 @@ namespace OloEngine
             {
                 case GL_DEBUG_SEVERITY_HIGH:
                     OLO_CORE_CRITICAL("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
-                    if (type == GL_DEBUG_TYPE_ERROR)
-                    {
-                        LogGLErrorCallStack();
-                    }
-                    return;
+                    break;
                 case GL_DEBUG_SEVERITY_MEDIUM:
                     OLO_CORE_ERROR("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
-                    if (type == GL_DEBUG_TYPE_ERROR)
-                    {
-                        LogGLErrorCallStack();
-                    }
-                    return;
+                    break;
                 case GL_DEBUG_SEVERITY_LOW:
                     OLO_CORE_WARN("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
                     return;
                 case GL_DEBUG_SEVERITY_NOTIFICATION:
                     OLO_CORE_INFO("OpenGL debug message (source: {0}, type: {1}, id: {2}): {3}", sourceStr, typeStr, id, message);
                     return;
+                default:
+                    OLO_CORE_ASSERT(false, "Unknown severity level!");
+                    return;
             }
+
+            // Reached only for HIGH / MEDIUM (the severities that log at
+            // CRITICAL / ERROR above): capture the offending call site once
+            // for both paths.
+            if (type == GL_DEBUG_TYPE_ERROR)
+            {
+                LogGLErrorCallStack();
+            }
+            return;
         }
 
         OLO_CORE_ASSERT(false, "Unknown severity level!");

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -163,6 +163,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/StarNestSkyVisualTest.cpp
 		Rendering/PropertyTests/StarNestReflectionEvidenceTest.cpp
 		Rendering/PropertyTests/WaterVisualEvidenceTest.cpp
+		Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
 		Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
 		Rendering/PropertyTests/OceanFFTVisualEvidenceTest.cpp
 		Rendering/PropertyTests/UnderwaterCausticsVisualTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheck.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheck.cpp
@@ -80,27 +80,6 @@ namespace OloEngine::Tests::GLErrorState
         return DrainAndGetFirstError(ignoredCount);
     }
 
-    u32 DrainAndGetFirstUnexpected(u32 allowedError)
-    {
-        if (glad_glGetError == nullptr || !HasGlContext())
-            return GL_NO_ERROR;
-
-        // Drain the WHOLE queue (so nothing leaks onward regardless), but skip
-        // the one allowed class when picking the error to report. 64-iteration
-        // bound as in DrainAndGetFirstError.
-        constexpr u32 kMaxDrainIterations = 64;
-        u32 firstUnexpected = GL_NO_ERROR;
-        for (u32 i = 0; i < kMaxDrainIterations; ++i)
-        {
-            const GLenum e = ::glGetError();
-            if (e == GL_NO_ERROR)
-                break;
-            if (e != allowedError && firstUnexpected == GL_NO_ERROR)
-                firstUnexpected = e;
-        }
-        return firstUnexpected;
-    }
-
     // =========================================================================
     // GoogleTest listener — asserts a clean GL error queue after every test.
     // =========================================================================

--- a/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheck.h
+++ b/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheck.h
@@ -49,14 +49,6 @@ namespace OloEngine::Tests::GLErrorState
     // error but don't care how many were pending (avoids a throwaway count).
     u32 DrainAndGetFirstError();
 
-    // Drains ALL pending GL errors and returns the FIRST one that is not
-    // `allowedError` (GL_NO_ERROR / 0 if the queue held only `allowedError` or
-    // was empty). Lets a caller contain one known-benign error class while still
-    // surfacing any OTHER error that follows it in the queue — a plain
-    // DrainAndGetFirstError() would stop reporting at the benign one and mask
-    // the rest. Bounded and no-GL-context-safe like DrainAndGetFirstError.
-    u32 DrainAndGetFirstUnexpected(u32 allowedError);
-
     // Human-readable name for a GL error enum (e.g. "GL_INVALID_OPERATION").
     // Pure; needs no GL context.
     const char* GlErrorString(u32 err);

--- a/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheckTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/GLErrorStateCheckTest.cpp
@@ -75,32 +75,4 @@ namespace OloEngine::Tests
         EXPECT_EQ(afterCount, 0u);
     }
 
-    // DrainAndGetFirstUnexpected contains one allowed error class while still
-    // surfacing anything else, and drains the whole queue either way.
-    TEST(GLErrorStateCheckTest, DrainUnexpectedContainsAllowedButSurfacesOthers)
-    {
-        OLO_ENSURE_GPU_OR_SKIP();
-
-        // Start clean.
-        (void)GLErrorState::DrainAndGetFirstError();
-
-        // Inject GL_INVALID_ENUM (GL_TRIANGLES is not a valid glEnable cap).
-        ::glEnable(GL_TRIANGLES);
-
-        // Allowing a DIFFERENT class must still surface the injected error...
-        EXPECT_EQ(GLErrorState::DrainAndGetFirstUnexpected(static_cast<u32>(GL_INVALID_OPERATION)),
-                  static_cast<u32>(GL_INVALID_ENUM))
-            << "an error outside the allowed class must be reported";
-        // ...and the queue must be drained by that call.
-        EXPECT_EQ(GLErrorState::DrainAndGetFirstError(), static_cast<u32>(GL_NO_ERROR))
-            << "DrainAndGetFirstUnexpected must clear the whole queue";
-
-        // Allowing the injected class must report nothing (contained) yet still drain.
-        ::glEnable(GL_TRIANGLES);
-        EXPECT_EQ(GLErrorState::DrainAndGetFirstUnexpected(static_cast<u32>(GL_INVALID_ENUM)),
-                  static_cast<u32>(GL_NO_ERROR))
-            << "the allowed error class must be contained, not reported";
-        EXPECT_EQ(GLErrorState::DrainAndGetFirstError(), static_cast<u32>(GL_NO_ERROR))
-            << "the allowed error must still have been drained from the queue";
-    }
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.cpp
@@ -27,13 +27,12 @@ namespace OloEngine::Tests
         //      / binding state (blend / stencil / viewport / program / VAO / FBO)
         //      is contained. Per-slot texture / UBO bindings are intentionally
         //      NOT restored by GLStateGuard (see its class comment).
-        //   3. Drain the errors THIS tick produced, but only treat the known
-        //      benign GL_INVALID_OPERATION stray as expected (the #505 stale-
-        //      handle bind — correct pixels, dirty error queue). Any OTHER error
-        //      class is a genuine render-side regression and is surfaced, not
-        //      swallowed. (A *new* GL_INVALID_OPERATION render bug is
-        //      indistinguishable from #505 by enum and remains contained until
-        //      #505 is fixed — the residual coverage gap tracked there.)
+        //   3. Fail on ANY GL error this tick produced, attributing it to the
+        //      exact tick. The #505 stale-texture GL_INVALID_OPERATION this
+        //      check used to tolerate is fixed at the root (per-frame reset of
+        //      the water-depth / planar-reflection texture publications in
+        //      RenderPipeline::PrepareFrame), so a full-pipeline render is now
+        //      expected to be error-clean — no benign-error carve-out remains.
         void RunGuardedRenderTick(const char* label, const std::function<void()>& tick)
         {
             if (const u32 preErr = GLErrorState::DrainAndGetFirstError(); preErr != 0u)
@@ -46,13 +45,10 @@ namespace OloEngine::Tests
                 tick();
             }
 
-            if (const u32 tickErr =
-                    GLErrorState::DrainAndGetFirstUnexpected(static_cast<u32>(GL_INVALID_OPERATION));
-                tickErr != 0u)
-                ADD_FAILURE() << label << " render tick left an unexpected GL error: "
+            if (const u32 tickErr = GLErrorState::DrainAndGetFirstError(); tickErr != 0u)
+                ADD_FAILURE() << label << " render tick left a GL error: "
                               << GLErrorState::GlErrorString(tickErr)
-                              << " (only the benign #505 GL_INVALID_OPERATION stray is contained here; "
-                                 "the whole error queue is drained regardless).";
+                              << " (the whole error queue is drained so the next test starts clean).";
         }
     } // namespace
 

--- a/OloEngine/tests/Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
@@ -1,0 +1,126 @@
+// OLO_TEST_LAYER: L4
+// =============================================================================
+// WaterStaleTexturePublicationTest.cpp — regression for issue #505.
+//
+// Root cause pinned by a synchronous-GL-debug stack capture: WaterRenderPass
+// publishes its depth FB's raw GL texture name through
+// `Renderer3D::SetWaterSurfaceDepthTextureID`, and cleared it only at the top
+// of its own Execute. When the render graph CULLS the water pass (any frame
+// with no water submissions), Execute never runs, so the publication from the
+// last water frame survives — across scenes and, in the test binary, across
+// tests. Meanwhile render-graph churn (a resize / reconfigure) deletes the
+// framebuffer that owned the name. ToneMapRenderPass binds the published id
+// unconditionally for its underwater-fog stage, so every subsequent
+// full-pipeline frame re-binds a deleted texture name:
+// `GL_INVALID_OPERATION (id 1282) "<texture> is not a valid texture name"` —
+// correct pixels (the fog branch never samples above water), dirty error
+// queue. `PlanarReflectionTextureID` had the identical lifecycle.
+//
+// The fix makes both publications strictly per-frame: cleared in
+// `RenderPipeline::PrepareFrame` (BeginScene), re-published only by an
+// executing pass. This test pins that contract deterministically:
+//
+//   1. Render a water frame → the publication must be non-zero.
+//   2. Remove the water entity, render again → the publication must be 0
+//      (this is the assert that fails pre-fix: the stale id survived).
+//   3. Resize the render-graph targets (the churn that deletes the old water
+//      depth FB) and render more frames → the fixture's strict per-tick GL
+//      check fails on any stale-name bind, closing the loop on the original
+//      symptom rather than just the publication value.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+#include "RendererAttachedTest.h"
+
+#include "OloEngine/Renderer/Camera/EditorCamera.h"
+#include "OloEngine/Renderer/Renderer3D.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+
+#include <gtest/gtest.h>
+#include <glm/glm.hpp>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        constexpr u32 kWidth = 160;
+        constexpr u32 kHeight = 120;
+    } // namespace
+
+    class WaterDepthPublicationScene : public RendererAttachedTest
+    {
+      protected:
+        void BuildScene() override
+        {
+            EnableRendering(kWidth, kHeight);
+
+            Scene& scene = GetScene();
+
+            {
+                Entity light = scene.CreateEntity("Sun");
+                auto& dl = light.AddComponent<DirectionalLightComponent>();
+                dl.m_Direction = glm::normalize(glm::vec3(-0.5f, -0.7f, -0.5f));
+                dl.m_Intensity = 2.0f;
+            }
+
+            {
+                m_Water = scene.CreateEntity("Ocean");
+                auto& wc = m_Water.AddComponent<WaterComponent>();
+                wc.m_WorldSizeX = 50.0f;
+                wc.m_WorldSizeZ = 50.0f;
+                wc.m_GridResolutionX = 32;
+                wc.m_GridResolutionZ = 32;
+            }
+        }
+
+        [[nodiscard]] EditorCamera MakePosedCamera() const
+        {
+            EditorCamera camera(60.0f, static_cast<f32>(kWidth) / static_cast<f32>(kHeight),
+                                0.05f, 1000.0f);
+            camera.SetViewportSize(static_cast<f32>(kWidth), static_cast<f32>(kHeight));
+            // Above the water plane (y = 0), looking down at it so the water
+            // geometry is comfortably inside the frustum.
+            camera.SetPose({ 0.0f, 8.0f, 25.0f }, 0.0f, -0.3f);
+            return camera;
+        }
+
+        Entity m_Water;
+    };
+
+    TEST_F(WaterDepthPublicationScene, WaterDepthPublicationDoesNotOutliveWaterFrames)
+    {
+        const EditorCamera camera = MakePosedCamera();
+
+        // 1. Water frame: WaterRenderPass executes its surface-depth capture and
+        //    publishes the depth texture for the tone-map underwater-fog stage.
+        RunEditorFrames(camera, 2);
+        EXPECT_NE(Renderer3D::GetWaterSurfaceDepthTextureID(), 0u)
+            << "A frame that renders water must publish the water-surface depth "
+               "texture (otherwise this test exercises nothing).";
+
+        // 2. No-water frame: the graph culls the water pass, so nothing
+        //    re-publishes. The per-frame reset in PrepareFrame must have cleared
+        //    the previous frame's id — a stale non-zero value here is exactly
+        //    the #505 lifetime bug.
+        GetScene().DestroyEntity(m_Water);
+        RunEditorFrames(camera, 1);
+        EXPECT_EQ(Renderer3D::GetWaterSurfaceDepthTextureID(), 0u)
+            << "The water-surface depth publication survived a frame whose graph "
+               "culled the water pass — a later consumer would bind a texture "
+               "name it no longer owns (issue #505).";
+        EXPECT_EQ(Renderer3D::GetPlanarReflectionTextureID(), 0u)
+            << "The planar-reflection publication has the same per-frame "
+               "contract as the water-surface depth (issue #505).";
+
+        // 3. The churn that made the stale id dangerous in the wild: resizing
+        //    the render-graph targets recreates the water depth FB, deleting the
+        //    GL texture the stale publication pointed at. With the per-frame
+        //    reset in place these frames bind no stale name; the fixture's
+        //    strict per-tick GL-error check fails the test if any pass still
+        //    re-binds a dead texture.
+        SetViewport(kWidth * 2, kHeight * 2);
+        Renderer3D::OnWindowResize(kWidth * 2, kHeight * 2);
+        RunEditorFrames(camera, 2);
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
@@ -71,6 +71,11 @@ namespace OloEngine::Tests
                 wc.m_WorldSizeZ = 50.0f;
                 wc.m_GridResolutionX = 32;
                 wc.m_GridResolutionZ = 32;
+                // Planar reflections ON so the water frame publishes BOTH raw-id
+                // side channels this test pins (water-surface depth + planar
+                // reflection colour) — otherwise the planar assertion below
+                // would compare 0 against a value that was never non-zero.
+                wc.m_PlanarReflectionsEnabled = true;
             }
         }
 
@@ -93,11 +98,17 @@ namespace OloEngine::Tests
         const EditorCamera camera = MakePosedCamera();
 
         // 1. Water frame: WaterRenderPass executes its surface-depth capture and
-        //    publishes the depth texture for the tone-map underwater-fog stage.
+        //    publishes the depth texture for the tone-map underwater-fog stage;
+        //    PlanarReflectionRenderPass publishes its reflection colour target.
+        //    Both must be observed non-zero or the reset assertions below would
+        //    be vacuous.
         RunEditorFrames(camera, 2);
         EXPECT_NE(Renderer3D::GetWaterSurfaceDepthTextureID(), 0u)
             << "A frame that renders water must publish the water-surface depth "
                "texture (otherwise this test exercises nothing).";
+        EXPECT_NE(Renderer3D::GetPlanarReflectionTextureID(), 0u)
+            << "A frame that renders reflective water must publish the planar-"
+               "reflection texture (otherwise this test exercises nothing).";
 
         // 2. No-water frame: the graph culls the water pass, so nothing
         //    re-publishes. The per-frame reset in PrepareFrame must have cleared

--- a/docs/agent-rules/cpp-coding-quality.md
+++ b/docs/agent-rules/cpp-coding-quality.md
@@ -225,3 +225,29 @@ if (auto it = map.find(key); it != map.end())
 ## 9. UI widget budget
 
 When creating ImGui editor panels for grid/array data, **never allocate a widget per cell** for potentially large grids. Use `ImGuiListClipper` for row virtualization and derive a visible column range from `ImGui::GetContentRegionAvail().x / per-widget-width`. Add paging or scrolling when the data exceeds the visible area.
+
+---
+
+## 10. Language-version gates: check `_MSVC_LANG`, not bare `__cplusplus` (MSVC quirk)
+
+MSVC reports `__cplusplus` as `199711L` unless `/Zc:__cplusplus` is set — and this repo does **not** set it. A guard like
+
+```cpp
+#if __has_include(<stacktrace>) && __cplusplus >= 202302L   // BAD — always false on MSVC here
+```
+
+**silently compiles the feature out** on our primary toolchain: no error, no warning, the code just never runs (this hid the GL-error stack-capture path in `OpenGLDebug.cpp` during the #505 hunt, and the same latent gate sits in `AllocationTracker.cpp`). Gate on both:
+
+```cpp
+#if __has_include(<stacktrace>) && (__cplusplus >= 202302L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))
+```
+
+If a feature-gate ever seems mysteriously inert on Windows, check for a bare `__cplusplus` comparison first.
+
+---
+
+## 11. Raw GL handles published through global state must be reset per frame
+
+A render pass that publishes a raw GL name (`u32` texture/buffer id) into process-wide renderer state (`Renderer3D::Set*TextureID`) **must not rely on its own `Execute()` to clear it** — the render graph can cull the pass entirely, so its "clear at top of Execute" never runs and last frame's (or last *test's*) id survives while the owning framebuffer is deleted by a resize/rebuild. Any consumer that binds the published id then re-binds a dead name: `GL_INVALID_OPERATION "<texture> is not a valid texture name"`, every frame, with visually-correct output (issue #505 — `WaterSurfaceDepthTextureID` / `PlanarReflectionTextureID`, consumed by `ToneMapRenderPass`).
+
+Rule: a raw-id publication is **per-frame state** — reset it in `RenderPipeline::PrepareFrame` (BeginScene) alongside the other per-frame rotations, and let the executing pass re-publish. Holding a `Ref<Texture>` instead sidesteps the dangling-name problem but extends resource lifetime; the per-frame reset is the default. Debugging technique that pins this class of bug in minutes: the GL debug context is synchronous in Debug builds, so `OpenGLMessageCallback` logs a `std::stacktrace` for every ERROR-type message — the offending `glBindTextureUnit` call site is in the log with file:line.


### PR DESCRIPTION
Fixes #505.

## Root cause — not diffuse after all

A `std::stacktrace` capture added to the (already synchronous) GL debug callback pinned **all 248** in-render `id 1282` errors from a full-suite run to a **single bind site**: `ToneMapRenderPass::Execute` binding `Renderer3D::GetWaterSurfaceDepthTextureID()` for the underwater-fog stage.

`WaterRenderPass` publishes its depth FB's raw GL texture name through `Renderer3D::SetWaterSurfaceDepthTextureID` and cleared it only at the top of its own `Execute()`. On any no-water frame the render graph **culls** the water pass, so `Execute` never runs — the id published by the last water-rendering test survived across scenes/tests while render-graph churn (resize/rebuild) deleted the framebuffer that owned the name. ToneMap, which is never culled, then re-bound the dead name every frame: `GL_INVALID_OPERATION "<texture> is not a valid texture name"`, with visually correct output (the fog branch never samples above water). `PlanarReflectionTextureID` had the identical lifecycle; the "shifting victim set" in the issue was just whichever water/reflection test happened to run last.

## Changes

- **`RenderPipeline.cpp` (the fix):** both publications are now strictly per-frame — reset in `PrepareFrame` (BeginScene), re-published only by an executing pass.
- **`GLStateGuard.cpp`:** `ApplyCore` validates FBO/program/VAO names via `glIs*` before restoring — the guarded tick may legitimately delete an object bound at entry, and the restore itself then manufactured an id-1282 (the stack capture caught one, from `SceneRenders3D`).
- **`OpenGLDebug.cpp`:** the stack capture is kept as permanent diagnostics (ERROR-type debug messages only — zero cost on clean runs). Gate note: bare `__cplusplus >= 202302L` is always false on MSVC without `/Zc:__cplusplus`; the guard also checks `_MSVC_LANG`.
- **`RendererAttachedTest.cpp`:** the per-tick GL check is now **strict** — the `GL_INVALID_OPERATION` carve-out this issue tracked is gone; any GL error fails the exact tick that produced it. The now-unreferenced `DrainAndGetFirstUnexpected` helper (+ its test) was removed.
- **New `WaterStaleTexturePublicationTest.cpp` (L4):** deterministic regression — water frame publishes → water entity removed → publication must read 0 → render-target resize churn + more frames under the strict tick check. Verified to **fail** with the `PrepareFrame` reset disabled and pass with it.
- **`docs/agent-rules/cpp-coding-quality.md`:** new §10 (`_MSVC_LANG` gate quirk) and §11 (raw GL-id publications through global renderer state are per-frame state).

## Verification

- Baseline (pre-fix): full suite produced **230** stale-texture `id 1282` messages across 15 victim tests (`ClothScene` alone: 148).
- Post-fix: **3 consecutive full-suite runs (4046 tests)** with **0** id-1282 / stale-texture messages. The only remaining GL-error stacks are the deliberate error-injection tests (`GLErrorStateCheckTest`, `ProceduralSkyBakeTest`) that exercise the drain machinery.
- Only failing test in every run (including the pre-fix baseline): `RebindMenuScene.RendersRebindPanelAndProducesPng` — the pre-existing, unrelated flake tracked as #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenGL state restoration to avoid rebinding deleted objects and reduce GL error noise.
  * Reset water-related texture IDs at the start of each frame so stale texture bindings no longer leak into later frames.
  * Tightened render-tick validation to fail on any unexpected GL errors after a frame.

* **Tests**
  * Added a regression test covering stale water texture publication and render-graph culling behavior.
  * Updated existing GL error checks to match the stricter frame-cleanliness expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->