### PR TITLE
editor: select bone's entity in hierarchy when clicked in Animation panel

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -2625,6 +2625,10 @@ namespace OloEngine
                                                                {
             m_CinematicTimelinePanel.OpenSequence(handle);
             m_ShowCinematicTimeline = true; });
+
+        // Clicking a bone in the Animation panel's Bone Hierarchy selects its entity.
+        m_AnimationPanel.SetSelectBoneEntityCallback([this](Entity boneEntity)
+                                                     { m_SceneHierarchyPanel.SetSelectedEntity(boneEntity); });
     }
 
     void EditorLayer::NewProject()

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -1745,7 +1745,16 @@ namespace OloEngine
         // Animation Panel
         if (m_ShowAnimationPanel)
         {
-            m_AnimationPanel.SetSelectedEntity(m_SceneHierarchyPanel.GetSelectedEntity());
+            // Only follow the hierarchy selection when it can actually be animated.
+            // A bone click drives hierarchy selection to the bone's own entity (via
+            // SetSelectBoneEntityCallback), which normally has neither component - so
+            // blindly re-syncing here would overwrite the panel's animated entity and
+            // flip it to the empty state on the very next frame.
+            if (Entity hierarchySelection = m_SceneHierarchyPanel.GetSelectedEntity();
+                hierarchySelection && (hierarchySelection.HasComponent<AnimationStateComponent>() || hierarchySelection.HasComponent<SkeletonComponent>()))
+            {
+                m_AnimationPanel.SetSelectedEntity(hierarchySelection);
+            }
             m_AnimationPanel.OnImGuiRender(&m_ShowAnimationPanel);
         }
 

--- a/OloEditor/src/Panels/AnimationPanel.cpp
+++ b/OloEditor/src/Panels/AnimationPanel.cpp
@@ -465,7 +465,17 @@ namespace OloEngine
                     // Show parent info in tooltip
                     if (ImGui::Selectable(displayName.c_str()))
                     {
-                        // TODO(olbu): Select bone entity in hierarchy when clicked (#593)
+                        if (m_SelectBoneEntityCallback && entity.HasComponent<AnimationStateComponent>())
+                        {
+                            const auto& animState = entity.GetComponent<AnimationStateComponent>();
+                            if (i < animState.m_BoneEntityIds.size())
+                            {
+                                if (Entity boneEntity = m_Context->GetEntityByUUID(animState.m_BoneEntityIds[i]))
+                                {
+                                    m_SelectBoneEntityCallback(boneEntity);
+                                }
+                            }
+                        }
                     }
 
                     // Tooltip with bone details

--- a/OloEditor/src/Panels/AnimationPanel.h
+++ b/OloEditor/src/Panels/AnimationPanel.h
@@ -4,6 +4,8 @@
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/Entity.h"
 
+#include <functional>
+
 namespace OloEngine
 {
     class CommandHistory;
@@ -19,6 +21,13 @@ namespace OloEngine
         void SetCommandHistory(CommandHistory* history)
         {
             m_CommandHistory = history;
+        }
+
+        // Set by EditorLayer: select a bone's entity in the Scene Hierarchy panel
+        // when the bone is clicked in the Bone Hierarchy list.
+        void SetSelectBoneEntityCallback(std::function<void(Entity)> cb)
+        {
+            m_SelectBoneEntityCallback = std::move(cb);
         }
 
         void OnImGuiRender(bool* p_open = nullptr);
@@ -55,6 +64,7 @@ namespace OloEngine
         Ref<Scene> m_Context;
         Entity m_SelectedEntity;
         CommandHistory* m_CommandHistory = nullptr;
+        std::function<void(Entity)> m_SelectBoneEntityCallback;
 
         // Playback state
         bool m_IsPlaying = false;


### PR DESCRIPTION
## Summary
- Resolves the stubbed TODO at `AnimationPanel.cpp:468` — clicking a bone in the Animation panel's Bone Hierarchy list now selects its scene entity in the Scene Hierarchy panel.
- Bone→entity resolution: `AnimationStateComponent::m_BoneEntityIds` is index-parallel to the skeleton's bone list; the clicked bone index resolves via `Scene::GetEntityByUUID`.
- Selection plumbing mirrors the existing `SceneHierarchyPanel::SetOpenCinematicTimelineCallback` pattern — added `AnimationPanel::SetSelectBoneEntityCallback(std::function<void(Entity)>)`, wired in `EditorLayer::OnAttach` to call `SceneHierarchyPanel::SetSelectedEntity`. No new selection channel was invented.

Closes #593

## Test plan
- [x] `cmake --build build --target OloEditor --config Debug` — succeeds cleanly, no new warnings.
- [x] Editor launches and renders correctly (verified via screenshot capture).
- [ ] Manual click-test not performed this session: open a scene with a skeletal rig, Animation panel → Bone Hierarchy → click a bone → confirm Scene Hierarchy selection jumps to that bone's entity. The automation used for editor verification has no input-injection capability yet (see follow-up filed on #607).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting a bone in the Animation panel now automatically selects the corresponding entity in the Scene Hierarchy.
  * Bone selection stays synchronized between the animation hierarchy and scene view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->