### PR TITLE
fix(task): bounds-check LocalQueue registry and guard steal div-by-zero

### DIFF
--- a/OloEngine/src/OloEngine/Algo/BinaryHeap.h
+++ b/OloEngine/src/OloEngine/Algo/BinaryHeap.h
@@ -13,6 +13,7 @@
 #include "OloEngine/Templates/IdentityFunctor.h"
 #include "OloEngine/Templates/Projection.h"
 #include "OloEngine/Templates/ReversePredicate.h"
+#include "OloEngine/Templates/UnrealTemplate.h"
 #include <type_traits>
 #include <limits>
 

--- a/OloEngine/src/OloEngine/Algo/BinaryHeap.h
+++ b/OloEngine/src/OloEngine/Algo/BinaryHeap.h
@@ -12,8 +12,8 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Templates/IdentityFunctor.h"
 #include "OloEngine/Templates/Projection.h"
-#include "OloEngine/Templates/ReversePredicate.h"
 #include "OloEngine/Templates/UnrealTemplate.h"
+#include "OloEngine/Templates/ReversePredicate.h"
 #include <type_traits>
 #include <limits>
 

--- a/OloEngine/src/OloEngine/Containers/Deque.h
+++ b/OloEngine/src/OloEngine/Containers/Deque.h
@@ -6,6 +6,7 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Containers/ContainerAllocationPolicies.h"
 #include "OloEngine/Memory/MemoryOps.h"
+#include "OloEngine/Templates/UnrealTemplate.h"
 
 #include <initializer_list>
 

--- a/OloEngine/src/OloEngine/Containers/LinkedList.h
+++ b/OloEngine/src/OloEngine/Containers/LinkedList.h
@@ -19,6 +19,7 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Containers/IntrusiveLinkedList.h"
+#include "OloEngine/Templates/UnrealTemplate.h"
 
 namespace OloEngine
 {

--- a/OloEngine/src/OloEngine/Containers/SparseSetElement.h
+++ b/OloEngine/src/OloEngine/Containers/SparseSetElement.h
@@ -13,6 +13,7 @@
 
 #include "OloEngine/Containers/SetUtilities.h"
 #include "OloEngine/Serialization/Archive.h"
+#include "OloEngine/Templates/UnrealTemplate.h"
 #include <initializer_list>
 #include <type_traits>
 

--- a/OloEngine/src/OloEngine/Task/LocalQueue.h
+++ b/OloEngine/src/OloEngine/Task/LocalQueue.h
@@ -218,7 +218,14 @@ namespace OloEngine::LowLevelTasks
                         m_QueueType = InQueueType;
 
                         // Local queues are never unregistered, everything is shutdown at once.
-                        m_Registry->AddLocalQueue(this);
+                        if (!m_Registry->AddLocalQueue(this))
+                        {
+                            // The registry is at capacity (MaxLocalQueues). The queue still works
+                            // for its own thread's Enqueue/Dequeue/overflow, it just won't be
+                            // discoverable by other threads' work-stealing.
+                            OLO_CORE_ERROR("TLocalQueue::Init: registry is full (MaxLocalQueues reached); "
+                                           "this queue will not participate in work stealing");
+                        }
                         for (i32 PriorityIndex = 0; PriorityIndex < static_cast<i32>(std::to_underlying(ETaskPriority::Count)); ++PriorityIndex)
                         {
                             m_DequeueHazards[PriorityIndex] = m_Registry->m_OverflowQueues[PriorityIndex].GetHeadHazard();
@@ -366,13 +373,26 @@ namespace OloEngine::LowLevelTasks
 
           private:
             // @brief Add a queue to the Registry. Thread-safe.
-            void AddLocalQueue(TLocalQueue* QueueToAdd)
+            // @return false if the registry is already at MaxLocalQueues capacity; the queue was
+            //         not added and the caller must not treat it as steal-able by other threads.
+            bool AddLocalQueue(TLocalQueue* QueueToAdd)
             {
                 u32 Index = m_NumLocalQueues.fetch_add(1, std::memory_order_relaxed);
-                OLO_CORE_ASSERT(Index < MaxLocalQueues, "Attempting to add more than the maximum allowed number of queues ({})", MaxLocalQueues);
+                if (Index >= MaxLocalQueues)
+                {
+                    // Registry is at capacity. This is a handled, recoverable condition (the
+                    // caller falls back to running without work-stealing support), not a
+                    // programmer error, so it is reported rather than asserted/debug-broken.
+                    // Undo the reservation so a burst of failed registrations doesn't leave the
+                    // counter climbing forever (it would otherwise never allow future callers to
+                    // observe a stable NumQueues either, since fetch_add never wraps back down).
+                    m_NumLocalQueues.fetch_sub(1, std::memory_order_relaxed);
+                    return false;
+                }
 
                 // std::memory_order_release to make sure values are all written to the TLocalQueue before publishing.
                 m_LocalQueues[Index].store(QueueToAdd, std::memory_order_release);
+                return true;
             }
 
             // @brief StealItem tries to steal an Item from a Registered LocalQueue
@@ -380,10 +400,15 @@ namespace OloEngine::LowLevelTasks
             FTask* StealItem(u32& CachedRandomIndex, u32& CachedPriorityIndex, bool GetBackGroundTasks)
             {
                 u32 NumQueues = m_NumLocalQueues.load(std::memory_order_relaxed);
+                if (NumQueues == 0)
+                {
+                    // Nothing registered to steal from yet (or ever, on this registry).
+                    return nullptr;
+                }
                 u32 MaxPriority = GetBackGroundTasks ? static_cast<i32>(std::to_underlying(ETaskPriority::Count)) : static_cast<i32>(std::to_underlying(ETaskPriority::ForegroundCount));
                 CachedRandomIndex = CachedRandomIndex % NumQueues;
 
-                for (u32 Index = 0; Index < m_NumLocalQueues; ++Index)
+                for (u32 Index = 0; Index < NumQueues; ++Index)
                 {
                     // Test for null in case we race on reading NumLocalQueues reserved index before the pointer is set
                     if (TLocalQueue* LocalQueue = m_LocalQueues[Index].load(std::memory_order_acquire))

--- a/OloEngine/src/OloEngine/Task/NamedThreads.h
+++ b/OloEngine/src/OloEngine/Task/NamedThreads.h
@@ -130,6 +130,15 @@ namespace OloEngine::Tasks
     //   2. Call AttachToThread(ENamedThread::YourThread) from that thread
     //   3. Process tasks via GetQueue(thread).ProcessAll() in the thread loop
     //
+    // @note issue #611 audit: FNamedThreadManager's m_Queues[]/m_ThreadIds[] are indexed by
+    // this enum and guarded only by OLO_CORE_ASSERT (elided in Dist), the same pattern
+    // SonarQube (S3519) and LocalQueue.h's TLocalQueueRegistry both flag. Unlike
+    // TLocalQueueRegistry's index — a runtime atomic counter that can grow past its array's
+    // compile-time size — every value reaching these arrays is either a compile-time-fixed
+    // ENamedThread enumerator or the output of GetNamedThread()'s switch, which can only
+    // return one of the enumerators below or Invalid (itself asserted against separately).
+    // There is no code path that can produce an out-of-range index here, so an assert-only
+    // guard is sufficient and this does not need the same bounds-check hardening.
     enum class ENamedThread : i32
     {
         GameThread = 0,    ///< Main application thread (active)

--- a/OloEngine/src/OloEngine/Templates/ReversePredicate.h
+++ b/OloEngine/src/OloEngine/Templates/ReversePredicate.h
@@ -7,6 +7,7 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Templates/Invoke.h"
+#include "OloEngine/Templates/UnrealTemplate.h"
 
 namespace OloEngine
 {

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -267,6 +267,7 @@ add_executable(OloEngine-Tests
 		Networking/MMOOptimizationTest.cpp
 		# Task / Scheduler config tests
 		Task/SchedulerConfigTest.cpp
+		Task/LocalQueueTest.cpp
 		# Localization tests
 		LocalizationTest.cpp
 		# Dialogue system tests

--- a/OloEngine/tests/Task/LocalQueueTest.cpp
+++ b/OloEngine/tests/Task/LocalQueueTest.cpp
@@ -1,0 +1,54 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Task/LocalQueue.h"
+
+// Regression coverage for issue #611: TLocalQueueRegistry guarded two invariants only
+// with OLO_CORE_ASSERT, which is a no-op in Dist builds:
+//   - AddLocalQueue() overflow past MaxLocalQueues used to write out of bounds.
+//   - StealItem() divided by NumQueues with no guard against NumQueues == 0.
+// Both are now handled without relying on asserts, so these tests exercise the
+// no-crash / no-UB behavior directly (not just under a debugger).
+
+namespace
+{
+    using OloEngine::LowLevelTasks::Private::ELocalQueueType;
+    using OloEngine::LowLevelTasks::Private::TLocalQueueRegistry;
+
+    // Small MaxLocalQueues so the overflow path is reachable without creating
+    // thousands of TLocalQueue instances.
+    using FSmallRegistry = TLocalQueueRegistry<16, 2>;
+} // namespace
+
+TEST(LocalQueueTest, StealItemOnEmptyRegistryDoesNotCrash)
+{
+    FSmallRegistry Registry;
+
+    // No TLocalQueue has ever registered with this registry: NumLocalQueues == 0.
+    // Previously this computed CachedRandomIndex % 0 (undefined behavior / crash).
+    EXPECT_EQ(Registry.DequeueSteal(/*GetBackGroundTasks*/ true), nullptr);
+    EXPECT_EQ(Registry.DequeueSteal(/*GetBackGroundTasks*/ false), nullptr);
+}
+
+TEST(LocalQueueTest, AddLocalQueueBeyondCapacityDoesNotCorruptRegistry)
+{
+    FSmallRegistry Registry;
+
+    // MaxLocalQueues is 2 for FSmallRegistry: register 2 successfully, then attempt a
+    // 3rd, which must fail safely instead of writing past m_LocalQueues[MaxLocalQueues].
+    FSmallRegistry::TLocalQueue QueueA;
+    FSmallRegistry::TLocalQueue QueueB;
+    FSmallRegistry::TLocalQueue QueueC;
+
+    QueueA.Init(Registry, ELocalQueueType::EForeground);
+    QueueB.Init(Registry, ELocalQueueType::EForeground);
+    // This registration is expected to be rejected (registry at capacity); it must not
+    // corrupt the registry's internal array or crash.
+    QueueC.Init(Registry, ELocalQueueType::EForeground);
+
+    // The registry must still be usable afterwards: stealing finds nothing (no tasks were
+    // enqueued) but must not crash or read/write out of bounds.
+    EXPECT_EQ(Registry.DequeueSteal(true), nullptr);
+    EXPECT_EQ(Registry.DequeueSteal(false), nullptr);
+}


### PR DESCRIPTION
## Summary
- `TLocalQueueRegistry::AddLocalQueue()` guarded the `MaxLocalQueues` (1024) bound only with `OLO_CORE_ASSERT`, which is a no-op in Dist builds — past that many queues it silently wrote out of bounds. It now returns `false` and rolls back its atomic reservation on overflow instead; `TLocalQueue::Init()` logs an error and continues in degraded mode (still works locally, just not steal-able).
- `TLocalQueueRegistry::StealItem()` computed `CachedRandomIndex % NumQueues` with no guard at all against `NumQueues == 0`, in any build config — a genuine divide-by-zero UB if reached before any local queue registered. It now early-returns `nullptr`.
- Audited the analogous `Task/NamedThreads.h` assert-only pattern (also flagged by SonarQube S3519) and documented why it's safe as-is: every index reaching `m_Queues[]`/`m_ThreadIds[]` is compile-time-fixed or funneled through `GetNamedThread()`'s switch, unlike `LocalQueueRegistry`'s runtime-growable counter.
- `Algo/BinaryHeap.h` called unqualified `Swap()` without including its declaration (`Templates/UnrealTemplate.h`), relying on include-order luck in every existing TU. Fixed by adding the missing include — surfaced because the new regression test was the first TU to include `LocalQueue.h` without something else pulling in `UnrealTemplate.h` first.

Closes #611.

## Test plan
- [x] New `OloEngine/tests/Task/LocalQueueTest.cpp` (`unit` layer): `StealItemOnEmptyRegistryDoesNotCrash`, `AddLocalQueueBeyondCapacityDoesNotCorruptRegistry` (small `TLocalQueueRegistry<16, 2>` to reach the overflow path without creating 1024 queues).
- [x] Full `OloEngine-Tests` suite: 4235 passed, 5 skipped (GPU/app-launch, expected), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)