### PR TITLE
fix(renderer): GTAO black-sky artifact — exact texelFetch HZB depth copy + ULP-tolerant far-plane test

### DIFF
--- a/OloEditor/SandboxProject/EditorPreferences.yaml
+++ b/OloEditor/SandboxProject/EditorPreferences.yaml
@@ -4,7 +4,7 @@ EditorPreferences:
   TranslateSnap: 0.5
   RotateSnap: 45
   ScaleSnap: 0.5
-  CameraFlySpeed: 17.5
+  CameraFlySpeed: 18
   ShowPhysicsColliders: false
   ShowLightGizmos: false
   ShowBoundingBoxes: false
@@ -16,7 +16,7 @@ EditorPreferences:
   FrameRateCap: 0
   FrameTimeSmoothing: 1
   RenderInterpolation: true
-  EnableAutoSave: true
+  EnableAutoSave: false
   AutoSaveIntervalSeconds: 300
   McpAutoStart: false
   McpPort: 7345

--- a/OloEditor/SandboxProject/Sandbox.oloproj
+++ b/OloEditor/SandboxProject/Sandbox.oloproj
@@ -1,5 +1,5 @@
 Project:
   Name: Sandbox
-  StartScene: "Scenes/FoliageGenerationTest.olo"
+  StartScene: "Scenes/ContactShadowTest.olo"
   AssetDirectory: "Assets"
   ScriptModulePath: "Scripts/Binaries/Sandbox-Scripting.dll"

--- a/OloEditor/assets/shaders/compute/GTAO.comp
+++ b/OloEditor/assets/shaders/compute/GTAO.comp
@@ -71,6 +71,14 @@ layout(binding = 5) uniform usampler2D u_HilbertLUT;     // 64x64 R16UI Hilbert 
 #define XE_GTAO_PI                  3.14159265358979
 #define XE_GTAO_HALF_PI             1.57079632679490
 
+// Far-plane (sky) classification tolerance. Never compare a sampled depth
+// against 1.0 exactly: any filtered read of a D24 depth source can
+// legitimately come back a few ULPs below 1.0 (1 D24 ULP ~= 5.96e-8), and an
+// exact >= 1.0 test then treats the entire sky as geometry sitting at the
+// far plane. 1e-6 (~17 ULPs) of slack is far below any depth separation real
+// geometry can have this close to the far plane.
+#define XE_GTAO_FAR_DEPTH_THRESHOLD (1.0 - 1e-6)
+
 // ---------------------------------------------------------------------------
 // Octahedral decode (must match the encoder in forward shaders)
 // Normals are stored in RG16F with range [-1,1] — no remapping needed.
@@ -152,7 +160,7 @@ void main()
     // Sample depth from HZB mip 0 (HZB maps scene UV [0,1] to full texture)
     float deviceZ = SampleHZBDepth(normalizedScreenPos, 0.0);
 
-    if (deviceZ <= 0.0 || deviceZ >= 1.0)
+    if (deviceZ <= 0.0 || deviceZ >= XE_GTAO_FAR_DEPTH_THRESHOLD)
     {
         imageStore(o_AOTerm, pixCoord, vec4(1.0));
         imageStore(o_Edges, pixCoord, vec4(0.0));

--- a/OloEditor/assets/shaders/compute/HZB.comp
+++ b/OloEditor/assets/shaders/compute/HZB.comp
@@ -140,16 +140,22 @@ void main()
     // Mip 0 of this batch: first pass copies scene depth directly, subsequent reduce
     if (u_IsFirstPass != 0)
     {
-        // Scene depth is at viewport size, but bufferUV is computed for
-        // HZB-texel-to-viewport-uv mapping (HZBGenerator.cpp uses
-        // 1 / viewport_size for first-pass DispatchThreadIdToBufferUV).
-        // For HZB texels outside the viewport sub-rect, bufferUV exceeds
-        // 1.0; clamp to u_InputViewportMaxBound = (viewport - 0.5) /
-        // viewport so we read scene depth's edge pixel rather than
-        // sampling outside [0,1] (which would still be CLAMP_TO_EDGE
-        // behaviour but is left explicit for safety).
-        vec2 sampleUV = min(bufferUV, u_InputViewportMaxBound);
-        WriteMip(0, dispatchThreadId, textureLod(u_InputDepth, sampleUV, 0.0).r);
+        // Exact 1:1 copy of scene depth into HZB mip 0 via texelFetch
+        // (integer addressing, no filtering). This MUST NOT be a filtered
+        // textureLod sample: the scene depth is a D24S8 texture whose
+        // sampler is GL_LINEAR, and the hardware's fixed-point depth
+        // filtering can return 1.0 - 1 D24 ULP (0.99999994) for an
+        // exactly-1.0 far-plane texel whenever the computed float UV does
+        // not hit the single-texel fast path. Downstream consumers that
+        // classify sky as depth >= far (GTAO's early-out) then treat the
+        // whole sky as geometry at the far plane, producing black/noisy
+        // AO over the background (viewport-size dependent, appeared after
+        // window maximize). HZB texels beyond the viewport sub-rect clamp
+        // to the depth image's edge texel (matches the previous
+        // u_InputViewportMaxBound clamp semantics).
+        ivec2 srcSize = textureSize(u_InputDepth, 0);
+        ivec2 srcCoord = min(dispatchThreadId, srcSize - ivec2(1));
+        WriteMip(0, dispatchThreadId, texelFetch(u_InputDepth, srcCoord, 0).r);
     }
     else
     {

--- a/OloEditor/assets/shaders/compute/HZB.comp
+++ b/OloEditor/assets/shaders/compute/HZB.comp
@@ -133,11 +133,8 @@ void main()
     // UV of center of this texel in the destination mip
     vec2 bufferUV = (vec2(dispatchThreadId) + vec2(0.5)) * u_DispatchThreadIdToBufferUV;
 
-    // Sample 2x2 from parent mip (or scene depth on first pass)
-    vec4 deviceZ = Gather4(u_InputDepth, bufferUV, float(u_FirstLod - 1));
-    float reducedDepth = Reduce4(deviceZ);
-
     // Mip 0 of this batch: first pass copies scene depth directly, subsequent reduce
+    float reducedDepth;
     if (u_IsFirstPass != 0)
     {
         // Exact 1:1 copy of scene depth into HZB mip 0 via texelFetch
@@ -153,12 +150,24 @@ void main()
         // window maximize). HZB texels beyond the viewport sub-rect clamp
         // to the depth image's edge texel (matches the previous
         // u_InputViewportMaxBound clamp semantics).
+        //
+        // The exact fetch is also this thread's contribution to the shared-
+        // memory reduction below: the first pass writes mip 0 at 1:1 scale,
+        // so thread t covers exactly source texel t and mips 1-3 become the
+        // true reduce of mip 0's quads. Feeding the filtered Gather4 value
+        // instead would make mips 1-3 disagree with mip 0 and reintroduce
+        // the same filter truncation one level up (and, in MIN-reduce mode,
+        // corner averages can exceed the true quad minimum).
         ivec2 srcSize = textureSize(u_InputDepth, 0);
         ivec2 srcCoord = min(dispatchThreadId, srcSize - ivec2(1));
-        WriteMip(0, dispatchThreadId, texelFetch(u_InputDepth, srcCoord, 0).r);
+        reducedDepth = texelFetch(u_InputDepth, srcCoord, 0).r;
+        WriteMip(0, dispatchThreadId, reducedDepth);
     }
     else
     {
+        // Subsequent batches: each thread covers a 2x2 block of the parent
+        // mip (u_DispatchThreadIdToBufferUV = 2 / parentSize), reduced here.
+        reducedDepth = Reduce4(Gather4(u_InputDepth, bufferUV, float(u_FirstLod - 1)));
         WriteMip(0, dispatchThreadId, reducedDepth);
     }
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -243,9 +243,12 @@ namespace OloEngine
                 auto& slot = slots[i];
                 slot.Alive = false;
                 slot.Name.clear();
+                // Increment first, then repair a wrap to 0: Generation 0 is
+                // the "never allocated" sentinel (IsValid() requires > 0), so
+                // an overflow must land on 1, not 0.
+                ++slot.Generation;
                 if (slot.Generation == 0)
                     slot.Generation = 1;
-                ++slot.Generation;
                 freeIndices.push_back(i);
             }
         };

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -409,6 +409,14 @@ namespace OloEngine
             slot.IsPlaceholder = isPlaceholder;
             slot.PlaceholderReason = std::string(placeholderReason);
             slot.PlaceholderWarnedThisFrame = false;
+            // Free-list reuse hands this slot to a DIFFERENT resource, so the
+            // generation must be bumped here, locally — not merely trusted to
+            // have been bumped by whichever free path retired the slot. A
+            // stale cached handle would otherwise resolve silently to the new
+            // occupant's texture instead of failing its generation check.
+            ++slot.Generation;
+            if (slot.Generation == 0)
+                slot.Generation = 1;
             handle.Generation = slot.Generation;
 
             if (handle.Index >= m_PhysicalTextures.size())
@@ -535,6 +543,13 @@ namespace OloEngine
             slot.IsPlaceholder = isPlaceholder;
             slot.PlaceholderReason = std::string(placeholderReason);
             slot.PlaceholderWarnedThisFrame = false;
+            // Free-list reuse hands this slot to a DIFFERENT resource — bump
+            // the generation locally so stale cached handles fail their
+            // generation check instead of silently resolving to the new
+            // occupant's framebuffer (see the texture allocator's twin).
+            ++slot.Generation;
+            if (slot.Generation == 0)
+                slot.Generation = 1;
             handle.Generation = slot.Generation;
 
             if (handle.Index >= m_PhysicalFramebuffers.size())
@@ -728,6 +743,13 @@ namespace OloEngine
             slot.IsPlaceholder = isPlaceholder;
             slot.PlaceholderReason = std::string(placeholderReason);
             slot.PlaceholderWarnedThisFrame = false;
+            // Free-list reuse hands this slot to a DIFFERENT resource — bump
+            // the generation locally so stale cached handles fail their
+            // generation check instead of silently resolving to the new
+            // occupant (see the texture allocator's twin).
+            ++slot.Generation;
+            if (slot.Generation == 0)
+                slot.Generation = 1;
             handle.Generation = slot.Generation;
 
             if (handle.Index >= m_PhysicalBuffers.size())
@@ -1998,6 +2020,10 @@ namespace OloEngine
         u32 index = m_FreeTextureHandleIndices.back();
         m_FreeTextureHandleIndices.pop_back();
         auto& slot = m_TextureHandleSlots[index];
+        // Free-list reuse hands this slot to a DIFFERENT resource — bump the
+        // generation locally so stale cached handles fail their generation
+        // check instead of silently resolving to the new occupant.
+        ++slot.Generation;
         if (slot.Generation == 0)
             slot.Generation = 1;
         slot.Alive = true;
@@ -2110,6 +2136,10 @@ namespace OloEngine
         u32 index = m_FreeFramebufferHandleIndices.back();
         m_FreeFramebufferHandleIndices.pop_back();
         auto& slot = m_FramebufferHandleSlots[index];
+        // Free-list reuse hands this slot to a DIFFERENT resource — bump the
+        // generation locally so stale cached handles fail their generation
+        // check instead of silently resolving to the new occupant.
+        ++slot.Generation;
         if (slot.Generation == 0)
             slot.Generation = 1;
         slot.Alive = true;
@@ -2218,6 +2248,10 @@ namespace OloEngine
         u32 index = m_FreeBufferHandleIndices.back();
         m_FreeBufferHandleIndices.pop_back();
         auto& slot = m_BufferHandleSlots[index];
+        // Free-list reuse hands this slot to a DIFFERENT resource — bump the
+        // generation locally so stale cached handles fail their generation
+        // check instead of silently resolving to the new occupant.
+        ++slot.Generation;
         if (slot.Generation == 0)
             slot.Generation = 1;
         slot.Alive = true;

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
@@ -53,9 +53,12 @@ namespace OloEngine::RenderGraphHandleAllocator
                 auto& slot = slots[staleHandle.Index];
                 slot.Alive = false;
                 slot.Name.clear();
+                // Increment first, then repair a wrap to 0: Generation 0 is
+                // the "never allocated" sentinel (IsValid() requires > 0), so
+                // an overflow must land on 1, not 0.
+                ++slot.Generation;
                 if (slot.Generation == 0)
                     slot.Generation = 1;
-                ++slot.Generation;
                 freeIndices.push_back(staleHandle.Index);
             }
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
@@ -94,6 +94,14 @@ namespace OloEngine::RenderGraphHandleAllocator
             auto& slot = slots[index];
             slot.Alive = true;
             slot.Name = name;
+            // A slot leaving the free list is being handed to a DIFFERENT
+            // resource than whatever it last named, so its generation must be
+            // fresh here, locally — not merely trusted to have been bumped by
+            // whichever free path retired it. Without this, a single free
+            // site that forgets to bump lets a stale cached handle resolve
+            // silently to the new occupant's physical resource instead of
+            // failing its generation check.
+            ++slot.Generation;
             if (slot.Generation == 0)
                 slot.Generation = 1;
 

--- a/OloEngine/tests/Rendering/GTAOMathTest.cpp
+++ b/OloEngine/tests/Rendering/GTAOMathTest.cpp
@@ -4,6 +4,10 @@
 #include <glm/glm.hpp>
 
 #include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
 
 // =============================================================================
 // GTAO — CPU contract tests.
@@ -250,4 +254,103 @@ TEST(GTAOMath, OffCentreViewVecDivergesFromFixedAxis)
     EXPECT_TRUE(foundDivergence)
         << "per-pixel viewVec produced the same basis as a fixed screen axis for an off-centre pixel -- the "
            "perspective-tracking fix has no effect";
+}
+
+// =============================================================================
+// Sky / far-plane classification robustness (GTAO black-background artifact).
+//
+// GTAO's per-pixel early-out classifies "sky" from the HZB mip-0 depth. Two
+// contracts guard the fix for the maximize-then-rotate artifact where the
+// whole background rendered as dark AO garbage:
+//
+//   1. The HZB first pass must copy scene depth into mip 0 with texelFetch
+//      (exact integer addressing). Sampling the D24S8 depth attachment via
+//      textureLod routes through the hardware's FIXED-POINT depth-filter
+//      path, which can return 1.0 - 1 D24 ULP (0.99999994) for a texel that
+//      is exactly 1.0 — in large, viewport-size-dependent regions.
+//   2. GTAO's sky early-out must never compare that depth against 1.0
+//      exactly; it uses a ULP-tolerant threshold so a filtered/truncated
+//      far-plane depth still classifies as sky.
+//
+// The classification test mirrors the shader logic on the CPU; the two
+// shader-source contract tests pin the load-bearing lines of GLSL the same
+// way the serializer coverage tests pin generated code, so a refactor that
+// silently reintroduces a filtered copy or an exact compare fails headless CI.
+// =============================================================================
+
+namespace
+{
+    // CPU mirror of GTAO.comp's sky early-out. Keep in sync with
+    // XE_GTAO_FAR_DEPTH_THRESHOLD in assets/shaders/compute/GTAO.comp.
+    constexpr float kGtaoFarDepthThreshold = 1.0f - 1e-6f;
+
+    bool ClassifiesAsSky(float deviceZ)
+    {
+        return deviceZ <= 0.0f || deviceZ >= kGtaoFarDepthThreshold;
+    }
+
+    std::string ReadRepoFile(const std::filesystem::path& relative)
+    {
+        const auto path = std::filesystem::path{ OLO_TEST_EDITOR_ROOT } / relative;
+        std::ifstream f(path, std::ios::binary);
+        EXPECT_TRUE(f.is_open()) << "cannot open " << path.string();
+        std::ostringstream buf;
+        buf << f.rdbuf();
+        return buf.str();
+    }
+} // namespace
+
+TEST(GTAOMath, FarPlaneClassificationToleratesFilteredDepthUlps)
+{
+    // Exact far-plane clear value.
+    EXPECT_TRUE(ClassifiesAsSky(1.0f));
+    // One float32 ULP below 1.0 — what a float round-trip can produce.
+    EXPECT_TRUE(ClassifiesAsSky(std::nextafter(1.0f, 0.0f)));
+    // One D24 ULP below 1.0 — what the fixed-point depth filter produced in
+    // the observed artifact (0.99999994).
+    EXPECT_TRUE(ClassifiesAsSky(1.0f - 1.0f / 16777215.0f));
+    // A few D24 ULPs of accumulated error must still classify as sky.
+    EXPECT_TRUE(ClassifiesAsSky(1.0f - 5.0f / 16777215.0f));
+    // Depth zero / negative garbage is also the early-out.
+    EXPECT_TRUE(ClassifiesAsSky(0.0f));
+    // Real geometry meaningfully in front of the far plane must NOT be sky.
+    EXPECT_FALSE(ClassifiesAsSky(0.9999f));
+    EXPECT_FALSE(ClassifiesAsSky(0.5f));
+}
+
+TEST(GTAOMath, GtaoShaderSkyEarlyOutIsUlpTolerant)
+{
+    const std::string src = ReadRepoFile(std::filesystem::path{ "assets" } / "shaders" / "compute" / "GTAO.comp");
+    ASSERT_FALSE(src.empty());
+    // The threshold must exist and be used by the early-out.
+    EXPECT_NE(src.find("XE_GTAO_FAR_DEPTH_THRESHOLD"), std::string::npos)
+        << "GTAO.comp lost its ULP-tolerant far-depth threshold";
+    EXPECT_NE(src.find("deviceZ >= XE_GTAO_FAR_DEPTH_THRESHOLD"), std::string::npos)
+        << "GTAO.comp's sky early-out no longer uses the tolerant threshold";
+    // The exact-compare regression this guards against.
+    EXPECT_EQ(src.find("deviceZ >= 1.0)"), std::string::npos)
+        << "GTAO.comp compares sampled depth against 1.0 exactly again — filtered far-plane "
+           "depth (1.0 - 1 D24 ULP) will classify as geometry and blacken the sky";
+}
+
+TEST(GTAOMath, HzbShaderFirstPassCopiesDepthWithTexelFetch)
+{
+    const std::string src = ReadRepoFile(std::filesystem::path{ "assets" } / "shaders" / "compute" / "HZB.comp");
+    ASSERT_FALSE(src.empty());
+
+    // Isolate the first-pass branch (mip-0 1:1 copy of scene depth).
+    const auto firstPassBegin = src.find("if (u_IsFirstPass != 0)");
+    ASSERT_NE(firstPassBegin, std::string::npos);
+    const auto firstPassEnd = src.find("else", firstPassBegin);
+    ASSERT_NE(firstPassEnd, std::string::npos);
+    const std::string firstPass = src.substr(firstPassBegin, firstPassEnd - firstPassBegin);
+
+    EXPECT_NE(firstPass.find("texelFetch("), std::string::npos)
+        << "HZB.comp's first pass no longer copies scene depth with texelFetch — a filtered "
+           "textureLod read of the D24S8 depth can truncate exact-1.0 far-plane depth by one "
+           "D24 ULP and downstream sky classification breaks";
+    // Match the call syntax specifically -- the explanatory comment in the
+    // shader legitimately mentions textureLod in prose.
+    EXPECT_EQ(firstPass.find("textureLod("), std::string::npos)
+        << "HZB.comp's first pass samples scene depth through the filtering path again";
 }


### PR DESCRIPTION
## Problem

After an OS window maximize, rotating the editor camera showed the white background rendering as large black wedges with checkered patches (and the floor over-darkened) whenever **GTAO** was enabled with **fog off** and **FSR off** — both forward and deferred paths. Once triggered, the artifact was pose-independent and persisted for the whole session; a fresh launch at the same window size was clean.

## Root cause

`HZB.comp`'s first pass copied the D24S8 scene depth into HZB mip 0 with a filtered `textureLod` sample. The depth attachment's sampler is `GL_LINEAR`, and the hardware's **fixed-point depth filter truncates an exactly-1.0 far-plane depth to 1.0 − 1 D24 ULP (0.99999994)** across large viewport-size/state-dependent regions (which is why the OS-maximize resize triggered it and why it was width-dependent). `GTAO.comp`'s sky early-out compared `deviceZ >= 1.0` **exactly**, so the entire sky was classified as geometry sitting at the far plane → garbage AO composited over the background. Fog/FSR/SSAO "hiding" the bug were red herrings (fog paints over the sky, FSR changes the render width, SSAO doesn't use the HZB).

This is the GPU flavour of the repo's own float rule: never exact-compare a filtered depth read.

## Fix

- **HZB.comp**: first-pass mip-0 copy now uses `texelFetch` (exact integer addressing — immune to sampler filter state and UV rounding), which is what the surrounding comments always claimed it intended.
- **GTAO.comp**: sky early-out uses `XE_GTAO_FAR_DEPTH_THRESHOLD (1.0 − 1e-6)` — ~17 ULPs of tolerance, still far tighter than any real geometry can approach the far plane.

## Hardening (found during the investigation)

All free-list handle-slot **reuse** sites in `RenderGraph.cpp` / `RenderGraphHandleAllocator.h` now bump the slot generation locally when a slot is handed to a different resource, instead of trusting every free path to have bumped it. A stale cached handle now fails its generation check rather than silently resolving to the slot's new occupant. (Stable-by-name handle reuse is untouched.)

## Verification

- Live repro (maximize + thorough rotation) clean, user-confirmed.
- Numeric MCP probes at the previously-broken viewport size (4239×2232): **zero** 1-ULP-contaminated HZB texels; sky AO exactly 1.0.
- New regression tests in `GTAOMathTest.cpp` (layer `shaderpipe`, headless CI): CPU mirror of the far-plane classification across ULP cases + shader-source contracts pinning the `texelFetch` copy and the tolerant threshold.
- 351 render-graph/determinism/path-switch tests, all 10 `GTAOMath` tests, and `GTAOVisualEvidenceTest.GTAODarkensContactsNotFlatSurfacesOrSky` (GPU) pass.

Also included: sandbox `StartScene` now points at the repro scene (`ContactShadowTest.olo`) and editor auto-save is disabled in `EditorPreferences.yaml` (its scene-switch crash interfered with the investigation — kept deliberately per review).

MCP capability gaps that made this hunt slow are logged on #607 (texel-space probe addressing, as-of-pass capture, per-pass resolved GL IDs in the topology export, float-exact target stats, `olo_render_validate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ambient occlusion handling for sky and far-plane pixels, reducing artifacts caused by depth precision.
  * Improved hierarchical depth generation by using precise, unfiltered depth reads.
  * Prevented stale rendering handles from resolving to reused resources.

* **Editor Improvements**
  * Increased camera fly speed slightly.
  * Disabled automatic saving by default.
  * Updated the project’s starting scene to the Contact Shadow test scene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->