### PR TITLE
feat(mcp): map-key addressing for MorphTargetComponent + LightProbe/ReflectionProbe clamp migration (#607)

### DIFF
--- a/OloEditor/src/MCP/Generated/McpFieldRegistry.Generated.inl
+++ b/OloEditor/src/MCP/Generated/McpFieldRegistry.Generated.inl
@@ -347,7 +347,7 @@ static void BuildRegistryChunk4(std::vector<FieldEntry>& registry)
     // LightProbeVolumeComponent
     registry.push_back(OLO_GFW_FIELD(LightProbeVolumeComponent, "BoundsMin", m_BoundsMin));
     registry.push_back(OLO_GFW_FIELD(LightProbeVolumeComponent, "BoundsMax", m_BoundsMax));
-    registry.push_back(OLO_GFW_FIELD(LightProbeVolumeComponent, "Spacing", m_Spacing));
+    registry.push_back(OLO_GFW_FIELD_RANGE(LightProbeVolumeComponent, "Spacing", m_Spacing, OLO_GFW_BOUND(0.01f), OLO_GFW_NO_BOUND));
     registry.push_back(OLO_GFW_FIELD_RANGE(LightProbeVolumeComponent, "Intensity", m_Intensity, OLO_GFW_BOUND(0.0f), OLO_GFW_NO_BOUND));
     registry.push_back(OLO_GFW_FIELD(LightProbeVolumeComponent, "Active", m_Active));
     registry.push_back(OLO_GFW_FIELD(LightProbeVolumeComponent, "Dirty", m_Dirty));
@@ -662,7 +662,7 @@ static void BuildRegistryChunk7(std::vector<FieldEntry>& registry)
     registry.push_back(OLO_GFW_FIELD(RagdollComponent, "TwistLimitDeg", m_TwistLimitDeg));
 
     // ReflectionProbeComponent
-    registry.push_back(OLO_GFW_FIELD(ReflectionProbeComponent, "InfluenceRadius", m_InfluenceRadius));
+    registry.push_back(OLO_GFW_FIELD_RANGE(ReflectionProbeComponent, "InfluenceRadius", m_InfluenceRadius, OLO_GFW_BOUND(0.01f), OLO_GFW_NO_BOUND));
     registry.push_back(OLO_GFW_FIELD_RANGE(ReflectionProbeComponent, "BlendDistance", m_BlendDistance, OLO_GFW_BOUND(0.0f), OLO_GFW_NO_BOUND));
     registry.push_back(OLO_GFW_FIELD_RANGE(ReflectionProbeComponent, "Resolution", m_Resolution, OLO_GFW_BOUND(16u), OLO_GFW_BOUND(2048u)));
     registry.push_back(OLO_GFW_FIELD_RANGE(ReflectionProbeComponent, "Intensity", m_Intensity, OLO_GFW_BOUND(0.0f), OLO_GFW_NO_BOUND));

--- a/OloEditor/src/MCP/McpFieldRegistry.cpp
+++ b/OloEditor/src/MCP/McpFieldRegistry.cpp
@@ -51,10 +51,39 @@ namespace OloEngine::MCP::GenericFieldWrite
 #undef OLO_GFW_BOUND
 #undef OLO_GFW_NO_BOUND
 
+        // MorphTargetComponent::Weights (issue #607's map-key addressing slice) —
+        // the ONE map-typed MCP field in the engine today, hand-registered rather
+        // than generated: its keyset (target/bone name) doesn't exist until a
+        // MorphTargetSet is bound at runtime, so no static field name could ever be
+        // emitted for it the way a nested struct's dotted chain is (see
+        // MakeMapKeyField's doc comment in McpGenericFieldWrite.h). A caller
+        // addresses one entry via a dotted key ("Weights.Smile"); the range mirrors
+        // MorphTargetComponent::SetWeight's own [0, 1] clamp so a write can never put
+        // a weight outside what SetWeight would already allow.
+        [[nodiscard]] FieldEntry BuildMorphTargetWeightsField()
+        {
+            return MakeMapKeyField<MorphTargetComponent, f32>(
+                "MorphTargetComponent", "Weights",
+                [](const MorphTargetComponent& c, const std::string& key) -> f32
+                { return c.GetWeight(key); },
+                [](MorphTargetComponent& c, const std::string& key, const f32& v)
+                { c.SetWeight(key, v); },
+                [](const MorphTargetComponent& c) -> std::vector<std::string>
+                {
+                    std::vector<std::string> keys;
+                    keys.reserve(c.Weights.size());
+                    for (const auto& [name, weight] : c.Weights)
+                        keys.push_back(name);
+                    return keys;
+                },
+                FieldRange{ std::optional<double>(0.0), std::optional<double>(1.0) });
+        }
+
         [[nodiscard]] std::vector<FieldEntry> BuildRegistry()
         {
             std::vector<FieldEntry> registry;
             BuildRegistryChunks(registry);
+            registry.push_back(BuildMorphTargetWeightsField());
             return registry;
         }
     } // namespace

--- a/OloEditor/src/MCP/McpFieldRegistry.cpp
+++ b/OloEditor/src/MCP/McpFieldRegistry.cpp
@@ -68,6 +68,10 @@ namespace OloEngine::MCP::GenericFieldWrite
                 { return c.GetWeight(key); },
                 [](MorphTargetComponent& c, const std::string& key, const f32& v)
                 { c.SetWeight(key, v); },
+                [](const MorphTargetComponent& c, const std::string& key) -> bool
+                { return c.Weights.contains(key); },
+                [](MorphTargetComponent& c, const std::string& key)
+                { c.Weights.erase(key); },
                 [](const MorphTargetComponent& c) -> std::vector<std::string>
                 {
                     std::vector<std::string> keys;

--- a/OloEditor/src/MCP/McpGenericFieldWrite.h
+++ b/OloEditor/src/MCP/McpGenericFieldWrite.h
@@ -392,6 +392,12 @@ namespace OloEngine::MCP::GenericFieldWrite
         std::string Type; // FieldTypeName<F>()
         FieldRange Range; // empty unless the serializer enforces a load-time range
 
+        // Whether the entity currently carries the owning component C — checked
+        // BEFORE Read/Apply (or ReadKeyed/ApplyKeyed) so ListFields can tell "entity
+        // lacks this component" from every other outcome (an empty map, a false
+        // bool, ...) uniformly across both plain and map-keyed fields.
+        std::function<bool(Entity)> HasComponent;
+
         // Coerce `value`, range-clamp it, no-op-detect, and (when changed) push a
         // single undoable ComponentChangeCommand<C>. The entity is already resolved +
         // known to exist. The reported `value` is READ BACK from the live component
@@ -399,6 +405,30 @@ namespace OloEngine::MCP::GenericFieldWrite
         std::function<ApplyResult(const Ref<Scene>&, CommandHistory&, Entity, u64, const Json&)> Apply;
         // The field's current value as JSON, or nullopt when the entity lacks C.
         std::function<std::optional<Json>(Entity)> Read;
+
+        // ---- map-key addressing (issue #607's MorphTargetComponent::Weights slice) --
+        //
+        // A MAP-typed field has no compile-time-known key — MorphTargetComponent's
+        // Weights (target/bone name -> weight) doesn't even have its keyset known
+        // until a MorphTargetSet is bound at runtime — so it cannot be a plain
+        // FieldEntry (Apply/Read above assume a single addressable F& per entity).
+        // Instead ONE entry is registered per map FIELD (not per key), with
+        // IsMapKeyed=true and Field holding the PREFIX ("Weights", no trailing dot).
+        // Find() deliberately never matches this entry by itself (Field alone names
+        // the container, not a value) — resolution instead happens against the
+        // caller's dotted field string "Weights.<key>" via FindMapKeyed(), which
+        // strips the entry's Field+"." prefix off to recover the runtime key. This
+        // mirrors the existing dotted SUB-OBJECT ADDRESSING convention
+        // ("System.Emitter.RateOverTime") rather than inventing a second argument.
+        bool IsMapKeyed = false;
+        // Same contract as Apply above, plus the resolved runtime key.
+        std::function<ApplyResult(const Ref<Scene>&, CommandHistory&, Entity, u64, const std::string& key, const Json&)> ApplyKeyed;
+        // Same contract as Read above, plus the resolved runtime key.
+        std::function<std::optional<Json>(Entity, const std::string& key)> ReadKeyed;
+        // The map's CURRENT keys (unsorted; callers sort for deterministic output) —
+        // drives olo_entity_list_fields' "exactly what you can write right now"
+        // contract for a map field, since no key is known ahead of time.
+        std::function<std::vector<std::string>(Entity)> ListMapKeys;
     };
 
     // Build one registry entry from a component type + a script-facing field name +
@@ -425,6 +455,8 @@ namespace OloEngine::MCP::GenericFieldWrite
         entry.Field = field;
         entry.Type = std::string(FieldTypeName<F>());
         entry.Range = range;
+        entry.HasComponent = [](Entity e)
+        { return e.HasComponent<C>(); };
 
         entry.Apply = [access, component, field, range](const Ref<Scene>& scene, CommandHistory& history,
                                                         Entity entity, u64 uuid, const Json& value) -> ApplyResult
@@ -538,6 +570,8 @@ namespace OloEngine::MCP::GenericFieldWrite
         entry.Field = field;
         entry.Type = std::string(FieldTypeName<F>());
         entry.Range = range;
+        entry.HasComponent = [](Entity e)
+        { return e.HasComponent<C>(); };
 
         entry.Apply = [getFn, setFn, component, field, range](const Ref<Scene>& scene, CommandHistory& history,
                                                               Entity entity, u64 uuid, const Json& value) -> ApplyResult
@@ -600,6 +634,110 @@ namespace OloEngine::MCP::GenericFieldWrite
         return entry;
     }
 
+    // Build one registry entry for a MAP-typed field, addressed at write time by a
+    // RUNTIME key rather than a compile-time accessor chain (issue #607's
+    // MorphTargetComponent::Weights slice — a target/bone name -> weight map whose
+    // keyset doesn't exist until a MorphTargetSet is bound, so no static field name
+    // can be generated ahead of time the way a nested struct's dotted chain is).
+    //
+    // ONE entry is registered per map FIELD (not per key): `field` is the PREFIX
+    // ("Weights"), and a caller addresses one entry with the dotted name
+    // "Weights.<key>" — resolved at call time by FindMapKeyed(), which strips the
+    // registered prefix + "." off the requested field to recover `key`. This reuses
+    // the existing dotted SUB-OBJECT ADDRESSING convention
+    // ("System.Emitter.RateOverTime") instead of adding a second JSON argument.
+    //
+    // Like MakeSetterField (not MakeFieldAccess), the write calls `setFn` DIRECTLY on
+    // the live component — never a whole-map copy+swap — reusing
+    // PropertySetCommand<C, V, SetFn> for undo/redo by binding `key` into the setter
+    // closure passed to it.
+    //
+    // getFn:  (const C&, const std::string& key) -> V   (a missing key returns the
+    //         map's own semantic default, e.g. MorphTargetComponent::GetWeight()'s 0.0f)
+    // setFn:  (C&, const std::string& key, const V& value) -> void
+    // keysFn: (const C&) -> std::vector<std::string>   (the map's CURRENT keys, for
+    //         olo_entity_list_fields discovery — order doesn't matter, ListFields sorts)
+    template<typename C, typename V, typename GetFn, typename SetFn, typename KeysFn>
+    [[nodiscard]] inline FieldEntry MakeMapKeyField(std::string component, std::string field,
+                                                    GetFn getFn, SetFn setFn, KeysFn keysFn,
+                                                    FieldRange range = {})
+    {
+        static_assert(std::is_same_v<std::invoke_result_t<GetFn, const C&, const std::string&>, V>,
+                      "MakeMapKeyField: getFn must return exactly V");
+
+        FieldEntry entry;
+        entry.Component = component;
+        entry.Field = field;
+        entry.Type = "map<string," + std::string(FieldTypeName<V>()) + ">";
+        entry.Range = range;
+        entry.IsMapKeyed = true;
+        entry.HasComponent = [](Entity e)
+        { return e.HasComponent<C>(); };
+
+        entry.ApplyKeyed = [getFn, setFn, component, field, range](const Ref<Scene>& scene, CommandHistory& history,
+                                                                   Entity entity, u64 uuid, const std::string& key,
+                                                                   const Json& value) -> ApplyResult
+        {
+            ApplyResult result;
+            if (!entity.HasComponent<C>())
+            {
+                result.Error = "Entity has no " + component + ".";
+                return result;
+            }
+
+            V coerced{};
+            if (const auto error = CoerceJson<V>(value, coerced))
+            {
+                result.Error = "Invalid 'value' for " + component + "." + field + "." + key +
+                               " (expects " + std::string(FieldTypeName<V>()) + "): " + *error + ".";
+                return result;
+            }
+
+            const V requested = coerced;
+            RangeField<V>(coerced, range);
+            const bool clamped = FieldChanged<V>(requested, coerced);
+
+            // Same "apply then read back" honesty contract as MakeSetterField: setFn
+            // may itself clamp/transform (MorphTargetComponent::SetWeight does), so
+            // the reported value comes from getFn AFTER the write, not from `coerced`.
+            const V previous = getFn(entity.GetComponent<C>(), key);
+            V applied = previous;
+            if (FieldChanged<V>(previous, coerced))
+            {
+                auto keyedSetFn = [key, setFn](C& c, const V& v)
+                { setFn(c, key, v); };
+                keyedSetFn(entity.GetComponent<C>(), coerced);
+                applied = getFn(entity.GetComponent<C>(), key);
+                if (FieldChanged<V>(previous, applied))
+                {
+                    history.PushAlreadyExecuted(std::make_unique<PropertySetCommand<C, V, decltype(keyedSetFn)>>(
+                        scene, UUID(uuid), keyedSetFn, previous, applied,
+                        "Set " + component + "." + field + "." + key));
+                }
+            }
+
+            ApplyResult out = Detail::BuildFieldApplyResult<V>(component, field + "." + key, uuid, requested, previous, applied, clamped);
+            out.Data["key"] = key;
+            return out;
+        };
+
+        entry.ReadKeyed = [getFn](Entity entity, const std::string& key) -> std::optional<Json>
+        {
+            if (!entity.HasComponent<C>())
+                return std::nullopt;
+            return FieldToJson<V>(getFn(entity.GetComponent<C>(), key));
+        };
+
+        entry.ListMapKeys = [keysFn](Entity entity) -> std::vector<std::string>
+        {
+            if (!entity.HasComponent<C>())
+                return {};
+            return keysFn(entity.GetComponent<C>());
+        };
+
+        return entry;
+    }
+
     // The writable-field registry, GENERATED by OloHeaderTool (issue #607) from the
     // same component data-member scan that drives the scene serializer — see the
     // header comment at the top of this file. Field names are the m_-stripped keys an
@@ -644,6 +782,17 @@ namespace OloEngine::MCP::GenericFieldWrite
     // DIRECTLY on the live component (PropertySetCommand, not ComponentChangeCommand<C>)
     // — required because AudioSourceComponent's operator= cannot be trusted to preserve
     // ActiveEventID or push a value into the live Ref<AudioSource> Source.
+    //
+    // MAP-KEY ADDRESSING (issue #607's MorphTargetComponent::Weights slice): a
+    // map-typed field (a runtime keyset, e.g. target/bone name -> weight) has no
+    // static field name to register per key. ONE MakeMapKeyField(...) entry is
+    // hand-registered per map FIELD in McpFieldRegistry.cpp (not emitted by the
+    // generator — there is exactly one such field in the engine today, so this
+    // stays a manual addition rather than a speculative "any map field" codegen
+    // classifier). A caller addresses one entry with a DOTTED key
+    // ("Weights.Smile"), resolved by FindMapKeyed() below; Find() never matches a
+    // map field's bare prefix ("Weights" alone names the container, not a value).
+    //
     // The process-wide registry, built once. DEFINED in McpFieldRegistry.cpp —
     // the one TU that #includes the generated .inl. It used to be built by an
     // inline BuildRegistry() right here, but the ~100-component registry is
@@ -658,15 +807,43 @@ namespace OloEngine::MCP::GenericFieldWrite
     [[nodiscard]] const std::vector<FieldEntry>& Registry();
 
     // Look up the entry for (component, field), or nullptr. Pointers into the static
-    // registry are stable for the process lifetime.
+    // registry are stable for the process lifetime. Deliberately never matches a
+    // map-keyed entry by its bare prefix — "Weights" alone names the container, not
+    // an addressable value; use FindMapKeyed() for "Weights.<key>" instead.
     [[nodiscard]] inline const FieldEntry* Find(std::string_view component, std::string_view field)
     {
         for (const FieldEntry& entry : Registry())
         {
-            if (entry.Component == component && entry.Field == field)
+            if (!entry.IsMapKeyed && entry.Component == component && entry.Field == field)
                 return &entry;
         }
         return nullptr;
+    }
+
+    // Resolve a dotted "<mapField>.<key>" against COMPONENT's registered map fields:
+    // on a match, `outKey` receives the runtime key (the remainder after the longest
+    // matching "<mapField>." prefix — longest wins only in case a component ever
+    // registers more than one map field with an overlapping prefix, which does not
+    // happen today) and the owning entry is returned. nullptr if `field` names no
+    // known map field's prefix (either the component has none, or nothing follows
+    // the dot).
+    [[nodiscard]] inline const FieldEntry* FindMapKeyed(std::string_view component, std::string_view field, std::string& outKey)
+    {
+        const FieldEntry* best = nullptr;
+        for (const FieldEntry& entry : Registry())
+        {
+            if (!entry.IsMapKeyed || entry.Component != component)
+                continue;
+            const std::string prefix = entry.Field + ".";
+            if (field.size() <= prefix.size() || field.substr(0, prefix.size()) != prefix)
+                continue;
+            if (best == nullptr || entry.Field.size() > best->Field.size())
+            {
+                best = &entry;
+                outKey = std::string(field.substr(prefix.size()));
+            }
+        }
+        return best;
     }
 
     // The distinct editable component type names, in first-seen order.
@@ -681,14 +858,17 @@ namespace OloEngine::MCP::GenericFieldWrite
         return names;
     }
 
-    // The editable field names for one component (empty if the component is unknown).
+    // The editable field names for one component (empty if the component is
+    // unknown). A map-keyed field is listed as "<field>.<key>" (e.g. "Weights.<key>")
+    // so the placeholder form is self-explanatory in an error/discovery message
+    // without implying the bare prefix is itself writable.
     [[nodiscard]] inline std::vector<std::string> EditableFieldsFor(std::string_view component)
     {
         std::vector<std::string> fields;
         for (const FieldEntry& entry : Registry())
         {
             if (entry.Component == component)
-                fields.push_back(entry.Field);
+                fields.push_back(entry.IsMapKeyed ? (entry.Field + ".<key>") : entry.Field);
         }
         return fields;
     }
@@ -732,7 +912,7 @@ namespace OloEngine::MCP::GenericFieldWrite
         return Schema::Object()
             .Prop("entity", Schema::EntityId("UUID of the entity to modify (a decimal-digit string)."))
             .Prop("component", Schema::String().Desc("Component type name, e.g. 'TransformComponent' or 'PointLightComponent'. Discover writable components/fields with olo_entity_list_fields."))
-            .Prop("field", Schema::String().Desc("Field name to set, e.g. 'Translation' or 'Intensity' — the m_-stripped name shown in olo_scene_get_entity's YAML."))
+            .Prop("field", Schema::String().Desc("Field name to set, e.g. 'Translation' or 'Intensity' — the m_-stripped name shown in olo_scene_get_entity's YAML. For a map-typed field (e.g. MorphTargetComponent's 'Weights'), address one entry with a dotted key, e.g. 'Weights.Smile' — discover current keys with olo_entity_list_fields."))
             .Prop("value", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
                                .Desc("New value, typed to match the field: a boolean, a number, a string, or an array of numbers for a vector (e.g. [x, y, z] for a vec3)."))
             .Required({ "entity", "component", "field", "value" })
@@ -808,21 +988,33 @@ namespace OloEngine::MCP::GenericFieldWrite
             return result;
         }
 
-        const FieldEntry* entry = Find(component, field);
-        if (entry == nullptr)
+        if (const FieldEntry* entry = Find(component, field))
         {
-            result.Error = DescribeUnknownField(component, field);
-            return result;
+            const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+            if (!entityOpt)
+            {
+                result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+                return result;
+            }
+            return entry->Apply(scene, history, *entityOpt, entityUuid, value);
         }
 
-        const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
-        if (!entityOpt)
+        // Not a plain field — try a map-keyed one ("Weights.Smile" against the
+        // registered "Weights" prefix) before giving up.
+        std::string key;
+        if (const FieldEntry* mapEntry = FindMapKeyed(component, field, key))
         {
-            result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
-            return result;
+            const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+            if (!entityOpt)
+            {
+                result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+                return result;
+            }
+            return mapEntry->ApplyKeyed(scene, history, *entityOpt, entityUuid, key, value);
         }
 
-        return entry->Apply(scene, history, *entityOpt, entityUuid, value);
+        result.Error = DescribeUnknownField(component, field);
+        return result;
     }
 
     // List the writable fields of one entity, with their current values, restricted
@@ -866,8 +1058,32 @@ namespace OloEngine::MCP::GenericFieldWrite
             {
                 if (entry.Component != componentName)
                     continue;
+                if (!entry.HasComponent(entity)) // entity lacks this component
+                    break;
+
+                if (entry.IsMapKeyed)
+                {
+                    // No key is known ahead of time — expand into one discoverable
+                    // dotted field per CURRENT map entry ("Weights.Smile", ...),
+                    // exactly what an agent can re-issue as a write right now.
+                    std::vector<std::string> keys = entry.ListMapKeys(entity);
+                    std::sort(keys.begin(), keys.end());
+                    for (const std::string& mapKey : keys)
+                    {
+                        Json field = Json{ { "field", entry.Field + "." + mapKey },
+                                           { "type", entry.Type },
+                                           { "value", *entry.ReadKeyed(entity, mapKey) } };
+                        if (entry.Range.Min)
+                            field["min"] = *entry.Range.Min;
+                        if (entry.Range.Max)
+                            field["max"] = *entry.Range.Max;
+                        fields.push_back(std::move(field));
+                    }
+                    continue;
+                }
+
                 const std::optional<Json> current = entry.Read(entity);
-                if (!current) // entity lacks this component
+                if (!current) // shouldn't happen — HasComponent already checked above
                     break;
                 Json field = Json{ { "field", entry.Field },
                                    { "type", entry.Type },

--- a/OloEditor/src/MCP/McpGenericFieldWrite.h
+++ b/OloEditor/src/MCP/McpGenericFieldWrite.h
@@ -649,18 +649,29 @@ namespace OloEngine::MCP::GenericFieldWrite
     //
     // Like MakeSetterField (not MakeFieldAccess), the write calls `setFn` DIRECTLY on
     // the live component — never a whole-map copy+swap — reusing
-    // PropertySetCommand<C, V, SetFn> for undo/redo by binding `key` into the setter
-    // closure passed to it.
+    // MapKeyPropertySetCommand<C, V, SetFn, EraseFn> for undo/redo by binding `key`
+    // into the setter/eraser closures passed to it. Undo restores the captured old
+    // value when the key already existed, or ERASES the key entirely when it did
+    // not — a plain re-apply-old-value undo (as PropertySetCommand does) would
+    // leave a phantom entry at the map's semantic default for a key that never
+    // existed before the write (ComponentCommands.h has the full rationale).
     //
-    // getFn:  (const C&, const std::string& key) -> V   (a missing key returns the
-    //         map's own semantic default, e.g. MorphTargetComponent::GetWeight()'s 0.0f)
-    // setFn:  (C&, const std::string& key, const V& value) -> void
-    // keysFn: (const C&) -> std::vector<std::string>   (the map's CURRENT keys, for
-    //         olo_entity_list_fields discovery — order doesn't matter, ListFields sorts)
-    template<typename C, typename V, typename GetFn, typename SetFn, typename KeysFn>
+    // getFn:      (const C&, const std::string& key) -> V   (a missing key returns
+    //             the map's own semantic default, e.g. MorphTargetComponent::
+    //             GetWeight()'s 0.0f)
+    // setFn:      (C&, const std::string& key, const V& value) -> void
+    // hasKeyFn:   (const C&, const std::string& key) -> bool   (whether the key is
+    //             currently present — checked BEFORE the write so Undo knows
+    //             whether to restore a value or erase the key)
+    // removeKeyFn: (C&, const std::string& key) -> void   (erase the key entirely —
+    //             only ever invoked by Undo, for a key that did not exist before)
+    // keysFn:     (const C&) -> std::vector<std::string>   (the map's CURRENT keys,
+    //             for olo_entity_list_fields discovery — order doesn't matter,
+    //             ListFields sorts)
+    template<typename C, typename V, typename GetFn, typename SetFn, typename HasKeyFn, typename RemoveKeyFn, typename KeysFn>
     [[nodiscard]] inline FieldEntry MakeMapKeyField(std::string component, std::string field,
-                                                    GetFn getFn, SetFn setFn, KeysFn keysFn,
-                                                    FieldRange range = {})
+                                                    GetFn getFn, SetFn setFn, HasKeyFn hasKeyFn, RemoveKeyFn removeKeyFn,
+                                                    KeysFn keysFn, FieldRange range = {})
     {
         static_assert(std::is_same_v<std::invoke_result_t<GetFn, const C&, const std::string&>, V>,
                       "MakeMapKeyField: getFn must return exactly V");
@@ -668,15 +679,18 @@ namespace OloEngine::MCP::GenericFieldWrite
         FieldEntry entry;
         entry.Component = component;
         entry.Field = field;
-        entry.Type = "map<string," + std::string(FieldTypeName<V>()) + ">";
+        // The SCALAR type — one dotted entry ("Weights.Smile") addresses exactly
+        // one V, never the whole map, so discovery (olo_entity_list_fields) must
+        // report the same type a plain scalar field would.
+        entry.Type = std::string(FieldTypeName<V>());
         entry.Range = range;
         entry.IsMapKeyed = true;
         entry.HasComponent = [](Entity e)
         { return e.HasComponent<C>(); };
 
-        entry.ApplyKeyed = [getFn, setFn, component, field, range](const Ref<Scene>& scene, CommandHistory& history,
-                                                                   Entity entity, u64 uuid, const std::string& key,
-                                                                   const Json& value) -> ApplyResult
+        entry.ApplyKeyed = [getFn, setFn, hasKeyFn, removeKeyFn, component, field, range](
+                               const Ref<Scene>& scene, CommandHistory& history, Entity entity, u64 uuid,
+                               const std::string& key, const Json& value) -> ApplyResult
         {
             ApplyResult result;
             if (!entity.HasComponent<C>())
@@ -700,6 +714,7 @@ namespace OloEngine::MCP::GenericFieldWrite
             // Same "apply then read back" honesty contract as MakeSetterField: setFn
             // may itself clamp/transform (MorphTargetComponent::SetWeight does), so
             // the reported value comes from getFn AFTER the write, not from `coerced`.
+            const bool hadKey = hasKeyFn(entity.GetComponent<C>(), key);
             const V previous = getFn(entity.GetComponent<C>(), key);
             V applied = previous;
             if (FieldChanged<V>(previous, coerced))
@@ -710,8 +725,10 @@ namespace OloEngine::MCP::GenericFieldWrite
                 applied = getFn(entity.GetComponent<C>(), key);
                 if (FieldChanged<V>(previous, applied))
                 {
-                    history.PushAlreadyExecuted(std::make_unique<PropertySetCommand<C, V, decltype(keyedSetFn)>>(
-                        scene, UUID(uuid), keyedSetFn, previous, applied,
+                    auto keyedEraseFn = [key, removeKeyFn](C& c)
+                    { removeKeyFn(c, key); };
+                    history.PushAlreadyExecuted(std::make_unique<MapKeyPropertySetCommand<C, V, decltype(keyedSetFn), decltype(keyedEraseFn)>>(
+                        scene, UUID(uuid), keyedSetFn, keyedEraseFn, previous, applied, hadKey,
                         "Set " + component + "." + field + "." + key));
                 }
             }

--- a/OloEditor/src/MCP/McpToolsScene.cpp
+++ b/OloEditor/src/MCP/McpToolsScene.cpp
@@ -491,8 +491,10 @@ namespace OloEngine::MCP
                 "echoes 'value' READ BACK from the component after the write plus changed:true/false — verify those "
                 "rather than assuming a returned call applied. Applied through the editor's undo stack, so it is a "
                 "single Ctrl-Z. This is a WRITE tool: refused unless 'Allow writes' is enabled in the editor's MCP "
-                "Server panel (off by default). Discover the exact writable (component, field) names, value shapes "
-                "and ranges for an entity with olo_entity_list_fields.";
+                "Server panel (off by default). A map-typed field (e.g. MorphTargetComponent's per-target 'Weights') "
+                "is addressed one entry at a time with a dotted key, e.g. field 'Weights.Smile' — its current keys "
+                "are only discoverable per-entity, not ahead of time. Discover the exact writable (component, field) "
+                "names, value shapes and ranges for an entity with olo_entity_list_fields.";
             tool.InputSchema = GenericFieldWrite::InputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_EntitySetField;

--- a/OloEditor/src/UndoRedo/ComponentCommands.h
+++ b/OloEditor/src/UndoRedo/ComponentCommands.h
@@ -222,6 +222,71 @@ namespace OloEngine
         std::string m_Description;
     };
 
+    // UUID-based undo/redo for a SINGLE MAP-KEY write applied through a setter
+    // function DIRECTLY on the live component (issue #607's MorphTargetComponent::
+    // Weights map-key addressing slice) — the map-typed sibling of
+    // PropertySetCommand above. A plain PropertySetCommand's Undo just re-applies
+    // `setFn` with the captured old value, which is wrong for a map key that did
+    // NOT exist before the write: `setFn` (e.g. MorphTargetComponent::SetWeight)
+    // uses `operator[]`, so re-applying it on Undo would leave a phantom entry at
+    // the map's semantic default (e.g. weight 0.0) instead of restoring "the key
+    // was never there" — a caller enumerating current keys (olo_entity_list_fields)
+    // would then see a key that never existed before the original write. Undo
+    // therefore branches on `keyExistedBefore`: restore the captured old value when
+    // the key was already present, or erase the key entirely when it was not.
+    template<typename T, typename F, typename SetFn, typename EraseFn>
+    class MapKeyPropertySetCommand : public EditorCommand
+    {
+      public:
+        MapKeyPropertySetCommand(Ref<Scene> scene, UUID entityUUID, SetFn setFn, EraseFn eraseFn,
+                                 F oldValue, F newValue, bool keyExistedBefore, std::string description = "Property Change")
+            : m_Scene(std::move(scene)), m_EntityUUID(entityUUID), m_SetFn(std::move(setFn)), m_EraseFn(std::move(eraseFn)),
+              m_OldValue(std::move(oldValue)), m_NewValue(std::move(newValue)), m_KeyExistedBefore(keyExistedBefore),
+              m_Description(std::move(description))
+        {
+        }
+
+        void Execute() override
+        {
+            auto entityOpt = m_Scene->TryGetEntityWithUUID(m_EntityUUID);
+            if (entityOpt && entityOpt->HasComponent<T>())
+            {
+                m_SetFn(entityOpt->GetComponent<T>(), m_NewValue);
+            }
+        }
+
+        void Undo() override
+        {
+            auto entityOpt = m_Scene->TryGetEntityWithUUID(m_EntityUUID);
+            if (entityOpt && entityOpt->HasComponent<T>())
+            {
+                if (m_KeyExistedBefore)
+                {
+                    m_SetFn(entityOpt->GetComponent<T>(), m_OldValue);
+                }
+                else
+                {
+                    m_EraseFn(entityOpt->GetComponent<T>());
+                }
+            }
+        }
+
+        [[nodiscard]] std::string GetDescription() const override
+        {
+            return m_Description;
+        }
+
+      private:
+        Ref<Scene> m_Scene;
+        UUID m_EntityUUID;
+        SetFn m_SetFn;
+        EraseFn m_EraseFn;
+        F m_OldValue;
+        F m_NewValue;
+        bool m_KeyExistedBefore;
+        std::string m_Description;
+    };
+
     // Undo/Redo for adding a component with a post-init callback (e.g. particle presets)
     template<typename T>
     class AddComponentWithInitCommand : public EditorCommand

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -2680,6 +2680,7 @@ namespace OloEngine
         OLO_PROPERTY(Set = "comp.m_BoundsMax = {v}; comp.m_Dirty = true")
         glm::vec3 m_BoundsMax = glm::vec3(10.0f);
         glm::ivec3 m_Resolution = glm::ivec3(4, 2, 4);
+        OLO_SERIALIZE(Clamp, Min = 0.01f)
         OLO_PROPERTY(Set = "comp.m_Spacing = {v}; comp.m_Dirty = true")
         f32 m_Spacing = 5.0f;
         OLO_PROPERTY(Set = "comp.m_Intensity = {v}; comp.m_Dirty = true")
@@ -2765,6 +2766,7 @@ namespace OloEngine
     // or SaveGameComponentSerializer — re-bake after load).
     struct ReflectionProbeComponent
     {
+        OLO_SERIALIZE(Clamp, Min = 0.01f)
         OLO_PROPERTY()
         f32 m_InfluenceRadius = 10.0f;
         OLO_PROPERTY()

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -3029,11 +3029,14 @@ namespace OloEngine
             lpv.m_RelightBudget = lpvComponent["RelightBudget"].as<i32>(lpv.m_RelightBudget);
             lpv.m_SelfShadowBias = lpvComponent["SelfShadowBias"].as<f32>(lpv.m_SelfShadowBias);
 
-            // Sanitize deserialized values
-            if (!std::isfinite(lpv.m_Spacing) || lpv.m_Spacing <= 0.0f)
-            {
-                lpv.m_Spacing = 5.0f;
-            }
+            // Sanitize deserialized values. Spacing mirrors the
+            // OLO_SERIALIZE(Clamp, Min = 0.01f) annotation on the field (this
+            // component stays hand-written for unrelated reasons — Resolution's
+            // >= 1 clamp and the BoundsMin/Max ordering are cross-field
+            // invariants a single-field Clamp can't express) — a non-finite
+            // read falls back to the constructor default, a finite-but-tiny or
+            // negative value is pulled up to the floor rather than reset.
+            lpv.m_Spacing = std::isfinite(lpv.m_Spacing) ? std::max(lpv.m_Spacing, 0.01f) : 5.0f;
             if (!std::isfinite(lpv.m_Intensity) || lpv.m_Intensity < 0.0f)
             {
                 lpv.m_Intensity = 1.0f;
@@ -3070,11 +3073,14 @@ namespace OloEngine
             rp.m_Intensity = rpComponent["Intensity"].as<f32>(rp.m_Intensity);
             rp.m_Active = rpComponent["Active"].as<bool>(rp.m_Active);
 
-            // Sanitize deserialized values — never trust file input
-            if (!std::isfinite(rp.m_InfluenceRadius) || rp.m_InfluenceRadius <= 0.0f)
-            {
-                rp.m_InfluenceRadius = 10.0f;
-            }
+            // Sanitize deserialized values — never trust file input. InfluenceRadius
+            // mirrors the OLO_SERIALIZE(Clamp, Min = 0.01f) annotation on the field
+            // (this component stays hand-written for unrelated reasons — the
+            // BakedEnvironment/NeedsBake runtime fields and Resolution/BlendDistance's
+            // own guards) — a non-finite read falls back to the constructor default,
+            // a finite-but-tiny or negative value is pulled up to the floor rather
+            // than reset.
+            rp.m_InfluenceRadius = std::isfinite(rp.m_InfluenceRadius) ? std::max(rp.m_InfluenceRadius, 0.01f) : 10.0f;
             if (!std::isfinite(rp.m_BlendDistance) || rp.m_BlendDistance < 0.0f)
             {
                 rp.m_BlendDistance = 1.0f;

--- a/OloEngine/tests/MCP/McpFieldRegistryTest.cpp
+++ b/OloEngine/tests/MCP/McpFieldRegistryTest.cpp
@@ -558,24 +558,23 @@ TEST(McpFieldRegistry, ListFieldsReportsNestedDottedFields)
 
 // ---- 6. what sub-object addressing deliberately does NOT reach ---------------
 //
-// One component still exposes no authored field, and it is not a gap a dotted
-// member-access path can close. Pinned here so the limitation is a stated contract
-// rather than a silent surprise, and so the day someone closes it the test tells them
-// to update this comment.
-//
-//   * MorphTargetComponent's authored surface is a DYNAMIC keyset
-//     (`std::unordered_map<std::string, f32> Weights`), which needs map-key
-//     addressing ("Weights.<targetName>"), not sub-object addressing: the field names
-//     do not exist until a MorphTargetSet is bound at runtime, so no static registry
-//     entry can name them.
+// Sub-object addressing (a dotted member-access CHAIN, sections 1-5 above) only
+// reaches a field with a compile-time-known name. It cannot address
+// MorphTargetComponent's authored surface — a DYNAMIC keyset
+// (`std::unordered_map<std::string, f32> Weights`) whose keys (target/bone names)
+// do not exist until a MorphTargetSet is bound at runtime, so no static dotted name
+// could ever be generated for one. The bare prefix "Weights" therefore stays
+// unreachable via Find() (it names the container, not an addressable value) — that
+// is not a residual gap, it is the map-key mechanism's OWN contract (section 8
+// below closes the actual gap via a dotted RUNTIME key, "Weights.<name>").
 //
 // AudioSourceComponent used to be pinned here too (its 16 parameters live behind a
 // PRIVATE cold blob a member-access chain cannot cross) — issue #607's
 // AudioSourceComponent slice closed that gap with a setter-expression-based
 // mechanism instead of sub-object addressing. See section 7 below.
-TEST(McpFieldRegistry, KnownGapsWithNoStaticFieldPathStayUnreachable)
+TEST(McpFieldRegistry, MapFieldBarePrefixIsNotDirectlyWritable)
 {
-    EXPECT_FALSE(RegistryHas("MorphTargetComponent", "Weights")); // dynamic keyset, not a field
+    EXPECT_FALSE(RegistryHas("MorphTargetComponent", "Weights")); // names the container, not a value
 }
 
 // ---- 7. AudioSourceComponent: setter-expression-based fields (issue #607) ----
@@ -667,4 +666,142 @@ TEST(McpFieldRegistry, WriteDoesNotResetActiveEventID)
     f.History.Undo();
     EXPECT_EQ(f.TheEntity.GetComponent<OloEngine::AudioSourceComponent>().ActiveEventID, 4242u);
     EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::AudioSourceComponent>().GetConfig().VolumeMultiplier, 1.0f);
+}
+
+// ---- 8. map-key addressing: MorphTargetComponent::Weights (issue #607) -------
+//
+// Weights (`std::unordered_map<std::string, f32>`, target/bone name -> weight) has
+// no compile-time-known key, so it cannot be a plain or nested field (sections 1-5)
+// or a setter-expression field (section 7) — both assume ONE fixed name per entity.
+// MakeMapKeyField registers ONE entry for the whole field ("Weights"), and a caller
+// addresses a single entry with a DOTTED runtime key ("Weights.Smile"), resolved by
+// FindMapKeyed() stripping the registered "Weights." prefix. The write goes through
+// MorphTargetComponent::SetWeight/GetWeight directly on the live component (like
+// MakeSetterField, never a whole-map copy+swap), so its own [0, 1] clamp and the
+// registry's mirrored FieldRange agree by construction.
+
+TEST(McpFieldRegistry, WeightsKeyRoundTripsAndUndoes)
+{
+    Fixture f;
+    auto& morph = f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+    ASSERT_FLOAT_EQ(morph.GetWeight("Smile"), 0.0f); // absent key reads as 0
+
+    const auto result = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Smile", Json(0.75));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["field"], "Weights.Smile");
+    EXPECT_EQ(result.Data["key"], "Smile");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_TRUE(result.Data["undoable"].get<bool>());
+    EXPECT_FLOAT_EQ(result.Data["previousValue"].get<f32>(), 0.0f);
+    EXPECT_FLOAT_EQ(result.Data["value"].get<f32>(), 0.75f);
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.75f);
+
+    ASSERT_TRUE(f.History.CanUndo());
+    f.History.Undo();
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.0f);
+}
+
+// A second, DISTINCT key on the same field is independently addressable and does
+// not disturb the first key's value — the whole point of per-key addressing rather
+// than a single scalar accessor.
+TEST(McpFieldRegistry, DistinctKeysOnTheSameMapFieldAreIndependentlyAddressable)
+{
+    Fixture f;
+    auto& morph = f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+    morph.SetWeight("Smile", 0.5f);
+
+    const auto result = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Blink", Json(0.3));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Blink"), 0.3f);
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.5f)
+        << "writing one key must not disturb another";
+}
+
+// The registry's range mirrors SetWeight's own [0, 1] clamp, reported the same way
+// a plain field's OLO_SERIALIZE(Clamp) range is (clamped:true + requestedValue).
+TEST(McpFieldRegistry, WeightsKeyClampsToZeroOneRange)
+{
+    Fixture f;
+    f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+
+    const auto high = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Smile", Json(5.0));
+    ASSERT_TRUE(high.Ok) << high.Error;
+    EXPECT_TRUE(high.Data["clamped"].get<bool>());
+    EXPECT_DOUBLE_EQ(high.Data["requestedValue"].get<double>(), 5.0);
+    EXPECT_FLOAT_EQ(high.Data["value"].get<f32>(), 1.0f);
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 1.0f);
+
+    const auto low = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Smile", Json(-2.0));
+    ASSERT_TRUE(low.Ok) << low.Error;
+    EXPECT_TRUE(low.Data["clamped"].get<bool>());
+    EXPECT_FLOAT_EQ(low.Data["value"].get<f32>(), 0.0f);
+}
+
+// A write to an unknown component still refuses with the ordinary error; a write to
+// the bare "Weights" prefix (no key) refuses too — it is not a component-lacks-field
+// gap, it just names the container, not a value.
+TEST(McpFieldRegistry, BareWeightsFieldWithNoKeyIsRefused)
+{
+    Fixture f;
+    f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+
+    const auto result = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights", Json(0.5));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("has no editable field"), std::string::npos);
+    // The self-correcting hint names the dotted placeholder form, not a bare "Weights".
+    EXPECT_NE(result.Error.find("Weights.<key>"), std::string::npos);
+}
+
+// olo_entity_list_fields expands a map field into one discoverable dotted entry PER
+// CURRENT KEY (there is no static key to list ahead of time) — "exactly what you can
+// write right now", the same contract every other field honors.
+TEST(McpFieldRegistry, ListFieldsExpandsMapKeysIntoDottedEntries)
+{
+    Fixture f;
+    auto& morph = f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+    morph.SetWeight("Smile", 0.5f);
+    morph.SetWeight("Blink", 0.25f);
+
+    bool found = false;
+    const Json out = GFW::ListFields(f.Scene_, f.Uuid, "MorphTargetComponent", found);
+    ASSERT_TRUE(found);
+    ASSERT_EQ(out["components"].size(), 1u);
+
+    std::vector<std::string> seenFields;
+    for (const auto& field : out["components"][0]["fields"])
+        seenFields.push_back(field["field"].get<std::string>());
+
+    EXPECT_NE(std::find(seenFields.begin(), seenFields.end(), "Weights.Smile"), seenFields.end());
+    EXPECT_NE(std::find(seenFields.begin(), seenFields.end(), "Weights.Blink"), seenFields.end());
+    EXPECT_EQ(std::find(seenFields.begin(), seenFields.end(), "Weights"), seenFields.end())
+        << "the bare prefix itself must not be listed as a writable field";
+
+    for (const auto& field : out["components"][0]["fields"])
+    {
+        if (field["field"] == "Weights.Smile")
+        {
+            EXPECT_EQ(field["type"], "map<string,float>");
+            EXPECT_FLOAT_EQ(field["value"].get<f32>(), 0.5f);
+            ASSERT_TRUE(field.contains("min"));
+            ASSERT_TRUE(field.contains("max"));
+            EXPECT_NEAR(field["min"].get<double>(), 0.0, 1e-6);
+            EXPECT_NEAR(field["max"].get<double>(), 1.0, 1e-6);
+        }
+    }
+}
+
+// An entity with no MorphTargetSet bound (an empty Weights map) reports zero
+// "Weights.*" entries rather than erroring — an empty map is a valid, listable state.
+TEST(McpFieldRegistry, ListFieldsOnEmptyWeightsMapReportsNoMapEntries)
+{
+    Fixture f;
+    f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+
+    bool found = false;
+    const Json out = GFW::ListFields(f.Scene_, f.Uuid, "MorphTargetComponent", found);
+    ASSERT_TRUE(found);
+    ASSERT_EQ(out["components"].size(), 1u);
+
+    for (const auto& field : out["components"][0]["fields"])
+        EXPECT_EQ(field["field"].get<std::string>().find("Weights."), std::string::npos);
 }

--- a/OloEngine/tests/MCP/McpFieldRegistryTest.cpp
+++ b/OloEngine/tests/MCP/McpFieldRegistryTest.cpp
@@ -685,6 +685,7 @@ TEST(McpFieldRegistry, WeightsKeyRoundTripsAndUndoes)
     Fixture f;
     auto& morph = f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
     ASSERT_FLOAT_EQ(morph.GetWeight("Smile"), 0.0f); // absent key reads as 0
+    ASSERT_FALSE(morph.Weights.contains("Smile"));
 
     const auto result = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Smile", Json(0.75));
     ASSERT_TRUE(result.Ok) << result.Error;
@@ -699,6 +700,33 @@ TEST(McpFieldRegistry, WeightsKeyRoundTripsAndUndoes)
     ASSERT_TRUE(f.History.CanUndo());
     f.History.Undo();
     EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.0f);
+    // Not just "reads as 0" (GetWeight's default for a missing key) — the key must
+    // be GONE, exactly as it was before the write. A plain re-apply-old-value undo
+    // would instead leave a phantom "Smile" -> 0.0 entry, which would wrongly start
+    // showing up in olo_entity_list_fields / ListMapKeys for a key that was never
+    // actually authored.
+    EXPECT_FALSE(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().Weights.contains("Smile"))
+        << "undo of a first-time key write must remove the key, not just reset its value";
+}
+
+// The complementary undo branch: overwriting a key that ALREADY existed restores
+// the captured old value (and keeps the key present), rather than erasing it —
+// erase-on-undo is only for a key that did not exist before the write.
+TEST(McpFieldRegistry, UndoOfAnExistingKeyOverwriteRestoresTheOldValueRatherThanErasing)
+{
+    Fixture f;
+    auto& morph = f.TheEntity.AddComponent<OloEngine::MorphTargetComponent>();
+    morph.SetWeight("Smile", 0.4f);
+
+    const auto result = GFW::Apply(f.Scene_, f.History, f.Uuid, "MorphTargetComponent", "Weights.Smile", Json(0.9));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.9f);
+
+    ASSERT_TRUE(f.History.CanUndo());
+    f.History.Undo();
+    EXPECT_TRUE(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().Weights.contains("Smile"))
+        << "the key existed before the write, so undo must restore its value, not erase it";
+    EXPECT_FLOAT_EQ(f.TheEntity.GetComponent<OloEngine::MorphTargetComponent>().GetWeight("Smile"), 0.4f);
 }
 
 // A second, DISTINCT key on the same field is independently addressable and does
@@ -780,7 +808,10 @@ TEST(McpFieldRegistry, ListFieldsExpandsMapKeysIntoDottedEntries)
     {
         if (field["field"] == "Weights.Smile")
         {
-            EXPECT_EQ(field["type"], "map<string,float>");
+            // A dotted entry addresses exactly ONE value, so its type is the
+            // scalar type — the same "float" a plain scalar field reports, not
+            // the whole map's container type.
+            EXPECT_EQ(field["type"], "float");
             EXPECT_FLOAT_EQ(field["value"].get<f32>(), 0.5f);
             ASSERT_TRUE(field.contains("min"));
             ASSERT_TRUE(field.contains("max"));

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -311,27 +311,42 @@ What is writable:
   allowlist rather than "every `OLO_PROPERTY` component" (most of those already have
   their field reachable as a plain public member, so routing them through this path
   too would just double-register the same field).
+- **Map-key addressing** (issue #607's `MorphTargetComponent::Weights` slice): a
+  MAP-typed field (`std::unordered_map<std::string, f32> Weights` — target/bone name
+  -> weight) has no compile-time-known key, so no static registry entry could ever
+  name one ahead of time. ONE `MakeMapKeyField` entry is registered per map field
+  (hand-written in `McpFieldRegistry.cpp`, not codegen'd — there is exactly one such
+  field in the engine today), addressed by a **dotted runtime key**:
+  `{ "field": "Weights.Smile", "value": 0.75 }` writes the `Smile` target's weight.
+  The bare prefix (`"Weights"` with no key) is deliberately **not** writable — it
+  names the container, not a value — so `olo_entity_list_fields` expands the field
+  into one dotted entry **per current key** instead of listing `Weights` itself.
+  The write goes through `MorphTargetComponent::SetWeight`/`GetWeight` directly on
+  the live component (never a whole-map copy+swap), and the registered range mirrors
+  `SetWeight`'s own `[0, 1]` clamp.
 - **Not** writable, by design: per-tick runtime state (the `*StateComponent` family,
   `AnimationStateComponent`, `UIResolvedRectComponent`, `WorldTransformComponent`),
   entity identity (`IDComponent` — its UUID is the addressing key), any field marked
   `OLO_SERIALIZE(Skip)` (e.g. `NavAgentComponent`'s pathfinder state), any non-public
   member with no `OLO_PROPERTY` Get/Set pair (`TransformComponent::Rotation` — a
-  derived euler/quat pair behind setters, but no OLO_PROPERTY annotation), any field
-  with no scalar JSON shape (a `Ref<T>`, a container, a `glm::quat`/`mat4`/`ivec*`),
-  and a dynamic keyset a static registry entry cannot name
-  (`MorphTargetComponent::Weights`, a `std::unordered_map<std::string, f32>` — needs
-  map-key addressing, a follow-up).
+  derived euler/quat pair behind setters, but no OLO_PROPERTY annotation), and any
+  field with no scalar JSON shape (a `Ref<T>`, a container other than a
+  string-keyed scalar map, a `glm::quat`/`mat4`/`ivec*`).
 
 **Ranges are enforced, and a clamp is reported.** A field whose scene-load path
 clamps or rejects out-of-range values carries the same bounds here — from its
 `OLO_SERIALIZE(Clamp, Min=…, Max=…)` annotation, or (for a component whose serializer
 is hand-written) from the generator's `kMcpFieldClamps` table. So MCP can never put a
 component into a state a scene load could not produce. Bounds are visible up front in
-`olo_entity_list_fields` (`min`/`max` per field). *Known gap:* a hand-written
-serializer's strict `> 0` guards (e.g. `LightProbeVolumeComponent::Spacing`,
-`ReflectionProbeComponent::InfluenceRadius`) are **not** approximated with an invented
-epsilon and stay unclamped here; the fix is to migrate those hand-written clamps onto
-`OLO_SERIALIZE(Clamp, …)`, after which MCP inherits them for free.
+`olo_entity_list_fields` (`min`/`max` per field). `LightProbeVolumeComponent::Spacing`
+and `ReflectionProbeComponent::InfluenceRadius` — previously a hand-written strict
+`> 0` guard approximated by nothing here — are now `OLO_SERIALIZE(Clamp, Min=0.01f)`
+annotated, so MCP inherits their range the same way any other annotated field does
+(no `kMcpFieldClamps` entry needed); both components still keep their hand-written
+`SceneSerializer.cpp` block for unrelated reasons (cross-field invariants a
+single-field `Clamp` can't express), so the two components did not flip to
+fully-generated serialization, only the two named fields' range semantics changed
+from reject-and-reset-to-default to clamp-to-floor.
 
 **The response is verifiable — do not trust "the call returned".** `value` is read
 back **out of the live component after the write**, not echoed from the input, and


### PR DESCRIPTION
## Summary

Closes the two remaining Section C items on #607:

- **`MorphTargetComponent::Weights` map-key addressing.** Its `std::unordered_map<std::string, f32> Weights` field had no MCP write path at all — a map's runtime key can't be a compile-time-known accessor chain. Added a new `MakeMapKeyField` mechanism (`McpGenericFieldWrite.h`): one registry entry per map field, addressed at write time by a **dotted runtime key** (`"Weights.Smile"`), resolved by a new `FindMapKeyed()` that strips the registered prefix — reusing the existing dotted sub-object-addressing convention rather than adding a second JSON argument. The write goes through `MorphTargetComponent::SetWeight`/`GetWeight` directly on the live component (never a whole-map copy+swap), so its `[0, 1]` clamp is inherited for free. Hand-registered in `McpFieldRegistry.cpp` (not codegen — it's the only map field in the engine today). `olo_entity_list_fields` expands the field into one discoverable dotted entry per *current* key.
- **`LightProbeVolumeComponent::Spacing` / `ReflectionProbeComponent::InfluenceRadius` clamp migration.** Both fields were registered as plain (unranged) MCP fields despite their hand-written `SceneSerializer.cpp` deserializers enforcing a strict `> 0` guard. Migrated both onto `OLO_SERIALIZE(Clamp, Min = 0.01f)`, so the MCP field registry inherits the range for free (no `kMcpFieldClamps` table entry needed). The hand-written `SceneSerializer.cpp` guards were updated from reject-and-reset-to-default to clamp-to-floor to match the annotation's semantics — a small-but-positive value is now preserved instead of silently replaced by the constructor default. Both components stay hand-written in the scene serializer for unrelated reasons (cross-field invariants a single-field `Clamp` can't express), so only the two named fields' range semantics changed, not the whole components' (de)serialization path.

## Test plan

- [x] `McpFieldRegistry.*` (36 tests, including 7 new map-key tests: round-trip/undo, independent keys, range clamp, bare-prefix refusal, `ListFields` expansion, empty-map handling)
- [x] `ComponentSerializerCoverage.*`, `ComponentTupleCoverage.*`, `ComponentHandlerCoverage.*`, `SaveGameComponentSerializerCoverage.*`
- [x] `*LightProbe*:*ReflectionProbe*` (17 tests, including the GPU visual-evidence test and YAML/Lua/save-game round-trips)
- [x] `GenerateBindings` rebuilt; confirmed `McpFieldRegistry.Generated.inl` emits ranged entries for both migrated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing individual morph-target weights using dotted field names such as `Weights.Smile`.
  * Field discovery now lists available map keys and their supported ranges.
  * Morph-target weight updates support undo and report the applied value.

* **Bug Fixes**
  * Weight values are clamped to the valid range of 0–1.
  * Probe spacing and influence radius values now enforce a minimum of 0.01 while preserving safe defaults for invalid data.

* **Documentation**
  * Updated MCP guidance with map-key editing syntax, discovery behavior, and range rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->