### PR TITLE
feat(mcp): close UE6-parity Tier 1 (#673) — outbound stdio client, Ou…

### DIFF
--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -7,6 +7,8 @@
 
 		"MCP/McpServer.cpp"
 		"MCP/McpServer.h"
+		"MCP/McpClient.cpp"
+		"MCP/McpClient.h"
 		"MCP/McpTools.cpp"
 		"MCP/McpTools.h"
 		"MCP/McpToolsCommon.h"

--- a/OloEditor/src/MCP/McpClient.cpp
+++ b/OloEditor/src/MCP/McpClient.cpp
@@ -1,0 +1,662 @@
+#include "OloEnginePCH.h"
+#include "MCP/McpClient.h"
+
+#include "OloEngine/Core/Log.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <thread>
+#include <utility>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#endif
+
+namespace OloEngine::MCP
+{
+    // ---- McpClientConnection: protocol + concurrency ---------------------------
+
+    McpClientConnection::McpClientConnection(McpClientConfig config,
+                                             std::function<void(const std::string&)> onDeath)
+        : m_Config(std::move(config)), m_OnDeath(std::move(onDeath))
+    {
+    }
+
+    McpClientConnection::~McpClientConnection()
+    {
+        Shutdown();
+    }
+
+    std::shared_ptr<McpClientConnection> McpClientConnection::Connect(
+        const McpClientConfig& config, const McpClientTransportFactory& factory,
+        std::function<void(const std::string& alias)> onDeath, std::string& outError)
+    {
+        outError.clear();
+        std::shared_ptr<McpClientConnection> connection(new McpClientConnection(config, std::move(onDeath)));
+
+        // Weak captures: the transport's reader-thread callbacks must not keep
+        // the connection alive (the connection owns the transport — a strong
+        // capture would be a permanent reference cycle, the exact leak the Lua
+        // script runtime's olo.call_tool closure had to break the same way).
+        std::weak_ptr<McpClientConnection> weak = connection;
+        std::string transportError;
+        auto transport = factory(
+            config.Command,
+            [weak](std::string line)
+            {
+                if (const std::shared_ptr<McpClientConnection> self = weak.lock())
+                    self->OnLine(line);
+            },
+            [weak]()
+            {
+                if (const std::shared_ptr<McpClientConnection> self = weak.lock())
+                    self->OnTransportClosed();
+            },
+            transportError);
+        if (!transport)
+        {
+            outError = transportError.empty() ? "failed to start the child process" : transportError;
+            return nullptr;
+        }
+        connection->m_Transport = std::move(transport);
+        connection->m_Alive.store(true, std::memory_order_release);
+
+        // MCP handshake: initialize -> notifications/initialized -> tools/list.
+        // 2025-06-18 is the newest revision whose features we rely on here
+        // (outputSchema/structuredContent pass-through); the child may echo an
+        // older one — transport framing is identical, so we accept any reply.
+        const Json initParams{ { "protocolVersion", "2025-06-18" },
+                               { "capabilities", Json::object() },
+                               { "clientInfo", Json{ { "name", "OloEditor" }, { "version", "0.0.1" } } } };
+        const std::optional<Json> initResponse =
+            connection->SendRequest("initialize", initParams, config.HandshakeTimeout);
+        if (!initResponse || !initResponse->contains("result"))
+        {
+            outError = "MCP initialize failed (no/invalid response from '" + config.Command + "')";
+            connection->Shutdown();
+            return nullptr;
+        }
+        connection->SendNotification("notifications/initialized", Json::object());
+
+        const std::optional<Json> toolsResponse =
+            connection->SendRequest("tools/list", Json::object(), config.HandshakeTimeout);
+        if (!toolsResponse || !toolsResponse->contains("result") ||
+            !(*toolsResponse)["result"].contains("tools") || !(*toolsResponse)["result"]["tools"].is_array())
+        {
+            outError = "MCP tools/list failed (no/invalid response from '" + config.Command + "')";
+            connection->Shutdown();
+            return nullptr;
+        }
+
+        connection->BuildBridgedTools((*toolsResponse)["result"]["tools"], connection);
+        return connection;
+    }
+
+    void McpClientConnection::BuildBridgedTools(const Json& toolsArray,
+                                                const std::shared_ptr<McpClientConnection>& self)
+    {
+        const std::string prefix = McpServer::ClientToolPrefix(m_Config.Alias);
+        for (const Json& entry : toolsArray)
+        {
+            if (!entry.is_object() || !entry.contains("name") || !entry["name"].is_string())
+            {
+                OLO_CORE_WARN("[MCP client '{}'] skipping a tools/list entry with no string name.",
+                              m_Config.Alias);
+                continue;
+            }
+            const std::string childName = entry["name"].get<std::string>();
+
+            ToolDef def;
+            def.Name = prefix + childName;
+            def.Title = entry.value("title", std::string{});
+            // The provenance note travels in the description so a calling agent
+            // knows this tool leaves the editor process (latency + trust).
+            def.Description = "(bridged from external MCP server '" + m_Config.Alias + "') " +
+                              entry.value("description", std::string{});
+            if (entry.contains("inputSchema") && entry["inputSchema"].is_object())
+                def.InputSchema = entry["inputSchema"]; // local validation before forwarding
+            if (entry.contains("outputSchema") && entry["outputSchema"].is_object())
+                def.OutputSchema = entry["outputSchema"];
+            if (entry.contains("icons"))
+                def.Icons = entry["icons"]; // ReplaceClientTools validates-or-drops
+            // Strong capture on purpose: an executing bridged call keeps this
+            // connection (and its transport) alive across a disconnect/re-merge.
+            def.Handler = [self, childName](McpServer&, const Json& arguments)
+            { return self->InvokeBridged(childName, arguments); };
+            m_BridgedTools.push_back(std::move(def));
+        }
+        m_BridgedToolCount = m_BridgedTools.size();
+    }
+
+    std::vector<ToolDef> McpClientConnection::TakeBridgedTools()
+    {
+        return std::move(m_BridgedTools);
+    }
+
+    ToolResult McpClientConnection::InvokeBridged(const std::string& childToolName, const Json& arguments)
+    {
+        const std::optional<Json> response = SendRequest(
+            "tools/call", Json{ { "name", childToolName }, { "arguments", arguments } }, m_Config.CallTimeout);
+        if (!response)
+            return ToolResult::Error("External server '" + m_Config.Alias +
+                                     "' did not respond (disconnected or timed out).");
+        if (response->contains("error"))
+        {
+            std::string message = "external server returned an error";
+            if ((*response)["error"].is_object())
+                message = (*response)["error"].value("message", message);
+            return ToolResult::Error("External server '" + m_Config.Alias + "': " + message);
+        }
+
+        const Json result = response->value("result", Json::object());
+        ToolResult out;
+        out.IsError = result.is_object() && result.value("isError", false);
+        if (result.is_object() && result.contains("content") && result["content"].is_array())
+            out.Content = result["content"];
+        else
+            out.Content = Json::array({ Json{ { "type", "text" }, { "text", result.dump(2) } } });
+        if (result.is_object() && result.contains("structuredContent") && result["structuredContent"].is_object())
+            out.StructuredContent = result["structuredContent"];
+        return out;
+    }
+
+    std::optional<Json> McpClientConnection::SendRequest(const std::string& method, const Json& params,
+                                                         std::chrono::milliseconds timeout)
+    {
+        if (!m_Alive.load(std::memory_order_acquire))
+            return std::nullopt;
+
+        // Exact-value id keying, the server's own cancellation-registry precedent.
+        const Json id = m_NextId.fetch_add(1, std::memory_order_relaxed);
+        const std::string key = id.dump();
+        auto pending = std::make_shared<PendingCall>();
+        {
+            std::lock_guard lock(m_PendingMutex);
+            m_Pending.emplace(key, pending);
+        }
+
+        const Json request{ { "jsonrpc", "2.0" }, { "id", id }, { "method", method }, { "params", params } };
+        bool written = false;
+        {
+            // Serialize concurrent bridged handlers' writes. Never held while
+            // waiting; compact dump() never contains a raw newline, so one line
+            // is one message (the NDJSON property McpEventStream.h relies on).
+            std::lock_guard lock(m_WriteMutex);
+            written = m_Transport && m_Transport->WriteLine(request.dump());
+        }
+        if (!written)
+        {
+            std::lock_guard lock(m_PendingMutex);
+            m_Pending.erase(key);
+            return std::nullopt;
+        }
+
+        std::unique_lock lock(pending->M);
+        pending->Cv.wait_for(lock, timeout, [&pending]
+                             { return pending->Done || pending->Aborted; });
+        const bool done = pending->Done;
+        Json response = std::move(pending->Response);
+        lock.unlock();
+        {
+            std::lock_guard g(m_PendingMutex);
+            m_Pending.erase(key);
+        }
+        if (!done)
+            return std::nullopt;
+        return response;
+    }
+
+    void McpClientConnection::SendNotification(const std::string& method, const Json& params)
+    {
+        const Json notification{ { "jsonrpc", "2.0" }, { "method", method }, { "params", params } };
+        std::lock_guard lock(m_WriteMutex);
+        if (m_Transport)
+            (void)m_Transport->WriteLine(notification.dump());
+    }
+
+    void McpClientConnection::OnLine(const std::string& line)
+    {
+        const Json message = Json::parse(line, /*cb=*/nullptr, /*allow_exceptions=*/false);
+        if (!message.is_object())
+        {
+            OLO_CORE_WARN("[MCP client '{}'] dropping an unparseable line from the child.", m_Config.Alias);
+            return;
+        }
+
+        const bool hasId = message.contains("id") && !message["id"].is_null();
+        if (hasId && (message.contains("result") || message.contains("error")))
+        {
+            // A response: complete the matching waiter.
+            std::shared_ptr<PendingCall> pending;
+            {
+                std::lock_guard lock(m_PendingMutex);
+                if (const auto it = m_Pending.find(message["id"].dump()); it != m_Pending.end())
+                    pending = it->second;
+            }
+            if (pending)
+            {
+                {
+                    std::lock_guard lock(pending->M);
+                    pending->Response = message;
+                    pending->Done = true;
+                }
+                pending->Cv.notify_all();
+            }
+            return;
+        }
+        if (hasId && message.contains("method"))
+        {
+            // A request FROM the child (sampling, roots, ...) — not supported.
+            // Answer cleanly so a well-behaved child never hangs waiting on us.
+            const Json reply{ { "jsonrpc", "2.0" },
+                              { "id", message["id"] },
+                              { "error", Json{ { "code", -32601 },
+                                               { "message",
+                                                 "OloEditor's outbound MCP client does not accept requests" } } } };
+            std::lock_guard lock(m_WriteMutex);
+            if (m_Transport)
+                (void)m_Transport->WriteLine(reply.dump());
+            return;
+        }
+
+        // A notification. v1 deliberately does not live-re-merge on
+        // tools/list_changed (reconnect picks the new list up); log so the
+        // operator can see why the surface looks stale.
+        if (message.value("method", std::string{}) == "notifications/tools/list_changed")
+            OLO_CORE_INFO("[MCP client '{}'] child announced a tool-list change; disconnect + reconnect to "
+                          "pick it up.",
+                          m_Config.Alias);
+    }
+
+    void McpClientConnection::OnTransportClosed()
+    {
+        m_Alive.store(false, std::memory_order_release);
+
+        // Fail every waiter promptly — a blocked httplib worker must never wait
+        // out its full timeout against a child that is already gone.
+        std::unordered_map<std::string, std::shared_ptr<PendingCall>> pending;
+        {
+            std::lock_guard lock(m_PendingMutex);
+            pending.swap(m_Pending);
+        }
+        for (auto& [key, call] : pending)
+        {
+            {
+                std::lock_guard lock(call->M);
+                call->Aborted = true;
+            }
+            call->Cv.notify_all();
+        }
+
+        // Deliberate teardown is not a death; only an unexpected end of stream
+        // unpublishes the alias's tools via the owner's callback.
+        if (!m_ShuttingDown.load(std::memory_order_acquire) && m_OnDeath)
+        {
+            OLO_CORE_WARN("[MCP client '{}'] child process ended; unpublishing its bridged tools.",
+                          m_Config.Alias);
+            m_OnDeath(m_Config.Alias);
+        }
+    }
+
+    void McpClientConnection::Shutdown()
+    {
+        if (m_ShuttingDown.exchange(true, std::memory_order_acq_rel))
+            return;
+        m_Alive.store(false, std::memory_order_release);
+
+        // Drain waiters first so no handler thread is parked while the
+        // transport tears the child down (mirrors Stop()'s consent-abort-
+        // before-join ordering).
+        std::unordered_map<std::string, std::shared_ptr<PendingCall>> pending;
+        {
+            std::lock_guard lock(m_PendingMutex);
+            pending.swap(m_Pending);
+        }
+        for (auto& [key, call] : pending)
+        {
+            {
+                std::lock_guard lock(call->M);
+                call->Aborted = true;
+            }
+            call->Cv.notify_all();
+        }
+
+        // No connection lock may be held here: Close() joins the reader thread,
+        // and the reader's callbacks take the pending/write mutexes.
+        if (m_Transport)
+            m_Transport->Close();
+    }
+
+    // ---- Windows stdio transport ----------------------------------------------
+
+#ifdef _WIN32
+    namespace
+    {
+        class WindowsPipeTransport final : public IMcpClientTransport
+        {
+          public:
+            static std::unique_ptr<WindowsPipeTransport> Spawn(const std::string& command,
+                                                               std::function<void(std::string)> onLine,
+                                                               std::function<void()> onClosed,
+                                                               std::string& outError)
+            {
+                SECURITY_ATTRIBUTES inheritable{};
+                inheritable.nLength = sizeof(SECURITY_ATTRIBUTES);
+                inheritable.bInheritHandle = TRUE;
+
+                HANDLE stdinRead = nullptr;
+                HANDLE stdinWrite = nullptr;
+                HANDLE stdoutRead = nullptr;
+                HANDLE stdoutWrite = nullptr;
+                HANDLE nulHandle = nullptr;
+                const auto closeAll = [&]
+                {
+                    for (HANDLE h : { stdinRead, stdinWrite, stdoutRead, stdoutWrite, nulHandle })
+                    {
+                        if (h != nullptr)
+                            ::CloseHandle(h);
+                    }
+                };
+
+                if (!::CreatePipe(&stdinRead, &stdinWrite, &inheritable, 0) ||
+                    !::CreatePipe(&stdoutRead, &stdoutWrite, &inheritable, 0))
+                {
+                    closeAll();
+                    outError = "CreatePipe failed";
+                    return nullptr;
+                }
+                // Our ends must NOT leak into the child, or the child holding a
+                // duplicate of stdoutWrite would keep our reader from ever
+                // seeing EOF (and stdinWrite would defeat the polite-EOF close).
+                ::SetHandleInformation(stdinWrite, HANDLE_FLAG_INHERIT, 0);
+                ::SetHandleInformation(stdoutRead, HANDLE_FLAG_INHERIT, 0);
+
+                // stderr -> NUL: a chatty child logging to stderr must never
+                // corrupt the NDJSON stdout stream, and the editor is a GUI app
+                // with no console to inherit.
+                nulHandle = ::CreateFileW(L"NUL", GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ,
+                                          &inheritable, OPEN_EXISTING, 0, nullptr);
+
+                // UTF-8 command line -> mutable UTF-16 buffer (CreateProcessW
+                // may modify it in place).
+                const int wideLength =
+                    ::MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, nullptr, 0);
+                std::wstring wideCommand(static_cast<std::size_t>(wideLength > 0 ? wideLength : 1), L'\0');
+                if (wideLength > 0)
+                    ::MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, wideCommand.data(), wideLength);
+
+                STARTUPINFOW startup{};
+                startup.cb = sizeof(startup);
+                startup.dwFlags = STARTF_USESTDHANDLES;
+                startup.hStdInput = stdinRead;
+                startup.hStdOutput = stdoutWrite;
+                startup.hStdError = nulHandle != nullptr ? nulHandle : INVALID_HANDLE_VALUE;
+
+                PROCESS_INFORMATION process{};
+                if (!::CreateProcessW(nullptr, wideCommand.data(), nullptr, nullptr, TRUE,
+                                      CREATE_NO_WINDOW, nullptr, nullptr, &startup, &process))
+                {
+                    const DWORD error = ::GetLastError();
+                    closeAll();
+                    outError = "CreateProcess failed (error " + std::to_string(error) + ") for: " + command;
+                    return nullptr;
+                }
+
+                // Child-side ends are the child's problem now.
+                ::CloseHandle(stdinRead);
+                ::CloseHandle(stdoutWrite);
+                if (nulHandle != nullptr)
+                    ::CloseHandle(nulHandle);
+
+                auto transport = std::unique_ptr<WindowsPipeTransport>(new WindowsPipeTransport());
+                transport->m_StdinWrite = stdinWrite;
+                transport->m_StdoutRead = stdoutRead;
+                transport->m_Process = process.hProcess;
+                transport->m_ProcessThread = process.hThread;
+                transport->m_OnLine = std::move(onLine);
+                transport->m_OnClosed = std::move(onClosed);
+                transport->m_Reader = std::thread([transportPtr = transport.get()]
+                                                  { transportPtr->ReaderLoop(); });
+                return transport;
+            }
+
+            ~WindowsPipeTransport() override
+            {
+                Close();
+            }
+
+            [[nodiscard]] bool WriteLine(const std::string& payload) override
+            {
+                std::lock_guard lock(m_StdinMutex);
+                if (m_StdinWrite == nullptr)
+                    return false;
+                std::string data = payload;
+                data.push_back('\n');
+                const char* cursor = data.data();
+                DWORD remaining = static_cast<DWORD>(data.size());
+                while (remaining > 0)
+                {
+                    DWORD written = 0;
+                    if (!::WriteFile(m_StdinWrite, cursor, remaining, &written, nullptr) || written == 0)
+                        return false;
+                    cursor += written;
+                    remaining -= written;
+                }
+                return true;
+            }
+
+            void Close() override
+            {
+                if (m_Closed.exchange(true, std::memory_order_acq_rel))
+                {
+                    // Second caller (e.g. destructor after an explicit Close)
+                    // must still not race the join.
+                    if (m_Reader.joinable())
+                        m_Reader.join();
+                    return;
+                }
+
+                // Polite first: closing the child's stdin is the conventional
+                // "we're done" signal for stdio MCP servers.
+                {
+                    std::lock_guard lock(m_StdinMutex);
+                    if (m_StdinWrite != nullptr)
+                    {
+                        ::CloseHandle(m_StdinWrite);
+                        m_StdinWrite = nullptr;
+                    }
+                }
+                if (m_Process != nullptr &&
+                    ::WaitForSingleObject(m_Process, kChildExitGraceMs) == WAIT_TIMEOUT)
+                {
+                    ::TerminateProcess(m_Process, 1);
+                    ::WaitForSingleObject(m_Process, kChildExitGraceMs);
+                }
+                // The child (and every write handle to its stdout pipe) is gone,
+                // so the reader's blocking ReadFile returns EOF and the thread
+                // exits — the only reliable way to unblock a pipe read.
+                if (m_Reader.joinable())
+                    m_Reader.join();
+
+                if (m_StdoutRead != nullptr)
+                {
+                    ::CloseHandle(m_StdoutRead);
+                    m_StdoutRead = nullptr;
+                }
+                if (m_ProcessThread != nullptr)
+                {
+                    ::CloseHandle(m_ProcessThread);
+                    m_ProcessThread = nullptr;
+                }
+                if (m_Process != nullptr)
+                {
+                    ::CloseHandle(m_Process);
+                    m_Process = nullptr;
+                }
+            }
+
+          private:
+            WindowsPipeTransport() = default;
+
+            void ReaderLoop()
+            {
+                std::string buffer;
+                char chunk[4096];
+                for (;;)
+                {
+                    DWORD read = 0;
+                    if (!::ReadFile(m_StdoutRead, chunk, sizeof(chunk), &read, nullptr) || read == 0)
+                        break;
+                    buffer.append(chunk, read);
+                    std::size_t newline = 0;
+                    while ((newline = buffer.find('\n')) != std::string::npos)
+                    {
+                        std::string line = buffer.substr(0, newline);
+                        buffer.erase(0, newline + 1);
+                        if (!line.empty() && line.back() == '\r')
+                            line.pop_back();
+                        if (!line.empty() && m_OnLine)
+                            m_OnLine(std::move(line));
+                    }
+                }
+                if (m_OnClosed)
+                    m_OnClosed();
+            }
+
+            static constexpr DWORD kChildExitGraceMs = 2000;
+
+            std::mutex m_StdinMutex; // guards m_StdinWrite (WriteLine vs Close)
+            HANDLE m_StdinWrite = nullptr;
+            HANDLE m_StdoutRead = nullptr;
+            HANDLE m_Process = nullptr;
+            HANDLE m_ProcessThread = nullptr;
+            std::thread m_Reader;
+            std::atomic<bool> m_Closed{ false };
+            std::function<void(std::string)> m_OnLine;
+            std::function<void()> m_OnClosed;
+        };
+    } // namespace
+#endif // _WIN32
+
+    McpClientTransportFactory MakeStdioTransportFactory()
+    {
+#ifdef _WIN32
+        return [](const std::string& command, std::function<void(std::string)> onLine,
+                  std::function<void()> onClosed, std::string& outError) -> std::unique_ptr<IMcpClientTransport>
+        { return WindowsPipeTransport::Spawn(command, std::move(onLine), std::move(onClosed), outError); };
+#else
+        return [](const std::string& /*command*/, std::function<void(std::string)> /*onLine*/,
+                  std::function<void()> /*onClosed*/, std::string& outError) -> std::unique_ptr<IMcpClientTransport>
+        {
+            outError = "outbound stdio MCP clients are not supported on this platform yet";
+            return nullptr;
+        };
+#endif
+    }
+
+    // ---- McpServer's connection ownership (defined here, not in McpServer.cpp,
+    // so the dispatch core TU stays transport-agnostic) --------------------------
+
+    std::string McpServer::ConnectStdioClient(const McpClientConfig& config)
+    {
+        return ConnectClientWithTransport(config, MakeStdioTransportFactory());
+    }
+
+    std::string McpServer::ConnectClientWithTransport(const McpClientConfig& config,
+                                                      const McpClientTransportFactory& factory)
+    {
+        if (!IsValidClientAlias(config.Alias))
+            return "invalid alias '" + config.Alias + "' (1-32 chars of [a-z0-9-], starting alphanumeric)";
+        if (config.Command.empty())
+            return "command must not be empty";
+        {
+            std::lock_guard lock(m_ClientsMutex);
+            const bool taken = std::any_of(m_Clients.begin(), m_Clients.end(),
+                                           [&config](const std::shared_ptr<McpClientConnection>& client)
+                                           { return client->Alias() == config.Alias; });
+            if (taken)
+                return "alias '" + config.Alias + "' is already in use (disconnect it first)";
+        }
+
+        std::string error;
+        auto connection = McpClientConnection::Connect(
+            config, factory,
+            // Reader-thread death callback: unpublish the alias's tools. The
+            // connection stays listed (Connected=false) for the panel until
+            // DisconnectClient reaps it. `this` outlives every connection —
+            // Stop()/~McpServer joins them before the server dies.
+            [this](const std::string& alias)
+            { ReplaceClientTools(alias, {}); }, error);
+        if (!connection)
+            return error.empty() ? "connection failed" : error;
+
+        const sizet merged = ReplaceClientTools(config.Alias, connection->TakeBridgedTools());
+        {
+            std::lock_guard lock(m_ClientsMutex);
+            m_Clients.push_back(connection);
+        }
+        OLO_CORE_INFO("[MCP] Outbound client '{}' connected: {} tool(s) bridged from `{}`.", config.Alias,
+                      merged, config.Command);
+        return {};
+    }
+
+    bool McpServer::DisconnectClient(const std::string& alias)
+    {
+        std::shared_ptr<McpClientConnection> found;
+        {
+            std::lock_guard lock(m_ClientsMutex);
+            const auto it = std::find_if(m_Clients.begin(), m_Clients.end(),
+                                         [&alias](const std::shared_ptr<McpClientConnection>& client)
+                                         { return client->Alias() == alias; });
+            if (it != m_Clients.end())
+            {
+                found = *it;
+                m_Clients.erase(it);
+            }
+        }
+        if (!found)
+            return false;
+        found->Shutdown();
+        ReplaceClientTools(alias, {});
+        OLO_CORE_INFO("[MCP] Outbound client '{}' disconnected.", alias);
+        return true;
+    }
+
+    std::vector<McpClientStatus> McpServer::ClientStatuses() const
+    {
+        std::vector<McpClientStatus> statuses;
+        std::lock_guard lock(m_ClientsMutex);
+        statuses.reserve(m_Clients.size());
+        for (const std::shared_ptr<McpClientConnection>& client : m_Clients)
+        {
+            McpClientStatus status;
+            status.Alias = client->Alias();
+            status.Command = client->Command();
+            status.Connected = client->IsConnected();
+            status.ToolCount = client->BridgedToolCount();
+            statuses.push_back(std::move(status));
+        }
+        return statuses;
+    }
+
+    void McpServer::ShutdownClients()
+    {
+        std::vector<std::shared_ptr<McpClientConnection>> clients;
+        {
+            std::lock_guard lock(m_ClientsMutex);
+            clients.swap(m_Clients);
+        }
+        for (const std::shared_ptr<McpClientConnection>& client : clients)
+        {
+            client->Shutdown();
+            ReplaceClientTools(client->Alias(), {});
+        }
+    }
+} // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpClient.h
+++ b/OloEditor/src/MCP/McpClient.h
@@ -1,0 +1,167 @@
+#pragma once
+
+// Outbound MCP client, stdio transport (issue #673 Tier 1, bullet 1): the
+// editor's MCP server can now also CONSUME tools — spawn a local MCP server
+// process (e.g. a filesystem or web-fetch server), speak newline-delimited
+// JSON-RPC over its stdin/stdout, and fold its tools into the native registry
+// as `ext.<alias>.<tool>` entries via McpServer::ReplaceClientTools (which
+// forces the untrusted-authority posture; see that method's contract).
+//
+// Layering:
+//   * IMcpClientTransport — the byte seam. The Windows implementation
+//     (MakeStdioTransportFactory, McpClient.cpp) owns CreateProcessW + pipes +
+//     a blocking reader thread; tests substitute an in-memory fake that
+//     replies synchronously inside WriteLine.
+//   * McpClientConnection — the protocol + concurrency layer: the initialize /
+//     initialized / tools/list handshake, request-id multiplexing (bridged
+//     tool handlers run CONCURRENTLY on httplib worker threads, so responses
+//     are matched to waiters by exact id, the same id.dump() keying the
+//     server's cancellation registry uses), timeouts, and teardown that never
+//     strands a blocked handler (Shutdown fails every pending request BEFORE
+//     the server joins its worker pool — the consent-abort pattern).
+//
+// Ownership: McpServer owns the connections (ConnectStdioClient /
+// DisconnectClient / ClientStatuses, defined in McpClient.cpp) and shuts them
+// down inside Stop(). Each bridged ToolDef::Handler strongly captures its
+// shared_ptr<McpClientConnection>, so a live re-merge or disconnect can never
+// destroy a connection under an executing call (the ScriptToolsRuntime
+// lifetime pattern).
+
+#include "MCP/McpServer.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace OloEngine::MCP
+{
+    // The byte-stream seam between the protocol layer and the child process.
+    //
+    // Threading contract:
+    //   * WriteLine receives one complete JSON-RPC message WITHOUT the trailing
+    //     newline (the transport appends it). Calls are serialized by the
+    //     connection's write mutex — implementations need no write lock.
+    //   * The transport delivers each incoming line via the onLine callback handed
+    //     to the factory, from its own reader thread (or synchronously inside
+    //     WriteLine for an in-memory test fake), and onClosed exactly once when
+    //     the stream ends for any reason.
+    //   * Close() is idempotent and must guarantee NO further onLine/onClosed
+    //     callback is in flight or forthcoming once it returns (the Windows
+    //     implementation joins its reader thread; it also ends the child:
+    //     stdin-EOF first, TerminateProcess after a short grace).
+    class IMcpClientTransport
+    {
+      public:
+        virtual ~IMcpClientTransport() = default;
+        [[nodiscard]] virtual bool WriteLine(const std::string& payload) = 0;
+        virtual void Close() = 0;
+    };
+
+    // Spawns the Windows stdio transport: CreateProcessW(command) with piped
+    // stdin/stdout (stderr -> NUL so a chatty child can never corrupt the
+    // NDJSON stream), plus a reader thread that splits stdout on '\n'.
+    // Returns nullptr with outError set on spawn failure. On non-Windows
+    // builds it always fails (outbound clients are Windows-only for now).
+    [[nodiscard]] McpClientTransportFactory MakeStdioTransportFactory();
+
+    // One outbound connection: a spawned child MCP server + its bridged tools.
+    class McpClientConnection
+    {
+      public:
+        // Spawn (via `factory`), run the MCP handshake (initialize ->
+        // notifications/initialized -> tools/list), and build the bridged
+        // ToolDefs. Returns nullptr with `outError` set on any failure (spawn,
+        // timeout, malformed handshake). `onDeath(alias)` is invoked at most
+        // once, from the transport's reader thread, when the child dies or the
+        // stream breaks OUTSIDE a deliberate Shutdown — the owner uses it to
+        // unpublish the alias's tools.
+        [[nodiscard]] static std::shared_ptr<McpClientConnection> Connect(
+            const McpClientConfig& config, const McpClientTransportFactory& factory,
+            std::function<void(const std::string& alias)> onDeath, std::string& outError);
+
+        ~McpClientConnection();
+        McpClientConnection(const McpClientConnection&) = delete;
+        McpClientConnection& operator=(const McpClientConnection&) = delete;
+
+        // The bridged ToolDefs built from the child's tools/list (names already
+        // prefixed `ext.<alias>.`; handlers strongly capture this connection).
+        // Hand them to McpServer::ReplaceClientTools — which re-validates and
+        // forces the authority posture; this class does not try to.
+        [[nodiscard]] std::vector<ToolDef> TakeBridgedTools();
+
+        // Fail every pending request, end the child, join the reader. Idempotent;
+        // suppresses the onDeath callback (deliberate teardown is not a death).
+        // Never blocks on the game thread or the server's locks.
+        void Shutdown();
+
+        [[nodiscard]] const std::string& Alias() const
+        {
+            return m_Config.Alias;
+        }
+        [[nodiscard]] const std::string& Command() const
+        {
+            return m_Config.Command;
+        }
+        [[nodiscard]] bool IsConnected() const
+        {
+            return m_Alive.load(std::memory_order_acquire);
+        }
+        [[nodiscard]] sizet BridgedToolCount() const
+        {
+            return m_BridgedToolCount;
+        }
+
+      private:
+        explicit McpClientConnection(McpClientConfig config,
+                                     std::function<void(const std::string&)> onDeath);
+
+        // Send one request and block the CALLING thread (an httplib worker or
+        // the connecting thread) until the child's response arrives, `timeout`
+        // expires, or the connection shuts down. Returns the full JSON-RPC
+        // response object, or nullopt on timeout/write-failure/shutdown.
+        [[nodiscard]] std::optional<Json> SendRequest(const std::string& method, const Json& params,
+                                                      std::chrono::milliseconds timeout);
+        void SendNotification(const std::string& method, const Json& params);
+
+        // Transport callbacks (reader thread / inline from a fake).
+        void OnLine(const std::string& line);
+        void OnTransportClosed();
+
+        [[nodiscard]] ToolResult InvokeBridged(const std::string& childToolName, const Json& arguments);
+        void BuildBridgedTools(const Json& toolsArray, const std::shared_ptr<McpClientConnection>& self);
+
+        struct PendingCall
+        {
+            std::mutex M;
+            std::condition_variable Cv;
+            bool Done = false;    // response arrived
+            bool Aborted = false; // shutdown / stream death
+            Json Response;
+        };
+
+        McpClientConfig m_Config;
+        std::function<void(const std::string&)> m_OnDeath;
+        std::unique_ptr<IMcpClientTransport> m_Transport;
+
+        // Serializes WriteLine calls (concurrent bridged handlers). NEVER held
+        // while waiting; never held together with m_PendingMutex.
+        std::mutex m_WriteMutex;
+
+        std::mutex m_PendingMutex;
+        std::unordered_map<std::string, std::shared_ptr<PendingCall>> m_Pending; // key: id.dump()
+        std::atomic<u64> m_NextId{ 1 };
+
+        std::atomic<bool> m_Alive{ false };
+        std::atomic<bool> m_ShuttingDown{ false };
+
+        std::vector<ToolDef> m_BridgedTools;
+        sizet m_BridgedToolCount = 0;
+    };
+} // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpScriptTools.cpp
+++ b/OloEditor/src/MCP/McpScriptTools.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "MCP/McpScriptTools.h"
+#include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpServer.h"
 #include "MCP/McpToolsCommon.h"
 
@@ -460,6 +461,20 @@ namespace OloEngine::MCP
                 }
                 if (target == nullptr)
                     return fail("unknown tool: " + name);
+                // A tool bridged from an OUTBOUND client connection (issue #673
+                // Tier 1) is out of reach for script tools ALTOGETHER — even for a
+                // write-tier script under AllowSession. The macro-consent bargain
+                // below ("the human consented to the macro; its inner writes are
+                // the macro's body") is justified by inner calls being local,
+                // undoable editor mutations the caller could have made itself;
+                // an external call leaves the editor's undo/revert envelope
+                // entirely, so routing one through a consented macro would
+                // launder the human's LOCAL-write consent into an outbound
+                // action (ADR 0005: authority is "never inherited, never
+                // ambient, and never laundered").
+                if (!target->ClientAlias.empty())
+                    return fail("tool '" + name + "' is bridged from an external MCP server ('" +
+                                target->ClientAlias + "'); script tools cannot invoke external tools");
                 if (target->ProjectWrite)
                 {
                     if (!runtime->CallMayWrite)
@@ -833,6 +848,14 @@ namespace OloEngine::MCP
             "loaded, failures with their messages). The server then emits notifications/tools/list_changed, so "
             "call tools/list again afterwards.";
         tool.InputSchema = Json{ { "type", "object" }, { "properties", Json::object() }, { "additionalProperties", false } };
+        tool.OutputSchema = Schema::Object()
+                                .Prop("directory", Schema::String().Desc("The scanned script-tools directory."))
+                                .Prop("toolsRegistered", Schema::Int().Min(0))
+                                .Prop("filesLoaded", Schema::Int().Min(0))
+                                .Prop("failures", Schema::Int().Min(0).Desc("Files that failed to run plus registrations rejected."))
+                                .Prop("messages", Schema::Array(Schema::String()).Desc("One line per failure/rejection."))
+                                .Prop("toolsGeneration", Schema::Int().Min(0).Desc("Tool-list generation after the swap."))
+                                .Required({ "directory", "toolsRegistered", "filesLoaded", "failures", "messages", "toolsGeneration" });
         // NOT ProjectWrite: it mutates no project data. It re-executes the project's
         // own Lua inside the capability-stripped sandbox, and a write-tier tool it
         // (re)registers still faces the write-consent gate on its own dispatch — so

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -509,24 +509,46 @@ namespace OloEngine::MCP
         // Scrub absolute filesystem paths from text (Windows drive-letter paths and
         // POSIX /home//Users paths) so project layout / usernames don't leak when
         // redaction is enabled. Heuristic, best-effort.
+        //
+        // The drive-path match requires a non-scheme character (or start of
+        // string) BEFORE the drive letter: without that guard, the trailing
+        // "o://..." of a URI like "olo://capture/1/shot.png" (#673 resource
+        // links) parses as drive "o:" + path and redaction corrupts the URI to
+        // "ol<path>". std::regex has no lookbehind, so the guard is a captured
+        // prefix restored via $1.
         std::string RedactPathsInText(const std::string& text)
         {
-            static const std::regex winPath(R"([A-Za-z]:[\\/][^\s"'<>|]*)");
+            static const std::regex winPath(R"((^|[^A-Za-z0-9+.\-])([A-Za-z]:[\\/][^\s"'<>|]*))");
             static const std::regex posixHome(R"(/(?:home|Users)/[^\s"'<>|]*)");
-            std::string out = std::regex_replace(text, winPath, "<path>");
+            std::string out = std::regex_replace(text, winPath, "$1<path>");
             out = std::regex_replace(out, posixHome, "<path>");
             return out;
         }
 
-        // Apply redaction in place to every text content block of an MCP content array.
+        // Apply redaction in place to every text content block of an MCP content
+        // array — plus the human-readable fields of resource_link blocks (#673
+        // Tier 1), whose name/description could carry a path (e.g. a golden's
+        // relative location); the olo:// uri never does, but scrubbing it too
+        // keeps the guarantee unconditional.
         void RedactContentArray(Json& content)
         {
             if (!content.is_array())
                 return;
             for (auto& block : content)
             {
-                if (block.is_object() && block.value("type", std::string{}) == "text" && block.contains("text") && block["text"].is_string())
+                if (!block.is_object())
+                    continue;
+                const std::string type = block.value("type", std::string{});
+                if (type == "text" && block.contains("text") && block["text"].is_string())
                     block["text"] = RedactPathsInText(block["text"].get<std::string>());
+                else if (type == "resource_link")
+                {
+                    for (const char* field : { "name", "description", "uri" })
+                    {
+                        if (block.contains(field) && block[field].is_string())
+                            block[field] = RedactPathsInText(block[field].get<std::string>());
+                    }
+                }
             }
         }
 
@@ -622,6 +644,21 @@ namespace OloEngine::MCP
         r.StructuredContent = data;
         r.IsError = false;
         return r;
+    }
+
+    Json ToolResult::ResourceLinkBlock(const std::string& uri, const std::string& name,
+                                       const std::string& description, const std::string& mimeType,
+                                       u64 sizeBytes)
+    {
+        Json block{ { "type", "resource_link" },
+                    { "uri", uri },
+                    { "name", name },
+                    { "description", description },
+                    { "mimeType", mimeType } };
+        // `size` is optional per spec; 0 means "unknown", so omit it then.
+        if (sizeBytes > 0)
+            block["size"] = sizeBytes;
+        return block;
     }
 
     // ---- McpServer -------------------------------------------------------------
@@ -748,6 +785,114 @@ namespace OloEngine::MCP
         ReplaceScriptTools({});
     }
 
+    bool McpServer::IsValidClientAlias(std::string_view alias)
+    {
+        if (alias.empty() || alias.size() > 32)
+            return false;
+        for (std::size_t i = 0; i < alias.size(); ++i)
+        {
+            const char c = alias[i];
+            const bool alnum = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+            if (!(alnum || (c == '-' && i > 0)))
+                return false;
+        }
+        return true;
+    }
+
+    std::string McpServer::ClientToolPrefix(const std::string& alias)
+    {
+        return "ext." + alias + ".";
+    }
+
+    sizet McpServer::ReplaceClientTools(const std::string& alias, std::vector<ToolDef> clientTools)
+    {
+        // Foreign definitions are runtime network data — validate-and-reject,
+        // never OLO_CORE_VERIFY (ADR 0005: asserts must not police data another
+        // process controls). An invalid alias rejects the whole batch: without a
+        // valid reserved prefix nothing below can be namespaced safely.
+        if (!IsValidClientAlias(alias))
+        {
+            OLO_CORE_WARN("[MCP] ReplaceClientTools: invalid client alias '{}' — batch rejected.", alias);
+            return 0;
+        }
+
+        const std::string prefix = ClientToolPrefix(alias);
+        std::vector<ToolDef> accepted;
+        accepted.reserve(clientTools.size());
+        for (ToolDef& tool : clientTools)
+        {
+            if (!IsValidToolName(tool.Name))
+            {
+                OLO_CORE_WARN("[MCP] ReplaceClientTools('{}'): dropping tool with invalid name '{}'.", alias,
+                              tool.Name);
+                continue;
+            }
+            if (tool.Name.size() <= prefix.size() || tool.Name.compare(0, prefix.size(), prefix) != 0)
+            {
+                OLO_CORE_WARN("[MCP] ReplaceClientTools('{}'): dropping tool '{}' — bridged names must live in "
+                              "the reserved '{}' namespace.",
+                              alias, tool.Name, prefix);
+                continue;
+            }
+            if (std::any_of(accepted.begin(), accepted.end(),
+                            [&tool](const ToolDef& existing)
+                            { return existing.Name == tool.Name; }))
+            {
+                OLO_CORE_WARN("[MCP] ReplaceClientTools('{}'): dropping duplicate tool '{}'.", alias, tool.Name);
+                continue;
+            }
+            if (!tool.Handler)
+            {
+                OLO_CORE_WARN("[MCP] ReplaceClientTools('{}'): dropping tool '{}' with no bridge handler.", alias,
+                              tool.Name);
+                continue;
+            }
+            if (!IsValidIcons(tool.Icons))
+            {
+                OLO_CORE_WARN("[MCP] ReplaceClientTools('{}'): dropping malformed icons on '{}'.", alias,
+                              tool.Name);
+                tool.Icons = Json();
+            }
+
+            // FORCE the authority posture — never trust the child's claims
+            // (ADR 0005: "a tool's write authority is its OWN declared tier...
+            // never inherited, never ambient, and never laundered"). A foreign
+            // tool always faces the full write-consent gate, is annotated as an
+            // open-world mutation (the first genuinely open-world tools in the
+            // surface — everything native acts on the local editor session), and
+            // keeps the spec's conservative destructiveHint default of true.
+            tool.ProjectWrite = true;
+            tool.ScriptOwned = false;
+            tool.ClientAlias = alias;
+            tool.Toolset = "ext." + alias;
+            tool.Annotations = Json{ { "readOnlyHint", false }, { "openWorldHint", true } };
+            accepted.push_back(std::move(tool));
+        }
+
+        {
+            std::lock_guard writeLock(m_ToolsWriteMutex);
+            const ToolSnapshot current = ToolsSnapshot();
+
+            auto next = std::make_shared<ToolList>();
+            next->reserve(current->size() + accepted.size());
+            for (const ToolDef& tool : *current)
+            {
+                if (tool.ClientAlias != alias)
+                    next->push_back(tool);
+            }
+            for (ToolDef& tool : accepted)
+                next->push_back(std::move(tool));
+
+            // Same linearization contract as ReplaceScriptTools: an in-flight
+            // call keeps executing against the snapshot (and any per-connection
+            // runtime its handler strongly captures) it started with.
+            m_Tools.store(std::shared_ptr<const ToolList>(std::move(next)), std::memory_order_release);
+        }
+
+        NotifyToolsListChanged();
+        return accepted.size();
+    }
+
     void McpServer::NotifyToolsListChanged()
     {
         // Bump FIRST: an SSE stream that polls the generation must never observe a
@@ -796,7 +941,112 @@ namespace OloEngine::MCP
 
     void McpServer::RegisterResource(ResourceDef resource)
     {
-        m_Resources.push_back(std::move(resource));
+        // Copy-on-write publish, mirroring RegisterTool: build the new vector,
+        // swap it in atomically. A duplicate URI REPLACES the existing entry
+        // instead of silently shadowing it (FindResource returns the first match).
+        std::shared_ptr<ResourceList> next;
+        {
+            std::lock_guard writeLock(m_ResourcesWriteMutex);
+            next = std::make_shared<ResourceList>(*ResourcesSnapshot());
+            std::erase_if(*next, [&resource](const ResourceDef& existing)
+                          { return existing.Uri == resource.Uri; });
+            next->push_back(std::move(resource));
+            m_Resources.store(std::shared_ptr<const ResourceList>(next), std::memory_order_release);
+        }
+        NotifyResourcesListChanged();
+    }
+
+    void McpServer::RegisterEphemeralResource(ResourceDef resource)
+    {
+        resource.Ephemeral = true;
+        {
+            std::lock_guard writeLock(m_ResourcesWriteMutex);
+            auto next = std::make_shared<ResourceList>(*ResourcesSnapshot());
+            std::erase_if(*next, [&resource](const ResourceDef& existing)
+                          { return existing.Uri == resource.Uri; });
+            next->push_back(std::move(resource));
+
+            // Evict OLDEST ephemerals (registration order) until both bounds
+            // hold. The just-published entry is only evicted if it alone busts a
+            // bound (an oversized capture with maxCount >= 1 still displaces
+            // everything older first).
+            const auto ephemeralCount = [&next]
+            {
+                sizet count = 0;
+                for (const ResourceDef& entry : *next)
+                    count += entry.Ephemeral ? 1 : 0;
+                return count;
+            };
+            const auto ephemeralBytes = [&next]
+            {
+                u64 bytes = 0;
+                for (const ResourceDef& entry : *next)
+                    bytes += entry.Ephemeral ? entry.SizeBytes : 0;
+                return bytes;
+            };
+            while (ephemeralCount() > m_EphemeralMaxCount ||
+                   (ephemeralBytes() > m_EphemeralMaxBytes && ephemeralCount() > 1))
+            {
+                const auto oldest = std::find_if(next->begin(), next->end(),
+                                                 [](const ResourceDef& entry)
+                                                 { return entry.Ephemeral; });
+                if (oldest == next->end())
+                    break;
+                next->erase(oldest);
+            }
+            m_Resources.store(std::shared_ptr<const ResourceList>(std::move(next)), std::memory_order_release);
+        }
+        NotifyResourcesListChanged();
+    }
+
+    void McpServer::ClearEphemeralResources()
+    {
+        bool changed = false;
+        {
+            std::lock_guard writeLock(m_ResourcesWriteMutex);
+            const ResourceSnapshot current = ResourcesSnapshot();
+            auto next = std::make_shared<ResourceList>();
+            next->reserve(current->size());
+            for (const ResourceDef& entry : *current)
+            {
+                if (!entry.Ephemeral)
+                    next->push_back(entry);
+            }
+            changed = next->size() != current->size();
+            if (changed)
+                m_Resources.store(std::shared_ptr<const ResourceList>(std::move(next)), std::memory_order_release);
+        }
+        if (changed)
+            NotifyResourcesListChanged();
+    }
+
+    void McpServer::SetEphemeralResourceLimits(sizet maxCount, u64 maxBytes)
+    {
+        std::lock_guard writeLock(m_ResourcesWriteMutex);
+        m_EphemeralMaxCount = maxCount;
+        m_EphemeralMaxBytes = maxBytes;
+    }
+
+    void McpServer::NotifyResourcesListChanged()
+    {
+        // Bump FIRST — same ordering contract as NotifyToolsListChanged: an SSE
+        // stream that polls the generation must never observe a stale generation
+        // alongside a fresh resource list.
+        m_ResourcesGeneration.fetch_add(1, std::memory_order_release);
+
+        std::vector<NotificationSink> sinks;
+        {
+            std::lock_guard lock(m_ListenerMutex);
+            sinks.reserve(m_Listeners.size());
+            for (const auto& [token, sink] : m_Listeners)
+                sinks.push_back(sink);
+        }
+        const Json notification{ { "jsonrpc", "2.0" }, { "method", "notifications/resources/list_changed" } };
+        for (const NotificationSink& sink : sinks)
+        {
+            if (sink)
+                sink(notification);
+        }
     }
 
     void McpServer::RegisterPrompt(PromptDef prompt)
@@ -903,7 +1153,13 @@ namespace OloEngine::MCP
     void McpServer::Stop()
     {
         if (!m_Http)
+        {
+            // Never started (or already stopped) — but outbound client
+            // connections can exist without a running HTTP server (tests, a
+            // panel connect before Start): tear those down regardless.
+            ShutdownClients();
             return;
+        }
 
         // Signal first so any handler blocked in MarshalRead aborts promptly
         // instead of deadlocking against this thread (Stop runs on the game thread).
@@ -917,6 +1173,11 @@ namespace OloEngine::MCP
             m_ConsentAborting = true;
         }
         m_ConsentCv.notify_all();
+
+        // Same reasoning for workers blocked on an outbound child's response
+        // (issue #673 Tier 1): fail every pending bridged call and join the
+        // client reader threads BEFORE the pool join below.
+        ShutdownClients();
 
         m_Http->stop();
         if (m_ListenThread.joinable())
@@ -932,6 +1193,12 @@ namespace OloEngine::MCP
             m_Sessions.clear();
         }
         m_Token.clear();
+
+        // Drop the session's ephemeral capture resources so a later Start()
+        // begins with a clean registry (their URIs would otherwise be stale
+        // advertisements to a newly attached agent). After m_Http.reset() no
+        // worker is left mid-read; any listener sink still fires harmlessly.
+        ClearEphemeralResources();
 
         // (The ephemeral sun-direction override clear that used to live here was
         // retired by issue #633 — olo_scene_set_time_of_day now edits the
@@ -1059,7 +1326,7 @@ namespace OloEngine::MCP
         {
             if (entry.Decision != ConsentDecision::Pending)
                 continue; // already resolved, waiting to be reaped by its handler thread
-            pending.push_back(PendingConsent{ entry.Id, entry.ToolName, entry.ToolTitle, entry.Summary });
+            pending.push_back(PendingConsent{ entry.Id, entry.ToolName, entry.ToolTitle, entry.Summary, entry.External });
         }
         return pending;
     }
@@ -1133,6 +1400,7 @@ namespace OloEngine::MCP
             entry.ToolName = tool.Name;
             entry.ToolTitle = tool.Title.empty() ? tool.Name : tool.Title;
             entry.Summary = BuildConsentSummary(arguments);
+            entry.External = !tool.ClientAlias.empty();
             m_ConsentQueue.push_back(std::move(entry));
 
             const bool resolved = m_ConsentCv.wait_for(lock, timeout, [this, myId, &cancelled]
@@ -1310,7 +1578,8 @@ namespace OloEngine::MCP
         res.set_chunked_content_provider(
             "text/event-stream",
             [this, cursor = startCursor, lastWrite = std::chrono::steady_clock::now(), greeted = false,
-             toolsGeneration = ToolsGeneration()](std::size_t /*offset*/, httplib::DataSink& sink) mutable -> bool
+             toolsGeneration = ToolsGeneration(),
+             resourcesGeneration = ResourcesGeneration()](std::size_t /*offset*/, httplib::DataSink& sink) mutable -> bool
             {
                 // Server tearing down: end the stream gracefully so the worker thread
                 // is free to be joined by Stop().
@@ -1346,6 +1615,20 @@ namespace OloEngine::MCP
                     if (!sink.write(frame.data(), frame.size()))
                         return false;
                     toolsGeneration = generation;
+                    lastWrite = std::chrono::steady_clock::now();
+                }
+
+                // Resource-list changes (ephemeral capture publishes/evictions,
+                // #673 Tier 1) — same polled-generation delivery as the tools
+                // block above, same single-writer-thread constraint. Advertised
+                // via capabilities.resources.listChanged.
+                if (const u64 generation = ResourcesGeneration(); generation != resourcesGeneration)
+                {
+                    const std::string frame = FormatSseData(
+                        Json{ { "jsonrpc", "2.0" }, { "method", "notifications/resources/list_changed" } });
+                    if (!sink.write(frame.data(), frame.size()))
+                        return false;
+                    resourcesGeneration = generation;
                     lastWrite = std::chrono::steady_clock::now();
                 }
 
@@ -1635,9 +1918,13 @@ namespace OloEngine::MCP
         // olo_script_tools_reload (and the MCP panel's "Reload script tools" button)
         // rescan <project assets>/McpTools while the server is serving and swap the
         // registry, then emit `notifications/tools/list_changed` on every live SSE
-        // stream. Resources and prompts are still fixed for a server run.
+        // stream. `resources.listChanged` is TRUE since the resource-link work
+        // (#673 Tier 1): capture tools publish ephemeral resources while serving
+        // (RegisterEphemeralResource), announced the same generation-polled way.
+        // Prompts are still fixed for a server run; per-URI `subscribe` stays
+        // unimplemented (nothing needs a subscription registry yet).
         result["capabilities"] = Json{ { "tools", { { "listChanged", true } } },
-                                       { "resources", { { "subscribe", false }, { "listChanged", false } } },
+                                       { "resources", { { "subscribe", false }, { "listChanged", true } } },
                                        { "prompts", { { "listChanged", false } } },
                                        { "logging", Json::object() } };
         // `description` on Implementation is a 2025-11-25 addition (aligns with
@@ -1945,13 +2232,19 @@ namespace OloEngine::MCP
 
     Json McpServer::HandleResourcesList(const Json& id) const
     {
+        const ResourceSnapshot snapshot = ResourcesSnapshot();
         Json resources = Json::array();
-        for (const auto& resource : m_Resources)
+        for (const auto& resource : *snapshot)
         {
-            resources.push_back(Json{ { "uri", resource.Uri },
-                                      { "name", resource.Name },
-                                      { "description", resource.Description },
-                                      { "mimeType", resource.MimeType } });
+            Json entry{ { "uri", resource.Uri },
+                        { "name", resource.Name },
+                        { "description", resource.Description },
+                        { "mimeType", resource.MimeType } };
+            // `size` (spec 2025-06-18) lets a client budget a read up front;
+            // 0 means unknown, so omit it then.
+            if (resource.SizeBytes > 0)
+                entry["size"] = resource.SizeBytes;
+            resources.push_back(std::move(entry));
         }
         return MakeResult(id, Json{ { "resources", std::move(resources) } });
     }
@@ -1962,9 +2255,32 @@ namespace OloEngine::MCP
             return MakeError(id, kInvalidParams, "Invalid params: 'uri' is required");
 
         const std::string uri = params["uri"].get<std::string>();
-        const ResourceDef* resource = FindResource(uri);
+        // Pin the snapshot for the WHOLE read — the Reader may block on a
+        // MarshalRead for seconds, and a concurrent publish/eviction must not
+        // dangle the ResourceDef (or free a capture's bytes) under it.
+        const ResourceSnapshot snapshot = ResourcesSnapshot();
+        const ResourceDef* resource = FindResource(*snapshot, uri);
         if (resource == nullptr)
             return MakeError(id, kInvalidParams, "Unknown resource: " + uri);
+
+        // Binary resource: emit the spec's base64 `blob` contents variant.
+        // (No path redaction — the payload is binary, not prose.)
+        if (resource->BlobReader)
+        {
+            std::vector<u8> bytes;
+            try
+            {
+                bytes = resource->BlobReader(*this);
+            }
+            catch (const std::exception& e)
+            {
+                return MakeError(id, kInvalidRequest, std::string("Failed to read resource: ") + e.what());
+            }
+            return MakeResult(id, Json{ { "contents",
+                                          Json::array({ Json{ { "uri", uri },
+                                                              { "mimeType", resource->MimeType },
+                                                              { "blob", Base64Encode(bytes) } } }) } });
+        }
 
         std::string text;
         try
@@ -1985,9 +2301,9 @@ namespace OloEngine::MCP
                                                           { "text", std::move(text) } } }) } });
     }
 
-    const ResourceDef* McpServer::FindResource(const std::string& uri) const
+    const ResourceDef* McpServer::FindResource(const ResourceList& resources, const std::string& uri)
     {
-        for (const auto& resource : m_Resources)
+        for (const auto& resource : resources)
         {
             if (resource.Uri == uri)
                 return &resource;

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -80,6 +80,38 @@ namespace OloEngine::MCP
     // body) carries, and clients ignore any response to a cancelled request.
     inline constexpr int kRequestCancelledCode = -32800;
 
+    // Standard base64 (RFC 4648, with padding). Shared by the capture tools'
+    // inline `image` content blocks (McpTools*.cpp) and resources/read's binary
+    // `blob` contents variant (issue #673 Tier 1) — which is why it lives here
+    // rather than in the editor-internal McpToolsCommon.h.
+    inline std::string Base64Encode(const std::vector<u8>& data)
+    {
+        static constexpr char kTable[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::string out;
+        out.reserve(((data.size() + 2) / 3) * 4);
+        std::size_t i = 0;
+        for (; i + 3 <= data.size(); i += 3)
+        {
+            const u32 n = (static_cast<u32>(data[i]) << 16) | (static_cast<u32>(data[i + 1]) << 8) | data[i + 2];
+            out.push_back(kTable[(n >> 18) & 0x3F]);
+            out.push_back(kTable[(n >> 12) & 0x3F]);
+            out.push_back(kTable[(n >> 6) & 0x3F]);
+            out.push_back(kTable[n & 0x3F]);
+        }
+        if (const std::size_t rem = data.size() - i; rem > 0)
+        {
+            u32 n = static_cast<u32>(data[i]) << 16;
+            if (rem == 2)
+                n |= static_cast<u32>(data[i + 1]) << 8;
+            out.push_back(kTable[(n >> 18) & 0x3F]);
+            out.push_back(kTable[(n >> 12) & 0x3F]);
+            out.push_back(rem == 2 ? kTable[(n >> 6) & 0x3F] : '=');
+            out.push_back('=');
+        }
+        return out;
+    }
+
     // How a project-mutating (ToolDef::ProjectWrite) tool call is authorized at
     // dispatch (issue #306 item C). Supersedes the old binary "Allow writes" gate,
     // which maps onto the two extremes (Disabled / AllowSession); the middle mode
@@ -127,6 +159,15 @@ namespace OloEngine::MCP
         // object) and mirrors it into `content` as pretty-printed text for clients
         // that don't read structured output. `IsError` stays false.
         [[nodiscard]] static ToolResult Structured(const Json& data);
+        // Build one `resource_link` content block (MCP spec 2025-06-18): a URI
+        // reference to a server resource the client fetches on demand via
+        // resources/read, instead of an inline base64 `image`/`blob` payload.
+        // Append it to `Content` by hand — capture tools offer this as an opt-in
+        // delivery mode for large captures (issue #673 Tier 1). `sizeBytes` is
+        // emitted as `size` only when non-zero.
+        [[nodiscard]] static Json ResourceLinkBlock(const std::string& uri, const std::string& name,
+                                                    const std::string& description, const std::string& mimeType,
+                                                    u64 sizeBytes = 0);
     };
 
     class McpServer;
@@ -135,6 +176,41 @@ namespace OloEngine::MCP
     // guarded diagnostics directly; main-marshaled tools wrap their registry/Scene
     // reads in server.MarshalRead(...).
     using ToolHandler = std::function<ToolResult(McpServer& server, const Json& arguments)>;
+
+    // ---- outbound MCP client (issue #673 Tier 1; see McpClient.h) --------------
+
+    class IMcpClientTransport;
+
+    // Creates the byte transport for one outbound connection: spawn `command`,
+    // deliver each incoming NDJSON line via `onLine`, signal `onClosed` exactly
+    // once when the stream ends. Returns nullptr with `outError` set on failure.
+    // The production factory is MakeStdioTransportFactory() (McpClient.h);
+    // tests substitute in-memory fakes.
+    using McpClientTransportFactory = std::function<std::unique_ptr<IMcpClientTransport>(
+        const std::string& command, std::function<void(std::string line)> onLine,
+        std::function<void()> onClosed, std::string& outError)>;
+
+    // Configuration for one outbound stdio connection.
+    struct McpClientConfig
+    {
+        std::string Alias;   // must satisfy McpServer::IsValidClientAlias
+        std::string Command; // full child-process command line
+        std::chrono::milliseconds HandshakeTimeout{ 10000 };
+        // Per bridged tools/call wait. Deliberately finite: a hung child must
+        // never pin an httplib worker forever (the MarshalRead-timeout lesson).
+        std::chrono::milliseconds CallTimeout{ 30000 };
+    };
+
+    // Panel-facing snapshot of one connection.
+    struct McpClientStatus
+    {
+        std::string Alias;
+        std::string Command;
+        bool Connected = false;
+        sizet ToolCount = 0;
+    };
+
+    class McpClientConnection;
 
     // A registered MCP tool. `MainMarshaled` is informational (documents that the
     // handler reads main-thread-only state); it does not change dispatch.
@@ -179,6 +255,15 @@ namespace OloEngine::MCP
         // server is RUNNING, via the copy-on-write tool snapshot (issue #607
         // live-reload item); see ReplaceScriptTools / UnregisterScriptTools.
         bool ScriptOwned = false;
+        // Non-empty for a tool BRIDGED from an outbound MCP client connection
+        // (issue #673 Tier 1): the alias of the external server it proxies to.
+        // Foreign provenance is deliberately a separate discriminator from
+        // ScriptOwned — ReplaceScriptTools wipes every ScriptOwned tool on a
+        // script rescan, and the two trust tiers are different (ADR 0005: a
+        // script tool's read-only hint is a sandbox-backed GUARANTEE; a foreign
+        // tool's behaviour lives in another process, so it is ALWAYS treated as
+        // an open-world write — ReplaceClientTools forces ProjectWrite=true).
+        std::string ClientAlias;
         // Optional MCP `icons` array (SEP-973, spec 2025-11-25): display icons a
         // client may show next to the tool. Each element is an object with a
         // required string `src` (an http(s) or data: URI) plus optional
@@ -494,6 +579,10 @@ namespace OloEngine::MCP
     // An MCP resource: a passive, addressable blob (vs. an active tool). The reader
     // returns the resource's text; it may marshal/throw exactly like a tool handler.
     using ResourceReader = std::function<std::string(McpServer& server)>;
+    // Binary sibling of ResourceReader (issue #673 Tier 1, resource links): returns
+    // raw bytes that resources/read emits as the spec's base64 `blob` contents
+    // variant. Same threading/throw contract as ResourceReader.
+    using ResourceBlobReader = std::function<std::vector<u8>(McpServer& server)>;
 
     struct ResourceDef
     {
@@ -502,6 +591,21 @@ namespace OloEngine::MCP
         std::string Description;
         std::string MimeType;
         ResourceReader Reader;
+        // When set, this is a BINARY resource: resources/read invokes BlobReader
+        // and returns `{ blob: <base64> }` contents instead of `{ text: ... }`
+        // (Reader is then ignored). Used by the capture tools' resource_link
+        // delivery mode, where the bytes are stashed at publish time and the
+        // reader is a trivial capture-by-value closure.
+        ResourceBlobReader BlobReader;
+        // Advertised as `size` in resources/list when non-zero (spec 2025-06-18),
+        // and charged against the ephemeral byte budget (RegisterEphemeralResource).
+        u64 SizeBytes = 0;
+        // True for a resource published at RUNTIME by a tool call (a capture handed
+        // out via a resource_link content block) rather than registered once at
+        // startup. Ephemeral resources are bounded — count + total bytes, evicted
+        // oldest-first — and cleared on server Stop(); startup resources are never
+        // evicted.
+        bool Ephemeral = false;
     };
 
     // An MCP prompt: a canned workflow shipped for non-expert users. prompts/get
@@ -605,6 +709,11 @@ namespace OloEngine::MCP
             std::string ToolName;  // e.g. "olo_entity_set_field"
             std::string ToolTitle; // display title (falls back to ToolName)
             std::string Summary;   // human-readable arguments (one "key = value" per line)
+            // True when the tool is bridged from an outbound MCP client
+            // (ToolDef::ClientAlias non-empty). The panel modal must NOT promise
+            // Ctrl-Z for these — the effects happen in another process, outside
+            // the editor's undo stack.
+            bool External = false;
         };
 
         // Snapshot of every prompt currently awaiting a decision, oldest first.
@@ -663,10 +772,30 @@ namespace OloEngine::MCP
             return m_ToolsGeneration.load(std::memory_order_acquire);
         }
 
-        [[nodiscard]] const std::vector<ResourceDef>& Resources() const
+        // ---- the resource registry: same copy-on-write contract as the tools ----
+        //
+        // Startup resources (RegisterResource) were once a fixed-for-a-run plain
+        // vector; the resource-link work (issue #673 Tier 1) made the registry
+        // MUTABLE while serving — capture tools publish ephemeral resources from
+        // httplib worker threads — so it now mirrors the m_Tools snapshot exactly:
+        // writers serialize on m_ResourcesWriteMutex and publish a fresh immutable
+        // vector; readers take a snapshot and hold it for as long as they use any
+        // ResourceDef* into it (a whole resources/read, including the Reader call).
+        using ResourceList = std::vector<ResourceDef>;
+        using ResourceSnapshot = std::shared_ptr<const ResourceList>;
+
+        [[nodiscard]] ResourceSnapshot ResourcesSnapshot() const
         {
-            return m_Resources;
+            return m_Resources.load(std::memory_order_acquire);
         }
+        // Monotonic counter bumped on every resource-list swap; the GET /mcp SSE
+        // stream polls it and emits `notifications/resources/list_changed` when it
+        // moves — the exact ToolsGeneration() pattern.
+        [[nodiscard]] u64 ResourcesGeneration() const
+        {
+            return m_ResourcesGeneration.load(std::memory_order_acquire);
+        }
+
         [[nodiscard]] const std::vector<PromptDef>& Prompts() const
         {
             return m_Prompts;
@@ -690,6 +819,26 @@ namespace OloEngine::MCP
         void RegisterResource(ResourceDef resource);
         void RegisterPrompt(PromptDef prompt);
 
+        // Publish a RUNTIME resource (issue #673 Tier 1, resource links) — the
+        // capture a tool just handed out as a resource_link block. Marks it
+        // Ephemeral, replaces any existing resource with the same URI, then
+        // evicts the OLDEST ephemeral resources until both bounds hold (count
+        // and total SizeBytes; startup resources are never evicted and don't
+        // count). Bumps ResourcesGeneration() and broadcasts
+        // `notifications/resources/list_changed`. Safe from any thread; an
+        // in-flight resources/read keeps serving the snapshot (and bytes) it
+        // started with, so eviction never frees data under a reader.
+        void RegisterEphemeralResource(ResourceDef resource);
+        // Drop every ephemeral resource (no-op when there are none). Called by
+        // Stop() so a later Start() begins with a clean capture registry.
+        void ClearEphemeralResources();
+        // Ephemeral bounds (defaults kDefaultEphemeralMaxCount/MaxBytes below).
+        // Exposed for tests and future panel configuration.
+        void SetEphemeralResourceLimits(sizet maxCount, u64 maxBytes);
+
+        static constexpr sizet kDefaultEphemeralMaxCount = 16;
+        static constexpr u64 kDefaultEphemeralMaxBytes = 128ull * 1024 * 1024;
+
         // Swap every ScriptOwned tool for `scriptTools` in one atomic publish
         // (issue #357 / ADR 0005 + the #607 live-reload item): the new vector is
         // (every non-ScriptOwned tool, in order) + (scriptTools). Safe while the
@@ -701,6 +850,56 @@ namespace OloEngine::MCP
 
         // Drop every ScriptOwned tool. Thin wrapper over ReplaceScriptTools({}).
         void UnregisterScriptTools();
+
+        // Swap every tool bridged from the outbound client connection `alias` for
+        // `clientTools` in one atomic publish (issue #673 Tier 1) — the foreign
+        // sibling of ReplaceScriptTools, with a per-alias filter so multiple
+        // connections coexist. Pass {} on disconnect / child death.
+        //
+        // Foreign tool definitions are RUNTIME NETWORK DATA (ADR 0005 forbids
+        // trusting them), so unlike RegisterTool this validates-and-rejects
+        // instead of asserting, and it FORCES the authority posture on every
+        // accepted tool regardless of what the child claimed:
+        //   * Name must be exactly ClientToolPrefix(alias) + <suffix> and pass
+        //     IsValidToolName — the reserved `ext.<alias>.` namespace means a
+        //     foreign server can never spoof an olo_* / script_* name (in the
+        //     consent modal or anywhere else), and two aliases can never collide.
+        //   * ProjectWrite = true — a foreign call always faces the full write
+        //     consent gate. Its behaviour lives in another process; read-only
+        //     can never be a guarantee, so it is never assumed.
+        //   * Annotations = { readOnlyHint:false, openWorldHint:true } (and no
+        //     destructiveHint, leaving the spec's conservative default of true).
+        //   * ScriptOwned = false, ClientAlias = alias, Toolset = "ext." + alias.
+        // Invalid tools are dropped with a logged warning; the valid remainder
+        // still publishes. Returns the number of tools accepted. An invalid
+        // `alias` rejects the whole batch (returns 0, registry untouched).
+        sizet ReplaceClientTools(const std::string& alias, std::vector<ToolDef> clientTools);
+
+        // Alias rules: 1..32 chars of [a-z0-9-], starting with a letter or digit.
+        [[nodiscard]] static bool IsValidClientAlias(std::string_view alias);
+        // The reserved tool-name namespace for one connection: "ext.<alias>.".
+        [[nodiscard]] static std::string ClientToolPrefix(const std::string& alias);
+
+        // ---- outbound stdio client connections (issue #673 Tier 1) ------------
+        // Defined in McpClient.cpp (the client module), not McpServer.cpp — the
+        // dispatch core stays transport-agnostic. The server OWNS the
+        // connections so Stop() can fail their pending calls BEFORE joining the
+        // httplib worker pool (a handler blocked on a child response would
+        // otherwise deadlock the join — the consent-abort lesson).
+
+        // Spawn `config.Command`, handshake, and merge its tools as
+        // `ext.<alias>.*` via ReplaceClientTools. BLOCKS the calling thread up
+        // to the handshake timeout. Returns an empty string on success, else a
+        // human-readable error (nothing merged). Fails on a duplicate alias.
+        [[nodiscard]] std::string ConnectStdioClient(const McpClientConfig& config);
+        // Test seam: identical merge/ownership path with a caller-supplied
+        // transport factory instead of the real process spawn.
+        [[nodiscard]] std::string ConnectClientWithTransport(const McpClientConfig& config,
+                                                             const McpClientTransportFactory& factory);
+        // Shut the connection down (fails in-flight bridged calls promptly) and
+        // unpublish its tools. Returns false when no such alias is connected.
+        bool DisconnectClient(const std::string& alias);
+        [[nodiscard]] std::vector<McpClientStatus> ClientStatuses() const;
 
         // Optional `icons` for the server itself (SEP-973): emitted under
         // `initialize`'s `serverInfo.icons` only when non-empty. Set before Start()
@@ -909,13 +1108,19 @@ namespace OloEngine::MCP
         // Locate a tool inside a snapshot the CALLER holds alive for as long as it
         // uses the returned pointer (see the ToolsSnapshot contract above).
         [[nodiscard]] static const ToolDef* FindTool(const ToolList& tools, const std::string& name);
-        [[nodiscard]] const ResourceDef* FindResource(const std::string& uri) const;
+        // Locate a resource inside a snapshot the CALLER holds alive for as long
+        // as it uses the returned pointer (same contract as FindTool).
+        [[nodiscard]] static const ResourceDef* FindResource(const ResourceList& resources, const std::string& uri);
         [[nodiscard]] const PromptDef* FindPrompt(const std::string& name) const;
         [[nodiscard]] bool CheckAuth(const httplib::Request& req) const;
 
         // Bump ToolsGeneration() and fan the tools/list_changed notification out to
         // the registered listeners. Called by ReplaceScriptTools.
         void NotifyToolsListChanged();
+        // Resource sibling of NotifyToolsListChanged: bump ResourcesGeneration()
+        // FIRST, then fan `notifications/resources/list_changed` to the listeners
+        // (the SSE streams pick it up by polling the generation).
+        void NotifyResourcesListChanged();
 
         EditorMcpContext m_Context;
         // Copy-on-write, atomically published (see ToolsSnapshot). Writers serialize
@@ -923,7 +1128,23 @@ namespace OloEngine::MCP
         std::atomic<ToolSnapshot> m_Tools{ std::make_shared<const ToolList>() };
         std::mutex m_ToolsWriteMutex;
         std::atomic<u64> m_ToolsGeneration{ 0 };
-        std::vector<ResourceDef> m_Resources;
+        // Copy-on-write, atomically published (see ResourcesSnapshot). Writers
+        // serialize on m_ResourcesWriteMutex; readers are lock-free.
+        std::atomic<ResourceSnapshot> m_Resources{ std::make_shared<const ResourceList>() };
+        std::mutex m_ResourcesWriteMutex;
+        std::atomic<u64> m_ResourcesGeneration{ 0 };
+        // Ephemeral-resource bounds (SetEphemeralResourceLimits). Guarded by
+        // m_ResourcesWriteMutex — only the writers consult them.
+        sizet m_EphemeralMaxCount = kDefaultEphemeralMaxCount;
+        u64 m_EphemeralMaxBytes = kDefaultEphemeralMaxBytes;
+
+        // Outbound client connections (ConnectStdioClient; McpClient.cpp).
+        // Dead connections stay listed (Connected=false) until DisconnectClient
+        // so the panel can show what fell over. Shutdown/join happens in
+        // ShutdownClients(), called from Stop() and the destructor.
+        void ShutdownClients();
+        mutable std::mutex m_ClientsMutex;
+        std::vector<std::shared_ptr<McpClientConnection>> m_Clients;
         std::vector<PromptDef> m_Prompts;
 
         // Server-initiated notification listeners (AddNotificationListener).
@@ -961,6 +1182,7 @@ namespace OloEngine::MCP
             std::string ToolName;
             std::string ToolTitle;
             std::string Summary;
+            bool External = false; // bridged from an outbound client (see PendingConsent)
             ConsentDecision Decision = ConsentDecision::Pending;
         };
         std::vector<ConsentEntry> m_ConsentQueue;      // guarded by m_ConsentMutex

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -201,8 +201,61 @@ namespace OloEngine::MCP
         ImGui::Text("Exposed (%s): %d tools, %d resources, %d prompts",
                     server.AllowWrites() ? "writes ON" : "read-only",
                     static_cast<int>(server.ToolCount()),
-                    static_cast<int>(server.Resources().size()),
+                    static_cast<int>(server.ResourcesSnapshot()->size()),
                     static_cast<int>(server.Prompts().size()));
+
+        // ---- outbound stdio MCP clients (issue #673 Tier 1) --------------------
+        ImGui::Separator();
+        if (ImGui::CollapsingHeader("Outbound MCP servers (stdio)"))
+        {
+            ImGui::TextWrapped(
+                "Spawn a local MCP server process and fold its tools into this editor's surface as "
+                "ext.<alias>.* entries. Bridged tools are ALWAYS treated as consent-gated writes — "
+                "their effects happen outside the editor and cannot be undone with Ctrl-Z.");
+
+            for (const McpClientStatus& status : server.ClientStatuses())
+            {
+                if (status.Connected)
+                    ImGui::TextColored(ImVec4(0.30f, 0.85f, 0.30f, 1.0f), "%s: connected, %d tool(s)",
+                                       status.Alias.c_str(), static_cast<int>(status.ToolCount));
+                else
+                    ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f), "%s: DISCONNECTED (child ended)",
+                                       status.Alias.c_str());
+                ImGui::SameLine();
+                if (ImGui::SmallButton(std::format("Disconnect##{}", status.Alias).c_str()))
+                    server.DisconnectClient(status.Alias);
+                ImGui::TextDisabled("  %s", status.Command.c_str());
+            }
+
+            static char s_ClientAlias[64] = "";
+            static char s_ClientCommand[512] = "";
+            static std::string s_ClientError;
+            ImGui::PushItemWidth(120.0f);
+            ImGui::InputTextWithHint("##client_alias", "alias (a-z0-9-)", s_ClientAlias, sizeof(s_ClientAlias));
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            ImGui::PushItemWidth(-90.0f);
+            ImGui::InputTextWithHint("##client_command", "command (e.g. npx -y @modelcontextprotocol/server-filesystem E:\\data)",
+                                     s_ClientCommand, sizeof(s_ClientCommand));
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            if (ImGui::Button("Connect"))
+            {
+                McpClientConfig config;
+                config.Alias = s_ClientAlias;
+                config.Command = s_ClientCommand;
+                // Blocks up to the handshake timeout — acceptable for an
+                // explicit operator action; failures land in the error line.
+                s_ClientError = server.ConnectStdioClient(config);
+                if (s_ClientError.empty())
+                {
+                    s_ClientAlias[0] = '\0';
+                    s_ClientCommand[0] = '\0';
+                }
+            }
+            if (!s_ClientError.empty())
+                ImGui::TextColored(ImVec4(0.90f, 0.35f, 0.30f, 1.0f), "%s", s_ClientError.c_str());
+        }
 
         ImGui::End();
     }
@@ -228,8 +281,15 @@ namespace OloEngine::MCP
 
         if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f),
-                               "An MCP agent wants to MODIFY your scene.");
+            // An EXTERNAL (outbound-client-bridged) tool acts in another process:
+            // the undo-stack promise below would be a lie for it, so the banner
+            // says what actually happens instead (issue #673 Tier 1).
+            if (request.External)
+                ImGui::TextColored(ImVec4(0.95f, 0.35f, 0.25f, 1.0f),
+                                   "An MCP agent wants to call an EXTERNAL tool on another server.");
+            else
+                ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f),
+                                   "An MCP agent wants to MODIFY your scene.");
             ImGui::Separator();
 
             ImGui::Text("Tool: %s", request.ToolTitle.c_str());
@@ -254,7 +314,10 @@ namespace OloEngine::MCP
             ImGui::EndChild();
 
             ImGui::Spacing();
-            ImGui::TextDisabled("Approving applies the change through the undo stack (Ctrl-Z to revert).");
+            if (request.External)
+                ImGui::TextDisabled("Approving sends the call to the external server. NOT undoable with Ctrl-Z.");
+            else
+                ImGui::TextDisabled("Approving applies the change through the undo stack (Ctrl-Z to revert).");
             if (const int extra = static_cast<int>(pending.size()) - 1; extra > 0)
                 ImGui::TextDisabled("(%d more request%s waiting)", extra, extra == 1 ? "" : "s");
             ImGui::Separator();

--- a/OloEditor/src/MCP/McpToolsAssets.cpp
+++ b/OloEditor/src/MCP/McpToolsAssets.cpp
@@ -87,7 +87,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_assets_problems (main-marshaled; failed/missing/invalid assets) -
@@ -121,7 +121,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
     } // namespace
@@ -141,6 +141,18 @@ namespace OloEngine::MCP
                                    .Prop("typeFilter", Schema::String().Desc("Asset type name to filter by (e.g. 'Texture2D'). Omit for all types."))
                                    .Pagination("Assets per page (default 50, max 200).")
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("total", Schema::Int().Min(0).Desc("Total registered assets after the type filter."))
+                                    .Prop("page", Schema::Int().Min(0))
+                                    .Prop("pageSize", Schema::Int().Min(1))
+                                    .Prop("returned", Schema::Int().Min(0).Desc("Number of entries in 'assets'."))
+                                    .Prop("nextPage", Schema::Int().Min(1).Desc("Next zero-based page index; omitted on the last page."))
+                                    .Prop("assets", Schema::Array(Schema::Object()
+                                                                      .Prop("handle", Schema::String().Desc("Asset handle (decimal u64)."))
+                                                                      .Prop("type", Schema::String())
+                                                                      .Prop("path", Schema::String().Desc("Project-relative path."))
+                                                                      .Prop("name", Schema::String())))
+                                    .Required({ "total", "page", "pageSize", "returned", "assets" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_AssetsList;
             server.RegisterTool(std::move(tool));
@@ -156,6 +168,14 @@ namespace OloEngine::MCP
                 "List assets that failed to load or are missing/invalid (handle, type, path, status). The "
                 "first thing to check when something references an asset that isn't showing up.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0).Desc("Number of problem assets; 0 with an empty list means all assets are healthy."))
+                                    .Prop("problems", Schema::Array(Schema::Object()
+                                                                        .Prop("handle", Schema::String().Desc("Asset handle (decimal u64)."))
+                                                                        .Prop("type", Schema::String())
+                                                                        .Prop("path", Schema::String())
+                                                                        .Prop("status", Schema::String().Desc("Error status name from the asset registry."))))
+                                    .Required({ "count", "problems" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_AssetsProblems;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsCamera.cpp
+++ b/OloEditor/src/MCP/McpToolsCamera.cpp
@@ -22,7 +22,7 @@ namespace OloEngine::MCP
                 return ToolResult::Error("Camera control is not available in this editor build.");
             const Json pose = server.MarshalRead([&server]() -> Json
                                                  { return PoseToJson(server.Context().GetCameraPose()); });
-            return ToolResult::Text(pose.dump(2));
+            return ToolResult::Structured(pose);
         }
 
         // ---- olo_camera_set_pose (main-marshaled; mutates editor camera) -------
@@ -38,7 +38,7 @@ namespace OloEngine::MCP
                                                  {
                 ApplyCameraRequest(server.Context(), request);
                 return PoseToJson(server.Context().GetCameraPose()); });
-            return ToolResult::Text(pose.dump(2));
+            return ToolResult::Structured(pose);
         }
 
         // ---- olo_camera_orbit (main-marshaled; mutates editor camera) ----------
@@ -54,7 +54,7 @@ namespace OloEngine::MCP
                                                  {
                 ApplyCameraRequest(server.Context(), request);
                 return PoseToJson(server.Context().GetCameraPose()); });
-            return ToolResult::Text(pose.dump(2));
+            return ToolResult::Structured(pose);
         }
 
         // ---- olo_camera_frame_entity (main-marshaled; mutates editor camera) ---
@@ -77,7 +77,7 @@ namespace OloEngine::MCP
                 return j; });
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_viewport_set_size (main-marshaled; mutates viewport override) -
@@ -109,7 +109,7 @@ namespace OloEngine::MCP
                     j["height"] = height;
                 }
                 return j; });
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_screenshot (main-marshaled; GL readback) ----------------------
@@ -123,6 +123,12 @@ namespace OloEngine::MCP
             int maxWidth = 1024;
             if (args.contains("maxWidth") && args["maxWidth"].is_number_integer())
                 maxWidth = static_cast<int>(std::clamp<long long>(args["maxWidth"].get<long long>(), 16, 4096));
+
+            // Opt-in resource-link delivery (issue #673 Tier 1): publish the PNG
+            // as an ephemeral olo://capture resource and return a resource_link
+            // block instead of inlining base64 — for high-res captures. Inline
+            // stays the default so existing clients see an unchanged shape.
+            const bool deliverLink = args.value("delivery", std::string{ "inline" }) == "resource_link";
 
             if (!server.Context().CaptureViewportPng)
                 return ToolResult::Error("Screenshot capture is not available in this editor build.");
@@ -243,15 +249,21 @@ namespace OloEngine::MCP
                 // The play state is RE-SAMPLED here, in the same job as the capture,
                 // so the sceneState meta below describes the frame actually captured
                 // even if Play/Stop flipped between the early guard and this job.
-                marshaled = server.MarshalRead([&server, maxWidth, restorePriorPose]() -> Json
+                marshaled = server.MarshalRead([&server, maxWidth, restorePriorPose, deliverLink]() -> Json
                                                {
-                    const std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
+                    std::vector<u8> png = server.Context().CaptureViewportPng(maxWidth);
                     restorePriorPose();
                     if (png.empty())
                         return Json{ { "__error", "Viewport capture failed (no framebuffer or empty viewport)." } };
-                    return Json{ { "b64", Base64Encode(png) },
-                                 { "bytes", static_cast<u64>(png.size()) },
-                                 { "playing", server.Context().IsPlaying ? server.Context().IsPlaying() : false } }; });
+                    Json j{ { "bytes", static_cast<u64>(png.size()) },
+                            { "playing", server.Context().IsPlaying ? server.Context().IsPlaying() : false } };
+                    // Link mode hands the RAW bytes out (base64 happens lazily at
+                    // resources/read); inline keeps encoding here, unchanged.
+                    if (deliverLink)
+                        j["png"] = Json::binary(std::move(png));
+                    else
+                        j["b64"] = Base64Encode(png);
+                    return j; });
             }
             catch (...)
             {
@@ -297,12 +309,67 @@ namespace OloEngine::MCP
             Json meta;
             meta["sceneState"] = capturedWhilePlaying ? "play" : "edit-or-simulate";
             meta["camera"] = capturedWhilePlaying ? "runtime primary CameraComponent" : "editor camera";
-            result.Content.push_back(Json{ { "type", "text" }, { "text", meta.dump(2) } });
-            result.Content.push_back(Json{ { "type", "image" },
-                                           { "data", marshaled["b64"] },
-                                           { "mimeType", "image/png" } });
+            if (deliverLink)
+            {
+                // Publish the capture as an ephemeral resource and hand back a
+                // resource_link instead of inline base64 (issue #673 Tier 1).
+                const Json::binary_t& png = marshaled["png"].get_binary();
+                std::vector<u8> bytes(png.begin(), png.end());
+                const u64 sizeBytes = static_cast<u64>(bytes.size());
+                const u64 sequence = NextCaptureSequence();
+                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/screenshot.png";
+                const std::string name = "screenshot-" + std::to_string(sequence) + ".png";
+
+                ResourceDef capture;
+                capture.Uri = uri;
+                capture.Name = name;
+                capture.Description = "Editor viewport PNG capture (scene-state meta in the olo_screenshot result).";
+                capture.MimeType = "image/png";
+                capture.SizeBytes = sizeBytes;
+                capture.BlobReader = [bytes = std::move(bytes)](McpServer&)
+                { return bytes; };
+                server.RegisterEphemeralResource(std::move(capture));
+
+                meta["resourceUri"] = uri;
+                result.Content.push_back(Json{ { "type", "text" }, { "text", meta.dump(2) } });
+                result.Content.push_back(ToolResult::ResourceLinkBlock(
+                    uri, name, "Editor viewport capture (PNG); fetch via resources/read.", "image/png",
+                    sizeBytes));
+            }
+            else
+            {
+                result.Content.push_back(Json{ { "type", "text" }, { "text", meta.dump(2) } });
+                result.Content.push_back(Json{ { "type", "image" },
+                                               { "data", marshaled["b64"] },
+                                               { "mimeType", "image/png" } });
+            }
+            // The same meta object, typed (structuredContent is JSON-only — the PNG
+            // stays an image content block / linked resource above).
+            result.StructuredContent = meta;
             result.IsError = false;
             return result;
+        }
+
+        // ---- shared pose output schema -----------------------------------------
+        // The 11-key pose object PoseToJson (McpToolsCommon.h) emits — the result
+        // shape of olo_camera_get/set_pose/orbit, extended by frame_entity.
+        Schema::Node PoseOutputSchema()
+        {
+            return Schema::Object()
+                .Prop("position", Schema::Vec3("Camera eye position [x, y, z] (world units)."))
+                .Prop("focalPoint", Schema::Vec3("Orbit focal point [x, y, z]."))
+                .Prop("forward", Schema::Vec3("Camera forward unit vector [x, y, z]."))
+                .Prop("yawDegrees", Schema::Number())
+                .Prop("pitchDegrees", Schema::Number())
+                .Prop("distance", Schema::Number())
+                .Prop("fovDegrees", Schema::Number())
+                .Prop("nearClip", Schema::Number())
+                .Prop("farClip", Schema::Number())
+                .Prop("viewportWidth", Schema::Int().Min(0))
+                .Prop("viewportHeight", Schema::Int().Min(0))
+                .Required({ "position", "focalPoint", "forward", "yawDegrees", "pitchDegrees",
+                            "distance", "fovDegrees", "nearClip", "farClip", "viewportWidth",
+                            "viewportHeight" });
         }
 
     } // namespace
@@ -330,14 +397,25 @@ namespace OloEngine::MCP
                 "captured without disturbing the viewport. In PLAY mode the frame is rendered from the "
                 "runtime scene's primary CameraComponent, so 'camera'/'orbit' poses are refused there "
                 "(the editor camera does not drive Play rendering); the reply's sceneState/camera meta "
-                "says which camera produced the frame.";
+                "says which camera produced the frame. With delivery:'resource_link' the PNG is published "
+                "as an ephemeral olo://capture resource and referenced by a resource_link content block "
+                "(fetch it via resources/read) instead of inlining base64 — prefer it for high-res captures.";
             tool.InputSchema = Schema::Object()
                                    .Prop("maxWidth", Schema::Int().Min(16).Max(4096).Desc("Max output width in pixels (default 1024); aspect ratio preserved."))
                                    .Prop("camera", Schema::Object().Desc("Capture from this pose, then restore the prior camera. Same shape as olo_camera_set_pose: position [x,y,z] plus target [x,y,z] or yaw/pitch (degrees); optional fov."))
                                    .Prop("orbit", Schema::Object().Desc("Capture from this orbit pose, then restore. Same shape as olo_camera_orbit: target [x,y,z], yaw/pitch (degrees), distance; optional fov."))
                                    .Prop("settleFrames", Schema::Int().Min(1).Max(30).Desc("Frames to render at the new pose before capturing (default 2). Raise for temporal effects (TAA, fog history) to settle."))
                                    .Prop("forceFrame", Schema::Bool().Desc("Without a 'camera'/'orbit' pose, render and settle fresh frames before capturing (default false). Use right after a scene open / setting change so the image cannot be a stale frame."))
+                                   .Prop("delivery", Schema::String().Enum({ "inline", "resource_link" }).Desc("How to return the PNG: 'inline' (default) embeds a base64 image block; 'resource_link' publishes an ephemeral olo://capture resource and returns a link to fetch via resources/read — for large captures."))
                                    .NoAdditional();
+            // Describes the sceneState/camera meta sidecar (also mirrored as a text
+            // block); the PNG itself stays an image content block / linked
+            // resource, which an outputSchema cannot describe.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("sceneState", Schema::String().Enum({ "play", "edit-or-simulate" }).Desc("Which mode rendered the captured frame."))
+                                    .Prop("camera", Schema::String().Enum({ "runtime primary CameraComponent", "editor camera" }).Desc("Which camera produced the frame."))
+                                    .Prop("resourceUri", Schema::String().Desc("Present only with delivery:'resource_link' — the olo://capture/... resource holding the PNG (resources/read returns it as base64 blob contents)."))
+                                    .Required({ "sceneState", "camera" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_Screenshot;
             server.RegisterTool(std::move(tool));
@@ -355,6 +433,7 @@ namespace OloEngine::MCP
                 "Read this before moving the camera so you can put it back, or to reason about what the "
                 "viewport is looking at.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = PoseOutputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_CameraGet;
             server.RegisterTool(std::move(tool));
@@ -380,6 +459,7 @@ namespace OloEngine::MCP
                                    .Prop("fov", Schema::Number().Min(1).Max(170).Desc("Vertical field of view in degrees (omit to keep current)."))
                                    .Required({ "position" })
                                    .NoAdditional();
+            tool.OutputSchema = PoseOutputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_CameraSetPose;
             server.RegisterTool(std::move(tool));
@@ -404,6 +484,7 @@ namespace OloEngine::MCP
                                    .Prop("fov", Schema::Number().Min(1).Max(170).Desc("Vertical field of view in degrees (omit to keep current)."))
                                    .Required({ "target" })
                                    .NoAdditional();
+            tool.OutputSchema = PoseOutputSchema();
             tool.MainMarshaled = true;
             tool.Handler = Handle_CameraOrbit;
             server.RegisterTool(std::move(tool));
@@ -424,6 +505,13 @@ namespace OloEngine::MCP
                                    .Prop("id", Schema::EntityId())
                                    .Required({ "id" })
                                    .NoAdditional();
+            // The shared pose plus the entity echo; Required is re-listed to add
+            // 'framedEntity' on top of the helper's 11 pose keys.
+            tool.OutputSchema = PoseOutputSchema()
+                                    .Prop("framedEntity", Schema::String().Desc("The framed entity's UUID as a decimal string."))
+                                    .Required({ "position", "focalPoint", "forward", "yawDegrees", "pitchDegrees",
+                                                "distance", "fovDegrees", "nearClip", "farClip", "viewportWidth",
+                                                "viewportHeight", "framedEntity" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_CameraFrameEntity;
             server.RegisterTool(std::move(tool));
@@ -445,6 +533,11 @@ namespace OloEngine::MCP
                                    .Prop("height", Schema::Int().Min(64).Max(8192).Desc("Viewport height in logical pixels."))
                                    .Prop("reset", Schema::Bool().Desc("true = clear the override and use the panel size again."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("override", Schema::Bool().Desc("true = a size override is now active; false = reset to the panel size."))
+                                    .Prop("width", Schema::Int().Min(64).Max(8192).Desc("Applied (clamped) width in logical pixels; omitted when 'override' is false."))
+                                    .Prop("height", Schema::Int().Min(64).Max(8192).Desc("Applied (clamped) height in logical pixels; omitted when 'override' is false."))
+                                    .Required({ "override" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ViewportSetSize;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsCamera.cpp
+++ b/OloEditor/src/MCP/McpToolsCamera.cpp
@@ -315,26 +315,12 @@ namespace OloEngine::MCP
                 // resource_link instead of inline base64 (issue #673 Tier 1).
                 const Json::binary_t& png = marshaled["png"].get_binary();
                 std::vector<u8> bytes(png.begin(), png.end());
-                const u64 sizeBytes = static_cast<u64>(bytes.size());
-                const u64 sequence = NextCaptureSequence();
-                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/screenshot.png";
-                const std::string name = "screenshot-" + std::to_string(sequence) + ".png";
-
-                ResourceDef capture;
-                capture.Uri = uri;
-                capture.Name = name;
-                capture.Description = "Editor viewport PNG capture (scene-state meta in the olo_screenshot result).";
-                capture.MimeType = "image/png";
-                capture.SizeBytes = sizeBytes;
-                capture.BlobReader = [bytes = std::move(bytes)](McpServer&)
-                { return bytes; };
-                server.RegisterEphemeralResource(std::move(capture));
-
-                meta["resourceUri"] = uri;
+                Json linkBlock = PublishCaptureResourceLink(
+                    server, std::move(bytes), "screenshot",
+                    "Editor viewport PNG capture (scene-state meta in the olo_screenshot result).",
+                    "Editor viewport capture (PNG); fetch via resources/read.", meta);
                 result.Content.push_back(Json{ { "type", "text" }, { "text", meta.dump(2) } });
-                result.Content.push_back(ToolResult::ResourceLinkBlock(
-                    uri, name, "Editor viewport capture (PNG); fetch via resources/read.", "image/png",
-                    sizeBytes));
+                result.Content.push_back(std::move(linkBlock));
             }
             else
             {

--- a/OloEditor/src/MCP/McpToolsCommon.h
+++ b/OloEditor/src/MCP/McpToolsCommon.h
@@ -15,6 +15,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <string>
@@ -78,32 +79,17 @@ namespace OloEngine::MCP
         return std::round(v * 100.0) / 100.0;
     }
 
-    inline std::string Base64Encode(const std::vector<u8>& data)
+    // (Base64Encode moved to McpServer.h — resources/read's binary `blob`
+    // contents variant needs it in the dispatch core, issue #673 Tier 1. Call
+    // sites here are unchanged: this header includes McpServer.h.)
+
+    // Monotonic per-process sequence for olo://capture/... resource URIs
+    // (issue #673 Tier 1, resource-link delivery). Uniqueness is what matters —
+    // RegisterEphemeralResource REPLACES a duplicate URI — ordering is cosmetic.
+    inline u64 NextCaptureSequence()
     {
-        static constexpr char kTable[] =
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        std::string out;
-        out.reserve(((data.size() + 2) / 3) * 4);
-        std::size_t i = 0;
-        for (; i + 3 <= data.size(); i += 3)
-        {
-            const u32 n = (static_cast<u32>(data[i]) << 16) | (static_cast<u32>(data[i + 1]) << 8) | data[i + 2];
-            out.push_back(kTable[(n >> 18) & 0x3F]);
-            out.push_back(kTable[(n >> 12) & 0x3F]);
-            out.push_back(kTable[(n >> 6) & 0x3F]);
-            out.push_back(kTable[n & 0x3F]);
-        }
-        if (const std::size_t rem = data.size() - i; rem > 0)
-        {
-            u32 n = static_cast<u32>(data[i]) << 16;
-            if (rem == 2)
-                n |= static_cast<u32>(data[i + 1]) << 8;
-            out.push_back(kTable[(n >> 18) & 0x3F]);
-            out.push_back(kTable[(n >> 12) & 0x3F]);
-            out.push_back(rem == 2 ? kTable[(n >> 6) & 0x3F] : '=');
-            out.push_back('=');
-        }
-        return out;
+        static std::atomic<u64> s_Next{ 1 };
+        return s_Next.fetch_add(1, std::memory_order_relaxed);
     }
 
     // ---- Camera tool helpers (Tier 0, #316) --------------------------------

--- a/OloEditor/src/MCP/McpToolsCommon.h
+++ b/OloEditor/src/MCP/McpToolsCommon.h
@@ -92,6 +92,40 @@ namespace OloEngine::MCP
         return s_Next.fetch_add(1, std::memory_order_relaxed);
     }
 
+    // Publish a captured PNG as an ephemeral olo://capture/<n>/<stem>.png resource
+    // and return the resource_link content block that hands it back (issue #673
+    // Tier 1 resource-link delivery). Shared by olo_screenshot (McpToolsCamera),
+    // olo_render_capture_target and olo_render_compare_golden (McpToolsRender) —
+    // the size/sequence/URI generation, ResourceDef + BlobReader construction,
+    // ephemeral registration, and link-block assembly were byte-for-byte identical
+    // across all three. `stem` names both the URI leaf and the resource name
+    // (uri = olo://capture/<n>/<stem>.png, name = <stem>-<n>.png). The chosen URI
+    // is stamped into `meta` under "resourceUri" BEFORE returning, so a caller that
+    // mirrors meta into a text block reports the same URI. Takes `bytes` by value
+    // and moves into the reader closure — pass an owned buffer with std::move.
+    inline Json PublishCaptureResourceLink(McpServer& server, std::vector<u8> bytes, const std::string& stem,
+                                           const std::string& resourceDescription,
+                                           const std::string& linkDescription, Json& meta)
+    {
+        const u64 sizeBytes = static_cast<u64>(bytes.size());
+        const u64 sequence = NextCaptureSequence();
+        const std::string uri = "olo://capture/" + std::to_string(sequence) + "/" + stem + ".png";
+        const std::string name = stem + "-" + std::to_string(sequence) + ".png";
+
+        ResourceDef capture;
+        capture.Uri = uri;
+        capture.Name = name;
+        capture.Description = resourceDescription;
+        capture.MimeType = "image/png";
+        capture.SizeBytes = sizeBytes;
+        capture.BlobReader = [bytes = std::move(bytes)](McpServer&)
+        { return bytes; };
+        server.RegisterEphemeralResource(std::move(capture));
+
+        meta["resourceUri"] = uri;
+        return ToolResult::ResourceLinkBlock(uri, name, linkDescription, "image/png", sizeBytes);
+    }
+
     // ---- Camera tool helpers (Tier 0, #316) --------------------------------
 
     // Parse a [x, y, z] JSON array of finite numbers.

--- a/OloEditor/src/MCP/McpToolsDiagnostics.cpp
+++ b/OloEditor/src/MCP/McpToolsDiagnostics.cpp
@@ -145,7 +145,7 @@ namespace OloEngine::MCP
             out["count"] = static_cast<int>(arr.size());
             out["directory"] = dir.generic_string();
             out["crashes"] = std::move(arr);
-            return ToolResult::Text(out.dump(2));
+            return ToolResult::Structured(out);
         }
 
         ToolResult Handle_CrashGet(McpServer& /*server*/, const Json& args)
@@ -185,7 +185,7 @@ namespace OloEngine::MCP
             out["id"] = id;
             out["truncated"] = truncated;
             out["content"] = std::move(content);
-            return ToolResult::Text(out.dump(2));
+            return ToolResult::Structured(out);
         }
 
         // ---- olo_events_tail (lock-safe; unified diagnostics event ring buffer) -
@@ -250,7 +250,7 @@ namespace OloEngine::MCP
             // above (same lock), and stable even when no events matched the filter.
             out["lastId"] = result.LastId;
             out["events"] = std::move(arr);
-            return ToolResult::Text(out.dump(2));
+            return ToolResult::Structured(out);
         }
 
     } // namespace
@@ -272,6 +272,7 @@ namespace OloEngine::MCP
                                    .Prop("minLevel", Schema::String().Enum({ "trace", "debug", "info", "warn", "error", "critical" }).Desc("Only return lines at this severity or higher."))
                                    .Prop("tag", Schema::String().Desc("Only return lines whose [Tag] matches exactly (e.g. Physics, Scene, Script)."))
                                    .NoAdditional();
+            // No outputSchema: raw spdlog lines are free text, which an outputSchema cannot constrain.
             tool.MainMarshaled = false;
             tool.Handler = Handle_LogTail;
             server.RegisterTool(std::move(tool));
@@ -287,6 +288,13 @@ namespace OloEngine::MCP
                 "List crash reports written by the engine (crash_<timestamp>.txt under CrashReports/). Each "
                 "entry has an id and size. Use olo_crash_get to read one.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0))
+                                    .Prop("directory", Schema::String().Desc("Absolute path of the CrashReports directory scanned."))
+                                    .Prop("crashes", Schema::Array(Schema::Object()
+                                                                       .Prop("id", Schema::String().Desc("Filename — the id olo_crash_get takes."))
+                                                                       .Prop("sizeBytes", Schema::Int().Min(0).Desc("File size in bytes (0 when the size could not be read)."))))
+                                    .Required({ "count", "directory", "crashes" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_CrashList;
             server.RegisterTool(std::move(tool));
@@ -305,6 +313,11 @@ namespace OloEngine::MCP
                                    .Prop("id", Schema::String().Desc("Crash report filename (e.g. crash_20260606_143025_123.txt) from olo_crash_list."))
                                    .Required({ "id" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("id", Schema::String().Desc("The crash report filename that was read (echoes the request)."))
+                                    .Prop("truncated", Schema::Bool().Desc("True when the file exceeded the 200 KiB read cap and content is a prefix."))
+                                    .Prop("content", Schema::String().Desc("Raw crash-report text (exception, system info, last 200 log lines), at most 200 KiB."))
+                                    .Required({ "id", "truncated", "content" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_CrashGet;
             server.RegisterTool(std::move(tool));
@@ -331,6 +344,18 @@ namespace OloEngine::MCP
                                    .Prop("categories", Schema::Array(Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error" }))
                                                            .Desc("Only return events whose category is in this list. Omit for all categories."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0))
+                                    .Prop("lastId", Schema::Int().Min(0).Desc("Highest event id in the buffer at snapshot time (0 when nothing was ever recorded) — pass back as the next call's sinceId; valid even when no events matched."))
+                                    .Prop("events", Schema::Array(Schema::Object()
+                                                                      .Prop("id", Schema::Int().Min(0))
+                                                                      .Prop("category", Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error" }))
+                                                                      .Prop("time", Schema::String().Desc("UTC wall-clock HH:MM:SS.mmm; omitted when the event carries no timestamp."))
+                                                                      .Prop("message", Schema::String())
+                                                                      .Prop("entity", Schema::String().Desc("Entity UUID as a decimal string (u64 — beyond JSON integer precision); omitted when the event has no entity."))
+                                                                      .Prop("context", Schema::String().Desc("Scene name / asset path / script name; omitted when empty.")))
+                                                        .Desc("Matching events, oldest first, newest last."))
+                                    .Required({ "count", "lastId", "events" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_EventsTail;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsInput.cpp
+++ b/OloEditor/src/MCP/McpToolsInput.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "MCP/McpInputInject.h"
+#include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpToolsCommon.h"
 
 #include <string>
@@ -162,7 +163,7 @@ namespace OloEngine::MCP
             end.ViewportPixelY = accepted.value("endPixelY", 0.0f);
             end.InsideViewport = accepted.value("endInside", false);
 
-            return ToolResult::Text(Inject::ToJson(result, state, info, request, start, end, timedOut).dump(2));
+            return ToolResult::Structured(Inject::ToJson(result, state, info, request, start, end, timedOut));
         }
     } // namespace
 
@@ -199,6 +200,26 @@ namespace OloEngine::MCP
             "olo_screenshot / olo_scene_summary and see the result. The response's 'after' block already "
             "reports the resulting selected/hovered entity and cursor position.";
         tool.InputSchema = Inject::InputSchema();
+        tool.OutputSchema = Schema::Object()
+                                .Prop("available", Schema::Bool())
+                                .Prop("ok", Schema::Bool().Desc("Injection accepted AND every planned frame rendered before the settle timeout; false with a timeout warning in 'message' means the 'after' state may be stale."))
+                                .Prop("framesInjected", Schema::Int().Min(0))
+                                .Prop("message", Schema::String())
+                                .Prop("resolved", Schema::Object().Desc("Mouse actions (click/move/drag) only; omitted for key/text. A resolved point {windowX, windowY, viewportPixelX, viewportPixelY, insideViewport} for click/move, or {from, to} of two such points for drag."))
+                                .Prop("viewport", Schema::Object()
+                                                      .Prop("pixelWidth", Schema::Number())
+                                                      .Prop("pixelHeight", Schema::Number())
+                                                      .Prop("dpiScale", Schema::Number())
+                                                      .Desc("Viewport geometry the coordinates were resolved against; mouse actions only."))
+                                .Prop("after", Schema::Object()
+                                                   .Prop("pending", Schema::Bool().Desc("True when injected events are still queued (only after a settle timeout)."))
+                                                   .Prop("viewportHovered", Schema::Bool())
+                                                   .Prop("mouseX", Schema::Number())
+                                                   .Prop("mouseY", Schema::Number())
+                                                   .Prop("selectedEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the selected entity, or null when none."))
+                                                   .Prop("hoveredEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the entity under the cursor, or null when none."))
+                                                   .Desc("Post-injection editor state — the state change the injection caused."))
+                                .Required({ "available", "ok", "framesInjected", "message", "after" });
         tool.MainMarshaled = true;
         tool.Handler = Handle_InputInject;
         server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsPerf.cpp
+++ b/OloEditor/src/MCP/McpToolsPerf.cpp
@@ -152,7 +152,7 @@ namespace OloEngine::MCP
                 o["detail"] = b.m_Description;
                 o["recommendations"] = b.m_Recommendations;
                 return o; });
-            return ToolResult::Text(j.dump(2));
+            return ToolResult::Structured(j);
         }
 
         // ---- olo_perf_frame_history (main-marshaled; server downsamples) -------
@@ -184,7 +184,7 @@ namespace OloEngine::MCP
                 return Json{ { "totalFrames", static_cast<u64>(n) },
                              { "returned", static_cast<int>(series.size()) },
                              { "series", std::move(series) } }; });
-            return ToolResult::Text(j.dump(2));
+            return ToolResult::Structured(j);
         }
 
         // ---- olo_perf_capture_frame (main-marshaled) ---------------------------
@@ -269,7 +269,7 @@ namespace OloEngine::MCP
             o["note"] = "Captured from the scene render command bucket (post-batch). GPU times come from the "
                         "renderer's timer-query pool. For the per-command / per-stage structural breakdown "
                         "(command list, draw keys, sort/batch analysis), use olo_render_frame_breakdown.";
-            return ToolResult::Text(o.dump(2));
+            return ToolResult::Structured(o);
         }
 
         // McpPassTimings.h duplicates the pool's slot count as a Jolt/engine-free
@@ -433,6 +433,12 @@ namespace OloEngine::MCP
                 "The engine's automatic bottleneck analysis: which of CPU/GPU/Memory/IO is limiting the "
                 "frame, a confidence score, a human description, and concrete recommendations.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("bottleneck", Schema::String().Enum({ "CPU", "GPU", "Memory", "IO", "Balanced", "Unknown" }))
+                                    .Prop("confidence", Schema::Number().Desc("Diagnosis confidence, 0-1."))
+                                    .Prop("detail", Schema::String())
+                                    .Prop("recommendations", Schema::Array(Schema::String()))
+                                    .Required({ "bottleneck", "confidence", "detail", "recommendations" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfBottlenecks;
             server.RegisterTool(std::move(tool));
@@ -450,6 +456,15 @@ namespace OloEngine::MCP
             tool.InputSchema = Schema::Object()
                                    .Prop("points", Schema::Int().Min(1).Max(300).Desc("Number of downsampled points to return (default 60)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("totalFrames", Schema::Int().Min(0).Desc("Frames in the profiler ring buffer, before downsampling."))
+                                    .Prop("returned", Schema::Int().Min(0).Desc("Samples actually emitted after downsampling."))
+                                    .Prop("series", Schema::Array(Schema::Object()
+                                                                      .Prop("frameTimeMs", Schema::Number())
+                                                                      .Prop("fps", Schema::Number())
+                                                                      .Prop("drawCalls", Schema::Int().Min(0)))
+                                                        .Desc("Downsampled samples, oldest first; empty when no frame history exists yet."))
+                                    .Required({ "totalFrames", "returned", "series" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfFrameHistory;
             server.RegisterTool(std::move(tool));
@@ -470,6 +485,26 @@ namespace OloEngine::MCP
             tool.InputSchema = Schema::Object()
                                    .Prop("topK", Schema::Int().Min(1).Max(50).Desc("How many of the most expensive draw calls to return (default 10)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("frameNumber", Schema::Int().Min(0))
+                                    .Prop("stats", Schema::Object()
+                                                       .Prop("drawCalls", Schema::Int().Min(0))
+                                                       .Prop("totalCommands", Schema::Int().Min(0))
+                                                       .Prop("batchedCommands", Schema::Int().Min(0))
+                                                       .Prop("stateChanges", Schema::Int().Min(0))
+                                                       .Prop("shaderBinds", Schema::Int().Min(0))
+                                                       .Prop("textureBinds", Schema::Int().Min(0))
+                                                       .Prop("sortMs", Schema::Number())
+                                                       .Prop("batchMs", Schema::Number())
+                                                       .Prop("executeMs", Schema::Number())
+                                                       .Prop("totalMs", Schema::Number()))
+                                    .Prop("topDrawCalls", Schema::Array(Schema::Object()
+                                                                            .Prop("name", Schema::String())
+                                                                            .Prop("type", Schema::String())
+                                                                            .Prop("gpuMs", Schema::Number()))
+                                                              .Desc("At most topK post-batch draw commands, sorted by GPU time descending."))
+                                    .Prop("note", Schema::String().Desc("Fixed provenance note pointing at olo_render_frame_breakdown for the per-command breakdown."))
+                                    .Required({ "frameNumber", "stats", "topDrawCalls", "note" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PerfCaptureFrame;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsPhysics.cpp
+++ b/OloEditor/src/MCP/McpToolsPhysics.cpp
@@ -256,7 +256,7 @@ namespace OloEngine::MCP
                       "Built-in object layers and their collide rules are fixed (NON_MOVING vs NON_MOVING never "
                       "collide; MOVING collides with all; TRIGGER/CHARACTER/DEBRIS have specific rules). "
                       "User-defined layers are authored in the editor's Physics settings." } };
-            return ToolResult::Text(j.dump(2));
+            return ToolResult::Structured(j);
         }
 
         // ---- olo_physics_list_colliders (main-marshaled) -----------------------
@@ -350,7 +350,7 @@ namespace OloEngine::MCP
 
             if (result.contains("error"))
                 return ToolResult::Error(result["error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_physics_contacts (main-marshaled) -----------------------------
@@ -409,7 +409,7 @@ namespace OloEngine::MCP
 
             if (result.contains("error"))
                 return ToolResult::Error(result["error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_physics_raycast (main-marshaled) ------------------------------
@@ -584,7 +584,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_physics_why_no_collision (main-marshaled) ---------------------
@@ -714,7 +714,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // Keep the schema's layer cap aligned with the engine's object-layer budget.
@@ -766,7 +766,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
     } // namespace
@@ -785,6 +785,25 @@ namespace OloEngine::MCP
                 "physics layer, with the pairwise collide/no-collide result from the real layer filter. Use "
                 "this to confirm whether two layers are even allowed to collide. Works in Edit mode too.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("objectLayers", Schema::Array(Schema::Object()
+                                                                            .Prop("objectLayer", Schema::Int().Min(0))
+                                                                            .Prop("name", Schema::String())
+                                                                            .Prop("kind", Schema::String().Enum({ "builtin", "user" }))
+                                                                            .Prop("userLayerId", Schema::Int().Min(0).Desc("Present only for user-defined layers."))))
+                                    .Prop("collisionMatrix", Schema::Array(Schema::Object()
+                                                                               .Prop("a", Schema::String())
+                                                                               .Prop("b", Schema::String())
+                                                                               .Prop("collides", Schema::Bool()))
+                                                                 .Desc("Pairwise layer-name results, upper triangle including self-pairs (the matrix is symmetric)."))
+                                    .Prop("userDefinedLayers", Schema::Array(Schema::Object()
+                                                                                 .Prop("id", Schema::Int().Min(0))
+                                                                                 .Prop("name", Schema::String())
+                                                                                 .Prop("bitValue", Schema::Int().Min(0))
+                                                                                 .Prop("collidesWithSelf", Schema::Bool())
+                                                                                 .Prop("collidesWith", Schema::Array(Schema::String()).Desc("Names of the user layers this layer collides with."))))
+                                    .Prop("note", Schema::String().Desc("Fixed explanation of the built-in layer rules."))
+                                    .Required({ "objectLayers", "collisionMatrix", "userDefinedLayers", "note" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_PhysicsLayerMatrix;
             server.RegisterTool(std::move(tool));
@@ -804,6 +823,25 @@ namespace OloEngine::MCP
             tool.InputSchema = Schema::Object()
                                    .Pagination("Entities per page (default 50, max 200).")
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("physicsRunning", Schema::Bool())
+                                    .Prop("total", Schema::Int().Min(0).Desc("Total entities with a Rigidbody3DComponent."))
+                                    .Prop("page", Schema::Int().Min(0))
+                                    .Prop("pageSize", Schema::Int().Min(1))
+                                    .Prop("returned", Schema::Int().Min(0).Desc("Entries in this page."))
+                                    .Prop("nextPage", Schema::Int().Min(1).Desc("Present only when more pages exist."))
+                                    .Prop("colliders", Schema::Array(Schema::Object()
+                                                                         .Prop("id", Schema::String())
+                                                                         .Prop("name", Schema::String())
+                                                                         .Prop("bodyType", Schema::String().Enum({ "Static", "Dynamic", "Kinematic" }))
+                                                                         .Prop("layerId", Schema::Int().Min(0))
+                                                                         .Prop("isTrigger", Schema::Bool())
+                                                                         .Prop("disableGravity", Schema::Bool())
+                                                                         .Prop("colliders", Schema::Array(Schema::Object().Desc("Shape descriptor: 'type' (Box/Sphere/Capsule/Mesh/ConvexMesh/TriangleMesh) plus shape-specific keys (halfExtents/radius/halfHeight/offset/colliderAsset).")))
+                                                                         .Prop("hasCollider", Schema::Bool())
+                                                                         .Prop("live", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } })
+                                                                                           .Desc("Live body state (bodyType, objectLayer, objectLayerName, isTrigger, position, active, sleeping); null when the authored body has no live counterpart; omitted in Edit mode."))))
+                                    .Required({ "physicsRunning", "total", "page", "pageSize", "returned", "colliders" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PhysicsListColliders;
             server.RegisterTool(std::move(tool));
@@ -822,6 +860,20 @@ namespace OloEngine::MCP
             tool.InputSchema = Schema::Object()
                                    .Prop("maxResults", Schema::Int().Min(1).Max(2000).Desc("Max contact pairs to return (default 200)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("physicsRunning", Schema::Bool())
+                                    .Prop("activeContactCount", Schema::Int().Min(0).Desc("Total live contact pairs; may exceed 'returned' when truncated."))
+                                    .Prop("contacts", Schema::Array(Schema::Object()
+                                                                        .Prop("a", Schema::Object()
+                                                                                       .Prop("id", Schema::String())
+                                                                                       .Prop("name", Schema::String()))
+                                                                        .Prop("b", Schema::Object()
+                                                                                       .Prop("id", Schema::String())
+                                                                                       .Prop("name", Schema::String()))))
+                                    .Prop("returned", Schema::Int().Min(0).Desc("Pairs emitted; omitted on the physics-not-running early return."))
+                                    .Prop("truncated", Schema::Bool().Desc("Present (true) only when the live pair count exceeds maxResults."))
+                                    .Prop("note", Schema::String().Desc("Present only when physics is not running."))
+                                    .Required({ "physicsRunning", "activeContactCount", "contacts" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PhysicsContacts;
             server.RegisterTool(std::move(tool));
@@ -882,12 +934,35 @@ namespace OloEngine::MCP
                                    .Prop("maxHits", Schema::Int().Min(1).Max(256).Desc("Max overlapping bodies to return (default 32)."))
                                    .Required({ "origin" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("shape", Schema::String().Enum({ "box", "sphere" }))
+                                    .Prop("origin", Schema::Array(Schema::Number()).Desc("Query centre [x, y, z]."))
+                                    .Prop("halfExtents", Schema::Array(Schema::Number()).Desc("Present only for a box query."))
+                                    .Prop("radius", Schema::Number().Desc("Present only for a sphere query."))
+                                    .Prop("overlapCount", Schema::Int().Min(0).Desc("Overlapping bodies returned."))
+                                    .Prop("truncated", Schema::Bool().Desc("Present (true) when the hit buffer filled (maxHits reached)."))
+                                    .Prop("overlaps", Schema::Array(Schema::Object()
+                                                                        .Prop("id", Schema::String())
+                                                                        .Prop("name", Schema::String())
+                                                                        .Prop("position", Schema::Array(Schema::Number()))))
+                                    .Required({ "shape", "origin", "overlapCount", "overlaps" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PhysicsOverlap;
             server.RegisterTool(std::move(tool));
         }
 
         {
+            // Per-entity fact block, identical for sides 'a' and 'b' under "facts".
+            const Schema::Node entityFacts = Schema::Object()
+                                                 .Prop("entityExists", Schema::Bool())
+                                                 .Prop("hasRigidbody", Schema::Bool())
+                                                 .Prop("hasCollider", Schema::Bool())
+                                                 .Prop("hasLiveBody", Schema::Bool())
+                                                 .Prop("bodyType", Schema::String().Enum({ "Static", "Dynamic", "Kinematic" }))
+                                                 .Prop("isTrigger", Schema::Bool())
+                                                 .Prop("layerId", Schema::Int().Min(0))
+                                                 .Prop("layerName", Schema::String());
+
             ToolDef tool;
             tool.Name = "olo_physics_why_no_collision";
             tool.Toolset = "physics";
@@ -904,6 +979,23 @@ namespace OloEngine::MCP
                                    .Prop("b", Schema::String().Desc("Second entity UUID (string; also accepts a number)."))
                                    .Required({ "a", "b" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("a", Schema::String().Desc("Echoed UUID of entity A."))
+                                    .Prop("b", Schema::String().Desc("Echoed UUID of entity B."))
+                                    .Prop("reasonCode", Schema::String().Enum({ "same_entity", "physics_not_running", "entity_a_missing",
+                                                                                "entity_b_missing", "entity_a_no_rigidbody", "entity_b_no_rigidbody",
+                                                                                "entity_a_no_collider", "entity_b_no_collider", "entity_a_no_body",
+                                                                                "entity_b_no_body", "both_static", "layers_dont_collide",
+                                                                                "trigger_no_solid_response", "not_overlapping", "would_collide" }))
+                                    .Prop("summary", Schema::String().Desc("One-line human explanation of the root cause."))
+                                    .Prop("canCollide", Schema::Bool().Desc("True only for not_overlapping / would_collide."))
+                                    .Prop("checks", Schema::Array(Schema::String()).Desc("Ordered [ok]/[fail]/[warn] trace of every check performed."))
+                                    .Prop("facts", Schema::Object()
+                                                       .Prop("a", entityFacts)
+                                                       .Prop("b", entityFacts)
+                                                       .Prop("layersCollide", Schema::Bool().Desc("Meaningful only when both sides have live bodies; false otherwise."))
+                                                       .Prop("boundsOverlap", Schema::Bool()))
+                                    .Required({ "a", "b", "reasonCode", "summary", "canCollide", "checks", "facts" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_PhysicsWhyNoCollision;
             server.RegisterTool(std::move(tool));
@@ -929,6 +1021,14 @@ namespace OloEngine::MCP
                 "editor's MCP Server panel (off by default). Discover valid layer ids with "
                 "olo_physics_layer_matrix.";
             tool.InputSchema = SetCollisionLayer::InputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("entity", Schema::String().Desc("Target entity UUID (decimal string)."))
+                                    .Prop("component", Schema::String().Enum({ "Rigidbody3DComponent", "CharacterController3DComponent" }).Desc("Which component carried the layer id."))
+                                    .Prop("previousLayer", Schema::Int().Min(0).Desc("Layer id before the write."))
+                                    .Prop("layer", Schema::Int().Min(0).Desc("Layer id now applied."))
+                                    .Prop("changed", Schema::Bool().Desc("False when the body was already on that layer (nothing pushed to the undo stack)."))
+                                    .Prop("undoable", Schema::Bool().Desc("Whether a single undo reverts this call (equals 'changed')."))
+                                    .Required({ "entity", "component", "previousLayer", "layer", "changed", "undoable" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SetCollisionLayer;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -222,7 +222,7 @@ namespace OloEngine::MCP
             const bool haveGraph = gathered.is_object() && gathered.value("haveGraph", false);
             const Json o = FrameBreakdown::BuildBreakdown(cap, requested, maxCommands,
                                                           haveGraph ? &attribution : nullptr);
-            return ToolResult::Text(o.dump(2));
+            return ToolResult::Structured(o);
         }
 
         // ---- Render-target capture (Part 4 of #316) ----------------------------
@@ -339,7 +339,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_render_graph_topology_export (main-marshaled) -----------------
@@ -456,7 +456,7 @@ namespace OloEngine::MCP
                 return ToolResult::Error(transport["__error"].get<std::string>());
             if (transport.is_object() && transport.contains("__text"))
                 return ToolResult::Text(transport["__text"].get<std::string>());
-            return ToolResult::Text(transport.dump(2));
+            return ToolResult::Structured(transport);
         }
 
         // (main thread) Resolve a render-graph resource name to a physical GL
@@ -552,6 +552,10 @@ namespace OloEngine::MCP
             if (args.contains("maxWidth") && args["maxWidth"].is_number_integer())
                 maxWidth = static_cast<int>(std::clamp<long long>(args["maxWidth"].get<long long>(), 16, 4096));
 
+            // Opt-in resource-link delivery (issue #673 Tier 1): publish the PNG
+            // as an ephemeral olo://capture resource instead of inlining base64.
+            const bool deliverLink = args.value("delivery", std::string{ "inline" }) == "resource_link";
+
             auto normalizeMode = GPUResourceInspector::CaptureNormalizeMode::Auto;
             if (args.contains("normalize") && args["normalize"].is_boolean())
                 normalizeMode = args["normalize"].get<bool>() ? GPUResourceInspector::CaptureNormalizeMode::On
@@ -586,7 +590,8 @@ namespace OloEngine::MCP
             }
 
             Json result = server.MarshalRead([&server, name, mipLevel, hasLayerSelector, requestedLayer,
-                                              normalizeMode, maxWidth, afterPass, afterPassFrameRendered]() -> Json
+                                              normalizeMode, maxWidth, afterPass, afterPassFrameRendered,
+                                              deliverLink]() -> Json
                                              {
                 const Ref<RenderGraph>& graph = RenderGraphDebugRuntime::GetActiveGraph();
                 if (!graph)
@@ -652,8 +657,14 @@ namespace OloEngine::MCP
                     meta["minValue"] = capture.MinValue;
                     meta["maxValue"] = capture.MaxValue;
                 }
-                return Json{ { "meta", std::move(meta) },
-                             { "b64", Base64Encode(capture.PngBytes) } }; });
+                Json out{ { "meta", std::move(meta) } };
+                // Link mode hands the RAW bytes out (base64 happens lazily at
+                // resources/read); inline keeps encoding here, unchanged.
+                if (deliverLink)
+                    out["png"] = Json::binary(std::move(capture.PngBytes));
+                else
+                    out["b64"] = Base64Encode(capture.PngBytes);
+                return out; });
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
@@ -669,10 +680,46 @@ namespace OloEngine::MCP
                                "fresh frame first, or compare 'frameIndex' between calls.";
 
             ToolResult toolResult;
-            toolResult.Content = Json::array({ Json{ { "type", "text" }, { "text", meta.dump(2) } },
-                                               Json{ { "type", "image" },
-                                                     { "data", result["b64"] },
-                                                     { "mimeType", "image/png" } } });
+            if (deliverLink)
+            {
+                // Publish the capture as an ephemeral resource and hand back a
+                // resource_link instead of inline base64 (issue #673 Tier 1).
+                const Json::binary_t& png = result["png"].get_binary();
+                std::vector<u8> bytes(png.begin(), png.end());
+                const u64 sizeBytes = static_cast<u64>(bytes.size());
+                const u64 sequence = NextCaptureSequence();
+                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/target.png";
+                const std::string linkName = "target-" + std::to_string(sequence) + ".png";
+
+                ResourceDef captureResource;
+                captureResource.Uri = uri;
+                captureResource.Name = linkName;
+                captureResource.Description =
+                    "Render-target PNG capture of '" + name + "' (capture meta in the tool result).";
+                captureResource.MimeType = "image/png";
+                captureResource.SizeBytes = sizeBytes;
+                captureResource.BlobReader = [bytes = std::move(bytes)](McpServer&)
+                { return bytes; };
+                server.RegisterEphemeralResource(std::move(captureResource));
+
+                meta["resourceUri"] = uri;
+                toolResult.Content = Json::array(
+                    { Json{ { "type", "text" }, { "text", meta.dump(2) } },
+                      ToolResult::ResourceLinkBlock(uri, linkName,
+                                                    "Render-target capture of '" + name +
+                                                        "' (PNG); fetch via resources/read.",
+                                                    "image/png", sizeBytes) });
+            }
+            else
+            {
+                toolResult.Content = Json::array({ Json{ { "type", "text" }, { "text", meta.dump(2) } },
+                                                   Json{ { "type", "image" },
+                                                         { "data", result["b64"] },
+                                                         { "mimeType", "image/png" } } });
+            }
+            // structuredContent must be a JSON object, so it mirrors the text meta
+            // block only; the PNG stays an image content block / linked resource.
+            toolResult.StructuredContent = std::move(meta);
             toolResult.IsError = false;
             return toolResult;
         }
@@ -795,7 +842,7 @@ namespace OloEngine::MCP
                     j["passes"] = std::move(passes);
                     j["activeAOTechnique"] = AOTechniqueToken(pp.ActiveAOTechnique);
                     return j; });
-                return ToolResult::Text(result.dump(2));
+                return ToolResult::Structured(result);
             }
 
             const std::string name = args["name"].get<std::string>();
@@ -884,7 +931,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // The virtual-geometry debug mode a vg* debug-view token selects. Returns
@@ -1040,7 +1087,7 @@ namespace OloEngine::MCP
                     j["modes"] = DescribeDebugViews();
                     j["current"] = ToJson(BuildDebugViewResult(pp, ActiveDebugView(pp)));
                     return j; });
-                return ToolResult::Text(result.dump(2));
+                return ToolResult::Structured(result);
             }
 
             // enabled:false takes precedence over mode: it is the explicit
@@ -1094,7 +1141,7 @@ namespace OloEngine::MCP
                 result = server.MarshalRead([view]() -> Json
                                             { return ToJson(BuildDebugViewResult(Renderer3D::GetPostProcessSettings(), view)); });
             }
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_scene_set_time_of_day / olo_scene_set_sun_angle (#633) --------
@@ -1176,7 +1223,7 @@ namespace OloEngine::MCP
                             "scene's TimeOfDayComponent is authoritative. Set 'hours' (or the other fields) "
                             "to move the sun instead.";
                 return j; });
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         ToolResult Handle_SceneSetTimeOfDay(McpServer& server, const Json& args)
@@ -1283,7 +1330,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         ToolResult Handle_SceneSetSunAngle(McpServer& server, const Json& args)
@@ -1345,7 +1392,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_scene_set_weather / olo_scene_get_atmosphere (#633) -----------
@@ -1463,7 +1510,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // Read-only one-call report over the three atmosphere components (#633):
@@ -1528,7 +1575,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_render_compare_golden (Part 4 of #316) ------------------------
@@ -1641,6 +1688,10 @@ namespace OloEngine::MCP
             if (args.contains("maxWidth") && args["maxWidth"].is_number_integer())
                 maxWidth = static_cast<int>(std::clamp<long long>(args["maxWidth"].get<long long>(), 16, 4096));
 
+            // Opt-in resource-link delivery for the returned capture (issue #673
+            // Tier 1); the golden FILE write below is unaffected either way.
+            const bool deliverLink = args.value("delivery", std::string{ "inline" }) == "resource_link";
+
             // Save the user's pose and apply the requested one (identical machinery
             // to Handle_Screenshot — the restore happens in the capture job / the
             // error path so it runs exactly once).
@@ -1718,6 +1769,38 @@ namespace OloEngine::MCP
             const std::string goldenPathStr = goldenPath.generic_string();
             const bool goldenExists = fs::exists(goldenPath);
 
+            // The second content block for either result shape: an inline base64
+            // image, or a published olo://capture resource + resource_link block
+            // (which also stamps resourceUri into the verdict object BEFORE it
+            // is mirrored into the text block).
+            const auto attachCapture = [&server, &capturedPng, deliverLink](Json& verdict) -> Json
+            {
+                if (!deliverLink)
+                    return Json{ { "type", "image" },
+                                 { "data", Base64Encode(capturedPng) },
+                                 { "mimeType", "image/png" } };
+                const u64 sizeBytes = static_cast<u64>(capturedPng.size());
+                const u64 sequence = NextCaptureSequence();
+                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/golden-capture.png";
+                const std::string linkName = "golden-capture-" + std::to_string(sequence) + ".png";
+
+                ResourceDef captureResource;
+                captureResource.Uri = uri;
+                captureResource.Name = linkName;
+                captureResource.Description =
+                    "Viewport capture from olo_render_compare_golden (verdict in the tool result).";
+                captureResource.MimeType = "image/png";
+                captureResource.SizeBytes = sizeBytes;
+                captureResource.BlobReader = [bytes = capturedPng](McpServer&)
+                { return bytes; };
+                server.RegisterEphemeralResource(std::move(captureResource));
+
+                verdict["resourceUri"] = uri;
+                return ToolResult::ResourceLinkBlock(uri, linkName,
+                                                     "Captured viewport frame (PNG); fetch via resources/read.",
+                                                     "image/png", sizeBytes);
+            };
+
             // Golden-missing / rebase: write the capture as the new golden and
             // report it (a test-artifact write under assets/tests/visual/, never
             // the user's scene/assets — see #316 Tier-0 framing).
@@ -1744,8 +1827,12 @@ namespace OloEngine::MCP
                     j["warning"] = "Timed out waiting for the new camera pose to render; the golden may be a stale frame.";
 
                 ToolResult result;
-                result.Content = Json::array({ Json{ { "type", "text" }, { "text", j.dump(2) } },
-                                               Json{ { "type", "image" }, { "data", Base64Encode(capturedPng) }, { "mimeType", "image/png" } } });
+                const Json captureBlock = attachCapture(j);
+                result.Content = Json::array({ Json{ { "type", "text" }, { "text", j.dump(2) } }, captureBlock });
+                // The verdict JSON also goes out as structuredContent; the image
+                // stays a content block / linked resource (structuredContent
+                // cannot carry images).
+                result.StructuredContent = std::move(j);
                 result.IsError = false;
                 return result;
             }
@@ -1807,8 +1894,12 @@ namespace OloEngine::MCP
                 j["warning"] = "Timed out waiting for the new camera pose to render; the comparison may use a stale frame.";
 
             ToolResult result;
-            result.Content = Json::array({ Json{ { "type", "text" }, { "text", j.dump(2) } },
-                                           Json{ { "type", "image" }, { "data", Base64Encode(capturedPng) }, { "mimeType", "image/png" } } });
+            const Json captureBlock = attachCapture(j);
+            result.Content = Json::array({ Json{ { "type", "text" }, { "text", j.dump(2) } }, captureBlock });
+            // The verdict JSON also goes out as structuredContent; the image
+            // stays a content block / linked resource (structuredContent cannot
+            // carry images).
+            result.StructuredContent = std::move(j);
             result.IsError = false;
             return result;
         }
@@ -1856,7 +1947,7 @@ namespace OloEngine::MCP
             {
                 const Json result = server.MarshalRead([&snapshotLever]() -> Json
                                                        { return Describe(Renderer3D::GetPostProcessSettings(), Renderer3D::GetRendererSettings(), snapshotLever()); });
-                return ToolResult::Text(result.dump(2));
+                return ToolResult::Structured(result);
             }
 
             const Json result = server.MarshalRead([setting, value, &snapshotLever]() -> Json
@@ -1921,7 +2012,7 @@ namespace OloEngine::MCP
                 AwaitRenderedFrames(server, baseFrame, kSettingsSettleFrames);
             }
 
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
         // ---- olo_render_why_not_visible (main-marshaled) -----------------------
         // The rendering counterpart of olo_physics_why_no_collision: explain why an
@@ -2229,7 +2320,7 @@ namespace OloEngine::MCP
                 j["shaderErrorCount"] = in.ShaderErrorCount;
                 return j; });
 
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // =====================================================================
@@ -3458,6 +3549,20 @@ namespace OloEngine::MCP
             return j;
         }
 
+        // The outputSchema sub-shape matching VirtualGeometrySettingsJson above,
+        // shared by both virtual-geometry tools (previous/current/settings).
+        Schema::Node VirtualGeometrySettingsSchema()
+        {
+            return Schema::Object()
+                .Prop("enabled", Schema::Bool())
+                .Prop("debugToViewport", Schema::Bool())
+                .Prop("debugMode", Schema::String().Enum({ "off", "clusterid", "lod", "overdraw" }))
+                .Prop("swRasterMode", Schema::String().Enum({ "auto", "forcesoftware", "disabled" }))
+                .Prop("swRasterThresholdPixels", Schema::Number())
+                .Prop("forcePortableSwRaster", Schema::Bool())
+                .Prop("debugTargetAvailable", Schema::Bool().Desc("True when the 'VirtualGeometryDebug' target has GPU backing this frame."));
+        }
+
         ToolResult Handle_VirtualGeometrySet(McpServer& server, const Json& args)
         {
             const bool hasDebugMode = args.contains("debugMode") && args["debugMode"].is_string();
@@ -4240,6 +4345,18 @@ namespace OloEngine::MCP
                 "olo_render_capture_target), kind, format, size, and producing passes. Requires the "
                 "editor to be rendering in 3D mode.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0).Desc("Number of capturable targets listed."))
+                                    .Prop("targets", Schema::Array(Schema::Object()
+                                                                       .Prop("name", Schema::String().Desc("Canonical resource name (pass to olo_render_capture_target)."))
+                                                                       .Prop("kind", Schema::String())
+                                                                       .Prop("format", Schema::String().Desc("Omitted when the format is unknown."))
+                                                                       .Prop("width", Schema::Int().Desc("Omitted when the size is unknown."))
+                                                                       .Prop("height", Schema::Int().Desc("Omitted when the size is unknown."))
+                                                                       .Prop("layers", Schema::Int().Desc("Layer count; array/cube/3D targets only."))
+                                                                       .Prop("viewOfParentLayer", Schema::Int().Desc("Parent-array layer this view resolves to; per-layer views only."))
+                                                                       .Prop("producers", Schema::Array(Schema::String()).Desc("Passes that write the target; omitted when empty."))))
+                                    .Required({ "count", "targets" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderListTargets;
             server.RegisterTool(std::move(tool));
@@ -4270,6 +4387,45 @@ namespace OloEngine::MCP
                                                        .Desc("'json' (default): full structured topology (passes, executionOrder, edges, resources). "
                                                              "'mermaid': a flowchart-LR DAG of the pass dependency graph."))
                                    .NoAdditional();
+            // outputSchema describes the json format only; mermaid returns
+            // free text, which an outputSchema cannot constrain.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("finalPass", Schema::String().Desc("The graph's designated final/output pass."))
+                                    .Prop("passCount", Schema::Int().Min(0))
+                                    .Prop("passes", Schema::Array(Schema::Object()
+                                                                      .Prop("name", Schema::String())
+                                                                      .Prop("workType", Schema::String())
+                                                                      .Prop("declaresResources", Schema::Bool())
+                                                                      .Prop("asyncComputeCandidate", Schema::Bool())
+                                                                      .Prop("culled", Schema::Bool())
+                                                                      .Prop("isFinalPass", Schema::Bool())
+                                                                      .Prop("accesses", Schema::Array(Schema::Object()
+                                                                                                          .Prop("resource", Schema::String())
+                                                                                                          .Prop("mode", Schema::String().Enum({ "write", "read" }))
+                                                                                                          .Prop("glTextureId", Schema::Int().Desc("Resolved physical texture id; omitted when unbacked."))
+                                                                                                          .Prop("glBufferId", Schema::Int().Desc("Omitted when not buffer-backed.")))
+                                                                                            .Desc("Resources the pass reads/writes; omitted when it accesses none."))))
+                                    .Prop("executionOrder", Schema::Array(Schema::String()).Desc("Topologically-sorted run order."))
+                                    .Prop("edgeCount", Schema::Int().Min(0))
+                                    .Prop("edges", Schema::Array(Schema::Object()
+                                                                     .Prop("from", Schema::String())
+                                                                     .Prop("to", Schema::String()))
+                                                       .Desc("Execution-ordering dependencies (from must run before to)."))
+                                    .Prop("resourceCount", Schema::Int().Min(0))
+                                    .Prop("resources", Schema::Array(Schema::Object()
+                                                                         .Prop("name", Schema::String())
+                                                                         .Prop("kind", Schema::String())
+                                                                         .Prop("format", Schema::String().Desc("Omitted when the format is unknown."))
+                                                                         .Prop("width", Schema::Int().Desc("Omitted when the size is unknown."))
+                                                                         .Prop("height", Schema::Int().Desc("Omitted when the size is unknown."))
+                                                                         .Prop("samples", Schema::Int().Desc("Omitted when single-sampled."))
+                                                                         .Prop("imported", Schema::Bool())
+                                                                         .Prop("hasExternalBacking", Schema::Bool())
+                                                                         .Prop("producers", Schema::Array(Schema::String()))
+                                                                         .Prop("consumers", Schema::Array(Schema::String()))
+                                                                         .Prop("gl", Schema::Object().Desc("Resolved physical GL object ids as of the last executed frame (textureId, framebufferId, colorAttachmentIds, depthAttachmentId, bufferId, viewOfParentLayer); omitted when unbacked."))))
+                                    .Prop("note", Schema::String())
+                                    .Required({ "finalPass", "passCount", "passes", "executionOrder", "edgeCount", "edges", "resourceCount", "resources", "note" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderGraphTopologyExport;
             server.RegisterTool(std::move(tool));
@@ -4311,8 +4467,37 @@ namespace OloEngine::MCP
                                    .Prop("maxWidth", Schema::Int().Min(16).Max(4096).Desc("Max output width in pixels (default 1024); aspect ratio preserved."))
                                    .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before capturing (default false). Use after any change (scene open, setting flip) so you cannot read a stale target. Implied by 'afterPass'."))
                                    .Prop("afterPass", Schema::String().Desc("Capture the resource AS OF this pass's execution (mid-frame snapshot), not end-of-frame. A pass name from olo_render_graph_topology_export's executionOrder; a culled/unknown pass is an error."))
+                                   .Prop("delivery", Schema::String().Enum({ "inline", "resource_link" }).Desc("How to return the PNG: 'inline' (default) embeds a base64 image block; 'resource_link' publishes an ephemeral olo://capture resource and returns a link to fetch via resources/read — for large captures."))
                                    .Required({ "name" })
                                    .NoAdditional();
+            // outputSchema describes the capture-meta object (the text block); the
+            // PNG stays an image content block, which structuredContent cannot carry.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("frameIndex", Schema::Int().Min(0).Desc("Frame the pixels came from (compare between calls to detect a stale read)."))
+                                    .Prop("timestampMs", Schema::Int().Min(0).Desc("Wall-clock capture stamp, ms since epoch."))
+                                    .Prop("name", Schema::String().Desc("Captured render-graph resource name."))
+                                    .Prop("afterPass", Schema::String().Desc("Mid-frame snapshot pass; omitted unless 'afterPass' was given."))
+                                    .Prop("snapshotSourceTextureId", Schema::Int().Desc("Source texture of the afterPass snapshot clone; omitted without 'afterPass'."))
+                                    .Prop("frameIndexNote", Schema::String().Desc("afterPass frameIndex semantics; omitted without 'afterPass'."))
+                                    .Prop("layer", Schema::Int().Min(0).Desc("GL array layer / cube face / z-slice actually read."))
+                                    .Prop("layers", Schema::Int().Desc("Layer count; array/cube/3D targets only."))
+                                    .Prop("layerNote", Schema::String().Desc("Layer-selection note; omitted when there is nothing to flag."))
+                                    .Prop("width", Schema::Int().Desc("Output PNG width."))
+                                    .Prop("height", Schema::Int().Desc("Output PNG height."))
+                                    .Prop("sourceWidth", Schema::Int())
+                                    .Prop("sourceHeight", Schema::Int())
+                                    .Prop("format", Schema::String())
+                                    .Prop("isDepth", Schema::Bool())
+                                    .Prop("normalized", Schema::Bool().Desc("Min-max normalisation was applied."))
+                                    .Prop("minValue", Schema::Number().Desc("Pre-normalisation minimum; present only when max > min."))
+                                    .Prop("maxValue", Schema::Number().Desc("Pre-normalisation maximum; present only when max > min."))
+                                    .Prop("forcedFreshFrame", Schema::Bool())
+                                    .Prop("warning", Schema::String().Desc("Fresh-frame timeout warning; omitted otherwise."))
+                                    .Prop("note", Schema::String().Desc("Staleness guidance; omitted when forceFrame was used."))
+                                    .Prop("resourceUri", Schema::String().Desc("Present only with delivery:'resource_link' — the olo://capture/... resource holding the PNG."))
+                                    .Required({ "frameIndex", "timestampMs", "name", "layer", "width", "height",
+                                                "sourceWidth", "sourceHeight", "format", "isDepth", "normalized",
+                                                "forcedFreshFrame" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderCaptureTarget;
             server.RegisterTool(std::move(tool));
@@ -4341,6 +4526,20 @@ namespace OloEngine::MCP
                                    .Prop("name", Schema::String().Desc("Pass token (e.g. 'bloom', 'ssao', 'ssr', 'fog', 'godrays'). Omit to list all passes + state."))
                                    .Prop("enabled", Schema::Bool().Desc("Desired state. Omit to toggle (flip the current value)."))
                                    .NoAdditional();
+            // Two result shapes (toggle vs introspection), so no field is
+            // unconditionally present and nothing is required.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("pass", Schema::String().Desc("Canonical token of the affected pass (toggle form only)."))
+                                    .Prop("enabled", Schema::Bool().Desc("State after the flip (toggle form only)."))
+                                    .Prop("previous", Schema::Bool().Desc("State before the flip (toggle form only)."))
+                                    .Prop("changed", Schema::Bool().Desc("enabled != previous (toggle form only)."))
+                                    .Prop("note", Schema::String().Desc("Precondition hint (AO technique switched, Deferred-only, fog disabled); omitted when none applies."))
+                                    .Prop("passes", Schema::Array(Schema::Object()
+                                                                      .Prop("name", Schema::String())
+                                                                      .Prop("description", Schema::String())
+                                                                      .Prop("enabled", Schema::Bool()))
+                                                        .Desc("Introspection form (no 'name' argument) only: every toggleable pass with its live state."))
+                                    .Prop("activeAOTechnique", Schema::String().Desc("Introspection form only: 'none', 'ssao', or 'gtao'."));
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderTogglePass;
             server.RegisterTool(std::move(tool));
@@ -4375,6 +4574,24 @@ namespace OloEngine::MCP
                                    .Prop("mode", Schema::String().Enum({ "none", "ssao", "gtao", "ssr", "ssgi", "overdraw", "vgclusterid", "vglod", "vgoverdraw" }).Desc("Debug view to show. 'none' clears all. The vg* modes write to the 'VirtualGeometryDebug' capture target. Omit to list modes + state."))
                                    .Prop("enabled", Schema::Bool().Desc("Set false as an alias for mode:'none' (clear all debug views)."))
                                    .NoAdditional();
+            // Two result shapes (set vs introspection), so no field is
+            // unconditionally present and nothing is required.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("mode", Schema::String().Desc("Active debug view token (set form only)."))
+                                    .Prop("ssaoDebugView", Schema::Bool())
+                                    .Prop("gtaoDebugView", Schema::Bool())
+                                    .Prop("ssrDebugView", Schema::Bool())
+                                    .Prop("ssgiDebugView", Schema::Bool())
+                                    .Prop("overdrawDebugView", Schema::Bool())
+                                    .Prop("virtualGeometryDebugMode", Schema::String().Desc("'off', 'clusterid', 'lod', or 'overdraw' — mirrors olo_virtual_geometry_set."))
+                                    .Prop("passEnabled", Schema::Bool().Desc("The pass producing the chosen buffer is running this frame."))
+                                    .Prop("captureTarget", Schema::String().Desc("Render-graph target to capture for this view; omitted when none applies."))
+                                    .Prop("note", Schema::String().Desc("Actionable hint when passEnabled is false; omitted otherwise."))
+                                    .Prop("modes", Schema::Array(Schema::Object()
+                                                                     .Prop("name", Schema::String())
+                                                                     .Prop("description", Schema::String()))
+                                                       .Desc("Introspection form (no arguments) only: every debug-view mode."))
+                                    .Prop("current", Schema::Object().Desc("Introspection form only: the live state in the set-form shape."));
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderSetDebugView;
             server.RegisterTool(std::move(tool));
@@ -4415,6 +4632,20 @@ namespace OloEngine::MCP
                                    .Prop("enabled", Schema::Bool().Desc("Enable/disable the component (disabled = TimeOfDaySystem stops driving the sun)."))
                                    .Prop("clear", Schema::Bool().Desc("Legacy no-op from the retired override interface: returns the current state + a note (the component is authoritative; there is nothing to clear)."))
                                    .NoAdditional();
+            // The legacy 'clear':true path succeeds with ONLY 'note' when no
+            // TimeOfDayComponent exists, so no field is unconditionally present.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("enabled", Schema::Bool())
+                                    .Prop("hours", Schema::Number().Desc("24-hour clock time in [0, 24)."))
+                                    .Prop("dayOfYear", Schema::Int())
+                                    .Prop("latitudeDegrees", Schema::Number())
+                                    .Prop("timeScale", Schema::Number())
+                                    .Prop("paused", Schema::Bool())
+                                    .Prop("sunElevationDegrees", Schema::Number().Desc("Derived sun elevation in degrees."))
+                                    .Prop("isNight", Schema::Bool().Desc("Derived night flag."))
+                                    .Prop("sunDirection", Schema::Vec3("Derived [x, y, z] sun direction."))
+                                    .Prop("moonDirection", Schema::Vec3("Derived [x, y, z] moon direction."))
+                                    .Prop("note", Schema::String().Desc("Disabled-component warning or legacy-clear explanation; omitted otherwise."));
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneSetTimeOfDay;
             server.RegisterTool(std::move(tool));
@@ -4450,6 +4681,22 @@ namespace OloEngine::MCP
                                    .Prop("pitch", Schema::Number().Min(-90).Max(90).Desc("Elevation in degrees above the horizon (90=up, 0=horizon, negative=below). Matched exactly when achievable, else clamped."))
                                    .Prop("clear", Schema::Bool().Desc("Legacy no-op from the retired override interface: returns the current state + a note (the component is authoritative; there is nothing to clear)."))
                                    .NoAdditional();
+            // The legacy 'clear':true path succeeds with ONLY 'note' when no
+            // TimeOfDayComponent exists, so no field is unconditionally present.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("enabled", Schema::Bool())
+                                    .Prop("hours", Schema::Number().Desc("Solved 24-hour clock time written to the component."))
+                                    .Prop("dayOfYear", Schema::Int())
+                                    .Prop("latitudeDegrees", Schema::Number())
+                                    .Prop("timeScale", Schema::Number())
+                                    .Prop("paused", Schema::Bool())
+                                    .Prop("sunElevationDegrees", Schema::Number().Desc("Derived sun elevation at the solved time."))
+                                    .Prop("isNight", Schema::Bool().Desc("Derived night flag."))
+                                    .Prop("sunDirection", Schema::Vec3("Derived [x, y, z] sun direction."))
+                                    .Prop("moonDirection", Schema::Vec3("Derived [x, y, z] moon direction."))
+                                    .Prop("achievedElevationDeg", Schema::Number().Desc("Elevation the solved time actually yields."))
+                                    .Prop("clamped", Schema::Bool().Desc("True when the requested elevation was outside the day's range."))
+                                    .Prop("note", Schema::String().Desc("Clamp explanation, disabled-component warning, or legacy-clear explanation; omitted otherwise."));
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneSetSunAngle;
             server.RegisterTool(std::move(tool));
@@ -4485,6 +4732,14 @@ namespace OloEngine::MCP
                                    .Prop("immediate", Schema::Bool().Desc("true = snap to 'state' with no transition (current = target, progress settled)."))
                                    .Required({ "state" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("currentState", Schema::String().Enum({ "Clear", "Overcast", "Rain", "Storm", "Snow", "FogBank" }))
+                                    .Prop("targetState", Schema::String().Enum({ "Clear", "Overcast", "Rain", "Storm", "Snow", "FogBank" }))
+                                    .Prop("transitionDuration", Schema::Number().Desc("Cross-blend duration in seconds."))
+                                    .Prop("transitionProgress", Schema::Number().Desc("Blend progress (1.0 when settled/immediate)."))
+                                    .Prop("wetness", Schema::Number())
+                                    .Prop("note", Schema::String().Desc("Disabled-component warning; omitted when the component is enabled."))
+                                    .Required({ "currentState", "targetState", "transitionDuration", "transitionProgress", "wetness" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneSetWeather;
             server.RegisterTool(std::move(tool));
@@ -4507,6 +4762,37 @@ namespace OloEngine::MCP
                 "omitted when its component is absent from the scene; the 'note' lists which components "
                 "were found. Read-only.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("timeOfDay", Schema::Object()
+                                                           .Prop("enabled", Schema::Bool())
+                                                           .Prop("hours", Schema::Number().Desc("24-hour clock time in [0, 24)."))
+                                                           .Prop("dayOfYear", Schema::Int())
+                                                           .Prop("latitudeDegrees", Schema::Number())
+                                                           .Prop("timeScale", Schema::Number())
+                                                           .Prop("paused", Schema::Bool())
+                                                           .Prop("sunElevationDegrees", Schema::Number().Desc("Derived sun elevation in degrees."))
+                                                           .Prop("isNight", Schema::Bool().Desc("Derived night flag."))
+                                                           .Prop("sunDirection", Schema::Vec3("Derived [x, y, z] sun direction."))
+                                                           .Prop("moonDirection", Schema::Vec3("Derived [x, y, z] moon direction."))
+                                                           .Desc("Omitted when the scene has no TimeOfDayComponent."))
+                                    .Prop("weather", Schema::Object()
+                                                         .Prop("enabled", Schema::Bool())
+                                                         .Prop("currentState", Schema::String())
+                                                         .Prop("targetState", Schema::String())
+                                                         .Prop("transitionDuration", Schema::Number())
+                                                         .Prop("transitionProgress", Schema::Number())
+                                                         .Prop("wetness", Schema::Number())
+                                                         .Prop("blendedCloudCoverage", Schema::Number())
+                                                         .Desc("Omitted when the scene has no WeatherStateComponent."))
+                                    .Prop("cloudscape", Schema::Object()
+                                                            .Prop("enabled", Schema::Bool())
+                                                            .Prop("coverage", Schema::Number())
+                                                            .Prop("layerBottom", Schema::Number())
+                                                            .Prop("layerTop", Schema::Number())
+                                                            .Prop("castCloudShadows", Schema::Bool())
+                                                            .Desc("Omitted when the scene has no CloudscapeComponent."))
+                                    .Prop("note", Schema::String().Desc("Which atmosphere components were found."))
+                                    .Required({ "note" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneGetAtmosphere;
             server.RegisterTool(std::move(tool));
@@ -4543,8 +4829,36 @@ namespace OloEngine::MCP
                                    .Prop("orbit", Schema::Object().Desc("Capture from this orbit pose, then restore. Same shape as olo_camera_orbit: target [x,y,z], yaw/pitch (degrees), distance; optional fov."))
                                    .Prop("settleFrames", Schema::Int().Min(1).Max(30).Desc("Frames to render at the new pose before capturing (default 2). Raise for temporal effects (TAA, fog history) to settle."))
                                    .Prop("maxWidth", Schema::Int().Min(16).Max(4096).Desc("Max capture width in pixels (default 1024); aspect ratio preserved. Must match between create and compare."))
+                                   .Prop("delivery", Schema::String().Enum({ "inline", "resource_link" }).Desc("How to return the captured frame: 'inline' (default) embeds a base64 image block; 'resource_link' publishes an ephemeral olo://capture resource and returns a link to fetch via resources/read. The golden FILE write is unaffected."))
                                    .Required({ "goldenPath" })
                                    .NoAdditional();
+            // outputSchema describes the verdict JSON (mirrored into
+            // structuredContent); the captured frame is a separate image content
+            // block outside the structured result. Two shapes: created/rebased
+            // vs compared — only the envelope is unconditional.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("goldenPath", Schema::String().Desc("Resolved golden PNG path."))
+                                    .Prop("created", Schema::Bool().Desc("True when the capture was WRITTEN as the (new/rebased) golden instead of compared."))
+                                    .Prop("rebased", Schema::Bool().Desc("Created path only: the golden existed and was overwritten."))
+                                    .Prop("bytes", Schema::Int().Min(0).Desc("Created path only: PNG bytes written."))
+                                    .Prop("pass", Schema::Bool().Desc("Compare path only: the verdict."))
+                                    .Prop("dimensionsMatch", Schema::Bool().Desc("Compare path only; the metric fields below need matching dimensions."))
+                                    .Prop("actual", Schema::Object().Prop("width", Schema::Int()).Prop("height", Schema::Int()).Desc("Compare path only: capture dimensions."))
+                                    .Prop("golden", Schema::Object().Prop("width", Schema::Int()).Prop("height", Schema::Int()).Desc("Compare path only: golden dimensions."))
+                                    .Prop("similarity", Schema::Number())
+                                    .Prop("ssim", Schema::Number())
+                                    .Prop("rmse", Schema::Number())
+                                    .Prop("mse", Schema::Number())
+                                    .Prop("threshold", Schema::Number().Desc("Effective minimum-SSIM pass threshold."))
+                                    .Prop("thresholdMode", Schema::String().Enum({ "suite-cascade", "explicit" }))
+                                    .Prop("mismatchPixels", Schema::Int().Min(0))
+                                    .Prop("totalPixels", Schema::Int().Min(0))
+                                    .Prop("maxChannelDelta", Schema::Int().Min(0))
+                                    .Prop("worstPixel", Schema::Object().Prop("x", Schema::Int()).Prop("y", Schema::Int()))
+                                    .Prop("message", Schema::String().Desc("Human-readable verdict / creation message."))
+                                    .Prop("warning", Schema::String().Desc("Settle-timeout stale-frame warning; omitted otherwise."))
+                                    .Prop("resourceUri", Schema::String().Desc("Present only with delivery:'resource_link' — the olo://capture/... resource holding the captured frame."))
+                                    .Required({ "goldenPath", "created", "message" });
             tool.MainMarshaled = true; // reads main-thread-only camera/viewport state (like olo_screenshot)
             tool.Handler = Handle_RenderCompareGolden;
             server.RegisterTool(std::move(tool));
@@ -4578,6 +4892,25 @@ namespace OloEngine::MCP
                 "This is a WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's MCP Server panel "
                 "(off by default).";
             tool.InputSchema = RendererSettings::InputSchema();
+            // Two disjoint shapes — introspection (no arguments) returns only
+            // 'settings'; an apply returns the ack fields — so no field is
+            // unconditionally present and the required list stays empty.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("settings", Schema::Array(Schema::Object()
+                                                                        .Prop("setting", Schema::String())
+                                                                        .Prop("description", Schema::String())
+                                                                        .Prop("currentValue", Schema::String())
+                                                                        .Prop("values", Schema::Array(Schema::Object()
+                                                                                                          .Prop("token", Schema::String())
+                                                                                                          .Prop("description", Schema::String()))
+                                                                                            .Desc("Allowed-value catalogue.")))
+                                                          .Desc("Introspection shape only (called with no arguments): every setting with its live value."))
+                                    .Prop("setting", Schema::String().Desc("Apply shape only: the setting written."))
+                                    .Prop("previousValue", Schema::String().Desc("Apply shape only: the prior value token — set it back to revert."))
+                                    .Prop("value", Schema::String().Desc("Apply shape only: the resulting value token ('auto' already resolved)."))
+                                    .Prop("changed", Schema::Bool().Desc("Apply shape only."))
+                                    .Prop("restoreWith", Schema::String().Desc("Apply shape only: same as previousValue, the explicit restore hint."))
+                                    .Prop("requested", Schema::String().Desc("Apply shape only: 'auto' when depthprepass auto was requested; omitted otherwise."));
             tool.MainMarshaled = true;
             tool.Handler = Handle_RendererSettingsSet;
             server.RegisterTool(std::move(tool));
@@ -4602,6 +4935,41 @@ namespace OloEngine::MCP
                                    .Prop("entity", Schema::String().Desc("Entity UUID (string; also accepts a number)."))
                                    .Required({ "entity" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("entity", Schema::String().Desc("Echoed entity UUID."))
+                                    .Prop("reasonCode", Schema::String()
+                                                            .Enum({ "no_scene", "entity_missing", "not_renderable", "geometry_missing",
+                                                                    "component_hidden", "degenerate_scale", "shader_compile_error",
+                                                                    "behind_camera", "outside_frustum", "should_be_visible" })
+                                                            .Desc("Machine-readable root cause."))
+                                    .Prop("summary", Schema::String())
+                                    .Prop("renderableConfigOk", Schema::Bool())
+                                    .Prop("visible", Schema::Bool())
+                                    .Prop("checks", Schema::Array(Schema::String()).Desc("Ordered '[ok]'/'[fail]'/'[warn]'-prefixed check trace."))
+                                    .Prop("facts", Schema::Object()
+                                                       .Prop("entityExists", Schema::Bool())
+                                                       .Prop("hasRenderable", Schema::Bool())
+                                                       .Prop("renderableKind", Schema::String())
+                                                       .Prop("geometryRequired", Schema::Bool())
+                                                       .Prop("geometryPresent", Schema::Bool())
+                                                       .Prop("geometryDetail", Schema::String())
+                                                       .Prop("hasVisibilityFlag", Schema::Bool())
+                                                       .Prop("visibilityFlagName", Schema::String())
+                                                       .Prop("visibilityFlagOn", Schema::Bool())
+                                                       .Prop("scaleDegenerate", Schema::Bool())
+                                                       .Prop("hasMaterialShader", Schema::Bool())
+                                                       .Prop("materialShaderName", Schema::String())
+                                                       .Prop("materialShaderHasErrors", Schema::Bool())
+                                                       .Prop("boundsKnown", Schema::Bool())
+                                                       .Prop("behindCamera", Schema::Bool())
+                                                       .Prop("inFrustum", Schema::Bool())
+                                                       .Desc("The raw gathered facts the verdict cascade ran on."))
+                                    .Prop("sceneLoaded", Schema::Bool())
+                                    .Prop("cameraKnown", Schema::Bool())
+                                    .Prop("anyShaderHasErrors", Schema::Bool())
+                                    .Prop("shaderErrorCount", Schema::Int().Min(0))
+                                    .Required({ "entity", "reasonCode", "summary", "renderableConfigOk", "visible", "checks",
+                                                "facts", "sceneLoaded", "cameraKnown", "anyShaderHasErrors", "shaderErrorCount" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderWhyNotVisible;
             server.RegisterTool(std::move(tool));
@@ -4649,6 +5017,33 @@ namespace OloEngine::MCP
                                    .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before probing (default false). Use after a scene open / setting change so you cannot read a stale target. Implied by 'afterPass'."))
                                    .Required({ "x", "y" })
                                    .NoAdditional();
+            // Two modes share only the envelope: single-target ('target' given)
+            // returns the raw-channel fields, G-Buffer mode the decoded channels —
+            // every mode-dependent field stays optional.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("x", Schema::Int().Min(0))
+                                    .Prop("y", Schema::Int().Min(0))
+                                    .Prop("origin", Schema::String().Desc("Coordinate-convention note (top-left)."))
+                                    .Prop("meta", Schema::Object()
+                                                      .Prop("frameIndex", Schema::Int().Min(0))
+                                                      .Prop("timestampMs", Schema::Int().Min(0))
+                                                      .Desc("Staleness stamp: the frame/time the values were read."))
+                                    .Prop("renderingPath", Schema::String().Desc("G-Buffer mode only."))
+                                    .Prop("channels", Schema::Object().Desc("G-Buffer mode only: decoded per-channel objects (albedo/metallic/normal/roughness/ao/emissive/flags?/velocity/entityID/depth/finalColor), each { available, source?, format?, value?, reason? }; depth adds device/linearViewDepth (null when the camera is unknown)/nearClip/farClip, normal adds encoded/space."))
+                                    .Prop("raw", Schema::Object().Desc("G-Buffer mode only: the undecoded texels per RT (GBufferAlbedo/GBufferNormal/GBufferEmissive/Velocity/EntityID/Depth/FinalColor)."))
+                                    .Prop("unavailableChannels", Schema::Array(Schema::String()).Desc("G-Buffer mode only."))
+                                    .Prop("note", Schema::String().Desc("G-Buffer mode: non-Deferred-path caveat; omitted otherwise."))
+                                    .Prop("available", Schema::Bool().Desc("Single-target mode only."))
+                                    .Prop("target", Schema::String().Desc("Single-target mode only: the probed resource."))
+                                    .Prop("mappedCoord", Schema::Object().Desc("Single-target mode: the exact texel read (space/requested/texel/glRowBottomUp/mip/mipWidth/mipHeight/origin/layer?); omitted when no mapping was attempted."))
+                                    .Prop("format", Schema::String().Desc("Single-target mode, when available."))
+                                    .Prop("width", Schema::Int().Desc("Single-target mode, when available."))
+                                    .Prop("height", Schema::Int().Desc("Single-target mode, when available."))
+                                    .Prop("value", Schema::Array(Schema::Number()).Desc("Single-target mode, when available: raw channel values (int-exact for integer formats)."))
+                                    .Prop("reason", Schema::String().Desc("Single-target mode: unavailability reason."))
+                                    .Prop("afterPass", Schema::String().Desc("Echoed when an afterPass snapshot was probed."))
+                                    .Prop("afterPassNote", Schema::String())
+                                    .Required({ "x", "y", "origin", "meta" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderProbePixel;
             server.RegisterTool(std::move(tool));
@@ -4688,6 +5083,45 @@ namespace OloEngine::MCP
                                    .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame first (default false). Implied by 'afterPass'."))
                                    .Required({ "name" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("name", Schema::String())
+                                    .Prop("format", Schema::String().Desc("Internal-format token (RGBA16F, R32I, ...)."))
+                                    .Prop("mip", Schema::Int().Min(0))
+                                    .Prop("mipWidth", Schema::Int().Min(0))
+                                    .Prop("mipHeight", Schema::Int().Min(0))
+                                    .Prop("layer", Schema::Int().Desc("Omitted when the resolved layer is 0."))
+                                    .Prop("rect", Schema::Object()
+                                                      .Prop("x", Schema::Int())
+                                                      .Prop("y", Schema::Int())
+                                                      .Prop("w", Schema::Int())
+                                                      .Prop("h", Schema::Int())
+                                                      .Desc("Texel region actually read (top-left origin)."))
+                                    .Prop("origin", Schema::String())
+                                    .Prop("texelCount", Schema::Int().Min(0))
+                                    .Prop("channels", Schema::Array(Schema::Object()
+                                                                        .Prop("channel", Schema::String())
+                                                                        .Prop("finiteCount", Schema::Int().Min(0))
+                                                                        .Prop("nanCount", Schema::Int().Desc("Omitted when 0."))
+                                                                        .Prop("infCount", Schema::Int().Desc("Omitted when 0."))
+                                                                        .Prop("min", Schema::Number().Desc("Over finite values; omitted when none."))
+                                                                        .Prop("max", Schema::Number().Desc("Over finite values; omitted when none."))
+                                                                        .Prop("mean", Schema::Number().Desc("Over finite values; omitted when none."))
+                                                                        .Prop("uniqueValues", Schema::Int().Min(0))
+                                                                        .Prop("uniqueTruncated", Schema::Bool().Desc("Present (true) only when the unique-value scan was capped."))
+                                                                        .Prop("uniqueNote", Schema::String())
+                                                                        .Prop("topValues", Schema::Array(Schema::Object()
+                                                                                                             .Prop("value", Schema::Raw(Json{ { "type", Json::array({ "number", "string" }) } }).Desc("Non-finite values encode as the strings 'NaN'/'+Inf'/'-Inf'."))
+                                                                                                             .Prop("bits", Schema::Int().Min(0).Desc("The exact bit pattern."))
+                                                                                                             .Prop("count", Schema::Int().Min(0)))
+                                                                                               .Desc("Most frequent bit-exact values."))))
+                                    .Prop("integerNote", Schema::String().Desc("Integer targets only."))
+                                    .Prop("afterPass", Schema::String().Desc("Echoed when an afterPass snapshot was read."))
+                                    .Prop("afterPassNote", Schema::String())
+                                    .Prop("layerNote", Schema::String().Desc("Omitted unless the layer selection has a caveat."))
+                                    .Prop("meta", Schema::Object()
+                                                      .Prop("frameIndex", Schema::Int().Min(0))
+                                                      .Prop("timestampMs", Schema::Int().Min(0)))
+                                    .Required({ "name", "format", "mip", "mipWidth", "mipHeight", "rect", "origin", "texelCount", "channels", "meta" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderTargetStats;
             server.RegisterTool(std::move(tool));
@@ -4726,6 +5160,45 @@ namespace OloEngine::MCP
                                                         .Desc("Optional bit-exact channel-0 compare of two targets over their overlapping top-left region."))
                                    .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame first (default false). Implied by compare.afterPass."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("ok", Schema::Bool().Desc("True iff hazards, resolveFailures and consumedButUnbacked are all empty (and 'compare', when given, did not error)."))
+                                    .Prop("hazardCount", Schema::Int().Min(0))
+                                    .Prop("hazards", Schema::Array(Schema::Object()
+                                                                       .Prop("kind", Schema::String())
+                                                                       .Prop("resource", Schema::String())
+                                                                       .Prop("producer", Schema::String().Desc("Omitted when unknown."))
+                                                                       .Prop("consumer", Schema::String().Desc("Omitted when unknown."))
+                                                                       .Prop("message", Schema::String())))
+                                    .Prop("barrierDiagnostics", Schema::Array(Schema::Object()
+                                                                                  .Prop("kind", Schema::String())
+                                                                                  .Prop("pass", Schema::String().Desc("Omitted when not pass-specific."))
+                                                                                  .Prop("resource", Schema::String().Desc("Omitted when not resource-specific."))
+                                                                                  .Prop("message", Schema::String())))
+                                    .Prop("buildDiagnostics", Schema::Array(Schema::Object()
+                                                                                .Prop("kind", Schema::String())
+                                                                                .Prop("pass", Schema::String().Desc("Omitted when not pass-specific."))
+                                                                                .Prop("resource", Schema::String().Desc("Omitted when not resource-specific."))
+                                                                                .Prop("message", Schema::String())))
+                                    .Prop("resolveFailures", Schema::Array(Schema::Object()
+                                                                               .Prop("pass", Schema::String())
+                                                                               .Prop("reason", Schema::String())
+                                                                               .Prop("count", Schema::Int().Min(0))))
+                                    .Prop("consumedButUnbacked", Schema::Array(Schema::String()).Desc("Resources consumed but resolving to no GL backing."))
+                                    .Prop("versionGroups", Schema::Array(Schema::Object()
+                                                                             .Prop("baseName", Schema::String())
+                                                                             .Prop("versions", Schema::Array(Schema::Object()
+                                                                                                                 .Prop("name", Schema::String())
+                                                                                                                 .Prop("glTextureId", Schema::Int().Desc("Omitted when unbacked."))
+                                                                                                                 .Prop("glBufferId", Schema::Int().Desc("Omitted when not buffer-backed."))
+                                                                                                                 .Prop("lastWriter", Schema::String().Desc("Omitted when unknown."))))
+                                                                             .Prop("multiplePhysicalIds", Schema::Bool()))
+                                                               .Desc("Versioned names (Base@Pass) grouped with their physical ids; single-version groups are dropped."))
+                                    .Prop("compare", Schema::Object().Desc("Only when 'compare' was requested: 'a'/'b' echoes plus either 'error' or the bit-exact result (comparedRegion/comparedTexels/bitwiseEqual/differingTexels/maxAbsDiff?/firstDiffs/note; firstDiffs a/b encode non-finite floats as the strings 'NaN'/'Inf')."))
+                                    .Prop("meta", Schema::Object()
+                                                      .Prop("frameIndex", Schema::Int().Min(0))
+                                                      .Prop("timestampMs", Schema::Int().Min(0)))
+                                    .Required({ "ok", "hazardCount", "hazards", "barrierDiagnostics", "buildDiagnostics",
+                                                "resolveFailures", "consumedButUnbacked", "versionGroups", "meta" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_RenderValidate;
             server.RegisterTool(std::move(tool));
@@ -4769,6 +5242,13 @@ namespace OloEngine::MCP
                                    .Prop("swRasterThresholdPixels", Schema::Number().Min(0).Max(4096).Desc("Auto-mode cutoff: a cluster whose projected screen radius is below this many pixels is software-rasterized (default 24)."))
                                    .Prop("forcePortableSwRaster", Schema::Bool().Desc("Force the portable two-pass 2x32 SW visibility path even where 64-bit atomics exist (exercises both rasterizers on capable hardware)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("changed", Schema::Bool().Desc("True when any knob argument was present."))
+                                    .Prop("previous", VirtualGeometrySettingsSchema().Desc("Knob state before the write."))
+                                    .Prop("current", VirtualGeometrySettingsSchema().Desc("Knob state after the write + settle (equals 'previous' on a no-arg read)."))
+                                    .Prop("captureTarget", Schema::String().Desc("'VirtualGeometryDebug' — only when a non-off debugMode was set."))
+                                    .Prop("message", Schema::String().Desc("Capture hint / target-not-backed guidance; only when a non-off debugMode was set."))
+                                    .Required({ "changed", "previous", "current" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_VirtualGeometrySet;
             server.RegisterTool(std::move(tool));
@@ -4793,6 +5273,28 @@ namespace OloEngine::MCP
                 "evictions climbing every frame under a tight budget). Zero everywhere means no "
                 "VirtualMeshComponent was submitted — virtual geometry renders on the DEFERRED path only.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("renderingPath", Schema::String())
+                                    .Prop("frameInstances", Schema::Int().Min(0))
+                                    .Prop("frameClusters", Schema::Int().Min(0))
+                                    .Prop("cull", Schema::Object()
+                                                      .Prop("instances", Schema::Int().Min(0))
+                                                      .Prop("testedClusters", Schema::Int().Min(0))
+                                                      .Prop("cutSelected", Schema::Int().Min(0))
+                                                      .Prop("hardwareDraws", Schema::Int().Min(0))
+                                                      .Prop("softwareRasterized", Schema::Int().Min(0))
+                                                      .Prop("drawnClusters", Schema::Int().Min(0)))
+                                    .Prop("residency", Schema::Object()
+                                                           .Prop("totalPages", Schema::Int().Min(0))
+                                                           .Prop("residentPages", Schema::Int().Min(0))
+                                                           .Prop("pinnedPages", Schema::Int().Min(0))
+                                                           .Prop("budgetSlots", Schema::Int().Min(0))
+                                                           .Prop("budget", Schema::String().Enum({ "unbounded (eager)", "budgeted" }))
+                                                           .Prop("pageUploads", Schema::Int().Min(0))
+                                                           .Prop("pageEvictions", Schema::Int().Min(0)))
+                                    .Prop("settings", VirtualGeometrySettingsSchema().Desc("Live knob state (same shape as olo_virtual_geometry_set's previous/current)."))
+                                    .Prop("note", Schema::String().Desc("Non-Deferred-path / no-instances caveat; omitted otherwise."))
+                                    .Required({ "renderingPath", "frameInstances", "frameClusters", "cull", "residency", "settings" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_VirtualGeometryStats;
             server.RegisterTool(std::move(tool));
@@ -4823,6 +5325,30 @@ namespace OloEngine::MCP
                                    .Prop("submesh", Schema::Int().Min(0).Desc("Submesh index. Omit for an array covering every submesh."))
                                    .Required({ "entity" })
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("entity", Schema::String())
+                                    .Prop("renderableKind", Schema::String().Enum({ "MeshComponent", "VirtualMeshComponent" }))
+                                    .Prop("submeshCount", Schema::Int().Min(0))
+                                    .Prop("hasMaterialComponentOverride", Schema::Bool())
+                                    .Prop("submeshes", Schema::Array(Schema::Object()
+                                                                         .Prop("submesh", Schema::Int().Min(0))
+                                                                         .Prop("source", Schema::String().Desc("Which material won: the MaterialComponent override, the submesh's imported material, or the engine default."))
+                                                                         .Prop("name", Schema::String())
+                                                                         .Prop("pbr", Schema::Bool())
+                                                                         .Prop("alphaMode", Schema::String().Enum({ "Opaque", "Mask", "Blend" }))
+                                                                         .Prop("alphaCutoff", Schema::Number())
+                                                                         .Prop("twoSided", Schema::Bool())
+                                                                         .Prop("baseColorFactor", Schema::Array(Schema::Number()).Desc("RGBA."))
+                                                                         .Prop("metallicFactor", Schema::Number())
+                                                                         .Prop("roughnessFactor", Schema::Number())
+                                                                         .Prop("normalScale", Schema::Number())
+                                                                         .Prop("occlusionStrength", Schema::Number())
+                                                                         .Prop("emissiveFactor", Schema::Array(Schema::Number()).Desc("RGB."))
+                                                                         .Prop("enableIBL", Schema::Bool())
+                                                                         .Prop("iblIntensity", Schema::Number())
+                                                                         .Prop("useMaps", Schema::Object().Desc("Booleans per slot: useAlbedoMap/useMetallicRoughnessMap/useNormalMap/useAOMap/useEmissiveMap."))
+                                                                         .Prop("textureIds", Schema::Object().Desc("Bound GL texture id per slot (albedo/metallicRoughness/normal/ao/emissive; 0 = none)."))))
+                                    .Required({ "entity", "renderableKind", "submeshCount", "hasMaterialComponentOverride", "submeshes" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_MaterialGet;
             server.RegisterTool(std::move(tool));
@@ -4849,6 +5375,53 @@ namespace OloEngine::MCP
                 "all, to find the depth slices that are hot, and to catch a scene that has quietly "
                 "exceeded the per-cluster budget. The plain Forward path does not run the cull.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("grid", Schema::Object()
+                                                      .Prop("countX", Schema::Int().Min(0))
+                                                      .Prop("countY", Schema::Int().Min(0))
+                                                      .Prop("countZ", Schema::Int().Min(0))
+                                                      .Prop("totalClusters", Schema::Int().Min(0))
+                                                      .Prop("maxLightsPerCluster", Schema::Int().Min(0)))
+                                    .Prop("clustersSampled", Schema::Int().Min(0))
+                                    .Prop("totalAssignedIndices", Schema::Int().Min(0))
+                                    .Prop("emptyClusters", Schema::Int().Min(0))
+                                    .Prop("overflowClusters", Schema::Int().Min(0).Desc("Clusters at the light cap — lights beyond it are DROPPED there."))
+                                    .Prop("maxLightsInAnyCluster", Schema::Int().Min(0))
+                                    .Prop("meanLightsPerCluster", Schema::Number())
+                                    .Prop("meanLightsPerNonEmptyCluster", Schema::Number())
+                                    .Prop("busiestCluster", Schema::Object()
+                                                                .Prop("index", Schema::Int().Min(0))
+                                                                .Prop("x", Schema::Int().Min(0))
+                                                                .Prop("y", Schema::Int().Min(0))
+                                                                .Prop("z", Schema::Int().Min(0))
+                                                                .Prop("lights", Schema::Int().Min(0)))
+                                    .Prop("perSlice", Schema::Array(Schema::Object()
+                                                                        .Prop("slice", Schema::Int().Min(0))
+                                                                        .Prop("clusters", Schema::Int().Min(0))
+                                                                        .Prop("assignedIndices", Schema::Int().Min(0))
+                                                                        .Prop("emptyClusters", Schema::Int().Min(0))
+                                                                        .Prop("overflowClusters", Schema::Int().Min(0))
+                                                                        .Prop("maxLights", Schema::Int().Min(0))
+                                                                        .Prop("meanLights", Schema::Number()))
+                                                          .Desc("Per-z-slice breakdown."))
+                                    .Prop("histogram", Schema::Array(Schema::Object()
+                                                                         .Prop("low", Schema::Int().Min(0))
+                                                                         .Prop("high", Schema::Int().Min(0))
+                                                                         .Prop("clusters", Schema::Int().Min(0)))
+                                                           .Desc("Light-count buckets over every cluster."))
+                                    .Prop("lightIndexList", Schema::Object()
+                                                                .Prop("usedSlots", Schema::Int().Min(0))
+                                                                .Prop("capacity", Schema::Int().Min(0))
+                                                                .Prop("utilization", Schema::Number()))
+                                    .Prop("warning", Schema::String().Desc("Per-cluster light-cap overflow warning; omitted when no cluster overflowed."))
+                                    .Prop("renderingPath", Schema::String())
+                                    .Prop("screen", Schema::Object()
+                                                        .Prop("width", Schema::Int().Min(0))
+                                                        .Prop("height", Schema::Int().Min(0)))
+                                    .Prop("note", Schema::String().Desc("Plain-Forward staleness caveat; omitted otherwise."))
+                                    .Required({ "grid", "clustersSampled", "totalAssignedIndices", "emptyClusters", "overflowClusters",
+                                                "maxLightsInAnyCluster", "meanLightsPerCluster", "meanLightsPerNonEmptyCluster",
+                                                "busiestCluster", "perSlice", "histogram", "lightIndexList", "renderingPath", "screen" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ClusterGridStats;
             server.RegisterTool(std::move(tool));
@@ -4883,6 +5456,49 @@ namespace OloEngine::MCP
                                    .Prop("worldPos", Schema::Vec3("World-space position [x, y, z], projected into froxel space with the shader's exact mapping."))
                                    .Prop("forceFrame", Schema::Bool().Desc("Render and settle a fresh frame before probing (default false). Use after a scene open / fog toggle so you cannot read a stale volume."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("volume", Schema::Object()
+                                                        .Prop("dims", Schema::Array(Schema::Int()).Desc("[x, y, z] froxel counts."))
+                                                        .Prop("near", Schema::Number())
+                                                        .Prop("far", Schema::Number())
+                                                        .Prop("depthDistribution", Schema::String())
+                                                        .Prop("renderOrigin", Schema::Vec3("Camera-relative rendering origin.")))
+                                    .Prop("froxel", Schema::Object()
+                                                        .Prop("coords", Schema::Array(Schema::Int()).Desc("The integer cell actually sampled."))
+                                                        .Prop("continuous", Schema::Array(Schema::Number()))
+                                                        .Prop("centerWorld", Schema::Vec3("World-space centre of the cell."))
+                                                        .Prop("viewDepth", Schema::Number())
+                                                        .Prop("clamped", Schema::Bool())
+                                                        .Prop("inFrustum", Schema::Bool())
+                                                        .Prop("inDepthRange", Schema::Bool())
+                                                        .Prop("cellBounds", Schema::Object()
+                                                                                .Prop("min", Schema::Vec3("World-space min corner."))
+                                                                                .Prop("max", Schema::Vec3("World-space max corner."))
+                                                                                .Prop("nearViewDepth", Schema::Number())
+                                                                                .Prop("farViewDepth", Schema::Number())))
+                                    .Prop("requestedWorldPos", Schema::Vec3("worldPos-mode echo; omitted in froxel mode."))
+                                    .Prop("scatter", Schema::Object()
+                                                         .Prop("available", Schema::Bool())
+                                                         .Prop("inScatter", Schema::Vec3("Per-froxel in-scattered radiance; only when available."))
+                                                         .Prop("extinction", Schema::Number().Desc("Only when available."))
+                                                         .Prop("reason", Schema::String().Desc("Unavailability reason."))
+                                                         .Desc("FroxelFogScatter.comp's output at the cell."))
+                                    .Prop("integrated", Schema::Object()
+                                                            .Prop("available", Schema::Bool())
+                                                            .Prop("inScatter", Schema::Vec3("Accumulated in-scatter camera->slice; only when available."))
+                                                            .Prop("transmittance", Schema::Number().Desc("Only when available."))
+                                                            .Prop("reason", Schema::String().Desc("Unavailability reason."))
+                                                            .Desc("FroxelFogIntegrate.comp's output — what the fog composite taps."))
+                                    .Prop("note", Schema::String().Desc("Out-of-frustum / out-of-depth-range / clamped-cell caveat; omitted otherwise."))
+                                    .Prop("fog", Schema::Object()
+                                                     .Prop("enabled", Schema::Bool())
+                                                     .Prop("volumetric", Schema::Bool())
+                                                     .Prop("ranThisFrame", Schema::Bool()))
+                                    .Prop("meta", Schema::Object()
+                                                      .Prop("frameIndex", Schema::Int().Min(0))
+                                                      .Prop("timestampMs", Schema::Int().Min(0)))
+                                    .Prop("staleness", Schema::String().Desc("Present only when the froxel chain did not run last frame."))
+                                    .Required({ "volume", "froxel", "scatter", "integrated", "fog", "meta" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_FroxelFogProbe;
             server.RegisterTool(std::move(tool));
@@ -4906,6 +5522,44 @@ namespace OloEngine::MCP
                 "light packed into a tiny 256px tile (blocky shadow) is obvious. Read-only; the "
                 "directional CSM is separate and is not packed into this atlas.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("enabled", Schema::Bool())
+                                    .Prop("atlasResolution", Schema::Int().Min(0))
+                                    .Prop("maxEntries", Schema::Int().Min(0))
+                                    .Prop("maxShadowedLights", Schema::Int().Min(0))
+                                    .Prop("entriesUsed", Schema::Int().Min(0))
+                                    .Prop("candidateCount", Schema::Int().Min(0))
+                                    .Prop("allocatedCasters", Schema::Int().Min(0))
+                                    .Prop("starvedCasters", Schema::Int().Min(0))
+                                    .Prop("atlasAreaUsed", Schema::Number().Desc("Fraction of atlas pixels used [0, 1]."))
+                                    .Prop("casters", Schema::Array(Schema::Object()
+                                                                       .Prop("lightEntity", Schema::String())
+                                                                       .Prop("casterType", Schema::String().Enum({ "Spot", "Point" }))
+                                                                       .Prop("sourceKind", Schema::String())
+                                                                       .Prop("score", Schema::Number())
+                                                                       .Prop("allocated", Schema::Bool())
+                                                                       .Prop("rank", Schema::Int().Desc("Allocated casters only."))
+                                                                       .Prop("baseEntry", Schema::Int().Desc("Allocated casters only."))
+                                                                       .Prop("entryCount", Schema::Int().Desc("Allocated casters only."))
+                                                                       .Prop("tiles", Schema::Array(Schema::Object()
+                                                                                                        .Prop("entry", Schema::Int())
+                                                                                                        .Prop("face", Schema::Int().Desc("0..5 = +X,-X,+Y,-Y,+Z,-Z for a point caster."))
+                                                                                                        .Prop("x", Schema::Int())
+                                                                                                        .Prop("y", Schema::Int())
+                                                                                                        .Prop("width", Schema::Int())
+                                                                                                        .Prop("height", Schema::Int())
+                                                                                                        .Prop("resolution", Schema::Int()))
+                                                                                          .Desc("Allocated casters only."))
+                                                                       .Prop("starvedReason", Schema::String().Desc("Starved casters only."))))
+                                    .Prop("entries", Schema::Array(Schema::Object().Desc("The same tiles flattened: the tile keys plus lightEntity/casterType/sourceKind/rank/score.")))
+                                    .Prop("directionalShadow", Schema::Object()
+                                                                   .Prop("csmCascades", Schema::Int().Min(0))
+                                                                   .Prop("resolution", Schema::Int().Min(0))
+                                                                   .Desc("The separate directional CSM (not packed into this atlas)."))
+                                    .Prop("note", Schema::String().Desc("Disabled / empty-atlas / starvation summary; omitted otherwise."))
+                                    .Required({ "enabled", "atlasResolution", "maxEntries", "maxShadowedLights", "entriesUsed",
+                                                "candidateCount", "allocatedCasters", "starvedCasters", "atlasAreaUsed",
+                                                "casters", "entries", "directionalShadow" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ShadowAtlasLayout;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -686,29 +686,12 @@ namespace OloEngine::MCP
                 // resource_link instead of inline base64 (issue #673 Tier 1).
                 const Json::binary_t& png = result["png"].get_binary();
                 std::vector<u8> bytes(png.begin(), png.end());
-                const u64 sizeBytes = static_cast<u64>(bytes.size());
-                const u64 sequence = NextCaptureSequence();
-                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/target.png";
-                const std::string linkName = "target-" + std::to_string(sequence) + ".png";
-
-                ResourceDef captureResource;
-                captureResource.Uri = uri;
-                captureResource.Name = linkName;
-                captureResource.Description =
-                    "Render-target PNG capture of '" + name + "' (capture meta in the tool result).";
-                captureResource.MimeType = "image/png";
-                captureResource.SizeBytes = sizeBytes;
-                captureResource.BlobReader = [bytes = std::move(bytes)](McpServer&)
-                { return bytes; };
-                server.RegisterEphemeralResource(std::move(captureResource));
-
-                meta["resourceUri"] = uri;
+                Json linkBlock = PublishCaptureResourceLink(
+                    server, std::move(bytes), "target",
+                    "Render-target PNG capture of '" + name + "' (capture meta in the tool result).",
+                    "Render-target capture of '" + name + "' (PNG); fetch via resources/read.", meta);
                 toolResult.Content = Json::array(
-                    { Json{ { "type", "text" }, { "text", meta.dump(2) } },
-                      ToolResult::ResourceLinkBlock(uri, linkName,
-                                                    "Render-target capture of '" + name +
-                                                        "' (PNG); fetch via resources/read.",
-                                                    "image/png", sizeBytes) });
+                    { Json{ { "type", "text" }, { "text", meta.dump(2) } }, std::move(linkBlock) });
             }
             else
             {
@@ -1773,32 +1756,19 @@ namespace OloEngine::MCP
             // image, or a published olo://capture resource + resource_link block
             // (which also stamps resourceUri into the verdict object BEFORE it
             // is mirrored into the text block).
+            // attachCapture runs exactly once per handler execution (the rebase
+            // branch and the compare branch are mutually exclusive and each is the
+            // last use of capturedPng), so the link branch may MOVE the buffer.
             const auto attachCapture = [&server, &capturedPng, deliverLink](Json& verdict) -> Json
             {
                 if (!deliverLink)
                     return Json{ { "type", "image" },
                                  { "data", Base64Encode(capturedPng) },
                                  { "mimeType", "image/png" } };
-                const u64 sizeBytes = static_cast<u64>(capturedPng.size());
-                const u64 sequence = NextCaptureSequence();
-                const std::string uri = "olo://capture/" + std::to_string(sequence) + "/golden-capture.png";
-                const std::string linkName = "golden-capture-" + std::to_string(sequence) + ".png";
-
-                ResourceDef captureResource;
-                captureResource.Uri = uri;
-                captureResource.Name = linkName;
-                captureResource.Description =
-                    "Viewport capture from olo_render_compare_golden (verdict in the tool result).";
-                captureResource.MimeType = "image/png";
-                captureResource.SizeBytes = sizeBytes;
-                captureResource.BlobReader = [bytes = capturedPng](McpServer&)
-                { return bytes; };
-                server.RegisterEphemeralResource(std::move(captureResource));
-
-                verdict["resourceUri"] = uri;
-                return ToolResult::ResourceLinkBlock(uri, linkName,
-                                                     "Captured viewport frame (PNG); fetch via resources/read.",
-                                                     "image/png", sizeBytes);
+                return PublishCaptureResourceLink(
+                    server, std::move(capturedPng), "golden-capture",
+                    "Viewport capture from olo_render_compare_golden (verdict in the tool result).",
+                    "Captured viewport frame (PNG); fetch via resources/read.", verdict);
             };
 
             // Golden-missing / rebase: write the capture as the new golden and

--- a/OloEditor/src/MCP/McpToolsScene.cpp
+++ b/OloEditor/src/MCP/McpToolsScene.cpp
@@ -174,7 +174,7 @@ namespace OloEngine::MCP
 
             if (result.contains("error"))
                 return ToolResult::Error(result["error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_entity_set_field (main-marshaled; PROJECT WRITE) --------------
@@ -242,7 +242,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_entity_list_fields (main-marshaled; read-only) ----------------
@@ -271,7 +271,7 @@ namespace OloEngine::MCP
                 bool entityFound = false;
                 return GenericFieldWrite::ListFields(scene, entityUuid, componentFilter, entityFound); });
 
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // MarshalRead's default 5s watchdog is sized for the typical read-only tool
@@ -356,7 +356,7 @@ namespace OloEngine::MCP
                 AwaitRenderedFrames(server, baseFrame, kPostLoadSettleFrames);
             }
 
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_scene_play / olo_scene_stop (main-marshaled; PROJECT WRITE) ---
@@ -418,7 +418,7 @@ namespace OloEngine::MCP
                     // Settle timed out — the transition result stands.
                 }
             }
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         ToolResult Handle_ScenePlay(McpServer& server, const Json&)
@@ -464,7 +464,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
     } // namespace
@@ -508,6 +508,18 @@ namespace OloEngine::MCP
                                    .Prop("namePattern", Schema::String().Desc("Case-sensitive substring to match against entity names."))
                                    .Pagination("Entities per page (default 50, max 200).")
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("total", Schema::Int().Min(0).Desc("Total matching entities before pagination."))
+                                    .Prop("page", Schema::Int().Min(0))
+                                    .Prop("pageSize", Schema::Int().Min(1).Desc("Effective page size after clamping (1..200)."))
+                                    .Prop("returned", Schema::Int().Min(0).Desc("Entities in this page."))
+                                    .Prop("nextPage", Schema::Int().Min(1).Desc("Next zero-based page; omitted on the last page."))
+                                    .Prop("entities", Schema::Array(Schema::Object()
+                                                                        .Prop("id", Schema::String().Desc("Entity UUID."))
+                                                                        .Prop("name", Schema::String())
+                                                                        .Prop("parent", Schema::String().Desc("Parent entity UUID; omitted when the entity has no parent."))
+                                                                        .Prop("childCount", Schema::Int().Min(0))))
+                                    .Required({ "total", "page", "pageSize", "returned", "entities" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneListEntities;
             server.RegisterTool(std::move(tool));
@@ -553,6 +565,19 @@ namespace OloEngine::MCP
                 "fields) are returned, so the result is exactly what you can write right now. Pass an optional "
                 "'component' to restrict the listing. Field names match the keys shown in olo_scene_get_entity's YAML.";
             tool.InputSchema = GenericFieldWrite::ListInputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("entity", Schema::String().Desc("Requested entity UUID echoed back."))
+                                    .Prop("found", Schema::Bool().Desc("Whether the UUID resolved in the active scene. A miss is a SUCCESS result with found:false and empty components, not isError."))
+                                    .Prop("components", Schema::Array(Schema::Object()
+                                                                          .Prop("component", Schema::String())
+                                                                          .Prop("fields", Schema::Array(Schema::Object()
+                                                                                                            .Prop("field", Schema::String().Desc("Field name; a map-typed field expands to one dotted entry per current key, e.g. 'Weights.Smile'."))
+                                                                                                            .Prop("type", Schema::String())
+                                                                                                            .Prop("value", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
+                                                                                                                               .Desc("Current value, typed to match the field."))
+                                                                                                            .Prop("min", Schema::Number().Desc("Serializer-enforced lower bound; omitted when the field has none."))
+                                                                                                            .Prop("max", Schema::Number().Desc("Serializer-enforced upper bound; omitted when the field has none."))))))
+                                    .Required({ "entity", "found", "components" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_EntityListFields;
             server.RegisterTool(std::move(tool));
@@ -587,6 +612,22 @@ namespace OloEngine::MCP
                 "are only discoverable per-entity, not ahead of time. Discover the exact writable (component, field) "
                 "names, value shapes and ranges for an entity with olo_entity_list_fields.";
             tool.InputSchema = GenericFieldWrite::InputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("entity", Schema::String().Desc("Target entity UUID."))
+                                    .Prop("component", Schema::String())
+                                    .Prop("field", Schema::String().Desc("Field written; the dotted 'Weights.<key>' form for a map-keyed write."))
+                                    .Prop("type", Schema::String().Desc("The field's type name (e.g. float, vec3, bool)."))
+                                    .Prop("previousValue", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
+                                                               .Desc("Value before the write, typed to match the field."))
+                                    .Prop("value", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
+                                                       .Desc("Value read back from the live component AFTER the write."))
+                                    .Prop("changed", Schema::Bool().Desc("Whether the write actually changed the field."))
+                                    .Prop("undoable", Schema::Bool().Desc("Whether an undo command was pushed (a no-op pushes nothing); always false for Play-mode direct writes."))
+                                    .Prop("clamped", Schema::Bool().Desc("True when the requested value was clamped into the field's serializer-enforced range."))
+                                    .Prop("requestedValue", Schema::Raw(Json{ { "type", Json::array({ "boolean", "number", "string", "array" }) } })
+                                                                .Desc("Original pre-clamp value; present only when clamped:true."))
+                                    .Prop("key", Schema::String().Desc("Map key; present only for a map-keyed (dotted-field) write."))
+                                    .Required({ "entity", "component", "field", "type", "previousValue", "value", "changed", "undoable", "clamped" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_EntitySetField;
             server.RegisterTool(std::move(tool));
@@ -614,6 +655,14 @@ namespace OloEngine::MCP
                 "entity count. This is a WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's "
                 "MCP Server panel (off by default).";
             tool.InputSchema = SceneControl::OpenInputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("available", Schema::Bool().Desc("False when this editor build has no scene-open hook."))
+                                    .Prop("ok", Schema::Bool().Desc("Whether the scene loaded."))
+                                    .Prop("path", Schema::String().Desc("Resolved scene path."))
+                                    .Prop("sceneName", Schema::String().Desc("Name of the newly active scene."))
+                                    .Prop("entityCount", Schema::Int().Min(0))
+                                    .Prop("message", Schema::String().Desc("Human-readable outcome detail."))
+                                    .Required({ "available", "ok", "path", "sceneName", "entityCount", "message" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneOpen;
             server.RegisterTool(std::move(tool));
@@ -640,6 +689,14 @@ namespace OloEngine::MCP
                 "WRITE tool: it is refused unless 'Allow writes' is enabled in the editor's MCP Server panel (off by "
                 "default).";
             tool.InputSchema = SceneControl::PlayStopInputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("available", Schema::Bool().Desc("False when this editor build has no play-mode hook."))
+                                    .Prop("ok", Schema::Bool().Desc("Editor is in the requested mode afterwards; entering Play can fail (e.g. no primary camera), then ok:false."))
+                                    .Prop("playing", Schema::Bool().Desc("Play state after the call."))
+                                    .Prop("changed", Schema::Bool().Desc("True only when this call actually transitioned (a no-op is changed:false)."))
+                                    .Prop("sceneName", Schema::String())
+                                    .Prop("message", Schema::String().Desc("Human-readable outcome detail."))
+                                    .Required({ "available", "ok", "playing", "changed", "sceneName", "message" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ScenePlay;
             server.RegisterTool(std::move(tool));
@@ -662,6 +719,16 @@ namespace OloEngine::MCP
                 "olo_scene_summary's isPlaying. This is a WRITE tool: it is refused unless 'Allow writes' is enabled "
                 "in the editor's MCP Server panel (off by default).";
             tool.InputSchema = SceneControl::PlayStopInputSchema();
+            // Same shape as olo_scene_play — both registrations mirror the shared
+            // Handle_ScenePlayState / SceneControl::ToJson(McpScenePlayResult) payload.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("available", Schema::Bool().Desc("False when this editor build has no play-mode hook."))
+                                    .Prop("ok", Schema::Bool().Desc("Editor is in the requested mode afterwards."))
+                                    .Prop("playing", Schema::Bool().Desc("Play state after the call."))
+                                    .Prop("changed", Schema::Bool().Desc("True only when this call actually transitioned (a no-op is changed:false)."))
+                                    .Prop("sceneName", Schema::String())
+                                    .Prop("message", Schema::String().Desc("Human-readable outcome detail."))
+                                    .Required({ "available", "ok", "playing", "changed", "sceneName", "message" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SceneStop;
             server.RegisterTool(std::move(tool));
@@ -695,6 +762,15 @@ namespace OloEngine::MCP
                 "the Properties panel outside the 3D viewport) to see the result. This is a WRITE tool: it is "
                 "refused unless 'Allow writes' is enabled in the editor's MCP Server panel (off by default).";
             tool.InputSchema = SelectEntity::InputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("available", Schema::Bool().Desc("False when this editor build has no selection hook."))
+                                    .Prop("ok", Schema::Bool().Desc("Requested transition applied; an unknown UUID is ok:false with the current selection untouched."))
+                                    .Prop("changed", Schema::Bool().Desc("Real transition vs. no-op (re-selecting the already-selected entity, or clearing an already-empty selection)."))
+                                    .Prop("selected", Schema::Bool().Desc("Whether an entity is selected after the call."))
+                                    .Prop("message", Schema::String().Desc("Human-readable outcome detail."))
+                                    .Prop("entity", Schema::String().Desc("Selected entity UUID; present only when selected:true."))
+                                    .Prop("name", Schema::String().Desc("Selected entity name; present only when selected:true."))
+                                    .Required({ "available", "ok", "changed", "selected", "message" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_SelectEntity;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsScripting.cpp
+++ b/OloEditor/src/MCP/McpToolsScripting.cpp
@@ -29,7 +29,7 @@ namespace OloEngine::MCP
             Json digest = BuildScriptApiDigest(language, typeFilter);
             if (digest.contains("error"))
                 return ToolResult::Error(digest["error"].get<std::string>());
-            return ToolResult::Text(digest.dump(2));
+            return ToolResult::Structured(digest);
         }
 
         // ---- olo_script_get_last_errors (lock-safe; script error ring buffer) --
@@ -58,7 +58,7 @@ namespace OloEngine::MCP
             Json out;
             out["count"] = static_cast<int>(arr.size());
             out["errors"] = std::move(arr);
-            return ToolResult::Text(out.dump(2));
+            return ToolResult::Structured(out);
         }
 
         // ---- olo_reload_script (main-marshaled; PROJECT WRITE) -----------------
@@ -86,7 +86,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
     } // namespace
@@ -108,6 +108,22 @@ namespace OloEngine::MCP
                                    .Prop("language", Schema::String().Enum({ "csharp", "lua" }).Desc("Scripting language (default csharp)."))
                                    .Prop("typeFilter", Schema::String().Desc("Case-insensitive substring; matching types are returned with their members."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("language", Schema::String().Enum({ "csharp", "lua" }))
+                                    .Prop("engineVersion", Schema::String())
+                                    .Prop("typeCount", Schema::Int().Min(0).Desc("Total types discovered, before typeFilter matching."))
+                                    .Prop("types", Schema::Array(Schema::Object()
+                                                                     .Prop("name", Schema::String())
+                                                                     .Prop("kind", Schema::String().Desc("csharp only: class/struct/enum/interface."))
+                                                                     .Prop("file", Schema::String().Desc("csharp only: declaring .cs file name."))
+                                                                     .Prop("members", Schema::Array(Schema::String()).Desc("csharp filter mode only: public member declaration lines."))
+                                                                     .Prop("registration", Schema::String().Desc("lua filter mode only: raw Sol2 registration block (capped)."))
+                                                                     .Prop("truncated", Schema::Bool().Desc("lua filter mode only: true when the registration block hit the cap."))
+                                                                     .Required({ "name" }))
+                                                       .Desc("Element shape varies by language and typeFilter mode; only 'name' is always present."))
+                                    .Prop("note", Schema::String().Desc("Index mode only (no typeFilter): hint to pass typeFilter."))
+                                    .Prop("matched", Schema::Int().Min(0).Desc("Filter mode only: number of matching types."))
+                                    .Required({ "language", "engineVersion", "typeCount", "types" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_ScriptGetApi;
             server.RegisterTool(std::move(tool));
@@ -126,6 +142,17 @@ namespace OloEngine::MCP
             tool.InputSchema = Schema::Object()
                                    .Prop("count", Schema::Int().Min(1).Max(64).Desc("How many of the most recent errors to return (default 20)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0).Desc("Number of entries in 'errors'."))
+                                    .Prop("errors", Schema::Array(Schema::Object()
+                                                                      .Prop("language", Schema::String().Enum({ "csharp", "lua" }))
+                                                                      .Prop("scriptName", Schema::String())
+                                                                      .Prop("entityId", Schema::String().Desc("Entity UUID (decimal); omitted when unknown."))
+                                                                      .Prop("message", Schema::String())
+                                                                      .Prop("stackTrace", Schema::String().Desc("Omitted when empty or folded into message."))
+                                                                      .Prop("timestamp", Schema::Number().Desc("Unix epoch seconds.")))
+                                                        .Desc("Oldest-first."))
+                                    .Required({ "count", "errors" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_ScriptGetLastErrors;
             server.RegisterTool(std::move(tool));
@@ -156,6 +183,13 @@ namespace OloEngine::MCP
                 "reloading executes the freshly-built assembly. If C# scripting is disabled or uninitialized "
                 "the call still succeeds but reports available:false.";
             tool.InputSchema = ReloadScript::InputSchema();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("language", Schema::String().Desc("Always \"csharp\" today."))
+                                    .Prop("available", Schema::Bool().Desc("C# scripting initialized in this build; false is a clean result, not an error."))
+                                    .Prop("ok", Schema::Bool().Desc("Whether the assembly reload succeeded."))
+                                    .Prop("scriptClassCount", Schema::Int().Min(0).Desc("Entity-script classes registered after the reload; non-zero signals the app assembly loaded."))
+                                    .Prop("message", Schema::String())
+                                    .Required({ "language", "available", "ok", "scriptClassCount", "message" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ReloadScript;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsShader.cpp
+++ b/OloEditor/src/MCP/McpToolsShader.cpp
@@ -53,7 +53,7 @@ namespace OloEngine::MCP
                                         { "errorMessage", info.m_LastCompilation.m_ErrorMessage } });
                 }
                 return Json{ { "count", static_cast<int>(arr.size()) }, { "errors", std::move(arr) } }; });
-            return ToolResult::Text(j.dump(2));
+            return ToolResult::Structured(j);
         }
 
         // ---- olo_shader_get (main-marshaled) -----------------------------------
@@ -128,7 +128,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
         // ---- olo_shader_list (main-marshaled; GetAllShaders is unguarded) ------
@@ -154,7 +154,7 @@ namespace OloEngine::MCP
                                         { "instructionCount", info.m_LastCompilation.m_InstructionCount } });
                 }
                 return Json{ { "count", static_cast<int>(arr.size()) }, { "shaders", std::move(arr) } }; });
-            return ToolResult::Text(j.dump(2));
+            return ToolResult::Structured(j);
         }
 
         // Best-effort compile/link log via the same read path as
@@ -318,7 +318,7 @@ namespace OloEngine::MCP
 
             if (result.is_object() && result.contains("__error"))
                 return ToolResult::Error(result["__error"].get<std::string>());
-            return ToolResult::Text(result.dump(2));
+            return ToolResult::Structured(result);
         }
 
     } // namespace
@@ -335,6 +335,12 @@ namespace OloEngine::MCP
                 "Shaders that currently have compile/link errors, with the error message. Empty when all "
                 "shaders compiled cleanly.";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0).Desc("Number of shaders currently in error (size of errors)."))
+                                    .Prop("errors", Schema::Array(Schema::Object()
+                                                                      .Prop("name", Schema::String())
+                                                                      .Prop("errorMessage", Schema::String())))
+                                    .Required({ "count", "errors" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ShaderErrors;
             server.RegisterTool(std::move(tool));
@@ -354,6 +360,28 @@ namespace OloEngine::MCP
                                    .Prop("id", Schema::Int().Desc("GL program id (alternative to name)."))
                                    .Prop("includeGlsl", Schema::Bool().Desc("Include the cross-compiled GLSL source per stage (default false)."))
                                    .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("name", Schema::String())
+                                    .Prop("filePath", Schema::String())
+                                    .Prop("hasErrors", Schema::Bool())
+                                    .Prop("instructionCount", Schema::Int().Min(0).Desc("Estimated from the SPIR-V binary."))
+                                    .Prop("compileTimeMs", Schema::Number().Desc("Rounded to 2 decimals."))
+                                    .Prop("reloadCount", Schema::Int().Min(0))
+                                    .Prop("uniformBuffers", Schema::Array(Schema::Object()
+                                                                              .Prop("name", Schema::String())
+                                                                              .Prop("binding", Schema::Int())
+                                                                              .Prop("size", Schema::Int())
+                                                                              .Prop("members", Schema::Array(Schema::String()))))
+                                    .Prop("samplers", Schema::Array(Schema::Object()
+                                                                        .Prop("name", Schema::String())
+                                                                        .Prop("binding", Schema::Int())
+                                                                        .Prop("type", Schema::String())))
+                                    .Prop("uniforms", Schema::Array(Schema::Object()
+                                                                        .Prop("name", Schema::String())
+                                                                        .Prop("location", Schema::Int())
+                                                                        .Prop("size", Schema::Int())))
+                                    .Prop("generatedGlsl", Schema::Object().Desc("Stage token (vertex/fragment/geometry/compute) -> cross-compiled GLSL source string. Only present when includeGlsl=true."))
+                                    .Required({ "name", "filePath", "hasErrors", "instructionCount", "compileTimeMs", "reloadCount", "uniformBuffers", "samplers", "uniforms" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ShaderGet;
             server.RegisterTool(std::move(tool));
@@ -371,6 +399,15 @@ namespace OloEngine::MCP
                 "true when the shader is backed by a file on disk (library- AND pass-owned shaders, including "
                 "compute); it is false only for source-string shaders (boot / fallback / shader-graph).";
             tool.InputSchema = Schema::EmptyObject();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0).Desc("Number of registered shaders (size of shaders)."))
+                                    .Prop("shaders", Schema::Array(Schema::Object()
+                                                                       .Prop("id", Schema::Int().Min(0).Desc("GL program id."))
+                                                                       .Prop("name", Schema::String())
+                                                                       .Prop("hasErrors", Schema::Bool())
+                                                                       .Prop("reloadable", Schema::Bool().Desc("Backed by a file on disk; feed to olo_shader_reload."))
+                                                                       .Prop("instructionCount", Schema::Int().Min(0))))
+                                    .Required({ "count", "shaders" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ShaderList;
             server.RegisterTool(std::move(tool));
@@ -406,6 +443,17 @@ namespace OloEngine::MCP
                                    .Prop("name", Schema::String().Desc("Shader name to reload (as shown by olo_shader_list)."))
                                    .Required({ "name" })
                                    .NoAdditional();
+            // Contract shaped by ShaderReload::ToJson (McpShaderReload.h), pinned by McpShaderReloadTest.
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("name", Schema::String().Desc("The requested shader name (echoed)."))
+                                    .Prop("found", Schema::Bool().Desc("Always true on a success response (a non-reloadable name is returned as isError instead)."))
+                                    .Prop("libraries", Schema::Array(Schema::String()).Desc("Owners that held it: Renderer3D / Renderer2D / PassOwned."))
+                                    .Prop("kind", Schema::String().Enum({ "graphics", "compute" }))
+                                    .Prop("status", Schema::String().Enum({ "pending", "compiling", "ready", "failed", "unknown" }).Desc("Post-reload status of the primary copy."))
+                                    .Prop("ok", Schema::Bool().Desc("True only when every reloaded copy is ready/valid."))
+                                    .Prop("rendererId", Schema::Int().Min(0).Desc("Current GL program id of the primary copy; 0 when a link failed."))
+                                    .Prop("log", Schema::String().Desc("Compile/link error log; empty on a clean reload (best-effort, debug builds)."))
+                                    .Required({ "name", "found", "libraries", "kind", "status", "ok", "rendererId", "log" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_ShaderReload;
             server.RegisterTool(std::move(tool));

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -432,6 +432,11 @@ add_executable(OloEngine-Tests
 		# below). McpServerPanel.* (ImGui) is NOT needed.
 		MCP/McpDispatchTest.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpServer.cpp
+		# The outbound stdio MCP client (#673 Tier 1): McpServer's connection-
+		# ownership members + the McpClientConnection protocol layer live here.
+		# The Win32 pipe transport is compiled but never spawned by unit tests —
+		# they inject in-memory fake transports (McpClientStdioTest.cpp).
+		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpClient.cpp
 		# Headless-attach stretch (issue #316): McpHeadlessAttachTest hosts the
 		# REAL tool surface (RegisterBuiltinTools) against the offscreen FB, so it
 		# needs the actual tool TUs too. These are editor-decoupled — they include
@@ -545,6 +550,19 @@ add_executable(OloEngine-Tests
 		# HandleToolsList / HandleToolsCall / ToolResult::Structured in the McpServer.cpp
 		# TU already pulled in above; no extra editor TU is needed.
 		MCP/McpStructuredOutputTest.cpp
+		# Resource links + the dynamic (copy-on-write) resource registry (#673
+		# Tier 1): the binary `blob` contents variant of resources/read, ephemeral
+		# capture publish/eviction + notifications/resources/list_changed, the
+		# held-snapshot-survives-eviction property, and the resource_link content
+		# block incl. redaction. Exercises the McpServer.cpp TU already pulled in
+		# above; no extra editor TU is needed.
+		MCP/McpResourceLinkTest.cpp
+		# OutputSchema adoption guard over the REAL builtin tool surface (#673
+		# Tier 1 sweep): registration-only (no tools/call, so no handler runs and
+		# no game thread / GL is needed) — asserts every declared outputSchema is
+		# a well-formed open object and pins the set of schema-declaring tools.
+		# Uses the McpTools*.cpp TUs already pulled in above.
+		MCP/McpOutputSchemaCoverageTest.cpp
 		# JSON-Schema builder DSL + byte-identical equivalence with the migrated tool
 		# schema literals (#357 Tier 2 P4). Header-only (MCP/McpSchemaBuilder.h,
 		# nlohmann::json + stdlib only), so no extra editor TU is pulled in.
@@ -567,6 +585,18 @@ add_executable(OloEngine-Tests
 		# Pulls the editor-decoupled McpScriptTools.cpp TU (sol2 + engine only).
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpScriptTools.cpp
 		MCP/McpScriptToolsTest.cpp
+		# The registry-merge trust seam for tools bridged from an OUTBOUND MCP
+		# client connection (#673 Tier 1): ReplaceClientTools validate-and-reject,
+		# the reserved ext.<alias>.* namespace, the forced authority posture
+		# (ProjectWrite + open-world annotations), per-alias replace semantics
+		# coexisting with native/script tools, and External-marked consent
+		# prompts. Exercises the McpServer.cpp TU already pulled in above.
+		MCP/McpClientToolsTest.cpp
+		# The outbound stdio client's protocol + lifecycle layer (#673 Tier 1):
+		# handshake, bridged round-trip, timeouts, child death, disconnect, and
+		# the polite -32601 to child-initiated requests — all through in-memory
+		# fake transports (McpClient.cpp TU pulled in above; no process spawn).
+		MCP/McpClientStdioTest.cpp
 		# MCP protocol surface from #607: tool + serverInfo `icons` (SEP-973), the
 		# now-true capabilities.tools.listChanged, and the copy-on-write tool-registry
 		# snapshot the live script-tool reload rests on. Exercises the McpServer.cpp TU

--- a/OloEngine/tests/MCP/McpClientStdioTest.cpp
+++ b/OloEngine/tests/MCP/McpClientStdioTest.cpp
@@ -1,0 +1,345 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// The outbound MCP client's protocol + lifecycle layer (#673 Tier 1, bullet 1),
+// driven end-to-end through McpServer::ConnectClientWithTransport with an
+// IN-MEMORY fake transport — no child process, socket, or GL: the initialize /
+// initialized / tools/list handshake, prefixed tool merging, the bridged
+// tools/call round-trip (content + structuredContent pass-through, child
+// errors, timeouts), child-death teardown (pending calls fail fast, tools
+// unpublish, status flips), disconnect, duplicate aliases, and the
+// polite -32601 reply to a request initiated BY the child.
+//
+// The registry-side trust seam (forced authority posture, namespace
+// validation) is McpClientToolsTest's job; this file assumes it and focuses on
+// the connection.
+#include "MCP/McpClient.h"
+#include "MCP/McpServer.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::IMcpClientTransport;
+    using OloEngine::MCP::McpClientConfig;
+    using OloEngine::MCP::McpClientStatus;
+    using OloEngine::MCP::McpClientTransportFactory;
+    using OloEngine::MCP::McpServer;
+    using Json = OloEngine::MCP::Json;
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    // An in-memory transport: replies synchronously inside WriteLine via a
+    // caller-supplied script. Close() invokes onClosed inline exactly once —
+    // satisfying the "no callbacks after Close returns" contract trivially.
+    class FakeTransport final : public IMcpClientTransport
+    {
+      public:
+        std::function<void(const Json& request, FakeTransport&)> Script;
+        std::vector<Json> Written;
+        std::function<void(std::string)> OnLineSink;
+        std::function<void()> OnClosedSink;
+
+        [[nodiscard]] bool WriteLine(const std::string& payload) override
+        {
+            const Json message = Json::parse(payload, nullptr, false);
+            Written.push_back(message);
+            if (Script)
+                Script(message, *this);
+            return true;
+        }
+
+        void Reply(const Json& message)
+        {
+            if (OnLineSink)
+                OnLineSink(message.dump());
+        }
+
+        void Close() override
+        {
+            if (!m_Closed.exchange(true) && OnClosedSink)
+                OnClosedSink();
+        }
+
+        [[nodiscard]] bool WroteMethod(const std::string& method) const
+        {
+            for (const Json& message : Written)
+            {
+                if (message.is_object() && message.value("method", std::string{}) == method)
+                    return true;
+            }
+            return false;
+        }
+
+      private:
+        std::atomic<bool> m_Closed{ false };
+    };
+
+    // The standard well-behaved child: answers initialize and serves one tool
+    // ("read_file"); tools/call behaviour comes from `onCall`.
+    std::function<void(const Json&, FakeTransport&)> WellBehavedScript(
+        std::function<void(const Json& request, FakeTransport&)> onCall = {})
+    {
+        return [onCall = std::move(onCall)](const Json& request, FakeTransport& transport)
+        {
+            const std::string method = request.value("method", std::string{});
+            if (method == "initialize")
+            {
+                transport.Reply(Json{
+                    { "jsonrpc", "2.0" },
+                    { "id", request["id"] },
+                    { "result",
+                      Json{ { "protocolVersion", "2025-06-18" },
+                            { "capabilities", Json::object() },
+                            { "serverInfo", Json{ { "name", "fake-child" }, { "version", "1.0" } } } } } });
+            }
+            else if (method == "tools/list")
+            {
+                transport.Reply(Json{
+                    { "jsonrpc", "2.0" },
+                    { "id", request["id"] },
+                    { "result",
+                      Json{ { "tools",
+                              Json::array(
+                                  { Json{ { "name", "read_file" },
+                                          { "title", "Read file" },
+                                          { "description", "Read a file from disk." },
+                                          { "inputSchema",
+                                            Json{ { "type", "object" },
+                                                  { "properties",
+                                                    { { "path", { { "type", "string" } } } } } } } } }) } } } });
+            }
+            else if (method == "tools/call" && onCall)
+            {
+                onCall(request, transport);
+            }
+        };
+    }
+
+    // Factory exposing the created fake so the test can poke it post-connect.
+    McpClientTransportFactory FakeFactory(FakeTransport*& outTransport,
+                                          std::function<void(const Json&, FakeTransport&)> script)
+    {
+        return [&outTransport, script = std::move(script)](
+                   const std::string& /*command*/, std::function<void(std::string)> onLine,
+                   std::function<void()> onClosed, std::string& /*outError*/)
+                   -> std::unique_ptr<IMcpClientTransport>
+        {
+            auto transport = std::make_unique<FakeTransport>();
+            transport->Script = script;
+            transport->OnLineSink = std::move(onLine);
+            transport->OnClosedSink = std::move(onClosed);
+            outTransport = transport.get();
+            return transport;
+        };
+    }
+
+    McpClientConfig FilesConfig(std::chrono::milliseconds callTimeout = std::chrono::milliseconds(5000))
+    {
+        McpClientConfig config;
+        config.Alias = "files";
+        config.Command = "fake-child.exe";
+        config.HandshakeTimeout = std::chrono::milliseconds(5000);
+        config.CallTimeout = callTimeout;
+        return config;
+    }
+
+    const Json* FindToolEntry(const Json& response, const std::string& name)
+    {
+        if (!response.contains("result") || !response["result"].contains("tools"))
+            return nullptr;
+        for (const auto& tool : response["result"]["tools"])
+        {
+            if (tool.value("name", std::string{}) == name)
+                return &tool;
+        }
+        return nullptr;
+    }
+} // namespace
+
+TEST(McpClientStdio, ConnectHandshakesAndMergesPrefixedTools)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const std::string error = server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript()));
+    ASSERT_TRUE(error.empty()) << error;
+    ASSERT_NE(fake, nullptr);
+
+    // Handshake order on the wire: initialize, then the initialized
+    // notification, then tools/list.
+    ASSERT_GE(fake->Written.size(), 3u);
+    EXPECT_EQ(fake->Written[0]["method"], "initialize");
+    EXPECT_EQ(fake->Written[1]["method"], "notifications/initialized");
+    EXPECT_FALSE(fake->Written[1].contains("id")) << "initialized must be a notification";
+    EXPECT_EQ(fake->Written[2]["method"], "tools/list");
+
+    const Json list = server.HandleMessage(MakeRequest(1, "tools/list"));
+    const Json* entry = FindToolEntry(list, "ext.files.read_file");
+    ASSERT_NE(entry, nullptr) << list.dump(2);
+    EXPECT_NE((*entry)["description"].get<std::string>().find("bridged from external MCP server 'files'"),
+              std::string::npos);
+    // The child's inputSchema is preserved for local pre-forward validation.
+    EXPECT_EQ((*entry)["inputSchema"]["properties"].contains("path"), true);
+
+    const std::vector<McpClientStatus> statuses = server.ClientStatuses();
+    ASSERT_EQ(statuses.size(), 1u);
+    EXPECT_EQ(statuses[0].Alias, "files");
+    EXPECT_TRUE(statuses[0].Connected);
+    EXPECT_EQ(statuses[0].ToolCount, 1u);
+}
+
+TEST(McpClientStdio, BridgedCallRoundTripsContentAndStructuredContent)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    Json seenArguments;
+    const auto onCall = [&seenArguments](const Json& request, FakeTransport& transport)
+    {
+        seenArguments = request["params"].value("arguments", Json::object());
+        transport.Reply(Json{
+            { "jsonrpc", "2.0" },
+            { "id", request["id"] },
+            { "result",
+              Json{ { "content", Json::array({ Json{ { "type", "text" }, { "text", "file data" } } }) },
+                    { "structuredContent", Json{ { "ok", true }, { "bytes", 9 } } },
+                    { "isError", false } } } });
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript(onCall))).empty());
+
+    server.SetAllowWrites(true); // bridged tools are always ProjectWrite
+    const Json response = server.HandleMessage(MakeRequest(
+        2, "tools/call", Json{ { "name", "ext.files.read_file" }, { "arguments", Json{ { "path", "a.txt" } } } }));
+
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(seenArguments["path"], "a.txt");
+    EXPECT_EQ(response["result"]["isError"], false);
+    EXPECT_EQ(response["result"]["content"][0]["text"], "file data");
+    EXPECT_EQ(response["result"]["structuredContent"]["ok"], true);
+    EXPECT_EQ(response["result"]["structuredContent"]["bytes"], 9);
+}
+
+TEST(McpClientStdio, ChildErrorSurfacesAsToolError)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto onCall = [](const Json& request, FakeTransport& transport)
+    {
+        transport.Reply(Json{ { "jsonrpc", "2.0" },
+                              { "id", request["id"] },
+                              { "error", Json{ { "code", -32000 }, { "message", "disk on fire" } } } });
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript(onCall))).empty());
+    server.SetAllowWrites(true);
+
+    const Json response =
+        server.HandleMessage(MakeRequest(3, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["isError"], true);
+    const std::string text = response["result"]["content"][0]["text"].get<std::string>();
+    EXPECT_NE(text.find("disk on fire"), std::string::npos);
+    EXPECT_NE(text.find("'files'"), std::string::npos);
+}
+
+TEST(McpClientStdio, UnansweredCallTimesOutWithACleanError)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    // Script answers the handshake but swallows tools/call.
+    ASSERT_TRUE(server
+                    .ConnectClientWithTransport(FilesConfig(std::chrono::milliseconds(100)),
+                                                FakeFactory(fake, WellBehavedScript()))
+                    .empty());
+    server.SetAllowWrites(true);
+
+    const Json response =
+        server.HandleMessage(MakeRequest(4, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["isError"], true);
+    EXPECT_NE(response["result"]["content"][0]["text"].get<std::string>().find("did not respond"),
+              std::string::npos);
+}
+
+TEST(McpClientStdio, ChildDeathUnpublishesToolsAndFlipsStatus)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript())).empty());
+    ASSERT_NE(FindToolEntry(server.HandleMessage(MakeRequest(5, "tools/list")), "ext.files.read_file"), nullptr);
+
+    fake->Close(); // the stream breaks — as if the child crashed
+
+    EXPECT_EQ(FindToolEntry(server.HandleMessage(MakeRequest(6, "tools/list")), "ext.files.read_file"), nullptr)
+        << "a dead child's tools must be unpublished";
+    const std::vector<McpClientStatus> statuses = server.ClientStatuses();
+    ASSERT_EQ(statuses.size(), 1u) << "the dead connection stays listed for the panel until disconnected";
+    EXPECT_FALSE(statuses[0].Connected);
+
+    // Reaping it frees the alias for a reconnect.
+    EXPECT_TRUE(server.DisconnectClient("files"));
+    EXPECT_TRUE(server.ClientStatuses().empty());
+}
+
+TEST(McpClientStdio, DisconnectRemovesToolsAndFreesTheAlias)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript())).empty());
+
+    // A second connect on a live alias is refused.
+    FakeTransport* second = nullptr;
+    EXPECT_FALSE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(second, WellBehavedScript())).empty());
+
+    EXPECT_TRUE(server.DisconnectClient("files"));
+    EXPECT_EQ(FindToolEntry(server.HandleMessage(MakeRequest(7, "tools/list")), "ext.files.read_file"), nullptr);
+    EXPECT_FALSE(server.DisconnectClient("files")) << "double-disconnect reports false";
+
+    // Alias is reusable afterwards.
+    FakeTransport* third = nullptr;
+    EXPECT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(third, WellBehavedScript())).empty());
+}
+
+TEST(McpClientStdio, RequestFromTheChildGetsAPoliteMethodNotFound)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript())).empty());
+
+    fake->Reply(Json{ { "jsonrpc", "2.0" }, { "id", 999 }, { "method", "sampling/createMessage" } });
+
+    const Json* reply = nullptr;
+    for (const Json& message : fake->Written)
+    {
+        if (message.is_object() && message.value("id", Json()) == Json(999) && message.contains("error"))
+            reply = &message;
+    }
+    ASSERT_NE(reply, nullptr) << "the child must not be left hanging on its request";
+    EXPECT_EQ((*reply)["error"]["code"], -32601);
+}
+
+TEST(McpClientStdio, StopShutsDownConnections)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript())).empty());
+
+    server.Stop(); // never Start()ed — takes the not-running path, which must still reap clients
+
+    EXPECT_TRUE(server.ClientStatuses().empty());
+    EXPECT_EQ(FindToolEntry(server.HandleMessage(MakeRequest(8, "tools/list")), "ext.files.read_file"), nullptr);
+}

--- a/OloEngine/tests/MCP/McpClientStdioTest.cpp
+++ b/OloEngine/tests/MCP/McpClientStdioTest.cpp
@@ -77,16 +77,6 @@ namespace
                 OnClosedSink();
         }
 
-        [[nodiscard]] bool WroteMethod(const std::string& method) const
-        {
-            for (const Json& message : Written)
-            {
-                if (message.is_object() && message.value("method", std::string{}) == method)
-                    return true;
-            }
-            return false;
-        }
-
       private:
         std::atomic<bool> m_Closed{ false };
     };

--- a/OloEngine/tests/MCP/McpClientToolsTest.cpp
+++ b/OloEngine/tests/MCP/McpClientToolsTest.cpp
@@ -1,0 +1,244 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// The registry-merge contract for tools bridged from an OUTBOUND MCP client
+// connection (#673 Tier 1, bullet 1) — the trust seam, tested independently of
+// any child process (the stdio transport has its own tests): foreign tool
+// definitions are runtime network data, so ReplaceClientTools must
+// validate-and-reject (never assert), confine every accepted tool to the
+// reserved `ext.<alias>.` namespace, FORCE the authority posture
+// (ProjectWrite=true, readOnlyHint:false, openWorldHint:true) regardless of
+// what the child claimed, coexist with native and ScriptOwned tools across
+// swaps, and mark its consent prompts External so the panel modal never
+// promises Ctrl-Z for an out-of-process effect.
+#include "MCP/McpServer.h"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::ConsentDecision;
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using OloEngine::MCP::WriteConsentMode;
+    using Json = OloEngine::MCP::Json;
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    ToolDef MakeBridgedTool(const std::string& name)
+    {
+        ToolDef tool;
+        tool.Name = name;
+        tool.Description = "Bridged from a fake external server.";
+        tool.InputSchema = Json{ { "type", "object" } };
+        tool.Handler = [](McpServer&, const Json&)
+        { return ToolResult::Text("external ran"); };
+        return tool;
+    }
+
+    const Json* FindToolEntry(const Json& response, const std::string& name)
+    {
+        if (!response.contains("result") || !response["result"].contains("tools"))
+            return nullptr;
+        for (const auto& tool : response["result"]["tools"])
+        {
+            if (tool.value("name", std::string{}) == name)
+                return &tool;
+        }
+        return nullptr;
+    }
+
+    Json ToolsList(McpServer& server)
+    {
+        return server.HandleMessage(MakeRequest(1, "tools/list"));
+    }
+} // namespace
+
+// ---- alias + name validation (reject, never assert) ---------------------------
+
+TEST(McpClientTools, InvalidAliasRejectsTheWholeBatch)
+{
+    McpServer server{ EditorMcpContext{} };
+    EXPECT_EQ(server.ReplaceClientTools("", { MakeBridgedTool("ext..x") }), 0u);
+    EXPECT_EQ(server.ReplaceClientTools("Has-Upper", { MakeBridgedTool("ext.Has-Upper.x") }), 0u);
+    EXPECT_EQ(server.ReplaceClientTools("-leading", { MakeBridgedTool("ext.-leading.x") }), 0u);
+    EXPECT_EQ(server.ReplaceClientTools("spaced alias", {}), 0u);
+    EXPECT_EQ(server.ToolCount(), 0u);
+}
+
+TEST(McpClientTools, NamesOutsideTheReservedNamespaceAreDropped)
+{
+    McpServer server{ EditorMcpContext{} };
+    std::vector<ToolDef> batch;
+    batch.push_back(MakeBridgedTool("read_file"));           // no prefix
+    batch.push_back(MakeBridgedTool("olo_scene_summary"));   // native spoof attempt
+    batch.push_back(MakeBridgedTool("script_sneaky"));       // script spoof attempt
+    batch.push_back(MakeBridgedTool("ext.other.read_file")); // wrong alias
+    batch.push_back(MakeBridgedTool("ext.files."));          // empty suffix
+    batch.push_back(MakeBridgedTool("ext.files.read file")); // invalid charset
+    batch.push_back(MakeBridgedTool("ext.files.read_file")); // the one valid tool
+    batch.push_back(MakeBridgedTool("ext.files.read_file")); // duplicate of it
+
+    EXPECT_EQ(server.ReplaceClientTools("files", std::move(batch)), 1u);
+    const Json list = ToolsList(server);
+    EXPECT_NE(FindToolEntry(list, "ext.files.read_file"), nullptr);
+    EXPECT_EQ(list["result"]["tools"].size(), 1u);
+}
+
+TEST(McpClientTools, ToolWithoutAHandlerIsDropped)
+{
+    McpServer server{ EditorMcpContext{} };
+    ToolDef noHandler = MakeBridgedTool("ext.files.broken");
+    noHandler.Handler = nullptr;
+    EXPECT_EQ(server.ReplaceClientTools("files", { std::move(noHandler) }), 0u);
+}
+
+// ---- forced authority posture --------------------------------------------------
+
+TEST(McpClientTools, AuthorityPostureIsForcedRegardlessOfChildClaims)
+{
+    McpServer server{ EditorMcpContext{} };
+    ToolDef liar = MakeBridgedTool("ext.files.read_file");
+    // The child claims it is a harmless read-only local tool. Never trusted.
+    liar.ProjectWrite = false;
+    liar.ScriptOwned = true;
+    liar.Toolset = "render";
+    liar.Annotations = Json{ { "readOnlyHint", true }, { "openWorldHint", false } };
+    ASSERT_EQ(server.ReplaceClientTools("files", { std::move(liar) }), 1u);
+
+    // Bind the response before taking a pointer into it — FindToolEntry on a
+    // temporary would dangle.
+    const Json list = ToolsList(server);
+    const Json* entry = FindToolEntry(list, "ext.files.read_file");
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ((*entry)["annotations"]["readOnlyHint"], false);
+    EXPECT_EQ((*entry)["annotations"]["openWorldHint"], true);
+    EXPECT_FALSE((*entry)["annotations"].contains("destructiveHint"))
+        << "keep the spec's conservative default (destructive) for foreign tools";
+    EXPECT_EQ((*entry)["_meta"]["io.oloengine/toolset"], "ext.files");
+
+    // ProjectWrite was forced true: with consent Disabled (the default), the
+    // call is refused by the write gate before the bridge handler ever runs.
+    const Json refused = server.HandleMessage(
+        MakeRequest(2, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(refused.contains("error")) << refused.dump(2);
+    EXPECT_EQ(refused["error"]["code"], -32602);
+
+    // Under AllowSession the bridge handler runs.
+    server.SetAllowWrites(true);
+    const Json allowed = server.HandleMessage(
+        MakeRequest(3, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(allowed.contains("result")) << allowed.dump(2);
+    EXPECT_EQ(allowed["result"]["content"][0]["text"], "external ran");
+}
+
+// ---- per-alias replace semantics ----------------------------------------------
+
+TEST(McpClientTools, ReplaceIsScopedToItsAliasAndCoexistsWithScriptTools)
+{
+    McpServer server{ EditorMcpContext{} };
+
+    ToolDef native;
+    native.Name = "fake_native";
+    native.Description = "A native tool.";
+    native.Handler = [](McpServer&, const Json&)
+    { return ToolResult::Text("native"); };
+    server.RegisterTool(std::move(native));
+
+    ToolDef scripted;
+    scripted.Name = "script_fake";
+    scripted.Description = "A script tool.";
+    scripted.ScriptOwned = true;
+    scripted.Handler = [](McpServer&, const Json&)
+    { return ToolResult::Text("script"); };
+    server.RegisterTool(std::move(scripted));
+
+    ASSERT_EQ(server.ReplaceClientTools("files", { MakeBridgedTool("ext.files.read_file") }), 1u);
+    ASSERT_EQ(server.ReplaceClientTools("web", { MakeBridgedTool("ext.web.fetch") }), 1u);
+    EXPECT_EQ(server.ToolCount(), 4u);
+
+    // Re-merging one alias replaces only that alias's tools.
+    ASSERT_EQ(server.ReplaceClientTools("files", { MakeBridgedTool("ext.files.write_file") }), 1u);
+    Json list = ToolsList(server);
+    EXPECT_EQ(FindToolEntry(list, "ext.files.read_file"), nullptr);
+    EXPECT_NE(FindToolEntry(list, "ext.files.write_file"), nullptr);
+    EXPECT_NE(FindToolEntry(list, "ext.web.fetch"), nullptr);
+
+    // A script rescan (wholesale ScriptOwned replace) must not touch client tools.
+    server.ReplaceScriptTools({});
+    list = ToolsList(server);
+    EXPECT_EQ(FindToolEntry(list, "script_fake"), nullptr);
+    EXPECT_NE(FindToolEntry(list, "ext.files.write_file"), nullptr);
+    EXPECT_NE(FindToolEntry(list, "ext.web.fetch"), nullptr);
+    EXPECT_NE(FindToolEntry(list, "fake_native"), nullptr);
+
+    // Disconnect: an empty batch removes the alias's tools and notifies.
+    const u64 generationBefore = server.ToolsGeneration();
+    EXPECT_EQ(server.ReplaceClientTools("web", {}), 0u);
+    EXPECT_GT(server.ToolsGeneration(), generationBefore);
+    EXPECT_EQ(FindToolEntry(ToolsList(server), "ext.web.fetch"), nullptr);
+}
+
+TEST(McpClientTools, MergeNotifiesToolsListChanged)
+{
+    McpServer server{ EditorMcpContext{} };
+    std::vector<std::string> notified;
+    server.AddNotificationListener([&notified](const Json& notification)
+                                   { notified.push_back(notification.value("method", std::string{})); });
+    ASSERT_EQ(server.ReplaceClientTools("files", { MakeBridgedTool("ext.files.read_file") }), 1u);
+    ASSERT_EQ(notified.size(), 1u);
+    EXPECT_EQ(notified[0], "notifications/tools/list_changed");
+}
+
+// ---- consent prompt honesty ----------------------------------------------------
+
+TEST(McpClientTools, PromptModeMarksExternalConsentEntries)
+{
+    McpServer server{ EditorMcpContext{} };
+    ASSERT_EQ(server.ReplaceClientTools("files", { MakeBridgedTool("ext.files.read_file") }), 1u);
+    server.SetWriteConsentMode(WriteConsentMode::Prompt);
+    server.SetConsentTimeout(std::chrono::milliseconds(5000));
+
+    Json response;
+    std::thread caller([&server, &response]
+                       { response = server.HandleMessage(
+                             MakeRequest(4, "tools/call", Json{ { "name", "ext.files.read_file" } })); });
+
+    // Wait for the prompt to surface (the caller thread is parked on the modal).
+    u64 promptId = 0;
+    bool external = false;
+    for (int i = 0; i < 200 && promptId == 0; ++i)
+    {
+        const auto pending = server.PendingConsents();
+        if (!pending.empty())
+        {
+            promptId = pending.front().Id;
+            external = pending.front().External;
+        }
+        else
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+    ASSERT_NE(promptId, 0u) << "consent prompt never surfaced";
+    EXPECT_TRUE(external) << "a bridged tool's consent prompt must be marked External";
+
+    server.ResolveConsent(promptId, ConsentDecision::Deny);
+    caller.join();
+    ASSERT_TRUE(response.contains("error")) << response.dump(2);
+}

--- a/OloEngine/tests/MCP/McpOutputSchemaCoverageTest.cpp
+++ b/OloEngine/tests/MCP/McpOutputSchemaCoverageTest.cpp
@@ -1,0 +1,144 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OutputSchema adoption guard for the REAL builtin tool surface (#673 Tier 1,
+// schema-adoption sweep). Unlike McpStructuredOutputTest (which pins the
+// outputSchema/structuredContent MECHANISM with fake tools), this test drives
+// the actual RegisterBuiltinTools registration and inspects tools/list — a
+// REGISTRATION-ONLY use: no tools/call is ever issued, so no handler runs, no
+// MarshalRead needs a pumped game thread, and no GL context is required.
+// Registration just builds ToolDefs (names, schemas, annotations) — pure data.
+//
+// Two invariants:
+//   1. Every declared OutputSchema is well-formed by the house rules
+//      (McpSchemaBuilder.h): an open root object (never additionalProperties
+//      at the root) whose `required` names a subset of `properties`.
+//   2. Schema adoption coverage: the tools expected to declare an OutputSchema
+//      actually do. This is the sweep's ratchet — a new tool that returns
+//      stringified JSON without declaring a schema fails here instead of
+//      silently regressing the adoption.
+#include "MCP/McpServer.h"
+#include "MCP/McpTools.h"
+
+#include <set>
+#include <string>
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using Json = OloEngine::MCP::Json;
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    // The full builtin surface, registered once and snapshotted as the
+    // tools/list result. The server is local to the lambda — only the JSON
+    // survives, so no handler can ever be invoked afterwards.
+    const Json& BuiltinToolsList()
+    {
+        static const Json response = []
+        {
+            McpServer server{ EditorMcpContext{} };
+            OloEngine::MCP::RegisterBuiltinTools(server);
+            return server.HandleMessage(MakeRequest(1, "tools/list"));
+        }();
+        return response;
+    }
+
+    const Json& BuiltinTools()
+    {
+        const Json& response = BuiltinToolsList();
+        EXPECT_TRUE(response.contains("result")) << response.dump(2);
+        EXPECT_TRUE(response["result"].contains("tools")) << response.dump(2);
+        return response["result"]["tools"];
+    }
+} // namespace
+
+// Every declared outputSchema obeys the house schema rules: the root is an
+// OPEN object (output schemas never close with additionalProperties:false —
+// McpSchemaBuilder.h's NoAdditional contract), and every `required` entry
+// names a declared property.
+TEST(McpOutputSchemaCoverage, EveryDeclaredOutputSchemaIsWellFormed)
+{
+    const Json& tools = BuiltinTools();
+    ASSERT_TRUE(tools.is_array());
+    ASSERT_FALSE(tools.empty());
+
+    for (const Json& tool : tools)
+    {
+        const std::string name = tool.value("name", std::string{});
+        if (!tool.contains("outputSchema"))
+            continue;
+
+        const Json& schema = tool["outputSchema"];
+        ASSERT_TRUE(schema.is_object()) << name;
+        EXPECT_EQ(schema.value("type", std::string{}), "object") << name;
+        EXPECT_FALSE(schema.contains("additionalProperties"))
+            << name << ": output schemas are left open — never close the root object.";
+
+        if (schema.contains("required"))
+        {
+            ASSERT_TRUE(schema["required"].is_array()) << name;
+            ASSERT_TRUE(schema.contains("properties"))
+                << name << ": `required` without any declared `properties`.";
+            for (const Json& requiredName : schema["required"])
+            {
+                ASSERT_TRUE(requiredName.is_string()) << name;
+                EXPECT_TRUE(schema["properties"].contains(requiredName.get<std::string>()))
+                    << name << ": required field '" << requiredName.get<std::string>()
+                    << "' is not a declared property.";
+            }
+        }
+    }
+}
+
+// Full-surface adoption (the #673 Tier 1 sweep): EVERY registered tool
+// declares an OutputSchema, except the deliberate text-only exemptions below.
+// This is the sweep's ratchet in both directions — a new tool returning
+// stringified JSON without a schema fails here, and an exemption that quietly
+// grows a schema (or a schema that disappears) fails here too.
+TEST(McpOutputSchemaCoverage, EveryToolDeclaresAnOutputSchemaExceptTextOnlyExemptions)
+{
+    // Genuinely free-form text a JSON outputSchema cannot constrain (the
+    // McpToolsRender "markdown returns free text" rule). Keep this list tiny
+    // and justified per entry.
+    static const std::set<std::string> kTextOnlyExempt = {
+        "olo_log_tail", // raw spdlog lines, deliberately unreshaped
+    };
+
+    const Json& tools = BuiltinTools();
+    ASSERT_TRUE(tools.is_array());
+    // 65 = the 66-tool surface minus olo_script_tools_reload, which is
+    // registered separately by the editor layer (it needs the project's script
+    // directory + budgets), not by RegisterBuiltinTools.
+    EXPECT_GE(tools.size(), 65u) << "the builtin surface shrank unexpectedly";
+
+    std::set<std::string> seenExempt;
+    for (const Json& tool : tools)
+    {
+        const std::string name = tool.value("name", std::string{});
+        if (kTextOnlyExempt.contains(name))
+        {
+            seenExempt.insert(name);
+            EXPECT_FALSE(tool.contains("outputSchema"))
+                << name << " is listed text-only exempt but now declares a schema — update the exempt list.";
+        }
+        else
+        {
+            EXPECT_TRUE(tool.contains("outputSchema"))
+                << name << " declares no outputSchema — migrate it (ToolResult::Structured + "
+                << "Schema::Object() at registration) or add it to kTextOnlyExempt with a reason.";
+        }
+    }
+    for (const std::string& name : kTextOnlyExempt)
+        EXPECT_TRUE(seenExempt.contains(name)) << name << " is no longer registered at all.";
+}

--- a/OloEngine/tests/MCP/McpProtocolIconsTest.cpp
+++ b/OloEngine/tests/MCP/McpProtocolIconsTest.cpp
@@ -168,8 +168,11 @@ namespace
                                      { "params", Json::object() } });
         ASSERT_TRUE(response.contains("result")) << response.dump(2);
         EXPECT_EQ(response["result"]["capabilities"]["tools"]["listChanged"], true);
-        // Resources / prompts are still fixed for a server run.
-        EXPECT_EQ(response["result"]["capabilities"]["resources"]["listChanged"], false);
+        // The resource registry is republishable at runtime too since the
+        // resource-link work (#673 Tier 1: ephemeral capture resources); only
+        // prompts are still fixed for a server run.
+        EXPECT_EQ(response["result"]["capabilities"]["resources"]["listChanged"], true);
+        EXPECT_EQ(response["result"]["capabilities"]["resources"]["subscribe"], false);
         EXPECT_EQ(response["result"]["capabilities"]["prompts"]["listChanged"], false);
     }
 

--- a/OloEngine/tests/MCP/McpResourceLinkTest.cpp
+++ b/OloEngine/tests/MCP/McpResourceLinkTest.cpp
@@ -1,0 +1,311 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Resource links + the dynamic resource registry (#673 Tier 1, bullet 3).
+// Drives the httplib-free dispatch seam (McpServer.cpp is compiled into the
+// test binary) with fake resources/tools — no live editor, GPU, or socket:
+//   * the binary `blob` contents variant of resources/read (ResourceDef::BlobReader);
+//   * RegisterEphemeralResource: runtime publish, duplicate-URI replace,
+//     oldest-first eviction under the count/byte bounds, startup resources
+//     never evicted, notifications/resources/list_changed fan-out + the
+//     ResourcesGeneration() counter the SSE stream polls;
+//   * the copy-on-write snapshot property (an eviction never invalidates a
+//     held snapshot — what keeps capture bytes alive under an in-flight read);
+//   * ToolResult::ResourceLinkBlock — the resource_link content block the
+//     capture tools emit in link-delivery mode — including its pass-through in
+//     tools/call and path redaction of its human-readable fields.
+#include "MCP/McpServer.h"
+
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ResourceDef;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    using Json = OloEngine::MCP::Json;
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    ResourceDef MakeBlobResource(const std::string& uri, std::vector<u8> bytes,
+                                 const std::string& name = "capture")
+    {
+        ResourceDef resource;
+        resource.Uri = uri;
+        resource.Name = name;
+        resource.Description = "A fake capture.";
+        resource.MimeType = "image/png";
+        resource.SizeBytes = bytes.size();
+        resource.BlobReader = [bytes = std::move(bytes)](McpServer&)
+        { return bytes; };
+        return resource;
+    }
+
+    Json ListResources(McpServer& server)
+    {
+        const Json response = server.HandleMessage(MakeRequest(1, "resources/list"));
+        EXPECT_TRUE(response.contains("result")) << response.dump(2);
+        return response["result"]["resources"];
+    }
+
+    bool ListContains(const Json& resources, const std::string& uri)
+    {
+        for (const auto& entry : resources)
+        {
+            if (entry.value("uri", std::string{}) == uri)
+                return true;
+        }
+        return false;
+    }
+} // namespace
+
+// ---- blob contents variant ---------------------------------------------------
+
+TEST(McpResourceLink, BlobResourceReadReturnsBase64BlobContents)
+{
+    McpServer server{ EditorMcpContext{} };
+    const std::vector<u8> bytes = { 0x89, 'P', 'N', 'G', 0x00, 0xFF };
+    server.RegisterResource(MakeBlobResource("olo://capture/000001/fake.png", bytes));
+
+    const Json response = server.HandleMessage(
+        MakeRequest(2, "resources/read", Json{ { "uri", "olo://capture/000001/fake.png" } }));
+
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    const Json& contents = response["result"]["contents"];
+    ASSERT_TRUE(contents.is_array());
+    ASSERT_EQ(contents.size(), 1u);
+    EXPECT_EQ(contents[0]["uri"], "olo://capture/000001/fake.png");
+    EXPECT_EQ(contents[0]["mimeType"], "image/png");
+    EXPECT_EQ(contents[0]["blob"], OloEngine::MCP::Base64Encode(bytes));
+    EXPECT_FALSE(contents[0].contains("text")) << "binary contents must use blob, not text";
+}
+
+TEST(McpResourceLink, ResourcesListAdvertisesSizeOnlyWhenKnown)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.RegisterResource(MakeBlobResource("olo://capture/1", { 1, 2, 3 }));
+
+    ResourceDef textResource;
+    textResource.Uri = "olo://fake/text";
+    textResource.Name = "text";
+    textResource.Description = "Text resource with unknown size.";
+    textResource.MimeType = "text/plain";
+    textResource.Reader = [](McpServer&)
+    { return std::string("hello"); };
+    server.RegisterResource(std::move(textResource));
+
+    const Json resources = ListResources(server);
+    ASSERT_EQ(resources.size(), 2u);
+    for (const auto& entry : resources)
+    {
+        if (entry["uri"] == "olo://capture/1")
+            EXPECT_EQ(entry["size"], 3);
+        else
+            EXPECT_FALSE(entry.contains("size"));
+    }
+}
+
+// ---- ephemeral publish / eviction --------------------------------------------
+
+TEST(McpResourceLink, EphemeralPublishAppearsInListNotifiesAndBumpsGeneration)
+{
+    McpServer server{ EditorMcpContext{} };
+    std::vector<std::string> notified;
+    server.AddNotificationListener([&notified](const Json& notification)
+                                   { notified.push_back(notification.value("method", std::string{})); });
+
+    const u64 generationBefore = server.ResourcesGeneration();
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/000001/shot.png", { 1, 2, 3, 4 }));
+
+    EXPECT_GT(server.ResourcesGeneration(), generationBefore);
+    ASSERT_EQ(notified.size(), 1u);
+    EXPECT_EQ(notified[0], "notifications/resources/list_changed");
+    EXPECT_TRUE(ListContains(ListResources(server), "olo://capture/000001/shot.png"));
+}
+
+TEST(McpResourceLink, EphemeralCountEvictionDropsOldestFirst)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.SetEphemeralResourceLimits(2, 1024 * 1024);
+
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/1", { 1 }));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/2", { 2 }));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/3", { 3 }));
+
+    const Json resources = ListResources(server);
+    EXPECT_FALSE(ListContains(resources, "olo://capture/1")) << "oldest ephemeral must be evicted";
+    EXPECT_TRUE(ListContains(resources, "olo://capture/2"));
+    EXPECT_TRUE(ListContains(resources, "olo://capture/3"));
+}
+
+TEST(McpResourceLink, EphemeralByteBudgetEvictsUntilWithinBounds)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.SetEphemeralResourceLimits(16, 100);
+
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/big1", std::vector<u8>(60, 0xAA)));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/big2", std::vector<u8>(60, 0xBB)));
+
+    const Json resources = ListResources(server);
+    EXPECT_FALSE(ListContains(resources, "olo://capture/big1")) << "byte budget must evict the oldest";
+    EXPECT_TRUE(ListContains(resources, "olo://capture/big2"));
+}
+
+TEST(McpResourceLink, OversizedSingleCaptureIsStillServed)
+{
+    // A capture bigger than the whole byte budget must not evict ITSELF into a
+    // dead link — the bound only displaces older entries.
+    McpServer server{ EditorMcpContext{} };
+    server.SetEphemeralResourceLimits(16, 10);
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/huge", std::vector<u8>(64, 0xCC)));
+    EXPECT_TRUE(ListContains(ListResources(server), "olo://capture/huge"));
+}
+
+TEST(McpResourceLink, StartupResourcesAreNeverEvicted)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.SetEphemeralResourceLimits(1, 1024);
+
+    ResourceDef startup;
+    startup.Uri = "olo://scene/fake";
+    startup.Name = "scene";
+    startup.Description = "Startup resource.";
+    startup.MimeType = "text/yaml";
+    startup.Reader = [](McpServer&)
+    { return std::string("scene: {}"); };
+    server.RegisterResource(std::move(startup));
+
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/1", { 1 }));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/2", { 2 }));
+
+    const Json resources = ListResources(server);
+    EXPECT_TRUE(ListContains(resources, "olo://scene/fake"));
+    EXPECT_FALSE(ListContains(resources, "olo://capture/1"));
+    EXPECT_TRUE(ListContains(resources, "olo://capture/2"));
+}
+
+TEST(McpResourceLink, ClearEphemeralResourcesRemovesOnlyEphemerals)
+{
+    McpServer server{ EditorMcpContext{} };
+
+    ResourceDef startup;
+    startup.Uri = "olo://logs/fake";
+    startup.Name = "logs";
+    startup.Description = "Startup resource.";
+    startup.MimeType = "text/plain";
+    startup.Reader = [](McpServer&)
+    { return std::string("log line"); };
+    server.RegisterResource(std::move(startup));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/1", { 1 }));
+
+    server.ClearEphemeralResources();
+
+    const Json resources = ListResources(server);
+    ASSERT_EQ(resources.size(), 1u);
+    EXPECT_EQ(resources[0]["uri"], "olo://logs/fake");
+}
+
+TEST(McpResourceLink, DuplicateUriReplacesInsteadOfShadowing)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/same", { 1, 1, 1 }));
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/same", { 2, 2 }));
+
+    const Json resources = ListResources(server);
+    ASSERT_EQ(resources.size(), 1u);
+    EXPECT_EQ(resources[0]["size"], 2);
+
+    const Json response =
+        server.HandleMessage(MakeRequest(3, "resources/read", Json{ { "uri", "olo://capture/same" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["contents"][0]["blob"],
+              OloEngine::MCP::Base64Encode({ 2, 2 }));
+}
+
+// The copy-on-write property the whole design leans on: a snapshot taken before
+// an eviction keeps every ResourceDef (and the capture bytes its BlobReader
+// owns) alive and readable — the resource-registry mirror of the tool-registry
+// swap test in McpProtocolIconsTest.
+TEST(McpResourceLink, HeldSnapshotSurvivesEviction)
+{
+    McpServer server{ EditorMcpContext{} };
+    server.SetEphemeralResourceLimits(1, 1024);
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/old", { 7, 7, 7 }));
+
+    const McpServer::ResourceSnapshot held = server.ResourcesSnapshot();
+    server.RegisterEphemeralResource(MakeBlobResource("olo://capture/new", { 8 })); // evicts "old"
+
+    EXPECT_FALSE(ListContains(ListResources(server), "olo://capture/old"));
+    const OloEngine::MCP::ResourceDef* old = nullptr;
+    for (const auto& entry : *held)
+    {
+        if (entry.Uri == "olo://capture/old")
+            old = &entry;
+    }
+    ASSERT_NE(old, nullptr) << "held snapshot lost an entry across a swap";
+    EXPECT_EQ(old->BlobReader(server), (std::vector<u8>{ 7, 7, 7 }));
+}
+
+// ---- the resource_link content block -----------------------------------------
+
+TEST(McpResourceLink, ResourceLinkBlockFactoryShape)
+{
+    const Json block = ToolResult::ResourceLinkBlock("olo://capture/000001/shot.png", "shot.png",
+                                                     "Viewport capture 1024x768.", "image/png", 123456);
+    EXPECT_EQ(block["type"], "resource_link");
+    EXPECT_EQ(block["uri"], "olo://capture/000001/shot.png");
+    EXPECT_EQ(block["name"], "shot.png");
+    EXPECT_EQ(block["description"], "Viewport capture 1024x768.");
+    EXPECT_EQ(block["mimeType"], "image/png");
+    EXPECT_EQ(block["size"], 123456);
+
+    // Unknown size is omitted, never emitted as 0.
+    const Json noSize = ToolResult::ResourceLinkBlock("olo://x", "x", "d", "image/png");
+    EXPECT_FALSE(noSize.contains("size"));
+}
+
+TEST(McpResourceLink, ToolCallPassesResourceLinkBlockThroughAndRedactsIt)
+{
+    McpServer server{ EditorMcpContext{} };
+    ToolDef tool;
+    tool.Name = "fake_capture";
+    tool.Description = "Returns a resource_link block.";
+    tool.Handler = [](McpServer&, const Json&)
+    {
+        ToolResult result;
+        result.Content = Json::array(
+            { Json{ { "type", "text" }, { "text", "Capture published." } },
+              ToolResult::ResourceLinkBlock("olo://capture/000001/shot.png", "shot.png",
+                                            "Golden at C:\\Projects\\Game\\golden.png", "image/png", 42) });
+        return result;
+    };
+    server.RegisterTool(std::move(tool));
+
+    // Pass-through, unredacted by default.
+    Json response = server.HandleMessage(MakeRequest(4, "tools/call", Json{ { "name", "fake_capture" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    ASSERT_EQ(response["result"]["content"].size(), 2u);
+    EXPECT_EQ(response["result"]["content"][1]["type"], "resource_link");
+    EXPECT_EQ(response["result"]["content"][1]["size"], 42);
+    EXPECT_EQ(response["result"]["content"][1]["description"], "Golden at C:\\Projects\\Game\\golden.png");
+
+    // With redaction on, the human-readable fields lose absolute paths.
+    server.SetRedactPaths(true);
+    response = server.HandleMessage(MakeRequest(5, "tools/call", Json{ { "name", "fake_capture" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["content"][1]["description"], "Golden at <path>");
+    EXPECT_EQ(response["result"]["content"][1]["uri"], "olo://capture/000001/shot.png")
+        << "an olo:// uri carries no path and must survive redaction unchanged";
+}

--- a/OloEngine/tests/MCP/McpScriptToolsTest.cpp
+++ b/OloEngine/tests/MCP/McpScriptToolsTest.cpp
@@ -621,4 +621,46 @@ RegisterMcpTool{ name = "script_bad_icon", description = "malformed icons",
         ASSERT_NE(withoutIcon, tools.end());
         EXPECT_FALSE((*withoutIcon).contains("icons"));
     }
+
+    // ---- outbound-client tools are unreachable from scripts (#673 Tier 1) -----
+
+    // The strongest possible caller — a WRITE-tier script tool under
+    // AllowSession — still cannot reach a tool bridged from an outbound MCP
+    // client through olo.call_tool. The macro-consent bargain covers local,
+    // undoable editor mutations only; an external call leaves the editor's
+    // undo/revert envelope, so routing one through a consented macro would
+    // launder local-write consent into an outbound action (ADR 0005).
+    TEST_F(McpScriptToolsTest, BridgeRefusesExternalClientToolsEvenForWriteTierUnderAllowSession)
+    {
+        ToolDef external;
+        external.Name = "ext.files.read_file";
+        external.Description = "Bridged from a fake external server.";
+        external.InputSchema = Json{ { "type", "object" } };
+        external.Handler = [](McpServer&, const Json&)
+        { return ToolResult::Text("external ran"); };
+        ASSERT_EQ(m_Server.ReplaceClientTools("files", { std::move(external) }), 1u);
+
+        WriteScript("call_ext.lua", R"lua(
+RegisterMcpTool{
+    name = "script_call_ext",
+    description = "Tries to reach an external bridged tool.",
+    writes = true,
+    handler = function(args)
+        local result, err = olo.call_tool("ext.files.read_file", {})
+        if err then return { refused = err } end
+        return { leaked = result }
+    end,
+}
+)lua");
+        ASSERT_EQ(Load().ToolsRegistered, 1);
+        m_Server.SetAllowWrites(true); // maximum authority for the caller
+
+        const Json response = CallTool("script_call_ext");
+        ASSERT_TRUE(response.contains("result")) << response.dump(2);
+        ASSERT_TRUE(response["result"].contains("structuredContent")) << response.dump(2);
+        const Json& payload = response["result"]["structuredContent"];
+        ASSERT_TRUE(payload.contains("refused"))
+            << "the bridge let a script tool reach an external client tool: " << payload.dump(2);
+        EXPECT_NE(payload["refused"].get<std::string>().find("external"), std::string::npos);
+    }
 } // namespace

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -171,6 +171,13 @@ the server, so update the config (or re-copy from the panel) accordingly.
 
 ### Tools
 
+Since the #673 Tier 1 schema sweep, tools whose result is a JSON document declare a real
+`outputSchema` in `tools/list` and return it as typed `structuredContent` alongside the
+spec-required text mirror — parse that instead of scraping the text blob. The exceptions are
+deliberate: `olo_log_tail` returns raw log lines (free text an `outputSchema` cannot
+constrain), and the `format:"markdown"`/`"mermaid"` paths of the dual-format tools stay
+text-only (their schemas describe the json format).
+
 | Tool | What it returns |
 |---|---|
 | `olo_log_tail` | recent engine log lines, filterable by `minLevel` and `tag` |
@@ -201,7 +208,7 @@ the server, so update the config (or re-copy from the panel) accordingly.
 | `olo_script_get_last_errors` | recent C# (Mono) / Lua (Sol2) script exceptions |
 | `olo_reload_script` | **(consented write)** reload the C# script assembly — the editor's *Script ▸ Reload assembly* (Ctrl+R) path — so a rebuilt game assembly is picked up without restarting the editor; reports whether scripting is available, whether the reload ran, and the post-reload script-class count. Gated behind **Agent writes** (Disabled/Prompt/Allow all) |
 | `olo_crash_list` / `olo_crash_get` | crash reports under `CrashReports/` |
-| `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera. In **Play mode** the frame comes from the runtime's primary `CameraComponent`, so poses are refused there (they could only move the unused editor camera) and the reply's `sceneState`/`camera` meta says which camera produced the frame |
+| `olo_screenshot` | the viewport rendered to a PNG image block; optional one-shot camera pose (`camera`/`orbit` + `settleFrames`) with automatic save/restore of the user's camera. In **Play mode** the frame comes from the runtime's primary `CameraComponent`, so poses are refused there (they could only move the unused editor camera) and the reply's `sceneState`/`camera` meta says which camera produced the frame. `delivery:"resource_link"` publishes the PNG as an ephemeral `olo://capture/...` resource + `resource_link` block instead of inline base64 (see [Resources](#resources)) |
 | `olo_camera_get` | the editor camera's pose (position, focal point, yaw/pitch, FOV, clips, viewport size) |
 | `olo_camera_set_pose` | move the editor camera: `position` + (`target` \| `yaw`/`pitch`), optional `fov` |
 | `olo_camera_orbit` | orbit-frame the camera around a world point: `target`, `yaw`, `pitch`, `distance` |
@@ -1467,6 +1474,40 @@ so keep a write-tier tool's description honest about what it changes.
 
 - `olo://scene/current` — the whole active scene serialized to YAML.
 - `olo://logs/recent` — the recent engine log lines.
+- `olo://capture/<seq>/<kind>.png` — **ephemeral capture resources** (issue #673 Tier 1):
+  when a capture tool is called with `delivery: "resource_link"` (`olo_screenshot`,
+  `olo_render_capture_target`, `olo_render_compare_golden`), the PNG is published here
+  instead of being inlined as base64, and the tool result carries a `resource_link`
+  content block referencing it. `resources/read` returns the bytes as base64 `blob`
+  contents. The registry is bounded (16 captures / 128 MB, oldest evicted first — an
+  in-flight read keeps serving the bytes it started with) and cleared on server stop;
+  `capabilities.resources.listChanged` is `true`, and every publish/eviction emits
+  `notifications/resources/list_changed` on the live SSE stream, so re-list after it.
+  Inline base64 stays the default — opt into links for high-res captures.
+
+### Outbound MCP servers (stdio) — composing external tools in (issue #673 Tier 1)
+
+The editor can also *consume* MCP tools: the MCP panel's **"Outbound MCP servers (stdio)"**
+section spawns a local MCP server process (e.g. `npx -y @modelcontextprotocol/server-filesystem
+E:\data`), speaks newline-delimited JSON-RPC over its stdin/stdout, and folds its tools into
+this server's surface under the reserved **`ext.<alias>.*`** namespace (toolset `ext.<alias>`),
+so your agent sees them in the same `tools/list` as the native ones.
+
+Trust posture (ADR 0005 applies — foreign definitions are runtime network data):
+
+- Every bridged tool is **forced to `ProjectWrite`** with `readOnlyHint:false` +
+  `openWorldHint:true`, regardless of what the external server claims: its behaviour lives
+  in another process, so read-only can never be a guarantee. Every call faces the full
+  write-consent gate, and the consent modal says explicitly that the call goes to an
+  **external server and is NOT undoable with Ctrl-Z**.
+- Script tools can never reach a bridged tool through `olo.call_tool` — not even a
+  write-tier script under Allow-all. The macro-consent bargain covers local, undoable
+  editor mutations only.
+- Malformed/namespace-violating tool definitions are dropped with a logged warning, never
+  asserted on. If the child process dies, its tools unpublish immediately
+  (`notifications/tools/list_changed`) and the panel shows the connection as DISCONNECTED.
+- v1 is deliberately stdio-only and does not live-re-merge on the child's
+  `tools/list_changed` (disconnect + reconnect picks up the new list).
 
 ### Prompts (canned workflows)
 


### PR DESCRIPTION
…tputSchema sweep (65/66), capture resource links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connect external MCP servers over stdio and use their tools within the editor.
  * Added management controls for connecting, monitoring, and disconnecting external servers.
  * Added binary resources and resource links for screenshots and render captures, reducing inline payloads.
  * MCP tools now return structured JSON with clearer output schemas.
  * Added ephemeral resource handling with limits, eviction, and live update notifications.
* **Bug Fixes**
  * Improved path redaction while preserving resource links.
  * External tool approvals are clearly identified and excluded from editor undo history.
* **Documentation**
  * Updated MCP diagnostics server guidance for schemas, resources, captures, and external servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->