### PR TITLE
SoundGraph: fill NodeDescription/NodeSchema editor-metadata gaps (#591)

### DIFF
--- a/OloEditor/src/Panels/SoundGraphEditorPanel.cpp
+++ b/OloEditor/src/Panels/SoundGraphEditorPanel.cpp
@@ -1989,7 +1989,8 @@ namespace OloEngine
             { "Array (float)", "GetRandom<float>" },
             { "Array (int)", "GetRandom<int>" },
             { "Music", "BPMToSeconds" },
-            { "Music", "NoteToFrequency" },
+            { "Music", "NoteToFrequency<float>" },
+            { "Music", "NoteToFrequency<int>" },
             { "Music", "FrequencyToNote" },
         };
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/NodeSchema.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/NodeSchema.cpp
@@ -130,12 +130,44 @@ namespace OloEngine::Audio::SoundGraph
                 { "BPMToSeconds", {
                                       { "BPM", NodeParamKind::Float, 120.0f, 0, false, 1.0f, 999.0f, 1.0f, "Beats per minute" },
                                   } },
-                { "NoteToFrequency", {
-                                         { "MIDINote", NodeParamKind::Int, 0.0f, 60, false, 0, 0, 0, "MIDI note number (0..127)" },
-                                     } },
+                { "NoteToFrequency<float>", {
+                                                { "MIDINote", NodeParamKind::Float, 60.0f, 0, false, 0.0f, 127.0f, 1.0f, "MIDI note number (0..127)" },
+                                            } },
+                { "NoteToFrequency<int>", {
+                                              { "MIDINote", NodeParamKind::Int, 0.0f, 60, false, 0, 0, 0, "MIDI note number (0..127)" },
+                                          } },
                 { "FrequencyToNote", {
                                          { "Frequency", NodeParamKind::Float, 440.0f, 0, false, 0.0f, 20000.0f, 1.0f, "Frequency in Hz" },
                                      } },
+                // Array nodes — m_Array itself is a raw std::vector<T>* plug, not
+                // expressible as a typed endpoint (see NodeDescriptors.h), so it has no
+                // schema entry; only the Int-typed Min/Max/Seed/Index controls do.
+                { "GetRandom<float>", {
+                                          { "Min", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Lower array index (inclusive)" },
+                                          { "Max", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Upper array index (inclusive)" },
+                                          { "Seed", NodeParamKind::Int, 0.0f, -1, false, 0, 0, 0, "-1 = unseeded (clock-derived)" },
+                                      } },
+                { "GetRandom<int>", {
+                                        { "Min", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Lower array index (inclusive)" },
+                                        { "Max", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Upper array index (inclusive)" },
+                                        { "Seed", NodeParamKind::Int, 0.0f, -1, false, 0, 0, 0, "-1 = unseeded (clock-derived)" },
+                                    } },
+                { "Get<float>", {
+                                    { "Index", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Array index to read" },
+                                } },
+                { "Get<int>", {
+                                  { "Index", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Array index to read" },
+                              } },
+                { "Random<float>", {
+                                       { "Min", NodeParamKind::Float, 0.0f, 0, false, -1000.0f, 1000.0f, 0.01f, "Lower bound" },
+                                       { "Max", NodeParamKind::Float, 1.0f, 0, false, -1000.0f, 1000.0f, 0.01f, "Upper bound" },
+                                       { "Seed", NodeParamKind::Int, 0.0f, -1, false, 0, 0, 0, "-1 = unseeded (clock-derived)" },
+                                   } },
+                { "Random<int>", {
+                                     { "Min", NodeParamKind::Int, 0.0f, 0, false, 0, 0, 0, "Lower bound" },
+                                     { "Max", NodeParamKind::Int, 0.0f, 1, false, 0, 0, 0, "Upper bound" },
+                                     { "Seed", NodeParamKind::Int, 0.0f, -1, false, 0, 0, 0, "-1 = unseeded (clock-derived)" },
+                                 } },
             };
             return s_Schemas;
         }
@@ -194,6 +226,11 @@ namespace OloEngine::Audio::SoundGraph
                 { "Power<float>", { { val("Base"), val("Exponent") }, { val("Out") } } },
                 { "Abs<float>", { { val("Value") }, { val("Out") } } },
 
+                // ----- Math (int) ----------------------------------------------------
+                { "Add<int>", { { val("Value1"), val("Value2") }, { val("Out") } } },
+                { "Subtract<int>", { { val("Value1"), val("Value2") }, { val("Out") } } },
+                { "Multiply<int>", { { val("Value"), val("Multiplier") }, { val("Out") } } },
+
                 // ----- Envelopes ----------------------------------------------------
                 { "ADEnvelope", {
                                     /* Inputs */ { ev("s_Trigger"), val("AttackTime"), val("DecayTime"), val("AttackCurve"), val("DecayCurve"), val("Looping") },
@@ -220,8 +257,37 @@ namespace OloEngine::Audio::SoundGraph
 
                 // ----- Music helpers ------------------------------------------------
                 { "BPMToSeconds", { { val("BPM") }, { val("OutSeconds") } } },
-                { "NoteToFrequency", { { val("MIDINote") }, { val("OutFrequency") } } },
+                { "NoteToFrequency<float>", { { val("MIDINote") }, { val("OutFrequency") } } },
+                { "NoteToFrequency<int>", { { val("MIDINote") }, { val("OutFrequency") } } },
                 { "FrequencyToNote", { { val("Frequency") }, { val("OutMIDINote") } } },
+
+                // ----- Array nodes ---------------------------------------------------
+                // m_Array (std::vector<T>*) is not a wireable endpoint (see
+                // NodeDescriptors.h's EndpointUtilities comment), so it has no pin here.
+                { "GetRandom<float>", {
+                                          /* Inputs */ { ev("Next"), ev("Reset"), val("Min"), val("Max"), val("Seed") },
+                                          /* Outputs */ { ev("OnNext"), ev("OnReset"), val("OutElement") },
+                                      } },
+                { "GetRandom<int>", {
+                                        /* Inputs */ { ev("Next"), ev("Reset"), val("Min"), val("Max"), val("Seed") },
+                                        /* Outputs */ { ev("OnNext"), ev("OnReset"), val("OutElement") },
+                                    } },
+                { "Get<float>", {
+                                    /* Inputs */ { ev("Trigger"), val("Index") },
+                                    /* Outputs */ { ev("OnTrigger"), val("OutElement") },
+                                } },
+                { "Get<int>", {
+                                  /* Inputs */ { ev("Trigger"), val("Index") },
+                                  /* Outputs */ { ev("OnTrigger"), val("OutElement") },
+                              } },
+                { "Random<float>", {
+                                       /* Inputs */ { ev("Next"), ev("Reset"), val("Min"), val("Max"), val("Seed") },
+                                       /* Outputs */ { ev("OnNext"), ev("OnReset"), val("OutValue") },
+                                   } },
+                { "Random<int>", {
+                                     /* Inputs */ { ev("Next"), ev("Reset"), val("Min"), val("Max"), val("Seed") },
+                                     /* Outputs */ { ev("OnNext"), ev("OnReset"), val("OutValue") },
+                                 } },
             };
             return s_Pins;
         }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/NodeDescriptors.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/NodeDescriptors.cpp
@@ -1,5 +1,25 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Audio/SoundGraph/NodeDescriptors.h"
 
-// TODO(olbu): NodeDescription specializations removed temporarily (#591)
-// The core SoundGraph system works without these - they're just for editor metadata
+// This file is intentionally near-empty (issue #591).
+//
+// The old comment here claimed the NodeDescription<T> specializations were
+// "removed temporarily" and needed re-adding for editor metadata. Archaeology
+// on this file's history found no commit that ever actually removed working
+// specializations from it — it has only ever held this include + comment.
+// The real specializations for every current node type live in
+// NodeDescriptions.h/.cpp (note the plural), which DESCRIBE_NODE-specializes
+// NodeDescription<T> for all 27 SoundGraph node types registered in
+// SoundGraphFactory.cpp; NodeTypes.cpp's INIT_ENDPOINTS_FUNCS macros rely on
+// them for reflection-driven endpoint registration (RegisterEndpointInputs /
+// RegisterEndpointOutputs in NodeDescriptors.h) and would assert at
+// construction if a node's specialization were missing.
+//
+// Separately, NodeDescription<T> only carries Inputs/Outputs member lists for
+// endpoint wiring — it has no notion of display names, tooltips, or parameter
+// ranges, so it was never actually usable as "editor metadata" in the first
+// place. That metadata is provided by a deliberately separate, hand-maintained
+// system: NodeSchema.h/.cpp (NodeParamSchema for the property panel,
+// NodePinSchema for pin display), consumed by SoundGraphEditorPanel.cpp. See
+// SoundGraphNodeSchemaCoverageTest.cpp for the guard that keeps that schema in
+// sync with every node type the factory can construct.

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(OloEngine-Tests
 		SoundGraphParameterWiringTest.cpp
 		SoundGraphControlRoutingTest.cpp
 		SoundGraphCacheTest.cpp
+		SoundGraphNodeSchemaCoverageTest.cpp
 		AudioEventQueueTest.cpp
 		AudioDSPTest.cpp
 		AudioSpatializerTest.cpp

--- a/OloEngine/tests/SoundGraphNodeSchemaCoverageTest.cpp
+++ b/OloEngine/tests/SoundGraphNodeSchemaCoverageTest.cpp
@@ -1,0 +1,89 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// =============================================================================
+// SoundGraphNodeSchemaCoverageTest — every factory-constructible node type has
+// a NodePinSchema entry (issue #591).
+//
+// NodeSchema.h/.cpp is the hand-maintained editor-metadata mirror of
+// SoundGraphFactory.cpp's s_NodeProcessors registry (see that file's own
+// "Hardcoded palette mirroring..." comment for the same pattern used by
+// SoundGraphEditorPanel.cpp's node-creation palette). Nothing enforced the two
+// stay in sync, so a node type could be constructible via the factory yet
+// invisible to the editor's pin display (falling back to slower
+// connection-derived discovery) or the property panel. This test hardcodes
+// the same type-string list the factory registers and asserts every one
+// resolves a pin schema; update BOTH this list and NodeSchema.cpp when adding
+// a node type to SoundGraphFactory.cpp.
+//
+// Param schema (NodeParamSchema) is NOT asserted here: wired-only nodes (pure
+// math/trigger nodes with no editable defaults worth exposing) legitimately
+// have no entry — see NodeSchema.cpp's own comment.
+// =============================================================================
+
+#include "OloEngine/Audio/SoundGraph/NodeSchema.h"
+
+using namespace OloEngine::Audio::SoundGraph;
+
+namespace
+{
+    // Mirrors SoundGraphFactory.cpp's s_NodeProcessors identifier strings exactly.
+    const char* const kAllRegisteredNodeTypes[] = {
+        "WavePlayer",
+        "SineOscillator",
+        "SquareOscillator",
+        "SawtoothOscillator",
+        "TriangleOscillator",
+        "Noise",
+        "Add<float>",
+        "Subtract<float>",
+        "Multiply<float>",
+        "Divide<float>",
+        "Min<float>",
+        "Max<float>",
+        "Clamp<float>",
+        "MapRange<float>",
+        "Power<float>",
+        "Abs<float>",
+        "Add<int>",
+        "Subtract<int>",
+        "Multiply<int>",
+        "ADEnvelope",
+        "ADSREnvelope",
+        "RepeatTrigger",
+        "TriggerCounter",
+        "DelayedTrigger",
+        "GetRandom<float>",
+        "GetRandom<int>",
+        "Get<float>",
+        "Get<int>",
+        "Random<float>",
+        "Random<int>",
+        "BPMToSeconds",
+        "NoteToFrequency<float>",
+        "NoteToFrequency<int>",
+        "FrequencyToNote",
+    };
+} // namespace
+
+TEST(SoundGraphNodeSchemaCoverage, EveryRegisteredNodeTypeHasAPinSchema)
+{
+    for (const char* typeName : kAllRegisteredNodeTypes)
+    {
+        const NodePinSchema* schema = GetNodePinSchema(typeName);
+        EXPECT_NE(schema, nullptr) << "No NodePinSchema entry for node type '" << typeName
+                                   << "' — add one in NodeSchema.cpp so the editor shows its pins immediately.";
+        if (schema != nullptr)
+        {
+            EXPECT_FALSE(schema->Inputs.empty() && schema->Outputs.empty())
+                << "NodePinSchema for '" << typeName << "' has no pins at all — likely a copy-paste mistake.";
+        }
+    }
+}
+
+TEST(SoundGraphNodeSchemaCoverage, UnknownNodeTypeReturnsNullptr)
+{
+    EXPECT_EQ(GetNodePinSchema("DefinitelyNotARealNodeType"), nullptr);
+    EXPECT_EQ(GetNodeSchema("DefinitelyNotARealNodeType"), nullptr);
+}


### PR DESCRIPTION
## Summary
- Archaeology on `NodeDescriptors.cpp`'s stale TODO found no commit ever actually removed working `NodeDescription` specializations from it — they live in `NodeDescriptions.h`/`.cpp` (plural) for all 27 node types and were never missing. Editor display metadata is a deliberately separate, already-working system: `NodeSchema.h`/`.cpp`, consumed by `SoundGraphEditorPanel.cpp`. Replaced the misleading TODO with an accurate explanation of both systems.
- Closed the real gap: `NodeSchema.cpp` was missing param/pin schema entries for `GetRandom<T>`, `Get<T>`, `Random<T>`, `NoteToFrequency<T>`, and the int math nodes (`Add`/`Subtract`/`Multiply<int>` — caught by the new coverage test itself), so those factory-constructible node types had no property-panel or pin display in the editor.
- Fixed a genuine palette bug found along the way: the editor's "NoteToFrequency" menu entry had no `<float>`/`<int>` suffix, matching no `SoundGraphFactory`-registered identifier, so placing that node would silently fail to compile.
- Added `SoundGraphNodeSchemaCoverageTest.cpp` — asserts every factory-registered node type resolves a `NodePinSchema` entry, so the two registries can't silently drift apart again.

Fixes #591

## Test plan
- [x] `OloEngine.lib` builds clean (Debug, msvc preset)
- [x] `OloEngine-Tests.exe` builds clean; all 67 `SoundGraph*` tests pass, including the new `SoundGraphNodeSchemaCoverage.EveryRegisteredNodeTypeHasAPinSchema` (which initially caught the missing `Add/Subtract/Multiply<int>` entries before I added them)
- [x] `OloEditor.exe` builds clean with the palette fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)