### PR TITLE
fix(audio): Inverse attenuation NaN-into-mix, WavePlayer refill dropouts/multichannel garble, SIMD gain index

### DIFF
--- a/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
+++ b/OloEngine/src/OloEngine/Audio/DSP/Spatializer/Spatializer.cpp
@@ -25,7 +25,13 @@ namespace OloEngine::Audio::DSP
         {
             case AttenuationModelType::Inverse:
             {
-                if (minDistance >= maxDistance)
+                // Guard minDistance <= 0 as well as minDistance >= maxDistance: with
+                // minDistance == 0 the ratio is 0 / (0 + rolloff * clampedDistance), which is
+                // 0/0 == NaN when the source sits on the listener (distance == 0) and a
+                // degenerate all-silent 0 for distance > 0. A NaN gain propagates through
+                // std::clamp (returns NaN) and VBAP straight into the master mix. Mirror the
+                // Exponential case, which already guards minDistance <= 0.
+                if (minDistance <= 0.0f || minDistance >= maxDistance)
                 {
                     return 1.0f;
                 }

--- a/OloEngine/src/OloEngine/Audio/SampleBufferOperations.h
+++ b/OloEngine/src/OloEngine/Audio/SampleBufferOperations.h
@@ -76,8 +76,16 @@ namespace OloEngine::Audio
             const f32 delta = (gainEnd - gainStart) / static_cast<f32>(numSamples - 1);
 
 #if defined(OLO_AUDIO_HAS_AVX)
-            // AVX path: process 8 floats at a time
-            if (totalSamples >= 8)
+            // AVX path: process 8 floats at a time.
+            // The per-lane frame index is precomputed once as indexOffsets[lane] = lane/numChannels
+            // and added to baseSampleIdx = i/numChannels each iteration. That equals the scalar
+            // reference frame index (i + lane)/numChannels ONLY when numChannels evenly divides the
+            // SIMD width (so i, always a multiple of the width, is also a multiple of numChannels and
+            // the two integer divisions distribute). For 3/5/6/7 channels they diverge — element
+            // (i+lane) straddles a frame boundary the split index misses — so restrict the fast path
+            // to channel counts dividing 8 and let everything else fall through to the exact scalar
+            // loop below. Mono/stereo (the common cases) stay fully vectorized.
+            if (totalSamples >= 8 && (8u % numChannels) == 0u)
             {
                 const u32 simdSamples = (totalSamples / 8) * 8;
 
@@ -119,8 +127,11 @@ namespace OloEngine::Audio
                 return;
             }
 #elif defined(OLO_AUDIO_HAS_SSE)
-            // SSE path: process 4 floats at a time
-            if (totalSamples >= 4)
+            // SSE path: process 4 floats at a time. Same per-lane index caveat as the AVX path
+            // above: the split frame index only matches the scalar reference when numChannels
+            // evenly divides the SIMD width (here 4), so gate on (4 % numChannels == 0) and let
+            // 3/5/6/7-channel buffers fall through to the exact scalar loop.
+            if (totalSamples >= 4 && (4u % numChannels) == 0u)
             {
                 const u32 simdSamples = (totalSamples / 4) * 4;
 

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/Nodes/WavePlayer.h
@@ -636,11 +636,29 @@ namespace OloEngine::Audio::SoundGraph
             if (!m_AudioData.IsValid())
                 return false;
 
+            // The circular buffer and the reader (ReadNextFrame) treat the queued data as
+            // mono or interleaved-stereo: at most two samples are stored per source frame.
+            // Storing all m_NumChannels samples/frame for a >2-channel source desyncs the
+            // reader (it consumes 2/frame) — the clip plays back too fast with channels 2+
+            // bleeding into L/R and ending early. Cap the stored width to the read width;
+            // channels beyond L/R are dropped (select first two). IsValid() guarantees
+            // m_NumChannels >= 1, so channelsToStore is always >= 1.
+            const u32 channelsToStore = glm::min(m_AudioData.m_NumChannels, 2u);
+
+            // Never push more than the circular buffer's free headroom. An overflowing
+            // Push silently advances the read pointer to discard the oldest not-yet-played
+            // samples (see CircularBuffer::Push) — that drops audio the reader was about to
+            // play, producing periodic clicks/dropouts. Clamp the chunk to the free frames
+            // (measured against the actual per-frame store width, channelsToStore).
+            const i32 capacitySamples = static_cast<i32>(source.m_Channels.GetSize());
+            const i32 headroomSamples = capacitySamples - source.m_Channels.Available();
+            const u32 headroomFrames = headroomSamples > 0 ? static_cast<u32>(headroomSamples) / channelsToStore : 0u;
+
             // Use m_NextRefillFrame as the source-of-truth read pointer rather than
             // source.m_ReadPosition, so both refill paths (ForceRefillBuffer at block
             // boundaries and the lazy refill from ReadNextFrame when the buffer empties)
             // produce a single non-overlapping stream of pushes.
-            const u32 framesToRead = 1024; // Read chunk size
+            const u32 framesToRead = glm::min(1024u, headroomFrames); // Read chunk size, clamped to buffer headroom
             const u64 startFrame = static_cast<u64>(m_NextRefillFrame);
             const u64 endFrame = glm::min(startFrame + framesToRead, static_cast<u64>(m_AudioData.m_NumFrames));
 
@@ -650,7 +668,7 @@ namespace OloEngine::Audio::SoundGraph
             // Fill the circular buffer with interleaved audio data
             for (u64 frame = startFrame; frame < endFrame; ++frame)
             {
-                for (u32 channel = 0; channel < m_AudioData.m_NumChannels; ++channel)
+                for (u32 channel = 0; channel < channelsToStore; ++channel)
                 {
                     // Safe cast: endFrame is already bounded by m_NumFrames (u32)
                     f32 sample = m_AudioData.GetSample(static_cast<u32>(frame), channel);

--- a/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
+++ b/OloEngine/tests/AudioSoundGraphSpatializerTest.cpp
@@ -34,6 +34,8 @@
 #include <glm/glm.hpp>
 #include <miniaudio.h>
 
+#include <cmath>
+
 using namespace OloEngine; // NOLINT(google-build-using-namespace)
 namespace sg = OloEngine::Audio::SoundGraph;
 namespace dsp = OloEngine::Audio::DSP;
@@ -205,4 +207,59 @@ TEST_F(SoundGraphSpatializerTest, UnregisterReleasesSource)
     const u32 reusedID = m_Source.GetSpatializerSourceID();
     EXPECT_NE(reusedID, 0u);
     EXPECT_NE(reusedID, id) << "the re-registered source must not reuse the released sourceID";
+}
+
+// Regression (primary): the Inverse distance-attenuation model is minDistance /
+// (minDistance + rolloff*(clamp(d, min, max) - minDistance)). With MinDistance == 0 (a legal
+// config value — the scene deserializer sanitizer permits [0, 1e6]) and a source co-located
+// with the listener (distance ~ 0), that is 0 / 0 == NaN. std::clamp(NaN, MinGain, MaxGain)
+// propagates the NaN, which flows through VBAP and AddAndApplyGainRamp straight into the master
+// mix (all audio corrupted, potential speaker damage). The Inverse case must guard MinDistance
+// <= 0 exactly like the Exponential case already does.
+TEST_F(SoundGraphSpatializerTest, InverseModelZeroMinDistanceCoLocatedStaysFinite)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+    config.AttenuationModel = AttenuationModelType::Inverse; // the default, spelled out for clarity
+    config.MinDistance = 0.0f;                               // the trigger
+    config.MaxDistance = 1000.0f;
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+
+    m_Spatializer.UpdateListener(Audio::Transform{});
+
+    // Source sitting exactly on the listener → distance ~ 0 → the 0/0 case.
+    Audio::Transform atListener; // position {0,0,0}
+    m_Source.UpdateSpatialPosition(atListener);
+
+    const float atten = m_Spatializer.GetCurrentDistanceAttenuation(id);
+    EXPECT_TRUE(std::isfinite(atten)) << "distance attenuation must never be NaN/Inf (got " << atten << ")";
+    EXPECT_GE(atten, 0.0f);
+    EXPECT_LE(atten, 1.0f);
+}
+
+// The same MinDistance == 0 Inverse config with the source at a real distance. Before the guard
+// this returned 0 / (rolloff*distance) == 0 for every distance > 0 — a permanently silent voice
+// (the degenerate all-silent behaviour). The guard now returns full gain, matching the
+// Exponential case's minDistance<=0 short-circuit.
+TEST_F(SoundGraphSpatializerTest, InverseModelZeroMinDistanceDistantStaysAudible)
+{
+    AudioSourceConfig config;
+    config.Spatialization = true;
+    config.AttenuationModel = AttenuationModelType::Inverse;
+    config.MinDistance = 0.0f;
+    config.MaxDistance = 1000.0f;
+    ASSERT_TRUE(m_Source.RegisterSpatializer(&m_Spatializer, config));
+    const u32 id = m_Source.GetSpatializerSourceID();
+
+    m_Spatializer.UpdateListener(Audio::Transform{});
+
+    Audio::Transform pose;
+    pose.Position = { 0.0f, 0.0f, -5.0f };
+    m_Source.UpdateSpatialPosition(pose);
+
+    const float atten = m_Spatializer.GetCurrentDistanceAttenuation(id);
+    EXPECT_TRUE(std::isfinite(atten));
+    EXPECT_GT(atten, 0.0f) << "MinDistance == 0 must not silence the voice at distance > 0";
+    EXPECT_LE(atten, 1.0f);
 }

--- a/OloEngine/tests/AudioSpatializerTest.cpp
+++ b/OloEngine/tests/AudioSpatializerTest.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <numeric>
+#include <vector>
 
 using namespace OloEngine::Audio::DSP;
 using namespace OloEngine::Audio;
@@ -286,4 +287,82 @@ TEST(SampleBufferOps, AddAndApplyGainRampInterpolates)
     EXPECT_NEAR(dest[1], 1.0f / 3.0f, 1e-5f);
     EXPECT_NEAR(dest[2], 2.0f / 3.0f, 1e-5f);
     EXPECT_NEAR(dest[3], 1.0f, 1e-5f);
+}
+
+//==============================================================================
+/// ApplyGainRamp SIMD-vs-scalar parity (Finding 4)
+///
+/// The AVX/SSE fast path built the per-lane frame index as (i/numChannels) +
+/// (lane/numChannels), but the correct index is (i + lane)/numChannels. Since i is always a
+/// multiple of the SIMD width, those two agree only when numChannels evenly divides the width
+/// (1/2/4/8) and DIVERGE from the scalar fallback for 3/5/6/7 channels. These tests pin the
+/// fixed behaviour: every channel count now matches the exact scalar reference.
+//==============================================================================
+
+namespace
+{
+    // Exact scalar reference: gain per frame is gainStart + delta*frameIndex with
+    // delta = (gainEnd - gainStart)/(numSamples - 1), applied to every channel of that frame.
+    // Mirrors SampleBufferOperations::ApplyGainRamp's scalar fallback.
+    void ApplyGainRampScalarReference(std::vector<f32>& data, u32 numSamples, u32 numChannels, f32 gainStart, f32 gainEnd)
+    {
+        if (numSamples == 1)
+        {
+            for (u32 ch = 0; ch < numChannels; ++ch)
+                data[ch] *= gainEnd;
+            return;
+        }
+        const f32 delta = (gainEnd - gainStart) / static_cast<f32>(numSamples - 1);
+        for (u32 i = 0; i < numSamples; ++i)
+        {
+            for (u32 ch = 0; ch < numChannels; ++ch)
+                data[i * numChannels + ch] *= gainStart + delta * static_cast<f32>(i);
+        }
+    }
+
+    void ExpectApplyGainRampMatchesScalar(u32 numSamples, u32 numChannels, f32 gainStart, f32 gainEnd)
+    {
+        std::vector<f32> actual(static_cast<sizet>(numSamples) * numChannels);
+        for (sizet i = 0; i < actual.size(); ++i)
+            actual[i] = 1.0f + 0.01f * static_cast<f32>(i); // distinct, non-trivial samples
+
+        std::vector<f32> expected = actual;
+
+        SampleBufferOperations::ApplyGainRamp(actual.data(), numSamples, numChannels, gainStart, gainEnd);
+        ApplyGainRampScalarReference(expected, numSamples, numChannels, gainStart, gainEnd);
+
+        ASSERT_EQ(actual.size(), expected.size());
+        for (sizet i = 0; i < actual.size(); ++i)
+        {
+            EXPECT_NEAR(actual[i], expected[i], 1e-4f)
+                << "mismatch at element " << i << " (numChannels=" << numChannels << ", numSamples=" << numSamples << ")";
+        }
+    }
+} // namespace
+
+// The channel counts that don't divide the SIMD width — where the old per-lane index bug bit.
+TEST(SampleBufferOps, ApplyGainRampThreeChannelMatchesScalar)
+{
+    ExpectApplyGainRampMatchesScalar(/*numSamples*/ 16, /*numChannels*/ 3, /*gainStart*/ 0.25f, /*gainEnd*/ 1.5f);
+}
+
+TEST(SampleBufferOps, ApplyGainRampSixChannelMatchesScalar)
+{
+    ExpectApplyGainRampMatchesScalar(16, 6, 0.0f, 2.0f);
+}
+
+TEST(SampleBufferOps, ApplyGainRampFiveAndSevenChannelMatchScalar)
+{
+    ExpectApplyGainRampMatchesScalar(9, 5, 0.5f, 1.0f);
+    ExpectApplyGainRampMatchesScalar(11, 7, 0.1f, 0.9f);
+}
+
+// Regression guard: the common mono/stereo (and 4/8-channel) paths still run through SIMD and
+// must stay correct after gating the fast path on (width % numChannels == 0).
+TEST(SampleBufferOps, ApplyGainRampWidthDividingChannelsMatchScalar)
+{
+    ExpectApplyGainRampMatchesScalar(64, 1, 0.0f, 1.0f);
+    ExpectApplyGainRampMatchesScalar(64, 2, 0.2f, 0.8f);
+    ExpectApplyGainRampMatchesScalar(16, 4, 0.0f, 1.0f);
+    ExpectApplyGainRampMatchesScalar(16, 8, 0.3f, 0.7f);
 }

--- a/docs/agent-rules/sonarqube-review-alignment.md
+++ b/docs/agent-rules/sonarqube-review-alignment.md
@@ -170,3 +170,12 @@ added after the scan); some moved.
   its `#include <stdio.h>` is **required and documented** (pl_mpeg's `FILE*` API needs it before the
   impl, and the no-PCH cacheable build can't force-include it). Treat that file like `vendor/` — don't
   clean it; only its first-party wrapper `PlMpegBackend.cpp` and the rest of `Video/` are fair game.
+- `S953` "replace union with std::variant" in `Audio/SampleBufferOperations.h` — **false: the
+  `union`s are the `__m128` / `__m256` SIMD intrinsic types** (MSVC/Clang model them as unions).
+  `std::variant` cannot back a vector register; do **not** "fix" these. **BUT** don't let the union
+  noise mask the file's real content: `SampleBufferOperations.h` had a genuine SIMD-vs-scalar
+  divergence in `ApplyGainRamp` (the per-lane gain index was `(i/numChannels)+(lane/numChannels)`
+  instead of `(i+lane)/numChannels`, wrong for 3/5/6/7-channel buffers — fixed by gating the fast
+  path on `width % numChannels == 0`; pinned by `SampleBufferOps.ApplyGainRamp*ChannelMatchesScalar`
+  in `AudioSpatializerTest.cpp`). When a hot SIMD file lights up with `S953`, skip the union hits but
+  **read the vectorized index math against the scalar fallback** — that's where the real bugs hide.


### PR DESCRIPTION
## Summary

A batch of verified Audio-DSP correctness/robustness fixes found in a code-review sweep (not pre-existing GitHub issues). Headlined by a safety bug that puts `NaN` into the master mix.

All Audio-subsystem, file-disjoint from sibling tasks. Build clean; **151/151 audio + soundgraph tests pass**, including 6 new tests.

## Findings & fixes

1. **(PRIMARY, high severity) Spatializer `Inverse` attenuation `0/0` → `NaN` into the master mix.**
   `ProcessDistanceAttenuation` computed `minDistance / (minDistance + rolloff*(clamp(d)-minDistance))`. With `MinDistance = 0` (a legal value — the scene deserializer sanitizer permits `[0, 1e6]`, and `Inverse` is the **default** model) and a spatialized source co-located with the listener (`distance ≈ 0`), this is `0/0 = NaN`. `std::clamp(NaN, MinGain, MaxGain)` returns `NaN`, which flows through VBAP and `AddAndApplyGainRamp` straight into the master mix (all audio corrupted, potential speaker damage). Fixed by guarding `minDistance <= 0.0f`, mirroring the sibling `Exponential` case. Also fixes the degenerate all-silent behaviour for `distance > 0` with `MinDistance = 0`.

2. **WavePlayer refill overflow discarded unread samples → dropouts.**
   `FillBufferFromAudioData` pushed up to 1024 frames × 2 ch = 2048 samples into a 3840-sample circular buffer without checking headroom. When `Available()` sat near the refill watermark, the `Push` overflowed and advanced the read pointer, **discarding the oldest not-yet-played samples** (periodic clicks/gaps). Fixed by clamping each refill chunk to the buffer's free frames.

3. **WavePlayer garbled sources with > 2 channels.**
   The refill pushed all `m_NumChannels` samples/frame, but `ReadNextFrame` consumes exactly 2 samples/output-frame for any `>= 2`-channel source — so a 3+-channel clip played ~2× too fast with channels 2+ bleeding into L/R and ending early. Fixed by capping the stored width to `min(numChannels, 2)` to match the reader (channels beyond L/R are dropped).

4. **`ApplyGainRamp` wrong gain for odd channel counts (SIMD-vs-scalar divergence).**
   The per-lane AVX/SSE gain index was `(i/numChannels) + (lane/numChannels)`, but the correct frame index is `(i + lane)/numChannels`. Since `i` is always a multiple of the SIMD width, these agree only when `numChannels ∈ {1,2,4,8}` and **diverge from the scalar fallback for 3/5/6/7 channels**. Fixed by gating the fast path on `(width % numChannels == 0)` so indivisible channel counts fall through to the exact scalar loop; mono/stereo (the common cases) stay fully vectorized. (This is a genuine logic bug — **not** the `__m128`/`__m256` `S953` "union" SonarQube false-positive in the same file.)

## Tests

- **Finding 1** — 2 tests in `AudioSoundGraphSpatializerTest.cpp` (device-free `ma_engine` fixture): `Inverse` + `MinDistance = 0` stays finite when co-located, and stays audible at distance > 0.
- **Finding 4** — 4 SIMD-vs-scalar parity tests in `AudioSpatializerTest.cpp` covering the divergent 3/5/6/7-channel counts plus a 1/2/4/8-channel regression guard. Confirmed meaningful: MSVC x64 unconditionally compiles the SSE path, so these exercise real vectorized code.
- **Findings 2 & 3** are fixed but not unit-pinned: `FillBufferFromAudioData` is private and only reachable through the async asset-load path (Project + AssetManager + a real wave file), so a fixture is disproportionately heavy and the manifestation is timing-dependent.

## Related issues

None — these are review-sourced correctness bugs, not tracked issues.

## Notes

Captured a lesson in `docs/agent-rules/sonarqube-review-alignment.md` §5 (and persistent memory): the `cpp:S953` "union" warnings in `SampleBufferOperations.h` are `__m128`/`__m256` SIMD false-positives — but the file had a real SIMD-vs-scalar gain bug (Finding 4), so the union noise must not mask a read of the vectorized index math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)