### PR TITLE
fix(nav): report partial paths as terminal + validate bake bounds

### DIFF
--- a/OloEngine-ScriptCore/src/OloEngine/InternalCalls.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/InternalCalls.cs
@@ -326,6 +326,8 @@ namespace OloEngine
 		[MethodImpl(MethodImplOptions.InternalCall)]
 		internal static extern bool NavAgentComponent_HasPath(ulong entityID);
 		[MethodImpl(MethodImplOptions.InternalCall)]
+		internal static extern bool NavAgentComponent_IsTargetUnreachable(ulong entityID);
+		[MethodImpl(MethodImplOptions.InternalCall)]
 		internal static extern void NavAgentComponent_ClearTarget(ulong entityID);
 		#endregion
 

--- a/OloEngine-ScriptCore/src/OloEngine/Scene/Components.cs
+++ b/OloEngine-ScriptCore/src/OloEngine/Scene/Components.cs
@@ -384,6 +384,11 @@ namespace OloEngine
 	{
 		public bool HasPath => InternalCalls.NavAgentComponent_HasPath(Entity.ID);
 
+		// True when the current target cannot be reached (no path, or only a partial
+		// path to the nearest reachable point). Poll this alongside HasPath: a partial
+		// path reports HasPath == true forever without arriving, so HasPath alone spins.
+		public bool IsTargetUnreachable => InternalCalls.NavAgentComponent_IsTargetUnreachable(Entity.ID);
+
 		public void ClearTarget() => InternalCalls.NavAgentComponent_ClearTarget(Entity.ID);
 	}
 

--- a/OloEngine/src/OloEngine/AI/BehaviorTree/BTTasks.cpp
+++ b/OloEngine/src/OloEngine/AI/BehaviorTree/BTTasks.cpp
@@ -88,6 +88,20 @@ namespace OloEngine
 
         auto& nav = entity.GetComponent<NavAgentComponent>();
 
+        // NavigationSystem flags a target it can't reach (no path, or a partial path to
+        // the nearest reachable point) as unreachable. Terminate with Failure instead of
+        // re-issuing the same impossible target forever (the agent would otherwise be
+        // stuck at the closest navmesh point while this node spins on Running).
+        if (nav.m_HasTarget && nav.m_TargetUnreachable)
+        {
+            nav.m_HasTarget = false;
+            nav.m_HasPath = false;
+            nav.m_TargetUnreachable = false;
+            nav.m_PathCorners.clear();
+            nav.m_CurrentCornerIndex = 0;
+            return BTStatus::Failure;
+        }
+
         // Set target from blackboard if we don't have one yet
         if (!nav.m_HasTarget)
         {
@@ -99,6 +113,8 @@ namespace OloEngine
 
             nav.m_TargetPosition = std::get<glm::vec3>(raw.value());
             nav.m_HasTarget = true;
+            nav.m_HasPath = false;
+            nav.m_TargetUnreachable = false; // fresh target: clear any stale terminal flag
         }
 
         // Check if agent reached destination

--- a/OloEngine/src/OloEngine/Navigation/NavMeshGenerator.cpp
+++ b/OloEngine/src/OloEngine/Navigation/NavMeshGenerator.cpp
@@ -517,6 +517,26 @@ namespace OloEngine
             return nullptr;
         }
 
+        // Validate bounds. Generate is a public API; a NaN/Inf or inverted (max <= min)
+        // bound feeds rcCalcGridSize a garbage or enormous grid size and blows up the
+        // heightfield allocation. The production caller passes finite, ordered bounds,
+        // but nothing upstream guarantees it.
+        auto finiteVec3 = [](const glm::vec3& v)
+        { return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z); };
+        if (!finiteVec3(boundsMin) || !finiteVec3(boundsMax))
+        {
+            OLO_CORE_ERROR("NavMeshGenerator: bounds contain non-finite values (min=({},{},{}), max=({},{},{}))",
+                           boundsMin.x, boundsMin.y, boundsMin.z, boundsMax.x, boundsMax.y, boundsMax.z);
+            return nullptr;
+        }
+        if (boundsMax.x <= boundsMin.x || boundsMax.y <= boundsMin.y || boundsMax.z <= boundsMin.z)
+        {
+            OLO_CORE_ERROR("NavMeshGenerator: bounds are not ordered (max must be > min on every axis): "
+                           "min=({},{},{}), max=({},{},{})",
+                           boundsMin.x, boundsMin.y, boundsMin.z, boundsMax.x, boundsMax.y, boundsMax.z);
+            return nullptr;
+        }
+
         // Step 1: Initialize Recast config
         rcConfig cfg{};
         cfg.cs = settings.CellSize;

--- a/OloEngine/src/OloEngine/Navigation/NavMeshQuery.cpp
+++ b/OloEngine/src/OloEngine/Navigation/NavMeshQuery.cpp
@@ -105,14 +105,14 @@ namespace OloEngine
         }
     }
 
-    bool NavMeshQuery::FindPath(const glm::vec3& start, const glm::vec3& end, std::vector<glm::vec3>& outPath) const
+    FindPathResult NavMeshQuery::FindPath(const glm::vec3& start, const glm::vec3& end, std::vector<glm::vec3>& outPath) const
     {
         OLO_PROFILE_FUNCTION();
 
         outPath.clear();
 
         if (!m_Query)
-            return false;
+            return FindPathResult::Failed;
 
         const f32 startPos[3] = { start.x, start.y, start.z };
         const f32 endPos[3] = { end.x, end.y, end.z };
@@ -131,17 +131,22 @@ namespace OloEngine
 
         dtStatus status = m_Query->findNearestPoly(startPos, extent, &filter, &startRef, nearestStart);
         if (dtStatusFailed(status) || !startRef)
-            return false;
+            return FindPathResult::Failed;
 
         status = m_Query->findNearestPoly(endPos, extent, &filter, &endRef, nearestEnd);
         if (dtStatusFailed(status) || !endRef)
-            return false;
+            return FindPathResult::Failed;
 
         std::vector<dtPolyRef> polys(static_cast<size_t>(m_MaxPolys));
         i32 npolys = 0;
         status = m_Query->findPath(startRef, endRef, nearestStart, nearestEnd, &filter, polys.data(), &npolys, m_MaxPolys);
         if (dtStatusFailed(status) || npolys == 0)
-            return false;
+            return FindPathResult::Failed;
+
+        // Detour flags DT_PARTIAL_RESULT when the target poly could not be reached and
+        // the path stops at the nearest reachable poly instead. Surface that so callers
+        // don't mistake "closest we could get" for "arrived".
+        const bool partial = dtStatusDetail(status, DT_PARTIAL_RESULT);
 
         // Find straight path
         std::vector<f32> straightPath(static_cast<size_t>(m_MaxPolys) * 3);
@@ -153,7 +158,7 @@ namespace OloEngine
                                            straightPath.data(), straightPathFlags.data(), straightPathPolys.data(),
                                            &nstraightPath, m_MaxPolys);
         if (dtStatusFailed(status))
-            return false;
+            return FindPathResult::Failed;
 
         if (dtStatusDetail(status, DT_BUFFER_TOO_SMALL))
             OLO_CORE_WARN("NavMeshQuery::FindPath: Straight path truncated to {} points", nstraightPath);
@@ -164,7 +169,10 @@ namespace OloEngine
             outPath.emplace_back(straightPath[i * 3], straightPath[i * 3 + 1], straightPath[i * 3 + 2]);
         }
 
-        return !outPath.empty();
+        if (outPath.empty())
+            return FindPathResult::Failed;
+
+        return partial ? FindPathResult::Partial : FindPathResult::Complete;
     }
 
     bool NavMeshQuery::FindNearestPoint(const glm::vec3& point, f32 searchRadius, glm::vec3& outNearest) const

--- a/OloEngine/src/OloEngine/Navigation/NavMeshQuery.h
+++ b/OloEngine/src/OloEngine/Navigation/NavMeshQuery.h
@@ -19,6 +19,18 @@ namespace OloEngine
         Error
     };
 
+    // Outcome of a FindPath query. Detour returns a path to the *nearest reachable*
+    // polygon (setting DT_PARTIAL_RESULT) when the requested target is off-navmesh or
+    // in a disconnected region — a partial result that must NOT be treated as arrival,
+    // or an agent following it stops short of the goal forever. Callers have to
+    // distinguish "reached the target" from "got as close as possible".
+    enum class FindPathResult : u8
+    {
+        Failed,  // No path at all (no query, start/end off the navmesh, or A* failure). outPath is empty.
+        Partial, // A path was produced but it does NOT reach the target; outPath ends at the nearest reachable point.
+        Complete // A full path to the target.
+    };
+
     class NavMeshQuery
     {
       public:
@@ -33,7 +45,7 @@ namespace OloEngine
 
         void Initialize(const Ref<NavMesh>& navMesh, i32 queryBudget = 2048);
 
-        [[nodiscard]] bool FindPath(const glm::vec3& start, const glm::vec3& end, std::vector<glm::vec3>& outPath) const;
+        [[nodiscard]] FindPathResult FindPath(const glm::vec3& start, const glm::vec3& end, std::vector<glm::vec3>& outPath) const;
         [[nodiscard]] bool FindNearestPoint(const glm::vec3& point, f32 searchRadius, glm::vec3& outNearest) const;
         [[nodiscard]] RaycastResult Raycast(const glm::vec3& start, const glm::vec3& end, glm::vec3& outHitPoint) const;
         [[nodiscard]] bool IsPointOnNavMesh(const glm::vec3& point, f32 tolerance = 0.5f) const;

--- a/OloEngine/src/OloEngine/Navigation/NavigationSystem.cpp
+++ b/OloEngine/src/OloEngine/Navigation/NavigationSystem.cpp
@@ -42,13 +42,31 @@ namespace OloEngine
                 continue;
             }
 
-            // Manual pathfinding for agents not in crowd
-            if (!agent.m_HasPath && agent.m_HasTarget)
+            // Manual pathfinding for agents not in crowd. Once a target is flagged
+            // unreachable we stop recomputing — otherwise a disconnected/off-navmesh
+            // target would re-run FindPath every frame and (via the manual follower or
+            // BTMoveTo) spin forever. The unreachable flag is the terminal signal.
+            if (!agent.m_HasPath && agent.m_HasTarget && !agent.m_TargetUnreachable)
             {
-                agent.m_HasPath = navQuery->FindPath(transform.Translation, agent.m_TargetPosition, agent.m_PathCorners);
+                const FindPathResult result =
+                    navQuery->FindPath(transform.Translation, agent.m_TargetPosition, agent.m_PathCorners);
                 agent.m_CurrentCornerIndex = 0;
-                if (!agent.m_HasPath)
-                    agent.m_HasTarget = false;
+
+                if (result == FindPathResult::Failed)
+                {
+                    // No path at all. Latch unreachable but keep m_HasTarget set so
+                    // consumers (BTMoveTo / scripts) can observe the terminal outcome.
+                    agent.m_HasPath = false;
+                    agent.m_TargetUnreachable = true;
+                }
+                else
+                {
+                    // Complete OR Partial: follow the corners we have. A partial path
+                    // walks the agent to the nearest reachable point; the flag marks
+                    // that it will never actually arrive at the requested target.
+                    agent.m_HasPath = true;
+                    agent.m_TargetUnreachable = (result == FindPathResult::Partial);
+                }
             }
 
             if (!agent.m_HasPath || agent.m_PathCorners.empty())
@@ -68,8 +86,14 @@ namespace OloEngine
                 if (agent.m_CurrentCornerIndex >= static_cast<u32>(agent.m_PathCorners.size()))
                 {
                     agent.m_HasPath = false;
-                    agent.m_HasTarget = false;
                     agent.m_PathCorners.clear();
+                    agent.m_CurrentCornerIndex = 0;
+                    // Only clear the target when we actually reached it. For a partial
+                    // path we've walked to the nearest reachable point but the target is
+                    // unreachable — keep m_HasTarget + m_TargetUnreachable set so the
+                    // consumer sees a stable terminal state instead of a re-issue loop.
+                    if (!agent.m_TargetUnreachable)
+                        agent.m_HasTarget = false;
                     continue;
                 }
             }

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -3674,7 +3674,7 @@ namespace OloEngine
         bool m_LockYAxis = false; // When true, navigation only moves on XZ plane
 
         // Runtime state (not serialized)
-        OLO_PROPERTY(Name = "TargetPosition", Type = "vec3", Set = "comp.m_TargetPosition = {v}; comp.m_HasTarget = true; comp.m_HasPath = false")
+        OLO_PROPERTY(Name = "TargetPosition", Type = "vec3", Set = "comp.m_TargetPosition = {v}; comp.m_HasTarget = true; comp.m_HasPath = false; comp.m_TargetUnreachable = false")
         OLO_SERIALIZE(Skip)
         glm::vec3 m_TargetPosition = { 0.0f, 0.0f, 0.0f };
         OLO_SERIALIZE(Skip)
@@ -3687,6 +3687,11 @@ namespace OloEngine
         u32 m_CurrentCornerIndex = 0;
         OLO_SERIALIZE(Skip)
         i32 m_CrowdAgentId = -1;
+        // Set by NavigationSystem when the current target can only be reached partially
+        // (unreachable / off-navmesh / disconnected). Terminal signal for consumers so
+        // they stop re-issuing an impossible target — see BTMoveTo and NavAgentComponent_IsTargetUnreachable.
+        OLO_SERIALIZE(Skip)
+        bool m_TargetUnreachable = false;
 
         NavAgentComponent() = default;
         NavAgentComponent(const NavAgentComponent& other)
@@ -3712,6 +3717,7 @@ namespace OloEngine
                 m_PathCorners.clear();
                 m_CurrentCornerIndex = 0;
                 m_CrowdAgentId = -1;
+                m_TargetUnreachable = false;
             }
             return *this;
         }
@@ -3738,6 +3744,7 @@ namespace OloEngine
                 m_PathCorners.clear();
                 m_CurrentCornerIndex = 0;
                 m_CrowdAgentId = -1;
+                m_TargetUnreachable = false;
             }
             return *this;
         }

--- a/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
+++ b/OloEngine/src/OloEngine/Scripting/C#/Generated/ScriptGlueBindings.inl
@@ -2222,6 +2222,7 @@ static void NavAgentComponent_SetTargetPosition(UUID entityID, glm::vec3 const* 
     comp.m_TargetPosition = *value;
     comp.m_HasTarget = true;
     comp.m_HasPath = false;
+    comp.m_TargetUnreachable = false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptGlue.cpp
@@ -1176,6 +1176,18 @@ namespace OloEngine
         return entity.GetComponent<NavAgentComponent>().m_HasPath;
     }
 
+    // True when the agent has a target it cannot actually reach (no path, or only a
+    // partial path to the nearest reachable point). Scripts must poll this in addition
+    // to HasPath — a partial path reports HasPath == true while never arriving, so
+    // relying on HasPath alone spins forever.
+    static bool NavAgentComponent_IsTargetUnreachable(UUID entityID)
+    {
+        OLO_PROFILE_FUNCTION();
+        auto entity = GetEntity(entityID);
+        OLO_CORE_ASSERT(entity.HasComponent<NavAgentComponent>());
+        return entity.GetComponent<NavAgentComponent>().m_TargetUnreachable;
+    }
+
     static void NavAgentComponent_ClearTarget(UUID entityID)
     {
         OLO_PROFILE_FUNCTION();
@@ -3467,6 +3479,7 @@ namespace OloEngine
         // NavAgentComponent (hand-written action/query only) ////////
         ///////////////////////////////////////////////////////////////
         OLO_ADD_INTERNAL_CALL(NavAgentComponent_HasPath);
+        OLO_ADD_INTERNAL_CALL(NavAgentComponent_IsTargetUnreachable);
         OLO_ADD_INTERNAL_CALL(NavAgentComponent_ClearTarget);
 
         ///////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -2878,15 +2878,20 @@ namespace OloEngine
                                                     a.m_TargetPosition = pos;
                                                     a.m_HasTarget = true;
                                                     a.m_HasPath = false;
+                                                    a.m_TargetUnreachable = false;
                                                     a.m_PathCorners.clear();
                                                     a.m_CurrentCornerIndex = 0; }),
                                             "hasTarget", sol::readonly(&NavAgentComponent::m_HasTarget),
                                             "hasPath", sol::readonly(&NavAgentComponent::m_HasPath),
+                                            // Terminal signal: target reachable only partially / not at all. Poll
+                                            // this alongside hasPath — a partial path keeps hasPath == true forever.
+                                            "targetUnreachable", sol::readonly(&NavAgentComponent::m_TargetUnreachable),
                                             "lockYAxis", &NavAgentComponent::m_LockYAxis,
                                             "clearTarget", [](NavAgentComponent& agent)
                                             {
                                                 agent.m_HasTarget = false;
                                                 agent.m_HasPath = false;
+                                                agent.m_TargetUnreachable = false;
                                                 agent.m_PathCorners.clear();
                                                 agent.m_CurrentCornerIndex = 0; });
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -598,6 +598,8 @@ add_executable(OloEngine-Tests
 		Functional/Gameplay/InventoryStackConsolidationTest.cpp
 		Functional/Navigation/NavMeshQueryFindPathBetweenPointsTest.cpp
 		Functional/Navigation/NavMeshOffMeshLinkBridgesGapTest.cpp
+		Functional/Navigation/NavAgentUnreachableTargetTerminatesTest.cpp
+		Functional/Navigation/NavMeshGeneratorBoundsValidationTest.cpp
 		Functional/Scripting/LuaRaycastHitsPhysicsBodyTest.cpp
 		Functional/Scripting/LuaCompletesQuestViaIncrementObjectiveTest.cpp
 		Functional/Dialogue/DialogueAdvanceMovesToNextNodeTest.cpp

--- a/OloEngine/tests/Functional/Navigation/NavAgentUnreachableTargetTerminatesTest.cpp
+++ b/OloEngine/tests/Functional/Navigation/NavAgentUnreachableTargetTerminatesTest.cpp
@@ -1,0 +1,176 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: Functional
+// =============================================================================
+// NavAgentUnreachableTargetTerminatesTest — Functional Test.
+//
+// Cross-subsystem seam under test:
+//   NavMeshGenerator (Recast bake) × NavMeshQuery::FindPath (Detour
+//   DT_PARTIAL_RESULT) × NavigationSystem (per-frame agent stepping) ×
+//   NavAgentComponent × BTMoveTo (behavior-tree consumer).
+//
+// Regression target: FindPath used to report a PARTIAL path (target off-navmesh
+// or in a disconnected region) as full success. The manual path-follower would
+// walk the agent to the nearest reachable point, clear its target, and the
+// BTMoveTo node — checking arrival against the raw, never-reached target — would
+// re-issue the same impossible target and return Running forever. The NPC was
+// physically stuck while the behavior tree hung.
+//
+// Scenario: two floor platforms separated by a gap wide enough that, after
+// agent-radius erosion, they are disconnected navmesh islands (same recipe as
+// NavMeshOffMeshLinkBridgesGapTest). An agent sits on platform 1; the target is
+// on platform 2 — reachable only as a partial path to the gap edge.
+//
+// Two assertions:
+//   1. The raw NavigationSystem follower LATCHES m_TargetUnreachable (instead of
+//      silently clearing the target) and does not teleport across the gap.
+//   2. BTMoveTo TERMINATES with Failure within a bounded number of ticks rather
+//      than spinning on Running.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Navigation/NavMeshGenerator.h"
+#include "OloEngine/Navigation/NavMeshSettings.h"
+#include "OloEngine/Navigation/NavMesh.h"
+#include "OloEngine/AI/BehaviorTree/BTTasks.h"
+#include "OloEngine/AI/BehaviorTree/BTBlackboard.h"
+
+#include <cmath>
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+class NavAgentUnreachableTargetTerminatesTest : public FunctionalTest
+{
+  protected:
+    // Agent starts on platform 1; the target sits on the disconnected platform 2.
+    static constexpr glm::vec3 kStart{ -8.0f, 0.5f, 0.0f };
+    static constexpr glm::vec3 kUnreachableTarget{ 8.0f, 0.5f, 0.0f };
+
+    void BuildScene() override
+    {
+        // Two thin static floors with a gap in x ∈ [-2, 2]. After radius erosion
+        // the walkable areas are disconnected — no path bridges the gap.
+        auto addPlatform = [this](const char* name, f32 centerX)
+        {
+            auto p = GetScene().CreateEntity(name);
+            p.GetComponent<TransformComponent>().Translation = { centerX, -0.05f, 0.0f };
+            Rigidbody3DComponent body;
+            body.m_Type = BodyType3D::Static;
+            BoxCollider3DComponent col;
+            col.m_HalfExtents = { 4.0f, 0.05f, 5.0f };
+            p.AddComponent<BoxCollider3DComponent>(col);
+            p.AddComponent<Rigidbody3DComponent>(body);
+        };
+        addPlatform("Platform1", -6.0f); // spans x ∈ [-10, -2]
+        addPlatform("Platform2", 6.0f);  // spans x ∈ [2, 10]
+
+        EnablePhysics3D();
+
+        NavMeshSettings settings;
+        const auto navMesh = NavMeshGenerator::Generate(
+            &GetScene(), settings,
+            /*boundsMin=*/glm::vec3(-15.0f, -2.0f, -7.0f),
+            /*boundsMax=*/glm::vec3(15.0f, 5.0f, 7.0f));
+        ASSERT_TRUE(navMesh && navMesh->IsValid())
+            << "two-platform bake failed — pre-condition broken.";
+        GetScene().SetNavMesh(navMesh);
+
+        // Agent on platform 1, no target yet (each test drives its own).
+        m_Agent = GetScene().CreateEntity("Agent");
+        m_Agent.GetComponent<TransformComponent>().Translation = kStart;
+        m_Agent.AddComponent<NavAgentComponent>();
+        auto& agent = m_Agent.GetComponent<NavAgentComponent>();
+        agent.m_MaxSpeed = 8.0f;
+        agent.m_StoppingDistance = 0.3f;
+        agent.m_LockYAxis = true;
+    }
+
+    static f32 DistXZ(const glm::vec3& a, const glm::vec3& b)
+    {
+        const f32 dx = a.x - b.x;
+        const f32 dz = a.z - b.z;
+        return std::sqrt(dx * dx + dz * dz);
+    }
+
+    Entity m_Agent;
+};
+
+// The raw follower must latch "unreachable" and hold the target observable, not
+// walk the agent across the gap and not silently drop the target.
+TEST_F(NavAgentUnreachableTargetTerminatesTest, ManualFollowerLatchesUnreachableInsteadOfArriving)
+{
+    {
+        auto& agent = m_Agent.GetComponent<NavAgentComponent>();
+        agent.m_TargetPosition = kUnreachableTarget;
+        agent.m_HasTarget = true;
+        agent.m_HasPath = false;
+        agent.m_TargetUnreachable = false;
+    }
+
+    // Plenty of time for the agent to walk to the gap edge and stop.
+    TickFor(/*seconds=*/3.0f);
+
+    const auto& agent = m_Agent.GetComponent<NavAgentComponent>();
+    const glm::vec3 pos = m_Agent.GetComponent<TransformComponent>().Translation;
+
+    EXPECT_TRUE(agent.m_TargetUnreachable)
+        << "NavigationSystem did not flag the disconnected target as unreachable — "
+           "FindPath is still reporting the partial path as a full success.";
+    EXPECT_TRUE(agent.m_HasTarget)
+        << "target was silently cleared; the terminal unreachable state must stay "
+           "observable so consumers can stop re-issuing it.";
+
+    EXPECT_TRUE(std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z))
+        << "agent transform contains NaN/Inf";
+    // The gap is x ∈ [-2, 2]; the agent must NOT have crossed to platform 2.
+    EXPECT_LT(pos.x, 0.0f)
+        << "agent crossed the impassable gap — a partial path was followed all the "
+           "way to the target as if it were reachable. Final x="
+        << pos.x;
+    EXPECT_GT(DistXZ(pos, kUnreachableTarget), 5.0f)
+        << "agent ended up near the unreachable target — the gap wasn't a gap.";
+}
+
+// BTMoveTo toward an unreachable target must return Failure within a bounded
+// number of ticks instead of spinning on Running forever.
+TEST_F(NavAgentUnreachableTargetTerminatesTest, BTMoveToTerminatesWithFailure)
+{
+    BTBlackboard bb;
+    bb.Set("moveTarget", kUnreachableTarget);
+
+    BTMoveTo node;
+    node.TargetBlackboardKey = "moveTarget";
+
+    constexpr i32 kMaxIterations = 600; // 10s of simulated time at 60 Hz — a hard ceiling
+    bool sawFailure = false;
+    i32 iterations = 0;
+
+    for (; iterations < kMaxIterations; ++iterations)
+    {
+        const BTStatus status = node.Tick(1.0f / 60.0f, bb, m_Agent);
+
+        ASSERT_NE(status, BTStatus::Success)
+            << "BTMoveTo reported arrival at an unreachable target on iteration " << iterations;
+
+        if (status == BTStatus::Failure)
+        {
+            sawFailure = true;
+            break;
+        }
+
+        // Advance NavigationSystem so it can compute the (partial) path and flag
+        // the target unreachable, which is what lets BTMoveTo terminate.
+        RunFrames(1);
+    }
+
+    EXPECT_TRUE(sawFailure)
+        << "BTMoveTo never terminated — it spun on Running for " << iterations
+        << " ticks against an unreachable target (the original infinite-hang bug).";
+    EXPECT_LT(iterations, 10)
+        << "BTMoveTo eventually failed but took " << iterations
+        << " ticks — the unreachable signal should propagate within a couple of frames.";
+}

--- a/OloEngine/tests/Functional/Navigation/NavMeshGeneratorBoundsValidationTest.cpp
+++ b/OloEngine/tests/Functional/Navigation/NavMeshGeneratorBoundsValidationTest.cpp
@@ -1,0 +1,103 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: Functional
+// =============================================================================
+// NavMeshGeneratorBoundsValidationTest — Functional Test.
+//
+// Subsystem under test:
+//   NavMeshGenerator::Generate (public API) — bounds validation guard.
+//
+// Regression target: Generate fed boundsMin/boundsMax straight into
+// rcCalcGridSize with no finiteness / ordering check. A NaN, Inf, or inverted
+// (max <= min) bound yields a garbage or enormous grid size and blows up the
+// heightfield allocation. The only production caller passes sane bounds, but
+// Generate is public — the guard makes bad bounds fail cleanly (nullptr) rather
+// than crash or allocate wildly.
+//
+// The bounds check lives AFTER scene-geometry collection, so the scene must
+// contain walkable geometry to reach it — hence the static floor + Physics3D.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Navigation/NavMeshGenerator.h"
+#include "OloEngine/Navigation/NavMeshSettings.h"
+#include "OloEngine/Navigation/NavMesh.h"
+
+#include <cmath>
+#include <limits>
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+class NavMeshGeneratorBoundsValidationTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        auto floor = GetScene().CreateEntity("Floor");
+        floor.GetComponent<TransformComponent>().Translation = { 0.0f, -0.05f, 0.0f };
+        Rigidbody3DComponent floorBody;
+        floorBody.m_Type = BodyType3D::Static;
+        BoxCollider3DComponent floorCol;
+        floorCol.m_HalfExtents = { 20.0f, 0.05f, 5.0f };
+        floor.AddComponent<BoxCollider3DComponent>(floorCol);
+        floor.AddComponent<Rigidbody3DComponent>(floorBody);
+
+        EnablePhysics3D();
+    }
+
+    Ref<NavMesh> Bake(const glm::vec3& boundsMin, const glm::vec3& boundsMax)
+    {
+        NavMeshSettings settings;
+        return NavMeshGenerator::Generate(&GetScene(), settings, boundsMin, boundsMax);
+    }
+
+    static constexpr glm::vec3 kValidMin{ -25.0f, -2.0f, -7.0f };
+    static constexpr glm::vec3 kValidMax{ 25.0f, 5.0f, 7.0f };
+};
+
+// Control: sane bounds still bake successfully — the guard doesn't reject valid input.
+TEST_F(NavMeshGeneratorBoundsValidationTest, ValidBoundsProduceMesh)
+{
+    auto mesh = Bake(kValidMin, kValidMax);
+    ASSERT_TRUE(mesh && mesh->IsValid())
+        << "valid, finite, ordered bounds were rejected — the guard is too strict.";
+}
+
+TEST_F(NavMeshGeneratorBoundsValidationTest, NaNBoundsRejected)
+{
+    const f32 nan = std::numeric_limits<f32>::quiet_NaN();
+    EXPECT_EQ(Bake(glm::vec3(nan, -2.0f, -7.0f), kValidMax), nullptr)
+        << "NaN in boundsMin was not rejected.";
+    EXPECT_EQ(Bake(kValidMin, glm::vec3(25.0f, nan, 7.0f)), nullptr)
+        << "NaN in boundsMax was not rejected.";
+}
+
+TEST_F(NavMeshGeneratorBoundsValidationTest, InfiniteBoundsRejected)
+{
+    const f32 inf = std::numeric_limits<f32>::infinity();
+    EXPECT_EQ(Bake(glm::vec3(-inf, -2.0f, -7.0f), kValidMax), nullptr)
+        << "-Inf in boundsMin was not rejected.";
+    EXPECT_EQ(Bake(kValidMin, glm::vec3(inf, 5.0f, 7.0f)), nullptr)
+        << "+Inf in boundsMax was not rejected.";
+}
+
+TEST_F(NavMeshGeneratorBoundsValidationTest, InvertedBoundsRejected)
+{
+    // max < min on every axis.
+    EXPECT_EQ(Bake(kValidMax, kValidMin), nullptr)
+        << "fully inverted bounds (max < min) were not rejected.";
+    // Inverted on a single axis is enough to reject.
+    EXPECT_EQ(Bake(kValidMin, glm::vec3(-30.0f, 5.0f, 7.0f)), nullptr)
+        << "bounds inverted on the x axis were not rejected.";
+}
+
+TEST_F(NavMeshGeneratorBoundsValidationTest, DegenerateEqualBoundsRejected)
+{
+    // A zero-extent axis (max == min) produces a zero-width grid — reject it.
+    EXPECT_EQ(Bake(kValidMin, glm::vec3(-25.0f, 5.0f, 7.0f)), nullptr)
+        << "zero-extent x axis (max == min) was not rejected.";
+}

--- a/OloEngine/tests/Functional/Navigation/NavMeshOffMeshLinkBridgesGapTest.cpp
+++ b/OloEngine/tests/Functional/Navigation/NavMeshOffMeshLinkBridgesGapTest.cpp
@@ -100,14 +100,18 @@ TEST_F(NavMeshOffMeshLinkBridgesGapTest, LinkClosesGapThatIsImpassableWithoutIt)
     ASSERT_TRUE(noLinkQuery.IsValid());
 
     std::vector<glm::vec3> noLinkPath;
-    const bool noLinkFound = noLinkQuery.FindPath(kStart, kEnd, noLinkPath);
-    // Detour returns a (partial) path to the nearest reachable poly even when the
-    // goal is unreachable, so the bool alone isn't the signal — the path must NOT
-    // arrive at the goal.
-    const bool noLinkReachedGoal = noLinkFound && !noLinkPath.empty() && DistXZ(noLinkPath.back(), kEnd) < 1.5f;
+    const FindPathResult noLinkResult = noLinkQuery.FindPath(kStart, kEnd, noLinkPath);
+    // Detour returns a (partial) path to the nearest reachable poly even when the goal
+    // is unreachable. FindPath now reports that as Partial (not a false Complete), which
+    // is the whole point of the disconnected-region fix — assert it directly.
+    EXPECT_EQ(noLinkResult, FindPathResult::Partial)
+        << "without an off-mesh link the two platforms must be disconnected, so FindPath "
+           "must report a Partial path to the nearest reachable point — not Complete "
+           "(gap isn't a gap) and not Failed (start/end should still snap to the mesh).";
+    // Belt-and-braces: the path must NOT actually arrive at the goal.
+    const bool noLinkReachedGoal = !noLinkPath.empty() && DistXZ(noLinkPath.back(), kEnd) < 1.5f;
     EXPECT_FALSE(noLinkReachedGoal)
-        << "without an off-mesh link the two platforms must be disconnected, but "
-           "FindPath reported a path reaching the goal — the gap isn't actually a gap, "
+        << "partial path unexpectedly ends at the goal — the gap isn't actually a gap, "
            "so this test can't prove the link does anything.";
 
     // ---- With link: the same geometry is now traversable end-to-end. ----
@@ -122,9 +126,10 @@ TEST_F(NavMeshOffMeshLinkBridgesGapTest, LinkClosesGapThatIsImpassableWithoutIt)
     ASSERT_TRUE(linkedQuery.IsValid());
 
     std::vector<glm::vec3> linkedPath;
-    const bool linkedFound = linkedQuery.FindPath(kStart, kEnd, linkedPath);
-    ASSERT_TRUE(linkedFound)
-        << "FindPath returned false with an off-mesh link present.";
+    const FindPathResult linkedResult = linkedQuery.FindPath(kStart, kEnd, linkedPath);
+    ASSERT_EQ(linkedResult, FindPathResult::Complete)
+        << "FindPath did not report a complete path with an off-mesh link present — the "
+           "link should now make the goal fully reachable.";
     ASSERT_GE(linkedPath.size(), 2u);
 
     EXPECT_LT(DistXZ(linkedPath.front(), kStart), 1.5f)

--- a/OloEngine/tests/Functional/Navigation/NavMeshQueryFindPathBetweenPointsTest.cpp
+++ b/OloEngine/tests/Functional/Navigation/NavMeshQueryFindPathBetweenPointsTest.cpp
@@ -73,11 +73,11 @@ TEST_F(NavMeshQueryFindPathBetweenPointsTest, DirectFindPathReturnsPolylineConne
            "NavMeshQuery::Initialize was not called or dtNavMeshQuery::init failed.";
 
     std::vector<glm::vec3> path;
-    const bool found = query->FindPath(kStart, kEnd, path);
-    ASSERT_TRUE(found)
-        << "FindPath returned false on a known-walkable straight-shot path.";
+    const FindPathResult result = query->FindPath(kStart, kEnd, path);
+    ASSERT_EQ(result, FindPathResult::Complete)
+        << "FindPath did not report a complete path on a known-walkable straight-shot path.";
     ASSERT_GE(path.size(), 2u)
-        << "FindPath returned 'true' but produced fewer than 2 corners — "
+        << "FindPath reported Complete but produced fewer than 2 corners — "
            "an empty/degenerate path that no agent can follow.";
 
     const glm::vec3 first = path.front();

--- a/OloEngine/tests/NavMeshTest.cpp
+++ b/OloEngine/tests/NavMeshTest.cpp
@@ -108,7 +108,7 @@ TEST(NavMeshQueryTest, FindPathWithoutNavMeshReturnsFalse)
 {
     NavMeshQuery query;
     std::vector<glm::vec3> path;
-    EXPECT_FALSE(query.FindPath({ 0, 0, 0 }, { 10, 0, 10 }, path));
+    EXPECT_EQ(query.FindPath({ 0, 0, 0 }, { 10, 0, 10 }, path), FindPathResult::Failed);
     EXPECT_TRUE(path.empty());
 }
 
@@ -425,7 +425,7 @@ TEST(NavMeshRoundTripTest, SerializeDeserializePreservesPathfinding)
     ASSERT_TRUE(origQuery.IsValid());
 
     std::vector<glm::vec3> origPath;
-    EXPECT_TRUE(origQuery.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, origPath));
+    EXPECT_EQ(origQuery.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, origPath), FindPathResult::Complete);
     EXPECT_FALSE(origPath.empty());
 
     // Serialize
@@ -447,7 +447,7 @@ TEST(NavMeshRoundTripTest, SerializeDeserializePreservesPathfinding)
     ASSERT_TRUE(restoredQuery.IsValid());
 
     std::vector<glm::vec3> restoredPath;
-    EXPECT_TRUE(restoredQuery.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, restoredPath));
+    EXPECT_EQ(restoredQuery.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, restoredPath), FindPathResult::Complete);
     EXPECT_EQ(restoredPath.size(), origPath.size());
 }
 
@@ -509,7 +509,7 @@ TEST(NavMeshQueryPositiveTest, CustomQueryBudget)
     ASSERT_TRUE(query.IsValid());
 
     std::vector<glm::vec3> path;
-    EXPECT_TRUE(query.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, path));
+    EXPECT_EQ(query.FindPath({ -5, 0, 0 }, { 5, 0, 0 }, path), FindPathResult::Complete);
     EXPECT_FALSE(path.empty());
 }
 


### PR DESCRIPTION
## Summary

Fixes two verified Navigation correctness/robustness bugs found in a code-review sweep (not a pre-existing issue).

### 1. Partial paths reported as full success → NPC infinite hang (primary)

Detour's `dtNavMeshQuery::findPath` returns a path to the **nearest reachable** poly and sets `DT_PARTIAL_RESULT` when the target is off-navmesh or in a disconnected region. `NavMeshQuery::FindPath` checked only `dtStatusFailed || npolys == 0` and reported this as success. The manual follower walked the agent to the closest point and cleared its target; `BTMoveTo` — checking arrival against the **raw** never-reached target — re-issued the same target and returned `Running` **forever**. The NPC was physically stuck while the behavior-tree node hung silently.

- `FindPath` now returns `FindPathResult { Failed, Partial, Complete }`, detecting `DT_PARTIAL_RESULT`.
- `NavAgentComponent` gains a runtime `m_TargetUnreachable` flag (`OLO_SERIALIZE(Skip)`).
- `NavigationSystem` latches the flag on Failed/Partial, keeps `m_HasTarget` **observable** so consumers see a stable terminal state, and stops recomputing every frame.
- `BTMoveTo` returns **Failure** on an unreachable target instead of spinning.
- Exposed to scripts: C# `NavAgentComponent.IsTargetUnreachable`, Lua `targetUnreachable`.

### 2. Unvalidated nav-bake bounds (hardening)

`NavMeshGenerator::Generate` (public API) fed `boundsMin/boundsMax` straight into `rcCalcGridSize` with no check. A NaN/Inf or inverted (`max <= min`) bound would yield a garbage/huge grid allocation. Added an `isfinite` + `max > min` guard alongside the existing settings validation. The only production caller passes sane bounds, so this is latent — but the API is public.

## Tests

- **New** `NavAgentUnreachableTargetTerminatesTest` — raw follower latches `m_TargetUnreachable` (doesn't cross the gap); `BTMoveTo` terminates with Failure in <10 ticks instead of spinning.
- **New** `NavMeshGeneratorBoundsValidationTest` — NaN/Inf/inverted/degenerate bounds rejected cleanly; valid control passes.
- Existing `FindPath` call-sites migrated to the enum API; `NavMeshOffMeshLinkBridgesGapTest` strengthened to assert `Partial` directly.
- Full build green; 138 behavior-tree / component-coverage / serializer tests pass (no regressions from the new component field). All nav tests pass.

## Related follow-up (not in this PR)

#616 — `CrowdManager` is initialized+ticked but `AddAgent` has zero production callers, so every `NavAgent` falls back to the naive follower with no inter-agent avoidance. That fix is behavior-changing and overlaps `NavigationSystem`/`Scene`; kept separate so this PR stays a shippable correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)