### PR TITLE
fix(renderer): invalidate IBL disk cache when source env-map edited in place (#542)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/EnvironmentMap.h
+++ b/OloEngine/src/OloEngine/Renderer/EnvironmentMap.h
@@ -46,12 +46,14 @@ namespace OloEngine
         // single-context bake rationale.
 
         // Disk-cache control. The IBL disk cache is keyed on the source
-        // cubemap's path + this config. That's correct for file-backed
-        // environment maps (a given .hdr always produces the same IBL), but
-        // WRONG for procedurally generated cubemaps whose pixels change at
-        // runtime while their debug path stays constant ("Generated Cubemap").
-        // Such sources must set this false so a stale cache entry can't be
-        // served for freshly-baked content (e.g. ProceduralSky changing sun
+        // cubemap's path + this config, and the cache header additionally
+        // stores the source file's last-write-time, so an in-place edit of a
+        // file-backed .hdr/.png is detected and re-baked (IBLCache::TryLoad
+        // rejects a stale entry). That timestamp check only works for real
+        // files, though: procedurally generated cubemaps whose pixels change at
+        // runtime keep a constant debug path ("Generated Cubemap") with no
+        // mtime, so they must still set this false so a stale cache entry can't
+        // be served for freshly-baked content (e.g. ProceduralSky changing sun
         // direction / turbidity / exposure).
         bool UseDiskCache = true;
     };

--- a/OloEngine/src/OloEngine/Renderer/IBLCache.cpp
+++ b/OloEngine/src/OloEngine/Renderer/IBLCache.cpp
@@ -32,7 +32,15 @@ namespace OloEngine
     // shaders. The advanced shaders now exist (IBLPrefilterImportance,
     // IrradianceConvolutionAdvanced, BRDFIntegrationAdvanced) with
     // mip-biased importance sampling, so the baked output differs.
-    constexpr u32 kIBLCacheVersion = 5;
+    // Version 6 adds SourceTimestamp to the header (staleness tracking):
+    // the cache is keyed on source-path + config only, so editing an
+    // environment-map file in place (same path, same config) previously
+    // served the IBL baked from the OLD image forever. The header now
+    // stores the source file's last-write-time; TryLoad rejects (and
+    // invalidates) an entry whose stored timestamp no longer matches the
+    // source, so an in-place edit re-bakes on next load. The layout change
+    // also makes older v1–v5 files unreadable, which is the intended reset.
+    constexpr u32 kIBLCacheVersion = 6;
 
     // Cache file header for version tracking
     // Use pragma pack to ensure consistent binary layout across compilers
@@ -45,13 +53,14 @@ namespace OloEngine
         u32 Height = 0;
         u32 Format = 0; // ImageFormat enum value
         u32 MipLevels = 0;
-        u32 FaceCount = 0; // 1 for Texture2D, 6 for cubemap
-        u64 DataSize = 0;  // Total data size following header
+        u32 FaceCount = 0;       // 1 for Texture2D, 6 for cubemap
+        u64 DataSize = 0;        // Total data size following header
+        u64 SourceTimestamp = 0; // Source file's last_write_time (0 if unknown / not file-backed)
     };
 #pragma pack(pop)
 
     // Verify header size at compile time
-    static_assert(sizeof(IBLCacheHeader) == 36, "IBLCacheHeader size mismatch - packing may be incorrect");
+    static_assert(sizeof(IBLCacheHeader) == 44, "IBLCacheHeader size mismatch - packing may be incorrect");
 
     namespace
     {
@@ -104,6 +113,56 @@ namespace OloEngine
         [[nodiscard]] bool IsInvalidBRDFLutPayload(ImageFormat format, const std::vector<u8>& data)
         {
             return format == ImageFormat::RG32F && !HasMeaningfulFloatPayload(data);
+        }
+
+        // Get the source file's last-write-time as a u64 for staleness tracking.
+        // Mirrors MeshCache::GetSourceTimestamp. Returns 0 when the source is not
+        // a real file on disk — e.g. synthetic keys for in-memory / procedural
+        // cubemaps ("cubemap_<name>_WxH_fmt"), which have no mtime and are
+        // deliberately allowed to keep hitting the cache (0 == 0 on compare).
+        [[nodiscard]] u64 GetSourceTimestamp(const std::string& sourcePath)
+        {
+            std::error_code ec;
+            auto ftime = std::filesystem::last_write_time(sourcePath, ec);
+            if (ec)
+            {
+                return 0;
+            }
+            return static_cast<u64>(ftime.time_since_epoch().count());
+        }
+
+        // Read only the header of a cache file and hand back its stored
+        // SourceTimestamp. Validates magic + version so a corrupt or
+        // stale-format file is treated as "no timestamp" (returns false),
+        // which the caller resolves to a cache miss.
+        [[nodiscard]] bool ReadCachedSourceTimestamp(const std::filesystem::path& path, u64& outTimestamp)
+        {
+            std::ifstream file(path, std::ios::binary);
+            if (!file.is_open())
+            {
+                return false;
+            }
+
+            IBLCacheHeader header;
+            file.read(reinterpret_cast<char*>(&header), sizeof(header));
+            if (!file || file.gcount() != static_cast<std::streamsize>(sizeof(header)))
+            {
+                return false;
+            }
+
+            if (header.Magic[0] != 'I' || header.Magic[1] != 'B' ||
+                header.Magic[2] != 'L' || header.Magic[3] != 'C')
+            {
+                return false;
+            }
+
+            if (header.Version != kIBLCacheVersion)
+            {
+                return false;
+            }
+
+            outTimestamp = header.SourceTimestamp;
+            return true;
         }
     } // anonymous namespace
 
@@ -246,6 +305,24 @@ namespace OloEngine
             return false;
         }
 
+        // Staleness check: the cache key folds only source-path + config, so an
+        // in-place edit of the source (same path, same config) would otherwise
+        // return the IBL baked from the OLD image forever. Compare the source
+        // file's current last-write-time against the timestamp stored in the
+        // cache header; on mismatch the entry is stale — drop it and miss so the
+        // caller re-bakes and overwrites. A synthetic key (in-memory / procedural
+        // cubemap) has no file, so both sides are 0 and it still hits.
+        u64 currentTimestamp = GetSourceTimestamp(sourcePath);
+        u64 cachedTimestamp = 0;
+        if (!ReadCachedSourceTimestamp(paths.Irradiance, cachedTimestamp) ||
+            cachedTimestamp != currentTimestamp)
+        {
+            OLO_CORE_INFO("IBLCache: Stale cache for {} (source modified) — invalidating", sourcePath);
+            Invalidate(sourcePath, config);
+            ++s_Stats.CacheMisses;
+            return false;
+        }
+
         // Try to load each texture
         outCached.Irradiance = LoadCubemapFromCache(paths.Irradiance);
         if (!outCached.Irradiance)
@@ -299,22 +376,27 @@ namespace OloEngine
         u64 hash = ComputeHash(sourcePath, config);
         CachePaths paths = GetCachePaths(hash);
 
+        // Stamp every cache file with the source file's current last-write-time
+        // so TryLoad can detect an in-place source edit and re-bake (0 for
+        // synthetic keys that aren't file-backed — they always hit).
+        u64 sourceTimestamp = GetSourceTimestamp(sourcePath);
+
         bool success = true;
 
-        if (!SaveCubemapToCache(irradiance, paths.Irradiance))
+        if (!SaveCubemapToCache(irradiance, paths.Irradiance, sourceTimestamp))
         {
             OLO_CORE_WARN("IBLCache: Failed to save irradiance map");
             success = false;
         }
 
-        if (!SaveCubemapToCache(prefilter, paths.Prefilter))
+        if (!SaveCubemapToCache(prefilter, paths.Prefilter, sourceTimestamp))
         {
             OLO_CORE_WARN("IBLCache: Failed to save prefilter map");
             success = false;
         }
 
         // Save BRDF LUT (resolution-specific via hash, so always save)
-        if (!SaveTexture2DToCache(brdfLut, paths.BRDFLut))
+        if (!SaveTexture2DToCache(brdfLut, paths.BRDFLut, sourceTimestamp))
         {
             OLO_CORE_WARN("IBLCache: Failed to save BRDF LUT");
             success = false;
@@ -341,9 +423,19 @@ namespace OloEngine
 
         try
         {
-            return std::filesystem::exists(paths.Irradiance) &&
-                   std::filesystem::exists(paths.Prefilter) &&
-                   std::filesystem::exists(paths.BRDFLut);
+            if (!std::filesystem::exists(paths.Irradiance) ||
+                !std::filesystem::exists(paths.Prefilter) ||
+                !std::filesystem::exists(paths.BRDFLut))
+            {
+                return false;
+            }
+
+            // A stale entry (source edited in place) is not a usable cache — match
+            // TryLoad's freshness contract so callers never see a "true" that would
+            // load the IBL baked from the old source.
+            u64 cachedTimestamp = 0;
+            return ReadCachedSourceTimestamp(paths.Irradiance, cachedTimestamp) &&
+                   (cachedTimestamp == GetSourceTimestamp(sourcePath));
         }
         catch (const std::filesystem::filesystem_error& e)
         {
@@ -544,7 +636,8 @@ namespace OloEngine
     }
 
     bool IBLCache::SaveCubemapToCache(const Ref<TextureCubemap>& cubemap,
-                                      const std::filesystem::path& path)
+                                      const std::filesystem::path& path,
+                                      u64 sourceTimestamp)
     {
         if (!cubemap)
             return false;
@@ -571,6 +664,7 @@ namespace OloEngine
         header.MipLevels = mipLevels;
         header.FaceCount = 6;
         header.DataSize = totalDataSize;
+        header.SourceTimestamp = sourceTimestamp;
 
         std::ofstream file(path, std::ios::binary);
         if (!file.is_open())
@@ -684,7 +778,8 @@ namespace OloEngine
     }
 
     bool IBLCache::SaveTexture2DToCache(const Ref<Texture2D>& texture,
-                                        const std::filesystem::path& path)
+                                        const std::filesystem::path& path,
+                                        u64 sourceTimestamp)
     {
         if (!texture)
             return false;
@@ -703,6 +798,7 @@ namespace OloEngine
         header.MipLevels = 1;
         header.FaceCount = 1;
         header.DataSize = dataSize;
+        header.SourceTimestamp = sourceTimestamp;
 
         std::ofstream file(path, std::ios::binary);
         if (!file.is_open())

--- a/OloEngine/src/OloEngine/Renderer/IBLCache.h
+++ b/OloEngine/src/OloEngine/Renderer/IBLCache.h
@@ -170,9 +170,13 @@ namespace OloEngine
          * @brief Save a cubemap to cache file
          *
          * Saves as raw binary format for fast loading (not KTX2 for simplicity).
+         * @param sourceTimestamp Source file's last-write-time, stamped into the
+         *        header so TryLoad can detect an in-place source edit (0 if the
+         *        source is not file-backed).
          */
         static bool SaveCubemapToCache(const Ref<TextureCubemap>& cubemap,
-                                       const std::filesystem::path& path);
+                                       const std::filesystem::path& path,
+                                       u64 sourceTimestamp);
 
         /**
          * @brief Load a 2D texture from cache file
@@ -181,9 +185,12 @@ namespace OloEngine
 
         /**
          * @brief Save a 2D texture to cache file
+         *
+         * @param sourceTimestamp Source file's last-write-time (see SaveCubemapToCache).
          */
         static bool SaveTexture2DToCache(const Ref<Texture2D>& texture,
-                                         const std::filesystem::path& path);
+                                         const std::filesystem::path& path,
+                                         u64 sourceTimestamp);
 
         static std::filesystem::path s_CacheDirectory;
         static bool s_Initialized;

--- a/OloEngine/tests/Rendering/PropertyTests/DataRoundTripTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/DataRoundTripTests.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
@@ -494,6 +495,124 @@ namespace OloEngine::Tests
         EXPECT_EQ(totalDiffs, 0u)
             << "IBL cache round-trip produced " << totalDiffs
             << " bit-different texels across all mips (classic 'only mip 0 loaded' symptom)";
+
+        // cacheGuard destructor runs IBLCache::Shutdown + remove_all(tempDir).
+    }
+
+    // =========================================================================
+    // IBL cache STALENESS (#542): the cache keys on source-path + config only,
+    // so editing an environment-map file in place (same path, same config) used
+    // to serve the IBL baked from the OLD image forever — including across
+    // editor restarts. The cache header now stores the source file's
+    // last-write-time; TryLoad must reject (and invalidate) an entry whose
+    // stored timestamp no longer matches the source on disk.
+    //
+    // We save an IBL triplet keyed on a REAL temp file, confirm a fresh hit,
+    // then bump the source file's mtime (simulating an in-place edit) and
+    // confirm TryLoad now MISSES and the stale entry is gone. Contrast: a
+    // synthetic key with no backing file (0 == 0 on compare) keeps hitting.
+    // =========================================================================
+    TEST(DataRoundTripTest, IblCacheInvalidatesWhenSourceFileEditedInPlace)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        std::random_device rd;
+        const auto randomTag = std::to_string(rd()) + "_" + std::to_string(rd());
+        auto tempDir = std::filesystem::temp_directory_path() /
+                       (std::string("olo_ibl_stale_test_") +
+                        std::to_string(
+#if defined(_WIN32)
+                            static_cast<unsigned long>(::_getpid())
+#else
+                            static_cast<unsigned long>(::getpid())
+#endif
+                                ) +
+                        "_" + randomTag);
+        std::error_code probeEc;
+        ASSERT_FALSE(std::filesystem::exists(tempDir, probeEc))
+            << "temp cache path unexpectedly exists: " << tempDir.string();
+        ScopedIBLCacheGuard cacheGuard(tempDir);
+
+        // Build a minimal but valid IBL triplet — content is irrelevant here,
+        // only the timestamp bookkeeping is under test.
+        auto MakeCubemap = [](u32 size) -> Ref<TextureCubemap>
+        {
+            CubemapSpecification spec{};
+            spec.Width = size;
+            spec.Height = size;
+            spec.Format = ImageFormat::RGBA32F;
+            spec.GenerateMips = false;
+            spec.MipLevels = 1;
+            Ref<TextureCubemap> cube = TextureCubemap::Create(spec);
+            std::vector<f32> pixels(static_cast<std::size_t>(size) * size * 4u, 0.25f);
+            for (u32 face = 0; face < 6; ++face)
+                cube->SetFaceDataMip(face, 0, pixels.data(),
+                                     static_cast<u32>(pixels.size() * sizeof(f32)));
+            return cube;
+        };
+        Ref<TextureCubemap> irradiance = MakeCubemap(8);
+        Ref<TextureCubemap> prefilter = MakeCubemap(8);
+        ASSERT_TRUE(irradiance && prefilter);
+
+        TextureSpecification brdfSpec{};
+        brdfSpec.Width = 8;
+        brdfSpec.Height = 8;
+        brdfSpec.Format = ImageFormat::RGBA32F;
+        brdfSpec.GenerateMips = false;
+        Ref<Texture2D> brdf = Texture2D::Create(brdfSpec);
+        ASSERT_TRUE(brdf != nullptr);
+        {
+            std::vector<f32> brdfPixels(8u * 8u * 4u, 0.5f);
+            brdf->SetData(brdfPixels.data(), static_cast<u32>(brdfPixels.size() * sizeof(f32)));
+        }
+
+        // A REAL source file on disk, so it has a real last_write_time.
+        const auto sourceFile = tempDir / "env_source.hdr";
+        {
+            std::ofstream out(sourceFile, std::ios::binary);
+            ASSERT_TRUE(out.is_open());
+            out << "original-hdr-bytes";
+        }
+        const std::string sourcePath = sourceFile.string();
+
+        IBLConfiguration config{};
+
+        // Save + confirm a fresh cache hit and a positive HasCache.
+        ASSERT_TRUE(IBLCache::Save(sourcePath, config, irradiance, prefilter, brdf));
+        EXPECT_TRUE(IBLCache::HasCache(sourcePath, config));
+        {
+            IBLCache::CachedIBL cached;
+            EXPECT_TRUE(IBLCache::TryLoad(sourcePath, config, cached))
+                << "Fresh cache (unmodified source) must hit";
+        }
+
+        // Simulate an in-place edit: bump the source file's last-write-time.
+        // Setting the time explicitly is deterministic (no wall-clock sleep) and
+        // guarantees a value distinct from the one stamped into the cache.
+        {
+            std::error_code ec;
+            auto ftime = std::filesystem::last_write_time(sourceFile, ec);
+            ASSERT_FALSE(ec) << "could not read source mtime: " << ec.message();
+            std::filesystem::last_write_time(sourceFile, ftime + std::chrono::hours(48), ec);
+            ASSERT_FALSE(ec) << "could not bump source mtime: " << ec.message();
+        }
+
+        // The stale entry must now miss AND be invalidated off disk.
+        {
+            IBLCache::CachedIBL cached;
+            EXPECT_FALSE(IBLCache::TryLoad(sourcePath, config, cached))
+                << "Edited-in-place source must invalidate the stale IBL cache";
+        }
+        EXPECT_FALSE(IBLCache::HasCache(sourcePath, config))
+            << "Stale cache files should have been removed by the staleness check";
+
+        // Re-baking with the current (bumped) mtime hits again.
+        ASSERT_TRUE(IBLCache::Save(sourcePath, config, irradiance, prefilter, brdf));
+        {
+            IBLCache::CachedIBL cached;
+            EXPECT_TRUE(IBLCache::TryLoad(sourcePath, config, cached))
+                << "Re-baked cache with the current mtime must hit";
+        }
 
         // cacheGuard destructor runs IBLCache::Shutdown + remove_all(tempDir).
     }


### PR DESCRIPTION
## Summary

`IBLCache` keyed its disk cache on **source-path + config only** — no source `last_write_time`/content hash — and `IBLCache::Invalidate` was **dead code**. Editing an environment-map `.hdr`/`.png` **in place** (same path, same config) yielded a cache hit returning the IBL baked from the **old** image, so diffuse ambient + specular reflections stayed locked to the stale environment **across editor restarts** until `assets/cache/ibl/` was hand-deleted. This is the same "valid-until-invalidated but never invalidated by the event that changes the underlying state" species as #505/#530.

## Fix

Mirror the correct `MeshCache` pattern — store the source's timestamp in the cache header and reject a stale entry on load:

- **`IBLCacheHeader`**: add `SourceTimestamp` (u64); bump `kIBLCacheVersion` 5→6 so older files are cleanly rejected; `static_assert` 36→44 bytes.
- **`Save`** stamps every cache file with the source file's `last_write_time`.
- **`TryLoad`** compares the source's current mtime against the stored value; on mismatch it wires the previously-**dead** `Invalidate` (removing the stale files) and misses, so the caller re-bakes. Synthetic keys (in-memory / procedural cubemaps with no backing file) stay `0 == 0` on compare and **still hit**, preserving `UseDiskCache=false` behavior (ProceduralSky unaffected).
- **`HasCache`** also checks freshness for a consistent contract.
- Fix the stale "a given `.hdr` always produces the same IBL" comment in `EnvironmentMap.h` that the issue flagged.

## Verification

- **New GPU-gated CPU/contract test** `IblCacheInvalidatesWhenSourceFileEditedInPlace`: real temp source file + real in-place mtime bump → asserts stale-detect, cache invalidation, and re-bake-hit; the existing `IblCacheCubemapRoundTripPreservesAllMips` still passes bit-exact through the new 44-byte header.
- **Live editor, real in-place edit + restart** (MaterialSpheres → `newport_loft.hdr`): the log shows the exact production path — first launch `Cache miss … Generating IBL … Saved`, then after overwriting the HDR in place and restarting: `IBLCache: Stale cache for assets/textures/hdr/newport_loft.hdr (source modified) — invalidating` → `Invalidated cache … (3 files)` → `Generating IBL textures`. The rebaked on-disk cache is confirmed version 6 with a populated `SourceTimestamp`.

**Note on the viewport pixel-delta:** this change adds **no render/shader math** — it only changes *which* cached textures load — so the appropriate evidence is the live-editor invalidation log + the content-verified unit test rather than a viewport color-delta screenshot (a synthetic uniform-bright test HDR bakes to a degenerate all-white IBL, which can't produce a clean before/after color delta; that's a bake property, not a cache-fix issue).

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment map caching now refreshes correctly when a source file is edited in place, helping prevent outdated lighting results.
  * Cached lighting data is now more reliably invalidated and rebuilt when source content changes.
  * Procedurally generated environment maps are handled more safely to avoid reusing stale cached results after rebakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->