### PR TITLE
feat(renderer): port animated MeshPrimitives to the MeshSource bone-influence system (#592)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
@@ -4,8 +4,81 @@
 #include "OloEngine/Renderer/VertexBuffer.h"
 #include "OloEngine/Renderer/IndexBuffer.h"
 
+#include <iterator>
+
 namespace OloEngine
 {
+    namespace
+    {
+        // Unit cube (1x1x1) vertex data: 24 verts (4 per face, duplicated at
+        // shared edges so each face gets its own normal/UV), optionally
+        // offset along Y. Single source of truth for every primitive that
+        // needs a plain axis-aligned unit-cube shell (CreateCube and the
+        // animated variants) so their geometry/UVs cannot silently drift
+        // apart from hand-copied duplicates.
+        std::vector<Vertex> MakeUnitCubeVertices(f32 centerY = 0.0f)
+        {
+            const f32 top = centerY + 0.5f;
+            const f32 bottom = centerY - 0.5f;
+            return {
+                // Front face
+                { { 0.5f, top, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },     // 0
+                { { 0.5f, bottom, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },  // 1
+                { { -0.5f, bottom, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } }, // 2
+                { { -0.5f, top, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },    // 3
+
+                // Back face
+                { { 0.5f, top, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 0.0f, 1.0f } },     // 4
+                { { 0.5f, bottom, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 0.0f, 0.0f } },  // 5
+                { { -0.5f, bottom, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 1.0f, 0.0f } }, // 6
+                { { -0.5f, top, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 1.0f, 1.0f } },    // 7
+
+                // Right face
+                { { 0.5f, top, 0.5f }, { 1.0f, 0.0f, 0.0f }, { 0.0f, 1.0f } },     // 8
+                { { 0.5f, bottom, 0.5f }, { 1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },  // 9
+                { { 0.5f, bottom, -0.5f }, { 1.0f, 0.0f, 0.0f }, { 1.0f, 0.0f } }, // 10
+                { { 0.5f, top, -0.5f }, { 1.0f, 0.0f, 0.0f }, { 1.0f, 1.0f } },    // 11
+
+                // Left face
+                { { -0.5f, top, 0.5f }, { -1.0f, 0.0f, 0.0f }, { 1.0f, 1.0f } },     // 12
+                { { -0.5f, bottom, 0.5f }, { -1.0f, 0.0f, 0.0f }, { 1.0f, 0.0f } },  // 13
+                { { -0.5f, bottom, -0.5f }, { -1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } }, // 14
+                { { -0.5f, top, -0.5f }, { -1.0f, 0.0f, 0.0f }, { 0.0f, 1.0f } },    // 15
+
+                // Top face
+                { { 0.5f, top, 0.5f }, { 0.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },   // 16
+                { { 0.5f, top, -0.5f }, { 0.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },  // 17
+                { { -0.5f, top, -0.5f }, { 0.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } }, // 18
+                { { -0.5f, top, 0.5f }, { 0.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },  // 19
+
+                // Bottom face
+                { { 0.5f, bottom, 0.5f }, { 0.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },   // 20
+                { { 0.5f, bottom, -0.5f }, { 0.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },  // 21
+                { { -0.5f, bottom, -0.5f }, { 0.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } }, // 22
+                { { -0.5f, bottom, 0.5f }, { 0.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } }   // 23
+            };
+        }
+
+        // Winding-order indices matching MakeUnitCubeVertices()'s layout.
+        std::vector<u32> MakeUnitCubeIndices()
+        {
+            return {
+                // Front face (CCW from outside, normal +Z)
+                0, 3, 1, 3, 2, 1,
+                // Back face (CCW from outside, normal -Z)
+                4, 5, 7, 5, 6, 7,
+                // Right face (CCW from outside, normal +X)
+                8, 9, 11, 9, 10, 11,
+                // Left face (CCW from outside, normal -X)
+                12, 15, 13, 15, 14, 13,
+                // Top face (CCW from outside, normal +Y)
+                16, 17, 19, 17, 18, 19,
+                // Bottom face (CCW from outside, normal -Y)
+                20, 23, 21, 23, 22, 21
+            };
+        }
+    } // namespace
+
     // Static shared fullscreen triangle VAO (lazy-initialized)
     static Ref<VertexArray> s_FullscreenTriangleVA;
 
@@ -59,58 +132,8 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        std::vector<Vertex> vertices = {
-            // Front face
-            { { 0.5f, 0.5f, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 1.0f, 1.0f } },   // 0
-            { { 0.5f, -0.5f, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 1.0f, 0.0f } },  // 1
-            { { -0.5f, -0.5f, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f } }, // 2
-            { { -0.5f, 0.5f, 0.5f }, { 0.0f, 0.0f, 1.0f }, { 0.0f, 1.0f } },  // 3
-
-            // Back face
-            { { 0.5f, 0.5f, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 0.0f, 1.0f } },   // 4
-            { { 0.5f, -0.5f, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 0.0f, 0.0f } },  // 5
-            { { -0.5f, -0.5f, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 1.0f, 0.0f } }, // 6
-            { { -0.5f, 0.5f, -0.5f }, { 0.0f, 0.0f, -1.0f }, { 1.0f, 1.0f } },  // 7
-
-            // Right face
-            { { 0.5f, 0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f }, { 0.0f, 1.0f } },   // 8
-            { { 0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },  // 9
-            { { 0.5f, -0.5f, -0.5f }, { 1.0f, 0.0f, 0.0f }, { 1.0f, 0.0f } }, // 10
-            { { 0.5f, 0.5f, -0.5f }, { 1.0f, 0.0f, 0.0f }, { 1.0f, 1.0f } },  // 11
-
-            // Left face
-            { { -0.5f, 0.5f, 0.5f }, { -1.0f, 0.0f, 0.0f }, { 1.0f, 1.0f } },   // 12
-            { { -0.5f, -0.5f, 0.5f }, { -1.0f, 0.0f, 0.0f }, { 1.0f, 0.0f } },  // 13
-            { { -0.5f, -0.5f, -0.5f }, { -1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } }, // 14
-            { { -0.5f, 0.5f, -0.5f }, { -1.0f, 0.0f, 0.0f }, { 0.0f, 1.0f } },  // 15
-
-            // Top face
-            { { 0.5f, 0.5f, 0.5f }, { 0.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },   // 16
-            { { 0.5f, 0.5f, -0.5f }, { 0.0f, 1.0f, 0.0f }, { 1.0f, 1.0f } },  // 17
-            { { -0.5f, 0.5f, -0.5f }, { 0.0f, 1.0f, 0.0f }, { 0.0f, 1.0f } }, // 18
-            { { -0.5f, 0.5f, 0.5f }, { 0.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },  // 19
-
-            // Bottom face
-            { { 0.5f, -0.5f, 0.5f }, { 0.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } },   // 20
-            { { 0.5f, -0.5f, -0.5f }, { 0.0f, -1.0f, 0.0f }, { 1.0f, 0.0f } },  // 21
-            { { -0.5f, -0.5f, -0.5f }, { 0.0f, -1.0f, 0.0f }, { 0.0f, 0.0f } }, // 22
-            { { -0.5f, -0.5f, 0.5f }, { 0.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } }   // 23
-        };
-
-        std::vector<u32> indices = {
-            // Front face (CCW from outside, normal +Z)
-            0, 3, 1, 3, 2, 1,
-            // Back face (CCW from outside, normal -Z)
-            4, 5, 7, 5, 6, 7,
-            // Right face (CCW from outside, normal +X)
-            8, 9, 11, 9, 10, 11,
-            // Left face (CCW from outside, normal -X)
-            12, 15, 13, 15, 14, 13,
-            // Top face (CCW from outside, normal +Y)
-            16, 17, 19, 17, 18, 19,
-            // Bottom face (CCW from outside, normal -Y)
-            20, 23, 21, 23, 22, 21
-        };
+        std::vector<Vertex> vertices = MakeUnitCubeVertices();
+        std::vector<u32> indices = MakeUnitCubeIndices();
 
         auto meshSource = Ref<MeshSource>::Create(vertices, indices);
 
@@ -905,6 +928,130 @@ namespace OloEngine
         submesh.m_MaterialIndex = 0;
         submesh.m_IsRigged = false;
         submesh.m_NodeName = "WaterGrid";
+        meshSource->AddSubmesh(submesh);
+
+        meshSource->Build();
+        return Ref<Mesh>::Create(meshSource, 0);
+    }
+
+    Ref<Mesh> MeshPrimitives::CreateAnimatedCube()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Same geometry as CreateCube(), rigged to a single root bone so the
+        // whole mesh moves rigidly with it. The minimal skinned primitive:
+        // proves the MeshSource <-> Skeleton wiring without any blend weights.
+        std::vector<Vertex> vertices = MakeUnitCubeVertices();
+        std::vector<u32> indices = MakeUnitCubeIndices();
+
+        auto meshSource = Ref<MeshSource>::Create(vertices, indices);
+
+        auto skeleton = Ref<Skeleton>::Create(1);
+        skeleton->m_BoneNames = { "Root" };
+        skeleton->m_ParentIndices = { -1 };
+        skeleton->m_LocalTransforms = { glm::mat4(1.0f) };
+        skeleton->m_BonePreTransforms = { glm::mat4(1.0f) };
+        skeleton->m_GlobalTransforms[0] = skeleton->m_LocalTransforms[0];
+        skeleton->SetBindPose();
+        meshSource->SetSkeleton(skeleton);
+
+        BoneInfluence rootInfluence;
+        rootInfluence.SetBoneData(0, /*boneId=*/0, /*weight=*/1.0f);
+        for (u32 i = 0, n = static_cast<u32>(vertices.size()); i < n; ++i)
+        {
+            meshSource->SetVertexBoneData(i, rootInfluence);
+        }
+
+        meshSource->GetBoneInfo().Add(BoneInfo(skeleton->m_InverseBindPoses[0], 0));
+
+        Submesh submesh;
+        submesh.m_BaseVertex = 0;
+        submesh.m_BaseIndex = 0;
+        submesh.m_IndexCount = static_cast<u32>(indices.size());
+        submesh.m_VertexCount = static_cast<u32>(vertices.size());
+        submesh.m_MaterialIndex = 0;
+        submesh.m_IsRigged = true;
+        submesh.m_NodeName = "AnimatedCube";
+        meshSource->AddSubmesh(submesh);
+
+        meshSource->Build();
+        return Ref<Mesh>::Create(meshSource, 0);
+    }
+
+    Ref<Mesh> MeshPrimitives::CreateMultiBoneAnimatedCube()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Two vertically stacked unit cubes forming a 1x2x1 column: the lower
+        // half (y in [-1, 0]) is rigged to bone 0 ("Lower"), the upper half
+        // (y in [0, 1]) to bone 1 ("Upper"). Both bones share the bind-pose
+        // origin (0, 0, 0) - the seam - so rotating "Upper" bends the column
+        // at the seam instead of tearing it. Vertices exactly at the seam
+        // (y == 0) are weighted 50/50 between the two bones - the case that
+        // actually exercises blended influences.
+        constexpr u32 kLowerBone = 0;
+        constexpr u32 kUpperBone = 1;
+        constexpr u32 kVertsPerBox = 24;
+
+        // Lower box: y in [-1, 0]; Upper box: y in [0, 1].
+        std::vector<Vertex> vertices = MakeUnitCubeVertices(-0.5f);
+        std::vector<Vertex> upperVertices = MakeUnitCubeVertices(0.5f);
+        vertices.reserve(vertices.size() + upperVertices.size());
+        vertices.insert(vertices.end(), std::make_move_iterator(upperVertices.begin()), std::make_move_iterator(upperVertices.end()));
+
+        const std::vector<u32> boxIndices = MakeUnitCubeIndices();
+        std::vector<u32> indices;
+        indices.reserve(boxIndices.size() * 2);
+        indices.insert(indices.end(), boxIndices.begin(), boxIndices.end());
+        for (u32 idx : boxIndices)
+        {
+            indices.push_back(idx + kVertsPerBox);
+        }
+
+        auto meshSource = Ref<MeshSource>::Create(vertices, indices);
+
+        auto skeleton = Ref<Skeleton>::Create(2);
+        skeleton->m_BoneNames = { "Lower", "Upper" };
+        skeleton->m_ParentIndices = { -1, 0 };
+        skeleton->m_LocalTransforms = { glm::mat4(1.0f), glm::mat4(1.0f) };
+        skeleton->m_BonePreTransforms = { glm::mat4(1.0f), glm::mat4(1.0f) };
+        skeleton->m_GlobalTransforms[0] = skeleton->m_LocalTransforms[0];
+        skeleton->m_GlobalTransforms[1] = skeleton->m_GlobalTransforms[0] * skeleton->m_LocalTransforms[1];
+        skeleton->SetBindPose();
+        meshSource->SetSkeleton(skeleton);
+
+        constexpr f32 kSeamEpsilon = 1e-4f;
+        for (u32 i = 0, n = static_cast<u32>(vertices.size()); i < n; ++i)
+        {
+            const f32 y = vertices[i].Position.y;
+            BoneInfluence influence;
+            if (y < -kSeamEpsilon)
+            {
+                influence.SetBoneData(0, kLowerBone, 1.0f);
+            }
+            else if (y > kSeamEpsilon)
+            {
+                influence.SetBoneData(0, kUpperBone, 1.0f);
+            }
+            else
+            {
+                influence.SetBoneData(0, kLowerBone, 0.5f);
+                influence.SetBoneData(1, kUpperBone, 0.5f);
+            }
+            meshSource->SetVertexBoneData(i, influence);
+        }
+
+        meshSource->GetBoneInfo().Add(BoneInfo(skeleton->m_InverseBindPoses[0], kLowerBone));
+        meshSource->GetBoneInfo().Add(BoneInfo(skeleton->m_InverseBindPoses[1], kUpperBone));
+
+        Submesh submesh;
+        submesh.m_BaseVertex = 0;
+        submesh.m_BaseIndex = 0;
+        submesh.m_IndexCount = static_cast<u32>(indices.size());
+        submesh.m_VertexCount = static_cast<u32>(vertices.size());
+        submesh.m_MaterialIndex = 0;
+        submesh.m_IsRigged = true;
+        submesh.m_NodeName = "MultiBoneAnimatedCube";
         meshSource->AddSubmesh(submesh);
 
         meshSource->Build();

--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
@@ -991,10 +991,10 @@ namespace OloEngine
         // actually exercises blended influences.
         constexpr u32 kLowerBone = 0;
         constexpr u32 kUpperBone = 1;
-        constexpr u32 kVertsPerBox = 24;
 
         // Lower box: y in [-1, 0]; Upper box: y in [0, 1].
         std::vector<Vertex> vertices = MakeUnitCubeVertices(-0.5f);
+        const auto lowerBoxVertexCount = static_cast<u32>(vertices.size());
         std::vector<Vertex> upperVertices = MakeUnitCubeVertices(0.5f);
         vertices.reserve(vertices.size() + upperVertices.size());
         vertices.insert(vertices.end(), std::make_move_iterator(upperVertices.begin()), std::make_move_iterator(upperVertices.end()));
@@ -1005,7 +1005,7 @@ namespace OloEngine
         indices.insert(indices.end(), boxIndices.begin(), boxIndices.end());
         for (u32 idx : boxIndices)
         {
-            indices.push_back(idx + kVertsPerBox);
+            indices.push_back(idx + lowerBoxVertexCount);
         }
 
         auto meshSource = Ref<MeshSource>::Create(vertices, indices);

--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.h
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.h
@@ -170,12 +170,24 @@ namespace OloEngine
         [[nodiscard]] static Ref<Mesh> CreateWaterGrid(f32 width = 100.0f, f32 length = 100.0f, u32 subdivisionsX = 128, u32 subdivisionsZ = 128);
 
         // =============================================================================
-        // ANIMATED MESH PRIMITIVES (TODO(olbu): Update for new MeshSource system, #592)
+        // ANIMATED MESH PRIMITIVES
         // =============================================================================
 
-        // TODO(olbu): Update these methods to work with new MeshSource bone influence system (#592)
-        // static Ref<Mesh> CreateAnimatedCube();
-        // static Ref<Mesh> CreateMultiBoneAnimatedCube();
+        // @brief Create a unit cube rigged to a single root bone
+        // @return Cube mesh with a MeshSource + one-bone Skeleton, all vertices
+        //         weighted 100% to the root bone (rigid skinning, no blending).
+        //         Minimal primitive for exercising the MeshSource<->Skeleton
+        //         bone-influence contract without external asset loading.
+        [[nodiscard]] static Ref<Mesh> CreateAnimatedCube();
+
+        // @brief Create a two-bone rigged column (1x2x1) for exercising blend weights
+        // @return Mesh made of two vertically stacked unit cubes: the lower half
+        //         is weighted to bone 0 ("Lower"), the upper half to bone 1
+        //         ("Upper"), both sharing a bind-pose origin at the seam
+        //         (y = 0). Vertices exactly at the seam are weighted 50/50
+        //         between the two bones, so rotating "Upper" visibly bends
+        //         the mesh at the seam instead of tearing it.
+        [[nodiscard]] static Ref<Mesh> CreateMultiBoneAnimatedCube();
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/MeshSource.h
+++ b/OloEngine/src/OloEngine/Renderer/MeshSource.h
@@ -298,6 +298,10 @@ namespace OloEngine
         {
             return m_Skeleton.get();
         }
+        Skeleton* GetSkeleton()
+        {
+            return m_Skeleton.get();
+        }
         void SetSkeleton(Ref<Skeleton> skeleton)
         {
             m_Skeleton = skeleton;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -737,6 +737,9 @@ add_executable(OloEngine-Tests
 		Functional/Scripting/LuaGrantsExperienceViaSceneTickTest.cpp
 		# FramePacer: frame-rate cap sleep/spin math + EMA delta smoothing (#456)
 		FramePacerTest.cpp
+		# Animated MeshPrimitives (issue #592): CreateAnimatedCube / CreateMultiBoneAnimatedCube
+		# skinning correctness against the MeshSource bone-influence contract.
+		Rendering/PropertyTests/AnimatedMeshPrimitivesPropertyTests.cpp
 )
 target_link_libraries(OloEngine-Tests
 	OloEngine

--- a/OloEngine/tests/Rendering/PropertyTests/AnimatedMeshPrimitivesPropertyTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/AnimatedMeshPrimitivesPropertyTests.cpp
@@ -1,0 +1,253 @@
+// OLO_TEST_LAYER: L1
+// =============================================================================
+// AnimatedMeshPrimitivesPropertyTests.cpp
+//
+// Correctness proof for MeshPrimitives::CreateAnimatedCube() and
+// CreateMultiBoneAnimatedCube() (issue #592): the procedurally generated
+// skinned primitives are built through MeshSource::Build(), which needs a
+// live GL context to create GPU buffers, so this lives in the L1 property
+// suite (gated on OLO_ENSURE_GPU_OR_SKIP) even though every assertion below
+// is pure CPU math over the MeshSource / Skeleton contract.
+//
+// The linear-blend-skinning formula pinned here — skinnedPos = sum(weight_k
+// * (finalBoneMatrix[boneId_k] * localPos)), with finalBoneMatrix = poseGlobal
+// * inverseBindPose — mirrors AnimationSystem::Update (AnimationSystem.cpp)
+// and PBR_MultiLight_Skinned.glsl's vertex-shader skinning step.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "RenderPropertyTest.h"
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Animation/Skeleton.h"
+#include "OloEngine/Renderer/Mesh.h"
+#include "OloEngine/Renderer/MeshPrimitives.h"
+#include "OloEngine/Renderer/MeshSource.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    // Recomputes global transforms + final skinning matrices from the
+    // skeleton's current local transforms, mirroring the hierarchy walk in
+    // AnimationSystem::Update (skeleton.m_GlobalTransforms[i] = parentGlobal
+    // * preTransform * localTransform, then finalBoneMatrices[i] = global *
+    // inverseBindPose). Both test skeletons here have identity pre-transforms.
+    void RecomputePose(Skeleton& skeleton)
+    {
+        const sizet boneCount = skeleton.m_LocalTransforms.size();
+        for (sizet i = 0; i < boneCount; ++i)
+        {
+            const i32 parent = skeleton.m_ParentIndices[i];
+            skeleton.m_GlobalTransforms[i] = (parent >= 0)
+                                                 ? skeleton.m_GlobalTransforms[static_cast<sizet>(parent)] * skeleton.m_LocalTransforms[i]
+                                                 : skeleton.m_LocalTransforms[i];
+        }
+        for (sizet i = 0; i < boneCount; ++i)
+        {
+            skeleton.m_FinalBoneMatrices[i] = skeleton.m_GlobalTransforms[i] * skeleton.m_InverseBindPoses[i];
+        }
+    }
+
+    // Applies linear-blend skinning to one vertex using the mesh's stored
+    // BoneInfluence, exactly as PBR_MultiLight_Skinned.glsl does.
+    glm::vec3 SkinVertex(const Skeleton& skeleton, const BoneInfluence& influence, const glm::vec3& localPos)
+    {
+        glm::vec4 blended(0.0f);
+        for (int k = 0; k < 4; ++k)
+        {
+            if (influence.m_Weights[k] > 0.0f)
+            {
+                blended += influence.m_Weights[k] * (skeleton.m_FinalBoneMatrices[influence.m_BoneIDs[k]] * glm::vec4(localPos, 1.0f));
+            }
+        }
+        return glm::vec3(blended);
+    }
+} // namespace
+
+TEST(AnimatedMeshPrimitives, AnimatedCubeHasRootBoneAndFullWeights)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    auto mesh = MeshPrimitives::CreateAnimatedCube();
+    ASSERT_TRUE(mesh);
+    auto meshSource = mesh->GetMeshSource();
+    ASSERT_TRUE(meshSource);
+
+    ASSERT_TRUE(meshSource->HasSkeleton());
+    EXPECT_TRUE(meshSource->HasBoneInfluences());
+    ASSERT_EQ(meshSource->GetBoneInfo().Num(), 1);
+    EXPECT_EQ(meshSource->GetBoneInfo(0).m_BoneIndex, 0u);
+
+    const auto& vertices = meshSource->GetVertices();
+    for (i32 i = 0; i < vertices.Num(); ++i)
+    {
+        const BoneInfluence& influence = meshSource->GetVertexBoneData(static_cast<u32>(i));
+        EXPECT_EQ(influence.m_BoneIDs[0], 0u);
+        EXPECT_FLOAT_EQ(influence.m_Weights[0], 1.0f);
+        EXPECT_FLOAT_EQ(influence.m_Weights[1], 0.0f);
+        EXPECT_FLOAT_EQ(influence.m_Weights[2], 0.0f);
+        EXPECT_FLOAT_EQ(influence.m_Weights[3], 0.0f);
+    }
+}
+
+TEST(AnimatedMeshPrimitives, AnimatedCubeRotatesRigidlyWithRootBone)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    auto mesh = MeshPrimitives::CreateAnimatedCube();
+    ASSERT_TRUE(mesh);
+    auto meshSource = mesh->GetMeshSource();
+    ASSERT_TRUE(meshSource);
+
+    Skeleton* skeleton = meshSource->GetSkeleton();
+    ASSERT_NE(skeleton, nullptr);
+
+    // Rotate the root bone 90 degrees about Y and recompute the pose — with
+    // every vertex weighted 100% to bone 0, the whole mesh must rotate as a
+    // rigid body, i.e. skinning must reproduce the same rotation applied
+    // directly to the original vertex positions.
+    const glm::mat4 rotation = glm::rotate(glm::mat4(1.0f), glm::radians(90.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+    skeleton->m_LocalTransforms[0] = rotation;
+    RecomputePose(*skeleton);
+
+    const auto& vertices = meshSource->GetVertices();
+    for (i32 i = 0; i < vertices.Num(); ++i)
+    {
+        const BoneInfluence& influence = meshSource->GetVertexBoneData(static_cast<u32>(i));
+        const glm::vec3 localPos = vertices[i].Position;
+        const glm::vec3 skinned = SkinVertex(*skeleton, influence, localPos);
+        const glm::vec3 expected = glm::vec3(rotation * glm::vec4(localPos, 1.0f));
+
+        EXPECT_NEAR(skinned.x, expected.x, 1e-4f) << "vertex " << i;
+        EXPECT_NEAR(skinned.y, expected.y, 1e-4f) << "vertex " << i;
+        EXPECT_NEAR(skinned.z, expected.z, 1e-4f) << "vertex " << i;
+    }
+}
+
+TEST(AnimatedMeshPrimitives, MultiBoneCubeHasTwoBonesAndSeamBlendWeights)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    auto mesh = MeshPrimitives::CreateMultiBoneAnimatedCube();
+    ASSERT_TRUE(mesh);
+    auto meshSource = mesh->GetMeshSource();
+    ASSERT_TRUE(meshSource);
+
+    ASSERT_TRUE(meshSource->HasSkeleton());
+    EXPECT_TRUE(meshSource->HasBoneInfluences());
+    ASSERT_EQ(meshSource->GetBoneInfo().Num(), 2);
+
+    const auto& vertices = meshSource->GetVertices();
+    bool sawPureLower = false;
+    bool sawPureUpper = false;
+    bool sawSeamBlend = false;
+
+    for (i32 i = 0; i < vertices.Num(); ++i)
+    {
+        const BoneInfluence& influence = meshSource->GetVertexBoneData(static_cast<u32>(i));
+        const f32 totalWeight = influence.m_Weights[0] + influence.m_Weights[1] + influence.m_Weights[2] + influence.m_Weights[3];
+        EXPECT_NEAR(totalWeight, 1.0f, 1e-4f) << "vertex " << i << " weights must sum to 1";
+
+        const f32 y = vertices[i].Position.y;
+        if (y < -1e-3f)
+        {
+            EXPECT_EQ(influence.m_BoneIDs[0], 0u);
+            EXPECT_FLOAT_EQ(influence.m_Weights[0], 1.0f);
+            sawPureLower = true;
+        }
+        else if (y > 1e-3f)
+        {
+            EXPECT_EQ(influence.m_BoneIDs[0], 1u);
+            EXPECT_FLOAT_EQ(influence.m_Weights[0], 1.0f);
+            sawPureUpper = true;
+        }
+        else
+        {
+            // Seam vertex: blended 50/50 between the lower and upper bone.
+            EXPECT_FLOAT_EQ(influence.m_Weights[0], 0.5f);
+            EXPECT_FLOAT_EQ(influence.m_Weights[1], 0.5f);
+            EXPECT_EQ(influence.m_BoneIDs[0], 0u);
+            EXPECT_EQ(influence.m_BoneIDs[1], 1u);
+            sawSeamBlend = true;
+        }
+    }
+
+    EXPECT_TRUE(sawPureLower) << "expected at least one vertex rigidly bound to the lower bone";
+    EXPECT_TRUE(sawPureUpper) << "expected at least one vertex rigidly bound to the upper bone";
+    EXPECT_TRUE(sawSeamBlend) << "expected at least one blended seam vertex — the case that exercises blend weights";
+}
+
+TEST(AnimatedMeshPrimitives, MultiBoneCubeBendsAtSeamWhenUpperBoneRotates)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    auto mesh = MeshPrimitives::CreateMultiBoneAnimatedCube();
+    ASSERT_TRUE(mesh);
+    auto meshSource = mesh->GetMeshSource();
+    ASSERT_TRUE(meshSource);
+
+    Skeleton* skeleton = meshSource->GetSkeleton();
+    ASSERT_NE(skeleton, nullptr);
+    ASSERT_EQ(skeleton->m_LocalTransforms.size(), 2u);
+
+    // Rotate only the upper bone 90 degrees about X, pivoting at the shared
+    // bind-pose origin (the seam, y = 0). The lower bone stays at bind pose.
+    const glm::mat4 rotation = glm::rotate(glm::mat4(1.0f), glm::radians(90.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+    skeleton->m_LocalTransforms[1] = rotation;
+    RecomputePose(*skeleton);
+
+    const auto& vertices = meshSource->GetVertices();
+    for (i32 i = 0; i < vertices.Num(); ++i)
+    {
+        const BoneInfluence& influence = meshSource->GetVertexBoneData(static_cast<u32>(i));
+        const glm::vec3 localPos = vertices[i].Position;
+        const glm::vec3 skinned = SkinVertex(*skeleton, influence, localPos);
+
+        const f32 y = localPos.y;
+        glm::vec3 expected;
+        if (y < -1e-3f)
+        {
+            // Pure lower-bone vertices are unaffected by the upper rotation.
+            expected = localPos;
+        }
+        else if (y > 1e-3f)
+        {
+            // Pure upper-bone vertices follow the rotation exactly.
+            expected = glm::vec3(rotation * glm::vec4(localPos, 1.0f));
+        }
+        else
+        {
+            // Seam vertices blend the un-rotated and rotated positions 50/50.
+            expected = 0.5f * localPos + 0.5f * glm::vec3(rotation * glm::vec4(localPos, 1.0f));
+        }
+
+        EXPECT_NEAR(skinned.x, expected.x, 1e-4f) << "vertex " << i;
+        EXPECT_NEAR(skinned.y, expected.y, 1e-4f) << "vertex " << i;
+        EXPECT_NEAR(skinned.z, expected.z, 1e-4f) << "vertex " << i;
+    }
+
+    // Sanity: the mesh actually bent — a pure-upper vertex must have moved
+    // away from its bind-pose position once rotated 90 degrees about X.
+    bool sawMovedUpperVertex = false;
+    for (i32 i = 0; i < vertices.Num(); ++i)
+    {
+        const glm::vec3 localPos = vertices[i].Position;
+        if (localPos.y > 1e-3f)
+        {
+            const BoneInfluence& influence = meshSource->GetVertexBoneData(static_cast<u32>(i));
+            const glm::vec3 skinned = SkinVertex(*skeleton, influence, localPos);
+            if (glm::length(skinned - localPos) > 1e-3f)
+            {
+                sawMovedUpperVertex = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(sawMovedUpperVertex) << "rotating the upper bone should visibly move the upper half of the mesh";
+}

--- a/docs/agent-rules/procedural-skinned-mesh-primitives.md
+++ b/docs/agent-rules/procedural-skinned-mesh-primitives.md
@@ -1,0 +1,43 @@
+# Procedural skinned mesh primitives (issue #592)
+
+`MeshPrimitives::CreateAnimatedCube()` / `CreateMultiBoneAnimatedCube()` build
+a `MeshSource` + `Skeleton` entirely in code — no external asset — for
+animation/skinning tests. Two non-obvious points from porting them to the
+current `MeshSource` bone-influence system:
+
+## `MeshSource::Build()` needs a live GL context
+
+`MeshSource::Build()` unconditionally creates GPU buffers
+(`VertexBuffer::Create` / `IndexBuffer::Create`), even for the CPU-only
+`BoneInfluence`/`Skeleton` data a skinning-correctness test actually cares
+about. Any test that calls a `MeshPrimitives::Create*()` factory therefore
+needs `OLO_ENSURE_GPU_OR_SKIP()` (`RenderPropertyTest.h`) — it cannot live on
+the headless `Functional` axis (ADR 0002) even though its assertions are pure
+math. Classify such a test `L1` (property/behavioural), not `Functional` or
+`unit`.
+
+## Give a multi-bone test skeleton a shared bind-pose origin so a bone rotation pivots at the seam
+
+For a skeleton built purely for a test (not an imported rig), setting every
+bone's `m_LocalTransforms[i]` to `glm::mat4(1.0f)` at bind time (mirroring
+`AnimationFixtures.h`'s `MakeTwoBoneSkeleton()`) places every bone's bind-pose
+global transform at the same world origin. Because a bone's *local* transform
+composes as `T * R * S`, later mutating only the rotation component (leaving
+`T` at the identity's zero translation) rotates that bone's whole subtree
+**around that shared origin** — which is exactly the mesh seam if you
+partition vertex weights around `y == 0`. This gives a deterministic,
+zero-setup "rotate the child bone, verify it bends at the seam" test without
+having to reason about an offset pivot. If bones instead need distinct
+bind-pose positions (mirroring a real rig), remember the pivot for a later
+rotation is wherever `T` is baked into that bone's local transform at bind
+time — not the origin.
+
+## `MeshSource::GetSkeleton()` needed a mutable overload
+
+`MeshSource` only exposed `const Skeleton* GetSkeleton() const` — sufficient
+for read-only import consumers, but a test that wants to pose a
+procedurally-built skeleton (mutate `m_LocalTransforms`, recompute
+`m_GlobalTransforms`/`m_FinalBoneMatrices`) needs write access. Added a
+`Skeleton* GetSkeleton()` non-const overload alongside it, matching the
+existing `GetVertices()`/`GetIndices()`/`GetSubmeshes()` const+non-const
+pattern on the same class.


### PR DESCRIPTION
Closes #592

## Summary

- Ports the long-commented-out `CreateAnimatedCube()` / `CreateMultiBoneAnimatedCube()` declarations in `MeshPrimitives.h` to the current `MeshSource` bone-influence + `Skeleton` API, closing #592.
- `CreateAnimatedCube()`: unit cube rigged to a single root bone, all vertices weighted 100% (rigid skinning) — proves the `MeshSource`↔`Skeleton` wiring.
- `CreateMultiBoneAnimatedCube()`: a two-bone 1x2x1 column ("Lower"/"Upper"), weighted per vertex with a real 50/50 blend at the seam — the case that exercises actual blend weights, not just rigid binding.
- Added a mutable `MeshSource::GetSkeleton()` overload (only `const` existed) so a test can pose a procedurally-built skeleton after construction.
- New `L1` property-test suite (`AnimatedMeshPrimitivesPropertyTests.cpp`, gated on GPU since `MeshSource::Build()` needs a GL context) proves the bone-influence data is correct and that CPU-side skinning matches the production linear-blend-skinning formula for both a rigid single-bone rotation and a two-bone bend at the seam.
- Factored the shared unit-cube vertex/index data into `MakeUnitCubeVertices()`/`MakeUnitCubeIndices()` helpers reused by `CreateCube()` and both new primitives — code review surfaced that the initial hand-copied draft had already introduced two UV copy-paste bugs (vertices 18 and 23), which this refactor fixes at the source.
- Captured the non-obvious skinning-contract gotchas (GPU-gating requirement, shared bind-pose-origin bend-pivot trick) in `docs/agent-rules/procedural-skinned-mesh-primitives.md`.

## Test plan

- [x] `OloEngine-Tests` (Debug/msvc) builds clean
- [x] New `AnimatedMeshPrimitives.*` suite (4 tests) passes
- [x] Broader `Mesh*:Skeleton*:Animation*` sweep (139 tests) passes with no regressions
- [x] `/code-review` (medium effort, 8 finder angles) run — correctness angles found zero bugs; cleanup/reuse angles surfaced a real copy-paste UV bug and code duplication, both fixed
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated cube mesh creation with single-bone and two-bone skinning support.
  * Added weighted seam blending for smoother multi-bone deformation.
  * Exposed access to modify skeleton data for animation workflows.

* **Tests**
  * Added coverage for bone weights, rigid deformation, and multi-bone bending behavior.

* **Documentation**
  * Documented procedural skinned mesh primitives and related testing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->