### PR TITLE
fix(renderer): lazily upload deferred font textures so headless-first-touch fonts render (#520)

### DIFF
--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -288,6 +288,25 @@ else()
 		Threads::Threads
 		${CMAKE_DL_LIBS}
 	)
+
+	# std::stacktrace runtime. Platform/OpenGL/OpenGLDebug.cpp calls
+	# std::stacktrace::current() behind __has_include(<stacktrace>). On GCC's
+	# libstdc++ (GCC 12+) that implementation lives in a SEPARATE archive,
+	# libstdc++exp.a, which is NOT linked by default — so on Linux/Clang (the
+	# sanitizer CI) and GCC the OpenGLDebug.cpp.o references are undefined at
+	# every executable link:
+	#   ld.lld: error: undefined symbol: std::__stacktrace_impl::_S_current(...)
+	#   ld.lld: error: undefined symbol: std::stacktrace_entry::_Info::_M_populate(...)
+	# MSVC's STL resolves std::stacktrace via DbgHelp (linked in the MSVC branch
+	# above), and libc++ gates the header out, so this is a libstdc++-only need.
+	# check_linker_flag adds the lib only where it actually exists (a no-op on
+	# libc++ / toolchains without it), and as an OloEngine link dep CMake orders
+	# it after libOloEngine.a so the static-archive references resolve.
+	include(CheckLinkerFlag)
+	check_linker_flag(CXX "-lstdc++exp" OLO_HAVE_LIBSTDCXXEXP)
+	if(OLO_HAVE_LIBSTDCXXEXP)
+		target_link_libraries(OloEngine stdc++exp)
+	endif()
 endif()
 
 # When fuzzing is enabled, instrument OloEngine with ASan/UBSan. Helper is

--- a/OloEngine/src/OloEngine/Renderer/Font.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Font.cpp
@@ -225,6 +225,24 @@ namespace OloEngine
 
     Font::~Font() = default;
 
+    Ref<Texture2D> Font::GetCurveTexture() const
+    {
+        if (!m_IsLoaded || !m_Data)
+            return nullptr;
+        // A headless-parsed font retained its texel data instead of uploading;
+        // create the GPU texture now that a draw is requesting it (issue #520).
+        SlugFontProcessor::EnsureGpuTextures(*m_Data);
+        return m_Data->CurveTexture;
+    }
+
+    Ref<Texture2D> Font::GetBandTexture() const
+    {
+        if (!m_IsLoaded || !m_Data)
+            return nullptr;
+        SlugFontProcessor::EnsureGpuTextures(*m_Data);
+        return m_Data->BandTexture;
+    }
+
     Ref<Font> Font::GetDefault()
     {
         static Ref<Font> DefaultFont;

--- a/OloEngine/src/OloEngine/Renderer/Font.h
+++ b/OloEngine/src/OloEngine/Renderer/Font.h
@@ -71,15 +71,12 @@ namespace OloEngine
             return nullptr;
         }
 
-        Ref<Texture2D> GetCurveTexture() const
-        {
-            return (m_IsLoaded && m_Data) ? m_Data->CurveTexture : nullptr;
-        }
-
-        Ref<Texture2D> GetBandTexture() const
-        {
-            return (m_IsLoaded && m_Data) ? m_Data->BandTexture : nullptr;
-        }
+        // Out-of-line: both first flush any GPU texture upload deferred by a
+        // headless load (SlugFontProcessor::EnsureGpuTextures), so a font parsed
+        // before the renderer came up becomes renderable on the first draw that
+        // needs it rather than staying permanently textureless (issue #520).
+        Ref<Texture2D> GetCurveTexture() const;
+        Ref<Texture2D> GetBandTexture() const;
 
         // Legacy accessor — returns nullptr. Use GetCurveTexture() / GetBandTexture().
         [[deprecated("Use GetCurveTexture() / GetBandTexture() instead")]]

--- a/OloEngine/src/OloEngine/Renderer/SlugData.h
+++ b/OloEngine/src/OloEngine/Renderer/SlugData.h
@@ -72,6 +72,27 @@ namespace OloEngine
         Ref<Texture2D> CurveTexture; // RGBA16F — control point data
         Ref<Texture2D> BandTexture;  // RG16UI  — band headers + curve lists
 
+        // Deferred GPU upload.
+        //
+        // A font parsed without a live GL context (a headless metrics-only load
+        // — e.g. Font::GetDefault() called from a unit test before the renderer
+        // is up, or an asset preprocessor) cannot create its curve/band textures
+        // yet. Rather than caching the font as permanently non-renderable, the
+        // processor retains the already-packed, already-padded texel data here
+        // and the GPU textures are uploaded lazily the first time a texture is
+        // requested with a context bound (SlugFontProcessor::EnsureGpuTextures).
+        // The CPU copies are freed once uploaded, so a font that does eventually
+        // render pays no lasting memory cost. Without this, a font first touched
+        // before the renderer exists would silently drop all its text on every
+        // later render even once a context is live (issue #520).
+        bool GpuUploadPending = false;
+        std::vector<f32> PendingCurveTexels; // RGBA16F, padded to Width*Height*4 floats
+        std::vector<u16> PendingBandTexels;  // RG16UI,  padded to Width*Height*2 u16s
+        u32 PendingCurveWidth = 0;
+        u32 PendingCurveHeight = 0;
+        u32 PendingBandWidth = 0;
+        u32 PendingBandHeight = 0;
+
         [[nodiscard]] const SlugGlyphData* GetGlyph(u32 codepoint) const
         {
             if (auto const it = Glyphs.find(codepoint); it != Glyphs.end())

--- a/OloEngine/src/OloEngine/Renderer/SlugFontProcessor.cpp
+++ b/OloEngine/src/OloEngine/Renderer/SlugFontProcessor.cpp
@@ -557,6 +557,30 @@ namespace OloEngine
             }
         }
 
+        // Compute final texture dimensions and pad the packed texel buffers up
+        // to a full width*height block. This is cheap CPU work and is done
+        // regardless of whether a GL context is currently bound, so the padded
+        // data is ready either for an immediate upload or a deferred one.
+        u32 curveWidth = 0;
+        u32 curveHeight = 0;
+        if (curveTexelCount > 0)
+        {
+            curveWidth = std::min(curveTexelCount, kBandTextureWidth);
+            curveHeight = (curveTexelCount + kBandTextureWidth - 1) / kBandTextureWidth;
+            auto totalTexels = static_cast<sizet>(curveWidth) * curveHeight;
+            curveTexelData.resize(totalTexels * 4, 0.0f); // RGBA16F: 4 floats/texel
+        }
+
+        u32 bandWidth = 0;
+        u32 bandHeight = 0;
+        if (bandTexelCount > 0)
+        {
+            bandWidth = std::min(bandTexelCount, kBandTextureWidth);
+            bandHeight = (bandTexelCount + kBandTextureWidth - 1) / kBandTextureWidth;
+            auto totalTexels = static_cast<sizet>(bandWidth) * bandHeight;
+            bandTexelData.resize(totalTexels * 2, 0); // RG16UI: 2 u16s/texel
+        }
+
         // Create GPU textures only if a live GL context is bound. Headless
         // harnesses (Functional tests, asset preprocessors) load fonts for
         // their metrics + glyph data without ever rendering them; calling
@@ -564,52 +588,101 @@ namespace OloEngine
         // through the null glad function pointer. Probing one DSA entry point
         // is sufficient because glad resolves them as a batch — if any one is
         // non-null, a context exists and the rest do too.
-        const bool hasGLContext = (glad_glCreateTextures != nullptr);
-
-        if (hasGLContext && curveTexelCount > 0)
+        //
+        // When NO context is bound we do NOT discard the packed data: it is
+        // retained on the SlugFontData so EnsureGpuTextures() can upload it the
+        // first time the font is rendered. Without this, a font first loaded
+        // headless (e.g. Font::GetDefault() from a metrics-only unit test) would
+        // be cached as permanently textureless and silently drop its text on
+        // every later render even once a context exists — issue #520.
+        if (const bool hasGLContext = (glad_glCreateTextures != nullptr); hasGLContext)
         {
-            auto curveWidth = std::min(curveTexelCount, kBandTextureWidth);
-            auto curveHeight = (curveTexelCount + kBandTextureWidth - 1) / kBandTextureWidth;
-
-            // Pad curve data to fill full texture dimensions (width * height * 4 floats).
-            auto totalTexels = static_cast<sizet>(curveWidth) * curveHeight;
-            curveTexelData.resize(totalTexels * 4, 0.0f);
-
-            TextureSpecification curveSpec;
-            curveSpec.Width = curveWidth;
-            curveSpec.Height = curveHeight;
-            curveSpec.Format = ImageFormat::RGBA16F;
-            curveSpec.GenerateMips = false;
-            fontData.CurveTexture = Texture2D::Create(curveSpec);
-            fontData.CurveTexture->SetData(curveTexelData.data(),
-                                           static_cast<u32>(totalTexels * 4 * sizeof(f32)));
+            if (curveWidth > 0)
+            {
+                TextureSpecification curveSpec;
+                curveSpec.Width = curveWidth;
+                curveSpec.Height = curveHeight;
+                curveSpec.Format = ImageFormat::RGBA16F;
+                curveSpec.GenerateMips = false;
+                fontData.CurveTexture = Texture2D::Create(curveSpec);
+                fontData.CurveTexture->SetData(curveTexelData.data(),
+                                               static_cast<u32>(curveTexelData.size() * sizeof(f32)));
+            }
+            if (bandWidth > 0)
+            {
+                TextureSpecification bandSpec;
+                bandSpec.Width = bandWidth;
+                bandSpec.Height = bandHeight;
+                bandSpec.Format = ImageFormat::RG16UI;
+                bandSpec.GenerateMips = false;
+                fontData.BandTexture = Texture2D::Create(bandSpec);
+                fontData.BandTexture->SetData(bandTexelData.data(),
+                                              static_cast<u32>(bandTexelData.size() * sizeof(u16)));
+            }
         }
-
-        if (hasGLContext && bandTexelCount > 0)
+        else if (curveWidth > 0 || bandWidth > 0)
         {
-            auto bandWidth = std::min(bandTexelCount, kBandTextureWidth);
-            auto bandHeight = (bandTexelCount + kBandTextureWidth - 1) / kBandTextureWidth;
-
-            auto totalTexels = static_cast<sizet>(bandWidth) * bandHeight;
-            bandTexelData.resize(totalTexels * 2, 0);
-
-            TextureSpecification bandSpec;
-            bandSpec.Width = bandWidth;
-            bandSpec.Height = bandHeight;
-            bandSpec.Format = ImageFormat::RG16UI;
-            bandSpec.GenerateMips = false;
-            fontData.BandTexture = Texture2D::Create(bandSpec);
-            fontData.BandTexture->SetData(bandTexelData.data(),
-                                          static_cast<u32>(totalTexels * 2 * sizeof(u16)));
-        }
-
-        if (!hasGLContext)
-        {
-            OLO_CORE_TRACE("SlugFontProcessor: no GL context — skipping curve/band texture upload (metrics-only load).");
+            fontData.GpuUploadPending = true;
+            fontData.PendingCurveTexels = std::move(curveTexelData);
+            fontData.PendingCurveWidth = curveWidth;
+            fontData.PendingCurveHeight = curveHeight;
+            fontData.PendingBandTexels = std::move(bandTexelData);
+            fontData.PendingBandWidth = bandWidth;
+            fontData.PendingBandHeight = bandHeight;
+            OLO_CORE_TRACE("SlugFontProcessor: no GL context — deferring curve/band texture upload for lazy creation on first render.");
         }
 
         OLO_CORE_INFO("SlugFontProcessor: processed {} glyphs, {} curve texels, {} band texels",
                       processedGlyphs, curveTexelCount, bandTexelCount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Deferred GPU upload
+    // -------------------------------------------------------------------------
+
+    void SlugFontProcessor::EnsureGpuTextures(SlugFontData& fontData)
+    {
+        if (!fontData.GpuUploadPending)
+        {
+            return;
+        }
+
+        // Still no context — leave the data pending for a later attempt.
+        if (glad_glCreateTextures == nullptr)
+        {
+            return;
+        }
+
+        if (fontData.PendingCurveWidth > 0 && fontData.PendingCurveHeight > 0)
+        {
+            TextureSpecification curveSpec;
+            curveSpec.Width = fontData.PendingCurveWidth;
+            curveSpec.Height = fontData.PendingCurveHeight;
+            curveSpec.Format = ImageFormat::RGBA16F;
+            curveSpec.GenerateMips = false;
+            fontData.CurveTexture = Texture2D::Create(curveSpec);
+            fontData.CurveTexture->SetData(fontData.PendingCurveTexels.data(),
+                                           static_cast<u32>(fontData.PendingCurveTexels.size() * sizeof(f32)));
+        }
+
+        if (fontData.PendingBandWidth > 0 && fontData.PendingBandHeight > 0)
+        {
+            TextureSpecification bandSpec;
+            bandSpec.Width = fontData.PendingBandWidth;
+            bandSpec.Height = fontData.PendingBandHeight;
+            bandSpec.Format = ImageFormat::RG16UI;
+            bandSpec.GenerateMips = false;
+            fontData.BandTexture = Texture2D::Create(bandSpec);
+            fontData.BandTexture->SetData(fontData.PendingBandTexels.data(),
+                                          static_cast<u32>(fontData.PendingBandTexels.size() * sizeof(u16)));
+        }
+
+        // Font is now renderable — free the retained CPU copies and clear the flag.
+        fontData.PendingCurveTexels = std::vector<f32>{};
+        fontData.PendingBandTexels = std::vector<u16>{};
+        fontData.PendingCurveWidth = fontData.PendingCurveHeight = 0;
+        fontData.PendingBandWidth = fontData.PendingBandHeight = 0;
+        fontData.GpuUploadPending = false;
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/SlugFontProcessor.h
+++ b/OloEngine/src/OloEngine/Renderer/SlugFontProcessor.h
@@ -25,6 +25,14 @@ namespace OloEngine
         // emScale converts from font units to em-space (1.0 / unitsPerEm).
         static void Process(const stbtt_fontinfo& fontInfo, f32 emScale, SlugFontData& fontData);
 
+        // Upload the curve/band textures deferred by a headless Process() call
+        // (SlugFontData::GpuUploadPending). No-op when nothing is pending or when
+        // a GL context still isn't bound; frees the retained CPU texel data once
+        // uploaded. Called by Font::GetCurveTexture()/GetBandTexture() so a font
+        // first parsed before the renderer came up becomes renderable on the
+        // first draw that needs it (issue #520).
+        static void EnsureGpuTextures(SlugFontData& fontData);
+
       private:
         static constexpr u32 kBandTextureWidth = 4096;
         static constexpr u32 kLogBandTextureWidth = 12;

--- a/OloEngine/tests/SlugFontRenderingTest.cpp
+++ b/OloEngine/tests/SlugFontRenderingTest.cpp
@@ -5,6 +5,9 @@
 #include "OloEngine/Renderer/SlugData.h"
 #include "OloEngine/Renderer/SlugFontProcessor.h"
 
+// GL-context fixture for the deferred-upload test below (OLO_ENSURE_GPU_OR_SKIP).
+#include "Rendering/PropertyTests/RenderPropertyTest.h"
+
 #include <stb_image/stb_truetype.h>
 
 #include <cmath>
@@ -394,4 +397,52 @@ TEST(FontMeasureLineTest, MultipleCodepointsAccumulate)
     const f32 widthABC = font->MeasureLine("ABC", fsScale, 0.0f);
     EXPECT_LT(widthA, widthAB);
     EXPECT_LT(widthAB, widthABC);
+}
+
+// ---------------------------------------------------------------------------
+// Deferred GPU texture upload (issue #520)
+//
+// A font parsed without a live GL context (a headless metrics-only load — e.g.
+// Font::GetDefault() called from one of the plain FontMeasureLineTest bodies
+// above, before any GPU test brings the renderer up) skips its curve/band GPU
+// texture creation and retains the packed texel data instead. It must upload
+// those textures lazily the first time it is rendered with a context bound.
+// Without this, such a font was cached as permanently textureless and silently
+// dropped ALL of its text on every later render — the cross-test dropout that
+// made RebindMenuScene.RendersRebindPanelAndProducesPng fail (maxLum 0.269,
+// button-fill grey with no glyphs) only in full-suite runs.
+//
+// This drives SlugFontProcessor::EnsureGpuTextures directly (the mechanism
+// Font::GetCurveTexture()/GetBandTexture() invoke) so the guard is
+// deterministic and order-independent, unlike the full-suite integration
+// symptom. SKIPs cleanly on headless CI.
+// ---------------------------------------------------------------------------
+TEST(SlugDeferredUploadTest, EnsureGpuTexturesUploadsRetainedData)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    SlugFontData data;
+    data.GpuUploadPending = true;
+    data.PendingCurveWidth = 2;
+    data.PendingCurveHeight = 1;
+    data.PendingCurveTexels.assign(static_cast<sizet>(2) * 4, 0.25f); // RGBA16F: 4 floats/texel
+    data.PendingBandWidth = 2;
+    data.PendingBandHeight = 1;
+    data.PendingBandTexels.assign(static_cast<sizet>(2) * 2, static_cast<u16>(3)); // RG16UI: 2 u16s/texel
+
+    ASSERT_EQ(data.CurveTexture.Raw(), nullptr);
+    ASSERT_EQ(data.BandTexture.Raw(), nullptr);
+
+    SlugFontProcessor::EnsureGpuTextures(data);
+
+    EXPECT_NE(data.CurveTexture.Raw(), nullptr) << "deferred curve texture was not uploaded once a context existed";
+    EXPECT_NE(data.BandTexture.Raw(), nullptr) << "deferred band texture was not uploaded once a context existed";
+    EXPECT_FALSE(data.GpuUploadPending) << "pending flag not cleared after upload";
+    EXPECT_TRUE(data.PendingCurveTexels.empty()) << "retained curve texels not freed after upload";
+    EXPECT_TRUE(data.PendingBandTexels.empty()) << "retained band texels not freed after upload";
+
+    // Idempotent: a second call with nothing pending must not re-create the texture.
+    const Texture2D* const curveBefore = data.CurveTexture.Raw();
+    SlugFontProcessor::EnsureGpuTextures(data);
+    EXPECT_EQ(data.CurveTexture.Raw(), curveBefore) << "second call re-created the texture instead of no-op";
 }

--- a/docs/agent-rules/testing-architecture.md
+++ b/docs/agent-rules/testing-architecture.md
@@ -157,6 +157,14 @@ A **global gtest listener** ([`GLErrorStateCheck.{h,cpp}`](../../OloEngine/tests
 
 When you write a raw-GL test, the discipline is: **unbind what you bound and drain what you provoked, at the end of the test.** The listener will pin any slip to its source with a `[ FAILED ]` naming the leaked GL enum — fix the named test, don't drain in its victim.
 
+### 6.5 Lazy-loaded GPU resources: a headless first-touch must not cache a non-renderable state (issue #520)
+
+A process-global **lazy singleton that owns a GPU resource** is a second class of cross-test state leak — one that §6.4's GL-error listener and `GLStateGuard` cannot see, because the corruption is at the *asset* layer, not the GL-binding layer. The trap: a headless test (no GL context) *first touches* the singleton before any GPU test brings the context up. If the loader correctly skips GPU-resource creation when no context is bound (it must — `glCreate*` through a null glad pointer segfaults) **but caches the result as fully loaded**, every later GPU test reuses a permanently non-renderable resource. It passes in isolation (there the singleton is first loaded *with* a context) and fails only in a full-suite ordering — deterministically, which reads like a state leak rather than timing flake.
+
+The worked case: `Font::GetDefault()` caches a `static Ref<Font>`; `SlugFontProcessor::Process` skips curve/band texture creation when `glad_glCreateTextures == nullptr`. `FontMeasureLineTest` (a plain metrics-only `TEST`) called `GetDefault()` first in the full-suite order, caching a **textureless** font; `RebindMenuScene.RendersRebindPanelAndProducesPng` then rendered its labels through that cached font (UI text falls back to `Font::GetDefault()`) and every glyph silently dropped — `maxLum 0.269`, the button-fill grey, no near-white text.
+
+The fix is **not** a test-ordering workaround: make the resource *upgradeable*. Retain the CPU-side data when the GPU upload is deferred and upload it lazily the first time the resource is used with a context bound (`SlugFontProcessor::EnsureGpuTextures`, called from `Font::GetCurveTexture()`/`GetBandTexture()`), freeing the CPU copy afterward. **Guard rule for any new lazy GPU-resource loader: if you skip GPU creation because no context is bound, do not cache the result as final — either retain enough to finish the upload later, or don't cache until the upload succeeds.** Deterministic guard: `SlugDeferredUploadTest.EnsureGpuTexturesUploadsRetainedData` drives the upgrade path directly; the `RebindMenuScene` visual test remains the full-suite integration guard.
+
 ---
 
 ## 7. Relevant files


### PR DESCRIPTION
Fixes #520.

## Problem

`RebindMenuScene.RendersRebindPanelAndProducesPng` failed **deterministically only in full-suite runs** (`maxLum 0.269014895` — the button-fill grey, every text glyph missing), while passing in isolation. A text-rendering dropout, not a threshold issue.

## Root cause

`Font::GetDefault()` caches a process-global `static Ref<Font>`, and `SlugFontProcessor::Process` only creates the Slug curve/band GPU textures when a GL context is bound (`glad_glCreateTextures != nullptr`) — headless loads correctly skip it, since `glCreate*` through a null glad pointer segfaults.

In full-suite order, `FontMeasureLineTest` (a plain metrics-only `TEST()`, **no GL context**) calls `Font::GetDefault()` *before* any GPU test brings the renderer up, caching a font with `m_IsLoaded=true` but **null curve/band textures**. `RebindMenuScene` then renders its labels through that poisoned cached font (UI text falls back to `Font::GetDefault()`), so `DrawString` gets null textures and every glyph silently drops. In isolation the default font is first loaded *during* a render, with a context live, so the textures exist — hence pass-in-isolation / fail-in-suite.

This is a cross-test / headless-boundary state leak at the **asset** layer — invisible to `GLStateGuard` and the GL-error listener (#485/#505), which only see the GL-binding layer.

## Fix

Make the resource *upgradeable* instead of caching a non-renderable state:

- `SlugFontProcessor::Process` retains the packed, padded texel data on the `SlugFontData` when the GPU upload is deferred (no context), rather than discarding it.
- New `SlugFontProcessor::EnsureGpuTextures(SlugFontData&)` uploads that retained data the first time a context is available, then frees the CPU copy.
- `Font::GetCurveTexture()` / `GetBandTexture()` (now out-of-line) call it, so a font first parsed headless becomes renderable on the first draw that needs it.

Not a test-ordering workaround — it fixes `Font::Create`-cached fonts too, not just the default.

## Verification

- **Full suite: 4046 ran, 4041 passed, 0 failed**; `RebindMenuScene` `[ OK ]` in the exact failing ordering; no font/text regressions (`SlugDataTest`, `SlugFontProcessorTest`, `FontMeasureLineTest`, `RuntimeInputRebindMenuTest`).
- Minimal repro `--gtest_filter=FontMeasureLineTest.*:RebindMenuScene.*` (headless poison → render) now passes.
- Evidence PNG shows all glyphs rendering (title, row labels, bindings, button captions).
- New deterministic, order-independent guard: `SlugDeferredUploadTest.EnsureGpuTexturesUploadsRetainedData`.
- Lesson documented in `docs/agent-rules/testing-architecture.md` §6.5 (lazy-loaded GPU resource headless-cache-leak class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fonts loaded without a graphics context now become fully usable once rendering starts, with textures created on demand.
  * Added support for preserving font texture data until it can be uploaded safely.

* **Bug Fixes**
  * Fixed an issue where some fonts could fail to render after being loaded in headless or test environments.
  * Improved reliability for first-draw font rendering.

* **Tests**
  * Added coverage for deferred texture upload behavior and repeat-safe loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->