### PR TITLE
Add scene YAML versioning + migration-chain mechanism

### DIFF
--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -67,6 +67,51 @@ namespace OloEngine
         return value;
     }
 
+    // ---------------------------------------------------------------------
+    // Scene YAML versioning
+    // ---------------------------------------------------------------------
+    // Ordered migration chain, applied in place from a file's recorded
+    // version up to SceneSerializer::CurrentVersion. Empty today -- v1 only
+    // seeds the version field, no schema has changed yet -- but this is
+    // where a future breaking change adds a Migrate_VN_to_VNplus1(node) step
+    // and a matching `case N:` below.
+    static void MigrateSceneYAML(YAML::Node& data, u32 fromVersion)
+    {
+        if (fromVersion >= SceneSerializer::CurrentVersion)
+            return;
+
+        OLO_CORE_INFO("SceneSerializer: migrating scene YAML from version {} to {}", fromVersion, SceneSerializer::CurrentVersion);
+
+        for (u32 v = fromVersion; v < SceneSerializer::CurrentVersion; ++v)
+        {
+            switch (v)
+            {
+                // case 0: Migrate_V0_to_V1(data); break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    // Absence of the "Version" key means the file predates this scheme
+    // entirely, so it defaults to SceneSerializer::ImplicitVersion rather
+    // than being rejected.
+    static u32 ReadSceneVersion(const YAML::Node& data)
+    {
+        if (auto versionNode = data["Version"]; versionNode && versionNode.IsScalar())
+        {
+            try
+            {
+                return versionNode.as<u32>();
+            }
+            catch (const YAML::Exception&)
+            {
+                return SceneSerializer::ImplicitVersion;
+            }
+        }
+        return SceneSerializer::ImplicitVersion;
+    }
+
     // Load a texture referenced by scene YAML through the asset registry so
     // it participates in hot-reload and is de-duplicated across the scene
     // graph. Falls back to a raw Texture2D::Create() when no EditorAssetManager
@@ -5827,6 +5872,7 @@ namespace OloEngine
         YAML::Emitter out;
         out << YAML::BeginMap;
         out << YAML::Key << "Scene" << YAML::Value << m_Scene->GetName();
+        out << YAML::Key << "Version" << YAML::Value << SceneSerializer::CurrentVersion;
 
         out << YAML::Key << "PostProcessSettings";
         out << YAML::BeginMap;
@@ -6030,6 +6076,9 @@ namespace OloEngine
         OLO_CORE_TRACE("Deserializing scene '{0}'", sceneName);
         m_Scene->SetName(sceneName);
 
+        const u32 fileVersion = ReadSceneVersion(data);
+        MigrateSceneYAML(data, fileVersion);
+
         try
         {
             if (auto ppNode = data["PostProcessSettings"]; ppNode && ppNode.IsMap())
@@ -6216,6 +6265,7 @@ namespace OloEngine
         YAML::Emitter out;
         out << YAML::BeginMap;
         out << YAML::Key << "Scene" << YAML::Value << m_Scene->GetName();
+        out << YAML::Key << "Version" << YAML::Value << SceneSerializer::CurrentVersion;
 
         out << YAML::Key << "PostProcessSettings";
         out << YAML::BeginMap;
@@ -6365,6 +6415,9 @@ namespace OloEngine
             return false;
         }
         OLO_CORE_TRACE("Deserializing scene '{0}'", sceneName);
+
+        const u32 fileVersion = ReadSceneVersion(data);
+        MigrateSceneYAML(data, fileVersion);
 
         // Top-level guard for the schema-walk: fuzz inputs that pass the
         // "is map + Scene scalar" check above can still hit `.as<T>()`

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.h
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.h
@@ -14,6 +14,15 @@ namespace OloEngine
     class SceneSerializer
     {
       public:
+        // Scene YAML schema version. Bump this and add a migration step to
+        // MigrateSceneYAML (in SceneSerializer.cpp) whenever a change to the
+        // on-disk format needs one. Every scene file written before this
+        // versioning scheme existed has no "Version" key at all; those are
+        // treated as ImplicitVersion so the entire existing scene library
+        // keeps loading unmodified.
+        static constexpr u32 CurrentVersion = 1;
+        static constexpr u32 ImplicitVersion = 0;
+
         explicit SceneSerializer(const Ref<Scene>& scene);
 
         void Serialize(const std::filesystem::path& filepath) const;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(OloEngine-Tests
 		ComponentTupleCoverageTest.cpp
 		ComponentHandlerCoverageTest.cpp
 		SceneSerializerFuzzRegressionTest.cpp
+		SceneVersionMigrationTest.cpp
 		EngineSubsystemSmokeTest.cpp
 		AppLaunchSmokeTest.cpp
 		FunctionalTestFixtureCoverageTest.cpp

--- a/OloEngine/tests/SceneVersionMigrationTest.cpp
+++ b/OloEngine/tests/SceneVersionMigrationTest.cpp
@@ -1,0 +1,93 @@
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// SceneVersionMigrationTest.cpp
+//
+// Locks in the scene-YAML versioning + forward-compat behaviour added for
+// issue #454: scenes now carry a top-level "Version" key, and a scene file
+// written before this scheme existed (no "Version" key at all) must still
+// load cleanly rather than being rejected — that's the entire pre-#454
+// scene library on disk.
+//
+// What this test does
+// --------------------
+//   1. Serializes a scene and asserts the emitted YAML carries
+//      "Version: <SceneSerializer::CurrentVersion>" so future PRs bumping
+//      the version don't have to touch this file.
+//   2. Feeds a hand-written "v0" fixture — a minimal scene document with no
+//      Version key, mirroring every scene saved before this feature existed
+//      — through DeserializeFromYAML and asserts it loads successfully with
+//      the expected entity data intact.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Scene/Scene.h"
+#include "OloEngine/Scene/SceneSerializer.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
+
+#include <string>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        Entity FindByTag(Scene& scene, const char* tag)
+        {
+            for (auto e : scene.GetAllEntitiesWith<TagComponent>())
+            {
+                Entity ent{ e, &scene };
+                if (ent.GetComponent<TagComponent>().Tag == tag)
+                    return ent;
+            }
+            return {};
+        }
+    } // namespace
+
+    TEST(SceneVersionMigration, SerializedSceneCarriesCurrentVersionKey)
+    {
+        auto scene = Scene::Create();
+        scene->CreateEntity("VersionedEntity");
+
+        SceneSerializer serializer(scene);
+        const std::string yaml = serializer.SerializeToYAML();
+
+        const std::string expectedKey =
+            "Version: " + std::to_string(SceneSerializer::CurrentVersion);
+        EXPECT_NE(yaml.find(expectedKey), std::string::npos)
+            << "Expected serialized scene to carry '" << expectedKey << "'\nYAML:\n"
+            << yaml;
+    }
+
+    TEST(SceneVersionMigration, V0SceneWithNoVersionKeyStillLoads)
+    {
+        // Mirrors the shape SceneSerializer::SerializeToYAML() produced
+        // before #454 added the "Version" key — no Version field at all.
+        constexpr const char* kV0Yaml = R"(
+Scene: LegacyScene
+Entities:
+  - Entity: 12345
+    TagComponent:
+      Tag: LegacyEntity
+    TransformComponent:
+      Translation: [1.0, 2.0, 3.0]
+      Rotation: [0.0, 0.0, 0.0]
+      Scale: [1.0, 1.0, 1.0]
+)";
+
+        auto scene = Scene::Create();
+        SceneSerializer serializer(scene);
+
+        ASSERT_TRUE(serializer.DeserializeFromYAML(kV0Yaml));
+
+        Entity entity = FindByTag(*scene, "LegacyEntity");
+        ASSERT_TRUE(entity);
+
+        const auto& transform = entity.GetComponent<TransformComponent>();
+        EXPECT_FLOAT_EQ(transform.Translation.x, 1.0f);
+        EXPECT_FLOAT_EQ(transform.Translation.y, 2.0f);
+        EXPECT_FLOAT_EQ(transform.Translation.z, 3.0f);
+    }
+} // namespace OloEngine::Tests


### PR DESCRIPTION
## Summary
- Adds a top-level `Version` key to scene YAML (`SceneSerializer::CurrentVersion`/`ImplicitVersion`), read/written by both the file-path and string-based (de)serialization entry points (`Serialize`/`Deserialize`, `SerializeToYAML`/`DeserializeFromYAML`).
- A file with no `Version` key (every scene saved before this change) defaults to `ImplicitVersion` (0) instead of being rejected — full forward compatibility with the existing scene library.
- Adds an ordered, in-place migration-chain mechanism (`MigrateSceneYAML`) that runs on load from the file's recorded version up to `CurrentVersion`. It's a no-op today (no schema has actually broken compatibility yet) — it exists so the next schema-breaking PR has a place to add a `Migrate_VN_to_VNplus1` step instead of silently corrupting old saves.
- Locks in the behavior with a new test file, `SceneVersionMigrationTest.cpp`: (1) newly-serialized scenes carry the current version key, (2) a hand-written "v0" fixture with no `Version` key at all still loads correctly and gets treated as version 0.

Addresses the scene-YAML portion of #454.

### Scoped out (follow-up)
Save-game (`SaveGame/SaveGameTypes.h`) and asset-pack (`Serialization/AssetPackFile.h`) versioning are **not** touched by this PR. Both use fixed-order binary archives — fields are read unconditionally in sequence — so a real migration there means version-gating every field read per component, a materially larger and riskier change than the YAML case. Left as an explicit follow-up (see issue comment) rather than rushed into this PR.

## Test plan
- [x] `OloEngine-Tests.exe --gtest_filter=SceneVersionMigration.*` — 2/2 passing
- [x] `OloEngine-Tests.exe --gtest_filter=SceneSerializerFuzzRegression.*:ComponentRoundTrip.*:ComponentSerializerCoverage*` — 94/94 passing, no regressions
- [x] Pre-commit hooks pass (clang-format, test classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)