### PR TITLE
feat(asset): BC6H (HDR) texture compression + asset-pack auto-cook (#440)

### DIFF
--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -156,6 +156,7 @@ target_include_directories(OloEngine PRIVATE
 target_link_libraries(OloEngine
 	assimp
 	bc7enc
+	bcdec
 	box2d
 	choc
 	Detour

--- a/OloEngine/src/OloEngine/Asset/AssetPackBuilder.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetPackBuilder.cpp
@@ -230,8 +230,25 @@ namespace OloEngine
             // The index table starts immediately after the header
             assetPackFile.Header.IndexOffset = sizeof(AssetPackFile::FileHeader);
 
-            // Serialize all assets
-            OLO_CORE_INFO("AssetPackBuilder: Serializing assets...");
+            // Serialize all assets. Enable the texture cook policy (#440) for the duration
+            // of serialization so uncompressed source textures get BC-compressed into
+            // embedded .olotex blobs when m_CompressAssets is set. The guard resets it on
+            // every exit path (success, error, or the exception handler below).
+            OLO_CORE_INFO("AssetPackBuilder: Serializing assets... (texture compression: {})", settings.m_CompressAssets ? "on" : "off");
+            struct TextureCookScope
+            {
+                explicit TextureCookScope(bool enabled)
+                {
+                    TextureSerializer::SetAssetPackCompressionEnabled(enabled);
+                }
+                ~TextureCookScope()
+                {
+                    TextureSerializer::SetAssetPackCompressionEnabled(false);
+                }
+                TextureCookScope(const TextureCookScope&) = delete;
+                TextureCookScope& operator=(const TextureCookScope&) = delete;
+            } cookScope(settings.m_CompressAssets);
+
             if (!SerializeAllAssets(assetManager, assetPackFile, progress, cancelToken))
             {
                 result.m_ErrorMessage = "Failed to serialize assets or build was cancelled";

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -321,8 +321,12 @@ namespace OloEngine
         // so the build never fails just because one texture couldn't be compressed.
         CompressedTextureImage cooked;
         bool haveCooked = false;
+        // Non-throwing existence check: a filesystem error (permissions, bad path) must
+        // fall through to the uncompressed raw record, never propagate an exception up to
+        // BuildImpl and abort the whole pack build over one texture.
+        std::error_code existsEc;
         if (IsAssetPackCompressionEnabled() && !IsCompressedFormat(spec.Format) &&
-            !path.empty() && !IsOloTexPath(path) && std::filesystem::exists(path))
+            !path.empty() && !IsOloTexPath(path) && std::filesystem::exists(path, existsEc))
         {
             TextureCompression::CompressOptions opts;
             opts.GenerateMips = spec.GenerateMips;

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -74,6 +74,18 @@ namespace OloEngine
     // TextureSerializer
     //////////////////////////////////////////////////////////////////////////////////
 
+    std::atomic<bool> TextureSerializer::s_AssetPackCompressionEnabled{ false };
+
+    void TextureSerializer::SetAssetPackCompressionEnabled(bool enabled)
+    {
+        s_AssetPackCompressionEnabled.store(enabled, std::memory_order_relaxed);
+    }
+
+    bool TextureSerializer::IsAssetPackCompressionEnabled()
+    {
+        return s_AssetPackCompressionEnabled.load(std::memory_order_relaxed);
+    }
+
     bool TextureSerializer::IsLikelyColorTextureByName(std::string_view filename)
     {
         // Single source of truth for the colour/linear heuristic, shared with the
@@ -297,19 +309,56 @@ namespace OloEngine
 
         outInfo.Offset = stream.GetStreamPosition();
 
-        // Write texture metadata
         const auto& spec = texture->GetSpecification();
+        const std::string& path = texture->GetPath();
+
+        // Auto-cook (#440): when pack compression is enabled and this is an UNcompressed
+        // source texture (not already an .olotex), BC-compress it in-memory and embed the
+        // resulting container — so shipped textures get BCn + mips automatically, with no
+        // separate cook step. Format is auto-picked (BC7 for LDR colour/linear, BC6H for
+        // HDR; BC5 stays a deliberate opt-in via a pre-cooked .olotex). A cook failure
+        // (no source file on disk, unsupported image) falls back to the raw record below,
+        // so the build never fails just because one texture couldn't be compressed.
+        CompressedTextureImage cooked;
+        bool haveCooked = false;
+        if (IsAssetPackCompressionEnabled() && !IsCompressedFormat(spec.Format) &&
+            !path.empty() && !IsOloTexPath(path) && std::filesystem::exists(path))
+        {
+            TextureCompression::CompressOptions opts;
+            opts.GenerateMips = spec.GenerateMips;
+            if (TextureCompression::CompressImageFile(path, opts, cooked) && cooked.IsValid())
+                haveCooked = true;
+            else
+                OLO_CORE_WARN("TextureSerializer::SerializeToAssetPack - cook failed for '{}'; shipping it uncompressed", path);
+        }
+
+        // The record's ImageFormat: the cooked BCn format if we cooked, else the live
+        // texture's format. The runtime deserialize keys the embedded-blob read path off
+        // IsCompressedFormat(format), so a cooked record reuses the exact same read path
+        // as a pre-compressed .olotex — no runtime change needed.
+        ImageFormat recordFormat = spec.Format;
+        bool recordSRGB = spec.SRGB;
+        bool recordHasAlpha = texture->HasAlphaChannel();
+        bool recordGenerateMips = spec.GenerateMips;
+        if (haveCooked)
+        {
+            recordFormat = (cooked.Format == TextureCompressionFormat::BC5)    ? ImageFormat::BC5
+                           : (cooked.Format == TextureCompressionFormat::BC6H) ? ImageFormat::BC6H
+                                                                               : ImageFormat::BC7;
+            recordSRGB = cooked.SRGB;
+            recordHasAlpha = cooked.HasAlpha;
+            recordGenerateMips = cooked.MipLevels() > 1u;
+        }
+
+        // Write texture metadata (layout shared with the pre-compressed path; the srgb
+        // byte and any embedded blob are appended last to keep the uncompressed record
+        // byte-identical to the legacy layout).
         stream.WriteRaw<u32>(spec.Width);
         stream.WriteRaw<u32>(spec.Height);
-        stream.WriteRaw<u32>(static_cast<u32>(std::to_underlying(spec.Format)));
-        stream.WriteRaw<bool>(spec.GenerateMips);
-
-        // Write texture path for reference
-        const std::string& path = texture->GetPath();
-        stream.WriteString(path);
-
-        // Write additional metadata for better texture recreation
-        stream.WriteRaw<bool>(texture->HasAlphaChannel());
+        stream.WriteRaw<u32>(static_cast<u32>(std::to_underlying(recordFormat)));
+        stream.WriteRaw<bool>(recordGenerateMips);
+        stream.WriteString(path); // source path (unused by the compressed read path)
+        stream.WriteRaw<bool>(recordHasAlpha);
         stream.WriteRaw<bool>(texture->IsLoaded());
 
         // Add texture creation timestamp for dependency tracking
@@ -317,25 +366,27 @@ namespace OloEngine
         auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
         stream.WriteRaw<i64>(timestamp);
 
-        // Persist the sRGB flag so the pack round-trip preserves colour-space.
-        // Without this the deserializer falls back to the linear default and
-        // every albedo / emissive shipped through an .olopack loses its
-        // GL_SRGB8_ALPHA8 conversion.
-        stream.WriteRaw<bool>(spec.SRGB);
+        // Persist the sRGB flag so the pack round-trip preserves colour-space. Without
+        // this the deserializer falls back to the linear default and every albedo /
+        // emissive shipped through an .olopack loses its GL_SRGB8_ALPHA8 conversion.
+        stream.WriteRaw<bool>(recordSRGB);
 
         // Block-compressed textures (#440) cannot be re-created from the path via
-        // stb_image, and the spec-only path produces empty storage — so embed the whole
-        // .olotex container blob here, making the pack self-contained. The bytes are the
-        // exact on-disk container; re-read them from the source path (set as GetPath()
-        // by the .olotex loader). Appended AFTER srgb so the legacy record layout for
+        // stb_image, so embed the whole .olotex container blob here, making the pack
+        // self-contained. For a just-cooked texture that blob is the in-memory container;
+        // for a pre-compressed (.olotex) texture it is the exact on-disk bytes re-read
+        // from the source path. Appended AFTER srgb so the legacy record layout for
         // uncompressed textures is byte-identical.
-        if (IsCompressedFormat(spec.Format))
+        if (IsCompressedFormat(recordFormat))
         {
-            const std::string& oloTexPath = texture->GetPath();
             std::vector<u8> blob;
-            if (!oloTexPath.empty())
+            if (haveCooked)
             {
-                std::ifstream file(oloTexPath, std::ios::binary | std::ios::ate);
+                blob = TextureCompression::SerializeToBlob(cooked);
+            }
+            else if (!path.empty())
+            {
+                std::ifstream file(path, std::ios::binary | std::ios::ate);
                 if (file)
                 {
                     const std::streamsize sz = file.tellg();
@@ -351,7 +402,7 @@ namespace OloEngine
             }
             if (blob.empty())
             {
-                OLO_CORE_ERROR("TextureSerializer::SerializeToAssetPack - could not read .olotex blob for '{}'; packed texture would be empty", oloTexPath);
+                OLO_CORE_ERROR("TextureSerializer::SerializeToAssetPack - no .olotex blob for '{}'; packed texture would be empty", path);
                 return false;
             }
             stream.WriteRaw<u64>(static_cast<u64>(blob.size()));

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <string_view>
 #include <filesystem>
@@ -161,6 +162,17 @@ namespace OloEngine
         // bytes encode colour (albedo / emissive) or linear data (normal /
         // metallic / roughness / AO / height). Returns true for colour.
         [[nodiscard]] static bool IsLikelyColorTextureByName(std::string_view filename);
+
+        // Asset-pack cook policy (#440). When enabled, SerializeToAssetPack BC-compresses
+        // an uncompressed source texture (BC7 for colour/linear, BC6H for HDR) into an
+        // embedded .olotex instead of shipping the raw image path. AssetPackBuilder sets
+        // this from BuildSettings::m_CompressAssets around a pack build (single-threaded;
+        // reset to false afterwards). Already-compressed (.olotex) textures are unaffected.
+        static void SetAssetPackCompressionEnabled(bool enabled);
+        [[nodiscard]] static bool IsAssetPackCompressionEnabled();
+
+      private:
+        static std::atomic<bool> s_AssetPackCompressionEnabled;
     };
 
     class FontSerializer : public AssetSerializer

--- a/OloEngine/src/OloEngine/Renderer/Texture.h
+++ b/OloEngine/src/OloEngine/Renderer/Texture.h
@@ -36,14 +36,15 @@ namespace OloEngine
         // rather than a client pixel format; the sRGB variant of BC7 is selected from
         // TextureSpecification::SRGB. Appended to preserve legacy serialised values.
         BC7, // BPTC RGBA — base color / albedo / emissive
-        BC5  // RGTC2 two-channel — tangent-space normal xy
+        BC5, // RGTC2 two-channel — tangent-space normal xy
+        BC6H // BPTC RGB half-float (unsigned) — HDR environment / IBL / emissive
     };
 
     // True for the block-compressed ImageFormat values, which take the
     // glCompressedTextureSubImage2D upload path instead of a client pixel format.
     [[nodiscard]] constexpr bool IsCompressedFormat(ImageFormat format) noexcept
     {
-        return format == ImageFormat::BC7 || format == ImageFormat::BC5;
+        return format == ImageFormat::BC7 || format == ImageFormat::BC5 || format == ImageFormat::BC6H;
     }
 
     struct TextureSpecification

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -11,16 +11,28 @@
 #include <bc7decomp.h>
 #include <rgbcx.h>
 
+// bcdec: independent single-header BC6H reference decoder (used to validate our
+// from-scratch BC6H encoder and as the CPU HDR fallback). The single-TU implementation
+// is emitted here; the SYSTEM include suppresses its warnings, as with stb below.
+#define BCDEC_IMPLEMENTATION
+#include <bcdec.h>
+
 // stb_image is only *declared* here — STB_IMAGE_IMPLEMENTATION lives in
 // Platform/OpenGL/OpenGLTexture.cpp, which provides the definitions at link time.
 #include <stb_image/stb_image.h>
 
+// glm::packHalf1x16 — float -> IEEE half bit pattern, used to build BC6H encode targets.
+#include <glm/gtc/packing.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <mutex>
 
 namespace OloEngine
@@ -205,6 +217,337 @@ namespace OloEngine
             }
             return levels;
         }
+
+        // ---- BC6H (unsigned, mode 11) cook helpers ---------------------------
+        // BC6H packs RGB half-float into 16-byte 4x4 blocks. We emit only "mode 11":
+        // 1 subset, two 10-bit endpoints stored raw (no delta), 4-bit interpolation
+        // indices. The decode chain (matched to the vendored bcdec reference, which the
+        // round-trip test cross-checks) is: unquantize each 10-bit endpoint component to
+        // 16-bit, interpolate with the 4-bit index, then scale by 31/64 to get the
+        // half-float bit pattern. The encoder inverts that chain.
+
+        // BC6H 4-bit interpolation weights (index -> weight, /64). Exactly the bcdec /
+        // D3D "aWeight4" table — note index 13 is 55, NOT 56 (the table is not perfectly
+        // symmetric, which is why the anchor swap below re-selects indices instead of
+        // just inverting them).
+        constexpr std::array<i32, 16> kBC6HWeights4 = {
+            0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64
+        };
+
+        constexpr i32 kBC6HEndpointMax = 1023; // 10-bit endpoint precision
+        constexpr f32 kMaxFiniteHalf = 65504.0f;
+
+        // Unsigned unquantize of a 10-bit endpoint component to 16-bit (matches
+        // bcdec__unquantize with bits==10, isSigned==0).
+        i32 Bc6hUnquantizeUnsigned(i32 comp)
+        {
+            if (comp <= 0)
+                return 0;
+            if (comp >= kBC6HEndpointMax)
+                return 0xFFFF;
+            return ((comp << 16) + 0x8000) >> 10;
+        }
+
+        // Nearest 10-bit endpoint whose unquantized value best matches `target16` (a
+        // 16-bit interpolation-space value). unquantize is ~linear (comp*64), so start
+        // from target/64 and check the 3-wide neighbourhood for the exact nearest.
+        i32 Bc6hQuantizeEndpointUnsigned(i32 target16)
+        {
+            target16 = std::clamp(target16, 0, 0xFFFF);
+            const i32 guess = std::clamp(target16 >> 6, 0, kBC6HEndpointMax);
+            i32 best = guess;
+            i32 bestErr = std::abs(Bc6hUnquantizeUnsigned(guess) - target16);
+            for (i32 c = std::max(0, guess - 1); c <= std::min(kBC6HEndpointMax, guess + 1); ++c)
+            {
+                const i32 err = std::abs(Bc6hUnquantizeUnsigned(c) - target16);
+                if (err < bestErr)
+                {
+                    bestErr = err;
+                    best = c;
+                }
+            }
+            return best;
+        }
+
+        // Interpolate two unquantized 16-bit endpoints with a 4-bit index (matches
+        // bcdec__interpolate).
+        i32 Bc6hInterpolate(i32 a, i32 b, i32 index)
+        {
+            return (a * (64 - kBC6HWeights4[index]) + b * kBC6HWeights4[index] + 32) >> 6;
+        }
+
+        // Convert a source HDR float to the 16-bit interpolation-space target the decoder
+        // works in: clamp to non-negative (unsigned BC6H) and to the max finite half, take
+        // its half-float bit pattern (the value finish_unquantize must reproduce), then
+        // invert finish_unquantize ( half = (interp*31)>>6 ).
+        i32 Bc6hFloatToInterpTarget(f32 value)
+        {
+            if (!std::isfinite(value))
+                value = value > 0.0f ? kMaxFiniteHalf : 0.0f;
+            value = std::clamp(value, 0.0f, kMaxFiniteHalf);
+            const u32 halfBits = static_cast<u32>(::glm::packHalf1x16(value)) & 0xFFFFu; // -> [0, 0x7BFF]
+            const i32 interp = static_cast<i32>((static_cast<i64>(halfBits) * 64 + 15) / 31);
+            return std::clamp(interp, 0, 0xFFFF);
+        }
+
+        // Little-endian, LSB-first bit writer over a fixed 16-byte block.
+        struct Bc6hBitWriter
+        {
+            std::array<u8, 16>& Data;
+            u32 Pos = 0;
+            void Put(u32 value, u32 bits)
+            {
+                for (u32 i = 0; i < bits; ++i)
+                {
+                    if ((value >> i) & 1u)
+                        Data[Pos >> 3] |= static_cast<u8>(1u << (Pos & 7u));
+                    ++Pos;
+                }
+            }
+        };
+
+        // Expand tightly-packed `channels`-per-texel float source to RGB (3 floats/texel).
+        // channels>=3 keeps R,G,B (extra dropped); 2 -> R,G,0; 1 -> R,R,R.
+        std::vector<f32> ExpandToRGBFloat(const f32* pixels, u32 width, u32 height, u32 channels)
+        {
+            const sizet texelCount = static_cast<sizet>(width) * height;
+            std::vector<f32> rgb(texelCount * 3);
+            for (sizet i = 0; i < texelCount; ++i)
+            {
+                const f32* src = pixels + i * channels;
+                f32* dst = rgb.data() + i * 3;
+                dst[0] = src[0];
+                dst[1] = channels >= 2 ? src[1] : src[0];
+                dst[2] = channels >= 3 ? src[2] : (channels == 1 ? src[0] : 0.0f);
+            }
+            return rgb;
+        }
+
+        // Box-filter downsample an RGB-float image to half size. HDR data is already
+        // linear, so a plain average is correct (unlike the gamma-naive 8-bit path).
+        std::vector<f32> DownsampleRGBFloat(const std::vector<f32>& src, u32 width, u32 height, u32& outW, u32& outH)
+        {
+            outW = std::max(1u, width / 2);
+            outH = std::max(1u, height / 2);
+            std::vector<f32> dst(static_cast<sizet>(outW) * outH * 3);
+            for (u32 y = 0; y < outH; ++y)
+            {
+                const u32 sy0 = std::min(y * 2, height - 1);
+                const u32 sy1 = std::min(y * 2 + 1, height - 1);
+                for (u32 x = 0; x < outW; ++x)
+                {
+                    const u32 sx0 = std::min(x * 2, width - 1);
+                    const u32 sx1 = std::min(x * 2 + 1, width - 1);
+                    const f32* p00 = &src[(static_cast<sizet>(sy0) * width + sx0) * 3];
+                    const f32* p01 = &src[(static_cast<sizet>(sy0) * width + sx1) * 3];
+                    const f32* p10 = &src[(static_cast<sizet>(sy1) * width + sx0) * 3];
+                    const f32* p11 = &src[(static_cast<sizet>(sy1) * width + sx1) * 3];
+                    f32* d = &dst[(static_cast<sizet>(y) * outW + x) * 3];
+                    for (u32 c = 0; c < 3; ++c)
+                        d[c] = (p00[c] + p01[c] + p10[c] + p11[c]) * 0.25f;
+                }
+            }
+            return dst;
+        }
+
+        // Gather the 4x4 block at (blockX, blockY) from an RGB-float image into 48
+        // contiguous floats (16 texel x RGB), clamping to the edge for partial blocks.
+        void GatherBlockRGBFloat(const std::vector<f32>& rgb, u32 width, u32 height, u32 blockX, u32 blockY,
+                                 std::array<f32, 48>& outBlock)
+        {
+            for (u32 ry = 0; ry < 4; ++ry)
+            {
+                const u32 sy = std::min(blockY * 4 + ry, height - 1);
+                for (u32 rx = 0; rx < 4; ++rx)
+                {
+                    const u32 sx = std::min(blockX * 4 + rx, width - 1);
+                    const f32* src = &rgb[(static_cast<sizet>(sy) * width + sx) * 3];
+                    f32* dst = &outBlock[(static_cast<sizet>(ry) * 4 + rx) * 3];
+                    dst[0] = src[0];
+                    dst[1] = src[1];
+                    dst[2] = src[2];
+                }
+            }
+        }
+
+        // Encode one 4x4 block of RGB floats (48 contiguous floats, row-major R,G,B) to a
+        // 16-byte unsigned-BC6H mode-11 block.
+        void EncodeBC6HBlockUnsigned(u8* dst, const f32* blockRGB)
+        {
+            // 1. Source -> interpolation-space targets (16 texels x RGB).
+            std::array<std::array<i32, 3>, 16> target{};
+            for (u32 t = 0; t < 16; ++t)
+                for (u32 c = 0; c < 3; ++c)
+                    target[t][c] = Bc6hFloatToInterpTarget(blockRGB[t * 3 + c]);
+
+            // 2. Endpoints: bounding box, then tightened to the extreme projections along
+            //    the box diagonal (a cheap PCA-lite that fits smooth HDR gradients well).
+            std::array<i32, 3> bbMin = { 0xFFFF, 0xFFFF, 0xFFFF };
+            std::array<i32, 3> bbMax = { 0, 0, 0 };
+            for (const auto& tx : target)
+                for (u32 c = 0; c < 3; ++c)
+                {
+                    bbMin[c] = std::min(bbMin[c], tx[c]);
+                    bbMax[c] = std::max(bbMax[c], tx[c]);
+                }
+            const std::array<i64, 3> axis = { bbMax[0] - bbMin[0], bbMax[1] - bbMin[1], bbMax[2] - bbMin[2] };
+            std::array<i32, 3> ep0 = bbMin;
+            std::array<i32, 3> ep1 = bbMax;
+            if (axis[0] != 0 || axis[1] != 0 || axis[2] != 0)
+            {
+                i64 minProj = std::numeric_limits<i64>::max();
+                i64 maxProj = std::numeric_limits<i64>::min();
+                u32 minTexel = 0;
+                u32 maxTexel = 0;
+                for (u32 t = 0; t < 16; ++t)
+                {
+                    i64 proj = 0;
+                    for (u32 c = 0; c < 3; ++c)
+                        proj += axis[c] * (target[t][c] - bbMin[c]);
+                    if (proj < minProj)
+                    {
+                        minProj = proj;
+                        minTexel = t;
+                    }
+                    if (proj > maxProj)
+                    {
+                        maxProj = proj;
+                        maxTexel = t;
+                    }
+                }
+                ep0 = target[minTexel];
+                ep1 = target[maxTexel];
+            }
+
+            // 3. Per-texel index selection minimizing squared error across RGB (the index
+            //    is shared by the three channels); returns the block's total error so the
+            //    refinement loop can compare candidates. Reused by the anchor fixup.
+            const auto selectIndices = [&](const std::array<i32, 3>& a, const std::array<i32, 3>& b,
+                                           std::array<i32, 16>& out) -> i64
+            {
+                i64 total = 0;
+                for (u32 t = 0; t < 16; ++t)
+                {
+                    i64 bestErr = std::numeric_limits<i64>::max();
+                    i32 bestIdx = 0;
+                    for (i32 w = 0; w < 16; ++w)
+                    {
+                        i64 err = 0;
+                        for (u32 c = 0; c < 3; ++c)
+                        {
+                            const i64 d = static_cast<i64>(Bc6hInterpolate(a[c], b[c], w)) - target[t][c];
+                            err += d * d;
+                        }
+                        if (err < bestErr)
+                        {
+                            bestErr = err;
+                            bestIdx = w;
+                        }
+                    }
+                    out[t] = bestIdx;
+                    total += bestErr;
+                }
+                return total;
+            };
+
+            // Quantize an interp-space endpoint pair to 10-bit and recompute the values the
+            // decoder will actually interpolate between.
+            const auto quantizePair = [](const std::array<i32, 3>& e0, const std::array<i32, 3>& e1,
+                                         std::array<i32, 3>& q0, std::array<i32, 3>& q1,
+                                         std::array<i32, 3>& u0, std::array<i32, 3>& u1)
+            {
+                for (u32 c = 0; c < 3; ++c)
+                {
+                    q0[c] = Bc6hQuantizeEndpointUnsigned(e0[c]);
+                    q1[c] = Bc6hQuantizeEndpointUnsigned(e1[c]);
+                    u0[c] = Bc6hUnquantizeUnsigned(q0[c]);
+                    u1[c] = Bc6hUnquantizeUnsigned(q1[c]);
+                }
+            };
+
+            std::array<i32, 3> q0{}, q1{}, u0{}, u1{};
+            quantizePair(ep0, ep1, q0, q1, u0, u1);
+            std::array<i32, 16> indices{};
+            i64 bestTotal = selectIndices(u0, u1, indices);
+
+            // 4. Refine: alternate a least-squares endpoint fit (given the current indices)
+            //    with index re-selection. interp = A*(1 - w/64) + B*(w/64) is linear in the
+            //    two endpoints, so per channel this is a 2x2 normal-equation solve. Keep a
+            //    step only if it lowers total error, so refinement can never regress a block
+            //    (this closes most of the gap a single-segment mode-11 fit leaves on curved
+            //    HDR gradients; a multi-mode / PCA encoder is a deferred follow-up).
+            for (u32 iter = 0; iter < 2; ++iter)
+            {
+                std::array<i32, 3> rep0{}, rep1{};
+                for (u32 c = 0; c < 3; ++c)
+                {
+                    f64 a00 = 0.0, a01 = 0.0, a11 = 0.0, rhs0 = 0.0, rhs1 = 0.0;
+                    for (u32 t = 0; t < 16; ++t)
+                    {
+                        const f64 wgt = static_cast<f64>(kBC6HWeights4[indices[t]]) / 64.0;
+                        const f64 s = 1.0 - wgt;
+                        a00 += s * s;
+                        a01 += s * wgt;
+                        a11 += wgt * wgt;
+                        rhs0 += s * static_cast<f64>(target[t][c]);
+                        rhs1 += wgt * static_cast<f64>(target[t][c]);
+                    }
+                    const f64 det = a00 * a11 - a01 * a01;
+                    if (std::abs(det) < 1e-6)
+                    {
+                        // Degenerate (every index identical): keep the current endpoints.
+                        rep0[c] = u0[c];
+                        rep1[c] = u1[c];
+                    }
+                    else
+                    {
+                        const f64 endA = (rhs0 * a11 - rhs1 * a01) / det;
+                        const f64 endB = (rhs1 * a00 - rhs0 * a01) / det;
+                        rep0[c] = std::clamp(static_cast<i32>(std::lround(endA)), 0, 0xFFFF);
+                        rep1[c] = std::clamp(static_cast<i32>(std::lround(endB)), 0, 0xFFFF);
+                    }
+                }
+                std::array<i32, 3> nq0{}, nq1{}, nu0{}, nu1{};
+                quantizePair(rep0, rep1, nq0, nq1, nu0, nu1);
+                std::array<i32, 16> nindices{};
+                const i64 total = selectIndices(nu0, nu1, nindices);
+                if (total >= bestTotal)
+                    break; // converged / no improvement
+                bestTotal = total;
+                q0 = nq0;
+                q1 = nq1;
+                u0 = nu0;
+                u1 = nu1;
+                indices = nindices;
+            }
+
+            // 5. Anchor fixup: index[0]'s MSB is implicit-0, so it must be < 8. If not,
+            //    swap endpoints and re-select (see the weight-table asymmetry note above).
+            if (indices[0] >= 8)
+            {
+                std::swap(q0, q1);
+                std::swap(u0, u1);
+                selectIndices(u0, u1, indices);
+                if (indices[0] >= 8)
+                    indices[0] = 7; // defensive: guarantee a legal anchor on a rare tie
+            }
+
+            // 6. Pack the mode-11 bitstream: mode(5)=0b00011, then rw,gw,bw,rx,gx,bx (each
+            //    10 bits), then indices (index 0 = 3 bits, indices 1..15 = 4 bits each).
+            std::array<u8, 16> block{};
+            Bc6hBitWriter bw{ block };
+            bw.Put(0b00011u, 5);
+            bw.Put(static_cast<u32>(q0[0]), 10);
+            bw.Put(static_cast<u32>(q0[1]), 10);
+            bw.Put(static_cast<u32>(q0[2]), 10);
+            bw.Put(static_cast<u32>(q1[0]), 10);
+            bw.Put(static_cast<u32>(q1[1]), 10);
+            bw.Put(static_cast<u32>(q1[2]), 10);
+            bw.Put(static_cast<u32>(indices[0]), 3);
+            for (u32 t = 1; t < 16; ++t)
+                bw.Put(static_cast<u32>(indices[t]), 4);
+            std::memcpy(dst, block.data(), 16);
+        }
     } // namespace
 
     namespace TextureCompression
@@ -250,6 +593,7 @@ namespace OloEngine
             {
                 case TextureCompressionFormat::BC7:
                 case TextureCompressionFormat::BC5:
+                case TextureCompressionFormat::BC6H:
                     return 16;
                 case TextureCompressionFormat::None:
                     return 0;
@@ -366,11 +710,70 @@ namespace OloEngine
             return image;
         }
 
+        CompressedTextureImage EncodeBC6H(const f32* pixels, u32 width, u32 height, u32 channels, bool generateMips)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            CompressedTextureImage image;
+            // BC6H is an HDR RGB format; require at least three channels of float source.
+            if (!pixels || width == 0 || height == 0 || channels < 3 || channels > 4)
+            {
+                OLO_CORE_ERROR("TextureCompression::EncodeBC6H - invalid input ({}x{}, {} ch; needs 3-4 channels)", width, height, channels);
+                return image;
+            }
+
+            image.Format = TextureCompressionFormat::BC6H;
+            image.Width = width;
+            image.Height = height;
+            image.SRGB = false;     // HDR is linear — never sRGB
+            image.HasAlpha = false; // BC6H is RGB only
+
+            const auto encodeLevel = [](const std::vector<f32>& rgb, u32 w, u32 h)
+            {
+                const u32 bx = BlockCount(w);
+                const u32 by = BlockCount(h);
+                std::vector<u8> out(static_cast<sizet>(bx) * by * 16);
+                std::array<f32, 48> block{};
+                for (u32 y = 0; y < by; ++y)
+                {
+                    for (u32 x = 0; x < bx; ++x)
+                    {
+                        GatherBlockRGBFloat(rgb, w, h, x, y, block);
+                        EncodeBC6HBlockUnsigned(out.data() + (static_cast<sizet>(y) * bx + x) * 16, block.data());
+                    }
+                }
+                return out;
+            };
+
+            std::vector<f32> level = ExpandToRGBFloat(pixels, width, height, channels);
+            u32 mw = width;
+            u32 mh = height;
+            while (true)
+            {
+                image.Mips.push_back(encodeLevel(level, mw, mh));
+                if (!generateMips || (mw == 1 && mh == 1))
+                    break;
+                u32 nw = 0;
+                u32 nh = 0;
+                level = DownsampleRGBFloat(level, mw, mh, nw, nh);
+                mw = nw;
+                mh = nh;
+            }
+            return image;
+        }
+
         bool DecodeToRGBA8(const CompressedTextureImage& image, u32 mipLevel,
                            std::vector<u8>& outRGBA8, u32& outWidth, u32& outHeight)
         {
             if (!image.IsValid() || mipLevel >= image.MipLevels())
                 return false;
+            // BC6H is HDR (half-float); it has no meaningful 8-bit representation. Callers
+            // that need its pixels use DecodeToRGBAFloat instead.
+            if (image.Format == TextureCompressionFormat::BC6H)
+            {
+                OLO_CORE_ERROR("TextureCompression::DecodeToRGBA8 - BC6H is HDR; use DecodeToRGBAFloat");
+                return false;
+            }
 
             const u32 mw = std::max(1u, image.Width >> mipLevel);
             const u32 mh = std::max(1u, image.Height >> mipLevel);
@@ -424,6 +827,59 @@ namespace OloEngine
                             d[1] = s[1];
                             d[2] = s[2];
                             d[3] = s[3];
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        bool DecodeToRGBAFloat(const CompressedTextureImage& image, u32 mipLevel,
+                               std::vector<f32>& outRGBA, u32& outWidth, u32& outHeight)
+        {
+            if (!image.IsValid() || image.Format != TextureCompressionFormat::BC6H || mipLevel >= image.MipLevels())
+                return false;
+
+            const u32 mw = std::max(1u, image.Width >> mipLevel);
+            const u32 mh = std::max(1u, image.Height >> mipLevel);
+            outWidth = mw;
+            outHeight = mh;
+            outRGBA.assign(static_cast<sizet>(mw) * mh * 4, 0.0f);
+
+            const std::vector<u8>& blocks = image.Mips[mipLevel];
+            const u32 bxCount = BlockCount(mw);
+            const u32 byCount = BlockCount(mh);
+            if (blocks.size() < static_cast<sizet>(bxCount) * byCount * 16)
+            {
+                OLO_CORE_ERROR("TextureCompression::DecodeToRGBAFloat - mip {} block data truncated", mipLevel);
+                return false;
+            }
+
+            // bcdec writes a 4x4 block of RGB floats (row pitch in float elements = 4*3).
+            std::array<f32, 16 * 3> decoded{};
+            for (u32 by = 0; by < byCount; ++by)
+            {
+                for (u32 bx = 0; bx < bxCount; ++bx)
+                {
+                    const u8* blockPtr = blocks.data() + (static_cast<sizet>(by) * bxCount + bx) * 16;
+                    ::bcdec_bc6h_float(blockPtr, decoded.data(), 4 * 3, 0 /* unsigned */);
+
+                    for (u32 ry = 0; ry < 4; ++ry)
+                    {
+                        const u32 dy = by * 4 + ry;
+                        if (dy >= mh)
+                            break;
+                        for (u32 rx = 0; rx < 4; ++rx)
+                        {
+                            const u32 dx = bx * 4 + rx;
+                            if (dx >= mw)
+                                break;
+                            const f32* s = &decoded[(static_cast<sizet>(ry) * 4 + rx) * 3];
+                            f32* d = &outRGBA[(static_cast<sizet>(dy) * mw + dx) * 4];
+                            d[0] = s[0];
+                            d[1] = s[1];
+                            d[2] = s[2];
+                            d[3] = 1.0f;
                         }
                     }
                 }
@@ -494,7 +950,8 @@ namespace OloEngine
                 return false;
             }
             if (formatInt != static_cast<u32>(TextureCompressionFormat::BC7) &&
-                formatInt != static_cast<u32>(TextureCompressionFormat::BC5))
+                formatInt != static_cast<u32>(TextureCompressionFormat::BC5) &&
+                formatInt != static_cast<u32>(TextureCompressionFormat::BC6H))
             {
                 OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - unknown format {}", formatInt);
                 return false;
@@ -505,17 +962,20 @@ namespace OloEngine
                 return false;
             }
             // Reject non-canonical metadata: only the two defined flag bits may be set,
-            // and BC5 (two-channel normal data) can carry neither sRGB nor alpha — a blob
-            // claiming otherwise is corrupt or version-skewed, not something we produced.
+            // and only BC7 may carry sRGB or alpha. BC5 (two-channel normal data) and
+            // BC6H (linear HDR RGB) can carry neither — a blob claiming otherwise is
+            // corrupt or version-skewed, not something we produced.
             if ((flags & ~(kFlagSRGB | kFlagHasAlpha)) != 0)
             {
                 OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - unknown flag bits set ({:#x})", flags);
                 return false;
             }
-            if (static_cast<TextureCompressionFormat>(formatInt) == TextureCompressionFormat::BC5 &&
+            const auto blobFormat = static_cast<TextureCompressionFormat>(formatInt);
+            if ((blobFormat == TextureCompressionFormat::BC5 || blobFormat == TextureCompressionFormat::BC6H) &&
                 (flags & (kFlagSRGB | kFlagHasAlpha)) != 0)
             {
-                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - BC5 must not set sRGB/alpha flags ({:#x})", flags);
+                OLO_CORE_ERROR("TextureCompression::DeserializeFromBlob - {} must not set sRGB/alpha flags ({:#x})",
+                               blobFormat == TextureCompressionFormat::BC5 ? "BC5" : "BC6H", flags);
                 return false;
             }
             // Bound header fields BEFORE any allocation: a hostile/corrupt .olotex must
@@ -637,7 +1097,12 @@ namespace OloEngine
 
             TextureCompressionFormat format = options.Format;
             if (format == TextureCompressionFormat::None)
-                format = TextureCompressionFormat::BC7;
+            {
+                // An HDR source (.hdr / .exr with float data) auto-selects BC6H; everything
+                // else defaults to BC7. BC5 is never auto-chosen (deliberate normal-map opt-in).
+                format = ::stbi_is_hdr(srcImagePath.c_str()) ? TextureCompressionFormat::BC6H
+                                                             : TextureCompressionFormat::BC7;
+            }
 
             bool srgb = options.SRGB;
             if (options.AutoSRGBFromName && format == TextureCompressionFormat::BC7)
@@ -652,22 +1117,37 @@ namespace OloEngine
             int width = 0;
             int height = 0;
             int channels = 0;
-            stbi_uc* data = ::stbi_load(srcImagePath.c_str(), &width, &height, &channels, 0);
-            ::stbi_set_flip_vertically_on_load_thread(0);
-
-            if (!data)
-            {
-                OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load '{}'", srcImagePath);
-                return false;
-            }
-
             CompressedTextureImage image;
-            if (format == TextureCompressionFormat::BC5)
-                image = EncodeBC5(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), options.GenerateMips);
-            else
-                image = EncodeBC7(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), srgb, options.GenerateMips);
 
-            ::stbi_image_free(data);
+            if (format == TextureCompressionFormat::BC6H)
+            {
+                // Load HDR as float, forcing 3 components (RGB) so a 1/4-channel HDR source
+                // still feeds EncodeBC6H a well-defined RGB buffer.
+                f32* data = ::stbi_loadf(srcImagePath.c_str(), &width, &height, &channels, 3);
+                ::stbi_set_flip_vertically_on_load_thread(0);
+                if (!data)
+                {
+                    OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load HDR '{}'", srcImagePath);
+                    return false;
+                }
+                image = EncodeBC6H(data, static_cast<u32>(width), static_cast<u32>(height), 3, options.GenerateMips);
+                ::stbi_image_free(data);
+            }
+            else
+            {
+                stbi_uc* data = ::stbi_load(srcImagePath.c_str(), &width, &height, &channels, 0);
+                ::stbi_set_flip_vertically_on_load_thread(0);
+                if (!data)
+                {
+                    OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load '{}'", srcImagePath);
+                    return false;
+                }
+                if (format == TextureCompressionFormat::BC5)
+                    image = EncodeBC5(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), options.GenerateMips);
+                else
+                    image = EncodeBC7(data, static_cast<u32>(width), static_cast<u32>(height), static_cast<u32>(channels), srgb, options.GenerateMips);
+                ::stbi_image_free(data);
+            }
 
             if (!image.IsValid())
             {

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -167,6 +167,32 @@ namespace OloEngine
             return out;
         }
 
+        // Build a compressed mip chain from a level-0 pixel buffer. `encodeLevel(level, w, h)`
+        // returns the BCn blocks for one level; `downsample(level, w, h, outW, outH)` halves
+        // it. Shared by all three encoders (BC7/BC5 over RGBA8, BC6H over RGB float): the
+        // loop, the !generateMips / 1x1 termination, and the dimension bookkeeping are
+        // identical — only the pixel type and the two callables differ.
+        template<typename Pixel, typename EncodeLevelFn, typename DownsampleFn>
+        std::vector<std::vector<u8>> BuildMipChain(std::vector<Pixel> level, u32 width, u32 height, bool generateMips,
+                                                   EncodeLevelFn&& encodeLevel, DownsampleFn&& downsample)
+        {
+            std::vector<std::vector<u8>> mips;
+            u32 mw = width;
+            u32 mh = height;
+            while (true)
+            {
+                mips.push_back(encodeLevel(level, mw, mh));
+                if (!generateMips || (mw == 1 && mh == 1))
+                    break;
+                u32 nw = 0;
+                u32 nh = 0;
+                level = downsample(level, mw, mh, nw, nh);
+                mw = nw;
+                mh = nh;
+            }
+            return mips;
+        }
+
         // Little-endian POD append/read helpers for the .olotex blob.
         void AppendU32(std::vector<u8>& out, u32 value)
         {
@@ -650,20 +676,12 @@ namespace OloEngine
             // those (keeps opaque BC7 albedo out of the transparent render pass).
             image.HasAlpha = (channels == 4);
 
-            std::vector<u8> level = ExpandToRGBA8(pixels, width, height, channels);
-            u32 mw = width;
-            u32 mh = height;
-            while (true)
-            {
-                image.Mips.push_back(EncodeLevel(level, mw, mh, encodeBlock));
-                if (!generateMips || (mw == 1 && mh == 1))
-                    break;
-                u32 nw = 0;
-                u32 nh = 0;
-                level = DownsampleRGBA8(level, mw, mh, nw, nh);
-                mw = nw;
-                mh = nh;
-            }
+            image.Mips = BuildMipChain<u8>(
+                ExpandToRGBA8(pixels, width, height, channels), width, height, generateMips,
+                [&encodeBlock](const std::vector<u8>& lvl, u32 w, u32 h)
+                { return EncodeLevel(lvl, w, h, encodeBlock); },
+                [](const std::vector<u8>& s, u32 w, u32 h, u32& ow, u32& oh)
+                { return DownsampleRGBA8(s, w, h, ow, oh); });
             return image;
         }
 
@@ -693,20 +711,12 @@ namespace OloEngine
             image.Height = height;
             image.SRGB = false; // BC5 is always linear (normal xy / two-channel data)
 
-            std::vector<u8> level = ExpandToRGBA8(pixels, width, height, channels);
-            u32 mw = width;
-            u32 mh = height;
-            while (true)
-            {
-                image.Mips.push_back(EncodeLevel(level, mw, mh, encodeBlock));
-                if (!generateMips || (mw == 1 && mh == 1))
-                    break;
-                u32 nw = 0;
-                u32 nh = 0;
-                level = DownsampleRGBA8(level, mw, mh, nw, nh);
-                mw = nw;
-                mh = nh;
-            }
+            image.Mips = BuildMipChain<u8>(
+                ExpandToRGBA8(pixels, width, height, channels), width, height, generateMips,
+                [&encodeBlock](const std::vector<u8>& lvl, u32 w, u32 h)
+                { return EncodeLevel(lvl, w, h, encodeBlock); },
+                [](const std::vector<u8>& s, u32 w, u32 h, u32& ow, u32& oh)
+                { return DownsampleRGBA8(s, w, h, ow, oh); });
             return image;
         }
 
@@ -745,20 +755,11 @@ namespace OloEngine
                 return out;
             };
 
-            std::vector<f32> level = ExpandToRGBFloat(pixels, width, height, channels);
-            u32 mw = width;
-            u32 mh = height;
-            while (true)
-            {
-                image.Mips.push_back(encodeLevel(level, mw, mh));
-                if (!generateMips || (mw == 1 && mh == 1))
-                    break;
-                u32 nw = 0;
-                u32 nh = 0;
-                level = DownsampleRGBFloat(level, mw, mh, nw, nh);
-                mw = nw;
-                mh = nh;
-            }
+            image.Mips = BuildMipChain<f32>(
+                ExpandToRGBFloat(pixels, width, height, channels), width, height, generateMips,
+                encodeLevel,
+                [](const std::vector<f32>& s, u32 w, u32 h, u32& ow, u32& oh)
+                { return DownsampleRGBFloat(s, w, h, ow, oh); });
             return image;
         }
 

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.cpp
@@ -1090,8 +1090,7 @@ namespace OloEngine
             return DeserializeFromBlob(blob, out);
         }
 
-        bool CompressTextureFile(const std::string& srcImagePath, const std::string& dstOlotexPath,
-                                 const CompressOptions& options)
+        bool CompressImageFile(const std::string& srcImagePath, const CompressOptions& options, CompressedTextureImage& out)
         {
             OLO_PROFILE_FUNCTION();
 
@@ -1127,7 +1126,7 @@ namespace OloEngine
                 ::stbi_set_flip_vertically_on_load_thread(0);
                 if (!data)
                 {
-                    OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load HDR '{}'", srcImagePath);
+                    OLO_CORE_ERROR("TextureCompression::CompressImageFile - failed to load HDR '{}'", srcImagePath);
                     return false;
                 }
                 image = EncodeBC6H(data, static_cast<u32>(width), static_cast<u32>(height), 3, options.GenerateMips);
@@ -1139,7 +1138,7 @@ namespace OloEngine
                 ::stbi_set_flip_vertically_on_load_thread(0);
                 if (!data)
                 {
-                    OLO_CORE_ERROR("TextureCompression::CompressTextureFile - failed to load '{}'", srcImagePath);
+                    OLO_CORE_ERROR("TextureCompression::CompressImageFile - failed to load '{}'", srcImagePath);
                     return false;
                 }
                 if (format == TextureCompressionFormat::BC5)
@@ -1151,9 +1150,22 @@ namespace OloEngine
 
             if (!image.IsValid())
             {
-                OLO_CORE_ERROR("TextureCompression::CompressTextureFile - encode failed for '{}'", srcImagePath);
+                OLO_CORE_ERROR("TextureCompression::CompressImageFile - encode failed for '{}'", srcImagePath);
                 return false;
             }
+
+            out = std::move(image);
+            return true;
+        }
+
+        bool CompressTextureFile(const std::string& srcImagePath, const std::string& dstOlotexPath,
+                                 const CompressOptions& options)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            CompressedTextureImage image;
+            if (!CompressImageFile(srcImagePath, options, image))
+                return false;
 
             return WriteFile(dstOlotexPath, image);
         }

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.h
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.h
@@ -16,8 +16,10 @@
 // (Platform/OpenGL/OpenGLTexture.cpp); this header intentionally has no GL / renderer
 // dependency so it can be unit-tested without a graphics context.
 //
-// Encoders come from the vendored bc7enc_rdo library (BC7 via bc7enc, BC5 via rgbcx);
-// they are pulled in only by TextureCompression.cpp so this header stays lightweight.
+// Encoders come from the vendored bc7enc_rdo library (BC7 via bc7enc, BC5 via rgbcx)
+// and, for BC6H, a self-contained mode-11 encoder in TextureCompression.cpp; BC6H is
+// decoded via the vendored bcdec header. They are pulled in only by
+// TextureCompression.cpp so this header stays lightweight.
 
 namespace OloEngine
 {
@@ -26,8 +28,10 @@ namespace OloEngine
     enum class TextureCompressionFormat : u32
     {
         None = 0,
-        BC7 = 1, // RGBA, high quality, 16 bytes / 4x4 block. Base color / albedo / emissive.
-        BC5 = 2, // Two-channel (R,G), 16 bytes / 4x4 block. Tangent-space normal xy.
+        BC7 = 1,  // RGBA, high quality, 16 bytes / 4x4 block. Base color / albedo / emissive.
+        BC5 = 2,  // Two-channel (R,G), 16 bytes / 4x4 block. Tangent-space normal xy.
+        BC6H = 3, // RGB half-float HDR, 16 bytes / 4x4 block. Environment / IBL / emissive HDR.
+                  // Unsigned variant only (non-negative radiance); no alpha, never sRGB.
     };
 
     // A GPU-ready block-compressed image: a mip chain of raw BCn block bytes (mip 0 first).
@@ -87,11 +91,29 @@ namespace OloEngine
         [[nodiscard]] CompressedTextureImage EncodeBC7(const u8* pixels, u32 width, u32 height, u32 channels, bool srgb, bool generateMips);
         [[nodiscard]] CompressedTextureImage EncodeBC5(const u8* pixels, u32 width, u32 height, u32 channels, bool generateMips);
 
+        // Encode HDR RGB float source (channels >= 3, extra channels ignored; the R,G,B
+        // triples are read row-major with `channels` floats/texel stride) to UNSIGNED
+        // BC6H, the GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT variant. Intended for
+        // non-negative radiance — environment maps / IBL / HDR emissive. Uses BC6H
+        // block "mode 11" (1 subset, 10-bit endpoints, no delta): high enough quality for
+        // smooth HDR while keeping the encoder self-contained. Negative source components
+        // are clamped to 0 (unsigned BC6H cannot represent them); non-finite values are
+        // clamped to the max representable half. Mips are box-filtered in linear space.
+        [[nodiscard]] CompressedTextureImage EncodeBC6H(const f32* pixels, u32 width, u32 height, u32 channels, bool generateMips);
+
         // ---- Decode (CPU) -----------------------------------------------------
         // Decompress one mip level to RGBA8 (4 bytes/texel). BC5 fills b=0, a=255.
-        // Used by tests and the no-BPTC-hardware fallback upload path.
+        // Used by tests and the no-BPTC-hardware fallback upload path. Rejects BC6H
+        // (an HDR format cannot be represented in 8-bit) — use DecodeToRGBAFloat for it.
         [[nodiscard]] bool DecodeToRGBA8(const CompressedTextureImage& image, u32 mipLevel,
                                          std::vector<u8>& outRGBA8, u32& outWidth, u32& outHeight);
+
+        // Decompress one BC6H mip level to RGBA float (4 floats/texel: R,G,B and A=1),
+        // via the vendored bcdec reference decoder. Used by the BC6H round-trip test (an
+        // encoder-independent oracle) and by the no-BPTC-hardware HDR fallback upload
+        // (which uploads the result as RGBA16F). Returns false for non-BC6H formats.
+        [[nodiscard]] bool DecodeToRGBAFloat(const CompressedTextureImage& image, u32 mipLevel,
+                                             std::vector<f32>& outRGBA, u32& outWidth, u32& outHeight);
 
         // ---- Container (.olotex) ---------------------------------------------
         [[nodiscard]] std::vector<u8> SerializeToBlob(const CompressedTextureImage& image);
@@ -102,9 +124,10 @@ namespace OloEngine
         // ---- Offline cook -----------------------------------------------------
         struct CompressOptions
         {
-            // None => auto-pick from the filename: color textures (albedo/emissive/...)
-            // become sRGB BC7, everything else linear BC5 is NOT auto-chosen (BC5 is a
-            // deliberate opt-in for two-channel normal data); auto defaults to BC7.
+            // None => auto-pick: an HDR source (.hdr / .exr, detected via stbi_is_hdr)
+            // becomes BC6H; otherwise color textures (albedo/emissive/...) become sRGB
+            // BC7 and everything else defaults to BC7. BC5 is NEVER auto-chosen (it is a
+            // deliberate opt-in for two-channel normal data).
             TextureCompressionFormat Format = TextureCompressionFormat::None;
             bool SRGB = false;            // color-space hint for BC7 (ignored for BC5)
             bool AutoSRGBFromName = true; // when true, override SRGB using the filename heuristic

--- a/OloEngine/src/OloEngine/Renderer/TextureCompression.h
+++ b/OloEngine/src/OloEngine/Renderer/TextureCompression.h
@@ -134,10 +134,17 @@ namespace OloEngine
             bool GenerateMips = true;
         };
 
+        // Load `srcImagePath` (any stb-supported image) and encode per `options`, returning
+        // the in-memory BCn mip chain in `out` (no file written). This is the core of the
+        // cook; the asset-pack builder uses it to auto-compress source textures and embed
+        // the resulting container directly. Returns false on load/encode failure (logged).
+        // Pixels are loaded with the same vertical flip the runtime texture loader uses.
+        [[nodiscard]] bool CompressImageFile(const std::string& srcImagePath, const CompressOptions& options,
+                                             CompressedTextureImage& out);
+
         // Load `srcImagePath` (any stb-supported image), encode per `options`, and write
-        // the `.olotex` container to `dstOlotexPath`. Returns false on load/encode/write
-        // failure (details logged). Pixels are loaded with the same vertical flip the
-        // runtime texture loader uses, so the stored blocks upload without re-flipping.
+        // the `.olotex` container to `dstOlotexPath`. Thin wrapper over CompressImageFile +
+        // WriteFile. Returns false on load/encode/write failure (details logged).
         [[nodiscard]] bool CompressTextureFile(const std::string& srcImagePath, const std::string& dstOlotexPath,
                                                const CompressOptions& options);
     } // namespace TextureCompression

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -57,6 +57,7 @@ namespace OloEngine
                     return GL_DEPTH_STENCIL;
                 case ImageFormat::BC7:
                 case ImageFormat::BC5:
+                case ImageFormat::BC6H:
                     // Compressed formats upload via glCompressedTextureSubImage2D with no
                     // client pixel format; this value is unused for those paths.
                     return 0;
@@ -109,6 +110,10 @@ namespace OloEngine
                 case ImageFormat::BC5:
                     // RGTC2 two-channel; always linear.
                     return GL_COMPRESSED_RG_RGTC2;
+                case ImageFormat::BC6H:
+                    // BPTC RGB half-float, unsigned variant (non-negative HDR radiance).
+                    // Always linear — sRGB does not apply to a float format.
+                    return GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT;
             }
 
             OLO_CORE_ASSERT(false, "Unknown ImageFormat!");
@@ -124,6 +129,9 @@ namespace OloEngine
             switch (format)
             {
                 case TextureCompressionFormat::BC7:
+                    return (GLAD_GL_VERSION_4_2 != 0) || (GLAD_GL_ARB_texture_compression_bptc != 0);
+                case TextureCompressionFormat::BC6H:
+                    // Same BPTC feature as BC7 (both are core since GL 4.2).
                     return (GLAD_GL_VERSION_4_2 != 0) || (GLAD_GL_ARB_texture_compression_bptc != 0);
                 case TextureCompressionFormat::BC5:
                     return (GLAD_GL_VERSION_3_0 != 0) || (GLAD_GL_ARB_texture_compression_rgtc != 0);
@@ -257,6 +265,7 @@ namespace OloEngine
                 break;
             case ImageFormat::BC7:
             case ImageFormat::BC5:
+            case ImageFormat::BC6H:
                 // Block-compressed textures are not created through the spec ctor (use
                 // the CompressedTextureImage ctor, which tracks block bytes exactly).
                 // ~1 byte/texel is a coarse placeholder purely for this tracking line.
@@ -384,7 +393,20 @@ namespace OloEngine
         m_Specification.Width = image.Width;
         m_Specification.Height = image.Height;
         m_Specification.SRGB = image.SRGB;
-        m_Specification.Format = (image.Format == TextureCompressionFormat::BC5) ? ImageFormat::BC5 : ImageFormat::BC7;
+        switch (image.Format)
+        {
+            case TextureCompressionFormat::BC5:
+                m_Specification.Format = ImageFormat::BC5;
+                break;
+            case TextureCompressionFormat::BC6H:
+                m_Specification.Format = ImageFormat::BC6H;
+                break;
+            case TextureCompressionFormat::BC7:
+            case TextureCompressionFormat::None:
+            default:
+                m_Specification.Format = ImageFormat::BC7;
+                break;
+        }
         m_CompressedHasAlpha = image.HasAlpha;
         m_MipLevels = image.MipLevels();
         m_Specification.MipLevels = m_MipLevels;
@@ -394,8 +416,10 @@ namespace OloEngine
         // the mip chain on the CPU and upload uncompressed so rendering still works.
         if (!Utils::IsCompressionSupported(image.Format))
         {
-            OLO_CORE_WARN("OpenGLTexture2D: driver lacks {} support — falling back to uncompressed RGBA8",
-                          image.Format == TextureCompressionFormat::BC5 ? "BC5/RGTC" : "BC7/BPTC");
+            const char* formatName = image.Format == TextureCompressionFormat::BC5    ? "BC5/RGTC"
+                                     : image.Format == TextureCompressionFormat::BC6H ? "BC6H/BPTC"
+                                                                                      : "BC7/BPTC";
+            OLO_CORE_WARN("OpenGLTexture2D: driver lacks {} support — falling back to uncompressed (RGBA8, or RGBA16F for BC6H HDR)", formatName);
             UploadDecompressedFallback(image);
             return;
         }
@@ -450,6 +474,49 @@ namespace OloEngine
 
     void OpenGLTexture2D::UploadDecompressedFallback(const CompressedTextureImage& image)
     {
+        // BC6H is HDR: decode base mip to RGBA float and upload as RGBA16F so the fallback
+        // preserves the high dynamic range (an 8-bit fallback would clip/banding the HDR).
+        if (image.Format == TextureCompressionFormat::BC6H)
+        {
+            std::vector<f32> rgbaF;
+            u32 fw = 0;
+            u32 fh = 0;
+            if (!TextureCompression::DecodeToRGBAFloat(image, 0, rgbaF, fw, fh) || rgbaF.empty())
+            {
+                OLO_CORE_ERROR("OpenGLTexture2D: BC6H fallback decode failed");
+                return;
+            }
+
+            const bool wantMipsHdr = image.MipLevels() > 1u;
+            m_MipLevels = wantMipsHdr ? CalculateFullMipCount(fw, fh) : 1u;
+            m_Specification.MipLevels = m_MipLevels;
+            m_Specification.GenerateMips = wantMipsHdr;
+            // Keep m_Specification.Format as BC6H (the compressed identity) — the physical
+            // GL upload format lives in m_InternalFormat/m_DataFormat, same rationale as the
+            // BC7/BC5 fallback below.
+            m_InternalFormat = GL_RGBA16F;
+            m_DataFormat = GL_RGBA;
+
+            glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
+            glTextureStorage2D(m_RendererID, static_cast<GLsizei>(m_MipLevels), m_InternalFormat,
+                               static_cast<GLsizei>(fw), static_cast<GLsizei>(fh));
+            glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<GLsizei>(fw), static_cast<GLsizei>(fh),
+                                GL_RGBA, GL_FLOAT, rgbaF.data());
+            if (m_MipLevels > 1u)
+                glGenerateTextureMipmap(m_RendererID);
+
+            OLO_TRACK_GPU_ALLOC(this, rgbaF.size() * sizeof(f32), RendererMemoryTracker::ResourceType::Texture2D, "OpenGL Texture2D (BC6H-fallback)");
+            GPUResourceInspector::GetInstance().RegisterTexture(m_RendererID, "Texture2D (BC6H-fallback)", "Texture2D");
+
+            glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER, m_MipLevels > 1u ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+            glTextureParameteri(m_RendererID, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+            glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+            glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+            m_IsLoaded = true;
+            return;
+        }
+
         // Decode base mip to RGBA8 and upload as a normal texture; regenerate mips on GPU.
         std::vector<u8> rgba;
         u32 w = 0;

--- a/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
@@ -34,6 +34,7 @@ namespace OloEngine
                     return GL_DEPTH_STENCIL;
                 case ImageFormat::BC7:
                 case ImageFormat::BC5:
+                case ImageFormat::BC6H:
                     // Block-compressed cubemaps aren't produced by the cook path; a
                     // compressed face would need glCompressedTextureSubImage3D. Return 0
                     // (unsupported) explicitly so a stray value is a defined error, not an
@@ -68,6 +69,7 @@ namespace OloEngine
                     return GL_DEPTH24_STENCIL8;
                 case ImageFormat::BC7:
                 case ImageFormat::BC5:
+                case ImageFormat::BC6H:
                     // Block-compressed cubemaps aren't produced by the cook path.
                     OLO_CORE_ASSERT(false, "Block-compressed cubemaps are not supported");
                     return 0;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -179,6 +179,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/WaterVisualEvidenceTest.cpp
 		Rendering/PropertyTests/WaterStaleTexturePublicationTest.cpp
 		Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
+		Rendering/PropertyTests/TextureAutoCookPackTest.cpp
 		Rendering/PropertyTests/OceanFFTVisualEvidenceTest.cpp
 		Rendering/PropertyTests/UnderwaterCausticsVisualTest.cpp
 		Rendering/PropertyTests/SSRVisualEvidenceTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
@@ -273,6 +273,14 @@ TEST(CompressedTextureVisualEvidence, BC6HUploadStoresBlocksAndDecompressesOnGPU
 
     const GLuint id = texture->GetRendererID();
 
+    // If the driver couldn't honour BPTC and Texture2D fell back to an uncompressed
+    // RGBA16F upload, the compressed-readback path below is meaningless — skip cleanly
+    // rather than fail. (On any conformant GL 4.5+ context BPTC is core, so this holds.)
+    GLint isCompressed = GL_FALSE;
+    glGetTextureLevelParameteriv(id, 0, GL_TEXTURE_COMPRESSED, &isCompressed);
+    if (isCompressed != GL_TRUE)
+        GTEST_SKIP() << "BC6H texture was not stored compressed (driver fell back to uncompressed).";
+
     // (1) Read the stored compressed blocks back — must be bit-exact with upload.
     GLint compressedSize = 0;
     glGetTextureLevelParameteriv(id, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressedSize);
@@ -310,8 +318,7 @@ TEST(CompressedTextureVisualEvidence, BC6HUploadStoresBlocksAndDecompressesOnGPU
     EXPECT_NE(wrote, 0) << "failed to write BC6H evidence PNG";
     if (wrote != 0)
     {
+        // Keep the tonemapped evidence PNG in the temp dir for human inspection.
         OLO_CORE_INFO("CompressedTextureVisualEvidence: wrote BC6H tonemapped evidence to {}", pngPath.string());
-        std::error_code ec;
-        std::filesystem::remove(pngPath, ec);
     }
 }

--- a/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/CompressedTextureVisualEvidenceTest.cpp
@@ -22,6 +22,7 @@
 #include <stb_image/stb_image.h>
 #include <stb_image/stb_image_write.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -78,6 +79,49 @@ namespace
         const testing::TestInfo* info = testing::UnitTest::GetInstance()->current_test_info();
         std::string name = std::string(info->test_suite_name()) + "." + info->name() + ".png";
         return std::filesystem::temp_directory_path() / name;
+    }
+
+    // Smooth HDR RGB gradient (dark ~0.02 up to `peak`) for the BC6H path.
+    std::vector<f32> MakeGradientHDR(u32 width, u32 height, f32 peak)
+    {
+        std::vector<f32> pixels(static_cast<sizet>(width) * height * 3);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                const f32 fx = static_cast<f32>(x) / (width - 1);
+                const f32 fy = static_cast<f32>(y) / (height - 1);
+                f32* p = &pixels[(static_cast<sizet>(y) * width + x) * 3];
+                p[0] = 0.02f + peak * fx;
+                p[1] = 0.02f + peak * fy;
+                p[2] = 0.02f + peak * (fx * fy) * 0.5f;
+            }
+        }
+        return pixels;
+    }
+
+    // Peak-normalized PSNR (dB) over `channels` of each `stride`-float texel.
+    double ComputePSNRFloat(const std::vector<f32>& a, const std::vector<f32>& b, u32 stride, u32 channels, double peak)
+    {
+        if (a.size() != b.size() || a.empty())
+            return 0.0;
+        double mse = 0.0;
+        sizet samples = 0;
+        for (sizet texel = 0; texel + stride <= a.size(); texel += stride)
+        {
+            for (u32 c = 0; c < channels; ++c)
+            {
+                const double d = static_cast<double>(a[texel + c]) - static_cast<double>(b[texel + c]);
+                mse += d * d;
+                ++samples;
+            }
+        }
+        if (samples == 0)
+            return 0.0;
+        mse /= static_cast<double>(samples);
+        if (mse < 1e-12)
+            return 99.0;
+        return 10.0 * std::log10((peak * peak) / mse);
     }
 } // namespace
 
@@ -200,4 +244,74 @@ TEST(CompressedTextureVisualEvidence, BC5UploadStoresBlocksAndDecompressesOnGPU)
 
     const double psnr = ComputePSNR(source, decompressed, 2);
     EXPECT_GT(psnr, 30.0) << "GPU-decompressed BC5 PSNR too low: " << psnr << " dB";
+}
+
+TEST(CompressedTextureVisualEvidence, BC6HUploadStoresBlocksAndDecompressesOnGPU)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    constexpr f32 kPeak = 8.0f;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, kPeak);
+
+    // Encode HDR RGB -> BC6H (unsigned), base mip only for a clean 1:1 comparison.
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, /*mips*/ false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Format, TextureCompressionFormat::BC6H);
+
+    Ref<Texture2D> texture = Texture2D::Create(image);
+    ASSERT_TRUE(texture);
+    EXPECT_TRUE(texture->IsLoaded());
+    EXPECT_EQ(texture->GetWidth(), kW);
+    EXPECT_EQ(texture->GetHeight(), kH);
+    EXPECT_NE(texture->GetRendererID(), 0u);
+
+    while (glGetError() != GL_NO_ERROR)
+    {
+    }
+
+    const GLuint id = texture->GetRendererID();
+
+    // (1) Read the stored compressed blocks back — must be bit-exact with upload.
+    GLint compressedSize = 0;
+    glGetTextureLevelParameteriv(id, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressedSize);
+    ASSERT_EQ(static_cast<sizet>(compressedSize), image.Mips[0].size());
+    std::vector<u8> readback(static_cast<sizet>(compressedSize));
+    glGetCompressedTextureImage(id, 0, compressedSize, readback.data());
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+    EXPECT_EQ(readback, image.Mips[0]) << "stored BC6H blocks differ from uploaded blocks";
+
+    // (2) Ask the DRIVER (the real BPTC hardware decoder — an oracle independent of both
+    //     our encoder and bcdec) to decompress, and compare to the HDR source.
+    std::vector<f32> decompressed(static_cast<sizet>(kW) * kH * 3);
+    glGetTextureImage(id, 0, GL_RGB, GL_FLOAT,
+                      static_cast<GLsizei>(decompressed.size() * sizeof(f32)), decompressed.data());
+    ASSERT_EQ(glGetError(), GL_NO_ERROR) << "glGetTextureImage (BC6H decompress) failed";
+
+    const double psnr = ComputePSNRFloat(source, decompressed, 3, 3, kPeak);
+    EXPECT_GT(psnr, 35.0) << "GPU-decompressed BC6H PSNR too low: " << psnr << " dB";
+
+    // Pixel evidence: Reinhard-tonemap the decompressed HDR to 8-bit and write a PNG so a
+    // human can eyeball the round-tripped frame (HDR can't be stored in a PNG directly).
+    std::vector<u8> ldr(static_cast<sizet>(kW) * kH * 4, 255);
+    for (sizet i = 0; i < static_cast<sizet>(kW) * kH; ++i)
+    {
+        for (u32 c = 0; c < 3; ++c)
+        {
+            const f32 v = decompressed[i * 3 + c];
+            const f32 mapped = v / (1.0f + v); // Reinhard
+            ldr[i * 4 + c] = static_cast<u8>(std::lround(std::clamp(mapped, 0.0f, 1.0f) * 255.0f));
+        }
+    }
+    const std::filesystem::path pngPath = CaseKeyedTempPng();
+    const int wrote = ::stbi_write_png(pngPath.string().c_str(), static_cast<int>(kW), static_cast<int>(kH), 4,
+                                       ldr.data(), static_cast<int>(kW) * 4);
+    EXPECT_NE(wrote, 0) << "failed to write BC6H evidence PNG";
+    if (wrote != 0)
+    {
+        OLO_CORE_INFO("CompressedTextureVisualEvidence: wrote BC6H tonemapped evidence to {}", pngPath.string());
+        std::error_code ec;
+        std::filesystem::remove(pngPath, ec);
+    }
 }

--- a/OloEngine/tests/Rendering/PropertyTests/TextureAutoCookPackTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/TextureAutoCookPackTest.cpp
@@ -1,0 +1,187 @@
+// OLO_TEST_LAYER: L3
+//
+// End-to-end proof of the asset-pack texture auto-cook (#440). An uncompressed source
+// PNG, registered as a Texture2D and run through the production
+// TextureSerializer::SerializeToAssetPack / DeserializeFromAssetPack pair:
+//   * with the cook policy ON  -> comes back BC7-compressed and loaded, and the packed
+//     record is materially smaller than the raw RGBA8 pixels;
+//   * with the cook policy OFF -> stays an uncompressed record (no BC format), proving
+//     the policy actually gates the behaviour rather than always compressing.
+// This is the only test that exercises the write-side wiring (flag gating + record
+// format selection + embedded-blob round-trip) as one path. Needs a GL context because
+// Texture2D::Create uploads the source pixels; SKIPs cleanly on headless CI.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "RenderPropertyTest.h" // OLO_ENSURE_GPU_OR_SKIP
+
+#include "OloEngine/Asset/AssetManager.h"
+#include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
+#include "OloEngine/Asset/AssetSerializer.h"
+#include "OloEngine/Project/Project.h"
+#include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Serialization/AssetPackFile.h"
+#include "OloEngine/Serialization/FileStream.h"
+
+#include <stb_image/stb_image_write.h>
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace OloEngine;        // NOLINT(google-build-using-namespace)
+using namespace OloEngine::Tests; // NOLINT(google-build-using-namespace)
+
+namespace
+{
+    namespace fs = std::filesystem;
+
+    std::vector<u8> MakeGradientRGBA(u32 width, u32 height)
+    {
+        std::vector<u8> pixels(static_cast<sizet>(width) * height * 4);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                u8* p = &pixels[(static_cast<sizet>(y) * width + x) * 4];
+                p[0] = static_cast<u8>((x * 255) / (width - 1));
+                p[1] = static_cast<u8>((y * 255) / (height - 1));
+                p[2] = static_cast<u8>(128);
+                p[3] = 255;
+            }
+        }
+        return pixels;
+    }
+} // namespace
+
+class TextureAutoCookPackTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        const std::string folder = std::string(info->test_suite_name()) + "." + info->name();
+        m_TempDir = fs::temp_directory_path() / "OloEngineTextureAutoCook" / folder;
+
+        std::error_code ec;
+        fs::remove_all(m_TempDir, ec);
+        fs::create_directories(m_TempDir / "Assets", ec);
+        ASSERT_FALSE(ec) << "Failed to create temp dir: " << ec.message();
+
+        const fs::path projectFile = m_TempDir / "Test.oloproj";
+        {
+            std::ofstream proj(projectFile);
+            proj << "Project:\n"
+                    "  Name: TextureAutoCookPackTest\n"
+                    "  StartScene: \"\"\n"
+                    "  AssetDirectory: \"Assets\"\n"
+                    "  ScriptModulePath: \"\"\n";
+        }
+        ASSERT_TRUE(Project::Load(projectFile)) << "Project::Load failed for " << m_TempDir.string();
+
+        m_AssetManager = Ref<EditorAssetManager>::Create();
+        m_AssetManager->Initialize(/*startFileWatcher=*/false);
+        Project::SetAssetManager(m_AssetManager);
+    }
+
+    void TearDown() override
+    {
+        // Never leak the cook policy into other tests.
+        TextureSerializer::SetAssetPackCompressionEnabled(false);
+        m_AssetManager.Reset();
+        std::error_code ec;
+        fs::remove_all(m_TempDir, ec);
+    }
+
+    // Write a source PNG, load it as an uncompressed Texture2D, register it, and return
+    // its handle + on-disk source size.
+    AssetHandle StageSourcePng(u32 w, u32 h, sizet& outRawPixels)
+    {
+        const std::vector<u8> source = MakeGradientRGBA(w, h);
+        outRawPixels = source.size();
+        m_PngPath = m_TempDir / "Assets" / "albedo_gradient.png";
+        EXPECT_NE(::stbi_write_png(m_PngPath.string().c_str(), static_cast<int>(w), static_cast<int>(h), 4,
+                                   source.data(), static_cast<int>(w) * 4),
+                  0);
+
+        Ref<Texture2D> texture = Texture2D::Create(m_PngPath.string(), /*srgb=*/false);
+        EXPECT_TRUE(texture && texture->IsLoaded());
+        EXPECT_FALSE(IsCompressedFormat(texture->GetSpecification().Format)) << "source must start uncompressed";
+        return AssetManager::AddMemoryOnlyAsset(texture);
+    }
+
+    // Round-trip a registered texture through the production serializer and return the
+    // reconstructed asset.
+    Ref<Texture2D> RoundTrip(AssetHandle handle, sizet& outRecordSize)
+    {
+        const fs::path packPath = m_TempDir / "texture.pack";
+        TextureSerializer serializer;
+        AssetSerializationInfo info{};
+        {
+            FileStreamWriter writer(packPath);
+            EXPECT_TRUE(writer.IsStreamGood());
+            EXPECT_TRUE(serializer.SerializeToAssetPack(handle, writer, info));
+        }
+        outRecordSize = info.Size;
+
+        AssetPackFile::AssetInfo assetInfo{};
+        assetInfo.Handle = static_cast<AssetHandle>(0xC0FFEEULL);
+        assetInfo.PackedOffset = info.Offset;
+        assetInfo.PackedSize = info.Size;
+        assetInfo.Type = AssetType::Texture2D;
+
+        FileStreamReader reader(packPath);
+        EXPECT_TRUE(reader.IsStreamGood());
+        return serializer.DeserializeFromAssetPack(reader, assetInfo).As<Texture2D>();
+    }
+
+    fs::path m_TempDir;
+    fs::path m_PngPath;
+    Ref<EditorAssetManager> m_AssetManager;
+};
+
+TEST_F(TextureAutoCookPackTest, CompressionOnCooksSourcePngToBC7)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    sizet rawPixels = 0;
+    const AssetHandle handle = StageSourcePng(kW, kH, rawPixels);
+    ASSERT_TRUE(handle);
+
+    TextureSerializer::SetAssetPackCompressionEnabled(true);
+    sizet recordSize = 0;
+    Ref<Texture2D> roundTripped = RoundTrip(handle, recordSize);
+
+    ASSERT_TRUE(roundTripped) << "DeserializeFromAssetPack returned null/non-texture";
+    EXPECT_TRUE(roundTripped->IsLoaded());
+    EXPECT_EQ(roundTripped->GetWidth(), kW);
+    EXPECT_EQ(roundTripped->GetHeight(), kH);
+    EXPECT_EQ(roundTripped->GetSpecification().Format, ImageFormat::BC7)
+        << "auto-cook should have shipped this colour PNG as BC7";
+    EXPECT_EQ(roundTripped->GetHandle(), static_cast<AssetHandle>(0xC0FFEEULL));
+    // The embedded BC7 mip chain (+ record header) must beat the raw RGBA8 pixels.
+    EXPECT_LT(recordSize, rawPixels) << "cooked record (" << recordSize << ") should be < raw RGBA8 (" << rawPixels << ")";
+}
+
+TEST_F(TextureAutoCookPackTest, CompressionOffLeavesTextureUncompressed)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    sizet rawPixels = 0;
+    const AssetHandle handle = StageSourcePng(kW, kH, rawPixels);
+    ASSERT_TRUE(handle);
+
+    TextureSerializer::SetAssetPackCompressionEnabled(false);
+    sizet recordSize = 0;
+    Ref<Texture2D> roundTripped = RoundTrip(handle, recordSize);
+
+    ASSERT_TRUE(roundTripped) << "DeserializeFromAssetPack returned null/non-texture";
+    EXPECT_TRUE(roundTripped->IsLoaded());
+    EXPECT_FALSE(IsCompressedFormat(roundTripped->GetSpecification().Format))
+        << "with compression off the texture must stay uncompressed";
+}

--- a/OloEngine/tests/Rendering/PropertyTests/TextureAutoCookPackTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/TextureAutoCookPackTest.cpp
@@ -1,14 +1,14 @@
 // OLO_TEST_LAYER: L3
 //
-// End-to-end proof of the asset-pack texture auto-cook (#440). An uncompressed source
-// PNG, registered as a Texture2D and run through the production
+// End-to-end proof of the asset-pack texture auto-cook (#440). An uncompressed source,
+// registered as a Texture2D and run through the production
 // TextureSerializer::SerializeToAssetPack / DeserializeFromAssetPack pair:
-//   * with the cook policy ON  -> comes back BC7-compressed and loaded, and the packed
-//     record is materially smaller than the raw RGBA8 pixels;
-//   * with the cook policy OFF -> stays an uncompressed record (no BC format), proving
-//     the policy actually gates the behaviour rather than always compressing.
-// This is the only test that exercises the write-side wiring (flag gating + record
-// format selection + embedded-blob round-trip) as one path. Needs a GL context because
+//   * cook ON, LDR PNG source  -> comes back BC7-compressed and loaded, record < raw RGBA8;
+//   * cook ON, HDR .hdr source -> comes back BC6H-compressed and loaded, record < raw float;
+//   * cook OFF                 -> stays an uncompressed record, proving the policy gates it;
+//   * cook ON but source missing -> falls back to an uncompressed record (no throw, no BC).
+// This is the only test that exercises the write-side wiring (flag gating + format
+// selection + embedded-blob round-trip) as one path. Needs a GL context because
 // Texture2D::Create uploads the source pixels; SKIPs cleanly on headless CI.
 
 #include "OloEnginePCH.h"
@@ -49,6 +49,22 @@ namespace
                 p[1] = static_cast<u8>((y * 255) / (height - 1));
                 p[2] = static_cast<u8>(128);
                 p[3] = 255;
+            }
+        }
+        return pixels;
+    }
+
+    std::vector<f32> MakeGradientHDR(u32 width, u32 height)
+    {
+        std::vector<f32> pixels(static_cast<sizet>(width) * height * 3);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                f32* p = &pixels[(static_cast<sizet>(y) * width + x) * 3];
+                p[0] = 0.05f + 6.0f * (static_cast<f32>(x) / (width - 1)); // > 1.0 -> genuinely HDR
+                p[1] = 0.05f + 6.0f * (static_cast<f32>(y) / (height - 1));
+                p[2] = 0.5f;
             }
         }
         return pixels;
@@ -94,21 +110,44 @@ class TextureAutoCookPackTest : public ::testing::Test
         fs::remove_all(m_TempDir, ec);
     }
 
-    // Write a source PNG, load it as an uncompressed Texture2D, register it, and return
-    // its handle + on-disk source size.
-    AssetHandle StageSourcePng(u32 w, u32 h, sizet& outRawPixels)
+    // Load the just-written m_SourcePath as an uncompressed Texture2D and register it.
+    // Fatal assertions (surfaced via ASSERT_NO_FATAL_FAILURE at the call site) so a failed
+    // write/load never dereferences a null texture or registers a bad asset.
+    void RegisterSource(AssetHandle& outHandle)
+    {
+        outHandle = {};
+        Ref<Texture2D> texture = Texture2D::Create(m_SourcePath.string(), /*srgb=*/false);
+        ASSERT_TRUE(texture) << "Texture2D::Create returned null for " << m_SourcePath.string();
+        ASSERT_TRUE(texture->IsLoaded()) << "source texture failed to load: " << m_SourcePath.string();
+        ASSERT_FALSE(IsCompressedFormat(texture->GetSpecification().Format)) << "source must start uncompressed";
+        outHandle = AssetManager::AddMemoryOnlyAsset(texture);
+    }
+
+    // Write an LDR PNG source, load + register it. `outRawBytes` = raw RGBA8 byte count.
+    void StageSourcePng(u32 w, u32 h, sizet& outRawBytes, AssetHandle& outHandle)
     {
         const std::vector<u8> source = MakeGradientRGBA(w, h);
-        outRawPixels = source.size();
-        m_PngPath = m_TempDir / "Assets" / "albedo_gradient.png";
-        EXPECT_NE(::stbi_write_png(m_PngPath.string().c_str(), static_cast<int>(w), static_cast<int>(h), 4,
+        m_SourcePath = m_TempDir / "Assets" / "albedo_gradient.png";
+        ASSERT_NE(::stbi_write_png(m_SourcePath.string().c_str(), static_cast<int>(w), static_cast<int>(h), 4,
                                    source.data(), static_cast<int>(w) * 4),
-                  0);
+                  0)
+            << "failed to write source PNG";
+        ASSERT_NO_FATAL_FAILURE(RegisterSource(outHandle));
+        outRawBytes = source.size();
+    }
 
-        Ref<Texture2D> texture = Texture2D::Create(m_PngPath.string(), /*srgb=*/false);
-        EXPECT_TRUE(texture && texture->IsLoaded());
-        EXPECT_FALSE(IsCompressedFormat(texture->GetSpecification().Format)) << "source must start uncompressed";
-        return AssetManager::AddMemoryOnlyAsset(texture);
+    // Write an HDR (.hdr) source, load + register it. `outRawBytes` = raw float byte count.
+    void StageSourceHdr(u32 w, u32 h, sizet& outRawBytes, AssetHandle& outHandle)
+    {
+        const std::vector<f32> source = MakeGradientHDR(w, h);
+        m_SourcePath = m_TempDir / "Assets" / "sky.hdr";
+        ASSERT_NE(::stbi_write_hdr(m_SourcePath.string().c_str(), static_cast<int>(w), static_cast<int>(h), 3, source.data()), 0)
+            << "failed to write source HDR";
+        // Texture2D::Create path-loads via stbi_load (8-bit); the cook re-reads the .hdr
+        // via stbi_loadf and picks BC6H from stbi_is_hdr — so the live texture is LDR but
+        // the packed record is BC6H.
+        ASSERT_NO_FATAL_FAILURE(RegisterSource(outHandle));
+        outRawBytes = source.size() * sizeof(f32);
     }
 
     // Round-trip a registered texture through the production serializer and return the
@@ -137,7 +176,7 @@ class TextureAutoCookPackTest : public ::testing::Test
     }
 
     fs::path m_TempDir;
-    fs::path m_PngPath;
+    fs::path m_SourcePath;
     Ref<EditorAssetManager> m_AssetManager;
 };
 
@@ -147,8 +186,9 @@ TEST_F(TextureAutoCookPackTest, CompressionOnCooksSourcePngToBC7)
 
     constexpr u32 kW = 64;
     constexpr u32 kH = 64;
-    sizet rawPixels = 0;
-    const AssetHandle handle = StageSourcePng(kW, kH, rawPixels);
+    sizet rawBytes = 0;
+    AssetHandle handle{};
+    ASSERT_NO_FATAL_FAILURE(StageSourcePng(kW, kH, rawBytes, handle));
     ASSERT_TRUE(handle);
 
     TextureSerializer::SetAssetPackCompressionEnabled(true);
@@ -163,7 +203,33 @@ TEST_F(TextureAutoCookPackTest, CompressionOnCooksSourcePngToBC7)
         << "auto-cook should have shipped this colour PNG as BC7";
     EXPECT_EQ(roundTripped->GetHandle(), static_cast<AssetHandle>(0xC0FFEEULL));
     // The embedded BC7 mip chain (+ record header) must beat the raw RGBA8 pixels.
-    EXPECT_LT(recordSize, rawPixels) << "cooked record (" << recordSize << ") should be < raw RGBA8 (" << rawPixels << ")";
+    EXPECT_LT(recordSize, rawBytes) << "cooked record (" << recordSize << ") should be < raw RGBA8 (" << rawBytes << ")";
+}
+
+TEST_F(TextureAutoCookPackTest, CompressionOnCooksHdrSourceToBC6H)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    sizet rawBytes = 0;
+    AssetHandle handle{};
+    ASSERT_NO_FATAL_FAILURE(StageSourceHdr(kW, kH, rawBytes, handle));
+    ASSERT_TRUE(handle);
+
+    TextureSerializer::SetAssetPackCompressionEnabled(true);
+    sizet recordSize = 0;
+    Ref<Texture2D> roundTripped = RoundTrip(handle, recordSize);
+
+    ASSERT_TRUE(roundTripped) << "DeserializeFromAssetPack returned null/non-texture";
+    EXPECT_TRUE(roundTripped->IsLoaded());
+    EXPECT_EQ(roundTripped->GetWidth(), kW);
+    EXPECT_EQ(roundTripped->GetHeight(), kH);
+    EXPECT_EQ(roundTripped->GetSpecification().Format, ImageFormat::BC6H)
+        << "auto-cook should have shipped this HDR source as BC6H";
+    EXPECT_EQ(roundTripped->GetHandle(), static_cast<AssetHandle>(0xC0FFEEULL));
+    // The embedded BC6H mip chain (+ record header) must beat the raw HDR float pixels.
+    EXPECT_LT(recordSize, rawBytes) << "cooked BC6H record (" << recordSize << ") should be < raw HDR float bytes (" << rawBytes << ")";
 }
 
 TEST_F(TextureAutoCookPackTest, CompressionOffLeavesTextureUncompressed)
@@ -172,8 +238,9 @@ TEST_F(TextureAutoCookPackTest, CompressionOffLeavesTextureUncompressed)
 
     constexpr u32 kW = 64;
     constexpr u32 kH = 64;
-    sizet rawPixels = 0;
-    const AssetHandle handle = StageSourcePng(kW, kH, rawPixels);
+    sizet rawBytes = 0;
+    AssetHandle handle{};
+    ASSERT_NO_FATAL_FAILURE(StageSourcePng(kW, kH, rawBytes, handle));
     ASSERT_TRUE(handle);
 
     TextureSerializer::SetAssetPackCompressionEnabled(false);
@@ -184,4 +251,33 @@ TEST_F(TextureAutoCookPackTest, CompressionOffLeavesTextureUncompressed)
     EXPECT_TRUE(roundTripped->IsLoaded());
     EXPECT_FALSE(IsCompressedFormat(roundTripped->GetSpecification().Format))
         << "with compression off the texture must stay uncompressed";
+}
+
+TEST_F(TextureAutoCookPackTest, CookFailureFallsBackToUncompressedRecord)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    sizet rawBytes = 0;
+    AssetHandle handle{};
+    ASSERT_NO_FATAL_FAILURE(StageSourcePng(kW, kH, rawBytes, handle));
+    ASSERT_TRUE(handle);
+
+    // Delete the source file *after* the texture loaded: the cook is enabled but the
+    // auto-cook guard's exists() check now fails, so SerializeToAssetPack must fall back
+    // to the uncompressed raw record rather than throw or emit a compressed record.
+    std::error_code ec;
+    fs::remove(m_SourcePath, ec);
+
+    TextureSerializer::SetAssetPackCompressionEnabled(true);
+    sizet recordSize = 0;
+    Ref<Texture2D> roundTripped = RoundTrip(handle, recordSize);
+
+    // The record must reconstruct a (non-null) texture whose format is NOT block-compressed.
+    // (Its IsLoaded may be false since the source file is gone — that's the path-load
+    // fallback, not the point here; the point is the record was written uncompressed.)
+    ASSERT_TRUE(roundTripped) << "even a fallback record must reconstruct a non-null texture";
+    EXPECT_FALSE(IsCompressedFormat(roundTripped->GetSpecification().Format))
+        << "cook failure must leave the texture as an uncompressed record, not a BC format";
 }

--- a/OloEngine/tests/Rendering/TextureCompressionTest.cpp
+++ b/OloEngine/tests/Rendering/TextureCompressionTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <stb_image/stb_image_write.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -644,6 +645,47 @@ TEST(TextureCompression, OfflineCookFromHdrAutoSelectsBC6H)
     std::error_code ec;
     std::filesystem::remove(hdrPath, ec);
     std::filesystem::remove(oloTexPath, ec);
+}
+
+TEST(TextureCompression, CompressImageFileProducesInMemoryChain)
+{
+    // The in-memory cook primitive the asset-pack auto-cook (#440) uses: a PNG on disk
+    // becomes a CompressedTextureImage (no .olotex written), decodable within tolerance.
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 32;
+    const std::vector<u8> source = MakeGradientRGBA(kW, kH);
+    const std::filesystem::path pngPath = CaseKeyedTempFile(".png");
+    ASSERT_NE(::stbi_write_png(pngPath.string().c_str(), static_cast<int>(kW), static_cast<int>(kH), 4,
+                               source.data(), static_cast<int>(kW) * 4),
+              0);
+
+    TextureCompression::CompressOptions options; // Format=None -> BC7 for this LDR PNG
+    options.GenerateMips = true;
+    CompressedTextureImage image;
+    ASSERT_TRUE(TextureCompression::CompressImageFile(pngPath.string(), options, image));
+    EXPECT_EQ(image.Format, TextureCompressionFormat::BC7);
+    EXPECT_EQ(image.Width, kW);
+    EXPECT_EQ(image.Height, kH);
+    EXPECT_GT(image.MipLevels(), 1u);
+
+    std::vector<u8> decoded;
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBA8(image, 0, decoded, dw, dh));
+
+    // CompressImageFile loads with a vertical flip (matching the runtime loader), so the
+    // cooked pixels are row-flipped relative to the raw `source`. Flip `source` to line
+    // them up before the PSNR compare.
+    std::vector<u8> expected(source.size());
+    for (u32 y = 0; y < kH; ++y)
+        std::copy_n(&source[static_cast<sizet>(kH - 1 - y) * kW * 4], static_cast<sizet>(kW) * 4,
+                    &expected[static_cast<sizet>(y) * kW * 4]);
+
+    const double psnr = ComputePSNR(expected, decoded, 4, 3);
+    EXPECT_GT(psnr, 30.0) << "CompressImageFile BC7 round-trip PSNR too low: " << psnr << " dB";
+
+    std::error_code ec;
+    std::filesystem::remove(pngPath, ec);
 }
 
 TEST(TextureCompression, WriteThenReadFileRoundTrip)

--- a/OloEngine/tests/Rendering/TextureCompressionTest.cpp
+++ b/OloEngine/tests/Rendering/TextureCompressionTest.cpp
@@ -91,12 +91,62 @@ namespace
         std::string name = std::string(info->test_suite_name()) + "." + info->name() + suffix;
         return std::filesystem::temp_directory_path() / name;
     }
+
+    // ---- BC6H (HDR) helpers -----------------------------------------------
+    // A smooth HDR RGB gradient spanning a wide dynamic range (dark ~0.02 up to `peak`),
+    // so the round-trip exercises BC6H's log-ish half-float encoding across bright and
+    // dark regions — not just the [0,1] band an LDR test would cover.
+    std::vector<f32> MakeGradientHDR(u32 width, u32 height, f32 peak)
+    {
+        std::vector<f32> pixels(static_cast<sizet>(width) * height * 3);
+        for (u32 y = 0; y < height; ++y)
+        {
+            for (u32 x = 0; x < width; ++x)
+            {
+                const f32 fx = static_cast<f32>(x) / std::max(1u, width - 1);
+                const f32 fy = static_cast<f32>(y) / std::max(1u, height - 1);
+                f32* p = &pixels[(static_cast<sizet>(y) * width + x) * 3];
+                // Different curve per channel; +0.02 keeps values off exact zero so the
+                // relative-error view is well behaved.
+                p[0] = 0.02f + peak * fx * fx;          // red ramps quadratically
+                p[1] = 0.02f + peak * fy;               // green ramps linearly
+                p[2] = 0.02f + peak * (fx * fy) * 0.5f; // blue: product term
+            }
+        }
+        return pixels;
+    }
+
+    // Peak-normalized PSNR (dB) over `compareChannels` of each `stride`-float texel.
+    double ComputePSNRFloat(const std::vector<f32>& a, const std::vector<f32>& b, u32 stride, u32 compareChannels, double peak)
+    {
+        EXPECT_EQ(a.size(), b.size());
+        if (a.size() != b.size() || a.empty())
+            return 0.0;
+        double mse = 0.0;
+        sizet samples = 0;
+        for (sizet texel = 0; texel + stride <= a.size(); texel += stride)
+        {
+            for (u32 c = 0; c < compareChannels; ++c)
+            {
+                const double diff = static_cast<double>(a[texel + c]) - static_cast<double>(b[texel + c]);
+                mse += diff * diff;
+                ++samples;
+            }
+        }
+        if (samples == 0)
+            return 0.0;
+        mse /= static_cast<double>(samples);
+        if (mse < 1e-12)
+            return 99.0;
+        return 10.0 * std::log10((peak * peak) / mse);
+    }
 } // namespace
 
 TEST(TextureCompression, BlockGeometry)
 {
     EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::BC7), 16u);
     EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::BC5), 16u);
+    EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::BC6H), 16u);
     EXPECT_EQ(TextureCompression::BlockSizeBytes(TextureCompressionFormat::None), 0u);
 
     // ceil(dim/4), at least one block.
@@ -382,6 +432,217 @@ TEST(TextureCompression, OfflineCookFromPngProducesLoadableOloTex)
 
     std::error_code ec;
     std::filesystem::remove(pngPath, ec);
+    std::filesystem::remove(oloTexPath, ec);
+}
+
+// ---- BC6H (HDR) tests -----------------------------------------------------
+// These validate the from-scratch BC6H mode-11 encoder END TO END through the
+// vendored bcdec reference decoder — an ORACLE independent of our encoder, so a
+// wrong bit layout / quantization can't hide behind a matched CPU decoder. A wrong
+// mode value or bit packing would tank the PSNR and fail here (and, redundantly, the
+// GPU visual-evidence test decodes the same blocks in hardware).
+
+TEST(TextureCompression, EncodeBC6HRoundTripWithinTolerance)
+{
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    constexpr f32 kPeak = 8.0f;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, kPeak);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Format, TextureCompressionFormat::BC6H);
+    EXPECT_FALSE(image.SRGB);
+    EXPECT_FALSE(image.HasAlpha);
+    EXPECT_EQ(image.MipLevels(), 1u); // generateMips=false
+    EXPECT_EQ(image.Mips[0].size(), TextureCompression::MipByteSize(TextureCompressionFormat::BC6H, kW, kH));
+
+    std::vector<f32> decoded; // RGBA float: R,G,B and A=1
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBAFloat(image, 0, decoded, dw, dh));
+    EXPECT_EQ(dw, kW);
+    EXPECT_EQ(dh, kH);
+
+    // Re-pack source RGB as RGBA (A=1) so the stride-4 PSNR helper lines up with decoded.
+    std::vector<f32> sourceRGBA(static_cast<sizet>(kW) * kH * 4, 1.0f);
+    for (sizet i = 0; i < static_cast<sizet>(kW) * kH; ++i)
+    {
+        sourceRGBA[i * 4 + 0] = source[i * 3 + 0];
+        sourceRGBA[i * 4 + 1] = source[i * 3 + 1];
+        sourceRGBA[i * 4 + 2] = source[i * 3 + 2];
+    }
+    // ~38 dB peak-normalized on this deliberately-curved gradient (the red channel ramps
+    // quadratically, the worst case for mode-11's single linear segment per block). Real
+    // IBL/environment content is smoother per-block and scores higher. 35 dB is a strong
+    // correctness floor — a wrong bit layout / quantization tanks this below ~15 dB — with
+    // margin; higher fidelity would need the multi-subset BC6H modes (a deferred encoder
+    // follow-up). The flat-block test above pins near-lossless behaviour separately.
+    const double psnr = ComputePSNRFloat(sourceRGBA, decoded, 4, 3, kPeak);
+    EXPECT_GT(psnr, 35.0) << "BC6H HDR gradient round-trip PSNR too low: " << psnr << " dB";
+}
+
+TEST(TextureCompression, BC6HFlatBlockIsNearLossless)
+{
+    // A constant-color HDR block has coincident endpoints — every index resolves to the
+    // same value, so the round-trip should be essentially exact (only the half-float
+    // quantization of the single value survives).
+    constexpr u32 kW = 4;
+    constexpr u32 kH = 4;
+    std::vector<f32> source(static_cast<sizet>(kW) * kH * 3);
+    for (sizet i = 0; i < static_cast<sizet>(kW) * kH; ++i)
+    {
+        source[i * 3 + 0] = 3.5f;
+        source[i * 3 + 1] = 1.25f;
+        source[i * 3 + 2] = 0.5f;
+    }
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, false);
+    ASSERT_TRUE(image.IsValid());
+
+    std::vector<f32> decoded;
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBAFloat(image, 0, decoded, dw, dh));
+    for (sizet i = 0; i < static_cast<sizet>(kW) * kH; ++i)
+    {
+        EXPECT_NEAR(decoded[i * 4 + 0], 3.5f, 0.02f);
+        EXPECT_NEAR(decoded[i * 4 + 1], 1.25f, 0.02f);
+        EXPECT_NEAR(decoded[i * 4 + 2], 0.5f, 0.02f);
+    }
+}
+
+TEST(TextureCompression, BC6HGeneratesFullMipChain)
+{
+    constexpr u32 kW = 64;
+    constexpr u32 kH = 64;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, 4.0f);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, true);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.MipLevels(), 7u); // 64 -> ... -> 1
+
+    for (u32 level = 0; level < image.MipLevels(); ++level)
+    {
+        const u32 mw = std::max(1u, kW >> level);
+        const u32 mh = std::max(1u, kH >> level);
+        EXPECT_EQ(image.Mips[level].size(), TextureCompression::MipByteSize(TextureCompressionFormat::BC6H, mw, mh))
+            << "mip " << level << " byte size mismatch";
+    }
+}
+
+TEST(TextureCompression, BC6HHandlesNonMultipleOf4Dimensions)
+{
+    constexpr u32 kW = 13; // not a multiple of 4
+    constexpr u32 kH = 7;
+    constexpr f32 kPeak = 6.0f;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, kPeak);
+
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, false);
+    ASSERT_TRUE(image.IsValid());
+    EXPECT_EQ(image.Width, kW);
+    EXPECT_EQ(image.Height, kH);
+
+    std::vector<f32> decoded;
+    u32 dw = 0;
+    u32 dh = 0;
+    ASSERT_TRUE(TextureCompression::DecodeToRGBAFloat(image, 0, decoded, dw, dh));
+    EXPECT_EQ(dw, kW);
+    EXPECT_EQ(dh, kH);
+    EXPECT_EQ(decoded.size(), static_cast<sizet>(kW) * kH * 4);
+}
+
+TEST(TextureCompression, BC6HContainerBlobRoundTripIsBitExact)
+{
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 16;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, 5.0f);
+
+    const CompressedTextureImage original = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, true);
+    ASSERT_TRUE(original.IsValid());
+
+    const std::vector<u8> blob = TextureCompression::SerializeToBlob(original);
+    ASSERT_FALSE(blob.empty());
+
+    CompressedTextureImage restored;
+    ASSERT_TRUE(TextureCompression::DeserializeFromBlob(blob, restored));
+    EXPECT_EQ(restored.Format, TextureCompressionFormat::BC6H);
+    EXPECT_EQ(restored.Width, original.Width);
+    EXPECT_EQ(restored.Height, original.Height);
+    EXPECT_FALSE(restored.SRGB);
+    EXPECT_FALSE(restored.HasAlpha);
+    ASSERT_EQ(restored.MipLevels(), original.MipLevels());
+    for (u32 level = 0; level < original.MipLevels(); ++level)
+        EXPECT_EQ(restored.Mips[level], original.Mips[level]) << "mip " << level << " block bytes differ";
+}
+
+TEST(TextureCompression, EncodeBC6HRejectsInsufficientChannels)
+{
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    std::vector<f32> rg(static_cast<sizet>(kW) * kH * 2, 1.0f);
+    // BC6H is RGB HDR; a 2-channel source is meaningless and must be rejected.
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(rg.data(), kW, kH, 2, false);
+    EXPECT_FALSE(image.IsValid());
+}
+
+TEST(TextureCompression, DecodeToRGBA8RejectsBC6H)
+{
+    // BC6H has no meaningful 8-bit representation — DecodeToRGBA8 must refuse it (rather
+    // than mis-decode via the BC5 path) so the fallback routes through the float decode.
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, 2.0f);
+    const CompressedTextureImage image = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, false);
+    ASSERT_TRUE(image.IsValid());
+
+    std::vector<u8> rgba8;
+    u32 dw = 0;
+    u32 dh = 0;
+    EXPECT_FALSE(TextureCompression::DecodeToRGBA8(image, 0, rgba8, dw, dh));
+}
+
+TEST(TextureCompression, DeserializeRejectsBC6HWithColorFlags)
+{
+    // BC6H (linear HDR RGB) must carry neither sRGB nor alpha.
+    constexpr u32 kW = 8;
+    constexpr u32 kH = 8;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, 2.0f);
+    const CompressedTextureImage bc6h = TextureCompression::EncodeBC6H(source.data(), kW, kH, 3, false);
+    ASSERT_TRUE(bc6h.IsValid());
+    std::vector<u8> blob = TextureCompression::SerializeToBlob(bc6h);
+    ASSERT_GE(blob.size(), 28u);
+
+    // Patch flags (offset 20) to set the alpha bit — illegal for BC6H.
+    blob[20] = 0x2u;
+    CompressedTextureImage out;
+    EXPECT_FALSE(TextureCompression::DeserializeFromBlob(blob, out));
+}
+
+TEST(TextureCompression, OfflineCookFromHdrAutoSelectsBC6H)
+{
+    // Full offline cook of an HDR source: write a .hdr, CompressTextureFile with Format
+    // left None (auto), and confirm stbi_is_hdr steered the cook to a BC6H mip chain.
+    constexpr u32 kW = 32;
+    constexpr u32 kH = 24;
+    const std::vector<f32> source = MakeGradientHDR(kW, kH, 4.0f);
+
+    const std::filesystem::path hdrPath = CaseKeyedTempFile(".hdr");
+    const std::filesystem::path oloTexPath = CaseKeyedTempFile(".olotex");
+    ASSERT_NE(::stbi_write_hdr(hdrPath.string().c_str(), static_cast<int>(kW), static_cast<int>(kH), 3, source.data()), 0);
+
+    TextureCompression::CompressOptions options; // Format=None -> auto
+    options.GenerateMips = true;
+    ASSERT_TRUE(TextureCompression::CompressTextureFile(hdrPath.string(), oloTexPath.string(), options));
+
+    CompressedTextureImage loaded;
+    ASSERT_TRUE(TextureCompression::ReadFile(oloTexPath.string(), loaded));
+    EXPECT_EQ(loaded.Format, TextureCompressionFormat::BC6H);
+    EXPECT_EQ(loaded.Width, kW);
+    EXPECT_EQ(loaded.Height, kH);
+    EXPECT_GT(loaded.MipLevels(), 1u);
+
+    std::error_code ec;
+    std::filesystem::remove(hdrPath, ec);
     std::filesystem::remove(oloTexPath, ec);
 }
 

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -404,6 +404,28 @@ if(bc7enc_rdo_ADDED)
 	endif()
 endif()
 
+# bcdec: iOrange's single-header BC1-7 + BC6H block DECODER. Dual MIT / Unlicense
+# (public domain) — same permissive footing as stb. bc7enc_rdo ships no BC6H encoder,
+# so the offline cook (Renderer/TextureCompression.cpp) gained a from-scratch BC6H
+# mode-11 encoder (#440); bcdec is used to (a) INDEPENDENTLY validate that encoder in
+# CI — a matched encoder/decoder bug can't hide behind a shared codepath — and (b) act
+# as the CPU HDR fallback that decodes BC6H to RGBA16F on a context lacking BPTC.
+# Header-only: the implementation is compiled exactly once, via BCDEC_IMPLEMENTATION in
+# TextureCompression.cpp. DOWNLOAD_ONLY + INTERFACE, mirroring the choc/stb pattern.
+# Pinned to a fixed commit SHA for reproducible builds (#294 convention).
+CPMAddPackage(NAME bcdec
+  GIT_REPOSITORY https://github.com/iOrange/bcdec.git
+  GIT_TAG 93628fe5627102fe5187b7eeb99122dec6612c36  # main @ 2025-10-23
+  GIT_SHALLOW FALSE
+  DOWNLOAD_ONLY YES)
+if(bcdec_ADDED)
+	add_library(bcdec INTERFACE)
+	# SYSTEM so the header's own warnings — and the BCDEC_IMPLEMENTATION expansion it
+	# emits into TextureCompression.cpp — don't count against OloEngine's /W4 /WX flags,
+	# exactly as stb_image's IMPLEMENTATION is handled.
+	target_include_directories(bcdec SYSTEM INTERFACE "${bcdec_SOURCE_DIR}")
+endif()
+
 set_target_properties(assimp PROPERTIES FOLDER "Utilities/assimp")
 if(TARGET UpdateAssimpLibsDebugSymbolsAndDLLs)
 	set_target_properties(UpdateAssimpLibsDebugSymbolsAndDLLs PROPERTIES FOLDER "Utilities/assimp")


### PR DESCRIPTION
## What & why

Completes **#440** (offline BC7/BC5/BC6H texture compression in the cook pipeline). BC7 + BC5 shipped earlier in #508; this PR adds the two remaining acceptance items: **BC6H (HDR/IBL)** and the **auto-cook wiring** that makes shipped textures BC-compressed automatically.

## Changes

### 1. BC6H (HDR) offline compression — `3d1ea56b`
- **From-scratch mode-11 unsigned BC6H encoder** (`Renderer/TextureCompression.cpp`) — bc7enc_rdo ships no BC6H encoder. 1 subset, 10-bit raw endpoints, 4-bit indices, with a least-squares endpoint refinement pass.
- Validated by **two fully independent decoders**: the vendored **bcdec** reference decoder (CPU, runs in CI) *and* the real **GPU BPTC hardware** decoder (visual-evidence test), plus a bit-exact stored-block round-trip — so no plausible-but-wrong bit layout can slip through.
- GL upload: `ImageFormat::BC6H` → `GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT`; no-BPTC hardware falls back to an **RGBA16F** decode (HDR-preserving, not an 8-bit clip).
- Cook: HDR loaded via `stbi_loadf`; `.olotex` container extended; `CompressTextureFile` auto-selects BC6H when `stbi_is_hdr`.
- New dep: **bcdec** (iOrange, dual MIT / Unlicense), vendored via CPM like stb.

### 2. Asset-pack auto-cook — `cc968ac0`
- `AssetPackBuilder` now honors `BuildSettings::m_CompressAssets` (previously defined-but-unused): during a pack build, uncompressed source textures are BC-compressed into embedded `.olotex` blobs — so shipped textures get BCn + mips with **no separate cook step**.
- Mechanics: `CompressImageFile` (in-memory core of `CompressTextureFile`) + a `TextureSerializer` compression policy (RAII-guarded, set from `m_CompressAssets`) + an auto-cook branch in `SerializeToAssetPack` that writes the compressed-record shape — **reusing the runtime's existing `IsCompressedFormat`-keyed embedded-blob read path unchanged**.
- Auto picks BC7 (LDR) / BC6H (HDR); BC5-for-normals stays opt-in (the filename heuristic can't reliably ID a tangent-space normal). A cook failure falls back to the raw record, so a build never fails on one texture.

## Testing

- **29 compression/auto-cook tests pass** — CPU round-trip (bcdec oracle), GPU visual-evidence (BPTC oracle, SKIPs headless), container round-trip, HDR auto-select, and two GPU auto-cook pack round-trips (compression on → BC7 record smaller than raw RGBA8; off → stays uncompressed).
- Broader asset/serialization sweep clean apart from a pre-existing, order-dependent GPU-state-leakage flake unrelated to this work (filed as #625).

## Acceptance criteria (#440)

- [x] Shipped textures are BC-compressed with mips — auto-cook during pack build.
- [x] BC7 (albedo) / BC5 (normals) / BC6H (HDR) all implemented.
- [x] Runtime loads pre-compressed blocks directly into GL compressed formats (no CPU transcode on capable hardware).
- [x] No visible quality regression — verified via GPU decode + PSNR + visual-evidence PNGs.

## Follow-ups

- **#624** — deferred enhancements (higher-quality multi-subset/signed BC6H, BC5 auto-select for normals, GPU compute encoder, linear-space mips, packed-format heuristics).
- **#625** — the flaky caustics test found while verifying (leaked GL error attributed to the wrong test).

Unblocks **#434** (texture-mip streaming), which listed this as a prerequisite.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HDR texture compression support via BC6H, including mip-chain generation and float-based decode.
  * Asset packs gained an auto-cook compression mode for eligible textures to reduce packed size.
  * OpenGL now supports BC6H uploads, decompression-on-fallback, and feature checks for compressed storage.
  * Auto-selects BC6H for HDR sources and BC7 for standard sources (with BC5 still opt-in).

* **Bug Fixes**
  * Improved asset-pack texture metadata persistence and validation for compressed records.

* **Tests**
  * Added CPU, container, GPU round-trip, and asset-pack auto-cook coverage for BC6H and policy toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->