### PR TITLE
docs(renderer): document FinalRenderPass::OnReset as intentional no-op (#595)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Passes/FinalRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/FinalRenderPass.cpp
@@ -142,6 +142,27 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        // TODO(olbu): Recreate the fullscreen triangle and shader if needed (#595)
+        // Intentional no-op — nothing this pass owns can go stale across a reset (#595):
+        //
+        //  * m_BlitShader is a plain Ref<Shader> GPU asset, not a render-graph
+        //    handle. RenderGraph::ResetTopology() only invalidates RG resource
+        //    slots / framebuffer handles; it never touches shaders. The only path
+        //    that would drop the shader is the heavier RenderPipeline::Setup(),
+        //    which destroys every pass object and reconstructs it — so Init()
+        //    re-creates m_BlitShader from scratch. A persisting FinalRenderPass
+        //    therefore always holds its live shader.
+        //
+        //  * The fullscreen triangle is NOT owned here: MeshPrimitives::
+        //    GetFullscreenTriangle() is a self-healing lazy static VAO, re-fetched
+        //    every Execute() and only released at renderer Shutdown(). It survives
+        //    every topology reset and re-creates itself on demand regardless.
+        //
+        //  * The input texture is resolved fresh from the current graph every
+        //    Execute(), so no cross-frame handle is cached to invalidate.
+        //
+        // (OnReset() is in fact never invoked anywhere in the engine — it is a
+        // vestigial RenderGraphNode hook from when passes were persistent-and-reset
+        // rather than destroyed-and-recreated. Kept as a documented no-op so the
+        // contract is explicit rather than a silent gap.)
     }
 } // namespace OloEngine

--- a/docs/agent-rules/render-pipeline-caches.md
+++ b/docs/agent-rules/render-pipeline-caches.md
@@ -120,3 +120,44 @@ the paired "same-dimension idle resize must **not** churn the pool" contract.
 `EASUVisualEvidenceTest.ForwardUpscaleOffTransitionKeepsSceneVisible`
 (GPU, SKIPs headless) reproduces the runtime `Performance`→`Off` transition with
 a 2-frame warm-up and fails on a black frame if the pool keeps stale transients.
+
+---
+
+# Pass objects survive a topology reset — but `RenderGraphNode::OnReset()` is a dead hook (#595)
+
+Two different "resets" exist and they have **different** lifetimes for the pass
+objects — don't conflate them:
+
+- **`RenderGraph::ResetTopology()`** — the per-build topology wipe, called at the
+  top of `BuildRenderPipelineGraph` (every path build). It clears `m_NodeLookup`,
+  invalidates every RG resource/framebuffer handle slot, and bumps
+  `GetTopologyGeneration()`. The **pass objects persist** across it: the pipeline
+  re-registers the *same* long-lived `PostProcessPasses.*` / `FrameCorePasses.*`
+  instances into the freshly-reset graph.
+- **`RenderPipeline::Setup()`** — the heavier reconfigure. It calls
+  `RenderPipeline::Reset()` (drops every pass `Ref<>`, destroying the objects)
+  then `CreateFramePasses` / `CreatePostProcessPasses` (constructs fresh objects
+  via `Ref<T>::Create()` and calls `Init()` on each). Here the pass objects
+  **do not** survive.
+
+Because a pass persists across `ResetTopology()`, any RG handle it cached is now
+dangling. The engine handles this **not** via a reset hook but by re-resolving
+every RG handle from the current graph inside `Execute()` each frame
+(`GetPrimaryInputTextureHandle()` → `context.ResolveTexture(...)`,
+`GetPrimaryOutputFramebufferHandle()` → `context.ResolveFramebuffer(...)`; a
+pass's `m_Target` is reassigned from that fresh resolve every Execute). So no
+cross-frame RG handle is trusted to survive a reset in the first place.
+
+Consequently **`RenderGraphNode::OnReset()` has zero call sites anywhere in the
+engine** (grep it — every occurrence is a definition/override or an unrelated
+SoundGraph `m_OnReset`). It is a vestigial virtual from an earlier
+persistent-and-reset design; the ~38 overrides that null `m_Target` / cached
+handles are dead-but-harmless (the fields are also re-resolved every Execute).
+Do **not** assume `OnReset()` runs on a topology reset — it does not. If you
+genuinely need per-reset work on a persistent pass, either wire a real call site
+into `BuildRenderPipelineGraph` / `ResetTopology` first, or (the existing idiom)
+re-resolve the state in `Execute()` from the live graph. `FinalRenderPass::OnReset`
+is documented as an intentional no-op on this basis: its `m_BlitShader` is a plain
+shader asset rebuilt only by `Init()` (i.e. only on the destroy-and-recreate
+`Setup()` path), and its fullscreen triangle is a self-healing static owned by
+`MeshPrimitives`, not the pass.


### PR DESCRIPTION
## Summary

Resolves the `// TODO(olbu)` in `FinalRenderPass::OnReset` (#595). Investigation showed this is a **legitimate no-op**, not a correctness gap — so the fix is a documented invariant, not speculative recreation code.

## Why it's a no-op

The issue's premise ("`OnReset` is presumably called on render-graph topology reset") does not hold:

1. **`OnReset()` has zero call sites in the engine.** `RenderGraphNode::OnReset()` is a vestigial virtual — nothing invokes it. It is dead across all ~38 passes, not just Final.
2. **Passes persist across `RenderGraph::ResetTopology()`** and re-resolve every RG handle from the live graph inside `Execute()` each frame, so no cross-frame handle is trusted to survive a reset in the first place. The heavier `RenderPipeline::Setup()` path destroys and recreates each pass object outright (fresh `Init()`).
3. **Neither resource `FinalRenderPass` touches can go stale:** `m_BlitShader` is a plain shader asset rebuilt only by `Init()` (the destroy-and-recreate path); the fullscreen triangle is a self-healing lazy static owned by `MeshPrimitives`, re-fetched every `Execute()`, not owned by the pass.

## Changes

- `FinalRenderPass.cpp` — replaced the TODO with a documented-invariant no-op (override kept for consistency with the other 37 passes).
- `docs/agent-rules/render-pipeline-caches.md` — captured the reusable lesson: pass lifecycle across the two reset kinds, and that `OnReset` is a dead hook you must not rely on.

## Testing

No test added: the change touches a dead, behavior-free code path; a "no-op does nothing" test would be a tautology per `docs/testing.md`. No behavior change — comment + docs only.

## Follow-up

Removing the dead `OnReset` mechanism engine-wide (base virtual + ~38 overrides) is worth a dedicated cleanup issue, deliberately scoped past the in-flight renderer branches to avoid a large merge-conflict surface.

Fixes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified render pipeline reset behavior and the lifecycle of cached rendering resources.
  * Documented how rendering passes refresh resource references after topology resets.
  * Added guidance on handling reset-related work and noted that the final rendering reset hook intentionally performs no action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->