### PR TITLE
fix(dialogue,gameplay,ui): guard against removed components and re-entrant dispatch

### DIFF
--- a/OloEngine/src/OloEngine/Dialogue/DialogueSystem.cpp
+++ b/OloEngine/src/OloEngine/Dialogue/DialogueSystem.cpp
@@ -150,6 +150,12 @@ namespace OloEngine
         }
 
         // Follow the default connection from current node
+        if (!entity.HasComponent<DialogueComponent>())
+        {
+            EndDialogue(entity);
+            return;
+        }
+
         const auto& dialogueComp = entity.GetComponent<DialogueComponent>();
         auto dialogueTree = AssetManager::GetAsset<DialogueTreeAsset>(dialogueComp.m_DialogueTree);
         if (!dialogueTree)
@@ -233,6 +239,12 @@ namespace OloEngine
         if (hopCount >= s_MaxHopCount)
         {
             OLO_CORE_ERROR("DialogueSystem::ProcessNode - Exceeded max hop count ({}), possible cycle detected at node {}", s_MaxHopCount, static_cast<u64>(nodeID));
+            EndDialogue(entity);
+            return;
+        }
+
+        if (!entity.HasComponent<DialogueComponent>())
+        {
             EndDialogue(entity);
             return;
         }

--- a/OloEngine/src/OloEngine/Gameplay/GameplayEventBus.h
+++ b/OloEngine/src/OloEngine/Gameplay/GameplayEventBus.h
@@ -48,7 +48,12 @@ namespace OloEngine
         }
 
         // Synchronously dispatch `event` to every handler subscribed to E.
-        // No-op when nothing subscribes to E.
+        // No-op when nothing subscribes to E. Safe against a handler calling
+        // Subscribe<E>() for the same event type mid-dispatch: indexing
+        // (rather than holding range-for iterators) tolerates the vector
+        // reallocating underneath us, and snapshotting the count means a
+        // handler subscribed during this Publish() is not itself invoked
+        // until the next Publish() call.
         template<typename E>
         void Publish(const E& event) const
         {
@@ -57,9 +62,10 @@ namespace OloEngine
             {
                 return;
             }
-            for (auto const& handler : it->second)
+            auto const& handlers = it->second;
+            for (sizet i = 0, count = handlers.size(); i < count; ++i)
             {
-                handler(&event);
+                handlers[i](&event);
             }
         }
 

--- a/OloEngine/src/OloEngine/UI/RuntimeInputRebindMenu.cpp
+++ b/OloEngine/src/OloEngine/UI/RuntimeInputRebindMenu.cpp
@@ -388,7 +388,38 @@ namespace OloEngine
 
     bool RuntimeInputRebindMenu::OnEvent(Event& e)
     {
-        if (!m_Open || m_Controller.GetCaptureMode() != InputRebindController::CaptureMode::KeyboardMouse)
+        if (!m_Open)
+        {
+            return false;
+        }
+
+        // Escape must cancel an in-progress capture in *any* mode (including
+        // Gamepad, where the overlay explicitly says "Esc to cancel" but no
+        // controller input can ever reach FinishCapture() if none is
+        // connected) — handled here, ahead of the KeyboardMouse-only guard
+        // below, so it isn't swallowed by CaptureMode::Gamepad.
+        if (m_Controller.IsCapturing())
+        {
+            EventDispatcher escDispatcher(e);
+            bool cancelled = false;
+            escDispatcher.Dispatch<KeyPressedEvent>(
+                [this, &cancelled](const KeyPressedEvent& ev)
+                {
+                    if (ev.GetKeyCode() == Key::Escape)
+                    {
+                        m_Controller.CancelCapture();
+                        cancelled = true;
+                        return true;
+                    }
+                    return false;
+                });
+            if (cancelled)
+            {
+                return true;
+            }
+        }
+
+        if (m_Controller.GetCaptureMode() != InputRebindController::CaptureMode::KeyboardMouse)
         {
             return false;
         }

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -601,6 +601,7 @@ add_executable(OloEngine-Tests
 		Functional/Scripting/LuaRaycastHitsPhysicsBodyTest.cpp
 		Functional/Scripting/LuaCompletesQuestViaIncrementObjectiveTest.cpp
 		Functional/Dialogue/DialogueAdvanceMovesToNextNodeTest.cpp
+		Functional/Dialogue/DialogueAdvanceGuardsRemovedComponentTest.cpp
 		Functional/Gameplay/InventoryTransferItemBetweenContainersTest.cpp
 		Functional/Gameplay/InventoryShopTradingTest.cpp
 		Functional/Gameplay/ChanneledAbilityAutoDeactivatesAtEndOfDurationTest.cpp

--- a/OloEngine/tests/Functional/Dialogue/DialogueAdvanceGuardsRemovedComponentTest.cpp
+++ b/OloEngine/tests/Functional/Dialogue/DialogueAdvanceGuardsRemovedComponentTest.cpp
@@ -1,0 +1,101 @@
+// OLO_TEST_LAYER: Functional
+#include "OloEnginePCH.h"
+
+// =============================================================================
+// DialogueAdvanceGuardsRemovedComponentTest — Functional Test.
+//
+// Cross-subsystem seam under test:
+//   DialogueSystem::AdvanceDialogue / ProcessNode × Entity::HasComponent ×
+//   DialogueComponent removal mid-conversation.
+//
+// AdvanceDialogue and ProcessNode used to call
+// entity.GetComponent<DialogueComponent>() unconditionally, unlike EndDialogue
+// which correctly guards with HasComponent<DialogueComponent>() first. If a
+// DialogueComponent is removed while an entity is mid-dialogue (editor
+// remove-component button, a script, or gameplay logic), the next
+// AdvanceDialogue/SelectChoice hit an EnTT assert / UB instead of ending the
+// dialogue cleanly.
+//
+// Scenario: start a dialogue, let the reveal finish, remove DialogueComponent
+// out from under the live DialogueStateComponent, then call AdvanceDialogue —
+// it must end the dialogue (remove DialogueStateComponent) instead of
+// asserting/crashing.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+
+#include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
+#include "OloEngine/Dialogue/DialogueSystem.h"
+#include "OloEngine/Dialogue/DialogueTreeAsset.h"
+#include "OloEngine/Dialogue/DialogueTypes.h"
+#include "OloEngine/Project/Project.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Scene/Entity.h"
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+class DialogueAdvanceGuardsRemovedComponentTest : public FunctionalTest
+{
+  protected:
+    static constexpr u64 kNodeA_ID = 0xA0ULL;
+    static constexpr const char* kTextA = "Hi.";
+
+    void BuildScene() override
+    {
+        EnableAssetManager({});
+
+        m_TreeAsset = Ref<DialogueTreeAsset>::Create();
+
+        DialogueNodeData a;
+        a.ID = OloEngine::UUID{ kNodeA_ID };
+        a.Type = "dialogue";
+        a.Name = "A";
+        a.Properties.emplace("text", DialoguePropertyValue{ std::string(kTextA) });
+
+        auto& nodes = m_TreeAsset->GetNodesWritable();
+        nodes.push_back(std::move(a));
+
+        m_TreeAsset->SetRootNodeID(OloEngine::UUID{ kNodeA_ID });
+        m_TreeAsset->RebuildNodeIndex();
+
+        m_TreeHandle = AssetManager::AddMemoryOnlyAsset<DialogueTreeAsset>(m_TreeAsset);
+        ASSERT_NE(static_cast<u64>(m_TreeHandle), 0ULL);
+
+        m_Speaker = GetScene().CreateEntity("Speaker");
+        auto& dc = m_Speaker.AddComponent<DialogueComponent>();
+        dc.m_DialogueTree = m_TreeHandle;
+        m_Speaker.AddComponent<DialogueStateComponent>();
+
+        EnableDialogue();
+    }
+
+    Ref<DialogueTreeAsset> m_TreeAsset;
+    AssetHandle m_TreeHandle{};
+    Entity m_Speaker;
+};
+
+TEST_F(DialogueAdvanceGuardsRemovedComponentTest, AdvanceEndsDialogueInsteadOfAssertingWhenComponentRemovedMidConversation)
+{
+    auto* dialogueSystem = GetScene().GetDialogueSystem();
+    ASSERT_NE(dialogueSystem, nullptr);
+
+    dialogueSystem->StartDialogue(m_Speaker);
+    ASSERT_TRUE(m_Speaker.HasComponent<DialogueStateComponent>());
+    EXPECT_EQ(m_Speaker.GetComponent<DialogueStateComponent>().m_State, DialogueState::Displaying);
+
+    TickFor(1.5f); // past the reveal duration, so the next Advance walks the graph
+
+    // Simulate the component vanishing mid-conversation (remove-component
+    // button / script) while DialogueStateComponent is still live.
+    m_Speaker.RemoveComponent<DialogueComponent>();
+    ASSERT_TRUE(m_Speaker.HasComponent<DialogueStateComponent>())
+        << "test setup invariant: state must still be live for this to exercise the guard.";
+
+    EXPECT_NO_FATAL_FAILURE(dialogueSystem->AdvanceDialogue(m_Speaker));
+
+    EXPECT_FALSE(m_Speaker.HasComponent<DialogueStateComponent>())
+        << "AdvanceDialogue must end the dialogue (EndDialogue removes DialogueStateComponent) "
+           "when DialogueComponent is missing, instead of dereferencing it unconditionally.";
+}

--- a/OloEngine/tests/GameplayEventBusTest.cpp
+++ b/OloEngine/tests/GameplayEventBusTest.cpp
@@ -92,6 +92,47 @@ TEST(GameplayEventBusTest, PublishWithNoSubscribersIsNoOp)
     EXPECT_EQ(bus.HandlerCount<AlphaEvent>(), 0u);
 }
 
+TEST(GameplayEventBusTest, SubscribingDuringDispatchOfSameEventTypeDoesNotCrashOrCorruptIteration)
+{
+    // A handler that lazily subscribes another handler for the SAME event
+    // type mid-Publish() used to reallocate the handler vector out from under
+    // the range-for loop iterating it (dangling iterators). No current engine
+    // caller does this, but the bus's own contract doesn't forbid it, so it
+    // must be safe.
+    GameplayEventBus bus;
+    std::vector<int> order;
+    bool resubscribed = false;
+
+    bus.Subscribe<AlphaEvent>(
+        [&](const AlphaEvent& e)
+        {
+            order.push_back(1);
+            if (!resubscribed)
+            {
+                resubscribed = true;
+                bus.Subscribe<AlphaEvent>([&](const AlphaEvent&)
+                                          { order.push_back(99); });
+            }
+        });
+    bus.Subscribe<AlphaEvent>([&](const AlphaEvent&)
+                              { order.push_back(2); });
+
+    EXPECT_NO_THROW(bus.Publish(AlphaEvent{ 0 }));
+
+    // The handler subscribed mid-dispatch must not itself fire during this
+    // same Publish() — only the two handlers present at the start of the
+    // loop do — but it must be registered correctly for the next Publish().
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 2);
+    EXPECT_EQ(bus.HandlerCount<AlphaEvent>(), 3u);
+
+    order.clear();
+    bus.Publish(AlphaEvent{ 0 });
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[2], 99);
+}
+
 TEST(GameplayEventBusTest, ClearDropsAllSubscriptions)
 {
     GameplayEventBus bus;

--- a/OloEngine/tests/UI/RuntimeInputRebindMenuTest.cpp
+++ b/OloEngine/tests/UI/RuntimeInputRebindMenuTest.cpp
@@ -13,6 +13,7 @@
 #include "OloEngine/Core/InputAction.h"
 #include "OloEngine/Core/InputActionManager.h"
 #include "OloEngine/Core/KeyCodes.h"
+#include "OloEngine/Events/KeyEvent.h"
 #include "OloEngine/Scene/Components.h"
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Scene.h"
@@ -169,4 +170,24 @@ TEST_F(RuntimeInputRebindMenuTest, OpenSuppressesUINavigationAndCloseRestoresIt)
     EXPECT_TRUE(m_Scene->GetUINavigation().IsInputSuppressed());
     m_Menu.Close();
     EXPECT_FALSE(m_Scene->GetUINavigation().IsInputSuppressed());
+}
+
+TEST_F(RuntimeInputRebindMenuTest, EscapeCancelsGamepadCaptureEvenThoughOnlyKeyboardMouseIsPolled)
+{
+    // Enter gamepad capture (the "Pad" button path) — the overlay tells the
+    // player "(Esc to cancel)" but PollGamepad() never sees keyboard input,
+    // and the old OnEvent() early-returned unless GetCaptureMode() was
+    // KeyboardMouse, so Escape used to be silently dropped with no
+    // controller connected. It must now cancel just the capture, not close
+    // the whole menu.
+    m_Menu.Controller().BeginCaptureNew("Jump", /*gamepad=*/true);
+    ASSERT_TRUE(m_Menu.Controller().IsCapturing());
+    ASSERT_EQ(m_Menu.Controller().GetCaptureMode(), InputRebindController::CaptureMode::Gamepad);
+
+    KeyPressedEvent escapeEvent(Key::Escape);
+    const bool handled = m_Menu.OnEvent(escapeEvent);
+
+    EXPECT_TRUE(handled);
+    EXPECT_FALSE(m_Menu.Controller().IsCapturing());
+    EXPECT_TRUE(m_Menu.IsOpen()) << "Escape must cancel only the in-progress capture, not the whole menu.";
 }


### PR DESCRIPTION
## Summary

Three small, verified latent robustness/UX bugs found in a `/start-work` review sweep (not pre-existing GitHub issues), grouped into one PR since each is a one-file, few-line guard fix:

- **Dialogue** — `DialogueSystem::AdvanceDialogue` and `ProcessNode` dereferenced `DialogueComponent` unconditionally, unlike `EndDialogue` which correctly guards with `HasComponent<DialogueComponent>()`. If the component is removed mid-conversation (editor remove-component button, script, or gameplay logic), the next `AdvanceDialogue`/`SelectChoice` hit an EnTT assert in debug / UB in release. Both call sites now guard the same way and fall through to `EndDialogue`.
- **Gameplay** — `GameplayEventBus::Publish` iterated its handler vector by reference (`for (auto const& handler : it->second)`); a handler that calls `Subscribe<E>()` for the same event type mid-dispatch could reallocate the vector and invalidate the iteration. No current caller does this, but the bus's own contract didn't forbid it. `Publish` now iterates by index over a snapshotted count, safe against reallocation, with a handler subscribed mid-dispatch deferred to the next `Publish()` call.
- **UI** — `RuntimeInputRebindMenu::OnEvent` only handled `Escape` in `KeyboardMouse` capture mode, so the "(Esc to cancel)" text shown during gamepad-button capture was a dead affordance — with no controller connected, there was no way to cancel just the capture (only F1, which closes the whole menu). `OnEvent` now intercepts Escape whenever `IsCapturing()` is true, ahead of the mode guard, and cancels just the capture.

No pre-existing issue/TODO backs this batch (review-sourced, not GitHub-issue-sourced), so there's nothing to close on merge.

## Test plan

- [x] New Functional test `DialogueAdvanceGuardsRemovedComponentTest` — removes `DialogueComponent` mid-conversation, asserts `AdvanceDialogue` ends the dialogue cleanly instead of asserting.
- [x] New `GameplayEventBusTest` case — subscribes to the same event type from within a handler during `Publish`, asserts no crash and correct deferred registration.
- [x] New `RuntimeInputRebindMenuTest` case — enters gamepad capture, feeds a `KeyPressedEvent(Escape)`, asserts `!IsCapturing()` and `IsOpen()`.
- [x] Full `OloEngine-Tests` suite: 4270 passed, 5 skipped (expected — app-launch/video/MCP smoke tests needing external processes/hardware), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)