### PR TITLE
feat(particle): per-system deterministic RNG + worker-dispatched ParticlesCPU split (#576 item 2)

### DIFF
--- a/OloEngine/src/OloEngine/Particle/EmissionShape.h
+++ b/OloEngine/src/OloEngine/Particle/EmissionShape.h
@@ -138,11 +138,11 @@ namespace OloEngine
             if constexpr (std::is_same_v<T, EmitMesh>)    return EmissionShapeType::Mesh; }, shape);
     }
 
-    // Sample a position offset from the emission shape
-    inline glm::vec3 SampleEmissionShape(const EmissionShape& shape)
+    // Sample a position offset from the emission shape. Randomness is drawn
+    // from the caller-supplied `rng` (the owning ParticleSystem's per-system
+    // deterministic stream — issue #452 / #576).
+    inline glm::vec3 SampleEmissionShape(const EmissionShape& shape, FastRandomPCG& rng)
     {
-        auto& rng = RandomUtils::GetGlobalRandom();
-
         return std::visit([&rng](auto&& s) -> glm::vec3
                           {
             using T = std::decay_t<decltype(s)>;
@@ -237,11 +237,10 @@ namespace OloEngine
         return glm::normalize(dir);
     }
 
-    // Get a direction from the emission shape for velocity initialization
-    inline glm::vec3 SampleEmissionDirection(const EmissionShape& shape)
+    // Get a direction from the emission shape for velocity initialization.
+    // Draws from the caller-supplied per-system `rng` (issue #452 / #576).
+    inline glm::vec3 SampleEmissionDirection(const EmissionShape& shape, FastRandomPCG& rng)
     {
-        auto& rng = RandomUtils::GetGlobalRandom();
-
         return std::visit([&rng](auto&& s) -> glm::vec3
                           {
             using T = std::decay_t<decltype(s)>;
@@ -314,7 +313,7 @@ namespace OloEngine
         glm::vec3 Direction{ 0.0f, 1.0f, 0.0f };
     };
 
-    inline EmissionSample SampleEmissionCombined(const EmissionShape& shape)
+    inline EmissionSample SampleEmissionCombined(const EmissionShape& shape, FastRandomPCG& rng)
     {
         EmissionSample sample;
 
@@ -322,7 +321,6 @@ namespace OloEngine
         // Skip the generic SampleEmissionShape call to avoid wasteful double-sampling.
         if (auto* mesh = std::get_if<EmitMesh>(&shape); mesh && mesh->IsValid())
         {
-            auto& rng = RandomUtils::GetGlobalRandom();
             f32 r = rng.GetFloat32InRange(0.0f, mesh->TotalArea);
             auto it = std::ranges::lower_bound(mesh->CumulativeAreas, r);
             u32 triIdx = static_cast<u32>(std::distance(mesh->CumulativeAreas.begin(), it));
@@ -340,8 +338,8 @@ namespace OloEngine
         }
         else
         {
-            sample.Position = SampleEmissionShape(shape);
-            sample.Direction = SampleEmissionDirection(shape);
+            sample.Position = SampleEmissionShape(shape, rng);
+            sample.Direction = SampleEmissionDirection(shape, rng);
         }
 
         return sample;

--- a/OloEngine/src/OloEngine/Particle/ParticleEmitter.cpp
+++ b/OloEngine/src/OloEngine/Particle/ParticleEmitter.cpp
@@ -5,7 +5,7 @@
 
 namespace OloEngine
 {
-    u32 ParticleEmitter::Update(f32 dt, ParticlePool& pool, const glm::vec3& emitterPosition, f32 rateMultiplier, const glm::quat& emitterRotation)
+    u32 ParticleEmitter::Update(f32 dt, ParticlePool& pool, const glm::vec3& emitterPosition, f32 rateMultiplier, const glm::quat& emitterRotation, FastRandomPCG& rng)
     {
         OLO_PROFILE_FUNCTION();
 
@@ -24,13 +24,12 @@ namespace OloEngine
             u32 emitted = pool.Emit(rateCount);
             for (u32 i = 0; i < emitted; ++i)
             {
-                InitializeParticle(firstSlot + i, pool, emitterPosition, emitterRotation);
+                InitializeParticle(firstSlot + i, pool, emitterPosition, emitterRotation, rng);
             }
             totalEmitted += emitted;
         }
 
         // Burst emission
-        auto& rng = RandomUtils::GetGlobalRandom();
         for (u32 b = m_NextBurstIndex; b < static_cast<u32>(Bursts.size()); ++b)
         {
             const auto& burst = Bursts[b];
@@ -42,7 +41,7 @@ namespace OloEngine
                     u32 emitted = pool.Emit(burst.Count);
                     for (u32 i = 0; i < emitted; ++i)
                     {
-                        InitializeParticle(firstSlot + i, pool, emitterPosition, emitterRotation);
+                        InitializeParticle(firstSlot + i, pool, emitterPosition, emitterRotation, rng);
                     }
                     totalEmitted += emitted;
                 }
@@ -66,12 +65,10 @@ namespace OloEngine
                           { return a.Time < b.Time; });
     }
 
-    void ParticleEmitter::InitializeParticle(u32 index, ParticlePool& pool, const glm::vec3& emitterPosition, const glm::quat& emitterRotation) const
+    void ParticleEmitter::InitializeParticle(u32 index, ParticlePool& pool, const glm::vec3& emitterPosition, const glm::quat& emitterRotation, FastRandomPCG& rng) const
     {
-        auto& rng = RandomUtils::GetGlobalRandom();
-
         // Use combined sampler to ensure mesh shapes pick position+direction from the same triangle
-        auto emission = SampleEmissionCombined(Shape);
+        auto emission = SampleEmissionCombined(Shape, rng);
         pool.m_Positions[index] = emitterPosition + emitterRotation * emission.Position;
         // Seed prev position to spawn position so the first rendered frame
         // emits zero per-particle motion vector (avoids popping into view

--- a/OloEngine/src/OloEngine/Particle/ParticleEmitter.h
+++ b/OloEngine/src/OloEngine/Particle/ParticleEmitter.h
@@ -37,13 +37,17 @@ namespace OloEngine
 
         std::vector<BurstEntry> Bursts;
 
-        // Emit particles for this frame, returns number emitted
-        u32 Update(f32 dt, ParticlePool& pool, const glm::vec3& emitterPosition, f32 rateMultiplier = 1.0f, const glm::quat& emitterRotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+        // Emit particles for this frame, returns number emitted. Draws all
+        // randomness (burst probability, spawn jitter, emission-shape sampling)
+        // from the caller-supplied `rng` so emission is deterministic per
+        // owning ParticleSystem rather than tied to the thread_local global
+        // stream (issue #452 / #576).
+        u32 Update(f32 dt, ParticlePool& pool, const glm::vec3& emitterPosition, f32 rateMultiplier, const glm::quat& emitterRotation, FastRandomPCG& rng);
 
         void Reset();
 
       private:
-        void InitializeParticle(u32 index, ParticlePool& pool, const glm::vec3& emitterPosition, const glm::quat& emitterRotation) const;
+        void InitializeParticle(u32 index, ParticlePool& pool, const glm::vec3& emitterPosition, const glm::quat& emitterRotation, FastRandomPCG& rng) const;
 
         f32 m_EmitAccumulator = 0.0f;
         f32 m_LoopTime = 0.0f;

--- a/OloEngine/src/OloEngine/Particle/ParticleSystem.cpp
+++ b/OloEngine/src/OloEngine/Particle/ParticleSystem.cpp
@@ -20,7 +20,7 @@ namespace OloEngine
     }
 
     ParticleSystem::ParticleSystem(const ParticleSystem& other)
-        : m_Pool(other.m_Pool), m_TrailData(other.m_TrailData), m_PendingTriggers(other.m_PendingTriggers), m_SortedIndices(other.m_SortedIndices), m_SortDistances(other.m_SortDistances), m_JoltScene(other.m_JoltScene), m_EmitterPosition(other.m_EmitterPosition), m_BoundingSphere(other.m_BoundingSphere), m_ParentVelocity(other.m_ParentVelocity), m_Time(other.m_Time), m_LODSpawnRateMultiplier(other.m_LODSpawnRateMultiplier), m_HasWarmedUp(other.m_HasWarmedUp), Playing(other.Playing), Looping(other.Looping), Duration(other.Duration), PlaybackSpeed(other.PlaybackSpeed), WarmUpTime(other.WarmUpTime), SimulationSpace(other.SimulationSpace), BlendMode(other.BlendMode), RenderMode(other.RenderMode), DepthSortEnabled(other.DepthSortEnabled), UseGPU(other.UseGPU), WindInfluence(other.WindInfluence), GPUNoiseStrength(other.GPUNoiseStrength), GPUNoiseFrequency(other.GPUNoiseFrequency), GPUGroundCollision(other.GPUGroundCollision), GPUGroundY(other.GPUGroundY), GPUCollisionBounce(other.GPUCollisionBounce), GPUCollisionFriction(other.GPUCollisionFriction), SoftParticlesEnabled(other.SoftParticlesEnabled), SoftParticleDistance(other.SoftParticleDistance), VelocityInheritance(other.VelocityInheritance), LODDistance1(other.LODDistance1), LODMaxDistance(other.LODMaxDistance), Emitter(other.Emitter), ColorModule(other.ColorModule), SizeModule(other.SizeModule), VelocityModule(other.VelocityModule), RotationModule(other.RotationModule), GravityModule(other.GravityModule), DragModule(other.DragModule), NoiseModule(other.NoiseModule), CollisionModule(other.CollisionModule), ForceFields(other.ForceFields), TrailModule(other.TrailModule), SubEmitterModule(other.SubEmitterModule), TextureSheetModule(other.TextureSheetModule)
+        : m_Pool(other.m_Pool), m_TrailData(other.m_TrailData), m_PendingTriggers(other.m_PendingTriggers), m_SortedIndices(other.m_SortedIndices), m_SortDistances(other.m_SortDistances), m_JoltScene(other.m_JoltScene), m_EmitterPosition(other.m_EmitterPosition), m_BoundingSphere(other.m_BoundingSphere), m_ParentVelocity(other.m_ParentVelocity), m_Time(other.m_Time), m_LODSpawnRateMultiplier(other.m_LODSpawnRateMultiplier), m_HasWarmedUp(other.m_HasWarmedUp), Playing(other.Playing), Looping(other.Looping), Duration(other.Duration), PlaybackSpeed(other.PlaybackSpeed), WarmUpTime(other.WarmUpTime), SimulationSpace(other.SimulationSpace), BlendMode(other.BlendMode), RenderMode(other.RenderMode), DepthSortEnabled(other.DepthSortEnabled), UseGPU(other.UseGPU), WindInfluence(other.WindInfluence), GPUNoiseStrength(other.GPUNoiseStrength), GPUNoiseFrequency(other.GPUNoiseFrequency), GPUGroundCollision(other.GPUGroundCollision), GPUGroundY(other.GPUGroundY), GPUCollisionBounce(other.GPUCollisionBounce), GPUCollisionFriction(other.GPUCollisionFriction), SoftParticlesEnabled(other.SoftParticlesEnabled), SoftParticleDistance(other.SoftParticleDistance), VelocityInheritance(other.VelocityInheritance), LODDistance1(other.LODDistance1), LODMaxDistance(other.LODMaxDistance), Emitter(other.Emitter), ColorModule(other.ColorModule), SizeModule(other.SizeModule), VelocityModule(other.VelocityModule), RotationModule(other.RotationModule), GravityModule(other.GravityModule), DragModule(other.DragModule), NoiseModule(other.NoiseModule), CollisionModule(other.CollisionModule), ForceFields(other.ForceFields), TrailModule(other.TrailModule), SubEmitterModule(other.SubEmitterModule), TextureSheetModule(other.TextureSheetModule), m_Random(other.m_Random), m_RandomSeeded(other.m_RandomSeeded)
     {
         // Rewire callback to THIS instance's trail data
         m_Pool.m_OnSwapCallback = [this](u32 a, u32 b)
@@ -84,6 +84,8 @@ namespace OloEngine
         m_Time = other.m_Time;
         m_LODSpawnRateMultiplier = other.m_LODSpawnRateMultiplier;
         m_HasWarmedUp = other.m_HasWarmedUp;
+        m_Random = other.m_Random;
+        m_RandomSeeded = other.m_RandomSeeded;
 
         // GPU system is not copied — it will be lazily initialized on next Update
         m_GPUSystem.reset();
@@ -96,7 +98,7 @@ namespace OloEngine
     }
 
     ParticleSystem::ParticleSystem(ParticleSystem&& other) noexcept
-        : m_Pool(std::move(other.m_Pool)), m_TrailData(std::move(other.m_TrailData)), m_GPUSystem(std::move(other.m_GPUSystem)), m_PendingTriggers(std::move(other.m_PendingTriggers)), m_SortedIndices(std::move(other.m_SortedIndices)), m_SortDistances(std::move(other.m_SortDistances)), m_JoltScene(other.m_JoltScene), m_EmitterPosition(other.m_EmitterPosition), m_BoundingSphere(other.m_BoundingSphere), m_ParentVelocity(other.m_ParentVelocity), m_Time(other.m_Time), m_LODSpawnRateMultiplier(other.m_LODSpawnRateMultiplier), m_HasWarmedUp(other.m_HasWarmedUp), Playing(other.Playing), Looping(other.Looping), Duration(other.Duration), PlaybackSpeed(other.PlaybackSpeed), WarmUpTime(other.WarmUpTime), SimulationSpace(other.SimulationSpace), BlendMode(other.BlendMode), RenderMode(other.RenderMode), DepthSortEnabled(other.DepthSortEnabled), UseGPU(other.UseGPU), WindInfluence(other.WindInfluence), GPUNoiseStrength(other.GPUNoiseStrength), GPUNoiseFrequency(other.GPUNoiseFrequency), GPUGroundCollision(other.GPUGroundCollision), GPUGroundY(other.GPUGroundY), GPUCollisionBounce(other.GPUCollisionBounce), GPUCollisionFriction(other.GPUCollisionFriction), SoftParticlesEnabled(other.SoftParticlesEnabled), SoftParticleDistance(other.SoftParticleDistance), VelocityInheritance(other.VelocityInheritance), LODDistance1(other.LODDistance1), LODMaxDistance(other.LODMaxDistance), Emitter(std::move(other.Emitter)), ColorModule(other.ColorModule), SizeModule(other.SizeModule), VelocityModule(other.VelocityModule), RotationModule(other.RotationModule), GravityModule(other.GravityModule), DragModule(other.DragModule), NoiseModule(other.NoiseModule), CollisionModule(other.CollisionModule), ForceFields(std::move(other.ForceFields)), TrailModule(other.TrailModule), SubEmitterModule(std::move(other.SubEmitterModule)), TextureSheetModule(other.TextureSheetModule)
+        : m_Pool(std::move(other.m_Pool)), m_TrailData(std::move(other.m_TrailData)), m_GPUSystem(std::move(other.m_GPUSystem)), m_PendingTriggers(std::move(other.m_PendingTriggers)), m_SortedIndices(std::move(other.m_SortedIndices)), m_SortDistances(std::move(other.m_SortDistances)), m_JoltScene(other.m_JoltScene), m_EmitterPosition(other.m_EmitterPosition), m_BoundingSphere(other.m_BoundingSphere), m_ParentVelocity(other.m_ParentVelocity), m_Time(other.m_Time), m_LODSpawnRateMultiplier(other.m_LODSpawnRateMultiplier), m_HasWarmedUp(other.m_HasWarmedUp), Playing(other.Playing), Looping(other.Looping), Duration(other.Duration), PlaybackSpeed(other.PlaybackSpeed), WarmUpTime(other.WarmUpTime), SimulationSpace(other.SimulationSpace), BlendMode(other.BlendMode), RenderMode(other.RenderMode), DepthSortEnabled(other.DepthSortEnabled), UseGPU(other.UseGPU), WindInfluence(other.WindInfluence), GPUNoiseStrength(other.GPUNoiseStrength), GPUNoiseFrequency(other.GPUNoiseFrequency), GPUGroundCollision(other.GPUGroundCollision), GPUGroundY(other.GPUGroundY), GPUCollisionBounce(other.GPUCollisionBounce), GPUCollisionFriction(other.GPUCollisionFriction), SoftParticlesEnabled(other.SoftParticlesEnabled), SoftParticleDistance(other.SoftParticleDistance), VelocityInheritance(other.VelocityInheritance), LODDistance1(other.LODDistance1), LODMaxDistance(other.LODMaxDistance), Emitter(std::move(other.Emitter)), ColorModule(other.ColorModule), SizeModule(other.SizeModule), VelocityModule(other.VelocityModule), RotationModule(other.RotationModule), GravityModule(other.GravityModule), DragModule(other.DragModule), NoiseModule(other.NoiseModule), CollisionModule(other.CollisionModule), ForceFields(std::move(other.ForceFields)), TrailModule(other.TrailModule), SubEmitterModule(std::move(other.SubEmitterModule)), TextureSheetModule(other.TextureSheetModule), m_Random(other.m_Random), m_RandomSeeded(other.m_RandomSeeded)
     {
         // Rewire callback to THIS instance
         m_Pool.m_OnSwapCallback = [this](u32 a, u32 b)
@@ -159,6 +161,8 @@ namespace OloEngine
         m_Time = other.m_Time;
         m_LODSpawnRateMultiplier = other.m_LODSpawnRateMultiplier;
         m_HasWarmedUp = other.m_HasWarmedUp;
+        m_Random = other.m_Random;
+        m_RandomSeeded = other.m_RandomSeeded;
 
         // Rewire callback to THIS instance
         m_Pool.m_OnSwapCallback = [this](u32 a, u32 b)
@@ -287,7 +291,7 @@ namespace OloEngine
         u32 prevAlive = m_Pool.GetAliveCount();
         if (emissionAllowed)
         {
-            Emitter.Update(scaledDt, m_Pool, emitPos, m_LODSpawnRateMultiplier, emitterRotation);
+            Emitter.Update(scaledDt, m_Pool, emitPos, m_LODSpawnRateMultiplier, emitterRotation, m_Random);
         }
         u32 newAlive = m_Pool.GetAliveCount();
 
@@ -499,7 +503,7 @@ namespace OloEngine
 
         // Triggers with ChildSystemIndex >= 0 are handled by Scene (emitted into child systems).
         // Only triggers with ChildSystemIndex == -1 fall back to the legacy parent-pool behavior.
-        auto& rng = RandomUtils::GetGlobalRandom();
+        auto& rng = m_Random;
 
         for (const auto& trigger : m_PendingTriggers)
         {
@@ -604,7 +608,7 @@ namespace OloEngine
         u32 prevAlive = m_Pool.GetAliveCount();
         if (emissionAllowed)
         {
-            Emitter.Update(scaledDt, m_Pool, emitPos, m_LODSpawnRateMultiplier, emitterRotation);
+            Emitter.Update(scaledDt, m_Pool, emitPos, m_LODSpawnRateMultiplier, emitterRotation, m_Random);
         }
         u32 newAlive = m_Pool.GetAliveCount();
 

--- a/OloEngine/src/OloEngine/Particle/ParticleSystem.h
+++ b/OloEngine/src/OloEngine/Particle/ParticleSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/FastRandom.h"
 #include "OloEngine/Particle/ParticlePool.h"
 #include "OloEngine/Particle/ParticleEmitter.h"
 #include "OloEngine/Particle/ParticleModules.h"
@@ -126,6 +127,56 @@ namespace OloEngine
             m_JoltScene = scene;
         }
 
+        // --- Deterministic per-system RNG (issue #452 / #576) ---
+        //
+        // Every ParticleSystem owns its own random stream rather than drawing
+        // from the thread_local RandomUtils::GetGlobalRandom(). This makes each
+        // system's emission reproducible independent of (a) which thread it runs
+        // on — the global stream is only seeded on the game thread, so a
+        // worker-dispatched particle update would otherwise ride an unseeded,
+        // time-seeded stream — and (b) how many other consumers (loot rolls,
+        // sibling systems, sub-emitters) drew from the shared stream this frame.
+        // Scene::OnRuntimeStart seeds each system via SeedRandom(DeriveSeed(...)).
+
+        // Re-seed this system's random stream. Deterministic: the same seed
+        // followed by the same Update() sequence reproduces the same particles.
+        void SeedRandom(u64 seed) noexcept
+        {
+            m_Random.SetSeed(seed);
+            m_RandomSeeded = true;
+        }
+
+        // Whether SeedRandom has been called. The Scene uses this to lazily
+        // seed edit-mode / simulate-preview systems exactly once (so twin
+        // emitters decorrelate) without re-seeding — and to skip re-seeding a
+        // system OnRuntimeStart already seeded authoritatively.
+        [[nodiscard]] bool IsRandomSeeded() const noexcept
+        {
+            return m_RandomSeeded;
+        }
+
+        // Random stream backing this system's emission (used by Scene when it
+        // spawns sub-emitter particles into a child system's pool).
+        [[nodiscard]] FastRandomPCG& GetRandom() noexcept
+        {
+            return m_Random;
+        }
+
+        // Combine the global run seed with an entity UUID (and an optional
+        // sub-stream index — 0 for the parent system, N+1 for child system N)
+        // into an independent, reproducible per-system seed. Honors the
+        // "global-seed × entity UUID" derivation: the UUID enters
+        // multiplicatively so two entities with the same global seed draw from
+        // distinct streams, while a SplitMix64 finalizer avoids the degenerate
+        // seeds a plain product would produce (uuid == 0, small factors).
+        [[nodiscard]] static u64 DeriveSeed(u64 globalSeed, u64 entityUUID, u32 subStream = 0) noexcept
+        {
+            u64 z = globalSeed + entityUUID * 0x9E3779B97F4A7C15ULL + (static_cast<u64>(subStream) + 1) * 0xD1B54A32D192ED03ULL;
+            z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+            z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+            return z ^ (z >> 31);
+        }
+
         // Public settings
         bool Playing = true;
         bool Looping = true;
@@ -198,6 +249,8 @@ namespace OloEngine
         f32 m_Time = 0.0f;
         f32 m_LODSpawnRateMultiplier = 1.0f;
         bool m_HasWarmedUp = false;
+        FastRandomPCG m_Random; // Per-system deterministic RNG (see SeedRandom/DeriveSeed)
+        bool m_RandomSeeded = false;
 
         void ProcessSubEmitterTriggers();
         void UpdateInternal(f32 dt, const glm::vec3& emitterPosition, const glm::vec3& parentVelocity, const glm::quat& emitterRotation);

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -252,6 +252,12 @@ namespace OloEngine
         (void)m_Registry.storage<AudioSoundGraphComponent>();
         (void)m_Registry.group<AudioListenerComponent>(entt::get<TransformComponent>);
         (void)m_Registry.group<AudioSourceComponent>(entt::get<TransformComponent>);
+        // ParticlesCPU (issue #576): the worker body walks this owning group and
+        // reads the CameraComponent storage for LOD — pre-create both so the
+        // first-touch is a pure read on the worker, never a pool-map mutation.
+        (void)m_Registry.storage<ParticleSystemComponent>();
+        (void)m_Registry.storage<CameraComponent>();
+        (void)m_Registry.group<ParticleSystemComponent>(entt::get<TransformComponent>);
     }
 
     template<typename T>
@@ -873,6 +879,25 @@ namespace OloEngine
         }
     }
 
+    // Fixed base seed for edit-mode / simulate-preview particle streams.
+    // Distinct from any run seed so a preview never accidentally matches a
+    // gameplay replay, but constant so previews are themselves reproducible.
+    static constexpr u64 kParticleEditorPreviewSeed = 0x0102030405060708ULL;
+
+    // Seed a ParticleSystemComponent's parent system + every child sub-system
+    // from baseSeed × entity UUID (issue #452 / #576). Each child gets a
+    // distinct sub-stream index so no two systems on the same entity share a
+    // stream. Used by OnRuntimeStart (run seed, authoritative for determinism)
+    // and OnSimulationStart (preview seed).
+    static void SeedParticleSystemComponent(ParticleSystemComponent& psc, u64 baseSeed, u64 entityUUID)
+    {
+        psc.System.SeedRandom(ParticleSystem::DeriveSeed(baseSeed, entityUUID));
+        for (sizet c = 0; c < psc.ChildSystems.size(); ++c)
+        {
+            psc.ChildSystems[c].SeedRandom(ParticleSystem::DeriveSeed(baseSeed, entityUUID, static_cast<u32>(c) + 1));
+        }
+    }
+
     void Scene::OnRuntimeStart()
     {
         m_IsRunning = true;
@@ -884,9 +909,13 @@ namespace OloEngine
         // OloRuntime — means every play-through starts from an identical RNG
         // state, tick 0, and time 0, so a run replays identically given the same
         // seed and inputs. This seeds the GAME THREAD's RandomUtils stream — the
-        // one game-thread gameplay (loot rolls, particle jitter, …) consumes. The
-        // generator is thread_local, so RNG drawn on worker/job threads rides a
+        // one game-thread gameplay (loot rolls, …) consumes. The generator is
+        // thread_local, so RNG drawn on worker/job threads still rides a
         // separate, time-seeded stream and is NOT reproducible (a #452 follow-up).
+        // Particle emission no longer depends on this shared stream: each
+        // ParticleSystem owns a per-system RNG, seeded just below from
+        // run-seed × entity UUID, so it replays identically even off the game
+        // thread (issue #576 — closes the #452 particle/sub-emitter gap).
         m_SimulationTick = 0;
         m_FixedTimeAccumulator = 0.0f;
         m_SimulationTime = 0.0f;
@@ -897,6 +926,23 @@ namespace OloEngine
         m_HasInterpSnapshots = false;
         m_RenderInterpAlpha = 0.0f;
         RandomUtils::SetGlobalSeed(Application::Get().GetRandomSeed());
+
+        // Seed each particle system's own deterministic RNG (issue #452 / #576).
+        // Particle emission draws from a per-ParticleSystem stream rather than
+        // the thread_local global one, so a system's jitter is reproducible
+        // regardless of how many other consumers share the global stream this
+        // frame and independent of which thread the update runs on. Deriving
+        // the seed from the run seed × entity UUID gives every emitter (and
+        // every child sub-emitter, via a distinct sub-stream index) its own
+        // independent, replay-stable stream.
+        {
+            const u64 runSeed = Application::Get().GetRandomSeed();
+            for (auto psView = m_Registry.view<ParticleSystemComponent, IDComponent>(); auto entity : psView)
+            {
+                auto& psc = psView.get<ParticleSystemComponent>(entity);
+                SeedParticleSystemComponent(psc, runSeed, static_cast<u64>(psView.get<IDComponent>(entity).ID));
+            }
+        }
 
         // Unified diagnostics timeline (#306 item B): the single authoritative fire for
         // "entered Play mode" — the editor copies the scene then calls this; OloRuntime
@@ -1179,6 +1225,17 @@ namespace OloEngine
         m_HasInterpSnapshots = false;
         m_RenderInterpAlpha = 0.0f;
 
+        // Seed each particle system's RNG from the fixed preview seed so a
+        // Simulate session's emission is decorrelated across systems and
+        // reproducible per session (issue #452 / #576). Simulate is a preview,
+        // not a determinism guarantee, so it uses the constant preview seed
+        // rather than the application run seed OnRuntimeStart uses.
+        for (auto psView = m_Registry.view<ParticleSystemComponent, IDComponent>(); auto entity : psView)
+        {
+            auto& psc = psView.get<ParticleSystemComponent>(entity);
+            SeedParticleSystemComponent(psc, kParticleEditorPreviewSeed, static_cast<u64>(psView.get<IDComponent>(entity).ID));
+        }
+
         OnPhysics2DStart();
         OnPhysics3DStart();
     }
@@ -1233,8 +1290,6 @@ namespace OloEngine
             return;
         }
 
-        auto& rng = RandomUtils::GetGlobalRandom();
-
         for (const auto& trigger : triggers)
         {
             if (trigger.ChildSystemIndex < 0 || static_cast<u32>(trigger.ChildSystemIndex) >= psc.ChildSystems.size())
@@ -1245,6 +1300,10 @@ namespace OloEngine
             auto& childSystem = psc.ChildSystems[trigger.ChildSystemIndex];
             auto& childPool = childSystem.GetPool();
             const auto& childEmitter = childSystem.Emitter;
+            // Spawn jitter draws from the child system's own deterministic
+            // stream (seeded per-child in OnRuntimeStart) — not the shared
+            // global RNG — so sub-emitter output is reproducible (issue #452).
+            auto& rng = childSystem.GetRandom();
 
             u32 firstSlot = childPool.GetAliveCount();
             u32 emitted = childPool.Emit(trigger.EmitCount);
@@ -2141,11 +2200,30 @@ namespace OloEngine
             //                       proximity — moving it would change what it
             //                       observes; the Reads(LocalTransforms) edge
             //                       below enforces its post-fence slot.)
-            //   Particles  UNSAFE — per-component UseGPU path issues GL compute
-            //                       from inside Update, and sub-emitters draw from
-            //                       the thread_local RNG (worker stream is time-
-            //                       seeded → breaks #452 determinism). CPU-only +
-            //                       reseeded RNG is the follow-up candidate.
+            //   ParticlesCPU SAFE — split from the GPU partition (issue #576).
+            //                       Updates only fully-CPU entities (parent AND
+            //                       every child !UseGPU — ParticleEntityUsesGPU),
+            //                       so the body issues NO GL. No EnTT structural
+            //                       changes (operates on internal particle pools;
+            //                       the group + the camera view's CameraComponent
+            //                       storage are pre-created in the Scene ctor). No
+            //                       GameplayEventBus publish. RNG is now the
+            //                       per-ParticleSystem stream seeded from
+            //                       run-seed × UUID (issue #452 fix), NOT the
+            //                       thread_local global — so emission replays
+            //                       identically off the game thread. Its Jolt
+            //                       collision raycast is a read-only NarrowPhase
+            //                       query and physics is fenced before particles
+            //                       run, so it is the only Jolt reader in the
+            //                       marked set. Its internal ColorModule/SizeModule/
+            //                       RotModule tasks (>=256 particles) are launched
+            //                       nested: safe because the task Wait retracts-and-
+            //                       executes independent leaf tasks inline, so a
+            //                       worker never deadlocks waiting on them.
+            //   ParticlesGPU UNSAFE — the UseGPU path issues GL compute dispatch
+            //                       from inside Update; stays game-thread (unmarked
+            //                       barrier). Handles every entity with any GPU
+            //                       system (parent or child).
             //   Snow       UNSAFE — GL compute dispatch / SSBO upload
             //                       (SnowAccumulationSystem::SubmitDeformers,
             //                       SnowEjectaSystem::EmitAt) must stay on the GL
@@ -2167,8 +2245,17 @@ namespace OloEngine
                             { s.UpdateAudio(ts); })
                 .Reads(kLocalTransforms)
                 .Parallelizable();
-            sched.AddSystem("Particles", [](Scene& s, Timestep ts)
-                            { s.UpdateParticles(ts); })
+            // Particles split into a worker-dispatched CPU partition and a
+            // game-thread GPU partition (issue #576). ParticlesGPU is an unmarked
+            // barrier, so it joins ParticlesCPU (and Abilities/Audio) before
+            // issuing any GL — the two partitions are guaranteed never to run
+            // concurrently, and they walk a disjoint set of entities besides.
+            sched.AddSystem("ParticlesCPU", [](Scene& s, Timestep ts)
+                            { s.UpdateParticlesCPU(ts); })
+                .Reads(kLocalTransforms)
+                .Parallelizable();
+            sched.AddSystem("ParticlesGPU", [](Scene& s, Timestep ts)
+                            { s.UpdateParticlesGPU(ts); })
                 .Reads(kLocalTransforms);
             sched.AddSystem("SnowDeformers", [](Scene& s, Timestep ts)
                             { s.UpdateSnowDeformers(ts); })
@@ -2539,11 +2626,47 @@ namespace OloEngine
         }
     }
 
-    void Scene::UpdateParticles(Timestep ts)
+    // Whether any particle work on this entity touches the GPU (issue #576):
+    // the parent system OR any child sub-system runs on the GPU compute path.
+    // Such an entity is routed to the game-thread ParticlesGPU partition; only
+    // a fully-CPU entity is eligible for the worker-dispatched ParticlesCPU
+    // partition, so the parallelizable path can never issue GL from a worker.
+    static bool ParticleEntityUsesGPU(const ParticleSystemComponent& psc)
+    {
+        if (psc.System.UseGPU)
+        {
+            return true;
+        }
+        for (const auto& child : psc.ChildSystems)
+        {
+            if (child.UseGPU)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Worker-safe CPU particle partition (issue #576). Marked Parallelizable in
+    // the schedule; see the audit note there for why this body is thread-safe.
+    void Scene::UpdateParticlesCPU(Timestep ts)
+    {
+        UpdateParticlesPartition(ts, /*gpuPartition=*/false);
+    }
+
+    // GPU particle partition — stays on the game thread (GL compute dispatch).
+    void Scene::UpdateParticlesGPU(Timestep ts)
+    {
+        UpdateParticlesPartition(ts, /*gpuPartition=*/true);
+    }
+
+    void Scene::UpdateParticlesPartition(Timestep ts, bool gpuPartition)
     {
         // Update particle systems
         {
-            // Quick camera position lookup for LOD
+            // Quick camera position lookup for LOD. Read-only; the CameraComponent
+            // storage is pre-created in the Scene constructor so this view's
+            // first-touch is not a structural registry mutation on the worker.
             glm::vec3 camPos(0.0f);
             for (const auto camView = m_Registry.view<TransformComponent, CameraComponent>(); const auto camEntity : camView)
             {
@@ -2556,12 +2679,24 @@ namespace OloEngine
             }
 
             // Partial-owning group: owns ParticleSystemComponent, borrows
-            // TransformComponent (issue #443 ownership map).
+            // TransformComponent (issue #443 ownership map). Pre-created in the
+            // Scene constructor so the worker-side group() call is a pure read.
             for (auto psGroup = m_Registry.group<ParticleSystemComponent>(entt::get<TransformComponent>); auto entity : psGroup)
             {
                 const auto& transform = psGroup.get<TransformComponent>(entity);
                 auto& psc = psGroup.get<ParticleSystemComponent>(entity);
-                // Provide Jolt scene for raycast collision
+
+                // Route each entity to exactly one partition by GPU usage. The
+                // two partitions never run concurrently (ParticlesGPU is an
+                // unmarked join-all barrier), so this split is a clean disjoint
+                // walk, not a data race.
+                if (ParticleEntityUsesGPU(psc) != gpuPartition)
+                {
+                    continue;
+                }
+
+                // Provide Jolt scene for raycast collision (read-only CastRay;
+                // physics is fenced by the time particles run — safe on a worker).
                 psc.System.SetJoltScene(m_JoltScene.get());
                 psc.System.UpdateLOD(camPos, transform.Translation);
 
@@ -3007,6 +3142,14 @@ namespace OloEngine
             {
                 const auto& transform = psGroup.get<TransformComponent>(entity);
                 auto& psc = psGroup.get<ParticleSystemComponent>(entity);
+                // Edit-mode preview has no start hook to seed the per-system
+                // RNG, so seed it lazily from the fixed preview seed exactly
+                // once (twin emitters would otherwise share the default stream
+                // and emit identically). SeedRandom marks the system seeded.
+                if (!psc.System.IsRandomSeeded())
+                {
+                    SeedParticleSystemComponent(psc, kParticleEditorPreviewSeed, static_cast<u64>(m_Registry.get<IDComponent>(entity).ID));
+                }
                 psc.System.UpdateLOD(camPos, transform.Translation);
                 psc.System.Update(ts, transform.Translation, glm::vec3(0.0f), transform.GetRotation());
 

--- a/OloEngine/src/OloEngine/Scene/Scene.h
+++ b/OloEngine/src/OloEngine/Scene/Scene.h
@@ -748,8 +748,14 @@ namespace OloEngine
         void UpdateQuest(Timestep ts);           // quest timers / conditions
         void UpdateAbilities(Timestep ts);       // gameplay ability system
         void UpdateAudio(Timestep ts);           // listener/source pose sync + events
-        void UpdateParticles(Timestep ts);       // particle systems + sub-emitters
-        void UpdateSnowDeformers(Timestep ts);   // snow deformation stamps + ejecta
+        // Particle update is split by GPU usage (issue #576): the CPU partition
+        // is worker-dispatchable (Parallelizable), the GPU partition stays on the
+        // game thread because it issues GL compute. UpdateParticlesPartition does
+        // the shared camera-LOD + group walk; each wrapper picks its partition.
+        void UpdateParticlesCPU(Timestep ts); // CPU-only systems (worker-safe)
+        void UpdateParticlesGPU(Timestep ts); // GPU / GL-compute systems (game thread)
+        void UpdateParticlesPartition(Timestep ts, bool gpuPartition);
+        void UpdateSnowDeformers(Timestep ts); // snow deformation stamps + ejecta
 
       public:
         // The process-wide gameplay system schedule. Built once (thread-safe

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -510,6 +510,7 @@ add_executable(OloEngine-Tests
 		Functional/AI/PerceptionDetectsTargetViaSceneTickTest.cpp
 		Functional/AI/PerceptionLineOfSightBlockedByWallViaSceneTickTest.cpp
 		Functional/Particles/ParticleSystemEmitsAndExpiresTest.cpp
+		Functional/Particles/ParticleSystemDeterminismTest.cpp
 		Functional/AnimationPhysics/CharacterControllerWalksTest.cpp
 		Functional/AnimationPhysics/AnimationBlendCompletesViaSceneTickTest.cpp
 		Functional/AnimationPhysics/SpringBoneJiggleViaSceneTickTest.cpp

--- a/OloEngine/tests/Functional/Particles/ParticleSystemDeterminismTest.cpp
+++ b/OloEngine/tests/Functional/Particles/ParticleSystemDeterminismTest.cpp
@@ -1,0 +1,208 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: Functional
+// =============================================================================
+// ParticleSystemDeterminismTest — Functional Test.
+//
+// Seam under test:
+//   ParticleSystem emission RNG × run determinism (issue #452 / #576).
+//
+// Each ParticleSystem now owns a per-system random stream (SeedRandom /
+// DeriveSeed) instead of drawing from the thread_local
+// RandomUtils::GetGlobalRandom(). This is the mechanism that closes the #452
+// sub-emitter / particle-jitter determinism gap: given the same run seed and
+// the same entity UUID, a system replays an identical particle stream —
+// independent of (a) how many other consumers (loot rolls, sibling emitters)
+// drew from the shared global stream this frame, and (b) which thread the
+// update ran on (the global stream is only seeded on the game thread).
+//
+// These tests drive ParticleSystem directly (the unit that owns the stream)
+// rather than through a full Scene: the property under test is the emission
+// stream itself, and a direct drive is both the tightest and the most robust
+// way to pin it. The Scene wiring that seeds each system from
+// global-seed × UUID lives in Scene::OnRuntimeStart / OnSimulationStart.
+// =============================================================================
+
+#include "OloEngine/Core/FastRandom.h"
+#include "OloEngine/Particle/ParticleSystem.h"
+
+#include <bit>
+#include <functional>
+#include <glm/glm.hpp>
+#include <vector>
+
+using namespace OloEngine;
+
+namespace
+{
+    // A configuration that exercises every RNG-driven code path in emission:
+    // rate-based spawn count, speed / size / rotation variance, a lifetime
+    // range, and a Sphere emission shape (rejection-sampled position +
+    // direction). If the stream is deterministic here it is deterministic
+    // everywhere the emitter draws randomness.
+    ParticleSystem MakeConfiguredSystem()
+    {
+        ParticleSystem sys(512);
+        sys.Playing = true;
+        sys.Looping = true;
+        sys.Duration = 1000.0f; // No mid-run loop reset within the test window.
+        sys.Emitter.RateOverTime = 40.0f;
+        sys.Emitter.InitialSpeed = 3.0f;
+        sys.Emitter.SpeedVariance = 1.5f;
+        sys.Emitter.InitialSize = 1.0f;
+        sys.Emitter.SizeVariance = 0.5f;
+        sys.Emitter.InitialRotation = 0.0f;
+        sys.Emitter.RotationVariance = 3.0f;
+        sys.Emitter.LifetimeMin = 0.8f;
+        sys.Emitter.LifetimeMax = 1.6f;
+        sys.Emitter.Shape = EmitSphere{ 2.0f };
+        return sys;
+    }
+
+    // Bit-exact signature of every alive particle's spawned state. Encoded as
+    // integers (via std::bit_cast) so the comparison is an exact identity
+    // check without float == : determinism means bit-identical, not "close".
+    std::vector<u32> Signature(const ParticleSystem& sys)
+    {
+        const u32 count = sys.GetAliveCount();
+        const ParticlePool& pool = sys.GetPool();
+        std::vector<u32> sig;
+        sig.reserve(static_cast<sizet>(count) * 9 + 1);
+        sig.push_back(count);
+        const auto push = [&sig](f32 v)
+        { sig.push_back(std::bit_cast<u32>(v)); };
+        for (u32 i = 0; i < count; ++i)
+        {
+            push(pool.m_Positions[i].x);
+            push(pool.m_Positions[i].y);
+            push(pool.m_Positions[i].z);
+            push(pool.m_Velocities[i].x);
+            push(pool.m_Velocities[i].y);
+            push(pool.m_Velocities[i].z);
+            push(pool.m_Sizes[i]);
+            push(pool.m_Rotations[i]);
+            push(pool.m_Lifetimes[i]);
+        }
+        return sig;
+    }
+
+    // Advance a system `frames` fixed steps, optionally running `between`
+    // before each Update (used to perturb the global RNG mid-run).
+    std::vector<u32> RunAndSnapshot(ParticleSystem& sys, u32 frames, const std::function<void()>& between = {})
+    {
+        constexpr f32 dt = 1.0f / 60.0f;
+        const glm::vec3 emitterPos{ 5.0f, 1.0f, -2.0f };
+        for (u32 f = 0; f < frames; ++f)
+        {
+            if (between)
+            {
+                between();
+            }
+            sys.Update(dt, emitterPos);
+        }
+        return Signature(sys);
+    }
+
+    constexpr u64 kRunSeed = 0xC0FFEEULL;
+    constexpr u64 kEntityUUID = 0x1234'5678'9ABC'DEF0ULL;
+    constexpr u32 kFrames = 40;
+} // namespace
+
+// Same run seed + same UUID ⇒ byte-identical particle stream.
+TEST(ParticleSystemDeterminism, SameSeedAndUUIDProducesIdenticalStream)
+{
+    const u64 seed = ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID);
+
+    ParticleSystem a = MakeConfiguredSystem();
+    a.SeedRandom(seed);
+    const std::vector<u32> sigA = RunAndSnapshot(a, kFrames);
+
+    ParticleSystem b = MakeConfiguredSystem();
+    b.SeedRandom(seed);
+    const std::vector<u32> sigB = RunAndSnapshot(b, kFrames);
+
+    ASSERT_GT(sigA[0], 5u) << "sanity: the configuration should have emitted a non-trivial pool";
+    EXPECT_EQ(sigA, sigB)
+        << "two systems seeded identically diverged — per-system RNG is not deterministic";
+}
+
+// Same run seed but a different entity UUID ⇒ a different stream (each emitter
+// in a scene has its own reproducible-but-distinct jitter).
+TEST(ParticleSystemDeterminism, DifferentUUIDProducesDifferentStream)
+{
+    ParticleSystem a = MakeConfiguredSystem();
+    a.SeedRandom(ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID));
+    const std::vector<u32> sigA = RunAndSnapshot(a, kFrames);
+
+    ParticleSystem b = MakeConfiguredSystem();
+    b.SeedRandom(ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID ^ 0x1ULL));
+    const std::vector<u32> sigB = RunAndSnapshot(b, kFrames);
+
+    ASSERT_GT(sigA[0], 5u);
+    EXPECT_NE(sigA, sigB)
+        << "distinct UUIDs produced identical streams — the UUID is not entering the seed";
+}
+
+// The regression that #452 left open: particle emission must NOT depend on the
+// shared thread_local global RNG. Draw heavily from the global stream between
+// every Update; the per-system stream — and therefore the particle output —
+// must be untouched. Before the per-system RNG this interleaving shifted the
+// jitter and the signatures would diverge.
+TEST(ParticleSystemDeterminism, StreamIsIndependentOfGlobalRandom)
+{
+    const u64 seed = ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID);
+
+    ParticleSystem baseline = MakeConfiguredSystem();
+    baseline.SeedRandom(seed);
+    const std::vector<u32> sigBaseline = RunAndSnapshot(baseline, kFrames);
+
+    // Perturb the global stream (as a sibling loot roll / another emitter would)
+    // before each frame's Update.
+    ParticleSystem perturbed = MakeConfiguredSystem();
+    perturbed.SeedRandom(seed);
+    const auto churnGlobal = []
+    {
+        auto& g = RandomUtils::GetGlobalRandom();
+        for (int k = 0; k < 7; ++k)
+        {
+            (void)g.GetFloat32();
+        }
+    };
+    const std::vector<u32> sigPerturbed = RunAndSnapshot(perturbed, kFrames, churnGlobal);
+
+    ASSERT_GT(sigBaseline[0], 5u);
+    EXPECT_EQ(sigBaseline, sigPerturbed)
+        << "particle emission changed when the global RNG was perturbed — the per-system "
+           "stream is not fully isolated from RandomUtils::GetGlobalRandom()";
+}
+
+// DeriveSeed contract: pure, stable, and distinct across UUID and sub-stream.
+TEST(ParticleSystemDeterminism, DeriveSeedIsStableAndDistinct)
+{
+    // Stable: same inputs ⇒ same output.
+    EXPECT_EQ(ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID),
+              ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID));
+
+    // The parent stream (subStream 0) differs from every child sub-stream, and
+    // the child sub-streams differ from each other — no two systems on one
+    // entity share a stream.
+    const u64 parent = ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID, 0);
+    const u64 child0 = ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID, 1);
+    const u64 child1 = ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID, 2);
+    EXPECT_NE(parent, child0);
+    EXPECT_NE(parent, child1);
+    EXPECT_NE(child0, child1);
+
+    // Distinct entities draw distinct parent streams under the same run seed.
+    EXPECT_NE(ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID),
+              ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID + 1));
+
+    // A different run seed reshuffles a given entity's stream (replays under a
+    // new seed do not alias the old run).
+    EXPECT_NE(ParticleSystem::DeriveSeed(kRunSeed, kEntityUUID),
+              ParticleSystem::DeriveSeed(kRunSeed + 1, kEntityUUID));
+
+    // A zero UUID must not collapse to a degenerate seed equal to the run seed.
+    EXPECT_NE(ParticleSystem::DeriveSeed(kRunSeed, 0), kRunSeed);
+}

--- a/OloEngine/tests/Scene/SystemSchedulerTest.cpp
+++ b/OloEngine/tests/Scene/SystemSchedulerTest.cpp
@@ -30,12 +30,14 @@
 #include "OloEngine/Scene/SystemScheduler.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Gameplay/Abilities/AbilityComponents.h"
 #include "OloEngine/Task/Scheduler.h"
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <chrono>
 #include <cstddef>
 #include <iterator>
@@ -260,7 +262,8 @@ TEST(SystemSchedulerTest, GameplayScheduleMatchesCanonicalOrder)
         "Inventory",
         "Abilities",
         "Audio",
-        "Particles",
+        "ParticlesCPU",
+        "ParticlesGPU",
         "SnowDeformers",
     };
     EXPECT_EQ(Scene::GetGameplaySystemOrderForTesting(), expected);
@@ -323,15 +326,23 @@ TEST(SystemSchedulerTest, GameplayScheduleHonoursDocumentedSeams)
     EXPECT_TRUE(sched.DependsOn("Inventory", "PhysicsFence"));           // pickup proximity reads post-physics transforms
     EXPECT_TRUE(sched.DependsOn("Audio", "PhysicsFence"));               // pose sync reads post-physics transforms
     EXPECT_TRUE(sched.DependsOn("Audio", "Navigation"));
-    EXPECT_TRUE(sched.DependsOn("Particles", "PhysicsFence"));
+    EXPECT_TRUE(sched.DependsOn("ParticlesCPU", "PhysicsFence"));
+    EXPECT_TRUE(sched.DependsOn("ParticlesGPU", "PhysicsFence"));
     EXPECT_TRUE(sched.DependsOn("SnowDeformers", "PhysicsFence"));
 
     // And the deliberate independence the parallel executor exploits: the
     // marked systems (and the transform read-only tail) have no path between
-    // one another.
-    EXPECT_FALSE(sched.DependsOn("Particles", "Audio"));
-    EXPECT_FALSE(sched.DependsOn("Audio", "Particles"));
-    EXPECT_FALSE(sched.DependsOn("SnowDeformers", "Particles"));
+    // one another. ParticlesCPU (marked) must be unordered against the other
+    // marked systems (Abilities, Audio) — that independence is what lets it run
+    // on a worker (issue #576). ParticlesGPU is an unmarked barrier, so it is
+    // free to be unordered here too; the executor still joins tasks before it.
+    EXPECT_FALSE(sched.DependsOn("ParticlesCPU", "Audio"));
+    EXPECT_FALSE(sched.DependsOn("Audio", "ParticlesCPU"));
+    EXPECT_FALSE(sched.DependsOn("ParticlesCPU", "Abilities"));
+    EXPECT_FALSE(sched.DependsOn("Abilities", "ParticlesCPU"));
+    EXPECT_FALSE(sched.DependsOn("ParticlesCPU", "ParticlesGPU"));
+    EXPECT_FALSE(sched.DependsOn("ParticlesGPU", "ParticlesCPU"));
+    EXPECT_FALSE(sched.DependsOn("SnowDeformers", "ParticlesCPU"));
     EXPECT_FALSE(sched.DependsOn("Audio", "Abilities"));
     EXPECT_FALSE(sched.DependsOn("Abilities", "Audio"));
 }
@@ -535,4 +546,94 @@ TEST_F(SystemSchedulerParallelTest, GameplayTickParallelMatchesSequential)
     // And the cooldown genuinely ticked: 30 frames at 1/60 s ≈ 0.5 s consumed.
     EXPECT_GT(sequential, 0.0f);
     EXPECT_LT(sequential, 1.0f);
+}
+
+// ── ParticlesCPU parallel acceptance (issue #576) ────────────────────────────
+// The CPU particle partition is now Parallelizable — it runs on a worker thread
+// while Audio/Abilities run. Because each ParticleSystem draws from its own
+// per-system RNG (seeded from run-seed × UUID, issue #452), the emitted stream
+// must be bit-identical whether ParticlesCPU is dispatched to a worker or run
+// inline. This drives real workers (the fixture StartWorkers()) so the parallel
+// path is genuinely concurrent, then compares the exact particle pools.
+namespace
+{
+    std::vector<u32> TickParticleScene(bool parallelEnabled, u32 tickCount)
+    {
+        const bool previous = SystemScheduler::IsParallelExecutionEnabled();
+        SystemScheduler::SetParallelExecutionEnabled(parallelEnabled);
+
+        Ref<Scene> scene = Scene::Create();
+        scene->SetRenderingEnabled(false);
+
+        Entity camera = scene->CreateEntity("Camera");
+        camera.AddComponent<CameraComponent>().Primary = true;
+
+        // Several CPU emitters with variance on every RNG-driven field + a Sphere
+        // shape, each seeded from a distinct per-system stream.
+        constexpr u32 kEmitters = 4;
+        std::vector<Entity> emitters;
+        emitters.reserve(kEmitters);
+        for (u32 e = 0; e < kEmitters; ++e)
+        {
+            Entity emitter = scene->CreateEntity("Emitter" + std::to_string(e));
+            emitter.GetComponent<TransformComponent>().Translation = { static_cast<f32>(e), 0.0f, 0.0f };
+            auto& sys = emitter.AddComponent<ParticleSystemComponent>().System;
+            sys.Playing = true;
+            sys.Looping = true;
+            sys.Duration = 1000.0f;
+            sys.UseGPU = false;
+            sys.Emitter.RateOverTime = 30.0f;
+            sys.Emitter.InitialSpeed = 2.0f;
+            sys.Emitter.SpeedVariance = 1.0f;
+            sys.Emitter.SizeVariance = 0.3f;
+            sys.Emitter.RotationVariance = 2.0f;
+            sys.Emitter.LifetimeMin = 1.0f;
+            sys.Emitter.LifetimeMax = 2.0f;
+            sys.Emitter.Shape = EmitSphere{ 1.5f };
+            sys.SeedRandom(ParticleSystem::DeriveSeed(0x00ABCDEFu, e + 1));
+            emitters.push_back(emitter);
+        }
+
+        for (u32 i = 0; i < tickCount; ++i)
+        {
+            scene->OnUpdateRuntime(Timestep{ 1.0f / 60.0f });
+        }
+
+        std::vector<u32> sig;
+        const auto push = [&sig](f32 v)
+        { sig.push_back(std::bit_cast<u32>(v)); };
+        for (Entity emitter : emitters)
+        {
+            const ParticleSystem& sys = emitter.GetComponent<ParticleSystemComponent>().System;
+            const ParticlePool& pool = sys.GetPool();
+            const u32 count = sys.GetAliveCount();
+            sig.push_back(count);
+            for (u32 i = 0; i < count; ++i)
+            {
+                push(pool.m_Positions[i].x);
+                push(pool.m_Positions[i].y);
+                push(pool.m_Positions[i].z);
+                push(pool.m_Velocities[i].x);
+                push(pool.m_Velocities[i].y);
+                push(pool.m_Velocities[i].z);
+                push(pool.m_Sizes[i]);
+                push(pool.m_Rotations[i]);
+                push(pool.m_Lifetimes[i]);
+            }
+        }
+
+        SystemScheduler::SetParallelExecutionEnabled(previous);
+        return sig;
+    }
+} // namespace
+
+TEST_F(SystemSchedulerParallelTest, ParticleTickParallelMatchesSequential)
+{
+    const std::vector<u32> sequential = TickParticleScene(false, 30);
+    const std::vector<u32> parallel = TickParticleScene(true, 30);
+
+    ASSERT_GT(sequential[0], 5u) << "sanity: emitters should have produced a non-trivial pool";
+    EXPECT_EQ(sequential, parallel)
+        << "ParticlesCPU produced a different particle stream on a worker thread than inline — "
+           "the per-system RNG is not fully isolated from execution placement (#576/#452)";
 }


### PR DESCRIPTION
## What & why

Implements **item 2 of #576** (the gameplay-scheduler particle expansion) — **both halves**:

### 1. Per-`ParticleSystem` deterministic RNG (closes the #452 particle/sub-emitter gap)
Each `ParticleSystem` now owns a `FastRandomPCG m_Random` instead of drawing from the thread-local `RandomUtils::GetGlobalRandom()`. A new static `ParticleSystem::DeriveSeed(globalSeed, uuid, subStream)` folds the entity UUID multiplicatively through a SplitMix64 finalizer; `Scene::OnRuntimeStart` seeds every system + child from `runSeed × UUID` (authoritative determinism), and `OnSimulationStart` / edit-preview seed from a fixed preview constant (once, guarded by `IsRandomSeeded()`) so twin emitters decorrelate.

All emission RNG is routed off the global stream: `ParticleEmitter::Update`/`InitializeParticle`, the three `EmissionShape` samplers, `ParticleSystem::ProcessSubEmitterTriggers`, and `Scene::ProcessChildSubEmitters` (each child draws from its own stream).

Result: a system's particle jitter replays identically given the same seed + UUID, independent of how many other consumers touched the shared stream and independent of which thread runs the update — which is exactly what unblocks moving particles to a worker.

### 2. Worker-dispatched `ParticlesCPU` / `ParticlesGPU` split
`UpdateParticles` splits into `UpdateParticlesCPU` / `UpdateParticlesGPU` over a shared `UpdateParticlesPartition(ts, gpuPartition)`; membership is per-entity by `ParticleEntityUsesGPU` (parent **or any child** `UseGPU`). The schedule's `Particles` node becomes `ParticlesCPU` (`.Parallelizable()`) + `ParticlesGPU` (unmarked barrier, game thread). ParticlesGPU joins ParticlesCPU before any GL and the two walk disjoint entity sets, so they never run concurrently — GPU compute stays on the game thread while the CPU partition overlaps Audio/Abilities on a worker.

## Thread-safety audit (ParticlesCPU) — recorded in the schedule's audit-table comment
- **No GL** — CPU-only partition; every GPU parent/child routed to the game-thread node.
- **No EnTT structural changes** — operates on internal particle pools; the owning group + the camera view's `CameraComponent` storage are pre-created in the `Scene` ctor (pre-warm list extended).
- **No `GameplayEventBus` publish.**
- **RNG** is the per-system stream (not thread-local), so emission is thread-placement-independent.
- **Jolt collision** is a read-only `NarrowPhaseQuery::CastRay`; physics is fenced before particles run, and it's the sole Jolt reader in the marked set.
- **Nested `Tasks::Launch`** (ColorModule/SizeModule/RotModule at ≥256 particles) is deadlock-free — the task `Wait` retracts-and-runs the independent leaf tasks inline (`TaskPrivate.h` `WaitImpl`/`TryRetractAndExecute`).

## Tests
- `Functional/Particles/ParticleSystemDeterminismTest.cpp` (new): same-seed→identical stream, different-UUID→divergence, **independence from a perturbed global RNG** (the #452 regression), and the `DeriveSeed` contract.
- `SystemSchedulerTest`: canonical-order + documented-seam assertions updated to the two nodes.
- `SystemSchedulerParallelTest.ParticleTickParallelMatchesSequential` (new): drives **real workers** and asserts bit-identical particle pools parallel vs sequential (#576 acceptance criterion).
- `OLO_GAMEPLAY_SCHEDULER_SEQUENTIAL=1` kill-switch still bisects both mechanisms.

Full suite green (4212 passed; only environmental skips). No rendering change — emission logic is byte-identical and `RenderParticleSystems` is untouched, so no visual-verification pass was needed.

## Scope
Does **not** touch `SceneSerializer.cpp` (RNG is runtime-only). Does not close #576 (umbrella of 6 items; 1, 3, 4, 5, 6 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Particle emission now uses deterministic, system-provided random seeds for more consistent results.
  * Added support for separate CPU and GPU particle update paths.
* **Bug Fixes**
  * Improved replay consistency for particle effects, including sub-emitters and burst spawning.
  * Reduced sensitivity to unrelated random number usage elsewhere in the app.
* **Tests**
  * Added coverage for particle determinism and for matching particle behavior between sequential and parallel updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->