### PR TITLE
Add unit tests for MCP render probe pixel, target stats, and validation

### DIFF
--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -12,6 +12,8 @@
 		"MCP/McpToolsCommon.h"
 		"MCP/McpClusterGridStats.h"
 		"MCP/McpRenderProbePixel.h"
+		"MCP/McpRenderTargetStats.h"
+		"MCP/McpRenderValidate.h"
 		"MCP/McpFroxelFogProbe.h"
 		"MCP/McpShadowCapture.h"
 		"MCP/McpInputInject.h"

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -3282,6 +3282,19 @@ namespace OloEngine
         // olo_scene_open, and the auto-save pre-answered paths that share this finalizer.
         ApplyRendererSettingsToGraph();
 
+        // A direct scene load supersedes any ARMED auto-save recovery (issue
+        // #607): an olo_scene_open (or File > Open) while the recovery modal
+        // is up would otherwise leave m_PendingRecovery* pointing at the
+        // previous scene, and a later modal button click would silently swap
+        // the just-opened scene back out — the "scene randomly reverted" race.
+        // Clearing m_ShowAutoSaveRecovery alone is not enough once the popup
+        // has opened; the cancel flag makes UI_AutoSaveRecoveryModal close it
+        // without loading.
+        m_ShowAutoSaveRecovery = false;
+        m_CancelAutoSaveRecovery = true;
+        m_PendingRecoveryScenePath.clear();
+        m_PendingRecoveryAutoPath.clear();
+
         m_TimeSinceLastAutoSave = 0.0f;
         return true;
     }
@@ -3485,11 +3498,25 @@ namespace OloEngine
         {
             ImGui::OpenPopup("Recover Auto-Save?");
             m_ShowAutoSaveRecovery = false; // Only open once; the popup stays open until user picks
+            // A fresh modal must not be closed by a cancel raised against an
+            // EARLIER recovery (issue #607) — consume any stale flag now.
+            m_CancelAutoSaveRecovery = false;
         }
 
         ImGui::SetNextWindowSize(ImVec2(480, 0), ImGuiCond_FirstUseEver);
         if (ImGui::BeginPopupModal("Recover Auto-Save?", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse))
         {
+            // A direct scene load (olo_scene_open / File > Open) superseded
+            // this recovery while the modal was up: close WITHOUT loading —
+            // the pending paths now reference a scene the user already
+            // navigated away from (issue #607).
+            if (m_CancelAutoSaveRecovery)
+            {
+                m_CancelAutoSaveRecovery = false;
+                ImGui::CloseCurrentPopup();
+                ImGui::EndPopup();
+                return;
+            }
             ImGui::TextWrapped("An auto-save file was found that is newer than the saved scene:");
             ImGui::Spacing();
             ImGui::TextWrapped("%s", m_PendingRecoveryAutoPath.filename().string().c_str());

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -392,6 +392,11 @@ namespace OloEngine
         // Auto-save
         f32 m_TimeSinceLastAutoSave = 0.0f;
         bool m_ShowAutoSaveRecovery = false;
+        // Set when a direct scene load supersedes an armed recovery (issue
+        // #607): the already-open modal must close WITHOUT loading, or its
+        // deferred load would swap the just-opened scene back out. Cleared
+        // whenever a fresh modal opens.
+        bool m_CancelAutoSaveRecovery = false;
         std::filesystem::path m_PendingRecoveryScenePath;
         std::filesystem::path m_PendingRecoveryAutoPath;
 

--- a/OloEditor/src/MCP/McpRenderGraphTopology.h
+++ b/OloEditor/src/MCP/McpRenderGraphTopology.h
@@ -67,6 +67,20 @@ namespace OloEngine::MCP::RenderGraphTopology
         bool HasExternalBacking = false; // resolves to caller-supplied frame-local backing
         std::vector<std::string> Producers;
         std::vector<std::string> Consumers;
+
+        // Resolved physical GL object ids, as of the last executed frame
+        // (issue #607) — the one-call answer to "do these two passes touch
+        // the same physical texture this frame". 0 = unbacked / not that
+        // kind. Texture VIEWS resolve to their PARENT texture object;
+        // ViewOfParentLayer carries the layer a layer/face view addresses.
+        // Transient ids are only meaningful within the frame they were
+        // resolved in (the transient pool memory-aliases across frames).
+        u32 GLTextureId = 0;
+        u32 GLFramebufferId = 0;
+        u32 GLBufferId = 0;
+        u32 GLDepthAttachmentId = 0;
+        std::vector<u32> GLColorAttachmentIds;
+        u32 ViewOfParentLayer = 0;
     };
 
     // The whole-graph snapshot the handler gathers off the live RenderGraph.
@@ -83,17 +97,78 @@ namespace OloEngine::MCP::RenderGraphTopology
     // default. Counts are reported alongside each array so a truncating client can
     // tell the full size, and a trailing `note` documents the edge / culled / final
     // semantics for the reader.
+    // The "gl" sub-object of one resource: every resolved id that is set.
+    // Returns an empty (null) Json when the resource has no resolved backing.
+    [[nodiscard]] inline Json ResourceGLJson(const ResourceInfo& r)
+    {
+        Json gl;
+        if (r.GLTextureId != 0)
+            gl["textureId"] = r.GLTextureId;
+        if (r.GLFramebufferId != 0)
+            gl["framebufferId"] = r.GLFramebufferId;
+        if (!r.GLColorAttachmentIds.empty())
+            gl["colorAttachmentIds"] = r.GLColorAttachmentIds;
+        if (r.GLDepthAttachmentId != 0)
+            gl["depthAttachmentId"] = r.GLDepthAttachmentId;
+        if (r.GLBufferId != 0)
+            gl["bufferId"] = r.GLBufferId;
+        if (r.ViewOfParentLayer != 0)
+            gl["viewOfParentLayer"] = r.ViewOfParentLayer;
+        return gl;
+    }
+
+    // The physical texture id a pass ACCESSES through this resource: the
+    // resolved texture for texture kinds, otherwise the framebuffer's first
+    // colour attachment (or depth attachment for depth-only targets) — the
+    // same physical-identity rule the capture tools use. 0 when unbacked.
+    [[nodiscard]] inline u32 AccessedPhysicalTextureId(const ResourceInfo& r)
+    {
+        if (r.GLTextureId != 0)
+            return r.GLTextureId;
+        if (!r.GLColorAttachmentIds.empty() && r.GLColorAttachmentIds.front() != 0)
+            return r.GLColorAttachmentIds.front();
+        return r.GLDepthAttachmentId;
+    }
+
     [[nodiscard]] inline Json BuildJson(const Snapshot& snap)
     {
+        // Per-pass access lists (issue #607): invert each resource's
+        // producers/consumers so a pass entry lists every resource it writes
+        // or reads WITH the resolved physical id — "do these two passes touch
+        // the same physical texture this frame" becomes a single lookup.
+        std::unordered_map<std::string, Json> accessesByPass;
+        const auto appendAccess = [&accessesByPass](const std::string& pass, const ResourceInfo& r, const char* mode)
+        {
+            Json access;
+            access["resource"] = r.Name;
+            access["mode"] = mode;
+            if (const u32 physicalId = AccessedPhysicalTextureId(r); physicalId != 0)
+                access["glTextureId"] = physicalId;
+            if (r.GLBufferId != 0)
+                access["glBufferId"] = r.GLBufferId;
+            auto [it, inserted] = accessesByPass.try_emplace(pass, Json::array());
+            it->second.push_back(std::move(access));
+        };
+        for (const auto& r : snap.Resources)
+        {
+            for (const auto& producer : r.Producers)
+                appendAccess(producer, r, "write");
+            for (const auto& consumer : r.Consumers)
+                appendAccess(consumer, r, "read");
+        }
+
         Json passes = Json::array();
         for (const auto& p : snap.Passes)
         {
-            passes.push_back(Json{ { "name", p.Name },
-                                   { "workType", p.WorkType },
-                                   { "declaresResources", p.DeclaresResources },
-                                   { "asyncComputeCandidate", p.AsyncComputeCandidate },
-                                   { "culled", p.Culled },
-                                   { "isFinalPass", p.IsFinalPass } });
+            Json pass = Json{ { "name", p.Name },
+                              { "workType", p.WorkType },
+                              { "declaresResources", p.DeclaresResources },
+                              { "asyncComputeCandidate", p.AsyncComputeCandidate },
+                              { "culled", p.Culled },
+                              { "isFinalPass", p.IsFinalPass } };
+            if (const auto it = accessesByPass.find(p.Name); it != accessesByPass.end())
+                pass["accesses"] = it->second;
+            passes.push_back(std::move(pass));
         }
 
         Json edges = Json::array();
@@ -119,6 +194,8 @@ namespace OloEngine::MCP::RenderGraphTopology
             e["hasExternalBacking"] = r.HasExternalBacking;
             e["producers"] = r.Producers;
             e["consumers"] = r.Consumers;
+            if (Json gl = ResourceGLJson(r); !gl.is_null() && !gl.empty())
+                e["gl"] = std::move(gl);
             resources.push_back(std::move(e));
         }
 
@@ -135,7 +212,11 @@ namespace OloEngine::MCP::RenderGraphTopology
                       "execution-ordering dependencies (from must run before to). 'executionOrder' is the "
                       "topologically-sorted run order. 'culled' passes were unreachable from the final pass "
                       "this frame and are skipped. Each resource's 'producers' write it and 'consumers' read "
-                      "it. Use format:\"mermaid\" for a flowchart DAG of the pass graph.";
+                      "it. Each resource's 'gl' (and each pass access's glTextureId) is the RESOLVED physical "
+                      "GL object id as of the last executed frame — two passes whose accesses share an id "
+                      "touch the same physical texture; texture views resolve to their parent object "
+                      "(see viewOfParentLayer); transient ids are only meaningful within one frame. "
+                      "Use format:\"mermaid\" for a flowchart DAG of the pass graph.";
         return out;
     }
 

--- a/OloEditor/src/MCP/McpRenderProbePixel.h
+++ b/OloEditor/src/MCP/McpRenderProbePixel.h
@@ -50,6 +50,140 @@ namespace OloEngine::MCP::ProbePixel
         Int = 1
     };
 
+    // ---- Coordinate mapping (issue #607: space:"texel" + mappedCoord) -----
+    //
+    // The GTAO hunt's motivating failure: probing the HZB pow2 pyramid with
+    // viewport coordinates silently read the wrong texel, because the tool
+    // applied the requested x/y RAW to a resource whose size differs from the
+    // viewport. Two explicit spaces replace that guesswork, and every probe
+    // reply now echoes the exact texel it read (mappedCoord).
+    enum class ProbeSpace : u8
+    {
+        // x/y are viewport pixels (top-left origin, the screenshot
+        // convention), mapped PROPORTIONALLY onto the target mip:
+        // texel = floor((coord + 0.5) / refSize * mipSize). Identity for a
+        // full-res mip-0 target (the G-Buffer), "same visual location" for a
+        // half-res AO buffer. WRONG for padded resources (the HZB pyramid,
+        // where content sits 1:1 in a pow2-padded extent) — use Texel there.
+        Viewport = 0,
+        // x/y are EXACT texel coordinates of the target at the requested mip,
+        // top-left origin — the same orientation as a capture PNG of that
+        // resource+mip, so a pixel picked off a capture image addresses the
+        // texel the agent actually pointed at. No scaling of any kind.
+        Texel = 1,
+    };
+
+    [[nodiscard]] inline const char* ProbeSpaceToken(ProbeSpace space) noexcept
+    {
+        return space == ProbeSpace::Texel ? "texel" : "viewport";
+    }
+
+    [[nodiscard]] inline bool ParseProbeSpace(std::string_view token, ProbeSpace& out) noexcept
+    {
+        if (token == "viewport")
+            out = ProbeSpace::Viewport;
+        else if (token == "texel")
+            out = ProbeSpace::Texel;
+        else
+            return false;
+        return true;
+    }
+
+    // The resolved texel a probe actually read — echoed in every reply so the
+    // requested-coordinate -> texel mapping is never guesswork.
+    struct CoordMapping
+    {
+        bool Valid = false;
+        std::string Error; // set when !Valid (out of bounds / bad mip / degenerate reference)
+        ProbeSpace Space = ProbeSpace::Viewport;
+        u32 RequestedX = 0; // the caller's x/y, in `Space`
+        u32 RequestedY = 0;
+        u32 TexelX = 0;        // texel column at `Mip`, top-left origin
+        u32 TexelY = 0;        // texel row at `Mip`, top-left origin
+        u32 GLRowBottomUp = 0; // the GL row actually read (GL rows run bottom-up)
+        u32 Mip = 0;
+        u32 MipWidth = 0;
+        u32 MipHeight = 0;
+    };
+
+    // Map a requested (x, y) in `space` onto an exact texel of a `mipWidth` x
+    // `mipHeight` mip level. `refWidth`/`refHeight` are the viewport-space
+    // reference dimensions (the render size the screenshot shows); unused in
+    // texel space. Pure math — unit-tested headlessly.
+    [[nodiscard]] inline CoordMapping MapProbeCoord(ProbeSpace space, u32 x, u32 y,
+                                                    u32 refWidth, u32 refHeight,
+                                                    u32 mipWidth, u32 mipHeight, u32 mip) noexcept
+    {
+        CoordMapping m;
+        m.Space = space;
+        m.RequestedX = x;
+        m.RequestedY = y;
+        m.Mip = mip;
+        m.MipWidth = mipWidth;
+        m.MipHeight = mipHeight;
+
+        if (mipWidth == 0 || mipHeight == 0)
+        {
+            m.Error = "The target has no storage at mip " + std::to_string(mip) + ".";
+            return m;
+        }
+
+        if (space == ProbeSpace::Texel)
+        {
+            if (x >= mipWidth || y >= mipHeight)
+            {
+                m.Error = "Texel (" + std::to_string(x) + ", " + std::to_string(y) + ") is outside mip " +
+                          std::to_string(mip) + " (" + std::to_string(mipWidth) + "x" + std::to_string(mipHeight) +
+                          ").";
+                return m;
+            }
+            m.TexelX = x;
+            m.TexelY = y;
+        }
+        else
+        {
+            if (refWidth == 0 || refHeight == 0)
+            {
+                m.Error = "The viewport reference size is unknown; probe with space:\"texel\" instead.";
+                return m;
+            }
+            if (x >= refWidth || y >= refHeight)
+            {
+                m.Error = "Viewport pixel (" + std::to_string(x) + ", " + std::to_string(y) +
+                          ") is outside the viewport (" + std::to_string(refWidth) + "x" +
+                          std::to_string(refHeight) + ").";
+                return m;
+            }
+            // Pixel-centre proportional mapping; clamped so the last viewport
+            // row/column never rounds past the mip edge.
+            const f64 u = (static_cast<f64>(x) + 0.5) / static_cast<f64>(refWidth);
+            const f64 v = (static_cast<f64>(y) + 0.5) / static_cast<f64>(refHeight);
+            m.TexelX = std::min(static_cast<u32>(u * static_cast<f64>(mipWidth)), mipWidth - 1u);
+            m.TexelY = std::min(static_cast<u32>(v * static_cast<f64>(mipHeight)), mipHeight - 1u);
+        }
+
+        m.GLRowBottomUp = mipHeight - 1u - m.TexelY;
+        m.Valid = true;
+        return m;
+    }
+
+    [[nodiscard]] inline Json CoordMappingJson(const CoordMapping& m)
+    {
+        Json j;
+        j["space"] = ProbeSpaceToken(m.Space);
+        j["requested"] = Json::array({ m.RequestedX, m.RequestedY });
+        if (m.Valid)
+        {
+            j["texel"] = Json::array({ m.TexelX, m.TexelY });
+            j["glRowBottomUp"] = m.GLRowBottomUp;
+        }
+        j["mip"] = m.Mip;
+        j["mipWidth"] = m.MipWidth;
+        j["mipHeight"] = m.MipHeight;
+        j["origin"] = "top-left";
+        return j;
+    }
+
     // One 1x1 readback of one render-graph target. `Available` false means the
     // target did not exist this frame (wrong rendering path, effect disabled,
     // no frame rendered yet) — `Unavailable` then carries the reason and the
@@ -64,8 +198,14 @@ namespace OloEngine::MCP::ProbePixel
         i32 Channels = 0;
         std::array<f32, 4> F{ 0.0f, 0.0f, 0.0f, 0.0f };
         std::array<i32, 4> I{ 0, 0, 0, 0 };
-        u32 SourceWidth = 0;
+        u32 SourceWidth = 0; // dims of the mip actually probed
         u32 SourceHeight = 0;
+        // The exact texel this sample read (issue #607) — echoed in the reply
+        // as "mappedCoord" so the requested-coord -> texel mapping is never
+        // guesswork. Layer is the GL z-offset applied (a CSM cascade view's
+        // own layer, or the caller's layer selector).
+        CoordMapping Mapped;
+        u32 Layer = 0;
     };
 
     // Octahedral decode — the EXACT inverse of octEncodeGB() in PBR_GBuffer.glsl
@@ -162,6 +302,16 @@ namespace OloEngine::MCP::ProbePixel
         Json j;
         j["available"] = sample.Available;
         j["target"] = sample.Target;
+        // The exact texel read (or the mapping failure) — issue #607. Present
+        // even for unavailable samples whenever a mapping was attempted, so
+        // an out-of-bounds probe shows WHERE it would have read.
+        if (sample.Mapped.MipWidth > 0 || sample.Mapped.MipHeight > 0 || sample.Mapped.Valid)
+        {
+            Json mapped = CoordMappingJson(sample.Mapped);
+            if (sample.Layer != 0)
+                mapped["layer"] = sample.Layer;
+            j["mappedCoord"] = std::move(mapped);
+        }
         if (!sample.Available)
         {
             j["reason"] = sample.Unavailable;

--- a/OloEditor/src/MCP/McpRenderTargetStats.h
+++ b/OloEditor/src/MCP/McpRenderTargetStats.h
@@ -1,0 +1,233 @@
+#pragma once
+
+// Pure stats math + JSON shaping for the olo_render_target_stats MCP tool
+// (issue #607): exact float min/max/mean + a unique-value histogram over a
+// rect of one render-graph target.
+//
+// The motivating failure: 8-bit PNG captures hide 1-ULP corruption — 1.0 and
+// 0.99999994 both encode as 255 — so mapping a corrupt HZB region during the
+// GTAO hunt took hundreds of single-pixel probe round-trips. One stats call
+// answers "is this region EXACTLY 1.0f, and if not, what distinct values does
+// it hold and how often" bit-exactly.
+//
+// The handler in McpToolsRender.cpp does the GL-bound work on the main thread
+// (resolve the target, glGetTextureSubImage the rect at the requested mip) and
+// hands the decoded channel-interleaved values here. Everything below is free
+// functions over PODs with NO GL / renderer / editor dependency, so the math
+// (bit-exact uniqueness, finite-only min/max/mean, truncation behavior) is
+// unit-tested headlessly — the same split McpRenderProbePixel.h uses.
+//
+// Only Core/Base.h (the u32/f32/... typedefs) and nlohmann::json are pulled
+// in; everything else is the standard library.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace OloEngine::MCP::RenderTargetStats
+{
+    using Json = nlohmann::json;
+
+    // Distinct-bit-pattern cap: past this many unique values the histogram
+    // stops admitting NEW keys (already-tracked keys keep counting) and the
+    // result is flagged truncated. 64k distinct floats is far beyond any
+    // "is this buffer quantized / corrupted" question; an untruncated answer
+    // for a genuinely continuous buffer would just be noise.
+    inline constexpr u32 kMaxUniqueValues = 65536;
+
+    // How many of the most frequent distinct values the reply lists.
+    inline constexpr u32 kTopValueCount = 16;
+
+    struct ValueCount
+    {
+        f32 Value = 0.0f; // bit-exact representative (bit_cast of the key)
+        u32 Count = 0;
+    };
+
+    struct ChannelStats
+    {
+        u32 FiniteCount = 0;
+        u32 NaNCount = 0;
+        u32 InfCount = 0;
+        // Finite-only extrema/mean. Meaningless when FiniteCount == 0.
+        f64 Min = 0.0;
+        f64 Max = 0.0;
+        f64 Mean = 0.0;
+        u32 UniqueValueCount = 0; // distinct bit patterns seen (incl. non-finite)
+        bool UniqueTruncated = false;
+        std::vector<ValueCount> TopValues; // most frequent first; ties by value
+    };
+
+    // Bit-exact stats over one channel's values. NaNs with different payloads
+    // count as distinct bit patterns but are all excluded from min/max/mean.
+    [[nodiscard]] inline ChannelStats ComputeChannelStats(const std::vector<f32>& values)
+    {
+        ChannelStats stats;
+        std::unordered_map<u32, u32> counts;
+        counts.reserve(std::min<sizet>(values.size(), kMaxUniqueValues));
+
+        f64 sum = 0.0;
+        for (const f32 value : values)
+        {
+            const u32 bits = std::bit_cast<u32>(value);
+            if (const auto it = counts.find(bits); it != counts.end())
+                ++it->second;
+            else if (counts.size() < kMaxUniqueValues)
+                counts.emplace(bits, 1u);
+            else
+                stats.UniqueTruncated = true;
+
+            if (std::isnan(value))
+            {
+                ++stats.NaNCount;
+                continue;
+            }
+            if (std::isinf(value))
+            {
+                ++stats.InfCount;
+                continue;
+            }
+            ++stats.FiniteCount;
+            const f64 v = static_cast<f64>(value);
+            if (stats.FiniteCount == 1u)
+            {
+                stats.Min = v;
+                stats.Max = v;
+            }
+            else
+            {
+                stats.Min = std::min(stats.Min, v);
+                stats.Max = std::max(stats.Max, v);
+            }
+            sum += v;
+        }
+        if (stats.FiniteCount > 0)
+            stats.Mean = sum / static_cast<f64>(stats.FiniteCount);
+
+        stats.UniqueValueCount = static_cast<u32>(counts.size());
+
+        std::vector<ValueCount> top;
+        top.reserve(counts.size());
+        for (const auto& [bits, count] : counts)
+            top.push_back(ValueCount{ std::bit_cast<f32>(bits), count });
+        std::sort(top.begin(), top.end(),
+                  [](const ValueCount& a, const ValueCount& b)
+                  {
+                      if (a.Count != b.Count)
+                          return a.Count > b.Count;
+                      // Deterministic tie-break on the bit pattern (never
+                      // compare NaN-containing floats with operator<).
+                      return std::bit_cast<u32>(a.Value) < std::bit_cast<u32>(b.Value);
+                  });
+        if (top.size() > kTopValueCount)
+            top.resize(kTopValueCount);
+        stats.TopValues = std::move(top);
+        return stats;
+    }
+
+    [[nodiscard]] inline Json ChannelStatsJson(const ChannelStats& stats, std::string_view channelName)
+    {
+        Json j;
+        j["channel"] = std::string(channelName);
+        j["finiteCount"] = stats.FiniteCount;
+        if (stats.NaNCount > 0)
+            j["nanCount"] = stats.NaNCount;
+        if (stats.InfCount > 0)
+            j["infCount"] = stats.InfCount;
+        if (stats.FiniteCount > 0)
+        {
+            j["min"] = stats.Min;
+            j["max"] = stats.Max;
+            j["mean"] = stats.Mean;
+        }
+        j["uniqueValues"] = stats.UniqueValueCount;
+        if (stats.UniqueTruncated)
+        {
+            j["uniqueTruncated"] = true;
+            j["uniqueNote"] = "More than " + std::to_string(kMaxUniqueValues) +
+                              " distinct bit patterns; uniqueValues is a lower bound and topValues only "
+                              "covers the patterns seen before the cap.";
+        }
+        Json top = Json::array();
+        for (const auto& vc : stats.TopValues)
+        {
+            Json entry;
+            // NaN/Inf are not representable in JSON numbers — encode the
+            // exact bit pattern instead, plus a readable token.
+            if (std::isfinite(vc.Value))
+                entry["value"] = vc.Value;
+            else
+                entry["value"] = std::isnan(vc.Value) ? "NaN" : (vc.Value > 0.0f ? "+Inf" : "-Inf");
+            entry["bits"] = std::bit_cast<u32>(vc.Value);
+            entry["count"] = vc.Count;
+            top.push_back(std::move(entry));
+        }
+        j["topValues"] = std::move(top);
+        return j;
+    }
+
+    // Channel letter for interleaved data ("r", "g", "b", "a").
+    [[nodiscard]] inline const char* ChannelName(const i32 channel) noexcept
+    {
+        switch (channel)
+        {
+            case 0:
+                return "r";
+            case 1:
+                return "g";
+            case 2:
+                return "b";
+            case 3:
+                return "a";
+            default:
+                return "?";
+        }
+    }
+
+    // De-interleave channel `channel` out of `interleaved` (texel-major,
+    // `channels` values per texel) — the shape glGetTextureSubImage returns.
+    [[nodiscard]] inline std::vector<f32> ExtractChannel(const std::vector<f32>& interleaved,
+                                                         const i32 channels, const i32 channel)
+    {
+        std::vector<f32> values;
+        if (channels <= 0 || channel < 0 || channel >= channels)
+            return values;
+        values.reserve(interleaved.size() / static_cast<sizet>(channels));
+        for (sizet i = static_cast<sizet>(channel); i < interleaved.size(); i += static_cast<sizet>(channels))
+            values.push_back(interleaved[i]);
+        return values;
+    }
+
+    // The whole reply body (the handler appends "meta" itself).
+    [[nodiscard]] inline Json BuildStatsJson(const std::string& name, const std::string& format,
+                                             u32 rectX, u32 rectY, u32 rectW, u32 rectH,
+                                             u32 mip, u32 mipWidth, u32 mipHeight, u32 layer,
+                                             const std::vector<f32>& interleaved, const i32 channels)
+    {
+        Json j;
+        j["name"] = name;
+        j["format"] = format;
+        j["mip"] = mip;
+        j["mipWidth"] = mipWidth;
+        j["mipHeight"] = mipHeight;
+        if (layer != 0)
+            j["layer"] = layer;
+        j["rect"] = Json{ { "x", rectX }, { "y", rectY }, { "w", rectW }, { "h", rectH } };
+        j["origin"] = "top-left (rect addresses texels of the mip, same orientation as a capture PNG)";
+        j["texelCount"] = static_cast<u64>(rectW) * static_cast<u64>(rectH);
+        Json channelStats = Json::array();
+        for (i32 c = 0; c < channels; ++c)
+            channelStats.push_back(ChannelStatsJson(ComputeChannelStats(ExtractChannel(interleaved, channels, c)),
+                                                    ChannelName(c)));
+        j["channels"] = std::move(channelStats);
+        return j;
+    }
+} // namespace OloEngine::MCP::RenderTargetStats

--- a/OloEditor/src/MCP/McpRenderValidate.h
+++ b/OloEditor/src/MCP/McpRenderValidate.h
@@ -1,0 +1,339 @@
+#pragma once
+
+// Pure shaping + compare math for the olo_render_validate MCP tool (issue
+// #607): an on-demand render-graph frame validation sweep, plus an optional
+// bit-exact texture compare (the "assert HZB mip0 == scene depth bitwise
+// after GTAOPass" ask from the GTAO hunt).
+//
+// The default sweep gathers, from the live graph: the compiled resource-hazard
+// validation, the barrier/build diagnostics and execute-path resolve failures
+// the graph already records, and a physical-identity report — every resource's
+// resolved GL id grouped by base name, with resources that are CONSUMED but
+// resolve to no physical backing flagged. The optional {compare:{a,b,...}}
+// mode reads both textures back as floats and compares bit-exactly (with the
+// first differing texels listed), optionally AS OF a given pass via the
+// afterPass snapshot.
+//
+// The handler in McpToolsRender.cpp gathers everything on the main thread and
+// pre-stringifies engine enums; everything below is free functions over PODs
+// with NO GL / renderer / editor dependency, unit-tested headlessly — the
+// same split McpRenderProbePixel.h / McpRenderGraphTopology.h use.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace OloEngine::MCP::RenderValidate
+{
+    using Json = nlohmann::json;
+
+    // ---- Default-sweep input (pre-stringified by the handler) --------------
+
+    struct HazardInfo
+    {
+        std::string Kind; // "ReadAfterWrite", "Cycle", ... (pre-resolved)
+        std::string Resource;
+        std::string Producer;
+        std::string Consumer;
+        std::string Message;
+    };
+
+    struct DiagnosticInfo
+    {
+        std::string Kind;
+        std::string Pass;
+        std::string Resource;
+        std::string Message;
+    };
+
+    struct ResolveFailureInfo
+    {
+        std::string Pass;
+        std::string Reason;
+        u32 Count = 0;
+    };
+
+    // One registered resource's physical identity this frame.
+    struct ResourceIdentity
+    {
+        std::string Name;
+        u32 GLTextureId = 0; // the physical texture accesses resolve to (0 = none)
+        u32 GLBufferId = 0;
+        bool HasProducers = false;
+        bool HasConsumers = false;
+        std::string LastWriter; // empty when none recorded
+    };
+
+    // Strip a versioned name ("SceneColor@ParticlePass") to its base name.
+    [[nodiscard]] inline std::string_view BaseName(std::string_view name) noexcept
+    {
+        const sizet at = name.find('@');
+        return at == std::string_view::npos ? name : name.substr(0, at);
+    }
+
+    // A resource that is read by at least one pass but resolves to no
+    // physical backing — a reader sampling nothing (or a stale binding).
+    [[nodiscard]] inline bool IsUnbackedConsumed(const ResourceIdentity& r) noexcept
+    {
+        return r.HasConsumers && r.GLTextureId == 0 && r.GLBufferId == 0;
+    }
+
+    // Group identities by base name and report every group where versions
+    // resolve to MORE THAN ONE distinct physical texture — legitimate for
+    // copy-on-write versioning, but exactly the map an agent needs to answer
+    // "which physical texture did this reader actually see". Pure and
+    // deterministic (insertion order preserved).
+    [[nodiscard]] inline Json VersionGroupsJson(const std::vector<ResourceIdentity>& identities)
+    {
+        Json groups = Json::array();
+        std::vector<std::string> seenBases;
+        for (const auto& identity : identities)
+        {
+            const std::string base(BaseName(identity.Name));
+            if (std::find(seenBases.begin(), seenBases.end(), base) != seenBases.end())
+                continue;
+            seenBases.push_back(base);
+
+            Json versions = Json::array();
+            std::vector<u32> distinctIds;
+            for (const auto& other : identities)
+            {
+                if (BaseName(other.Name) != base)
+                    continue;
+                Json v;
+                v["name"] = other.Name;
+                if (other.GLTextureId != 0)
+                    v["glTextureId"] = other.GLTextureId;
+                if (other.GLBufferId != 0)
+                    v["glBufferId"] = other.GLBufferId;
+                if (!other.LastWriter.empty())
+                    v["lastWriter"] = other.LastWriter;
+                versions.push_back(std::move(v));
+                const u32 id = other.GLTextureId != 0 ? other.GLTextureId : other.GLBufferId;
+                if (id != 0 && std::find(distinctIds.begin(), distinctIds.end(), id) == distinctIds.end())
+                    distinctIds.push_back(id);
+            }
+            if (versions.size() <= 1)
+                continue; // a single version can't alias-split
+            Json group;
+            group["baseName"] = base;
+            group["versions"] = std::move(versions);
+            group["multiplePhysicalIds"] = distinctIds.size() > 1;
+            groups.push_back(std::move(group));
+        }
+        return groups;
+    }
+
+    // ---- Bit-exact compare --------------------------------------------------
+
+    struct CompareRequest
+    {
+        std::string A;
+        std::string B;
+        u32 MipA = 0;
+        u32 MipB = 0;
+        // Explicit layer selectors. When Has* is false the handler applies
+        // the target's OWN view layer (a CSM cascade view compares ITS
+        // cascade, never silently layer 0 — the capture/probe/stats rule).
+        u32 LayerA = 0;
+        u32 LayerB = 0;
+        bool HasLayerA = false;
+        bool HasLayerB = false;
+        std::string AfterPass; // optional: snapshot both AS OF this pass
+    };
+
+    struct DiffTexel
+    {
+        u32 X = 0;
+        u32 Y = 0;
+        f32 ValueA = 0.0f;
+        f32 ValueB = 0.0f;
+    };
+
+    struct CompareResult
+    {
+        std::string Error; // non-empty = the compare could not run
+        u32 Width = 0;     // compared region (min of both mips)
+        u32 Height = 0;
+        u32 WidthA = 0;
+        u32 HeightA = 0;
+        u32 WidthB = 0;
+        u32 HeightB = 0;
+        std::string FormatA;
+        std::string FormatB;
+        u64 ComparedTexels = 0;
+        u64 DifferingTexels = 0;
+        bool BitwiseEqual = false;
+        f64 MaxAbsDiff = 0.0;
+        std::vector<DiffTexel> FirstDiffs; // first few differing texels, row-major
+    };
+
+    inline constexpr u32 kMaxReportedDiffs = 8;
+
+    // Compare channel 0 of two float readbacks bit-exactly over the
+    // overlapping top-left region. `a`/`b` are row-major, TOP-LEFT origin
+    // (the handler flips GL rows before calling), one value per texel.
+    [[nodiscard]] inline CompareResult CompareFloatBuffers(const std::vector<f32>& a, u32 widthA, u32 heightA,
+                                                           const std::vector<f32>& b, u32 widthB, u32 heightB)
+    {
+        CompareResult result;
+        result.WidthA = widthA;
+        result.HeightA = heightA;
+        result.WidthB = widthB;
+        result.HeightB = heightB;
+        result.Width = std::min(widthA, widthB);
+        result.Height = std::min(heightA, heightB);
+        if (result.Width == 0 || result.Height == 0 ||
+            a.size() < static_cast<sizet>(widthA) * heightA ||
+            b.size() < static_cast<sizet>(widthB) * heightB)
+        {
+            result.Error = "Degenerate compare region (a target has no storage at the requested mip).";
+            return result;
+        }
+
+        for (u32 y = 0; y < result.Height; ++y)
+        {
+            for (u32 x = 0; x < result.Width; ++x)
+            {
+                const f32 va = a[static_cast<sizet>(y) * widthA + x];
+                const f32 vb = b[static_cast<sizet>(y) * widthB + x];
+                if (std::bit_cast<u32>(va) == std::bit_cast<u32>(vb))
+                    continue;
+                ++result.DifferingTexels;
+                if (std::isfinite(va) && std::isfinite(vb))
+                    result.MaxAbsDiff = std::max(result.MaxAbsDiff,
+                                                 std::abs(static_cast<f64>(va) - static_cast<f64>(vb)));
+                if (result.FirstDiffs.size() < kMaxReportedDiffs)
+                    result.FirstDiffs.push_back(DiffTexel{ x, y, va, vb });
+            }
+        }
+        result.ComparedTexels = static_cast<u64>(result.Width) * result.Height;
+        result.BitwiseEqual = result.DifferingTexels == 0;
+        return result;
+    }
+
+    [[nodiscard]] inline Json CompareResultJson(const CompareRequest& request, const CompareResult& result)
+    {
+        Json j;
+        j["a"] = Json{ { "name", request.A }, { "mip", request.MipA }, { "width", result.WidthA }, { "height", result.HeightA }, { "format", result.FormatA } };
+        j["b"] = Json{ { "name", request.B }, { "mip", request.MipB }, { "width", result.WidthB }, { "height", result.HeightB }, { "format", result.FormatB } };
+        if (request.LayerA != 0)
+            j["a"]["layer"] = request.LayerA;
+        if (request.LayerB != 0)
+            j["b"]["layer"] = request.LayerB;
+        if (!request.AfterPass.empty())
+            j["afterPass"] = request.AfterPass;
+        if (!result.Error.empty())
+        {
+            j["error"] = result.Error;
+            return j;
+        }
+        j["comparedRegion"] = Json{ { "width", result.Width }, { "height", result.Height } };
+        j["comparedTexels"] = result.ComparedTexels;
+        j["bitwiseEqual"] = result.BitwiseEqual;
+        j["differingTexels"] = result.DifferingTexels;
+        if (result.DifferingTexels > 0)
+        {
+            j["maxAbsDiff"] = result.MaxAbsDiff;
+            Json diffs = Json::array();
+            for (const auto& d : result.FirstDiffs)
+            {
+                Json e;
+                e["x"] = d.X;
+                e["y"] = d.Y;
+                e["a"] = std::isfinite(d.ValueA) ? Json(d.ValueA) : Json(std::isnan(d.ValueA) ? "NaN" : "Inf");
+                e["b"] = std::isfinite(d.ValueB) ? Json(d.ValueB) : Json(std::isnan(d.ValueB) ? "NaN" : "Inf");
+                e["aBits"] = std::bit_cast<u32>(d.ValueA);
+                e["bBits"] = std::bit_cast<u32>(d.ValueB);
+                diffs.push_back(std::move(e));
+            }
+            j["firstDiffs"] = std::move(diffs);
+        }
+        j["note"] = "bitwiseEqual compares channel 0 bit patterns over the overlapping top-left region. "
+                    "A D24 source quantizes on float readback, so cross-format compares against D24 are "
+                    "only bit-exact when both sides went through the same conversion; D32F/R32F pairs "
+                    "compare exactly.";
+        return j;
+    }
+
+    // ---- Whole-reply assembly ----------------------------------------------
+
+    [[nodiscard]] inline Json BuildValidateJson(const std::vector<HazardInfo>& hazards,
+                                                const std::vector<DiagnosticInfo>& barrierDiagnostics,
+                                                const std::vector<DiagnosticInfo>& buildDiagnostics,
+                                                const std::vector<ResolveFailureInfo>& resolveFailures,
+                                                const std::vector<ResourceIdentity>& identities)
+    {
+        Json j;
+
+        Json hazardArray = Json::array();
+        for (const auto& h : hazards)
+        {
+            Json e;
+            e["kind"] = h.Kind;
+            e["resource"] = h.Resource;
+            if (!h.Producer.empty())
+                e["producer"] = h.Producer;
+            if (!h.Consumer.empty())
+                e["consumer"] = h.Consumer;
+            e["message"] = h.Message;
+            hazardArray.push_back(std::move(e));
+        }
+        j["hazardCount"] = static_cast<u32>(hazards.size());
+        j["hazards"] = std::move(hazardArray);
+
+        const auto diagnosticsArray = [](const std::vector<DiagnosticInfo>& diagnostics)
+        {
+            Json arr = Json::array();
+            for (const auto& d : diagnostics)
+            {
+                Json e;
+                e["kind"] = d.Kind;
+                if (!d.Pass.empty())
+                    e["pass"] = d.Pass;
+                if (!d.Resource.empty())
+                    e["resource"] = d.Resource;
+                e["message"] = d.Message;
+                arr.push_back(std::move(e));
+            }
+            return arr;
+        };
+        j["barrierDiagnostics"] = diagnosticsArray(barrierDiagnostics);
+        j["buildDiagnostics"] = diagnosticsArray(buildDiagnostics);
+
+        Json failures = Json::array();
+        for (const auto& f : resolveFailures)
+        {
+            Json e;
+            e["pass"] = f.Pass;
+            e["reason"] = f.Reason;
+            e["count"] = f.Count;
+            failures.push_back(std::move(e));
+        }
+        j["resolveFailures"] = std::move(failures);
+
+        // Physical identity: consumed-but-unbacked resources are the "readers
+        // did not resolve to what the writer produced" red flag; version
+        // groups map the copy-on-write aliasing for the rest.
+        Json unbacked = Json::array();
+        for (const auto& identity : identities)
+        {
+            if (IsUnbackedConsumed(identity))
+                unbacked.push_back(identity.Name);
+        }
+        j["consumedButUnbacked"] = std::move(unbacked);
+        j["versionGroups"] = VersionGroupsJson(identities);
+
+        const bool clean = hazards.empty() && resolveFailures.empty() && j["consumedButUnbacked"].empty();
+        j["ok"] = clean;
+        return j;
+    }
+} // namespace OloEngine::MCP::RenderValidate

--- a/OloEditor/src/MCP/McpToolsCamera.cpp
+++ b/OloEditor/src/MCP/McpToolsCamera.cpp
@@ -143,6 +143,28 @@ namespace OloEngine::MCP
                     return ToolResult::Error(error);
             }
 
+            // In Play mode the frame is rendered from the runtime's primary
+            // CameraComponent — the editor camera the pose machinery moves is
+            // not consulted at all, so a posed capture would silently return
+            // the runtime view while claiming the requested pose (issue #607,
+            // the grey-frame confusion). Refuse honestly instead. The
+            // sceneState is also reported alongside every capture below so an
+            // un-posed Play capture is never mistaken for an Edit-mode one.
+            bool isPlaying = false;
+            if (server.Context().IsPlaying)
+            {
+                isPlaying = server.MarshalRead([&server]() -> Json
+                                               { return Json{ { "playing", server.Context().IsPlaying() } }; })
+                                .value("playing", false);
+            }
+            if (isPlaying && (hasCamera || hasOrbit))
+                return ToolResult::Error(
+                    "A 'camera'/'orbit' pose cannot be applied in Play mode: the frame is rendered from the "
+                    "runtime scene's primary CameraComponent, not the editor camera, so the posed capture would "
+                    "silently show the runtime view from the runtime camera instead of the requested pose. "
+                    "Capture without a pose to see what is playing, or olo_scene_stop first for editor-camera "
+                    "captures.");
+
             int settleFrames = 2;
             if (args.contains("settleFrames") && args["settleFrames"].is_number_integer())
                 settleFrames = static_cast<int>(std::clamp<long long>(args["settleFrames"].get<long long>(), 1, 30));
@@ -218,13 +240,18 @@ namespace OloEngine::MCP
 
                 // 3. Capture — and restore the user's camera in the same main-thread
                 // job, so the restore happens exactly once whatever the capture did.
+                // The play state is RE-SAMPLED here, in the same job as the capture,
+                // so the sceneState meta below describes the frame actually captured
+                // even if Play/Stop flipped between the early guard and this job.
                 marshaled = server.MarshalRead([&server, maxWidth, restorePriorPose]() -> Json
                                                {
                     const std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
                     restorePriorPose();
                     if (png.empty())
                         return Json{ { "__error", "Viewport capture failed (no framebuffer or empty viewport)." } };
-                    return Json{ { "b64", Base64Encode(png) }, { "bytes", static_cast<u64>(png.size()) } }; });
+                    return Json{ { "b64", Base64Encode(png) },
+                                 { "bytes", static_cast<u64>(png.size()) },
+                                 { "playing", server.Context().IsPlaying ? server.Context().IsPlaying() : false } }; });
             }
             catch (...)
             {
@@ -260,6 +287,17 @@ namespace OloEngine::MCP
                 result.Content.push_back(Json{ { "type", "text" },
                                                { "text", "Warning: timed out waiting for the new camera pose to render; "
                                                          "the image may show a stale frame." } });
+            // Which state (and so whose camera) produced this frame — Play
+            // renders from the runtime's primary CameraComponent, Edit /
+            // Simulate from the editor camera (issue #607: a Play-mode frame
+            // must never be misread as an editor-camera one). Read from the
+            // capture job's own sample, not the earlier guard's — Play/Stop
+            // could have flipped between the two.
+            const bool capturedWhilePlaying = marshaled.value("playing", isPlaying);
+            Json meta;
+            meta["sceneState"] = capturedWhilePlaying ? "play" : "edit-or-simulate";
+            meta["camera"] = capturedWhilePlaying ? "runtime primary CameraComponent" : "editor camera";
+            result.Content.push_back(Json{ { "type", "text" }, { "text", meta.dump(2) } });
             result.Content.push_back(Json{ { "type", "image" },
                                            { "data", marshaled["b64"] },
                                            { "mimeType", "image/png" } });
@@ -289,7 +327,10 @@ namespace OloEngine::MCP
                 "'orbit' (target + yaw/pitch/distance): the prior camera is saved, the new pose is "
                 "rendered ('settleFrames' frames, default 2, for TAA/temporal effects to settle), the "
                 "frame is captured, and the user's camera is restored — so multiple angles can be "
-                "captured without disturbing the viewport.";
+                "captured without disturbing the viewport. In PLAY mode the frame is rendered from the "
+                "runtime scene's primary CameraComponent, so 'camera'/'orbit' poses are refused there "
+                "(the editor camera does not drive Play rendering); the reply's sceneState/camera meta "
+                "says which camera produced the frame.";
             tool.InputSchema = Schema::Object()
                                    .Prop("maxWidth", Schema::Int().Min(16).Max(4096).Desc("Max output width in pixels (default 1024); aspect ratio preserved."))
                                    .Prop("camera", Schema::Object().Desc("Capture from this pose, then restore the prior camera. Same shape as olo_camera_set_pose: position [x,y,z] plus target [x,y,z] or yaw/pitch (degrees); optional fov."))

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -9,6 +9,8 @@
 #include "MCP/McpRenderGraphTopology.h"
 #include "MCP/McpRenderOverrides.h"
 #include "MCP/McpRenderProbePixel.h"
+#include "MCP/McpRenderTargetStats.h"
+#include "MCP/McpRenderValidate.h"
 #include "MCP/McpRendererSettings.h"
 #include "MCP/McpShadowCapture.h"
 #include "OloEngine/Asset/AssetManager.h"
@@ -83,6 +85,15 @@ namespace OloEngine::MCP
         // forward-declared so the frame-breakdown handler can reuse the same
         // enum -> string mapping the topology export uses.
         const char* PassWorkTypeName(RenderGraphPassWorkType type);
+
+        // Defined in the issue-#607 probe/snapshot section further down;
+        // forward-declared so the capture handler (earlier in the TU) can share
+        // the afterPass snapshot machinery with probe/stats/validate.
+        std::string ArmAfterPassSnapshot(McpServer& server, const std::string& passName,
+                                         const std::vector<std::string>& resources,
+                                         bool& outFrameRendered);
+        std::string CollectAfterPassSnapshot(const std::string& passName, const std::string& name,
+                                             bool frameRendered, RenderGraphPassSnapshot::Result& outResult);
 
         // Defined further down in the virtual-geometry section. Forward-declared so
         // olo_render_set_debug_view's vg* modes read and write the SAME
@@ -391,6 +402,46 @@ namespace OloEngine::MCP
                     info.HasExternalBacking = resource.HasExternalBacking;
                     info.Producers = resource.Producers;
                     info.Consumers = resource.Consumers;
+
+                    // Resolved physical GL object ids (issue #607) — the
+                    // one-call answer to "do these two passes touch the same
+                    // physical texture this frame". Resolved inside this same
+                    // main-thread job as the enumeration so the snapshot is
+                    // internally consistent; the ids are the LAST EXECUTED
+                    // frame's (transients can re-alias next frame).
+                    if (resource.TextureHandle.IsValid())
+                    {
+                        info.GLTextureId = graph->ResolveTexture(resource.TextureHandle);
+                        info.ViewOfParentLayer = graph->GetTextureViewLayerIndex(resource.Name);
+                    }
+                    if (resource.FramebufferHandle.IsValid())
+                    {
+                        if (const Ref<Framebuffer> framebuffer = graph->ResolveFramebuffer(resource.FramebufferHandle))
+                        {
+                            info.GLFramebufferId = framebuffer->GetRendererID();
+                            const auto& attachments = framebuffer->GetSpecification().Attachments.Attachments;
+                            u32 colorIndex = 0;
+                            for (const auto& attachment : attachments)
+                            {
+                                if (attachment.TextureFormat == FramebufferTextureFormat::None)
+                                    continue;
+                                if (attachment.TextureFormat == FramebufferTextureFormat::DEPTH24STENCIL8 ||
+                                    attachment.TextureFormat == FramebufferTextureFormat::DEPTH_COMPONENT32F)
+                                {
+                                    info.GLDepthAttachmentId = framebuffer->GetDepthAttachmentRendererID();
+                                }
+                                else
+                                {
+                                    info.GLColorAttachmentIds.push_back(
+                                        framebuffer->GetColorAttachmentRendererID(colorIndex));
+                                    ++colorIndex;
+                                }
+                            }
+                        }
+                    }
+                    if (resource.BufferHandle.IsValid())
+                        info.GLBufferId = graph->ResolveBuffer(resource.BufferHandle);
+
                     snap.Resources.push_back(std::move(info));
                 }
 
@@ -506,25 +557,55 @@ namespace OloEngine::MCP
                 normalizeMode = args["normalize"].get<bool>() ? GPUResourceInspector::CaptureNormalizeMode::On
                                                               : GPUResourceInspector::CaptureNormalizeMode::Off;
 
+            // afterPass (issue #607): snapshot the resource AS OF that pass's
+            // execution and capture the snapshot clone — end-of-frame contents
+            // can differ (ParticlePass re-exports SceneDepth after GTAOPass).
+            std::string afterPass;
+            if (args.contains("afterPass") && args["afterPass"].is_string())
+                afterPass = args["afterPass"].get<std::string>();
+
             // Staleness (issue #607). A render-graph texture holds whatever was
             // last drawn into it: right after an olo_scene_open the new scene has
             // not been rendered yet, so a capture silently returns the PREVIOUS
             // scene's pixels — byte-identical, no error, no clue. 'forceFrame'
             // renders + settles fresh frames first; the meta always reports the
             // frame index the capture came from so the hazard is at least visible.
+            // (afterPass always renders a fresh frame — the snapshot fires
+            // during it — so forceFrame is implied there.)
             const bool forceFrame = args.value("forceFrame", false);
             bool freshFrameTimedOut = false;
-            if (forceFrame)
+            if (forceFrame && afterPass.empty())
                 freshFrameTimedOut = !ForceFreshFrame(server, /*settleFrames*/ 2);
 
+            bool afterPassFrameRendered = true;
+            if (!afterPass.empty())
+            {
+                if (const std::string error = ArmAfterPassSnapshot(server, afterPass, { name }, afterPassFrameRendered);
+                    !error.empty())
+                    return ToolResult::Error(error);
+            }
+
             Json result = server.MarshalRead([&server, name, mipLevel, hasLayerSelector, requestedLayer,
-                                              normalizeMode, maxWidth]() -> Json
+                                              normalizeMode, maxWidth, afterPass, afterPassFrameRendered]() -> Json
                                              {
                 const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
                 if (!graph)
                     return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
 
-                const u32 textureId = ResolveTargetTexture(name);
+                u32 textureId = 0;
+                RenderGraphPassSnapshot::Result snapshotResult;
+                if (!afterPass.empty())
+                {
+                    if (const std::string error =
+                            CollectAfterPassSnapshot(afterPass, name, afterPassFrameRendered, snapshotResult);
+                        !error.empty())
+                        return Json{ { "__error", error } };
+                    textureId = snapshotResult.TextureID;
+                }
+                else
+                {
+                    textureId = ResolveTargetTexture(name);
+                }
                 if (textureId == 0)
                     return Json{ { "__error", "Unknown render-graph resource '" + name +
                                                   "' (or it has no GPU backing this frame). Call olo_render_list_targets for the live list." } };
@@ -532,7 +613,8 @@ namespace OloEngine::MCP
                 // Which GL layer to read. The default is NOT unconditionally 0: a
                 // per-cascade layer view resolves to the whole parent array, so
                 // capturing "ShadowMapCSMCascade3" without applying the view's own
-                // layer would silently return cascade 0's pixels.
+                // layer would silently return cascade 0's pixels. (The snapshot
+                // clone preserves every layer, so the same selection applies.)
                 const CaptureLayer::TargetLayers layers = ResolveTargetLayers(*graph, name);
                 const CaptureLayer::Selection selection =
                     CaptureLayer::SelectLayer(layers, name, hasLayerSelector, requestedLayer);
@@ -546,6 +628,13 @@ namespace OloEngine::MCP
 
                 Json meta = CaptureStampJson(server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0);
                 meta["name"] = name;
+                if (!afterPass.empty())
+                {
+                    meta["afterPass"] = afterPass;
+                    meta["snapshotSourceTextureId"] = snapshotResult.SourceTextureID;
+                    meta["frameIndexNote"] = "frameIndex is the collect-time frame; the snapshot was cloned "
+                                             "mid-frame during the immediately preceding rendered frame.";
+                }
                 meta["layer"] = selection.Layer;
                 if (CaptureLayer::IsArrayTarget(layers))
                     meta["layers"] = layers.LayerCount;
@@ -2255,21 +2344,46 @@ namespace OloEngine::MCP
             }
         }
 
+        // Options for one texel probe (issue #607). Defaults reproduce the
+        // simple "viewport pixel at mip 0" probe; the G-Buffer mode fills the
+        // viewport reference dims, the single-target mode adds space / mip /
+        // layer / afterPass control.
+        struct ProbeRequest
+        {
+            ProbePixel::ProbeSpace Space = ProbePixel::ProbeSpace::Viewport;
+            u32 Mip = 0;
+            // Viewport-space reference dims (the render size a screenshot
+            // shows). 0 = use the target mip's own dims (identity mapping).
+            u32 RefWidth = 0;
+            u32 RefHeight = 0;
+            // Read THIS texture instead of resolving `name` — the afterPass
+            // snapshot scratch clone.
+            u32 OverrideTextureId = 0;
+            // Explicit array-layer / cube-face / 3D-slice selector; when
+            // absent the target's own view layer applies (a CSM cascade view
+            // must not silently read cascade 0).
+            bool HasLayer = false;
+            long long Layer = 0;
+        };
+
         // (main thread) Read back a SINGLE texel of one named render-graph target.
         // Uses glGetTextureSubImage (DSA, GL 4.5+) with a 1x1 region — never a
         // whole-texture readback, so probing a 4K G-Buffer costs a handful of
         // bytes, not 64 MB.
         //
-        // `yTopLeft` is in screenshot coordinates (top-left origin); GL texture
-        // rows run bottom-up, so it is flipped here — exactly the flip
-        // CaptureTexturePng applies when it writes a PNG, so a pixel picked off an
-        // olo_screenshot image probes the pixel the agent actually pointed at.
-        ProbePixel::TexelSample ProbeTexel(const std::string& name, u32 x, u32 yTopLeft)
+        // Coordinates go through ProbePixel::MapProbeCoord (issue #607):
+        // viewport space maps proportionally onto the target mip, texel space
+        // addresses the exact texel; both are top-left-origin (the screenshot
+        // convention — GL's bottom-up flip happens here) and the mapping is
+        // echoed in the sample so it is never guesswork.
+        ProbePixel::TexelSample ProbeTexel(const RenderGraph& graph, const std::string& name,
+                                           u32 x, u32 yTopLeft, const ProbeRequest& request = {})
         {
             ProbePixel::TexelSample sample;
             sample.Target = name;
 
-            const u32 textureId = ResolveTargetTexture(name);
+            const u32 textureId = request.OverrideTextureId != 0 ? request.OverrideTextureId
+                                                                 : ResolveTargetTexture(name);
             if (textureId == 0 || glIsTexture(textureId) == GL_FALSE)
             {
                 sample.Unavailable = "Render-graph resource '" + name +
@@ -2277,15 +2391,30 @@ namespace OloEngine::MCP
                 return sample;
             }
 
+            // Which GL layer (z offset) to read: an explicit selector, or the
+            // target's own view layer — a per-cascade view resolves to the
+            // whole parent array, so reading z=0 unconditionally would
+            // silently answer from cascade 0 (the capture tool's exact rule).
+            const CaptureLayer::TargetLayers layers = ResolveTargetLayers(graph, name);
+            const CaptureLayer::Selection selection =
+                CaptureLayer::SelectLayer(layers, name, request.HasLayer, request.Layer);
+            if (!selection.Error.empty())
+            {
+                sample.Unavailable = selection.Error;
+                return sample;
+            }
+            sample.Layer = selection.Layer;
+
             GLint width = 0;
             GLint height = 0;
             GLint internalFormat = 0;
-            glGetTextureLevelParameteriv(textureId, 0, GL_TEXTURE_WIDTH, &width);
-            glGetTextureLevelParameteriv(textureId, 0, GL_TEXTURE_HEIGHT, &height);
-            glGetTextureLevelParameteriv(textureId, 0, GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
+            const auto mipLevel = static_cast<GLint>(request.Mip);
+            glGetTextureLevelParameteriv(textureId, mipLevel, GL_TEXTURE_WIDTH, &width);
+            glGetTextureLevelParameteriv(textureId, mipLevel, GL_TEXTURE_HEIGHT, &height);
+            glGetTextureLevelParameteriv(textureId, mipLevel, GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
             if (width <= 0 || height <= 0)
             {
-                sample.Unavailable = "'" + name + "' has no storage at mip 0.";
+                sample.Unavailable = "'" + name + "' has no storage at mip " + std::to_string(request.Mip) + ".";
                 return sample;
             }
             sample.SourceWidth = static_cast<u32>(width);
@@ -2300,15 +2429,15 @@ namespace OloEngine::MCP
             }
             sample.Format = format.Token;
 
-            if (x >= sample.SourceWidth || yTopLeft >= sample.SourceHeight)
+            const u32 refWidth = request.RefWidth != 0 ? request.RefWidth : sample.SourceWidth;
+            const u32 refHeight = request.RefHeight != 0 ? request.RefHeight : sample.SourceHeight;
+            sample.Mapped = ProbePixel::MapProbeCoord(request.Space, x, yTopLeft, refWidth, refHeight,
+                                                      sample.SourceWidth, sample.SourceHeight, request.Mip);
+            if (!sample.Mapped.Valid)
             {
-                sample.Unavailable = "Pixel (" + std::to_string(x) + ", " + std::to_string(yTopLeft) +
-                                     ") is outside '" + name + "' (" + std::to_string(sample.SourceWidth) + "x" +
-                                     std::to_string(sample.SourceHeight) + ").";
+                sample.Unavailable = sample.Mapped.Error;
                 return sample;
             }
-
-            const GLint glY = static_cast<GLint>(sample.SourceHeight - 1u - yTopLeft);
 
             // Tight packing + PBO unbind guard, same rationale as
             // GPUResourceInspector::CaptureTexturePng: a bound pixel-pack buffer
@@ -2329,8 +2458,10 @@ namespace OloEngine::MCP
                                                  : static_cast<void*>(floats.data());
             const auto bytes = static_cast<GLsizei>(4 * sizeof(f32));
 
-            glGetTextureSubImage(textureId, 0,
-                                 static_cast<GLint>(x), glY, 0,
+            glGetTextureSubImage(textureId, mipLevel,
+                                 static_cast<GLint>(sample.Mapped.TexelX),
+                                 static_cast<GLint>(sample.Mapped.GLRowBottomUp),
+                                 static_cast<GLint>(selection.Layer),
                                  1, 1, 1,
                                  format.ReadFormat, format.ReadType,
                                  bytes, destination);
@@ -2354,11 +2485,120 @@ namespace OloEngine::MCP
             return sample;
         }
 
+        // ---- afterPass snapshots (issue #607) ---------------------------------
+        // Arm the shared RenderGraphPassSnapshot for `passName` over the named
+        // resources, then force a frame so the post-pass hook fires. Returns an
+        // empty string on success; `outFrameRendered` reports whether a frame
+        // actually rendered inside the wait (false = throttle/stall/cancel —
+        // the collect side uses it to diagnose an unfired hook honestly). The
+        // CALLER's next MarshalRead job must read
+        // RenderGraphDebugRuntime::GetPassSnapshot() (checking IsPending() for
+        // "the pass never executed") and Disarm() when done — reading and
+        // disarming in the same main-thread job keeps the scratch textures from
+        // being re-armed under a concurrent tool call.
+        std::string ArmAfterPassSnapshot(McpServer& server, const std::string& passName,
+                                         const std::vector<std::string>& resources,
+                                         bool& outFrameRendered)
+        {
+            const Json armed = server.MarshalRead([passName, resources]() -> Json
+                                                  {
+                const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
+                if (!graph)
+                    return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
+
+                const auto& order = graph->GetExecutionOrder();
+                if (std::find(order.begin(), order.end(), passName) == order.end())
+                {
+                    std::string valid;
+                    for (const auto& pass : order)
+                    {
+                        if (!valid.empty())
+                            valid += ", ";
+                        valid += pass;
+                    }
+                    return Json{ { "__error", "Unknown pass '" + passName +
+                                                  "' for afterPass. Passes in this frame's execution order: " + valid + "." } };
+                }
+
+                std::vector<RenderGraphPassSnapshot::Request> requests;
+                requests.reserve(resources.size());
+                for (const auto& resourceName : resources)
+                {
+                    requests.push_back(RenderGraphPassSnapshot::Request{
+                        resourceName,
+                        [resourceName]() -> u32
+                        { return ResolveTargetTexture(resourceName); } });
+                }
+                // Installing a post-pass hook is a logical mutation of the
+                // live graph behind a read-only accessor — the same confined
+                // const_cast RenderGraphDebugger uses for its frame capture.
+                RenderGraphDebugRuntime::GetPassSnapshot().Arm(const_cast<RenderGraph*>(graph.Raw()),
+                                                               passName, std::move(requests));
+                return Json::object(); });
+
+            if (armed.is_object() && armed.contains("__error"))
+                return armed["__error"].get<std::string>();
+
+            // Render a frame so the armed hook actually fires. A false return
+            // (throttle / main-thread stall / cancellation) is threaded to the
+            // caller's collect job so an unfired hook is diagnosed honestly
+            // instead of as "culled".
+            outFrameRendered = ForceFreshFrame(server, /*settleFrames*/ 1);
+            return {};
+        }
+
+        // (main thread) The collect half: fetch the snapshot result for `name`
+        // after ArmAfterPassSnapshot + a rendered frame, or an error message.
+        // Leaves the snapshot disarmed. `outResult` is only valid when the
+        // returned string is empty. `frameRendered` is ArmAfterPassSnapshot's
+        // out-flag — it picks the honest diagnosis when the hook never fired.
+        std::string CollectAfterPassSnapshot(const std::string& passName, const std::string& name,
+                                             bool frameRendered, RenderGraphPassSnapshot::Result& outResult)
+        {
+            auto& snapshot = RenderGraphDebugRuntime::GetPassSnapshot();
+            // A concurrent afterPass tool call could have re-armed the shared
+            // snapshot between this call's arm and collect jobs — matching by
+            // resource name alone would then silently hand back the OTHER
+            // call's clone. The armed pass name is the discriminator.
+            if (snapshot.GetPassName() != passName)
+            {
+                return "Another tool call re-armed the afterPass snapshot concurrently (now armed for pass '" +
+                       snapshot.GetPassName() + "', expected '" + passName +
+                       "'). afterPass requests are one-at-a-time; retry.";
+            }
+            if (snapshot.IsPending())
+            {
+                snapshot.Disarm();
+                if (!frameRendered)
+                    return "Timed out waiting for a frame to render after arming the afterPass snapshot (viewport "
+                           "render-throttled, the editor stalled, or the call was cancelled) — nothing was "
+                           "snapshotted. Retry, or make sure the viewport is rendering.";
+                return "Pass '" + passName + "' did not execute this frame (culled or disabled) — nothing was "
+                                             "snapshotted. Check olo_render_graph_topology_export for the culled list.";
+            }
+            for (const auto& result : snapshot.GetResults())
+            {
+                if (result.ResourceName != name)
+                    continue;
+                if (!result.Captured)
+                {
+                    const std::string error = result.Error;
+                    snapshot.Disarm();
+                    return error;
+                }
+                outResult = result;
+                snapshot.Disarm();
+                return {};
+            }
+            snapshot.Disarm();
+            return "Internal error: no snapshot result recorded for '" + name + "'.";
+        }
+
         ToolResult Handle_RenderProbePixel(McpServer& server, const Json& args)
         {
             if (!args.contains("x") || !args["x"].is_number_integer() ||
                 !args.contains("y") || !args["y"].is_number_integer())
-                return ToolResult::Error("Missing required arguments 'x' and 'y' (viewport pixel, top-left origin).");
+                return ToolResult::Error("Missing required arguments 'x' and 'y' (pixel, top-left origin).");
             const auto x = static_cast<u32>(std::max<long long>(0, args["x"].get<long long>()));
             const auto y = static_cast<u32>(std::max<long long>(0, args["y"].get<long long>()));
 
@@ -2366,10 +2606,44 @@ namespace OloEngine::MCP
             if (args.contains("target") && args["target"].is_string())
                 target = args["target"].get<std::string>();
 
-            if (args.value("forceFrame", false))
+            // space:"texel" + mip + layer + afterPass (issue #607). All four
+            // address ONE specific resource, so they require 'target' — the
+            // G-Buffer multi-target mode probes seven differently-sized
+            // resources for which a single texel coordinate is ambiguous.
+            auto space = ProbePixel::ProbeSpace::Viewport;
+            if (args.contains("space") && args["space"].is_string())
+            {
+                if (!ProbePixel::ParseProbeSpace(args["space"].get<std::string>(), space))
+                    return ToolResult::Error("Invalid 'space': expected \"viewport\" or \"texel\".");
+            }
+            u32 mip = 0;
+            if (args.contains("mip") && args["mip"].is_number_integer())
+                mip = static_cast<u32>(std::clamp<long long>(args["mip"].get<long long>(), 0, 16));
+            const bool hasLayer = args.contains("layer") && args["layer"].is_number_integer();
+            const long long layer = hasLayer ? args["layer"].get<long long>() : 0;
+            std::string afterPass;
+            if (args.contains("afterPass") && args["afterPass"].is_string())
+                afterPass = args["afterPass"].get<std::string>();
+            if (target.empty() && (space == ProbePixel::ProbeSpace::Texel || mip != 0 || hasLayer || !afterPass.empty()))
+                return ToolResult::Error("'space':\"texel\", 'mip', 'layer' and 'afterPass' require 'target' — the "
+                                         "G-Buffer multi-target probe spans several differently-sized resources.");
+
+            if (args.value("forceFrame", false) && afterPass.empty())
                 (void)ForceFreshFrame(server, /*settleFrames*/ 2);
 
-            const Json result = server.MarshalRead([&server, x, y, target]() -> Json
+            // afterPass: snapshot the target as of that pass's execution, then
+            // probe the snapshot clone instead of the (later-overwritten) live
+            // resource.
+            bool afterPassFrameRendered = true;
+            if (!afterPass.empty())
+            {
+                if (const std::string error = ArmAfterPassSnapshot(server, afterPass, { target }, afterPassFrameRendered);
+                    !error.empty())
+                    return ToolResult::Error(error);
+            }
+
+            const Json result = server.MarshalRead([&server, x, y, target, space, mip, hasLayer, layer,
+                                                    afterPass, afterPassFrameRendered]() -> Json
                                                    {
                 const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
                 if (!graph)
@@ -2377,16 +2651,46 @@ namespace OloEngine::MCP
 
                 const u64 frameIndex = server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0;
 
+                // Viewport-space reference: the physical (display) render size —
+                // the frame olo_screenshot shows, so a pixel picked off a
+                // screenshot maps to the same visual location on any target.
+                const u32 refWidth = graph->GetPhysicalWidth();
+                const u32 refHeight = graph->GetPhysicalHeight();
+
                 // Single-target mode: raw channels of whatever was asked for, so
                 // the tool works for ANY capturable target (AOBuffer, BloomColor,
                 // VirtualGeometryDebug, ...), not just the G-Buffer.
                 if (!target.empty())
                 {
-                    const ProbePixel::TexelSample sample = ProbeTexel(target, x, y);
+                    ProbeRequest request;
+                    request.Space = space;
+                    request.Mip = mip;
+                    request.RefWidth = refWidth;
+                    request.RefHeight = refHeight;
+                    request.HasLayer = hasLayer;
+                    request.Layer = layer;
+
+                    if (!afterPass.empty())
+                    {
+                        RenderGraphPassSnapshot::Result snapshotResult;
+                        if (const std::string error =
+                                CollectAfterPassSnapshot(afterPass, target, afterPassFrameRendered, snapshotResult);
+                            !error.empty())
+                            return Json{ { "__error", error } };
+                        request.OverrideTextureId = snapshotResult.TextureID;
+                    }
+
+                    const ProbePixel::TexelSample sample = ProbeTexel(*graph, target, x, y, request);
                     if (!sample.Available && sample.SourceWidth == 0)
                         return Json{ { "__error", sample.Unavailable +
                                                       " Call olo_render_list_targets for the live list." } };
                     Json j = ProbePixel::BuildRawProbe(sample, x, y);
+                    if (!afterPass.empty())
+                    {
+                        j["afterPass"] = afterPass;
+                        j["afterPassNote"] = "meta.frameIndex is the collect-time frame; the snapshot was cloned "
+                                             "mid-frame during the immediately preceding rendered frame.";
+                    }
                     j["meta"] = CaptureStampJson(frameIndex);
                     return j;
                 }
@@ -2404,12 +2708,16 @@ namespace OloEngine::MCP
                     in.FarClip = pose.FarClip;
                 }
 
-                in.Albedo = ProbeTexel(std::string(ResourceNames::GBufferAlbedo), x, y);
-                in.Normal = ProbeTexel(std::string(ResourceNames::GBufferNormal), x, y);
-                in.Emissive = ProbeTexel(std::string(ResourceNames::GBufferEmissive), x, y);
-                in.Velocity = ProbeTexel(std::string(ResourceNames::Velocity), x, y);
-                in.EntityId = ProbeTexel(std::string(ResourceNames::SceneEntityID), x, y);
-                in.Depth = ProbeTexel(std::string(ResourceNames::SceneDepth), x, y);
+                ProbeRequest gbufferRequest;
+                gbufferRequest.RefWidth = refWidth;
+                gbufferRequest.RefHeight = refHeight;
+
+                in.Albedo = ProbeTexel(*graph, std::string(ResourceNames::GBufferAlbedo), x, y, gbufferRequest);
+                in.Normal = ProbeTexel(*graph, std::string(ResourceNames::GBufferNormal), x, y, gbufferRequest);
+                in.Emissive = ProbeTexel(*graph, std::string(ResourceNames::GBufferEmissive), x, y, gbufferRequest);
+                in.Velocity = ProbeTexel(*graph, std::string(ResourceNames::Velocity), x, y, gbufferRequest);
+                in.EntityId = ProbeTexel(*graph, std::string(ResourceNames::SceneEntityID), x, y, gbufferRequest);
+                in.Depth = ProbeTexel(*graph, std::string(ResourceNames::SceneDepth), x, y, gbufferRequest);
 
                 // The presented colour is whatever the LAST enabled post stage
                 // wrote, and which stage that is depends on the live toggles — so
@@ -2424,7 +2732,7 @@ namespace OloEngine::MCP
                 };
                 for (const std::string_view candidate : kFinalColorChain)
                 {
-                    ProbePixel::TexelSample sample = ProbeTexel(std::string(candidate), x, y);
+                    ProbePixel::TexelSample sample = ProbeTexel(*graph, std::string(candidate), x, y, gbufferRequest);
                     if (sample.Available)
                     {
                         in.FinalColor = std::move(sample);
@@ -2436,6 +2744,623 @@ namespace OloEngine::MCP
 
                 Json j = ProbePixel::BuildGBufferProbe(in);
                 j["meta"] = CaptureStampJson(frameIndex);
+                return j; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Structured(result);
+        }
+
+        // ---- olo_render_target_stats (main-marshaled; GL readback) -------------
+        // Exact float min/max/mean + bit-exact unique-value histogram over a
+        // rect of one target (issue #607). An 8-bit PNG capture hides 1-ULP
+        // corruption (1.0 and 0.99999994 both encode as 255), so mapping a
+        // corrupt region by single-texel probes took hundreds of round-trips
+        // during the GTAO hunt; this answers "is this region EXACTLY 1.0f,
+        // and if not what distinct values does it hold" in one call.
+
+        // Rect readback ceiling: 4M texels * 4 channels * 4 bytes = 64 MB —
+        // roomy for any full-HD mip while keeping a stray 8K request from
+        // stalling the main thread for seconds.
+        constexpr u64 kMaxStatsRectTexels = 4ull * 1024ull * 1024ull;
+
+        // (main thread) Read a rect of one mip as channel-interleaved floats.
+        // Integer formats are converted (exact below 2^24 — entity ids and
+        // counters qualify); the caller notes the conversion in the reply.
+        std::vector<f32> ReadRectFloats(const u32 textureId, const u32 mip, const u32 layer,
+                                        const u32 rectX, const u32 glRectY, const u32 rectW, const u32 rectH,
+                                        const ProbeFormat& format, std::string& outError)
+        {
+            std::vector<f32> interleaved;
+            const sizet texels = static_cast<sizet>(rectW) * rectH;
+            const sizet valueCount = texels * static_cast<sizet>(format.Channels);
+
+            // Drain any stale error left by earlier rendering so the check
+            // below attributes failures to THIS readback — a lingering error
+            // would otherwise discard a perfectly valid read.
+            while (glGetError() != GL_NO_ERROR)
+            {
+            }
+
+            GLint prevPackAlignment = 4;
+            glGetIntegerv(GL_PACK_ALIGNMENT, &prevPackAlignment);
+            glPixelStorei(GL_PACK_ALIGNMENT, 1);
+            GLint prevPackPBO = 0;
+            glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &prevPackPBO);
+            if (prevPackPBO != 0)
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+            if (format.IsInteger)
+            {
+                std::vector<i32> ints(valueCount, 0);
+                glGetTextureSubImage(textureId, static_cast<GLint>(mip),
+                                     static_cast<GLint>(rectX), static_cast<GLint>(glRectY),
+                                     static_cast<GLint>(layer),
+                                     static_cast<GLsizei>(rectW), static_cast<GLsizei>(rectH), 1,
+                                     format.ReadFormat, format.ReadType,
+                                     static_cast<GLsizei>(ints.size() * sizeof(i32)), ints.data());
+                interleaved.reserve(valueCount);
+                for (const i32 v : ints)
+                    interleaved.push_back(static_cast<f32>(v));
+            }
+            else
+            {
+                interleaved.assign(valueCount, 0.0f);
+                glGetTextureSubImage(textureId, static_cast<GLint>(mip),
+                                     static_cast<GLint>(rectX), static_cast<GLint>(glRectY),
+                                     static_cast<GLint>(layer),
+                                     static_cast<GLsizei>(rectW), static_cast<GLsizei>(rectH), 1,
+                                     format.ReadFormat, format.ReadType,
+                                     static_cast<GLsizei>(interleaved.size() * sizeof(f32)), interleaved.data());
+            }
+
+            if (prevPackPBO != 0)
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, static_cast<GLuint>(prevPackPBO));
+            glPixelStorei(GL_PACK_ALIGNMENT, prevPackAlignment);
+
+            if (const GLenum error = glGetError(); error != GL_NO_ERROR)
+            {
+                outError = "glGetTextureSubImage failed (GL 0x" +
+                           std::format("{:X}", static_cast<u32>(error)) + ").";
+                interleaved.clear();
+            }
+            return interleaved;
+        }
+
+        ToolResult Handle_RenderTargetStats(McpServer& server, const Json& args)
+        {
+            if (!args.contains("name") || !args["name"].is_string())
+                return ToolResult::Error("Missing required argument 'name' (render-graph resource name; see olo_render_list_targets).");
+            const std::string name = args["name"].get<std::string>();
+
+            u32 mip = 0;
+            if (args.contains("mip") && args["mip"].is_number_integer())
+                mip = static_cast<u32>(std::clamp<long long>(args["mip"].get<long long>(), 0, 16));
+
+            const bool hasLayer = args.contains("layer") && args["layer"].is_number_integer();
+            const long long requestedLayer = hasLayer ? args["layer"].get<long long>() : 0;
+
+            // rect {x, y, w, h} in texel coordinates of the mip, top-left
+            // origin (a capture PNG's orientation). Omitted = the whole mip.
+            bool hasRect = false;
+            u32 rectX = 0;
+            u32 rectY = 0;
+            u32 rectW = 0;
+            u32 rectH = 0;
+            if (args.contains("rect"))
+            {
+                const Json& rect = args["rect"];
+                if (!rect.is_object() || !rect.contains("x") || !rect.contains("y") ||
+                    !rect.contains("w") || !rect.contains("h") ||
+                    !rect["x"].is_number_integer() || !rect["y"].is_number_integer() ||
+                    !rect["w"].is_number_integer() || !rect["h"].is_number_integer())
+                    return ToolResult::Error("Invalid 'rect': expected { x, y, w, h } integers (texel coords of the mip, top-left origin).");
+                const long long rx = rect["x"].get<long long>();
+                const long long ry = rect["y"].get<long long>();
+                const long long rw = rect["w"].get<long long>();
+                const long long rh = rect["h"].get<long long>();
+                if (rx < 0 || ry < 0 || rw <= 0 || rh <= 0)
+                    return ToolResult::Error("Invalid 'rect': x/y must be >= 0 and w/h > 0.");
+                hasRect = true;
+                rectX = static_cast<u32>(rx);
+                rectY = static_cast<u32>(ry);
+                rectW = static_cast<u32>(rw);
+                rectH = static_cast<u32>(rh);
+            }
+
+            std::string afterPass;
+            if (args.contains("afterPass") && args["afterPass"].is_string())
+                afterPass = args["afterPass"].get<std::string>();
+
+            if (args.value("forceFrame", false) && afterPass.empty())
+                (void)ForceFreshFrame(server, /*settleFrames*/ 2);
+            bool afterPassFrameRendered = true;
+            if (!afterPass.empty())
+            {
+                if (const std::string error = ArmAfterPassSnapshot(server, afterPass, { name }, afterPassFrameRendered);
+                    !error.empty())
+                    return ToolResult::Error(error);
+            }
+
+            const Json result = server.MarshalRead([&server, name, mip, hasLayer, requestedLayer, hasRect,
+                                                    rectX, rectY, rectW, rectH, afterPass,
+                                                    afterPassFrameRendered]() -> Json
+                                                   {
+                const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
+                if (!graph)
+                    return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
+
+                u32 textureId = 0;
+                RenderGraphPassSnapshot::Result snapshotResult;
+                if (!afterPass.empty())
+                {
+                    if (const std::string error =
+                            CollectAfterPassSnapshot(afterPass, name, afterPassFrameRendered, snapshotResult);
+                        !error.empty())
+                        return Json{ { "__error", error } };
+                    textureId = snapshotResult.TextureID;
+                }
+                else
+                {
+                    textureId = ResolveTargetTexture(name);
+                }
+                if (textureId == 0 || glIsTexture(textureId) == GL_FALSE)
+                    return Json{ { "__error", "Unknown render-graph resource '" + name +
+                                                  "' (or it has no GPU backing this frame). Call olo_render_list_targets for the live list." } };
+
+                const CaptureLayer::TargetLayers layers = ResolveTargetLayers(*graph, name);
+                const CaptureLayer::Selection selection =
+                    CaptureLayer::SelectLayer(layers, name, hasLayer, requestedLayer);
+                if (!selection.Error.empty())
+                    return Json{ { "__error", selection.Error } };
+
+                GLint mipWidth = 0;
+                GLint mipHeight = 0;
+                GLint internalFormat = 0;
+                glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_WIDTH, &mipWidth);
+                glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_HEIGHT, &mipHeight);
+                glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_INTERNAL_FORMAT,
+                                             &internalFormat);
+                if (mipWidth <= 0 || mipHeight <= 0)
+                    return Json{ { "__error", "'" + name + "' has no storage at mip " + std::to_string(mip) + "." } };
+
+                ProbeFormat format;
+                if (!DescribeProbeFormat(internalFormat, format))
+                    return Json{ { "__error", "'" + name + "' has an internal format stats cannot decode (0x" +
+                                                  std::format("{:X}", static_cast<u32>(internalFormat)) + ")." } };
+
+                const auto fullW = static_cast<u32>(mipWidth);
+                const auto fullH = static_cast<u32>(mipHeight);
+                u32 x = hasRect ? rectX : 0u;
+                u32 y = hasRect ? rectY : 0u;
+                u32 w = hasRect ? rectW : fullW;
+                u32 h = hasRect ? rectH : fullH;
+                if (x >= fullW || y >= fullH || x + w > fullW || y + h > fullH)
+                    return Json{ { "__error", "rect (" + std::to_string(x) + ", " + std::to_string(y) + ", " +
+                                                  std::to_string(w) + "x" + std::to_string(h) + ") exceeds mip " +
+                                                  std::to_string(mip) + " (" + std::to_string(fullW) + "x" +
+                                                  std::to_string(fullH) + ")." } };
+                if (static_cast<u64>(w) * h > kMaxStatsRectTexels)
+                    return Json{ { "__error", "rect covers " + std::to_string(static_cast<u64>(w) * h) +
+                                                  " texels; the ceiling is " + std::to_string(kMaxStatsRectTexels) +
+                                                  ". Shrink the rect or use a higher mip." } };
+
+                // Stats aggregate per channel, so GL row order is irrelevant —
+                // only the rect's PLACEMENT must be flipped to GL's bottom-up
+                // rows: top-left rect row y..y+h maps to GL rows
+                // [mipH - y - h, mipH - y).
+                const u32 glRectY = fullH - y - h;
+                std::string readError;
+                const std::vector<f32> interleaved =
+                    ReadRectFloats(textureId, mip, selection.Layer, x, glRectY, w, h, format, readError);
+                if (!readError.empty())
+                    return Json{ { "__error", "Stats readback of '" + name + "' failed: " + readError } };
+
+                Json j = RenderTargetStats::BuildStatsJson(name, format.Token, x, y, w, h, mip, fullW, fullH,
+                                                           selection.Layer, interleaved, format.Channels);
+                if (format.IsInteger)
+                    j["integerNote"] = "Integer target: values converted to float for stats (bit-exact below 2^24).";
+                if (!afterPass.empty())
+                {
+                    j["afterPass"] = afterPass;
+                    j["afterPassNote"] = "meta.frameIndex is the collect-time frame; the snapshot was cloned "
+                                         "mid-frame during the immediately preceding rendered frame.";
+                }
+                if (!selection.Note.empty())
+                    j["layerNote"] = selection.Note;
+                j["meta"] = CaptureStampJson(server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0);
+                return j; });
+
+            if (result.is_object() && result.contains("__error"))
+                return ToolResult::Error(result["__error"].get<std::string>());
+            return ToolResult::Structured(result);
+        }
+
+        // ---- olo_render_validate (main-marshaled; GL readback for compare) -----
+        // On-demand render-graph frame validation (issue #607): the compiled
+        // hazard sweep + barrier/build diagnostics + resolve failures +
+        // physical-identity report, plus an optional bit-exact texture compare
+        // ("assert HZB mip0 == scene depth bitwise after GTAOPass").
+
+        const char* HazardKindName(RenderGraph::HazardKind kind)
+        {
+            using HK = RenderGraph::HazardKind;
+            switch (kind)
+            {
+                case HK::ReadAfterWrite:
+                    return "ReadAfterWrite";
+                case HK::WriteAfterWrite:
+                    return "WriteAfterWrite";
+                case HK::WriteAfterRead:
+                    return "WriteAfterRead";
+                case HK::ResourceKindMismatch:
+                    return "ResourceKindMismatch";
+                case HK::FeedbackWithoutDeclaration:
+                    return "FeedbackWithoutDeclaration";
+                case HK::ImportedResourceLifetimeMisuse:
+                    return "ImportedResourceLifetimeMisuse";
+                case HK::Cycle:
+                    return "Cycle";
+            }
+            return "Unknown";
+        }
+
+        const char* BarrierDiagnosticKindName(RenderGraph::BarrierDiagnosticKind kind)
+        {
+            using BK = RenderGraph::BarrierDiagnosticKind;
+            switch (kind)
+            {
+                case BK::MissingProducer:
+                    return "MissingProducer";
+                case BK::CulledProducer:
+                    return "CulledProducer";
+                case BK::UnmappedTransition:
+                    return "UnmappedTransition";
+                case BK::StaleExtractionHandle:
+                    return "StaleExtractionHandle";
+                case BK::ExtractionOfCulledResource:
+                    return "ExtractionOfCulledResource";
+                case BK::InvalidHistoryContract:
+                    return "InvalidHistoryContract";
+            }
+            return "Unknown";
+        }
+
+        // (main thread) Channel 0 of one mip/layer as row-major floats with
+        // rows flipped to TOP-LEFT order, so diff coordinates match the
+        // capture/probe convention. Depth formats read the depth plane.
+        std::vector<f32> ReadChannel0TopLeft(const u32 textureId, const u32 mip, const u32 layer,
+                                             u32& outWidth, u32& outHeight, std::string& outFormat,
+                                             std::string& outError)
+        {
+            outWidth = 0;
+            outHeight = 0;
+            GLint mipWidth = 0;
+            GLint mipHeight = 0;
+            GLint internalFormat = 0;
+            glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_WIDTH, &mipWidth);
+            glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_HEIGHT, &mipHeight);
+            glGetTextureLevelParameteriv(textureId, static_cast<GLint>(mip), GL_TEXTURE_INTERNAL_FORMAT,
+                                         &internalFormat);
+            if (mipWidth <= 0 || mipHeight <= 0)
+            {
+                outError = "no storage at mip " + std::to_string(mip);
+                return {};
+            }
+            ProbeFormat format;
+            if (!DescribeProbeFormat(internalFormat, format))
+            {
+                outError = "undecodable internal format (0x" +
+                           std::format("{:X}", static_cast<u32>(internalFormat)) + ")";
+                return {};
+            }
+            outFormat = format.Token;
+            const auto w = static_cast<u32>(mipWidth);
+            const auto h = static_cast<u32>(mipHeight);
+            if (static_cast<u64>(w) * h > kMaxStatsRectTexels * 4ull)
+            {
+                outError = "mip is larger than the compare ceiling (" + std::to_string(w) + "x" +
+                           std::to_string(h) + "); compare a higher mip";
+                return {};
+            }
+
+            // Same stale-error drain rationale as ReadRectFloats.
+            while (glGetError() != GL_NO_ERROR)
+            {
+            }
+
+            const bool isDepth = format.ReadFormat == GL_DEPTH_COMPONENT;
+            const GLenum readFormat = isDepth ? GL_DEPTH_COMPONENT
+                                              : (format.IsInteger ? GL_RED_INTEGER : GL_RED);
+
+            GLint prevPackAlignment = 4;
+            glGetIntegerv(GL_PACK_ALIGNMENT, &prevPackAlignment);
+            glPixelStorei(GL_PACK_ALIGNMENT, 1);
+            GLint prevPackPBO = 0;
+            glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &prevPackPBO);
+            if (prevPackPBO != 0)
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+            std::vector<f32> bottomUp;
+            if (format.IsInteger)
+            {
+                std::vector<i32> ints(static_cast<sizet>(w) * h, 0);
+                glGetTextureSubImage(textureId, static_cast<GLint>(mip), 0, 0, static_cast<GLint>(layer),
+                                     static_cast<GLsizei>(w), static_cast<GLsizei>(h), 1,
+                                     readFormat, GL_INT,
+                                     static_cast<GLsizei>(ints.size() * sizeof(i32)), ints.data());
+                bottomUp.reserve(ints.size());
+                for (const i32 v : ints)
+                    bottomUp.push_back(static_cast<f32>(v));
+            }
+            else
+            {
+                bottomUp.assign(static_cast<sizet>(w) * h, 0.0f);
+                glGetTextureSubImage(textureId, static_cast<GLint>(mip), 0, 0, static_cast<GLint>(layer),
+                                     static_cast<GLsizei>(w), static_cast<GLsizei>(h), 1,
+                                     readFormat, GL_FLOAT,
+                                     static_cast<GLsizei>(bottomUp.size() * sizeof(f32)), bottomUp.data());
+            }
+
+            if (prevPackPBO != 0)
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, static_cast<GLuint>(prevPackPBO));
+            glPixelStorei(GL_PACK_ALIGNMENT, prevPackAlignment);
+
+            if (const GLenum error = glGetError(); error != GL_NO_ERROR)
+            {
+                outError = "glGetTextureSubImage failed (GL 0x" +
+                           std::format("{:X}", static_cast<u32>(error)) + ")";
+                return {};
+            }
+
+            // Flip rows to top-left order.
+            std::vector<f32> topLeft(bottomUp.size());
+            for (u32 row = 0; row < h; ++row)
+            {
+                const f32* src = bottomUp.data() + static_cast<sizet>(h - 1u - row) * w;
+                f32* dst = topLeft.data() + static_cast<sizet>(row) * w;
+                std::copy(src, src + w, dst);
+            }
+            outWidth = w;
+            outHeight = h;
+            return topLeft;
+        }
+
+        ToolResult Handle_RenderValidate(McpServer& server, const Json& args)
+        {
+            // Optional bit-exact compare of two targets.
+            RenderValidate::CompareRequest compare;
+            bool hasCompare = false;
+            if (args.contains("compare"))
+            {
+                const Json& c = args["compare"];
+                if (!c.is_object() || !c.contains("a") || !c.contains("b") ||
+                    !c["a"].is_string() || !c["b"].is_string())
+                    return ToolResult::Error("Invalid 'compare': expected { a, b, mipA?, mipB?, layerA?, layerB?, afterPass? } with 'a'/'b' target names.");
+                hasCompare = true;
+                compare.A = c["a"].get<std::string>();
+                compare.B = c["b"].get<std::string>();
+                if (c.contains("mipA") && c["mipA"].is_number_integer())
+                    compare.MipA = static_cast<u32>(std::clamp<long long>(c["mipA"].get<long long>(), 0, 16));
+                if (c.contains("mipB") && c["mipB"].is_number_integer())
+                    compare.MipB = static_cast<u32>(std::clamp<long long>(c["mipB"].get<long long>(), 0, 16));
+                if (c.contains("layerA") && c["layerA"].is_number_integer())
+                {
+                    compare.LayerA = static_cast<u32>(std::max<long long>(0, c["layerA"].get<long long>()));
+                    compare.HasLayerA = true;
+                }
+                if (c.contains("layerB") && c["layerB"].is_number_integer())
+                {
+                    compare.LayerB = static_cast<u32>(std::max<long long>(0, c["layerB"].get<long long>()));
+                    compare.HasLayerB = true;
+                }
+                if (c.contains("afterPass") && c["afterPass"].is_string())
+                    compare.AfterPass = c["afterPass"].get<std::string>();
+            }
+
+            if (args.value("forceFrame", false) && compare.AfterPass.empty())
+                (void)ForceFreshFrame(server, /*settleFrames*/ 2);
+
+            // Both compare sides are snapshotted by the SAME hook firing, so
+            // the bitwise verdict describes one consistent frame.
+            bool afterPassFrameRendered = true;
+            if (hasCompare && !compare.AfterPass.empty())
+            {
+                if (const std::string error =
+                        ArmAfterPassSnapshot(server, compare.AfterPass, { compare.A, compare.B },
+                                             afterPassFrameRendered);
+                    !error.empty())
+                    return ToolResult::Error(error);
+            }
+
+            const Json result = server.MarshalRead([&server, hasCompare, compare, afterPassFrameRendered]() -> Json
+                                                   {
+                const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
+                if (!graph)
+                    return Json{ { "__error", "No active render graph (the editor is not in 3D mode, or no frame has been rendered yet)." } };
+
+                // The graph getters below are const but ValidateCompiledResourceHazards
+                // is not — the same confined const_cast the debugger's capture uses.
+                auto& mutableGraph = *const_cast<RenderGraph*>(graph.Raw());
+
+                std::vector<RenderValidate::HazardInfo> hazards;
+                for (const auto& hazard : mutableGraph.ValidateCompiledResourceHazards())
+                {
+                    hazards.push_back(RenderValidate::HazardInfo{ HazardKindName(hazard.Kind), hazard.Resource,
+                                                                  hazard.Producer, hazard.Consumer, hazard.Message });
+                }
+
+                std::vector<RenderValidate::DiagnosticInfo> barrierDiagnostics;
+                for (const auto& diagnostic : graph->GetBarrierDiagnostics())
+                {
+                    barrierDiagnostics.push_back(RenderValidate::DiagnosticInfo{
+                        BarrierDiagnosticKindName(diagnostic.Kind), diagnostic.PassName, diagnostic.Resource,
+                        diagnostic.Message });
+                }
+
+                std::vector<RenderValidate::DiagnosticInfo> buildDiagnostics;
+                for (const auto& diagnostic : graph->GetBuildDiagnostics())
+                {
+                    buildDiagnostics.push_back(RenderValidate::DiagnosticInfo{
+                        "RegistrationOrderSensitivity", std::string{}, diagnostic.Resource, diagnostic.Message });
+                }
+
+                std::vector<RenderValidate::ResolveFailureInfo> resolveFailures;
+                for (const auto& failure : graph->GetResolveFailures())
+                {
+                    resolveFailures.push_back(
+                        RenderValidate::ResolveFailureInfo{ failure.PassName, failure.Reason, failure.Count });
+                }
+
+                std::vector<RenderValidate::ResourceIdentity> identities;
+                for (const auto& resource : graph->GetRegisteredResources())
+                {
+                    RenderValidate::ResourceIdentity identity;
+                    identity.Name = resource.Name;
+                    if (resource.TextureHandle.IsValid())
+                        identity.GLTextureId = graph->ResolveTexture(resource.TextureHandle);
+                    else if (resource.FramebufferHandle.IsValid())
+                        identity.GLTextureId = ResolveTargetTexture(resource.Name);
+                    if (resource.BufferHandle.IsValid())
+                        identity.GLBufferId = graph->ResolveBuffer(resource.BufferHandle);
+                    identity.HasProducers = !resource.Producers.empty();
+                    identity.HasConsumers = !resource.Consumers.empty();
+                    identity.LastWriter = graph->GetLastWriterPassName(resource.Name);
+                    identities.push_back(std::move(identity));
+                }
+
+                Json j = RenderValidate::BuildValidateJson(hazards, barrierDiagnostics, buildDiagnostics,
+                                                           resolveFailures, identities);
+
+                if (hasCompare)
+                {
+                    RenderValidate::CompareResult compareResult;
+                    u32 textureA = 0;
+                    u32 textureB = 0;
+                    if (!compare.AfterPass.empty())
+                    {
+                        // Both results come from the one armed snapshot; read
+                        // them here and disarm exactly once.
+                        auto& snapshot = RenderGraphDebugRuntime::GetPassSnapshot();
+                        if (snapshot.GetPassName() != compare.AfterPass)
+                        {
+                            compareResult.Error = "Another tool call re-armed the afterPass snapshot concurrently "
+                                                  "(now armed for pass '" + snapshot.GetPassName() +
+                                                  "'). afterPass requests are one-at-a-time; retry.";
+                        }
+                        else if (snapshot.IsPending())
+                        {
+                            snapshot.Disarm();
+                            compareResult.Error =
+                                !afterPassFrameRendered
+                                    ? "Timed out waiting for a frame to render after arming the afterPass "
+                                      "snapshot (viewport render-throttled, editor stalled, or cancelled)."
+                                    : "Pass '" + compare.AfterPass +
+                                          "' did not execute this frame (culled or disabled).";
+                        }
+                        else
+                        {
+                            for (const auto& snapshotResult : snapshot.GetResults())
+                            {
+                                if (!snapshotResult.Captured)
+                                {
+                                    compareResult.Error = snapshotResult.Error;
+                                    continue;
+                                }
+                                if (snapshotResult.ResourceName == compare.A)
+                                    textureA = snapshotResult.TextureID;
+                                if (snapshotResult.ResourceName == compare.B)
+                                    textureB = snapshotResult.TextureID;
+                            }
+                            snapshot.Disarm();
+                        }
+                    }
+                    else
+                    {
+                        textureA = ResolveTargetTexture(compare.A);
+                        textureB = ResolveTargetTexture(compare.B);
+                    }
+
+                    // Per-side layer selection, same rule as capture/probe/
+                    // stats: an explicit layerA/layerB is validated, and a
+                    // layer-VIEW resource (ShadowMapCSMCascade3) defaults to
+                    // ITS OWN layer — reading z=0 unconditionally would
+                    // silently compare cascade 0 vs cascade 0. The snapshot
+                    // clone preserves every layer, so the same selection
+                    // applies on the afterPass path.
+                    u32 layerA = compare.LayerA;
+                    u32 layerB = compare.LayerB;
+                    if (compareResult.Error.empty())
+                    {
+                        const auto selectLayer = [&graph](const std::string& targetName, bool hasLayer,
+                                                          u32 requestedLayer, u32& outLayer) -> std::string
+                        {
+                            const CaptureLayer::TargetLayers layers = ResolveTargetLayers(*graph, targetName);
+                            const CaptureLayer::Selection selection = CaptureLayer::SelectLayer(
+                                layers, targetName, hasLayer, static_cast<long long>(requestedLayer));
+                            if (!selection.Error.empty())
+                                return selection.Error;
+                            outLayer = selection.Layer;
+                            return {};
+                        };
+                        if (const std::string error = selectLayer(compare.A, compare.HasLayerA, compare.LayerA, layerA);
+                            !error.empty())
+                            compareResult.Error = error;
+                        else if (const std::string error =
+                                     selectLayer(compare.B, compare.HasLayerB, compare.LayerB, layerB);
+                                 !error.empty())
+                            compareResult.Error = error;
+                    }
+
+                    if (compareResult.Error.empty())
+                    {
+                        if (textureA == 0 || textureB == 0)
+                        {
+                            compareResult.Error = std::string("Unknown compare target '") +
+                                                  (textureA == 0 ? compare.A : compare.B) +
+                                                  "' (or it has no GPU backing). Call olo_render_list_targets.";
+                        }
+                        else
+                        {
+                            u32 widthA = 0;
+                            u32 heightA = 0;
+                            u32 widthB = 0;
+                            u32 heightB = 0;
+                            std::string errorA;
+                            std::string errorB;
+                            const std::vector<f32> a = ReadChannel0TopLeft(textureA, compare.MipA, layerA,
+                                                                           widthA, heightA, compareResult.FormatA,
+                                                                           errorA);
+                            const std::vector<f32> b = ReadChannel0TopLeft(textureB, compare.MipB, layerB,
+                                                                           widthB, heightB, compareResult.FormatB,
+                                                                           errorB);
+                            if (!errorA.empty())
+                                compareResult.Error = "'" + compare.A + "': " + errorA;
+                            else if (!errorB.empty())
+                                compareResult.Error = "'" + compare.B + "': " + errorB;
+                            else
+                            {
+                                const std::string formatA = compareResult.FormatA;
+                                const std::string formatB = compareResult.FormatB;
+                                compareResult = RenderValidate::CompareFloatBuffers(a, widthA, heightA,
+                                                                                    b, widthB, heightB);
+                                compareResult.FormatA = formatA;
+                                compareResult.FormatB = formatB;
+                            }
+                        }
+                    }
+                    // Echo the RESOLVED layers (a view's own layer may have
+                    // been applied) so the reply states which layers were
+                    // actually compared.
+                    RenderValidate::CompareRequest compareEcho = compare;
+                    compareEcho.LayerA = layerA;
+                    compareEcho.LayerB = layerB;
+                    j["compare"] = RenderValidate::CompareResultJson(compareEcho, compareResult);
+                    if (!compareResult.Error.empty())
+                        j["ok"] = false;
+                }
+
+                j["meta"] = CaptureStampJson(server.Context().GetFrameIndex ? server.Context().GetFrameIndex() : 0);
                 return j; });
 
             if (result.is_object() && result.contains("__error"))
@@ -3332,9 +4257,13 @@ namespace OloEngine::MCP
                 "dependency edges, and every registered resource (texture/framebuffer/buffer) with the passes "
                 "that produce and consume it. Each pass reports its work type (Graphics/Compute/Copy), whether "
                 "it declares resources, whether it is an async-compute candidate, whether it was culled "
-                "(unreachable from the final pass this frame), and whether it is the final/output pass. Use "
-                "format:\"mermaid\" for a flowchart DAG of the pass graph instead of JSON. Read-only; requires "
-                "the editor to be rendering in 3D mode.";
+                "(unreachable from the final pass this frame), whether it is the final/output pass, and its "
+                "'accesses' — every resource it reads/writes WITH the resolved physical GL object id, so 'do "
+                "these two passes touch the same physical texture this frame' is a single lookup (each "
+                "resource also carries a 'gl' block: texture/framebuffer/attachment/buffer ids as of the last "
+                "executed frame; texture views resolve to their parent object). Use format:\"mermaid\" for a "
+                "flowchart DAG of the pass graph instead of JSON. Read-only; requires the editor to be "
+                "rendering in 3D mode.";
             tool.InputSchema = Schema::Object()
                                    .Prop("format", Schema::String()
                                                        .Enum({ "json", "mermaid" })
@@ -3368,15 +4297,20 @@ namespace OloEngine::MCP
                 "under one pixel rather than a picture, use olo_render_probe_pixel. ARRAY TARGETS (the CSM "
                 "cascade array 'ShadowMapCSM', the raw-depth views 'ShadowCSMRaw' / 'ShadowAtlasRaw'): pass "
                 "'layer' to pick one cascade — olo_render_list_targets reports each array target's 'layers' "
-                "count, and an out-of-range layer is an error, never a silent layer-0 capture.";
+                "count, and an out-of-range layer is an error, never a silent layer-0 capture. MID-FRAME "
+                "STATE: pass 'afterPass' to capture the resource AS OF that pass's execution instead of "
+                "end-of-frame — decisive when a later pass overwrites it (ParticlePass re-exports "
+                "SceneDepth after GTAOPass, so an end-of-frame SceneDepth can never show what GTAO "
+                "sampled). Pass names come from olo_render_graph_topology_export's executionOrder.";
             tool.InputSchema = Schema::Object()
                                    .Prop("name", Schema::String().Desc("Render-graph resource name (see olo_render_list_targets)."))
                                    .Prop("mip", Schema::Int().Min(0).Max(16).Desc("Mip level to capture (default 0)."))
-                                   .Prop("layer", Schema::Int().Min(0).Max(64).Desc("Texture-array layer (e.g. CSM cascade 0..3) or cubemap face (0..5 = +X,-X,+Y,-Y,+Z,-Z). Default 0, or the resource's own layer when it is a per-layer view. Out of range is an error."))
+                                   .Prop("layer", Schema::Int().Min(0).Max(64).Desc("Texture-array layer (e.g. CSM cascade 0..3), cubemap face (0..5 = +X,-X,+Y,-Y,+Z,-Z), or 3D-volume z-slice (e.g. the froxel fog volumes). Default 0, or the resource's own layer when it is a per-layer view. Out of range is an error."))
                                    .Prop("face", Schema::Int().Min(0).Max(64).Desc("Alias of 'layer' (the original spelling); give only one."))
                                    .Prop("normalize", Schema::Bool().Desc("Min-max normalise float values to [0,1] before encoding (default: true for depth, false otherwise)."))
                                    .Prop("maxWidth", Schema::Int().Min(16).Max(4096).Desc("Max output width in pixels (default 1024); aspect ratio preserved."))
-                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before capturing (default false). Use after any change (scene open, setting flip) so you cannot read a stale target."))
+                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before capturing (default false). Use after any change (scene open, setting flip) so you cannot read a stale target. Implied by 'afterPass'."))
+                                   .Prop("afterPass", Schema::String().Desc("Capture the resource AS OF this pass's execution (mid-frame snapshot), not end-of-frame. A pass name from olo_render_graph_topology_export's executionOrder; a culled/unknown pass is an error."))
                                    .Required({ "name" })
                                    .NoAdditional();
             tool.MainMarshaled = true;
@@ -3696,16 +4630,104 @@ namespace OloEngine::MCP
                 "G-Buffer is Deferred-only) are reported as unavailable with a reason, never as a "
                 "failed call. Pass 'target' to probe ONE named render-graph resource instead and get "
                 "its raw channel values (works for any capturable target: AOBuffer, BloomColor, "
-                "VirtualGeometryDebug, ...). Only a 1x1 region is read back, so it is cheap.";
+                "VirtualGeometryDebug, ...). Only a 1x1 region is read back, so it is cheap. "
+                "COORDINATES: every reply echoes 'mappedCoord' — the exact texel read — so the mapping "
+                "is never guesswork. Default space \"viewport\" maps the pixel proportionally onto the "
+                "target; space \"texel\" (with optional 'mip') addresses an EXACT texel of the target — "
+                "required for padded resources like the HZB pow2 pyramid, where proportional mapping "
+                "reads the wrong texel. 'afterPass' probes the target AS OF that pass's execution "
+                "(mid-frame snapshot) instead of end-of-frame. space/mip/layer/afterPass require "
+                "'target'.";
             tool.InputSchema = Schema::Object()
-                                   .Prop("x", Schema::Int().Min(0).Desc("Pixel column, 0 = left edge."))
+                                   .Prop("x", Schema::Int().Min(0).Desc("Pixel column, 0 = left edge (in 'space' units)."))
                                    .Prop("y", Schema::Int().Min(0).Desc("Pixel row, 0 = TOP edge (screenshot convention; the GL bottom-up flip is handled for you)."))
                                    .Prop("target", Schema::String().Desc("Optional: probe only this render-graph resource (see olo_render_list_targets) and return its raw channels instead of the decoded G-Buffer."))
-                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before probing (default false). Use after a scene open / setting change so you cannot read a stale target."))
+                                   .Prop("space", Schema::String().Enum({ "viewport", "texel" }).Desc("How x/y address the target (requires 'target'). \"viewport\" (default): viewport pixels mapped proportionally onto the target mip. \"texel\": exact texel coordinates of the target at 'mip' — use for padded resources (HZB pyramid). Both top-left origin; the reply's mappedCoord shows the texel actually read."))
+                                   .Prop("mip", Schema::Int().Min(0).Max(16).Desc("Mip level to probe (default 0; requires 'target'). Texel coordinates address this mip's own grid."))
+                                   .Prop("layer", Schema::Int().Min(0).Max(64).Desc("Texture-array layer / cubemap face / 3D z-slice to probe (requires 'target'). Default: the resource's own view layer (a CSM cascade view probes ITS cascade, never silently cascade 0)."))
+                                   .Prop("afterPass", Schema::String().Desc("Probe the target AS OF this pass's execution (mid-frame snapshot), not end-of-frame (requires 'target'). A pass name from olo_render_graph_topology_export's executionOrder."))
+                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before probing (default false). Use after a scene open / setting change so you cannot read a stale target. Implied by 'afterPass'."))
                                    .Required({ "x", "y" })
                                    .NoAdditional();
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderProbePixel;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_render_target_stats";
+            tool.Toolset = "render";
+            tool.Title = "Exact stats over a render-target region";
+            // A bounded rect readback; changes no camera / setting / scene state.
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "Exact float min/max/mean and a BIT-EXACT unique-value histogram over a rect of one "
+                "render-graph target — the tool for 1-ULP questions an 8-bit PNG capture cannot answer "
+                "(1.0 and 0.99999994 both encode as 255). Per channel it reports finite/NaN/Inf counts, "
+                "min/max/mean over finite values, the number of DISTINCT bit patterns, and the most "
+                "frequent values with their exact counts — so 'is this HZB region exactly 1.0f' or 'what "
+                "garbage values leaked into this buffer' is one call, not hundreds of probes. 'rect' is "
+                "in texel coordinates of the chosen 'mip' (top-left origin, a capture PNG's orientation); "
+                "omit it for the whole mip (ceiling 4M texels — shrink the rect or raise the mip above "
+                "that). 'afterPass' computes the stats over the resource AS OF that pass's execution. "
+                "Use olo_render_capture_target to SEE the region, this to know its numbers.";
+            tool.InputSchema = Schema::Object()
+                                   .Prop("name", Schema::String().Desc("Render-graph resource name (see olo_render_list_targets)."))
+                                   .Prop("rect", Schema::Object()
+                                                     .Prop("x", Schema::Int().Min(0).Desc("Left texel column of the region."))
+                                                     .Prop("y", Schema::Int().Min(0).Desc("Top texel row of the region."))
+                                                     .Prop("w", Schema::Int().Min(1).Desc("Region width in texels."))
+                                                     .Prop("h", Schema::Int().Min(1).Desc("Region height in texels."))
+                                                     .Required({ "x", "y", "w", "h" })
+                                                     .NoAdditional()
+                                                     .Desc("Region in texel coords of the mip, top-left origin. Omit for the whole mip."))
+                                   .Prop("mip", Schema::Int().Min(0).Max(16).Desc("Mip level (default 0). rect addresses this mip's texel grid."))
+                                   .Prop("layer", Schema::Int().Min(0).Max(64).Desc("Texture-array layer / cubemap face / 3D z-slice. Default: the resource's own view layer."))
+                                   .Prop("afterPass", Schema::String().Desc("Compute stats over the resource AS OF this pass's execution (mid-frame snapshot). A pass name from olo_render_graph_topology_export's executionOrder."))
+                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame first (default false). Implied by 'afterPass'."))
+                                   .Required({ "name" })
+                                   .NoAdditional();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_RenderTargetStats;
+            server.RegisterTool(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_render_validate";
+            tool.Toolset = "render";
+            tool.Title = "Validate the render-graph frame";
+            // Read-only diagnostics sweep (+ an optional readback compare).
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "On-demand render-graph frame validation: runs the compiled resource-hazard sweep "
+                "(read-after-write / write-after-write / cycle / imported-lifetime misuse), reports the "
+                "graph's barrier and build diagnostics and any execute-path resolve failures, and maps "
+                "every resource's RESOLVED physical GL id — flagging resources that are consumed but "
+                "resolve to no backing, and grouping versioned names (SceneColor@PassB) with their "
+                "physical ids so copy-on-write aliasing is visible. 'ok': true means the sweep found "
+                "nothing. Optionally pass 'compare' to check two targets BIT-EXACTLY (channel 0, "
+                "overlapping top-left region): e.g. compare:{a:\"SceneDepth\", b:\"HZB\", mipB:0, "
+                "afterPass:\"GTAOPass\"} answers 'is HZB mip0 identical to the depth GTAO sampled' with "
+                "the first differing texels listed. With compare.afterPass BOTH sides are snapshotted in "
+                "the SAME frame by the same post-pass hook.";
+            tool.InputSchema = Schema::Object()
+                                   .Prop("compare", Schema::Object()
+                                                        .Prop("a", Schema::String().Desc("First target name."))
+                                                        .Prop("b", Schema::String().Desc("Second target name."))
+                                                        .Prop("mipA", Schema::Int().Min(0).Max(16).Desc("Mip of 'a' to compare (default 0)."))
+                                                        .Prop("mipB", Schema::Int().Min(0).Max(16).Desc("Mip of 'b' to compare (default 0)."))
+                                                        .Prop("layerA", Schema::Int().Min(0).Max(64).Desc("Layer / face / z-slice of 'a' (default 0)."))
+                                                        .Prop("layerB", Schema::Int().Min(0).Max(64).Desc("Layer / face / z-slice of 'b' (default 0)."))
+                                                        .Prop("afterPass", Schema::String().Desc("Snapshot BOTH targets as of this pass's execution (same frame, same hook) before comparing."))
+                                                        .Required({ "a", "b" })
+                                                        .NoAdditional()
+                                                        .Desc("Optional bit-exact channel-0 compare of two targets over their overlapping top-left region."))
+                                   .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame first (default false). Implied by compare.afterPass."))
+                                   .NoAdditional();
+            tool.MainMarshaled = true;
+            tool.Handler = Handle_RenderValidate;
             server.RegisterTool(std::move(tool));
         }
 

--- a/OloEditor/src/MCP/McpToolsScene.cpp
+++ b/OloEditor/src/MCP/McpToolsScene.cpp
@@ -387,6 +387,37 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
+
+            // Settle rendered frames before returning (issue #607 — the
+            // uniform-grey olo_screenshot case). MarshalRead jobs drain BEFORE
+            // the frame's OnUpdate, so the state transition above has not been
+            // RENDERED yet when this tool returns; an immediate follow-up
+            // olo_screenshot captured the last pre-transition frame (an
+            // Edit-mode frame — for a 2D-sprite scene in the 3D editor, a
+            // uniform-grey clear, since sprites only draw through the Play
+            // overlay callback). Waiting until the new state has produced
+            // frames makes "olo_scene_play then olo_screenshot" show what is
+            // actually playing.
+            // Best-effort: the transition above already SUCCEEDED, and these
+            // settle marshals run on the 5s default timeout right after a
+            // transition that legitimately gets 120s — a heavy scene's first
+            // post-transition frame can outlive 5s, and that must degrade to
+            // "returned before settling", never to a reported tool failure.
+            if (result.value("changed", false) && server.Context().GetFrameIndex)
+            {
+                try
+                {
+                    constexpr int kPostTransitionSettleFrames = 2;
+                    const u64 baseFrame = server.MarshalRead([&server]() -> Json
+                                                             { return Json{ { "frame", server.Context().GetFrameIndex() } }; })
+                                              .value("frame", static_cast<u64>(0));
+                    AwaitRenderedFrames(server, baseFrame, kPostTransitionSettleFrames);
+                }
+                catch (...)
+                {
+                    // Settle timed out — the transition result stands.
+                }
+            }
             return ToolResult::Text(result.dump(2));
         }
 

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -693,6 +693,8 @@
 		"OloEngine/Renderer/Debug/RenderGraphDebugger.cpp"
 		"OloEngine/Renderer/Debug/RenderGraphFrameCapture.h"
 		"OloEngine/Renderer/Debug/RenderGraphFrameCapture.cpp"
+		"OloEngine/Renderer/Debug/RenderGraphPassSnapshot.h"
+		"OloEngine/Renderer/Debug/RenderGraphPassSnapshot.cpp"
 		"OloEngine/Renderer/Debug/CapturedFrameData.h"
 		"OloEngine/Renderer/Debug/CapturedFrameData.cpp"
 		"OloEngine/Renderer/Debug/CommandPacketDebugger.h"

--- a/OloEngine/src/OloEngine/Renderer/DDGI/DDGIProbeUpdatePass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/DDGI/DDGIProbeUpdatePass.cpp
@@ -206,11 +206,60 @@ namespace OloEngine
             [[maybe_unused]] const auto atlasRead = builder.Read(blackboard.Shadows.ShadowMapAtlas, RGReadUsage::ShaderSample);
         }
 
-        // The atlases themselves are NOT declared as graph resources: the
-        // render graph has no cheap import path for externally-owned pass
-        // textures (VolumetricFogPass / PlanarReflectionRenderPass publish
-        // through Renderer3D accessors for the same reason), so MCP capture of
-        // the DDGI atlases goes through the pass accessors instead.
+        // Publish the pass-owned atlases into the graph so they appear in
+        // RenderGraph::GetRegisteredResources() — without this, both
+        // olo_render_list_targets and olo_render_capture_target were blind to
+        // them and black/leaking probes could not be diagnosed from an agent
+        // session without a full visual repro (issue #607). Import-only, the
+        // FluidIntermediatesPass pattern: the pass renders into them through
+        // its own FBOs and consumers sample them at engine slots 56/57/58, so
+        // there is deliberately no Read/Write declaration to change ordering
+        // or culling.
+        //
+        // EnsureResources() runs here as well as in Execute so the atlases
+        // exist by Setup time on the very rebuild a volume submission
+        // triggers (the VirtualGeometryPass "id 0 on first rebuild" lesson).
+        // Both ping-pong atlases are imported under stable per-ping names —
+        // "current" flips every blended frame and must not churn the
+        // fingerprint (see the header comment on GetIrradianceAtlasID(ping)).
+        // The raw ids are hashed into ComputeBlackboardFingerprint so a
+        // Resolution/HitCacheTexels recreate re-imports instead of keeping a
+        // dangling id.
+        if (m_VolumeSubmitted)
+            EnsureResources();
+
+        const auto importAtlas = [&builder](const char* name, u32 textureID, RGResourceFormat format,
+                                            u32 width, u32 height)
+        {
+            if (textureID == 0)
+                return;
+            RGResourceDesc desc = RGResourceDesc::FromHandleKind(ResourceHandle::Kind::Texture2D, name);
+            desc.Format = format;
+            desc.Width = width;
+            desc.Height = height;
+            [[maybe_unused]] const RGTextureHandle handle = builder.ImportTexture(name, textureID, desc);
+        };
+        for (u32 ping = 0; ping < 2u; ++ping)
+        {
+            if (m_IrradianceFB[ping])
+            {
+                const auto& spec = m_IrradianceFB[ping]->GetSpecification();
+                importAtlas(ping == 0 ? "DDGIIrradianceAtlas0" : "DDGIIrradianceAtlas1",
+                            GetIrradianceAtlasID(ping), RGResourceFormat::RGBA16Float, spec.Width, spec.Height);
+            }
+            if (m_VisibilityFB[ping])
+            {
+                const auto& spec = m_VisibilityFB[ping]->GetSpecification();
+                importAtlas(ping == 0 ? "DDGIVisibilityAtlas0" : "DDGIVisibilityAtlas1",
+                            GetVisibilityAtlasID(ping), RGResourceFormat::RG16Float, spec.Width, spec.Height);
+            }
+        }
+        if (m_ProbeDataTexture != 0)
+        {
+            const glm::ivec2 tileDims = DDGI::AtlasTileDimensions(m_ResourceResolution);
+            importAtlas("DDGIProbeData", m_ProbeDataTexture, RGResourceFormat::RGBA16Float,
+                        static_cast<u32>(std::max(tileDims.x, 1)), static_cast<u32>(std::max(tileDims.y, 1)));
+        }
     }
 
     bool DDGIProbeUpdatePass::IsReadyForExecution() const noexcept
@@ -253,6 +302,20 @@ namespace OloEngine
         return m_IrradianceFB[m_IrradianceCurrent]
                    ? m_IrradianceFB[m_IrradianceCurrent]->GetColorAttachmentRendererID(0)
                    : 0;
+    }
+
+    u32 DDGIProbeUpdatePass::GetIrradianceAtlasID(const u32 pingIndex) const
+    {
+        if (pingIndex >= 2u || !m_IrradianceFB[pingIndex])
+            return 0;
+        return m_IrradianceFB[pingIndex]->GetColorAttachmentRendererID(0);
+    }
+
+    u32 DDGIProbeUpdatePass::GetVisibilityAtlasID(const u32 pingIndex) const
+    {
+        if (pingIndex >= 2u || !m_VisibilityFB[pingIndex])
+            return 0;
+        return m_VisibilityFB[pingIndex]->GetColorAttachmentRendererID(0);
     }
 
     u32 DDGIProbeUpdatePass::GetVisibilityAtlasID() const

--- a/OloEngine/src/OloEngine/Renderer/DDGI/DDGIProbeUpdatePass.h
+++ b/OloEngine/src/OloEngine/Renderer/DDGI/DDGIProbeUpdatePass.h
@@ -109,6 +109,22 @@ namespace OloEngine
         [[nodiscard]] u32 GetIrradianceAtlasID() const; // current (post-blend) — 0 until first run
         [[nodiscard]] u32 GetVisibilityAtlasID() const;
         [[nodiscard]] u32 GetProbeDataTextureID() const;
+        // Explicit-ping accessors (issue #607): Setup() imports BOTH ping-pong
+        // atlases into the render graph under stable per-ping names — "which
+        // ping is current" flips every blended frame, and chasing the flip
+        // with a single "current" import would invalidate the BuildFrameGraph
+        // fingerprint cache every frame. The pipeline fingerprint hashes these
+        // ids so atlas (re)creation triggers the rebuild that re-imports them.
+        [[nodiscard]] u32 GetIrradianceAtlasID(u32 pingIndex) const;
+        [[nodiscard]] u32 GetVisibilityAtlasID(u32 pingIndex) const;
+        [[nodiscard]] u32 GetIrradianceCurrentIndex() const
+        {
+            return m_IrradianceCurrent;
+        }
+        [[nodiscard]] u32 GetVisibilityCurrentIndex() const
+        {
+            return m_VisibilityCurrent;
+        }
         [[nodiscard]] bool RanThisFrame() const;
         [[nodiscard]] f32 GetCapturedFraction() const; // captured probes / total
 

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/Debug/RenderGraphPassSnapshot.h"
 
 namespace OloEngine
 {
@@ -12,6 +13,17 @@ namespace OloEngine
         static void SetActiveGraph(const Ref<RenderGraph>& graph)
         {
             s_ActiveGraph = graph;
+            // A graph teardown invalidates the snapshot's installed-hook
+            // bookkeeping; disarm so a stale graph pointer is never touched.
+            // Renderer shutdown (graph == null) is also the last moment the
+            // GL context is guaranteed alive, so free the scratch clone here —
+            // the snapshot object itself is a process-static whose destructor
+            // must never call GL.
+            if (!graph)
+            {
+                s_PassSnapshot.Disarm();
+                s_PassSnapshot.ReleaseScratch();
+            }
         }
 
         [[nodiscard]] static const Ref<RenderGraph>& GetActiveGraph()
@@ -19,7 +31,15 @@ namespace OloEngine
             return s_ActiveGraph;
         }
 
+        // The process-wide afterPass snapshot the MCP capture/probe/stats
+        // tools share (issue #607). Main-thread only, like the graph itself.
+        [[nodiscard]] static RenderGraphPassSnapshot& GetPassSnapshot()
+        {
+            return s_PassSnapshot;
+        }
+
       private:
         inline static Ref<RenderGraph> s_ActiveGraph = nullptr;
+        inline static RenderGraphPassSnapshot s_PassSnapshot;
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphDebugger.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphDebugger.cpp
@@ -949,7 +949,7 @@ namespace OloEngine
     void RenderGraphDebugger::DrawCapturePanel(const Ref<RenderGraph>& graph)
     {
         ImGui::SameLine();
-        if (const bool hookInstalled = graph && graph->HasPostPassHook(); ImGui::Button(hookInstalled ? "Recapture Frame" : "Capture Frame"))
+        if (const bool hookInstalled = m_FrameCapture.IsHookInstalled(graph.get()); ImGui::Button(hookInstalled ? "Recapture Frame" : "Capture Frame"))
         {
             // Debug instrumentation: installing a post-pass hook on the live
             // graph is a logical mutation, but RenderDebugView() takes the
@@ -971,7 +971,10 @@ namespace OloEngine
         // reflects the latest pipeline output without manual button presses.
         if (m_AutoCaptureEachFrame && graph)
         {
-            if (!graph->HasPostPassHook())
+            // IsHookInstalled (not the graph's HasPostPassHook) — another tool's
+            // post-pass listener (the MCP afterPass snapshot, issue #607) must
+            // not suppress re-arming the frame capture's own hook.
+            if (!m_FrameCapture.IsHookInstalled(graph.get()))
                 m_FrameCapture.InstallHook(const_cast<RenderGraph*>(graph.get()));
             m_FrameCapture.RequestCapture();
         }

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphFrameCapture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphFrameCapture.cpp
@@ -167,14 +167,18 @@ namespace OloEngine
 
         if (m_InstalledGraph)
         {
-            m_InstalledGraph->SetPostPassHook({});
+            m_InstalledGraph->RemovePostPassHook(kPostPassHookKey);
         }
 
         m_InstalledGraph = graph;
 
         if (graph)
         {
-            graph->SetPostPassHook([this](const std::string& passName, RenderGraph& g)
+            // Keyed registration (issue #607): the MCP afterPass snapshot can
+            // hold its own post-pass hook on the same graph without either
+            // tool clobbering the other.
+            graph->AddPostPassHook(kPostPassHookKey,
+                                   [this](const std::string& passName, RenderGraph& g)
                                    { this->OnPassExecuted(passName, g); });
         }
     }

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphFrameCapture.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphFrameCapture.h
@@ -121,6 +121,14 @@ namespace OloEngine
         // Pass nullptr to uninstall. Safe to call multiple times.
         void InstallHook(RenderGraph* graph);
 
+        // Whether THIS tool's hook is installed on `graph`. The graph's own
+        // HasPostPassHook() reports ANY listener (the MCP afterPass snapshot
+        // registers one too, issue #607), so the debugger must ask here.
+        [[nodiscard]] bool IsHookInstalled(const RenderGraph* graph) const
+        {
+            return graph != nullptr && m_InstalledGraph == graph;
+        }
+
         // Hook entry-point — invoked from RenderGraph::Execute once per pass
         // after that pass returns. Public because the hook itself is a
         // std::function captured by InstallHook().
@@ -198,5 +206,9 @@ namespace OloEngine
         std::unordered_set<std::string> m_PassesSeenThisCapture;
 
         RenderGraph* m_InstalledGraph = nullptr;
+
+        // Key under which the hook registers on the graph's keyed post-pass
+        // listener list (issue #607).
+        static constexpr const char* kPostPassHookKey = "framecapture";
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphPassSnapshot.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphPassSnapshot.cpp
@@ -1,0 +1,255 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/Debug/RenderGraphPassSnapshot.h"
+
+#include "OloEngine/Renderer/RenderGraph.h"
+
+#include <glad/gl.h>
+
+#include <algorithm>
+#include <format>
+
+namespace OloEngine
+{
+    namespace
+    {
+        // Mip count of a texture object: immutable storage reports it
+        // directly; mutable storage is probed level-by-level (an unallocated
+        // level reports width 0).
+        u32 QueryMipLevels(const u32 textureId)
+        {
+            GLint immutableLevels = 0;
+            glGetTextureParameteriv(textureId, GL_TEXTURE_IMMUTABLE_LEVELS, &immutableLevels);
+            if (immutableLevels > 0)
+                return static_cast<u32>(immutableLevels);
+
+            u32 levels = 0;
+            for (u32 level = 0; level < 16u; ++level)
+            {
+                GLint levelWidth = 0;
+                glGetTextureLevelParameteriv(textureId, static_cast<GLint>(level), GL_TEXTURE_WIDTH, &levelWidth);
+                if (levelWidth <= 0)
+                    break;
+                ++levels;
+            }
+            return std::max(levels, 1u);
+        }
+    } // namespace
+
+    RenderGraphPassSnapshot::~RenderGraphPassSnapshot()
+    {
+        // Deliberately no GL calls: the instance lives as a process-static
+        // (RenderGraphDebugRuntime), destroyed after the GL context. The real
+        // cleanup site is ReleaseScratch(), invoked from renderer shutdown via
+        // RenderGraphDebugRuntime::SetActiveGraph(nullptr).
+    }
+
+    void RenderGraphPassSnapshot::Arm(RenderGraph* graph, std::string passName, std::vector<Request> requests)
+    {
+        if (m_InstalledGraph && m_InstalledGraph != graph)
+            m_InstalledGraph->RemovePostPassHook(kPostPassHookKey);
+
+        m_InstalledGraph = graph;
+        m_PassName = std::move(passName);
+        m_Requests = std::move(requests);
+        m_Results.clear();
+        m_Pending = graph != nullptr && !m_Requests.empty();
+
+        if (graph)
+        {
+            graph->AddPostPassHook(kPostPassHookKey,
+                                   [this](const std::string& executedPass, RenderGraph& g)
+                                   { this->OnPassExecuted(executedPass, g); });
+        }
+    }
+
+    void RenderGraphPassSnapshot::Disarm()
+    {
+        if (m_InstalledGraph)
+            m_InstalledGraph->RemovePostPassHook(kPostPassHookKey);
+        m_InstalledGraph = nullptr;
+        m_Pending = false;
+        m_Requests.clear();
+    }
+
+    void RenderGraphPassSnapshot::ReleaseScratch()
+    {
+        for (auto& slot : m_Scratch)
+        {
+            if (slot.Texture != 0)
+                glDeleteTextures(1, &slot.Texture);
+        }
+        m_Scratch.clear();
+        m_Results.clear();
+    }
+
+    u32 RenderGraphPassSnapshot::AcquireScratch(const sizet slot, const u32 glTarget, const u32 glInternalFormat,
+                                                const u32 width, const u32 height, const u32 depthOrLayers,
+                                                const u32 mipLevels)
+    {
+        if (slot >= m_Scratch.size())
+            m_Scratch.resize(slot + 1u);
+
+        ScratchSlot& scratch = m_Scratch[slot];
+        if (scratch.Texture != 0 && scratch.Target == glTarget && scratch.Format == glInternalFormat &&
+            scratch.Width == width && scratch.Height == height && scratch.Depth == depthOrLayers &&
+            scratch.Mips == mipLevels)
+        {
+            return scratch.Texture;
+        }
+
+        if (scratch.Texture != 0)
+        {
+            glDeleteTextures(1, &scratch.Texture);
+            scratch = {};
+        }
+
+        u32 texture = 0;
+        glCreateTextures(glTarget, 1, &texture);
+        switch (glTarget)
+        {
+            case GL_TEXTURE_2D:
+            case GL_TEXTURE_CUBE_MAP:
+                glTextureStorage2D(texture, static_cast<GLsizei>(mipLevels), glInternalFormat,
+                                   static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+                break;
+            case GL_TEXTURE_2D_ARRAY:
+            case GL_TEXTURE_3D:
+            case GL_TEXTURE_CUBE_MAP_ARRAY:
+                glTextureStorage3D(texture, static_cast<GLsizei>(mipLevels), glInternalFormat,
+                                   static_cast<GLsizei>(width), static_cast<GLsizei>(height),
+                                   static_cast<GLsizei>(depthOrLayers));
+                break;
+            default:
+                glDeleteTextures(1, &texture);
+                return 0;
+        }
+
+        // NEAREST filters: an INTEGER-format texture (the R32I entity-id
+        // buffer) is texture-INcomplete under the default LINEAR filters
+        // (GL 4.6 §8.17), and glCopyImageSubData mandates INVALID_OPERATION
+        // on an incomplete texture (§18.3.2) — NVIDIA is lenient, other
+        // drivers are not. Harmless for every other format; the scratch is
+        // never shader-sampled (readback-only).
+        glTextureParameteri(texture, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTextureParameteri(texture, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+        if (glGetError() != GL_NO_ERROR)
+        {
+            glDeleteTextures(1, &texture);
+            return 0;
+        }
+
+        scratch.Texture = texture;
+        scratch.Target = glTarget;
+        scratch.Format = glInternalFormat;
+        scratch.Width = width;
+        scratch.Height = height;
+        scratch.Depth = depthOrLayers;
+        scratch.Mips = mipLevels;
+        return texture;
+    }
+
+    void RenderGraphPassSnapshot::CaptureOne(const sizet slot, const Request& request, Result& out)
+    {
+        out.ResourceName = request.ResourceName;
+
+        const u32 sourceId = request.Resolve ? request.Resolve() : 0u;
+        if (sourceId == 0u || glIsTexture(sourceId) == GL_FALSE)
+        {
+            out.Error = "Resource '" + request.ResourceName + "' did not resolve to a GL texture after pass '" +
+                        m_PassName + "' (wrong rendering path, effect disabled, or no GPU backing).";
+            return;
+        }
+        out.SourceTextureID = sourceId;
+
+        GLint glTarget = 0;
+        glGetTextureParameteriv(sourceId, GL_TEXTURE_TARGET, &glTarget);
+        GLint samples = 0;
+        glGetTextureLevelParameteriv(sourceId, 0, GL_TEXTURE_SAMPLES, &samples);
+        if (samples > 1)
+        {
+            out.Error = "'" + request.ResourceName +
+                        "' is multisampled; afterPass snapshots support single-sample textures only.";
+            return;
+        }
+
+        GLint width = 0;
+        GLint height = 0;
+        GLint depth = 0;
+        GLint internalFormat = 0;
+        glGetTextureLevelParameteriv(sourceId, 0, GL_TEXTURE_WIDTH, &width);
+        glGetTextureLevelParameteriv(sourceId, 0, GL_TEXTURE_HEIGHT, &height);
+        glGetTextureLevelParameteriv(sourceId, 0, GL_TEXTURE_DEPTH, &depth);
+        glGetTextureLevelParameteriv(sourceId, 0, GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
+        if (width <= 0 || height <= 0)
+        {
+            out.Error = "'" + request.ResourceName + "' has no storage at mip 0.";
+            return;
+        }
+
+        // glCopyImageSubData addresses a cube map as 6 array layers.
+        u32 depthOrLayers = std::max(static_cast<u32>(depth), 1u);
+        if (glTarget == GL_TEXTURE_CUBE_MAP)
+            depthOrLayers = 6u;
+
+        const u32 mipLevels = QueryMipLevels(sourceId);
+        const u32 scratch = AcquireScratch(slot, static_cast<u32>(glTarget), static_cast<u32>(internalFormat),
+                                           static_cast<u32>(width), static_cast<u32>(height), depthOrLayers,
+                                           mipLevels);
+        if (scratch == 0u)
+        {
+            out.Error = "Could not allocate a snapshot clone for '" + request.ResourceName + "' (GL target 0x" +
+                        std::format("{:X}", static_cast<u32>(glTarget)) + ").";
+            return;
+        }
+
+        for (u32 mip = 0; mip < mipLevels; ++mip)
+        {
+            const auto mipWidth = std::max(static_cast<u32>(width) >> mip, 1u);
+            const auto mipHeight = std::max(static_cast<u32>(height) >> mip, 1u);
+            // A 3D volume's depth halves per mip; array layers / cube faces
+            // stay constant.
+            const u32 mipDepth = (glTarget == GL_TEXTURE_3D) ? std::max(depthOrLayers >> mip, 1u) : depthOrLayers;
+            glCopyImageSubData(sourceId, static_cast<GLenum>(glTarget), static_cast<GLint>(mip), 0, 0, 0,
+                               scratch, static_cast<GLenum>(glTarget), static_cast<GLint>(mip), 0, 0, 0,
+                               static_cast<GLsizei>(mipWidth), static_cast<GLsizei>(mipHeight),
+                               static_cast<GLsizei>(mipDepth));
+        }
+
+        if (const GLenum error = glGetError(); error != GL_NO_ERROR)
+        {
+            out.Error = "glCopyImageSubData on '" + request.ResourceName + "' failed (GL 0x" +
+                        std::format("{:X}", static_cast<u32>(error)) + ").";
+            return;
+        }
+
+        out.Captured = true;
+        out.TextureID = scratch;
+        out.Width = static_cast<u32>(width);
+        out.Height = static_cast<u32>(height);
+        out.DepthOrLayers = depthOrLayers;
+        out.MipLevels = mipLevels;
+        out.GLInternalFormat = static_cast<u32>(internalFormat);
+        out.GLTarget = static_cast<u32>(glTarget);
+    }
+
+    void RenderGraphPassSnapshot::OnPassExecuted(const std::string& passName, RenderGraph& /*graph*/)
+    {
+        if (!m_Pending || passName != m_PassName)
+            return;
+
+        // One-shot: whatever happens below, this request is consumed.
+        m_Pending = false;
+        m_Results.clear();
+        m_Results.resize(m_Requests.size());
+
+        // Drain any stale error so the checks in CaptureOne attribute
+        // failures to THIS copy, not to whatever the executing pass left.
+        while (glGetError() != GL_NO_ERROR)
+        {
+        }
+
+        for (sizet i = 0; i < m_Requests.size(); ++i)
+            CaptureOne(i, m_Requests[i], m_Results[i]);
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphPassSnapshot.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RenderGraphPassSnapshot.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace OloEngine
+{
+    class RenderGraph;
+
+    // @brief One-shot mid-frame snapshot of render-graph resources AS OF a
+    // given pass's execution (issue #607 — the MCP tools' 'afterPass' param).
+    //
+    // End-of-frame readbacks cannot show what a mid-frame consumer sampled:
+    // ParticlePass re-exports SceneDepth after GTAOPass, so by the time an MCP
+    // capture reads "SceneDepth" the texels GTAO actually consumed are gone —
+    // that single blindness cost six instrumented C++ rebuild rounds during
+    // the GTAO black-sky hunt. Arm() installs a keyed post-pass hook on the
+    // graph (coexisting with RenderGraphFrameCapture's hook); when the named
+    // pass finishes executing, every requested resource is cloned bitwise
+    // (glCopyImageSubData — every mip and layer, identical internal format)
+    // into a scratch texture owned here. Capture/probe/stats/compare tools
+    // then read the scratches instead of the live resources. Multiple
+    // resources are cloned in the SAME hook firing so a bitwise compare of
+    // two targets (olo_render_validate) sees one consistent frame.
+    //
+    // The copy must happen AT HOOK TIME, not by remembering the GL id: the
+    // transient pool memory-aliases same-descriptor resources, so a mid-frame
+    // id may be recycled for a different logical resource later in the frame.
+    //
+    // Threading: Arm/Disarm/GetResults run on the main thread (the MCP server
+    // marshals them there); the hook fires on the main thread inside
+    // RenderGraph::Execute(). GL state hygiene: glCopyImageSubData binds
+    // nothing — no FBO, program, sampler, or UBO state is touched, so the
+    // engine-global publications the render-pass-published-state rules
+    // protect are unaffected.
+    class RenderGraphPassSnapshot
+    {
+      public:
+        // Resolves a source GL texture id at hook time (main thread,
+        // mid-frame). Returning 0 records a resolve failure in the result.
+        using Resolver = std::function<u32()>;
+
+        struct Request
+        {
+            std::string ResourceName;
+            Resolver Resolve;
+        };
+
+        struct Result
+        {
+            bool Captured = false;
+            std::string Error; // non-empty when the pass fired but this copy failed
+            std::string ResourceName;
+            u32 TextureID = 0; // the scratch clone (owned by this class)
+            u32 SourceTextureID = 0;
+            u32 Width = 0;
+            u32 Height = 0;
+            u32 DepthOrLayers = 1;
+            u32 MipLevels = 1;
+            u32 GLInternalFormat = 0;
+            u32 GLTarget = 0;
+        };
+
+        RenderGraphPassSnapshot() = default;
+        ~RenderGraphPassSnapshot();
+
+        RenderGraphPassSnapshot(const RenderGraphPassSnapshot&) = delete;
+        RenderGraphPassSnapshot& operator=(const RenderGraphPassSnapshot&) = delete;
+
+        // Arm a one-shot snapshot: after `passName` executes during the next
+        // RenderGraph::Execute(), clone every requested resource. Installs
+        // this tool's keyed post-pass hook on `graph` (replacing any previous
+        // armed request). Results are reset to empty.
+        void Arm(RenderGraph* graph, std::string passName, std::vector<Request> requests);
+
+        // Uninstall the hook and drop any pending request. The scratch
+        // textures and the last results stay valid until the next Arm() or
+        // ReleaseScratch().
+        void Disarm();
+
+        // True after Arm() until the named pass fires (or Disarm()).
+        [[nodiscard]] bool IsPending() const
+        {
+            return m_Pending;
+        }
+
+        [[nodiscard]] const std::string& GetPassName() const
+        {
+            return m_PassName;
+        }
+
+        // One Result per Arm() request, in request order. Empty while pending
+        // (the pass has not fired since arming).
+        [[nodiscard]] const std::vector<Result>& GetResults() const
+        {
+            return m_Results;
+        }
+
+        // Free all scratch GL textures. Call at renderer shutdown (needs a
+        // live GL context) — the destructor deliberately does NOT (the
+        // instance is a process-static outliving the GL context).
+        void ReleaseScratch();
+
+        // Hook entry point — public because the std::function installed by
+        // Arm() captures `this` and forwards here.
+        void OnPassExecuted(const std::string& passName, RenderGraph& graph);
+
+      private:
+        struct ScratchSlot
+        {
+            u32 Texture = 0;
+            u32 Target = 0;
+            u32 Format = 0;
+            u32 Width = 0;
+            u32 Height = 0;
+            u32 Depth = 0;
+            u32 Mips = 0;
+        };
+
+        // Reuse (or reallocate) scratch slot `slot` for the given shape.
+        // Returns 0 when the target/format cannot be allocated.
+        [[nodiscard]] u32 AcquireScratch(sizet slot, u32 glTarget, u32 glInternalFormat, u32 width, u32 height,
+                                         u32 depthOrLayers, u32 mipLevels);
+
+        // Clone one resolved source into scratch slot `slot`, filling `out`.
+        void CaptureOne(sizet slot, const Request& request, Result& out);
+
+        RenderGraph* m_InstalledGraph = nullptr;
+        bool m_Pending = false;
+        std::string m_PassName;
+        std::vector<Request> m_Requests;
+        std::vector<Result> m_Results;
+        std::vector<ScratchSlot> m_Scratch;
+
+        static constexpr const char* kPostPassHookKey = "mcp-afterpass-snapshot";
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Passes/VolumetricFogPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/VolumetricFogPass.cpp
@@ -83,6 +83,34 @@ namespace OloEngine
         {
             [[maybe_unused]] const auto atlasRead = builder.Read(blackboard.Shadows.ShadowMapAtlas, RGReadUsage::ShaderSample);
         }
+
+        // Publish the pass-owned froxel volumes into the graph so they appear
+        // in RenderGraph::GetRegisteredResources() (issue #607) — previously
+        // only the dedicated olo_froxel_fog_probe tool could see them, so a
+        // scatter-vs-integrate defect could not be bisected with slice
+        // captures. Import-only, the FluidIntermediatesPass pattern: the
+        // compute chain writes them as images and FogRenderPass samples the
+        // integrated volume at engine slot 53, so no Read/Write declaration
+        // changes ordering or culling. The volumes are genuine 3D textures
+        // (Kind::Texture3D, DepthOrLayers = depth); capture tools address one
+        // z-slice via 'layer'. Both scatter pings are imported under stable
+        // names — "current" flips every frame (temporal history), the same
+        // reason the DDGI atlases import per-ping. Ids are created once in
+        // Init and never change, so no fingerprint hashing is needed.
+        const auto importVolume = [&builder](const char* name, const Ref<Texture3D>& volume)
+        {
+            if (!volume)
+                return;
+            RGResourceDesc desc = RGResourceDesc::FromHandleKind(ResourceHandle::Kind::Texture3D, name);
+            desc.Format = RGResourceFormat::RGBA16Float;
+            desc.Width = kVolumeWidth;
+            desc.Height = kVolumeHeight;
+            desc.DepthOrLayers = kVolumeDepth;
+            [[maybe_unused]] const RGTextureHandle handle = builder.ImportTexture(name, volume->GetRendererID(), desc);
+        };
+        importVolume("FroxelFogScatter0", m_ScatterVolume[0]);
+        importVolume("FroxelFogScatter1", m_ScatterVolume[1]);
+        importVolume("FroxelFogIntegrated", m_IntegratedVolume);
     }
 
     void VolumetricFogPass::Execute(RGCommandContext& context)

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -1034,6 +1034,7 @@ namespace OloEngine
         {
             return kind == ResourceHandle::Kind::Texture2D ||
                    kind == ResourceHandle::Kind::Texture2DArray ||
+                   kind == ResourceHandle::Kind::Texture3D ||
                    kind == ResourceHandle::Kind::TextureCube ||
                    kind == ResourceHandle::Kind::TextureCubeArray;
         };
@@ -1242,6 +1243,7 @@ namespace OloEngine
         {
             return kind == ResourceHandle::Kind::Texture2D ||
                    kind == ResourceHandle::Kind::Texture2DArray ||
+                   kind == ResourceHandle::Kind::Texture3D ||
                    kind == ResourceHandle::Kind::TextureCube ||
                    kind == ResourceHandle::Kind::TextureCubeArray;
         };
@@ -2557,6 +2559,28 @@ namespace OloEngine
         m_DependencyGraphDirty = true;
     }
 
+    void RenderGraph::AddPostPassHook(const std::string_view key, PostPassHook hook)
+    {
+        if (key.empty() || !hook)
+            return;
+        for (auto& [existingKey, existingHook] : m_PostPassHooks)
+        {
+            if (existingKey == key)
+            {
+                existingHook = std::move(hook);
+                return;
+            }
+        }
+        m_PostPassHooks.emplace_back(std::string(key), std::move(hook));
+    }
+
+    void RenderGraph::RemovePostPassHook(const std::string_view key)
+    {
+        std::erase_if(m_PostPassHooks,
+                      [key](const auto& entry)
+                      { return entry.first == key; });
+    }
+
     void RenderGraph::Execute()
     {
         OLO_PROFILE_FUNCTION();
@@ -2611,6 +2635,22 @@ namespace OloEngine
         // OpenGLRendererAPI.
         RGCommandContext commandContext;
         commandContext.SetRenderGraph(this);
+        // Compose the keyed post-pass listeners (issue #607) into the single
+        // callable the plan executor expects. Empty when no listener is
+        // registered, so the executor's per-pass hook check stays a cheap
+        // bool test in the common case.
+        PostPassHook composedPostPassHook;
+        if (!m_PostPassHooks.empty())
+        {
+            composedPostPassHook = [this](const std::string& passName, RenderGraph& graph)
+            {
+                for (const auto& [key, hook] : m_PostPassHooks)
+                {
+                    if (hook)
+                        hook(passName, graph);
+                }
+            };
+        }
         m_LastExecutionTimings = RenderGraphPlanExecutor::ExecutePlan({
             .SubmissionPlan = m_CachedSubmissionPlan,
             .Context = commandContext,
@@ -2618,7 +2658,7 @@ namespace OloEngine
             .IsPassReachable = [this](const std::string& passName)
             { return IsPassReachable(passName); },
             .BatchEventHook = m_BatchEventHook,
-            .PostPassHook = m_PostPassHook,
+            .PostPassHook = composedPostPassHook,
             .GraphForPostPassHook = this,
         });
         commandContext.SetRenderGraph(nullptr);
@@ -4048,6 +4088,7 @@ namespace OloEngine
         {
             return kind == ResourceHandle::Kind::Texture2D ||
                    kind == ResourceHandle::Kind::Texture2DArray ||
+                   kind == ResourceHandle::Kind::Texture3D ||
                    kind == ResourceHandle::Kind::TextureCube ||
                    kind == ResourceHandle::Kind::TextureCubeArray;
         };

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.h
@@ -885,20 +885,34 @@ namespace OloEngine
         }
 
         // -------------------------------------------------------------------
-        // Debug — Post-pass execution hook
+        // Debug — Post-pass execution hooks
         // -------------------------------------------------------------------
         // Fired after each pass->Execute() returns inside RenderGraph::Execute(),
         // BEFORE the post-pass extraction phase. Used by debug tooling
-        // (e.g. RenderGraphFrameCapture) to snapshot intermediate state.
-        // Pass the empty function (or assign {}) to disable.
+        // (e.g. RenderGraphFrameCapture, the MCP afterPass snapshot) to snapshot
+        // intermediate state. Multiple listeners can coexist, each registered
+        // under a distinct key (issue #607 — the debugger's frame capture and
+        // the MCP snapshot must not clobber each other's hook). Listeners fire
+        // in registration order; a listener must not add/remove hooks from
+        // inside its own callback.
         using PostPassHook = std::function<void(const std::string& passName, RenderGraph& graph)>;
+        void AddPostPassHook(std::string_view key, PostPassHook hook);
+        void RemovePostPassHook(std::string_view key);
+        // Legacy single-slot form: equivalent to Add/Remove under a reserved
+        // key. Pass the empty function (or assign {}) to disable.
         void SetPostPassHook(PostPassHook hook)
         {
-            m_PostPassHook = std::move(hook);
+            if (hook)
+                AddPostPassHook("__default", std::move(hook));
+            else
+                RemovePostPassHook("__default");
         }
+        // True when ANY post-pass listener is registered (not just the legacy
+        // slot). A tool that needs to know whether ITS hook is installed must
+        // track that itself (see RenderGraphFrameCapture::IsHookInstalled).
         [[nodiscard]] bool HasPostPassHook() const
         {
-            return static_cast<bool>(m_PostPassHook);
+            return !m_PostPassHooks.empty();
         }
 
         // -------------------------------------------------------------------
@@ -1280,7 +1294,9 @@ namespace OloEngine
         bool m_RuntimeTransientMaterializationEnabled = false;
         u32 m_TransientPoolMaxBucketSize = 2u;
 
-        PostPassHook m_PostPassHook;
+        // Keyed post-pass listeners, fired in registration order (see
+        // AddPostPassHook). A small vector — at most a couple of debug tools.
+        std::vector<std::pair<std::string, PostPassHook>> m_PostPassHooks;
         BatchEventCallback m_BatchEventHook;
 
         // Execution-ready cache — rebuilt when m_DependencyGraphDirty is set.

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -1557,6 +1557,21 @@ namespace OloEngine
         HashPassState(h, FrameCorePasses.Shadow);
         HashPassState(h, FrameCorePasses.Scene);
         HashPassState(h, FrameCorePasses.DDGIProbeUpdate);
+        // DDGI atlas imports (issue #607): DDGIProbeUpdatePass::Setup imports
+        // the ping-pong atlases + probe-data texture, which are created lazily
+        // (first submitted volume) and recreated on a Resolution /
+        // HitCacheTexels edit — the ids change with NO pass-enable change.
+        // Hash the raw ids so the rebuild that (re)imports them actually
+        // happens — the exact VirtualGeometryDebug rule below.
+        if (FrameCorePasses.DDGIProbeUpdate)
+        {
+            const auto& ddgiPass = *FrameCorePasses.DDGIProbeUpdate;
+            HashU32(h, ddgiPass.GetIrradianceAtlasID(0u));
+            HashU32(h, ddgiPass.GetIrradianceAtlasID(1u));
+            HashU32(h, ddgiPass.GetVisibilityAtlasID(0u));
+            HashU32(h, ddgiPass.GetVisibilityAtlasID(1u));
+            HashU32(h, ddgiPass.GetProbeDataTextureID());
+        }
         HashPassState(h, SceneCompositePasses.DeferredLighting);
         HashPassState(h, SceneCompositePasses.DeferredOpaqueDecal);
         HashPassState(h, SceneCompositePasses.DeferredGPUOcclusion);

--- a/OloEngine/src/OloEngine/Renderer/ResourceHandle.h
+++ b/OloEngine/src/OloEngine/Renderer/ResourceHandle.h
@@ -30,6 +30,10 @@ namespace OloEngine
             Unknown = 0,
             Texture2D,
             Texture2DArray,
+            // A genuine 3D (volume) texture — e.g. the froxel-fog scatter /
+            // integrated volumes (issue #607). DepthOrLayers carries the
+            // volume depth; capture tools address one z-slice via 'layer'.
+            Texture3D,
             TextureCube,
             TextureCubeArray,
             Framebuffer,
@@ -165,6 +169,8 @@ namespace OloEngine
                 return "Texture2D";
             case ResourceHandle::Kind::Texture2DArray:
                 return "Texture2DArray";
+            case ResourceHandle::Kind::Texture3D:
+                return "Texture3D";
             case ResourceHandle::Kind::TextureCube:
                 return "TextureCube";
             case ResourceHandle::Kind::TextureCubeArray:

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -494,9 +494,19 @@ add_executable(OloEngine-Tests
 		# no extra editor TU pulled in.
 		MCP/McpRenderGraphTopologyTest.cpp
 		# Pure octahedral-normal decode / depth linearization / per-channel shaping
-		# behind olo_render_probe_pixel (#607: the per-pixel numeric G-Buffer readout).
-		# Header-only (MCP/McpRenderProbePixel.h), no extra editor TU pulled in.
+		# behind olo_render_probe_pixel (#607: the per-pixel numeric G-Buffer readout),
+		# plus the space:"viewport"/"texel" coordinate mapping + mappedCoord echo
+		# (#607 GTAO-hunt slice). Header-only (MCP/McpRenderProbePixel.h), no extra
+		# editor TU pulled in.
 		MCP/McpRenderProbePixelTest.cpp
+		# Pure bit-exact unique-value histogram / finite min-max-mean math behind
+		# olo_render_target_stats (#607: 1-ULP corruption an 8-bit PNG hides).
+		# Header-only (MCP/McpRenderTargetStats.h), no extra editor TU pulled in.
+		MCP/McpRenderTargetStatsTest.cpp
+		# Pure version-group / consumed-but-unbacked shaping + the bit-exact
+		# float-buffer compare behind olo_render_validate (#607). Header-only
+		# (MCP/McpRenderValidate.h), no extra editor TU pulled in.
+		MCP/McpRenderValidateTest.cpp
 		# Pure light-grid aggregation (per-slice / per-cluster histogram, overflow +
 		# empty cluster counts) behind olo_cluster_grid_stats (#607). Header-only
 		# (MCP/McpClusterGridStats.h), no extra editor TU pulled in.

--- a/OloEngine/tests/MCP/McpRenderGraphTopologyTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderGraphTopologyTest.cpp
@@ -214,3 +214,94 @@ TEST(McpRenderGraphTopology, MermaidEscapesQuotesAndUsesSyntheticIds)
     // The literal double quote must not leak into the label unescaped.
     EXPECT_EQ(std::string::npos, mermaid.find("\"Post\"Process"));
 }
+
+// ---- Resolved GL ids + per-pass access lists (issue #607) -------------------
+
+TEST(McpRenderGraphTopology, ResourceEmitsResolvedGlIdsWhenSet)
+{
+    Snapshot snap;
+    ResourceInfo tex;
+    tex.Name = "SceneDepth";
+    tex.Kind = "Texture2D";
+    tex.GLTextureId = 42;
+    tex.ViewOfParentLayer = 3;
+    snap.Resources.push_back(std::move(tex));
+
+    ResourceInfo fb;
+    fb.Name = "SceneColor";
+    fb.Kind = "Framebuffer";
+    fb.GLFramebufferId = 7;
+    fb.GLColorAttachmentIds = { 10, 11 };
+    fb.GLDepthAttachmentId = 12;
+    snap.Resources.push_back(std::move(fb));
+
+    ResourceInfo unbacked;
+    unbacked.Name = "OptionalVelocity";
+    unbacked.Kind = "Texture2D"; // no ids resolved
+    snap.Resources.push_back(std::move(unbacked));
+
+    const Json j = BuildJson(snap);
+    const Json& texJson = j["resources"][0];
+    ASSERT_TRUE(texJson.contains("gl"));
+    EXPECT_EQ(42u, texJson["gl"]["textureId"].get<u32>());
+    EXPECT_EQ(3u, texJson["gl"]["viewOfParentLayer"].get<u32>());
+
+    const Json& fbJson = j["resources"][1];
+    ASSERT_TRUE(fbJson.contains("gl"));
+    EXPECT_EQ(7u, fbJson["gl"]["framebufferId"].get<u32>());
+    ASSERT_EQ(2u, fbJson["gl"]["colorAttachmentIds"].size());
+    EXPECT_EQ(10u, fbJson["gl"]["colorAttachmentIds"][0].get<u32>());
+    EXPECT_EQ(12u, fbJson["gl"]["depthAttachmentId"].get<u32>());
+
+    // No resolved backing -> no "gl" block at all (absence is the signal).
+    EXPECT_FALSE(j["resources"][2].contains("gl"));
+}
+
+TEST(McpRenderGraphTopology, PassAccessesInvertProducersConsumersWithPhysicalIds)
+{
+    Snapshot snap;
+    snap.Passes.push_back(PassInfo{ "GTAOPass", "Compute", true, false, false, false });
+    snap.Passes.push_back(PassInfo{ "ParticlePass", "Graphics", true, false, false, false });
+
+    ResourceInfo depth;
+    depth.Name = "SceneDepth";
+    depth.Kind = "Texture2D";
+    depth.GLTextureId = 99;
+    depth.Producers = { "ParticlePass" };
+    depth.Consumers = { "GTAOPass" };
+    snap.Resources.push_back(std::move(depth));
+
+    const Json j = BuildJson(snap);
+    // GTAOPass reads SceneDepth; ParticlePass writes it — both accesses carry
+    // the SAME resolved physical id, the one-call aliasing answer.
+    const Json& gtao = j["passes"][0];
+    ASSERT_TRUE(gtao.contains("accesses"));
+    ASSERT_EQ(1u, gtao["accesses"].size());
+    EXPECT_EQ("SceneDepth", gtao["accesses"][0]["resource"].get<std::string>());
+    EXPECT_EQ("read", gtao["accesses"][0]["mode"].get<std::string>());
+    EXPECT_EQ(99u, gtao["accesses"][0]["glTextureId"].get<u32>());
+
+    const Json& particle = j["passes"][1];
+    ASSERT_TRUE(particle.contains("accesses"));
+    EXPECT_EQ("write", particle["accesses"][0]["mode"].get<std::string>());
+    EXPECT_EQ(99u, particle["accesses"][0]["glTextureId"].get<u32>());
+}
+
+TEST(McpRenderGraphTopology, AccessPhysicalIdFallsBackToFramebufferAttachments)
+{
+    using OloEngine::MCP::RenderGraphTopology::AccessedPhysicalTextureId;
+
+    ResourceInfo colorFb;
+    colorFb.GLColorAttachmentIds = { 21 };
+    colorFb.GLDepthAttachmentId = 22;
+    EXPECT_EQ(21u, AccessedPhysicalTextureId(colorFb));
+
+    ResourceInfo depthOnlyFb;
+    depthOnlyFb.GLDepthAttachmentId = 22;
+    EXPECT_EQ(22u, AccessedPhysicalTextureId(depthOnlyFb));
+
+    ResourceInfo tex;
+    tex.GLTextureId = 5;
+    tex.GLColorAttachmentIds = { 21 }; // texture id wins when both set
+    EXPECT_EQ(5u, AccessedPhysicalTextureId(tex));
+}

--- a/OloEngine/tests/MCP/McpRenderProbePixelTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderProbePixelTest.cpp
@@ -296,4 +296,122 @@ namespace
         EXPECT_FALSE(j.at("available").get<bool>());
         EXPECT_EQ(j.at("reason").get<std::string>(), "AO is disabled");
     }
+
+    // ---- Coordinate mapping: space:"texel" + mappedCoord (issue #607) ------
+    // The GTAO hunt's exact failure: probing the HZB pow2 pyramid with
+    // viewport coordinates silently read the wrong texel. These pin the two
+    // explicit spaces and the echoed mapping.
+
+    TEST(McpRenderProbePixel, TexelSpaceAddressesTheExactTexel)
+    {
+        // A 2048x1024 pow2 target behind a 1600x900 viewport: texel space
+        // ignores the viewport entirely.
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Texel, 1700, 1000, 1600, 900, 2048, 1024, 0);
+        ASSERT_TRUE(m.Valid);
+        EXPECT_EQ(1700u, m.TexelX);
+        EXPECT_EQ(1000u, m.TexelY);
+        EXPECT_EQ(1024u - 1u - 1000u, m.GLRowBottomUp);
+    }
+
+    TEST(McpRenderProbePixel, TexelSpaceBoundsCheckAgainstTheMip)
+    {
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Texel, 2048, 0, 0, 0, 2048, 1024, 0);
+        EXPECT_FALSE(m.Valid);
+        EXPECT_NE(std::string::npos, m.Error.find("outside mip 0"));
+    }
+
+    TEST(McpRenderProbePixel, TexelSpaceAddressesTheMipsOwnGrid)
+    {
+        // Mip 3 of 2048x1024 is 256x128; texel (255, 127) is its last texel.
+        const CoordMapping ok = MapProbeCoord(ProbeSpace::Texel, 255, 127, 0, 0, 256, 128, 3);
+        ASSERT_TRUE(ok.Valid);
+        EXPECT_EQ(0u, ok.GLRowBottomUp);
+        const CoordMapping out = MapProbeCoord(ProbeSpace::Texel, 256, 0, 0, 0, 256, 128, 3);
+        EXPECT_FALSE(out.Valid);
+    }
+
+    TEST(McpRenderProbePixel, ViewportSpaceIsIdentityForFullResTargets)
+    {
+        // Same-size target: every viewport pixel maps to its own texel — the
+        // G-Buffer case, which must keep behaving exactly as before.
+        const std::pair<u32, u32> cases[] = { { 0u, 0u }, { 799u, 449u }, { 1599u, 899u } };
+        for (const auto& [x, y] : cases)
+        {
+            const CoordMapping m = MapProbeCoord(ProbeSpace::Viewport, x, y, 1600, 900, 1600, 900, 0);
+            ASSERT_TRUE(m.Valid);
+            EXPECT_EQ(x, m.TexelX);
+            EXPECT_EQ(y, m.TexelY);
+            EXPECT_EQ(900u - 1u - y, m.GLRowBottomUp);
+        }
+    }
+
+    TEST(McpRenderProbePixel, ViewportSpaceMapsProportionallyOntoHalfRes)
+    {
+        // A half-res AO buffer: viewport pixel (100, 200) lands on texel (50, 100).
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Viewport, 100, 200, 1600, 900, 800, 450, 0);
+        ASSERT_TRUE(m.Valid);
+        EXPECT_EQ(50u, m.TexelX);
+        EXPECT_EQ(100u, m.TexelY);
+    }
+
+    TEST(McpRenderProbePixel, ViewportSpaceClampsTheLastRowToTheMipEdge)
+    {
+        // The last viewport pixel must never round past the mip edge.
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Viewport, 1599, 899, 1600, 900, 800, 450, 0);
+        ASSERT_TRUE(m.Valid);
+        EXPECT_LT(m.TexelX, 800u);
+        EXPECT_LT(m.TexelY, 450u);
+    }
+
+    TEST(McpRenderProbePixel, ViewportSpaceRejectsOutOfViewportPixels)
+    {
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Viewport, 1600, 0, 1600, 900, 2048, 1024, 0);
+        EXPECT_FALSE(m.Valid);
+        EXPECT_NE(std::string::npos, m.Error.find("outside the viewport"));
+    }
+
+    TEST(McpRenderProbePixel, CoordMappingJsonEchoesTheExactTexel)
+    {
+        const CoordMapping m = MapProbeCoord(ProbeSpace::Texel, 12, 34, 0, 0, 256, 128, 2);
+        const Json j = CoordMappingJson(m);
+        EXPECT_EQ("texel", j.at("space").get<std::string>());
+        EXPECT_EQ(12u, j.at("requested")[0].get<u32>());
+        EXPECT_EQ(34u, j.at("requested")[1].get<u32>());
+        EXPECT_EQ(12u, j.at("texel")[0].get<u32>());
+        EXPECT_EQ(34u, j.at("texel")[1].get<u32>());
+        EXPECT_EQ(2u, j.at("mip").get<u32>());
+        EXPECT_EQ("top-left", j.at("origin").get<std::string>());
+    }
+
+    TEST(McpRenderProbePixel, RawSampleJsonCarriesMappedCoord)
+    {
+        TexelSample sample;
+        sample.Available = true;
+        sample.Target = "HZB";
+        sample.Format = "R32F";
+        sample.Kind = SampleKind::Float;
+        sample.Channels = 1;
+        sample.F = { 0.5f, 0.0f, 0.0f, 0.0f };
+        sample.SourceWidth = 2048;
+        sample.SourceHeight = 1024;
+        sample.Mapped = MapProbeCoord(ProbeSpace::Texel, 7, 9, 0, 0, 2048, 1024, 0);
+        sample.Layer = 3;
+
+        const Json j = RawSampleJson(sample);
+        ASSERT_TRUE(j.contains("mappedCoord"));
+        EXPECT_EQ(7u, j.at("mappedCoord").at("texel")[0].get<u32>());
+        EXPECT_EQ(3u, j.at("mappedCoord").at("layer").get<u32>());
+    }
+
+    TEST(McpRenderProbePixel, ParseProbeSpaceAcceptsOnlyTheTwoTokens)
+    {
+        ProbeSpace space{};
+        EXPECT_TRUE(ParseProbeSpace("viewport", space));
+        EXPECT_EQ(ProbeSpace::Viewport, space);
+        EXPECT_TRUE(ParseProbeSpace("texel", space));
+        EXPECT_EQ(ProbeSpace::Texel, space);
+        EXPECT_FALSE(ParseProbeSpace("texels", space));
+        EXPECT_FALSE(ParseProbeSpace("", space));
+    }
+
 } // namespace

--- a/OloEngine/tests/MCP/McpRenderTargetStatsTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderTargetStatsTest.cpp
@@ -1,0 +1,171 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+
+// Unit tests for the pure stats math behind olo_render_target_stats (issue
+// #607): bit-exact unique-value histograms, finite-only min/max/mean, NaN/Inf
+// accounting, channel de-interleave, and the reply JSON shape. The GL-bound
+// rect readback lives in McpToolsRender.cpp's handler (deliberately NOT
+// compiled here) — this pins the math an 8-bit PNG capture cannot express
+// (1.0f vs 0.99999994f both quantize to 255).
+#include "MCP/McpRenderTargetStats.h"
+
+#include <bit>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace
+{
+    using namespace OloEngine;
+    using namespace OloEngine::MCP::RenderTargetStats;
+} // namespace
+
+TEST(McpRenderTargetStats, ExactMinMaxMeanOverFiniteValues)
+{
+    const std::vector<f32> values{ 1.0f, 2.0f, 3.0f, 4.0f };
+    const ChannelStats stats = ComputeChannelStats(values);
+
+    EXPECT_EQ(4u, stats.FiniteCount);
+    EXPECT_EQ(0u, stats.NaNCount);
+    EXPECT_EQ(0u, stats.InfCount);
+    EXPECT_DOUBLE_EQ(1.0, stats.Min);
+    EXPECT_DOUBLE_EQ(4.0, stats.Max);
+    EXPECT_DOUBLE_EQ(2.5, stats.Mean);
+    EXPECT_EQ(4u, stats.UniqueValueCount);
+    EXPECT_FALSE(stats.UniqueTruncated);
+}
+
+TEST(McpRenderTargetStats, OneUlpNeighboursAreDistinct)
+{
+    // The motivating case: 1.0f and its 1-ULP neighbour both encode to PNG
+    // byte 255 — the histogram must keep them apart bit-exactly.
+    const f32 one = 1.0f;
+    const f32 nearlyOne = std::nextafter(1.0f, 0.0f); // 0.99999994f
+    const std::vector<f32> values{ one, one, nearlyOne };
+    const ChannelStats stats = ComputeChannelStats(values);
+
+    EXPECT_EQ(2u, stats.UniqueValueCount);
+    ASSERT_EQ(2u, stats.TopValues.size());
+    // Most frequent first: 1.0f twice, the neighbour once.
+    EXPECT_EQ(std::bit_cast<u32>(one), std::bit_cast<u32>(stats.TopValues[0].Value));
+    EXPECT_EQ(2u, stats.TopValues[0].Count);
+    EXPECT_EQ(std::bit_cast<u32>(nearlyOne), std::bit_cast<u32>(stats.TopValues[1].Value));
+    EXPECT_EQ(1u, stats.TopValues[1].Count);
+}
+
+TEST(McpRenderTargetStats, NaNAndInfExcludedFromAggregatesButCounted)
+{
+    const f32 quietNaN = std::numeric_limits<f32>::quiet_NaN();
+    const f32 positiveInf = std::numeric_limits<f32>::infinity();
+    const std::vector<f32> values{ 0.5f, quietNaN, positiveInf, -positiveInf, 0.5f };
+    const ChannelStats stats = ComputeChannelStats(values);
+
+    EXPECT_EQ(2u, stats.FiniteCount);
+    EXPECT_EQ(1u, stats.NaNCount);
+    EXPECT_EQ(2u, stats.InfCount);
+    EXPECT_DOUBLE_EQ(0.5, stats.Min);
+    EXPECT_DOUBLE_EQ(0.5, stats.Max);
+    EXPECT_DOUBLE_EQ(0.5, stats.Mean);
+    // 0.5, NaN, +Inf, -Inf = four distinct bit patterns.
+    EXPECT_EQ(4u, stats.UniqueValueCount);
+}
+
+TEST(McpRenderTargetStats, TrackedKeysKeepCountingPastTheCapWithoutTruncation)
+{
+    // Fill the map to exactly kMaxUniqueValues distinct values, then append
+    // repeats of an ALREADY-TRACKED value: those must keep incrementing their
+    // count and must NOT flag truncation (only a rejected NEW key does).
+    std::vector<f32> values;
+    values.reserve(kMaxUniqueValues + 4u);
+    for (u32 i = 0; i < kMaxUniqueValues; ++i)
+        values.push_back(static_cast<f32>(i));
+    for (u32 i = 0; i < 4u; ++i)
+        values.push_back(0.0f); // already tracked (i == 0)
+    const ChannelStats stats = ComputeChannelStats(values);
+
+    EXPECT_FALSE(stats.UniqueTruncated);
+    EXPECT_EQ(kMaxUniqueValues, stats.UniqueValueCount);
+    ASSERT_FALSE(stats.TopValues.empty());
+    // 0.0f was seen 1 (pre-cap) + 4 (post-cap) times — the most frequent value.
+    EXPECT_EQ(std::bit_cast<u32>(0.0f), std::bit_cast<u32>(stats.TopValues[0].Value));
+    EXPECT_EQ(5u, stats.TopValues[0].Count);
+}
+
+TEST(McpRenderTargetStats, NewKeyPastTheCapFlagsTruncation)
+{
+    // Fill the map to exactly kMaxUniqueValues distinct values, then append a
+    // NEW distinct value: its key is rejected (truncation flagged, unique
+    // count stays at the cap) but it still participates in min/max/mean.
+    std::vector<f32> values;
+    values.reserve(kMaxUniqueValues + 4u);
+    for (u32 i = 0; i < kMaxUniqueValues; ++i)
+        values.push_back(static_cast<f32>(i));
+    for (u32 i = 0; i < 4u; ++i)
+        values.push_back(1.0e30f); // a NEW distinct value past the cap
+    const ChannelStats stats = ComputeChannelStats(values);
+
+    EXPECT_TRUE(stats.UniqueTruncated);
+    EXPECT_EQ(kMaxUniqueValues, stats.UniqueValueCount);
+    EXPECT_DOUBLE_EQ(static_cast<f64>(1.0e30f), stats.Max);
+}
+
+TEST(McpRenderTargetStats, ExtractChannelDeinterleaves)
+{
+    // Two RG texels: (1,2), (3,4).
+    const std::vector<f32> interleaved{ 1.0f, 2.0f, 3.0f, 4.0f };
+    const std::vector<f32> r = ExtractChannel(interleaved, 2, 0);
+    const std::vector<f32> g = ExtractChannel(interleaved, 2, 1);
+    ASSERT_EQ(2u, r.size());
+    EXPECT_FLOAT_EQ(1.0f, r[0]);
+    EXPECT_FLOAT_EQ(3.0f, r[1]);
+    ASSERT_EQ(2u, g.size());
+    EXPECT_FLOAT_EQ(2.0f, g[0]);
+    EXPECT_FLOAT_EQ(4.0f, g[1]);
+    EXPECT_TRUE(ExtractChannel(interleaved, 2, 2).empty()); // out-of-range channel
+}
+
+TEST(McpRenderTargetStats, BuildStatsJsonShape)
+{
+    // A 2x1 R32F rect holding {1.0, 0.5}.
+    const std::vector<f32> interleaved{ 1.0f, 0.5f };
+    const Json j = BuildStatsJson("HZB", "R32F", 4, 8, 2, 1, 3, 256, 128, 0, interleaved, 1);
+
+    EXPECT_EQ("HZB", j["name"].get<std::string>());
+    EXPECT_EQ("R32F", j["format"].get<std::string>());
+    EXPECT_EQ(3u, j["mip"].get<u32>());
+    EXPECT_EQ(256u, j["mipWidth"].get<u32>());
+    EXPECT_EQ(128u, j["mipHeight"].get<u32>());
+    EXPECT_EQ(4u, j["rect"]["x"].get<u32>());
+    EXPECT_EQ(8u, j["rect"]["y"].get<u32>());
+    EXPECT_EQ(2u, j["rect"]["w"].get<u32>());
+    EXPECT_EQ(1u, j["rect"]["h"].get<u32>());
+    EXPECT_EQ(2u, j["texelCount"].get<u64>());
+    EXPECT_FALSE(j.contains("layer")); // layer 0 is omitted
+    ASSERT_EQ(1u, j["channels"].size());
+    const Json& channel = j["channels"][0];
+    EXPECT_EQ("r", channel["channel"].get<std::string>());
+    EXPECT_EQ(2u, channel["finiteCount"].get<u32>());
+    EXPECT_DOUBLE_EQ(0.5, channel["min"].get<f64>());
+    EXPECT_DOUBLE_EQ(1.0, channel["max"].get<f64>());
+    EXPECT_DOUBLE_EQ(0.75, channel["mean"].get<f64>());
+    EXPECT_EQ(2u, channel["uniqueValues"].get<u32>());
+}
+
+TEST(McpRenderTargetStats, NonFiniteTopValuesEncodeAsTokensWithBits)
+{
+    const f32 quietNaN = std::numeric_limits<f32>::quiet_NaN();
+    const std::vector<f32> interleaved{ quietNaN, quietNaN, 1.0f };
+    const Json j = BuildStatsJson("Weird", "R32F", 0, 0, 3, 1, 0, 3, 1, 0, interleaved, 1);
+
+    const Json& top = j["channels"][0]["topValues"];
+    ASSERT_EQ(2u, top.size());
+    // NaN twice is the most frequent; it must encode as a token + exact bits,
+    // never as a JSON number (which cannot hold NaN).
+    EXPECT_TRUE(top[0]["value"].is_string());
+    EXPECT_EQ("NaN", top[0]["value"].get<std::string>());
+    EXPECT_EQ(std::bit_cast<u32>(quietNaN), top[0]["bits"].get<u32>());
+    EXPECT_EQ(2u, top[0]["count"].get<u32>());
+    EXPECT_TRUE(top[1]["value"].is_number());
+}

--- a/OloEngine/tests/MCP/McpRenderValidateTest.cpp
+++ b/OloEngine/tests/MCP/McpRenderValidateTest.cpp
@@ -1,0 +1,193 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+
+// Unit tests for the pure shaping + compare math behind olo_render_validate
+// (issue #607): base-name grouping of versioned resources, the consumed-but-
+// unbacked flag, the bit-exact float-buffer compare (the "HZB mip0 == scene
+// depth bitwise" instrument), and the reply JSON shape. The GL readbacks and
+// the live graph sweep live in McpToolsRender.cpp's handler (deliberately NOT
+// compiled here).
+#include "MCP/McpRenderValidate.h"
+
+#include <bit>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace
+{
+    using namespace OloEngine;
+    using namespace OloEngine::MCP::RenderValidate;
+} // namespace
+
+TEST(McpRenderValidate, BaseNameStripsVersionQualifier)
+{
+    EXPECT_EQ("SceneColor", BaseName("SceneColor@ParticlePass"));
+    EXPECT_EQ("SceneColor", BaseName("SceneColor"));
+    EXPECT_EQ("", BaseName("@LeadingAt"));
+}
+
+TEST(McpRenderValidate, ConsumedButUnbackedFlag)
+{
+    ResourceIdentity consumedUnbacked;
+    consumedUnbacked.HasConsumers = true;
+    EXPECT_TRUE(IsUnbackedConsumed(consumedUnbacked));
+
+    ResourceIdentity consumedBacked = consumedUnbacked;
+    consumedBacked.GLTextureId = 5;
+    EXPECT_FALSE(IsUnbackedConsumed(consumedBacked));
+
+    ResourceIdentity unconsumed;
+    unconsumed.HasConsumers = false;
+    EXPECT_FALSE(IsUnbackedConsumed(unconsumed)); // nobody reads it — not a hazard
+}
+
+TEST(McpRenderValidate, VersionGroupsReportDistinctPhysicalIds)
+{
+    std::vector<ResourceIdentity> identities;
+    ResourceIdentity base;
+    base.Name = "SceneColor";
+    base.GLTextureId = 10;
+    base.LastWriter = "Lighting";
+    identities.push_back(base);
+    ResourceIdentity version;
+    version.Name = "SceneColor@ParticlePass";
+    version.GLTextureId = 11; // copy-on-write: a DIFFERENT physical texture
+    version.LastWriter = "ParticlePass";
+    identities.push_back(version);
+    ResourceIdentity lone;
+    lone.Name = "SceneDepth"; // single version — no group emitted
+    lone.GLTextureId = 12;
+    identities.push_back(lone);
+
+    const Json groups = VersionGroupsJson(identities);
+    ASSERT_EQ(1u, groups.size());
+    EXPECT_EQ("SceneColor", groups[0]["baseName"].get<std::string>());
+    EXPECT_TRUE(groups[0]["multiplePhysicalIds"].get<bool>());
+    ASSERT_EQ(2u, groups[0]["versions"].size());
+    EXPECT_EQ("Lighting", groups[0]["versions"][0]["lastWriter"].get<std::string>());
+}
+
+TEST(McpRenderValidate, VersionGroupSharedPhysicalIdIsNotFlagged)
+{
+    std::vector<ResourceIdentity> identities;
+    for (const char* name : { "SceneDepth", "SceneDepth@ParticlePass" })
+    {
+        ResourceIdentity identity;
+        identity.Name = name;
+        identity.GLTextureId = 33; // SSA versions aliasing ONE physical texture
+        identities.push_back(identity);
+    }
+    const Json groups = VersionGroupsJson(identities);
+    ASSERT_EQ(1u, groups.size());
+    EXPECT_FALSE(groups[0]["multiplePhysicalIds"].get<bool>());
+}
+
+TEST(McpRenderValidate, CompareIdenticalBuffersIsBitwiseEqual)
+{
+    const std::vector<f32> a{ 0.25f, 0.5f, 0.75f, 1.0f };
+    const CompareResult result = CompareFloatBuffers(a, 2, 2, a, 2, 2);
+
+    EXPECT_TRUE(result.Error.empty());
+    EXPECT_TRUE(result.BitwiseEqual);
+    EXPECT_EQ(4u, result.ComparedTexels);
+    EXPECT_EQ(0u, result.DifferingTexels);
+}
+
+TEST(McpRenderValidate, CompareFindsOneUlpDifference)
+{
+    // The exact corruption class the tool exists for: a value one ULP off.
+    std::vector<f32> a{ 1.0f, 1.0f, 1.0f, 1.0f };
+    std::vector<f32> b = a;
+    b[2] = std::nextafter(1.0f, 0.0f);
+    const CompareResult result = CompareFloatBuffers(a, 2, 2, b, 2, 2);
+
+    EXPECT_FALSE(result.BitwiseEqual);
+    EXPECT_EQ(1u, result.DifferingTexels);
+    ASSERT_EQ(1u, result.FirstDiffs.size());
+    EXPECT_EQ(0u, result.FirstDiffs[0].X); // row-major: index 2 = (0, 1)
+    EXPECT_EQ(1u, result.FirstDiffs[0].Y);
+    EXPECT_GT(result.MaxAbsDiff, 0.0);
+    EXPECT_LT(result.MaxAbsDiff, 1.0e-6);
+}
+
+TEST(McpRenderValidate, CompareOverlapsDifferentlySizedBuffers)
+{
+    // A 3x2 vs 2x2: only the overlapping top-left 2x2 is compared, with each
+    // buffer indexed by its OWN row stride.
+    const std::vector<f32> a{ 1.0f, 2.0f, 9.0f,
+                              3.0f, 4.0f, 9.0f };
+    const std::vector<f32> b{ 1.0f, 2.0f,
+                              3.0f, 4.0f };
+    const CompareResult result = CompareFloatBuffers(a, 3, 2, b, 2, 2);
+
+    EXPECT_EQ(2u, result.Width);
+    EXPECT_EQ(2u, result.Height);
+    EXPECT_TRUE(result.BitwiseEqual);
+}
+
+TEST(McpRenderValidate, CompareIdenticalNaNsAreEqualDifferingNaNIsNot)
+{
+    const f32 quietNaN = std::numeric_limits<f32>::quiet_NaN();
+    const std::vector<f32> a{ quietNaN, 1.0f };
+    const std::vector<f32> sameNaN{ quietNaN, 1.0f };
+    EXPECT_TRUE(CompareFloatBuffers(a, 2, 1, sameNaN, 2, 1).BitwiseEqual);
+
+    const std::vector<f32> noNaN{ 1.0f, 1.0f };
+    const CompareResult result = CompareFloatBuffers(a, 2, 1, noNaN, 2, 1);
+    EXPECT_FALSE(result.BitwiseEqual);
+    EXPECT_EQ(1u, result.DifferingTexels);
+    // A NaN-vs-finite diff must not poison MaxAbsDiff.
+    EXPECT_DOUBLE_EQ(0.0, result.MaxAbsDiff);
+}
+
+TEST(McpRenderValidate, BuildValidateJsonOkOnlyWhenClean)
+{
+    const Json clean = BuildValidateJson({}, {}, {}, {}, {});
+    EXPECT_TRUE(clean["ok"].get<bool>());
+    EXPECT_EQ(0u, clean["hazardCount"].get<u32>());
+
+    std::vector<HazardInfo> hazards;
+    hazards.push_back(HazardInfo{ "ReadAfterWrite", "SceneDepth", "GTAOPass", "ParticlePass", "reader precedes writer" });
+    const Json dirty = BuildValidateJson(hazards, {}, {}, {}, {});
+    EXPECT_FALSE(dirty["ok"].get<bool>());
+    EXPECT_EQ(1u, dirty["hazardCount"].get<u32>());
+    EXPECT_EQ("ReadAfterWrite", dirty["hazards"][0]["kind"].get<std::string>());
+
+    std::vector<ResourceIdentity> identities;
+    ResourceIdentity unbacked;
+    unbacked.Name = "GhostBuffer";
+    unbacked.HasConsumers = true;
+    identities.push_back(unbacked);
+    const Json ghost = BuildValidateJson({}, {}, {}, {}, identities);
+    EXPECT_FALSE(ghost["ok"].get<bool>());
+    ASSERT_EQ(1u, ghost["consumedButUnbacked"].size());
+    EXPECT_EQ("GhostBuffer", ghost["consumedButUnbacked"][0].get<std::string>());
+}
+
+TEST(McpRenderValidate, CompareResultJsonShape)
+{
+    CompareRequest request;
+    request.A = "SceneDepth";
+    request.B = "HZB";
+    request.MipB = 0;
+    request.AfterPass = "GTAOPass";
+
+    std::vector<f32> a{ 0.5f };
+    std::vector<f32> b{ 0.25f };
+    CompareResult result = CompareFloatBuffers(a, 1, 1, b, 1, 1);
+    result.FormatA = "DEPTH24_STENCIL8";
+    result.FormatB = "R32F";
+
+    const Json j = CompareResultJson(request, result);
+    EXPECT_EQ("SceneDepth", j["a"]["name"].get<std::string>());
+    EXPECT_EQ("HZB", j["b"]["name"].get<std::string>());
+    EXPECT_EQ("GTAOPass", j["afterPass"].get<std::string>());
+    EXPECT_FALSE(j["bitwiseEqual"].get<bool>());
+    EXPECT_EQ(1u, j["differingTexels"].get<u64>());
+    ASSERT_EQ(1u, j["firstDiffs"].size());
+    EXPECT_DOUBLE_EQ(0.25, j["maxAbsDiff"].get<f64>());
+    EXPECT_EQ(std::bit_cast<u32>(0.5f), j["firstDiffs"][0]["aBits"].get<u32>());
+}

--- a/docs/agent-rules/render-pass-published-state.md
+++ b/docs/agent-rules/render-pass-published-state.md
@@ -61,3 +61,35 @@ LightProbesTest sandbox scene shipped three such "spheres" that had never
 rendered; Sphere is 2.) When a mesh entity mysteriously contributes
 nothing — no draw, no shadow, no GI — check the primitive enum value
 before suspecting the renderer.
+
+## 5. Pass-owned textures: import from Setup, hash the ids, stable ping names
+
+To make a pass-owned raw GL texture visible to the render graph (and so to
+`olo_render_list_targets` / `olo_render_capture_target`), `ImportTexture` it
+from the pass's **`Setup()`** (never Execute — the resource must be resolvable
+the same rebuild that registers it) and hash **both the gate and the raw
+texture ids** into `ComputeBlackboardFingerprint`, because imports are wiped by
+every non-cached `PopulateBlackboard` and Setup only reruns on a fingerprint
+miss. Two refinements learned in the #607 batch (DDGI atlases, froxel-fog
+volumes; precedents: VirtualGeometryDebug, FluidIntermediates):
+
+- **Ping-pong resources import BOTH pings under stable per-ping names**
+  (`DDGIIrradianceAtlas0/1`). Importing "the current ping" would flip the
+  fingerprint every blended frame and defeat the BuildFrameGraph cache.
+- A genuine 3D volume imports as `ResourceHandle::Kind::Texture3D` with
+  `DepthOrLayers = depth`; the capture path already reads one z-slice via its
+  `layer` selector.
+
+## 6. Post-pass hooks are keyed and multi-listener; snapshots must copy at hook time
+
+`RenderGraph::AddPostPassHook(key, fn)` / `RemovePostPassHook(key)` replaced
+the single-slot `SetPostPassHook` (#607): the debugger's frame capture
+(`"framecapture"`) and the MCP afterPass snapshot (`"mcp-afterpass-snapshot"`)
+coexist on the same graph. Never re-introduce a single-slot install, and never
+use the graph's `HasPostPassHook()` to test whether *your* hook is installed —
+it reports ANY listener (`RenderGraphFrameCapture::IsHookInstalled` exists for
+that). A mid-frame snapshot must `glCopyImageSubData` the resolved texture
+INSIDE the hook, not remember the GL id: the transient pool memory-aliases
+same-descriptor resources, so a mid-frame id can be recycled for a different
+logical resource later in the same frame. `glCopyImageSubData` binds nothing,
+so the publish-last rules of §1 are unaffected.

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -176,8 +176,8 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_log_tail` | recent engine log lines, filterable by `minLevel` and `tag` |
 | `olo_events_tail` | unified "what just happened?" timeline — scene load, play/stop, entity spawn/destroy, asset reload, script error — newest last with a monotonic `id`; incremental polling via `sinceId`, plus a `categories` filter |
 | `olo_scene_summary` | active scene name, play state, entity count |
-| `olo_scene_open` | **(consented write)** open / switch the active scene by `path` (a `.olo`/`.scene` file, relative paths resolve against the project asset directory) — the scriptable scene switch. Loads directly, bypassing the auto-save recovery modal a remote agent can't click; stops Play mode first. Reports the loaded scene name + entity count. Gated behind **Agent writes** |
-| `olo_scene_play` / `olo_scene_stop` | **(consented write)** enter / leave Play mode — the same as the editor's Play/Stop buttons, so an agent can verify anything that only runs in Play (physics, cloth, scripts). Transient + fully reversible (stop restores the authored scene); idempotent (`changed:false` when already in that state); `olo_scene_summary` reports `isPlaying` to confirm. Gated behind **Agent writes** |
+| `olo_scene_open` | **(consented write)** open / switch the active scene by `path` (a `.olo`/`.scene` file, relative paths resolve against the project asset directory) — the scriptable scene switch. Loads directly, bypassing the auto-save recovery modal a remote agent can't click; stops Play mode first; **cancels any pending auto-save recovery** (an armed recovery modal used to be able to swap the freshly opened scene back out when its button was clicked later, issue #607). Reports the loaded scene name + entity count and settles rendered frames before returning. Gated behind **Agent writes** |
+| `olo_scene_play` / `olo_scene_stop` | **(consented write)** enter / leave Play mode — the same as the editor's Play/Stop buttons, so an agent can verify anything that only runs in Play (physics, cloth, scripts). Transient + fully reversible (stop restores the authored scene); idempotent (`changed:false` when already in that state); **settles rendered frames after a real transition** so an immediately following `olo_screenshot` shows the new state, not the last pre-transition frame (the uniform-grey trap, issue #607); `olo_scene_summary` reports `isPlaying` to confirm. Gated behind **Agent writes** |
 | `olo_editor_select_entity` | **(consented write)** select (or `clear`) the entity in the editor's Scene Hierarchy / Properties panels — the only way to drive the Properties inspector onto a given entity over MCP, unblocking screenshot verification of its rendered component UI. `olo_input_inject` cannot reliably land a Scene Hierarchy row click (the OS cursor reasserts over the synthetic position between injected frames). An unknown `entity` UUID leaves the current selection untouched (`ok:false`), never silently clearing it. Not undoable (selection isn't project data). Gated behind **Agent writes** |
 | `olo_scene_list_entities` | paginated entity list (id, name, parent, child count) + name filter |
 | `olo_scene_get_entity` | one entity's full component data (YAML) by UUID |
@@ -201,14 +201,17 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_script_get_last_errors` | recent C# (Mono) / Lua (Sol2) script exceptions |
 | `olo_reload_script` | **(consented write)** reload the C# script assembly — the editor's *Script ▸ Reload assembly* (Ctrl+R) path — so a rebuilt game assembly is picked up without restarting the editor; reports whether scripting is available, whether the reload ran, and the post-reload script-class count. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
 | `olo_crash_list` / `olo_crash_get` | crash reports under `CrashReports/` |
-| `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera |
+| `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera. In **Play mode** the frame comes from the runtime's primary `CameraComponent`, so poses are refused there (they could only move the unused editor camera) and the reply's `sceneState`/`camera` meta says which camera produced the frame |
 | `olo_camera_get` | the editor camera's pose (position, focal point, yaw/pitch, FOV, clips, viewport size) |
 | `olo_camera_set_pose` | move the editor camera: `position` + (`target` \| `yaw`/`pitch`), optional `fov` |
 | `olo_camera_orbit` | orbit-frame the camera around a world point: `target`, `yaw`, `pitch`, `distance` |
 | `olo_camera_frame_entity` | point the camera at an entity (by UUID) and fit it in view |
 | `olo_viewport_set_size` | override the viewport's logical render size for deterministic captures (`reset` to clear). The override wins over window/panel resizes (the editor reasserts it after any OS window-resize event); verify with `olo_perf_snapshot`'s `renderWidth`/`renderHeight` before perf measurements |
 | `olo_render_list_targets` | the render graph's live texture/framebuffer resources (name, kind, format, size, producers) |
-| `olo_render_capture_target` | read back one intermediate render target (depth, normals, G-buffer, shadow map, AO, post-process stages, …) as a PNG image block; depth is min-max normalised by default. `layer` picks one slice of an **array** target (CSM cascade 0–3, `ShadowCSMRaw` / `ShadowAtlasRaw`); out-of-range is an error, never a silent layer-0 capture |
+| `olo_render_capture_target` | read back one intermediate render target (depth, normals, G-buffer, shadow map, AO, the DDGI atlases, the froxel-fog volumes, post-process stages, …) as a PNG image block; depth is min-max normalised by default. `layer` picks one slice of an **array / cube / 3D** target (CSM cascade 0–3, cubemap faces, froxel z-slices); out-of-range is an error, never a silent layer-0 capture. `afterPass` captures the resource **as of that pass's execution** (mid-frame snapshot) instead of end-of-frame — see [Mid-frame state & exact texels](#mid-frame-state--exact-texels-afterpass-texel-space-stats-validate) |
+| `olo_render_probe_pixel` | the exact NUMBERS under one pixel: every decoded G-Buffer channel (albedo, metallic, decoded world normal, roughness, AO, emissive, velocity, integer entityID, raw + linearized depth) plus the final presented colour — or, with `target`, the raw channels of ONE named resource. Every reply echoes `mappedCoord` (the exact texel read); `space`:"texel" + `mip` address an exact texel of a padded resource (the HZB pyramid), `layer` picks an array slice, `afterPass` probes mid-frame state |
+| `olo_render_target_stats` | exact float min/max/mean + a **bit-exact unique-value histogram** over a `rect` of one target at a `mip` — the 1-ULP instrument an 8-bit PNG cannot be (1.0 and 0.99999994 both encode as 255). Per channel: finite/NaN/Inf counts, distinct-bit-pattern count, most frequent values with exact counts. Supports `layer` and `afterPass` |
+| `olo_render_validate` | on-demand render-graph frame validation: the compiled resource-hazard sweep, barrier/build diagnostics, execute-path resolve failures, consumed-but-unbacked resources, and versioned-name physical-id groups; optional `compare` checks two targets **bit-exactly** (channel 0), e.g. `compare:{a:"SceneDepth", b:"HZB", afterPass:"GTAOPass"}` — both sides snapshotted in the SAME frame |
 | `olo_froxel_fog_probe` | sample the volumetric-fog **froxel volume** at one cell (`froxel`:[x,y,z] or `worldPos`:[x,y,z]) — returns the RAW scatter (in-scatter + extinction) **and** the INTEGRATED values (accumulated in-scatter + transmittance) plus the cell's world bounds, so "scatter pass wrong" and "composite tap wrong" separate without a PNG round trip |
 | `olo_render_compare_golden` | capture the viewport (optional `camera`/`orbit` pose) and diff it against a golden PNG (`goldenPath`): returns a numeric `similarity`/`rmse`/`ssim` + `pass` verdict; missing golden or `rebase`:true writes the capture as the new baseline (the `OLOENGINE_GOLDEN_REBASE` workflow) |
 | `olo_render_toggle_pass` | flip a post-process / fog feature on/off (`name` + optional `enabled`) — the ephemeral A/B loop: toggle off → `olo_screenshot` → toggle on → `olo_screenshot`. No `name` lists every pass + its live state |
@@ -375,7 +378,7 @@ round-trip rather than looking like a write that quietly did nothing.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (52 built-in tools; the full `tools/list` measures
+The tool surface is large enough (~64 built-in tools; the full `tools/list` measures
 ~60 KB ≈ 15k tokens) that paging the whole flat list to find the right one is
 wasteful. Every tool is tagged with a **toolset** (grouping category), and a custom
 `tools/search` JSON-RPC method lets an agent discover tools by keyword and/or
@@ -387,7 +390,7 @@ appear under the `script` toolset — see "Script-defined tools" below):
 | `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity`, `olo_entity_list_fields`, `olo_entity_set_field`, `olo_scene_open`, `olo_scene_play`, `olo_scene_stop`, `olo_editor_select_entity` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings`, `olo_perf_cpu_scopes` |
-| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_scene_set_weather`, `olo_scene_get_atmosphere`, `olo_render_compare_golden`, `olo_render_why_not_visible`, `olo_froxel_fog_probe` |
+| `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_probe_pixel`, `olo_render_target_stats`, `olo_render_validate`, `olo_render_toggle_pass`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_scene_set_weather`, `olo_scene_get_atmosphere`, `olo_render_compare_golden`, `olo_render_why_not_visible`, `olo_froxel_fog_probe`, `olo_cluster_grid_stats`, `olo_shadow_atlas_layout`, `olo_virtual_geometry_set`, `olo_virtual_geometry_stats`, `olo_material_get` |
 | `shader` | `olo_shader_list`, `olo_shader_errors`, `olo_shader_get`, `olo_shader_reload` |
 | `assets` | `olo_assets_list`, `olo_assets_problems` |
 | `scripting` | `olo_script_get_api`, `olo_script_get_last_errors`, `olo_reload_script` |
@@ -911,6 +914,62 @@ to remove. Two related rules the capture path now honours:
   defaults to **its own** layer, and reports it in the capture meta.
 - Depth targets are min-max **normalised** by default (`normalize` overrides), so a
   cascade is legible rather than a flat white field.
+
+### Mid-frame state & exact texels (`afterPass`, texel space, stats, validate)
+
+Four instruments added after the GTAO black-sky hunt (issue #607), where each missing one
+cost hours:
+
+**`afterPass:"<PassName>"`** (on `olo_render_capture_target`, `olo_render_probe_pixel`,
+`olo_render_target_stats`, and `olo_render_validate`'s `compare`) snapshots a resource
+**as of that pass's execution**, not end-of-frame. The motivating case: ParticlePass
+re-exports `SceneDepth` *after* GTAOPass, so an end-of-frame read of `SceneDepth` can
+never show what GTAO actually sampled mid-frame. Mechanics: the tool arms a one-shot
+post-pass hook, renders a frame, and the hook clones the resolved texture bitwise
+(`glCopyImageSubData`, every mip and layer) the moment the named pass finishes — so
+transient-pool aliasing can't swap the contents before the readback. Pass names come from
+`olo_render_graph_topology_export`'s `executionOrder`; a culled or unknown pass is an
+error, never an empty image.
+
+**`space:"texel"`** (on `olo_render_probe_pixel`, with `mip`) addresses an **exact texel**
+of the target's own mip grid, top-left origin — required for padded resources like the
+HZB pow2 pyramid, where the default proportional viewport mapping reads the wrong texel.
+Every probe reply now carries `mappedCoord` — requested coords, the texel actually read,
+the GL row, and the mip dims — so the mapping is never guesswork in either space.
+
+**`olo_render_target_stats {name, rect?, mip?, layer?, afterPass?}`** answers the 1-ULP
+questions a PNG cannot: exact min/max/mean over finite values, NaN/Inf counts, and a
+**bit-exact unique-value histogram** (distinct bit patterns + the most frequent values
+with counts). "Is this HZB region exactly 1.0f?" is one call:
+
+```jsonc
+// olo_render_target_stats { "name": "HZB", "mip": 0, "rect": { "x": 0, "y": 0, "w": 256, "h": 256 } }
+{ "channels": [ { "channel": "r", "finiteCount": 65536, "min": 1.0, "max": 1.0, "mean": 1.0,
+                  "uniqueValues": 1, "topValues": [ { "value": 1.0, "bits": 1065353216, "count": 65536 } ] } ] }
+```
+
+**`olo_render_validate`** is the on-demand frame-validation sweep: compiled resource
+hazards, barrier/build diagnostics, resolve failures, resources that are *consumed but
+resolve to no physical backing*, and versioned-name groups (`SceneColor@ParticlePass`)
+with their resolved GL ids. The optional `compare` block is the bitwise instrument:
+
+```jsonc
+// olo_render_validate { "compare": { "a": "SceneDepth", "b": "HZB", "afterPass": "GTAOPass" } }
+// -> "compare": { "bitwiseEqual": false, "differingTexels": 3,
+//                 "firstDiffs": [ { "x": 511, "y": 12, "a": 1.0, "b": 0.99999994, ... } ] }
+```
+
+With `compare.afterPass`, BOTH sides are cloned by the *same* hook firing, so the verdict
+describes one consistent frame. Note the format caveat: a D24 depth source quantizes on
+float readback, so only same-conversion pairs (D32F/R32F) compare bit-exactly.
+
+The **DDGI probe atlases** (`DDGIIrradianceAtlas0/1`, `DDGIVisibilityAtlas0/1`,
+`DDGIProbeData`) and the **froxel-fog volumes** (`FroxelFogScatter0/1`,
+`FroxelFogIntegrated`, 3D — pick a z-slice with `layer`) are registered render-graph
+resources now (Setup-time imports, the FluidIntermediates pattern), so all of the above —
+plus plain `olo_render_capture_target` — works on them. The atlases ping-pong: which ping
+is "current" flips every blended frame, so both are listed under stable names; either
+shows a black/leaking probe.
 
 ### Probing the froxel fog volume (`olo_froxel_fog_probe`)
 


### PR DESCRIPTION
- Introduced comprehensive unit tests for MCP render probe pixel functionality, addressing coordinate mapping and JSON serialization.
- Added tests for MCP render target statistics, including exact min/max/mean calculations, NaN/Inf handling, and unique value histograms.
- Implemented validation tests for resource identity handling, buffer comparisons, and JSON response shapes.
- Enhanced documentation to reflect new features and clarify usage of mid-frame state capturing and exact texel probing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mid-frame render capture and inspection using `afterPass`.
  * Added exact texel and viewport pixel probing with mip and layer support.
  * Added render-target statistics, including min/max/mean values and unique-value histograms.
  * Added render validation with hazard reporting and bitwise buffer comparisons.
  * Enhanced render-graph topology exports with physical resource IDs and pass access details.

* **Bug Fixes**
  * Direct scene loads now cancel stale auto-save recovery prompts.
  * Screenshot camera controls are rejected in Play mode and identify the camera used.
  * Play/Stop transitions now wait for rendered frames to settle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->