### PR TITLE
fix(audio): analyze real audio metadata in AssetSerializer

### DIFF
--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -1235,7 +1235,7 @@ namespace OloEngine
         // Default metadata, used as a fallback when the source path couldn't be
         // resolved (e.g. no active project for a relative packed path), the source
         // file doesn't exist on disk, or analysis fails/produces out-of-bounds values.
-        double duration = 0.0;
+        f64 duration = 0.0;
         u32 samplingRate = 44100;
         u16 bitDepth = 16;
         u16 numChannels = 2;
@@ -1279,7 +1279,7 @@ namespace OloEngine
         return audioFile;
     }
 
-    bool AudioFileSourceSerializer::AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, double& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels)
+    bool AudioFileSourceSerializer::AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, f64& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels)
     {
         u32 channels = 0;
         u32 frames = 0;

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -18,6 +18,7 @@
 #include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Renderer/Mesh.h"
 #include "OloEngine/Renderer/GPUResourceQueue.h"
+#include "OloEngine/Audio/AudioLoader.h"
 #include "OloEngine/Audio/AudioSource.h"
 #include "OloEngine/Asset/SoundGraphAsset.h"
 #include "OloEngine/Audio/SoundGraph/SoundGraphSerializer.h"
@@ -58,6 +59,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <limits>
 
 namespace OloEngine
@@ -1151,68 +1153,11 @@ namespace OloEngine
         // Get the file path for analysis
         std::filesystem::path filePath = Project::GetProjectDirectory() / metadata.FilePath;
 
-        // Initialize default values
-        double duration = 0.0;
-        u32 samplingRate = 44100;
-        u16 bitDepth = 16;
-        u16 numChannels = 2;
-        u64 fileSize = 0;
-
-        // Get file size
-        std::error_code ec;
-        if (std::filesystem::exists(filePath, ec) && !ec)
-        {
-            fileSize = std::filesystem::file_size(filePath, ec);
-            if (ec)
-                fileSize = 0;
-        }
-
-        // Basic audio file format detection and analysis
-        std::string extension = filePath.extension().string();
-        std::ranges::transform(extension, extension.begin(),
-                               [](unsigned char c)
-                               { return static_cast<char>(std::tolower(c)); });
-
-        if (extension == ".wav")
-        {
-            // Basic WAV header analysis
-            if (GetWavFileInfo(filePath, duration, samplingRate, bitDepth, numChannels))
-            {
-                OLO_CORE_TRACE("AudioFileSourceSerializer: Analyzed WAV file - Duration: {:.2f}s, Rate: {}Hz, Depth: {}bit, Channels: {}",
-                               duration, samplingRate, bitDepth, numChannels);
-            }
-        }
-        else if (extension == ".mp3" || extension == ".ogg" || extension == ".flac")
-        {
-            // For other formats, use estimated values based on file size
-            // These are rough estimates - in the future, proper audio decoding should be implemented
-            if (fileSize > 0)
-            {
-                // Estimate duration based on average bitrate assumptions
-                double estimatedBitrate = 128000.0; // 128 kbps average for compressed audio
-                if (extension == ".flac")
-                    estimatedBitrate = 1000000.0; // 1 Mbps for FLAC
-
-                duration = (fileSize * 8.0) / estimatedBitrate; // Convert bytes to duration
-                samplingRate = 44100;                           // Standard CD quality
-                bitDepth = 16;                                  // Standard for compressed formats
-                numChannels = 2;                                // Assume stereo
-            }
-
-            OLO_CORE_TRACE("AudioFileSourceSerializer: Estimated audio properties for {} - Duration: {:.2f}s (estimated)",
-                           extension, duration);
-        }
-        else
-        {
-            // No additional handling required.
-        }
-
-        // Create AudioFile asset with extracted/estimated metadata
-        asset = Ref<AudioFile>::Create(duration, samplingRate, bitDepth, numChannels, fileSize);
-        asset->SetHandle(metadata.Handle);
+        Ref<AudioFile> audioFile = BuildAudioFileFromSource(filePath, metadata.Handle, /*fromPack*/ false);
+        asset = audioFile;
 
         OLO_CORE_TRACE("AudioFileSourceSerializer: Loaded AudioFile asset {} - {}MB",
-                       metadata.Handle, fileSize / (1024 * 1024));
+                       metadata.Handle, audioFile->GetFileSize() / (1024 * 1024));
         return true;
     }
 
@@ -1260,111 +1205,122 @@ namespace OloEngine
         std::string filePath;
         stream.ReadString(filePath);
 
-        // Create AudioFile asset with file path information
-        // TODO(olbu): In runtime, analyze the audio file to get proper metadata (#598)
-        Ref<AudioFile> audioFile = Ref<AudioFile>::Create();
-        audioFile->SetHandle(assetInfo.Handle);
+        // SerializeToAssetPack writes an asset-directory-relative path, falling back to
+        // an absolute one if relative() couldn't compute one - resolve the same way. A
+        // relative path needs an active project to resolve against; an absolute one
+        // doesn't (this also keeps DeserializeFromAssetPack usable in headless tests
+        // that build a pack without ever creating a Project). The active project is
+        // captured once into a local Ref so the absolute path it's resolved against
+        // can't change between the availability check and the resolve call (this may
+        // run off the main thread - see CanDeserializeFromAssetPackOffThread below).
+        std::optional<std::filesystem::path> resolvedSourcePath;
+        if (!filePath.empty())
+        {
+            std::filesystem::path sourcePath(filePath);
+            if (sourcePath.is_absolute())
+                resolvedSourcePath = sourcePath;
+            else if (Ref<Project> activeProject = Project::GetActive())
+                resolvedSourcePath = activeProject->GetAssetDir() / sourcePath;
+        }
 
-        OLO_CORE_TRACE("AudioFileSourceSerializer: Deserialized AudioFile from pack - Handle: {0}, Path: {1}",
-                       assetInfo.Handle, filePath);
+        Ref<AudioFile> audioFile = BuildAudioFileFromSource(resolvedSourcePath, assetInfo.Handle, /*fromPack*/ true);
+
+        OLO_CORE_TRACE("AudioFileSourceSerializer: Deserialized AudioFile from pack - Handle: {0}, Path: {1}, Duration: {2:.2f}s, Rate: {3}Hz, Channels: {4}",
+                       assetInfo.Handle, filePath, audioFile->GetDuration(), audioFile->GetSamplingRate(), audioFile->GetNumChannels());
         return audioFile;
     }
 
-    bool AudioFileSourceSerializer::GetWavFileInfo(const std::filesystem::path& filePath, double& duration, u32& samplingRate, u16& bitDepth, u16& numChannels) const
+    Ref<AudioFile> AudioFileSourceSerializer::BuildAudioFileFromSource(const std::optional<std::filesystem::path>& resolvedSourcePath, AssetHandle handle, bool fromPack)
     {
-        std::ifstream file(filePath, std::ios::binary);
-        if (!file.is_open())
+        // Default metadata, used as a fallback when the source path couldn't be
+        // resolved (e.g. no active project for a relative packed path), the source
+        // file doesn't exist on disk, or analysis fails/produces out-of-bounds values.
+        double duration = 0.0;
+        u32 samplingRate = 44100;
+        u16 bitDepth = 16;
+        u16 numChannels = 2;
+        u64 fileSize = 0;
+
+        const char* context = fromPack ? "packed " : "";
+        if (resolvedSourcePath)
         {
-            OLO_CORE_WARN("AudioFileSourceSerializer: Failed to open WAV file: {}", filePath.string());
-            return false;
-        }
+            const std::filesystem::path& sourcePath = *resolvedSourcePath;
 
-        // Read RIFF header
-        char riffHeader[4];
-        file.read(riffHeader, 4);
-        if (std::memcmp(riffHeader, "RIFF", 4) != 0)
-        {
-            OLO_CORE_WARN("AudioFileSourceSerializer: Invalid RIFF header in WAV file: {}", filePath.string());
-            return false;
-        }
-
-        // Skip chunk size (4 bytes)
-        file.seekg(4, std::ios::cur);
-
-        // Read WAVE format
-        char waveHeader[4];
-        file.read(waveHeader, 4);
-        if (std::memcmp(waveHeader, "WAVE", 4) != 0)
-        {
-            OLO_CORE_WARN("AudioFileSourceSerializer: Invalid WAVE header in WAV file: {}", filePath.string());
-            return false;
-        }
-
-        // Find fmt chunk
-        bool fmtFound = false;
-        u32 dataSize = 0;
-
-        while (!file.eof() && (!fmtFound || dataSize == 0))
-        {
-            char chunkId[4];
-            u32 chunkSize;
-
-            file.read(chunkId, 4);
-            file.read(reinterpret_cast<char*>(&chunkSize), 4);
-
-            if (std::strncmp(chunkId, "fmt ", 4) == 0)
+            // A single file_size() call serves as both the existence check and the size
+            // query - std::filesystem::file_size's error_code overload reports a missing
+            // file via ec instead of throwing, so a separate exists() stat is redundant.
+            std::error_code ec;
+            const u64 size = static_cast<u64>(std::filesystem::file_size(sourcePath, ec));
+            if (ec)
             {
-                // Read format chunk
-                u16 audioFormat, channels, blockAlign, bitsPerSample;
-                u32 sampleRate, byteRate;
-
-                file.read(reinterpret_cast<char*>(&audioFormat), 2);
-                file.read(reinterpret_cast<char*>(&channels), 2);
-                file.read(reinterpret_cast<char*>(&sampleRate), 4);
-                file.read(reinterpret_cast<char*>(&byteRate), 4);
-                file.read(reinterpret_cast<char*>(&blockAlign), 2);
-                file.read(reinterpret_cast<char*>(&bitsPerSample), 2);
-
-                // Store values
-                numChannels = channels;
-                samplingRate = sampleRate;
-                bitDepth = bitsPerSample;
-                fmtFound = true;
-
-                // Skip any extra fmt data
-                if (chunkSize > 16)
-                {
-                    file.seekg(chunkSize - 16, std::ios::cur);
-                }
-            }
-            else if (std::strncmp(chunkId, "data", 4) == 0)
-            {
-                dataSize = chunkSize;
-                // Skip the data chunk content
-                file.seekg(chunkSize, std::ios::cur);
+                OLO_CORE_WARN("AudioFileSourceSerializer: {}audio source file '{}' not found, using default metadata", context, sourcePath.string());
             }
             else
             {
-                // Skip unknown chunk
-                file.seekg(chunkSize, std::ios::cur);
+                fileSize = size;
+                if (AnalyzeAudioFile(sourcePath, fileSize, duration, samplingRate, bitDepth, numChannels))
+                {
+                    OLO_CORE_TRACE("AudioFileSourceSerializer: Analyzed {}audio file - Duration: {:.2f}s, Rate: {}Hz, Depth: {}bit, Channels: {}",
+                                   context, duration, samplingRate, bitDepth, numChannels);
+                }
+                else
+                {
+                    OLO_CORE_WARN("AudioFileSourceSerializer: Failed to analyze {}audio file '{}', using default metadata", context, sourcePath.string());
+                }
             }
         }
-
-        if (fmtFound && dataSize > 0)
+        else
         {
-            // Calculate duration: dataSize / (sampleRate * channels * (bitDepth/8))
-            if (u32 bytesPerSample = (bitDepth / 8) * numChannels; bytesPerSample > 0 && samplingRate > 0)
-            {
-                duration = static_cast<double>(dataSize) / (samplingRate * bytesPerSample);
-            }
-
-            OLO_CORE_TRACE("AudioFileSourceSerializer: WAV analysis complete - {}Hz, {}bit, {} channels, {:.2f}s",
-                           samplingRate, bitDepth, numChannels, duration);
-            return true;
+            OLO_CORE_WARN("AudioFileSourceSerializer: No resolvable source path for {}audio asset {}, using default metadata", context, handle);
         }
 
-        OLO_CORE_WARN("AudioFileSourceSerializer: Failed to find required chunks in WAV file: {}", filePath.string());
-        return false;
+        Ref<AudioFile> audioFile = Ref<AudioFile>::Create(duration, samplingRate, bitDepth, numChannels, fileSize);
+        audioFile->SetHandle(handle);
+        return audioFile;
+    }
+
+    bool AudioFileSourceSerializer::AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, double& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels)
+    {
+        u32 channels = 0;
+        u32 frames = 0;
+        f64 sampleRate = 0.0;
+        f64 duration = 0.0;
+        u16 bitDepth = 0;
+
+        if (!Audio::AudioLoader::GetAudioFileInfo(filePath, channels, frames, sampleRate, duration, bitDepth))
+            return false;
+
+        // Validate decoder output before trusting it - a corrupt or malicious audio
+        // file must not propagate garbage (NaN/absurd values) into the AudioFile asset.
+        constexpr f64 kMaxSampleRateHz = 384000.0; // covers every format miniaudio supports, well beyond hi-res audio
+        constexpr u32 kMaxChannels = 32;
+        if (!std::isfinite(sampleRate) || sampleRate <= 0.0 || sampleRate > kMaxSampleRateHz)
+            return false;
+        if (!std::isfinite(duration) || duration < 0.0)
+            return false;
+        if (channels == 0 || channels > kMaxChannels)
+            return false;
+        if (bitDepth != 8 && bitDepth != 16 && bitDepth != 24 && bitDepth != 32)
+            return false;
+
+        // Some formats (e.g. Vorbis) decode successfully but can't report a frame count
+        // (AudioLoader::GetAudioFileInfo documents this as MA_NOT_IMPLEMENTED / totalFrames
+        // == 0), leaving duration at exactly 0.0. Propagating that verbatim makes
+        // downstream consumers - e.g. SoundGraphSource::DataSourceContext, which derives
+        // TotalFrames from duration * sampleRate - treat the source as already finished
+        // before any audio plays. Fall back to a rough size-based estimate for this case
+        // only, so a real (if approximate) nonzero duration reaches those consumers.
+        if (frames == 0 && duration <= 0.0 && fileSize > 0)
+        {
+            constexpr f64 kAssumedBitrateBps = 128000.0; // 128 kbps average compressed-audio estimate
+            duration = (static_cast<f64>(fileSize) * 8.0) / kAssumedBitrateBps;
+        }
+
+        outDuration = duration;
+        outSamplingRate = static_cast<u32>(sampleRate);
+        outBitDepth = bitDepth;
+        outNumChannels = static_cast<u16>(channels);
+        return true;
     }
 
     //////////////////////////////////////////////////////////////////////////////////

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <filesystem>
+#include <optional>
 #include <variant>
 #include "AssetMetadata.h"
 #include "MeshColliderAsset.h"
@@ -230,7 +231,23 @@ namespace OloEngine
         } // CPU-only: no GPU resources
 
       private:
-        [[nodiscard]] bool GetWavFileInfo(const std::filesystem::path& filePath, double& duration, u32& samplingRate, u16& bitDepth, u16& numChannels) const;
+        // Resolves a source path (already-resolved, or absent if it couldn't be
+        // resolved - e.g. a relative packed path with no active project) into an
+        // AudioFile: analyzes the file via AnalyzeAudioFile when present, and falls
+        // back to default metadata (with a warning) when the path is absent, the file
+        // is missing, or analysis fails. `fromPack` only affects log message wording.
+        // Shared tail for both TryLoadData and DeserializeFromAssetPack.
+        [[nodiscard]] static Ref<AudioFile> BuildAudioFileFromSource(const std::optional<std::filesystem::path>& resolvedSourcePath, AssetHandle handle, bool fromPack);
+
+        // Analyzes an audio file via the miniaudio-backed AudioLoader and validates the
+        // decoded values (finite/sane sample rate, channel count, bit depth) before
+        // trusting them - a corrupt or malicious file must not propagate garbage into
+        // the AudioFile asset. `fileSize` is used only as a rough duration-estimate
+        // fallback for formats miniaudio can decode but can't length-query (e.g.
+        // Vorbis), so a real source never reports an exact-but-wrong zero duration.
+        // Returns false (out params left untouched) if the file can't be analyzed or
+        // fails validation; callers should fall back to defaults.
+        [[nodiscard]] static bool AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, double& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels);
     };
 
     class SoundConfigSerializer : public AssetSerializer

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.h
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.h
@@ -247,7 +247,7 @@ namespace OloEngine
         // Vorbis), so a real source never reports an exact-but-wrong zero duration.
         // Returns false (out params left untouched) if the file can't be analyzed or
         // fails validation; callers should fall back to defaults.
-        [[nodiscard]] static bool AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, double& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels);
+        [[nodiscard]] static bool AnalyzeAudioFile(const std::filesystem::path& filePath, u64 fileSize, f64& outDuration, u32& outSamplingRate, u16& outBitDepth, u16& outNumChannels);
     };
 
     class SoundConfigSerializer : public AssetSerializer

--- a/OloEngine/tests/RuntimeAssetPackTest.cpp
+++ b/OloEngine/tests/RuntimeAssetPackTest.cpp
@@ -467,7 +467,7 @@ TEST(RuntimeAssetPackTest, DeserializeFromAssetPackFallsBackToDefaultsWhenSource
     EXPECT_EQ(audioFile->GetSamplingRate(), 44100u);
     EXPECT_EQ(audioFile->GetBitDepth(), 16u);
     EXPECT_EQ(audioFile->GetNumChannels(), 2u);
-    EXPECT_EQ(audioFile->GetDuration(), 0.0);
+    EXPECT_NEAR(audioFile->GetDuration(), 0.0, 1e-6);
     EXPECT_EQ(audioFile->GetFileSize(), 0u);
 
     std::error_code ec;

--- a/OloEngine/tests/RuntimeAssetPackTest.cpp
+++ b/OloEngine/tests/RuntimeAssetPackTest.cpp
@@ -19,6 +19,15 @@
 //   4. AsyncLoadIntegratesThroughManager — the full async path
 //      (GetAssetAsync -> worker -> SyncWithAssetThread -> loaded cache) for a
 //      CPU-only asset type (Audio).
+//   5. DeserializeFromAssetPackAnalyzesRealAudioMetadata — the runtime pack path
+//      (AudioFileSourceSerializer::DeserializeFromAssetPack) analyzes the actual
+//      audio file (via the miniaudio-backed AudioLoader) instead of returning a
+//      default-constructed AudioFile (issue #598). Uses a real fixture under
+//      SandboxProject/Assets, resolved through an absolute packed path so the
+//      test doesn't need an active Project.
+//   6. DeserializeFromAssetPackFallsBackToDefaultsWhenSourceMissing — a packed
+//      path that doesn't resolve to a file on disk must not crash; it degrades to
+//      the same default metadata the pre-#598 code always returned.
 //
 // All headless: scenes/audio deserialize on the CPU with no GL context.
 // =============================================================================
@@ -26,6 +35,7 @@
 #include "OloEngine/Asset/AssetPack.h"
 #include "OloEngine/Asset/AssetSerializer.h"
 #include "OloEngine/Asset/AssetManager/RuntimeAssetManager.h"
+#include "OloEngine/Asset/Asset.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Serialization/AssetPackFile.h"
 #include "OloEngine/Serialization/FileStream.h"
@@ -369,4 +379,97 @@ TEST(RuntimeAssetPackTest, AsyncLoadIntegratesThroughManager)
 
     std::error_code ec;
     fs::remove(packPath, ec);
+}
+
+// -----------------------------------------------------------------------------
+// 5. DeserializeFromAssetPack analyzes the real audio file instead of returning
+//    a default-constructed AudioFile (issue #598).
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, DeserializeFromAssetPackAnalyzesRealAudioMetadata)
+{
+    // Real fixture, known via its RIFF fmt chunk: PCM, 2 channels, 44100 Hz,
+    // 24-bit, ~979868 bytes of data -> ~3.7024s duration.
+    const fs::path wavPath = fs::path{ OLO_TEST_EDITOR_ROOT } / "SandboxProject" / "Assets" / "Audio" / "ding.wav";
+    ASSERT_TRUE(fs::exists(wavPath)) << "Fixture missing: " << wavPath.string();
+    const u64 expectedFileSize = static_cast<u64>(fs::file_size(wavPath));
+
+    // Write the (absolute) fixture path into a synthetic pack blob exactly as
+    // AudioFileSourceSerializer::SerializeToAssetPack does: a single length-prefixed
+    // string. An absolute path resolves without needing an active Project.
+    const fs::path tmp = fs::temp_directory_path() / ("olo_audio_meta_" + std::to_string(OloRapGetPid()) + ".bin");
+    {
+        FileStreamWriter writer(tmp);
+        ASSERT_TRUE(writer.IsStreamGood());
+        writer.WriteString(wavPath.string());
+    }
+
+    AssetPackFile::AssetInfo assetInfo;
+    assetInfo.Handle = static_cast<AssetHandle>(0xA0D10ULL);
+    assetInfo.PackedOffset = 0;
+    assetInfo.PackedSize = 0; // unused by the reader
+    assetInfo.Type = AssetType::Audio;
+    assetInfo.Flags = 0;
+
+    FileStreamReader reader(tmp);
+    ASSERT_TRUE(reader.IsStreamGood());
+
+    AudioFileSourceSerializer serializer;
+    Ref<Asset> result = serializer.DeserializeFromAssetPack(reader, assetInfo);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result->GetHandle(), assetInfo.Handle);
+
+    Ref<AudioFile> audioFile = result.As<AudioFile>();
+    ASSERT_TRUE(audioFile);
+    EXPECT_EQ(audioFile->GetSamplingRate(), 44100u);
+    EXPECT_EQ(audioFile->GetBitDepth(), 24u);
+    EXPECT_EQ(audioFile->GetNumChannels(), 2u);
+    EXPECT_EQ(audioFile->GetFileSize(), expectedFileSize);
+    EXPECT_NEAR(audioFile->GetDuration(), 3.7024, 0.01)
+        << "Duration must reflect the real decoded frame count, not the pre-#598 default of 0";
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+}
+
+// -----------------------------------------------------------------------------
+// 6. A packed path that can't be resolved/opened must not crash - it degrades to
+//    the same default metadata the code always returned before #598.
+// -----------------------------------------------------------------------------
+TEST(RuntimeAssetPackTest, DeserializeFromAssetPackFallsBackToDefaultsWhenSourceMissing)
+{
+    const fs::path missingPath = fs::temp_directory_path() / ("olo_missing_audio_" + std::to_string(OloRapGetPid()) + ".wav");
+    std::error_code removeEc;
+    fs::remove(missingPath, removeEc); // make sure it really doesn't exist
+
+    const fs::path tmp = fs::temp_directory_path() / ("olo_audio_meta_missing_" + std::to_string(OloRapGetPid()) + ".bin");
+    {
+        FileStreamWriter writer(tmp);
+        ASSERT_TRUE(writer.IsStreamGood());
+        writer.WriteString(missingPath.string());
+    }
+
+    AssetPackFile::AssetInfo assetInfo;
+    assetInfo.Handle = static_cast<AssetHandle>(0xA0D11ULL);
+    assetInfo.PackedOffset = 0;
+    assetInfo.PackedSize = 0;
+    assetInfo.Type = AssetType::Audio;
+    assetInfo.Flags = 0;
+
+    FileStreamReader reader(tmp);
+    ASSERT_TRUE(reader.IsStreamGood());
+
+    AudioFileSourceSerializer serializer;
+    Ref<Asset> result = serializer.DeserializeFromAssetPack(reader, assetInfo);
+    ASSERT_TRUE(result) << "A missing source file must still yield a default-metadata AudioFile, not nullptr";
+
+    Ref<AudioFile> audioFile = result.As<AudioFile>();
+    ASSERT_TRUE(audioFile);
+    EXPECT_EQ(audioFile->GetSamplingRate(), 44100u);
+    EXPECT_EQ(audioFile->GetBitDepth(), 16u);
+    EXPECT_EQ(audioFile->GetNumChannels(), 2u);
+    EXPECT_EQ(audioFile->GetDuration(), 0.0);
+    EXPECT_EQ(audioFile->GetFileSize(), 0u);
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
 }


### PR DESCRIPTION
## Summary

- `AudioFileSourceSerializer::DeserializeFromAssetPack` (the runtime asset-pack path) previously constructed a default-initialized `AudioFile` and discarded the source path, so every runtime-loaded audio asset got fake duration/sample-rate/bit-depth/channel-count.
- Both the runtime pack path and the editor's `TryLoadData` now share a single `AnalyzeAudioFile` helper that decodes real metadata via the existing miniaudio-backed `AudioLoader`, replacing the hand-rolled WAV header parser (`GetWavFileInfo`, removed) and the file-size-based bitrate estimate for mp3/ogg/flac.
- Chose the miniaudio decoder (`AudioLoader::GetAudioFileInfo`) over extending the hand-parsed WAV header approach, since it's format-general and already used elsewhere in the engine for playback. Kept eager-at-load analysis (matching the existing editor behavior) over lazy-on-first-playback, since the metadata query is cheap and duration/sample-rate are already consumed at load time by `SoundGraphSource`.

### Fixed during review (`/code-review`, medium effort, 8 finder angles + verification)
- **Correctness:** a decoded-but-length-unqueryable file (e.g. Vorbis/.ogg — `AudioLoader::GetAudioFileInfo` explicitly returns `duration=0.0` with success for formats miniaudio can't length-query) used to report an exact `0.0` duration. Downstream, `SoundGraphSource::DataSourceContext` derives `TotalFrames` from `duration * sampleRate`, so the source was treated as already finished before any audio played. Now falls back to a rough size-based estimate for that specific case only.
- **Thread-safety (latent):** `DeserializeFromAssetPack` is off-thread-eligible (`CanDeserializeFromAssetPackOffThread() == true`) and now touches `Project` state to resolve a relative packed path. Closed the TOCTOU window between the availability check and the resolve call by capturing the active project into a single local `Ref<Project>` instead of re-reading the unsynchronized `Project::s_ActiveProject` static twice. (No current call path actually triggers the race — `OloRuntimeApp` never calls `Project::Load` — so this was latent, not exploitable today.)
- **Diagnostics:** added a missing warning when a relative packed path can't be resolved (no active project) — previously silent, unlike the other failure branches.
- **Efficiency/simplification:** collapsed 3 redundant filesystem stat calls (`exists()` + `file_size()` at the call site, plus `AudioLoader`'s own internal `exists()`) down to 1, and de-duplicated the resolve/analyze/construct logic shared by `TryLoadData` and `DeserializeFromAssetPack` into `AudioFileSourceSerializer::BuildAudioFileFromSource`.

### Consciously not fixed (documented trade-offs)
- Bounds validation (max sample rate/channels, `isfinite`) lives in `AssetSerializer`'s private `AnalyzeAudioFile` rather than in `AudioLoader::GetAudioFileInfo` itself, so a future caller of that public API wouldn't get the same protection. Left as-is since moving it would touch a shared, more broadly-used API beyond this issue's scope.
- Removing the hand-rolled WAV parser lost its specific "Invalid RIFF/WAVE header" diagnostic messages in favor of a generic miniaudio decoder-init-failure log. Diagnostic-quality regression only (a malformed file is still correctly rejected either way) — restoring it would mean reintroducing the header-parsing this issue set out to remove.

Closes #598.

## Test plan
- [x] `RuntimeAssetPackTest.DeserializeFromAssetPackAnalyzesRealAudioMetadata` — round-trips a real fixture (`ding.wav`, 44.1kHz/24-bit/stereo/~3.7s) through the runtime pack path.
- [x] `RuntimeAssetPackTest.DeserializeFromAssetPackFallsBackToDefaultsWhenSourceMissing` — missing source file degrades gracefully instead of crashing.
- [x] Full `OloEngine-Tests` audio/asset suite (240 tests) passes with no regressions.
- [x] `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio assets loaded from asset packs now retain accurate metadata, including duration, sampling rate, bit depth, channel count, and file size.
  * Missing or unavailable audio sources now load safely with sensible default metadata.
  * Audio analysis now supports more formats and handles invalid or incomplete metadata reliably.

* **Tests**
  * Added coverage for audio metadata extraction and missing-source fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->