### PR TITLE
feat(net): harden LAN lobby discovery (+ cross-platform hook & RHEL/Rocky build support)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/claude-stop-hook.ps1"
+            "shell": "bash",
+            "command": "if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/claude-stop-hook.ps1; else sh scripts/claude-stop-hook.sh; fi"
           }
         ]
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,6 +55,24 @@
 			}
 		},
 		{
+			"name": "linux-gcc-toolset",
+			"displayName": "Linux GCC (toolset / system gcc, Ninja)",
+			"description": "For distros where the compiler is `gcc`/`g++` on PATH rather than versioned gcc-14 binaries — e.g. an activated RHEL/Rocky gcc-toolset-N. Shares build-linux/ with linux-gcc, so use one or the other. FFmpeg is off by default (its from-source build needs nasm); enable with -DOLO_VIDEO_FFMPEG=ON once nasm is installed. Pass -DCMAKE_PREFIX_PATH=$VULKAN_SDK for the shader stack. See docs/ops/build.md.",
+			"generator": "Ninja Multi-Config",
+			"binaryDir": "${sourceDir}/build-linux",
+			"cacheVariables": {
+				"BUILD_TESTS": "ON",
+				"CMAKE_C_COMPILER": "gcc",
+				"CMAKE_CXX_COMPILER": "g++",
+				"OLO_VIDEO_FFMPEG": "OFF"
+			},
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Linux"
+			}
+		},
+		{
 			"name": "linux-asan",
 			"displayName": "Linux GCC + ASan",
 			"description": "GCC ASan build; also enables LSan automatically per cmake/Sanitizers.cmake.",

--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -315,6 +315,36 @@ else()
 	check_linker_flag(CXX "-lstdc++exp" OLO_HAVE_LIBSTDCXXEXP)
 	if(OLO_HAVE_LIBSTDCXXEXP)
 		target_link_libraries(OloEngine stdc++exp)
+	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		# Some GCC toolchains ship <stacktrace> but NOT libstdc++exp on the default
+		# library search path — notably the RHEL/Rocky gcc-toolset-N SCL packages
+		# (e.g. gcc-toolset-15), which omit libstdc++exp.a even though a compatible
+		# copy exists under the base GCC install. Without it the OpenGLDebug.cpp
+		# std::stacktrace call is undefined at every executable link. Search the
+		# base GCC lib dirs and add the newest match explicitly. (Clang here already
+		# resolves -lstdc++exp via its selected GCC install, so the check above
+		# passes and this branch is GNU-only.)
+		file(GLOB _olo_stdcxxexp_candidates
+			/usr/lib/gcc/*/*/libstdc++exp.a
+			/usr/lib64/gcc/*/*/libstdc++exp.a)
+		if(_olo_stdcxxexp_candidates)
+			list(SORT _olo_stdcxxexp_candidates COMPARE NATURAL ORDER DESCENDING)
+			list(GET _olo_stdcxxexp_candidates 0 _olo_stdcxxexp_lib)
+			get_filename_component(_olo_stdcxxexp_dir "${_olo_stdcxxexp_lib}" DIRECTORY)
+			message(STATUS "libstdc++exp not on the default link path; using "
+				"${_olo_stdcxxexp_lib} for std::stacktrace (base-GCC fallback for a "
+				"toolset that omits it).")
+			# PUBLIC so the -L and the lib propagate to the executables that actually
+			# link (tests / editor / runtime); -L precedes the -lstdc++exp search.
+			target_link_options(OloEngine PUBLIC "-L${_olo_stdcxxexp_dir}")
+			target_link_libraries(OloEngine stdc++exp)
+			set(OLO_HAVE_LIBSTDCXXEXP TRUE)
+		else()
+			message(WARNING "libstdc++exp (std::stacktrace) not found. Executable links that "
+				"reference std::stacktrace (Platform/OpenGL/OpenGLDebug.cpp) will fail to resolve "
+				"std::__stacktrace_impl::_S_current. Install libstdc++-static / the matching "
+				"libstdc++exp for your GCC, or use a toolchain that ships it.")
+		endif()
 	endif()
 endif()
 

--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -285,6 +285,7 @@ if(MSVC)
 		BCrypt
 		DbgHelp.lib
 		dwmapi
+		Iphlpapi   # GetAdaptersAddresses — NetworkLobby LAN-discovery broadcast enumeration
 		Synchronization
 		Version
 		ws2_32

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkLobby.cpp
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkLobby.cpp
@@ -12,6 +12,7 @@
 #endif
 #include <WinSock2.h>
 #include <WS2tcpip.h>
+#include <iphlpapi.h> // GetAdaptersAddresses — enumerate per-interface broadcast targets
 using SocketType = SOCKET;
 using socklen_t = int;
 static constexpr SocketType kInvalidSocket = INVALID_SOCKET;
@@ -34,6 +35,8 @@ static inline bool SetNonBlocking(SocketType s)
 #include <sys/select.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <net/if.h>  // IFF_UP / IFF_LOOPBACK / IFF_BROADCAST flags
+#include <ifaddrs.h> // getifaddrs — enumerate per-interface broadcast targets
 #include <unistd.h>
 #include <fcntl.h>
 #include <cerrno>
@@ -59,6 +62,56 @@ static inline bool SetNonBlocking(SocketType s)
 }
 #endif
 
+namespace
+{
+    // Ensures the platform socket subsystem is initialised before the first
+    // socket() call and torn down at process exit. On Windows WinSock requires
+    // a WSAStartup/WSACleanup pair (both are OS-refcounted, so pairing with
+    // GameNetworkingSockets' own init is safe); on POSIX this is a no-op.
+    //
+    // Implemented as a Meyers singleton behind EnsureSocketSubsystem() so the
+    // very first CreateNonBlockingUDPSocket() call brings WinSock up — removing
+    // the old "Winsock may or may not be initialised" ambiguity that made LAN
+    // discovery silently fail when NetworkManager (and thus GNS) wasn't running.
+    class SocketSubsystem
+    {
+      public:
+        SocketSubsystem()
+        {
+#ifdef _WIN32
+            WSADATA data{};
+            m_Started = (WSAStartup(MAKEWORD(2, 2), &data) == 0);
+#endif
+        }
+
+        ~SocketSubsystem()
+        {
+#ifdef _WIN32
+            if (m_Started)
+            {
+                WSACleanup();
+            }
+#endif
+        }
+
+        SocketSubsystem(const SocketSubsystem&) = delete;
+        SocketSubsystem& operator=(const SocketSubsystem&) = delete;
+        SocketSubsystem(SocketSubsystem&&) = delete;
+        SocketSubsystem& operator=(SocketSubsystem&&) = delete;
+
+#ifdef _WIN32
+      private:
+        bool m_Started = false;
+#endif
+    };
+
+    static void EnsureSocketSubsystem()
+    {
+        static SocketSubsystem s_Subsystem;
+        (void)s_Subsystem;
+    }
+} // namespace
+
 namespace OloEngine
 {
     // Discovery protocol constants
@@ -71,6 +124,8 @@ namespace OloEngine
 
     static SocketType CreateNonBlockingUDPSocket()
     {
+        EnsureSocketSubsystem();
+
         SocketType sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         if (sock == kInvalidSocket)
         {
@@ -85,7 +140,106 @@ namespace OloEngine
         return sock;
     }
 
+    // Enumerate the directed-broadcast address of every up, non-loopback IPv4
+    // interface, always including the limited broadcast (255.255.255.255) as a
+    // fallback. Sending the discovery probe to each directed broadcast reaches
+    // hosts on every locally attached subnet — limited broadcast alone is
+    // dropped by many stacks/routers and only ever hits the default interface.
+    // Returns network-order in_addr values, de-duplicated.
+    static std::vector<in_addr> CollectBroadcastTargets()
+    {
+        std::vector<in_addr> targets;
+
+        auto pushUnique = [&targets](u32 netOrderAddr)
+        {
+            for (const in_addr& existing : targets)
+            {
+                if (existing.s_addr == netOrderAddr)
+                {
+                    return;
+                }
+            }
+            in_addr addr{};
+            addr.s_addr = netOrderAddr;
+            targets.push_back(addr);
+        };
+
+#ifdef _WIN32
+        ULONG bufLen = 15000; // Recommended starting size (MSDN GetAdaptersAddresses)
+        std::vector<u8> buffer(bufLen);
+        auto* adapters = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buffer.data());
+        constexpr ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
+
+        ULONG result = GetAdaptersAddresses(AF_INET, flags, nullptr, adapters, &bufLen);
+        if (result == ERROR_BUFFER_OVERFLOW)
+        {
+            buffer.resize(bufLen);
+            adapters = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buffer.data());
+            result = GetAdaptersAddresses(AF_INET, flags, nullptr, adapters, &bufLen);
+        }
+
+        if (result == NO_ERROR)
+        {
+            for (const IP_ADAPTER_ADDRESSES* adapter = adapters; adapter; adapter = adapter->Next)
+            {
+                if (adapter->OperStatus != IfOperStatusUp || adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
+                {
+                    continue;
+                }
+
+                for (const IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress; unicast;
+                     unicast = unicast->Next)
+                {
+                    const sockaddr* sa = unicast->Address.lpSockaddr;
+                    if (!sa || sa->sa_family != AF_INET || unicast->OnLinkPrefixLength > 32)
+                    {
+                        continue;
+                    }
+
+                    const u32 hostAddr = ntohl(reinterpret_cast<const sockaddr_in*>(sa)->sin_addr.s_addr);
+                    pushUnique(htonl(NetworkLobby::DirectedBroadcast(hostAddr, static_cast<u8>(unicast->OnLinkPrefixLength))));
+                }
+            }
+        }
+#else
+        struct ifaddrs* ifaddr = nullptr;
+        if (getifaddrs(&ifaddr) == 0)
+        {
+            for (const struct ifaddrs* ifa = ifaddr; ifa; ifa = ifa->ifa_next)
+            {
+                if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET)
+                {
+                    continue;
+                }
+                if (!(ifa->ifa_flags & IFF_UP) || (ifa->ifa_flags & IFF_LOOPBACK) ||
+                    !(ifa->ifa_flags & IFF_BROADCAST) || !ifa->ifa_broadaddr)
+                {
+                    continue;
+                }
+
+                pushUnique(reinterpret_cast<const sockaddr_in*>(ifa->ifa_broadaddr)->sin_addr.s_addr);
+            }
+            freeifaddrs(ifaddr);
+        }
+#endif
+
+        // Limited broadcast fallback — guarantees at least one target even if
+        // interface enumeration failed or yielded nothing.
+        pushUnique(htonl(INADDR_BROADCAST));
+        return targets;
+    }
+
     // ── Lifecycle ────────────────────────────────────────────────────
+
+    u32 NetworkLobby::DirectedBroadcast(u32 hostOrderAddr, u8 prefixLen)
+    {
+        // Clamp defensively — a prefix > 32 is meaningless; treat it as /32
+        // (the host itself). Shifting a 32-bit value by 32 is UB, so prefix 0
+        // is special-cased to an all-ones host mask (limited broadcast).
+        const u8 prefix = prefixLen > 32 ? 32 : prefixLen;
+        const u32 mask = prefix == 0 ? 0u : (0xFFFFFFFFu << (32 - prefix));
+        return hostOrderAddr | ~mask;
+    }
 
     NetworkLobby::NetworkLobby() = default;
 
@@ -203,7 +357,7 @@ namespace OloEngine
 
         u32 responseMagic = kDiscoveryMagic;
         u8 responseType = kProbeResponse;
-        u32 playerCount = 0; // Caller should set this via future API if needed
+        u32 playerCount = m_PlayerCountProvider ? m_PlayerCountProvider() : 0u;
         u8 nameLen = static_cast<u8>(std::min<size_t>(m_LobbyName.size(), 255));
 
         writer << responseMagic;
@@ -224,6 +378,11 @@ namespace OloEngine
         {
             OLO_CORE_WARN("[NetworkLobby] PollDiscovery: sendto failed (error {})", GetLastSocketError());
         }
+    }
+
+    void NetworkLobby::SetPlayerCountProvider(std::function<u32()> provider)
+    {
+        m_PlayerCountProvider = std::move(provider);
     }
 
     void NetworkLobby::FindLobbies(std::function<void(const std::vector<LobbyInfo>&)> callback) const
@@ -261,18 +420,23 @@ namespace OloEngine
             return;
         }
 
-        // Send broadcast probe
-        sockaddr_in broadcastAddr{};
-        broadcastAddr.sin_family = AF_INET;
-        broadcastAddr.sin_addr.s_addr = INADDR_BROADCAST;
-        broadcastAddr.sin_port = htons(kDiscoveryPort);
-
+        // Send the probe to the directed broadcast of every local subnet (plus
+        // limited broadcast as a fallback) so hosts on any attached interface
+        // can answer — not just the default route.
         u8 probe[5];
         std::memcpy(probe, &kDiscoveryMagic, sizeof(u32));
         probe[4] = kProbeRequest;
 
-        sendto(sock, reinterpret_cast<const char*>(probe), sizeof(probe), 0,
-               reinterpret_cast<sockaddr*>(&broadcastAddr), sizeof(broadcastAddr));
+        for (const in_addr& target : CollectBroadcastTargets())
+        {
+            sockaddr_in broadcastAddr{};
+            broadcastAddr.sin_family = AF_INET;
+            broadcastAddr.sin_addr = target;
+            broadcastAddr.sin_port = htons(kDiscoveryPort);
+
+            sendto(sock, reinterpret_cast<const char*>(probe), sizeof(probe), 0,
+                   reinterpret_cast<sockaddr*>(&broadcastAddr), sizeof(broadcastAddr));
+        }
 
         // Collect responses with a deadline-based timeout using select()
         std::vector<LobbyInfo> results;

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkLobby.h
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkLobby.h
@@ -28,6 +28,13 @@ namespace OloEngine
         // Well-known UDP port used for LAN lobby discovery.
         static constexpr u16 kDiscoveryPort = 27099;
 
+        // Compute the directed-broadcast address of a subnet from a host address
+        // and its CIDR prefix length (argument and result in host byte order).
+        // prefix 0 → 255.255.255.255, prefix 32 → the host address unchanged.
+        // Pure helper backing the Windows interface-enumeration path (POSIX reads
+        // the interface broadcast address directly); exposed for unit testing.
+        [[nodiscard]] static u32 DirectedBroadcast(u32 hostOrderAddr, u8 prefixLen);
+
         NetworkLobby();
         ~NetworkLobby();
 
@@ -62,6 +69,12 @@ namespace OloEngine
         // Should be called periodically while hosting (e.g. from the network thread).
         void PollDiscovery();
 
+        // Supply a callback that reports the current player count for discovery
+        // responses. Called from PollDiscovery when answering a probe, so it
+        // always reflects live state. If unset, responses report 0 players.
+        // NetworkManager wires this to the live server/session count.
+        void SetPlayerCountProvider(std::function<u32()> provider);
+
         // Query
         [[nodiscard]] bool IsHosting() const;
         [[nodiscard]] bool IsInLobby() const;
@@ -77,6 +90,10 @@ namespace OloEngine
         std::string m_LobbyName;
         u16 m_Port = 0;
         u32 m_MaxPlayers = 0;
+
+        // Reports the live player count for discovery responses (see
+        // SetPlayerCountProvider). Empty until wired; treated as 0 when unset.
+        std::function<u32()> m_PlayerCountProvider;
 
         // Platform socket handle for the discovery beacon (INVALID_SOCKET when closed).
         u64 m_DiscoverySocket = UINT64_MAX;

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
@@ -112,6 +112,22 @@ namespace OloEngine
         ComponentReplicator::RegisterDefaults();
         ComponentInterpolationRegistry::RegisterDefaults();
 
+        // Wire LAN-discovery responses to the live player count. The provider is
+        // invoked from NetworkLobby::PollDiscovery when a host answers a probe;
+        // it reads the same server connection count / session player count the
+        // server console (CmdPlayers) and debug panel already read from the game
+        // thread. Prefer the transport truth (a running dedicated server), and
+        // fall back to the session roster (e.g. a P2P/lobby host with no server).
+        s_Lobby.SetPlayerCountProvider(
+            []() -> u32
+            {
+                if (s_Server)
+                {
+                    return s_Server->GetConnectionCount();
+                }
+                return s_Session.GetPlayerCount();
+            });
+
         s_Initialized = true;
         OLO_CORE_INFO("NetworkManager initialized (GameNetworkingSockets)");
         return true;

--- a/OloEngine/tests/Networking/SessionLobbyTest.cpp
+++ b/OloEngine/tests/Networking/SessionLobbyTest.cpp
@@ -258,3 +258,84 @@ TEST(NetworkLobby, CloseLobbyClosesDiscoverySocket)
     lobby.PollDiscovery();
     EXPECT_FALSE(lobby.IsHosting());
 }
+
+// ── Directed-broadcast math (Windows interface-enumeration path) ─────────────
+//
+// Host byte order throughout. Verifies the CIDR-prefix → subnet-broadcast
+// computation used to fan LAN-discovery probes across every local subnet.
+
+TEST(NetworkLobby, DirectedBroadcastClass24)
+{
+    // 192.168.1.10/24 → 192.168.1.255
+    const u32 addr = (192u << 24) | (168u << 16) | (1u << 8) | 10u;
+    const u32 expected = (192u << 24) | (168u << 16) | (1u << 8) | 255u;
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(addr, 24), expected);
+}
+
+TEST(NetworkLobby, DirectedBroadcastClass16)
+{
+    // 10.5.3.7/16 → 10.5.255.255
+    const u32 addr = (10u << 24) | (5u << 16) | (3u << 8) | 7u;
+    const u32 expected = (10u << 24) | (5u << 16) | (255u << 8) | 255u;
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(addr, 16), expected);
+}
+
+TEST(NetworkLobby, DirectedBroadcastPrefix0IsLimitedBroadcast)
+{
+    // /0 → all-ones, regardless of the host bits (no UB from a 32-bit shift)
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(0x0A000001u, 0), 0xFFFFFFFFu);
+}
+
+TEST(NetworkLobby, DirectedBroadcastPrefix32IsHostItself)
+{
+    // /32 → the host address unchanged
+    const u32 addr = (172u << 24) | (16u << 16) | (0u << 8) | 42u;
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(addr, 32), addr);
+}
+
+TEST(NetworkLobby, DirectedBroadcastPrefixAbove32ClampsTo32)
+{
+    // Defensive clamp: an out-of-range prefix behaves as /32, not UB.
+    const u32 addr = 0xC0A80105u; // 192.168.1.5
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(addr, 40), addr);
+}
+
+TEST(NetworkLobby, DirectedBroadcastClass25)
+{
+    // 192.168.1.130/25 → 192.168.1.255 (upper half of the /24)
+    const u32 addr = (192u << 24) | (168u << 16) | (1u << 8) | 130u;
+    const u32 expected = (192u << 24) | (168u << 16) | (1u << 8) | 255u;
+    EXPECT_EQ(NetworkLobby::DirectedBroadcast(addr, 25), expected);
+}
+
+// ── Player-count provider ────────────────────────────────────────────────────
+
+TEST(NetworkLobby, PlayerCountProviderDoesNotCrashWhenSet)
+{
+    NetworkLobby lobby;
+    u32 fakeCount = 3;
+    lobby.SetPlayerCountProvider([&fakeCount]()
+                                 { return fakeCount; });
+
+    // Provider is consulted from PollDiscovery when answering a probe; exercising
+    // the host path with a provider set must not crash even if the discovery
+    // socket failed to open (sandboxed CI) or no probe arrives.
+    lobby.CreateLobby("Provider Test", 27015, 8);
+    lobby.PollDiscovery();
+    fakeCount = 5;
+    lobby.PollDiscovery();
+    lobby.CloseLobby();
+    SUCCEED();
+}
+
+TEST(NetworkLobby, PlayerCountProviderCanBeCleared)
+{
+    NetworkLobby lobby;
+    lobby.SetPlayerCountProvider([]()
+                                 { return 7u; });
+    lobby.SetPlayerCountProvider(nullptr); // back to reporting 0
+    lobby.CreateLobby("Cleared", 27015);
+    lobby.PollDiscovery();
+    lobby.CloseLobby();
+    SUCCEED();
+}

--- a/docs/ops/build.md
+++ b/docs/ops/build.md
@@ -107,6 +107,61 @@ export CC=gcc-14
 export CXX=g++-14
 ```
 
+#### Rocky / RHEL 10 (and other dnf-based distros)
+
+On RHEL-family distros the shader stack is split across repos and **SPIRV-Cross
+is not packaged at all**, so the simplest route is: install the GL/X11/Wayland dev
+libs from dnf and get the whole shader stack (SPIRV-Cross, glslang, shaderc,
+SPIRV-Tools) plus the Vulkan loader from the **LunarG Vulkan SDK** (installs to your
+home dir, no root).
+
+```bash
+# Compiler — the latest packaged GCC is the gcc-toolset-15 SCL (GCC 15.x). The
+# base `gcc gcc-c++` (GCC 14.x) also works and matches CI.
+sudo dnf install -y gcc-toolset-15          # or: sudo dnf install -y gcc gcc-c++
+source /opt/rh/gcc-toolset-15/enable 2>/dev/null \
+    || export PATH=/opt/rh/gcc-toolset-15/root/usr/bin:$PATH   # if there's no enable script
+
+# Graphics & windowing (X11 headers are needed to build the vendored GLFW)
+sudo dnf install -y mesa-libGL-devel \
+    libX11-devel libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel libXext-devel \
+    wayland-devel wayland-protocols-devel libxkbcommon-devel
+
+# CMake 4.2+ and Ninja (the packaged cmake is too old for CMakePresets), plus
+# Jinja2 for the glad GL-loader generator — via pip, no root.
+python3 -m ensurepip --user        # only if pip is missing
+python3 -m pip install --user "cmake>=4.2" ninja jinja2
+
+# Vulkan SDK — bundles SPIRV-Cross (absent from dnf), glslang, shaderc,
+# SPIRV-Tools and the Vulkan loader. Installs to your home dir, no root.
+curl -L https://sdk.lunarg.com/sdk/download/latest/linux/vulkan_sdk.tar.xz -o ~/vulkan_sdk.tar.xz
+mkdir -p ~/vulkan-sdk && tar -xf ~/vulkan_sdk.tar.xz -C ~/vulkan-sdk
+source ~/vulkan-sdk/*/setup-env.sh   # sets VULKAN_SDK
+```
+
+Then configure with the **`linux-gcc-toolset`** preset (it uses `gcc`/`g++` from
+PATH instead of the Ubuntu-style `gcc-14` names, and turns FFmpeg off — see notes):
+
+```bash
+cmake --preset linux-gcc-toolset -DCMAKE_PREFIX_PATH="$VULKAN_SDK"
+cmake --build build-linux --target OloEngine-Tests --config Debug --parallel
+./build-linux/OloEngine/tests/Debug/OloEngine-Tests --gtest_filter='NetworkLobby.*:NetworkSession.*'
+```
+
+**RHEL/Rocky-specific notes:**
+- **FFmpeg** (`OLO_VIDEO_FFMPEG`, on by default) builds from source and needs
+  `nasm` (`sudo dnf install -y nasm`). The `linux-gcc-toolset` preset turns it
+  **off** (the engine falls back to the pl_mpeg MPEG-1 decoder); re-enable with
+  `-DOLO_VIDEO_FFMPEG=ON` once nasm is installed.
+- **`libstdc++exp`** (which holds `std::stacktrace`) is **not shipped by
+  gcc-toolset-15**. The build auto-detects a compatible copy under the base GCC
+  install (`/usr/lib/gcc/*/*/libstdc++exp.a`) and links it. If configure warns that
+  it wasn't found, install `libstdc++-static` (or the base `gcc`).
+- The distro `vulkan-loader-devel` package is only the loader — it does **not**
+  include SPIRV-Cross. Use the LunarG SDK above (or build SPIRV-Cross from source).
+- The `linux-gcc-toolset` preset shares `build-linux/` with `linux-gcc`; use one
+  or the other, not both against the same directory.
+
 ### Vulkan SDK Environment
 
 Ensure `VULKAN_SDK` is set before configuring:

--- a/scripts/claude-stop-hook.sh
+++ b/scripts/claude-stop-hook.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# POSIX companion to claude-stop-hook.ps1 — runs pre-commit at the end of a
+# Claude Code turn on Linux/macOS (and Windows via Git Bash). Wired up via
+# .claude/settings.json (Stop hook), which prefers pwsh + the .ps1 when pwsh is
+# available and falls back to this script otherwise.
+#
+# Uses --all-files (not --files <changed>) so pre-existing formatting drift in
+# untouched files is also caught — the whole point of the hook is "I never have
+# to think about pre-commit", and a scoped run leaves drift unfixed. At a few
+# seconds on this repo (vendor/mono excluded), the cost is negligible.
+
+# Always exit 0: pre-commit exits non-zero when it auto-fixes files — that's
+# expected, not a failure — and a non-zero Stop hook surfaces as an error in the
+# Claude UI. pre-commit's own output already reports what it fixed.
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ]; then
+    echo "[claude-stop-hook] not in a git repo, skipping"
+    exit 0
+fi
+
+cd "$repo_root" || exit 0
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+    echo "[claude-stop-hook] pre-commit not installed, skipping"
+    exit 0
+fi
+
+echo "[claude-stop-hook] running pre-commit on all files..."
+pre-commit run --all-files
+echo "[claude-stop-hook] done"
+exit 0


### PR DESCRIPTION
## Summary

Three related changes, developed and verified together on Linux (Rocky 10.2 / GCC 15.2.1).

### 1. LAN lobby discovery hardening (`feat(net)`)
`NetworkLobby` already had a POSIX socket branch, so this hardens the discovery path rather than porting it:
- **Cross-platform socket init** — a Meyers-singleton `SocketSubsystem` does WSAStartup/WSACleanup on Windows (no-op on POSIX), invoked before the first `socket()`. Removes the "Winsock may or may not be initialised" ambiguity that made discovery silently fail when GameNetworkingSockets wasn't running.
- **Per-subnet directed broadcast** (`getifaddrs` / `GetAdaptersAddresses`) instead of bare `255.255.255.255`, so probes reach hosts on every local interface; limited broadcast kept as a fallback.
- **`NetworkLobby::DirectedBroadcast`** — pure, unit-tested helper for the CIDR→subnet-broadcast math.
- **`SetPlayerCountProvider`**, wired in `NetworkManager` to the live server/session count so probe responses report the real player count instead of a hard-coded `0`.
- Links `Iphlpapi` on Windows.

### 2. Cross-platform Claude Code Stop hook (`chore(hooks)`)
The Stop hook hard-coded `pwsh` and failed on non-Windows. Now dispatches to pwsh + the `.ps1` when available, else a POSIX `.sh` companion (same `pre-commit run --all-files`, always exit 0).

### 3. RHEL/Rocky Linux build support (`build(linux)`)
- CMake **auto-discovers `libstdc++exp`** under the base GCC install when the active toolchain (e.g. gcc-toolset-15) omits it — fixes the `std::stacktrace` link failure without a manual `-L`.
- New **`linux-gcc-toolset` preset** (gcc/g++ from PATH, FFmpeg off) for distros without versioned `gcc-14` binaries.
- **`docs/ops/build.md`**: a Rocky/RHEL 10 recipe (dnf deps, LunarG Vulkan SDK for the unpackaged SPIRV-Cross, jinja2 for glad, FFmpeg/nasm + libstdc++exp notes).

## Testing
Verified on Rocky Linux 10.2 + gcc-toolset-15 (GCC 15.2.1) — the first full Linux build of the engine under GCC 15:
- Whole engine + all vendored deps compile clean; `OloEngine-Tests` links via the new `libstdc++exp` auto-fallback.
- **New tests**: 6 `DirectedBroadcast` cases + 2 player-count-provider tests in `SessionLobbyTest.cpp`; the platform `getifaddrs`/socket path also verified standalone on GCC 15.2.1 **and** Clang 21.
- **Networking sweep: 190/190 tests across 38 suites pass** (transport, replication, snapshots, prediction, lag-comp, lockstep, P2P rollback, MMO zones, chat, persistence, Functional cross-subsystem).
- `NetworkIntegrationTest` (live GNS localhost handshake) was not run here — it hangs on the sandbox's restricted loopback, an environment limitation unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LAN lobby discovery across multiple network interfaces and subnets.
  * Lobby discovery responses now report the current player count.
  * Added Linux GCC toolset build support with testing enabled and FFmpeg optional.

* **Bug Fixes**
  * Improved networking compatibility on Windows and Linux systems.
  * Ensured UDP networking initializes reliably before socket creation.

* **Documentation**
  * Added build instructions for Rocky/RHEL 10 and other DNF-based distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->