### PR TITLE
feat(renderer): apply renderer settings at startup and scene load (#534)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -306,6 +306,13 @@ namespace OloEngine
         // never run against an uninitialized renderer when m_Is3DMode is true.
         TryInitialize3DMode();
 
+        // Apply the config's renderer settings to the freshly-built render graph
+        // (#534). TryInitialize3DMode ran Renderer3D::Init, which builds the graph
+        // from the real window size, so the graph exists here — but nothing had yet
+        // pushed the RendererSettings defaults (depth-prepass / Forward+ auto-switch)
+        // into it, so the editor booted with those silently off until a panel toggle.
+        ApplyRendererSettingsToGraph();
+
         // Frame the start scene's terrain AFTER TryInitialize3DMode: it calls
         // ApplyDefault3DCameraPose, which would otherwise clobber the framing.
         // (OpenProject() opened the start scene before the camera reconstruction
@@ -2707,6 +2714,10 @@ namespace OloEngine
         Ref<Scene> newScene = Ref<Scene>::Create();
         SetEditorScene(newScene);
         m_EditorScenePath = std::filesystem::path();
+
+        // Re-apply renderer settings after the scene swap so the graph reflects the
+        // current config (#534) — mirrors the scene-load finalizers below.
+        ApplyRendererSettingsToGraph();
     }
 
     void EditorLayer::OpenScene()
@@ -2818,6 +2829,13 @@ namespace OloEngine
             ApplyTieringToSettings(project->GetConfig().QualityTiering, Renderer3D::GetPostProcessSettings(), shadowCopy);
             Renderer3D::GetShadowMap().SetSettings(shadowCopy);
         }
+
+        // Push the (now scene-loaded + quality-tiered) settings into the render graph
+        // (#534). Runs AFTER the PostProcessSettings copy above because
+        // ApplyRendererSettings rebuilds the graph on an AO-technique change, so the
+        // scene's ActiveAOTechnique must already be live. Covers OpenScene, MCP
+        // olo_scene_open, and the auto-save pre-answered paths that share this finalizer.
+        ApplyRendererSettingsToGraph();
 
         m_TimeSinceLastAutoSave = 0.0f;
         return true;
@@ -3029,6 +3047,11 @@ namespace OloEngine
             ApplyTieringToSettings(project->GetConfig().QualityTiering, Renderer3D::GetPostProcessSettings(), shadowCopy);
             Renderer3D::GetShadowMap().SetSettings(shadowCopy);
         }
+
+        // Same rationale as LoadEditorSceneFile (#534): apply after the scene's
+        // settings are live so the graph reflects them. This finalizer backs the
+        // auto-save recovery modal's load paths.
+        ApplyRendererSettingsToGraph();
 
         return true;
     }
@@ -3312,6 +3335,22 @@ namespace OloEngine
         Renderer3D::ClearSunDirectionOverride();
 
         SyncWindowTitle();
+    }
+
+    void EditorLayer::ApplyRendererSettingsToGraph()
+    {
+        // No renderer to configure until 3D mode has brought Renderer3D up (the
+        // render graph is built inside Renderer3D::Init). In 2D mode this is a
+        // no-op; the call re-runs when 3D mode initializes.
+        if (!Renderer3D::HasInitialized())
+            return;
+
+        // Mirror the settings-panel / MCP-write call sites: this pushes the config's
+        // rendering path, culling toggles, and the Forward+/depth-prepass derivation
+        // into the live graph. Safe to re-run (idempotent); must be on the main thread
+        // after the graph exists — both guaranteed here (post-TryInitialize3DMode at
+        // startup, and inside the main-thread scene-load finalizers).
+        Renderer3D::ApplyRendererSettings();
     }
 
     void EditorLayer::SyncWindowTitle() const

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -158,6 +158,14 @@ namespace OloEngine
         void SyncPrefsFromMembers();
 
         void SetEditorScene(const Ref<Scene>& scene);
+        // Push the live RendererSettings (rendering path, culling, Forward+/depth-prepass
+        // derivation) into the render graph / pass state — the same call the settings
+        // panel and the MCP write tool make on every edit (#534). Nothing else calls it
+        // at editor startup or scene-load, so without this the config/scene defaults
+        // (depth-prepass, Forward+ auto-switch) silently never apply until a human toggles
+        // a panel setting. Guarded on HasInitialized() and MUST run post-render-graph-build
+        // on the main thread — see Renderer3D::ApplyRendererSettings.
+        void ApplyRendererSettingsToGraph();
         void SyncWindowTitle() const;
         void BindContentBrowserSelectionCallback();
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(OloEngine-Tests
 		Rendering/TextureCompressionTest.cpp
 		Rendering/BoundingVolumeTest.cpp
 		Rendering/FrustumCullingTest.cpp
+		Rendering/RendererSettingsBootstrapTest.cpp
 		Rendering/ReflectionProbeSelectionTest.cpp
 		Rendering/PlanarReflectionMathTest.cpp
 		Rendering/LODTest.cpp

--- a/OloEngine/tests/Rendering/RendererSettingsBootstrapTest.cpp
+++ b/OloEngine/tests/Rendering/RendererSettingsBootstrapTest.cpp
@@ -1,0 +1,138 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Renderer/Renderer3D.h"
+#include "OloEngine/Renderer/RenderingPath.h"
+#include "OloEngine/Renderer/LightCulling/TiledForwardPlus.h"
+
+// OLO_TEST_LAYER: unit
+
+// =============================================================================
+// RendererSettingsBootstrapTest — unit (headless, no GL context required).
+//
+// Pins the config->live-state sync that issue #534 fixed: Renderer3D's live
+// depth-prepass / Forward+ mode are derived from RendererSettings, but that
+// derivation only fires inside Renderer3D::ApplyRendererSettings(). Nothing
+// called that at editor startup or scene-load, so the editor booted with
+// DepthPrepassEnabled=false and Forward+ never auto-switching even though the
+// config default asks for both — a measured ~2.8x GPU regression on light-heavy
+// scenes until a human toggled a settings-panel control.
+//
+// These tests are the CI-safe half of the fix (the editor call sites are the
+// other half, verified live over MCP): they prove ApplyRendererSettings() makes
+// the LIVE renderer state match the settings-DERIVED value, so the boot/scene-load
+// calls added to EditorLayer actually apply the defaults. ApplyRendererSettings
+// touches no GL when the renderer is uninitialized (the graph rebuild is guarded
+// on a null RGraph, the ForwardPlus setters no-op until Initialize()), so the
+// contract is exercised without a live context.
+//
+// Each test mutates the global RendererSettings; the fixture snapshots and
+// restores them (and re-derives the live flags) so ordering can't leak state
+// into the GL-context renderer tests that share this process.
+// =============================================================================
+
+namespace
+{
+    using OloEngine::ForwardPlusMode;
+    using OloEngine::Renderer3D;
+    using OloEngine::RendererSettings;
+    using OloEngine::RenderingPath;
+
+    class RendererSettingsBootstrapTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            m_Saved = Renderer3D::GetRendererSettings();
+        }
+
+        void TearDown() override
+        {
+            // Restore the config AND re-derive the live flags from it so a later
+            // test never observes this test's mutated depth-prepass / Forward+ mode.
+            Renderer3D::GetRendererSettings() = m_Saved;
+            Renderer3D::ApplyRendererSettings();
+        }
+
+        RendererSettings m_Saved{};
+    };
+
+    // The shipped default (Forward path + Forward+ auto-switch) derives depth-prepass
+    // ON — the config genuinely wants the prepass, so "live prepass == false at boot"
+    // is a real divergence, not the intended default.
+    TEST_F(RendererSettingsBootstrapTest, DefaultConfigDerivesDepthPrepassOn)
+    {
+        Renderer3D::GetRendererSettings() = RendererSettings{}; // pristine shipped defaults
+        EXPECT_TRUE(Renderer3D::ComputeSettingsDerivedDepthPrepass());
+    }
+
+    // The #534 regression, reproduced at the Renderer3D seam and then fixed by the
+    // apply call: force the live prepass flag to the wrong value the editor booted
+    // with, confirm it diverges from the config-derived value, then ApplyRendererSettings
+    // must reconcile them. This is exactly what EditorLayer now invokes at startup /
+    // scene-load.
+    TEST_F(RendererSettingsBootstrapTest, ApplyReconcilesLiveDepthPrepassWithConfig)
+    {
+        Renderer3D::GetRendererSettings() = RendererSettings{}; // Forward + auto-switch -> derives true
+
+        // Simulate the un-applied boot state: live flag stuck at its zero default.
+        Renderer3D::EnableDepthPrepass(false);
+        ASSERT_TRUE(Renderer3D::ComputeSettingsDerivedDepthPrepass());
+        ASSERT_FALSE(Renderer3D::IsDepthPrepassEnabled()) << "precondition: live state diverges from config before apply";
+
+        Renderer3D::ApplyRendererSettings();
+
+        EXPECT_EQ(Renderer3D::IsDepthPrepassEnabled(), Renderer3D::ComputeSettingsDerivedDepthPrepass());
+        EXPECT_TRUE(Renderer3D::IsDepthPrepassEnabled());
+    }
+
+    // The ForwardPlus path forces the tile-culling mode to Always and requires the
+    // depth prepass — apply must push both into the live renderer.
+    TEST_F(RendererSettingsBootstrapTest, ApplyForwardPlusPathEnablesAlwaysModeAndPrepass)
+    {
+        RendererSettings settings{};
+        settings.Path = RenderingPath::ForwardPlus;
+        Renderer3D::GetRendererSettings() = settings;
+
+        Renderer3D::GetForwardPlus().SetMode(ForwardPlusMode::Never); // wrong value to overwrite
+        Renderer3D::EnableDepthPrepass(false);
+
+        Renderer3D::ApplyRendererSettings();
+
+        EXPECT_EQ(Renderer3D::GetForwardPlus().GetMode(), ForwardPlusMode::Always);
+        EXPECT_TRUE(Renderer3D::IsDepthPrepassEnabled());
+    }
+
+    // With auto-switch OFF on the plain Forward path, the derivation drops the prepass
+    // — the reconciliation must be able to turn the live flag back off too, not just on.
+    TEST_F(RendererSettingsBootstrapTest, ApplyForwardNoAutoSwitchDisablesPrepassAndAutoMode)
+    {
+        RendererSettings settings{};
+        settings.Path = RenderingPath::Forward;
+        settings.ForwardPlusAutoSwitch = false;
+        settings.DepthPrepassEnabled = false;
+        Renderer3D::GetRendererSettings() = settings;
+
+        Renderer3D::EnableDepthPrepass(true); // wrong value to overwrite
+
+        Renderer3D::ApplyRendererSettings();
+
+        EXPECT_FALSE(Renderer3D::ComputeSettingsDerivedDepthPrepass());
+        EXPECT_FALSE(Renderer3D::IsDepthPrepassEnabled());
+        EXPECT_EQ(Renderer3D::GetForwardPlus().GetMode(), ForwardPlusMode::Never);
+    }
+
+    // Culling toggles round-trip through apply too — a scene/config that turns frustum
+    // culling off must be honoured at boot, not left at the live default.
+    TEST_F(RendererSettingsBootstrapTest, ApplySyncsFrustumCullingToggle)
+    {
+        RendererSettings settings{};
+        settings.FrustumCullingEnabled = false;
+        Renderer3D::GetRendererSettings() = settings;
+
+        Renderer3D::EnableFrustumCulling(true); // wrong value to overwrite
+        Renderer3D::ApplyRendererSettings();
+
+        EXPECT_FALSE(Renderer3D::IsFrustumCullingEnabled());
+    }
+} // namespace


### PR DESCRIPTION
- Implemented ApplyRendererSettingsToGraph to ensure renderer settings are applied during editor startup and scene loading.
- Added unit tests to verify that renderer settings are correctly synchronized with the live state.
- Updated CMakeLists to include new test file for renderer settings bootstrap.