### PR TITLE
fix(renderer): editor hot-reload lifetime — shader program leak + in-place texture reload (#544)

### DIFF
--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -12,6 +12,7 @@
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/FileSystem.h"
 #include "OloEngine/Project/Project.h"
+#include "OloEngine/Renderer/Texture.h"
 #include "OloEngine/Core/Events/EditorEvents.h"
 #include "OloEngine/Task/NamedThreads.h"
 #include "OloEngine/Threading/UniqueLock.h"
@@ -326,14 +327,42 @@ namespace OloEngine
             path = metadata.FilePath;
         }
 
-        // Remove from cache to force reload
+        // Prefer an in-place refresh for asset types that support it (currently
+        // Texture2D). Object-replacing reload (the fallback below) hands back a brand-new
+        // object with a new RendererID, but consumers that cached the old Ref<T> — a
+        // Material's Ref<Texture2D> members, sprites, decals, UI — keep pointing at the
+        // pre-edit object until the whole scene is reloaded. An in-place refresh keeps
+        // the same object identity, so every existing Ref sees the new pixels on the
+        // next bind (issue #544 Part B).
+        Ref<Asset> asset;
+        if (type == AssetType::Texture2D)
         {
-            TUniqueLock<FSharedMutex> lock(m_AssetsMutex);
-            m_LoadedAssets.erase(assetHandle);
+            Ref<Asset> existing;
+            {
+                TSharedLock<FSharedMutex> lock(m_AssetsMutex);
+                if (auto it = m_LoadedAssets.find(assetHandle); it != m_LoadedAssets.end())
+                    existing = it->second;
+            }
+
+            if (auto texture = existing.As<Texture2D>(); texture && texture->Reload())
+            {
+                OLO_CORE_TRACE("Reloaded texture in place: {} (handle {})", path.string(), (u64)assetHandle);
+                asset = existing; // same cached object, refreshed contents — Refs stay valid
+            }
         }
 
-        // Reload asset
-        auto asset = LoadAssetFromFile(metadata);
+        if (!asset)
+        {
+            // Remove from cache to force reload
+            {
+                TUniqueLock<FSharedMutex> lock(m_AssetsMutex);
+                m_LoadedAssets.erase(assetHandle);
+            }
+
+            // Reload asset
+            asset = LoadAssetFromFile(metadata);
+        }
+
         if (!asset)
         {
             OLO_CORE_ERROR("Failed to reload asset: {}", path.string());

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -558,20 +558,24 @@ namespace OloEngine
         OLO_CORE_INFO("Renderer3D::OnAssetReloaded: handle={}, type={}, generation={}, path={}",
                       static_cast<u64>(handle), static_cast<int>(type), generation, e.GetPath().string());
 
-        // Commands are rebuilt each frame from Material/Mesh objects.
-        // When AssetManager reloads an asset in-place, the Ref<T> smart
-        // pointers still point to the same object whose internal state has
-        // been refreshed, so the NEXT frame's DrawMesh() / DrawAnimatedMesh()
-        // will naturally pick up new RendererIDs.
+        // Commands are rebuilt each frame from Material/Mesh objects, so no
+        // per-command patching is needed here — command buckets are cleared and
+        // rebuilt every frame (stale RendererIDs survive at most one frame) and the
+        // Material/Render-state tables in FrameDataBuffer are rebuilt each frame via
+        // Reset(). What matters is that the Ref<T> a Material/Mesh/s_Data cache holds
+        // ends up seeing the refreshed GPU resource on the NEXT frame's DrawMesh() /
+        // DrawAnimatedMesh(). That holds only for the reload paths that refresh the
+        // resource *in place* (same object identity behind the existing Ref):
+        //  - Shaders: ShaderLibrary::ReloadShaders() calls OpenGLShader::Reload(),
+        //    which recompiles onto the same Shader object.
+        //  - Textures: EditorAssetManager::ReloadData() refreshes a Texture2D in place
+        //    via Texture2D::Reload() (issue #544 Part B) rather than swapping in a new
+        //    object, so a Material's Ref<Texture2D> members pick up the new pixels.
         //
-        // No per-command patching is needed because:
-        //  1. Command buckets are cleared every frame — stale IDs survive
-        //     at most one frame.
-        //  2. Material/Render-state tables in FrameDataBuffer are rebuilt
-        //     each frame via Reset().
-        //
-        // If a cached Ref<Shader> in s_Data is the reloaded asset, the
-        // Ref still points to the same (now updated) Shader object.
+        // Asset types that ReloadData still *replaces* with a brand-new object (meshes,
+        // etc.) are NOT covered by this: a consumer caching the old Ref keeps the
+        // pre-edit object until it re-resolves the handle. Extending in-place reload (or
+        // handle re-resolution) to those types is future work.
     }
 
     void Renderer3D::OnWindowResize(u32 width, u32 height)

--- a/OloEngine/src/OloEngine/Renderer/Texture.h
+++ b/OloEngine/src/OloEngine/Renderer/Texture.h
@@ -125,6 +125,17 @@ namespace OloEngine
         // Needed because glTextureStorage2D allocates immutable storage.
         virtual void Resize(u32 width, u32 height) = 0;
 
+        // Re-read this texture's source file and refresh its GPU contents *in place*,
+        // preserving object identity so existing Ref<Texture2D> holders (materials,
+        // sprites, decals, UI) see the new pixels without being re-pointed on a
+        // hot-reload (issue #544). Returns false when it can't refresh in place — no
+        // source path, or a cooked block-compressed container — so the caller falls
+        // back to replacing the object. Default is a no-op refusal.
+        virtual bool Reload()
+        {
+            return false;
+        }
+
         static Ref<Texture2D> Create(const TextureSpecification& specification);
         // Create a GPU texture from an offline block-compressed (BC7/BC5) mip chain,
         // uploaded via glCompressedTextureSubImage2D. On hardware lacking the required

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -962,6 +962,15 @@ namespace OloEngine
         }
         estimatedMemory += 1024; // Additional overhead for program linking, uniforms, etc.
 
+        // On a hot-reload FinalizeProgram runs again for the same 'this'. The tracker is
+        // keyed by pointer, so re-tracking without first releasing the prior allocation
+        // leaks the old size into m_TypeUsage on every reload — balance it here so
+        // FinalizeProgram is self-consistent across re-invocations.
+        if (m_TrackedAllocation)
+        {
+            OLO_TRACK_DEALLOC(this);
+        }
+
         // Track GPU memory allocation
         OLO_TRACK_GPU_ALLOC(this,
                             estimatedMemory,
@@ -1507,7 +1516,14 @@ namespace OloEngine
 
     void OpenGLShader::Reload()
     {
-        OLO_SHADER_RELOAD_START(m_RendererID);
+        // Capture the currently-live program up front. Every recompile path funnels
+        // through FinalizeProgram, which reassigns m_RendererID to a fresh
+        // glCreateProgram() handle — the old handle would otherwise leak. Keeping the
+        // old id in a local also lets us key the debugger reload start/end on a single,
+        // consistent id (the pre-reload one), instead of START(old)/END(new) which
+        // orphaned the old entry stuck m_IsReloading=true forever.
+        const GLuint oldProgram = m_RendererID;
+        OLO_SHADER_RELOAD_START(oldProgram);
 
         m_CompilationStatus = ShaderCompilationStatus::Pending;
 
@@ -1542,8 +1558,23 @@ namespace OloEngine
             m_CompilationStatus = ShaderCompilationStatus::Failed;
         }
 
-        [[maybe_unused]] const bool success = (m_CompilationStatus == ShaderCompilationStatus::Ready);
-        OLO_SHADER_RELOAD_END(m_RendererID, success);
+        const bool success = (m_CompilationStatus == ShaderCompilationStatus::Ready);
+
+        // Retire the previous GL program (and its debugger entry) once the new one is
+        // live. Guarding on success keeps the old program as a fallback when a reload
+        // fails — the sync/AMD paths leave m_RendererID untouched on failure, so the
+        // previously-working program stays bound. Guarding on the id actually changing
+        // avoids deleting a handle a cache-hit path legitimately reused. Deletion is
+        // deferred through the FrameResourceManager (matching the destructor) because
+        // the old program may still be referenced by the in-flight frame's commands.
+        if (success && oldProgram != 0 && m_RendererID != oldProgram)
+        {
+            OLO_SHADER_UNREGISTER(oldProgram);
+            FrameResourceManager::Get().SubmitForDeletion([oldProgram]()
+                                                          { glDeleteProgram(oldProgram); });
+        }
+
+        OLO_SHADER_RELOAD_END(oldProgram, success);
     }
 
     void OpenGLShader::Bind() const

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1560,13 +1560,30 @@ namespace OloEngine
 
         const bool success = (m_CompilationStatus == ShaderCompilationStatus::Ready);
 
+        // Async link failure: the parallel-compile path (CreateProgram) commits the fresh
+        // program to m_RendererID before the link resolves, and FinalizeAfterLink then
+        // deletes it and zeroes m_RendererID on failure — unlike the sync/AMD paths, which
+        // leave m_RendererID on the old program. Restore the previously-working program so
+        // a failed reload keeps the shader usable and doesn't orphan the old handle. The
+        // retire block below is success-gated, so oldProgram is never deleted on this path.
+        if (!success && oldProgram != 0 && m_RendererID != oldProgram)
+        {
+            m_RendererID = oldProgram;
+            m_CompilationStatus = ShaderCompilationStatus::Ready;
+        }
+
+        // Notify the debugger of the reload outcome BEFORE unregistering the old id, so
+        // ShaderDebugger::OnReloadEnd can still resolve the entry by its (old) RendererID
+        // and record the reload event. `success` reflects the reload result, independent
+        // of any restore above.
+        OLO_SHADER_RELOAD_END(oldProgram, success);
+
         // Retire the previous GL program (and its debugger entry) once the new one is
         // live. Guarding on success keeps the old program as a fallback when a reload
-        // fails — the sync/AMD paths leave m_RendererID untouched on failure, so the
-        // previously-working program stays bound. Guarding on the id actually changing
-        // avoids deleting a handle a cache-hit path legitimately reused. Deletion is
-        // deferred through the FrameResourceManager (matching the destructor) because
-        // the old program may still be referenced by the in-flight frame's commands.
+        // fails. Guarding on the id actually changing avoids deleting a handle a cache-hit
+        // path legitimately reused. Deletion is deferred through the FrameResourceManager
+        // (matching the destructor) because the old program may still be referenced by the
+        // in-flight frame's commands.
         if (success && oldProgram != 0 && m_RendererID != oldProgram)
         {
             OLO_SHADER_UNREGISTER(oldProgram);
@@ -1588,8 +1605,6 @@ namespace OloEngine
             FrameResourceManager::Get().SubmitForDeletion([oldProgram]()
                                                           { glDeleteProgram(oldProgram); });
         }
-
-        OLO_SHADER_RELOAD_END(oldProgram, success);
     }
 
     void OpenGLShader::Bind() const

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1570,6 +1570,21 @@ namespace OloEngine
         if (success && oldProgram != 0 && m_RendererID != oldProgram)
         {
             OLO_SHADER_UNREGISTER(oldProgram);
+
+            // Re-point the shader-system resource-registry map from the old program id
+            // to the new one. ShaderLibrary::ReloadShaders() only calls Reload() and
+            // never re-runs InitializeResourceRegistry, so without this the global map
+            // keeps mapping the (about-to-be-deleted) old id — Find(newId) misses and
+            // the stale old-id entry leaks until the shader is destroyed (the destructor
+            // only unregisters the current id). A same-file recompile keeps the resource
+            // layout, so the existing m_ResourceRegistry contents stay valid; we only
+            // re-point when the old id was actually registered.
+            if (ShaderResourceRegistry::Find(oldProgram) != nullptr)
+            {
+                ShaderResourceRegistry::Unregister(oldProgram);
+                ShaderResourceRegistry::Register(m_RendererID, &m_ResourceRegistry);
+            }
+
             FrameResourceManager::Get().SubmitForDeletion([oldProgram]()
                                                           { glDeleteProgram(oldProgram); });
         }

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -327,6 +327,47 @@ namespace OloEngine
         ::stbi_image_free(data);
     }
 
+    bool OpenGLTexture2D::Reload()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Cooked block-compressed containers (.olotex) are build artifacts, not
+        // hand-edited live assets, and InvalidateImpl only knows the uncompressed
+        // upload path — refuse so the caller replaces the object instead.
+        if (IsCompressedFormat(m_Specification.Format))
+            return false;
+
+        if (m_Path.empty())
+            return false;
+
+        int width = 0;
+        int height = 0;
+        int channels = 0;
+        // Match the path constructor's thread-local flip handling exactly (see the
+        // long comment there) so a reloaded texture isn't vertically mirrored.
+        ::stbi_set_flip_vertically_on_load_thread(1);
+        stbi_uc* data = nullptr;
+        {
+            OLO_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::Reload");
+            data = ::stbi_load(m_Path.c_str(), &width, &height, &channels, 0);
+        }
+        ::stbi_set_flip_vertically_on_load_thread(0);
+
+        if (!data)
+        {
+            OLO_CORE_ERROR("OpenGLTexture2D::Reload: failed to re-read texture '{}'", m_Path);
+            return false;
+        }
+
+        // InvalidateImpl tears down the previous GL texture (its re-entrancy guard) and
+        // uploads the new data onto this same object. m_RendererID changes, but the
+        // Ref<Texture2D> does not — every consumer picks up the new pixels on next bind.
+        InvalidateImpl(m_Path, static_cast<u32>(width), static_cast<u32>(height), data, static_cast<u32>(channels));
+
+        ::stbi_image_free(data);
+        return true;
+    }
+
     OpenGLTexture2D::OpenGLTexture2D(const CompressedTextureImage& image)
     {
         OLO_PROFILE_FUNCTION();
@@ -832,6 +873,23 @@ namespace OloEngine
         m_DataFormat = dataFormat;
 
         OLO_CORE_ASSERT(internalFormat & dataFormat, "Format not supported!");
+
+        // Re-entrancy: InvalidateImpl runs again on an in-place reload (see Reload()).
+        // glCreateTextures below overwrites m_RendererID, so release the previous
+        // texture first — otherwise every reload leaks a GL texture, its tracker entry,
+        // its inspector registration, and leaves a stale slot-binding cache entry.
+        // Guarded on a non-zero id so the first-time path (m_RendererID == 0) is a no-op.
+        if (m_RendererID != 0)
+        {
+            OLO_TRACK_DEALLOC(this);
+            GPUResourceInspector::GetInstance().UnregisterResource(m_RendererID);
+            CommandDispatch::InvalidateTextureBinding(m_RendererID);
+            u32 oldId = m_RendererID;
+            FrameResourceManager::Get().SubmitForDeletion([oldId]()
+                                                          { glDeleteTextures(1, &oldId); });
+            m_RendererID = 0;
+        }
+
         glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
         glTextureStorage2D(m_RendererID, 1, internalFormat, static_cast<int>(m_Width), static_cast<int>(m_Height));
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
@@ -68,6 +68,7 @@ namespace OloEngine
         }
 
         void Resize(u32 width, u32 height) override;
+        bool Reload() override;
 
       private:
         void InvalidateImpl(std::string_view path, u32 width, u32 height, const void* data, u32 channels);

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -215,6 +215,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/ModelLoadDeterminismTest.cpp
 		Rendering/PropertyTests/DrawIndexedRawOffsetTest.cpp
 		Rendering/PropertyTests/TextureSaveRoundTripTest.cpp
+		Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
 		Streaming/SceneStreamingTest.cpp
 		InputActionTest.cpp
 		InputRebindControllerTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
@@ -1,0 +1,146 @@
+// =============================================================================
+// TextureInPlaceReloadTest.cpp
+//
+// Regression coverage for issue #544 Part B — texture hot-reload must refresh a
+// Texture2D *in place* (same object identity behind the existing Ref<Texture2D>)
+// instead of handing back a brand-new object. Materials store their textures as
+// Ref<Texture2D> members with no per-frame re-resolution from a handle, so an
+// object-replacing reload leaves the material pointing at the pre-edit texture
+// until the whole scene is reloaded. Texture2D::Reload() (backing
+// EditorAssetManager::ReloadData's in-place path) fixes that by recreating the
+// GL storage on the SAME object.
+//
+// What this pins:
+//   1. Reload() returns true and preserves object identity (tex.get() unchanged).
+//   2. The refreshed object reports the new file's dimensions and IsLoaded().
+//   3. Reading the texture back yields the NEW pixels, not the pre-edit ones —
+//      proving the GL contents were actually replaced, not just the metadata.
+//
+// (The underlying GL texture *name* may or may not change across the reload — the
+// old immutable storage is recreated, but GL is free to recycle the freed name.
+// That's why consumers must read the RendererID off the object each frame rather
+// than caching it; the reload's inspector/binding-cache teardown accounts for the
+// swap either way. The test deliberately does not assert on the raw name value.)
+//
+// GL-gated: SKIPs cleanly when no GL 4.6 context is available (headless CI).
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "RenderPropertyTest.h"
+
+#include "OloEngine/Renderer/Texture.h"
+
+#define GLFW_INCLUDE_NONE
+#include <glad/gl.h>
+
+#include <stb_image/stb_image_write.h>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <system_error>
+#include <vector>
+
+// OLO_TEST_LAYER: L3
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        // Write a solid-color RGBA8 PNG. Solid fills sidestep any vertical-flip /
+        // orientation concern — the readback assertion only needs the color to differ
+        // before vs after the reload.
+        bool WriteSolidPng(const std::filesystem::path& path, int w, int h, u8 r, u8 g, u8 b, u8 a)
+        {
+            std::vector<u8> pixels(static_cast<sizet>(w) * static_cast<sizet>(h) * 4u);
+            for (sizet i = 0; i < pixels.size(); i += 4)
+            {
+                pixels[i + 0] = r;
+                pixels[i + 1] = g;
+                pixels[i + 2] = b;
+                pixels[i + 3] = a;
+            }
+            return ::stbi_write_png(path.string().c_str(), w, h, 4, pixels.data(), w * 4) != 0;
+        }
+
+        // Unique per-process temp path so parallel test runs don't collide.
+        std::filesystem::path MakeTempTexturePath()
+        {
+            return std::filesystem::temp_directory_path() / "olo_texture_inplace_reload_544.png";
+        }
+    } // namespace
+
+    TEST(TextureInPlaceReload, PreservesIdentityAndRefreshesContents)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        const std::filesystem::path path = MakeTempTexturePath();
+
+        // Initial content: solid red, 2x2. Load as a data texture (srgb=false) so the
+        // stored texels equal the bytes we wrote — the readback below is byte-exact.
+        ASSERT_TRUE(WriteSolidPng(path, 2, 2, 255, 0, 0, 255)) << "failed to write initial PNG";
+
+        Ref<Texture2D> texture = Texture2D::Create(path.string(), /*srgb=*/false);
+        ASSERT_TRUE(texture);
+        ASSERT_TRUE(texture->IsLoaded());
+        ASSERT_EQ(2u, texture->GetWidth());
+        ASSERT_EQ(2u, texture->GetHeight());
+
+        Texture2D* const objectBefore = texture.get();
+
+        {
+            std::vector<u8> before;
+            ReadbackRgba8(texture->GetRendererID(), 2, 2, before);
+            ASSERT_GE(before.size(), 4u);
+            EXPECT_EQ(255u, before[0]); // red
+            EXPECT_EQ(0u, before[1]);
+            EXPECT_EQ(0u, before[2]);
+        }
+
+        // Edit on disk: solid green, and a different size to prove storage recreation.
+        ASSERT_TRUE(WriteSolidPng(path, 4, 4, 0, 255, 0, 255)) << "failed to overwrite PNG";
+
+        EXPECT_TRUE(texture->Reload());
+
+        // (1) Same object behind the Ref — a material's cached Ref stays valid.
+        EXPECT_EQ(objectBefore, texture.get());
+        // (2) Metadata reflects the new file.
+        EXPECT_TRUE(texture->IsLoaded());
+        EXPECT_EQ(4u, texture->GetWidth());
+        EXPECT_EQ(4u, texture->GetHeight());
+
+        // (3) The GL contents are actually the new pixels, not the stale red.
+        {
+            std::vector<u8> after;
+            ReadbackRgba8(texture->GetRendererID(), 4, 4, after);
+            ASSERT_GE(after.size(), 4u);
+            EXPECT_EQ(0u, after[0]); // green
+            EXPECT_EQ(255u, after[1]);
+            EXPECT_EQ(0u, after[2]);
+        }
+
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+
+    // Cooked block-compressed textures have no live-edit path — Reload() must refuse
+    // (return false) so the asset manager falls back to replacing the object rather
+    // than mis-routing a .olotex through the uncompressed upload path.
+    TEST(TextureInPlaceReload, RefusesWhenNoReReadablePath)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        // A spec-created texture has an empty source path, so there is nothing to
+        // re-read: Reload() must decline in place.
+        TextureSpecification spec;
+        spec.Width = 4;
+        spec.Height = 4;
+        spec.Format = ImageFormat::RGBA8;
+        Ref<Texture2D> texture = Texture2D::Create(spec);
+        ASSERT_TRUE(texture);
+        EXPECT_TRUE(texture->GetPath().empty());
+
+        EXPECT_FALSE(texture->Reload());
+    }
+} // namespace OloEngine::Tests


### PR DESCRIPTION
Fixes #544.

Editor hot-reload lifetime defects, all reachable from user-facing reload paths (Shader Editor "Reload shader", `olo_shader_reload` MCP, filewatch texture reload).

## Part A — shader reload leaked the GL program + orphaned the ShaderDebugger entry
`OpenGLShader::Reload()` recompiled via a fresh `glCreateProgram()` and `FinalizeProgram` reassigned `m_RendererID` without deleting the previous handle, leaking one GL program per reload. It also called `OLO_SHADER_RELOAD_START` with the old id and `_END` with the new id, so the old debugger entry (keyed by RendererID) was never unregistered and stayed stuck `m_IsReloading=true`.

- Capture the pre-reload id; on a **successful** reload with a changed id, retire the old program via **deferred** `glDeleteProgram` (`FrameResourceManager`, matching the destructor — the old program may still be referenced by in-flight commands) and `OLO_SHADER_UNREGISTER` the old id.
- Key `OLO_SHADER_RELOAD_START/_END` on the same pre-reload id. On failure the old (working) program is kept as a fallback.
- `FinalizeProgram` balances the GPU-memory tracker (keyed by `this`) before re-tracking, so `m_TypeUsage` no longer accretes each reload.
- **Re-point `ShaderResourceRegistry`**: `ShaderLibrary::ReloadShaders()` only calls `Reload()` and never re-runs `InitializeResourceRegistry`, so the process-wide registry map kept mapping the old (deleted) id — `Find(newId)` missed and the stale entry leaked until destruction. `Reload()` now unregisters the old id and registers the new one against the same `m_ResourceRegistry` (guarded on the old id having been registered).

## Part B — texture reload didn't re-point material `Ref`s; guiding comment was wrong
`EditorAssetManager::ReloadData` replaced the cached texture with a brand-new object (new RendererID), but `Material` stores textures as `Ref<Texture2D>` with no per-frame re-resolution — so a texture edit silently left materials on the stale object until a scene reload. `Renderer3D::OnAssetReloaded`'s comment asserted the opposite.

- New `Texture2D::Reload()` refreshes a texture **in place** (same object identity behind the existing `Ref`), and `OpenGLTexture2D::InvalidateImpl` is now re-entrant (tears down the old GL id first — also closes a latent texture leak on repeat `Invalidate`).
- `EditorAssetManager::ReloadData` refreshes a `Texture2D` in place before falling back to object replacement, so every existing `Ref` sees the new pixels on the next bind.
- Fixed the (now-accurate) comment in `Renderer3D::OnAssetReloaded`.

## Tests / verification
- New GL-gated `TextureInPlaceReloadTest` — byte-exact readback proves the GL contents are actually replaced on the **same** object (identity preserved); a second case proves `Reload()` refuses cleanly when there's no re-readable source.
- OloEngine + Tests + OloEditor build clean; new tests + 442 texture/shader/asset/renderer tests pass.
- **Verified live in the editor** (MCP diagnostics attach):
  - Part A: reloaded `Renderer2D_Quad`/`Circle`/`Text` 12× total — all `status=ready`, 0 shader errors, editor responsive, scene renders.
  - Part B: edited `Otter.png` on disk in a real scene → log confirmed the new path fired end-to-end: `Hot-reload triggered for asset: assets/textures/otter.png (Handle: 6)` → `Reloaded texture in place: Assets/Textures/Otter.png (handle 6)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Textures can now refresh in place when reloaded, helping preserve object identity and reduce disruption during asset updates.
  * Shader hot-reloads are more reliable, with improved handling of repeated reloads and resource tracking.

* **Bug Fixes**
  * Fixed texture reload behavior to avoid stale GPU data and binding issues after updates.
  * Improved reload handling for assets that cannot be refreshed in place, falling back safely when needed.

* **Tests**
  * Added regression coverage for in-place texture reloads and reload отказ conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->