### PR TITLE
fix(rendergraph): extend parent framebuffer lifetime on attachment-view writes

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/RGBuilder.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RGBuilder.cpp
@@ -14,6 +14,7 @@ namespace OloEngine
         m_DeclaredAccesses.clear();
         m_DeclaredFeedbacks.clear();
         m_DeclaredPassDependencies.clear();
+        m_DeclaredLifetimeExtensions.clear();
         m_NextVersionOrdinalByResource.clear();
     }
 
@@ -132,6 +133,18 @@ namespace OloEngine
         });
     }
 
+    void RGBuilder::RecordLifetimeExtension(std::string_view resourceName)
+    {
+        if (resourceName.empty())
+            return;
+
+        if (const auto alreadyDeclared = std::ranges::find(m_DeclaredLifetimeExtensions, resourceName);
+            alreadyDeclared == m_DeclaredLifetimeExtensions.end())
+        {
+            m_DeclaredLifetimeExtensions.emplace_back(resourceName);
+        }
+    }
+
     // -------------------------------------------------------------------
     // Read operations
     // -------------------------------------------------------------------
@@ -235,6 +248,41 @@ namespace OloEngine
         else
         {
             RecordWrite(resourceName, usage, range);
+
+            // When the write targets a framebuffer attachment view, also
+            // extend the parent framebuffer's transient lifetime back to
+            // this pass. Without this, a pass that seeds an MRT purely
+            // through attachment-view writes (e.g. OITPreparePass writing
+            // OITAccum/OITRevealage/OITDepthAttachment but never the parent
+            // OITBuffer directly) doesn't count as a writer of the parent
+            // framebuffer, so the transient planner's FirstPassIndex for the
+            // parent starts at the first *reader* instead of this earlier
+            // write — under-reporting the parent's lifetime and letting the
+            // transient allocator alias its storage while the attachment is
+            // still logically live.
+            //
+            // This deliberately does NOT mirror Read's propagation by
+            // calling RecordWrite(parent, ...): that would declare a real
+            // write access under the parent's name, which (a) collides with
+            // this same pass's propagated Read(parent) whenever it also
+            // reads a *different* attachment view of the same framebuffer
+            // (a legitimate RMW pattern, e.g. DecalRenderPass/ParticleRender
+            // Pass sampling one OIT attachment while rewriting another) —
+            // producing a false same-pass feedback hazard on the parent's
+            // name even though the individual views involved never overlap
+            // and are correctly declared via AllowSamePassReadWrite; and (b)
+            // gets expanded by expandTextureViewAccesses back down onto
+            // *every* sibling attachment view of the parent, falsely
+            // implying this pass wrote attachments it never touched (e.g.
+            // marking OITDepthAttachment written just because OITAccum was).
+            // RecordLifetimeExtension sidesteps both by feeding only the
+            // transient planner, not hazard validation or the view-expansion
+            // pass.
+            if (auto parent = m_Graph.FindAttachmentViewParent(resourceName);
+                !parent.empty() && parent != resourceName)
+            {
+                RecordLifetimeExtension(parent);
+            }
         }
 
         (void)usage;

--- a/OloEngine/src/OloEngine/Renderer/RGBuilder.h
+++ b/OloEngine/src/OloEngine/Renderer/RGBuilder.h
@@ -360,6 +360,22 @@ namespace OloEngine
             return m_DeclaredPassDependencies;
         }
 
+        // Resources whose transient lifetime this pass extends without a
+        // full hazard-tracked access declaration — currently just the parent
+        // framebuffer of an attachment view this pass writes (see Write()).
+        // Deliberately NOT folded into GetDeclaredAccesses(): unlike Read's
+        // parent propagation (safe because same-pass Read+Read and harmless
+        // sibling-view expansion never trigger a hazard), a propagated
+        // *write* on the parent's name would (a) collide with a same-pass
+        // read of a sibling view under the feedback-hazard validator, and
+        // (b) get expanded by expandTextureViewAccesses back down onto every
+        // sibling attachment view, falsely implying this pass wrote views it
+        // never touched. Consumed only by RenderGraphTransientPlanner.
+        [[nodiscard]] const std::vector<std::string>& GetDeclaredLifetimeExtensions() const noexcept
+        {
+            return m_DeclaredLifetimeExtensions;
+        }
+
         // Builder-side accessor for the owning graph. Used by free helpers
         // (e.g. `RenderPipelineBuilderInternal::ReadFirstValidVersionedInputForPass`)
         // that need to look up the latest-version handle for a resource base
@@ -376,6 +392,7 @@ namespace OloEngine
         void RecordFeedback(std::string_view resourceName, const RGSubresourceRange& range);
         void RecordRead(std::string_view resourceName, RGReadUsage usage, const RGSubresourceRange& range);
         void RecordWrite(std::string_view resourceName, RGWriteUsage usage, const RGSubresourceRange& range);
+        void RecordLifetimeExtension(std::string_view resourceName);
 
         RenderGraph& m_Graph;
         const FrameBlackboard& m_Blackboard;
@@ -385,6 +402,7 @@ namespace OloEngine
         std::vector<RGAccessDeclaration> m_DeclaredAccesses;
         std::vector<RGFeedbackDeclaration> m_DeclaredFeedbacks;
         std::vector<std::string> m_DeclaredPassDependencies;
+        std::vector<std::string> m_DeclaredLifetimeExtensions;
         std::unordered_map<std::string, u32> m_NextVersionOrdinalByResource;
     };
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -132,6 +132,7 @@ namespace OloEngine
         m_LastBuildStats = {};
         m_PassAccessDeclarations.clear();
         m_PassFeedbackDeclarations.clear();
+        m_PassLifetimeExtensions.clear();
         m_PassBarrierFlags.clear();
         m_PlannedBarriers.clear();
         m_BuildDiagnostics.clear();
@@ -208,6 +209,7 @@ namespace OloEngine
         m_LastBuildStats = {};
         m_PassAccessDeclarations.clear();
         m_PassFeedbackDeclarations.clear();
+        m_PassLifetimeExtensions.clear();
         m_PassBarrierFlags.clear();
         m_PlannedBarriers.clear();
         m_BuildDiagnostics.clear();
@@ -4123,6 +4125,7 @@ namespace OloEngine
             .TransientResourceDescs = m_TransientResourceDescs,
             .ExecutionOrder = m_ExecutionOrder,
             .PassAccessDeclarations = m_PassAccessDeclarations,
+            .PassLifetimeExtensions = m_PassLifetimeExtensions,
             .IsPassReachable = [this](const std::string& passName)
             { return IsPassReachable(passName); },
             .IsExternallyBackedTransientResource = [this](std::string_view name)
@@ -5674,6 +5677,7 @@ namespace OloEngine
         m_DependencyGraphDirty = true;
         m_PassAccessDeclarations.clear();
         m_PassFeedbackDeclarations.clear();
+        m_PassLifetimeExtensions.clear();
         m_PassBarrierFlags.clear();
         m_PlannedBarriers.clear();
         m_BuildDiagnostics.clear();
@@ -6049,6 +6053,8 @@ namespace OloEngine
 
             const auto& feedbacks = builder.GetDeclaredFeedbacks();
             m_PassFeedbackDeclarations[nodeName] = expandTextureViewFeedbacks(feedbacks);
+
+            m_PassLifetimeExtensions[nodeName] = builder.GetDeclaredLifetimeExtensions();
 
             const auto& passDependencies = builder.GetDeclaredPassDependencies();
             declaredPassDependenciesByPass[nodeName] = passDependencies;

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.h
@@ -1239,6 +1239,11 @@ namespace OloEngine
         // Barrier planning/execution
         std::unordered_map<std::string, std::vector<RGAccessDeclaration>> m_PassAccessDeclarations;
         std::unordered_map<std::string, std::vector<RGFeedbackDeclaration>> m_PassFeedbackDeclarations;
+        // Parent framebuffers whose transient lifetime a pass extends via an
+        // attachment-view write (RGBuilder::GetDeclaredLifetimeExtensions).
+        // Consumed only by RenderGraphTransientPlanner — deliberately kept
+        // out of m_PassAccessDeclarations; see the comment in RGBuilder::Write.
+        std::unordered_map<std::string, std::vector<std::string>> m_PassLifetimeExtensions;
         std::unordered_map<std::string, MemoryBarrierFlags> m_PassBarrierFlags;
         std::vector<PlannedBarrier> m_PlannedBarriers;
         std::vector<BuildDiagnostic> m_BuildDiagnostics;

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphTransientPlanner.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphTransientPlanner.cpp
@@ -232,33 +232,50 @@ namespace OloEngine::RenderGraphTransientPlanner
         std::unordered_map<std::string, Lifetime> lifetimes;
         lifetimes.reserve(input.TransientResourceDescs.size());
 
+        const auto touchResource = [&input, &lifetimes](const std::string& resourceName,
+                                                        u32 passIndex,
+                                                        const std::string& passName)
+        {
+            if (!input.TransientResourceDescs.contains(resourceName))
+                return;
+
+            auto& lifetime = lifetimes[resourceName];
+            if (!input.IsPassReachable(passName))
+                return;
+
+            lifetime.Reachable = true;
+            if (passIndex < lifetime.First)
+            {
+                lifetime.First = passIndex;
+                lifetime.FirstPass = passName;
+            }
+            if (passIndex >= lifetime.Last)
+            {
+                lifetime.Last = passIndex;
+                lifetime.LastPass = passName;
+            }
+        };
+
         for (u32 passIndex = 0; passIndex < static_cast<u32>(input.ExecutionOrder.size()); ++passIndex)
         {
             const auto& passName = input.ExecutionOrder[passIndex];
-            const auto accessIt = input.PassAccessDeclarations.find(passName);
-            if (accessIt == input.PassAccessDeclarations.end())
-                continue;
-
-            for (const auto& access : accessIt->second)
+            if (const auto accessIt = input.PassAccessDeclarations.find(passName);
+                accessIt != input.PassAccessDeclarations.end())
             {
-                if (!input.TransientResourceDescs.contains(access.ResourceName))
-                    continue;
+                for (const auto& access : accessIt->second)
+                    touchResource(access.ResourceName, passIndex, passName);
+            }
 
-                auto& lifetime = lifetimes[access.ResourceName];
-                if (!input.IsPassReachable(passName))
-                    continue;
-
-                lifetime.Reachable = true;
-                if (passIndex < lifetime.First)
-                {
-                    lifetime.First = passIndex;
-                    lifetime.FirstPass = passName;
-                }
-                if (passIndex >= lifetime.Last)
-                {
-                    lifetime.Last = passIndex;
-                    lifetime.LastPass = passName;
-                }
+            // Attachment-view writes extend their parent framebuffer's
+            // lifetime without a hazard-tracked access declaration (see
+            // RGBuilder::Write) — fold those touches in too so a pass that
+            // seeds an MRT purely through attachment views (e.g.
+            // OITPreparePass) isn't excluded from the parent's FirstPassIndex.
+            if (const auto lifetimeIt = input.PassLifetimeExtensions.find(passName);
+                lifetimeIt != input.PassLifetimeExtensions.end())
+            {
+                for (const auto& resourceName : lifetimeIt->second)
+                    touchResource(resourceName, passIndex, passName);
             }
         }
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphTransientPlanner.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphTransientPlanner.h
@@ -43,6 +43,12 @@ namespace OloEngine::RenderGraphTransientPlanner
         const std::unordered_map<std::string, RGResourceDesc>& TransientResourceDescs;
         std::span<const std::string> ExecutionOrder;
         const std::unordered_map<std::string, std::vector<RGAccessDeclaration>>& PassAccessDeclarations;
+        // Parent framebuffers whose lifetime a pass extends via an
+        // attachment-view write, without a hazard-tracked access declaration
+        // (RGBuilder::GetDeclaredLifetimeExtensions — see the comment in
+        // RGBuilder::Write for why this is kept separate from
+        // PassAccessDeclarations).
+        const std::unordered_map<std::string, std::vector<std::string>>& PassLifetimeExtensions;
         std::function<bool(const std::string&)> IsPassReachable;
         std::function<bool(std::string_view)> IsExternallyBackedTransientResource;
     };

--- a/OloEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/OloEngine/tests/Rendering/RenderGraphTest.cpp
@@ -7230,6 +7230,68 @@ TEST(RenderGraphTransientPool, PhaseD_MRTEstimatedBytesAreCorrect)
         << "RGBA16F+RG16F+Depth MRT estimated bytes must sum to 16 bytes/px";
 }
 
+// Regression test for issue #547: a pass that seeds an MRT purely through
+// attachment-view writes (mirroring OITPreparePass writing OITAccum /
+// OITRevealage without ever writing the parent OITBuffer directly) must
+// still extend the parent framebuffer's transient lifetime back to that
+// write. Before the fix, RGBuilder::Write() had no FindAttachmentViewParent
+// propagation (unlike Read()), so the parent's FirstPassIndex was set by the
+// first pass that *read* an attachment view, silently excluding the earlier
+// writer.
+TEST(RenderGraphTransientPool, AttachmentViewOnlyWriteExtendsParentFramebufferLifetime)
+{
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false);
+
+    RGResourceDesc mrtDesc;
+    mrtDesc.Kind = ResourceHandle::Kind::Framebuffer;
+    mrtDesc.Width = 640;
+    mrtDesc.Height = 360;
+    mrtDesc.Attachments = { RGResourceFormat::RGBA16Float, RGResourceFormat::RG16Float };
+
+    const auto oitHandle = graph.DeclareTransientFramebuffer("OITBufferTest", mrtDesc);
+    const auto accumView = graph.CreateFramebufferAttachmentView("OITAccumTest", oitHandle, 0u);
+    const auto revealageView = graph.CreateFramebufferAttachmentView("OITRevealageTest", oitHandle, 1u);
+    ASSERT_TRUE(accumView.IsValid());
+    ASSERT_TRUE(revealageView.IsValid());
+
+    // Mirrors OITPreparePass: seeds the MRT purely through attachment-view
+    // writes, never writing the parent framebuffer handle directly.
+    AddSetupNode(graph, "PrepPass", [accumView, revealageView](RGBuilder& builder)
+                 {
+                     builder.Write(accumView, RGWriteUsage::Clear);
+                     builder.Write(revealageView, RGWriteUsage::Clear); });
+
+    // Mirrors OITResolvePass/DecalRenderPass: samples the attachment views
+    // as textures. Read() already propagates to the parent, so this alone
+    // (without the Write-side fix) would make the parent's FirstPassIndex
+    // resolve to this pass instead of the earlier PrepPass.
+    AddSetupNode(graph, "ResolvePass", [accumView, revealageView](RGBuilder& builder)
+                 {
+                     [[maybe_unused]] const auto accumRead = builder.Read(accumView, RGReadUsage::ShaderSample);
+                     [[maybe_unused]] const auto revealageRead = builder.Read(revealageView, RGReadUsage::ShaderSample); });
+
+    graph.AddExecutionDependency("PrepPass", "ResolvePass");
+    graph.SetFinalPass("ResolvePass");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto hazards = graph.ValidateCompiledResourceHazards();
+    EXPECT_TRUE(hazards.empty());
+
+    const auto& plan = graph.GetTransientPlan();
+    const auto it = std::ranges::find_if(plan,
+                                         [](const RenderGraph::TransientPlanEntry& e)
+                                         { return e.Resource == "OITBufferTest"; });
+    ASSERT_NE(it, plan.end());
+    EXPECT_TRUE(it->Reachable);
+    EXPECT_TRUE(it->WillAllocate);
+    EXPECT_EQ(it->FirstPass, "PrepPass")
+        << "Parent framebuffer's FirstPassIndex must be the pass that seeds it via "
+           "attachment-view writes, not the later pass that only reads the views";
+    EXPECT_EQ(it->LastPass, "ResolvePass");
+}
+
 // =============================================================================
 // Phase D Slice 8 — Post-process chain outputs as transient FBs
 //


### PR DESCRIPTION
## Summary

- `RGBuilder::Write()` had no `FindAttachmentViewParent` propagation (unlike `Read()`), so a pass that seeds an MRT purely through attachment-view writes (e.g. `OITPreparePass` clearing `OITAccum`/`OITRevealage`/`OITDepthAttachment` without ever writing the parent `OITBuffer` directly) didn't count as a writer of the parent framebuffer — the transient planner's `FirstPassIndex` for the parent started at the first *reader* instead, under-reporting its lifetime and risking the transient allocator aliasing its storage while the attachment was still logically live.
- Naively mirroring `Read`'s propagation (`RecordWrite(parent, ...)`) breaks real passes: `DecalRenderPass`/`ParticleRenderPass` legitimately read one OIT attachment view while rewriting another in the same pass (a declared RMW pattern via `AllowSamePassReadWrite`). Promoting the write to the parent's name collides with the existing propagated read on that same name (false same-pass feedback hazard), and `expandTextureViewAccesses` reverse-expands a parent-named access onto *every* sibling attachment view — falsely implying attachments the pass never touched (e.g. `OITDepthAttachment`) were written.
- Fixed by adding a narrow `RecordLifetimeExtension` path (`RGBuilder` → `RenderGraph::m_PassLifetimeExtensions` → `RenderGraphTransientPlanner::PlanInput`) that feeds only the transient planner's lifetime scan, bypassing hazard validation and view expansion entirely.

This is a latent/masked robustness fix (issue #547 filer's own framing) — no visible corruption has been demonstrated with the current pass set, since materialization currently allocates a dedicated framebuffer per entry regardless of lifetime. The goal is closing the invariant gap before a future pass addition (or transient-pool change) triggers it.

Closes #547

## Test plan

- [x] New regression test `RenderGraphTransientPool.AttachmentViewOnlyWriteExtendsParentFramebufferLifetime` — verified it fails without the fix (`FirstPass` resolves to the reader pass instead of the writer) and passes with it.
- [x] Full `OloEngine-Tests` suite: 4144/4149 passed (5 pre-existing environment-dependent skips: app launch smoke tests, video decoder fixture, MCP headless attach — unrelated to this change).
- [x] Discovered and fixed a real regression during review: naively mirroring `Read`'s propagation broke `RenderGraphResourceHazards.DynamicOITDepthContractDerivesPrepareAndContributorEdges` (false feedback hazards on `OITBuffer`/`OITDepthAttachment`); the narrower `RecordLifetimeExtension` path resolves this cleanly with no remaining hazard regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed render graph lifetime tracking so attachment-view writes extend the owning parent framebuffer’s transient lifetime through the required passes.
  * Improved transient planning to incorporate per-pass lifetime extensions when computing alias-slot lifetimes, reducing incorrect transient reuse.
* **Tests**
  * Added a regression test ensuring the parent framebuffer lifetime starts at the attachment-view write pass and ends at the resolve pass, with no hazard validation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->