### PR TITLE
Add olo_perf_cpu_scopes MCP tool for per-scope CPU timings (#519, first slice)

### DIFF
--- a/OloEditor/src/MCP/McpCpuScopes.h
+++ b/OloEditor/src/MCP/McpCpuScopes.h
@@ -1,0 +1,104 @@
+#pragma once
+
+// Pure JSON shaping for the olo_perf_cpu_scopes MCP tool (issue #519, first
+// slice: expose PerformanceProfiler's per-scope CPU timings — every system in
+// Scene.cpp wrapped in OLO_PERF_SCOPE / OLO_PERF_SCOPE_AUTO — over MCP,
+// read-only). The MCP handler in McpTools.cpp reads
+// Application::Get().GetProfilerPreviousFrameData() inside a MarshalRead,
+// pre-resolves it into the plain input structs below, and hands it here.
+//
+// OLO_PERF_SCOPE / OLO_PERF_SCOPE_AUTO compile to a no-op in Distribution
+// builds (see PerformanceProfiler.h), so an empty scope list is ambiguous:
+// "nothing was timed this frame" vs "this build can't time anything at all".
+// The handler resolves that ambiguity by passing `scopesCompiledIn` (a
+// compile-time constant in McpTools.cpp, not something this pure function can
+// know) so callers get an explicit "unavailable in this build" status instead
+// of a silently empty list that looks broken.
+//
+// Keeping the shaping in a free function over engine-free input means it
+// unit-tests directly against synthetic data — the test binary compiles this
+// header but deliberately NOT McpTools.cpp. Mirrors the sibling pattern of
+// McpPassTimings.h / McpFrameBreakdown.h.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace OloEngine::MCP::CpuScopes
+{
+    using Json = nlohmann::json;
+
+    // One named scope's accumulated CPU time for the previous frame (mirrors
+    // OloEngine::PerFrameData, kept engine-free for pure-header testability).
+    struct ScopeEntry
+    {
+        std::string Name;
+        f32 TimeMs = 0.0f;
+        u32 Samples = 0;
+    };
+
+    // Millisecond values span sub-ms scopes to multi-ms frame roots — keep 3 decimals.
+    [[nodiscard]] inline f64 Round3(f64 v)
+    {
+        return std::round(v * 1000.0) / 1000.0;
+    }
+
+    // scopesCompiledIn: whether OLO_PERF_SCOPE / OLO_PERF_SCOPE_AUTO emit real
+    // timers in this build (false in Distribution — the handler resolves this
+    // from the same #if that guards the macros). When false, `scopes` is
+    // expected to be empty and the result reports status "unavailable"
+    // regardless of what was passed, rather than a misleadingly empty
+    // "ok" / zero-scopes result.
+    [[nodiscard]] inline Json BuildCpuScopes(const std::vector<ScopeEntry>& scopes, bool scopesCompiledIn, u32 limit)
+    {
+        Json o;
+
+        if (!scopesCompiledIn)
+        {
+            o["status"] = "unavailable";
+            o["note"] = "CPU scopes unavailable in this build (OLO_PERF_SCOPE is compiled out in Distribution). "
+                        "Rebuild Debug or Release to collect per-scope CPU timings.";
+            o["scopes"] = Json::array();
+            o["totalTimeMs"] = 0.0;
+            o["scopeCount"] = 0;
+            return o;
+        }
+
+        std::vector<const ScopeEntry*> sorted;
+        sorted.reserve(scopes.size());
+        for (const auto& s : scopes)
+            sorted.push_back(&s);
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const ScopeEntry* a, const ScopeEntry* b)
+                  { return a->TimeMs > b->TimeMs; });
+
+        f64 totalTimeMs = 0.0;
+        for (const auto& s : scopes)
+            totalTimeMs += s.TimeMs;
+
+        Json arr = Json::array();
+        const sizet count = limit > 0 ? std::min<sizet>(sorted.size(), limit) : sorted.size();
+        for (sizet i = 0; i < count; ++i)
+        {
+            arr.push_back(Json{ { "name", sorted[i]->Name },
+                                { "timeMs", Round3(sorted[i]->TimeMs) },
+                                { "samples", sorted[i]->Samples } });
+        }
+
+        o["status"] = scopes.empty() ? "ok_no_data" : "ok";
+        o["note"] = scopes.empty()
+                        ? "No scopes recorded last frame — OLO_PERF_SCOPE code paths may not have run, or the "
+                          "engine hasn't completed a frame yet."
+                        : "Per-scope CPU time accumulated across all invocations of that scope name last frame "
+                          "(a scope hit multiple times per frame sums into one entry, see samples).";
+        o["scopes"] = std::move(arr);
+        o["totalTimeMs"] = Round3(totalTimeMs);
+        o["scopeCount"] = static_cast<u64>(scopes.size());
+        return o;
+    }
+} // namespace OloEngine::MCP::CpuScopes

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -3,6 +3,7 @@
 #include "MCP/McpServer.h"
 #include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpScriptApi.h"
+#include "MCP/McpCpuScopes.h"
 #include "MCP/McpFrameBreakdown.h"
 #include "MCP/McpGoldenCompare.h"
 #include "MCP/McpPassTimings.h"
@@ -21,6 +22,7 @@
 #include "OloEngine/Asset/AssetManager.h"
 #include "OloEngine/Asset/AssetMetadata.h"
 #include "OloEngine/Asset/AssetTypes.h"
+#include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/UUID.h"
 #include "OloEngine/Debug/DiagnosticsEventLog.h"
@@ -652,6 +654,41 @@ namespace OloEngine::MCP
                         ? pool.GetCurrentFrameNumber() - pool.GetLastResolvedFrameNumber()
                         : 0;
                 return PassTimings::BuildPassTimings(gpuPasses, cpuPasses, totals); });
+            return ToolResult::Structured(j);
+        }
+
+        // ---- olo_perf_cpu_scopes (main-marshaled) -------------------------------
+        // Per-scope CPU timings collected by PerformanceProfiler (every system in
+        // Scene.cpp is wrapped in OLO_PERF_SCOPE / OLO_PERF_SCOPE_AUTO) — the same
+        // data the editor's PerformanceLayer CPU Scopes table reads, exposed
+        // read-only over MCP (#519, first slice). OLO_PERF_SCOPE compiles to a
+        // no-op in Distribution builds, so this reports an explicit "unavailable"
+        // status there rather than a misleadingly empty scope list — shaping (incl.
+        // that degradation) lives in the pure McpCpuScopes.h so it unit-tests
+        // without this TU.
+        ToolResult Handle_PerfCpuScopes(McpServer& server, const Json& args)
+        {
+            u32 limit = 0; // 0 = no limit
+            if (args.contains("limit") && args["limit"].is_number_integer())
+                limit = static_cast<u32>(std::clamp<long long>(args["limit"].get<long long>(), 1, 1000));
+
+#if defined(OLO_DEBUG) || defined(OLO_RELEASE)
+            constexpr bool scopesCompiledIn = true;
+#else
+            constexpr bool scopesCompiledIn = false;
+#endif
+
+            Json j = server.MarshalRead([limit]() -> Json
+                                        {
+                std::vector<CpuScopes::ScopeEntry> entries;
+                if (Application* app = Application::TryGet())
+                {
+                    const auto& data = app->GetProfilerPreviousFrameData();
+                    entries.reserve(data.size());
+                    for (const auto& [name, perFrame] : data)
+                        entries.push_back(CpuScopes::ScopeEntry{ name, perFrame.Time, perFrame.Samples });
+                }
+                return CpuScopes::BuildCpuScopes(entries, scopesCompiledIn, limit); });
             return ToolResult::Structured(j);
         }
 
@@ -4277,6 +4314,37 @@ namespace OloEngine::MCP
                                     .Required({ "frame", "passes", "passGpuTotalMs" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfPassTimings;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_perf_cpu_scopes";
+            tool.Toolset = "perf";
+            tool.Title = "Per-scope CPU timings";
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "Per-scope CPU time from PerformanceProfiler — every system in Scene.cpp (and other "
+                "OLO_PERF_SCOPE / OLO_PERF_SCOPE_AUTO call sites) reports how long it took last frame, sorted "
+                "descending by time. Mirrors the editor's PerformanceLayer CPU Scopes table. OLO_PERF_SCOPE is "
+                "compiled out entirely in Distribution builds; this reports status \"unavailable\" there instead "
+                "of an empty list. status \"ok_no_data\" means the build supports scope timing but nothing was "
+                "recorded last frame (e.g. queried before the first frame completed).";
+            tool.InputSchema = Schema::Object()
+                                   .Prop("limit", Schema::Int().Min(1).Max(1000).Desc("Max scopes to return, sorted by time descending (default: all)."))
+                                   .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("status", Schema::String().Enum({ "ok", "ok_no_data", "unavailable" }))
+                                    .Prop("note", Schema::String())
+                                    .Prop("scopes", Schema::Array(Schema::Object()
+                                                                      .Prop("name", Schema::String())
+                                                                      .Prop("timeMs", Schema::Number())
+                                                                      .Prop("samples", Schema::Int().Min(0))))
+                                    .Prop("totalTimeMs", Schema::Number())
+                                    .Prop("scopeCount", Schema::Int().Min(0).Desc("Total distinct scopes recorded last frame, before `limit` truncation."))
+                                    .Required({ "status", "note", "scopes", "totalTimeMs", "scopeCount" });
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_PerfCpuScopes;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -369,6 +369,11 @@ add_executable(OloEngine-Tests
 		# (#316: split whole-frame GPU time by render-graph pass). Header-only
 		# (MCP/McpPassTimings.h), no extra editor TU pulled in.
 		MCP/McpPassTimingsTest.cpp
+		# Pure per-scope CPU timings shaping behind olo_perf_cpu_scopes (#519,
+		# first slice: expose PerformanceProfiler's per-scope CPU timings, incl.
+		# the Distribution-build "unavailable" degradation). Header-only
+		# (MCP/McpCpuScopes.h), no extra editor TU pulled in.
+		MCP/McpCpuScopesTest.cpp
 		# Pure JSON / Mermaid topology shaping behind olo_render_graph_topology_export
 		# (#316 Part 4, LLM-analysis exports). Header-only (MCP/McpRenderGraphTopology.h),
 		# no extra editor TU pulled in.

--- a/OloEngine/tests/MCP/McpCpuScopesTest.cpp
+++ b/OloEngine/tests/MCP/McpCpuScopesTest.cpp
@@ -1,0 +1,115 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Unit tests for the pure JSON shaping behind olo_perf_cpu_scopes (issue #519,
+// first slice: expose PerformanceProfiler's per-scope CPU timings over MCP).
+// The shaping lives in a header over engine-free input structs
+// (MCP/McpCpuScopes.h), so it is exercised here against synthetic scope data —
+// the test binary deliberately does NOT compile McpTools.cpp (the
+// editor-backed handler). The live tool's Application::GetProfilerPreviousFrameData
+// -> JSON path is verified over the MCP attach loop; this pins the
+// sort/limit/rounding/degradation shape.
+#include "MCP/McpCpuScopes.h"
+
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::CpuScopes::BuildCpuScopes;
+    using OloEngine::MCP::CpuScopes::Round3;
+    using OloEngine::MCP::CpuScopes::ScopeEntry;
+    using Json = OloEngine::MCP::CpuScopes::Json;
+} // namespace
+
+TEST(McpCpuScopesTest, UnavailableReportsEmptyScopesRegardlessOfInput)
+{
+    // Even if the caller (erroneously) passes populated entries, a Dist build
+    // must not surface them as real data — the status alone communicates
+    // "can't time anything here", not "nothing happened to run".
+    const std::vector<ScopeEntry> entries = { { "Scene::OnUpdateRuntime", 5.0f, 1 } };
+
+    const Json o = BuildCpuScopes(entries, /*scopesCompiledIn*/ false, /*limit*/ 0);
+
+    EXPECT_EQ(o["status"], "unavailable");
+    EXPECT_TRUE(o["scopes"].empty());
+    EXPECT_DOUBLE_EQ(o["totalTimeMs"].get<double>(), 0.0);
+    EXPECT_EQ(o["scopeCount"].get<int>(), 0);
+    EXPECT_NE(o["note"].get<std::string>().find("Distribution"), std::string::npos);
+}
+
+TEST(McpCpuScopesTest, EmptyScopesWhenCompiledInReportsOkNoData)
+{
+    const Json o = BuildCpuScopes({}, /*scopesCompiledIn*/ true, /*limit*/ 0);
+
+    EXPECT_EQ(o["status"], "ok_no_data");
+    EXPECT_TRUE(o["scopes"].empty());
+    EXPECT_DOUBLE_EQ(o["totalTimeMs"].get<double>(), 0.0);
+    EXPECT_EQ(o["scopeCount"].get<int>(), 0);
+}
+
+TEST(McpCpuScopesTest, SortsScopesByTimeDescending)
+{
+    const std::vector<ScopeEntry> entries = {
+        { "Scene::UpdatePhysics", 1.5f, 1 },
+        { "Scene::OnUpdateRuntime", 6.2f, 1 },
+        { "Scene::UpdateScripts", 3.1f, 2 },
+    };
+
+    const Json o = BuildCpuScopes(entries, true, 0);
+
+    EXPECT_EQ(o["status"], "ok");
+    ASSERT_EQ(o["scopes"].size(), 3u);
+    EXPECT_EQ(o["scopes"][0]["name"], "Scene::OnUpdateRuntime");
+    EXPECT_EQ(o["scopes"][1]["name"], "Scene::UpdateScripts");
+    EXPECT_EQ(o["scopes"][2]["name"], "Scene::UpdatePhysics");
+    EXPECT_EQ(o["scopes"][1]["samples"].get<unsigned>(), 2u);
+}
+
+TEST(McpCpuScopesTest, LimitTruncatesButScopeCountReflectsFullSet)
+{
+    const std::vector<ScopeEntry> entries = {
+        { "A", 3.0f, 1 },
+        { "B", 2.0f, 1 },
+        { "C", 1.0f, 1 },
+    };
+
+    const Json o = BuildCpuScopes(entries, true, /*limit*/ 2);
+
+    ASSERT_EQ(o["scopes"].size(), 2u);
+    EXPECT_EQ(o["scopes"][0]["name"], "A");
+    EXPECT_EQ(o["scopes"][1]["name"], "B");
+    EXPECT_EQ(o["scopeCount"].get<int>(), 3);
+}
+
+TEST(McpCpuScopesTest, TotalTimeMsSumsAllScopesNotJustLimited)
+{
+    const std::vector<ScopeEntry> entries = {
+        { "A", 3.0f, 1 },
+        { "B", 2.0f, 1 },
+        { "C", 1.0f, 1 },
+    };
+
+    const Json o = BuildCpuScopes(entries, true, /*limit*/ 1);
+
+    EXPECT_DOUBLE_EQ(o["totalTimeMs"].get<double>(), 6.0);
+}
+
+TEST(McpCpuScopesTest, RoundsToThreeDecimals)
+{
+    EXPECT_DOUBLE_EQ(Round3(0.0004999), 0.0);
+    EXPECT_DOUBLE_EQ(Round3(0.0005001), 0.001);
+    EXPECT_DOUBLE_EQ(Round3(1.23456), 1.235);
+}
+
+TEST(McpCpuScopesTest, ZeroLimitMeansNoTruncation)
+{
+    std::vector<ScopeEntry> entries;
+    for (int i = 0; i < 10; ++i)
+        entries.push_back({ "Scope" + std::to_string(i), static_cast<float>(i), 1 });
+
+    const Json o = BuildCpuScopes(entries, true, /*limit*/ 0);
+
+    EXPECT_EQ(o["scopes"].size(), 10u);
+}

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -173,6 +173,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_perf_frame_history` | downsampled recent-frame time series |
 | `olo_perf_capture_frame` | triggers a real frame capture: stats + top-K draw commands by GPU time (per-draw times resolve via a deferred commit one-plus frames after the capture; draws carry their submesh debug names) |
 | `olo_perf_pass_timings` | whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs ToneMap…): per-pass GPU (always-on timestamp queries) + CPU dispatch ms, frame totals incl. `gpuWaitMs`, and `unattributedGpuMs`. `ScenePass` carries `subPasses` splitting its GPU time into `DepthPrepass` vs `Color` (no DepthPrepass entry = prepass off; sub times are inside the parent's `gpuMs`, not additional) |
+| `olo_perf_cpu_scopes` | per-scope CPU time from `PerformanceProfiler` (every system in `Scene.cpp` wrapped in `OLO_PERF_SCOPE`/`OLO_PERF_SCOPE_AUTO`), sorted descending by time — mirrors the editor's PerformanceLayer CPU Scopes table. `OLO_PERF_SCOPE` is compiled out entirely in Distribution builds, so `status` reports `"unavailable"` there instead of a misleadingly empty list (`"ok_no_data"` = build supports it but nothing ran last frame; `"ok"` = real data). Optional `limit` truncates the returned list; `totalTimeMs`/`scopeCount` always reflect the full set |
 | `olo_render_frame_breakdown` | triggers a real frame capture and returns its **per-command / per-pipeline-stage** structural breakdown (the granularity `olo_perf_capture_frame` omits): pipeline stats + the ordered command list (type, debug-name pass label, draw key shader/material/depth, group, execution order, static flag, GPU time) + a command-type histogram, at the chosen `viewMode` (`presort`/`postsort`/`postbatch`); `format:"markdown"` returns the Command Bucket Inspector's LLM-analysis report (sort/state-change/batching analysis + optimization hints) |
 | `olo_memory_report` | GPU/CPU memory total + per-type breakdown + suspected leaks |
 | `olo_shader_list` | inventory of all registered shaders (id, name, hasErrors) |
@@ -253,7 +254,7 @@ keyword and/or category instead of pulling the entire list:
 |---|---|
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity`, `olo_entity_list_fields`, `olo_entity_set_field`, `olo_scene_open`, `olo_scene_play`, `olo_scene_stop` |
-| `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings` |
+| `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings`, `olo_perf_cpu_scopes` |
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_render_compare_golden`, `olo_render_why_not_visible` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |


### PR DESCRIPTION
## Summary
- Adds `olo_perf_cpu_scopes`, a read-only MCP tool exposing `PerformanceProfiler`'s per-scope CPU timings (every system in `Scene.cpp` wrapped in `OLO_PERF_SCOPE`/`OLO_PERF_SCOPE_AUTO`) — the same data the editor's PerformanceLayer CPU Scopes table already reads.
- `OLO_PERF_SCOPE`/`OLO_PERF_SCOPE_AUTO` compile to a no-op in Distribution builds, so the tool reports an explicit `status: "unavailable"` there instead of a misleadingly empty scope list (`"ok_no_data"` = compiled in but nothing ran last frame, `"ok"` = real data).
- Pure JSON shaping lives in `MCP/McpCpuScopes.h` (mirrors the `McpPassTimings.h` pattern) so it unit-tests without pulling in the editor-backed `McpTools.cpp`.

This is the **first shippable slice of #519** only. Scoped out deliberately, to be filed as follow-ups on the issue thread:
- GPU-timing accuracy bugs (`cpuMs` > `frameTimeMs` at saturation, `gpuWaitMs` reading 0 under GPU-bound load, erratic per-pass numbers on long frames) — touches `RendererProfiler`.
- Overdraw debug view — a real renderer feature per the issue itself, out of scope for a tooling PR.

## Test plan
- [x] `OloEngine-Tests` (Debug, MSVC) builds clean.
- [x] New `McpCpuScopesTest` suite (7 tests: Dist-degradation, sort order, `limit` vs. full-set totals, rounding) passes.
- [x] Full `Mcp*`/`MCP*` filtered suite: 342 passed, 1 expected skip (`McpHeadlessAttachTest.HostUntilDetached`, opt-in only).
- [x] `docs/guides/mcp-diagnostics-server.md` updated with the new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)