### PR TITLE
fix(animation): map graph clip channels to bones by name, not array index (#543)

### DIFF
--- a/OloEngine/src/OloEngine/Animation/AnimationGraph.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraph.cpp
@@ -24,7 +24,8 @@ namespace OloEngine
 
     void AnimationGraph::Update(f32 dt, sizet boneCount, std::vector<glm::mat4>& outFinalBoneMatrices,
                                 const std::vector<std::string>& boneNames,
-                                const std::vector<i32>& parentIndices)
+                                const std::vector<i32>& parentIndices,
+                                const std::vector<BoneTransform>& bindPoseLocal)
     {
         OLO_PROFILE_FUNCTION();
         if (Layers.empty() || boneCount == 0)
@@ -33,8 +34,15 @@ namespace OloEngine
             return;
         }
 
-        // Start with identity transforms
-        std::vector<BoneTransform> accumulatedTransforms(boneCount);
+        // Shared per-skeleton sampling context: clip channels map to bones by
+        // name (not array index) and un-keyed bones fall back to bind pose (#543).
+        const PoseEvalContext ctx{ boneNames, bindPoseLocal };
+
+        // Start each bone at its bind-pose local transform so a full-weight
+        // Override layer that leaves a bone un-keyed rests it at bind pose
+        // rather than blending toward identity.
+        std::vector<BoneTransform> accumulatedTransforms;
+        BlendTree::FillBindPose(ctx, boneCount, accumulatedTransforms);
 
         // Evaluate each layer bottom-to-top
         for (auto& layer : Layers)
@@ -45,7 +53,7 @@ namespace OloEngine
             }
 
             std::vector<BoneTransform> layerTransforms;
-            layer.StateMachine->Update(dt, Parameters, boneCount, layerTransforms);
+            layer.StateMachine->Update(dt, Parameters, boneCount, ctx, layerTransforms);
 
             if (layerTransforms.size() < boneCount)
             {

--- a/OloEngine/src/OloEngine/Animation/AnimationGraph.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraph.h
@@ -21,9 +21,13 @@ namespace OloEngine
         std::vector<AnimationLayer> Layers;
 
         void Start();
+        // bindPoseLocal supplies each bone's rest local transform so bones a clip
+        // does not animate fall back to bind pose rather than identity (#543); it
+        // may be empty (identity fallback). boneNames drives by-name channel mapping.
         void Update(f32 dt, sizet boneCount, std::vector<glm::mat4>& outFinalBoneMatrices,
                     const std::vector<std::string>& boneNames,
-                    const std::vector<i32>& parentIndices);
+                    const std::vector<i32>& parentIndices,
+                    const std::vector<BoneTransform>& bindPoseLocal);
 
         [[nodiscard("cloned graph must be assigned")]] Ref<AnimationGraph> Clone() const;
         void ResolveClips(const std::vector<Ref<AnimationClip>>& availableClips);

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphComponent.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphComponent.h
@@ -18,10 +18,18 @@ namespace OloEngine
         // Per-entity parameter instance (copied from graph at start)
         AnimationParameterSet Parameters;
 
+        // Runtime-only cache of the entity skeleton's bind-pose local transforms
+        // in TRS form, so AnimationGraphSystem::Update doesn't re-decompose every
+        // bind-pose mat4 each tick (the bind pose is stable for a given skeleton).
+        // Filled lazily and rebuilt only when the bone count changes; reset on
+        // copy like RuntimeGraph.
+        std::vector<BoneTransform> BindPoseLocalTRS;
+
         AnimationGraphComponent() = default;
 
         // Copying shares the RuntimeGraph Ref which causes aliasing.
-        // Reset RuntimeGraph on copy so each entity gets its own runtime instance via lazy-load.
+        // Reset RuntimeGraph (and the bind-pose cache) on copy so each entity gets
+        // its own runtime instance via lazy-load.
         AnimationGraphComponent(const AnimationGraphComponent& other)
             : AnimationGraphAssetHandle(other.AnimationGraphAssetHandle), Parameters(other.Parameters)
         {
@@ -34,6 +42,7 @@ namespace OloEngine
                 AnimationGraphAssetHandle = other.AnimationGraphAssetHandle;
                 RuntimeGraph = nullptr;
                 Parameters = other.Parameters;
+                BindPoseLocalTRS.clear();
             }
             return *this;
         }

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
@@ -47,20 +47,26 @@ namespace OloEngine::Animation
         // Decompose the skeleton's bind-pose local transforms into TRS so the
         // graph can fall back to bind pose (not identity) for bones a clip does
         // not animate — mirrors AnimationSystem's bind-pose reset (issue #543).
-        // Empty when the skeleton has no captured bind pose; the graph then
-        // degrades to an identity fallback.
-        std::vector<BoneTransform> bindPoseLocal;
-        if (skeleton.m_BindPoseLocalTransforms.size() == boneCount)
+        // The bind pose is stable per skeleton, so cache the decomposed TRS on the
+        // component and rebuild only when the bone count changes (or on first tick)
+        // rather than re-decomposing every mat4 each frame. Stays empty when the
+        // skeleton has no captured bind pose; the graph then degrades to an
+        // identity fallback.
+        if (graphComp.BindPoseLocalTRS.size() != boneCount)
         {
-            bindPoseLocal.resize(boneCount);
-            for (sizet i = 0; i < boneCount; ++i)
+            graphComp.BindPoseLocalTRS.clear();
+            if (skeleton.m_BindPoseLocalTransforms.size() == boneCount)
             {
-                bindPoseLocal[i] = BlendUtils::DecomposeMatrix(skeleton.m_BindPoseLocalTransforms[i]);
+                graphComp.BindPoseLocalTRS.resize(boneCount);
+                for (sizet i = 0; i < boneCount; ++i)
+                {
+                    graphComp.BindPoseLocalTRS[i] = BlendUtils::DecomposeMatrix(skeleton.m_BindPoseLocalTransforms[i]);
+                }
             }
         }
 
         // Evaluate the animation graph directly into the skeleton's local transform buffer
-        graphComp.RuntimeGraph->Update(deltaTime, boneCount, skeleton.m_LocalTransforms, skeleton.m_BoneNames, skeleton.m_ParentIndices, bindPoseLocal);
+        graphComp.RuntimeGraph->Update(deltaTime, boneCount, skeleton.m_LocalTransforms, skeleton.m_BoneNames, skeleton.m_ParentIndices, graphComp.BindPoseLocalTRS);
 
         // Copy parameters back (triggers may have been consumed)
         graphComp.Parameters = graphComp.RuntimeGraph->Parameters;

--- a/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationGraphSystem.cpp
@@ -8,6 +8,8 @@
 #include "OloEngine/Animation/Procedural/NoisePostPass.h"
 #include "OloEngine/Animation/MorphTargets/MorphTargetComponents.h"
 #include "OloEngine/Animation/MorphTargets/MorphTargetSystem.h"
+#include "OloEngine/Animation/BlendNode.h"
+#include "OloEngine/Animation/BlendUtils.h"
 #include "OloEngine/Core/Log.h"
 
 #include <vector>
@@ -42,8 +44,23 @@ namespace OloEngine::Animation
         // Sync per-entity parameters into the runtime graph
         graphComp.RuntimeGraph->Parameters = graphComp.Parameters;
 
+        // Decompose the skeleton's bind-pose local transforms into TRS so the
+        // graph can fall back to bind pose (not identity) for bones a clip does
+        // not animate — mirrors AnimationSystem's bind-pose reset (issue #543).
+        // Empty when the skeleton has no captured bind pose; the graph then
+        // degrades to an identity fallback.
+        std::vector<BoneTransform> bindPoseLocal;
+        if (skeleton.m_BindPoseLocalTransforms.size() == boneCount)
+        {
+            bindPoseLocal.resize(boneCount);
+            for (sizet i = 0; i < boneCount; ++i)
+            {
+                bindPoseLocal[i] = BlendUtils::DecomposeMatrix(skeleton.m_BindPoseLocalTransforms[i]);
+            }
+        }
+
         // Evaluate the animation graph directly into the skeleton's local transform buffer
-        graphComp.RuntimeGraph->Update(deltaTime, boneCount, skeleton.m_LocalTransforms, skeleton.m_BoneNames, skeleton.m_ParentIndices);
+        graphComp.RuntimeGraph->Update(deltaTime, boneCount, skeleton.m_LocalTransforms, skeleton.m_BoneNames, skeleton.m_ParentIndices, bindPoseLocal);
 
         // Copy parameters back (triggers may have been consumed)
         graphComp.Parameters = graphComp.RuntimeGraph->Parameters;

--- a/OloEngine/src/OloEngine/Animation/AnimationState.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationState.cpp
@@ -1,34 +1,10 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Animation/AnimationState.h"
-#include "OloEngine/Renderer/AnimatedModel.h"
 
 namespace OloEngine
 {
-    namespace
-    {
-        // Sample a single clip into the output pose: clear to bind pose, then
-        // per-bone TRS for every bone that has an animation channel.
-        void SampleClipIntoPose(const AnimationClip& clip, f32 normalizedTime, sizet boneCount,
-                                std::vector<BoneTransform>& out)
-        {
-            f32 timeSeconds = normalizedTime * clip.Duration;
-            out.assign(boneCount, BoneTransform{});
-            auto boneAnimCount = clip.BoneAnimations.size();
-            for (sizet i = 0; i < boneCount; ++i)
-            {
-                if (i < boneAnimCount)
-                {
-                    auto const& boneAnim = clip.BoneAnimations[i];
-                    out[i].Translation = AnimatedModel::SampleBonePosition(boneAnim.PositionKeys, timeSeconds);
-                    out[i].Rotation = AnimatedModel::SampleBoneRotation(boneAnim.RotationKeys, timeSeconds);
-                    out[i].Scale = AnimatedModel::SampleBoneScale(boneAnim.ScaleKeys, timeSeconds);
-                }
-            }
-        }
-    } // namespace
-
     void AnimationState::Evaluate(f32 normalizedTime, const AnimationParameterSet& params,
-                                  sizet boneCount,
+                                  sizet boneCount, const PoseEvalContext& ctx,
                                   std::vector<BoneTransform>& outBoneTransforms) const
     {
         OLO_PROFILE_FUNCTION();
@@ -39,27 +15,29 @@ namespace OloEngine
             {
                 if (!Clip)
                 {
-                    outBoneTransforms.assign(boneCount, BoneTransform{});
+                    BlendTree::FillBindPose(ctx, boneCount, outBoneTransforms);
                     return;
                 }
-                SampleClipIntoPose(*Clip, normalizedTime, boneCount, outBoneTransforms);
+                // Sample by bone NAME with a bind-pose fallback (issue #543);
+                // shares BlendTree's sampler so both graph paths behave identically.
+                BlendTree::SampleClipBoneTransforms(Clip, normalizedTime * Clip->Duration, boneCount, ctx, outBoneTransforms);
                 break;
             }
             case MotionType::BlendTree:
             {
                 if (!Tree)
                 {
-                    outBoneTransforms.assign(boneCount, BoneTransform{});
+                    BlendTree::FillBindPose(ctx, boneCount, outBoneTransforms);
                     return;
                 }
-                Tree->Evaluate(normalizedTime, params, boneCount, outBoneTransforms);
+                Tree->Evaluate(normalizedTime, params, boneCount, ctx, outBoneTransforms);
                 break;
             }
             default:
             {
-                // Unknown motion type — emit identity transforms so the output is
+                // Unknown motion type — emit bind-pose transforms so the output is
                 // always fully initialised for the caller.
-                outBoneTransforms.assign(boneCount, BoneTransform{});
+                BlendTree::FillBindPose(ctx, boneCount, outBoneTransforms);
                 break;
             }
         }

--- a/OloEngine/src/OloEngine/Animation/AnimationState.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationState.h
@@ -34,7 +34,7 @@ namespace OloEngine
         Ref<BlendTree> Tree;
 
         void Evaluate(f32 normalizedTime, const AnimationParameterSet& params,
-                      sizet boneCount,
+                      sizet boneCount, const PoseEvalContext& ctx,
                       std::vector<BoneTransform>& outBoneTransforms) const;
 
         [[nodiscard("clip duration needed for time calculations")]] f32 GetClipDuration() const;

--- a/OloEngine/src/OloEngine/Animation/AnimationStateMachine.cpp
+++ b/OloEngine/src/OloEngine/Animation/AnimationStateMachine.cpp
@@ -56,7 +56,7 @@ namespace OloEngine
     }
 
     void AnimationStateMachine::Update(f32 dt, AnimationParameterSet& params,
-                                       sizet boneCount,
+                                       sizet boneCount, const PoseEvalContext& ctx,
                                        std::vector<BoneTransform>& outBoneTransforms)
     {
         OLO_PROFILE_FUNCTION();
@@ -130,7 +130,7 @@ namespace OloEngine
                     {
                         normalizedTime = m_CurrentStateTime / dur;
                     }
-                    currentState->Evaluate(normalizedTime, params, boneCount, outBoneTransforms);
+                    currentState->Evaluate(normalizedTime, params, boneCount, ctx, outBoneTransforms);
                 }
                 else
                 {
@@ -152,7 +152,7 @@ namespace OloEngine
                 {
                     normalizedTime = m_CurrentStateTime / currentDuration;
                 }
-                currentState->Evaluate(normalizedTime, params, boneCount, currentTransforms);
+                currentState->Evaluate(normalizedTime, params, boneCount, ctx, currentTransforms);
             }
 
             if (targetState)
@@ -163,7 +163,7 @@ namespace OloEngine
                 {
                     normalizedTime = m_TargetStateTime / targetDuration;
                 }
-                targetState->Evaluate(normalizedTime, params, boneCount, targetTransforms);
+                targetState->Evaluate(normalizedTime, params, boneCount, ctx, targetTransforms);
             }
 
             // Blend
@@ -177,7 +177,7 @@ namespace OloEngine
         {
             normalizedTime = m_CurrentStateTime / currentDuration;
         }
-        currentState->Evaluate(normalizedTime, params, boneCount, outBoneTransforms);
+        currentState->Evaluate(normalizedTime, params, boneCount, ctx, outBoneTransforms);
 
         // Check for transitions
         CheckTransitions(params, boneCount);

--- a/OloEngine/src/OloEngine/Animation/AnimationStateMachine.h
+++ b/OloEngine/src/OloEngine/Animation/AnimationStateMachine.h
@@ -22,7 +22,7 @@ namespace OloEngine
 
         void Start(const AnimationParameterSet& params);
         void Update(f32 dt, AnimationParameterSet& params,
-                    sizet boneCount,
+                    sizet boneCount, const PoseEvalContext& ctx,
                     std::vector<BoneTransform>& outBoneTransforms);
 
         [[nodiscard("state name needed for UI or logic")]] const std::string& GetCurrentStateName() const

--- a/OloEngine/src/OloEngine/Animation/BlendNode.h
+++ b/OloEngine/src/OloEngine/Animation/BlendNode.h
@@ -5,6 +5,8 @@
 #include "OloEngine/Animation/AnimationParameter.h"
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <span>
+#include <string>
 #include <vector>
 
 namespace OloEngine
@@ -14,6 +16,25 @@ namespace OloEngine
         glm::vec3 Translation = glm::vec3(0.0f);
         glm::quat Rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
         glm::vec3 Scale = glm::vec3(1.0f);
+    };
+
+    // Per-skeleton context threaded through the animation-graph pose pipeline
+    // (graph -> state machine -> state -> blend tree -> clip sampling).
+    //
+    // A clip's channels must map to skeleton bones BY NAME: channel/array order
+    // is exporter-dependent and does NOT match the skeleton's depth-first bone
+    // index order, so sampling clip.BoneAnimations[i] onto bone i scrambles the
+    // pose (issue #543). BoneNames is index-aligned to the output pose so each
+    // bone can look up its channel via AnimationClip::FindBoneAnimation.
+    //
+    // BindPose holds each bone's rest local transform; bones a clip does not
+    // animate fall back to it rather than to identity (mirrors AnimationSystem).
+    // Either span may be empty (e.g. a skeleton without a captured bind pose),
+    // in which case the corresponding fallback degrades to identity.
+    struct PoseEvalContext
+    {
+        std::span<const std::string> BoneNames;  // index-aligned to the output pose
+        std::span<const BoneTransform> BindPose; // bind-pose local TRS per bone (may be empty)
     };
 
     class BlendNode : public RefCounted

--- a/OloEngine/src/OloEngine/Animation/BlendTree.cpp
+++ b/OloEngine/src/OloEngine/Animation/BlendTree.cpp
@@ -7,15 +7,30 @@
 
 namespace OloEngine
 {
+    void BlendTree::FillBindPose(const PoseEvalContext& ctx, sizet boneCount,
+                                 std::vector<BoneTransform>& out)
+    {
+        // Fill an output pose with each bone's bind-pose local transform (or
+        // identity when no bind pose is available). Used both as the starting
+        // point of a clip sample — so bones the clip does not key rest at bind
+        // pose, not identity (#543) — and for degenerate "no animation" returns.
+        out.resize(boneCount);
+        auto bindCount = ctx.BindPose.size();
+        for (sizet i = 0; i < boneCount; ++i)
+        {
+            out[i] = (i < bindCount) ? ctx.BindPose[i] : BoneTransform{};
+        }
+    }
+
     void BlendTree::Evaluate(f32 normalizedTime, const AnimationParameterSet& params,
-                             sizet boneCount,
+                             sizet boneCount, const PoseEvalContext& ctx,
                              std::vector<BoneTransform>& outBoneTransforms) const
     {
         OLO_PROFILE_FUNCTION();
 
         if (Children.empty())
         {
-            outBoneTransforms.resize(boneCount);
+            FillBindPose(ctx, boneCount, outBoneTransforms);
             return;
         }
 
@@ -25,7 +40,7 @@ namespace OloEngine
             case Simple1D:
             {
                 f32 paramValue = params.GetFloat(BlendParameterX);
-                Evaluate1D(paramValue, normalizedTime, boneCount, outBoneTransforms);
+                Evaluate1D(paramValue, normalizedTime, boneCount, ctx, outBoneTransforms);
                 break;
             }
             case SimpleDirectional2D:
@@ -34,14 +49,14 @@ namespace OloEngine
             {
                 f32 paramX = params.GetFloat(BlendParameterX);
                 f32 paramY = params.GetFloat(BlendParameterY);
-                Evaluate2D(paramX, paramY, normalizedTime, boneCount, outBoneTransforms);
+                Evaluate2D(paramX, paramY, normalizedTime, boneCount, ctx, outBoneTransforms);
                 break;
             }
             default:
             {
-                // Unknown blend type — emit default transforms so the output is
+                // Unknown blend type — emit bind-pose transforms so the output is
                 // always sized for the caller.
-                outBoneTransforms.resize(boneCount);
+                FillBindPose(ctx, boneCount, outBoneTransforms);
                 break;
             }
         }
@@ -197,7 +212,7 @@ namespace OloEngine
     }
 
     void BlendTree::Evaluate1D(f32 paramValue, f32 normalizedTime, sizet boneCount,
-                               std::vector<BoneTransform>& out) const
+                               const PoseEvalContext& ctx, std::vector<BoneTransform>& out) const
     {
         OLO_PROFILE_FUNCTION();
 
@@ -207,7 +222,7 @@ namespace OloEngine
 
         if (!selection.HasPlayable)
         {
-            out.resize(boneCount);
+            FillBindPose(ctx, boneCount, out);
             return;
         }
 
@@ -215,7 +230,7 @@ namespace OloEngine
         {
             auto const& child = Children[selection.IndexA];
             f32 timeSeconds = normalizedTime * child.Clip->Duration;
-            SampleClipBoneTransforms(child.Clip, timeSeconds, boneCount, out);
+            SampleClipBoneTransforms(child.Clip, timeSeconds, boneCount, ctx, out);
             return;
         }
 
@@ -228,14 +243,14 @@ namespace OloEngine
         f32 timeA = normalizedTime * childA.Clip->Duration;
         f32 timeB = normalizedTime * childB.Clip->Duration;
 
-        SampleClipBoneTransforms(childA.Clip, timeA, boneCount, transformsA);
-        SampleClipBoneTransforms(childB.Clip, timeB, boneCount, transformsB);
+        SampleClipBoneTransforms(childA.Clip, timeA, boneCount, ctx, transformsA);
+        SampleClipBoneTransforms(childB.Clip, timeB, boneCount, ctx, transformsB);
 
         BlendBoneTransforms(transformsA, transformsB, selection.Weight, out);
     }
 
     void BlendTree::Evaluate2D(f32 paramX, f32 paramY, f32 normalizedTime, sizet boneCount,
-                               std::vector<BoneTransform>& out) const
+                               const PoseEvalContext& ctx, std::vector<BoneTransform>& out) const
     {
         OLO_PROFILE_FUNCTION();
 
@@ -257,7 +272,7 @@ namespace OloEngine
             {
                 // Exact match - use this child exclusively
                 f32 timeSeconds = normalizedTime * Children[i].Clip->Duration;
-                SampleClipBoneTransforms(Children[i].Clip, timeSeconds, boneCount, out);
+                SampleClipBoneTransforms(Children[i].Clip, timeSeconds, boneCount, ctx, out);
                 return;
             }
             weights[i] = 1.0f / (dist * dist);
@@ -271,6 +286,13 @@ namespace OloEngine
             {
                 w /= totalWeight;
             }
+        }
+
+        // No playable child contributed — rest at bind pose (not identity).
+        if (totalWeight <= 0.0f)
+        {
+            FillBindPose(ctx, boneCount, out);
+            return;
         }
 
         // Blend all children by weight using cumulative-weight slerp for rotations
@@ -288,7 +310,7 @@ namespace OloEngine
             f32 clipDur = Children[i].Clip ? Children[i].Clip->Duration : 0.0f;
             // Speed is already factored into GetDuration (and thus normalizedTime)
             f32 timeSeconds = normalizedTime * clipDur;
-            SampleClipBoneTransforms(Children[i].Clip, timeSeconds, boneCount, childTransforms);
+            SampleClipBoneTransforms(Children[i].Clip, timeSeconds, boneCount, ctx, childTransforms);
 
             accumulatedWeight += weights[i];
 
@@ -317,24 +339,33 @@ namespace OloEngine
     }
 
     void BlendTree::SampleClipBoneTransforms(const Ref<AnimationClip>& clip, f32 timeSeconds,
-                                             sizet boneCount,
+                                             sizet boneCount, const PoseEvalContext& ctx,
                                              std::vector<BoneTransform>& out)
     {
         OLO_PROFILE_FUNCTION();
 
-        out.resize(boneCount);
+        // Start every bone at its bind-pose local transform so bones the clip
+        // does not animate keep their rest pose instead of snapping to identity
+        // (mirrors AnimationSystem's bind-pose reset — issue #543).
+        FillBindPose(ctx, boneCount, out);
         if (!clip)
         {
             return;
         }
 
-        auto boneAnimCount = clip->BoneAnimations.size();
-        for (sizet i = 0; i < boneCount && i < boneAnimCount; ++i)
+        // Map each skeleton bone to its clip channel BY NAME. Clip channel order
+        // is exporter-dependent and does not match the skeleton's DFS bone index
+        // order, so the old clip.BoneAnimations[i] -> bone i fill wrote each
+        // channel onto the wrong bone on any real imported rig (issue #543).
+        auto boneNameCount = ctx.BoneNames.size();
+        for (sizet i = 0; i < boneCount && i < boneNameCount; ++i)
         {
-            auto const& boneAnim = clip->BoneAnimations[i];
-            out[i].Translation = AnimatedModel::SampleBonePosition(boneAnim.PositionKeys, timeSeconds);
-            out[i].Rotation = AnimatedModel::SampleBoneRotation(boneAnim.RotationKeys, timeSeconds);
-            out[i].Scale = AnimatedModel::SampleBoneScale(boneAnim.ScaleKeys, timeSeconds);
+            if (const auto* boneAnim = clip->FindBoneAnimation(ctx.BoneNames[i]); boneAnim)
+            {
+                out[i].Translation = AnimatedModel::SampleBonePosition(boneAnim->PositionKeys, timeSeconds);
+                out[i].Rotation = AnimatedModel::SampleBoneRotation(boneAnim->RotationKeys, timeSeconds);
+                out[i].Scale = AnimatedModel::SampleBoneScale(boneAnim->ScaleKeys, timeSeconds);
+            }
         }
     }
 

--- a/OloEngine/src/OloEngine/Animation/BlendTree.h
+++ b/OloEngine/src/OloEngine/Animation/BlendTree.h
@@ -39,23 +39,31 @@ namespace OloEngine
         std::vector<BlendChild> Children;
 
         void Evaluate(f32 normalizedTime, const AnimationParameterSet& params,
-                      sizet boneCount,
+                      sizet boneCount, const PoseEvalContext& ctx,
                       std::vector<BoneTransform>& outBoneTransforms) const;
 
         [[nodiscard("duration needed for time normalization")]] f32 GetDuration(const AnimationParameterSet& params) const;
 
-        // Static blend utilities - used by BlendTree and AnimationStateMachine
+        // Static blend utilities - used by BlendTree and AnimationStateMachine.
+        // SampleClipBoneTransforms maps clip channels to bones BY NAME via ctx
+        // (not by array index) and fills un-keyed bones from ctx.BindPose (#543).
         static void SampleClipBoneTransforms(const Ref<AnimationClip>& clip, f32 timeSeconds,
-                                             sizet boneCount,
+                                             sizet boneCount, const PoseEvalContext& ctx,
                                              std::vector<BoneTransform>& out);
         static void BlendBoneTransforms(const std::vector<BoneTransform>& a,
                                         const std::vector<BoneTransform>& b,
                                         f32 weight, std::vector<BoneTransform>& out);
 
+        // Fill out with each bone's bind-pose local transform from ctx (or
+        // identity when ctx.BindPose is empty). Used as the rest-pose baseline
+        // for clip sampling and for "no animation" fallbacks (issue #543).
+        static void FillBindPose(const PoseEvalContext& ctx, sizet boneCount,
+                                 std::vector<BoneTransform>& out);
+
       private:
         void Evaluate1D(f32 paramValue, f32 normalizedTime, sizet boneCount,
-                        std::vector<BoneTransform>& out) const;
+                        const PoseEvalContext& ctx, std::vector<BoneTransform>& out) const;
         void Evaluate2D(f32 paramX, f32 paramY, f32 normalizedTime, sizet boneCount,
-                        std::vector<BoneTransform>& out) const;
+                        const PoseEvalContext& ctx, std::vector<BoneTransform>& out) const;
     };
 } // namespace OloEngine

--- a/OloEngine/tests/Animation/AnimationGraphBoneMappingTest.cpp
+++ b/OloEngine/tests/Animation/AnimationGraphBoneMappingTest.cpp
@@ -23,30 +23,16 @@
 #include "OloEngine/Animation/AnimationClip.h"
 #include "OloEngine/Animation/BlendNode.h"
 #include "OloEngine/Core/Ref.h"
+#include "Animation/AnimationTestHelpers.h"
 
 #include <string>
 #include <vector>
 
 using namespace OloEngine;
+using OloEngine::AnimTest::MakeConstantChannel;
 
 namespace
 {
-    // A clip channel that holds a constant translation across the whole clip, so
-    // sampling at any time yields exactly that translation — makes the bone a
-    // channel lands on unambiguous.
-    BoneAnimation MakeConstantChannel(const std::string& boneName, const glm::vec3& translation)
-    {
-        BoneAnimation anim;
-        anim.BoneName = boneName;
-        anim.PositionKeys.push_back({ 0.0, translation });
-        anim.PositionKeys.push_back({ 1.0, translation });
-        anim.RotationKeys.push_back({ 0.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
-        anim.RotationKeys.push_back({ 1.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
-        anim.ScaleKeys.push_back({ 0.0, glm::vec3(1.0f) });
-        anim.ScaleKeys.push_back({ 1.0, glm::vec3(1.0f) });
-        return anim;
-    }
-
     // Skeleton bone order (depth-first): Hips(0), Spine(1), Head(2).
     const std::vector<std::string> kBoneNames = { "Hips", "Spine", "Head" };
 

--- a/OloEngine/tests/Animation/AnimationGraphBoneMappingTest.cpp
+++ b/OloEngine/tests/Animation/AnimationGraphBoneMappingTest.cpp
@@ -1,0 +1,236 @@
+// OLO_TEST_LAYER: unit
+//
+// Regression tests for issue #543: the animation-graph pose pipeline
+// (AnimationGraphComponent -> state machine -> state -> blend tree) used to map
+// a clip's channels to skeleton bones BY ARRAY INDEX (out[i] = clip.BoneAnimations[i]).
+// That invariant does not hold for imported rigs — a clip's channel order is
+// exporter-dependent and covers only the animated subset of nodes, while skeleton
+// bone indices come from a depth-first traversal — so every channel landed on the
+// wrong bone (head rotation on a leg) and un-keyed bones snapped to identity.
+//
+// The fix maps by bone NAME (via PoseEvalContext) and falls back to the bind-pose
+// local transform for bones a clip does not animate. The fixtures below build a
+// clip whose channel order deliberately DIFFERS from the skeleton bone order — the
+// case the old single-"Bone0" fixtures (BlendTreeTest / AnimationStateMachineTest)
+// could never catch because there index trivially equalled name.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Animation/BlendTree.h"
+#include "OloEngine/Animation/AnimationState.h"
+#include "OloEngine/Animation/AnimationStateMachine.h"
+#include "OloEngine/Animation/AnimationClip.h"
+#include "OloEngine/Animation/BlendNode.h"
+#include "OloEngine/Core/Ref.h"
+
+#include <string>
+#include <vector>
+
+using namespace OloEngine;
+
+namespace
+{
+    // A clip channel that holds a constant translation across the whole clip, so
+    // sampling at any time yields exactly that translation — makes the bone a
+    // channel lands on unambiguous.
+    BoneAnimation MakeConstantChannel(const std::string& boneName, const glm::vec3& translation)
+    {
+        BoneAnimation anim;
+        anim.BoneName = boneName;
+        anim.PositionKeys.push_back({ 0.0, translation });
+        anim.PositionKeys.push_back({ 1.0, translation });
+        anim.RotationKeys.push_back({ 0.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.RotationKeys.push_back({ 1.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.ScaleKeys.push_back({ 0.0, glm::vec3(1.0f) });
+        anim.ScaleKeys.push_back({ 1.0, glm::vec3(1.0f) });
+        return anim;
+    }
+
+    // Skeleton bone order (depth-first): Hips(0), Spine(1), Head(2).
+    const std::vector<std::string> kBoneNames = { "Hips", "Spine", "Head" };
+
+    // Distinctive bind-pose translations so an un-keyed bone (Spine) is
+    // distinguishable from both identity and any animated channel.
+    std::vector<BoneTransform> MakeBindPose()
+    {
+        std::vector<BoneTransform> bind(3);
+        bind[0].Translation = glm::vec3(0.1f, 0.0f, 0.0f); // Hips
+        bind[1].Translation = glm::vec3(0.2f, 0.0f, 0.0f); // Spine
+        bind[2].Translation = glm::vec3(0.3f, 0.0f, 0.0f); // Head
+        return bind;
+    }
+
+    // A clip whose channels are stored in a DIFFERENT order than the skeleton
+    // (Head first, then Hips) and which omits Spine entirely. Under the old
+    // index-based mapping this put Head's anim on Hips, Hips' anim on Spine, and
+    // left Head at identity.
+    Ref<AnimationClip> MakeScrambledOrderClip(const std::string& name = "Clip")
+    {
+        auto clip = Ref<AnimationClip>::Create();
+        clip->Name = name;
+        clip->Duration = 1.0f;
+        clip->BoneAnimations.push_back(MakeConstantChannel("Head", glm::vec3(30.0f, 0.0f, 0.0f)));
+        clip->BoneAnimations.push_back(MakeConstantChannel("Hips", glm::vec3(10.0f, 0.0f, 0.0f)));
+        clip->InitializeBoneCache();
+        return clip;
+    }
+
+    // The expectation shared by every path: each channel lands on its NAMED bone,
+    // and the un-keyed Spine keeps its bind pose (not identity).
+    void ExpectByNameMapping(const std::vector<BoneTransform>& pose)
+    {
+        ASSERT_EQ(pose.size(), 3u);
+        EXPECT_NEAR(pose[0].Translation.x, 10.0f, 1e-4f) << "Hips must sample the Hips channel";
+        EXPECT_NEAR(pose[1].Translation.x, 0.2f, 1e-4f) << "Un-keyed Spine must fall back to bind pose";
+        EXPECT_NEAR(pose[2].Translation.x, 30.0f, 1e-4f) << "Head must sample the Head channel";
+    }
+} // namespace
+
+// The lowest level: the shared static sampler. This is the exact site the bug
+// lived in (was clip.BoneAnimations[i] -> bone i).
+TEST(AnimationGraphBoneMappingTest, SampleClipBoneTransforms_MapsByName_NotIndex)
+{
+    auto clip = MakeScrambledOrderClip();
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    std::vector<BoneTransform> pose;
+    BlendTree::SampleClipBoneTransforms(clip, 0.0f, kBoneNames.size(), ctx, pose);
+
+    ExpectByNameMapping(pose);
+}
+
+// With no bind pose supplied, un-keyed bones degrade to identity (not garbage).
+TEST(AnimationGraphBoneMappingTest, SampleClipBoneTransforms_NoBindPose_UnkeyedBoneIsIdentity)
+{
+    auto clip = MakeScrambledOrderClip();
+    const PoseEvalContext ctx{ kBoneNames, {} };
+
+    std::vector<BoneTransform> pose;
+    BlendTree::SampleClipBoneTransforms(clip, 0.0f, kBoneNames.size(), ctx, pose);
+
+    ASSERT_EQ(pose.size(), 3u);
+    EXPECT_NEAR(pose[0].Translation.x, 10.0f, 1e-4f); // Hips channel
+    EXPECT_NEAR(pose[1].Translation.x, 0.0f, 1e-4f);  // Spine -> identity fallback
+    EXPECT_NEAR(pose[2].Translation.x, 30.0f, 1e-4f); // Head channel
+}
+
+// The AnimationState.cpp path (MotionType::SingleClip) — previously its own
+// index-based SampleClipIntoPose helper.
+TEST(AnimationGraphBoneMappingTest, AnimationState_SingleClip_MapsByName)
+{
+    AnimationState state;
+    state.Name = "Clip";
+    state.Type = AnimationState::MotionType::SingleClip;
+    state.Clip = MakeScrambledOrderClip();
+
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    AnimationParameterSet params;
+    std::vector<BoneTransform> pose;
+    state.Evaluate(0.0f, params, kBoneNames.size(), ctx, pose);
+
+    ExpectByNameMapping(pose);
+}
+
+// A SingleClip state with no clip must rest at bind pose, not collapse to identity.
+TEST(AnimationGraphBoneMappingTest, AnimationState_NullClip_FallsBackToBindPose)
+{
+    AnimationState state;
+    state.Type = AnimationState::MotionType::SingleClip;
+    // Clip intentionally left null.
+
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    AnimationParameterSet params;
+    std::vector<BoneTransform> pose;
+    state.Evaluate(0.0f, params, kBoneNames.size(), ctx, pose);
+
+    ASSERT_EQ(pose.size(), 3u);
+    EXPECT_NEAR(pose[0].Translation.x, 0.1f, 1e-4f);
+    EXPECT_NEAR(pose[1].Translation.x, 0.2f, 1e-4f);
+    EXPECT_NEAR(pose[2].Translation.x, 0.3f, 1e-4f);
+}
+
+// The BlendTree.cpp path — a 1D tree with a single child routes through
+// Evaluate1D -> SampleClipBoneTransforms.
+TEST(AnimationGraphBoneMappingTest, BlendTree_SingleChild_MapsByName)
+{
+    BlendTree tree;
+    tree.Type = BlendTree::BlendType::Simple1D;
+    tree.BlendParameterX = "Speed";
+    tree.Children.push_back({ MakeScrambledOrderClip(), 0.0f, {}, 1.0f });
+
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    AnimationParameterSet params;
+    params.DefineFloat("Speed", 0.0f);
+
+    std::vector<BoneTransform> pose;
+    tree.Evaluate(0.0f, params, kBoneNames.size(), ctx, pose);
+
+    ExpectByNameMapping(pose);
+}
+
+// A 1D blend between two clips: both children carry the SAME per-name channels,
+// so the by-name-blended result equals the per-bone values (and the un-keyed
+// Spine stays at bind pose through the blend). A blend of two scrambled-order
+// clips would still scramble under the old index mapping.
+TEST(AnimationGraphBoneMappingTest, BlendTree_BlendedChildren_MapByName)
+{
+    auto clipA = MakeScrambledOrderClip("A");
+    // clipB stores channels in yet another order (Hips first) to prove neither
+    // child's array order leaks into the mapping.
+    auto clipB = Ref<AnimationClip>::Create();
+    clipB->Name = "B";
+    clipB->Duration = 1.0f;
+    clipB->BoneAnimations.push_back(MakeConstantChannel("Hips", glm::vec3(10.0f, 0.0f, 0.0f)));
+    clipB->BoneAnimations.push_back(MakeConstantChannel("Head", glm::vec3(30.0f, 0.0f, 0.0f)));
+    clipB->InitializeBoneCache();
+
+    BlendTree tree;
+    tree.Type = BlendTree::BlendType::Simple1D;
+    tree.BlendParameterX = "Speed";
+    tree.Children.push_back({ clipA, 0.0f, {}, 1.0f });
+    tree.Children.push_back({ clipB, 1.0f, {}, 1.0f });
+
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    AnimationParameterSet params;
+    params.DefineFloat("Speed", 0.5f); // 50/50 blend of two identical-by-name poses
+
+    std::vector<BoneTransform> pose;
+    tree.Evaluate(0.0f, params, kBoneNames.size(), ctx, pose);
+
+    ExpectByNameMapping(pose);
+}
+
+// End-to-end through the state machine (the object AnimationGraph drives per
+// layer): the ctx must be threaded all the way from Update down to the sampler.
+TEST(AnimationGraphBoneMappingTest, StateMachine_ThreadsContext_MapsByName)
+{
+    AnimationStateMachine sm;
+
+    AnimationState state;
+    state.Name = "Clip";
+    state.Type = AnimationState::MotionType::SingleClip;
+    state.Clip = MakeScrambledOrderClip();
+    sm.AddState(state);
+    sm.SetDefaultState("Clip");
+
+    auto bind = MakeBindPose();
+    const PoseEvalContext ctx{ kBoneNames, bind };
+
+    AnimationParameterSet params;
+    sm.Start(params);
+
+    std::vector<BoneTransform> pose;
+    sm.Update(0.0f, params, kBoneNames.size(), ctx, pose);
+
+    ExpectByNameMapping(pose);
+}

--- a/OloEngine/tests/Animation/AnimationTestHelpers.h
+++ b/OloEngine/tests/Animation/AnimationTestHelpers.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// =============================================================================
+// AnimationTestHelpers.h — small shared helpers for the animation-graph tests
+// (unit and functional). Keep this additive and dependency-light: only helpers
+// used by more than one animation test file belong here.
+// =============================================================================
+
+#include "OloEngine/Animation/AnimationClip.h" // BoneAnimation
+#include "OloEngine/Animation/BlendNode.h"     // BoneTransform, PoseEvalContext
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <string>
+#include <vector>
+
+namespace OloEngine::AnimTest
+{
+    // A clip channel that holds a constant translation across the whole clip, so
+    // sampling at any time yields exactly that translation — makes the bone a
+    // channel lands on unambiguous.
+    inline BoneAnimation MakeConstantChannel(const std::string& boneName, const glm::vec3& translation)
+    {
+        BoneAnimation anim;
+        anim.BoneName = boneName;
+        anim.PositionKeys.push_back({ 0.0, translation });
+        anim.PositionKeys.push_back({ 1.0, translation });
+        anim.RotationKeys.push_back({ 0.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.RotationKeys.push_back({ 1.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.ScaleKeys.push_back({ 0.0, glm::vec3(1.0f) });
+        anim.ScaleKeys.push_back({ 1.0, glm::vec3(1.0f) });
+        return anim;
+    }
+
+    // Single-"Bone0" sampling context shared by the single-bone fixtures in
+    // BlendTreeTest / AnimationStateMachineTest: bone 0 is named "Bone0", so
+    // by-name sampling reduces to the historical index-0 behaviour there.
+    // inline so the PoseEvalContext's span refers to one program-wide names
+    // instance across every including TU.
+    inline const std::vector<std::string> s_Bone0Names = { "Bone0" };
+    inline const PoseEvalContext s_Bone0Ctx{ s_Bone0Names, {} };
+} // namespace OloEngine::AnimTest

--- a/OloEngine/tests/AnimationStateMachineTest.cpp
+++ b/OloEngine/tests/AnimationStateMachineTest.cpp
@@ -10,6 +10,12 @@
 
 using namespace OloEngine;
 
+// Single-bone sampling context: bone 0 is named "Bone0" (matching CreateTestClip's
+// channel), so by-name mapping resolves to the historical index-0 behaviour. The
+// channel-order regression for #543 lives in Animation/AnimationGraphBoneMappingTest.cpp.
+static const std::vector<std::string> s_Bone0Names = { "Bone0" };
+static const PoseEvalContext s_Bone0Ctx{ s_Bone0Names, {} };
+
 // Helper to create a simple animation clip with one bone
 static Ref<AnimationClip> CreateTestClip(const std::string& name, float duration,
                                          const glm::vec3& startPos = glm::vec3(0.0f),
@@ -199,17 +205,17 @@ TEST(AnimationStateMachineTest, BasicTransition)
 
     // Speed below threshold - should stay in Idle
     std::vector<BoneTransform> bones;
-    sm.Update(0.1f, params, 1, bones);
+    sm.Update(0.1f, params, 1, s_Bone0Ctx, bones);
     EXPECT_EQ(sm.GetCurrentStateName(), "Idle");
     EXPECT_FALSE(sm.IsInTransition());
 
     // Set speed above threshold
     params.SetFloat("Speed", 0.5f);
-    sm.Update(0.1f, params, 1, bones);
+    sm.Update(0.1f, params, 1, s_Bone0Ctx, bones);
     EXPECT_TRUE(sm.IsInTransition());
 
     // Complete the transition
-    sm.Update(0.3f, params, 1, bones);
+    sm.Update(0.3f, params, 1, s_Bone0Ctx, bones);
     EXPECT_EQ(sm.GetCurrentStateName(), "Walk");
     EXPECT_FALSE(sm.IsInTransition());
 }
@@ -260,11 +266,11 @@ TEST(AnimationStateMachineTest, AnyStateTransition)
     // Trigger jump from any state
     params.SetTrigger("Jump");
     std::vector<BoneTransform> bones;
-    sm.Update(0.01f, params, 1, bones);
+    sm.Update(0.01f, params, 1, s_Bone0Ctx, bones);
     EXPECT_TRUE(sm.IsInTransition());
 
     // Complete transition
-    sm.Update(0.15f, params, 1, bones);
+    sm.Update(0.15f, params, 1, s_Bone0Ctx, bones);
     EXPECT_EQ(sm.GetCurrentStateName(), "Jump");
 
     // Trigger should have been consumed
@@ -306,12 +312,12 @@ TEST(AnimationStateMachineTest, ExitTimeTransition)
     std::vector<BoneTransform> bones;
 
     // Before exit time
-    sm.Update(0.5f, params, 1, bones);
+    sm.Update(0.5f, params, 1, s_Bone0Ctx, bones);
     EXPECT_EQ(sm.GetCurrentStateName(), "Attack");
     EXPECT_FALSE(sm.IsInTransition());
 
     // At exit time (0.8)
-    sm.Update(0.35f, params, 1, bones);
+    sm.Update(0.35f, params, 1, s_Bone0Ctx, bones);
     EXPECT_TRUE(sm.IsInTransition());
 }
 
@@ -354,12 +360,12 @@ TEST(AnimationStateMachineTest, CrossFadeBlending)
     std::vector<BoneTransform> bones;
 
     // Trigger transition
-    sm.Update(0.01f, params, 1, bones);
+    sm.Update(0.01f, params, 1, s_Bone0Ctx, bones);
     EXPECT_TRUE(sm.IsInTransition());
     EXPECT_EQ(bones.size(), 1u);
 
     // Mid-transition - should produce blended bone transforms
-    sm.Update(0.25f, params, 1, bones);
+    sm.Update(0.25f, params, 1, s_Bone0Ctx, bones);
     EXPECT_TRUE(sm.IsInTransition());
     EXPECT_EQ(bones.size(), 1u);
     // Blended between idle (x=0) and walk (x=10) — result should be between 0 and 10
@@ -367,7 +373,7 @@ TEST(AnimationStateMachineTest, CrossFadeBlending)
     EXPECT_LT(bones[0].Translation.x, 10.0f);
 
     // Complete transition
-    sm.Update(0.5f, params, 1, bones);
+    sm.Update(0.5f, params, 1, s_Bone0Ctx, bones);
     EXPECT_EQ(sm.GetCurrentStateName(), "Walk");
     EXPECT_FALSE(sm.IsInTransition());
 }

--- a/OloEngine/tests/AnimationStateMachineTest.cpp
+++ b/OloEngine/tests/AnimationStateMachineTest.cpp
@@ -7,14 +7,14 @@
 #include "OloEngine/Animation/AnimationParameter.h"
 #include "OloEngine/Animation/BlendNode.h"
 #include "OloEngine/Animation/AnimationClip.h"
+#include "Animation/AnimationTestHelpers.h"
 
 using namespace OloEngine;
 
 // Single-bone sampling context: bone 0 is named "Bone0" (matching CreateTestClip's
 // channel), so by-name mapping resolves to the historical index-0 behaviour. The
 // channel-order regression for #543 lives in Animation/AnimationGraphBoneMappingTest.cpp.
-static const std::vector<std::string> s_Bone0Names = { "Bone0" };
-static const PoseEvalContext s_Bone0Ctx{ s_Bone0Names, {} };
+using OloEngine::AnimTest::s_Bone0Ctx;
 
 // Helper to create a simple animation clip with one bone
 static Ref<AnimationClip> CreateTestClip(const std::string& name, float duration,

--- a/OloEngine/tests/BlendTreeTest.cpp
+++ b/OloEngine/tests/BlendTreeTest.cpp
@@ -8,6 +8,13 @@
 
 using namespace OloEngine;
 
+// These fixtures use a single "Bone0" clip where the channel index trivially
+// equals the bone-name order, so the by-name sampling context below reduces to
+// the historical index-0 behaviour. The dedicated channel-order regression for
+// issue #543 lives in Animation/AnimationGraphBoneMappingTest.cpp.
+static const std::vector<std::string> s_Bone0Names = { "Bone0" };
+static const PoseEvalContext s_Bone0Ctx{ s_Bone0Names, {} };
+
 // Helper to create a simple animation clip for blend tree testing
 static Ref<AnimationClip> CreateBlendTestClip(const std::string& name, float duration, const glm::vec3& startPos, const glm::vec3& endPos)
 {
@@ -51,7 +58,7 @@ TEST(BlendTreeTest, Simple1D_AtFirstThreshold)
     params.DefineFloat("Speed", 0.0f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // At Speed=0, should be 100% idle (position = 0,0,0 at t=0)
     EXPECT_NEAR(result[0].Translation.x, 0.0f, 0.01f);
@@ -75,7 +82,7 @@ TEST(BlendTreeTest, Simple1D_AtMidThreshold)
     params.DefineFloat("Speed", 0.5f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // At Speed=0.5, should be 100% walk (position = 1,0,0 at t=0)
     EXPECT_NEAR(result[0].Translation.x, 1.0f, 0.01f);
@@ -97,7 +104,7 @@ TEST(BlendTreeTest, Simple1D_BetweenThresholds)
     params.DefineFloat("Speed", 0.5f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // At Speed=0.5, should be 50% idle (0) + 50% walk (2) = 1
     EXPECT_NEAR(result[0].Translation.x, 1.0f, 0.01f);
@@ -119,7 +126,7 @@ TEST(BlendTreeTest, Simple1D_AtLastThreshold)
     params.DefineFloat("Speed", 1.0f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // At Speed=1, should be 100% run (position = 4,0,0 at t=0)
     EXPECT_NEAR(result[0].Translation.x, 4.0f, 0.01f);
@@ -141,7 +148,7 @@ TEST(BlendTreeTest, Simple1D_ClampBelowFirst)
     params.DefineFloat("Speed", -0.5f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // Below first threshold, should clamp to idle
     EXPECT_NEAR(result[0].Translation.x, 0.0f, 0.01f);
@@ -163,7 +170,7 @@ TEST(BlendTreeTest, Simple1D_ClampAboveLast)
     params.DefineFloat("Speed", 1.5f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // Above last threshold, should clamp to walk
     EXPECT_NEAR(result[0].Translation.x, 2.0f, 0.01f);
@@ -191,7 +198,7 @@ TEST(BlendTreeTest, SimpleDirectional2D_AtChild)
     params.DefineFloat("VelocityZ", 1.0f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // Exactly on the Forward child, should be 100% forward
     // With inverse distance weighting, when exactly on a point, that point gets full weight
@@ -212,7 +219,7 @@ TEST(BlendTreeTest, EmptyBlendTree)
     params.DefineFloat("Speed", 0.5f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     // Empty tree should produce identity bone transforms sized to boneCount
     EXPECT_EQ(result.size(), 1u);
 }
@@ -231,7 +238,7 @@ TEST(BlendTreeTest, SingleChild)
     params.DefineFloat("Speed", 0.0f);
 
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     // Single child should get full weight regardless of parameter
     EXPECT_NEAR(result[0].Translation.x, 3.0f, 0.01f);
@@ -280,7 +287,7 @@ TEST(BlendTreeTest, Simple1D_UnboundParam_DurationMatchesEvaluatedPose)
 
     // Evaluate samples the lowest-threshold child (First, x=10), not the 2.0s average child.
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     EXPECT_NEAR(result[0].Translation.x, 10.0f, 0.01f);
 
@@ -313,7 +320,7 @@ TEST(BlendTreeTest, Simple1D_NonPlayableMiddleChild_DurationMatchesEvaluatedPose
     // Evaluate skips the null middle child and blends First<->Last at t=0.5:
     // x = mix(10, 30, 0.5) = 20.
     std::vector<BoneTransform> result;
-    tree.Evaluate(0.0f, params, 1, result);
+    tree.Evaluate(0.0f, params, 1, s_Bone0Ctx, result);
     ASSERT_EQ(result.size(), 1u);
     EXPECT_NEAR(result[0].Translation.x, 20.0f, 0.01f);
 

--- a/OloEngine/tests/BlendTreeTest.cpp
+++ b/OloEngine/tests/BlendTreeTest.cpp
@@ -5,15 +5,16 @@
 #include "OloEngine/Animation/AnimationParameter.h"
 #include "OloEngine/Animation/AnimationClip.h"
 #include "OloEngine/Animation/BlendNode.h"
+#include "Animation/AnimationTestHelpers.h"
 
 using namespace OloEngine;
 
 // These fixtures use a single "Bone0" clip where the channel index trivially
-// equals the bone-name order, so the by-name sampling context below reduces to
-// the historical index-0 behaviour. The dedicated channel-order regression for
-// issue #543 lives in Animation/AnimationGraphBoneMappingTest.cpp.
-static const std::vector<std::string> s_Bone0Names = { "Bone0" };
-static const PoseEvalContext s_Bone0Ctx{ s_Bone0Names, {} };
+// equals the bone-name order, so the shared s_Bone0Ctx (by-name) sampling
+// context reduces to the historical index-0 behaviour. The dedicated
+// channel-order regression for issue #543 lives in
+// Animation/AnimationGraphBoneMappingTest.cpp.
+using OloEngine::AnimTest::s_Bone0Ctx;
 
 // Helper to create a simple animation clip for blend tree testing
 static Ref<AnimationClip> CreateBlendTestClip(const std::string& name, float duration, const glm::vec3& startPos, const glm::vec3& endPos)

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -290,6 +290,7 @@ add_executable(OloEngine-Tests
 		Animation/SpringBoneSolverTest.cpp
 		Animation/NoiseSolverTest.cpp
 		Animation/AnimationRetargetTest.cpp
+		Animation/AnimationGraphBoneMappingTest.cpp
 		# Cinematic Sequencer Tests
 		Cinematic/CinematicCurveTest.cpp
 		Cinematic/CinematicPlayerTest.cpp

--- a/OloEngine/tests/Functional/AnimationPhysics/AnimationGraphStateMachineTickTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/AnimationGraphStateMachineTickTest.cpp
@@ -30,6 +30,7 @@
 #include "OloEngine/Animation/AnimationState.h"
 #include "OloEngine/Animation/AnimationLayer.h"
 #include "OloEngine/Animation/Skeleton.h"
+#include "Animation/AnimationTestHelpers.h"
 
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -121,19 +122,7 @@ TEST_F(AnimationGraphStateMachineTickTest, RuntimeGraphIsStartedAndCurrentStateM
 
 namespace
 {
-    // Constant-translation channel: sampling at any time yields `translation`.
-    BoneAnimation ConstantChannel(std::string boneName, const glm::vec3& translation)
-    {
-        BoneAnimation anim;
-        anim.BoneName = std::move(boneName);
-        anim.PositionKeys.push_back({ 0.0, translation });
-        anim.PositionKeys.push_back({ 1.0, translation });
-        anim.RotationKeys.push_back({ 0.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
-        anim.RotationKeys.push_back({ 1.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
-        anim.ScaleKeys.push_back({ 0.0, glm::vec3(1.0f) });
-        anim.ScaleKeys.push_back({ 1.0, glm::vec3(1.0f) });
-        return anim;
-    }
+    using OloEngine::AnimTest::MakeConstantChannel;
 
     // Attach a single-state, single-clip graph (one full-weight base layer)
     // that plays `clip` to `entity`.
@@ -178,8 +167,8 @@ class AnimationGraphBoneMappingTickTest : public FunctionalTest
         auto clip = Ref<AnimationClip>::Create();
         clip->Name = "ReverseOrder";
         clip->Duration = 1.0f;
-        clip->BoneAnimations.push_back(ConstantChannel("Child", glm::vec3(0.0f, 20.0f, 0.0f)));
-        clip->BoneAnimations.push_back(ConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
+        clip->BoneAnimations.push_back(MakeConstantChannel("Child", glm::vec3(0.0f, 20.0f, 0.0f)));
+        clip->BoneAnimations.push_back(MakeConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
         clip->InitializeBoneCache();
 
         m_Animated = GetScene().CreateEntity("Animated");
@@ -223,7 +212,7 @@ class AnimationGraphUnkeyedBindPoseTickTest : public FunctionalTest
         auto clip = Ref<AnimationClip>::Create();
         clip->Name = "RootOnly";
         clip->Duration = 1.0f;
-        clip->BoneAnimations.push_back(ConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
+        clip->BoneAnimations.push_back(MakeConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
         clip->InitializeBoneCache();
 
         m_Animated = GetScene().CreateEntity("Animated");

--- a/OloEngine/tests/Functional/AnimationPhysics/AnimationGraphStateMachineTickTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/AnimationGraphStateMachineTickTest.cpp
@@ -29,6 +29,9 @@
 #include "OloEngine/Animation/AnimationStateMachine.h"
 #include "OloEngine/Animation/AnimationState.h"
 #include "OloEngine/Animation/AnimationLayer.h"
+#include "OloEngine/Animation/Skeleton.h"
+
+#include <glm/gtc/matrix_transform.hpp>
 
 using namespace OloEngine;
 using namespace OloEngine::Functional;
@@ -99,4 +102,146 @@ TEST_F(AnimationGraphStateMachineTickTest, RuntimeGraphIsStartedAndCurrentStateM
         << "current state changed without any transition configured.";
     EXPECT_FALSE(graphComp.RuntimeGraph->Layers[0].StateMachine->IsInTransition())
         << "state machine entered a transition without one being configured.";
+}
+
+// =============================================================================
+// AnimationGraphBoneMappingTickTest — Functional Test (issue #543).
+//
+// Drives the graph pose pipeline through the REAL Scene::OnUpdateRuntime ->
+// AnimationGraphSystem::Update path (Scene.cpp), which — unlike the unit tests
+// that call Evaluate() directly — also exercises the bind-pose decomposition
+// AnimationGraphSystem does before handing the graph its PoseEvalContext.
+//
+// The clip's channels are stored in the OPPOSITE order to the skeleton's bones,
+// with only one bone keyed, so the two failure modes the fix targets are both
+// observable in the ticked skeleton's local transforms:
+//   (1) by-index mapping would swap the two channels onto the wrong bones;
+//   (2) an un-keyed bone would collapse to identity instead of its bind pose.
+// =============================================================================
+
+namespace
+{
+    // Constant-translation channel: sampling at any time yields `translation`.
+    BoneAnimation ConstantChannel(std::string boneName, const glm::vec3& translation)
+    {
+        BoneAnimation anim;
+        anim.BoneName = std::move(boneName);
+        anim.PositionKeys.push_back({ 0.0, translation });
+        anim.PositionKeys.push_back({ 1.0, translation });
+        anim.RotationKeys.push_back({ 0.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.RotationKeys.push_back({ 1.0, glm::quat(1.0f, 0.0f, 0.0f, 0.0f) });
+        anim.ScaleKeys.push_back({ 0.0, glm::vec3(1.0f) });
+        anim.ScaleKeys.push_back({ 1.0, glm::vec3(1.0f) });
+        return anim;
+    }
+
+    // Attach a single-state, single-clip graph (one full-weight base layer)
+    // that plays `clip` to `entity`.
+    void AttachSingleClipGraph(Entity entity, const Ref<AnimationClip>& clip)
+    {
+        AnimationState state;
+        state.Name = "Mapping";
+        state.Type = AnimationState::MotionType::SingleClip;
+        state.Clip = clip;
+        state.Looping = true;
+
+        auto stateMachine = Ref<AnimationStateMachine>::Create();
+        stateMachine->AddState(state);
+        stateMachine->SetDefaultState("Mapping");
+
+        auto graph = Ref<AnimationGraph>::Create();
+        AnimationLayer layer;
+        layer.Name = "Base";
+        layer.StateMachine = stateMachine;
+        graph->Layers.push_back(std::move(layer));
+
+        AnimationGraphComponent graphComp;
+        graphComp.RuntimeGraph = graph;
+        entity.AddComponent<AnimationGraphComponent>(std::move(graphComp));
+    }
+
+    glm::vec3 LocalTranslation(const Ref<Skeleton>& skeleton, sizet bone)
+    {
+        return glm::vec3(skeleton->m_LocalTransforms[bone][3]);
+    }
+} // namespace
+
+// Both bones keyed, channels stored in reverse (Child channel first). After a
+// real tick each channel must land on its NAMED bone, not its array slot.
+class AnimationGraphBoneMappingTickTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Skeleton = Fixtures::MakeTwoBoneSkeleton(); // bones: Root(0), Child(1)
+
+        auto clip = Ref<AnimationClip>::Create();
+        clip->Name = "ReverseOrder";
+        clip->Duration = 1.0f;
+        clip->BoneAnimations.push_back(ConstantChannel("Child", glm::vec3(0.0f, 20.0f, 0.0f)));
+        clip->BoneAnimations.push_back(ConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
+        clip->InitializeBoneCache();
+
+        m_Animated = GetScene().CreateEntity("Animated");
+        m_Animated.AddComponent<SkeletonComponent>(m_Skeleton);
+        AttachSingleClipGraph(m_Animated, clip);
+    }
+
+    Entity m_Animated;
+    Ref<Skeleton> m_Skeleton;
+};
+
+TEST_F(AnimationGraphBoneMappingTickTest, ClipChannelsLandOnNamedBonesAfterSceneTick)
+{
+    RunFrames(3);
+
+    // Root(0) must carry the Root channel (x=10); Child(1) the Child channel
+    // (y=20). Under the old by-index fill these were swapped.
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 0).x, 10.0f, 1e-3f) << "Root bone did not get the Root channel";
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 0).y, 0.0f, 1e-3f);
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 1).y, 20.0f, 1e-3f) << "Child bone did not get the Child channel";
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 1).x, 0.0f, 1e-3f);
+}
+
+// Only Root is keyed; Child carries a distinctive bind-pose local translation.
+// After a tick the un-keyed Child must rest at its bind pose, not identity.
+class AnimationGraphUnkeyedBindPoseTickTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        // Two-bone skeleton with a NON-identity Child bind-pose local transform.
+        m_Skeleton = Ref<Skeleton>::Create(2);
+        m_Skeleton->m_BoneNames = { "Root", "Child" };
+        m_Skeleton->m_ParentIndices = { -1, 0 };
+        m_Skeleton->m_LocalTransforms = { glm::mat4(1.0f), glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 5.0f, 0.0f)) };
+        m_Skeleton->m_BonePreTransforms = { glm::mat4(1.0f), glm::mat4(1.0f) };
+        m_Skeleton->m_GlobalTransforms[0] = m_Skeleton->m_LocalTransforms[0];
+        m_Skeleton->m_GlobalTransforms[1] = m_Skeleton->m_GlobalTransforms[0] * m_Skeleton->m_LocalTransforms[1];
+        m_Skeleton->SetBindPose();
+
+        auto clip = Ref<AnimationClip>::Create();
+        clip->Name = "RootOnly";
+        clip->Duration = 1.0f;
+        clip->BoneAnimations.push_back(ConstantChannel("Root", glm::vec3(10.0f, 0.0f, 0.0f)));
+        clip->InitializeBoneCache();
+
+        m_Animated = GetScene().CreateEntity("Animated");
+        m_Animated.AddComponent<SkeletonComponent>(m_Skeleton);
+        AttachSingleClipGraph(m_Animated, clip);
+    }
+
+    Entity m_Animated;
+    Ref<Skeleton> m_Skeleton;
+};
+
+TEST_F(AnimationGraphUnkeyedBindPoseTickTest, UnkeyedBoneRestsAtBindPoseNotIdentity)
+{
+    RunFrames(3);
+
+    // Root(0) is animated (x=10); Child(1) is un-keyed and must keep its
+    // bind-pose local translation (y=5), NOT collapse to identity (y=0).
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 0).x, 10.0f, 1e-3f) << "Root channel not applied";
+    EXPECT_NEAR(LocalTranslation(m_Skeleton, 1).y, 5.0f, 1e-3f)
+        << "un-keyed Child collapsed to identity instead of falling back to bind pose";
 }


### PR DESCRIPTION
## Summary

Fixes the **animation-graph** pose pipeline (`AnimationGraphComponent` → state machine → blend tree), which mapped a clip's channels to skeleton bones **by array index** (`out[i] = clip.BoneAnimations[i]`). That invariant does not hold for imported rigs: clip channel order is exporter-dependent (`aiAnimation->mChannels` order) and covers only the *animated subset* of nodes, while skeleton bone indices come from a depth-first `AnimatedModel::ProcessSkeleton` traversal. So on any real rig the graph path wrote each channel's TRS onto the **wrong bone** (head rotation on a leg) and un-keyed bones **snapped to identity**. Every other sampling path in the engine (`AnimationSystem`, `OneShotBlend`) already maps by name — the graph path was the lone index-based outlier, live on every runtime tick (`Scene.cpp` → `AnimationGraphSystem::Update`).

## What changed

- New `PoseEvalContext { std::span<const std::string> BoneNames; std::span<const BoneTransform> BindPose; }` (in `Animation/BlendNode.h`) threaded down the whole graph path: `AnimationGraph::Update` → `AnimationStateMachine::Update` → `AnimationState::Evaluate` → `BlendTree::Evaluate`/`Evaluate1D`/`Evaluate2D` → `BlendTree::SampleClipBoneTransforms`.
- The shared sampler now maps **by name** (`AnimationClip::FindBoneAnimation`, O(1) cached) and fills un-keyed bones from the **bind-pose local transform** (`BlendTree::FillBindPose`) instead of identity — mirroring the already-correct `AnimationSystem`/`OneShotBlend` behaviour.
- `AnimationGraphSystem::Update` decomposes `skeleton.m_BindPoseLocalTransforms` (mat4) into TRS via `BlendUtils::DecomposeMatrix` to build the context (empty → identity fallback, matching `AnimationSystem`'s bind-pose guard).
- `AnimationState`'s single-clip path now delegates to the shared sampler, removing the duplicate index-based `SampleClipIntoPose`.

No `Scene.cpp` / FK / skinning / renderer code was touched — the change is confined to per-bone **local** TRS computation.

## Testing

- **`Animation/AnimationGraphBoneMappingTest.cpp`** (7 new unit tests): a clip whose channel order deliberately differs from skeleton bone order (the case the single-`Bone0` fixtures could never catch), exercised at every graph-path level — the static sampler, `AnimationState`, single-child + blended `BlendTree`, and end-to-end through `AnimationStateMachine`. Covers by-name mapping, bind-pose fallback, and the no-bind-pose→identity degrade.
- **`AnimationGraphStateMachineTickTest.cpp`** (2 new functional tests): drive the **real `Scene::OnUpdateRuntime` → `AnimationGraphSystem::Update`** path (including the new bind-pose-decompose plumbing) with a reverse-channel-order clip on a two-bone skeleton, asserting each channel lands on its named bone and an un-keyed bone keeps its bind pose (not identity).
- Migrated the 21 existing `BlendTreeTest`/`AnimationStateMachineTest` call sites to the new signature.
- **196 animation-subsystem tests pass**, no regressions from the widely-included `BlendNode.h` change.

### Visual verification note

A pixel-level editor pass was **not** run: `AnimationGraphComponent` loads its graph from a separate AnimationGraph asset by handle, and no graph-driven scene or graph asset exists in the sandbox (every rig scene uses the simpler, already-correct `AnimationStateComponent`). The change only computes per-bone local TRS — the downstream FK → `m_FinalBoneMatrices` → GPU skinning → pixels is unchanged code shared with the visually-verified `AnimationStateComponent` path — and the functional tests assert the exact thing a frame would show (channels on the correct bones, un-keyed bones at bind pose), numerically, through the live runtime tick.

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Animation sampling now respects bone names, so clips with channel orders different from the skeleton still animate the correct bones.
  * Unkeyed bones now fall back to their bind pose instead of resetting to default/identity transforms.
  * State machine blending and animation graph playback now preserve pose context more consistently during transitions and runtime updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->