### PR TITLE
fix(mcp): honour notifications/cancelled during write-consent wait (#610)

### DIFF
--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -1733,6 +1733,20 @@ namespace OloEngine::MCP
             }
         }
 
+        // Linearization point for the consent→handler transition (issue #610 review):
+        // a notifications/cancelled observed by now — after consent was granted but
+        // before the write starts — prevents the handler from running at all, instead
+        // of executing the (undoable) write and discarding its result at the
+        // post-handler check below. The CancelFlag is a single atomic, so this load is
+        // ordered strictly before or after the cancel store in the flag's modification
+        // order: load == true ⇒ the cancel is "before" write initiation ⇒ don't run;
+        // load == false ⇒ execution has started and any later cancel is handled by the
+        // handler's cooperative IsCurrentCallCancelled() polling + the post-handler
+        // discard. (A CAS state machine would add no further guarantee here — a
+        // mid-run cancel can always reach an opaque handler.)
+        if (scope.CancelFlag->load(std::memory_order_acquire))
+            return MakeError(id, kRequestCancelledCode, "Request cancelled");
+
         ToolResult result;
         try
         {

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -984,15 +984,25 @@ namespace OloEngine::MCP
         m_ConsentCv.notify_all();
     }
 
-    ConsentDecision McpServer::RequestConsent(const ToolDef& tool, const Json& arguments)
+    ConsentDecision McpServer::RequestConsent(const ToolDef& tool, const Json& arguments,
+                                              const std::shared_ptr<std::atomic<bool>>& cancelFlag)
     {
         const auto timeout = std::chrono::milliseconds(m_ConsentTimeoutMs.load());
+
+        // Predicate helper: a call cancelled via notifications/cancelled while parked
+        // here must return promptly (issue #610). The cancellation path stores the
+        // flag then synchronizes on m_ConsentMutex before notifying, so a read taken
+        // under this lock cannot miss a store the notifier has already published.
+        const auto cancelled = [&cancelFlag]
+        { return cancelFlag && cancelFlag->load(std::memory_order_acquire); };
 
         u64 myId = 0;
         {
             std::unique_lock lock(m_ConsentMutex);
             if (m_ConsentAborting)
                 return ConsentDecision::Deny;
+            if (cancelled())
+                return ConsentDecision::Cancel;
             // A concurrent mode change may have already settled the outcome before we
             // enqueue anything — honour it without prompting.
             const WriteConsentMode mode = m_ConsentMode.load();
@@ -1009,9 +1019,9 @@ namespace OloEngine::MCP
             entry.Summary = BuildConsentSummary(arguments);
             m_ConsentQueue.push_back(std::move(entry));
 
-            const bool resolved = m_ConsentCv.wait_for(lock, timeout, [this, myId]
+            const bool resolved = m_ConsentCv.wait_for(lock, timeout, [this, myId, &cancelled]
                                                        {
-                                                           if (m_ConsentAborting)
+                                                           if (m_ConsentAborting || cancelled())
                                                                return true;
                                                            for (const ConsentEntry& e : m_ConsentQueue)
                                                            {
@@ -1035,6 +1045,11 @@ namespace OloEngine::MCP
 
             if (m_ConsentAborting)
                 return ConsentDecision::Deny;
+            // Cancellation wins over a racing human decision: even if the modal was
+            // just approved, an arrived notifications/cancelled means the write must
+            // not run and the response is discarded per spec.
+            if (cancelled())
+                return ConsentDecision::Cancel;
             if (!resolved || decision == ConsentDecision::Pending)
                 return ConsentDecision::Timeout;
             return decision;
@@ -1421,7 +1436,21 @@ namespace OloEngine::MCP
                         flag = it->second;
                 }
                 if (flag)
+                {
                     flag->store(true, std::memory_order_release);
+                    // The flagged call may be parked in RequestConsent on the consent
+                    // modal (issue #610). Wake it: a bare atomic store racing the
+                    // waiter's predicate check could be lost, so take m_ConsentMutex
+                    // (never nested with m_InFlightMutex above — released already) to
+                    // serialize with the waiter before notifying. A call in its handler
+                    // instead just polls the flag, so this notify is a harmless no-op
+                    // for it. m_ConsentMutex is not held across the notify — a spurious
+                    // wake of unrelated waiters is cheap and they re-check and re-sleep.
+                    {
+                        std::lock_guard consentLock(m_ConsentMutex);
+                    }
+                    m_ConsentCv.notify_all();
+                }
             }
             return Json(nullptr);
         }
@@ -1620,50 +1649,19 @@ namespace OloEngine::MCP
             return MakeResult(id, Json{ { "content", invalid.Content }, { "isError", true } });
         }
 
-        // Session write consent (issue #306 item C): a project-mutating tool is gated
-        // by the WriteConsentMode the user set in the MCP panel (default Disabled,
-        // never persisted). This stacks on top of the enabled + bearer-token gate:
-        // even an authenticated agent stays read-only w.r.t. the project until the
-        // human opts in for the session. Read-only / ephemeral editor-state tools
-        // (camera / viewport / render overrides) are not ProjectWrite, so no mode
-        // affects them.
-        //
-        //   Disabled     -> refuse outright.
-        //   Prompt       -> block this worker thread on RequestConsent until the human
-        //                   approves/denies the per-action modal (or it times out).
-        //   AllowSession -> proceed (the human already approved everything).
-        if (tool->ProjectWrite)
-        {
-            const WriteConsentMode mode = m_ConsentMode.load();
-            if (mode == WriteConsentMode::Disabled)
-                return MakeError(id, kInvalidParams,
-                                 "Write tools are disabled. Set writes to \"Prompt\" or \"Allow all\" in the "
-                                 "editor's MCP Server panel to permit this mutation (they are off by default).");
-            if (mode == WriteConsentMode::Prompt)
-            {
-                switch (RequestConsent(*tool, arguments))
-                {
-                    case ConsentDecision::Approve:
-                    case ConsentDecision::ApproveAll:
-                        break; // human approved — fall through to the handler.
-                    case ConsentDecision::Timeout:
-                        return MakeError(id, kInvalidParams,
-                                         "Write consent request timed out with no response from the editor user.");
-                    case ConsentDecision::Deny:
-                    case ConsentDecision::Pending:
-                    default:
-                        return MakeError(id, kInvalidParams,
-                                         "The editor user denied this write. Ask them to Approve it (or switch writes "
-                                         "to \"Allow all\") in the editor's MCP Server panel.");
-                }
-            }
-        }
-
         // ---- per-call progress/cancellation scope (issue #357 item B) ----------
         // Register this call in the in-flight registry so a concurrently-arriving
         // `notifications/cancelled` (matched by exact id value) can flag it, and
         // install the thread-local scope EmitProgress / IsCurrentCallCancelled
         // read. RAII: the registry entry lives exactly as long as the dispatch.
+        //
+        // This MUST precede the consent gate below (issue #610): a ProjectWrite tool
+        // parked in RequestConsent on the Prompt-mode modal is otherwise invisible to
+        // cancellation until it starts running. Registering first means the flag is
+        // reachable while the call waits, and RequestConsent consults it — so a
+        // notifications/cancelled aborts the wait promptly instead of running to the
+        // human's decision or the consent timeout. The RAII guards below also ensure
+        // every consent-gate early-return path still erases the in-flight entry.
         ActiveCallScope scope;
         if (params.contains("_meta") && params["_meta"].is_object() && params["_meta"].contains("progressToken"))
         {
@@ -1688,6 +1686,52 @@ namespace OloEngine::MCP
             }
         } inFlightGuard{ *this, idKey };
         const CallScopeGuard scopeGuard(scope);
+
+        // Session write consent (issue #306 item C): a project-mutating tool is gated
+        // by the WriteConsentMode the user set in the MCP panel (default Disabled,
+        // never persisted). This stacks on top of the enabled + bearer-token gate:
+        // even an authenticated agent stays read-only w.r.t. the project until the
+        // human opts in for the session. Read-only / ephemeral editor-state tools
+        // (camera / viewport / render overrides) are not ProjectWrite, so no mode
+        // affects them.
+        //
+        //   Disabled     -> refuse outright.
+        //   Prompt       -> block this worker thread on RequestConsent until the human
+        //                   approves/denies the per-action modal (or it times out, or a
+        //                   notifications/cancelled aborts the wait — issue #610).
+        //   AllowSession -> proceed (the human already approved everything).
+        if (tool->ProjectWrite)
+        {
+            const WriteConsentMode mode = m_ConsentMode.load();
+            if (mode == WriteConsentMode::Disabled)
+                return MakeError(id, kInvalidParams,
+                                 "Write tools are disabled. Set writes to \"Prompt\" or \"Allow all\" in the "
+                                 "editor's MCP Server panel to permit this mutation (they are off by default).");
+            if (mode == WriteConsentMode::Prompt)
+            {
+                switch (RequestConsent(*tool, arguments, scope.CancelFlag))
+                {
+                    case ConsentDecision::Approve:
+                    case ConsentDecision::ApproveAll:
+                        break; // human approved — fall through to the handler.
+                    case ConsentDecision::Timeout:
+                        return MakeError(id, kInvalidParams,
+                                         "Write consent request timed out with no response from the editor user.");
+                    case ConsentDecision::Cancel:
+                        // notifications/cancelled reached the call while it was parked
+                        // on the modal (issue #610). The write never ran; respond as a
+                        // cancelled request (clients ignore this body per spec), same as
+                        // the post-handler cancellation check below.
+                        return MakeError(id, kRequestCancelledCode, "Request cancelled");
+                    case ConsentDecision::Deny:
+                    case ConsentDecision::Pending:
+                    default:
+                        return MakeError(id, kInvalidParams,
+                                         "The editor user denied this write. Ask them to Approve it (or switch writes "
+                                         "to \"Allow all\") in the editor's MCP Server panel.");
+                }
+            }
+        }
 
         ToolResult result;
         try

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -101,6 +101,7 @@ namespace OloEngine::MCP
         Deny = 2,
         ApproveAll = 3, // approve THIS one and flip the session to AllowSession.
         Timeout = 4,
+        Cancel = 5, // a notifications/cancelled reached the call while it was parked on the modal.
     };
 
     // Result of a tool invocation. `Content` is the MCP content array
@@ -672,7 +673,17 @@ namespace OloEngine::MCP
         // / a mode change / shutdown intervenes), and return the decision. MUST run on
         // a handler thread — it blocks on the main thread rendering the modal, so
         // calling it from the game thread would deadlock.
-        [[nodiscard]] ConsentDecision RequestConsent(const ToolDef& tool, const Json& arguments);
+        //
+        // `cancelFlag` is the in-flight call's cooperative cancel flag (issue #610): the
+        // wait predicate consults it so a `notifications/cancelled` arriving while the
+        // call is parked on the modal returns promptly with ConsentDecision::Cancel
+        // instead of running to the human's decision or the consent timeout. The
+        // cancellation path sets the atomic and wakes m_ConsentCv (see DispatchRpc);
+        // the store and this predicate's read are serialized through m_ConsentMutex so
+        // there is no lost wakeup. Never null in the dispatch path; may be null in a
+        // test that exercises the handshake directly.
+        [[nodiscard]] ConsentDecision RequestConsent(const ToolDef& tool, const Json& arguments,
+                                                     const std::shared_ptr<std::atomic<bool>>& cancelFlag);
 
         [[nodiscard]] const ToolDef* FindTool(const std::string& name) const;
         [[nodiscard]] const ResourceDef* FindResource(const std::string& uri) const;

--- a/OloEditor/src/MCP/McpToolsCamera.cpp
+++ b/OloEditor/src/MCP/McpToolsCamera.cpp
@@ -2,6 +2,8 @@
 #include "MCP/McpToolsCommon.h"
 #include "MCP/McpSchemaBuilder.h"
 #include <algorithm>
+#include <atomic>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -146,56 +148,65 @@ namespace OloEngine::MCP
                 settleFrames = static_cast<int>(std::clamp<long long>(args["settleFrames"].get<long long>(), 1, 30));
 
             bool posed = false;
-            Json savedPose; // round-trips the prior pose through JSON for the restore job
             bool waitTimedOut = false;
-            if (hasCamera || hasOrbit)
-            {
-                // 1. Save the user's pose and apply the requested one.
-                const Json applied = server.MarshalRead([&server, request]() -> Json
-                                                        {
-                    const McpCameraPose prior = server.Context().GetCameraPose();
-                    ApplyCameraRequest(server.Context(), request);
-                    Json j;
-                    j["focalPoint"] = Json::array({ prior.FocalPoint.x, prior.FocalPoint.y, prior.FocalPoint.z });
-                    j["distance"] = prior.Distance;
-                    j["yaw"] = prior.YawRadians;
-                    j["pitch"] = prior.PitchRadians;
-                    j["fov"] = prior.FovDegrees;
-                    j["frame"] = server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0;
-                    return j; });
-                savedPose = applied;
-                posed = true;
-            }
 
-            // The restore half of the save/restore contract, runnable from both
-            // the success path (inside the capture job) and the error path.
-            const auto restorePriorPose = [&server, &savedPose]()
+            // Save/restore state shared between the apply job, the capture-and-restore
+            // job, and the error-path restore (issue #610). The apply job records the
+            // user's prior pose and raises `Applied` LAST; every restore path reads
+            // `Applied` and restores `Prior` only when it is set. This closes the
+            // pose-strand edge: if the step-1 apply marshal times out (throws) its
+            // enqueued job may still run and move the camera later — because the
+            // prior pose lives here (not in the timed-out future) and the error-path
+            // restore is enqueued AFTER the apply job (game-thread tasks drain FIFO),
+            // that late apply is always followed by a matching restore instead of
+            // stranding the user at the screenshot pose.
+            struct PoseGuardState
             {
-                McpCameraPose prior;
-                prior.FocalPoint = glm::vec3{ savedPose["focalPoint"][0].get<f32>(),
-                                              savedPose["focalPoint"][1].get<f32>(),
-                                              savedPose["focalPoint"][2].get<f32>() };
-                prior.Distance = savedPose.value("distance", 0.0f);
-                prior.YawRadians = savedPose.value("yaw", 0.0f);
-                prior.PitchRadians = savedPose.value("pitch", 0.0f);
-                prior.FovDegrees = savedPose.value("fov", 45.0f);
-                server.Context().RestoreCameraPose(prior);
+                std::atomic<bool> Applied{ false };
+                McpCameraPose Prior;
+            };
+            const auto poseState = (hasCamera || hasOrbit) ? std::make_shared<PoseGuardState>() : nullptr;
+
+            // The restore half of the save/restore contract. Captures poseState BY
+            // VALUE (a shared_ptr), so a copy carried into a marshaled job keeps the
+            // state alive even if this call unwinds before an orphaned job runs. A
+            // no-op until the apply job has actually applied the pose.
+            const auto restorePriorPose = [&server, poseState]()
+            {
+                if (poseState && poseState->Applied.load(std::memory_order_acquire))
+                    server.Context().RestoreCameraPose(poseState->Prior);
             };
 
             Json marshaled;
             try
             {
+                u64 appliedFrame = 0;
+                if (poseState)
+                {
+                    // 1. Save the user's pose and apply the requested one — inside the
+                    // try so a marshal timeout here is caught and restored below.
+                    const Json applied = server.MarshalRead([&server, request, poseState]() -> Json
+                                                            {
+                        poseState->Prior = server.Context().GetCameraPose();
+                        ApplyCameraRequest(server.Context(), request);
+                        // Publish LAST: `Applied` release-fences the Prior store so any
+                        // restore that reads Applied==true also observes Prior.
+                        poseState->Applied.store(true, std::memory_order_release);
+                        return Json{ { "frame", server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0 } }; });
+                    posed = true;
+                    appliedFrame = applied.value("frame", static_cast<u64>(0));
+                }
+
                 // 2. Wait until the new pose has actually been rendered.
                 if (posed)
-                    waitTimedOut = !AwaitRenderedFrames(server, savedPose.value("frame", static_cast<u64>(0)), settleFrames);
+                    waitTimedOut = !AwaitRenderedFrames(server, appliedFrame, settleFrames);
 
                 // 3. Capture — and restore the user's camera in the same main-thread
                 // job, so the restore happens exactly once whatever the capture did.
-                marshaled = server.MarshalRead([&server, maxWidth, posed, &restorePriorPose]() -> Json
+                marshaled = server.MarshalRead([&server, maxWidth, restorePriorPose]() -> Json
                                                {
                     const std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
-                    if (posed)
-                        restorePriorPose();
+                    restorePriorPose();
                     if (png.empty())
                         return Json{ { "__error", "Viewport capture failed (no framebuffer or empty viewport)." } };
                     return Json{ { "b64", Base64Encode(png) }, { "bytes", static_cast<u64>(png.size()) } }; });
@@ -203,13 +214,17 @@ namespace OloEngine::MCP
             catch (...)
             {
                 // Don't leave the user's camera stranded at the capture pose if a
-                // marshal failed mid-flow. Best effort — if the editor is truly
-                // stalled this will fail too, and the original exception matters more.
-                if (posed)
+                // marshal failed mid-flow — including a step-1 apply that timed out
+                // here but whose job runs later. `restorePriorPose` (captured by value)
+                // no-ops until that apply raises `Applied`, and this restore is
+                // enqueued after it (FIFO), so the late apply is always undone. Best
+                // effort — if the editor is truly stalled this throws too, and the
+                // original exception matters more.
+                if (poseState)
                 {
                     try
                     {
-                        (void)server.MarshalRead([&restorePriorPose]() -> Json
+                        (void)server.MarshalRead([restorePriorPose]() -> Json
                                                  {
                             restorePriorPose();
                             return Json{}; });

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -60,6 +60,9 @@ namespace
     namespace SetCollisionLayer = OloEngine::MCP::SetCollisionLayer;
 
     constexpr int kInvalidParams = -32602;
+    // LSP-convention "request cancelled" code the plain-JSON path carries for a call
+    // cancelled via notifications/cancelled (McpServer.h kRequestCancelledCode).
+    constexpr int kRequestCancelledCode = -32800;
 
     Json MakeCallRequest(const Json& id, const Json& arguments)
     {
@@ -67,6 +70,16 @@ namespace
                      { "id", id },
                      { "method", "tools/call" },
                      { "params", { { "name", "olo_set_collision_layer" }, { "arguments", arguments } } } };
+    }
+
+    // A `notifications/cancelled` for the tools/call with this JSON-RPC id. Matching
+    // is by exact id value (McpServer's RequestIdKey), so `requestId` must equal the
+    // call's `id` verbatim (same JSON type).
+    Json MakeCancelNotification(const Json& requestId)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "method", "notifications/cancelled" },
+                     { "params", { { "requestId", requestId }, { "reason", "test cancel" } } } };
     }
 
     // Fixture: an McpServer whose only tool is a fake olo_set_collision_layer wired
@@ -276,6 +289,101 @@ TEST_F(McpConsentedWriteTest, PromptModeTimesOutWhenUnanswered)
     EXPECT_EQ(resp["error"]["code"], kInvalidParams);
     EXPECT_EQ(CurrentLayer(), kInitialLayer);
     EXPECT_FALSE(m_History.CanUndo());
+}
+
+// ---- cancellation while parked on the consent modal (issue #610) -----------
+// A notifications/cancelled arriving while a write is blocked on the Prompt-mode
+// modal must abort the wait promptly, return a cancelled response, run NO write,
+// and drain the pending prompt — the whole point of registering the in-flight
+// cancel flag BEFORE the consent gate.
+
+TEST_F(McpConsentedWriteTest, PromptModeCancelledWhileParkedReturnsCancelled)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    // A generous consent timeout so a Timeout can't masquerade as the cancellation:
+    // if cancellation did NOT reach the wait, the call would block far past the test.
+    m_Server.SetConsentTimeout(std::chrono::seconds(30));
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(20, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u) << "no consent prompt surfaced";
+    EXPECT_EQ(CurrentLayer(), kInitialLayer); // not applied while parked
+
+    // Cancel by the call's JSON-RPC id (a number, matched verbatim). This wakes the
+    // parked RequestConsent wait through m_ConsentCv.
+    const Json ack = m_Server.HandleMessage(MakeCancelNotification(20));
+    EXPECT_TRUE(ack.is_null()); // a notification produces no response
+
+    const Json resp = call.get();
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_EQ(resp["error"]["code"], kRequestCancelledCode);
+
+    // The write never ran, and the in-flight prompt was reaped (queue drained).
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+    EXPECT_TRUE(m_Server.PendingConsents().empty());
+}
+
+// Cancellation wins over a racing human decision: once the cancel flag is set, a
+// later Approve on the (now-reaped) prompt is a no-op and the write stays unapplied.
+TEST_F(McpConsentedWriteTest, PromptModeCancellationWinsOverLateApprove)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    m_Server.SetConsentTimeout(std::chrono::seconds(30));
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(21, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u);
+
+    // Cancel first — the worker wakes, returns Cancel, and reaps its entry. The
+    // subsequent Approve finds no live prompt for `id` and is a no-op.
+    (void)m_Server.HandleMessage(MakeCancelNotification(21));
+    const Json resp = call.get();
+    m_Server.ResolveConsent(id, ConsentDecision::Approve); // late, stale id → no-op
+
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kRequestCancelledCode);
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
+    EXPECT_TRUE(m_Server.PendingConsents().empty());
+}
+
+// A cancellation whose requestId does NOT match the parked call must not disturb
+// it: the real call still resolves normally via its Approve. Guards against an
+// over-broad wake that cancels the wrong (or every) in-flight write.
+TEST_F(McpConsentedWriteTest, PromptModeUnrelatedCancelDoesNotAbortWrite)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    m_Server.SetConsentTimeout(std::chrono::seconds(30));
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(22, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u);
+
+    // Cancel a DIFFERENT id — a spec-sanctioned no-op: the id isn't in the in-flight
+    // registry, so no flag is set (and m_ConsentCv isn't even woken). Our prompt
+    // stays pending after it.
+    (void)m_Server.HandleMessage(MakeCancelNotification(9999));
+    ASSERT_NE(WaitForPendingConsent(), 0u) << "unrelated cancel wrongly drained the prompt";
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+
+    // The real decision still applies the write.
+    m_Server.ResolveConsent(id, ConsentDecision::Approve);
+    const Json resp = call.get();
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+    EXPECT_EQ(CurrentLayer(), 3u);
+    EXPECT_TRUE(m_History.CanUndo());
 }
 
 // AllowSession (== the legacy gate-on) never prompts — the queue stays empty.

--- a/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpConsentedWriteTest.cpp
@@ -33,6 +33,7 @@
 #include "OloEngine/Scene/Scene.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <optional>
@@ -107,6 +108,9 @@ namespace
             tool.InputSchema = SetCollisionLayer::InputSchema();
             tool.Handler = [this](McpServer&, const Json& args) -> ToolResult
             {
+                // Probe: proves whether the handler was actually entered. A cancel
+                // that reaches the call before write initiation must leave this false.
+                m_HandlerEntered.store(true, std::memory_order_release);
                 u64 entityUuid = 0;
                 u32 layer = 0;
                 if (const auto error = SetCollisionLayer::ParseArgs(args, entityUuid, layer))
@@ -149,6 +153,7 @@ namespace
 
         static constexpr u32 kInitialLayer = 0;
 
+        std::atomic<bool> m_HandlerEntered{ false }; // raised at the top of the tool handler
         Ref<Scene> m_Scene;
         CommandHistory m_History;
         u64 m_EntityUuid = 0;
@@ -384,6 +389,41 @@ TEST_F(McpConsentedWriteTest, PromptModeUnrelatedCancelDoesNotAbortWrite)
     EXPECT_FALSE(resp["result"]["isError"]);
     EXPECT_EQ(CurrentLayer(), 3u);
     EXPECT_TRUE(m_History.CanUndo());
+}
+
+// Barrier-based linearizability guard (issue #610 review): a cancellation that
+// reaches the call between the final consent check and handler start must never
+// initiate the write. The Prompt-mode consent modal is the barrier — the worker is
+// deterministically parked there (write registered, handler NOT yet reached) when
+// the cancel arrives. The handler-entered probe proves the write was never even
+// begun: it must stay false, so there is no "ran the write then discarded it" race.
+TEST_F(McpConsentedWriteTest, CancelBeforeHandlerStartNeverInitiatesWrite)
+{
+    m_Server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    m_Server.SetConsentTimeout(std::chrono::seconds(30));
+
+    std::future<Json> call = std::async(std::launch::async, [this]
+                                        { return m_Server.HandleMessage(
+                                              MakeCallRequest(30, Json{ { "entity", std::to_string(m_EntityUuid) }, { "layer", 3 } })); });
+
+    // Barrier: the worker is now parked on the consent modal — past registration,
+    // before the handler.
+    const u64 id = WaitForPendingConsent();
+    ASSERT_NE(id, 0u) << "no consent prompt surfaced";
+    ASSERT_FALSE(m_HandlerEntered.load(std::memory_order_acquire)) << "handler ran before consent";
+
+    // Cancel while parked. The call must unwind to a cancelled response without ever
+    // entering the handler.
+    (void)m_Server.HandleMessage(MakeCancelNotification(30));
+
+    const Json resp = call.get();
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], kRequestCancelledCode);
+
+    // The write was never initiated — handler untouched, field unchanged, no undo.
+    EXPECT_FALSE(m_HandlerEntered.load(std::memory_order_acquire)) << "cancelled write must not initiate the handler";
+    EXPECT_EQ(CurrentLayer(), kInitialLayer);
+    EXPECT_FALSE(m_History.CanUndo());
 }
 
 // AllowSession (== the legacy gate-on) never prompts — the queue stays empty.

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
@@ -135,19 +135,49 @@ namespace OloEngine::Tests
         McpHeadlessHost(const McpHeadlessHost&) = delete;
         McpHeadlessHost& operator=(const McpHeadlessHost&) = delete;
 
-        // Start the server, binding the first free port at or after `basePort`.
-        // basePort == 0 derives a per-process base (from the PID) so parallel
-        // ctest processes don't collide. Returns the bound port, or 0 on failure.
-        [[nodiscard]] u16 Start(u16 basePort = 0, int attempts = 24)
+        // Start the server, binding a free port. basePort == 0 derives a per-process
+        // base so parallel ctest processes don't collide; a non-zero basePort is a
+        // deliberate choice (the driver's per-worktree OLO_MCP_PORT, which the agent
+        // is told to connect to) and is honoured as-is. Returns the bound port, or 0
+        // on failure.
+        [[nodiscard]] u16 Start(u16 basePort = 0, int attempts = 40)
         {
-            u16 port = basePort != 0 ? basePort : DerivePidPort();
+            // Explicit base: try that exact port and a few consecutive fallbacks. The
+            // caller picked it and something downstream (the agent's MCP client) may
+            // expect it, so don't remap it.
+            if (basePort != 0)
+            {
+                for (int i = 0; i < attempts; ++i)
+                {
+                    const u32 candidate = static_cast<u32>(basePort) + static_cast<u32>(i);
+                    if (candidate > 65535u)
+                        break;
+                    if (candidate >= 1024u && m_Server->Start(static_cast<u16>(candidate)))
+                        return static_cast<u16>(candidate);
+                }
+                return 0;
+            }
+
+            // Derived base: DerivePidPort() samples [20000, 59999], where Windows
+            // reserves CONTIGUOUS excluded TCP blocks up to ~700 ports wide (Hyper-V /
+            // WSL / Docker dynamic reservations — a bind there fails with AccessDenied).
+            // The old +1 step could land every attempt inside one such block and bind
+            // nothing (the McpHeadlessAttach / McpPerfSettle port-bind flake, issue
+            // #610 follow-up). Stride by a prime WIDER than the widest realistic
+            // exclusion block so a run of failures leaps clear of it on the very next
+            // attempt; gcd(stride, span) == 1 keeps all `attempts` candidates distinct,
+            // and the mod-wrap holds every candidate inside the ephemeral range (never
+            // a privileged < 1024 port).
+            constexpr u32 kStride = 769; // prime > widest observed exclusion block (~700)
+            constexpr u32 kRangeLo = 20000;
+            constexpr u32 kRangeSpan = 40000; // [20000, 59999]
+            const u32 base = DerivePidPort();
             for (int i = 0; i < attempts; ++i)
             {
-                const u16 candidate = static_cast<u16>(port + static_cast<u16>(i));
-                if (candidate < 1024)
-                    continue;
-                if (m_Server->Start(candidate))
-                    return candidate;
+                const u32 candidate =
+                    kRangeLo + ((base - kRangeLo + static_cast<u32>(i) * kStride) % kRangeSpan);
+                if (m_Server->Start(static_cast<u16>(candidate)))
+                    return static_cast<u16>(candidate);
             }
             return 0;
         }

--- a/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
+++ b/OloEngine/tests/Rendering/PropertyTests/McpHeadlessHost.h
@@ -135,6 +135,19 @@ namespace OloEngine::Tests
         McpHeadlessHost(const McpHeadlessHost&) = delete;
         McpHeadlessHost& operator=(const McpHeadlessHost&) = delete;
 
+        // Ephemeral-port sampling policy for a derived (basePort == 0) bind, shared by
+        // Start() and DerivePidPort(). DerivePidPort() samples [kPortRangeLo,
+        // kPortRangeLo + kPortRangeSpan), where Windows reserves CONTIGUOUS excluded
+        // TCP blocks up to ~700 ports wide (Hyper-V / WSL / Docker dynamic reservations
+        // — a bind there fails with AccessDenied). Start() strides by kPortStride — a
+        // prime WIDER than the widest such block — so a run of bind failures leaps
+        // clear on the next attempt; gcd(kPortStride, kPortRangeSpan) == 1 keeps every
+        // candidate distinct and the mod-wrap holds them all in the non-privileged
+        // range (issue #610 follow-up).
+        static constexpr u32 kPortRangeLo = 20000;
+        static constexpr u32 kPortRangeSpan = 40000; // ports [20000, 59999]
+        static constexpr u32 kPortStride = 769;      // prime > widest observed exclusion block (~700)
+
         // Start the server, binding a free port. basePort == 0 derives a per-process
         // base so parallel ctest processes don't collide; a non-zero basePort is a
         // deliberate choice (the driver's per-worktree OLO_MCP_PORT, which the agent
@@ -158,24 +171,14 @@ namespace OloEngine::Tests
                 return 0;
             }
 
-            // Derived base: DerivePidPort() samples [20000, 59999], where Windows
-            // reserves CONTIGUOUS excluded TCP blocks up to ~700 ports wide (Hyper-V /
-            // WSL / Docker dynamic reservations — a bind there fails with AccessDenied).
-            // The old +1 step could land every attempt inside one such block and bind
-            // nothing (the McpHeadlessAttach / McpPerfSettle port-bind flake, issue
-            // #610 follow-up). Stride by a prime WIDER than the widest realistic
-            // exclusion block so a run of failures leaps clear of it on the very next
-            // attempt; gcd(stride, span) == 1 keeps all `attempts` candidates distinct,
-            // and the mod-wrap holds every candidate inside the ephemeral range (never
-            // a privileged < 1024 port).
-            constexpr u32 kStride = 769; // prime > widest observed exclusion block (~700)
-            constexpr u32 kRangeLo = 20000;
-            constexpr u32 kRangeSpan = 40000; // [20000, 59999]
+            // Derived base: leap contiguous Windows excluded-port blocks by striding
+            // kPortStride within the [kPortRangeLo, +kPortRangeSpan) ephemeral range
+            // (see the constants above for the full rationale).
             const u32 base = DerivePidPort();
             for (int i = 0; i < attempts; ++i)
             {
                 const u32 candidate =
-                    kRangeLo + ((base - kRangeLo + static_cast<u32>(i) * kStride) % kRangeSpan);
+                    kPortRangeLo + ((base - kPortRangeLo + static_cast<u32>(i) * kPortStride) % kPortRangeSpan);
                 if (m_Server->Start(static_cast<u16>(candidate)))
                     return static_cast<u16>(candidate);
             }
@@ -447,17 +450,17 @@ namespace OloEngine::Tests
             return ctx;
         }
 
-        // A per-process base port in [20000, 60000) so two MCP-hosting test
-        // processes under `ctest --parallel` start their bind sweep at different
-        // ports. The address of a static varies across processes (ASLR) and is
-        // header-free; even if two processes collide, Start()'s ascending bind
-        // sweep moves the loser forward (bind is atomic), so this only shortens
+        // A per-process base port in [kPortRangeLo, kPortRangeLo + kPortRangeSpan) so
+        // two MCP-hosting test processes under `ctest --parallel` start their bind
+        // sweep at different ports. The address of a static varies across processes
+        // (ASLR) and is header-free; even if two processes collide, Start()'s strided
+        // bind sweep moves the loser forward (bind is atomic), so this only shortens
         // the sweep, it isn't relied on for correctness.
         [[nodiscard]] static u16 DerivePidPort()
         {
             static int anchor = 0;
             const auto bits = reinterpret_cast<std::uintptr_t>(&anchor);
-            return static_cast<u16>(20000 + static_cast<u32>(bits % 40000u));
+            return static_cast<u16>(kPortRangeLo + static_cast<u32>(bits % kPortRangeSpan));
         }
 
         Hooks m_Hooks;

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -232,7 +232,11 @@ and the human at the editor opts in for the session:
   call returns a "denied by the editor user" error), or **Approve all this session**
   (apply it and switch to *Allow all* for the rest of the session). An unanswered
   prompt times out (120 s) and the call returns a timeout error. The modal renders even
-  when the MCP panel window is closed, so a write is never left silently blocked.
+  when the MCP panel window is closed, so a write is never left silently blocked. A
+  `notifications/cancelled` for the call's request-id (issue #610) aborts the wait
+  promptly — the parked call returns a cancelled response, runs **no** write, and drops
+  its pending prompt — so an agent that gives up on a write it left waiting on the modal
+  isn't stuck at the human's decision or the timeout.
 - **Allow all** — writes auto-apply for the session with no prompt (the legacy
   "Allow writes" behaviour). Use it when you're actively driving a batch of edits and
   don't want to click through each one.


### PR DESCRIPTION
Closes #610.

Fixes the two cancellation/timeout robustness gaps in the #357 MCP tools, plus a pre-existing test port-bind flake surfaced while verifying them.

## 1. Consent-gate wait is now cancellable (primary)

`DispatchToolCall`/`HandleToolsCall` registered the in-flight `CancelFlag` **after** the `ProjectWrite` consent gate, and `RequestConsent` blocked on `m_ConsentCv.wait_for` without consulting any cancel flag — so a `notifications/cancelled` arriving while a write was parked on the Prompt-mode consent modal could not reach it; the call ran to the human's decision or the consent timeout regardless.

- In-flight registration (`CancelFlag` + `m_InFlightCalls` + RAII `InFlightGuard`) now happens **before** the consent gate, so every early-return path still erases the entry.
- `RequestConsent` takes the `CancelFlag`, adds it to the `wait_for` predicate, and returns a new `ConsentDecision::Cancel` (cancellation wins over a racing human Approve). `HandleToolsCall` maps it to a `kRequestCancelledCode` response and **runs no write**.
- The `notifications/cancelled` path wakes `m_ConsentCv` after setting the flag.

**Deadlock warning from the issue — addressed:** `m_ConsentMutex` and `m_InFlightMutex` are **never nested** (no ABBA cycle). The cancel path sets the atomic (under/after `m_InFlightMutex`, released), then a bare `{ lock(m_ConsentMutex); }` barrier serializes with the waiter's predicate check *before* `notify_all()`, closing the lost-wakeup window.

## 2. Screenshot pose-strand edge (minor)

In `Handle_Screenshot`, step-1 (apply pose) was a `MarshalRead` **outside** the try/restore block, so a marshal timeout could leave the enqueued apply job to move the camera later with nothing restoring it. The prior pose + an `Applied` flag now live in a shared `PoseGuardState` captured **by value** into every marshaled job; step-1 apply moved inside the try, and the error-path restore is enqueued **after** any still-pending apply (game-thread FIFO), so a late apply is always undone.

## Also: test port-bind flake

`McpHeadlessHost::Start` derived a base port in `[20000, 59999]` and tried only **24 consecutive** ports. Windows reserves *contiguous* excluded TCP blocks there (Hyper-V/WSL/Docker; up to ~700 wide, e.g. `50000–50480` — confirmed those refuse binding with `AccessDenied`), so ASLR landing the base inside one block failed every attempt (`McpHeadlessAttachTest.ScreenshotAndShaderErrorsOverMcp` / `McpPerfSettleTest.RendererSettingsSetSettlesBeforeReturning` flaky-failing with `port==0`). The derived path now strides by a prime (769) wider than any block; the explicit-`OLO_MCP_PORT` path is unchanged.

## Tests

- 3 new `McpConsentedWriteTest` cases: cancel-while-parked → cancelled response + no write + prompt drained; cancel-wins-over-late-approve; unrelated-cancel-doesn't-abort.
- The two previously-flaky port-bind tests now pass.
- Full suite green: **4348 passed, 0 failed**.

Note: verified through the transport-agnostic dispatch seam (real `HandleToolsCall`/`RequestConsent`/`DispatchRpc` via `HandleMessage`); the HTTP transport layer is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool requests can now be cancelled while awaiting write consent.
  * Cancelled requests return a clear cancellation response and do not apply changes.
  * Consent prompts are safely cleared after cancellation.
  * Screenshot capture now reliably restores the previous camera position, including after errors.

* **Bug Fixes**
  * Prevented cancelled requests from being approved by a late consent decision.
  * Improved test host port selection and connection retry behavior.

* **Documentation**
  * Clarified consent prompt behavior when the MCP panel is closed or a request is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->