### PR TITLE
fix(shaderdebugger): wire Refresh All to reload tracked shaders

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Debug/ShaderDebugger.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/ShaderDebugger.cpp
@@ -2,6 +2,8 @@
 #include "ShaderDebugger.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Core/Application.h"
+#include "OloEngine/Renderer/Renderer2D.h"
+#include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Threading/UniqueLock.h"
 
 #include <spirv_cross/spirv_cross.hpp>
@@ -963,7 +965,13 @@ namespace OloEngine
         // Bottom controls
         if (ImGui::Button("Refresh All"))
         {
-            // TODO(olbu): Trigger reload of all shaders (#594)
+            // Same reload path the filewatch hot-reload uses (ShaderLibrary::ReloadShaders()
+            // -> Shader::Reload() per shader) so compile errors surface identically — via
+            // OLO_SHADER_COMPILATION_END / OnReloadEnd, both invoked from Reload() itself.
+            // Must run on the render/main thread: Reload() recompiles GL programs directly.
+            OLO_CORE_INFO("ShaderDebugger: Refresh All triggered — reloading all tracked shaders");
+            Renderer3D::GetShaderLibrary().ReloadShaders();
+            Renderer2D::GetShaderLibrary().ReloadShaders();
         }
         ImGui::SameLine();
         if (ImGui::Button("Clear Selection"))


### PR DESCRIPTION
## Summary
- The Shader Debugger panel's "Refresh All" button was a no-op TODO.
- Wires it to `ShaderLibrary::ReloadShaders()` for both `Renderer3D` and `Renderer2D`'s shader libraries — the same reload path (`Shader::Reload()`) used by the filewatch hot-reload, and already exposed via Lua/C# scripting (`ShaderLibrary3D_ReloadAll` / `ShaderLibrary2D_ReloadAll`) and the `olo_shader_reload` MCP tool, so this matches established convention rather than introducing a new one.
- Compile errors surface identically to the automatic hot-reload path, via the existing `OnCompilationEnd`/`OnReloadEnd` ShaderDebugger hooks.

Fixes #594

## Test plan
- [x] `OloEditor` Debug build succeeds (proves the code compiles/links correctly)
- [x] `OloEngine-Tests` Debug build succeeds
- [x] `ShaderCompileFailureRecovery.*` (the #568/#583 graceful GLSL-failure-recovery contract for this exact reload path) — 3/3 passed
- [x] `McpShaderReload.*` — 4/4 passed
- [x] Ran the editor and confirmed it launches/renders correctly with no regressions