### PR TITLE
fix(rendergraph): evict transient pool on scene-band resize — no more black frames after a forward upscale-off transition (#563)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -2946,9 +2946,24 @@ namespace OloEngine
         m_PhysicalWidth = width;
         m_PhysicalHeight = height;
 
+        // Resize every node's framebuffer, tracking whether ANY node actually
+        // changed size. A node can change size here even when the display
+        // (physical) dimensions did not: a prior FSR1 scene-band render
+        // (Upscale != Off shrinks the ScenePass / AO targets below display res —
+        // see RenderPipeline::PopulateBlackboard) leaves those nodes reduced, and
+        // this loop restores them to full display res. That must still evict the
+        // pool (below), or its stale reduced-size transients leak into the next
+        // frames — see the Clear() comment.
+        bool anyNodeResized = false;
         for (auto& [name, node] : m_NodeLookup)
         {
+            const auto& beforeSpec = node->GetFramebufferSpecification();
+            const u32 beforeW = beforeSpec.Width;
+            const u32 beforeH = beforeSpec.Height;
             node->ResizeFramebuffer(width, height);
+            const auto& afterSpec = node->GetFramebufferSpecification();
+            if (afterSpec.Width != beforeW || afterSpec.Height != beforeH)
+                anyNodeResized = true;
         }
 
         // Evict cached transient framebuffers / textures whose dimensions are
@@ -2964,7 +2979,20 @@ namespace OloEngine
         // safe here because Resize() runs in OnUpdate before the frame's
         // rendering begins; the previous frame's ReleaseAll has already
         // returned everything to the pool.
-        if (dimensionsChanged)
+        //
+        // We clear when the display dims changed OR any node's framebuffer
+        // actually resized — NOT only on a display-dimension change. The latter
+        // misses the case where the display size is unchanged but a node was
+        // restored from a reduced FSR1 scene band to full res (a forward
+        // Upscale-off transition inside one process), which leaves the pool
+        // holding stale reduced-size (and paired stale full-size) transients
+        // whose alias groups get handed to a downstream pass for the first
+        // frames after the transition — the order-dependent black-scene-for-
+        // ~2-frames regression of issue #563. A genuinely idle resize (the
+        // editor re-emitting the same viewport size with no node actually
+        // changing size) still skips the Clear, so steady-state frames don't
+        // churn the pool.
+        if (dimensionsChanged || anyNodeResized)
         {
             m_TransientPool.Clear();
         }

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -2994,7 +2994,7 @@ namespace OloEngine
         // churn the pool.
         if (dimensionsChanged || anyNodeResized)
         {
-            m_TransientPool.Clear();
+            NotifyNodeFramebufferResized();
         }
 
         // Physical resize resets render viewport overrides on all FBOs.

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.h
@@ -660,6 +660,21 @@ namespace OloEngine
             return m_TransientPool;
         }
 
+        // Single chokepoint for the "a graph node's framebuffer changed size =>
+        // the transient pool must be evicted" rule (issue #563). The pool keys
+        // its buckets by full spec (incl. width/height), so any node resize can
+        // leave stale-size (and paired stale-size) transients that the
+        // alias-group resolver then hands to a downstream pass. Resize() calls
+        // this after its node-resize loop; call sites that resize a node's
+        // framebuffer OUT OF BAND — without going through Resize(), e.g.
+        // RenderPipeline's FSR1 scene-band resize on a runtime Upscale-mode
+        // toggle — must call this instead of reaching into GetTransientPool()
+        // directly, so every direct-resize path shares one eviction decision.
+        void NotifyNodeFramebufferResized()
+        {
+            m_TransientPool.Clear();
+        }
+
         // -------------------------------------------------------------------
         // Builder support for transient resource allocation
         // -------------------------------------------------------------------

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -1351,6 +1351,22 @@ namespace OloEngine
                         pipeline.SceneCompositePasses.SSAO->ResizeFramebuffer(sceneW, sceneH);
                     if (pipeline.SceneCompositePasses.GTAO)
                         pipeline.SceneCompositePasses.GTAO->ResizeFramebuffer(sceneW, sceneH);
+
+                    // The scene-band size just changed WITHOUT a window/viewport
+                    // resize (a runtime FSR1 Upscale-mode toggle: e.g. Performance
+                    // -> Off restores the ScenePass / AO targets to full display
+                    // res). That changes the SceneColor / SceneDepth / SceneNormals
+                    // / Velocity transient descriptors, so the transient pool now
+                    // holds stale reduced-size (and paired stale full-size)
+                    // framebuffers/textures. Unlike a genuine viewport resize this
+                    // path never reaches RenderGraph::Resize, so evict the pool here
+                    // too — otherwise the alias-group resolver can hand a stale
+                    // transient to a downstream pass for the first ~2 frames after
+                    // the transition, rendering a black scene (issue #563; the
+                    // render-graph half of #549). Safe here: PopulateBlackboard runs
+                    // before this frame's MaterializeTransientResources acquires, and
+                    // the previous frame's ReleaseAll already returned everything.
+                    graph.GetTransientPool().Clear();
                 }
             }
         }

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -1359,14 +1359,15 @@ namespace OloEngine
                     // / Velocity transient descriptors, so the transient pool now
                     // holds stale reduced-size (and paired stale full-size)
                     // framebuffers/textures. Unlike a genuine viewport resize this
-                    // path never reaches RenderGraph::Resize, so evict the pool here
-                    // too — otherwise the alias-group resolver can hand a stale
-                    // transient to a downstream pass for the first ~2 frames after
-                    // the transition, rendering a black scene (issue #563; the
-                    // render-graph half of #549). Safe here: PopulateBlackboard runs
-                    // before this frame's MaterializeTransientResources acquires, and
-                    // the previous frame's ReleaseAll already returned everything.
-                    graph.GetTransientPool().Clear();
+                    // path never reaches RenderGraph::Resize, so route through the
+                    // graph's node-resize eviction chokepoint — otherwise the
+                    // alias-group resolver can hand a stale transient to a downstream
+                    // pass for the first ~2 frames after the transition, rendering a
+                    // black scene (issue #563; the render-graph half of #549). Safe
+                    // here: PopulateBlackboard runs before this frame's
+                    // MaterializeTransientResources acquires, and the previous
+                    // frame's ReleaseAll already returned everything.
+                    graph.NotifyNodeFramebufferResized();
                 }
             }
         }

--- a/OloEngine/tests/Rendering/PropertyTests/EASUVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/EASUVisualEvidenceTest.cpp
@@ -494,4 +494,91 @@ namespace OloEngine::Tests
             << "runtime Upscale switch made the GTAO-lit frame substantially darker than native (native="
             << nativeMean << " up=" << upMean << ") — see EASU_GTAONative.png / EASU_GTAOPerformance.png";
     }
+
+    // Guard for issue #563 (the render-graph half of #549): a forward FSR1
+    // Upscale -> Off transition must NOT leave the scene black for the short
+    // warm-up a temporal-sensitive visual test reads back.
+    //
+    // An FSR1 render shrinks the ScenePass / AO scene-band framebuffers below
+    // display res and pools reduced-size SceneColor / SceneDepth / SceneNormals /
+    // Velocity transients. When the band is later restored to full res by a
+    // viewport-resize event whose DISPLAY size is UNCHANGED (exactly what happens
+    // when the next full-size scene is entered in one process — e.g. a following
+    // visual test's EnableRendering -> OnWindowResize -> RenderGraph::Resize),
+    // the old display-size-gated pool eviction did not fire. The pool kept the
+    // stale reduced-size transients and the alias-group resolver handed one to
+    // the scene chain for the first frames after the transition — a black scene.
+    // This models the real order-dependent CAS-after-EASU shuffle failure (which
+    // enters CAS's full-size scene right after an FSR1 render) deterministically
+    // in one fixture, via the same-display-size ResizeRenderTarget below.
+    //
+    // Frame 0 after any scene/config change is a legitimate warm-up frame (black
+    // even in isolation, which the pipeline's ~1-frame temporal latency explains);
+    // the regression was that frame 1 was ALSO black. So warm exactly two frames
+    // (the minimum a temporal-sensitive victim like CASVisualEvidenceTest uses)
+    // after the transition and assert the composited frame is not black. SKIPs
+    // without a GL 4.6 context.
+    TEST_F(EASUVisualEvidenceTest, ForwardUpscaleOffTransitionKeepsSceneVisible)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        struct ScopedMockTime
+        {
+            explicit ScopedMockTime(f32 t)
+            {
+                Time::SetMockTime(t);
+            }
+            ~ScopedMockTime()
+            {
+                Time::ClearMockTime();
+            }
+        } scopedMockTime(kCaptureTime);
+
+        EditorCamera camera(60.0f, static_cast<f32>(kWidth) / static_cast<f32>(kHeight), 0.05f, 1000.0f);
+        camera.SetViewportSize(static_cast<f32>(kWidth), static_cast<f32>(kHeight));
+        camera.SetPose({ 0.0f, 7.0f, 16.0f }, 0.0f, 0.32f);
+
+        auto& pp = Renderer3D::GetPostProcessSettings();
+
+        // Mimic the producer's full render history so the transient pool ends up
+        // in the same stale state the real cross-test ordering produces: a native
+        // (full-res) render pools full-size SceneColor transients, then an FSR1
+        // Performance render shrinks the band and pools reduced-size ones.
+        pp.Upscale = UpscaleMode::Off;
+        pp.RCASSharpness = 0.6f;
+        RunEditorFrames(camera, 3);
+
+        pp.Upscale = UpscaleMode::Performance;
+        RunEditorFrames(camera, 3);
+
+        // Back to native, then re-enter the full-size scene via a same-display-
+        // size viewport resize (mimicking the next visual test's EnableRendering
+        // -> OnWindowResize). This restores the reduced band to full res through
+        // RenderGraph::Resize WITHOUT a display-dimension change — the arm that
+        // the old display-only pool eviction missed and that leaves stale
+        // reduced-size transients in the pool.
+        pp.Upscale = UpscaleMode::Off;
+        ResizeRenderTarget(kWidth, kHeight);
+
+        // Warm only two frames after the transition. Frame 1 must carry scene
+        // content, not the stale-transient black.
+        RunEditorFrames(camera, 2);
+
+        auto fb = Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::UIComposite);
+        if (!fb)
+            fb = Renderer3D::ResolveFrameGraphFramebuffer(ResourceNames::ToneMapColor);
+        ASSERT_TRUE(fb) << "No composited framebuffer after the upscale-off transition";
+
+        std::vector<u8> px;
+        ReadbackRgba8(fb->GetColorAttachmentRendererID(0), kWidth, kHeight, px);
+        ASSERT_EQ(px.size(), static_cast<std::size_t>(kWidth) * kHeight * 4u);
+
+        const f64 meanLuma = MeanLuma(px);
+        EXPECT_GT(meanLuma, 20.0)
+            << "scene rendered (near-)black on the 2-frame warm-up after a forward FSR1 "
+               "Upscale->Off transition (#563): mean luma="
+            << meanLuma
+            << ". The render-graph transient pool likely kept a stale reduced-size "
+               "framebuffer across the scene-band resize.";
+    }
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/OloEngine/tests/Rendering/RenderGraphTest.cpp
@@ -75,6 +75,36 @@ class StubRenderPass : public RenderGraphNode
     u32 m_ExecuteCount = 0;
 };
 
+// A stub whose framebuffer spec starts at an arbitrary (possibly reduced) size
+// and is updated by ResizeFramebuffer, so GetFramebufferSpecification() reflects
+// the current size — used to exercise RenderGraph::Resize's node-size-change
+// detection (issue #563: a node restored from a reduced FSR1 scene band to full
+// res while the display size is unchanged must still evict the transient pool).
+class ResizableStubPass : public RenderGraphNode
+{
+  public:
+    ResizableStubPass(const std::string& name, u32 width, u32 height)
+    {
+        m_Name = name;
+        m_FramebufferSpec.Width = width;
+        m_FramebufferSpec.Height = height;
+    }
+
+    void Init(const FramebufferSpecification& /*spec*/) override {}
+    void Execute(RGCommandContext& /*context*/) override {}
+    [[nodiscard]] Ref<Framebuffer> GetTarget() const override
+    {
+        return nullptr;
+    }
+    void SetupFramebuffer(u32 /*w*/, u32 /*h*/) override {}
+    void ResizeFramebuffer(u32 width, u32 height) override
+    {
+        m_FramebufferSpec.Width = width;
+        m_FramebufferSpec.Height = height;
+    }
+    void OnReset() override {}
+};
+
 class CallbackStyleStubPass : public RenderGraphNode
 {
   public:
@@ -4625,6 +4655,85 @@ TEST(RenderGraphTransientPool, ResizeEvictsStalePoolEntries)
     EXPECT_EQ(idle.TexturePoolSize, beforeNoOp.TexturePoolSize)
         << "Same-dimension resize must not churn the texture pool.";
     EXPECT_EQ(idle.BufferPoolSize, beforeNoOp.BufferPoolSize);
+}
+
+TEST(RenderGraphTransientPool, ResizeEvictsPoolWhenNodeResizedButDisplayUnchanged)
+{
+    // Regression for issue #563 (the render-graph half of #549): a forward FSR1
+    // Upscale-off transition restores the ScenePass / AO scene-band framebuffers
+    // from a reduced render resolution back to full display res. When that
+    // happens via a window/viewport resize event whose DISPLAY size is unchanged
+    // (e.g. re-entering a full-size scene after a prior test/frame left the band
+    // reduced), the old display-size-gated pool eviction did NOT fire, so the
+    // transient pool kept stale reduced-size (and paired stale full-size)
+    // framebuffers. The alias-group resolver then handed one to the scene chain
+    // for the first ~2 frames after the transition, rendering a black scene.
+    //
+    // The fix evicts the pool whenever the display dims changed OR any node's
+    // framebuffer actually resized. This pins the "node resized while display
+    // size unchanged" arm — the one the display-only gate missed. Needs a live
+    // GL backend to populate the pool with real Acquire+ReleaseAll cycles.
+    if (RendererAPI::GetAPI() == RendererAPI::API::None)
+        GTEST_SKIP() << "TransientPool eviction requires an active rendering backend";
+
+    OloEngine::Tests::RenderPropertyFixture::IsGpuAvailable();
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    RenderGraph graph;
+    graph.SetTransientPoolMaxBucketSize(2u);
+
+    // Establish the display size (clears the empty pool as a side effect).
+    graph.Resize(1280, 720);
+
+    // Register a node, then shrink it to a REDUCED scene band (half res) — as an
+    // FSR1 Performance render does via RenderPipeline::PopulateBlackboard's
+    // ScenePass->ResizeFramebuffer. (AddNode itself syncs the node to the current
+    // display size, so the reduction must happen explicitly afterwards, exactly
+    // as the runtime upscale path does.)
+    auto reducedNode = Ref<ResizableStubPass>::Create("ReducedSceneBand", 1280u, 720u);
+    graph.AddNode(reducedNode.As<RenderGraphNode>());
+    reducedNode->ResizeFramebuffer(640u, 360u);
+    ASSERT_EQ(reducedNode->GetFramebufferSpecification().Width, 640u)
+        << "Sanity: node should be reduced to the FSR1 scene band before the restoring resize.";
+
+    // Seed both pool buckets at the reduced size, mimicking the reduced-band
+    // transients pooled during the upscale render.
+    {
+        TransientPool& pool = graph.GetTransientPool();
+
+        TextureSpecification texSpec;
+        texSpec.Width = 640;
+        texSpec.Height = 360;
+        texSpec.Format = ImageFormat::RGBA8;
+        (void)pool.AcquireTexture(texSpec);
+
+        FramebufferSpecification fbSpec;
+        fbSpec.Width = 640;
+        fbSpec.Height = 360;
+        fbSpec.Attachments = { FramebufferTextureFormat::RGBA8 };
+        (void)pool.AcquireFramebuffer(fbSpec);
+
+        pool.ReleaseAll();
+    }
+
+    const auto before = graph.GetTransientPool().GetStats();
+    ASSERT_GT(before.FramebufferPoolSize, 0u)
+        << "Sanity: ReleaseAll should have parked the reduced-size framebuffer in its bucket.";
+    ASSERT_GT(before.TexturePoolSize, 0u)
+        << "Sanity: ReleaseAll should have parked the reduced-size texture in its bucket.";
+
+    // SAME display dimensions as the seeding Resize above — but this restores the
+    // reduced node to full res, so the pool MUST be evicted even though the
+    // display size did not change.
+    graph.Resize(1280, 720);
+
+    const auto after = graph.GetTransientPool().GetStats();
+    EXPECT_EQ(after.FramebufferPoolSize, 0u)
+        << "A resize that restores a reduced-band node to full res must evict the "
+           "transient framebuffer pool even when the display size is unchanged (#563).";
+    EXPECT_EQ(after.TexturePoolSize, 0u)
+        << "A resize that restores a reduced-band node to full res must evict the "
+           "transient texture pool even when the display size is unchanged (#563).";
 }
 
 TEST(RenderGraphTransientPool, UnreachableTransientResourceIsNotPlannedForAllocation)

--- a/docs/agent-rules/render-pipeline-caches.md
+++ b/docs/agent-rules/render-pipeline-caches.md
@@ -54,3 +54,69 @@ topology reset", fold `GetTopologyGeneration()` into the key.
 (GPU, `OcclusionCullDeferredVisualEvidenceTest.cpp`, SKIPs headless)
 reproduces the full reconfigure→reconfigure→rerender sequence and fails on a
 blank frame if the cull returns.
+
+---
+
+# The transient pool is a size-keyed cache: evict it on any node resize, not just a display resize
+
+The `TransientPool` (owned by `RenderGraph`) recycles GPU framebuffers/textures
+across frames, bucketed by **full spec including width/height**. It is the same
+family of trap as the blackboard cache above: a *process-wide cache* that must
+be invalidated by the **structural event that makes its entries stale**, not by
+a proxy for that event.
+
+## The trap (issue #563 — the render-graph half of #549)
+
+An FSR1 upscale (`Upscale != Off`) renders the scene at a **reduced band**:
+`RenderPipeline::PopulateBlackboard` shrinks the ScenePass / SSAO / GTAO
+framebuffers below display res, which cascades to the `SceneColor` / `SceneDepth`
+/ `SceneNormals` / `Velocity` transient descriptors. Toggling back to native
+restores those nodes to full res. Crucially, **this restore can happen without
+the display (physical) dimensions ever changing** — a runtime `Upscale`→`Off`
+toggle, or re-entering a full-size scene in one process after a prior test left
+the band reduced.
+
+`RenderGraph::Resize` used to evict the pool **only when the display dimensions
+changed**. So a same-display-size resize that restored a reduced node to full
+res left the pool holding stale reduced-size (and paired stale full-size)
+framebuffers. The alias-group resolver in `MaterializeTransientResources` then
+handed one of those stale transients to the scene chain for the first ~2 frames
+after the transition, so `SceneColor` resolved to a never-written (zeroed)
+texture and the whole frame rendered **black for ~2 frames**, then recovered.
+Order-dependent: it only bit when an earlier test (or runtime action) had left
+reduced-band transients in the pool.
+
+## The rule
+
+**Evict the transient pool whenever a transient descriptor's size can have
+changed — i.e. whenever any graph node's framebuffer actually resized — not only
+when the display dimensions changed.** Two sites drive a scene-band resize and
+both must evict:
+
+- `RenderGraph::Resize` — clears the pool when `dimensionsChanged || anyNode
+  resized` (it now compares each node's `GetFramebufferSpecification()` before/
+  after `ResizeFramebuffer`). This catches the window/viewport-resize entry path
+  where a node is restored from a reduced band while the display size is
+  unchanged. A genuinely idle resize (same display size, no node actually
+  resized) still skips the clear, so steady-state frames don't churn the pool.
+- `RenderPipeline::PopulateBlackboard`'s FSR1 scene-band resize block — clears
+  the pool right after `ScenePass->ResizeFramebuffer`, because a **runtime**
+  `Upscale`-mode toggle changes the band with no window resize and never reaches
+  `RenderGraph::Resize`.
+
+Generalise: if you add a transient whose size is derived from something other
+than the display resolution (a render-scale, a half-res AO band, a shadow
+cascade size), ask *what changes that size, and does the pool get evicted when
+it does?* A size-keyed cache that outlives a size change silently serves stale
+(or wrong-alias) entries.
+
+## Guard
+
+`RenderGraphTransientPool.ResizeEvictsPoolWhenNodeResizedButDisplayUnchanged`
+(CPU/GL-gated, `RenderGraphTest.cpp`, SKIPs headless) shrinks a registered node
+to a reduced band then resizes at the **same display size** and asserts the pool
+is emptied. `RenderGraphTransientPool.ResizeEvictsStalePoolEntries` still pins
+the paired "same-dimension idle resize must **not** churn the pool" contract.
+`EASUVisualEvidenceTest.ForwardUpscaleOffTransitionKeepsSceneVisible`
+(GPU, SKIPs headless) reproduces the runtime `Performance`→`Off` transition with
+a 2-frame warm-up and fails on a black frame if the pool keeps stale transients.


### PR DESCRIPTION
## Summary

Fixes **#563** — the render-graph half of #549: renderer post-process visual tests were order-dependent under `--gtest_shuffle` because a **render-graph transient was left invalid for ~2 frames after a forward FSR-upscale transition**, rendering a black scene.

## Root cause (confirmed by per-frame instrumentation)

An FSR1 upscale (`Upscale != Off`) renders the scene at a **reduced band** — `RenderPipeline::PopulateBlackboard` shrinks the ScenePass / SSAO / GTAO framebuffers below display res, which cascades to the `SceneColor` / `SceneDepth` / `SceneNormals` / `Velocity` transient descriptors. When the band is later restored to full res **without a display-dimension change** (a runtime `Upscale`→`Off` toggle, or re-entering a full-size scene in one process after an FSR1 render), the `TransientPool` — keyed by full spec incl. width/height — was **not evicted**:

- `RenderGraph::Resize` cleared the pool **only when the display dimensions changed**; a same-display-size resize that restored a reduced node to full res left stale reduced-size (and paired full-size) framebuffers pooled.
- The **runtime** `Upscale`-toggle path (`PopulateBlackboard`) changes the band with no window resize and never reaches `Resize` at all.

`MaterializeTransientResources`' alias-group resolver then handed one of those stale transients to the scene chain for the first ~2 frames after the transition, so `SceneColor` resolved to a never-written (zeroed) texture and the whole frame rendered **black**, then recovered.

Instrumented trace of the polluted CAS run (my `sum` counts the alpha byte; `sum=0` = fully zero, `200540160` = RGB black + opaque alpha):

```
frame0  SceneColor tex=36 sum=0        UIComposite RGB=black   <- black
frame1  SceneColor tex=53 sum=0        UIComposite RGB=black   <- black (the regression: extra frame)
frame2  SceneColor tex=47 sum=347M     UIComposite content     <- recovered
```

Frame 0 black is the pipeline's inherent ~1-frame warm-up latency (black even in isolation); the **bug was the extra black frame 1**, which the fix removes — restoring the polluted-order case to match isolation behavior.

## Fix

Same family as #530/#548 (invalidate the cache on the **structural event**, not a proxy for it):

- **`RenderGraph::Resize`** now evicts the pool when the display dims changed **OR any node's framebuffer actually resized** — detected via each node's `GetFramebufferSpecification()` before/after `ResizeFramebuffer`. A genuinely idle same-size resize (no node resized) still skips the clear, so steady-state frames don't churn the pool (existing `ResizeEvictsStalePoolEntries` no-op contract preserved).
- **`RenderPipeline::PopulateBlackboard`** evicts the pool when its FSR1 scene-band resize fires — the runtime `Upscale`-toggle path that never reaches `Resize` (also the minor production glitch the issue notes).

The blackboard-populate fingerprint cache stays untouched (it was already correct and is load-bearing).

## Verification

Every result below reproduced on real GL 4.6 (Debug). Guards were confirmed to **fail without the fix and pass with it**:

| Test | Without fix | With fix |
|------|:---:|:---:|
| `RenderGraphTransientPool.ResizeEvictsPoolWhenNodeResizedButDisplayUnchanged` (CPU/GL-gated) | ❌ FAIL | ✅ PASS |
| `RenderGraphTransientPool.ResizeEvictsStalePoolEntries` (idle no-churn contract) | pass | ✅ PASS |
| `EASUVisualEvidenceTest.ForwardUpscaleOffTransitionKeepsSceneVisible` (GPU, SKIPs headless) | ❌ FAIL (luma=0) | ✅ PASS |
| Original victim `CAS after EASU` (`--gtest_shuffle --gtest_random_seed=4`) | ❌ FAIL (`off=0`) | ✅ PASS |

Plus **no regressions**: 345 tests (RenderGraph + TransientPool + EASU + CAS) and a further 101 full-pipeline visual/rendering tests all green.

Rule captured in `docs/agent-rules/render-pipeline-caches.md` (new section: *the transient pool is a size-keyed cache — evict it on any node resize, not just a display resize*).

## Notes

- New tests extend existing files (`RenderGraphTest.cpp`, `EASUVisualEvidenceTest.cpp`) — no `tests/CMakeLists.txt` change, avoiding the known cross-branch conflict point.
- If this was #549's last remaining render-graph mechanism, #549 can likely be closed once the shuffled-renderer-visual CI job it wants is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rendering issue where switching upscale modes or resizing render targets could leave the scene black.
  * Ensured transient render resources are cleared when framebuffer sizes change, even if the display resolution stays the same.

* **Tests**
  * Added regression coverage for upscale on/off transitions and for resize cases where graph nodes change size without a display-size change.

* **Documentation**
  * Added guidance for when render caches should be invalidated to prevent stale frame data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->