### PR TITLE
fix(physics3d): route JoltScene through PhysicsSettings, fix contact-…

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -219,12 +219,12 @@ namespace OloEngine
         {
             // Throttle: an overflow (e.g. ContactConstraintsFull) otherwise re-logs every
             // fixed step for as long as it persists. Log immediately on the first hit / on
-            // a transition to a different error, then only every s_PhysicsUpdateErrorLogInterval
+            // a transition to a different error, then only every kPhysicsUpdateErrorLogInterval
             // steps while it repeats (issue #523).
             const bool isNewError = error != m_LastPhysicsUpdateError;
             if (isNewError)
                 m_PhysicsUpdateErrorRepeatCount = 0;
-            if (isNewError || m_PhysicsUpdateErrorRepeatCount % s_PhysicsUpdateErrorLogInterval == 0)
+            if (isNewError || m_PhysicsUpdateErrorRepeatCount % kPhysicsUpdateErrorLogInterval == 0)
             {
                 OLO_CORE_ERROR("Jolt physics update error: {0} - raise the matching PhysicsSettings limit "
                                "(m_MaxContactConstraints / m_MaxBodyPairs / m_MaxBodies)",
@@ -2521,18 +2521,28 @@ namespace OloEngine
         const PhysicsSettings& settings = Physics3DSystem::GetSettings();
         const u32 maxBodies = std::max(settings.m_MaxBodies, 1u);
         const u32 maxBodyPairs = std::max(settings.m_MaxBodyPairs, 1u);
-        const u32 maxContactConstraints = std::max(settings.m_MaxContactConstraints, 1u);
+
+        // Create temp allocator, scaled against kBaselineTempAllocatorSize (see its
+        // comment): Jolt's per-step scratch usage scales with maxContactConstraints, and
+        // TempAllocatorImpl is a fixed-size ring buffer, so a bigger constraint capacity
+        // needs a proportionally bigger scratch buffer or Jolt silently corrupts memory.
+        // Cap maxContactConstraints itself to whatever the 512 MB scratch-buffer ceiling
+        // can support *before* it reaches PhysicsSystem::Init — Physics3DSystem::SetSettings()
+        // has no validating caller other than ProjectSerializer, so a direct caller (test,
+        // script) could otherwise hand Jolt a constraint capacity the scratch buffer can't
+        // back, corrupting memory instead of just under-allocating.
+        constexpr u64 kMaxTempAllocatorSize = 512ull * 1024 * 1024;
+        const u64 maxSafeContactConstraints =
+            (static_cast<u64>(kBaselineMaxContactConstraints) * kMaxTempAllocatorSize) / kBaselineTempAllocatorSize;
+        const u32 maxContactConstraints = static_cast<u32>(
+            std::clamp<u64>(std::max(settings.m_MaxContactConstraints, 1u), 1ull, maxSafeContactConstraints));
         m_AppliedMaxBodies = maxBodies;
         m_AppliedMaxBodyPairs = maxBodyPairs;
         m_AppliedMaxContactConstraints = maxContactConstraints;
 
-        // Create temp allocator, scaled against s_BaselineTempAllocatorSize (see its
-        // comment): Jolt's per-step scratch usage scales with maxContactConstraints, and
-        // TempAllocatorImpl is a fixed-size ring buffer, so a bigger constraint capacity
-        // needs a proportionally bigger scratch buffer or Jolt silently corrupts memory.
-        const u64 scaledTempAllocatorSize = (static_cast<u64>(s_BaselineTempAllocatorSize) * maxContactConstraints) / s_BaselineMaxContactConstraints;
+        const u64 scaledTempAllocatorSize = (static_cast<u64>(kBaselineTempAllocatorSize) * maxContactConstraints) / kBaselineMaxContactConstraints;
         const u32 tempAllocatorSize = static_cast<u32>(
-            std::clamp<u64>(scaledTempAllocatorSize, s_BaselineTempAllocatorSize, 512ull * 1024 * 1024));
+            std::clamp<u64>(scaledTempAllocatorSize, kBaselineTempAllocatorSize, kMaxTempAllocatorSize));
         m_TempAllocator = std::make_unique<JPH::TempAllocatorImpl>(tempAllocatorSize);
 
         // Create job system adapter that wraps FScheduler

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -4,6 +4,7 @@
 #include "SceneQueries.h"
 #include "JoltShapes.h"
 #include "PhysicsEvents.h"
+#include "Physics3DSystem.h" // Physics3DSystem::GetSettings() - single source of truth for PhysicsSettings (issue #523)
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Scene/Scene.h"
@@ -216,7 +217,26 @@ namespace OloEngine
 
         if (error != JPH::EPhysicsUpdateError::None)
         {
-            OLO_CORE_ERROR("Jolt physics update error: {0}", static_cast<i32>(error));
+            // Throttle: an overflow (e.g. ContactConstraintsFull) otherwise re-logs every
+            // fixed step for as long as it persists. Log immediately on the first hit / on
+            // a transition to a different error, then only every s_PhysicsUpdateErrorLogInterval
+            // steps while it repeats (issue #523).
+            const bool isNewError = error != m_LastPhysicsUpdateError;
+            if (isNewError)
+                m_PhysicsUpdateErrorRepeatCount = 0;
+            if (isNewError || m_PhysicsUpdateErrorRepeatCount % s_PhysicsUpdateErrorLogInterval == 0)
+            {
+                OLO_CORE_ERROR("Jolt physics update error: {0} - raise the matching PhysicsSettings limit "
+                               "(m_MaxContactConstraints / m_MaxBodyPairs / m_MaxBodies)",
+                               static_cast<i32>(error));
+            }
+            ++m_PhysicsUpdateErrorRepeatCount;
+            m_LastPhysicsUpdateError = error;
+        }
+        else
+        {
+            m_LastPhysicsUpdateError = JPH::EPhysicsUpdateError::None;
+            m_PhysicsUpdateErrorRepeatCount = 0;
         }
 
         // Post-simulate character controllers
@@ -2492,8 +2512,28 @@ namespace OloEngine
             JPH::RegisterTypes();
         }
 
-        // Create temp allocator
-        m_TempAllocator = std::make_unique<JPH::TempAllocatorImpl>(s_TempAllocatorSize);
+        // Route the system limits through PhysicsSettings (the same source
+        // Physics3DSystem::Init reads) instead of hardcoding them, so a project can
+        // actually raise them past the old fixed constants (issue #523). Clamp to a
+        // sane minimum defensively: Physics3DSystem::SetSettings() has no validating
+        // caller other than ProjectSerializer, so a test or script that sets the
+        // settings directly could otherwise hand Jolt a zero-sized Init().
+        const PhysicsSettings& settings = Physics3DSystem::GetSettings();
+        const u32 maxBodies = std::max(settings.m_MaxBodies, 1u);
+        const u32 maxBodyPairs = std::max(settings.m_MaxBodyPairs, 1u);
+        const u32 maxContactConstraints = std::max(settings.m_MaxContactConstraints, 1u);
+        m_AppliedMaxBodies = maxBodies;
+        m_AppliedMaxBodyPairs = maxBodyPairs;
+        m_AppliedMaxContactConstraints = maxContactConstraints;
+
+        // Create temp allocator, scaled against s_BaselineTempAllocatorSize (see its
+        // comment): Jolt's per-step scratch usage scales with maxContactConstraints, and
+        // TempAllocatorImpl is a fixed-size ring buffer, so a bigger constraint capacity
+        // needs a proportionally bigger scratch buffer or Jolt silently corrupts memory.
+        const u64 scaledTempAllocatorSize = (static_cast<u64>(s_BaselineTempAllocatorSize) * maxContactConstraints) / s_BaselineMaxContactConstraints;
+        const u32 tempAllocatorSize = static_cast<u32>(
+            std::clamp<u64>(scaledTempAllocatorSize, s_BaselineTempAllocatorSize, 512ull * 1024 * 1024));
+        m_TempAllocator = std::make_unique<JPH::TempAllocatorImpl>(tempAllocatorSize);
 
         // Create job system adapter that wraps FScheduler
         m_JobSystem = std::make_unique<JoltJobSystemAdapter>(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers);
@@ -2505,7 +2545,7 @@ namespace OloEngine
 
         // Create physics system
         m_JoltSystem = std::make_unique<JPH::PhysicsSystem>();
-        m_JoltSystem->Init(s_MaxBodies, s_NumBodyMutexes, s_MaxBodyPairs, s_MaxContactConstraints,
+        m_JoltSystem->Init(maxBodies, s_NumBodyMutexes, maxBodyPairs, maxContactConstraints,
                            *m_BroadPhaseLayerInterface, *m_ObjectVsBroadPhaseLayerFilter, *m_ObjectLayerPairFilter);
 
         // Create contact listener
@@ -2515,8 +2555,9 @@ namespace OloEngine
         // Set default gravity
         m_JoltSystem->SetGravity(JPH::Vec3(0.0f, -9.81f, 0.0f));
 
-        OLO_CORE_INFO("Jolt Physics initialized - MaxBodies: {0}, MaxBodyPairs: {1}, MaxContactConstraints: {2}",
-                      s_MaxBodies, s_MaxBodyPairs, s_MaxContactConstraints);
+        OLO_CORE_INFO("Jolt Physics initialized - MaxBodies: {0}, MaxBodyPairs: {1}, MaxContactConstraints: {2}, "
+                      "TempAllocatorSize: {3} bytes",
+                      maxBodies, maxBodyPairs, maxContactConstraints, tempAllocatorSize);
     }
 
     void JoltScene::ShutdownJolt()

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -267,6 +267,22 @@ namespace OloEngine
         {
             return m_JoltSystem ? m_JoltSystem->GetNumActiveBodies(JPH::EBodyType::RigidBody) : 0;
         }
+        // The system limits InitializeJolt() actually passed to JPH::PhysicsSystem::Init,
+        // read from PhysicsSettings at init time (0 before Initialize()). Exposed so tests
+        // can verify a custom PhysicsSettings is honoured rather than silently ignored in
+        // favor of a hardcoded constant (issue #523).
+        u32 GetMaxBodies() const
+        {
+            return m_AppliedMaxBodies;
+        }
+        u32 GetMaxBodyPairs() const
+        {
+            return m_AppliedMaxBodyPairs;
+        }
+        u32 GetMaxContactConstraints() const
+        {
+            return m_AppliedMaxContactConstraints;
+        }
 
         // Read-only snapshot of the entity pairs whose bodies are currently in
         // contact, deduplicated per entity pair. Empty when the contact listener
@@ -429,19 +445,43 @@ namespace OloEngine
         i32 m_CollisionSteps = 1;
         i32 m_IntegrationSubSteps = 1;
 
+        // Throttling state for the JPH::EPhysicsUpdateError overflow log (see Step()):
+        // logs immediately on the first occurrence / on an error-type transition, then
+        // only every s_PhysicsUpdateErrorLogInterval steps while the same error persists,
+        // instead of spamming every fixed step (issue #523).
+        JPH::EPhysicsUpdateError m_LastPhysicsUpdateError = JPH::EPhysicsUpdateError::None;
+        u32 m_PhysicsUpdateErrorRepeatCount = 0;
+
+        // System limits actually passed to JPH::PhysicsSystem::Init (from PhysicsSettings),
+        // cached for the GetMax*() diagnostics accessors above.
+        u32 m_AppliedMaxBodies = 0;
+        u32 m_AppliedMaxBodyPairs = 0;
+        u32 m_AppliedMaxContactConstraints = 0;
+
         // Constants
         // CollisionGroup group id reserved for joint "collide connected" filtering.
         // The engine uses CollisionGroup for nothing else, so every filtered body
         // shares this group id and a unique sub-group id (see ApplyJointCollisionFilters).
         static constexpr u32 s_JointCollisionGroupID = 0;
-        static constexpr u32 s_MaxBodies = 65536;
-        static constexpr u32 s_NumBodyMutexes = 0; // Autodetect
-        static constexpr u32 s_MaxBodyPairs = 65536;
+        static constexpr u32 s_NumBodyMutexes = 0;    // Autodetect
         static constexpr u32 s_MaxStepsPerFrame = 10; // Prevent "spiral of death" in fixed timestep
-        static constexpr u32 s_MaxContactConstraints = 10240;
-        static constexpr u32 s_TempAllocatorSize = 10 * 1024 * 1024; // 10 MB
+        // Baseline temp-allocator scratch size, tuned for the *old* hardcoded
+        // s_MaxContactConstraints (10240) that used to be the only value Jolt ever saw.
+        // Jolt's per-step scratch allocations (contact-constraint solving buffers etc.)
+        // scale with the constraint capacity passed to PhysicsSystem::Init, and
+        // JPH::TempAllocatorImpl is a fixed-size ring buffer — handing Jolt a bigger
+        // maxContactConstraints without growing this proportionally silently corrupts
+        // memory the moment a step's scratch usage exceeds the buffer (reproduced: raising
+        // PhysicsSettings::m_MaxContactConstraints from 10240 to 32768 with this constant
+        // still at 10 MB crashed JoltScene::Step with SEH 0xc0000005, even in a trivial
+        // 2-body test). InitializeJolt() scales the actual allocator size against this
+        // baseline — see the maxContactConstraints ratio there. Issue #523.
+        static constexpr u32 s_BaselineTempAllocatorSize = 10 * 1024 * 1024; // 10 MB
+        static constexpr u32 s_BaselineMaxContactConstraints = 10240;
         static constexpr u32 s_JobSystemMaxJobs = 2048;
         static constexpr u32 s_JobSystemMaxBarriers = 8;
+        // How often (in fixed steps) to re-log a persisting physics update error.
+        static constexpr u32 s_PhysicsUpdateErrorLogInterval = 300; // ~5s at a 60Hz fixed step
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -447,7 +447,7 @@ namespace OloEngine
 
         // Throttling state for the JPH::EPhysicsUpdateError overflow log (see Step()):
         // logs immediately on the first occurrence / on an error-type transition, then
-        // only every s_PhysicsUpdateErrorLogInterval steps while the same error persists,
+        // only every kPhysicsUpdateErrorLogInterval steps while the same error persists,
         // instead of spamming every fixed step (issue #523).
         JPH::EPhysicsUpdateError m_LastPhysicsUpdateError = JPH::EPhysicsUpdateError::None;
         u32 m_PhysicsUpdateErrorRepeatCount = 0;
@@ -476,12 +476,12 @@ namespace OloEngine
         // still at 10 MB crashed JoltScene::Step with SEH 0xc0000005, even in a trivial
         // 2-body test). InitializeJolt() scales the actual allocator size against this
         // baseline — see the maxContactConstraints ratio there. Issue #523.
-        static constexpr u32 s_BaselineTempAllocatorSize = 10 * 1024 * 1024; // 10 MB
-        static constexpr u32 s_BaselineMaxContactConstraints = 10240;
+        static constexpr u32 kBaselineTempAllocatorSize = 10 * 1024 * 1024; // 10 MB
+        static constexpr u32 kBaselineMaxContactConstraints = 10240;
         static constexpr u32 s_JobSystemMaxJobs = 2048;
         static constexpr u32 s_JobSystemMaxBarriers = 8;
         // How often (in fixed steps) to re-log a persisting physics update error.
-        static constexpr u32 s_PhysicsUpdateErrorLogInterval = 300; // ~5s at a 60Hz fixed step
+        static constexpr u32 kPhysicsUpdateErrorLogInterval = 300; // ~5s at a 60Hz fixed step
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Physics3D/PhysicsSettings.h
+++ b/OloEngine/src/OloEngine/Physics3D/PhysicsSettings.h
@@ -25,7 +25,16 @@ namespace OloEngine
         // System limits
         u32 m_MaxBodies = 65536;
         u32 m_MaxBodyPairs = 65536;
-        u32 m_MaxContactConstraints = 10240;
+        // A contact constraint is generated per touching body pair, so this can never
+        // exceed m_MaxBodyPairs — match it, rather than the old 10240 (issue #523: far too
+        // small for the advertised 65536 max bodies, letting Jolt's contact-constraint
+        // buffer overflow and bodies tunnel through static geometry in dense piles well
+        // under that body count). NOTE: raising this requires JoltScene's temp allocator to
+        // scale with it (see JoltScene.h's s_BaselineTempAllocatorSize) — Jolt's per-step
+        // scratch usage scales with the constraint capacity, and handing Jolt a bigger
+        // capacity without a proportionally bigger fixed-size scratch buffer corrupts
+        // memory. Do not raise this default without checking that scaling is still wired up.
+        u32 m_MaxContactConstraints = 65536;
 
         // Debug and capture settings (capture is off by default for production)
         bool m_CaptureOnPlay = false;

--- a/OloEngine/src/OloEngine/Physics3D/PhysicsSettings.h
+++ b/OloEngine/src/OloEngine/Physics3D/PhysicsSettings.h
@@ -30,7 +30,7 @@ namespace OloEngine
         // small for the advertised 65536 max bodies, letting Jolt's contact-constraint
         // buffer overflow and bodies tunnel through static geometry in dense piles well
         // under that body count). NOTE: raising this requires JoltScene's temp allocator to
-        // scale with it (see JoltScene.h's s_BaselineTempAllocatorSize) — Jolt's per-step
+        // scale with it (see JoltScene.h's kBaselineTempAllocatorSize) — Jolt's per-step
         // scratch usage scales with the constraint capacity, and handing Jolt a bigger
         // capacity without a proportionally bigger fixed-size scratch buffer corrupts
         // memory. Do not raise this default without checking that scaling is still wired up.

--- a/OloEngine/src/OloEngine/Project/ProjectSerializer.cpp
+++ b/OloEngine/src/OloEngine/Project/ProjectSerializer.cpp
@@ -205,7 +205,7 @@ namespace
         validated.m_MaxBodyPairs = ValidateAndClampUInt(Settings.m_MaxBodyPairs,
                                                         s_MinMaxPairs, s_MaxMaxPairs, 65536u, "MaxBodyPairs");
         validated.m_MaxContactConstraints = ValidateAndClampUInt(Settings.m_MaxContactConstraints,
-                                                                 s_MinMaxContacts, s_MaxMaxContacts, 10240u, "MaxContactConstraints");
+                                                                 s_MinMaxContacts, s_MaxMaxContacts, 65536u, "MaxContactConstraints");
 
         // Validate advanced Jolt settings
         validated.m_Baumgarte = ValidateAndClampFloat(Settings.m_Baumgarte,
@@ -313,7 +313,7 @@ namespace OloEngine
                 out << YAML::Comment("Maximum body pairs for collision detection (range: 100-1000000, default: 65536)");
                 out << YAML::Key << "MaxBodyPairs" << YAML::Value << physicsSettings.m_MaxBodyPairs;
 
-                out << YAML::Comment("Maximum contact constraints (range: 100-100000, default: 10240)");
+                out << YAML::Comment("Maximum contact constraints (range: 100-100000, default: 65536)");
                 out << YAML::Key << "MaxContactConstraints" << YAML::Value << physicsSettings.m_MaxContactConstraints;
 
                 // Debug and capture settings (booleans don't need validation)

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -542,6 +542,7 @@ add_executable(OloEngine-Tests
 		Functional/Gameplay/AbilityActivationEffectAppliesToCasterTest.cpp
 		Functional/Gameplay/AbilityRequiredTagGatesActivationTest.cpp
 		Functional/AnimationPhysics/TwoCharacterControllersCoexistTest.cpp
+		Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
 		Functional/Gameplay/AbilityResourceCostDeductedFromManaTest.cpp
 		Functional/Dialogue/DialogueSelectChoiceBranchesToTargetTest.cpp
 		Functional/Dialogue/DialogueAcceptsQuestAndGatesOnStateTest.cpp

--- a/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
@@ -1,0 +1,150 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: Functional
+
+// =============================================================================
+// ContactConstraintLimitsHonouredTest — Functional Test.
+//
+// Cross-subsystem seam under test:
+//   PhysicsSettings (project config) × JoltScene::Initialize (Jolt bootstrap).
+//   Before issue #523, JoltScene hardcoded its own s_MaxBodies / s_MaxBodyPairs /
+//   s_MaxContactConstraints constexpr constants and silently ignored
+//   PhysicsSettings entirely — a project could raise MaxContactConstraints and
+//   it would have zero effect, and the default (10240) was far too small for
+//   the advertised 65536-body ceiling, so a dense pile could overflow Jolt's
+//   contact-constraint buffer and bodies would tunnel through static geometry.
+//
+// Scenario:
+//   (a) Set a custom PhysicsSettings before physics starts and assert
+//       JoltScene actually passed those exact numbers to
+//       JPH::PhysicsSystem::Init (via the GetMaxBodies/GetMaxBodyPairs/
+//       GetMaxContactConstraints diagnostics accessors) instead of its own
+//       hardcoded constants.
+//   (b) Drop a modest pile of dynamic bodies onto a static floor under the
+//       (now-raised) default settings and assert every one settles at floor
+//       height instead of tunnelling through it.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Physics3D/Physics3DSystem.h"
+#include "OloEngine/Physics3D/PhysicsSettings.h"
+#include "OloEngine/Physics3D/JoltScene.h"
+
+#include <cmath>
+#include <vector>
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+namespace
+{
+    Entity CreateFloor(Scene& scene, f32 topY)
+    {
+        Entity floor = scene.CreateEntity("Floor");
+        floor.GetComponent<TransformComponent>().Translation = { 0.0f, topY - 0.5f, 0.0f };
+        auto& floorBody = floor.AddComponent<Rigidbody3DComponent>();
+        floorBody.m_Type = BodyType3D::Static;
+        auto& floorCol = floor.AddComponent<BoxCollider3DComponent>();
+        floorCol.m_HalfExtents = { 50.0f, 0.5f, 50.0f };
+        return floor;
+    }
+} // namespace
+
+class ContactConstraintLimitsHonouredTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        // BuildScene() intentionally does nothing subsystem-specific — each
+        // TEST_F configures PhysicsSettings and the scene itself, since the
+        // two tests in this file need different settings before
+        // EnablePhysics3D() bootstraps JoltScene::Initialize().
+    }
+
+    void TearDown() override
+    {
+        FunctionalTest::TearDown();
+        // PhysicsSettings is a process-static (Physics3DSystem::s_PhysicsSettings);
+        // reset it so this test can't leak custom limits into later tests.
+        Physics3DSystem::SetSettings(PhysicsSettings::GetDefaults());
+    }
+};
+
+TEST_F(ContactConstraintLimitsHonouredTest, CustomSettingsAreAppliedNotHardcoded)
+{
+    PhysicsSettings settings = PhysicsSettings::GetDefaults();
+    settings.m_MaxBodies = 4096;
+    settings.m_MaxBodyPairs = 8192;
+    settings.m_MaxContactConstraints = 2048;
+    Physics3DSystem::SetSettings(settings);
+
+    CreateFloor(GetScene(), /*topY=*/0.0f);
+    EnablePhysics3D();
+
+    JoltScene* joltScene = GetScene().GetPhysicsScene();
+    ASSERT_NE(joltScene, nullptr);
+
+    EXPECT_EQ(joltScene->GetMaxBodies(), settings.m_MaxBodies)
+        << "JoltScene::Init ignored PhysicsSettings::m_MaxBodies";
+    EXPECT_EQ(joltScene->GetMaxBodyPairs(), settings.m_MaxBodyPairs)
+        << "JoltScene::Init ignored PhysicsSettings::m_MaxBodyPairs";
+    EXPECT_EQ(joltScene->GetMaxContactConstraints(), settings.m_MaxContactConstraints)
+        << "JoltScene::Init ignored PhysicsSettings::m_MaxContactConstraints — the two-init-path "
+           "divergence from issue #523 regressed";
+}
+
+TEST_F(ContactConstraintLimitsHonouredTest, DensePileSettlesOnFloorInsteadOfTunnelling)
+{
+    // Defaults now match m_MaxContactConstraints to m_MaxBodyPairs (65536) rather
+    // than the old 10240, which was too small for the advertised 65536-body
+    // ceiling — see PhysicsSettings.h.
+    Physics3DSystem::SetSettings(PhysicsSettings::GetDefaults());
+
+    constexpr f32 kFloorTop = 0.0f;
+    constexpr f32 kBoxHalfExtent = 0.5f;
+    constexpr u32 kBodyCount = 40;
+
+    CreateFloor(GetScene(), kFloorTop);
+
+    std::vector<Entity> boxes;
+    boxes.reserve(kBodyCount);
+    for (u32 i = 0; i < kBodyCount; ++i)
+    {
+        // Stack in a tight grid a little above the floor so most bodies are
+        // in simultaneous mutual contact once they land — the scenario that
+        // overflowed the old undersized contact-constraint buffer.
+        const f32 x = static_cast<f32>(i % 5) * (kBoxHalfExtent * 2.0f);
+        const f32 z = static_cast<f32>(i / 5 % 8) * (kBoxHalfExtent * 2.0f);
+        const f32 y = 2.0f + static_cast<f32>(i / 40) * (kBoxHalfExtent * 2.0f);
+
+        Entity box = GetScene().CreateEntity("PileBox");
+        box.GetComponent<TransformComponent>().Translation = { x, y, z };
+        auto& body = box.AddComponent<Rigidbody3DComponent>();
+        body.m_Type = BodyType3D::Dynamic;
+        body.m_Mass = 1.0f;
+        auto& col = box.AddComponent<BoxCollider3DComponent>();
+        col.m_HalfExtents = { kBoxHalfExtent, kBoxHalfExtent, kBoxHalfExtent };
+        boxes.push_back(box);
+    }
+
+    EnablePhysics3D();
+
+    // Generous settle window: piles take longer than a single dropped body.
+    TickFor(/*seconds=*/5.0f);
+
+    // Resting on the floor or stacked on another box both keep y >= floor
+    // top; tunnelling through the static floor is the only way to end up
+    // below it.
+    constexpr f32 kTunnelEpsilon = 0.1f;
+    for (Entity box : boxes)
+    {
+        const auto& translation = box.GetComponent<TransformComponent>().Translation;
+        ASSERT_TRUE(std::isfinite(translation.x) && std::isfinite(translation.y) && std::isfinite(translation.z))
+            << "box transform contains NaN/Inf";
+        EXPECT_GE(translation.y, kFloorTop - kTunnelEpsilon)
+            << "box tunnelled through the static floor (y=" << translation.y << ")";
+    }
+}

--- a/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
@@ -105,7 +105,9 @@ TEST_F(ContactConstraintLimitsHonouredTest, DensePileSettlesOnFloorInsteadOfTunn
 
     constexpr f32 kFloorTop = 0.0f;
     constexpr f32 kBoxHalfExtent = 0.5f;
-    constexpr u32 kBodyCount = 40;
+    constexpr u32 kGridX = 5;
+    constexpr u32 kGridZ = 4;
+    constexpr u32 kBodyCount = 80;
 
     CreateFloor(GetScene(), kFloorTop);
 
@@ -115,10 +117,13 @@ TEST_F(ContactConstraintLimitsHonouredTest, DensePileSettlesOnFloorInsteadOfTunn
     {
         // Stack in a tight grid a little above the floor so most bodies are
         // in simultaneous mutual contact once they land — the scenario that
-        // overflowed the old undersized contact-constraint buffer.
-        const f32 x = static_cast<f32>(i % 5) * (kBoxHalfExtent * 2.0f);
-        const f32 z = static_cast<f32>(i / 5 % 8) * (kBoxHalfExtent * 2.0f);
-        const f32 y = 2.0f + static_cast<f32>(i / 40) * (kBoxHalfExtent * 2.0f);
+        // overflowed the old undersized contact-constraint buffer. The grid
+        // footprint (kGridX * kGridZ) is smaller than kBodyCount so the pile
+        // wraps into additional vertical layers instead of staying flat.
+        const u32 layerSize = kGridX * kGridZ;
+        const f32 x = static_cast<f32>(i % kGridX) * (kBoxHalfExtent * 2.0f);
+        const f32 z = static_cast<f32>(i / kGridX % kGridZ) * (kBoxHalfExtent * 2.0f);
+        const f32 y = 2.0f + static_cast<f32>(i / layerSize) * (kBoxHalfExtent * 2.0f);
 
         Entity box = GetScene().CreateEntity("PileBox");
         box.GetComponent<TransformComponent>().Translation = { x, y, z };


### PR DESCRIPTION
…constraint overflow

Closes #523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Physics capacity limits are now derived from the configured Physics Settings and applied at initialization; the active limits are available via diagnostics.
* **Bug Fixes**
  * Physics update errors are now throttled to reduce repetitive log spam.
* **Changes**
  * The default Max Contact Constraints value was increased to better support larger scenes; validation and serialization reflect the new default.
* **Tests**
  * Added functional tests to verify configured limits are honored and that objects settle on the floor without tunneling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->