### PR TITLE
fix(physics3d): apply project PhysicsSettings to the live JoltScene simulation

### DIFF
--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -2562,12 +2562,50 @@ namespace OloEngine
         m_ContactListener = std::make_unique<JoltContactListener>(*this);
         m_JoltSystem->SetContactListener(m_ContactListener.get());
 
-        // Set default gravity
-        m_JoltSystem->SetGravity(JPH::Vec3(0.0f, -9.81f, 0.0f));
+        // Apply gravity from PhysicsSettings instead of hardcoding Earth gravity —
+        // a project authoring non-Earth gravity (underwater levels, low-g, etc.) had
+        // zero effect on the live simulation before issue #540.
+        m_JoltSystem->SetGravity(JoltUtils::ToJoltVector(settings.m_Gravity));
+
+        // Mirror Physics3DSystem::UpdatePhysicsSystemSettings's solver/sleep tuning
+        // onto the system that's actually stepped every frame (JoltScene::Simulate).
+        // Physics3DSystem::m_PhysicsSystem is never stepped — nothing calls
+        // Physics3DSystem::Update — so applying this tuning only there (as it was
+        // before #540) was a no-op on the live sim; JoltScene::m_JoltSystem is the
+        // only system that matters at runtime.
+        JPH::PhysicsSettings joltSettings;
+        joltSettings.mNumVelocitySteps = settings.m_VelocitySolverIterations;
+        joltSettings.mNumPositionSteps = settings.m_PositionSolverIterations;
+        joltSettings.mBaumgarte = settings.m_Baumgarte;
+        joltSettings.mSpeculativeContactDistance = settings.m_SpeculativeContactDistance;
+        joltSettings.mPenetrationSlop = settings.m_PenetrationSlop;
+        joltSettings.mLinearCastThreshold = settings.m_LinearCastThreshold;
+        joltSettings.mMinVelocityForRestitution = settings.m_MinVelocityForRestitution;
+        joltSettings.mTimeBeforeSleep = settings.m_TimeBeforeSleep;
+        joltSettings.mPointVelocitySleepThreshold = settings.m_PointVelocitySleepThreshold;
+        joltSettings.mDeterministicSimulation = settings.m_DeterministicSimulation;
+        joltSettings.mConstraintWarmStart = settings.m_ConstraintWarmStart;
+        joltSettings.mUseBodyPairContactCache = settings.m_UseBodyPairContactCache;
+        joltSettings.mUseManifoldReduction = settings.m_UseManifoldReduction;
+        joltSettings.mUseLargeIslandSplitter = settings.m_UseLargeIslandSplitter;
+        joltSettings.mAllowSleeping = settings.m_AllowSleeping;
+        m_JoltSystem->SetPhysicsSettings(joltSettings);
+
+        // Seed the fixed timestep from PhysicsSettings instead of leaving the 1/60
+        // default initializer in place (issue #540). Guard defensively — same
+        // rationale as the maxBodies/maxContactConstraints clamps above:
+        // SetSettings() has no validating caller other than ProjectSerializer, so a
+        // direct caller (test, script) could hand this a non-positive/non-finite
+        // value that would spin Simulate()'s accumulator loop forever.
+        if (std::isfinite(settings.m_FixedTimestep) && settings.m_FixedTimestep > 0.0f)
+        {
+            m_FixedTimeStep = settings.m_FixedTimestep;
+        }
 
         OLO_CORE_INFO("Jolt Physics initialized - MaxBodies: {0}, MaxBodyPairs: {1}, MaxContactConstraints: {2}, "
-                      "TempAllocatorSize: {3} bytes",
-                      maxBodies, maxBodyPairs, maxContactConstraints, tempAllocatorSize);
+                      "TempAllocatorSize: {3} bytes, Gravity: ({4}, {5}, {6}), FixedTimeStep: {7}",
+                      maxBodies, maxBodyPairs, maxContactConstraints, tempAllocatorSize,
+                      settings.m_Gravity.x, settings.m_Gravity.y, settings.m_Gravity.z, m_FixedTimeStep);
     }
 
     void JoltScene::ShutdownJolt()

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -283,6 +283,22 @@ namespace OloEngine
         {
             return m_AppliedMaxContactConstraints;
         }
+        // The fixed timestep InitializeJolt() actually seeded from PhysicsSettings
+        // (defaults to 1/60 before Initialize(), or if PhysicsSettings::m_FixedTimestep
+        // was non-positive/non-finite). Exposed so tests can verify it, mirroring the
+        // GetMaxBodies()-style accessors above (issue #540).
+        f32 GetFixedTimeStep() const
+        {
+            return m_FixedTimeStep;
+        }
+        // The solver/sleep tuning InitializeJolt() actually passed to
+        // JPH::PhysicsSystem::SetPhysicsSettings, read from PhysicsSettings at init
+        // time. Exposed so tests can verify solver/sleep settings are honoured by the
+        // live sim rather than only reaching the never-stepped Physics3DSystem (issue #540).
+        JPH::PhysicsSettings GetAppliedPhysicsSettings() const
+        {
+            return m_JoltSystem ? m_JoltSystem->GetPhysicsSettings() : JPH::PhysicsSettings{};
+        }
 
         // Read-only snapshot of the entity pairs whose bodies are currently in
         // contact, deduplicated per entity pair. Empty when the contact listener

--- a/OloEngine/src/OloEngine/Physics3D/Physics3DSystem.h
+++ b/OloEngine/src/OloEngine/Physics3D/Physics3DSystem.h
@@ -142,6 +142,17 @@ namespace OloEngine
         void OnContactRemoved(const JPH::SubShapeIDPair& inSubShapePair) override;
     };
 
+    // NOTE (issue #540): m_PhysicsSystem here is a *second*, parallel JPH::PhysicsSystem —
+    // distinct from the one each Scene actually simulates (JoltScene::m_JoltSystem,
+    // stepped every frame from JoltScene::Simulate()). Nothing calls
+    // Physics3DSystem::Update(), so this system is never stepped; it only exists as an
+    // apply-target for SetSettings()/ApplySettings() (gravity + solver/sleep tuning),
+    // which historically meant those settings had zero effect on the live simulation.
+    // As of #540, JoltScene::InitializeJolt() applies the full PhysicsSettings (gravity,
+    // solver iterations, Baumgarte, sleep thresholds, etc.) directly to its own
+    // m_JoltSystem, so the live sim no longer depends on this class at all. Before
+    // wiring a new PhysicsSettings field, confirm you're applying it to
+    // JoltScene::m_JoltSystem (the one that matters at runtime), not just here.
     class Physics3DSystem
     {
       public:

--- a/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/ContactConstraintLimitsHonouredTest.cpp
@@ -96,6 +96,87 @@ TEST_F(ContactConstraintLimitsHonouredTest, CustomSettingsAreAppliedNotHardcoded
            "divergence from issue #523 regressed";
 }
 
+// Issue #540: before this fix, JoltScene::InitializeJolt hardcoded gravity to
+// -9.81 and the fixed timestep to 1/60, and never pushed solver/sleep tuning
+// onto its own JPH::PhysicsSystem at all — those settings only ever reached
+// the never-stepped Physics3DSystem::m_PhysicsSystem, a no-op on the live sim.
+// A project authoring non-Earth gravity, a custom timestep, or solver/sleep
+// tuning had zero effect on how bodies actually simulated.
+TEST_F(ContactConstraintLimitsHonouredTest, GravityTimestepAndSolverSettingsAreAppliedToLiveScene)
+{
+    PhysicsSettings settings = PhysicsSettings::GetDefaults();
+    settings.m_Gravity = { 0.0f, -1.62f, 0.0f }; // lunar gravity — far from the -9.81 default
+    settings.m_FixedTimestep = 1.0f / 30.0f;     // far from the 1/60 default
+    settings.m_VelocitySolverIterations = 6;     // far from the default of 10
+    settings.m_PositionSolverIterations = 4;     // far from the default of 2
+    settings.m_AllowSleeping = false;            // far from the default of true
+    Physics3DSystem::SetSettings(settings);
+
+    CreateFloor(GetScene(), /*topY=*/0.0f);
+    EnablePhysics3D();
+
+    JoltScene* joltScene = GetScene().GetPhysicsScene();
+    ASSERT_NE(joltScene, nullptr);
+
+    const glm::vec3 gravity = joltScene->GetGravity();
+    EXPECT_NEAR(gravity.x, settings.m_Gravity.x, 1e-4f) << "JoltScene ignored PhysicsSettings::m_Gravity.x";
+    EXPECT_NEAR(gravity.y, settings.m_Gravity.y, 1e-4f)
+        << "JoltScene::InitializeJolt ignored PhysicsSettings::m_Gravity — still hardcoded -9.81";
+    EXPECT_NEAR(gravity.z, settings.m_Gravity.z, 1e-4f) << "JoltScene ignored PhysicsSettings::m_Gravity.z";
+
+    EXPECT_NEAR(joltScene->GetFixedTimeStep(), settings.m_FixedTimestep, 1e-6f)
+        << "JoltScene::InitializeJolt ignored PhysicsSettings::m_FixedTimestep — still hardcoded 1/60";
+
+    const JPH::PhysicsSettings appliedJoltSettings = joltScene->GetAppliedPhysicsSettings();
+    EXPECT_EQ(appliedJoltSettings.mNumVelocitySteps, settings.m_VelocitySolverIterations)
+        << "JoltScene::InitializeJolt never applied PhysicsSettings::m_VelocitySolverIterations to "
+           "the live JPH::PhysicsSystem";
+    EXPECT_EQ(appliedJoltSettings.mNumPositionSteps, settings.m_PositionSolverIterations)
+        << "JoltScene::InitializeJolt never applied PhysicsSettings::m_PositionSolverIterations to "
+           "the live JPH::PhysicsSystem";
+    EXPECT_EQ(appliedJoltSettings.mAllowSleeping, settings.m_AllowSleeping)
+        << "JoltScene::InitializeJolt never applied PhysicsSettings::m_AllowSleeping to the live "
+           "JPH::PhysicsSystem";
+}
+
+// Issue #540: a dropped body's fall distance depends on gravity actually
+// reaching the live simulation, not just on the accessor reporting the right
+// number back. This is the runtime-behavior half of the settings-plumbing
+// check above.
+TEST_F(ContactConstraintLimitsHonouredTest, CustomGravityChangesFallBehavior)
+{
+    PhysicsSettings settings = PhysicsSettings::GetDefaults();
+    settings.m_Gravity = { 0.0f, -1.62f, 0.0f }; // lunar gravity — much weaker than -9.81
+    Physics3DSystem::SetSettings(settings);
+
+    CreateFloor(GetScene(), /*topY=*/-1000.0f); // far below so the body never lands during the test
+
+    Entity ball = GetScene().CreateEntity("FallingBall");
+    constexpr f32 kStartY = 10.0f;
+    ball.GetComponent<TransformComponent>().Translation = { 0.0f, kStartY, 0.0f };
+    auto& body = ball.AddComponent<Rigidbody3DComponent>();
+    body.m_Type = BodyType3D::Dynamic;
+    body.m_Mass = 1.0f;
+    auto& col = ball.AddComponent<SphereCollider3DComponent>();
+    col.m_Radius = 0.5f;
+
+    EnablePhysics3D();
+    TickFor(/*seconds=*/1.0f);
+
+    const f32 fallDistance = kStartY - ball.GetComponent<TransformComponent>().Translation.y;
+    ASSERT_TRUE(std::isfinite(fallDistance)) << "ball transform contains NaN/Inf";
+
+    // Under Earth gravity (-9.81) the ball would fall ~4.9m in 1s (0.5 * 9.81 * 1^2);
+    // under lunar gravity (-1.62) it falls ~0.81m. Assert it's well below the
+    // Earth-gravity distance, catching a JoltScene that silently kept -9.81.
+    constexpr f32 kEarthGravityOneSecondFallDistance = 4.9f;
+    EXPECT_LT(fallDistance, kEarthGravityOneSecondFallDistance * 0.75f)
+        << "ball fell as if under Earth gravity (-9.81) — JoltScene ignored the authored lunar "
+           "gravity (fallDistance="
+        << fallDistance << ")";
+    EXPECT_GT(fallDistance, 0.1f) << "ball didn't fall at all — gravity may be zero or disabled";
+}
+
 TEST_F(ContactConstraintLimitsHonouredTest, DensePileSettlesOnFloorInsteadOfTunnelling)
 {
     // Defaults now match m_MaxContactConstraints to m_MaxBodyPairs (65536) rather


### PR DESCRIPTION
## Summary
- `JoltScene::InitializeJolt` hardcoded gravity (-9.81), the fixed timestep (1/60), and never applied solver/sleep tuning to its own `JPH::PhysicsSystem` — those settings only ever reached the never-stepped `Physics3DSystem::m_PhysicsSystem`, a no-op on the live sim. A project authoring non-Earth gravity, a custom timestep, or solver/sleep tuning had zero effect on how bodies actually simulated.
- `JoltScene::InitializeJolt` now applies gravity, the full `JPH::PhysicsSettings` solver/sleep block (velocity/position iterations, Baumgarte, penetration slop, speculative contact, restitution threshold, sleep thresholds, determinism/warm-start/manifold flags), and the fixed timestep (defensively clamped) directly to the live `JoltScene::m_JoltSystem`.
- Documented the `Physics3DSystem` vs `JoltScene` dead-parallel-system split directly on `Physics3DSystem` so a future `PhysicsSettings` field doesn't get wired to the wrong system again.
- Added `JoltScene::GetFixedTimeStep()` / `GetAppliedPhysicsSettings()` accessors for test verification.

Fixes #540. Not a dup of #539 (PR #539 only routed the 3 buffer-limit fields; gravity/timestep/solver/sleep were still ignored — verified in code post-#539).

## Test plan
- [x] Extended `ContactConstraintLimitsHonouredTest.cpp` (no new test file, per this batch's coordination note) with:
  - `GravityTimestepAndSolverSettingsAreAppliedToLiveScene` — asserts authored gravity/timestep/solver-iteration/sleep settings reach the live `JoltScene`/`JPH::PhysicsSystem`, not just `Physics3DSystem`.
  - `CustomGravityChangesFallBehavior` — asserts a real runtime behavior change (lunar vs. Earth gravity fall distance), not just that the accessors report the right numbers.
- [x] Built `OloEngine-Tests` (Debug) from a clean configure.
- [x] Ran the full physics-related test sweep: 127 tests across 32 suites (joints, vehicles, ragdolls, character controllers, physics-settings) — all passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)