### PR TITLE
feat(mcp): runtime (Play-mode) field write for olo_entity_set_field

### DIFF
--- a/OloEditor/src/MCP/McpGenericFieldWrite.h
+++ b/OloEditor/src/MCP/McpGenericFieldWrite.h
@@ -406,6 +406,15 @@ namespace OloEngine::MCP::GenericFieldWrite
         // The field's current value as JSON, or nullopt when the entity lacks C.
         std::function<std::optional<Json>(Entity)> Read;
 
+        // Play-mode counterpart of Apply (issue #607's runtime field-write slice):
+        // same coerce/clamp/no-op-detect core, but writes STRAIGHT into the live
+        // component with no CommandHistory involved at all — there is no undo stack
+        // to push onto while the scene is playing (CommandHistory is nulled for the
+        // duration of Play), and the mutation does not survive Stop anyway. Callers
+        // must still mark the result `undoable: false` themselves (ApplyDirect() at
+        // namespace scope below does this uniformly for both entry kinds).
+        std::function<ApplyResult(Entity, u64, const Json&)> ApplyDirect;
+
         // ---- map-key addressing (issue #607's MorphTargetComponent::Weights slice) --
         //
         // A MAP-typed field has no compile-time-known key — MorphTargetComponent's
@@ -429,6 +438,8 @@ namespace OloEngine::MCP::GenericFieldWrite
         // drives olo_entity_list_fields' "exactly what you can write right now"
         // contract for a map field, since no key is known ahead of time.
         std::function<std::vector<std::string>(Entity)> ListMapKeys;
+        // Play-mode counterpart of ApplyKeyed — see ApplyDirect above.
+        std::function<ApplyResult(Entity, u64, const std::string& key, const Json&)> ApplyKeyedDirect;
     };
 
     // Build one registry entry from a component type + a script-facing field name +
@@ -516,6 +527,39 @@ namespace OloEngine::MCP::GenericFieldWrite
             if (!entity.HasComponent<C>())
                 return std::nullopt;
             return FieldToJson<F>(access(entity.GetComponent<C>()));
+        };
+
+        entry.ApplyDirect = [access, component, field, range](Entity entity, u64 uuid, const Json& value) -> ApplyResult
+        {
+            ApplyResult result;
+            if (!entity.HasComponent<C>())
+            {
+                result.Error = "Entity has no " + component + ".";
+                return result;
+            }
+
+            F coerced{};
+            if (const auto error = CoerceJson<F>(value, coerced))
+            {
+                result.Error = "Invalid 'value' for " + component + "." + field +
+                               " (expects " + std::string(FieldTypeName<F>()) + "): " + *error + ".";
+                return result;
+            }
+
+            const F requested = coerced;
+            RangeField<F>(coerced, range);
+            const bool clamped = FieldChanged<F>(requested, coerced);
+
+            // No whole-object copy/swap and no command — write the accessor's
+            // lvalue directly on the live component. Safe because, unlike the
+            // undoable path, there is nothing else that needs the pre-write value
+            // preserved (no Undo to serve).
+            const F previous = access(entity.GetComponent<C>());
+            if (FieldChanged<F>(previous, coerced))
+                access(entity.GetComponent<C>()) = coerced;
+
+            const F applied = access(entity.GetComponent<C>());
+            return Detail::BuildFieldApplyResult<F>(component, field, uuid, requested, previous, applied, clamped);
         };
 
         return entry;
@@ -629,6 +673,41 @@ namespace OloEngine::MCP::GenericFieldWrite
             if (!entity.HasComponent<C>())
                 return std::nullopt;
             return FieldToJson<F>(getFn(entity.GetComponent<C>()));
+        };
+
+        entry.ApplyDirect = [getFn, setFn, component, field, range](Entity entity, u64 uuid, const Json& value) -> ApplyResult
+        {
+            ApplyResult result;
+            if (!entity.HasComponent<C>())
+            {
+                result.Error = "Entity has no " + component + ".";
+                return result;
+            }
+
+            F coerced{};
+            if (const auto error = CoerceJson<F>(value, coerced))
+            {
+                result.Error = "Invalid 'value' for " + component + "." + field +
+                               " (expects " + std::string(FieldTypeName<F>()) + "): " + *error + ".";
+                return result;
+            }
+
+            const F requested = coerced;
+            RangeField<F>(coerced, range);
+            const bool clamped = FieldChanged<F>(requested, coerced);
+
+            // Same "call setFn, read back" honesty contract as Apply above — just
+            // with no PropertySetCommand pushed, since there is no undo stack to
+            // serve while playing.
+            const F previous = getFn(entity.GetComponent<C>());
+            F applied = previous;
+            if (FieldChanged<F>(previous, coerced))
+            {
+                setFn(entity.GetComponent<C>(), coerced);
+                applied = getFn(entity.GetComponent<C>());
+            }
+
+            return Detail::BuildFieldApplyResult<F>(component, field, uuid, requested, previous, applied, clamped);
         };
 
         return entry;
@@ -750,6 +829,41 @@ namespace OloEngine::MCP::GenericFieldWrite
             if (!entity.HasComponent<C>())
                 return {};
             return keysFn(entity.GetComponent<C>());
+        };
+
+        entry.ApplyKeyedDirect = [getFn, setFn, component, field, range](
+                                     Entity entity, u64 uuid, const std::string& key, const Json& value) -> ApplyResult
+        {
+            ApplyResult result;
+            if (!entity.HasComponent<C>())
+            {
+                result.Error = "Entity has no " + component + ".";
+                return result;
+            }
+
+            V coerced{};
+            if (const auto error = CoerceJson<V>(value, coerced))
+            {
+                result.Error = "Invalid 'value' for " + component + "." + field + "." + key +
+                               " (expects " + std::string(FieldTypeName<V>()) + "): " + *error + ".";
+                return result;
+            }
+
+            const V requested = coerced;
+            RangeField<V>(coerced, range);
+            const bool clamped = FieldChanged<V>(requested, coerced);
+
+            const V previous = getFn(entity.GetComponent<C>(), key);
+            V applied = previous;
+            if (FieldChanged<V>(previous, coerced))
+            {
+                setFn(entity.GetComponent<C>(), key, coerced);
+                applied = getFn(entity.GetComponent<C>(), key);
+            }
+
+            ApplyResult out = Detail::BuildFieldApplyResult<V>(component, field + "." + key, uuid, requested, previous, applied, clamped);
+            out.Data["key"] = key;
+            return out;
         };
 
         return entry;
@@ -1028,6 +1142,60 @@ namespace OloEngine::MCP::GenericFieldWrite
                 return result;
             }
             return mapEntry->ApplyKeyed(scene, history, *entityOpt, entityUuid, key, value);
+        }
+
+        result.Error = DescribeUnknownField(component, field);
+        return result;
+    }
+
+    // Play-mode counterpart of Apply (issue #607's runtime field-write slice): set
+    // one component field on the LIVE running scene with no CommandHistory at all
+    // — CommandHistory is nulled for the duration of Play, so there is no undo
+    // stack to push onto, and a Play-mode mutation is discarded on Stop regardless
+    // (Scene::OnScenePlay copies the edit-mode scene into m_ActiveScene; nothing
+    // here writes back). MUST run on the main (game) thread, same as Apply.
+    //
+    // The result always carries `undoable: false` (forced here rather than left to
+    // derive from `changed`, unlike Apply's `undoable == changed`) — a direct write
+    // is never undoable, changed or not, so a calling agent can tell at a glance
+    // that Ctrl-Z will not revert it and it will not survive Stop.
+    [[nodiscard]] inline ApplyResult ApplyDirect(const Ref<Scene>& scene, u64 entityUuid,
+                                                 const std::string& component, const std::string& field, const Json& value)
+    {
+        ApplyResult result;
+        if (!scene)
+        {
+            result.Error = "No active scene.";
+            return result;
+        }
+
+        if (const FieldEntry* entry = Find(component, field))
+        {
+            const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+            if (!entityOpt)
+            {
+                result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+                return result;
+            }
+            ApplyResult applied = entry->ApplyDirect(*entityOpt, entityUuid, value);
+            if (applied.Ok)
+                applied.Data["undoable"] = false;
+            return applied;
+        }
+
+        std::string key;
+        if (const FieldEntry* mapEntry = FindMapKeyed(component, field, key))
+        {
+            const auto entityOpt = scene->TryGetEntityWithUUID(UUID(entityUuid));
+            if (!entityOpt)
+            {
+                result.Error = "No entity with UUID " + std::to_string(entityUuid) + " in the active scene.";
+                return result;
+            }
+            ApplyResult applied = mapEntry->ApplyKeyedDirect(*entityOpt, entityUuid, key, value);
+            if (applied.Ok)
+                applied.Data["undoable"] = false;
+            return applied;
         }
 
         result.Error = DescribeUnknownField(component, field);

--- a/OloEditor/src/MCP/McpToolsScene.cpp
+++ b/OloEditor/src/MCP/McpToolsScene.cpp
@@ -186,6 +186,18 @@ namespace OloEngine::MCP
         // in McpGenericFieldWrite.h so it is unit-tested at the dispatch seam without
         // this TU. The command is built + executed inside the MarshalRead job, i.e.
         // on the main thread, since it touches the EnTT registry and command stack.
+        //
+        // Play-mode branch (issue #607's runtime field-write slice): CommandHistory
+        // is deliberately nulled while the scene is playing, so a Play-mode call used
+        // to hard-fail with "No editor command history available." — blocking an
+        // agent from driving/verifying live gameplay state without stopping Play,
+        // editing, and restarting. When EditorMcpContext.IsPlaying() reports the
+        // scene is running, skip the history requirement entirely and write straight
+        // into the live m_ActiveScene component via GenericFieldWrite::ApplyDirect —
+        // a real mutation with no undo and no persistence back to the edit-mode
+        // scene (mirrors the non-undoable framing of SelectEntityInEditor /
+        // olo_renderer_settings_set). The result's `undoable: false` tells the caller
+        // this write won't survive Stop and can't be Ctrl-Z'd.
         ToolResult Handle_EntitySetField(McpServer& server, const Json& args)
         {
             if (!server.Context().GetActiveScene || !server.Context().GetCommandHistory)
@@ -203,11 +215,22 @@ namespace OloEngine::MCP
                 const Ref<Scene> scene = server.Context().GetActiveScene
                                              ? server.Context().GetActiveScene()
                                              : nullptr;
+                if (!scene)
+                    return Json{ { "__error", "No active scene." } };
+
+                const bool isPlaying = server.Context().IsPlaying && server.Context().IsPlaying();
+                if (isPlaying)
+                {
+                    const GenericFieldWrite::ApplyResult applied =
+                        GenericFieldWrite::ApplyDirect(scene, entityUuid, component, field, value);
+                    if (!applied.Ok)
+                        return Json{ { "__error", applied.Error } };
+                    return applied.Data;
+                }
+
                 CommandHistory* history = server.Context().GetCommandHistory
                                               ? server.Context().GetCommandHistory()
                                               : nullptr;
-                if (!scene)
-                    return Json{ { "__error", "No active scene." } };
                 if (!history)
                     return Json{ { "__error", "No editor command history available." } };
 

--- a/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
@@ -417,6 +417,173 @@ TEST(McpGenericFieldWriteApply, RejectsNonFiniteVector)
     EXPECT_FALSE(history.CanUndo());
 }
 
+// ---- the shared apply core, Play-mode direct path (no CommandHistory) ------
+// GFW::ApplyDirect (issue #607's runtime field-write slice): the same
+// coerce/clamp/no-op-detect core as GFW::Apply, but with no CommandHistory
+// parameter at all — mirrors Handle_EntitySetField's Play-mode branch, where
+// CommandHistory is nulled for the duration of Play.
+
+TEST(McpGenericFieldWriteApplyDirect, ChangesVec3AndNeverTouchesHistory)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history; // present in the environment; must stay untouched
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "TransformComponent", "Scale", Json::array({ 2.0, 3.0, 4.0 }));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    // Direct writes are never undoable — forced false regardless of `changed`,
+    // unlike GFW::Apply where undoable == changed.
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_EQ(result.Data["type"], "vec3");
+    ExpectVec3(entity.GetComponent<TransformComponent>().Scale, 2.0f, 3.0f, 4.0f);
+    EXPECT_FALSE(history.CanUndo());
+}
+
+TEST(McpGenericFieldWriteApplyDirect, ChangesFloatField)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    entity.AddComponent<DirectionalLightComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "DirectionalLightComponent", "Intensity", Json(2.5));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "float");
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_FLOAT_EQ(entity.GetComponent<DirectionalLightComponent>().m_Intensity, 2.5f);
+}
+
+// A no-op write still reports `changed: false` AND `undoable: false` — the
+// latter is always false for a direct write, not merely coincident with the
+// no-op here (see ChangesVec3AndNeverTouchesHistory above for the changed case).
+TEST(McpGenericFieldWriteApplyDirect, NoOpWhenUnchanged)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    // Scale defaults to (1,1,1).
+    const auto result = GFW::ApplyDirect(scene, uuid, "TransformComponent", "Scale", Json::array({ 1.0, 1.0, 1.0 }));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_FALSE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+}
+
+TEST(McpGenericFieldWriteApplyDirect, UnknownComponentListsEditableComponents)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "NotAComponent", "Field", Json(1));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("Editable components"), std::string::npos);
+}
+
+TEST(McpGenericFieldWriteApplyDirect, EntityLackingComponentIsError)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E"); // no SpriteRendererComponent
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "SpriteRendererComponent", "Color", Json::array({ 1.0, 1.0, 1.0, 1.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_NE(result.Error.find("has no SpriteRendererComponent"), std::string::npos);
+}
+
+TEST(McpGenericFieldWriteApplyDirect, MissingEntityIsError)
+{
+    auto scene = Ref<Scene>::Create();
+    const auto result = GFW::ApplyDirect(scene, /*uuid*/ 424242, "TransformComponent", "Scale", Json::array({ 1.0, 1.0, 1.0 }));
+    EXPECT_FALSE(result.Ok);
+    EXPECT_FALSE(result.Error.empty());
+}
+
+// ---- dispatch seam: Play-mode uses ApplyDirect and never touches CommandHistory
+
+// Mirrors Handle_EntitySetField's (McpToolsScene.cpp) Play-mode branch:
+// EditorMcpContext.IsPlaying() true → GFW::ApplyDirect, no CommandHistory
+// involved at all (the real editor nulls CommandHistory for the duration of
+// Play; this fixture models that by never setting GetCommandHistory).
+class McpGenericFieldWritePlayModeTest : public ::testing::Test
+{
+  protected:
+    McpGenericFieldWritePlayModeTest()
+        : m_Server(MakeContext())
+    {
+        Entity entity = m_Scene->CreateEntity("Thing"); // gets Transform + Tag
+        entity.AddComponent<DirectionalLightComponent>();
+        m_EntityUuid = static_cast<u64>(entity.GetUUID());
+
+        ToolDef tool;
+        tool.Name = "olo_entity_set_field";
+        tool.Description = "Set any registered component field (fake; test wiring).";
+        tool.ProjectWrite = true;
+        tool.InputSchema = GFW::InputSchema();
+        tool.Handler = [this](McpServer& server, const Json& args) -> ToolResult
+        {
+            u64 entityUuid = 0;
+            std::string component;
+            std::string field;
+            Json value;
+            if (const auto error = GFW::ParseArgs(args, entityUuid, component, field, value))
+                return ToolResult::Error(*error);
+
+            const bool isPlaying = server.Context().IsPlaying && server.Context().IsPlaying();
+            if (isPlaying)
+            {
+                const GFW::ApplyResult applied = GFW::ApplyDirect(m_Scene, entityUuid, component, field, value);
+                if (!applied.Ok)
+                    return ToolResult::Error(applied.Error);
+                return ToolResult::Text(applied.Data.dump());
+            }
+
+            CommandHistory* history = server.Context().GetCommandHistory ? server.Context().GetCommandHistory() : nullptr;
+            if (!history)
+                return ToolResult::Error("No editor command history available.");
+            const GFW::ApplyResult applied = GFW::Apply(m_Scene, *history, entityUuid, component, field, value);
+            if (!applied.Ok)
+                return ToolResult::Error(applied.Error);
+            return ToolResult::Text(applied.Data.dump());
+        };
+        m_Server.RegisterTool(std::move(tool));
+    }
+
+    // GetCommandHistory is deliberately left unset, matching the real editor
+    // nulling CommandHistory for the duration of Play.
+    static EditorMcpContext MakeContext()
+    {
+        EditorMcpContext context;
+        context.IsPlaying = []
+        { return true; };
+        return context;
+    }
+
+    Ref<Scene> m_Scene = Ref<Scene>::Create();
+    u64 m_EntityUuid = 0;
+    McpServer m_Server;
+};
+
+TEST_F(McpGenericFieldWritePlayModeTest, WritesLiveComponentWithoutCommandHistory)
+{
+    m_Server.SetAllowWrites(true);
+
+    const Json resp = m_Server.HandleMessage(MakeCallRequest(
+        1, Json{ { "entity", std::to_string(m_EntityUuid) }, { "component", "DirectionalLightComponent" }, { "field", "Intensity" }, { "value", Json(3.0) } }));
+
+    ASSERT_TRUE(resp.contains("result"));
+    EXPECT_FALSE(resp.contains("error"));
+    EXPECT_FALSE(resp["result"]["isError"]);
+
+    EXPECT_FLOAT_EQ((*m_Scene->TryGetEntityWithUUID(UUID(m_EntityUuid))).GetComponent<DirectionalLightComponent>().m_Intensity, 3.0f);
+
+    const Json data = Json::parse(resp["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(data["changed"].get<bool>());
+    EXPECT_FALSE(data["undoable"].get<bool>());
+}
+
 // ---- the shared coercion (CoerceJson<F>) -----------------------------------
 
 TEST(McpGenericFieldWriteCoerce, Primitives)

--- a/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
+++ b/OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp
@@ -44,9 +44,11 @@
 
 namespace
 {
+    using OloEngine::AudioSourceComponent;
     using OloEngine::CommandHistory;
     using OloEngine::DirectionalLightComponent;
     using OloEngine::Entity;
+    using OloEngine::MorphTargetComponent;
     using OloEngine::Ref;
     using OloEngine::Scene;
     using OloEngine::SpriteRendererComponent;
@@ -499,6 +501,55 @@ TEST(McpGenericFieldWriteApplyDirect, MissingEntityIsError)
     const auto result = GFW::ApplyDirect(scene, /*uuid*/ 424242, "TransformComponent", "Scale", Json::array({ 1.0, 1.0, 1.0 }));
     EXPECT_FALSE(result.Ok);
     EXPECT_FALSE(result.Error.empty());
+}
+
+// A setter-expression-backed field (MakeSetterField's ApplyDirect closure) —
+// AudioSourceComponent's Volume lives behind a private cold blob reached only
+// through an OLO_PROPERTY Get/Set pair, so this exercises the "call setFn
+// directly, read back" path rather than MakeFieldAccess's whole-object swap.
+TEST(McpGenericFieldWriteApplyDirect, ChangesSetterBackedFieldWithoutTouchingHistory)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    auto& audio = entity.AddComponent<AudioSourceComponent>();
+    audio.GetConfig().VolumeMultiplier = 1.0f;
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history; // present in the environment; must stay untouched
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "AudioSourceComponent", "Volume", Json(0.4));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["type"], "float");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_FLOAT_EQ(result.Data["previousValue"].get<f32>(), 1.0f);
+    EXPECT_FLOAT_EQ(entity.GetComponent<AudioSourceComponent>().GetConfig().VolumeMultiplier, 0.4f);
+    EXPECT_FALSE(history.CanUndo());
+}
+
+// A map-keyed field (MakeMapKeyField's ApplyKeyedDirect closure), addressed via
+// GFW::ApplyDirect's dotted-key resolution (FindMapKeyed) — the direct-write
+// counterpart of the FindMapKeyed()-driven ApplyKeyed tests in
+// McpFieldRegistryTest.cpp's "map-key addressing" section.
+TEST(McpGenericFieldWriteApplyDirect, ChangesMapKeyedFieldWithoutTouchingHistory)
+{
+    auto scene = Ref<Scene>::Create();
+    Entity entity = scene->CreateEntity("E");
+    auto& morph = entity.AddComponent<MorphTargetComponent>();
+    const u64 uuid = static_cast<u64>(entity.GetUUID());
+    CommandHistory history; // present in the environment; must stay untouched
+
+    ASSERT_FLOAT_EQ(morph.GetWeight("Smile"), 0.0f); // absent key reads as 0
+
+    const auto result = GFW::ApplyDirect(scene, uuid, "MorphTargetComponent", "Weights.Smile", Json(0.75));
+    ASSERT_TRUE(result.Ok) << result.Error;
+    EXPECT_EQ(result.Data["field"], "Weights.Smile");
+    EXPECT_EQ(result.Data["key"], "Smile");
+    EXPECT_EQ(result.Data["type"], "float");
+    EXPECT_TRUE(result.Data["changed"].get<bool>());
+    EXPECT_FALSE(result.Data["undoable"].get<bool>());
+    EXPECT_FLOAT_EQ(result.Data["value"].get<f32>(), 0.75f);
+    EXPECT_FLOAT_EQ(entity.GetComponent<MorphTargetComponent>().GetWeight("Smile"), 0.75f);
+    EXPECT_FALSE(history.CanUndo());
 }
 
 // ---- dispatch seam: Play-mode uses ApplyDirect and never touches CommandHistory


### PR DESCRIPTION
## Summary
- `olo_entity_set_field` used to hard-refuse in Play mode ("No editor command history available.") because it routed through the editor undo `CommandHistory`, which is deliberately null for the duration of Play — blocking an agent from driving/verifying live gameplay state without stopping Play, editing, and restarting.
- `Handle_EntitySetField` (`McpToolsScene.cpp`) now branches on `EditorMcpContext.IsPlaying()`: in Play mode it writes straight into the live component via a new `GenericFieldWrite::ApplyDirect` path (`McpGenericFieldWrite.h`) that reuses the same coerce → range-clamp → no-op-detect core as the undoable `Apply()`, but with no `CommandHistory` involved at all. The result always reports `undoable: false` (forced regardless of `changed`), so a caller can tell at a glance the write won't survive Stop and can't be Ctrl-Z'd.
- Edit-mode behavior is unchanged (same `CommandHistory`-routed path as before).

Closes the "Runtime (Play-mode) field write" capability gap logged in #607.

## Test plan
- [x] `OloEngine/tests/MCP/McpGenericFieldWriteTest.cpp`: new `ApplyDirect` unit-test block (vec3/float/no-op/error paths, confirms a live `CommandHistory` is never touched) plus a `McpGenericFieldWritePlayModeTest` dispatch fixture mirroring the real handler's Play-mode branch end-to-end.
- [x] Full local suite: 513 passed, 1 skipped (`McpHeadlessAttachTest.HostUntilDetached`, expected — needs an interactive host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field updates now work directly on live scene data while the editor is in Play mode.
  * Play-mode updates report the actual applied value and are marked as non-undoable.
  * Existing edit-mode updates continue to support undo and redo.

* **Bug Fixes**
  * Improved validation, type handling, and value reporting for direct field updates.
  * Added support for direct updates to map-keyed fields.

* **Tests**
  * Added coverage for successful, unchanged, and invalid direct field updates, including Play-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->