### PR TITLE
fix(renderer): throttle FrameDataBuffer overflow logging, raise capacity caps

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.cpp
@@ -605,10 +605,30 @@ namespace OloEngine
         // ── Phase 2: Merge groups with count > 1 ──────────────────────
         FrameDataBuffer& frameBuffer = FrameDataBufferManager::Get();
 
+        // Once-per-BatchCommands-call throttles (this function runs once per
+        // frame, so a local flag here is equivalent to the once-per-frame
+        // throttle used by FrameDataBuffer's own internal overflow logs —
+        // without it, a stress scene with many overflowing groups logs once
+        // per group instead of once per frame).
+        bool truncationLogged = false;
+        bool transformOverflowLogged = false;
+        bool prevTransformOverflowLogged = false;
+        bool entityIDOverflowLogged = false;
+        bool colorOverflowLogged = false;
+        bool customOverflowLogged = false;
+
         for (auto& [key, indices] : groups)
         {
             if (indices.size() <= 1)
                 continue;
+
+            if (indices.size() > m_Config.MaxMeshInstances && !truncationLogged)
+            {
+                OLO_CORE_WARN("CommandBucket::BatchCommands: Instance group of {} exceeds MaxMeshInstances ({}); "
+                              "truncating to the cap. Subsequent truncations this frame will be silent.",
+                              indices.size(), m_Config.MaxMeshInstances);
+                truncationLogged = true;
+            }
 
             u32 totalInstances = static_cast<u32>(
                 std::min(indices.size(), static_cast<sizet>(m_Config.MaxMeshInstances)));
@@ -621,13 +641,25 @@ namespace OloEngine
             u32 transformOffset = frameBuffer.AllocateTransforms(totalInstances);
             if (transformOffset == UINT32_MAX)
             {
-                OLO_CORE_ERROR("CommandBucket::BatchCommands: Failed to allocate {} transforms in FrameDataBuffer", totalInstances);
+                if (!transformOverflowLogged)
+                {
+                    OLO_CORE_ERROR("CommandBucket::BatchCommands: Failed to allocate {} transforms in FrameDataBuffer. "
+                                   "Subsequent failures this frame will be silent.",
+                                   totalInstances);
+                    transformOverflowLogged = true;
+                }
                 continue;
             }
             u32 prevTransformOffset = frameBuffer.AllocateTransforms(totalInstances);
             if (prevTransformOffset == UINT32_MAX)
             {
-                OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} prev-transforms; batched motion vectors will alias current frame", totalInstances);
+                if (!prevTransformOverflowLogged)
+                {
+                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} prev-transforms; batched motion vectors will alias current frame. "
+                                  "Subsequent failures this frame will be silent.",
+                                  totalInstances);
+                    prevTransformOverflowLogged = true;
+                }
                 // Continue without prev-transform stream — dispatcher falls back
                 // to prevTransforms = transforms, producing zero velocity for
                 // this draw (same behaviour as a brand-new entity in frame 0).
@@ -635,7 +667,13 @@ namespace OloEngine
             u32 entityIDOffset = frameBuffer.AllocateEntityIDs(totalInstances);
             if (entityIDOffset == UINT32_MAX)
             {
-                OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} entity IDs; batched picking will return -1", totalInstances);
+                if (!entityIDOverflowLogged)
+                {
+                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} entity IDs; batched picking will return -1. "
+                                  "Subsequent failures this frame will be silent.",
+                                  totalInstances);
+                    entityIDOverflowLogged = true;
+                }
             }
 
             // Only allocate Color / Custom streams when at least one source has
@@ -665,14 +703,24 @@ namespace OloEngine
             if (anyNonDefaultColor)
             {
                 colorOffset = frameBuffer.AllocateColors(totalInstances);
-                if (colorOffset == UINT32_MAX)
-                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} colors; per-entity tint lost in batched draw", totalInstances);
+                if (colorOffset == UINT32_MAX && !colorOverflowLogged)
+                {
+                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} colors; per-entity tint lost in batched draw. "
+                                  "Subsequent failures this frame will be silent.",
+                                  totalInstances);
+                    colorOverflowLogged = true;
+                }
             }
             if (anyNonDefaultCustom)
             {
                 customOffset = frameBuffer.AllocateCustoms(totalInstances);
-                if (customOffset == UINT32_MAX)
-                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} customs; per-entity Custom lost in batched draw", totalInstances);
+                if (customOffset == UINT32_MAX && !customOverflowLogged)
+                {
+                    OLO_CORE_WARN("CommandBucket::BatchCommands: Failed to allocate {} customs; per-entity Custom lost in batched draw. "
+                                  "Subsequent failures this frame will be silent.",
+                                  totalInstances);
+                    customOverflowLogged = true;
+                }
             }
 
             // Write each source command's per-instance data contiguously.

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
@@ -71,10 +71,20 @@ namespace OloEngine
     {
         bool EnableSorting = true;    // Sort commands to minimize state changes
         bool EnableBatching = true;   // Batch similar DrawMesh → DrawMeshInstanced (requires instanced shader support)
-        u32 MaxMeshInstances = 16384; // Maximum instances per DrawMeshInstanced packet. Capped at the FrameDataBuffer
-                                      // EntityID stream capacity (16384) so an N-into-1 collapse never silently
-                                      // truncates per-source picking IDs. Dispatcher uses a TLS heap scratch so
-                                      // raising this doesn't bloat the stack.
+        u32 MaxMeshInstances = 16384; // Maximum instances per DrawMeshInstanced packet, for CommandBucket's CPU
+                                      // auto-batching of separate DrawMesh entities that share mesh/material/render
+                                      // state — a different path from the GPU-cull InstancedMeshComponent draw (see
+                                      // FrameDataBuffer::DEFAULT_ENTITY_ID_CAPACITY, 262144, for that one; issue
+                                      // #524's draws_unique/draws_instanced/anim_crowd stress scenes all route
+                                      // around this path — unique materials, single-InstancedMeshComponent, and
+                                      // animated-mesh-skips-batching, respectively — so there's no evidence this
+                                      // needs to scale with those). Well below FrameDataBuffer's EntityID/Color/
+                                      // Custom capacity (so an N-into-1 collapse never truncates per-source picking
+                                      // IDs) and below DEFAULT_TRANSFORM_CAPACITY (65536) with headroom — a group
+                                      // at this cap uses only 1/4 of the transform buffer for its current-transform
+                                      // allocation, leaving room for the prev-transform stream plus other groups in
+                                      // the same frame. Dispatcher uses a TLS heap scratch so raising this doesn't
+                                      // bloat the stack.
         u32 InitialCapacity = 1024;   // Initial capacity for command arrays
     };
 

--- a/OloEngine/src/OloEngine/Renderer/Commands/FrameDataBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/FrameDataBuffer.cpp
@@ -28,22 +28,27 @@ namespace OloEngine
         {
             TUniqueLock<FMutex> boneLock(m_BoneMutex);
             m_BoneMatrixOffset = 0;
+            m_BoneOverflowLogged = false;
         }
         {
             TUniqueLock<FMutex> transformLock(m_TransformMutex);
             m_TransformOffset = 0;
+            m_TransformOverflowLogged = false;
         }
         {
             TUniqueLock<FMutex> entityIDLock(m_EntityIDMutex);
             m_EntityIDOffset = 0;
+            m_EntityIDOverflowLogged = false;
         }
         {
             TUniqueLock<FMutex> colorLock(m_ColorMutex);
             m_ColorOffset = 0;
+            m_ColorOverflowLogged = false;
         }
         {
             TUniqueLock<FMutex> customLock(m_CustomMutex);
             m_CustomOffset = 0;
+            m_CustomOverflowLogged = false;
         }
 
         // Reset parallel submission state
@@ -82,8 +87,13 @@ namespace OloEngine
         // Check for overflow before addition
         if (count > static_cast<u32>(m_BoneMatrices.size()) - offset)
         {
-            OLO_CORE_ERROR("FrameDataBuffer: Bone matrix buffer overflow! Requested {} matrices at offset {}, capacity {}",
-                           count, offset, m_BoneMatrices.size());
+            if (!m_BoneOverflowLogged)
+            {
+                OLO_CORE_ERROR("FrameDataBuffer: Bone matrix buffer overflow! Requested {} matrices at offset {}, capacity {}. "
+                               "Subsequent overflows this frame will be silent.",
+                               count, offset, m_BoneMatrices.size());
+                m_BoneOverflowLogged = true;
+            }
             return UINT32_MAX;
         }
 
@@ -103,8 +113,13 @@ namespace OloEngine
         // Check for overflow before addition
         if (count > static_cast<u32>(m_Transforms.size()) - offset)
         {
-            OLO_CORE_ERROR("FrameDataBuffer: Transform buffer overflow! Requested {} transforms at offset {}, capacity {}",
-                           count, offset, m_Transforms.size());
+            if (!m_TransformOverflowLogged)
+            {
+                OLO_CORE_ERROR("FrameDataBuffer: Transform buffer overflow! Requested {} transforms at offset {}, capacity {}. "
+                               "Subsequent overflows this frame will be silent.",
+                               count, offset, m_Transforms.size());
+                m_TransformOverflowLogged = true;
+            }
             return UINT32_MAX;
         }
 
@@ -188,8 +203,13 @@ namespace OloEngine
         u32 offset = m_EntityIDOffset;
         if (count > static_cast<u32>(m_EntityIDs.size()) - offset)
         {
-            OLO_CORE_ERROR("FrameDataBuffer: EntityID buffer overflow! Requested {} ids at offset {}, capacity {}",
-                           count, offset, m_EntityIDs.size());
+            if (!m_EntityIDOverflowLogged)
+            {
+                OLO_CORE_ERROR("FrameDataBuffer: EntityID buffer overflow! Requested {} ids at offset {}, capacity {}. "
+                               "Subsequent overflows this frame will be silent.",
+                               count, offset, m_EntityIDs.size());
+                m_EntityIDOverflowLogged = true;
+            }
             return UINT32_MAX;
         }
         m_EntityIDOffset = offset + count;
@@ -232,8 +252,13 @@ namespace OloEngine
         u32 offset = m_ColorOffset;
         if (count > static_cast<u32>(m_Colors.size()) - offset)
         {
-            OLO_CORE_ERROR("FrameDataBuffer: Color buffer overflow! Requested {} at offset {}, capacity {}",
-                           count, offset, m_Colors.size());
+            if (!m_ColorOverflowLogged)
+            {
+                OLO_CORE_ERROR("FrameDataBuffer: Color buffer overflow! Requested {} at offset {}, capacity {}. "
+                               "Subsequent overflows this frame will be silent.",
+                               count, offset, m_Colors.size());
+                m_ColorOverflowLogged = true;
+            }
             return UINT32_MAX;
         }
         m_ColorOffset = offset + count;
@@ -276,8 +301,13 @@ namespace OloEngine
         u32 offset = m_CustomOffset;
         if (count > static_cast<u32>(m_Customs.size()) - offset)
         {
-            OLO_CORE_ERROR("FrameDataBuffer: Custom buffer overflow! Requested {} at offset {}, capacity {}",
-                           count, offset, m_Customs.size());
+            if (!m_CustomOverflowLogged)
+            {
+                OLO_CORE_ERROR("FrameDataBuffer: Custom buffer overflow! Requested {} at offset {}, capacity {}. "
+                               "Subsequent overflows this frame will be silent.",
+                               count, offset, m_Customs.size());
+                m_CustomOverflowLogged = true;
+            }
             return UINT32_MAX;
         }
         m_CustomOffset = offset + count;

--- a/OloEngine/src/OloEngine/Renderer/Commands/FrameDataBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/FrameDataBuffer.h
@@ -23,7 +23,10 @@ namespace OloEngine
     static constexpr u16 MAX_RENDER_STATES_PER_FRAME = 256;
 
     // MaterialData table capacity — max unique material configs per frame
-    static constexpr u16 MAX_MATERIAL_DATA_PER_FRAME = 1024;
+    // Raised 1024 -> 4096 (issue #524): draws_unique_10000 stress scene overflowed
+    // the old cap every frame. ~150 bytes/entry, so 4096 costs ~600KB, cheap
+    // relative to the crowd/instancing stalls the old cap caused.
+    static constexpr u16 MAX_MATERIAL_DATA_PER_FRAME = 4096;
 
     /**
      * @brief Per-worker scratch buffer for thread-local bone/transform accumulation
@@ -85,11 +88,20 @@ namespace OloEngine
     class FrameDataBuffer
     {
       public:
-        static constexpr sizet DEFAULT_BONE_CAPACITY = 4096;       // ~256KB for bones
+        // Raised 4096 -> 16384 (issue #524): anim_crowd_200 (200 skinned foxes) overflowed
+        // the old cap every frame, and the resulting unthrottled error log spam stalled
+        // the editor main thread. ~1MB for bones — cheap relative to that stall.
+        static constexpr sizet DEFAULT_BONE_CAPACITY = 16384;
         static constexpr sizet DEFAULT_TRANSFORM_CAPACITY = 65536; // ~4MB for transforms; doubled to cover the parallel prev-transform stream
                                                                    // that CommandBucket auto-batching now allocates alongside the current
                                                                    // stream (~32k current + ~32k prev with headroom for non-batched draws).
-        static constexpr sizet DEFAULT_ENTITY_ID_CAPACITY = 16384; // ~64KB i32 stream (auto-batching can collapse many small draws)
+        // Raised 16384 -> 262144 (issue #524): draws_instanced_200000 — one
+        // InstancedMeshComponent with 200,000 instances, the GPU-cull path's own
+        // documented design point (SubmitGPUCulledInstanced sizes its transform SSBO
+        // to the full pre-cull count; only this stream was still capped) — measured
+        // overflowing even the first 65536 bump when actually run in the editor.
+        // 262144 clears 200k with ~30% headroom. ~1MB i32 stream.
+        static constexpr sizet DEFAULT_ENTITY_ID_CAPACITY = 262144;
 
         FrameDataBuffer(sizet boneCapacity = DEFAULT_BONE_CAPACITY,
                         sizet transformCapacity = DEFAULT_TRANSFORM_CAPACITY,
@@ -199,8 +211,10 @@ namespace OloEngine
         // leaves InstanceData.Color = (1,1,1,1) and InstanceData.Custom = 0
         // in the SSBO upload.
         // ====================================================================
-        static constexpr sizet DEFAULT_COLOR_CAPACITY = 16384;
-        static constexpr sizet DEFAULT_CUSTOM_CAPACITY = 16384;
+        // Raised 16384 -> 262144 (issue #524), matching DEFAULT_ENTITY_ID_CAPACITY —
+        // same 200k-instance GPU-cull draw populates all three streams together.
+        static constexpr sizet DEFAULT_COLOR_CAPACITY = 262144;
+        static constexpr sizet DEFAULT_CUSTOM_CAPACITY = 262144;
 
         u32 AllocateColors(u32 count);
         glm::vec4* GetColorPtr(u32 offset);
@@ -380,6 +394,12 @@ namespace OloEngine
         mutable FMutex m_EntityIDMutex;
         mutable FMutex m_ColorMutex;
         mutable FMutex m_CustomMutex;
+
+        bool m_BoneOverflowLogged = false;      // Once-per-frame overflow warning
+        bool m_TransformOverflowLogged = false; // Once-per-frame overflow warning
+        bool m_EntityIDOverflowLogged = false;  // Once-per-frame overflow warning
+        bool m_ColorOverflowLogged = false;     // Once-per-frame overflow warning
+        bool m_CustomOverflowLogged = false;    // Once-per-frame overflow warning
 
         // ====================================================================
         // RenderState Table Storage

--- a/OloEngine/tests/Rendering/CommandBucketTest.cpp
+++ b/OloEngine/tests/Rendering/CommandBucketTest.cpp
@@ -773,11 +773,13 @@ TEST_F(CommandBucketBatchTest, BatchedTransformsAreContiguous)
 // 10k-Instance Stress: GPU Instancing acceptance criterion
 // =============================================================================
 // Issue #173 acceptance: "10,000+ instances rendered in 1-2 draw calls". The
-// default CommandBucketConfig::MaxMeshInstances is now 16384 (capped at the
-// FrameDataBuffer EntityID stream capacity), so 10k same-mesh draws collapse
-// into a single DrawMeshInstanced packet without raising the cap in the test.
-// Dispatcher uses a TLS heap scratch buffer, so the 10k * 224 B = 2.24 MB of
-// per-instance data lives off-stack.
+// default CommandBucketConfig::MaxMeshInstances is 16384 (well below the
+// FrameDataBuffer EntityID/Color/Custom capacity of 262144 raised for the
+// GPU-cull InstancedMeshComponent path by issue #524 — a different subsystem;
+// see CommandBucket.h), so 10k same-mesh draws collapse into a single
+// DrawMeshInstanced packet without raising the cap in the test. Dispatcher
+// uses a TLS heap scratch buffer, so the 10k * 224 B = 2.24 MB of per-instance
+// data lives off-stack.
 
 TEST_F(CommandBucketBatchTest, TenThousandInstancesCollapseToSinglePacket)
 {

--- a/OloEngine/tests/Rendering/FrameDataBufferTest.cpp
+++ b/OloEngine/tests/Rendering/FrameDataBufferTest.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "RenderingTestUtils.h"
+#include "OloEngine/Core/Log.h"
 #include "OloEngine/Renderer/Commands/FrameDataBuffer.h"
 
 #include <cstring>
@@ -10,6 +11,24 @@
 #include <vector>
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    // Counts how many currently-buffered log messages (spdlog ringbuffer sink,
+    // capacity 200 — see Log.cpp) contain the given marker substring. Used to
+    // assert overflow logging is throttled to once-per-frame rather than
+    // growing with allocation-failure count (issue #524).
+    sizet CountLogOccurrences(std::string_view marker)
+    {
+        sizet count = 0;
+        for (const auto& message : Log::Get().GetRecentLogMessages(0))
+        {
+            if (message.find(marker) != std::string::npos)
+                ++count;
+        }
+        return count;
+    }
+} // namespace
 
 // =============================================================================
 // Basic Write-Read Round-Trip
@@ -575,4 +594,121 @@ TEST(FrameDataBuffer, PBRAndLegacyMaterialsDedupIndependently)
     EXPECT_EQ(buffer.AllocateMaterialData(pbrMat), pbrIdx);
     EXPECT_EQ(buffer.AllocateMaterialData(legacyMat), legacyIdx);
     EXPECT_EQ(buffer.GetMaterialDataCount(), 2u);
+}
+
+// =============================================================================
+// Overflow Logging Throttle (issue #524)
+//
+// FrameDataBuffer's five per-stream allocators (bone/transform/entityID/color/
+// custom) must log an overflow at most once per frame, not once per failed
+// allocation — the unthrottled version produced 126,410 log lines in a ~60s
+// stress-scene session and stalled the editor main thread. Reset() clears the
+// throttle so the next frame's first overflow logs again.
+// =============================================================================
+
+TEST(FrameDataBuffer, BoneOverflowLoggedOncePerFrame)
+{
+    FrameDataBuffer buffer(4, 4);
+    buffer.Reset();
+
+    // Baseline: other tests in this binary share the same ring-buffer sink and
+    // may have already logged this exact marker, so compare deltas, not
+    // absolute counts.
+    sizet baseline = CountLogOccurrences("Bone matrix buffer overflow");
+
+    for (int i = 0; i < 20; ++i)
+    {
+        EXPECT_EQ(buffer.AllocateBoneMatrices(100), UINT32_MAX);
+    }
+    EXPECT_EQ(CountLogOccurrences("Bone matrix buffer overflow") - baseline, 1u)
+        << "20 overflowing allocations in one frame must log exactly once";
+
+    buffer.Reset(); // Simulate next frame
+    EXPECT_EQ(buffer.AllocateBoneMatrices(100), UINT32_MAX);
+    EXPECT_EQ(CountLogOccurrences("Bone matrix buffer overflow") - baseline, 2u)
+        << "Reset() must clear the throttle so the next frame logs again";
+}
+
+TEST(FrameDataBuffer, TransformOverflowLoggedOncePerFrame)
+{
+    FrameDataBuffer buffer(4, 4);
+    buffer.Reset();
+
+    sizet baseline = CountLogOccurrences("Transform buffer overflow");
+
+    for (int i = 0; i < 20; ++i)
+    {
+        EXPECT_EQ(buffer.AllocateTransforms(100), UINT32_MAX);
+    }
+    EXPECT_EQ(CountLogOccurrences("Transform buffer overflow") - baseline, 1u)
+        << "20 overflowing allocations in one frame must log exactly once";
+
+    buffer.Reset();
+    EXPECT_EQ(buffer.AllocateTransforms(100), UINT32_MAX);
+    EXPECT_EQ(CountLogOccurrences("Transform buffer overflow") - baseline, 2u)
+        << "Reset() must clear the throttle so the next frame logs again";
+}
+
+TEST(FrameDataBuffer, EntityIDOverflowLoggedOncePerFrame)
+{
+    FrameDataBuffer buffer(4, 4, 4);
+    buffer.Reset();
+
+    sizet baseline = CountLogOccurrences("EntityID buffer overflow");
+
+    for (int i = 0; i < 20; ++i)
+    {
+        EXPECT_EQ(buffer.AllocateEntityIDs(100), UINT32_MAX);
+    }
+    EXPECT_EQ(CountLogOccurrences("EntityID buffer overflow") - baseline, 1u)
+        << "20 overflowing allocations in one frame must log exactly once";
+
+    buffer.Reset();
+    EXPECT_EQ(buffer.AllocateEntityIDs(100), UINT32_MAX);
+    EXPECT_EQ(CountLogOccurrences("EntityID buffer overflow") - baseline, 2u)
+        << "Reset() must clear the throttle so the next frame logs again";
+}
+
+TEST(FrameDataBuffer, ColorOverflowLoggedOncePerFrame)
+{
+    FrameDataBuffer buffer(4, 4);
+    buffer.Reset();
+
+    // DEFAULT_COLOR_CAPACITY is fixed (not constructor-configurable), so
+    // request more than that to force overflow.
+    constexpr u32 kOver = static_cast<u32>(FrameDataBuffer::DEFAULT_COLOR_CAPACITY) + 1;
+    sizet baseline = CountLogOccurrences("Color buffer overflow");
+
+    for (int i = 0; i < 20; ++i)
+    {
+        EXPECT_EQ(buffer.AllocateColors(kOver), UINT32_MAX);
+    }
+    EXPECT_EQ(CountLogOccurrences("Color buffer overflow") - baseline, 1u)
+        << "20 overflowing allocations in one frame must log exactly once";
+
+    buffer.Reset();
+    EXPECT_EQ(buffer.AllocateColors(kOver), UINT32_MAX);
+    EXPECT_EQ(CountLogOccurrences("Color buffer overflow") - baseline, 2u)
+        << "Reset() must clear the throttle so the next frame logs again";
+}
+
+TEST(FrameDataBuffer, CustomOverflowLoggedOncePerFrame)
+{
+    FrameDataBuffer buffer(4, 4);
+    buffer.Reset();
+
+    constexpr u32 kOver = static_cast<u32>(FrameDataBuffer::DEFAULT_CUSTOM_CAPACITY) + 1;
+    sizet baseline = CountLogOccurrences("Custom buffer overflow");
+
+    for (int i = 0; i < 20; ++i)
+    {
+        EXPECT_EQ(buffer.AllocateCustoms(kOver), UINT32_MAX);
+    }
+    EXPECT_EQ(CountLogOccurrences("Custom buffer overflow") - baseline, 1u)
+        << "20 overflowing allocations in one frame must log exactly once";
+
+    buffer.Reset();
+    EXPECT_EQ(buffer.AllocateCustoms(kOver), UINT32_MAX);
+    EXPECT_EQ(CountLogOccurrences("Custom buffer overflow") - baseline, 2u)
+        << "Reset() must clear the throttle so the next frame logs again";
 }


### PR DESCRIPTION
## Summary
- Extends the existing once-per-frame overflow-log throttle (already used for RenderState/MaterialData) to the five remaining `FrameDataBuffer` streams — bone, transform, entityID, color, custom — and adds matching throttles to `CommandBucket::BatchCommands`'s downstream logs, so an overflowing stress scene now logs a bounded number of lines per frame instead of thousands (previously 126,410 lines in a ~60s crowd-scene session, which stalled the editor main thread hard enough to time out MCP calls).
- Raises the underlying capacity defaults, verified against the `anim_crowd_200` / `draws_unique_10000` / `draws_instanced_200000` perf-stress scenes in both Debug and Dist builds: bone 4096→16384, entityID/color/custom 16384→262144 (262144 was needed specifically to actually *clear* a single 200,000-instance GPU-cull draw, not just degrade under it gracefully), MaterialData table 1024→4096.
- `CommandBucketConfig::MaxMeshInstances` intentionally left at 16384 — it governs a different subsystem (CPU auto-batching of separate `DrawMesh` entities), none of the three stress scenes exercise it, and raising it would have silently pushed overflow onto the shared `Transform` buffer instead.
- Added 5 regression tests proving each overflow log fires exactly once per frame and resets on `Reset()` (using the existing spdlog ringbuffer sink with baseline-delta counting, since other tests share the same log buffer).

## Test plan
- [x] `OloEngine-Tests.exe --gtest_filter="FrameDataBuffer.*:CommandBucket*:*CommandBucketBatchTest*"` — 58/58 pass
- [x] Full `OloEngine-Tests` suite — 4092 passed, 5 skipped (no-GPU/launch-smoke, expected), 1 pre-existing flaky failure unrelated to this change (confirmed passing in isolation)
- [x] Ran `anim_crowd_200`, `draws_unique_10000`, `draws_instanced_200000` perf-stress scenes live in the editor (Debug + Dist) via MCP-adjacent driver tooling — zero overflow-log lines at the new caps, scenes render without corruption
- [x] Dist-mode perf sanity on `draws_instanced_200000`: 49 FPS / 20.6ms (vs. 4 FPS / 237ms in Debug — expected Debug-build overhead, not a regression)

Fixes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced log spam during heavy rendering or stress scenes by limiting repeated overflow and instancing failure messages to once per frame or batch.
  - Increased frame-local rendering capacity limits to better handle larger scenes and reduce overflow-related failures.
  - Overflow logging now resets cleanly each frame, so new issues are reported again after a reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->