### PR TITLE
mcp: wire olo_camera_frame_entity and olo_viewport_set_size in the headless MCP host

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -30,6 +30,7 @@
 #include "OloEngine/Renderer/Debug/RenderGraphDebugger.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
 #include "OloEngine/Scene/SceneCamera.h"
+#include "OloEngine/Scene/SceneCameraFraming.h"
 #include "OloEngine/Scene/SceneSerializer.h"
 #include "OloEngine/Scene/ModelImporter.h"
 #include "OloEngine/Scene/Prefab.h"
@@ -2890,76 +2891,10 @@ namespace OloEngine
 
     bool EditorLayer::FrameEditorCameraOnEntity(u64 entityUuid)
     {
-        const Ref<Scene> scene = m_ActiveScene;
-        if (!scene)
-            return false;
-        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
-        if (!entityOpt)
-            return false;
-        Entity entity = *entityOpt;
-        if (!entity.HasComponent<TransformComponent>())
-            return false;
-
-        // World transform: compose local transforms up the parent chain (the
-        // scene stores parent-relative transforms; gizmos and rendering do the
-        // same composition).
-        glm::mat4 world = entity.GetComponent<TransformComponent>().GetTransform();
-        for (UUID parentId = entity.GetParentUUID(); static_cast<u64>(parentId) != 0;)
-        {
-            const auto parentOpt = scene->TryGetEntityWithUUID(parentId);
-            if (!parentOpt)
-                break;
-            Entity parent = *parentOpt;
-            if (parent.HasComponent<TransformComponent>())
-                world = parent.GetComponent<TransformComponent>().GetTransform() * world;
-            parentId = parent.GetParentUUID();
-        }
-
-        // Bounds: prefer real mesh bounds, fall back to a scale-derived radius.
-        glm::vec3 center = glm::vec3(world[3]);
-        f32 radius = 0.0f;
-        if (entity.HasComponent<ModelComponent>())
-        {
-            if (const auto& model = entity.GetComponent<ModelComponent>().m_Model; model)
-            {
-                const BoundingBox worldBox = model->GetTransformedBoundingBox(world);
-                center = worldBox.GetCenter();
-                radius = glm::length(worldBox.GetExtents());
-            }
-        }
-        else if (entity.HasComponent<MeshComponent>())
-        {
-            if (const auto& meshSource = entity.GetComponent<MeshComponent>().m_MeshSource; meshSource)
-            {
-                const BoundingBox worldBox = meshSource->GetBoundingBox().Transform(world);
-                center = worldBox.GetCenter();
-                radius = glm::length(worldBox.GetExtents());
-            }
-        }
-        else if (entity.HasComponent<TerrainComponent>())
-        {
-            const auto& tc = entity.GetComponent<TerrainComponent>();
-            center += glm::vec3(tc.m_WorldSizeX * 0.5f, tc.m_HeightScale * 0.4f, tc.m_WorldSizeZ * 0.5f);
-            radius = std::max(tc.m_WorldSizeX, tc.m_WorldSizeZ) * 0.5f;
-        }
-        if (radius < 0.5f)
-        {
-            // Scale-derived fallback: length of the world matrix's basis columns.
-            const f32 sx = glm::length(glm::vec3(world[0]));
-            const f32 sy = glm::length(glm::vec3(world[1]));
-            const f32 sz = glm::length(glm::vec3(world[2]));
-            radius = std::max({ sx, sy, sz, 0.5f });
-        }
-
-        // Keep the current view direction; just re-pivot and fit. Derive the
-        // distance from the camera's vertical FOV so the bounding sphere fills
-        // the frame at any FOV (a fixed multiplier underfits at the editor's
-        // default 30 degrees), with a small margin so silhouettes don't touch
-        // the frame edge.
-        const f32 fovRadians = glm::radians(m_EditorCamera.GetFOV());
-        const f32 fitDistance = (radius / std::tan(fovRadians * 0.5f)) * 1.05f;
-        m_EditorCamera.Focus(center, fitDistance, m_EditorCamera.GetYaw(), m_EditorCamera.GetPitch());
-        return true;
+        // Shared with the headless MCP test host (McpHeadlessHost) — see
+        // SceneCameraFraming.h. Keep the bounds-computation + fit logic there,
+        // not here, so the editor and the headless host can't drift apart.
+        return FrameCameraOnEntity(m_ActiveScene, entityUuid, m_EditorCamera);
     }
 
     bool EditorLayer::SaveScene()

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -942,6 +942,8 @@
 		"OloEngine/Scene/Scene.h"
 		"OloEngine/Scene/SceneCamera.cpp"
 		"OloEngine/Scene/SceneCamera.h"
+		"OloEngine/Scene/SceneCameraFraming.cpp"
+		"OloEngine/Scene/SceneCameraFraming.h"
 		"OloEngine/Scene/SceneMeshRaycast.cpp"
 		"OloEngine/Scene/SceneMeshRaycast.h"
 		"OloEngine/Scene/SceneSerializer.cpp"

--- a/OloEngine/src/OloEngine/Scene/SceneCameraFraming.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneCameraFraming.cpp
@@ -1,0 +1,88 @@
+#include "OloEnginePCH.h"
+#include "SceneCameraFraming.h"
+
+#include "OloEngine/Core/UUID.h"
+#include "OloEngine/Renderer/Camera/EditorCamera.h"
+#include "OloEngine/Renderer/Model.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Scene.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace OloEngine
+{
+    bool FrameCameraOnEntity(const Ref<Scene>& scene, u64 entityUuid, EditorCamera& camera)
+    {
+        if (!scene)
+            return false;
+        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+        if (!entityOpt)
+            return false;
+        Entity entity = *entityOpt;
+        if (!entity.HasComponent<TransformComponent>())
+            return false;
+
+        // World transform: compose local transforms up the parent chain (the
+        // scene stores parent-relative transforms; gizmos and rendering do the
+        // same composition).
+        glm::mat4 world = entity.GetComponent<TransformComponent>().GetTransform();
+        for (UUID parentId = entity.GetParentUUID(); static_cast<u64>(parentId) != 0;)
+        {
+            const auto parentOpt = scene->TryGetEntityWithUUID(parentId);
+            if (!parentOpt)
+                break;
+            Entity parent = *parentOpt;
+            if (parent.HasComponent<TransformComponent>())
+                world = parent.GetComponent<TransformComponent>().GetTransform() * world;
+            parentId = parent.GetParentUUID();
+        }
+
+        // Bounds: prefer real mesh bounds, fall back to a scale-derived radius.
+        glm::vec3 center = glm::vec3(world[3]);
+        f32 radius = 0.0f;
+        if (entity.HasComponent<ModelComponent>())
+        {
+            if (const auto& model = entity.GetComponent<ModelComponent>().m_Model; model)
+            {
+                const BoundingBox worldBox = model->GetTransformedBoundingBox(world);
+                center = worldBox.GetCenter();
+                radius = glm::length(worldBox.GetExtents());
+            }
+        }
+        else if (entity.HasComponent<MeshComponent>())
+        {
+            if (const auto& meshSource = entity.GetComponent<MeshComponent>().m_MeshSource; meshSource)
+            {
+                const BoundingBox worldBox = meshSource->GetBoundingBox().Transform(world);
+                center = worldBox.GetCenter();
+                radius = glm::length(worldBox.GetExtents());
+            }
+        }
+        else if (entity.HasComponent<TerrainComponent>())
+        {
+            const auto& tc = entity.GetComponent<TerrainComponent>();
+            center += glm::vec3(tc.m_WorldSizeX * 0.5f, tc.m_HeightScale * 0.4f, tc.m_WorldSizeZ * 0.5f);
+            radius = std::max(tc.m_WorldSizeX, tc.m_WorldSizeZ) * 0.5f;
+        }
+        if (radius < 0.5f)
+        {
+            // Scale-derived fallback: length of the world matrix's basis columns.
+            const f32 sx = glm::length(glm::vec3(world[0]));
+            const f32 sy = glm::length(glm::vec3(world[1]));
+            const f32 sz = glm::length(glm::vec3(world[2]));
+            radius = std::max({ sx, sy, sz, 0.5f });
+        }
+
+        // Keep the current view direction; just re-pivot and fit. Derive the
+        // distance from the camera's vertical FOV so the bounding sphere fills
+        // the frame at any FOV (a fixed multiplier underfits at the editor's
+        // default 30 degrees), with a small margin so silhouettes don't touch
+        // the frame edge.
+        const f32 fovRadians = glm::radians(camera.GetFOV());
+        const f32 fitDistance = (radius / std::tan(fovRadians * 0.5f)) * 1.05f;
+        camera.Focus(center, fitDistance, camera.GetYaw(), camera.GetPitch());
+        return true;
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Scene/SceneCameraFraming.h
+++ b/OloEngine/src/OloEngine/Scene/SceneCameraFraming.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/Ref.h"
+
+namespace OloEngine
+{
+    class Scene;
+    class EditorCamera;
+
+    // @brief Point `camera` at the entity identified by `entityUuid` in `scene`
+    // and fit its world-space bounds in view, preserving the camera's current
+    // view direction (yaw/pitch) and re-pivoting/zooming to frame the entity.
+    //
+    // Shared by `EditorLayer::FrameEditorCameraOnEntity` (the live editor's
+    // `olo_camera_frame_entity` wiring) and `McpHeadlessHost` (the headless MCP
+    // test host's wiring of the same tool) so the bounds-computation + fit
+    // logic lives in exactly one place.
+    //
+    // Bounds preference: `ModelComponent` / `MeshComponent` world-space
+    // bounding box (composed up the parent chain), then a `TerrainComponent`
+    // footprint, falling back to a radius derived from the entity's world
+    // transform scale when no renderable geometry is present. The fit distance
+    // is derived from `camera`'s current vertical FOV so the bounding sphere
+    // fills the frame regardless of FOV.
+    //
+    // Returns false (leaving `camera` untouched) if `scene` is null or
+    // `entityUuid` does not resolve to an entity with a `TransformComponent`.
+    bool FrameCameraOnEntity(const Ref<Scene>& scene, u64 entityUuid, EditorCamera& camera);
+} // namespace OloEngine

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessAttachTest.cpp
@@ -238,6 +238,8 @@ namespace OloEngine::Tests
             .RenderHeight = kHeight,
             .RenderOneFrame = [this, &camera]()
             { RunEditorFrames(camera, 1); },
+            .SetViewportSize = [this](u32 w, u32 h)
+            { ResizeRenderTarget(w, h); },
         });
 
         const u16 port = host.Start();
@@ -352,6 +354,83 @@ namespace OloEngine::Tests
             }
         }
 
+        // ---- olo_camera_frame_entity: no longer "not available" (#316 follow-on) -
+        // Proves the headless host actually moves the camera to frame the Cube
+        // entity, sharing OloEngine::FrameCameraOnEntity with the editor's wiring.
+        {
+            Entity cube = GetScene().FindEntityByName("Cube");
+            ASSERT_TRUE(static_cast<bool>(cube)) << "BuildScene's 'Cube' entity is missing";
+            const u64 cubeUuid = static_cast<u64>(cube.GetUUID());
+
+            // MakeCamera() posed the camera with SetPose, which collapses the
+            // orbit to distance 0 — so ANY successful frame moves distance off
+            // zero. That makes "did framing actually run" unambiguous without
+            // parsing the response JSON.
+            ASSERT_NEAR(camera.GetDistance(), 0.0f, 1e-4f) << "test precondition: MakeCamera should start at distance 0";
+
+            const Json resp = host.CallTool("olo_camera_frame_entity", Json{ { "id", std::to_string(cubeUuid) } });
+            ASSERT_TRUE(resp.contains("result")) << "olo_camera_frame_entity returned an error: " << resp.dump(2);
+            EXPECT_FALSE(resp["result"].value("isError", false))
+                << "olo_camera_frame_entity is still reporting unavailable: " << resp.dump(2);
+
+            const std::string text = FindTextData(resp);
+            ASSERT_FALSE(text.empty()) << "olo_camera_frame_entity returned no text: " << resp.dump(2);
+            const Json pose = Json::parse(text, nullptr, /*allow_exceptions=*/false);
+            ASSERT_TRUE(pose.is_object()) << "olo_camera_frame_entity text was not JSON: " << text;
+            EXPECT_EQ(pose.value("framedEntity", std::string{}), std::to_string(cubeUuid)) << text;
+
+            // The camera (shared with the host via the Hooks::Camera pointer) must
+            // have actually moved: pivoted onto the cube (world-space origin) at a
+            // non-zero fit distance, not left at the pre-call pose.
+            EXPECT_GT(camera.GetDistance(), 0.5f) << "camera was not re-pivoted to a real orbit distance";
+            EXPECT_NEAR(camera.GetFocalPoint().x, 0.0f, 0.5f) << "camera did not focus on the cube (at the origin)";
+            EXPECT_NEAR(camera.GetFocalPoint().y, 0.0f, 0.5f) << "camera did not focus on the cube (at the origin)";
+            EXPECT_NEAR(camera.GetFocalPoint().z, 0.0f, 0.5f) << "camera did not focus on the cube (at the origin)";
+        }
+
+        // ---- olo_viewport_set_size: no longer "not available" (#316 follow-on) -
+        // Proves a resize actually changes the offscreen composite framebuffer's
+        // dimensions (not just that the tool call succeeds), then proves `reset`
+        // restores the fixture's original resolution.
+        {
+            constexpr int kOverrideWidth = 320;
+            constexpr int kOverrideHeight = 200;
+            const Json setResp = host.CallTool(
+                "olo_viewport_set_size", Json{ { "width", kOverrideWidth }, { "height", kOverrideHeight } });
+            ASSERT_TRUE(setResp.contains("result")) << "olo_viewport_set_size returned an error: " << setResp.dump(2);
+            EXPECT_FALSE(setResp["result"].value("isError", false))
+                << "olo_viewport_set_size is still reporting unavailable: " << setResp.dump(2);
+
+            const Json shotResp = host.CallTool("olo_screenshot", Json{ { "maxWidth", 1000 } });
+            ASSERT_TRUE(shotResp.contains("result")) << shotResp.dump(2);
+            const std::string b64 = FindImageData(shotResp);
+            ASSERT_FALSE(b64.empty()) << "olo_screenshot returned no image after resize: " << shotResp.dump(2);
+            const std::vector<u8> png = Base64Decode(b64);
+            int dw = 0, dh = 0, dch = 0;
+            stbi_uc* decoded = ::stbi_load_from_memory(png.data(), static_cast<int>(png.size()), &dw, &dh, &dch, 4);
+            ASSERT_NE(decoded, nullptr) << "resized screenshot PNG did not decode";
+            ::stbi_image_free(decoded);
+            EXPECT_EQ(dw, kOverrideWidth) << "olo_viewport_set_size did not resize the composite framebuffer's width";
+            EXPECT_EQ(dh, kOverrideHeight) << "olo_viewport_set_size did not resize the composite framebuffer's height";
+
+            // reset: true restores the fixture's original kWidth x kHeight.
+            const Json resetResp = host.CallTool("olo_viewport_set_size", Json{ { "reset", true } });
+            ASSERT_TRUE(resetResp.contains("result")) << resetResp.dump(2);
+            EXPECT_FALSE(resetResp["result"].value("isError", false)) << resetResp.dump(2);
+
+            const Json shotResp2 = host.CallTool("olo_screenshot", Json{ { "maxWidth", 1000 } });
+            ASSERT_TRUE(shotResp2.contains("result")) << shotResp2.dump(2);
+            const std::string b64_2 = FindImageData(shotResp2);
+            ASSERT_FALSE(b64_2.empty()) << "olo_screenshot returned no image after reset: " << shotResp2.dump(2);
+            const std::vector<u8> png2 = Base64Decode(b64_2);
+            int dw2 = 0, dh2 = 0, dch2 = 0;
+            stbi_uc* decoded2 = ::stbi_load_from_memory(png2.data(), static_cast<int>(png2.size()), &dw2, &dh2, &dch2, 4);
+            ASSERT_NE(decoded2, nullptr) << "post-reset screenshot PNG did not decode";
+            ::stbi_image_free(decoded2);
+            EXPECT_EQ(dw2, static_cast<int>(kWidth)) << "olo_viewport_set_size{reset:true} did not restore the original width";
+            EXPECT_EQ(dh2, static_cast<int>(kHeight)) << "olo_viewport_set_size{reset:true} did not restore the original height";
+        }
+
         host.Stop();
     }
 
@@ -380,6 +459,8 @@ namespace OloEngine::Tests
             .RenderHeight = kHeight,
             .RenderOneFrame = [this, &camera]()
             { RunEditorFrames(camera, 1); },
+            .SetViewportSize = [this](u32 w, u32 h)
+            { ResizeRenderTarget(w, h); },
         });
 
         // Honour the per-worktree port the driver picked (OLO_MCP_PORT); the

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
@@ -40,6 +40,7 @@
 //       .Camera                = &camera,
 //       .RenderWidth = w, .RenderHeight = h,
 //       .RenderOneFrame        = [&]{ RunEditorFrames(camera, 1); },
+//       .SetViewportSize       = [&](u32 w, u32 h){ ResizeRenderTarget(w, h); }, // optional
 //   });
 //   const u16 port = host.Start(/*basePort=*/0);   // 0 => derive a free port
 //   const Json result = host.CallTool("olo_screenshot", { {"maxWidth", 256} });
@@ -61,6 +62,7 @@
 #include "OloEngine/Renderer/Camera/EditorCamera.h"
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Scene/Scene.h"
+#include "OloEngine/Scene/SceneCameraFraming.h"
 #include "OloEngine/Task/NamedThreads.h"
 
 #include <glad/gl.h>
@@ -107,10 +109,19 @@ namespace OloEngine::Tests
             // job always sees a fresh frame and AwaitRenderedFrames sees the frame
             // counter advance.
             std::function<void()> RenderOneFrame;
+            // Resize the fixture's render target so olo_viewport_set_size can pin a
+            // deterministic capture resolution (issue #316 follow-on). Optional —
+            // leaving it null keeps the tool's clean "not available" response.
+            // Implementations must resize BOTH the Scene's viewport-driven cameras
+            // and the Renderer3D render-graph targets (see
+            // RendererAttachedTest::ResizeRenderTarget), mirroring the editor's
+            // OnUpdate resize block so the NEXT RenderOneFrame actually produces a
+            // composite framebuffer at the new size.
+            std::function<void(u32 width, u32 height)> SetViewportSize;
         };
 
         explicit McpHeadlessHost(Hooks hooks)
-            : m_Hooks(std::move(hooks))
+            : m_Hooks(std::move(hooks)), m_InitialRenderWidth(m_Hooks.RenderWidth), m_InitialRenderHeight(m_Hooks.RenderHeight)
         {
             m_Server = CreateScope<MCP::McpServer>(BuildContext());
             MCP::RegisterBuiltinTools(*m_Server);
@@ -303,9 +314,11 @@ namespace OloEngine::Tests
         // Build the EditorMcpContext that backs the server with the OFFSCREEN FB
         // and the test's EditorCamera. Mirrors EditorLayer's wiring (#316) but
         // sources its frame from the fixture's render-graph composite rather than
-        // a live viewport. GetCommandHistory / FrameEntity / SetViewportSizeOverride
-        // are intentionally null (no project writes in the headless host; the
-        // remaining two degrade to a clean "not available" from their tools).
+        // a live viewport. GetCommandHistory is intentionally null (no project
+        // writes in the headless host — out of scope, #306-C). FrameEntity and
+        // SetViewportSizeOverride are wired when the test supplies GetScene/Camera
+        // and SetViewportSize respectively; a host built without them keeps the
+        // clean "not available" response from their tools.
         MCP::EditorMcpContext BuildContext()
         {
             MCP::EditorMcpContext ctx;
@@ -364,6 +377,43 @@ namespace OloEngine::Tests
             { return m_FrameIndex.load(std::memory_order_relaxed); };
             ctx.IsCaptureUnready = [this]() -> bool
             { return m_FrameIndex.load(std::memory_order_relaxed) == 0; };
+
+            // olo_camera_frame_entity (#316 follow-on): shares the exact
+            // bounds-computation + fit logic EditorLayer uses, just pointed at the
+            // fixture's Scene/EditorCamera instead of the editor's.
+            ctx.FrameEntity = [this](u64 entityUuid) -> bool
+            {
+                if (!m_Hooks.Camera)
+                    return false;
+                const Ref<Scene> scene = m_Hooks.GetScene ? m_Hooks.GetScene() : nullptr;
+                return FrameCameraOnEntity(scene, entityUuid, *m_Hooks.Camera);
+            };
+
+            // olo_viewport_set_size (#316 follow-on): only wired when the test
+            // supplies a resize callback; otherwise the tool keeps reporting
+            // "not available" (no fixture render target to resize). `width`/
+            // `height` == 0 (the tool's `reset` request) restores the size the
+            // host was originally constructed with, mirroring the editor's
+            // "override cleared -> falls back to the natural size" behaviour.
+            if (m_Hooks.SetViewportSize)
+            {
+                ctx.SetViewportSizeOverride = [this](u32 width, u32 height)
+                {
+                    if (width == 0 && height == 0)
+                    {
+                        width = m_InitialRenderWidth;
+                        height = m_InitialRenderHeight;
+                    }
+                    else
+                    {
+                        width = std::clamp(width, 64u, 8192u);
+                        height = std::clamp(height, 64u, 8192u);
+                    }
+                    m_Hooks.SetViewportSize(width, height);
+                    m_Hooks.RenderWidth = width;
+                    m_Hooks.RenderHeight = height;
+                };
+            }
             return ctx;
         }
 
@@ -381,6 +431,12 @@ namespace OloEngine::Tests
         }
 
         Hooks m_Hooks;
+        // The size the host was constructed with — the "reset" target for
+        // olo_viewport_set_size's { reset: true } request (see BuildContext's
+        // SetViewportSizeOverride). Snapshotted in the ctor init list, before
+        // any resize can mutate m_Hooks.RenderWidth/RenderHeight.
+        const u32 m_InitialRenderWidth;
+        const u32 m_InitialRenderHeight;
         Scope<MCP::McpServer> m_Server;
         std::atomic<u64> m_FrameIndex{ 0 };
         std::atomic<int> m_NextId{ 0 };

--- a/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.cpp
@@ -202,6 +202,14 @@ namespace OloEngine::Tests
         m_RenderingEnabled = true;
     }
 
+    void RendererAttachedTest::ResizeRenderTarget(u32 width, u32 height)
+    {
+        m_RenderWidth = width;
+        m_RenderHeight = height;
+        m_Scene->OnViewportResize(width, height);
+        Renderer3D::OnWindowResize(width, height);
+    }
+
     bool RendererAttachedTest::ReadbackComposite(std::vector<u8>& outRgba, u32& outWidth, u32& outHeight)
     {
         outWidth = 0;

--- a/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.h
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererAttachedTest.h
@@ -126,6 +126,16 @@ namespace OloEngine::Tests
         /// `ReadbackComposite()` can read the result back.
         void EnableRendering(u32 width = 256, u32 height = 256);
 
+        /// Resize the render target AFTER `EnableRendering` already brought the
+        /// scene into 3D mode — the runtime analogue of the editor's MCP
+        /// viewport-override resize block in `EditorLayer::OnUpdate`. Re-sizes
+        /// the Scene's viewport-driven cameras and the Renderer3D render-graph
+        /// targets, so the next `RunFrames`/`RunEditorFrames` tick — and
+        /// `ReadbackComposite()` afterward — produce a composite framebuffer at
+        /// the new dimensions. Used to back `McpHeadlessHost::Hooks::SetViewportSize`
+        /// (`olo_viewport_set_size`, issue #316 follow-on).
+        void ResizeRenderTarget(u32 width, u32 height);
+
         /// Read back the final composited frame (the render graph's
         /// `UIComposite` RT0 — the same image the editor viewport shows)
         /// into a tightly-packed RGBA8 buffer. Returns false if rendering

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -103,10 +103,15 @@ Two entry points, both in
   The session runs for `OLO_MCP_ATTACH_SECONDS` (default 600, capped 7200), or stops early
   when the sentinel file `<discovery-file>.stop` is created and then removed.
 
-Honesty boundary: the headless host wires the read-only/inspection hooks only —
-`olo_camera_frame_entity`, `olo_viewport_set_size`, and the consented project-write tools
-return a clean "not available" because the test owns no editor undo stack / panel viewport.
-The screenshot, shader, scene, perf, physics, and render-capture/override tools all work.
+Honesty boundary: the headless host wires the read-only/inspection hooks, plus the two
+Tier-0 camera/viewport hooks the Part-1 follow-on closed out — `olo_camera_frame_entity`
+(shares `OloEngine::FrameCameraOnEntity`, the same bounds-computation + fit logic
+`EditorLayer::FrameEditorCameraOnEntity` uses, pointed at the fixture's `Scene`/`EditorCamera`)
+and `olo_viewport_set_size` (resizes the fixture's `Scene` viewport + the Renderer3D render
+graph via `RendererAttachedTest::ResizeRenderTarget`, wired through `Hooks::SetViewportSize`).
+The consented project-write tools (`GetCommandHistory` and friends) remain null by design —
+no project writes in the headless host; that's Tier 2 / #306-C, out of scope. The screenshot,
+shader, scene, perf, physics, and render-capture/override tools all work.
 
 ## Attaching an agent
 


### PR DESCRIPTION
## Summary

Closes the last open item on **#316** — the Part-1 follow-on. The headless test host's `EditorMcpContext` (`McpHeadlessHost.h`) previously left `FrameEntity` and `SetViewportSizeOverride` null, so `olo_camera_frame_entity` and `olo_viewport_set_size` always answered "not available" against the headless offscreen render path.

- Extracted `EditorLayer::FrameEditorCameraOnEntity`'s bounds-computation + camera-fit logic into a shared `OloEngine::FrameCameraOnEntity` (`OloEngine/src/OloEngine/Scene/SceneCameraFraming.{h,cpp}`), so the editor and `McpHeadlessHost` share one implementation instead of duplicating it.
- Added `RendererAttachedTest::ResizeRenderTarget` and a `McpHeadlessHost::Hooks::SetViewportSize` callback so `olo_viewport_set_size` actually resizes the fixture's Scene viewport + Renderer3D render graph (`reset` restores the host's original construction size).
- Extended `McpHeadlessAttachTest.ScreenshotAndShaderErrorsOverMcp` with assertions that a frame-entity call actually re-pivots the camera onto the target entity, and a viewport-resize call actually changes the captured screenshot's dimensions.
- Updated `docs/guides/mcp-diagnostics-server.md`'s "Honesty boundary" section to reflect both hooks now being wired.
- `GetCommandHistory` remains null by design — no consented project writes in the headless host (Tier 2 / #306-C, out of scope).

## Test plan

- [x] `OloEngine-Tests` builds clean (Debug, MSVC)
- [x] `McpHeadlessAttachTest.ScreenshotAndShaderErrorsOverMcp` passes, including the new frame-entity and viewport-resize assertions
- [x] `OloEditor` builds clean
- [x] Visually verified live against a running editor over MCP: `olo_camera_frame_entity` moved the real `EditorCamera` and framed the target entity (screenshot confirmed), and `olo_viewport_set_size` changed the actual render resolution (confirmed via `olo_perf_snapshot`'s `renderWidth`/`renderHeight` and a decoded screenshot), with `reset` restoring the original size

🤖 Generated with [Claude Code](https://claude.com/claude-code)