### PR TITLE
perf(scene): split PrefabComponent/TagComponent/AudioSourceComponent into hot/cold halves

### DIFF
--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -560,7 +560,7 @@ namespace OloEngine
         {
             if (ImGui::MenuItem("Rename"))
             {
-                tagComponent.renaming = true;
+                m_RenamingEntityUUID = entity.GetUUID();
                 m_RenameOldName = tag;
             }
 
@@ -667,9 +667,9 @@ namespace OloEngine
                     Ref<Prefab> prefab = AssetManager::GetAsset<Prefab>(pc.m_PrefabID);
                     if (prefab)
                     {
-                        RevertComponentList(prefab, entity, pc.m_OverriddenComponents);
-                        RevertComponentList(prefab, entity, pc.m_AddedComponents);
-                        RevertComponentList(prefab, entity, pc.m_RemovedComponents);
+                        RevertComponentList(prefab, entity, pc.GetOverriddenComponents());
+                        RevertComponentList(prefab, entity, pc.GetAddedComponents());
+                        RevertComponentList(prefab, entity, pc.GetRemovedComponents());
                         pc.ClearAllOverrides();
                         OLO_CORE_INFO("Reverted all overrides on '{}'", tag);
                     }
@@ -683,9 +683,9 @@ namespace OloEngine
                         Ref<Prefab> prefab = AssetManager::GetAsset<Prefab>(pc.m_PrefabID);
                         if (prefab)
                         {
-                            ApplyComponentList(prefab, entity, pc.m_OverriddenComponents);
-                            ApplyComponentList(prefab, entity, pc.m_AddedComponents);
-                            ApplyComponentList(prefab, entity, pc.m_RemovedComponents);
+                            ApplyComponentList(prefab, entity, pc.GetOverriddenComponents());
+                            ApplyComponentList(prefab, entity, pc.GetAddedComponents());
+                            ApplyComponentList(prefab, entity, pc.GetRemovedComponents());
                             pc.ClearAllOverrides();
                             OLO_CORE_INFO("Applied all overrides from '{}' to prefab", tag);
                         }
@@ -727,7 +727,7 @@ namespace OloEngine
             ImGui::EndDragDropTarget();
         }
 
-        if (tagComponent.renaming)
+        if (m_RenamingEntityUUID == entity.GetUUID())
         {
             char buffer[256];
             ::memset(buffer, 0, sizeof(buffer));
@@ -741,7 +741,7 @@ namespace OloEngine
 
             if (ImGui::IsMouseClicked(0) && ImGui::IsWindowHovered())
             {
-                tagComponent.renaming = false;
+                m_RenamingEntityUUID = UUID(0);
                 if (m_CommandHistory && tag != m_RenameOldName)
                 {
                     m_CommandHistory->PushAlreadyExecuted(std::make_unique<RenameEntityCommand>(
@@ -3905,8 +3905,8 @@ namespace OloEngine
             // SoundConfig (.olosoundc) preset. Assigning one stamps its values into the inline
             // Config below for instant editor feedback and is re-applied at play
             // (Scene::InitAudioRuntime). Drag a .olosoundc from the content browser onto the button.
-            std::string presetLabel = component.SoundConfigHandle != 0
-                ? "Preset: " + std::to_string(static_cast<u64>(component.SoundConfigHandle))
+            std::string presetLabel = component.GetSoundConfigHandle() != 0
+                ? "Preset: " + std::to_string(static_cast<u64>(component.GetSoundConfigHandle()))
                 : "Preset: <none — drag a .olosoundc here>";
             ImGui::Button(presetLabel.c_str(), ImVec2(-1.0f, 0.0f));
             if (ImGui::BeginDragDropTarget())
@@ -3919,10 +3919,10 @@ namespace OloEngine
                         AssetHandle handle = assetManager->ImportAsset(assetPath);
                         if (handle != 0 && AssetManager::GetAssetType(handle) == AssetType::SoundConfig)
                         {
-                            component.SoundConfigHandle = handle;
+                            component.SetSoundConfigHandle(handle);
                             // Stamp the preset into Config immediately so the fields below preview it.
                             if (auto preset = AssetManager::GetAsset<SoundConfigAsset>(handle))
-                                component.Config = preset->m_Config;
+                                component.GetConfig() = preset->m_Config;
                         }
                         else if (handle != 0)
                         {
@@ -3937,106 +3937,109 @@ namespace OloEngine
                 }
                 ImGui::EndDragDropTarget();
             }
-            if (component.SoundConfigHandle != 0)
+            if (component.GetSoundConfigHandle() != 0)
             {
                 ImGui::SameLine();
                 if (ImGui::SmallButton("Clear##SoundConfig"))
                 {
-                    component.SoundConfigHandle = 0;
+                    component.SetSoundConfigHandle(0);
                 }
                 ImGui::SetItemTooltip("Unlinks the preset; the values already stamped into the fields below stay.");
             }
             ImGui::Separator();
 
-            ImGui::DragFloat("Volume##AudioSource", &component.Config.VolumeMultiplier, 0.01f, 0.0f, 2.0f);
-            ImGui::DragFloat("Pitch##AudioSource", &component.Config.PitchMultiplier, 0.01f, 0.1f, 3.0f);
-            ImGui::Checkbox("Play On Awake##AudioSource", &component.Config.PlayOnAwake);
-            ImGui::Checkbox("Looping##AudioSource", &component.Config.Looping);
+            auto& config = component.GetConfig();
+            ImGui::DragFloat("Volume##AudioSource", &config.VolumeMultiplier, 0.01f, 0.0f, 2.0f);
+            ImGui::DragFloat("Pitch##AudioSource", &config.PitchMultiplier, 0.01f, 0.1f, 3.0f);
+            ImGui::Checkbox("Play On Awake##AudioSource", &config.PlayOnAwake);
+            ImGui::Checkbox("Looping##AudioSource", &config.Looping);
 
             ImGui::Separator();
             ImGui::Text("Spatialization");
-            ImGui::Checkbox("Spatialization##AudioSource", &component.Config.Spatialization);
+            ImGui::Checkbox("Spatialization##AudioSource", &config.Spatialization);
 
-            if (component.Config.Spatialization)
+            if (config.Spatialization)
             {
                 const char* attenuationModels[] = { "None", "Inverse", "Linear", "Exponential" };
-                if (int currentModel = static_cast<int>(component.Config.AttenuationModel); ImGui::Combo("Attenuation Model##AudioSource", &currentModel, attenuationModels, IM_ARRAYSIZE(attenuationModels)))
-                    component.Config.AttenuationModel = static_cast<AttenuationModelType>(currentModel);
+                if (int currentModel = static_cast<int>(config.AttenuationModel); ImGui::Combo("Attenuation Model##AudioSource", &currentModel, attenuationModels, IM_ARRAYSIZE(attenuationModels)))
+                    config.AttenuationModel = static_cast<AttenuationModelType>(currentModel);
 
-                ImGui::DragFloat("Roll Off##AudioSource", &component.Config.RollOff, 0.1f, 0.0f, 10.0f);
-                ImGui::DragFloat("Min Gain##AudioSource", &component.Config.MinGain, 0.01f, 0.0f, 1.0f);
-                ImGui::DragFloat("Max Gain##AudioSource", &component.Config.MaxGain, 0.01f, 0.0f, 2.0f);
-                ImGui::DragFloat("Min Distance##AudioSource", &component.Config.MinDistance, 0.1f, 0.0f, 100.0f);
-                ImGui::DragFloat("Max Distance##AudioSource", &component.Config.MaxDistance, 1.0f, 0.0f, 1000.0f);
+                ImGui::DragFloat("Roll Off##AudioSource", &config.RollOff, 0.1f, 0.0f, 10.0f);
+                ImGui::DragFloat("Min Gain##AudioSource", &config.MinGain, 0.01f, 0.0f, 1.0f);
+                ImGui::DragFloat("Max Gain##AudioSource", &config.MaxGain, 0.01f, 0.0f, 2.0f);
+                ImGui::DragFloat("Min Distance##AudioSource", &config.MinDistance, 0.1f, 0.0f, 100.0f);
+                ImGui::DragFloat("Max Distance##AudioSource", &config.MaxDistance, 1.0f, 0.0f, 1000.0f);
 
                 ImGui::Separator();
                 ImGui::Text("Cone Settings");
-                ImGui::DragFloat("Inner Angle##AudioSource", &component.Config.ConeInnerAngle, 1.0f, 0.0f, 360.0f);
-                ImGui::DragFloat("Outer Angle##AudioSource", &component.Config.ConeOuterAngle, 1.0f, 0.0f, 360.0f);
-                ImGui::DragFloat("Outer Gain##AudioSource", &component.Config.ConeOuterGain, 0.01f, 0.0f, 1.0f);
-                ImGui::DragFloat("Doppler Factor##AudioSource", &component.Config.DopplerFactor, 0.1f, 0.0f, 10.0f);
+                ImGui::DragFloat("Inner Angle##AudioSource", &config.ConeInnerAngle, 1.0f, 0.0f, 360.0f);
+                ImGui::DragFloat("Outer Angle##AudioSource", &config.ConeOuterAngle, 1.0f, 0.0f, 360.0f);
+                ImGui::DragFloat("Outer Gain##AudioSource", &config.ConeOuterGain, 0.01f, 0.0f, 1.0f);
+                ImGui::DragFloat("Doppler Factor##AudioSource", &config.DopplerFactor, 0.1f, 0.0f, 10.0f);
 
                 ImGui::Separator();
                 ImGui::Text("VBAP Panning");
-                ImGui::SliderFloat("Spread##AudioSource", &component.Config.Spread, 0.0f, 1.0f, "%.3f");
+                ImGui::SliderFloat("Spread##AudioSource", &config.Spread, 0.0f, 1.0f, "%.3f");
                 ImGui::SetItemTooltip("Virtual source spread [0..1]. 1.0 = full spread");
-                ImGui::SliderFloat("Focus##AudioSource", &component.Config.Focus, 0.0f, 1.0f, "%.3f");
+                ImGui::SliderFloat("Focus##AudioSource", &config.Focus, 0.0f, 1.0f, "%.3f");
                 ImGui::SetItemTooltip("Channel focus [0..1]. 1.0 = fully focused");
             }
 
             ImGui::Separator();
             ImGui::Text("DSP Filters");
-            ImGui::SliderFloat("Low-Pass Cutoff##AudioSource", &component.Config.LowPassCutoff, 0.0f, 1.0f, "%.3f");
+            ImGui::SliderFloat("Low-Pass Cutoff##AudioSource", &config.LowPassCutoff, 0.0f, 1.0f, "%.3f");
             ImGui::SetItemTooltip("Normalized cutoff [0..1]. 1.0 = 20 kHz (bypassed)");
-            ImGui::SliderFloat("High-Pass Cutoff##AudioSource", &component.Config.HighPassCutoff, 0.0f, 1.0f, "%.3f");
+            ImGui::SliderFloat("High-Pass Cutoff##AudioSource", &config.HighPassCutoff, 0.0f, 1.0f, "%.3f");
             ImGui::SetItemTooltip("Normalized cutoff [0..1]. 0.0 = 20 Hz (bypassed)");
-            ImGui::SliderFloat("Reverb Send##AudioSource", &component.Config.ReverbSend, 0.0f, 1.0f, "%.3f");
+            ImGui::SliderFloat("Reverb Send##AudioSource", &config.ReverbSend, 0.0f, 1.0f, "%.3f");
             ImGui::SetItemTooltip("Reverb send level [0..1]");
 
             ImGui::Separator();
             ImGui::Text("Event System");
-            if (auto prev = component.UseEventSystem; ImGui::Checkbox("Use Event System##AudioSource", &component.UseEventSystem))
+            bool useEventSystem = component.GetUseEventSystem();
+            if (bool prev = useEventSystem; ImGui::Checkbox("Use Event System##AudioSource", &useEventSystem))
             {
-                if (component.UseEventSystem && !prev)
+                component.SetUseEventSystem(useEventSystem);
+                if (useEventSystem && !prev)
                 {
                     if (auto* reg = m_Context->GetAudioCommandRegistry())
                     {
-                        if (auto resolved = Audio::CommandID::FromString(component.StartEvent); reg->Contains(resolved))
+                        if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); reg->Contains(resolved))
                         {
-                            component.StartCommandID = resolved;
+                            component.SetStartCommandID(resolved);
                         }
                         else
                         {
-                            component.StartCommandID = {};
+                            component.SetStartCommandID({});
                         }
                     }
                     else
                     {
-                        component.StartCommandID = {};
+                        component.SetStartCommandID({});
                     }
                 }
             }
-            if (component.UseEventSystem)
+            if (component.GetUseEventSystem())
             {
                 char eventBuf[256] = {};
-                std::strncpy(eventBuf, component.StartEvent.c_str(), sizeof(eventBuf) - 1);
+                std::strncpy(eventBuf, component.GetStartEvent().c_str(), sizeof(eventBuf) - 1);
                 if (ImGui::InputText("Start Event##AudioSource", eventBuf, sizeof(eventBuf)))
                 {
-                    component.StartEvent = eventBuf;
+                    component.SetStartEvent(eventBuf);
                     if (auto* reg = m_Context->GetAudioCommandRegistry())
                     {
-                        if (auto resolved = Audio::CommandID::FromString(component.StartEvent); reg->Contains(resolved))
+                        if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); reg->Contains(resolved))
                         {
-                            component.StartCommandID = resolved;
+                            component.SetStartCommandID(resolved);
                         }
                         else
                         {
-                            component.StartCommandID = {};
+                            component.SetStartCommandID({});
                         }
                     }
                     else
                     {
-                        component.StartCommandID = {};
+                        component.SetStartCommandID({});
                     }
                 }
 
@@ -4044,34 +4047,34 @@ namespace OloEngine
                 bool validated = false;
                 if (auto* reg = m_Context->GetAudioCommandRegistry())
                 {
-                    if (!component.StartEvent.empty() && !component.StartCommandID.IsValid())
+                    if (!component.GetStartEvent().empty() && !component.GetStartCommandID().IsValid())
                     {
-                        if (auto resolved = Audio::CommandID::FromString(component.StartEvent); reg->Contains(resolved))
+                        if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); reg->Contains(resolved))
                         {
-                            component.StartCommandID = resolved;
+                            component.SetStartCommandID(resolved);
                         }
                     }
-                    if (component.StartCommandID.IsValid())
+                    if (component.GetStartCommandID().IsValid())
                     {
-                        validated = reg->Contains(component.StartCommandID);
+                        validated = reg->Contains(component.GetStartCommandID());
                     }
                 }
 
-                if (component.StartEvent.empty())
+                if (component.GetStartEvent().empty())
                 {
                     ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "No event name set");
                 }
-                else if (!component.StartCommandID.IsValid())
+                else if (!component.GetStartCommandID().IsValid())
                 {
                     ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.2f, 1.0f), "Unresolved start event");
                 }
                 else if (!validated && m_Context->IsRunning())
                 {
-                    ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.2f, 1.0f), "CommandID: %u (not found in registry)", component.StartCommandID.ID);
+                    ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.2f, 1.0f), "CommandID: %u (not found in registry)", component.GetStartCommandID().ID);
                 }
                 else
                 {
-                    ImGui::Text("CommandID: %u", component.StartCommandID.ID);
+                    ImGui::Text("CommandID: %u", component.GetStartCommandID().ID);
                 }
             } });
 

--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -3894,6 +3894,23 @@ namespace OloEngine
             ImGui::TextDisabled("Built at play; bones missing a body get a dynamic one."); });
 
         // Audio Components
+
+        // Resolves component's StartEvent against the registry and updates StartCommandID
+        // accordingly (clears it if unresolved or no registry is available). Shared by every
+        // start-event edit path below so they can't drift out of sync with each other.
+        static auto ResolveStartCommandID = [](AudioSourceComponent& component, Audio::AudioCommandRegistry* registry)
+        {
+            if (registry)
+            {
+                if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); registry->Contains(resolved))
+                {
+                    component.SetStartCommandID(resolved);
+                    return;
+                }
+            }
+            component.SetStartCommandID({});
+        };
+
         DrawComponent<AudioSourceComponent>("Audio Source", entity, [this](auto& component)
                                             {
             ImGui::Text("Audio Source: %s", component.Source ? "Loaded" : "None");
@@ -4002,21 +4019,7 @@ namespace OloEngine
                 component.SetUseEventSystem(useEventSystem);
                 if (useEventSystem && !prev)
                 {
-                    if (auto* reg = m_Context->GetAudioCommandRegistry())
-                    {
-                        if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); reg->Contains(resolved))
-                        {
-                            component.SetStartCommandID(resolved);
-                        }
-                        else
-                        {
-                            component.SetStartCommandID({});
-                        }
-                    }
-                    else
-                    {
-                        component.SetStartCommandID({});
-                    }
+                    ResolveStartCommandID(component, m_Context->GetAudioCommandRegistry());
                 }
             }
             if (component.GetUseEventSystem())
@@ -4026,21 +4029,7 @@ namespace OloEngine
                 if (ImGui::InputText("Start Event##AudioSource", eventBuf, sizeof(eventBuf)))
                 {
                     component.SetStartEvent(eventBuf);
-                    if (auto* reg = m_Context->GetAudioCommandRegistry())
-                    {
-                        if (auto resolved = Audio::CommandID::FromString(component.GetStartEvent()); reg->Contains(resolved))
-                        {
-                            component.SetStartCommandID(resolved);
-                        }
-                        else
-                        {
-                            component.SetStartCommandID({});
-                        }
-                    }
-                    else
-                    {
-                        component.SetStartCommandID({});
-                    }
+                    ResolveStartCommandID(component, m_Context->GetAudioCommandRegistry());
                 }
 
                 // Validate against registry if available; re-resolve stale IDs

--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -3983,14 +3983,19 @@ namespace OloEngine
 
                 ImGui::DragFloat("Roll Off##AudioSource", &config.RollOff, 0.1f, 0.0f, 10.0f);
                 ImGui::DragFloat("Min Gain##AudioSource", &config.MinGain, 0.01f, 0.0f, 1.0f);
-                ImGui::DragFloat("Max Gain##AudioSource", &config.MaxGain, 0.01f, 0.0f, 2.0f);
+                ImGui::DragFloat("Max Gain##AudioSource", &config.MaxGain, 0.01f, 0.0f, 1.0f);
                 ImGui::DragFloat("Min Distance##AudioSource", &config.MinDistance, 0.1f, 0.0f, 100.0f);
                 ImGui::DragFloat("Max Distance##AudioSource", &config.MaxDistance, 1.0f, 0.0f, 1000.0f);
 
                 ImGui::Separator();
                 ImGui::Text("Cone Settings");
-                ImGui::DragFloat("Inner Angle##AudioSource", &config.ConeInnerAngle, 1.0f, 0.0f, 360.0f);
-                ImGui::DragFloat("Outer Angle##AudioSource", &config.ConeOuterAngle, 1.0f, 0.0f, 360.0f);
+                // ConeInnerAngle/ConeOuterAngle are stored in radians (miniaudio units); edit in degrees to match the serializer's radian clamp.
+                f32 coneInnerDegrees = glm::degrees(config.ConeInnerAngle);
+                if (ImGui::DragFloat("Inner Angle##AudioSource", &coneInnerDegrees, 1.0f, 0.0f, 360.0f))
+                    config.ConeInnerAngle = glm::radians(coneInnerDegrees);
+                f32 coneOuterDegrees = glm::degrees(config.ConeOuterAngle);
+                if (ImGui::DragFloat("Outer Angle##AudioSource", &coneOuterDegrees, 1.0f, 0.0f, 360.0f))
+                    config.ConeOuterAngle = glm::radians(coneOuterDegrees);
                 ImGui::DragFloat("Outer Gain##AudioSource", &config.ConeOuterGain, 0.01f, 0.0f, 1.0f);
                 ImGui::DragFloat("Doppler Factor##AudioSource", &config.DopplerFactor, 0.1f, 0.0f, 10.0f);
 
@@ -4073,8 +4078,13 @@ namespace OloEngine
 
             ImGui::Separator();
             ImGui::Text("Cone Settings");
-            ImGui::DragFloat("Inner Angle##AudioListener", &component.Config.ConeInnerAngle, 1.0f, 0.0f, 360.0f);
-            ImGui::DragFloat("Outer Angle##AudioListener", &component.Config.ConeOuterAngle, 1.0f, 0.0f, 360.0f);
+            // ConeInnerAngle/ConeOuterAngle are stored in radians (miniaudio units); edit in degrees to match the serializer's radian clamp.
+            f32 coneInnerDegrees = glm::degrees(component.Config.ConeInnerAngle);
+            if (ImGui::DragFloat("Inner Angle##AudioListener", &coneInnerDegrees, 1.0f, 0.0f, 360.0f))
+                component.Config.ConeInnerAngle = glm::radians(coneInnerDegrees);
+            f32 coneOuterDegrees = glm::degrees(component.Config.ConeOuterAngle);
+            if (ImGui::DragFloat("Outer Angle##AudioListener", &coneOuterDegrees, 1.0f, 0.0f, 360.0f))
+                component.Config.ConeOuterAngle = glm::radians(coneOuterDegrees);
             ImGui::DragFloat("Outer Gain##AudioListener", &component.Config.ConeOuterGain, 0.01f, 0.0f, 1.0f); });
 
         DrawComponent<AudioSoundGraphComponent>("Audio Sound Graph", entity, [](auto& component)

--- a/OloEditor/src/Panels/SceneHierarchyPanel.h
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.h
@@ -78,6 +78,12 @@ namespace OloEngine
         // Rename tracking for undo
         std::string m_RenameOldName;
 
+        // Entity currently being renamed (inline text-edit state). Panel-local
+        // rather than a TagComponent flag (issue #444 hot/cold split) — only one
+        // entity can be mid-rename at a time, so this doesn't need to live on
+        // the runtime component.
+        UUID m_RenamingEntityUUID{ 0 };
+
         // Entity search filter
         char m_FilterText[256] = {};
     };

--- a/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
+++ b/OloEngine/src/OloEngine/SaveGame/SaveGameComponentSerializer.cpp
@@ -1095,19 +1095,21 @@ namespace OloEngine
 
     void SaveGameComponentSerializer::Serialize(FArchive& ar, AudioSourceComponent& c)
     {
-        SerializeAudioSourceConfig(ar, c.Config);
+        SerializeAudioSourceConfig(ar, c.GetConfig());
 
         // SoundConfig (.olosoundc) preset link — appended after the config block, so
         // probe AtEnd() on load and default to "no preset" for legacy archives written
         // before this field existed (the per-component buffer ends after the config).
+        AssetHandle soundConfigHandle = c.GetSoundConfigHandle();
         if (ar.IsLoading() && ar.AtEnd())
         {
-            c.SoundConfigHandle = 0;
+            soundConfigHandle = 0;
         }
         else
         {
-            ar << c.SoundConfigHandle;
+            ar << soundConfigHandle;
         }
+        c.SetSoundConfigHandle(soundConfigHandle);
         // Ref<AudioSource> is runtime — not serialized
     }
 

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -56,6 +56,7 @@
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
 
+#include <memory>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -82,7 +83,6 @@ namespace OloEngine
     struct TagComponent
     {
         std::string Tag;
-        bool renaming = false; // Transient editor flag — NOT authoring data.
 
         TagComponent() = default;
         TagComponent(const TagComponent& other) = default;
@@ -98,13 +98,31 @@ namespace OloEngine
             return Tag;
         }
 
-        // Authoring-only equality — `renaming` is a transient editor flag toggled
-        // while the user is mid-rename. Including it would treat start/end of an
-        // inline edit as a real change and pollute the undo stack.
         auto operator==(const TagComponent& other) const -> bool
         {
             return Tag == other.Tag;
         }
+    };
+
+    // Cold, editor/prefab-authoring-only override-tracking data (issue #444
+    // hot/cold split). Most prefab instances have no per-instance overrides at
+    // all, so PrefabComponent heap-allocates this on first mutation instead of
+    // carrying three empty std::unordered_sets (~180 bytes) on every instance —
+    // "present only on prefab instances that actually have overrides" is then
+    // literally true (null == no overrides) rather than just conventionally so.
+    struct PrefabOverrideSets
+    {
+        // Components listed here have been intentionally modified on this instance
+        // and will not be updated when the source prefab changes.
+        std::unordered_set<std::string> Overridden;
+
+        // Components added to this instance that do not exist in the source prefab.
+        std::unordered_set<std::string> Added;
+
+        // Components removed from this instance that exist in the source prefab.
+        std::unordered_set<std::string> Removed;
+
+        auto operator==(const PrefabOverrideSets&) const -> bool = default;
     };
 
     struct PrefabComponent
@@ -112,22 +130,24 @@ namespace OloEngine
         UUID m_PrefabID{};
         UUID m_PrefabEntityID{};
 
-        // Component-level override tracking for prefab instances.
-        // Components listed here have been intentionally modified on this instance
-        // and will not be updated when the source prefab changes.
-        std::unordered_set<std::string> m_OverriddenComponents;
-
-        // Components added to this instance that do not exist in the source prefab.
-        std::unordered_set<std::string> m_AddedComponents;
-
-        // Components removed from this instance that exist in the source prefab.
-        std::unordered_set<std::string> m_RemovedComponents;
-
         PrefabComponent() = default;
-        PrefabComponent(const PrefabComponent&) = default;
+        PrefabComponent(const PrefabComponent& other)
+            : m_PrefabID(other.m_PrefabID), m_PrefabEntityID(other.m_PrefabEntityID),
+              m_Overrides(other.m_Overrides ? std::make_unique<PrefabOverrideSets>(*other.m_Overrides) : nullptr)
+        {
+        }
         PrefabComponent(PrefabComponent&&) = default;
-        PrefabComponent& operator=(const PrefabComponent&) = default;
-        PrefabComponent& operator=(PrefabComponent&&) = default;
+        auto operator=(const PrefabComponent& other) -> PrefabComponent&
+        {
+            if (this != &other)
+            {
+                m_PrefabID = other.m_PrefabID;
+                m_PrefabEntityID = other.m_PrefabEntityID;
+                m_Overrides = other.m_Overrides ? std::make_unique<PrefabOverrideSets>(*other.m_Overrides) : nullptr;
+            }
+            return *this;
+        }
+        auto operator=(PrefabComponent&&) -> PrefabComponent& = default;
         PrefabComponent(UUID prefabID, UUID prefabEntityID)
             : m_PrefabID(prefabID), m_PrefabEntityID(prefabEntityID) {}
 
@@ -136,52 +156,116 @@ namespace OloEngine
             return static_cast<u64>(m_PrefabID) != 0 && static_cast<u64>(m_PrefabEntityID) != 0;
         }
 
+        [[nodiscard]] const std::unordered_set<std::string>& GetOverriddenComponents() const noexcept
+        {
+            static const std::unordered_set<std::string> kEmpty;
+            return m_Overrides ? m_Overrides->Overridden : kEmpty;
+        }
+
+        [[nodiscard]] const std::unordered_set<std::string>& GetAddedComponents() const noexcept
+        {
+            static const std::unordered_set<std::string> kEmpty;
+            return m_Overrides ? m_Overrides->Added : kEmpty;
+        }
+
+        [[nodiscard]] const std::unordered_set<std::string>& GetRemovedComponents() const noexcept
+        {
+            static const std::unordered_set<std::string> kEmpty;
+            return m_Overrides ? m_Overrides->Removed : kEmpty;
+        }
+
         [[nodiscard]] inline bool IsComponentOverridden(const std::string& componentName) const
         {
-            return m_OverriddenComponents.contains(componentName);
+            return m_Overrides && m_Overrides->Overridden.contains(componentName);
         }
 
         [[nodiscard]] inline bool IsComponentAdded(const std::string& componentName) const
         {
-            return m_AddedComponents.contains(componentName);
+            return m_Overrides && m_Overrides->Added.contains(componentName);
         }
 
         [[nodiscard]] inline bool IsComponentRemoved(const std::string& componentName) const
         {
-            return m_RemovedComponents.contains(componentName);
+            return m_Overrides && m_Overrides->Removed.contains(componentName);
         }
 
         [[nodiscard]] inline bool HasAnyOverrides() const noexcept
         {
-            return !m_OverriddenComponents.empty() || !m_AddedComponents.empty() || !m_RemovedComponents.empty();
+            return m_Overrides && (!m_Overrides->Overridden.empty() || !m_Overrides->Added.empty() || !m_Overrides->Removed.empty());
         }
 
         inline void MarkComponentOverridden(const std::string& componentName)
         {
-            m_OverriddenComponents.insert(componentName);
+            EnsureOverrides().Overridden.insert(componentName);
+        }
+
+        inline void MarkComponentAdded(const std::string& componentName)
+        {
+            EnsureOverrides().Added.insert(componentName);
+        }
+
+        inline void MarkComponentRemoved(const std::string& componentName)
+        {
+            EnsureOverrides().Removed.insert(componentName);
+        }
+
+        inline void SetOverriddenComponents(std::unordered_set<std::string> names)
+        {
+            EnsureOverrides().Overridden = std::move(names);
+        }
+
+        inline void SetAddedComponents(std::unordered_set<std::string> names)
+        {
+            EnsureOverrides().Added = std::move(names);
+        }
+
+        inline void SetRemovedComponents(std::unordered_set<std::string> names)
+        {
+            EnsureOverrides().Removed = std::move(names);
         }
 
         inline void ClearComponentOverride(const std::string& componentName)
         {
-            m_OverriddenComponents.erase(componentName);
-            m_AddedComponents.erase(componentName);
-            m_RemovedComponents.erase(componentName);
+            if (!m_Overrides)
+                return;
+            m_Overrides->Overridden.erase(componentName);
+            m_Overrides->Added.erase(componentName);
+            m_Overrides->Removed.erase(componentName);
         }
 
         inline void ClearAllOverrides()
         {
-            m_OverriddenComponents.clear();
-            m_AddedComponents.clear();
-            m_RemovedComponents.clear();
+            m_Overrides.reset();
         }
 
         // Manual operator== — UUID members would trigger C2666 ambiguity with
-        // defaulted ==. Compare UUIDs via u64.
+        // defaulted ==. Compare UUIDs via u64; treat a null override blob as
+        // equivalent to one with all-empty sets.
         auto operator==(const PrefabComponent& other) const -> bool
         {
-            return static_cast<u64>(m_PrefabID) == static_cast<u64>(other.m_PrefabID) && static_cast<u64>(m_PrefabEntityID) == static_cast<u64>(other.m_PrefabEntityID) && m_OverriddenComponents == other.m_OverriddenComponents && m_AddedComponents == other.m_AddedComponents && m_RemovedComponents == other.m_RemovedComponents;
+            if (static_cast<u64>(m_PrefabID) != static_cast<u64>(other.m_PrefabID) || static_cast<u64>(m_PrefabEntityID) != static_cast<u64>(other.m_PrefabEntityID))
+                return false;
+            static const PrefabOverrideSets kEmpty;
+            const auto& a = m_Overrides ? *m_Overrides : kEmpty;
+            const auto& b = other.m_Overrides ? *other.m_Overrides : kEmpty;
+            return a == b;
+        }
+
+      private:
+        std::unique_ptr<PrefabOverrideSets> m_Overrides;
+
+        PrefabOverrideSets& EnsureOverrides()
+        {
+            if (!m_Overrides)
+                m_Overrides = std::make_unique<PrefabOverrideSets>();
+            return *m_Overrides;
         }
     };
+
+    // Regression guard for issue #444: before the hot/cold split PrefabComponent
+    // carried three inline std::unordered_sets (~184-208 bytes depending on
+    // stdlib); it should now be just the two UUIDs plus one pointer.
+    static_assert(sizeof(PrefabComponent) <= 32, "PrefabComponent grew back into hot-array bloat — keep override tracking behind PrefabOverrideSets (issue #444)");
 
     struct TransformComponent
     {
@@ -1332,44 +1416,64 @@ namespace OloEngine
         auto operator==(const LuaScriptComponent&) const -> bool = default;
     };
 
-    struct AudioSourceComponent
+    // Cold, editor/scripting-authoring data for AudioSourceComponent (issue #444
+    // hot/cold split): playback config, event wiring, and the SoundConfig asset
+    // handle. Scene::UpdateAudio's per-frame position-sync loop only reads
+    // AudioSourceComponent::Source (see below) — never any of this — so it is
+    // heap-owned instead of inline to keep that hot per-entity iteration small.
+    // Always allocated (a config semantically always exists for an audio
+    // source), unlike PrefabOverrideSets' lazy allocation above.
+    struct AudioSourceColdData
     {
-        OLO_PROPERTY(Name = "Volume", Type = "float", Get = "comp.Config.VolumeMultiplier", Set = "comp.Config.VolumeMultiplier = {v}; if (comp.Source) comp.Source->SetVolume({v})")
-        OLO_PROPERTY(Name = "Pitch", Type = "float", Get = "comp.Config.PitchMultiplier", Set = "comp.Config.PitchMultiplier = {v}; if (comp.Source) comp.Source->SetPitch({v})")
-        OLO_PROPERTY(Name = "PlayOnAwake", Type = "bool", Get = "comp.Config.PlayOnAwake", Set = "comp.Config.PlayOnAwake = {v}")
-        OLO_PROPERTY(Name = "Looping", Type = "bool", Get = "comp.Config.Looping", Set = "comp.Config.Looping = {v}; if (comp.Source) comp.Source->SetLooping({v})")
-        OLO_PROPERTY(Name = "Spatialization", Type = "bool", Get = "comp.Config.Spatialization", Set = "comp.Config.Spatialization = {v}; if (comp.Source) comp.Source->SetSpatialization({v})")
-        OLO_PROPERTY(Name = "AttenuationModel", Type = "int", Get = "static_cast<int>(comp.Config.AttenuationModel)", Set = "comp.Config.AttenuationModel = static_cast<AttenuationModelType>({v}); if (comp.Source) comp.Source->SetAttenuationModel(comp.Config.AttenuationModel)")
-        OLO_PROPERTY(Name = "RollOff", Type = "float", Get = "comp.Config.RollOff", Set = "comp.Config.RollOff = {v}; if (comp.Source) comp.Source->SetRollOff({v})")
-        OLO_PROPERTY(Name = "MinGain", Type = "float", Get = "comp.Config.MinGain", Set = "comp.Config.MinGain = {v}; if (comp.Source) comp.Source->SetMinGain({v})")
-        OLO_PROPERTY(Name = "MaxGain", Type = "float", Get = "comp.Config.MaxGain", Set = "comp.Config.MaxGain = {v}; if (comp.Source) comp.Source->SetMaxGain({v})")
-        OLO_PROPERTY(Name = "MinDistance", Type = "float", Get = "comp.Config.MinDistance", Set = "comp.Config.MinDistance = {v}; if (comp.Source) comp.Source->SetMinDistance({v})")
-        OLO_PROPERTY(Name = "MaxDistance", Type = "float", Get = "comp.Config.MaxDistance", Set = "comp.Config.MaxDistance = {v}; if (comp.Source) comp.Source->SetMaxDistance({v})")
-        OLO_PROPERTY(Name = "ConeInnerAngle", Type = "float", Get = "comp.Config.ConeInnerAngle", Set = "comp.Config.ConeInnerAngle = {v}; if (comp.Source) comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain)")
-        OLO_PROPERTY(Name = "ConeOuterAngle", Type = "float", Get = "comp.Config.ConeOuterAngle", Set = "comp.Config.ConeOuterAngle = {v}; if (comp.Source) comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain)")
-        OLO_PROPERTY(Name = "ConeOuterGain", Type = "float", Get = "comp.Config.ConeOuterGain", Set = "comp.Config.ConeOuterGain = {v}; if (comp.Source) comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain)")
-        OLO_PROPERTY(Name = "DopplerFactor", Type = "float", Get = "comp.Config.DopplerFactor", Set = "comp.Config.DopplerFactor = {v}; if (comp.Source) comp.Source->SetDopplerFactor({v})")
         AudioSourceConfig Config;
 
         // Optional SoundConfig (.olosoundc) preset. When non-zero, Scene::InitAudioRuntime
         // loads the referenced SoundConfigAsset and overwrites Config with its values at
         // playback — a reusable preset shared across entities. Zero means "use the inline
-        // Config above". Exposed as ulong so scripts can swap presets at runtime.
-        OLO_PROPERTY()
+        // Config above".
         AssetHandle SoundConfigHandle = 0;
-
-        Ref<AudioSource> Source = nullptr;
 
         // Event-driven audio
         std::string StartEvent;          // Event name, e.g. "PlayFootsteps"
         Audio::CommandID StartCommandID; // CRC32 of StartEvent (cached)
         bool UseEventSystem = false;     // If true, uses events instead of direct play
-        u64 ActiveEventID = 0;           // Runtime handle from AudioPlayback::PostTrigger
+
+        auto operator==(const AudioSourceColdData& other) const -> bool
+        {
+            return Math::BitwiseEqual(Config, other.Config) && SoundConfigHandle == other.SoundConfigHandle && StartEvent == other.StartEvent && StartCommandID == other.StartCommandID && UseEventSystem == other.UseEventSystem;
+        }
+    };
+
+    struct AudioSourceComponent
+    {
+        // Every property below is a window into the cold m_Cold blob, not the
+        // Source field it happens to be anchored to syntactically (OLO_PROPERTY
+        // just needs a real field declaration to follow the stack — same
+        // precedent as TransformComponent's Rotation/RotationEuler pair above).
+        OLO_PROPERTY(Name = "Volume", Type = "float", Get = "comp.GetConfig().VolumeMultiplier", Set = "comp.GetConfig().VolumeMultiplier = {v}; if (comp.Source) comp.Source->SetVolume({v})")
+        OLO_PROPERTY(Name = "Pitch", Type = "float", Get = "comp.GetConfig().PitchMultiplier", Set = "comp.GetConfig().PitchMultiplier = {v}; if (comp.Source) comp.Source->SetPitch({v})")
+        OLO_PROPERTY(Name = "PlayOnAwake", Type = "bool", Get = "comp.GetConfig().PlayOnAwake", Set = "comp.GetConfig().PlayOnAwake = {v}")
+        OLO_PROPERTY(Name = "Looping", Type = "bool", Get = "comp.GetConfig().Looping", Set = "comp.GetConfig().Looping = {v}; if (comp.Source) comp.Source->SetLooping({v})")
+        OLO_PROPERTY(Name = "Spatialization", Type = "bool", Get = "comp.GetConfig().Spatialization", Set = "comp.GetConfig().Spatialization = {v}; if (comp.Source) comp.Source->SetSpatialization({v})")
+        OLO_PROPERTY(Name = "AttenuationModel", Type = "int", Get = "static_cast<int>(comp.GetConfig().AttenuationModel)", Set = "comp.GetConfig().AttenuationModel = static_cast<AttenuationModelType>({v}); if (comp.Source) comp.Source->SetAttenuationModel(comp.GetConfig().AttenuationModel)")
+        OLO_PROPERTY(Name = "RollOff", Type = "float", Get = "comp.GetConfig().RollOff", Set = "comp.GetConfig().RollOff = {v}; if (comp.Source) comp.Source->SetRollOff({v})")
+        OLO_PROPERTY(Name = "MinGain", Type = "float", Get = "comp.GetConfig().MinGain", Set = "comp.GetConfig().MinGain = {v}; if (comp.Source) comp.Source->SetMinGain({v})")
+        OLO_PROPERTY(Name = "MaxGain", Type = "float", Get = "comp.GetConfig().MaxGain", Set = "comp.GetConfig().MaxGain = {v}; if (comp.Source) comp.Source->SetMaxGain({v})")
+        OLO_PROPERTY(Name = "MinDistance", Type = "float", Get = "comp.GetConfig().MinDistance", Set = "comp.GetConfig().MinDistance = {v}; if (comp.Source) comp.Source->SetMinDistance({v})")
+        OLO_PROPERTY(Name = "MaxDistance", Type = "float", Get = "comp.GetConfig().MaxDistance", Set = "comp.GetConfig().MaxDistance = {v}; if (comp.Source) comp.Source->SetMaxDistance({v})")
+        OLO_PROPERTY(Name = "ConeInnerAngle", Type = "float", Get = "comp.GetConfig().ConeInnerAngle", Set = "comp.GetConfig().ConeInnerAngle = {v}; if (comp.Source) comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain)")
+        OLO_PROPERTY(Name = "ConeOuterAngle", Type = "float", Get = "comp.GetConfig().ConeOuterAngle", Set = "comp.GetConfig().ConeOuterAngle = {v}; if (comp.Source) comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain)")
+        OLO_PROPERTY(Name = "ConeOuterGain", Type = "float", Get = "comp.GetConfig().ConeOuterGain", Set = "comp.GetConfig().ConeOuterGain = {v}; if (comp.Source) comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain)")
+        OLO_PROPERTY(Name = "DopplerFactor", Type = "float", Get = "comp.GetConfig().DopplerFactor", Set = "comp.GetConfig().DopplerFactor = {v}; if (comp.Source) comp.Source->SetDopplerFactor({v})")
+        OLO_PROPERTY(Name = "SoundConfigHandle", Type = "ulong", Get = "static_cast<u64>(comp.GetSoundConfigHandle())", Set = "comp.SetSoundConfigHandle(AssetHandle({v}))")
+        Ref<AudioSource> Source = nullptr;
+
+        u64 ActiveEventID = 0; // Runtime handle from AudioPlayback::PostTrigger
 
         AudioSourceComponent() = default;
 
         AudioSourceComponent(const AudioSourceComponent& other)
-            : Config(other.Config), SoundConfigHandle(other.SoundConfigHandle), Source(other.Source), StartEvent(other.StartEvent), StartCommandID(other.StartCommandID), UseEventSystem(other.UseEventSystem)
+            : Source(other.Source), m_Cold(std::make_unique<AudioSourceColdData>(*other.m_Cold))
         {
         }
 
@@ -1377,23 +1481,69 @@ namespace OloEngine
         {
             if (this != &other)
             {
-                Config = other.Config;
-                SoundConfigHandle = other.SoundConfigHandle;
                 Source = other.Source;
-                StartEvent = other.StartEvent;
-                StartCommandID = other.StartCommandID;
-                UseEventSystem = other.UseEventSystem;
                 ActiveEventID = 0;
+                *m_Cold = *other.m_Cold;
             }
             return *this;
+        }
+
+        [[nodiscard]] AudioSourceConfig& GetConfig() noexcept
+        {
+            return m_Cold->Config;
+        }
+        [[nodiscard]] const AudioSourceConfig& GetConfig() const noexcept
+        {
+            return m_Cold->Config;
+        }
+        [[nodiscard]] AssetHandle GetSoundConfigHandle() const noexcept
+        {
+            return m_Cold->SoundConfigHandle;
+        }
+        void SetSoundConfigHandle(AssetHandle handle) noexcept
+        {
+            m_Cold->SoundConfigHandle = handle;
+        }
+        [[nodiscard]] const std::string& GetStartEvent() const noexcept
+        {
+            return m_Cold->StartEvent;
+        }
+        void SetStartEvent(std::string event)
+        {
+            m_Cold->StartEvent = std::move(event);
+        }
+        [[nodiscard]] Audio::CommandID GetStartCommandID() const noexcept
+        {
+            return m_Cold->StartCommandID;
+        }
+        void SetStartCommandID(Audio::CommandID id) noexcept
+        {
+            m_Cold->StartCommandID = id;
+        }
+        [[nodiscard]] bool GetUseEventSystem() const noexcept
+        {
+            return m_Cold->UseEventSystem;
+        }
+        void SetUseEventSystem(bool value) noexcept
+        {
+            m_Cold->UseEventSystem = value;
         }
 
         // Equality for undo/redo — compares serialized/editor-visible fields only
         auto operator==(const AudioSourceComponent& other) const -> bool
         {
-            return Math::BitwiseEqual(Config, other.Config) && SoundConfigHandle == other.SoundConfigHandle && StartEvent == other.StartEvent && StartCommandID == other.StartCommandID && UseEventSystem == other.UseEventSystem;
+            return *m_Cold == *other.m_Cold;
         }
+
+      private:
+        std::unique_ptr<AudioSourceColdData> m_Cold = std::make_unique<AudioSourceColdData>();
     };
+
+    // Regression guard for issue #444: before the hot/cold split
+    // AudioSourceComponent carried AudioSourceConfig (~76 bytes) plus a
+    // std::string, an AssetHandle, a CommandID and a bool inline; the tight
+    // per-frame position-sync loop in Scene::UpdateAudio only ever needs Source.
+    static_assert(sizeof(AudioSourceComponent) <= 32, "AudioSourceComponent grew back into hot-array bloat — keep config/strings/handles behind AudioSourceColdData (issue #444)");
 
     struct AudioListenerComponent
     {

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -1488,6 +1488,9 @@ namespace OloEngine
             return *this;
         }
 
+        AudioSourceComponent(AudioSourceComponent&&) noexcept = default;
+        auto operator=(AudioSourceComponent&&) noexcept -> AudioSourceComponent& = default;
+
         [[nodiscard]] AudioSourceConfig& GetConfig() noexcept
         {
             return m_Cold->Config;

--- a/OloEngine/src/OloEngine/Scene/Generated/SceneDeserializeComponents.Generated.inl
+++ b/OloEngine/src/OloEngine/Scene/Generated/SceneDeserializeComponents.Generated.inl
@@ -230,34 +230,6 @@ if (auto node = entity["PointLightComponent"]; node)
         comp.m_ShadowNormalBias = v;
 }
 
-if (auto node = entity["PrefabComponent"]; node)
-{
-    auto& comp = deserializedEntity.AddComponent<PrefabComponent>();
-    comp.m_PrefabID = node["PrefabID"].as<u64>(static_cast<u64>(comp.m_PrefabID));
-    comp.m_PrefabEntityID = node["PrefabEntityID"].as<u64>(static_cast<u64>(comp.m_PrefabEntityID));
-    if (auto seqNode = node["OverriddenComponents"]; seqNode && seqNode.IsSequence())
-    {
-        comp.m_OverriddenComponents.clear();
-        for (auto const& e : seqNode)
-            if (decltype(comp.m_OverriddenComponents)::value_type v{}; ::YAML::convert<decltype(comp.m_OverriddenComponents)::value_type>::decode(e, v))
-                comp.m_OverriddenComponents.insert(v);
-    }
-    if (auto seqNode = node["AddedComponents"]; seqNode && seqNode.IsSequence())
-    {
-        comp.m_AddedComponents.clear();
-        for (auto const& e : seqNode)
-            if (decltype(comp.m_AddedComponents)::value_type v{}; ::YAML::convert<decltype(comp.m_AddedComponents)::value_type>::decode(e, v))
-                comp.m_AddedComponents.insert(v);
-    }
-    if (auto seqNode = node["RemovedComponents"]; seqNode && seqNode.IsSequence())
-    {
-        comp.m_RemovedComponents.clear();
-        for (auto const& e : seqNode)
-            if (decltype(comp.m_RemovedComponents)::value_type v{}; ::YAML::convert<decltype(comp.m_RemovedComponents)::value_type>::decode(e, v))
-                comp.m_RemovedComponents.insert(v);
-    }
-}
-
 if (auto node = entity["QuestGiverComponent"]; node)
 {
     auto& comp = deserializedEntity.AddComponent<QuestGiverComponent>();

--- a/OloEngine/src/OloEngine/Scene/Generated/SceneSerializeComponents.Generated.inl
+++ b/OloEngine/src/OloEngine/Scene/Generated/SceneSerializeComponents.Generated.inl
@@ -242,40 +242,6 @@ if (entity.HasComponent<PointLightComponent>())
     out << YAML::EndMap; // PointLightComponent
 }
 
-if (entity.HasComponent<PrefabComponent>())
-{
-    out << YAML::Key << "PrefabComponent";
-    out << YAML::BeginMap; // PrefabComponent
-    auto const& comp = entity.GetComponent<PrefabComponent>();
-    out << YAML::Key << "PrefabID" << YAML::Value << static_cast<u64>(comp.m_PrefabID);
-    out << YAML::Key << "PrefabEntityID" << YAML::Value << static_cast<u64>(comp.m_PrefabEntityID);
-    {
-        std::vector<decltype(comp.m_OverriddenComponents)::value_type> sorted0(comp.m_OverriddenComponents.begin(), comp.m_OverriddenComponents.end());
-        std::ranges::sort(sorted0);
-        out << YAML::Key << "OverriddenComponents" << YAML::Value << YAML::BeginSeq;
-        for (auto const& e : sorted0)
-            out << e;
-        out << YAML::EndSeq;
-    }
-    {
-        std::vector<decltype(comp.m_AddedComponents)::value_type> sorted0(comp.m_AddedComponents.begin(), comp.m_AddedComponents.end());
-        std::ranges::sort(sorted0);
-        out << YAML::Key << "AddedComponents" << YAML::Value << YAML::BeginSeq;
-        for (auto const& e : sorted0)
-            out << e;
-        out << YAML::EndSeq;
-    }
-    {
-        std::vector<decltype(comp.m_RemovedComponents)::value_type> sorted0(comp.m_RemovedComponents.begin(), comp.m_RemovedComponents.end());
-        std::ranges::sort(sorted0);
-        out << YAML::Key << "RemovedComponents" << YAML::Value << YAML::BeginSeq;
-        for (auto const& e : sorted0)
-            out << e;
-        out << YAML::EndSeq;
-    }
-    out << YAML::EndMap; // PrefabComponent
-}
-
 if (entity.HasComponent<QuestGiverComponent>())
 {
     out << YAML::Key << "QuestGiverComponent";

--- a/OloEngine/src/OloEngine/Scene/Prefab.cpp
+++ b/OloEngine/src/OloEngine/Scene/Prefab.cpp
@@ -364,13 +364,7 @@ namespace OloEngine
             // Preserve the prefab link: keep source entity ID for child-level resolution
             if (prefabChild.HasComponent<PrefabComponent>())
             {
-                const auto& srcPc = prefabChild.GetComponent<PrefabComponent>();
-                auto& dstPc = targetChild.AddOrReplaceComponent<PrefabComponent>();
-                dstPc.m_PrefabID = srcPc.m_PrefabID;
-                dstPc.m_PrefabEntityID = srcPc.m_PrefabEntityID;
-                dstPc.m_OverriddenComponents = srcPc.m_OverriddenComponents;
-                dstPc.m_AddedComponents = srcPc.m_AddedComponents;
-                dstPc.m_RemovedComponents = srcPc.m_RemovedComponents;
+                targetChild.AddOrReplaceComponent<PrefabComponent>(prefabChild.GetComponent<PrefabComponent>());
             }
 
             targetChild.SetParent(targetParent);
@@ -426,7 +420,7 @@ namespace OloEngine
         if (instanceEntity.HasComponent<PrefabComponent>())
         {
             const auto& pc = instanceEntity.GetComponent<PrefabComponent>();
-            for (const auto& name : pc.m_OverriddenComponents)
+            for (const auto& name : pc.GetOverriddenComponents())
                 outOverridden.insert(name);
         }
     }

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -501,8 +501,6 @@ namespace OloEngine
         if (prefab->RevertComponent(entity, componentName))
         {
             pc.ClearComponentOverride(componentName);
-            pc.m_AddedComponents.erase(componentName);
-            pc.m_RemovedComponents.erase(componentName);
         }
     }
 
@@ -524,8 +522,6 @@ namespace OloEngine
         if (prefab->ApplyComponentToPrefab(entity, componentName))
         {
             pc.ClearComponentOverride(componentName);
-            pc.m_AddedComponents.erase(componentName);
-            pc.m_RemovedComponents.erase(componentName);
         }
     }
 
@@ -715,17 +711,17 @@ namespace OloEngine
             // A SoundConfig (.olosoundc) preset, when assigned, is the source of truth for this
             // source's playback parameters: load it and stamp Config before either the event path
             // or the direct-play path reads it.
-            if (ac.SoundConfigHandle != 0)
+            if (ac.GetSoundConfigHandle() != 0)
             {
-                if (auto preset = AssetManager::GetAsset<SoundConfigAsset>(ac.SoundConfigHandle))
-                    ac.Config = preset->m_Config;
+                if (auto preset = AssetManager::GetAsset<SoundConfigAsset>(ac.GetSoundConfigHandle()))
+                    ac.GetConfig() = preset->m_Config;
             }
 
             // Event-driven audio: post the start event instead of direct play
-            if (ac.UseEventSystem && ac.StartCommandID.IsValid() && ac.Config.PlayOnAwake)
+            if (ac.GetUseEventSystem() && ac.GetStartCommandID().IsValid() && ac.GetConfig().PlayOnAwake)
             {
                 Entity entity(e, this);
-                ac.ActiveEventID = Audio::AudioPlayback::PostTrigger(ac.StartCommandID, static_cast<u64>(entity.GetUUID()));
+                ac.ActiveEventID = Audio::AudioPlayback::PostTrigger(ac.GetStartCommandID(), static_cast<u64>(entity.GetUUID()));
                 continue;
             }
 
@@ -733,10 +729,10 @@ namespace OloEngine
             {
                 const glm::mat4 inverted = glm::inverse(Entity(e, this).GetLocalTransform());
                 const glm::vec3 forward = SafeAudioBasis(glm::vec3(inverted[2]), glm::vec3(0.0f, 0.0f, 1.0f));
-                ac.Source->SetConfig(ac.Config);
+                ac.Source->SetConfig(ac.GetConfig());
                 ac.Source->SetPosition(tc.Translation);
                 ac.Source->SetDirection(forward);
-                if (ac.Config.PlayOnAwake)
+                if (ac.GetConfig().PlayOnAwake)
                 {
                     ac.Source->Play();
                 }
@@ -6736,12 +6732,12 @@ namespace OloEngine
                 const auto& [tc, audioSource] = view.get<TransformComponent, AudioSourceComponent>(entity);
 
                 // Only draw gizmo if spatialization is enabled
-                if (audioSource.Config.Spatialization)
+                if (audioSource.GetConfig().Spatialization)
                 {
                     Renderer3D::DrawAudioSourceGizmo(
                         tc.Translation,
-                        audioSource.Config.MinDistance,
-                        audioSource.Config.MaxDistance,
+                        audioSource.GetConfig().MinDistance,
+                        audioSource.GetConfig().MaxDistance,
                         glm::vec3(0.2f, 0.6f, 1.0f) // Blue color for audio
                     );
                 }

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -1716,23 +1716,24 @@ namespace OloEngine
         if (const auto& audioSourceComponent = entity["AudioSourceComponent"])
         {
             auto& src = deserializedEntity.AddComponent<AudioSourceComponent>();
+            auto& config = src.GetConfig();
             std::string audioFilepath;
             TrySet(audioFilepath, audioSourceComponent["Filepath"]);
-            TrySet(src.Config.VolumeMultiplier, audioSourceComponent["VolumeMultiplier"]);
-            TrySet(src.Config.PitchMultiplier, audioSourceComponent["PitchMultiplier"]);
-            TrySet(src.Config.PlayOnAwake, audioSourceComponent["PlayOnAwake"]);
-            TrySet(src.Config.Looping, audioSourceComponent["Looping"]);
-            TrySet(src.Config.Spatialization, audioSourceComponent["Spatialization"]);
-            TrySetEnum(src.Config.AttenuationModel, audioSourceComponent["AttenuationModel"]);
-            TrySet(src.Config.RollOff, audioSourceComponent["RollOff"]);
-            TrySet(src.Config.MinGain, audioSourceComponent["MinGain"]);
-            TrySet(src.Config.MaxGain, audioSourceComponent["MaxGain"]);
-            TrySet(src.Config.MinDistance, audioSourceComponent["MinDistance"]);
-            TrySet(src.Config.MaxDistance, audioSourceComponent["MaxDistance"]);
-            TrySet(src.Config.ConeInnerAngle, audioSourceComponent["ConeInnerAngle"]);
-            TrySet(src.Config.ConeOuterAngle, audioSourceComponent["ConeOuterAngle"]);
-            TrySet(src.Config.ConeOuterGain, audioSourceComponent["ConeOuterGain"]);
-            TrySet(src.Config.DopplerFactor, audioSourceComponent["DopplerFactor"]);
+            TrySet(config.VolumeMultiplier, audioSourceComponent["VolumeMultiplier"]);
+            TrySet(config.PitchMultiplier, audioSourceComponent["PitchMultiplier"]);
+            TrySet(config.PlayOnAwake, audioSourceComponent["PlayOnAwake"]);
+            TrySet(config.Looping, audioSourceComponent["Looping"]);
+            TrySet(config.Spatialization, audioSourceComponent["Spatialization"]);
+            TrySetEnum(config.AttenuationModel, audioSourceComponent["AttenuationModel"]);
+            TrySet(config.RollOff, audioSourceComponent["RollOff"]);
+            TrySet(config.MinGain, audioSourceComponent["MinGain"]);
+            TrySet(config.MaxGain, audioSourceComponent["MaxGain"]);
+            TrySet(config.MinDistance, audioSourceComponent["MinDistance"]);
+            TrySet(config.MaxDistance, audioSourceComponent["MaxDistance"]);
+            TrySet(config.ConeInnerAngle, audioSourceComponent["ConeInnerAngle"]);
+            TrySet(config.ConeOuterAngle, audioSourceComponent["ConeOuterAngle"]);
+            TrySet(config.ConeOuterGain, audioSourceComponent["ConeOuterGain"]);
+            TrySet(config.DopplerFactor, audioSourceComponent["DopplerFactor"]);
 
             // DSP parameters: load + sanitize in one step to prevent drift
             auto TrySetDsp = [&audioSourceComponent](f32& field, const char* key, f32 lo, f32 hi, f32 fallback)
@@ -1740,25 +1741,30 @@ namespace OloEngine
                 TrySet(field, audioSourceComponent[key]);
                 SanitizeFloat(field, lo, hi, fallback);
             };
-            TrySetDsp(src.Config.Spread, "Spread", 0.0f, 1.0f, 1.0f);
-            TrySetDsp(src.Config.Focus, "Focus", 0.0f, 1.0f, 1.0f);
-            TrySetDsp(src.Config.LowPassCutoff, "LowPassCutoff", 0.0f, 1.0f, 1.0f);
-            TrySetDsp(src.Config.HighPassCutoff, "HighPassCutoff", 0.0f, 1.0f, 0.0f);
-            TrySetDsp(src.Config.ReverbSend, "ReverbSend", 0.0f, 1.0f, 0.0f);
+            TrySetDsp(config.Spread, "Spread", 0.0f, 1.0f, 1.0f);
+            TrySetDsp(config.Focus, "Focus", 0.0f, 1.0f, 1.0f);
+            TrySetDsp(config.LowPassCutoff, "LowPassCutoff", 0.0f, 1.0f, 1.0f);
+            TrySetDsp(config.HighPassCutoff, "HighPassCutoff", 0.0f, 1.0f, 0.0f);
+            TrySetDsp(config.ReverbSend, "ReverbSend", 0.0f, 1.0f, 0.0f);
 
             if (const auto handleNode = audioSourceComponent["SoundConfigHandle"])
-                src.SoundConfigHandle = handleNode.as<u64>(0);
+                src.SetSoundConfigHandle(AssetHandle(handleNode.as<u64>(0)));
 
-            TrySet(src.UseEventSystem, audioSourceComponent["UseEventSystem"]);
-            TrySet(src.StartEvent, audioSourceComponent["StartEvent"]);
-            if (!src.StartEvent.empty())
+            bool useEventSystem = false;
+            TrySet(useEventSystem, audioSourceComponent["UseEventSystem"]);
+            src.SetUseEventSystem(useEventSystem);
+
+            std::string startEvent;
+            TrySet(startEvent, audioSourceComponent["StartEvent"]);
+            src.SetStartEvent(startEvent);
+            if (!startEvent.empty())
             {
                 // Always derive CommandID from StartEvent — StartEvent is the single source of truth
-                src.StartCommandID = Audio::CommandID::FromString(src.StartEvent);
+                src.SetStartCommandID(Audio::CommandID::FromString(startEvent));
             }
             else if (const auto cmdIDNode = audioSourceComponent["StartCommandID"])
             {
-                src.StartCommandID = Audio::CommandID(cmdIDNode.as<u32>(0));
+                src.SetStartCommandID(Audio::CommandID(cmdIDNode.as<u32>(0)));
             }
             else
             {
@@ -2357,10 +2363,30 @@ namespace OloEngine
                 cc3d.m_Material.SetRestitution(cc3dComponent["Restitution"].as<f32>());
         }
 
-        // PrefabComponent: auto-generated (issue #451 unordered_map/set slice) — see
-        // Scene/Generated/SceneDeserializeComponents.Generated.inl. Its three
-        // std::unordered_set<std::string> override-tracking fields are now a
-        // codegen-recognised trivial type.
+        // PrefabComponent: hand-written (issue #444 hot/cold split) — the three
+        // override-tracking sets now live behind PrefabComponent's private,
+        // lazily-allocated PrefabOverrideSets pointer, so the codegen classifies
+        // the component non-trivial and skips it. Kept under this ONE
+        // "PrefabComponent" key (unchanged since before #451) rather than a
+        // second sub-map, so the on-disk scene format doesn't change.
+        if (auto node = entity["PrefabComponent"]; node)
+        {
+            auto& comp = deserializedEntity.AddComponent<PrefabComponent>();
+            comp.m_PrefabID = node["PrefabID"].as<u64>(static_cast<u64>(comp.m_PrefabID));
+            comp.m_PrefabEntityID = node["PrefabEntityID"].as<u64>(static_cast<u64>(comp.m_PrefabEntityID));
+            if (auto seqNode = node["OverriddenComponents"]; seqNode && seqNode.IsSequence())
+                for (auto const& e : seqNode)
+                    if (std::string v; ::YAML::convert<std::string>::decode(e, v))
+                        comp.MarkComponentOverridden(v);
+            if (auto seqNode = node["AddedComponents"]; seqNode && seqNode.IsSequence())
+                for (auto const& e : seqNode)
+                    if (std::string v; ::YAML::convert<std::string>::decode(e, v))
+                        comp.MarkComponentAdded(v);
+            if (auto seqNode = node["RemovedComponents"]; seqNode && seqNode.IsSequence())
+                for (auto const& e : seqNode)
+                    if (std::string v; ::YAML::convert<std::string>::decode(e, v))
+                        comp.MarkComponentRemoved(v);
+        }
 
         if (auto mc3dComponent = entity["MeshCollider3DComponent"]; mc3dComponent)
         {
@@ -3785,35 +3811,36 @@ namespace OloEngine
             out << YAML::BeginMap; // AudioSourceComponent
 
             const auto& audioSourceComponent = entity.GetComponent<AudioSourceComponent>();
+            const auto& config = audioSourceComponent.GetConfig();
             std::string f = (audioSourceComponent.Source ? Project::GetAssetRelativeFileSystemPath(audioSourceComponent.Source->GetPath()).string().c_str() : "");
             out << YAML::Key << "Filepath" << YAML::Value << f.c_str();
-            out << YAML::Key << "VolumeMultiplier" << YAML::Value << audioSourceComponent.Config.VolumeMultiplier;
-            out << YAML::Key << "PitchMultiplier" << YAML::Value << audioSourceComponent.Config.PitchMultiplier;
-            out << YAML::Key << "PlayOnAwake" << YAML::Value << audioSourceComponent.Config.PlayOnAwake;
-            out << YAML::Key << "Looping" << YAML::Value << audioSourceComponent.Config.Looping;
-            out << YAML::Key << "Spatialization" << YAML::Value << audioSourceComponent.Config.Spatialization;
-            out << YAML::Key << "AttenuationModel" << YAML::Value << (int)audioSourceComponent.Config.AttenuationModel;
-            out << YAML::Key << "RollOff" << YAML::Value << audioSourceComponent.Config.RollOff;
-            out << YAML::Key << "MinGain" << YAML::Value << audioSourceComponent.Config.MinGain;
-            out << YAML::Key << "MaxGain" << YAML::Value << audioSourceComponent.Config.MaxGain;
-            out << YAML::Key << "MinDistance" << YAML::Value << audioSourceComponent.Config.MinDistance;
-            out << YAML::Key << "MaxDistance" << YAML::Value << audioSourceComponent.Config.MaxDistance;
-            out << YAML::Key << "ConeInnerAngle" << YAML::Value << audioSourceComponent.Config.ConeInnerAngle;
-            out << YAML::Key << "ConeOuterAngle" << YAML::Value << audioSourceComponent.Config.ConeOuterAngle;
-            out << YAML::Key << "ConeOuterGain" << YAML::Value << audioSourceComponent.Config.ConeOuterGain;
-            out << YAML::Key << "DopplerFactor" << YAML::Value << audioSourceComponent.Config.DopplerFactor;
-            out << YAML::Key << "Spread" << YAML::Value << audioSourceComponent.Config.Spread;
-            out << YAML::Key << "Focus" << YAML::Value << audioSourceComponent.Config.Focus;
-            out << YAML::Key << "LowPassCutoff" << YAML::Value << audioSourceComponent.Config.LowPassCutoff;
-            out << YAML::Key << "HighPassCutoff" << YAML::Value << audioSourceComponent.Config.HighPassCutoff;
-            out << YAML::Key << "ReverbSend" << YAML::Value << audioSourceComponent.Config.ReverbSend;
-            out << YAML::Key << "SoundConfigHandle" << YAML::Value << static_cast<u64>(audioSourceComponent.SoundConfigHandle);
-            out << YAML::Key << "UseEventSystem" << YAML::Value << audioSourceComponent.UseEventSystem;
-            out << YAML::Key << "StartEvent" << YAML::Value << audioSourceComponent.StartEvent;
+            out << YAML::Key << "VolumeMultiplier" << YAML::Value << config.VolumeMultiplier;
+            out << YAML::Key << "PitchMultiplier" << YAML::Value << config.PitchMultiplier;
+            out << YAML::Key << "PlayOnAwake" << YAML::Value << config.PlayOnAwake;
+            out << YAML::Key << "Looping" << YAML::Value << config.Looping;
+            out << YAML::Key << "Spatialization" << YAML::Value << config.Spatialization;
+            out << YAML::Key << "AttenuationModel" << YAML::Value << (int)config.AttenuationModel;
+            out << YAML::Key << "RollOff" << YAML::Value << config.RollOff;
+            out << YAML::Key << "MinGain" << YAML::Value << config.MinGain;
+            out << YAML::Key << "MaxGain" << YAML::Value << config.MaxGain;
+            out << YAML::Key << "MinDistance" << YAML::Value << config.MinDistance;
+            out << YAML::Key << "MaxDistance" << YAML::Value << config.MaxDistance;
+            out << YAML::Key << "ConeInnerAngle" << YAML::Value << config.ConeInnerAngle;
+            out << YAML::Key << "ConeOuterAngle" << YAML::Value << config.ConeOuterAngle;
+            out << YAML::Key << "ConeOuterGain" << YAML::Value << config.ConeOuterGain;
+            out << YAML::Key << "DopplerFactor" << YAML::Value << config.DopplerFactor;
+            out << YAML::Key << "Spread" << YAML::Value << config.Spread;
+            out << YAML::Key << "Focus" << YAML::Value << config.Focus;
+            out << YAML::Key << "LowPassCutoff" << YAML::Value << config.LowPassCutoff;
+            out << YAML::Key << "HighPassCutoff" << YAML::Value << config.HighPassCutoff;
+            out << YAML::Key << "ReverbSend" << YAML::Value << config.ReverbSend;
+            out << YAML::Key << "SoundConfigHandle" << YAML::Value << static_cast<u64>(audioSourceComponent.GetSoundConfigHandle());
+            out << YAML::Key << "UseEventSystem" << YAML::Value << audioSourceComponent.GetUseEventSystem();
+            out << YAML::Key << "StartEvent" << YAML::Value << audioSourceComponent.GetStartEvent();
             // Derive CommandID from StartEvent to keep YAML consistent
-            auto derivedCmdID = audioSourceComponent.StartEvent.empty()
-                                    ? audioSourceComponent.StartCommandID
-                                    : Audio::CommandID::FromString(audioSourceComponent.StartEvent);
+            auto derivedCmdID = audioSourceComponent.GetStartEvent().empty()
+                                    ? audioSourceComponent.GetStartCommandID()
+                                    : Audio::CommandID::FromString(audioSourceComponent.GetStartEvent());
             out << YAML::Key << "StartCommandID" << YAML::Value << derivedCmdID.ID;
 
             out << YAML::EndMap; // AudioSourceComponent
@@ -4243,8 +4270,41 @@ namespace OloEngine
             out << YAML::EndMap; // CapsuleCollider3DComponent
         }
 
-        // PrefabComponent: auto-generated (issue #451 unordered_map/set slice) — see
-        // Scene/Generated/SceneSerializeComponents.Generated.inl.
+        // PrefabComponent: hand-written (issue #444 hot/cold split) — see the
+        // matching comment in DeserializeEntityComponents above.
+        if (entity.HasComponent<PrefabComponent>())
+        {
+            out << YAML::Key << "PrefabComponent";
+            out << YAML::BeginMap; // PrefabComponent
+            auto const& comp = entity.GetComponent<PrefabComponent>();
+            out << YAML::Key << "PrefabID" << YAML::Value << static_cast<u64>(comp.m_PrefabID);
+            out << YAML::Key << "PrefabEntityID" << YAML::Value << static_cast<u64>(comp.m_PrefabEntityID);
+            {
+                std::vector<std::string> sorted(comp.GetOverriddenComponents().begin(), comp.GetOverriddenComponents().end());
+                std::ranges::sort(sorted);
+                out << YAML::Key << "OverriddenComponents" << YAML::Value << YAML::BeginSeq;
+                for (auto const& e : sorted)
+                    out << e;
+                out << YAML::EndSeq;
+            }
+            {
+                std::vector<std::string> sorted(comp.GetAddedComponents().begin(), comp.GetAddedComponents().end());
+                std::ranges::sort(sorted);
+                out << YAML::Key << "AddedComponents" << YAML::Value << YAML::BeginSeq;
+                for (auto const& e : sorted)
+                    out << e;
+                out << YAML::EndSeq;
+            }
+            {
+                std::vector<std::string> sorted(comp.GetRemovedComponents().begin(), comp.GetRemovedComponents().end());
+                std::ranges::sort(sorted);
+                out << YAML::Key << "RemovedComponents" << YAML::Value << YAML::BeginSeq;
+                for (auto const& e : sorted)
+                    out << e;
+                out << YAML::EndSeq;
+            }
+            out << YAML::EndMap; // PrefabComponent
+        }
 
         if (entity.HasComponent<MeshCollider3DComponent>())
         {

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -1719,28 +1719,34 @@ namespace OloEngine
             auto& config = src.GetConfig();
             std::string audioFilepath;
             TrySet(audioFilepath, audioSourceComponent["Filepath"]);
-            TrySet(config.VolumeMultiplier, audioSourceComponent["VolumeMultiplier"]);
-            TrySet(config.PitchMultiplier, audioSourceComponent["PitchMultiplier"]);
             TrySet(config.PlayOnAwake, audioSourceComponent["PlayOnAwake"]);
             TrySet(config.Looping, audioSourceComponent["Looping"]);
             TrySet(config.Spatialization, audioSourceComponent["Spatialization"]);
             TrySetEnum(config.AttenuationModel, audioSourceComponent["AttenuationModel"]);
-            TrySet(config.RollOff, audioSourceComponent["RollOff"]);
-            TrySet(config.MinGain, audioSourceComponent["MinGain"]);
-            TrySet(config.MaxGain, audioSourceComponent["MaxGain"]);
-            TrySet(config.MinDistance, audioSourceComponent["MinDistance"]);
-            TrySet(config.MaxDistance, audioSourceComponent["MaxDistance"]);
-            TrySet(config.ConeInnerAngle, audioSourceComponent["ConeInnerAngle"]);
-            TrySet(config.ConeOuterAngle, audioSourceComponent["ConeOuterAngle"]);
-            TrySet(config.ConeOuterGain, audioSourceComponent["ConeOuterGain"]);
-            TrySet(config.DopplerFactor, audioSourceComponent["DopplerFactor"]);
 
-            // DSP parameters: load + sanitize in one step to prevent drift
+            // Load + sanitize in one step to prevent drift — ranges mirror
+            // SaveGameComponentSerializer::SerializeAudioSourceConfig exactly,
+            // since both paths feed the same miniaudio-backed AudioSourceConfig.
             auto TrySetDsp = [&audioSourceComponent](f32& field, const char* key, f32 lo, f32 hi, f32 fallback)
             {
                 TrySet(field, audioSourceComponent[key]);
                 SanitizeFloat(field, lo, hi, fallback);
             };
+            TrySetDsp(config.VolumeMultiplier, "VolumeMultiplier", 0.0f, 10.0f, 1.0f);
+            TrySetDsp(config.PitchMultiplier, "PitchMultiplier", 0.0f, 10.0f, 1.0f);
+            TrySetDsp(config.RollOff, "RollOff", 0.0f, 100.0f, 1.0f);
+            TrySetDsp(config.MinGain, "MinGain", 0.0f, 1.0f, 0.0f);
+            TrySetDsp(config.MaxGain, "MaxGain", 0.0f, 1.0f, 1.0f);
+            TrySetDsp(config.MinDistance, "MinDistance", 0.0f, 1e6f, 0.3f);
+            TrySetDsp(config.MaxDistance, "MaxDistance", 0.0f, 1e6f, 1000.0f);
+            if (config.MinDistance > config.MaxDistance)
+            {
+                config.MinDistance = config.MaxDistance;
+            }
+            TrySetDsp(config.ConeInnerAngle, "ConeInnerAngle", 0.0f, glm::radians(360.0f), glm::radians(360.0f));
+            TrySetDsp(config.ConeOuterAngle, "ConeOuterAngle", 0.0f, glm::radians(360.0f), glm::radians(360.0f));
+            TrySetDsp(config.ConeOuterGain, "ConeOuterGain", 0.0f, 1.0f, 0.0f);
+            TrySetDsp(config.DopplerFactor, "DopplerFactor", 0.0f, 10.0f, 1.0f);
             TrySetDsp(config.Spread, "Spread", 0.0f, 1.0f, 1.0f);
             TrySetDsp(config.Focus, "Focus", 0.0f, 1.0f, 1.0f);
             TrySetDsp(config.LowPassCutoff, "LowPassCutoff", 0.0f, 1.0f, 1.0f);

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -1789,9 +1789,16 @@ namespace OloEngine
         {
             auto& src = deserializedEntity.AddComponent<AudioListenerComponent>();
             TrySet(src.Active, audioListenerComponent["Active"]);
-            TrySet(src.Config.ConeInnerAngle, audioListenerComponent["ConeInnerAngle"]);
-            TrySet(src.Config.ConeOuterAngle, audioListenerComponent["ConeOuterAngle"]);
-            TrySet(src.Config.ConeOuterGain, audioListenerComponent["ConeOuterGain"]);
+            // Load + sanitize in one step to prevent drift — cone angles are radians (miniaudio units),
+            // matching the AudioSourceComponent path and AudioListenerConfig's defaults.
+            auto TrySetDsp = [&audioListenerComponent](f32& field, const char* key, f32 lo, f32 hi, f32 fallback)
+            {
+                TrySet(field, audioListenerComponent[key]);
+                SanitizeFloat(field, lo, hi, fallback);
+            };
+            TrySetDsp(src.Config.ConeInnerAngle, "ConeInnerAngle", 0.0f, glm::radians(360.0f), glm::radians(360.0f));
+            TrySetDsp(src.Config.ConeOuterAngle, "ConeOuterAngle", 0.0f, glm::radians(360.0f), glm::radians(360.0f));
+            TrySetDsp(src.Config.ConeOuterGain, "ConeOuterGain", 0.0f, 1.0f, 0.0f);
         }
 
         if (const auto& soundGraphComponent = entity["AudioSoundGraphComponent"])

--- a/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.cpp
+++ b/OloEngine/src/OloEngine/Scene/Streaming/SceneStreamer.cpp
@@ -540,9 +540,9 @@ namespace OloEngine
                 if (ac.Source)
                 {
                     const auto& tc = entity.GetComponent<TransformComponent>();
-                    ac.Source->SetConfig(ac.Config);
+                    ac.Source->SetConfig(ac.GetConfig());
                     ac.Source->SetPosition(tc.Translation);
-                    if (ac.Config.PlayOnAwake)
+                    if (ac.GetConfig().PlayOnAwake)
                     {
                         ac.Source->Play();
                     }

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
@@ -120,7 +120,7 @@ static float AudioSourceComponent_GetVolume(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.VolumeMultiplier;
+    return comp.GetConfig().VolumeMultiplier;
 }
 
 static void AudioSourceComponent_SetVolume(UUID entityID, float value)
@@ -132,7 +132,7 @@ static void AudioSourceComponent_SetVolume(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.VolumeMultiplier = value;
+    comp.GetConfig().VolumeMultiplier = value;
     if (comp.Source)
         comp.Source->SetVolume(value);
 }
@@ -144,7 +144,7 @@ static float AudioSourceComponent_GetPitch(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.PitchMultiplier;
+    return comp.GetConfig().PitchMultiplier;
 }
 
 static void AudioSourceComponent_SetPitch(UUID entityID, float value)
@@ -156,7 +156,7 @@ static void AudioSourceComponent_SetPitch(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.PitchMultiplier = value;
+    comp.GetConfig().PitchMultiplier = value;
     if (comp.Source)
         comp.Source->SetPitch(value);
 }
@@ -168,7 +168,7 @@ static bool AudioSourceComponent_GetPlayOnAwake(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.PlayOnAwake;
+    return comp.GetConfig().PlayOnAwake;
 }
 
 static void AudioSourceComponent_SetPlayOnAwake(UUID entityID, bool value)
@@ -178,7 +178,7 @@ static void AudioSourceComponent_SetPlayOnAwake(UUID entityID, bool value)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.PlayOnAwake = value;
+    comp.GetConfig().PlayOnAwake = value;
 }
 
 static bool AudioSourceComponent_GetLooping(UUID entityID)
@@ -188,7 +188,7 @@ static bool AudioSourceComponent_GetLooping(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.Looping;
+    return comp.GetConfig().Looping;
 }
 
 static void AudioSourceComponent_SetLooping(UUID entityID, bool value)
@@ -198,7 +198,7 @@ static void AudioSourceComponent_SetLooping(UUID entityID, bool value)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.Looping = value;
+    comp.GetConfig().Looping = value;
     if (comp.Source)
         comp.Source->SetLooping(value);
 }
@@ -210,7 +210,7 @@ static bool AudioSourceComponent_GetSpatialization(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.Spatialization;
+    return comp.GetConfig().Spatialization;
 }
 
 static void AudioSourceComponent_SetSpatialization(UUID entityID, bool value)
@@ -220,7 +220,7 @@ static void AudioSourceComponent_SetSpatialization(UUID entityID, bool value)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.Spatialization = value;
+    comp.GetConfig().Spatialization = value;
     if (comp.Source)
         comp.Source->SetSpatialization(value);
 }
@@ -232,7 +232,7 @@ static int AudioSourceComponent_GetAttenuationModel(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return static_cast<int>(comp.Config.AttenuationModel);
+    return static_cast<int>(comp.GetConfig().AttenuationModel);
 }
 
 static void AudioSourceComponent_SetAttenuationModel(UUID entityID, int value)
@@ -242,9 +242,9 @@ static void AudioSourceComponent_SetAttenuationModel(UUID entityID, int value)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.AttenuationModel = static_cast<AttenuationModelType>(value);
+    comp.GetConfig().AttenuationModel = static_cast<AttenuationModelType>(value);
     if (comp.Source)
-        comp.Source->SetAttenuationModel(comp.Config.AttenuationModel);
+        comp.Source->SetAttenuationModel(comp.GetConfig().AttenuationModel);
 }
 
 static float AudioSourceComponent_GetRollOff(UUID entityID)
@@ -254,7 +254,7 @@ static float AudioSourceComponent_GetRollOff(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.RollOff;
+    return comp.GetConfig().RollOff;
 }
 
 static void AudioSourceComponent_SetRollOff(UUID entityID, float value)
@@ -266,7 +266,7 @@ static void AudioSourceComponent_SetRollOff(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.RollOff = value;
+    comp.GetConfig().RollOff = value;
     if (comp.Source)
         comp.Source->SetRollOff(value);
 }
@@ -278,7 +278,7 @@ static float AudioSourceComponent_GetMinGain(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.MinGain;
+    return comp.GetConfig().MinGain;
 }
 
 static void AudioSourceComponent_SetMinGain(UUID entityID, float value)
@@ -290,7 +290,7 @@ static void AudioSourceComponent_SetMinGain(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.MinGain = value;
+    comp.GetConfig().MinGain = value;
     if (comp.Source)
         comp.Source->SetMinGain(value);
 }
@@ -302,7 +302,7 @@ static float AudioSourceComponent_GetMaxGain(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.MaxGain;
+    return comp.GetConfig().MaxGain;
 }
 
 static void AudioSourceComponent_SetMaxGain(UUID entityID, float value)
@@ -314,7 +314,7 @@ static void AudioSourceComponent_SetMaxGain(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.MaxGain = value;
+    comp.GetConfig().MaxGain = value;
     if (comp.Source)
         comp.Source->SetMaxGain(value);
 }
@@ -326,7 +326,7 @@ static float AudioSourceComponent_GetMinDistance(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.MinDistance;
+    return comp.GetConfig().MinDistance;
 }
 
 static void AudioSourceComponent_SetMinDistance(UUID entityID, float value)
@@ -338,7 +338,7 @@ static void AudioSourceComponent_SetMinDistance(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.MinDistance = value;
+    comp.GetConfig().MinDistance = value;
     if (comp.Source)
         comp.Source->SetMinDistance(value);
 }
@@ -350,7 +350,7 @@ static float AudioSourceComponent_GetMaxDistance(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.MaxDistance;
+    return comp.GetConfig().MaxDistance;
 }
 
 static void AudioSourceComponent_SetMaxDistance(UUID entityID, float value)
@@ -362,7 +362,7 @@ static void AudioSourceComponent_SetMaxDistance(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.MaxDistance = value;
+    comp.GetConfig().MaxDistance = value;
     if (comp.Source)
         comp.Source->SetMaxDistance(value);
 }
@@ -374,7 +374,7 @@ static float AudioSourceComponent_GetConeInnerAngle(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.ConeInnerAngle;
+    return comp.GetConfig().ConeInnerAngle;
 }
 
 static void AudioSourceComponent_SetConeInnerAngle(UUID entityID, float value)
@@ -386,9 +386,9 @@ static void AudioSourceComponent_SetConeInnerAngle(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.ConeInnerAngle = value;
+    comp.GetConfig().ConeInnerAngle = value;
     if (comp.Source)
-        comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain);
+        comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain);
 }
 
 static float AudioSourceComponent_GetConeOuterAngle(UUID entityID)
@@ -398,7 +398,7 @@ static float AudioSourceComponent_GetConeOuterAngle(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.ConeOuterAngle;
+    return comp.GetConfig().ConeOuterAngle;
 }
 
 static void AudioSourceComponent_SetConeOuterAngle(UUID entityID, float value)
@@ -410,9 +410,9 @@ static void AudioSourceComponent_SetConeOuterAngle(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.ConeOuterAngle = value;
+    comp.GetConfig().ConeOuterAngle = value;
     if (comp.Source)
-        comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain);
+        comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain);
 }
 
 static float AudioSourceComponent_GetConeOuterGain(UUID entityID)
@@ -422,7 +422,7 @@ static float AudioSourceComponent_GetConeOuterGain(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.ConeOuterGain;
+    return comp.GetConfig().ConeOuterGain;
 }
 
 static void AudioSourceComponent_SetConeOuterGain(UUID entityID, float value)
@@ -434,9 +434,9 @@ static void AudioSourceComponent_SetConeOuterGain(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.ConeOuterGain = value;
+    comp.GetConfig().ConeOuterGain = value;
     if (comp.Source)
-        comp.Source->SetCone(comp.Config.ConeInnerAngle, comp.Config.ConeOuterAngle, comp.Config.ConeOuterGain);
+        comp.Source->SetCone(comp.GetConfig().ConeInnerAngle, comp.GetConfig().ConeOuterAngle, comp.GetConfig().ConeOuterGain);
 }
 
 static float AudioSourceComponent_GetDopplerFactor(UUID entityID)
@@ -446,7 +446,7 @@ static float AudioSourceComponent_GetDopplerFactor(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.Config.DopplerFactor;
+    return comp.GetConfig().DopplerFactor;
 }
 
 static void AudioSourceComponent_SetDopplerFactor(UUID entityID, float value)
@@ -458,7 +458,7 @@ static void AudioSourceComponent_SetDopplerFactor(UUID entityID, float value)
     if (!std::isfinite(value))
         return;
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.Config.DopplerFactor = value;
+    comp.GetConfig().DopplerFactor = value;
     if (comp.Source)
         comp.Source->SetDopplerFactor(value);
 }
@@ -470,7 +470,7 @@ static u64 AudioSourceComponent_GetSoundConfigHandle(UUID entityID)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    return comp.SoundConfigHandle;
+    return static_cast<u64>(comp.GetSoundConfigHandle());
 }
 
 static void AudioSourceComponent_SetSoundConfigHandle(UUID entityID, u64 value)
@@ -480,7 +480,7 @@ static void AudioSourceComponent_SetSoundConfigHandle(UUID entityID, u64 value)
     Entity entity = scene->GetEntityByUUID(entityID);
     OLO_CORE_ASSERT(entity);
     auto& comp = entity.GetComponent<AudioSourceComponent>();
-    comp.SoundConfigHandle = value;
+    comp.SetSoundConfigHandle(AssetHandle(value));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
@@ -205,19 +205,20 @@ namespace OloEngine
     void AudioSourceComponent_SetCone(u64 entityID, const f32* coneInnerAngle, const f32* coneOuterAngle, const f32* coneOuterGain)
     {
         auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        component.Config.ConeInnerAngle = *coneInnerAngle;
-        component.Config.ConeOuterAngle = *coneOuterAngle;
-        component.Config.ConeOuterGain = *coneOuterGain;
+        auto& config = component.GetConfig();
+        config.ConeInnerAngle = *coneInnerAngle;
+        config.ConeOuterAngle = *coneOuterAngle;
+        config.ConeOuterGain = *coneOuterGain;
         if (component.Source)
         {
-            component.Source->SetCone(component.Config.ConeInnerAngle, component.Config.ConeOuterAngle, component.Config.ConeOuterGain);
+            component.Source->SetCone(config.ConeInnerAngle, config.ConeOuterAngle, config.ConeOuterGain);
         }
     }
 
     void AudioSourceComponent_IsPlaying(u64 entityID, bool* outIsPlaying)
     {
         const auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        if (component.UseEventSystem && component.ActiveEventID != 0)
+        if (component.GetUseEventSystem() && component.ActiveEventID != 0)
         {
             *outIsPlaying = Audio::AudioPlayback::IsEventActive(component.ActiveEventID);
         }
@@ -234,13 +235,13 @@ namespace OloEngine
     void AudioSourceComponent_Play(u64 entityID)
     {
         auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        if (component.UseEventSystem && component.StartCommandID.IsValid())
+        if (component.GetUseEventSystem() && component.GetStartCommandID().IsValid())
         {
             if (component.ActiveEventID != 0)
             {
                 Audio::AudioPlayback::StopEvent(component.ActiveEventID);
             }
-            component.ActiveEventID = Audio::AudioPlayback::PostTrigger(component.StartCommandID, entityID);
+            component.ActiveEventID = Audio::AudioPlayback::PostTrigger(component.GetStartCommandID(), entityID);
             return;
         }
         if (component.Source)
@@ -252,7 +253,7 @@ namespace OloEngine
     void AudioSourceComponent_Pause(u64 entityID)
     {
         auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        if (component.UseEventSystem && component.ActiveEventID != 0)
+        if (component.GetUseEventSystem() && component.ActiveEventID != 0)
         {
             Audio::AudioPlayback::PauseEvent(component.ActiveEventID);
             return;
@@ -266,7 +267,7 @@ namespace OloEngine
     void AudioSourceComponent_UnPause(u64 entityID)
     {
         auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        if (component.UseEventSystem && component.ActiveEventID != 0)
+        if (component.GetUseEventSystem() && component.ActiveEventID != 0)
         {
             Audio::AudioPlayback::ResumeEvent(component.ActiveEventID);
             return;
@@ -280,7 +281,7 @@ namespace OloEngine
     void AudioSourceComponent_Stop(u64 entityID)
     {
         auto& component = GetEntity(entityID).GetComponent<AudioSourceComponent>();
-        if (component.UseEventSystem && component.ActiveEventID != 0)
+        if (component.GetUseEventSystem() && component.ActiveEventID != 0)
         {
             Audio::AudioPlayback::StopEvent(component.ActiveEventID);
             component.ActiveEventID = 0;

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -2092,58 +2092,61 @@ namespace OloEngine
 
         // --- AudioSourceComponent ---
         lua.new_usertype<AudioSourceComponent>("AudioSourceComponent", "volume", sol::property([](const AudioSourceComponent& c)
-                                                                                               { return c.Config.VolumeMultiplier; }, [](AudioSourceComponent& c, f32 v)
+                                                                                               { return c.GetConfig().VolumeMultiplier; }, [](AudioSourceComponent& c, f32 v)
                                                                                                {
                     if (!std::isfinite(v)) v = 1.0f;
                     v = std::clamp(v, 0.0f, 2.0f);
-                    c.Config.VolumeMultiplier = v;
+                    c.GetConfig().VolumeMultiplier = v;
                     if (c.Source) { c.Source->SetVolume(v); } }),
                                                "pitch", sol::property([](const AudioSourceComponent& c)
-                                                                      { return c.Config.PitchMultiplier; }, [](AudioSourceComponent& c, f32 v)
+                                                                      { return c.GetConfig().PitchMultiplier; }, [](AudioSourceComponent& c, f32 v)
                                                                       {
                     if (!std::isfinite(v)) v = 1.0f;
                     v = std::clamp(v, 0.1f, 3.0f);
-                    c.Config.PitchMultiplier = v;
+                    c.GetConfig().PitchMultiplier = v;
                     if (c.Source) { c.Source->SetPitch(v); } }),
                                                "playOnAwake", sol::property([](const AudioSourceComponent& c)
-                                                                            { return c.Config.PlayOnAwake; }, [](AudioSourceComponent& c, bool v)
-                                                                            { c.Config.PlayOnAwake = v; }),
+                                                                            { return c.GetConfig().PlayOnAwake; }, [](AudioSourceComponent& c, bool v)
+                                                                            { c.GetConfig().PlayOnAwake = v; }),
                                                "looping", sol::property([](const AudioSourceComponent& c)
-                                                                        { return c.Config.Looping; }, [](AudioSourceComponent& c, bool v)
+                                                                        { return c.GetConfig().Looping; }, [](AudioSourceComponent& c, bool v)
                                                                         {
-                    c.Config.Looping = v;
+                    c.GetConfig().Looping = v;
                     if (c.Source) { c.Source->SetLooping(v); } }),
                                                "spatialization", sol::property([](const AudioSourceComponent& c)
-                                                                               { return c.Config.Spatialization; }, [](AudioSourceComponent& c, bool v)
+                                                                               { return c.GetConfig().Spatialization; }, [](AudioSourceComponent& c, bool v)
                                                                                {
-                    c.Config.Spatialization = v;
+                    c.GetConfig().Spatialization = v;
                     if (c.Source) { c.Source->SetSpatialization(v); } }),
-                                               "useEventSystem", &AudioSourceComponent::UseEventSystem, "startEvent", sol::property([](const AudioSourceComponent& c)
-                                                                                                                                    { return c.StartEvent; }, [](AudioSourceComponent& c, const std::string& v)
-                                                                                                                                    {
-                    c.StartEvent = v;
-                    c.StartCommandID = Audio::CommandID::FromString(v); }),
+                                               "useEventSystem", sol::property([](const AudioSourceComponent& c)
+                                                                               { return c.GetUseEventSystem(); }, [](AudioSourceComponent& c, bool v)
+                                                                               { c.SetUseEventSystem(v); }),
+                                               "startEvent", sol::property([](const AudioSourceComponent& c)
+                                                                           { return c.GetStartEvent(); }, [](AudioSourceComponent& c, const std::string& v)
+                                                                           {
+                    c.SetStartEvent(v);
+                    c.SetStartCommandID(Audio::CommandID::FromString(v)); }),
                                                "isPlaying", [](const AudioSourceComponent& c) -> bool
                                                {
-                if (c.UseEventSystem && c.ActiveEventID != 0)
+                if (c.GetUseEventSystem() && c.ActiveEventID != 0)
                 {
                     return Audio::AudioPlayback::IsEventActive(c.ActiveEventID);
                 }
                 return c.Source && c.Source->IsPlaying(); }, "Play", [](AudioSourceComponent& c, sol::optional<u64> ownerUUID)
                                                {
-                if (c.UseEventSystem && c.StartCommandID.IsValid())
+                if (c.GetUseEventSystem() && c.GetStartCommandID().IsValid())
                 {
                     if (c.ActiveEventID != 0)
                     {
                         Audio::AudioPlayback::StopEvent(c.ActiveEventID);
                     }
                     u64 objectID = ownerUUID.value_or(0);
-                    c.ActiveEventID = Audio::AudioPlayback::PostTrigger(c.StartCommandID, objectID);
+                    c.ActiveEventID = Audio::AudioPlayback::PostTrigger(c.GetStartCommandID(), objectID);
                     return;
                 }
                 if (c.Source) { c.Source->Play(); } }, "Stop", [](AudioSourceComponent& c)
                                                {
-                if (c.UseEventSystem && c.ActiveEventID != 0)
+                if (c.GetUseEventSystem() && c.ActiveEventID != 0)
                 {
                     Audio::AudioPlayback::StopEvent(c.ActiveEventID);
                     c.ActiveEventID = 0;
@@ -2151,14 +2154,14 @@ namespace OloEngine
                 }
                 if (c.Source) { c.Source->Stop(); } }, "Pause", [](AudioSourceComponent& c)
                                                {
-                if (c.UseEventSystem && c.ActiveEventID != 0)
+                if (c.GetUseEventSystem() && c.ActiveEventID != 0)
                 {
                     Audio::AudioPlayback::PauseEvent(c.ActiveEventID);
                     return;
                 }
                 if (c.Source) { c.Source->Pause(); } }, "UnPause", [](AudioSourceComponent& c)
                                                {
-                if (c.UseEventSystem && c.ActiveEventID != 0)
+                if (c.GetUseEventSystem() && c.ActiveEventID != 0)
                 {
                     Audio::AudioPlayback::ResumeEvent(c.ActiveEventID);
                     return;
@@ -2166,71 +2169,71 @@ namespace OloEngine
                 if (c.Source) { c.Source->UnPause(); } },
                                                // --- Spatial audio properties ---
                                                "attenuationModel", sol::property([](const AudioSourceComponent& c)
-                                                                                 { return std::to_underlying(c.Config.AttenuationModel); }, [](AudioSourceComponent& c, int v)
+                                                                                 { return std::to_underlying(c.GetConfig().AttenuationModel); }, [](AudioSourceComponent& c, int v)
                                                                                  {
                     if (v < 0 || v > std::to_underlying(AttenuationModelType::Exponential)) return;
-                    c.Config.AttenuationModel = static_cast<AttenuationModelType>(v);
-                    if (c.Source) { c.Source->SetAttenuationModel(c.Config.AttenuationModel); } }),
+                    c.GetConfig().AttenuationModel = static_cast<AttenuationModelType>(v);
+                    if (c.Source) { c.Source->SetAttenuationModel(c.GetConfig().AttenuationModel); } }),
                                                "rollOff", sol::property([](const AudioSourceComponent& c)
-                                                                        { return c.Config.RollOff; }, [](AudioSourceComponent& c, f32 v)
+                                                                        { return c.GetConfig().RollOff; }, [](AudioSourceComponent& c, f32 v)
                                                                         {
                     if (!std::isfinite(v)) v = 1.0f;
                     v = std::max(v, 0.0f);
-                    c.Config.RollOff = v;
+                    c.GetConfig().RollOff = v;
                     if (c.Source) { c.Source->SetRollOff(v); } }),
                                                "minGain", sol::property([](const AudioSourceComponent& c)
-                                                                        { return c.Config.MinGain; }, [](AudioSourceComponent& c, f32 v)
+                                                                        { return c.GetConfig().MinGain; }, [](AudioSourceComponent& c, f32 v)
                                                                         {
                     if (!std::isfinite(v)) v = 0.0f;
                     v = std::max(v, 0.0f);
-                    c.Config.MinGain = v;
-                    if (c.Config.MinGain > c.Config.MaxGain) c.Config.MaxGain = c.Config.MinGain;
-                    if (c.Source) { c.Source->SetMinGain(c.Config.MinGain); c.Source->SetMaxGain(c.Config.MaxGain); } }),
+                    c.GetConfig().MinGain = v;
+                    if (c.GetConfig().MinGain > c.GetConfig().MaxGain) c.GetConfig().MaxGain = c.GetConfig().MinGain;
+                    if (c.Source) { c.Source->SetMinGain(c.GetConfig().MinGain); c.Source->SetMaxGain(c.GetConfig().MaxGain); } }),
                                                "maxGain", sol::property([](const AudioSourceComponent& c)
-                                                                        { return c.Config.MaxGain; }, [](AudioSourceComponent& c, f32 v)
+                                                                        { return c.GetConfig().MaxGain; }, [](AudioSourceComponent& c, f32 v)
                                                                         {
                     if (!std::isfinite(v)) v = 1.0f;
                     v = std::clamp(v, 0.0f, 1.0f);
-                    c.Config.MaxGain = v;
-                    if (c.Config.MinGain > c.Config.MaxGain) c.Config.MinGain = c.Config.MaxGain;
-                    if (c.Source) { c.Source->SetMinGain(c.Config.MinGain); c.Source->SetMaxGain(c.Config.MaxGain); } }),
+                    c.GetConfig().MaxGain = v;
+                    if (c.GetConfig().MinGain > c.GetConfig().MaxGain) c.GetConfig().MinGain = c.GetConfig().MaxGain;
+                    if (c.Source) { c.Source->SetMinGain(c.GetConfig().MinGain); c.Source->SetMaxGain(c.GetConfig().MaxGain); } }),
                                                "minDistance", sol::property([](const AudioSourceComponent& c)
-                                                                            { return c.Config.MinDistance; }, [](AudioSourceComponent& c, f32 v)
+                                                                            { return c.GetConfig().MinDistance; }, [](AudioSourceComponent& c, f32 v)
                                                                             {
                     if (!std::isfinite(v)) v = 0.3f;
                     v = std::max(v, 0.0f);
-                    c.Config.MinDistance = v;
-                    if (c.Config.MinDistance > c.Config.MaxDistance) c.Config.MaxDistance = c.Config.MinDistance;
-                    if (c.Source) { c.Source->SetMinDistance(v); c.Source->SetMaxDistance(c.Config.MaxDistance); } }),
+                    c.GetConfig().MinDistance = v;
+                    if (c.GetConfig().MinDistance > c.GetConfig().MaxDistance) c.GetConfig().MaxDistance = c.GetConfig().MinDistance;
+                    if (c.Source) { c.Source->SetMinDistance(v); c.Source->SetMaxDistance(c.GetConfig().MaxDistance); } }),
                                                "maxDistance", sol::property([](const AudioSourceComponent& c)
-                                                                            { return c.Config.MaxDistance; }, [](AudioSourceComponent& c, f32 v)
+                                                                            { return c.GetConfig().MaxDistance; }, [](AudioSourceComponent& c, f32 v)
                                                                             {
                     if (!std::isfinite(v)) v = 1000.0f;
                     v = std::max(v, 0.0f);
-                    c.Config.MaxDistance = v;
-                    if (c.Config.MinDistance > c.Config.MaxDistance) c.Config.MinDistance = c.Config.MaxDistance;
-                    if (c.Source) { c.Source->SetMaxDistance(v); c.Source->SetMinDistance(c.Config.MinDistance); } }),
+                    c.GetConfig().MaxDistance = v;
+                    if (c.GetConfig().MinDistance > c.GetConfig().MaxDistance) c.GetConfig().MinDistance = c.GetConfig().MaxDistance;
+                    if (c.Source) { c.Source->SetMaxDistance(v); c.Source->SetMinDistance(c.GetConfig().MinDistance); } }),
                                                "coneInnerAngle", sol::property([](const AudioSourceComponent& c)
-                                                                               { return c.Config.ConeInnerAngle; }, [](AudioSourceComponent& c, f32 v)
+                                                                               { return c.GetConfig().ConeInnerAngle; }, [](AudioSourceComponent& c, f32 v)
                                                                                {
                     if (!std::isfinite(v)) v = glm::radians(360.0f);
                     v = std::clamp(v, 0.0f, glm::radians(360.0f));
-                    c.Config.ConeInnerAngle = v;
-                    if (c.Source) { c.Source->SetCone(c.Config.ConeInnerAngle, c.Config.ConeOuterAngle, c.Config.ConeOuterGain); } }),
+                    c.GetConfig().ConeInnerAngle = v;
+                    if (c.Source) { c.Source->SetCone(c.GetConfig().ConeInnerAngle, c.GetConfig().ConeOuterAngle, c.GetConfig().ConeOuterGain); } }),
                                                "coneOuterAngle", sol::property([](const AudioSourceComponent& c)
-                                                                               { return c.Config.ConeOuterAngle; }, [](AudioSourceComponent& c, f32 v)
+                                                                               { return c.GetConfig().ConeOuterAngle; }, [](AudioSourceComponent& c, f32 v)
                                                                                {
                     if (!std::isfinite(v)) v = glm::radians(360.0f);
                     v = std::clamp(v, 0.0f, glm::radians(360.0f));
-                    c.Config.ConeOuterAngle = v;
-                    if (c.Source) { c.Source->SetCone(c.Config.ConeInnerAngle, c.Config.ConeOuterAngle, c.Config.ConeOuterGain); } }),
+                    c.GetConfig().ConeOuterAngle = v;
+                    if (c.Source) { c.Source->SetCone(c.GetConfig().ConeInnerAngle, c.GetConfig().ConeOuterAngle, c.GetConfig().ConeOuterGain); } }),
                                                "coneOuterGain", sol::property([](const AudioSourceComponent& c)
-                                                                              { return c.Config.ConeOuterGain; }, [](AudioSourceComponent& c, f32 v)
+                                                                              { return c.GetConfig().ConeOuterGain; }, [](AudioSourceComponent& c, f32 v)
                                                                               {
                     if (!std::isfinite(v)) v = 0.0f;
                     v = std::max(v, 0.0f);
-                    c.Config.ConeOuterGain = v;
-                    if (c.Source) { c.Source->SetCone(c.Config.ConeInnerAngle, c.Config.ConeOuterAngle, c.Config.ConeOuterGain); } }),
+                    c.GetConfig().ConeOuterGain = v;
+                    if (c.Source) { c.Source->SetCone(c.GetConfig().ConeInnerAngle, c.GetConfig().ConeOuterAngle, c.GetConfig().ConeOuterGain); } }),
                                                "SetCone", [](AudioSourceComponent& c, f32 innerAngle, f32 outerAngle, f32 outerGain)
                                                {
                     if (!std::isfinite(innerAngle)) { innerAngle = glm::radians(360.0f); }
@@ -2239,15 +2242,15 @@ namespace OloEngine
                     innerAngle = std::clamp(innerAngle, 0.0f, glm::radians(360.0f));
                     outerAngle = std::clamp(outerAngle, 0.0f, glm::radians(360.0f));
                     outerGain = std::max(outerGain, 0.0f);
-                    c.Config.ConeInnerAngle = innerAngle;
-                    c.Config.ConeOuterAngle = outerAngle;
-                    c.Config.ConeOuterGain = outerGain;
+                    c.GetConfig().ConeInnerAngle = innerAngle;
+                    c.GetConfig().ConeOuterAngle = outerAngle;
+                    c.GetConfig().ConeOuterGain = outerGain;
                     if (c.Source) { c.Source->SetCone(innerAngle, outerAngle, outerGain); } }, "dopplerFactor", sol::property([](const AudioSourceComponent& c)
-                                                                                   { return c.Config.DopplerFactor; }, [](AudioSourceComponent& c, f32 v)
+                                                                                   { return c.GetConfig().DopplerFactor; }, [](AudioSourceComponent& c, f32 v)
                                                                                    {
                     if (!std::isfinite(v)) v = 1.0f;
                     v = std::max(v, 0.0f);
-                    c.Config.DopplerFactor = v;
+                    c.GetConfig().DopplerFactor = v;
                     if (c.Source) { c.Source->SetDopplerFactor(v); } }));
 
         // --- AudioListenerComponent ---

--- a/OloEngine/tests/Audio/AudioEventsSceneIntegrationTest.cpp
+++ b/OloEngine/tests/Audio/AudioEventsSceneIntegrationTest.cpp
@@ -387,16 +387,16 @@ TEST_F(AudioEventsSceneIntegrationTest, AudioSourceComponentEventSystemFlag)
     auto entity = m_Scene->CreateEntity("AudioEntity");
     auto& asc = entity.AddComponent<AudioSourceComponent>();
 
-    EXPECT_FALSE(asc.UseEventSystem);
-    EXPECT_FALSE(asc.StartCommandID.IsValid());
+    EXPECT_FALSE(asc.GetUseEventSystem());
+    EXPECT_FALSE(asc.GetStartCommandID().IsValid());
 
     // Configure for event-driven audio
-    asc.UseEventSystem = true;
-    asc.StartEvent = "PlayBGM";
-    asc.StartCommandID = CommandID::FromString("PlayBGM");
+    asc.SetUseEventSystem(true);
+    asc.SetStartEvent("PlayBGM");
+    asc.SetStartCommandID(CommandID::FromString("PlayBGM"));
 
-    EXPECT_TRUE(asc.UseEventSystem);
-    EXPECT_TRUE(asc.StartCommandID.IsValid());
+    EXPECT_TRUE(asc.GetUseEventSystem());
+    EXPECT_TRUE(asc.GetStartCommandID().IsValid());
 }
 
 TEST_F(AudioEventsSceneIntegrationTest, CommandIDFromStartEventMatchesRegistry)

--- a/OloEngine/tests/ComponentRoundTripTest.cpp
+++ b/OloEngine/tests/ComponentRoundTripTest.cpp
@@ -1999,12 +1999,14 @@ namespace OloEngine::Tests
     }
 
     // -------------------------------------------------------------------------
-    // PrefabComponent — exercises the GENERATED std::unordered_set<std::string>
-    // serializer path (#451 unordered_map/set slice). The three override-tracking
-    // sets are populated with MULTIPLE entries each (rather than a single one) so
-    // a bug that only appends/reads the first inserted element would be caught;
-    // the generated code sorts before emit, so this also exercises that the
-    // insertion order doesn't matter for round-trip equality.
+    // PrefabComponent — exercises the hand-written serializer path (issue #444
+    // hot/cold split moved the three override-tracking sets behind a private,
+    // lazily-allocated PrefabOverrideSets pointer, so the component is no
+    // longer codegen-trivial). Sets are populated with MULTIPLE entries each
+    // (rather than a single one) so a bug that only appends/reads the first
+    // inserted element would be caught; the hand-written serializer still
+    // sorts before emit, so this also exercises that insertion order doesn't
+    // matter for round-trip equality.
     // -------------------------------------------------------------------------
     TEST(ComponentRoundTrip, PrefabComponentSurvivesYAMLRoundTrip)
     {
@@ -2021,9 +2023,9 @@ namespace OloEngine::Tests
             auto& pc = entity.AddComponent<PrefabComponent>();
             pc.m_PrefabID = expectedPrefabID;
             pc.m_PrefabEntityID = expectedPrefabEntityID;
-            pc.m_OverriddenComponents = expectedOverridden;
-            pc.m_AddedComponents = expectedAdded;
-            pc.m_RemovedComponents = expectedRemoved;
+            pc.SetOverriddenComponents(expectedOverridden);
+            pc.SetAddedComponents(expectedAdded);
+            pc.SetRemovedComponents(expectedRemoved);
             yaml = SceneSerializer(scene).SerializeToYAML();
         }
 
@@ -2037,9 +2039,9 @@ namespace OloEngine::Tests
         const auto& pc = restored.GetComponent<PrefabComponent>();
         EXPECT_EQ(static_cast<u64>(pc.m_PrefabID), static_cast<u64>(expectedPrefabID));
         EXPECT_EQ(static_cast<u64>(pc.m_PrefabEntityID), static_cast<u64>(expectedPrefabEntityID));
-        EXPECT_EQ(pc.m_OverriddenComponents, expectedOverridden);
-        EXPECT_EQ(pc.m_AddedComponents, expectedAdded);
-        EXPECT_EQ(pc.m_RemovedComponents, expectedRemoved);
+        EXPECT_EQ(pc.GetOverriddenComponents(), expectedOverridden);
+        EXPECT_EQ(pc.GetAddedComponents(), expectedAdded);
+        EXPECT_EQ(pc.GetRemovedComponents(), expectedRemoved);
     }
 
     // -------------------------------------------------------------------------
@@ -2260,12 +2262,12 @@ namespace OloEngine::Tests
             auto scene = Scene::Create();
             Entity entity = scene->CreateEntity(kTestTag);
             auto& as = entity.AddComponent<AudioSourceComponent>();
-            as.Config.VolumeMultiplier = expectedVolume;
-            as.Config.PitchMultiplier = expectedPitch;
-            as.Config.Looping = expectedLooping;
-            as.Config.MinDistance = expectedMinDistance;
-            as.Config.MaxDistance = expectedMaxDistance;
-            as.SoundConfigHandle = expectedPreset;
+            as.GetConfig().VolumeMultiplier = expectedVolume;
+            as.GetConfig().PitchMultiplier = expectedPitch;
+            as.GetConfig().Looping = expectedLooping;
+            as.GetConfig().MinDistance = expectedMinDistance;
+            as.GetConfig().MaxDistance = expectedMaxDistance;
+            as.SetSoundConfigHandle(expectedPreset);
             yaml = SceneSerializer(scene).SerializeToYAML();
         }
 
@@ -2277,12 +2279,12 @@ namespace OloEngine::Tests
         ASSERT_TRUE(restored.HasComponent<AudioSourceComponent>());
 
         const auto& as = restored.GetComponent<AudioSourceComponent>();
-        EXPECT_NEAR(as.Config.VolumeMultiplier, expectedVolume, kFloatEpsilon);
-        EXPECT_NEAR(as.Config.PitchMultiplier, expectedPitch, kFloatEpsilon);
-        EXPECT_EQ(as.Config.Looping, expectedLooping);
-        EXPECT_NEAR(as.Config.MinDistance, expectedMinDistance, kFloatEpsilon);
-        EXPECT_NEAR(as.Config.MaxDistance, expectedMaxDistance, kFloatEpsilon);
-        EXPECT_EQ(as.SoundConfigHandle, expectedPreset)
+        EXPECT_NEAR(as.GetConfig().VolumeMultiplier, expectedVolume, kFloatEpsilon);
+        EXPECT_NEAR(as.GetConfig().PitchMultiplier, expectedPitch, kFloatEpsilon);
+        EXPECT_EQ(as.GetConfig().Looping, expectedLooping);
+        EXPECT_NEAR(as.GetConfig().MinDistance, expectedMinDistance, kFloatEpsilon);
+        EXPECT_NEAR(as.GetConfig().MaxDistance, expectedMaxDistance, kFloatEpsilon);
+        EXPECT_EQ(as.GetSoundConfigHandle(), expectedPreset)
             << "SoundConfigHandle dropped on scene YAML round-trip — check SceneSerializer emit/read.";
     }
 
@@ -2337,7 +2339,7 @@ namespace OloEngine::Tests
             // firstYaml/secondYaml differ.
             Entity prefabInstance = scene->CreateEntity("PrefabInstance");
             auto& pc = prefabInstance.AddComponent<PrefabComponent>(UUID(0xAAAAULL), UUID(0xBBBBULL));
-            pc.m_OverriddenComponents = { "TransformComponent", "SpriteRendererComponent" };
+            pc.SetOverriddenComponents({ "TransformComponent", "SpriteRendererComponent" });
 
             return scene;
         };
@@ -2427,10 +2429,10 @@ namespace OloEngine::Tests
             Entity src = scene->CreateEntity("AudioSrc");
             {
                 auto& s = src.AddComponent<AudioSourceComponent>();
-                s.Config.VolumeMultiplier = 0.6f;
-                s.Config.Looping = true;
-                s.Config.MinDistance = 2.0f;
-                s.Config.MaxDistance = 25.0f;
+                s.GetConfig().VolumeMultiplier = 0.6f;
+                s.GetConfig().Looping = true;
+                s.GetConfig().MinDistance = 2.0f;
+                s.GetConfig().MaxDistance = 25.0f;
             }
             Entity listener = scene->CreateEntity("AudioListen");
             {

--- a/OloEngine/tests/Lua/LuaBindingTest.cpp
+++ b/OloEngine/tests/Lua/LuaBindingTest.cpp
@@ -1050,21 +1050,21 @@ TEST_F(LuaBindingTest, AudioSourceComponent_BasicProperties)
     lua["a"] = &audio;
 
     lua.script("a.volume = 0.5");
-    EXPECT_FLOAT_EQ(audio.Config.VolumeMultiplier, 0.5f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().VolumeMultiplier, 0.5f);
 
     lua.script("a.pitch = 1.5");
-    EXPECT_FLOAT_EQ(audio.Config.PitchMultiplier, 1.5f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().PitchMultiplier, 1.5f);
 
     lua.script("a.playOnAwake = false; a.looping = true; a.spatialization = true");
-    EXPECT_FALSE(audio.Config.PlayOnAwake);
-    EXPECT_TRUE(audio.Config.Looping);
-    EXPECT_TRUE(audio.Config.Spatialization);
+    EXPECT_FALSE(audio.GetConfig().PlayOnAwake);
+    EXPECT_TRUE(audio.GetConfig().Looping);
+    EXPECT_TRUE(audio.GetConfig().Spatialization);
 
     lua.script("a.useEventSystem = true");
-    EXPECT_TRUE(audio.UseEventSystem);
+    EXPECT_TRUE(audio.GetUseEventSystem());
 
     lua.script("a.startEvent = 'PlayFootsteps'");
-    EXPECT_EQ(audio.StartEvent, "PlayFootsteps");
+    EXPECT_EQ(audio.GetStartEvent(), "PlayFootsteps");
 }
 
 TEST_F(LuaBindingTest, AudioSourceComponent_VolumeClamping)
@@ -1073,10 +1073,10 @@ TEST_F(LuaBindingTest, AudioSourceComponent_VolumeClamping)
     lua["a"] = &audio;
 
     lua.script("a.volume = 5.0");
-    EXPECT_FLOAT_EQ(audio.Config.VolumeMultiplier, 2.0f); // clamped to max
+    EXPECT_FLOAT_EQ(audio.GetConfig().VolumeMultiplier, 2.0f); // clamped to max
 
     lua.script("a.volume = -1.0");
-    EXPECT_FLOAT_EQ(audio.Config.VolumeMultiplier, 0.0f); // clamped to min
+    EXPECT_FLOAT_EQ(audio.GetConfig().VolumeMultiplier, 0.0f); // clamped to min
 }
 
 TEST_F(LuaBindingTest, AudioSourceComponent_PitchClamping)
@@ -1085,10 +1085,10 @@ TEST_F(LuaBindingTest, AudioSourceComponent_PitchClamping)
     lua["a"] = &audio;
 
     lua.script("a.pitch = 10.0");
-    EXPECT_FLOAT_EQ(audio.Config.PitchMultiplier, 3.0f); // clamped to max
+    EXPECT_FLOAT_EQ(audio.GetConfig().PitchMultiplier, 3.0f); // clamped to max
 
     lua.script("a.pitch = 0.01");
-    EXPECT_FLOAT_EQ(audio.Config.PitchMultiplier, 0.1f); // clamped to min
+    EXPECT_FLOAT_EQ(audio.GetConfig().PitchMultiplier, 0.1f); // clamped to min
 }
 
 TEST_F(LuaBindingTest, AudioSourceComponent_SpatialProperties)
@@ -1098,34 +1098,34 @@ TEST_F(LuaBindingTest, AudioSourceComponent_SpatialProperties)
 
     // AttenuationModel (enum as int)
     lua.script("a.attenuationModel = 2"); // Linear
-    EXPECT_EQ(audio.Config.AttenuationModel, AttenuationModelType::Linear);
+    EXPECT_EQ(audio.GetConfig().AttenuationModel, AttenuationModelType::Linear);
 
     auto result = lua.script("return a.attenuationModel");
     EXPECT_EQ(result.get<int>(), 2);
 
     // RollOff
     lua.script("a.rollOff = 2.5");
-    EXPECT_FLOAT_EQ(audio.Config.RollOff, 2.5f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().RollOff, 2.5f);
 
     // Gain range
     lua.script("a.minGain = 0.1; a.maxGain = 0.9");
-    EXPECT_FLOAT_EQ(audio.Config.MinGain, 0.1f);
-    EXPECT_FLOAT_EQ(audio.Config.MaxGain, 0.9f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MinGain, 0.1f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MaxGain, 0.9f);
 
     // Distance range
     lua.script("a.minDistance = 1.0; a.maxDistance = 500.0");
-    EXPECT_FLOAT_EQ(audio.Config.MinDistance, 1.0f);
-    EXPECT_FLOAT_EQ(audio.Config.MaxDistance, 500.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MinDistance, 1.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MaxDistance, 500.0f);
 
     // Cone angles
     lua.script("a.coneInnerAngle = 1.57; a.coneOuterAngle = 3.14; a.coneOuterGain = 0.2");
-    EXPECT_NEAR(audio.Config.ConeInnerAngle, 1.57f, 1e-5f);
-    EXPECT_NEAR(audio.Config.ConeOuterAngle, 3.14f, 1e-5f);
-    EXPECT_FLOAT_EQ(audio.Config.ConeOuterGain, 0.2f);
+    EXPECT_NEAR(audio.GetConfig().ConeInnerAngle, 1.57f, 1e-5f);
+    EXPECT_NEAR(audio.GetConfig().ConeOuterAngle, 3.14f, 1e-5f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().ConeOuterGain, 0.2f);
 
     // Doppler
     lua.script("a.dopplerFactor = 2.0");
-    EXPECT_FLOAT_EQ(audio.Config.DopplerFactor, 2.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().DopplerFactor, 2.0f);
 }
 
 TEST_F(LuaBindingTest, AudioSourceComponent_NaNSafety)
@@ -1135,22 +1135,22 @@ TEST_F(LuaBindingTest, AudioSourceComponent_NaNSafety)
 
     // NaN should reset to defaults
     lua.script("a.volume = 0/0"); // NaN
-    EXPECT_FLOAT_EQ(audio.Config.VolumeMultiplier, 1.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().VolumeMultiplier, 1.0f);
 
     lua.script("a.pitch = 0/0");
-    EXPECT_FLOAT_EQ(audio.Config.PitchMultiplier, 1.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().PitchMultiplier, 1.0f);
 
     lua.script("a.rollOff = 0/0");
-    EXPECT_FLOAT_EQ(audio.Config.RollOff, 1.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().RollOff, 1.0f);
 
     lua.script("a.dopplerFactor = 0/0");
-    EXPECT_FLOAT_EQ(audio.Config.DopplerFactor, 1.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().DopplerFactor, 1.0f);
 
     lua.script("a.minDistance = 0/0");
-    EXPECT_FLOAT_EQ(audio.Config.MinDistance, 0.3f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MinDistance, 0.3f);
 
     lua.script("a.maxDistance = 0/0");
-    EXPECT_FLOAT_EQ(audio.Config.MaxDistance, 1000.0f);
+    EXPECT_FLOAT_EQ(audio.GetConfig().MaxDistance, 1000.0f);
 }
 
 // --- AudioListenerComponent ---

--- a/OloEngine/tests/PrefabOverrideTest.cpp
+++ b/OloEngine/tests/PrefabOverrideTest.cpp
@@ -58,9 +58,9 @@ TEST_F(PrefabOverrideTest, PrefabComponent_DefaultHasNoOverrides)
 {
     PrefabComponent pc;
     EXPECT_FALSE(pc.HasAnyOverrides());
-    EXPECT_TRUE(pc.m_OverriddenComponents.empty());
-    EXPECT_TRUE(pc.m_AddedComponents.empty());
-    EXPECT_TRUE(pc.m_RemovedComponents.empty());
+    EXPECT_TRUE(pc.GetOverriddenComponents().empty());
+    EXPECT_TRUE(pc.GetAddedComponents().empty());
+    EXPECT_TRUE(pc.GetRemovedComponents().empty());
 }
 
 TEST_F(PrefabOverrideTest, PrefabComponent_MarkAndQueryOverride)
@@ -86,8 +86,8 @@ TEST_F(PrefabOverrideTest, PrefabComponent_ClearAllOverrides)
 {
     PrefabComponent pc{ UUID{}, UUID{} };
     pc.MarkComponentOverridden("TransformComponent");
-    pc.m_AddedComponents.insert("ScriptComponent");
-    pc.m_RemovedComponents.insert("CameraComponent");
+    pc.MarkComponentAdded("ScriptComponent");
+    pc.MarkComponentRemoved("CameraComponent");
     EXPECT_TRUE(pc.HasAnyOverrides());
 
     pc.ClearAllOverrides();
@@ -97,11 +97,11 @@ TEST_F(PrefabOverrideTest, PrefabComponent_ClearAllOverrides)
 TEST_F(PrefabOverrideTest, PrefabComponent_AddedAndRemoved)
 {
     PrefabComponent pc{ UUID{}, UUID{} };
-    pc.m_AddedComponents.insert("ScriptComponent");
+    pc.MarkComponentAdded("ScriptComponent");
     EXPECT_TRUE(pc.IsComponentAdded("ScriptComponent"));
     EXPECT_FALSE(pc.IsComponentRemoved("ScriptComponent"));
 
-    pc.m_RemovedComponents.insert("CameraComponent");
+    pc.MarkComponentRemoved("CameraComponent");
     EXPECT_TRUE(pc.IsComponentRemoved("CameraComponent"));
     EXPECT_FALSE(pc.IsComponentAdded("CameraComponent"));
 }
@@ -422,7 +422,7 @@ TEST_F(PrefabOverrideTest, Prefab_UpdateInstance_SkipsRemovedComponents)
     // Remove the component on the instance and mark it as removed
     instance.RemoveComponent<SpriteRendererComponent>();
     auto& pc = instance.GetComponent<PrefabComponent>();
-    pc.m_RemovedComponents.insert("SpriteRendererComponent");
+    pc.MarkComponentRemoved("SpriteRendererComponent");
 
     // Update should NOT re-add the removed component
     prefab->UpdateInstanceFromPrefab(instance);
@@ -443,7 +443,7 @@ TEST_F(PrefabOverrideTest, Prefab_ApplyRemovedComponent_RemovesFromPrefab)
     // Remove the component on the instance and mark as removed
     instance.RemoveComponent<SpriteRendererComponent>();
     auto& pc = instance.GetComponent<PrefabComponent>();
-    pc.m_RemovedComponents.insert("SpriteRendererComponent");
+    pc.MarkComponentRemoved("SpriteRendererComponent");
 
     // Apply the removal to the prefab
     bool applied = prefab->ApplyComponentToPrefab(instance, "SpriteRendererComponent");
@@ -642,8 +642,8 @@ TEST_F(PrefabOverrideTest, PrefabComponent_ClearComponentOverride_ClearsAllSets)
 {
     PrefabComponent pc;
     pc.MarkComponentOverridden("TransformComponent");
-    pc.m_AddedComponents.insert("TransformComponent");
-    pc.m_RemovedComponents.insert("TransformComponent");
+    pc.MarkComponentAdded("TransformComponent");
+    pc.MarkComponentRemoved("TransformComponent");
 
     pc.ClearComponentOverride("TransformComponent");
 


### PR DESCRIPTION
## Summary
Issue #444 — move editor-only / cold data out of hot runtime ECS components to shrink their per-instance memory footprint.

- **`PrefabComponent`** — the three `std::unordered_set<std::string>` override-tracking sets (overridden/added/removed) move behind a lazily-allocated `PrefabOverrideSets` (`std::unique_ptr`, null when a prefab instance has no overrides — the common case). `sizeof(PrefabComponent)`: ~184-208 bytes → **24 bytes**.
- **`TagComponent`** — the transient `renaming` editor-only flag moves out to `SceneHierarchyPanel::m_RenamingEntityUUID` (panel-local state; only one entity can be mid-rename at a time, so it doesn't need to live on the runtime component).
- **`AudioSourceComponent`** — playback config, event wiring, and the SoundConfig asset handle move behind an always-allocated `AudioSourceColdData` blob, leaving only `Source` and `ActiveEventID` inline (the only fields `Scene::UpdateAudio`'s per-frame position-sync loop touches). `sizeof(AudioSourceComponent)`: ~150+ bytes → **24 bytes**.

Both `PrefabComponent` and `AudioSourceComponent` are now automatically classified non-trivial by OloHeaderTool's private-member detection (their cold data lives behind a private `std::unique_ptr`), so they fall out of the generated `AllComponents`/`SceneSerializer` codegen paths with **no exclusion-set edits needed**. `PrefabComponent`'s scene YAML serializer is hand-written to preserve the exact on-disk shape the codegen'd version had (same top-level keys, same sorted-sequence emit) — no scene migration required. All call sites (`SceneSerializer`, `SaveGame` serializer, `Scene`/`Prefab`/`SceneStreamer`, C#/Lua script glue, the editor panel, and tests) now go through the new accessor methods (`GetConfig()`, `GetOverriddenComponents()`, `SetSoundConfigHandle()`, etc.).

`static_assert(sizeof(...) <= 32)` guards `PrefabComponent` and `AudioSourceComponent` against regressing back into hot-array bloat.

Closes #444

## Test plan
- [x] `GenerateBindings` rebuilt — all generated `.inl` files reported "(unchanged)", confirming the codegen classifier already excludes both split components via private-member auto-detection.
- [x] Full `OloEngine-Tests` suite: **4182 passed**, 5 skipped (no GL context / launch smoke — expected in this environment), 0 failed.
- [x] Targeted suites verified green: `ComponentTupleCoverageTest`, `ComponentSerializerCoverageTest`, `ComponentHandlerCoverageTest`, `SaveGameComponentSerializerCoverageTest`, `PrefabOverrideTest`, `ComponentRoundTrip.*`, `AudioEventsSceneIntegrationTest`, `LuaBindingTest`.
- [x] `OloEditor` builds clean.
- [x] `sizeof()` verified via a temporary throwaway test (not committed): `PrefabComponent`=24, `AudioSourceComponent`=24 (both previously well over 150 bytes). `TagComponent` stays 40 in this Debug build because MSVC's debug-iterator `std::string` overhead already pads to a multiple of 8 regardless of the trailing bool; the real win shows up in Release builds where `std::string` is 32 bytes (40→32).
- [x] `/code-review high` — 8 independent finder angles (line-by-line, removed-behavior audit, cross-file call-site tracer, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) found **zero correctness bugs**. A few low-severity duplication notes (repeated accessor triples, repeated YAML sort/emit blocks) were surfaced but not acted on — they mirror the project's explicit anti-over-engineering guidance ("three similar lines is better than a premature abstraction") and an existing pattern already present elsewhere in `SceneSerializer.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene hierarchy renaming now stays consistently tied to the active entity, reducing incorrect/lingering rename behavior.
  * Audio source configuration (including sound preset links and event-system start behavior) is now handled more uniformly across the editor, scripting, and runtime.

* **Bug Fixes**
  * Prefab override apply/revert is more reliable, and prefab override data round-trips through serialization more consistently.
  * Legacy saves load missing sound preset data more safely and preserve expected audio startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->