### PR TITLE
fix(renderer): throttle GL debug-callback log spam and stop per-frame precipitation buffer readback

### DIFF
--- a/OloEngine/src/OloEngine/Precipitation/PrecipitationSystem.cpp
+++ b/OloEngine/src/OloEngine/Precipitation/PrecipitationSystem.cpp
@@ -264,7 +264,6 @@ namespace OloEngine
 
         f32 deltaTime = static_cast<f32>(dt);
         s_Data.m_AccumulatedTime += deltaTime;
-        s_Data.m_LastAccumulationFeedCount = 0;
 
         if (!settings.Enabled)
         {
@@ -302,6 +301,7 @@ namespace OloEngine
             }
 
             s_Data.m_LastCameraPos = cameraPos;
+            s_Data.m_LastAccumulationFeedCount = 0;
             return;
         }
 
@@ -375,17 +375,32 @@ namespace OloEngine
             // because far-field Simulate()/Compact() left the far-field SSBO bound.
             s_Data.m_NearFieldSystem->GetParticleSSBO()->Bind();
 
-            // Feed from near-field system
-            // The compute shader reads from the particle SSBO (already bound)
-            // and writes to the snow depth image
-            u32 nearAlive = s_Data.m_NearFieldSystem->GetAliveCount();
-            s_Data.m_LastAccumulationFeedCount = nearAlive;
-            if (nearAlive > 0)
+            // Feed from near-field system. Precipitation_Feed.comp reads the alive
+            // count straight from the already-bound counter SSBO and self-bounds via
+            // `if (idx >= aliveCount) return;`, so we dispatch a fixed group count
+            // sized to buffer capacity instead of reading the alive count back to the
+            // CPU every frame. A per-frame GetAliveCount() here forced a
+            // glGetNamedBufferSubData readback of a GL_DYNAMIC_COPY buffer every
+            // frame, which the driver reported as a per-frame VIDEO->HOST buffer
+            // migration (issue #551, hundreds of log lines/sec). The feed-count stat
+            // is refreshed periodically instead of every frame — see below.
+            u32 nearMaxParticles = s_Data.m_NearFieldSystem->GetMaxParticles();
+            if (nearMaxParticles > 0)
             {
-                u32 groups = (nearAlive + 255) / 256;
+                u32 groups = (nearMaxParticles + 255) / 256;
                 RenderCommand::DispatchCompute(groups, 1, 1);
                 RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderImageAccess | MemoryBarrierFlags::TextureFetch);
             }
+
+            constexpr u32 k_FeedStatRefreshIntervalFrames = 30;
+            if ((s_Data.m_FeedStatRefreshCounter++ % k_FeedStatRefreshIntervalFrames) == 0)
+            {
+                s_Data.m_LastAccumulationFeedCount = s_Data.m_NearFieldSystem->GetAliveCount();
+            }
+        }
+        else
+        {
+            s_Data.m_LastAccumulationFeedCount = 0;
         }
 
         // --- End GPU timer ---

--- a/OloEngine/src/OloEngine/Precipitation/PrecipitationSystem.h
+++ b/OloEngine/src/OloEngine/Precipitation/PrecipitationSystem.h
@@ -143,6 +143,10 @@ namespace OloEngine
             f32 m_EmissionReductionFactor = 1.0f;
             f32 m_LastFrameTimeMs = 0.0f;
             u32 m_LastAccumulationFeedCount = 0;
+            // Counts frames since the feed-count stat above was last refreshed from a
+            // GPU->CPU readback (see PrecipitationSystem::Update) — refreshed periodically
+            // rather than every frame to avoid a per-frame counter-SSBO stall/migration.
+            u32 m_FeedStatRefreshCounter = 0;
 
             // Drain timer: when precipitation is disabled, keep simulating
             // for long enough that all alive particles expire naturally.

--- a/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLDebug.cpp
@@ -5,7 +5,9 @@
 
 #include <atomic>
 #include <cstring>
+#include <mutex>
 #include <sstream>
+#include <unordered_map>
 
 // Stack trace support - available when <stacktrace> header is present (C++23).
 // MSVC reports __cplusplus as 199711L unless /Zc:__cplusplus is set, so check
@@ -22,6 +24,36 @@ namespace OloEngine
     namespace
     {
         std::atomic<u32> s_GLErrorCount{ 0 };
+
+        std::mutex s_PerfThrottleMutex;
+        std::unordered_map<unsigned int, u64> s_PerfMessageCounts;
+
+        // GL_DEBUG_TYPE_PERFORMANCE notifications can repeat the same message ID
+        // every single frame (issue #551 - e.g. NVIDIA id 131186 "buffer migrated
+        // VIDEO->HOST" on a per-frame GPU->CPU readback), flooding OloEngine.log at
+        // hundreds of lines/sec - the same log-spam-stalls-main-thread failure mode
+        // as #524. Log the first 10 occurrences of a given id, then every 10th up to
+        // 100, every 100th up to 1000, etc. - keeps the warning visible without the
+        // per-frame flood. Returns the running occurrence count for this id so the
+        // caller can report it ("x123") in the (possibly suppressed) log line.
+        [[nodiscard]] bool ShouldLogThrottledPerfMessage(unsigned int id, u64& outOccurrence)
+        {
+            std::lock_guard lock(s_PerfThrottleMutex);
+            const u64 count = ++s_PerfMessageCounts[id];
+            outOccurrence = count;
+
+            if (count <= 10)
+            {
+                return true;
+            }
+
+            u64 step = 10;
+            while (step * 10 <= count)
+            {
+                step *= 10;
+            }
+            return (count % step) == 0;
+        }
     } // namespace
 
     u32 GetGLErrorCount()
@@ -150,18 +182,24 @@ namespace OloEngine
         // Performance and portability messages should generally be less severe
         if (type == GL_DEBUG_TYPE_PERFORMANCE)
         {
+            u64 occurrence = 0;
+            const bool shouldLog = ShouldLogThrottledPerfMessage(id, occurrence);
+
             // Performance messages are usually informational, not errors
             switch (severity)
             {
                 case GL_DEBUG_SEVERITY_HIGH:
-                    OLO_CORE_ERROR("OpenGL performance issue (source: {0}, id: {1}): {2}", sourceStr, id, message);
+                    if (shouldLog)
+                        OLO_CORE_ERROR("OpenGL performance issue (source: {0}, id: {1}, occurrence: {2}): {3}", sourceStr, id, occurrence, message);
                     return;
                 case GL_DEBUG_SEVERITY_MEDIUM:
                 case GL_DEBUG_SEVERITY_LOW:
-                    OLO_CORE_WARN("OpenGL performance warning (source: {0}, id: {1}): {2}", sourceStr, id, message);
+                    if (shouldLog)
+                        OLO_CORE_WARN("OpenGL performance warning (source: {0}, id: {1}, occurrence: {2}): {3}", sourceStr, id, occurrence, message);
                     return;
                 case GL_DEBUG_SEVERITY_NOTIFICATION:
-                    OLO_CORE_TRACE("OpenGL performance hint (source: {0}, id: {1}): {2}", sourceStr, id, message);
+                    if (shouldLog)
+                        OLO_CORE_TRACE("OpenGL performance hint (source: {0}, id: {1}, occurrence: {2}): {3}", sourceStr, id, occurrence, message);
                     return;
             }
         }


### PR DESCRIPTION
## Summary
- Throttle `GL_DEBUG_TYPE_PERFORMANCE` messages in the GL debug callback (`OpenGLDebug.cpp`) by deduping per message id with exponential backoff (occurrences 1-10 logged individually, then every 10th, 100th, ...) instead of logging every single occurrence unthrottled - this was flooding `OloEngine.log` at hundreds of lines/sec (the same log-spam-stalls-main-thread failure mode as #524).
- Fix the root cause behind the specific flood observed during a 26-scene sweep: `PrecipitationSystem::Update` read `GPUParticleSystem::GetAliveCount()` (a `glGetNamedBufferSubData` on a `GL_DYNAMIC_COPY` SSBO) back to the CPU every frame purely to size a compute dispatch group count, causing the driver to report a per-frame VIDEO->HOST buffer migration (id 131186). `Precipitation_Feed.comp` already self-bounds against the GPU-resident alive count, so the dispatch is now sized to fixed buffer capacity instead - the CPU never needs to read the buffer back for this. The debug-only feed-count stat is still refreshed, just every 30 frames instead of every frame.

Fixes #551

## Test plan
- [x] `OloEngine` and `OloEditor` build clean (Debug, MSVC)
- [x] Ran the editor for several minutes with no crashes
- [x] Confirmed the throttle's occurrence-counting live in `OloEngine.log` against a real GL performance message (id 131218): logged individually for occurrences 1-4, no flood
- [x] Reviewed diff is scoped to the two intended files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)