### PR TITLE
Robustness: sanitize hand-written SceneSerializer float reads (Rigidbody mass, AnimationState timing, camera/collider/terrain fields)

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/JoltBody.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltBody.cpp
@@ -280,6 +280,13 @@ namespace OloEngine
         if (m_BodyID.IsInvalid() || !IsDynamic())
             return;
 
+        // Guard the reciprocal: a zero/negative/non-finite mass (e.g. from a
+        // C#/Lua SetMass(0) call, which bypasses the editor's soft DragFloat
+        // range) would yield an inf/nan inverse mass and NaN-propagate the
+        // solver island.
+        if (!std::isfinite(mass) || mass <= 0.0f)
+            return;
+
         const auto& bodyLockInterface = GetBodyLockInterface();
         if (JPH::BodyLockWrite lock(bodyLockInterface, m_BodyID); lock.Succeeded())
         {

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -286,6 +286,7 @@ namespace OloEngine
                         // No additional handling required.
                     }
                     mod.Magnitude = modNode["Magnitude"].as<f32>(0.0f);
+                    SanitizeFloat(mod.Magnitude, -1.0e6f, 1.0e6f, 0.0f);
                     ge.Modifiers.push_back(mod);
                 }
             }
@@ -1127,8 +1128,11 @@ namespace OloEngine
 
         terrain.m_HeightmapPath = terrainComponent["HeightmapPath"].as<std::string>(terrain.m_HeightmapPath);
         terrain.m_WorldSizeX = terrainComponent["WorldSizeX"].as<f32>(terrain.m_WorldSizeX);
+        SanitizeFloat(terrain.m_WorldSizeX, 1.0e-3f, 1.0e6f, 256.0f);
         terrain.m_WorldSizeZ = terrainComponent["WorldSizeZ"].as<f32>(terrain.m_WorldSizeZ);
+        SanitizeFloat(terrain.m_WorldSizeZ, 1.0e-3f, 1.0e6f, 256.0f);
         terrain.m_HeightScale = terrainComponent["HeightScale"].as<f32>(terrain.m_HeightScale);
+        SanitizeFloat(terrain.m_HeightScale, 0.0f, 1.0e6f, 64.0f);
         terrain.m_CollisionEnabled = terrainComponent["CollisionEnabled"].as<bool>(terrain.m_CollisionEnabled);
 
         // Procedural generation settings
@@ -1137,8 +1141,11 @@ namespace OloEngine
         terrain.m_ProceduralResolution = terrainComponent["ProceduralResolution"].as<u32>(terrain.m_ProceduralResolution);
         terrain.m_ProceduralOctaves = terrainComponent["ProceduralOctaves"].as<u32>(terrain.m_ProceduralOctaves);
         terrain.m_ProceduralFrequency = terrainComponent["ProceduralFrequency"].as<f32>(terrain.m_ProceduralFrequency);
+        SanitizeFloat(terrain.m_ProceduralFrequency, 0.0f, 1.0e4f, 3.0f);
         terrain.m_ProceduralLacunarity = terrainComponent["ProceduralLacunarity"].as<f32>(terrain.m_ProceduralLacunarity);
+        SanitizeFloat(terrain.m_ProceduralLacunarity, 1.0e-3f, 64.0f, 2.0f);
         terrain.m_ProceduralPersistence = terrainComponent["ProceduralPersistence"].as<f32>(terrain.m_ProceduralPersistence);
+        SanitizeFloat(terrain.m_ProceduralPersistence, 0.0f, 1.0f, 0.45f);
         terrain.m_ProceduralErosionIterations = terrainComponent["ProceduralErosionIterations"].as<i32>(terrain.m_ProceduralErosionIterations);
 
         // Advanced height-field shaping
@@ -1207,13 +1214,16 @@ namespace OloEngine
 
         terrain.m_TessellationEnabled = terrainComponent["TessellationEnabled"].as<bool>(terrain.m_TessellationEnabled);
         terrain.m_TargetTriangleSize = terrainComponent["TargetTriangleSize"].as<f32>(terrain.m_TargetTriangleSize);
+        SanitizeFloat(terrain.m_TargetTriangleSize, 1.0e-3f, 1.0e4f, 8.0f);
         terrain.m_MorphRegion = terrainComponent["MorphRegion"].as<f32>(terrain.m_MorphRegion);
+        SanitizeFloat(terrain.m_MorphRegion, 0.0f, 1.0f, 0.3f);
 
         // Streaming settings
         terrain.m_StreamingEnabled = terrainComponent["StreamingEnabled"].as<bool>(terrain.m_StreamingEnabled);
         terrain.m_TileDirectory = terrainComponent["TileDirectory"].as<std::string>(terrain.m_TileDirectory);
         terrain.m_TileFilePattern = terrainComponent["TileFilePattern"].as<std::string>(terrain.m_TileFilePattern);
         terrain.m_TileWorldSize = terrainComponent["TileWorldSize"].as<f32>(terrain.m_TileWorldSize);
+        SanitizeFloat(terrain.m_TileWorldSize, 1.0e-3f, 1.0e6f, 256.0f);
         terrain.m_TileResolution = terrainComponent["TileResolution"].as<u32>(terrain.m_TileResolution);
         terrain.m_StreamingLoadRadius = terrainComponent["StreamingLoadRadius"].as<u32>(terrain.m_StreamingLoadRadius);
         terrain.m_StreamingMaxTiles = terrainComponent["StreamingMaxTiles"].as<u32>(terrain.m_StreamingMaxTiles);
@@ -1221,6 +1231,7 @@ namespace OloEngine
         // Voxel override settings
         terrain.m_VoxelEnabled = terrainComponent["VoxelEnabled"].as<bool>(terrain.m_VoxelEnabled);
         terrain.m_VoxelSize = terrainComponent["VoxelSize"].as<f32>(terrain.m_VoxelSize);
+        SanitizeFloat(terrain.m_VoxelSize, 1.0e-3f, 1.0e6f, 1.0f);
 
         // Deserialize terrain material layers
         if (auto layersNode = terrainComponent["Layers"]; layersNode && layersNode.IsSequence())
@@ -1563,13 +1574,29 @@ namespace OloEngine
             auto cameraProps = cameraComponent["Camera"];
             cc.Camera.SetProjectionType(static_cast<SceneCamera::ProjectionType>(cameraProps["ProjectionType"].as<int>()));
 
-            cc.Camera.SetPerspectiveVerticalFOV(cameraProps["PerspectiveFOV"].as<f32>());
-            cc.Camera.SetPerspectiveNearClip(cameraProps["PerspectiveNear"].as<f32>());
-            cc.Camera.SetPerspectiveFarClip(cameraProps["PerspectiveFar"].as<f32>());
+            f32 perspectiveFov = cameraProps["PerspectiveFOV"].as<f32>();
+            SanitizeFloat(perspectiveFov, glm::radians(0.1f), glm::radians(179.0f), glm::radians(45.0f));
+            cc.Camera.SetPerspectiveVerticalFOV(perspectiveFov);
 
-            cc.Camera.SetOrthographicSize(cameraProps["OrthographicSize"].as<f32>());
-            cc.Camera.SetOrthographicNearClip(cameraProps["OrthographicNear"].as<f32>());
-            cc.Camera.SetOrthographicFarClip(cameraProps["OrthographicFar"].as<f32>());
+            f32 perspectiveNear = cameraProps["PerspectiveNear"].as<f32>();
+            SanitizeFloat(perspectiveNear, 1.0e-4f, 1.0e6f, 0.01f);
+            cc.Camera.SetPerspectiveNearClip(perspectiveNear);
+
+            f32 perspectiveFar = cameraProps["PerspectiveFar"].as<f32>();
+            SanitizeFloat(perspectiveFar, 1.0e-3f, 1.0e9f, 1000.0f);
+            cc.Camera.SetPerspectiveFarClip(perspectiveFar);
+
+            f32 orthographicSize = cameraProps["OrthographicSize"].as<f32>();
+            SanitizeFloat(orthographicSize, 1.0e-3f, 1.0e9f, 10.0f);
+            cc.Camera.SetOrthographicSize(orthographicSize);
+
+            f32 orthographicNear = cameraProps["OrthographicNear"].as<f32>();
+            SanitizeFloat(orthographicNear, -1.0e9f, 1.0e9f, -1.0f);
+            cc.Camera.SetOrthographicNearClip(orthographicNear);
+
+            f32 orthographicFar = cameraProps["OrthographicFar"].as<f32>();
+            SanitizeFloat(orthographicFar, -1.0e9f, 1.0e9f, 1.0f);
+            cc.Camera.SetOrthographicFarClip(orthographicFar);
 
             cc.Primary = cameraComponent["Primary"].as<bool>();
             cc.FixedAspectRatio = cameraComponent["FixedAspectRatio"].as<bool>();
@@ -1772,9 +1799,13 @@ namespace OloEngine
             bc2d.Offset = boxCollider2DComponent["Offset"].as<glm::vec2>();
             bc2d.Size = boxCollider2DComponent["Size"].as<glm::vec2>();
             bc2d.Density = boxCollider2DComponent["Density"].as<f32>();
+            SanitizeFloat(bc2d.Density, 1.0e-6f, 1.0e6f, 1.0f);
             bc2d.Friction = boxCollider2DComponent["Friction"].as<f32>();
+            SanitizeFloat(bc2d.Friction, 0.0f, 1.0f, 0.5f);
             bc2d.Restitution = boxCollider2DComponent["Restitution"].as<f32>();
+            SanitizeFloat(bc2d.Restitution, 0.0f, 1.0f, 0.0f);
             bc2d.RestitutionThreshold = boxCollider2DComponent["RestitutionThreshold"].as<f32>();
+            SanitizeFloat(bc2d.RestitutionThreshold, 0.0f, 1.0e6f, 0.5f);
         }
 
         if (auto circleCollider2DComponent = entity["CircleCollider2DComponent"]; circleCollider2DComponent)
@@ -1782,10 +1813,15 @@ namespace OloEngine
             auto& cc2d = deserializedEntity.AddComponent<CircleCollider2DComponent>();
             cc2d.Offset = circleCollider2DComponent["Offset"].as<glm::vec2>();
             cc2d.Radius = circleCollider2DComponent["Radius"].as<f32>();
+            SanitizeFloat(cc2d.Radius, 1.0e-6f, 1.0e6f, 0.5f);
             cc2d.Density = circleCollider2DComponent["Density"].as<f32>();
+            SanitizeFloat(cc2d.Density, 1.0e-6f, 1.0e6f, 1.0f);
             cc2d.Friction = circleCollider2DComponent["Friction"].as<f32>();
+            SanitizeFloat(cc2d.Friction, 0.0f, 1.0f, 0.5f);
             cc2d.Restitution = circleCollider2DComponent["Restitution"].as<f32>();
+            SanitizeFloat(cc2d.Restitution, 0.0f, 1.0f, 0.0f);
             cc2d.RestitutionThreshold = circleCollider2DComponent["RestitutionThreshold"].as<f32>();
+            SanitizeFloat(cc2d.RestitutionThreshold, 0.0f, 1.0e6f, 0.5f);
         }
 
         if (auto textComponent = entity["TextComponent"]; textComponent)
@@ -2233,8 +2269,11 @@ namespace OloEngine
             auto& rb3d = deserializedEntity.AddComponent<Rigidbody3DComponent>();
             rb3d.m_Type = static_cast<BodyType3D>(rb3dComponent["BodyType"].as<int>(std::to_underlying(rb3d.m_Type)));
             rb3d.m_Mass = rb3dComponent["Mass"].as<f32>(rb3d.m_Mass);
+            SanitizeFloat(rb3d.m_Mass, 1.0e-6f, 1.0e6f, 1.0f);
             rb3d.m_LinearDrag = rb3dComponent["LinearDrag"].as<f32>(rb3d.m_LinearDrag);
+            SanitizeFloat(rb3d.m_LinearDrag, 0.0f, 1.0e6f, 0.01f);
             rb3d.m_AngularDrag = rb3dComponent["AngularDrag"].as<f32>(rb3d.m_AngularDrag);
+            SanitizeFloat(rb3d.m_AngularDrag, 0.0f, 1.0e6f, 0.05f);
             rb3d.m_DisableGravity = rb3dComponent["DisableGravity"].as<bool>(rb3d.m_DisableGravity);
             rb3d.m_IsTrigger = rb3dComponent["IsTrigger"].as<bool>(rb3d.m_IsTrigger);
         }
@@ -2796,7 +2835,9 @@ namespace OloEngine
             auto& anim = deserializedEntity.AddComponent<AnimationStateComponent>();
             anim.m_State = static_cast<AnimationStateComponent::State>(animComponent["State"].as<int>(std::to_underlying(anim.m_State)));
             anim.m_CurrentTime = animComponent["CurrentTime"].as<f32>(anim.m_CurrentTime);
+            SanitizeFloat(anim.m_CurrentTime, 0.0f, 1.0e6f, 0.0f);
             anim.m_BlendDuration = animComponent["BlendDuration"].as<f32>(anim.m_BlendDuration);
+            SanitizeFloat(anim.m_BlendDuration, 0.0f, 1.0e6f, 0.3f);
             anim.m_CurrentClipIndex = animComponent["CurrentClipIndex"].as<int>(anim.m_CurrentClipIndex);
             anim.m_IsPlaying = animComponent["IsPlaying"].as<bool>(anim.m_IsPlaying);
 

--- a/OloEngine/tests/ComponentRoundTripTest.cpp
+++ b/OloEngine/tests/ComponentRoundTripTest.cpp
@@ -518,6 +518,43 @@ namespace OloEngine::Tests
         EXPECT_EQ(rb.m_IsTrigger, expectedIsTrigger);
     }
 
+    // A corrupted/hand-authored `Mass: 0` (or negative, or NaN) would otherwise
+    // produce an infinite inverse mass in JoltBody::CreateBodySettings, NaN-
+    // propagating across the whole solver island (issue #541).
+    TEST(ComponentRoundTrip, Rigidbody3DComponentInvalidMassIsSanitizedOnLoad)
+    {
+        std::string yaml;
+        {
+            auto scene = Scene::Create();
+            Entity entity = scene->CreateEntity(kTestTag);
+            auto& rb = entity.AddComponent<Rigidbody3DComponent>();
+            rb.m_Mass = 7.5f;
+            rb.m_LinearDrag = 0.25f;
+            rb.m_AngularDrag = 0.6f;
+            yaml = SceneSerializer(scene).SerializeToYAML();
+        }
+
+        yaml = std::regex_replace(yaml, std::regex(R"(Mass: [0-9.e+-]+)"), "Mass: .nan");
+        yaml = std::regex_replace(yaml, std::regex(R"(LinearDrag: [0-9.e+-]+)"), "LinearDrag: -5");
+        yaml = std::regex_replace(yaml, std::regex(R"(AngularDrag: [0-9.e+-]+)"), "AngularDrag: .inf");
+
+        auto reloaded = Scene::Create();
+        ASSERT_TRUE(SceneSerializer(reloaded).DeserializeFromYAML(yaml))
+            << "Deserialize rejected the (structurally valid) NaN/Inf-injected scene.";
+
+        Entity restored = FindByTag(*reloaded, kTestTag);
+        ASSERT_TRUE(static_cast<bool>(restored));
+        ASSERT_TRUE(restored.HasComponent<Rigidbody3DComponent>());
+
+        const auto& rb = restored.GetComponent<Rigidbody3DComponent>();
+        EXPECT_TRUE(std::isfinite(rb.m_Mass));
+        EXPECT_GT(rb.m_Mass, 0.0f) << "NaN mass must not become a zero/negative inverse-mass divisor";
+        EXPECT_TRUE(std::isfinite(rb.m_LinearDrag));
+        EXPECT_GE(rb.m_LinearDrag, 0.0f) << "Negative drag should fall back to a non-negative value";
+        EXPECT_TRUE(std::isfinite(rb.m_AngularDrag));
+        EXPECT_GE(rb.m_AngularDrag, 0.0f) << "Inf drag should be sanitized to a finite value";
+    }
+
     // -------------------------------------------------------------------------
     // BoxCollider2DComponent
     // -------------------------------------------------------------------------
@@ -3189,6 +3226,41 @@ namespace OloEngine::Tests
         EXPECT_NEAR(nc.m_ManaBarColor.b, expectedManaColor.b, kFloatEpsilon);
         EXPECT_NEAR(nc.m_BarBackgroundColor.g, expectedBgColor.g, kFloatEpsilon);
         EXPECT_NEAR(nc.m_ManaBarGap, expectedManaBarGap, kFloatEpsilon);
+    }
+
+    // -------------------------------------------------------------------------
+    // AnimationStateComponent
+    // -------------------------------------------------------------------------
+    // A corrupted/hand-authored `CurrentTime: .nan` would otherwise flow through
+    // AnimationSystem::Update's LoopTime (a NaN passes the `while` guards
+    // unchanged) into SampleBonePosition/Rotation/Scale, NaN-propagating forward
+    // kinematics across the whole skeleton (issue #541).
+    TEST(ComponentRoundTrip, AnimationStateComponentInvalidTimingIsSanitizedOnLoad)
+    {
+        std::string yaml;
+        {
+            auto scene = Scene::Create();
+            Entity entity = scene->CreateEntity(kTestTag);
+            auto& anim = entity.AddComponent<AnimationStateComponent>();
+            anim.m_CurrentTime = 1.5f;
+            anim.m_BlendDuration = 0.2f;
+            yaml = SceneSerializer(scene).SerializeToYAML();
+        }
+
+        yaml = std::regex_replace(yaml, std::regex(R"(CurrentTime: [0-9.e+-]+)"), "CurrentTime: .nan");
+        yaml = std::regex_replace(yaml, std::regex(R"(BlendDuration: [0-9.e+-]+)"), "BlendDuration: -.inf");
+
+        auto reloaded = Scene::Create();
+        ASSERT_TRUE(SceneSerializer(reloaded).DeserializeFromYAML(yaml))
+            << "Deserialize rejected the (structurally valid) NaN/Inf-injected scene.";
+
+        Entity restored = FindByTag(*reloaded, kTestTag);
+        ASSERT_TRUE(static_cast<bool>(restored));
+        ASSERT_TRUE(restored.HasComponent<AnimationStateComponent>());
+
+        const auto& anim = restored.GetComponent<AnimationStateComponent>();
+        EXPECT_TRUE(std::isfinite(anim.m_CurrentTime)) << "NaN CurrentTime must not propagate into forward kinematics";
+        EXPECT_TRUE(std::isfinite(anim.m_BlendDuration)) << "Inf BlendDuration should be sanitized to a finite value";
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Several hand-written `SceneSerializer` deserialize blocks read floats via `.as<f32>()` with no `std::isfinite`/range validation, unlike the codegen path (`TryReadFiniteF32`) and the ragdoll/joint blocks (`SanitizeFloat`). The worst gap: `Rigidbody3DComponent::m_Mass` — a corrupt/hand-authored `Mass: 0`/negative/NaN becomes an infinite or garbage inverse mass that NaN-propagates across the whole solver island. `AnimationStateComponent::m_CurrentTime` NaN similarly collapses the skeleton via forward kinematics.
- Routed the following through the existing `SanitizeFloat` helper: `Rigidbody3DComponent` (Mass strictly > 0, LinearDrag/AngularDrag), `AnimationStateComponent` (CurrentTime/BlendDuration), and a sweep of other unguarded hand-written reads that flow into physics/projection/noise math: `CameraComponent` (perspective/orthographic FOV & clip planes), `BoxCollider2DComponent`/`CircleCollider2DComponent` (Density/Friction/Restitution/Radius), `GameplayEffect` modifier Magnitude, and `TerrainComponent` (world size, height scale, procedural frequency/lacunarity/persistence, tessellation, voxel size).
- Added a last-line-of-defence guard in `JoltBody::SetMass()`: rejects non-finite/non-positive mass before computing `1.0f / mass`, since a C#/Lua `SetMass(0)` call bypasses the editor's soft `DragFloat` range and reaches this reciprocal directly.
- Extended `ComponentRoundTripTest.cpp` with `Rigidbody3DComponentInvalidMassIsSanitizedOnLoad` and `AnimationStateComponentInvalidTimingIsSanitizedOnLoad`, following the existing NaN/Inf-injection pattern (`SpringBoneComponentNonFiniteFieldsAreSanitizedOnLoad`) — no new test file added, per this batch's coordination constraint on `tests/CMakeLists.txt`.

Fixes #541

## Test plan
- [x] Built `OloEngine-Tests` (Debug, MSVC preset)
- [x] `ComponentRoundTrip.*` — 72/72 pass, including the two new sanitization tests
- [x] `ComponentSerializerCoverage.*` / `ComponentTupleCoverage.*` / `ComponentHandlerCoverage.*` — all pass
- [x] `ComponentReplicatorTest.Rigidbody3DRejects{NonFiniteWireFloats,NegativeMass,ZeroMass}` and `LuaBindingTest.Rigidbody3DComponent_PropertyRoundTrip` — pass (confirms no conflict with the new `JoltBody::SetMass` guard)
- [x] Full suite (3941 tests): 3935 passed, 5 skipped (env-gated GPU/editor-launch/video tests), 1 failed (`TwoInstancedFieldsLitScene.BothInstancedSubmissionPathsAreLitInDeferred` — unrelated deferred-lighting/instancing test, passes cleanly on isolated re-run, not touched by this diff)
- [x] pre-commit (clang-format, test classification) passes

Remaining lower-priority gaps noted but out of scope for this pass (no NaN-propagation-into-physics/skeleton risk, just visual/gameplay-tunable values): `FoliageComponent` layer params, `TerrainComponent::Layers` blend sharpness, cosmetic PBR/UI fields (TilingFactor, Metallic/Roughness, CullDistance, ItemAffix.Value, quest cooldowns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)