### PR TITLE
fix(renderer): build occlusion HZB from active-path depth, not stale G-Buffer (#549)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DFrameExecution.cpp
@@ -67,8 +67,24 @@ namespace OloEngine
         // target's depth attachment otherwise — mirrors SceneRenderPass's own
         // export resolution (SceneRenderPass.cpp). The depth attachment holds
         // the final geometry depth now that the whole graph has executed.
+        //
+        // The G-Buffer branch MUST be gated on the deferred path being active,
+        // not merely on the G-Buffer existing: `SceneRenderPass` is a
+        // process-global pass object whose `m_GBuffer` is lazily created on the
+        // first Deferred frame and never released, so after any Deferred render
+        // `GetGBuffer()` stays non-null for the rest of the process. In
+        // Forward/Forward+ the scene renders to `GetTarget()`, NOT the G-Buffer,
+        // so reading the retained-but-stale G-Buffer depth here builds the HZB
+        // from a prior Deferred scene's depth — a false occlusion cull that
+        // punches a hole in the forward frame. This surfaced as the #549
+        // cross-test order-dependence (a Deferred test earlier in the shuffle
+        // leaves the G-Buffer non-null), and is equally a runtime Deferred→
+        // Forward path-switch bug. Mirror SceneRenderPass's `deferredActive &&
+        // m_GBuffer` gate so the HZB always samples the depth the ACTIVE path
+        // actually wrote this frame.
+        const bool deferredActive = (s_Data.Settings.Path == RenderingPath::Deferred);
         u32 depthTexID = 0;
-        if (const Ref<GBuffer>& gbuffer = scenePass->GetGBuffer())
+        if (const Ref<GBuffer>& gbuffer = scenePass->GetGBuffer(); deferredActive && gbuffer)
         {
             depthTexID = gbuffer->GetDepthAttachmentID();
         }


### PR DESCRIPTION
## What

`Renderer3D::GenerateOcclusionHZB` built the Hi-Z occlusion pyramid from the **G-Buffer depth whenever the G-Buffer merely existed**, instead of only when the **Deferred path is active**:

```cpp
// before
if (const Ref<GBuffer>& gbuffer = scenePass->GetGBuffer())   // non-null check only
    depthTexID = gbuffer->GetDepthAttachmentID();
else if (Ref<Framebuffer> target = scenePass->GetTarget())
    depthTexID = target->GetDepthAttachmentRendererID();

// after
const bool deferredActive = (s_Data.Settings.Path == RenderingPath::Deferred);
if (const Ref<GBuffer>& gbuffer = scenePass->GetGBuffer(); deferredActive && gbuffer)
    depthTexID = gbuffer->GetDepthAttachmentID();
else if (Ref<Framebuffer> target = scenePass->GetTarget())
    depthTexID = target->GetDepthAttachmentRendererID();
```

## Why

`SceneRenderPass` is a **process-global** pass object; its `m_GBuffer` is lazily created on the first Deferred frame and **never released**. So after *any* Deferred render, `GetGBuffer()` stays non-null for the rest of the process. In Forward/Forward+ the scene renders to `GetTarget()`, **not** the G-Buffer — so the HZB was being built from **stale, unpopulated G-Buffer depth**, producing a **false occlusion cull that punches a black hole** in the forward frame.

This is a **real runtime bug** (a Deferred→Forward path switch in the editor/game false-culls identically), and it was the **occlusion instance** of #549's renderer-visual-test order-dependence: a Deferred test earlier in a `--gtest_shuffle` leaves the G-Buffer non-null, poisoning a later Forward HZB-occlusion test. The fix mirrors `SceneRenderPass`'s own `deferredActive && m_GBuffer` gate so the HZB always samples the depth the **active path** wrote this frame.

## Verification

- Repro seeds `58250` / `58251` / `58252` → green (were failing under shuffle).
- `DeferredTwoPhaseOcclusion*`, `DeferredOccludedInstanceFieldScene.*`, and `...ReenteringDeferredPathDoesNotCullEntireGraph_Issue530` → still pass (G-Buffer used correctly in Deferred).
- Visual: the polluted-seed `OcclusionCull_VisualEvidence` frame is correct (cube grid, no hole).
- Broader shuffle sweep (seeds 1 / 123456 / 999) → green.

## Scope / follow-up

`Fixes #549` — this resolves the occlusion instance; the shadow-golden instance was already fixed by #548. The **remaining** render-graph temporal-latency order-dependence (post-process tests render black for ~2 frames after a forward FSR-upscale transition, e.g. `CASVisualEvidenceTest`) is a distinct render-graph-subsystem mechanism, tracked in **#563**. A shuffled renderer-visual CI job should land once #563 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
