### PR TITLE
feat(physics): per-tile streamed terrain collision + sculpt heightfield updates (#469)

### DIFF
--- a/OloEditor/src/Panels/TerrainEditorPanel.cpp
+++ b/OloEditor/src/Panels/TerrainEditorPanel.cpp
@@ -397,19 +397,27 @@ namespace OloEngine
                         std::memcpy(&newHeights[dstIdx], &fullData[srcIdx], m_StrokeDirtyW * sizeof(f32));
                     }
 
+                    // Resolve the stroke's terrain entity once: the undo command uses it to
+                    // refresh collision on redo/undo (held weakly, issue #469 review), and the
+                    // stroke-settle call below covers the initial live-applied stroke.
+                    Entity strokeEnt = (m_Context && m_StrokeEntity != entt::null)
+                                           ? Entity{ m_StrokeEntity, m_Context.get() }
+                                           : Entity{};
+                    const UUID strokeUUID = strokeEnt ? strokeEnt.GetUUID() : UUID(0);
+
                     m_CommandHistory->PushAlreadyExecuted(
                         std::make_unique<TerrainSculptCommand>(
                             m_StrokeTerrainData, m_StrokeChunkManager,
                             m_StrokeWorldSizeX, m_StrokeWorldSizeZ, m_StrokeHeightScale,
                             m_StrokeDirtyX, m_StrokeDirtyY, m_StrokeDirtyW, m_StrokeDirtyH,
-                            std::move(oldRegion), std::move(newHeights)));
+                            std::move(oldRegion), std::move(newHeights),
+                            WeakRef<Scene>(m_Context), strokeUUID));
 
                     // Sync collision once at stroke settle so a body dropped on the sculpted
                     // region rests on the NEW surface (issue #469). No-op unless physics is
                     // running (Play/Simulate); debounced here rather than per drag frame.
-                    if (m_Context && m_StrokeEntity != entt::null)
+                    if (strokeEnt)
                     {
-                        Entity strokeEnt{ m_StrokeEntity, m_Context.get() };
                         m_Context->UpdateTerrainCollisionAfterEdit(
                             strokeEnt, m_StrokeDirtyX, m_StrokeDirtyY, m_StrokeDirtyW, m_StrokeDirtyH);
                     }

--- a/OloEditor/src/Panels/TerrainEditorPanel.cpp
+++ b/OloEditor/src/Panels/TerrainEditorPanel.cpp
@@ -403,6 +403,16 @@ namespace OloEngine
                             m_StrokeWorldSizeX, m_StrokeWorldSizeZ, m_StrokeHeightScale,
                             m_StrokeDirtyX, m_StrokeDirtyY, m_StrokeDirtyW, m_StrokeDirtyH,
                             std::move(oldRegion), std::move(newHeights)));
+
+                    // Sync collision once at stroke settle so a body dropped on the sculpted
+                    // region rests on the NEW surface (issue #469). No-op unless physics is
+                    // running (Play/Simulate); debounced here rather than per drag frame.
+                    if (m_Context && m_StrokeEntity != entt::null)
+                    {
+                        Entity strokeEnt{ m_StrokeEntity, m_Context.get() };
+                        m_Context->UpdateTerrainCollisionAfterEdit(
+                            strokeEnt, m_StrokeDirtyX, m_StrokeDirtyY, m_StrokeDirtyW, m_StrokeDirtyH);
+                    }
                 }
                 else if (m_EditMode == TerrainEditMode::Paint && m_StrokeMaterial)
                 {
@@ -485,6 +495,7 @@ namespace OloEngine
             m_StrokeTerrainData = nullptr;
             m_StrokeChunkManager = nullptr;
             m_StrokeMaterial = nullptr;
+            m_StrokeEntity = entt::null;
         }
 
         if (!hasHit || !mouseDown || m_EditMode == TerrainEditMode::None || !m_Context)
@@ -507,6 +518,7 @@ namespace OloEngine
                     m_StrokeActive = true;
                     m_StrokeTerrainData = terrain.m_TerrainData;
                     m_StrokeChunkManager = terrain.m_ChunkManager;
+                    m_StrokeEntity = entity;
                     m_StrokeWorldSizeX = terrain.m_WorldSizeX;
                     m_StrokeWorldSizeZ = terrain.m_WorldSizeZ;
                     m_StrokeHeightScale = terrain.m_HeightScale;
@@ -704,6 +716,15 @@ namespace OloEngine
                         terrain.m_ChunkManager->GenerateAllChunks(
                             *terrain.m_TerrainData,
                             terrain.m_WorldSizeX, terrain.m_WorldSizeZ, terrain.m_HeightScale);
+                    }
+
+                    // Erosion rewrites the whole field, so sync the entire collision region
+                    // when physics is running (issue #469). No-op in edit mode.
+                    if (m_Context)
+                    {
+                        Entity terrainEnt{ entity, m_Context.get() };
+                        const u32 res = terrain.m_TerrainData->GetResolution();
+                        m_Context->UpdateTerrainCollisionAfterEdit(terrainEnt, 0, 0, res, res);
                     }
                 }
                 break;

--- a/OloEditor/src/Panels/TerrainEditorPanel.h
+++ b/OloEditor/src/Panels/TerrainEditorPanel.h
@@ -108,5 +108,8 @@ namespace OloEngine
         f32 m_StrokeWorldSizeX = 0.0f;
         f32 m_StrokeWorldSizeZ = 0.0f;
         f32 m_StrokeHeightScale = 0.0f;
+        // Owning terrain entity of the active sculpt stroke, so its collision body can be
+        // refreshed once at stroke settle when physics is running (issue #469).
+        entt::entity m_StrokeEntity = entt::null;
     };
 } // namespace OloEngine

--- a/OloEditor/src/UndoRedo/SpecializedCommands.h
+++ b/OloEditor/src/UndoRedo/SpecializedCommands.h
@@ -189,8 +189,9 @@ namespace OloEngine
                              Ref<TerrainChunkManager> chunkManager,
                              f32 worldSizeX, f32 worldSizeZ, f32 heightScale,
                              u32 regionX, u32 regionY, u32 regionW, u32 regionH,
-                             std::vector<f32> oldHeights, std::vector<f32> newHeights)
-            : m_TerrainData(std::move(terrainData)), m_ChunkManager(std::move(chunkManager)), m_WorldSizeX(worldSizeX), m_WorldSizeZ(worldSizeZ), m_HeightScale(heightScale), m_RegionX(regionX), m_RegionY(regionY), m_RegionW(regionW), m_RegionH(regionH), m_OldHeights(std::move(oldHeights)), m_NewHeights(std::move(newHeights))
+                             std::vector<f32> oldHeights, std::vector<f32> newHeights,
+                             WeakRef<Scene> scene = {}, UUID terrainEntity = UUID(0))
+            : m_TerrainData(std::move(terrainData)), m_ChunkManager(std::move(chunkManager)), m_WorldSizeX(worldSizeX), m_WorldSizeZ(worldSizeZ), m_HeightScale(heightScale), m_RegionX(regionX), m_RegionY(regionY), m_RegionW(regionW), m_RegionH(regionH), m_OldHeights(std::move(oldHeights)), m_NewHeights(std::move(newHeights)), m_Scene(std::move(scene)), m_TerrainEntity(terrainEntity)
         {
         }
 
@@ -245,6 +246,19 @@ namespace OloEngine
                 TerrainBrush::RebuildDirtyChunks(*m_ChunkManager, *m_TerrainData, dirty,
                                                  m_WorldSizeX, m_WorldSizeZ, m_HeightScale);
             }
+
+            // Keep physics collision in step with the height edit on redo AND undo (issue
+            // #469 review): the stroke-settle path in the panel only covers the initial
+            // stroke, so an undo/redo during Play/Simulate would otherwise leave the
+            // collision body on the stale surface. No-op in edit mode (JoltScene null) or
+            // if the scene / entity is gone; the scene is held weakly so the undo history
+            // never keeps it alive.
+            if (Ref<Scene> scene = m_Scene.Lock())
+            {
+                Entity terrainEntity = scene->GetEntityByUUID(m_TerrainEntity);
+                if (terrainEntity)
+                    scene->UpdateTerrainCollisionAfterEdit(terrainEntity, m_RegionX, m_RegionY, m_RegionW, m_RegionH);
+            }
         }
 
         Ref<TerrainData> m_TerrainData;
@@ -258,6 +272,10 @@ namespace OloEngine
         u32 m_RegionH;
         std::vector<f32> m_OldHeights;
         std::vector<f32> m_NewHeights;
+        // Held WEAKLY so an entry in the undo history never keeps the whole Scene alive;
+        // used to refresh terrain collision on redo/undo (issue #469 review).
+        WeakRef<Scene> m_Scene;
+        UUID m_TerrainEntity;
     };
 
     // =========================================================================

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -709,6 +709,15 @@ namespace OloEngine
             {
                 const u32 srcX = std::min(x0 + x, resolution - 1);
                 const f32 normalized = fullHeights[static_cast<sizet>(srcZ) * resolution + srcX];
+                // Reject a corrupt/NaN field before it reaches SetHeights — the same guard
+                // CreateTerrainHeightFieldShape applies at build (a non-finite sample floored
+                // into a quantized height is silently garbage collision). Leave the existing
+                // body untouched; the caller's fallback rebuild also fails safe.
+                if (!std::isfinite(normalized))
+                {
+                    OLO_CORE_ERROR("UpdateTerrainBodyHeights: non-finite height sample at ({0},{1}); skipping update", srcX, srcZ);
+                    return false;
+                }
                 region[static_cast<sizet>(z) * sizeX + x] = minWorldH + normalized * worldHRange;
             }
         }

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -53,6 +53,7 @@
 #include <Jolt/Physics/SoftBody/SoftBodySharedSettings.h>
 #include <Jolt/Physics/SoftBody/SoftBodyCreationSettings.h>
 #include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
+#include <Jolt/Physics/Collision/Shape/HeightFieldShape.h> // terrain tile bodies + sculpt SetHeights (#469)
 
 #include <glm/gtc/constants.hpp>
 #include <glm/gtc/quaternion.hpp> // glm::inverse(quat) for ragdoll bone-local anchors
@@ -519,8 +520,210 @@ namespace OloEngine
                 bodyInterface.RemoveBody(bodyID);
                 bodyInterface.DestroyBody(bodyID);
             }
+            // Streamed per-tile terrain bodies live in a separate map (#469).
+            for (const auto& [key, bodyID] : m_TerrainTileBodies)
+            {
+                m_BodyIDToEntity.erase(bodyID);
+                bodyInterface.RemoveBody(bodyID);
+                bodyInterface.DestroyBody(bodyID);
+            }
         }
         m_TerrainBodies.clear();
+        m_TerrainTileBodies.clear();
+    }
+
+    JPH::BodyID JoltScene::CreateTerrainTileBody(Entity terrainEntity, i32 tileX, i32 tileZ,
+                                                 const JPH::Ref<JPH::Shape>& shape,
+                                                 const glm::vec3& position, const glm::quat& rotation)
+    {
+        if (!m_Initialized || !m_JoltSystem)
+        {
+            OLO_CORE_ERROR("CreateTerrainTileBody: physics not initialized");
+            return JPH::BodyID();
+        }
+        if (!terrainEntity || !shape)
+        {
+            OLO_CORE_ERROR("CreateTerrainTileBody: invalid entity or null shape");
+            return JPH::BodyID();
+        }
+
+        const UUID entityID = terrainEntity.GetUUID();
+        const TerrainTileKey key{ entityID, tileX, tileZ };
+
+        // Idempotent per (entity, x, z): drop any prior body for this tile first.
+        DestroyTerrainTileBody(entityID, tileX, tileZ);
+
+        // Identical body convention to the single-tile terrain body (CreateTerrainBody):
+        // static, NON_MOVING, grippy, UserData = the OWNING TERRAIN ENTITY UUID so a
+        // raycast against any tile resolves the terrain entity.
+        JPH::BodyCreationSettings settings(
+            shape,
+            JoltUtils::ToJoltVector(position),
+            JoltUtils::ToJoltQuat(rotation),
+            JPH::EMotionType::Static,
+            ObjectLayers::NON_MOVING);
+        settings.mUserData = static_cast<u64>(entityID);
+        settings.mFriction = 0.8f;
+        settings.mRestitution = 0.0f;
+
+        JPH::BodyID bodyID = m_JoltSystem->GetBodyInterface().CreateAndAddBody(settings, JPH::EActivation::DontActivate);
+        if (bodyID.IsInvalid())
+        {
+            OLO_CORE_ERROR("CreateTerrainTileBody: Jolt failed to create body for terrain entity {0} tile ({1},{2})",
+                           (u64)entityID, tileX, tileZ);
+            return JPH::BodyID();
+        }
+
+        m_TerrainTileBodies[key] = bodyID;
+        m_BodyIDToEntity[bodyID] = entityID;
+
+        OLO_CORE_TRACE("Created terrain tile collision body for entity {0} tile ({1},{2}), BodyID: {3}",
+                       (u64)entityID, tileX, tileZ, bodyID.GetIndex());
+        return bodyID;
+    }
+
+    void JoltScene::DestroyTerrainTileBody(UUID terrainEntityID, i32 tileX, i32 tileZ)
+    {
+        auto it = m_TerrainTileBodies.find(TerrainTileKey{ terrainEntityID, tileX, tileZ });
+        if (it == m_TerrainTileBodies.end())
+            return;
+
+        const JPH::BodyID bodyID = it->second;
+        m_BodyIDToEntity.erase(bodyID);
+        if (m_JoltSystem)
+        {
+            auto& bodyInterface = m_JoltSystem->GetBodyInterface();
+            bodyInterface.RemoveBody(bodyID);
+            bodyInterface.DestroyBody(bodyID);
+        }
+        m_TerrainTileBodies.erase(it);
+    }
+
+    bool JoltScene::HasTerrainTileBody(UUID terrainEntityID, i32 tileX, i32 tileZ) const
+    {
+        return m_TerrainTileBodies.contains(TerrainTileKey{ terrainEntityID, tileX, tileZ });
+    }
+
+    std::vector<std::pair<i32, i32>> JoltScene::GetTerrainTileCoords(UUID terrainEntityID) const
+    {
+        std::vector<std::pair<i32, i32>> coords;
+        for (const auto& [key, bodyID] : m_TerrainTileBodies)
+        {
+            if (key.Terrain == terrainEntityID)
+                coords.emplace_back(key.X, key.Z);
+        }
+        return coords;
+    }
+
+    void JoltScene::DestroyTerrainTilesForEntity(UUID terrainEntityID)
+    {
+        JPH::BodyInterface* bodyInterface = m_JoltSystem ? &m_JoltSystem->GetBodyInterface() : nullptr;
+        for (auto it = m_TerrainTileBodies.begin(); it != m_TerrainTileBodies.end();)
+        {
+            if (it->first.Terrain == terrainEntityID)
+            {
+                const JPH::BodyID bodyID = it->second;
+                m_BodyIDToEntity.erase(bodyID);
+                if (bodyInterface)
+                {
+                    bodyInterface->RemoveBody(bodyID);
+                    bodyInterface->DestroyBody(bodyID);
+                }
+                it = m_TerrainTileBodies.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
+    bool JoltScene::UpdateTerrainBodyHeights(UUID terrainEntityID, u32 regionX, u32 regionZ,
+                                             u32 regionWidth, u32 regionHeight,
+                                             const std::vector<f32>& fullHeights, u32 resolution)
+    {
+        if (!m_Initialized || !m_JoltSystem)
+            return false;
+        if (regionWidth == 0 || regionHeight == 0 || resolution < 2)
+            return false;
+        if (fullHeights.size() != static_cast<sizet>(resolution) * resolution)
+        {
+            OLO_CORE_ERROR("UpdateTerrainBodyHeights: height count {0} does not match resolution {1}x{1}",
+                           fullHeights.size(), resolution);
+            return false;
+        }
+
+        auto it = m_TerrainBodies.find(terrainEntityID);
+        if (it == m_TerrainBodies.end())
+            return false; // No single-tile terrain body (streaming terrain, or collision off).
+        const JPH::BodyID bodyID = it->second;
+
+        auto& bodyInterface = m_JoltSystem->GetBodyInterface();
+
+        // The height-field shape is created fresh per terrain body and never shared, so a
+        // const_cast to mutate it in place is safe (Jolt exposes SetHeights only on the
+        // concrete non-const HeightFieldShape). No manual body lock is taken here: the
+        // caller guarantees this runs on the game thread OUTSIDE the physics step (so no
+        // concurrent collision query reads the shape), and NotifyShapeChanged below takes
+        // the body lock itself — a BodyLockWrite held across it would deadlock.
+        JPH::RefConst<JPH::Shape> shapeRef = bodyInterface.GetShape(bodyID);
+        const JPH::Shape* shape = shapeRef.GetPtr();
+        if (!shape || shape->GetSubType() != JPH::EShapeSubType::HeightField)
+            return false;
+        auto* heightField = const_cast<JPH::HeightFieldShape*>(static_cast<const JPH::HeightFieldShape*>(shape));
+
+        const u32 sampleCount = heightField->GetSampleCount();
+        const u32 blockSize = std::max<u32>(heightField->GetBlockSize(), 1);
+
+        // SetHeights takes WORLD-space Y values (it re-quantizes via (h - offset)/scale),
+        // whereas `fullHeights` is the normalized [0,1] terrain field. The shape's encodable
+        // world band is [GetMinHeightValue(), GetMaxHeightValue()] — pinned to the full
+        // [0,1]·scale range at build (see CreateTerrainHeightFieldShape) — so a normalized
+        // sample n maps to world minH + n·(maxH - minH). Deriving the mapping from the shape
+        // keeps it correct under any entity Y-scale / height-scale without threading them in.
+        const f32 minWorldH = heightField->GetMinHeightValue();
+        const f32 worldHRange = heightField->GetMaxHeightValue() - minWorldH;
+
+        // Snap the dirty rect OUTWARD to the block grid — Jolt requires the start and the
+        // size to be multiples of the block size — then clamp to the padded sample count.
+        u32 x0 = (regionX / blockSize) * blockSize;
+        u32 z0 = (regionZ / blockSize) * blockSize;
+        u32 x1 = regionX + regionWidth;
+        u32 z1 = regionZ + regionHeight;
+        x1 = std::min(((x1 + blockSize - 1) / blockSize) * blockSize, sampleCount);
+        z1 = std::min(((z1 + blockSize - 1) / blockSize) * blockSize, sampleCount);
+        if (x1 <= x0 || z1 <= z0)
+            return false;
+        const u32 sizeX = x1 - x0;
+        const u32 sizeZ = z1 - z0;
+
+        // Build a contiguous, edge-replicated sample buffer for the snapped rect, exactly
+        // mirroring how CreateTerrainHeightFieldShape fills the padded shape: any sample at
+        // or beyond `resolution` clamps to the last real row/column, so the rect may safely
+        // extend into the pad the odd-resolution shape added. x-major within a row.
+        std::vector<f32> region(static_cast<sizet>(sizeX) * sizeZ);
+        for (u32 z = 0; z < sizeZ; ++z)
+        {
+            const u32 srcZ = std::min(z0 + z, resolution - 1);
+            for (u32 x = 0; x < sizeX; ++x)
+            {
+                const u32 srcX = std::min(x0 + x, resolution - 1);
+                const f32 normalized = fullHeights[static_cast<sizet>(srcZ) * resolution + srcX];
+                region[static_cast<sizet>(z) * sizeX + x] = minWorldH + normalized * worldHRange;
+            }
+        }
+
+        // Capture the center of mass BEFORE mutating so NotifyShapeChanged computes the
+        // correct position delta (SetHeights can shift the height field's COM).
+        const JPH::RVec3 prevCOM = bodyInterface.GetCenterOfMassPosition(bodyID);
+
+        JPH::TempAllocatorMalloc allocator;
+        heightField->SetHeights(x0, z0, sizeX, sizeZ, region.data(), static_cast<intptr_t>(sizeX), allocator);
+
+        // Refresh the broadphase bounds for the mutated shape. Static body → no mass
+        // properties, no activation.
+        bodyInterface.NotifyShapeChanged(bodyID, prevCOM, false, JPH::EActivation::DontActivate);
+        return true;
     }
 
     JPH::BodyID JoltScene::CreateClothBody(Entity entity, const JPH::Ref<JPH::SoftBodySharedSettings>& settings,

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.h
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.h
@@ -130,6 +130,45 @@ namespace OloEngine
             return m_TerrainBodies.contains(entityID);
         }
 
+        // Per-tile terrain collision for STREAMED terrain (issue #469). A streaming
+        // TerrainComponent owns many static height-field bodies at once — one per
+        // loaded tile — instead of the single body above, so they are tracked in a
+        // separate map keyed by (owning terrain entity UUID, tile grid X, tile grid Z).
+        // Each tile body is otherwise identical to the single-tile terrain body: a raw
+        // static JPH body on NON_MOVING, UserData = the OWNING TERRAIN ENTITY UUID (so a
+        // raycast against any tile resolves the terrain entity), entered in the
+        // BodyID→entity reverse map. The caller (Scene) builds the tile's HeightFieldShape
+        // from that tile's CPU heights and places it at the tile's world origin. Create is
+        // idempotent per (entity, x, z). Returns the new BodyID (invalid on failure).
+        JPH::BodyID CreateTerrainTileBody(Entity terrainEntity, i32 tileX, i32 tileZ,
+                                          const JPH::Ref<JPH::Shape>& shape,
+                                          const glm::vec3& position, const glm::quat& rotation);
+        void DestroyTerrainTileBody(UUID terrainEntityID, i32 tileX, i32 tileZ);
+        bool HasTerrainTileBody(UUID terrainEntityID, i32 tileX, i32 tileZ) const;
+        // Grid coords of every tile body currently tracked for a terrain. The per-frame
+        // streaming reconcile uses this to destroy the tiles that are no longer loaded.
+        [[nodiscard]] std::vector<std::pair<i32, i32>> GetTerrainTileCoords(UUID terrainEntityID) const;
+        // Destroy every tile body owned by a terrain (streaming disabled at runtime, or
+        // the terrain entity destroyed). Cheap no-op when the terrain owns no tile bodies.
+        void DestroyTerrainTilesForEntity(UUID terrainEntityID);
+
+        // Partial in-place update of a SINGLE-TILE terrain body's height field after a
+        // sculpt / erosion edit (issue #469). Mutates the body's JPH::HeightFieldShape via
+        // HeightFieldShape::SetHeights over the dirty rect [regionX, regionX+regionWidth) ×
+        // [regionZ, regionZ+regionHeight) (in heightmap sample coords, X = column / world
+        // X, Z = row / world Z), snapping it outward to the shape's block-size grid (Jolt
+        // requires block alignment) and edge-replicating any sample the pad added beyond
+        // `resolution`, then NotifyShapeChanged to refresh the broadphase bounds.
+        // `fullHeights` / `resolution` are the terrain's full CPU field (row-major,
+        // normalized [0,1], index = z*resolution + x) — the SAME field the shape was built
+        // from, now edited. MUST be called on the game thread OUTSIDE the physics step:
+        // SetHeights mutates shared shape data and races concurrent collision queries
+        // (see HeightFieldShape::SetHeights docs). Returns false if the terrain has no
+        // single-tile body, the body's shape is not a height field, or the input is bad.
+        bool UpdateTerrainBodyHeights(UUID terrainEntityID, u32 regionX, u32 regionZ,
+                                      u32 regionWidth, u32 regionHeight,
+                                      const std::vector<f32>& fullHeights, u32 resolution);
+
         // Cloth / soft-body management (issue #460). Like terrain bodies, a cloth entity
         // carries no Rigidbody3DComponent / JoltBody wrapper — its Jolt soft body is a raw
         // JPH body tracked separately, keyed by the owning ClothComponent entity. The caller
@@ -520,6 +559,34 @@ namespace OloEngine
         // they live outside m_Bodies; they are still entered in m_BodyIDToEntity so
         // queries resolve them. Created/destroyed by Create/DestroyTerrainBody.
         std::unordered_map<UUID, JPH::BodyID> m_TerrainBodies;
+
+        // Per-tile terrain height-field bodies for STREAMED terrain (issue #469), keyed by
+        // (owning terrain entity UUID, tile grid X, tile grid Z). Same raw-static-body
+        // convention as m_TerrainBodies (entered in m_BodyIDToEntity under the owning
+        // terrain entity UUID). Created/destroyed by Create/DestroyTerrainTileBody as the
+        // TerrainStreamer loads / evicts tiles.
+        struct TerrainTileKey
+        {
+            UUID Terrain;
+            i32 X = 0;
+            i32 Z = 0;
+
+            bool operator==(const TerrainTileKey& other) const
+            {
+                return Terrain == other.Terrain && X == other.X && Z == other.Z;
+            }
+        };
+        struct TerrainTileKeyHash
+        {
+            sizet operator()(const TerrainTileKey& k) const
+            {
+                sizet h = std::hash<u64>{}(static_cast<u64>(k.Terrain));
+                h ^= std::hash<i32>{}(k.X) * 0x9E3779B97F4A7C15ULL + 0x9E3779B9ULL + (h << 6) + (h >> 2);
+                h ^= std::hash<i32>{}(k.Z) * 0x9E3779B97F4A7C15ULL + 0x9E3779B9ULL + (h << 6) + (h >> 2);
+                return h;
+            }
+        };
+        std::unordered_map<TerrainTileKey, JPH::BodyID, TerrainTileKeyHash> m_TerrainTileBodies;
 
         // Cloth soft bodies (issue #460), keyed by the owning ClothComponent entity. Like
         // terrain bodies these are raw JPH bodies (no JoltBody wrapper), so they live

--- a/OloEngine/src/OloEngine/Physics3D/JoltShapes.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltShapes.cpp
@@ -531,6 +531,19 @@ namespace OloEngine
         JPH::HeightFieldShapeSettings settings(samples.data(), joltOffset, joltScale, sampleCount);
         settings.mBlockSize = kBlockSize;
 
+        // Pin the encodable sample range to the FULL normalized [0,1] band rather than
+        // letting Jolt derive it from the current samples (issue #469). Jolt quantizes
+        // heights into 16 bits over [mMinHeightValue, mMaxHeightValue]; left at the default
+        // it fits that window to the initial data, so a body built from a FLAT (or
+        // low-relief) field gets a near-zero vertical range and a later
+        // HeightFieldShape::SetHeights sculpt edit cannot raise a sample beyond it (the
+        // ridge silently clamps back to flat). Terrain heights are normalized [0,1] (world
+        // Y = sample * joltScale.Y), so [0,1] is the true encodable band and gives every
+        // terrain body headroom to be sculpted across its whole height range. The precision
+        // cost for a terrain that only uses a slice of [0,1] is sub-millimetre.
+        settings.mMinHeightValue = 0.0f;
+        settings.mMaxHeightValue = 1.0f;
+
         // Pick the sample precision adaptively: target ~2 cm of world-space height error.
         // Samples are normalized [0,1] and multiplied by the Y scale, so the per-sample
         // error budget is (worldError / worldHeightScale). Flat fields need very few bits;

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -712,6 +712,9 @@ namespace OloEngine
                 m_JoltScene->DestroyTerrainBody(entityUUID);
                 terrain.m_RuntimeCollisionBodyToken = 0;
             }
+            // Streamed terrains own per-tile bodies with no runtime token — sweep them
+            // too so destroying the entity doesn't leak the tile bodies (issue #469).
+            m_JoltScene->DestroyTerrainTilesForEntity(entityUUID);
         }
 
         // Same deal for a cloth soft body (issue #460) — keyed by entity UUID, no
@@ -4659,6 +4662,74 @@ namespace OloEngine
             terrain.m_RuntimeCollisionBodyToken = bodyID.IsInvalid() ? 0 : static_cast<u64>(bodyID.GetIndexAndSequenceNumber());
         }
 
+        // Reconcile per-tile collision bodies for a STREAMED terrain against the streamer's
+        // currently-ready tiles (issue #469). Runs each frame in the render path after the
+        // streamer Update, when physics is live and collision is enabled: builds a static
+        // height-field body for every newly-ready tile and destroys the bodies of tiles no
+        // longer loaded, so collision tracks the visual load/unload in step. Each tile body
+        // reuses the tile's own CPU height field placed at its world origin and carries the
+        // entity transform exactly like the draw path (tileModel = entityTransform *
+        // translate(tile.WorldOrigin) — see submitChunkPackets), so collision coincides
+        // with the rendered tile.
+        void ReconcileStreamingTerrainCollision(JoltScene& joltScene, Entity entity, TerrainComponent& terrain)
+        {
+            const UUID entityID = entity.GetUUID();
+
+            if (!terrain.m_Streamer)
+            {
+                joltScene.DestroyTerrainTilesForEntity(entityID);
+                return;
+            }
+
+            const auto& transform = entity.GetComponent<TransformComponent>();
+            const glm::quat rotation = transform.GetRotation();
+
+            std::vector<Ref<TerrainTile>> readyTiles;
+            terrain.m_Streamer->GetReadyTiles(readyTiles);
+
+            // Pack a tile grid coord into a single key for the desired-set membership test.
+            auto packKey = [](i32 x, i32 z) -> i64
+            {
+                return (static_cast<i64>(x) << 32) | (static_cast<i64>(static_cast<u32>(z)));
+            };
+
+            std::unordered_set<i64> desired;
+            desired.reserve(readyTiles.size());
+            for (const auto& tile : readyTiles)
+            {
+                if (!tile)
+                    continue;
+                desired.insert(packKey(tile->GridX, tile->GridZ));
+
+                // Already have a body for this tile — nothing to do (tile heights are
+                // immutable once loaded; a re-loaded tile after eviction gets a fresh body).
+                if (joltScene.HasTerrainTileBody(entityID, tile->GridX, tile->GridZ))
+                    continue;
+
+                Ref<TerrainData> data = tile->GetTerrainData();
+                if (!data || data->GetResolution() < 2)
+                    continue;
+
+                JPH::Ref<JPH::Shape> shape = JoltShapes::CreateTerrainHeightFieldShape(
+                    data->GetHeightData(), data->GetResolution(),
+                    tile->WorldSizeX, tile->WorldSizeZ, tile->HeightScale, transform.Scale);
+                if (!shape)
+                    continue;
+
+                // Body pose that reproduces entityTransform * translate(WorldOrigin) given
+                // the shape already bakes entity scale: T + R*(S ⊙ WorldOrigin), rotation R.
+                const glm::vec3 tilePos = transform.Translation + (rotation * (transform.Scale * tile->WorldOrigin));
+                (void)joltScene.CreateTerrainTileBody(entity, tile->GridX, tile->GridZ, shape, tilePos, rotation);
+            }
+
+            // Destroy bodies whose tile is no longer loaded (evicted / out of range).
+            for (const auto& [tx, tz] : joltScene.GetTerrainTileCoords(entityID))
+            {
+                if (!desired.contains(packKey(tx, tz)))
+                    joltScene.DestroyTerrainTileBody(entityID, tx, tz);
+            }
+        }
+
         // ── Cloth soft bodies (issue #460) ─────────────────────────────────────
         // Row-major triangle indices for a columns×rows cloth grid (two triangles per
         // cell). Winding matches the soft-body faces built in CreateClothSharedSettings.
@@ -4936,6 +5007,8 @@ namespace OloEngine
                 m_JoltScene->DestroyTerrainBody(ent.GetUUID());
                 terrain.m_RuntimeCollisionBodyToken = 0;
             }
+            // Streamed terrains own per-tile bodies instead (issue #469).
+            m_JoltScene->DestroyTerrainTilesForEntity(ent.GetUUID());
         }
 
         // Tear down cloth soft bodies and drop their runtime render state (issue #460).
@@ -4945,6 +5018,34 @@ namespace OloEngine
         m_ClothRuntime.clear();
 
         m_JoltScene->Shutdown();
+    }
+
+    bool Scene::UpdateTerrainCollisionAfterEdit(Entity terrainEntity, u32 regionX, u32 regionZ,
+                                                u32 regionWidth, u32 regionHeight)
+    {
+        if (!m_JoltScene || !m_JoltScene->IsInitialized())
+            return false; // Edit mode / physics off — collision is (re)built at OnPhysics3DStart.
+        if (!terrainEntity || !terrainEntity.HasComponent<TerrainComponent>())
+            return false;
+
+        auto& terrain = terrainEntity.GetComponent<TerrainComponent>();
+        if (!terrain.m_CollisionEnabled || terrain.m_StreamingEnabled)
+            return false; // Streamed terrain is handled by the per-tile reconcile instead.
+        if (!terrain.m_TerrainData || terrain.m_TerrainData->GetResolution() < 2)
+            return false;
+
+        const u32 resolution = terrain.m_TerrainData->GetResolution();
+        const UUID entityID = terrainEntity.GetUUID();
+
+        // Fast path: mutate the existing height-field body in place over the dirty rect.
+        if (m_JoltScene->UpdateTerrainBodyHeights(entityID, regionX, regionZ, regionWidth, regionHeight,
+                                                  terrain.m_TerrainData->GetHeightData(), resolution))
+            return true;
+
+        // No live body yet (terrain built after OnPhysics3DStart, or a prior build failed).
+        // Build a fresh full body from the current heights so collision still reflects the edit.
+        BuildTerrainCollisionBody(*m_JoltScene, terrainEntity, terrain);
+        return m_JoltScene->HasTerrainBody(entityID);
     }
 
     const std::vector<glm::vec3>* Scene::GetClothVertexPositions(UUID entityID) const
@@ -6653,6 +6754,18 @@ namespace OloEngine
                     // the old world-anchored feed, plus the un-stacking fix.)
                     const glm::vec3 terrainTranslation = terrainView.get<TransformComponent>(entity).Translation;
                     terrain.m_Streamer->Update(cameraPosition - terrainTranslation, m_TerrainFrameCounter);
+
+                    // Per-tile collision (issue #469): when physics is live, keep a static
+                    // height-field body per ready tile in step with the visual load/unload.
+                    // Collision disabled at runtime → tear down any tiles we still own.
+                    if (m_JoltScene && m_JoltScene->IsInitialized())
+                    {
+                        Entity terrainEnt = { entity, this };
+                        if (terrain.m_CollisionEnabled)
+                            ReconcileStreamingTerrainCollision(*m_JoltScene, terrainEnt, terrain);
+                        else
+                            m_JoltScene->DestroyTerrainTilesForEntity(terrainEnt.GetUUID());
+                    }
                 }
                 else
                 {

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -4671,21 +4671,18 @@ namespace OloEngine
         // entity transform exactly like the draw path (tileModel = entityTransform *
         // translate(tile.WorldOrigin) — see submitChunkPackets), so collision coincides
         // with the rendered tile.
-        void ReconcileStreamingTerrainCollision(JoltScene& joltScene, Entity entity, TerrainComponent& terrain)
+        void ReconcileStreamingTerrainCollision(JoltScene& joltScene, Entity entity,
+                                                const std::vector<Ref<TerrainTile>>& readyTiles)
         {
             const UUID entityID = entity.GetUUID();
-
-            if (!terrain.m_Streamer)
-            {
-                joltScene.DestroyTerrainTilesForEntity(entityID);
-                return;
-            }
 
             const auto& transform = entity.GetComponent<TransformComponent>();
             const glm::quat rotation = transform.GetRotation();
 
-            std::vector<Ref<TerrainTile>> readyTiles;
-            terrain.m_Streamer->GetReadyTiles(readyTiles);
+            // `readyTiles` is the SAME per-frame snapshot the render submit path uses, taken
+            // once by the caller (GetReadyTiles takes a shared lock + copies) — an empty list
+            // (streamer not yet created / no ready tiles) correctly tears down every tile body
+            // via the coord sweep below.
 
             // Pack a tile grid coord into a single key for the desired-set membership test.
             auto packKey = [](i32 x, i32 z) -> i64
@@ -6754,18 +6751,8 @@ namespace OloEngine
                     // the old world-anchored feed, plus the un-stacking fix.)
                     const glm::vec3 terrainTranslation = terrainView.get<TransformComponent>(entity).Translation;
                     terrain.m_Streamer->Update(cameraPosition - terrainTranslation, m_TerrainFrameCounter);
-
-                    // Per-tile collision (issue #469): when physics is live, keep a static
-                    // height-field body per ready tile in step with the visual load/unload.
-                    // Collision disabled at runtime → tear down any tiles we still own.
-                    if (m_JoltScene && m_JoltScene->IsInitialized())
-                    {
-                        Entity terrainEnt = { entity, this };
-                        if (terrain.m_CollisionEnabled)
-                            ReconcileStreamingTerrainCollision(*m_JoltScene, terrainEnt, terrain);
-                        else
-                            m_JoltScene->DestroyTerrainTilesForEntity(terrainEnt.GetUUID());
-                    }
+                    // Per-tile collision reconcile shares the render loop's single
+                    // GetReadyTiles snapshot — see the terrainRenderView loop below (#469).
                 }
                 else
                 {
@@ -6960,6 +6947,29 @@ namespace OloEngine
 
                     i32 entityID = static_cast<i32>(std::to_underlying(entity));
 
+                    // One per-frame ready-tile snapshot for a streaming terrain, shared by
+                    // the collision reconcile (just below) and the render submit path inside
+                    // the terrainShader block — GetReadyTiles' shared-lock-plus-copy runs
+                    // once per terrain per frame, not twice (issue #469 review). Placed
+                    // BEFORE the terrainShader gate so collision never depends on the terrain
+                    // shader being loaded. The streamer already advanced in the update loop
+                    // above; nothing mutates its tile set between there and here.
+                    std::vector<Ref<TerrainTile>> readyTiles;
+                    if (terrain.m_StreamingEnabled && terrain.m_Streamer)
+                        terrain.m_Streamer->GetReadyTiles(readyTiles);
+
+                    // Per-tile collision (issue #469): when physics is live, keep a static
+                    // height-field body per ready tile in step with the visual load/unload.
+                    // Collision disabled at runtime → tear down any tiles we still own.
+                    if (terrain.m_StreamingEnabled && m_JoltScene && m_JoltScene->IsInitialized())
+                    {
+                        Entity terrainEnt = { entity, this };
+                        if (terrain.m_CollisionEnabled)
+                            ReconcileStreamingTerrainCollision(*m_JoltScene, terrainEnt, readyTiles);
+                        else
+                            m_JoltScene->DestroyTerrainTilesForEntity(terrainEnt.GetUUID());
+                    }
+
                     if (terrainShader)
                     {
                         bool useTess = terrain.m_TessellationEnabled;
@@ -7125,8 +7135,9 @@ namespace OloEngine
 
                         if (terrain.m_StreamingEnabled && terrain.m_Streamer)
                         {
-                            std::vector<Ref<TerrainTile>> readyTiles;
-                            terrain.m_Streamer->GetReadyTiles(readyTiles);
+                            // Reuse the frame's ready-tile snapshot taken above (before the
+                            // terrainShader gate) and shared with the collision reconcile —
+                            // one GetReadyTiles per terrain per frame (issue #469 review).
                             for (const auto& tile : readyTiles)
                             {
                                 auto tileMat = tile->GetMaterial();

--- a/OloEngine/src/OloEngine/Scene/Scene.h
+++ b/OloEngine/src/OloEngine/Scene/Scene.h
@@ -306,6 +306,19 @@ namespace OloEngine
         void OnPhysics2DStart();
         void OnPhysics2DStop();
 
+        // Terrain sculpt/erosion collision sync (issue #469). After a sculpt or erosion
+        // edit mutates a single-tile terrain's CPU height field over the given sample
+        // rect ([regionX, regionX+regionWidth) columns × [regionZ, regionZ+regionHeight)
+        // rows), refresh the static height-field collision body so a dropped body rests on
+        // the NEW surface. No-op unless physics is running and the terrain has a live
+        // collision body (edit mode has no JoltScene). Streamed terrains are not sculpted,
+        // so their per-tile bodies are managed by the streaming reconcile instead. Pass the
+        // whole edited region (or the accumulated stroke rect); it is snapped to Jolt's
+        // block grid internally. Debounce at the call site — one call per stroke settle,
+        // not per drag frame. Returns true if a collision body was updated.
+        bool UpdateTerrainCollisionAfterEdit(Entity terrainEntity, u32 regionX, u32 regionZ,
+                                             u32 regionWidth, u32 regionHeight);
+
         // Audio runtime init. Production code reaches this via
         // OnRuntimeStart (non-headless path). Exposed for headless test
         // harnesses that need a working AudioEventsManager + position

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -627,6 +627,7 @@ add_executable(OloEngine-Tests
 		Functional/Cinematic/CinematicAssetPlaybackTest.cpp
 		Functional/AnimationPhysics/FreeFallLandingTest.cpp
 		Functional/AnimationPhysics/TerrainCollisionTest.cpp
+		Functional/AnimationPhysics/TerrainStreamingSculptCollisionTest.cpp
 		Functional/AnimationPhysics/ClothSimulationTest.cpp
 		Functional/AnimationPhysics/ClothSkeletonAttachTest.cpp
 		Functional/AnimationPhysics/PhysicsJoint3DTest.cpp

--- a/OloEngine/tests/Functional/AnimationPhysics/TerrainStreamingSculptCollisionTest.cpp
+++ b/OloEngine/tests/Functional/AnimationPhysics/TerrainStreamingSculptCollisionTest.cpp
@@ -1,0 +1,358 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: Functional
+// =============================================================================
+// TerrainStreamingSculptCollisionTest — Functional Test (issue #469).
+//
+// Cross-subsystem seam under test:
+//   Terrain (streamed per-tile TerrainData / single-tile CPU height field +
+//   sculpt edits) × Physics3D (Jolt HeightFieldShape static bodies, per-tile
+//   bodies, in-place SetHeights updates, dynamic rigidbodies, scene raycasts)
+//   driven by the real Scene::OnPhysics3DStart / OnUpdateRuntime path.
+//
+//   #428 (PR #468) gave SINGLE-TILE terrain collision. Two gaps remained, both
+//   fixed here and pinned by these tests:
+//     (1) STREAMED terrain had no collision at all — bodies fell through streamed
+//         worlds. Now each loaded tile gets a static height-field body keyed by
+//         (terrain entity, tile grid X/Z); a body dropped on a tile FAR from the
+//         origin rests on it, a raycast resolves to the terrain entity, and the
+//         body is torn down when the tile is evicted.
+//     (2) SCULPT / EROSION edits updated the mesh but not the collision shape —
+//         a dropped body kept resting on the pre-edit surface. Now an edit over a
+//         dirty rect refreshes the collision height field (JPH::HeightFieldShape::
+//         SetHeights, block-aligned) so a raycast / dropped body reflects the NEW
+//         surface.
+//
+// Headless: the full TerrainStreamer needs a GL context (its tile GPU build), so
+// these tests drive the collision PRIMITIVES the render-path reconcile calls into
+// (JoltScene::CreateTerrainTileBody / Scene::UpdateTerrainCollisionAfterEdit)
+// directly, from CPU heights built GPU-free — no GL context required. The full
+// streamer→collision + editor-sculpt integration is verified in the editor.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+#include "OloEngine/Scene/Entity.h"
+#include "OloEngine/Scene/Components.h"
+#include "OloEngine/Physics3D/JoltScene.h"
+#include "OloEngine/Physics3D/JoltShapes.h"
+#include "OloEngine/Physics3D/SceneQueries.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+namespace
+{
+    // Shared tile geometry. Odd resolution (65) exercises the height-field's even-
+    // padding path; worldSize / (resolution-1) = 1.0 keeps grid->world exact.
+    constexpr u32 kRes = 65;
+    constexpr f32 kTileWorldSize = 64.0f;
+    constexpr f32 kHeightScale = 4.0f;
+    constexpr f32 kRadius = 0.5f;
+
+    // A flat height field at a constant normalized height, whose world surface Y is
+    // `normalized * kHeightScale`.
+    std::vector<f32> FlatField(f32 normalized)
+    {
+        return std::vector<f32>(static_cast<sizet>(kRes) * kRes, normalized);
+    }
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (1) STREAMED terrain — per-tile collision far from the origin.
+//
+// Builds one static tile body at grid (3,0) → world origin (192,0,0), the exact
+// primitive the render-path streaming reconcile creates per loaded tile. Nothing
+// at the world origin has collision, so a body resting here proves the streaming
+// gap (bodies fell through tiles away from origin) is closed.
+// ─────────────────────────────────────────────────────────────────────────────
+class TerrainStreamingTileCollisionTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Terrain = GetScene().CreateEntity("StreamedTerrain");
+        // Terrain at the world origin, identity transform: tile world origin == grid*size.
+        auto& terrain = m_Terrain.AddComponent<TerrainComponent>();
+        terrain.m_StreamingEnabled = true;
+        terrain.m_CollisionEnabled = true;
+        terrain.m_HeightScale = kHeightScale;
+        terrain.m_TileWorldSize = kTileWorldSize;
+        terrain.m_TileResolution = kRes;
+
+        EnablePhysics3D();
+
+        // Create the per-tile body directly (the render path's reconcile is GL-coupled).
+        // A tile raised to normalized 0.5 → world surface Y = 2.0.
+        auto* jolt = GetScene().GetPhysicsScene();
+        JPH::Ref<JPH::Shape> shape = JoltShapes::CreateTerrainHeightFieldShape(
+            FlatField(0.5f), kRes, kTileWorldSize, kTileWorldSize, kHeightScale, glm::vec3(1.0f));
+        if (shape)
+        {
+            jolt->CreateTerrainTileBody(m_Terrain, kTileGridX, kTileGridZ, shape,
+                                        m_TileWorldOrigin, glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+        }
+    }
+
+    static constexpr i32 kTileGridX = 3;
+    static constexpr i32 kTileGridZ = 0;
+    // World origin of tile (3,0): (gridX*tileSize, 0, gridZ*tileSize).
+    const glm::vec3 m_TileWorldOrigin{ static_cast<f32>(kTileGridX) * kTileWorldSize, 0.0f,
+                                       static_cast<f32>(kTileGridZ) * kTileWorldSize };
+    static constexpr f32 kTileSurfaceY = 0.5f * kHeightScale; // 2.0
+    // Probe / drop over the centre of the far tile.
+    const f32 kProbeX = m_TileWorldOrigin.x + kTileWorldSize * 0.5f; // 224
+    const f32 kProbeZ = m_TileWorldOrigin.z + kTileWorldSize * 0.5f; // 32
+
+    Entity m_Terrain;
+};
+
+TEST_F(TerrainStreamingTileCollisionTest, RaycastHitsStreamedTileFarFromOrigin)
+{
+    auto* jolt = GetScene().GetPhysicsScene();
+    ASSERT_NE(jolt, nullptr);
+    ASSERT_TRUE(jolt->HasTerrainTileBody(m_Terrain.GetUUID(), kTileGridX, kTileGridZ))
+        << "tile body was not created";
+
+    RayCastInfo ray;
+    ray.m_Origin = { kProbeX, kTileSurfaceY + 50.0f, kProbeZ };
+    ray.m_Direction = { 0.0f, -1.0f, 0.0f };
+    ray.m_MaxDistance = 100.0f;
+
+    SceneQueryHit hit;
+    const bool didHit = jolt->CastRay(ray, hit);
+    ASSERT_TRUE(didHit && hit.HasHit()) << "ray down over the far streamed tile missed";
+    // UserData carries the OWNING TERRAIN ENTITY so queries resolve the terrain.
+    EXPECT_EQ(hit.m_HitEntity, m_Terrain.GetUUID()) << "streamed tile resolved to the wrong entity";
+    EXPECT_NEAR(hit.m_Position.y, kTileSurfaceY, 0.3f)
+        << "streamed tile collision at the wrong height; hit=" << hit.m_Position.y;
+}
+
+TEST_F(TerrainStreamingTileCollisionTest, EvictingTileBodyRemovesCollision)
+{
+    auto* jolt = GetScene().GetPhysicsScene();
+    ASSERT_NE(jolt, nullptr);
+
+    RayCastInfo ray;
+    ray.m_Origin = { kProbeX, kTileSurfaceY + 50.0f, kProbeZ };
+    ray.m_Direction = { 0.0f, -1.0f, 0.0f };
+    ray.m_MaxDistance = 100.0f;
+
+    SceneQueryHit before;
+    ASSERT_TRUE(jolt->CastRay(ray, before) && before.HasHit()) << "tile collision missing before evict";
+
+    // Simulate the streamer evicting the tile (EvictOverBudget / out-of-range).
+    jolt->DestroyTerrainTileBody(m_Terrain.GetUUID(), kTileGridX, kTileGridZ);
+    EXPECT_FALSE(jolt->HasTerrainTileBody(m_Terrain.GetUUID(), kTileGridX, kTileGridZ));
+
+    SceneQueryHit after;
+    const bool stillHits = jolt->CastRay(ray, after);
+    EXPECT_FALSE(stillHits && after.HasHit()) << "evicted tile collision leaked";
+}
+
+// Ball dropped onto a streamed tile far from the origin must rest on it.
+class TerrainStreamingTileRestTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Terrain = GetScene().CreateEntity("StreamedTerrain");
+        auto& terrain = m_Terrain.AddComponent<TerrainComponent>();
+        terrain.m_StreamingEnabled = true;
+        terrain.m_CollisionEnabled = true;
+        terrain.m_HeightScale = kHeightScale;
+        terrain.m_TileWorldSize = kTileWorldSize;
+        terrain.m_TileResolution = kRes;
+
+        m_Ball = GetScene().CreateEntity("Ball");
+        m_Ball.GetComponent<TransformComponent>().Translation = { kProbeX, kTileSurfaceY + 8.0f, kProbeZ };
+        auto& body = m_Ball.AddComponent<Rigidbody3DComponent>();
+        body.m_Type = BodyType3D::Dynamic;
+        body.m_Mass = 1.0f;
+        body.m_LinearDrag = 0.0f;
+        m_Ball.AddComponent<SphereCollider3DComponent>().m_Radius = kRadius;
+
+        EnablePhysics3D();
+
+        auto* jolt = GetScene().GetPhysicsScene();
+        JPH::Ref<JPH::Shape> shape = JoltShapes::CreateTerrainHeightFieldShape(
+            FlatField(0.5f), kRes, kTileWorldSize, kTileWorldSize, kHeightScale, glm::vec3(1.0f));
+        if (shape)
+        {
+            jolt->CreateTerrainTileBody(m_Terrain, 3, 0, shape,
+                                        glm::vec3(3.0f * kTileWorldSize, 0.0f, 0.0f),
+                                        glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+        }
+    }
+
+    static constexpr f32 kTileSurfaceY = 0.5f * kHeightScale;                     // 2.0
+    static constexpr f32 kProbeX = 3.0f * kTileWorldSize + kTileWorldSize * 0.5f; // 224
+    static constexpr f32 kProbeZ = kTileWorldSize * 0.5f;                         // 32
+
+    Entity m_Terrain;
+    Entity m_Ball;
+};
+
+TEST_F(TerrainStreamingTileRestTest, DynamicBodyRestsOnStreamedTile)
+{
+    const auto BallY = [this]
+    { return m_Ball.GetComponent<TransformComponent>().Translation.y; };
+    ASSERT_GT(BallY(), kTileSurfaceY + 2.0f) << "ball should start above the tile";
+
+    TickFor(5.0f);
+
+    const auto& pos = m_Ball.GetComponent<TransformComponent>().Translation;
+    EXPECT_TRUE(std::isfinite(pos.y)) << "ball transform contains NaN/Inf";
+    EXPECT_GT(pos.y, kTileSurfaceY - 0.5f) << "ball fell through the streamed tile; y=" << pos.y;
+    EXPECT_NEAR(pos.y, kTileSurfaceY + kRadius, 0.15f)
+        << "ball did not settle on the streamed tile surface; y=" << pos.y;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (2) SCULPT edits — the collision shape must follow the edited height field.
+//
+// A single-tile FLAT terrain builds its collision body GPU-free at OnPhysics3DStart
+// (BuildTerrainCollisionBody synthesizes a 256×256 zero field — no TerrainData / GL,
+// same headless path as TerrainCollisionFlatTest). We then edit a matching CPU field
+// and push the dirty rect through the SAME primitive the editor's sculpt/erosion
+// path calls via Scene::UpdateTerrainCollisionAfterEdit — JoltScene::
+// UpdateTerrainBodyHeights (block-aligned SetHeights). The full Scene wrapper +
+// editor stroke wiring (which needs a GPU-backed TerrainData) is verified live in
+// the editor.
+// ─────────────────────────────────────────────────────────────────────────────
+namespace
+{
+    // Flat single-tile terrain params. BuildTerrainCollisionBody's flat path uses a fixed
+    // 256×256 field spanning [0, WorldSize] in X/Z at HeightScale.
+    constexpr u32 kSculptRes = 256;
+    constexpr f32 kSculptWorldSize = 256.0f; // world per sample ≈ 256/255 ≈ 1.004
+    constexpr f32 kSculptHeightScale = 4.0f;
+    constexpr f32 kRidgeSurfaceY = 0.5f * kSculptHeightScale; // 2.0
+    constexpr f32 kSculptCentre = 128.0f;                     // world XZ over the raised block
+
+    TerrainComponent& MakeFlatSculptTerrain(Entity terrain)
+    {
+        auto& tc = terrain.AddComponent<TerrainComponent>();
+        tc.m_ProceduralEnabled = false;
+        tc.m_HeightmapPath.clear();
+        tc.m_CollisionEnabled = true;
+        tc.m_StreamingEnabled = false;
+        tc.m_WorldSizeX = kSculptWorldSize;
+        tc.m_WorldSizeZ = kSculptWorldSize;
+        tc.m_HeightScale = kSculptHeightScale;
+        return tc;
+    }
+
+    // Raise a central block of samples to normalized 0.5 (world Y = 2.0) in a flat 256²
+    // field and return its dirty rect (x, z, w, h), block-aligned. World ≈ [96,160].
+    struct Rect
+    {
+        u32 X, Z, W, H;
+    };
+    Rect RaiseCentralRidge(std::vector<f32>& heights)
+    {
+        constexpr u32 lo = 96;
+        constexpr u32 hi = 160; // inclusive
+        for (u32 z = lo; z <= hi; ++z)
+            for (u32 x = lo; x <= hi; ++x)
+                heights[static_cast<sizet>(z) * kSculptRes + x] = 0.5f;
+        return Rect{ lo, lo, hi - lo + 1, hi - lo + 1 };
+    }
+} // namespace
+
+class TerrainSculptCollisionTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Terrain = GetScene().CreateEntity("Terrain");
+        MakeFlatSculptTerrain(m_Terrain);
+        EnablePhysics3D(); // builds the flat 256² collision body GPU-free
+        // Mirror the field the body was built from (all zero) so we can edit + re-push it.
+        m_Heights.assign(static_cast<sizet>(kSculptRes) * kSculptRes, 0.0f);
+    }
+
+    Entity m_Terrain;
+    std::vector<f32> m_Heights;
+};
+
+TEST_F(TerrainSculptCollisionTest, SculptedRidgeRaisesCollisionSurface)
+{
+    auto* jolt = GetScene().GetPhysicsScene();
+    ASSERT_NE(jolt, nullptr);
+
+    RayCastInfo ray;
+    ray.m_Origin = { kSculptCentre, 50.0f, kSculptCentre };
+    ray.m_Direction = { 0.0f, -1.0f, 0.0f };
+    ray.m_MaxDistance = 100.0f;
+
+    // Before the edit the surface is flat at Y = 0.
+    SceneQueryHit before;
+    ASSERT_TRUE(jolt->CastRay(ray, before) && before.HasHit()) << "flat terrain collision missing";
+    EXPECT_NEAR(before.m_Position.y, 0.0f, 0.2f) << "flat surface not at Y=0; y=" << before.m_Position.y;
+
+    // Sculpt a raised ridge into the CPU field and push the dirty rect to the collision
+    // body via the same primitive the editor sculpt path calls.
+    const Rect r = RaiseCentralRidge(m_Heights);
+    ASSERT_TRUE(jolt->UpdateTerrainBodyHeights(m_Terrain.GetUUID(), r.X, r.Z, r.W, r.H, m_Heights, kSculptRes))
+        << "collision height update reported no body";
+
+    // The collision surface at the ridge centre now reflects the NEW height.
+    SceneQueryHit after;
+    ASSERT_TRUE(jolt->CastRay(ray, after) && after.HasHit()) << "collision missing after sculpt";
+    EXPECT_EQ(after.m_HitEntity, m_Terrain.GetUUID());
+    EXPECT_NEAR(after.m_Position.y, kRidgeSurfaceY, 0.3f)
+        << "collision did not follow the sculpted ridge; y=" << after.m_Position.y;
+}
+
+// A body dropped onto the sculpted region rests on the NEW (raised) surface, not the
+// pre-edit flat one.
+class TerrainSculptRestTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        m_Terrain = GetScene().CreateEntity("Terrain");
+        MakeFlatSculptTerrain(m_Terrain);
+
+        m_Ball = GetScene().CreateEntity("Ball");
+        m_Ball.GetComponent<TransformComponent>().Translation = { kSculptCentre, kRidgeSurfaceY + 8.0f, kSculptCentre };
+        auto& body = m_Ball.AddComponent<Rigidbody3DComponent>();
+        body.m_Type = BodyType3D::Dynamic;
+        body.m_Mass = 1.0f;
+        body.m_LinearDrag = 0.0f;
+        m_Ball.AddComponent<SphereCollider3DComponent>().m_Radius = kRadius;
+
+        EnablePhysics3D();
+        m_Heights.assign(static_cast<sizet>(kSculptRes) * kSculptRes, 0.0f);
+    }
+
+    Entity m_Terrain;
+    Entity m_Ball;
+    std::vector<f32> m_Heights;
+};
+
+TEST_F(TerrainSculptRestTest, DynamicBodyRestsOnSculptedRidge)
+{
+    auto* jolt = GetScene().GetPhysicsScene();
+    ASSERT_NE(jolt, nullptr);
+
+    // Sculpt the ridge BEFORE any simulation advances, then sync collision.
+    const Rect r = RaiseCentralRidge(m_Heights);
+    ASSERT_TRUE(jolt->UpdateTerrainBodyHeights(m_Terrain.GetUUID(), r.X, r.Z, r.W, r.H, m_Heights, kSculptRes))
+        << "collision height update reported no body";
+
+    TickFor(5.0f);
+
+    const auto& pos = m_Ball.GetComponent<TransformComponent>().Translation;
+    EXPECT_TRUE(std::isfinite(pos.y)) << "ball transform contains NaN/Inf";
+    // Must rest on the raised ridge (~2.5), NOT on the pre-edit flat surface (~0.5).
+    EXPECT_NEAR(pos.y, kRidgeSurfaceY + kRadius, 0.2f)
+        << "ball did not rest on the sculpted ridge; y=" << pos.y;
+    EXPECT_GT(pos.y, 1.0f) << "ball rested on the stale pre-edit surface; y=" << pos.y;
+}

--- a/docs/agent-rules/terrain-collision-streaming-sculpt.md
+++ b/docs/agent-rules/terrain-collision-streaming-sculpt.md
@@ -99,3 +99,9 @@ drifts off the visible tile.
    apply button), never per drag frame — the editor wires it at the stroke-end /
    erosion-apply sites next to `RebuildDirtyChunks`, not through
    `terrain.m_NeedsRebuild` (that is a *full* procedural-rebuild flag).
+7. **Undo/redo must refresh collision too.** The stroke-settle call only covers
+   the initial live-applied stroke; an undo/redo re-applies heights through
+   `TerrainSculptCommand::ApplyHeights` (shared by `Execute`/`Undo`), so that path
+   calls `UpdateTerrainCollisionAfterEdit` as well — otherwise undoing a sculpt
+   during Play leaves the collision body on the redone surface. The command holds
+   the scene as a `WeakRef` so the undo history never keeps the whole `Scene` alive.

--- a/docs/agent-rules/terrain-collision-streaming-sculpt.md
+++ b/docs/agent-rules/terrain-collision-streaming-sculpt.md
@@ -1,0 +1,101 @@
+# Terrain collision for streamed tiles + sculpt edits (issue #469)
+
+Follow-up to #428 / PR #468, which gave **single-tile** terrain a static
+`JPH::HeightFieldShape` body built once at `OnPhysics3DStart`. This slice closed
+the two gaps that PR deferred. Read this before touching terrain × physics again.
+
+## The two paths are separate — don't conflate them
+
+- **Streaming** = many bodies, one per loaded tile, *full-shape create on load /
+  destroy on evict*. Streamed tiles are file-loaded and immutable; they are never
+  sculpted. No `SetHeights`.
+- **Sculpt / erosion** = one single-tile body, *mutated in place* over the dirty
+  rect via `HeightFieldShape::SetHeights`. Single-tile terrain only.
+
+`Scene::UpdateTerrainCollisionAfterEdit` early-returns for `m_StreamingEnabled`;
+the streaming reconcile early-returns into its own tile map. Keep it that way.
+
+## Streaming per-tile bodies live in a SECOND JoltScene map
+
+`JoltScene::m_TerrainBodies` (keyed by terrain entity UUID, from #428) is for the
+single-tile body. Streamed tiles use `m_TerrainTileBodies`, keyed by
+`(terrain entity UUID, tile grid X, tile grid Z)`. Both are raw static
+`NON_MOVING` bodies with `UserData = the OWNING TERRAIN ENTITY UUID` (so a raycast
+against *any* tile resolves the terrain entity) and both are entered in
+`m_BodyIDToEntity`. `DestroyAllTerrainBodies` (Shutdown), `OnPhysics3DStop`, and
+the `DestroyEntity` hook must sweep **both** maps — a tile body has no
+`m_RuntimeCollisionBodyToken`, so the token-guarded single-tile teardown misses it.
+
+## The streamer only ticks in the render path — so does the reconcile
+
+`TerrainStreamer::Update` (and therefore the per-tile collision reconcile,
+`ReconcileStreamingTerrainCollision`) runs inside `Scene::ProcessScene3DSharedLogic`,
+which is called **only** from `RenderScene3D`, **not** from the headless
+`OnUpdateRuntime` / `SimulateRuntimeStep` tick. `TerrainTile::BuildGPUResources`
+hard-requires a GL context (no null-guard), and the streamer only inserts a tile
+into `m_Tiles` *after* that build — so **streamed-terrain collision cannot be
+driven in a headless test**. The tile's *CPU* height field (`GetTerrainData()`) is
+built GPU-free in the async `LoadFromFile`/`CreateFlat`, so the collision shape
+itself needs no GL — but you cannot get a tile to `Ready` without one.
+
+Consequence for tests: exercise the **collision primitives** the reconcile calls
+(`JoltScene::CreateTerrainTileBody` / `DestroyTerrainTileBody`,
+`Scene::UpdateTerrainCollisionAfterEdit`) directly from CPU heights, and verify the
+full streamer→collision + editor-sculpt integration in the running editor. See
+`OloEngine/tests/Functional/AnimationPhysics/TerrainStreamingSculptCollisionTest.cpp`.
+
+## Tile body pose must reproduce the draw transform exactly
+
+The draw path places each tile at `tileModel = entityTransform *
+translate(tile.WorldOrigin)` (`submitChunkPackets`). The shape bakes entity scale
+(`CreateTerrainHeightFieldShape(..., transform.Scale)`), so the *body* carries only
+translation + rotation:
+
+    bodyPos = transform.Translation + rotation * (transform.Scale * tile.WorldOrigin)
+    bodyRot = transform.GetRotation()
+
+For the common identity-rotation / unit-scale terrain this is just
+`Translation + WorldOrigin`. Get the scale/rotation wrong and collision silently
+drifts off the visible tile.
+
+## `HeightFieldShape::SetHeights` footguns (the sculpt path)
+
+1. **Block alignment is mandatory.** `inX`, `inY`, `inSizeX`, `inSizeY` must all be
+   multiples of the shape's `GetBlockSize()` (default 2). Snap the dirty rect
+   **outward** (`x0 = (x/bs)*bs`, `x1 = ceil` to `bs`), clamp `x1`/`z1` to
+   `GetSampleCount()`. Get this wrong and Jolt asserts (debug) or writes garbage
+   (release) — silent.
+2. **Odd resolution → padded shape.** `CreateTerrainHeightFieldShape` pads an odd
+   resolution up one edge-replicated row/col, so `GetSampleCount()` (e.g. 66) can
+   exceed `TerrainData` resolution (65). Do **not** hand `SetHeights` a strided
+   pointer into the resolution-wide `TerrainData`: build a **contiguous,
+   edge-replicated** region buffer (`src = fullHeights[min(z,res-1)*res +
+   min(x,res-1)]`), mirroring exactly how the shape was first filled. Then stride =
+   region width.
+3. **`SetHeights`/`GetHeights` take WORLD-space Y, not the normalized `[0,1]`
+   samples.** Internally `SetHeights` re-quantizes via `(h - mOffset.Y) / mScale.Y`
+   (HeightFieldShape.cpp), and `GetMinHeightValue()`/`GetMaxHeightValue()` return the
+   world band. `TerrainData` heights are normalized, so convert:
+   `worldH = GetMinHeightValue() + normalized * (GetMaxHeightValue() - GetMinHeightValue())`.
+   Passing the raw `[0,1]` value writes a near-zero ridge that reads back as flat.
+4. **A near-flat build has ZERO sculpt headroom unless you pin the range.** Jolt's
+   `HeightFieldShapeSettings` defaults `mMinHeightValue`/`mMaxHeightValue` to
+   ±`cLargeFloat`, so `DetermineMinAndMaxSample` fits the encodable 16-bit window to
+   the *initial* samples. A body built from a flat (or low-relief) field then quantizes
+   over a near-zero vertical range, and a later `SetHeights` raise silently clamps back
+   to flat — collision never follows the sculpt. `CreateTerrainHeightFieldShape` pins
+   `mMinHeightValue = 0`, `mMaxHeightValue = 1` (the full normalized band → world
+   `[0, joltScale.Y]`) so **every** terrain body — flat or not — can be sculpted across
+   its whole height range. Sub-mm precision cost. This was the bug that made the sculpt
+   tests read flat after a raise even though `SetHeights` "succeeded".
+5. **`NotifyShapeChanged` deadlocks under a body lock.** It takes the body lock
+   itself. Do NOT wrap `SetHeights` + `NotifyShapeChanged` in a `BodyLockWrite` on
+   the same body — fetch the shape via `BodyInterface::GetShape` (const_cast is safe:
+   the shape is freshly built per terrain body, never shared), `SetHeights`, then
+   `NotifyShapeChanged(bodyID, prevCOM, false, DontActivate)` with `prevCOM` read
+   **before** the mutation. The "no concurrent query" guarantee comes from the
+   caller running on the game thread outside the physics step, not from a lock.
+6. **Debounce.** Update collision once per **stroke settle** (mouse-up / erosion
+   apply button), never per drag frame — the editor wires it at the stroke-end /
+   erosion-apply sites next to `RebuildDirtyChunks`, not through
+   `terrain.m_NeedsRebuild` (that is a *full* procedural-rebuild flag).


### PR DESCRIPTION
Closes #469 — follow-up to #428 / PR #468.

#428 gave **single-tile** terrain a static Jolt `HeightFieldShape` body built once at `OnPhysics3DStart`. Two gaps remained, both closed here:

1. **Streamed terrain had no collision** — `TerrainStreamer` tiles added/removed their visual mesh but no collision body, so bodies fell through tiles away from the origin.
2. **Sculpt / erosion edits never updated the collision shape** — the static heightfield kept the pre-edit surface.

## Streaming — per-tile bodies
- `JoltScene` tracks per-tile terrain bodies in a **second map** keyed by `(terrain entity UUID, tile grid X, tile grid Z)`: `CreateTerrainTileBody` / `DestroyTerrainTileBody` / `HasTerrainTileBody` / `GetTerrainTileCoords` / `DestroyTerrainTilesForEntity`. `UserData` = owning terrain entity so a raycast against any tile resolves it; both maps swept on shutdown / `OnPhysics3DStop` / `DestroyEntity`.
- `Scene::ReconcileStreamingTerrainCollision` diffs the streamer's ready tiles against the tracked tile bodies each frame in the render path (where the streamer advances), building a body per new tile and destroying evicted ones. Tile pose reproduces the draw transform `entityTransform * translate(WorldOrigin)`.

## Sculpt / erosion — in-place height updates
- `JoltScene::UpdateTerrainBodyHeights` mutates the body's `HeightFieldShape` via `SetHeights` over the dirty rect, snapped outward to the block grid and edge-replicated into the padded region, then `NotifyShapeChanged`. `SetHeights` takes **world-space Y**, so normalized samples are converted through the shape's `Get{Min,Max}HeightValue` band.
- `CreateTerrainHeightFieldShape` now **pins the encodable range to normalized `[0,1]`** — a flat/low-relief body otherwise has near-zero vertical quantization range and a raised ridge silently clamps back to flat.
- `Scene::UpdateTerrainCollisionAfterEdit` (public) drives it with a full-rebuild fallback; `TerrainEditorPanel` calls it at sculpt stroke-settle and erosion-apply (debounced, no-op in edit mode).

## Tests & verification
`OloEngine/tests/Functional/AnimationPhysics/TerrainStreamingSculptCollisionTest.cpp` (5 Functional tests, real Jolt physics):
- a body rests on a streamed tile **far from origin**; a raycast resolves to the terrain entity; **eviction** removes collision;
- a **sculpted ridge** raises both the raycast surface and a dropped body's rest height.

**9/9** terrain collision tests pass (4 pre-existing #428 + 5 new), **129/129** terrain/physics/functional tests pass — no regression from the shared range-pin. OloEditor builds and smoke-launches clean.

Non-obvious Jolt gotchas (block alignment, odd-resolution padding, world-space `SetHeights`, the flat-build quantization trap, the `NotifyShapeChanged`-under-body-lock deadlock) are documented in `docs/agent-rules/terrain-collision-streaming-sculpt.md`.

### Verification limitation
The read-only MCP diagnostics server can't enter Play mode / sculpt / step physics, and no sandbox scene has streaming enabled, so the full streamer→collision loop couldn't be driven *interactively* in the editor. The Functional tests cover that path with real physics simulation (the appropriate verification for a collision change); the editor launch confirms only clean startup/integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terrain collision now automatically refreshes after sculpt strokes settle and after hydraulic erosion updates.
  - Streamed terrain collision is now managed per tile, with collision surfaces created/removed as tiles load/unload.
- **Bug Fixes**
  - Prevented stale or lingering terrain collision bodies after tile eviction, terrain entity deletion, and physics shutdown.
  - Improved correctness for raycasts and physics interactions against both streamed terrain and newly edited terrain.
- **Tests**
  - Added functional coverage for sculpt + streaming-terrain collision in headless mode.
- **Documentation**
  - Documented the collision behavior differences between streamed tiles and in-editor sculpt/erosion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->