### PR TITLE
fix(renderer): align RendererProfiler frame/CPU/GPU-wait measurements

### DIFF
--- a/OloEditor/src/MCP/McpPassTimings.h
+++ b/OloEditor/src/MCP/McpPassTimings.h
@@ -28,6 +28,12 @@ namespace OloEngine::MCP::PassTimings
 {
     using Json = nlohmann::json;
 
+    // Matches GPUPassTimerPool::kSlotCount — the number of in-flight
+    // timestamp slots. An age at or beyond this means a slot was dropped
+    // (GPU fell more than a full ring's worth of frames behind) rather than
+    // the normal 1-3 frame resolve latency.
+    inline constexpr u64 kGpuResultsStaleThreshold = 4;
+
     // One render-graph pass's GPU time (execution order preserved).
     struct GpuPassEntry
     {
@@ -151,6 +157,15 @@ namespace OloEngine::MCP::PassTimings
         // edges by a timestamp tick.
         o["unattributedGpuMs"] = Round3(totals.GpuMs > passGpuTotal ? totals.GpuMs - passGpuTotal : 0.0);
         o["gpuResultsAgeFrames"] = totals.GpuResultsAgeFrames;
+        // GPUPassTimerPool has kGpuResultsStaleThreshold in-flight timestamp
+        // slots; normal steady-state results lag 1-3 frames behind. An age at
+        // or beyond that means the GPU fell far enough behind that a slot was
+        // dropped rather than resolved (or nothing has resolved recently at
+        // all) — the numbers above are from an old, possibly no-longer-
+        // representative frame. Surfaced explicitly (issue #519) so a caller
+        // doesn't have to know to compare gpuResultsAgeFrames against the
+        // pool's slot count themselves.
+        o["gpuResultsStale"] = totals.GpuResultsAgeFrames >= kGpuResultsStaleThreshold;
         return o;
     }
 } // namespace OloEngine::MCP::PassTimings

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -465,7 +465,14 @@ namespace OloEngine::MCP
         {
             Json j = server.MarshalRead([]() -> Json
                                         {
-                const RendererProfiler::FrameData& f = RendererProfiler::GetInstance().GetCurrentFrameData();
+                // GetLastCompletedFrameData(), not GetCurrentFrameData(): the
+                // latter's FrameTime is only a live estimate carried over
+                // from the previous frame, while CPUTime/GPUTime describe the
+                // in-progress frame — mixing them could read as cpuMs >
+                // frameTimeMs whenever frame times swing (#519). The
+                // "completed" snapshot keeps every field describing the same
+                // finished frame, at the cost of up to one frame of latency.
+                const RendererProfiler::FrameData& f = RendererProfiler::GetInstance().GetLastCompletedFrameData();
                 Json o;
                 o["fps"] = f.m_FrameTime > 0.0 ? Round2(1000.0 / f.m_FrameTime) : 0.0;
                 o["frameTimeMs"] = Round2(f.m_FrameTime);
@@ -643,7 +650,9 @@ namespace OloEngine::MCP
                         cpuPasses.push_back(PassTimings::CpuPassEntry{ timing.NodeName, timing.CpuMs });
                 }
 
-                const RendererProfiler::FrameData& f = RendererProfiler::GetInstance().GetCurrentFrameData();
+                // See Handle_PerfSnapshot: use the last fully-completed frame
+                // so frameTimeMs/cpuMs/gpuWaitMs all describe the same frame.
+                const RendererProfiler::FrameData& f = RendererProfiler::GetInstance().GetLastCompletedFrameData();
                 PassTimings::FrameTotals totals;
                 totals.FrameTimeMs = f.m_FrameTime;
                 totals.CpuMs = f.m_CPUTime;
@@ -4344,8 +4353,12 @@ namespace OloEngine::MCP
                 "frames after issue) and its CPU dispatch time from the live graph. ScenePass "
                 "additionally reports subPasses splitting its GPU time into DepthPrepass vs Color (no "
                 "DepthPrepass sub-entry = depth prepass off; sub-pass times are inside the parent's gpuMs, "
-                "not additional). Frame totals include gpuWaitMs (CPU blocked on the GPU fence — the direct "
-                "GPU-bound signal); unattributedGpuMs is frame GPU time spent between/outside the timed passes.";
+                "not additional). Frame totals include gpuWaitMs (CPU blocked on the GPU fence AND any "
+                "SwapBuffers/vsync stall — the direct GPU-bound signal); unattributedGpuMs is frame GPU time "
+                "spent between/outside the timed passes. Check gpuResultsStale before trusting the numbers on "
+                "very long/GPU-backlogged frames: true means the GPU fell behind far enough that a timestamp "
+                "slot was dropped rather than resolved, so gpuMs/passes describe an old, possibly "
+                "unrepresentative frame.";
             tool.InputSchema = Schema::EmptyObject();
             tool.OutputSchema = Schema::Object()
                                     .Prop("frame", Schema::Object()
@@ -4364,6 +4377,7 @@ namespace OloEngine::MCP
                                     .Prop("passGpuTotalMs", Schema::Number())
                                     .Prop("unattributedGpuMs", Schema::Number())
                                     .Prop("gpuResultsAgeFrames", Schema::Int().Min(0).Desc("How many frames old the GPU numbers are (results resolve 1-3 frames after issue)."))
+                                    .Prop("gpuResultsStale", Schema::Bool().Desc("True when gpuResultsAgeFrames is at or beyond the timer pool's slot count — a slot was dropped rather than resolved, so gpuMs/passes are from a stale frame."))
                                     .Required({ "frame", "passes", "passGpuTotalMs" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfPassTimings;

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -627,6 +627,13 @@ namespace OloEngine::MCP
             return ToolResult::Text(o.dump(2));
         }
 
+        // McpPassTimings.h duplicates the pool's slot count as a Jolt/engine-free
+        // constant so it stays unit-testable without pulling in GPUPassTimerPool.h;
+        // pin the two together here — where both are in scope — so a future ring
+        // resize fails the build instead of silently desyncing the staleness flag.
+        static_assert(PassTimings::kGpuResultsStaleThreshold == GPUPassTimerPool::kSlotCount,
+                      "olo_perf_pass_timings staleness threshold is out of sync with GPUPassTimerPool's slot count");
+
         // ---- olo_perf_pass_timings (main-marshaled) -----------------------------
         // Per-render-graph-pass GPU/CPU times: GPU from the always-on
         // GPUPassTimerPool (GL_TIMESTAMP pairs around each executed pass, resolved

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -12,6 +12,7 @@
 #include "OloEngine/Networking/Core/NetworkManager.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
+#include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Debug/ShaderDebugger.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
 #include "OloEngine/Scripting/Lua/LuaScriptEngine.h"
@@ -19,6 +20,7 @@
 #include "OloEngine/Task/Scheduler.h"
 #include "OloEngine/Task/NamedThreads.h"
 
+#include <chrono>
 #include <stdexcept>
 #include <ranges>
 #include <thread>
@@ -335,9 +337,23 @@ namespace OloEngine
                 OloEngine::ImGuiLayer::End();
             }
 
+            // Timed separately from the FRAMEMARK scope: SwapBuffers is the
+            // real GPU-sync point for a windowed app (vsync, or the driver
+            // throttling submission when the GPU is behind) and previously
+            // wasn't attributed to gpuWaitMs at all — only the
+            // FrameResourceManager fence wait was, which left gpuWaitMs
+            // reading ~0 even when clearly GPU-bound (#519). EndFrame() has
+            // already finalized this frame's numbers by the time SwapBuffers
+            // returns, so the wait is handed to the profiler and patched into
+            // this already-recorded frame at the next BeginFrame() (see
+            // RendererProfiler::BeginFrame()).
+            const auto swapStart = std::chrono::high_resolution_clock::now();
             OLO_PROFILE_FRAMEMARK_START("Window SwapBuffers");
             m_Window->SwapBuffers();
             OLO_PROFILE_FRAMEMARK_END("Window SwapBuffers");
+            const auto swapEnd = std::chrono::high_resolution_clock::now();
+            RendererProfiler::GetInstance().AddPostFrameGPUWaitTime(
+                std::chrono::duration<f64, std::milli>(swapEnd - swapStart).count());
 
             // Frame-rate cap (issue #456). Placed AFTER SwapBuffers so it only
             // sleeps for the budget vsync (if on) didn't already consume — no

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -347,13 +347,25 @@ namespace OloEngine
             // returns, so the wait is handed to the profiler and patched into
             // this already-recorded frame at the next BeginFrame() (see
             // RendererProfiler::BeginFrame()).
+            //
+            // Only reported while !m_Minimized: RendererProfiler::BeginFrame()/
+            // EndFrame() are only called from the render path above, which is
+            // itself skipped while minimized. Reporting unconditionally would
+            // accumulate into m_PendingPostFrameGPUWaitTime for as long as the
+            // window stays minimized (no BeginFrame() runs to drain it), and
+            // the whole pent-up total would then land on the first frame
+            // rendered after restore, reading as a bogus multi-{minutes,hours}
+            // GPU-wait spike on that one frame.
             const auto swapStart = std::chrono::high_resolution_clock::now();
             OLO_PROFILE_FRAMEMARK_START("Window SwapBuffers");
             m_Window->SwapBuffers();
             OLO_PROFILE_FRAMEMARK_END("Window SwapBuffers");
             const auto swapEnd = std::chrono::high_resolution_clock::now();
-            RendererProfiler::GetInstance().AddPostFrameGPUWaitTime(
-                std::chrono::duration<f64, std::milli>(swapEnd - swapStart).count());
+            if (!m_Minimized)
+            {
+                RendererProfiler::GetInstance().AddPostFrameGPUWaitTime(
+                    std::chrono::duration<f64, std::milli>(swapEnd - swapStart).count());
+            }
 
             // Frame-rate cap (issue #456). Placed AFTER SwapBuffers so it only
             // sleeps for the budget vsync (if on) didn't already consume — no

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUPassTimerPool.h
@@ -28,6 +28,14 @@ namespace OloEngine
             f64 GpuMs = 0.0;
         };
 
+        // 4 slots: results are read back 1-3 frames after issue without ever
+        // blocking; a slot still pending when its turn comes again (GPU >3
+        // frames behind — pathological) is dropped instead of waited on.
+        // Public so callers (e.g. the MCP olo_perf_pass_timings staleness
+        // flag) can statically pin their own "results are stale" threshold
+        // to this ring size instead of duplicating the number.
+        static constexpr u32 kSlotCount = 4;
+
         static GPUPassTimerPool& GetInstance();
 
         /// @brief Allocate query objects. Call once after the GL context is valid.
@@ -99,11 +107,6 @@ namespace OloEngine
         ~GPUPassTimerPool();
         GPUPassTimerPool(const GPUPassTimerPool&) = delete;
         GPUPassTimerPool& operator=(const GPUPassTimerPool&) = delete;
-
-        // 4 slots: results are read back 1-3 frames after issue without ever
-        // blocking; a slot still pending when its turn comes again (GPU >3
-        // frames behind — pathological) is dropped instead of waited on.
-        static constexpr u32 kSlotCount = 4;
 
         struct FrameSlot
         {

--- a/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.cpp
@@ -59,9 +59,14 @@ namespace OloEngine
         m_FrameHistory.clear();
         m_FrameHistory.resize(OLO_FRAME_HISTORY_SIZE);
         m_HistoryIndex = 0;
+        m_LastWrittenHistoryIndex = 0;
 
         // Reset current frame data
         m_CurrentFrame = {};
+        m_PreviousFrame = {};
+        m_LastCompletedFrame = {};
+        m_HasCompletedFrame = false;
+        m_PendingPostFrameGPUWaitTime = 0.0;
 
         // Reset timing data
         m_FrameStartTime = std::chrono::high_resolution_clock::now();
@@ -75,10 +80,45 @@ namespace OloEngine
         m_FrameStartTime = std::chrono::high_resolution_clock::now();
         ++m_FrameNumber;
 
-        // Calculate frame time from previous frame
-        auto frameTime = std::chrono::duration<f64, std::milli>(m_FrameStartTime - m_LastFrameTime).count();
-        m_CurrentFrame.m_FrameTime = frameTime;
+        // The wall-clock delta since the last BeginFrame() is the PREVIOUS
+        // frame's true total duration: its CPU submission + GPU fence wait,
+        // PLUS everything that happens after its EndFrame() and before this
+        // call (SwapBuffers/vsync, frame-rate pacing, next frame's CPU-side
+        // prep). EndFrame() already finalized that previous frame's
+        // CPUTime/GPUTime/history entry *before* any of that post-render time
+        // had elapsed, so this frame-time value — and any post-frame GPU wait
+        // reported via AddPostFrameGPUWaitTime() (e.g. SwapBuffers blocking)
+        // — can only be attributed correctly here, patched into the
+        // already-recorded previous frame, rather than stamped onto the
+        // frame that's only just starting. Without this the MCP/UI snapshot
+        // paired frame N-1's frame time with frame N's CPU time, which could
+        // read as cpuMs > frameTimeMs whenever frame times swing (#519).
+        const f64 frameTime = std::chrono::duration<f64, std::milli>(m_FrameStartTime - m_LastFrameTime).count();
+        if (m_HasCompletedFrame)
+        {
+            const f64 patchedWait = m_PreviousFrame.m_GPUWaitTime + m_PendingPostFrameGPUWaitTime;
+            m_PreviousFrame.m_FrameTime = frameTime;
+            m_PreviousFrame.m_GPUWaitTime = patchedWait;
+
+            if (!m_FrameHistory.empty())
+            {
+                m_FrameHistory[m_LastWrittenHistoryIndex].m_FrameTime = frameTime;
+                m_FrameHistory[m_LastWrittenHistoryIndex].m_GPUWaitTime = patchedWait;
+            }
+
+            m_Counters[MetricType::FrameTime].AddSample(frameTime);
+            m_Counters[MetricType::GPUWaitTime].AddSample(patchedWait);
+
+            // m_PreviousFrame is now fully self-consistent (every field
+            // describes the same completed frame) — publish it.
+            m_LastCompletedFrame = m_PreviousFrame;
+        }
+        m_PendingPostFrameGPUWaitTime = 0.0;
         m_LastFrameTime = m_FrameStartTime;
+
+        // Live estimate for UI consumers reading m_CurrentFrame mid-frame;
+        // corrected to this frame's own value at the next BeginFrame() above.
+        m_CurrentFrame.m_FrameTime = frameTime;
 
         // Reset frame counters
         m_CurrentFrame.m_GPUWaitTime = 0.0;
@@ -115,15 +155,17 @@ namespace OloEngine
         const f64 wallMs = std::chrono::duration<f64, std::milli>(frameEndTime - m_FrameStartTime).count();
         m_CurrentFrame.m_CPUTime = std::max(0.0, wallMs - m_CurrentFrame.m_GPUWaitTime);
 
-        // Store frame data in history
+        // Store frame data in history. FrameTime and any post-frame GPU wait
+        // (SwapBuffers etc.) aren't known yet — the next BeginFrame() patches
+        // both fields into this exact slot and into m_PreviousFrame once they
+        // are (see there), so their counter samples are added there too.
         m_FrameHistory[m_HistoryIndex] = m_CurrentFrame;
+        m_LastWrittenHistoryIndex = m_HistoryIndex;
         m_HistoryIndex = (m_HistoryIndex + 1) % OLO_FRAME_HISTORY_SIZE;
 
         // Update performance counters
-        m_Counters[MetricType::FrameTime].AddSample(m_CurrentFrame.m_FrameTime);
         m_Counters[MetricType::CPUTime].AddSample(m_CurrentFrame.m_CPUTime);
         m_Counters[MetricType::GPUTime].AddSample(m_CurrentFrame.m_GPUTime);
-        m_Counters[MetricType::GPUWaitTime].AddSample(m_CurrentFrame.m_GPUWaitTime);
         m_Counters[MetricType::DrawCalls].AddSample(m_CurrentFrame.m_DrawCalls);
         m_Counters[MetricType::StateChanges].AddSample(m_CurrentFrame.m_StateChanges);
         m_Counters[MetricType::ShaderBinds].AddSample(m_CurrentFrame.m_ShaderBinds);
@@ -138,8 +180,10 @@ namespace OloEngine
         m_Counters[MetricType::InstancesRendered].AddSample(m_CurrentFrame.m_InstancesRendered);
         m_Counters[MetricType::InstancesBatched].AddSample(m_CurrentFrame.m_InstancesBatched);
 
-        // Move current to previous
+        // Move current to previous — FrameTime/GPUWaitTime patched at the
+        // next BeginFrame() once they're known (see there).
         m_PreviousFrame = m_CurrentFrame;
+        m_HasCompletedFrame = true;
     }
 
     void RendererProfiler::AddTimingSample(const std::string& name, f64 timeMs, MetricType type)

--- a/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RendererProfiler.h
@@ -206,13 +206,44 @@ namespace OloEngine
             m_CurrentFrame.m_GPUWaitTime += timeMs;
         }
 
+        // @brief Accumulate CPU time spent blocked on GPU/present sync that
+        // happens AFTER this frame's EndFrame() has already run — e.g. the
+        // SwapBuffers() call, which can block on vsync or on the driver
+        // throttling a GPU-bound app. EndFrame() has already finalized this
+        // frame's CPUTime/GPUWaitTime/history entry by the time SwapBuffers
+        // returns, so the wait recorded here is patched into that
+        // already-recorded frame at the START of the NEXT BeginFrame() (the
+        // only point where it's known) instead of being silently dropped.
+        // See BeginFrame() for why. Fixes gpuWaitMs reading ~0 while clearly
+        // GPU-bound (#519).
+        void AddPostFrameGPUWaitTime(f64 timeMs)
+        {
+            m_PendingPostFrameGPUWaitTime += timeMs;
+        }
+
         // @brief Render the profiler UI
         void RenderUI(bool* open = nullptr);
 
-        // @brief Get current frame data
+        // @brief Get current (in-progress) frame data. FrameTime here is a
+        // LIVE ESTIMATE carried over from the previous frame's measurement —
+        // fine for a live-updating UI, but do NOT use this for a snapshot
+        // that must be internally self-consistent (its CPUTime/GPUTime
+        // describe the in-progress frame while FrameTime describes the
+        // previous one). Use GetLastCompletedFrameData() for that.
         const FrameData& GetCurrentFrameData() const
         {
             return m_CurrentFrame;
+        }
+
+        // @brief Get the most recently fully-finalized frame: FrameTime,
+        // CPUTime, GPUTime and GPUWaitTime all describe the SAME completed
+        // frame (unlike GetCurrentFrameData(), whose FrameTime is only a
+        // live estimate — see there). Lags the in-progress frame by up to
+        // one frame. Use this for any external snapshot that must not mix
+        // measurements from different frames, e.g. the MCP perf tools (#519).
+        const FrameData& GetLastCompletedFrameData() const
+        {
+            return m_LastCompletedFrame;
         }
 
         // @brief Get performance counter
@@ -363,7 +394,8 @@ namespace OloEngine
 
         // Data storage
         FrameData m_CurrentFrame;
-        FrameData m_PreviousFrame;
+        FrameData m_PreviousFrame;      // raw EndFrame() output for the last frame; FrameTime/GPUWaitTime unpatched until the next BeginFrame()
+        FrameData m_LastCompletedFrame; // fully patched, self-consistent snapshot — see GetLastCompletedFrameData()
         std::unordered_map<MetricType, PerformanceCounter> m_Counters;
         std::unordered_map<std::string, PerformanceCounter> m_CustomTimings;
 
@@ -371,10 +403,13 @@ namespace OloEngine
         static constexpr u32 OLO_FRAME_HISTORY_SIZE = 300; // 5 seconds at 60fps
         std::vector<FrameData> m_FrameHistory;
         u32 m_HistoryIndex = 0;
+        u32 m_LastWrittenHistoryIndex = 0; // slot EndFrame() last wrote; patched in place by the next BeginFrame()
 
         // Frame timing
         std::chrono::high_resolution_clock::time_point m_FrameStartTime;
         std::chrono::high_resolution_clock::time_point m_LastFrameTime;
+        bool m_HasCompletedFrame = false;        // true once at least one EndFrame() has run — guards the BeginFrame() patch step
+        f64 m_PendingPostFrameGPUWaitTime = 0.0; // accumulated via AddPostFrameGPUWaitTime() since the last EndFrame()
 
         // Configuration
         f32 m_TargetFrameRate = 60.0f;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -342,6 +342,8 @@ add_executable(OloEngine-Tests
 		StaticMeshColliderGenerationTest.cpp
 		# CrashReporter / platform handlers (Windows SEH + Linux signal hooks)
 		Debug/CrashReporterTest.cpp
+		# RendererProfiler frame-time/CPU/GPU-wait alignment (#519)
+		Debug/RendererProfilerTest.cpp
 		# Gameplay Ability Tests
 		Gameplay/GameplayAbilityTest.cpp
 		# Content Browser Tests

--- a/OloEngine/tests/Debug/RendererProfilerTest.cpp
+++ b/OloEngine/tests/Debug/RendererProfilerTest.cpp
@@ -1,0 +1,103 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/Debug/RendererProfiler.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace
+{
+    // RendererProfiler is a process-wide singleton (GetInstance()), so every
+    // test resets it in SetUp/TearDown to avoid leaking frame state into
+    // whatever else runs in this binary.
+    class RendererProfilerTimingTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            OloEngine::RendererProfiler::GetInstance().Reset();
+        }
+
+        void TearDown() override
+        {
+            OloEngine::RendererProfiler::GetInstance().Reset();
+        }
+    };
+
+    // Issue #519 bug 1: RendererProfiler measured m_FrameTime at BeginFrame()
+    // (the previous frame's wall-clock delta) and m_CPUTime at EndFrame() (the
+    // current bracket), so a consumer reading GetCurrentFrameData() mid-frame
+    // saw frameTimeMs from frame N-1 paired with cpuMs from frame N — which
+    // could read as cpuMs > frameTimeMs whenever frame times swing. This test
+    // drives two frames with deliberately different durations and asserts
+    // GetLastCompletedFrameData() never mixes them: FrameTime/CPUTime/
+    // GPUWaitTime for the reported frame must all be mutually consistent.
+    TEST_F(RendererProfilerTimingTest, LastCompletedFrameNeverMixesMeasurementsAcrossFrames)
+    {
+        using namespace std::chrono_literals;
+        auto& profiler = OloEngine::RendererProfiler::GetInstance();
+
+        // Frame 1: long CPU-bound frame.
+        profiler.BeginFrame();
+        std::this_thread::sleep_for(20ms);
+        profiler.EndFrame();
+
+        // Gap between EndFrame(1) and BeginFrame(2) — stands in for
+        // SwapBuffers/pacing time that happens outside the profiler bracket.
+        std::this_thread::sleep_for(10ms);
+        profiler.AddPostFrameGPUWaitTime(4.0);
+
+        // Frame 2: short frame. BeginFrame() here is what patches frame 1's
+        // FrameTime/GPUWaitTime now that they're fully known.
+        profiler.BeginFrame();
+        std::this_thread::sleep_for(1ms);
+        profiler.EndFrame();
+
+        const auto& completed = profiler.GetLastCompletedFrameData();
+
+        // Frame 1 (the one just completed and patched) must describe a
+        // single, self-consistent frame: its CPU time plus the post-frame
+        // GPU wait we reported cannot exceed its total frame time.
+        EXPECT_GE(completed.m_FrameTime, completed.m_CPUTime)
+            << "frameTimeMs must never be smaller than cpuMs for the same completed frame";
+        EXPECT_GE(completed.m_FrameTime, completed.m_CPUTime + completed.m_GPUWaitTime - 0.5)
+            << "frameTimeMs must account for CPU work plus any reported GPU wait (small tolerance for scheduler jitter)";
+
+        // The post-frame wait (e.g. SwapBuffers blocking) reported between
+        // EndFrame(1) and BeginFrame(2) must land on frame 1, not be dropped.
+        EXPECT_GE(completed.m_GPUWaitTime, 4.0 - 1e-6)
+            << "gpuWaitMs must include GPU/present waits reported after EndFrame() via AddPostFrameGPUWaitTime()";
+
+        // Frame 1 ran ~20ms of CPU work plus a ~10ms gap — its total frame
+        // time should reflect that, not the ~1ms of frame 2.
+        EXPECT_GT(completed.m_FrameTime, 25.0)
+            << "frameTimeMs for frame 1 must reflect frame 1's own duration, not frame 2's short one";
+    }
+
+    // GetCurrentFrameData() is documented as a live, in-progress approximation
+    // (its FrameTime is carried over from the previous frame) — this test
+    // just pins that GetLastCompletedFrameData() is the one that stays
+    // self-consistent even while a new frame is mid-flight.
+    TEST_F(RendererProfilerTimingTest, CompletedFrameStaysStableWhileNextFrameIsInProgress)
+    {
+        using namespace std::chrono_literals;
+        auto& profiler = OloEngine::RendererProfiler::GetInstance();
+
+        profiler.BeginFrame();
+        std::this_thread::sleep_for(5ms);
+        profiler.EndFrame();
+
+        std::this_thread::sleep_for(2ms);
+        profiler.BeginFrame(); // patches frame 1 into GetLastCompletedFrameData()
+
+        const auto snapshotBefore = profiler.GetLastCompletedFrameData();
+        std::this_thread::sleep_for(3ms); // frame 2 still in progress
+
+        const auto& snapshotDuring = profiler.GetLastCompletedFrameData();
+        EXPECT_DOUBLE_EQ(snapshotBefore.m_FrameTime, snapshotDuring.m_FrameTime);
+        EXPECT_DOUBLE_EQ(snapshotBefore.m_CPUTime, snapshotDuring.m_CPUTime);
+
+        profiler.EndFrame();
+    }
+} // namespace

--- a/OloEngine/tests/MCP/McpPassTimingsTest.cpp
+++ b/OloEngine/tests/MCP/McpPassTimingsTest.cpp
@@ -21,6 +21,7 @@ namespace
     using OloEngine::MCP::PassTimings::CpuPassEntry;
     using OloEngine::MCP::PassTimings::FrameTotals;
     using OloEngine::MCP::PassTimings::GpuPassEntry;
+    using OloEngine::MCP::PassTimings::kGpuResultsStaleThreshold;
     using OloEngine::MCP::PassTimings::Round3;
     using Json = OloEngine::MCP::PassTimings::Json;
 
@@ -119,6 +120,30 @@ TEST(McpPassTimingsTest, FrameTotalsAndUnattributedGpu)
 
     // 8.1 total - 6.0 attributed = 2.1 unattributed (barriers, HZB rebuild, ...).
     EXPECT_NEAR(o["unattributedGpuMs"].get<double>(), 2.1, 1e-9);
+
+    // MakeTotals() uses an age of 2, comfortably inside the normal 1-3 frame
+    // resolve latency — not stale.
+    EXPECT_FALSE(o["gpuResultsStale"].get<bool>());
+}
+
+// #519: an age at or beyond GPUPassTimerPool's slot count means a timestamp
+// slot was dropped (GPU fell more than a full ring's worth of frames behind)
+// rather than resolved through the normal 1-3 frame latency — the numbers
+// are from a stale, possibly no-longer-representative frame. Surfaced as an
+// explicit flag so a caller doesn't have to know to compare
+// gpuResultsAgeFrames against the pool's slot count itself.
+TEST(McpPassTimingsTest, FlagsGpuResultsAsStaleAtOrBeyondSlotCount)
+{
+    FrameTotals totals = MakeTotals();
+
+    totals.GpuResultsAgeFrames = kGpuResultsStaleThreshold - 1;
+    EXPECT_FALSE(BuildPassTimings({}, {}, totals)["gpuResultsStale"].get<bool>());
+
+    totals.GpuResultsAgeFrames = kGpuResultsStaleThreshold;
+    EXPECT_TRUE(BuildPassTimings({}, {}, totals)["gpuResultsStale"].get<bool>());
+
+    totals.GpuResultsAgeFrames = kGpuResultsStaleThreshold + 5;
+    EXPECT_TRUE(BuildPassTimings({}, {}, totals)["gpuResultsStale"].get<bool>());
 }
 
 TEST(McpPassTimingsTest, UnattributedGpuClampsToZeroWhenPassesExceedFrameSpan)


### PR DESCRIPTION
## Summary
- Fixes the two GPU-timing accuracy bugs tracked in #519's "Accuracy bugs" section (bug 1: `cpuMs`>`frameTimeMs` at saturation; bug 2: `gpuWaitMs` reading ~0 while GPU-bound), and investigates bug 3 (erratic per-pass numbers on long frames).
- Root cause of bug 1: `RendererProfiler::BeginFrame()` computed frame time from the wall-clock delta since the *previous* `BeginFrame()` (i.e. the previous frame's duration) but stamped it onto the about-to-start current frame's record — so a mid-frame read of `GetCurrentFrameData()` paired frame N-1's `frameTimeMs` with frame N's `cpuMs`/`gpuMs`.
- Root cause of bug 2: only the `FrameResourceManager::BeginFrame` fence wait was attributed to `gpuWaitMs`; the real GPU-bound stall for a windowed app is `Window::SwapBuffers()`, which runs in `Application::Run` *after* `RendererProfiler::EndFrame()` already finalized the frame — invisible to the profiler entirely.
- Fix: patch FrameTime and GPUWaitTime into the *previous* frame's already-recorded data at the start of the next `BeginFrame()`, once both are fully known (SwapBuffers wait threaded in via a new `AddPostFrameGPUWaitTime()`), and publish that as a new `GetLastCompletedFrameData()` — every field describes the same completed frame (≤1 frame latency). `GetCurrentFrameData()` remains for live/approximate UI display. MCP's `olo_perf_snapshot`/`olo_perf_pass_timings` now read the completed-frame accessor.
- Bug 3: investigated `GPUPassTimerPool` — it's already a correctly non-blocking, N-frame-in-flight timestamp ring; found no separate root cause beyond bug 1 making the whole snapshot look inconsistent. Per the issue's own suggestion, added an explicit `gpuResultsStale` flag to `olo_perf_pass_timings` (true once `gpuResultsAgeFrames` reaches the timer pool's slot count) so a caller doesn't have to know to compare the age manually.

## Test plan
- [x] `OloEngine-Tests`: added `Debug/RendererProfilerTest.cpp` (unit) pinning the frame-alignment invariant with synthetic `BeginFrame`/`EndFrame`/`AddPostFrameGPUWaitTime` sequences.
- [x] `OloEngine-Tests`: added `McpPassTimingsTest.FlagsGpuResultsAsStaleAtOrBeyondSlotCount`.
- [x] Full `OloEngine`, `OloEditor`, `OloRuntime`, `OloServer`, `OloEngine-Tests` build clean (Debug/MSVC).
- [x] Live-verified against a running Debug editor over the MCP `olo_perf_snapshot`/`olo_perf_pass_timings` tools: `cpuMs` ≤ `frameTimeMs` held across every sampled frame, `gpuWaitMs` now reads a small non-zero value (real vsync/present wait) instead of a hard 0.00.

Refs #519 (comment: https://github.com/drsnuggles8/OloEngineBase/issues/519#issuecomment-4889613421)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer performance timing output, including a new indicator when GPU timing data may be stale.
  * Performance snapshot tools now report a more consistent “last completed frame” view for timing data.

* **Bug Fixes**
  * Improved GPU wait-time tracking so frame timing results are aligned with the correct frame.
  * Fixed timing snapshots to avoid mixing partial and completed frame measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->