### PR TITLE
feat(mcp): audience-tagged content blocks + Tier 3 runtime-endpoint ADR (#673)

### DIFF
--- a/OloEditor/src/MCP/McpAudienceReport.h
+++ b/OloEditor/src/MCP/McpAudienceReport.h
@@ -1,0 +1,328 @@
+#pragma once
+
+// Pure, engine-light rendering of a structured MCP tool payload into the
+// HUMAN-facing content block of a dual-audience tool result (issue #673 Tier 2;
+// MCP spec 2025-06-18 `Annotations.audience` on a ContentBlock).
+//
+// A dual-audience result carries the SAME data twice:
+//   * a compact JSON block tagged audience ["assistant"] — what the model
+//     parses (it also receives the identical `structuredContent`), and
+//   * the Markdown report built here, tagged audience ["user"] — what the human
+//     watching the same session reads.
+// Clients that honour annotations show each side only what it asked for;
+// clients that ignore them show both, which is exactly why the machine mirror
+// is emitted compact — the pair then costs about what the single
+// pretty-printed block of ToolResult::Structured() did.
+//
+// Markdown, not space-aligned plain text: a client that renders the user block
+// as Markdown collapses runs of spaces and soft line breaks, which would
+// destroy a space-aligned table. Cells are ALSO padded, so the same string
+// still reads as a tidy table in a raw terminal or log.
+//
+// Engine-free by design (nlohmann + std only), so it unit-tests directly
+// against synthetic payloads — the same pattern as McpPassTimings.h /
+// McpFrameBreakdown.h / McpRenderExplain.h.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace OloEngine::MCP::AudienceReport
+{
+    using Json = nlohmann::json;
+
+    // The human block is a GLANCEABLE summary, never the archive: the assistant
+    // block and `structuredContent` always carry the payload in full, so every
+    // bound below elides rather than loses.
+    inline constexpr sizet kMaxTableRows = 24;       // rows printed per table.
+    inline constexpr sizet kMaxInlineListItems = 12; // items printed for a scalar array.
+    inline constexpr sizet kMaxCellChars = 64;       // characters printed per table cell.
+    inline constexpr sizet kMaxParagraphChars = 600; // characters printed for a long free-text field.
+    // Below this depth a nested object/table is rendered as its own section;
+    // at or beyond it, as one compact-JSON cell. Bounds the report against a
+    // deeply nested payload without needing a per-tool opinion.
+    inline constexpr int kMaxDepth = 3;
+
+    namespace Detail
+    {
+        [[nodiscard]] inline bool IsScalar(const Json& value)
+        {
+            return !value.is_object() && !value.is_array();
+        }
+
+        // An array every element of which is an object — the shape that renders
+        // as a table. An empty array is NOT one (there are no columns to infer).
+        [[nodiscard]] inline bool IsObjectArray(const Json& value)
+        {
+            if (!value.is_array() || value.empty())
+                return false;
+            for (const Json& element : value)
+            {
+                if (!element.is_object())
+                    return false;
+            }
+            return true;
+        }
+
+        // Truncate to at most `maxBytes` WITHOUT splitting a UTF-8 sequence.
+        // nlohmann::json::dump() throws on invalid UTF-8, so a byte-wise resize
+        // through a multi-byte codepoint (an entity name, an asset path) would
+        // turn a cosmetic bound into a failed tool response.
+        [[nodiscard]] inline std::string TruncateUtf8(std::string text, sizet maxBytes)
+        {
+            if (text.size() <= maxBytes)
+                return text;
+            sizet cut = maxBytes;
+            while (cut > 0 && (static_cast<unsigned char>(text[cut]) & 0xC0u) == 0x80u)
+                --cut;
+            text.resize(cut);
+            text.append("...");
+            return text;
+        }
+
+        // One table/field cell: strings raw (no JSON quoting — this is prose,
+        // not a payload), everything else via dump(). Newlines would end the
+        // Markdown row early and a literal '|' would open a phantom column, so
+        // both are neutralised.
+        [[nodiscard]] inline std::string Cell(const Json& value)
+        {
+            const std::string source = value.is_string() ? value.get<std::string>()
+                                       : value.is_null() ? std::string("-")
+                                                         : value.dump();
+            std::string out;
+            out.reserve(source.size());
+            for (const char c : source)
+            {
+                if (c == '\n' || c == '\r' || c == '\t')
+                    out.push_back(' ');
+                else if (c == '|')
+                    out.append("\\|");
+                else
+                    out.push_back(c);
+            }
+            return TruncateUtf8(std::move(out), kMaxCellChars);
+        }
+
+        [[nodiscard]] inline std::string Pad(std::string text, sizet width)
+        {
+            if (text.size() < width)
+                text.append(width - text.size(), ' ');
+            return text;
+        }
+
+        inline void EmitRow(const std::vector<std::string>& cells, const std::vector<sizet>& widths,
+                            std::string& out)
+        {
+            out += '|';
+            for (sizet c = 0; c < cells.size(); ++c)
+            {
+                out += ' ';
+                out += Pad(cells[c], widths[c]);
+                out += " |";
+            }
+            out += '\n';
+        }
+
+        inline void EmitSeparator(const std::vector<sizet>& widths, std::string& out)
+        {
+            out += '|';
+            for (const sizet width : widths)
+            {
+                out += ' ';
+                out.append(width, '-');
+                out += " |";
+            }
+            out += '\n';
+        }
+
+        // A Markdown table over an array of objects. Columns are the union of
+        // the rows' keys in first-appearance order, so a row that omits an
+        // optional field still lines up (missing cells render as "-").
+        inline void RenderTable(const Json& rows, std::string& out)
+        {
+            std::vector<std::string> columns;
+            for (const Json& row : rows)
+            {
+                for (auto it = row.begin(); it != row.end(); ++it)
+                {
+                    if (std::find(columns.begin(), columns.end(), it.key()) == columns.end())
+                        columns.push_back(it.key());
+                }
+            }
+            if (columns.empty())
+            {
+                out += "_(rows carry no fields)_\n";
+                return;
+            }
+
+            const sizet shown = std::min<sizet>(rows.size(), kMaxTableRows);
+            std::vector<std::vector<std::string>> cells;
+            cells.reserve(shown);
+            for (sizet i = 0; i < shown; ++i)
+            {
+                std::vector<std::string> line;
+                line.reserve(columns.size());
+                for (const std::string& column : columns)
+                {
+                    const auto found = rows[i].find(column);
+                    line.push_back(found == rows[i].end() ? std::string("-") : Cell(*found));
+                }
+                cells.push_back(std::move(line));
+            }
+
+            std::vector<sizet> widths;
+            widths.reserve(columns.size());
+            for (const std::string& column : columns)
+                widths.push_back(column.size());
+            for (const auto& line : cells)
+            {
+                for (sizet c = 0; c < columns.size(); ++c)
+                    widths[c] = std::max(widths[c], line[c].size());
+            }
+
+            EmitRow(columns, widths, out);
+            EmitSeparator(widths, out);
+            for (const auto& line : cells)
+                EmitRow(line, widths, out);
+            if (rows.size() > shown)
+            {
+                out += "_... " + std::to_string(rows.size() - shown) +
+                       " more row(s) omitted; the JSON block has the full list._\n";
+            }
+        }
+
+        // Split one object's members into the four things they can render as,
+        // preserving key order within each bucket, then emit scalars first (the
+        // at-a-glance summary), prose second, and the structural sections last.
+        inline void RenderObject(const Json& object, int depth, std::string& out)
+        {
+            std::vector<std::pair<std::string, std::string>> fields;
+            std::vector<std::pair<std::string, std::string>> paragraphs;
+            std::vector<std::pair<std::string, const Json*>> sections;
+            std::vector<std::pair<std::string, const Json*>> tables;
+
+            for (auto it = object.begin(); it != object.end(); ++it)
+            {
+                const Json& value = it.value();
+                if (value.is_object())
+                {
+                    if (value.empty())
+                        fields.emplace_back(it.key(), "(empty)");
+                    else if (depth >= kMaxDepth)
+                        fields.emplace_back(it.key(), Cell(value));
+                    else
+                        sections.emplace_back(it.key(), &value);
+                }
+                else if (IsObjectArray(value))
+                {
+                    if (depth >= kMaxDepth)
+                        fields.emplace_back(it.key(), Cell(value));
+                    else
+                        tables.emplace_back(it.key(), &value);
+                }
+                else if (value.is_array())
+                {
+                    if (value.empty())
+                    {
+                        fields.emplace_back(it.key(), "(none)");
+                    }
+                    else
+                    {
+                        std::string joined;
+                        sizet emitted = 0;
+                        for (const Json& element : value)
+                        {
+                            if (emitted == kMaxInlineListItems)
+                            {
+                                joined += ", ...";
+                                break;
+                            }
+                            if (emitted > 0)
+                                joined += ", ";
+                            joined += Cell(element);
+                            ++emitted;
+                        }
+                        fields.emplace_back(it.key(), TruncateUtf8(std::move(joined), kMaxParagraphChars));
+                    }
+                }
+                else if (value.is_string() && value.get<std::string>().size() > kMaxCellChars)
+                {
+                    // A `note` / `warning` / explainer sentence: a table cell
+                    // would elide the part that matters, so give it a paragraph.
+                    paragraphs.emplace_back(it.key(),
+                                            TruncateUtf8(value.get<std::string>(), kMaxParagraphChars));
+                }
+                else
+                {
+                    fields.emplace_back(it.key(), Cell(value));
+                }
+            }
+
+            if (!fields.empty())
+            {
+                const std::vector<std::string> header = { "field", "value" };
+                std::vector<sizet> widths = { header[0].size(), header[1].size() };
+                for (const auto& [key, value] : fields)
+                {
+                    widths[0] = std::max(widths[0], key.size());
+                    widths[1] = std::max(widths[1], value.size());
+                }
+                EmitRow(header, widths, out);
+                EmitSeparator(widths, out);
+                for (const auto& [key, value] : fields)
+                    EmitRow({ key, value }, widths, out);
+                out += '\n';
+            }
+
+            for (const auto& [key, text] : paragraphs)
+                out += "**" + key + "**\n\n" + text + "\n\n";
+
+            for (const auto& [key, nested] : sections)
+            {
+                out += "**" + key + "**\n\n";
+                RenderObject(*nested, depth + 1, out);
+            }
+
+            for (const auto& [key, rows] : tables)
+            {
+                out += "**" + key + "** (" + std::to_string(rows->size()) + ")\n\n";
+                RenderTable(*rows, out);
+                out += '\n';
+            }
+        }
+    } // namespace Detail
+
+    // Render `data` as the Markdown report for the user-audience content block.
+    // `title` becomes the heading (omitted when empty). Always returns a
+    // non-empty, newline-terminated string, so the block is never blank.
+    [[nodiscard]] inline std::string Render(const Json& data, std::string_view title)
+    {
+        std::string out;
+        if (!title.empty())
+        {
+            out += "### ";
+            out.append(title);
+            out += "\n\n";
+        }
+
+        if (data.is_object() && !data.empty())
+            Detail::RenderObject(data, 0, out);
+        else if (data.is_object() || data.is_null())
+            out += "_(no data)_\n";
+        else if (Detail::IsObjectArray(data))
+            Detail::RenderTable(data, out);
+        else
+            out += Detail::Cell(data) + "\n";
+
+        while (!out.empty() && out.back() == '\n')
+            out.pop_back();
+        out += '\n';
+        return out;
+    }
+} // namespace OloEngine::MCP::AudienceReport

--- a/OloEditor/src/MCP/McpAudienceReport.h
+++ b/OloEditor/src/MCP/McpAudienceReport.h
@@ -86,15 +86,18 @@ namespace OloEngine::MCP::AudienceReport
             return text;
         }
 
-        // One table/field cell: strings raw (no JSON quoting — this is prose,
-        // not a payload), everything else via dump(). Newlines would end the
-        // Markdown row early and a literal '|' would open a phantom column, so
-        // both are neutralised.
-        [[nodiscard]] inline std::string Cell(const Json& value)
+        // Make one piece of text safe to drop into a Markdown table: a newline
+        // would end the row early and a literal '|' would open a phantom column,
+        // so both are neutralised, then the result is bounded.
+        //
+        // Applied to KEYS as well as values. Today's payload keys are all
+        // code-controlled field names, but a JSON object keyed by data (a
+        // `std::unordered_map<std::string, V>` field — entity/morph-target names,
+        // asset paths) renders its keys as column headers or section titles, and
+        // one stray '|' there would corrupt the whole table. Cheap insurance on a
+        // renderer that is deliberately generic over any tool's payload.
+        [[nodiscard]] inline std::string SanitizeText(const std::string& source)
         {
-            const std::string source = value.is_string() ? value.get<std::string>()
-                                       : value.is_null() ? std::string("-")
-                                                         : value.dump();
             std::string out;
             out.reserve(source.size());
             for (const char c : source)
@@ -107,6 +110,15 @@ namespace OloEngine::MCP::AudienceReport
                     out.push_back(c);
             }
             return TruncateUtf8(std::move(out), kMaxCellChars);
+        }
+
+        // One table/field cell: strings raw (no JSON quoting — this is prose, not
+        // a payload), everything else via dump().
+        [[nodiscard]] inline std::string Cell(const Json& value)
+        {
+            return SanitizeText(value.is_string() ? value.get<std::string>()
+                                : value.is_null() ? std::string("-")
+                                                  : value.dump());
         }
 
         [[nodiscard]] inline std::string Pad(std::string text, sizet width)
@@ -161,6 +173,15 @@ namespace OloEngine::MCP::AudienceReport
                 return;
             }
 
+            // `columns` stays RAW for row.find(); `headers` is the escaped form
+            // that is actually printed and sized. Keeping them parallel (rather
+            // than escaping in place) is what lets a key containing '|' still
+            // resolve its cells.
+            std::vector<std::string> headers;
+            headers.reserve(columns.size());
+            for (const std::string& column : columns)
+                headers.push_back(SanitizeText(column));
+
             const sizet shown = std::min<sizet>(rows.size(), kMaxTableRows);
             std::vector<std::vector<std::string>> cells;
             cells.reserve(shown);
@@ -177,16 +198,16 @@ namespace OloEngine::MCP::AudienceReport
             }
 
             std::vector<sizet> widths;
-            widths.reserve(columns.size());
-            for (const std::string& column : columns)
-                widths.push_back(column.size());
+            widths.reserve(headers.size());
+            for (const std::string& header : headers)
+                widths.push_back(header.size());
             for (const auto& line : cells)
             {
-                for (sizet c = 0; c < columns.size(); ++c)
+                for (sizet c = 0; c < headers.size(); ++c)
                     widths[c] = std::max(widths[c], line[c].size());
             }
 
-            EmitRow(columns, widths, out);
+            EmitRow(headers, widths, out);
             EmitSeparator(widths, out);
             for (const auto& line : cells)
                 EmitRow(line, widths, out);
@@ -210,27 +231,30 @@ namespace OloEngine::MCP::AudienceReport
             for (auto it = object.begin(); it != object.end(); ++it)
             {
                 const Json& value = it.value();
+                // Escape once, here: every bucket below prints the key — as a
+                // table cell, or inside a bold section/table title.
+                const std::string key = SanitizeText(it.key());
                 if (value.is_object())
                 {
                     if (value.empty())
-                        fields.emplace_back(it.key(), "(empty)");
+                        fields.emplace_back(key, "(empty)");
                     else if (depth >= kMaxDepth)
-                        fields.emplace_back(it.key(), Cell(value));
+                        fields.emplace_back(key, Cell(value));
                     else
-                        sections.emplace_back(it.key(), &value);
+                        sections.emplace_back(key, &value);
                 }
                 else if (IsObjectArray(value))
                 {
                     if (depth >= kMaxDepth)
-                        fields.emplace_back(it.key(), Cell(value));
+                        fields.emplace_back(key, Cell(value));
                     else
-                        tables.emplace_back(it.key(), &value);
+                        tables.emplace_back(key, &value);
                 }
                 else if (value.is_array())
                 {
                     if (value.empty())
                     {
-                        fields.emplace_back(it.key(), "(none)");
+                        fields.emplace_back(key, "(none)");
                     }
                     else
                     {
@@ -248,19 +272,19 @@ namespace OloEngine::MCP::AudienceReport
                             joined += Cell(element);
                             ++emitted;
                         }
-                        fields.emplace_back(it.key(), TruncateUtf8(std::move(joined), kMaxParagraphChars));
+                        fields.emplace_back(key, TruncateUtf8(std::move(joined), kMaxParagraphChars));
                     }
                 }
                 else if (value.is_string() && value.get<std::string>().size() > kMaxCellChars)
                 {
                     // A `note` / `warning` / explainer sentence: a table cell
                     // would elide the part that matters, so give it a paragraph.
-                    paragraphs.emplace_back(it.key(),
+                    paragraphs.emplace_back(key,
                                             TruncateUtf8(value.get<std::string>(), kMaxParagraphChars));
                 }
                 else
                 {
-                    fields.emplace_back(it.key(), Cell(value));
+                    fields.emplace_back(key, Cell(value));
                 }
             }
 

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -6,6 +6,7 @@
 #include <httplib.h>
 
 #include "MCP/McpServer.h"
+#include "MCP/McpAudienceReport.h"
 #include "MCP/McpEventStream.h"
 
 #include "OloEngine/Core/Log.h"
@@ -659,6 +660,38 @@ namespace OloEngine::MCP
         if (sizeBytes > 0)
             block["size"] = sizeBytes;
         return block;
+    }
+
+    Json& ToolResult::AnnotateBlock(Json& block, Audience audience, f64 priority)
+    {
+        Json annotations{ { "audience",
+                            Json::array({ audience == Audience::User ? "user" : "assistant" }) } };
+        // Clamp rather than trust the caller: an out-of-range priority is not a
+        // spec-legal hint, and a tool author passing 100 "for emphasis" would
+        // otherwise ship an invalid annotation to every client.
+        if (priority >= 0.0)
+            annotations["priority"] = std::clamp(priority, 0.0, 1.0);
+        block["annotations"] = std::move(annotations);
+        return block;
+    }
+
+    ToolResult ToolResult::StructuredDualAudience(const Json& data, std::string_view title)
+    {
+        ToolResult r;
+        // dump() compact, not dump(2): the model also receives the identical
+        // `structuredContent`, and a client that ignores audience annotations
+        // renders BOTH blocks — emitting the machine mirror compact keeps that
+        // pair costing about what Structured()'s single pretty-printed block did.
+        Json machine{ { "type", "text" }, { "text", data.dump() } };
+        AnnotateBlock(machine, Audience::Assistant, kAssistantBlockPriority);
+
+        Json human{ { "type", "text" }, { "text", AudienceReport::Render(data, title) } };
+        AnnotateBlock(human, Audience::User, kUserBlockPriority);
+
+        r.Content = Json::array({ std::move(machine), std::move(human) });
+        r.StructuredContent = data;
+        r.IsError = false;
+        return r;
     }
 
     // ---- McpServer -------------------------------------------------------------
@@ -2204,6 +2237,20 @@ namespace OloEngine::MCP
         // cancellation arrived — the client has already stopped listening.
         if (scope.CancelFlag->load(std::memory_order_acquire))
             return MakeError(id, kRequestCancelledCode, "Request cancelled");
+
+        // Audience-tagged content blocks for a tool that declared them (#673 Tier
+        // 2). Rebuilding from StructuredContent — rather than annotating what the
+        // handler returned — is what makes the machine block compact; the
+        // single-block guard means a handler that appended its own extra block (a
+        // resource_link) or already emitted the pair itself is left alone, so this
+        // is idempotent and never drops content. Runs BEFORE redaction so the
+        // human report is scrubbed on exactly the same terms as the JSON mirror.
+        if (tool->DualAudienceContent && !result.IsError && !result.StructuredContent.is_null() &&
+            result.Content.is_array() && result.Content.size() == 1)
+        {
+            result = ToolResult::StructuredDualAudience(result.StructuredContent,
+                                                        tool->Title.empty() ? tool->Name : tool->Title);
+        }
 
         if (RedactPaths())
         {

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -168,6 +168,53 @@ namespace OloEngine::MCP
         [[nodiscard]] static Json ResourceLinkBlock(const std::string& uri, const std::string& name,
                                                     const std::string& description, const std::string& mimeType,
                                                     u64 sizeBytes = 0);
+
+        // ---- audience-tagged content blocks (#673 Tier 2) ---------------------
+        //
+        // Which side of the session one CONTENT BLOCK is meant for (MCP spec
+        // 2025-06-18 `Annotations.audience`). This is a different spec field on a
+        // different object from ToolDef::Annotations, which carries the tool-level
+        // readOnlyHint / openWorldHint hints — don't conflate the two.
+        //
+        // Absent annotations already mean "no preference", so there is deliberately
+        // no `Both`: a block for everyone is simply left unannotated.
+        enum class Audience : u8
+        {
+            Assistant, // the model driving the session: compact and parseable.
+            User,      // the human watching it: formatted and glanceable.
+        };
+
+        // Spec priority is an importance hint in [0,1] — 1 is "effectively
+        // required", 0 "entirely optional". The machine block IS the result, so it
+        // is required; the human rendering is presentation over the same data, so a
+        // client under pressure may drop it first.
+        static constexpr f64 kAssistantBlockPriority = 1.0;
+        static constexpr f64 kUserBlockPriority = 0.3;
+
+        // Stamp `annotations` onto one content block in place and return it, so it
+        // composes with the block factories (e.g. AnnotateBlock(ResourceLinkBlock(...),
+        // Audience::User)). A negative `priority` omits the field rather than
+        // emitting a meaningless 0 (the same omit-when-unset rule as `size` on a
+        // resource link). `audience` is always written, so `annotations` is never
+        // emitted as an empty object.
+        static Json& AnnotateBlock(Json& block, Audience audience, f64 priority = -1.0);
+
+        // Typed success result that renders its payload TWICE, each block tagged
+        // for one audience: a compact `data.dump()` for the assistant and a
+        // Markdown report (McpAudienceReport.h) for the human. `StructuredContent`
+        // is `data`, exactly as with Structured(), so the outputSchema contract is
+        // unchanged and only the `content` array differs. The assistant block stays
+        // at index 0 — content[0] remains the machine-readable JSON mirror.
+        //
+        // WHEN TO ADOPT THIS OVER Structured(): only when a human watching the
+        // session would genuinely read the payload differently from how the model
+        // parses it — i.e. it is multi-field or tabular AND is something you'd stare
+        // at while debugging (a per-pass timing table, a per-channel stats table, an
+        // explainer's check list). For a one-scalar result, a status echo, or a
+        // payload that is already a sentence, a second rendering is noise: keep
+        // Structured(). Blanket adoption across the whole tool surface would be
+        // bloat, not spec parity.
+        [[nodiscard]] static ToolResult StructuredDualAudience(const Json& data, std::string_view title);
     };
 
     class McpServer;
@@ -271,6 +318,26 @@ namespace OloEngine::MCP
         // empty => omitted from tools/list entirely (never emit an empty
         // `icons` key). Validated by McpServer::IsValidIcons at registration.
         Json Icons;
+        // Opt in to AUDIENCE-TAGGED content blocks for this tool's typed results
+        // (#673 Tier 2). When true, HandleToolsCall re-shapes a successful
+        // ToolResult::Structured() into the dual-audience pair via
+        // ToolResult::StructuredDualAudience — a compact JSON block tagged
+        // audience ["assistant"] plus a Markdown report tagged ["user"], headed by
+        // `Title` (falling back to `Name`). The handler stays a plain
+        // `ToolResult::Structured(...)`; adoption is declared HERE, next to
+        // OutputSchema and Annotations, so the adopter set is inspectable from
+        // registration alone — which is what McpAudienceBlocksTest ratchets
+        // without ever issuing a tools/call.
+        //
+        // THE INCLUSION RULE — set this only when a human watching the session
+        // would genuinely read the payload differently from how the model parses
+        // it: the result is multi-field or tabular AND is something you'd stare at
+        // while debugging (a per-pass timing table, per-channel target stats, an
+        // explainer's check list). For a one-scalar result, a status echo, or a
+        // payload that is already a sentence, the second rendering is pure noise —
+        // leave this false. Blanket adoption across the tool surface would be
+        // bloat, not spec parity.
+        bool DualAudienceContent = false;
     };
 
     // Snapshot of the editor camera's full pose, returned by GetCameraPose and

--- a/OloEditor/src/MCP/McpToolsPerf.cpp
+++ b/OloEditor/src/MCP/McpToolsPerf.cpp
@@ -362,6 +362,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_memory_report";
             tool.Toolset = "perf";
             tool.Title = "Renderer memory report";
+            // The per-resource-type breakdown is the editor's own memory table —
+            // a human reads it as rows, not as JSON.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Renderer GPU/CPU memory usage: total bytes/MB, a per-resource-type breakdown (vertex/index/"
@@ -389,6 +392,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_perf_snapshot";
             tool.Toolset = "perf";
             tool.Title = "Performance snapshot";
+            // ~18 frame counters: a human scans them as an aligned table, the
+            // model wants the object.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Current-frame renderer performance: fps, frame/CPU/GPU time (ms), draw calls, instanced "
@@ -515,6 +521,8 @@ namespace OloEngine::MCP
             tool.Name = "olo_perf_pass_timings";
             tool.Toolset = "perf";
             tool.Title = "Per-pass GPU timings";
+            // A per-pass gpuMs/cpuMs table is THE "where did the frame go" read.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Whole-frame GPU time split by render-graph pass (Shadow vs Scene vs GTAO vs Bloom vs "
@@ -558,6 +566,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_perf_cpu_scopes";
             tool.Toolset = "perf";
             tool.Title = "Per-scope CPU timings";
+            // Literally the editor's PerformanceLayer CPU Scopes table — the
+            // strongest possible evidence a human wants it back as a table.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Per-scope CPU time from PerformanceProfiler — every system in Scene.cpp (and other "

--- a/OloEditor/src/MCP/McpToolsPhysics.cpp
+++ b/OloEditor/src/MCP/McpToolsPhysics.cpp
@@ -967,6 +967,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_physics_why_no_collision";
             tool.Toolset = "physics";
             tool.Title = "Explain missing collision";
+            // An explainer's ordered check list is the one result a human reads
+            // end-to-end rather than greps.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Explain why two entities are NOT colliding — the 'player falls through the floor' debugger. "

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -4340,8 +4340,8 @@ namespace OloEngine::MCP
             tool.Toolset = "render";
             tool.Title = "Export render graph topology";
             // passes / edges / resources are three tables a human scans to see the
-            // graph's shape. The `format: "dot"` variant returns free text with no
-            // structuredContent, so the dispatcher's guard leaves it untouched.
+            // graph's shape. The `format: "mermaid"` variant returns free text with
+            // no structuredContent, so the dispatcher's guard leaves it untouched.
             tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -4229,6 +4229,8 @@ namespace OloEngine::MCP
             tool.Name = "olo_render_frame_breakdown";
             tool.Toolset = "render";
             tool.Title = "Frame command breakdown";
+            // The command list + per-pass breakdown are tables a human reads down.
+            tool.DualAudienceContent = true;
             // Same transient one-frame capture as olo_perf_capture_frame — read-only.
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -4337,6 +4339,10 @@ namespace OloEngine::MCP
             tool.Name = "olo_render_graph_topology_export";
             tool.Toolset = "render";
             tool.Title = "Export render graph topology";
+            // passes / edges / resources are three tables a human scans to see the
+            // graph's shape. The `format: "dot"` variant returns free text with no
+            // structuredContent, so the dispatcher's guard leaves it untouched.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Export the live render graph's topology as structured data for reasoning about the render "
@@ -4891,6 +4897,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_render_why_not_visible";
             tool.Toolset = "render";
             tool.Title = "Explain entity not visible";
+            // An explainer's ordered check list is the one result a human reads
+            // end-to-end rather than greps.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Explain why an entity is NOT visible on screen — the rendering counterpart of "
@@ -5024,6 +5033,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_render_target_stats";
             tool.Toolset = "render";
             tool.Title = "Exact stats over a render-target region";
+            // Per-channel min/max/mean/NaN is a table — the numeric read that
+            // replaces squinting at a capture PNG.
+            tool.DualAudienceContent = true;
             // A bounded rect readback; changes no camera / setting / scene state.
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
@@ -5329,6 +5341,9 @@ namespace OloEngine::MCP
             tool.Name = "olo_cluster_grid_stats";
             tool.Toolset = "render";
             tool.Title = "Clustered light-grid stats";
+            // The per-slice + histogram tables are how a human sees WHERE the cull
+            // is hot, not merely that it is.
+            tool.DualAudienceContent = true;
             // Stages the light-grid SSBOs through a temporary read buffer; no
             // observable state changes.
             tool.Annotations = ReadOnlyAnnotations();
@@ -5479,6 +5494,8 @@ namespace OloEngine::MCP
             tool.Name = "olo_shadow_atlas_layout";
             tool.Toolset = "render";
             tool.Title = "Shadow atlas layout";
+            // Who won a tile vs who was STARVED is a two-table read at a glance.
+            tool.DualAudienceContent = true;
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Report this frame's local-light shadow-atlas allocation — every shadow-casting spot / "

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -564,6 +564,13 @@ add_executable(OloEngine-Tests
 		# a well-formed open object and pins the set of schema-declaring tools.
 		# Uses the McpTools*.cpp TUs already pulled in above.
 		MCP/McpOutputSchemaCoverageTest.cpp
+		# Audience-tagged content blocks (#673 Tier 2): the ToolResult::AnnotateBlock /
+		# StructuredDualAudience mechanism + the ToolDef::DualAudienceContent
+		# re-shaping in HandleToolsCall (fake tools over the dispatch seam), the pure
+		# Markdown renderer (MCP/McpAudienceReport.h), and the adoption ratchet over
+		# the REAL builtin surface — registration-only like the outputSchema guard
+		# above, so no handler runs and no game thread / GL is needed.
+		MCP/McpAudienceBlocksTest.cpp
 		# JSON-Schema builder DSL + byte-identical equivalence with the migrated tool
 		# schema literals (#357 Tier 2 P4). Header-only (MCP/McpSchemaBuilder.h,
 		# nlohmann::json + stdlib only), so no extra editor TU is pulled in.

--- a/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
+++ b/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
@@ -1,0 +1,425 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Audience-tagged content blocks (#673 Tier 2; MCP spec 2025-06-18
+// `Annotations.audience` / `.priority` on a ContentBlock). Three concerns, in
+// increasing scope:
+//
+//   1. The MECHANISM, over the httplib-free dispatch seam with fake tools:
+//      ToolResult::AnnotateBlock's emitted shape, ToolResult::StructuredDualAudience,
+//      and the ToolDef::DualAudienceContent re-shaping in HandleToolsCall —
+//      including the guards that make it idempotent and content-preserving.
+//   2. The pure Markdown renderer (MCP/McpAudienceReport.h) that produces the
+//      user block: tables, elision bounds, and the escaping/truncation rules
+//      that keep the result valid Markdown AND valid UTF-8.
+//   3. The ADOPTION RATCHET over the REAL builtin surface. Like
+//      McpOutputSchemaCoverageTest this is registration-only — it drives
+//      RegisterBuiltinTools and reads the ToolDefs, never issuing a tools/call —
+//      so no handler runs, no game thread is pumped, and no GL context is
+//      needed. That is exactly why adoption is declared on the ToolDef rather
+//      than chosen inside the handler.
+//
+// NOTE this is a DIFFERENT spec field from ToolDef::Annotations (readOnlyHint /
+// openWorldHint), which McpToolAnnotationsTest guards: those annotate the tool
+// DECLARATION, these annotate content blocks inside a tool RESULT.
+#include "MCP/McpAudienceReport.h"
+#include "MCP/McpServer.h"
+#include "MCP/McpTools.h"
+
+#include <set>
+#include <string>
+#include <utility>
+
+namespace
+{
+    using OloEngine::MCP::EditorMcpContext;
+    using OloEngine::MCP::McpServer;
+    using OloEngine::MCP::ToolDef;
+    using OloEngine::MCP::ToolResult;
+    namespace AudienceReport = OloEngine::MCP::AudienceReport;
+    using Json = OloEngine::MCP::Json;
+
+    Json MakeRequest(const Json& id, const std::string& method, const Json& params = Json::object())
+    {
+        Json req = { { "jsonrpc", "2.0" }, { "method", method } };
+        if (!id.is_null())
+            req["id"] = id;
+        if (!params.is_null())
+            req["params"] = params;
+        return req;
+    }
+
+    Json SamplePayload()
+    {
+        return Json{ { "drawCalls", 412 },
+                     { "frameTimeMs", 17.2 },
+                     { "passes", Json::array({ Json{ { "pass", "ShadowPass" }, { "gpuMs", 1.2 } },
+                                               Json{ { "pass", "ScenePass" }, { "gpuMs", 6.7 } } }) } };
+    }
+
+    // A tool that declares the dual-audience opt-in and returns a plain
+    // Structured() result — the shape every real adopter has.
+    void AddDualAudienceTool(McpServer& server, std::string name, Json payload = SamplePayload())
+    {
+        ToolDef tool;
+        tool.Name = std::move(name);
+        tool.Title = "Fake report";
+        tool.Description = "A dual-audience tool.";
+        tool.DualAudienceContent = true;
+        tool.Handler = [payload = std::move(payload)](McpServer&, const Json&)
+        { return ToolResult::Structured(payload); };
+        server.RegisterTool(std::move(tool));
+    }
+
+    Json CallTool(McpServer& server, const Json& id, const std::string& name)
+    {
+        return server.HandleMessage(MakeRequest(id, "tools/call", Json{ { "name", name } }));
+    }
+
+    // Every ToolDef the real builtin registration produces. The snapshot is a
+    // shared_ptr<const ToolList>, so it outlives the local server — no handler is
+    // ever invoked, only the declarations are read.
+    const McpServer::ToolList& BuiltinTools()
+    {
+        static const McpServer::ToolSnapshot snapshot = []
+        {
+            McpServer server{ EditorMcpContext{} };
+            OloEngine::MCP::RegisterBuiltinTools(server);
+            return server.ToolsSnapshot();
+        }();
+        return *snapshot;
+    }
+} // namespace
+
+// ---- AnnotateBlock: the emitted annotation shape ------------------------------
+
+TEST(McpAudienceBlocks, AnnotateBlockEmitsAudienceArrayAndPriority)
+{
+    Json block{ { "type", "text" }, { "text", "hi" } };
+    ToolResult::AnnotateBlock(block, ToolResult::Audience::User, 0.25);
+
+    ASSERT_TRUE(block.contains("annotations"));
+    const Json& annotations = block["annotations"];
+    ASSERT_TRUE(annotations["audience"].is_array());
+    ASSERT_EQ(annotations["audience"].size(), 1u);
+    EXPECT_EQ(annotations["audience"][0], "user");
+    EXPECT_DOUBLE_EQ(annotations["priority"].get<double>(), 0.25);
+    // The block itself is untouched apart from the added key.
+    EXPECT_EQ(block["text"], "hi");
+}
+
+TEST(McpAudienceBlocks, AnnotateBlockOmitsPriorityWhenUnset)
+{
+    Json block{ { "type", "text" }, { "text", "hi" } };
+    ToolResult::AnnotateBlock(block, ToolResult::Audience::Assistant);
+
+    EXPECT_EQ(block["annotations"]["audience"][0], "assistant");
+    EXPECT_FALSE(block["annotations"].contains("priority"))
+        << "an unset priority must be omitted, never emitted as 0 (0 means 'entirely optional')";
+}
+
+TEST(McpAudienceBlocks, AnnotateBlockClampsAnOutOfRangePriority)
+{
+    Json high{ { "type", "text" } };
+    Json low{ { "type", "text" } };
+    ToolResult::AnnotateBlock(high, ToolResult::Audience::User, 42.0);
+    ToolResult::AnnotateBlock(low, ToolResult::Audience::User, 0.0);
+    EXPECT_DOUBLE_EQ(high["annotations"]["priority"].get<double>(), 1.0);
+    EXPECT_DOUBLE_EQ(low["annotations"]["priority"].get<double>(), 0.0);
+}
+
+// It composes with the other block factories rather than replacing them.
+TEST(McpAudienceBlocks, AnnotateBlockComposesWithResourceLinkBlock)
+{
+    Json link = ToolResult::ResourceLinkBlock("olo://capture/1", "shot.png", "A capture.", "image/png", 9);
+    ToolResult::AnnotateBlock(link, ToolResult::Audience::User, 0.5);
+    EXPECT_EQ(link["type"], "resource_link");
+    EXPECT_EQ(link["size"], 9);
+    EXPECT_EQ(link["annotations"]["audience"][0], "user");
+}
+
+// ---- StructuredDualAudience: the factory --------------------------------------
+
+TEST(McpAudienceBlocks, DualAudienceFactoryEmitsOneBlockPerAudience)
+{
+    const Json data = SamplePayload();
+    const ToolResult r = ToolResult::StructuredDualAudience(data, "Performance snapshot");
+
+    EXPECT_FALSE(r.IsError);
+    EXPECT_EQ(r.StructuredContent, data) << "structuredContent is unchanged — only `content` differs";
+    ASSERT_TRUE(r.Content.is_array());
+    ASSERT_EQ(r.Content.size(), 2u);
+
+    // Block 0 stays the machine-readable JSON mirror, so content[0] keeps meaning
+    // what it always meant for a client that only reads the first block.
+    EXPECT_EQ(r.Content[0]["type"], "text");
+    EXPECT_EQ(r.Content[0]["annotations"]["audience"][0], "assistant");
+    EXPECT_EQ(Json::parse(r.Content[0]["text"].get<std::string>()), data);
+    EXPECT_EQ(r.Content[0]["text"], data.dump()) << "the machine mirror is compact, not dump(2)";
+
+    EXPECT_EQ(r.Content[1]["type"], "text");
+    EXPECT_EQ(r.Content[1]["annotations"]["audience"][0], "user");
+    const std::string report = r.Content[1]["text"].get<std::string>();
+    EXPECT_NE(report.find("Performance snapshot"), std::string::npos);
+    EXPECT_NE(report.find("ShadowPass"), std::string::npos);
+
+    // Priorities: the data is required, the rendering is presentational.
+    EXPECT_GT(r.Content[0]["annotations"]["priority"].get<double>(),
+              r.Content[1]["annotations"]["priority"].get<double>());
+}
+
+// ---- dispatch: ToolDef::DualAudienceContent -----------------------------------
+
+TEST(McpAudienceBlocks, ToolsCallReshapesADeclaredToolIntoTwoAudienceBlocks)
+{
+    McpServer server{ EditorMcpContext{} };
+    AddDualAudienceTool(server, "olo_fake_dual");
+
+    const Json resp = CallTool(server, 1, "olo_fake_dual");
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    const Json& content = resp["result"]["content"];
+    ASSERT_EQ(content.size(), 2u);
+    EXPECT_EQ(content[0]["annotations"]["audience"][0], "assistant");
+    EXPECT_EQ(content[1]["annotations"]["audience"][0], "user");
+    // The typed result is untouched by the re-shaping.
+    EXPECT_EQ(resp["result"]["structuredContent"], SamplePayload());
+    // The heading comes from ToolDef::Title.
+    EXPECT_NE(content[1]["text"].get<std::string>().find("Fake report"), std::string::npos);
+}
+
+TEST(McpAudienceBlocks, ToolsCallLeavesAnUndeclaredToolAlone)
+{
+    McpServer server{ EditorMcpContext{} };
+    ToolDef tool;
+    tool.Name = "olo_fake_plain";
+    tool.Description = "A plain structured tool.";
+    tool.Handler = [](McpServer&, const Json&)
+    { return ToolResult::Structured(SamplePayload()); };
+    server.RegisterTool(std::move(tool));
+
+    const Json resp = CallTool(server, 2, "olo_fake_plain");
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    const Json& content = resp["result"]["content"];
+    ASSERT_EQ(content.size(), 1u) << "opting out must leave the single-block shape byte-identical";
+    EXPECT_EQ(content[0]["text"], SamplePayload().dump(2));
+    EXPECT_FALSE(content[0].contains("annotations"));
+}
+
+// The guards: the re-shaping only fires on a plain single-block typed success,
+// so it can never drop a block a handler deliberately added, annotate an error,
+// or double-apply to a result that already carries the pair.
+TEST(McpAudienceBlocks, ReshapingSkipsErrorsTextResultsAndExtraBlocks)
+{
+    McpServer server{ EditorMcpContext{} };
+
+    ToolDef failing;
+    failing.Name = "olo_fake_dual_error";
+    failing.Description = "Fails.";
+    failing.DualAudienceContent = true;
+    failing.Handler = [](McpServer&, const Json&)
+    { return ToolResult::Error("boom"); };
+    server.RegisterTool(std::move(failing));
+
+    ToolDef textual;
+    textual.Name = "olo_fake_dual_text";
+    textual.Description = "Text only.";
+    textual.DualAudienceContent = true;
+    textual.Handler = [](McpServer&, const Json&)
+    { return ToolResult::Text("digraph {}"); };
+    server.RegisterTool(std::move(textual));
+
+    ToolDef withLink;
+    withLink.Name = "olo_fake_dual_link";
+    withLink.Description = "Structured plus a resource link.";
+    withLink.DualAudienceContent = true;
+    withLink.Handler = [](McpServer&, const Json&)
+    {
+        ToolResult r = ToolResult::Structured(SamplePayload());
+        r.Content.push_back(ToolResult::ResourceLinkBlock("olo://capture/1", "shot.png", "A capture.", "image/png"));
+        return r;
+    };
+    server.RegisterTool(std::move(withLink));
+
+    const Json errorResp = CallTool(server, 3, "olo_fake_dual_error");
+    EXPECT_EQ(errorResp["result"]["isError"], true);
+    ASSERT_EQ(errorResp["result"]["content"].size(), 1u);
+    EXPECT_FALSE(errorResp["result"]["content"][0].contains("annotations"));
+
+    const Json textResp = CallTool(server, 4, "olo_fake_dual_text");
+    ASSERT_EQ(textResp["result"]["content"].size(), 1u)
+        << "no structuredContent (e.g. the topology tool's dot format) => nothing to render";
+    EXPECT_EQ(textResp["result"]["content"][0]["text"], "digraph {}");
+
+    const Json linkResp = CallTool(server, 5, "olo_fake_dual_link");
+    ASSERT_EQ(linkResp["result"]["content"].size(), 2u)
+        << "a handler's own extra block must survive, not be replaced by the audience pair";
+    EXPECT_EQ(linkResp["result"]["content"][1]["type"], "resource_link");
+}
+
+// The human block goes out over the same wire as the JSON mirror, so it must be
+// scrubbed on exactly the same terms — the re-shaping runs BEFORE redaction.
+TEST(McpAudienceBlocks, RedactionScrubsBothAudienceBlocks)
+{
+    McpServer server{ EditorMcpContext{} };
+    AddDualAudienceTool(server, "olo_fake_dual_paths",
+                        Json{ { "asset", "C:\\Projects\\Game\\mesh.obj" }, { "count", 1 } });
+    server.SetRedactPaths(true);
+
+    const Json resp = CallTool(server, 6, "olo_fake_dual_paths");
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    const Json& content = resp["result"]["content"];
+    ASSERT_EQ(content.size(), 2u);
+    for (const Json& block : content)
+    {
+        const std::string text = block["text"].get<std::string>();
+        EXPECT_EQ(text.find("C:\\"), std::string::npos) << "a raw drive path leaked in: " << text;
+        EXPECT_NE(text.find("<path>"), std::string::npos) << text;
+    }
+}
+
+// ---- the pure Markdown renderer ----------------------------------------------
+
+TEST(McpAudienceReport, RendersScalarsAsAFieldTableAndObjectArraysAsTables)
+{
+    const std::string report = AudienceReport::Render(SamplePayload(), "Perf");
+
+    EXPECT_NE(report.find("### Perf"), std::string::npos);
+    // Scalars land in the field table...
+    EXPECT_NE(report.find("| drawCalls"), std::string::npos);
+    EXPECT_NE(report.find("412"), std::string::npos);
+    // ...and the array of objects becomes its own table with a header row.
+    EXPECT_NE(report.find("**passes** (2)"), std::string::npos);
+    EXPECT_NE(report.find("| pass"), std::string::npos);
+    EXPECT_NE(report.find("ScenePass"), std::string::npos);
+    EXPECT_EQ(report.back(), '\n');
+}
+
+TEST(McpAudienceReport, EmptyAndNonObjectPayloadsStillProduceABlock)
+{
+    // A tool result is never allowed to render as an empty user block.
+    EXPECT_FALSE(AudienceReport::Render(Json::object(), "Empty").empty());
+    EXPECT_NE(AudienceReport::Render(Json::object(), "Empty").find("(no data)"), std::string::npos);
+    EXPECT_NE(AudienceReport::Render(Json(42), "Scalar").find("42"), std::string::npos);
+    // A bare array of objects renders as one table (no enclosing key).
+    const Json rows = Json::array({ Json{ { "a", 1 } }, Json{ { "a", 2 } } });
+    EXPECT_NE(AudienceReport::Render(rows, "Rows").find("| a"), std::string::npos);
+}
+
+TEST(McpAudienceReport, NeutralisesPipesAndNewlinesThatWouldBreakTheTable)
+{
+    const Json data{ { "name", "a|b" }, { "multi", "one\ntwo" } };
+    const std::string report = AudienceReport::Render(data, "Escapes");
+    EXPECT_NE(report.find("a\\|b"), std::string::npos) << "a literal pipe would open a phantom column";
+    EXPECT_EQ(report.find("one\ntwo"), std::string::npos) << "a newline would end the row early";
+    EXPECT_NE(report.find("one two"), std::string::npos);
+}
+
+TEST(McpAudienceReport, ElidesLongTablesAndListsRatherThanLosingThem)
+{
+    Json rows = Json::array();
+    for (int i = 0; i < 100; ++i)
+        rows.push_back(Json{ { "i", i } });
+    const std::string report = AudienceReport::Render(Json{ { "rows", rows } }, "Big");
+
+    EXPECT_NE(report.find("**rows** (100)"), std::string::npos) << "the true count is always stated";
+    EXPECT_NE(report.find("more row(s) omitted"), std::string::npos);
+    // The bound actually held: row 99 is not printed.
+    EXPECT_EQ(report.find("| 99 "), std::string::npos);
+}
+
+// The truncation bound must never split a UTF-8 sequence: nlohmann's dump()
+// throws on invalid UTF-8, so a byte-wise cut through a multi-byte codepoint
+// would turn a cosmetic limit into a failed tool response.
+TEST(McpAudienceReport, TruncationKeepsTheOutputValidUtf8)
+{
+    // A cut that lands mid-sequence must back off to the codepoint boundary.
+    // "x" + 3-byte U+20AC repeated puts a continuation byte at every index
+    // where (i - 1) % 3 != 0, so this exercises the backoff directly.
+    std::string wide = "x";
+    for (int i = 0; i < 400; ++i)
+        wide += "\xE2\x82\xAC";
+
+    for (const sizet limit : { sizet{ 60 }, sizet{ 61 }, sizet{ 62 }, sizet{ 600 } })
+    {
+        const std::string cut = AudienceReport::Detail::TruncateUtf8(wide, limit);
+        // The proof of validity: nlohmann's dump() throws on invalid UTF-8.
+        EXPECT_NO_THROW((void)Json(cut).dump()) << "cut at " << limit << " split a UTF-8 sequence";
+        EXPECT_LT(cut.size(), wide.size());
+    }
+
+    // ...and end to end, through both the paragraph and the table-cell path.
+    const Json data{ { "name", wide }, { "rows", Json::array({ Json{ { "cell", wide } } }) } };
+    const Json block{ { "type", "text" }, { "text", AudienceReport::Render(data, "Utf8") } };
+    EXPECT_NO_THROW((void)block.dump());
+}
+
+TEST(McpAudienceReport, NestedObjectsBecomeSectionsAndEmptyContainersAreLabelled)
+{
+    const Json data{ { "frame", Json{ { "cpuMs", 3.1 }, { "gpuMs", 9.4 } } },
+                     { "warnings", Json::array() },
+                     { "tags", Json::array({ "a", "b" }) } };
+    const std::string report = AudienceReport::Render(data, "Nested");
+
+    EXPECT_NE(report.find("**frame**"), std::string::npos);
+    EXPECT_NE(report.find("cpuMs"), std::string::npos);
+    EXPECT_NE(report.find("(none)"), std::string::npos) << "an empty array must read as empty, not vanish";
+    EXPECT_NE(report.find("a, b"), std::string::npos) << "a scalar array is inlined";
+}
+
+// ---- adoption ratchet over the REAL builtin surface --------------------------
+
+// The deliberate adopter list (#673 Tier 2). Each entry is multi-field or
+// tabular AND is something a human stares at while debugging — see the
+// inclusion rule on ToolDef::DualAudienceContent, and the per-tool reason at
+// each registration site. This test is the ratchet in BOTH directions: a new
+// tool that opts in without being considered fails here, and an adopter that
+// silently loses the flag fails here too.
+TEST(McpAudienceBlocks, BuiltinAdoptionMatchesTheDeliberateList)
+{
+    static const std::set<std::string> kExpectedAdopters = {
+        "olo_memory_report",                // per-resource-type breakdown table
+        "olo_perf_snapshot",                // ~18 frame counters
+        "olo_perf_pass_timings",            // per-pass gpuMs/cpuMs table
+        "olo_perf_cpu_scopes",              // the editor's own CPU Scopes table
+        "olo_render_frame_breakdown",       // command list + per-pass breakdown
+        "olo_render_graph_topology_export", // passes / edges / resources tables
+        "olo_render_why_not_visible",       // explainer check list
+        "olo_render_target_stats",          // per-channel min/max/mean/NaN table
+        "olo_cluster_grid_stats",           // per-slice + histogram tables
+        "olo_shadow_atlas_layout",          // granted vs starved casters
+        "olo_physics_why_no_collision",     // explainer check list
+    };
+
+    const McpServer::ToolList& tools = BuiltinTools();
+    ASSERT_FALSE(tools.empty());
+
+    std::set<std::string> actual;
+    for (const ToolDef& tool : tools)
+    {
+        if (tool.DualAudienceContent)
+            actual.insert(tool.Name);
+    }
+
+    EXPECT_EQ(actual, kExpectedAdopters)
+        << "the dual-audience adopter set drifted — re-read the inclusion rule on "
+           "ToolDef::DualAudienceContent before widening it; blanket adoption is bloat, not parity.";
+}
+
+// An adopter must be able to PRODUCE the pair: the re-shaping only fires on a
+// typed result, and the report is headed by Title. A tool that opts in without
+// an OutputSchema/Structured result would silently render nothing new.
+TEST(McpAudienceBlocks, EveryAdopterDeclaresAnOutputSchemaAndATitle)
+{
+    for (const ToolDef& tool : BuiltinTools())
+    {
+        if (!tool.DualAudienceContent)
+            continue;
+        EXPECT_FALSE(tool.Title.empty())
+            << tool.Name << " opts into dual-audience content but has no Title to head the report.";
+        EXPECT_TRUE(tool.OutputSchema.is_object() && !tool.OutputSchema.empty())
+            << tool.Name
+            << " opts into dual-audience content but declares no OutputSchema — the re-shaping only "
+               "fires on a ToolResult::Structured result, so it would never take effect.";
+    }
+}

--- a/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
+++ b/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
@@ -226,7 +226,7 @@ TEST(McpAudienceBlocks, ReshapingSkipsErrorsTextResultsAndExtraBlocks)
     textual.Description = "Text only.";
     textual.DualAudienceContent = true;
     textual.Handler = [](McpServer&, const Json&)
-    { return ToolResult::Text("digraph {}"); };
+    { return ToolResult::Text("flowchart LR"); };
     server.RegisterTool(std::move(textual));
 
     ToolDef withLink;
@@ -248,8 +248,8 @@ TEST(McpAudienceBlocks, ReshapingSkipsErrorsTextResultsAndExtraBlocks)
 
     const Json textResp = CallTool(server, 4, "olo_fake_dual_text");
     ASSERT_EQ(textResp["result"]["content"].size(), 1u)
-        << "no structuredContent (e.g. the topology tool's dot format) => nothing to render";
-    EXPECT_EQ(textResp["result"]["content"][0]["text"], "digraph {}");
+        << "no structuredContent (e.g. the topology tool's mermaid format) => nothing to render";
+    EXPECT_EQ(textResp["result"]["content"][0]["text"], "flowchart LR");
 
     const Json linkResp = CallTool(server, 5, "olo_fake_dual_link");
     ASSERT_EQ(linkResp["result"]["content"].size(), 2u)
@@ -313,6 +313,29 @@ TEST(McpAudienceReport, NeutralisesPipesAndNewlinesThatWouldBreakTheTable)
     EXPECT_NE(report.find("a\\|b"), std::string::npos) << "a literal pipe would open a phantom column";
     EXPECT_EQ(report.find("one\ntwo"), std::string::npos) << "a newline would end the row early";
     EXPECT_NE(report.find("one two"), std::string::npos);
+}
+
+// KEYS are escaped too, not just values: a payload keyed by data (a
+// std::unordered_map<std::string, V> field — entity names, asset paths) renders
+// its keys as column headers and section titles, where one stray '|' would
+// corrupt the whole table.
+TEST(McpAudienceReport, EscapesDataDerivedKeysInHeadersAndSectionTitles)
+{
+    const Json data{ { "a|b", 1 },                                             // field key
+                     { "sec|tion", Json{ { "x", 1 } } },                       // section title
+                     { "tbl|e", Json::array({ Json{ { "col|umn", 1 } } }) } }; // table title + header
+
+    const std::string report = AudienceReport::Render(data, "Keys");
+    EXPECT_NE(report.find("a\\|b"), std::string::npos) << report;
+    EXPECT_NE(report.find("**sec\\|tion**"), std::string::npos) << report;
+    EXPECT_NE(report.find("**tbl\\|e**"), std::string::npos) << report;
+    EXPECT_NE(report.find("col\\|umn"), std::string::npos) << report;
+
+    // An escaped column header must still resolve its cells — the lookup uses the
+    // RAW key while only the printed header is escaped.
+    const auto rowLine = report.find("\n| 1 ");
+    EXPECT_NE(rowLine, std::string::npos) << "escaped header lost its row value:\n"
+                                          << report;
 }
 
 TEST(McpAudienceReport, ElidesLongTablesAndListsRatherThanLosingThem)

--- a/cmake/vendor/OpenUSD.cmake
+++ b/cmake/vendor/OpenUSD.cmake
@@ -33,14 +33,30 @@ set(_olo_tbb_rel_libfile "${CMAKE_STATIC_LIBRARY_PREFIX}tbb12${CMAKE_STATIC_LIBR
 set(_olo_tbb_dbg_libfile "${CMAKE_STATIC_LIBRARY_PREFIX}tbb12_debug${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 if(OLO_USD_INSTALL_DIR AND EXISTS "${OLO_USD_INSTALL_DIR}/include/pxr")
+    # A flat prefix carries exactly ONE oneTBB variant, and its name says which CRT it was
+    # built against: tbb12 (release) vs tbb12_debug. Probe rather than assume release — a
+    # Debug prefix (e.g. one config of the per-config cache below, handed in directly) has
+    # only tbb12_debug, so hardcoding tbb12 made the documented fast path unusable for a
+    # Debug build: it configured cleanly and then failed at link on a missing lib.
+    if(EXISTS "${OLO_USD_INSTALL_DIR}/lib/${_olo_tbb_rel_libfile}")
+        set(_olo_usd_prebuilt_tbb "${_olo_tbb_rel_libfile}")
+    elseif(EXISTS "${OLO_USD_INSTALL_DIR}/lib/${_olo_tbb_dbg_libfile}")
+        set(_olo_usd_prebuilt_tbb "${_olo_tbb_dbg_libfile}")
+    else()
+        message(FATAL_ERROR
+            "OLO_USD_INSTALL_DIR=${OLO_USD_INSTALL_DIR} has include/pxr but neither "
+            "lib/${_olo_tbb_rel_libfile} nor lib/${_olo_tbb_dbg_libfile} — it is not a complete "
+            "static USD + oneTBB prefix. Point at a full install or unset it to build from source.")
+    endif()
     set(OloEngine_USD_INCLUDE_DIR "${OLO_USD_INSTALL_DIR}/include"          CACHE INTERNAL "")
     set(OloEngine_USD_LIB_DIR     "${OLO_USD_INSTALL_DIR}/lib"              CACHE INTERNAL "")
-    set(OloEngine_USD_LIB         "${OLO_USD_INSTALL_DIR}/lib/${_olo_usd_libfile}"     CACHE INTERNAL "")
-    set(OloEngine_USD_TBB_LIB     "${OLO_USD_INSTALL_DIR}/lib/${_olo_tbb_rel_libfile}" CACHE INTERNAL "")
+    set(OloEngine_USD_LIB         "${OLO_USD_INSTALL_DIR}/lib/${_olo_usd_libfile}"      CACHE INTERNAL "")
+    set(OloEngine_USD_TBB_LIB     "${OLO_USD_INSTALL_DIR}/lib/${_olo_usd_prebuilt_tbb}" CACHE INTERNAL "")
     set(OloEngine_USD_PLUGIN_TREE "${OLO_USD_INSTALL_DIR}/lib/usd"          CACHE INTERNAL "")
     add_custom_target(olo_usd_ext)  # no-op; keeps the engine's add_dependencies() uniform
     message(STATUS "OLO_WITH_USD: using prebuilt OpenUSD install at ${OLO_USD_INSTALL_DIR} "
-                   "(flat single-config — ensure it matches your engine build's CRT/config)")
+                   "(flat single-config, oneTBB=${_olo_usd_prebuilt_tbb} — ensure it matches "
+                   "your engine build's CRT/config)")
     return()
 endif()
 
@@ -69,6 +85,50 @@ set(OloEngine_USD_TBB_LIB
     "$<IF:$<CONFIG:Debug>,${_olo_usd_install}/Debug/lib/${_olo_tbb_dbg_libfile},${_olo_usd_install}/Release/lib/${_olo_tbb_rel_libfile}>"
     CACHE INTERNAL "")
 set(OloEngine_USD_PLUGIN_TREE "${_olo_usd_install}/${_olo_usd_cfg}/lib/usd" CACHE INTERNAL "")
+
+# --- Cache hit: a COMPLETE install is already in the shared cache, so don't re-enter the build ---
+#
+# The cache holds the source/binary/install trees, but ExternalProject's STAMP_DIR defaults to
+# the CONSUMING build tree. A second worktree therefore has no stamps, concludes every step is
+# out of date, and re-runs configure+build inside the FIRST worktree's usd-build — which is not
+# idempotent: BUILD_COMMAND is `--config Release` then `--config Debug` in one binary dir, so
+# re-entering a finished tree hits `error C2859: ...arch.pdb is not the pdb file that was used
+# when this precompiled header was created` across USD's arch target. The artifacts were shared
+# but the "already done" record was not.
+#
+# Fixing it by moving STAMP_DIR into the cache would only relocate the problem (two worktrees
+# configuring for the first time would then race on the stamps). Instead: if every artifact the
+# engine actually consumes is present for BOTH configs, skip ExternalProject entirely and treat
+# the cache as a prebuilt install — the second and every later worktree then never writes to the
+# shared tree at all. Deliberately requires both configs and the plugInfo trees: a partial cache
+# (interrupted first build) falls through and resumes the real build.
+#
+# Bumping _OLO_USD_TAG changes the cache key, so a version bump invalidates this automatically;
+# to force a genuine rebuild, delete ${_olo_usd_cache}.
+#
+# Still NOT safe: two worktrees running their FIRST USD build concurrently — they share one
+# binary dir. Same rule as the msvc/clangcl trees (docs/agent-rules/build-trees-and-windows-asan.md):
+# sequence the first build, then every tree after it is a lock-free cache hit.
+set(_olo_usd_cache_complete TRUE)
+foreach(_olo_cfg Debug Release)
+    if(_olo_cfg STREQUAL "Debug")
+        set(_olo_cfg_tbb "${_olo_tbb_dbg_libfile}")
+    else()
+        set(_olo_cfg_tbb "${_olo_tbb_rel_libfile}")
+    endif()
+    if(NOT EXISTS "${_olo_usd_install}/${_olo_cfg}/lib/${_olo_usd_libfile}"
+       OR NOT EXISTS "${_olo_usd_install}/${_olo_cfg}/lib/${_olo_cfg_tbb}"
+       OR NOT EXISTS "${_olo_usd_install}/${_olo_cfg}/include/pxr"
+       OR NOT IS_DIRECTORY "${_olo_usd_install}/${_olo_cfg}/lib/usd")
+        set(_olo_usd_cache_complete FALSE)
+    endif()
+endforeach()
+if(_olo_usd_cache_complete)
+    add_custom_target(olo_usd_ext)  # no-op; keeps the engine's add_dependencies() uniform
+    message(STATUS "OLO_WITH_USD: reusing the complete OpenUSD cache at ${_olo_usd_install} "
+                   "(Debug + Release) — no build step. Delete ${_olo_usd_cache} to force a rebuild.")
+    return()
+endif()
 
 # Build+install BOTH configs. The VS generator is multi-config, so one configured tree compiles
 # either config; the Release compile is reused incrementally across the two build steps.

--- a/docs/adr/0008-no-mcp-endpoint-in-cooked-builds.md
+++ b/docs/adr/0008-no-mcp-endpoint-in-cooked-builds.md
@@ -1,0 +1,161 @@
+# No MCP endpoint in cooked/runtime builds — deferred behind seven preconditions, and if ever built it is a separate default-deny registry, not the editor's surface lifted into the engine
+
+Issue [#673](https://github.com/drsnuggles8/OloEngineBase/issues/673)'s Tier 3 is
+**runtime/cooked-build-capable diagnostic tools** — Unreal Engine 6.0's
+`AIRuntimeCallable`, tools that keep working in a packaged build so QA can
+triage a bug on a test device from their own machine. The issue itself scoped
+this as *"worth a design doc before building, not now"* and *"Don't build
+opportunistically."* This ADR is that design doc: it records the threat model,
+the conditions that would have to hold before the idea is worth revisiting, and
+the decision to **not build it**.
+
+Nothing in this ADR is implemented. It exists so the roadmap bullet stops being
+an open invitation and becomes a recorded decision with a re-open test.
+
+## What is being proposed
+
+A read-only MCP endpoint hosted by `OloRuntime` (and, in the most ambitious
+version, `OloServer`) instead of `OloEditor`, so an agent can call
+`olo_perf_snapshot` / `olo_render_why_not_visible` / `olo_log_tail` against a
+shipped binary running on a QA device.
+
+## Threat model
+
+The editor's server is safe because of five properties stated at the top of
+[`McpServer.h`](../../OloEditor/src/MCP/McpServer.h). Moving the endpoint into a
+cooked build breaks or hollows out **four of the five** — and the fifth turns
+out to protect the wrong thing.
+
+1. **"Binds 127.0.0.1 only, never a routable interface."** Loopback is exactly
+   what makes the feature pointless in the runtime case: the whole premise is
+   *remote* triage of a device you are not sitting at. So the feature creates
+   direct pressure to bind a routable interface — i.e. to delete the single
+   strongest control we have. A design that keeps loopback has to add an
+   operator-driven tunnel (`adb reverse`, SSH), at which point the "remote"
+   convenience it was built for is mostly gone.
+
+2. **"Off by default; started explicitly from the editor's MCP panel."** A
+   cooked build has no MCP panel and, usually, no operator sitting in front of
+   it. Whatever replaces the panel — a console command, a launch flag, an
+   in-game menu — becomes the thing an attacker targets, and it has to be
+   reachable enough for QA to use and unreachable enough that a player can't
+   flip it. Those two requirements are in direct tension.
+
+3. **"Every request must carry a bearer token the editor displays for the user
+   to paste."** In the editor the token is generated per run and shown to a
+   present human. A cooked build has neither. A token baked into the binary is a
+   shared secret shipped to every copy — recoverable with `strings` — and a
+   token generated per run needs an out-of-band channel to reach the QA
+   operator, which is a whole subsystem nobody has costed.
+
+4. **"The Origin header is validated (DNS-rebinding defence)."** This one still
+   works, but it only ever defended against a *browser* being used as a
+   confused deputy. It does nothing against a direct socket, which is the actual
+   threat once the port is reachable.
+
+5. **"Read-only with respect to the user's PROJECT."** This is the property
+   people reach for to argue the feature is safe, and in the runtime context it
+   is protecting the wrong asset. Read-only bounds what an attacker can *break*.
+   It says nothing about what they can *learn* — and in a shipped game the
+   diagnostics ARE the payload:
+
+   - `olo_scene_list_entities` / `olo_scene_get_entity` on a live multiplayer
+     client is a wallhack oracle: exact positions of everything the client has
+     been told about. "Read-only" is a safety property, never a
+     competitive-integrity one.
+   - `olo_log_tail`, asset paths, and shader sources are an IP and
+     reverse-engineering channel; absolute paths are also a PII channel
+     (`RedactPaths` is opt-in and off by default).
+   - `olo_screenshot` against an unreleased build is a spoiler pipe.
+
+Two risks are entirely new in the cooked case and have no editor analogue:
+
+6. **The binary is distributed, so every copy is an attack sample.** An attacker
+   can reverse the handshake, the token derivation, and the dispatch code
+   offline, at leisure, before ever touching a live instance. Nothing about the
+   editor deployment model has this property.
+
+7. **The request path can stall the game.** `MarshalRead` deliberately parks an
+   HTTP worker until the game thread reaches a frame boundary; capture tools
+   allocate megabytes and do GL readbacks. In the editor a hitch is an
+   annoyance. In a shipped multiplayer client, an unauthenticated pre-token
+   parse plus a marshal-heavy tool is a remote hitch/DoS primitive — and the
+   pre-auth surface (cpp-httplib framing + `nlohmann::json` over hostile bytes)
+   runs before any of our own checks do.
+
+`OloServer` is the sharpest version of all of the above: a diagnostics endpoint
+on a dedicated game server is a competitive-integrity hole with a network
+attacker permanently in front of it.
+
+## Decision
+
+**Defer. Do not build a runtime MCP endpoint, and do not add partial scaffolding
+"just in case".** The editor server stays the only MCP surface.
+
+Concretely, until every precondition below is met:
+
+- No MCP source moves from `OloEditor/src/MCP/` into `OloEngine/src/`.
+- No `ToolDef` flag is added to mark a tool runtime-callable.
+- `OloRuntime` and `OloServer` link no HTTP server.
+
+## What would have to be true to revisit
+
+All seven, not a subset. Any one of them missing reproduces a hole above.
+
+1. **Compile-time exclusion, not a runtime bool.** Gated behind an opt-in
+   definition whose absence removes the whole translation unit from the binary,
+   so a shipping build cannot be talked into enabling it at runtime and a
+   reverser finds no dormant server to wake.
+2. **A separate, default-deny tool registry.** The editor's ~66 tools are
+   curated for a *trusted local operator inspecting their own project*. That
+   assumption is invisible in each tool and fatal if it travels. A runtime tier
+   is a much smaller registry with explicit per-tool opt-in (UE's actual shape),
+   built from scratch — never the editor list minus a blocklist, because a
+   blocklist fails open for every tool added later.
+3. **Per-run token delivered out of band** — written where only device access
+   reaches it (platform log, app-private storage), never baked into the binary.
+4. **Loopback binding, always**, with exposure requiring a deliberate operator
+   tunnel. No configuration path binds a routable interface.
+5. **A hard budget on the request path**: no unbounded `MarshalRead`, no capture
+   or readback tools, rate limiting — so a hostile caller cannot hitch the
+   frame. Sized against a frame budget, not "generous".
+6. **A build configuration that is internal-only.** Today's `Distribution` ships
+   to end users; an internal-QA configuration distinct from it does not exist
+   and would have to be introduced first. Without it, "QA only" is a convention,
+   not a guarantee.
+7. **Never on a multiplayer client connected to a shared live server, and never
+   on `OloServer` in production** — enforced in code, not in documentation.
+
+If a future session can only satisfy some of these, the answer is still no.
+
+## Alternatives that solve most of the actual need without a listening socket
+
+The QA-triage need is real; a listening port is just the worst way to serve it.
+Prefer, in order:
+
+1. **Offline artifacts.** Frame captures, save-games, and the diagnostics event
+   log already serialize. A "dump diagnostics bundle to disk on request" path
+   gets QA the same data with no network surface and no timing, and it replays
+   in the editor where the full tool surface is already safe to use.
+2. **Log/telemetry upload.** Covers the majority of triage ("what did it say
+   before it broke") with an outbound, authenticated, one-way channel.
+3. **Dial-out instead of listen.** If live interaction is genuinely required,
+   the runtime should *connect out* to a rendezvous the developer controls
+   rather than accept connections — no listening port on the shipped binary, no
+   pre-auth parse surface exposed to the network, and the operator's machine
+   holds the trust anchor. Tier 1 already built the client half of this
+   (`McpClient.{h,cpp}`, stdio transport), so the shape is familiar. This is the
+   only *interactive* variant worth designing if the preconditions above are
+   ever met.
+
+## Consequences
+
+- OloEngine has no remote-triage story for packaged builds. Accepted: the
+  alternatives above cover the common cases, and the gap is documented rather
+  than silently open.
+- Issue #673's Tier 3 bullet closes as **decided**, not as done. Re-opening
+  requires meeting the seven preconditions, which is a deliberately high bar.
+- The editor MCP server's security posture is unchanged, and this ADR is now
+  the reference for why it is scoped to the editor — see also
+  [ADR 0005](0005-mcp-script-tools-lua-sandbox.md), which reasons about the
+  script-tool trust boundary inside that same posture.

--- a/docs/adr/0008-no-mcp-endpoint-in-cooked-builds.md
+++ b/docs/adr/0008-no-mcp-endpoint-in-cooked-builds.md
@@ -70,12 +70,12 @@ out to protect the wrong thing.
 
 Two risks are entirely new in the cooked case and have no editor analogue:
 
-6. **The binary is distributed, so every copy is an attack sample.** An attacker
+1. **The binary is distributed, so every copy is an attack sample.** An attacker
    can reverse the handshake, the token derivation, and the dispatch code
    offline, at leisure, before ever touching a live instance. Nothing about the
    editor deployment model has this property.
 
-7. **The request path can stall the game.** `MarshalRead` deliberately parks an
+2. **The request path can stall the game.** `MarshalRead` deliberately parks an
    HTTP worker until the game thread reaches a frame boundary; capture tools
    allocate megabytes and do GL readbacks. In the editor a hitch is an
    annoyance. In a shipped multiplayer client, an unauthenticated pre-token

--- a/docs/agent-rules/asset-import-usd-alembic.md
+++ b/docs/agent-rules/asset-import-usd-alembic.md
@@ -51,7 +51,7 @@ of date, and re-run configure+build *inside the first worktree's* `usd-build` â€
 idempotent, because `BUILD_COMMAND` is `--config Release` **then** `--config Debug` in one binary dir.
 Re-entering a finished tree fails across USD's `arch` target with:
 
-```
+```text
 error C2859: ...\arch.dir\Release\arch.pdb is not the pdb file that was used when this
              precompiled header was created, recreate the precompiled header.
 ```

--- a/docs/agent-rules/asset-import-usd-alembic.md
+++ b/docs/agent-rules/asset-import-usd-alembic.md
@@ -43,6 +43,44 @@ resolves USD one of two ways:
   `tbb12.lib`). First build ≈ 30–45 min + ~10 GB; later builds are machine-wide cache hits.
   **CI that doesn't need USD sets `-DOLO_WITH_USD=OFF`.**
 
+### The cache is shared across worktrees — the stamps are not (fixed; know the failure it caused)
+
+The cache holds the source/binary/install trees, but `ExternalProject`'s `STAMP_DIR` defaults to the
+**consuming** build tree. So a **second worktree** used to see no stamps, conclude every step was out
+of date, and re-run configure+build *inside the first worktree's* `usd-build` — which is not
+idempotent, because `BUILD_COMMAND` is `--config Release` **then** `--config Debug` in one binary dir.
+Re-entering a finished tree fails across USD's `arch` target with:
+
+```
+error C2859: ...\arch.dir\Release\arch.pdb is not the pdb file that was used when this
+             precompiled header was created, recreate the precompiled header.
+```
+
+The artifacts were shared; the "already done" record was not. **Symptom to recognise:** a *fresh
+worktree* failing in `olo_openusd` while `install/{Debug,Release}` is demonstrably complete
+(`usd_m.lib` ≈ 2.4 GB Debug / 2.1 GB Release).
+
+`OpenUSD.cmake` now **short-circuits on a complete cache**: if `usd_m` + the config's oneTBB lib +
+`include/pxr` + the `lib/usd` plugInfo tree all exist for **both** configs, it skips
+`ExternalProject_Add` entirely (`olo_usd_ext` becomes a no-op) and consumes the cache as a prebuilt
+install — so no worktree after the first ever writes to the shared tree. A *partial* cache (an
+interrupted first build) fails the check and resumes the real build. Bumping `_OLO_USD_TAG` changes
+the cache key; to force a genuine rebuild, delete `$LOCALAPPDATA/OloEngine/usd-<sha8>`.
+
+Two things that follow:
+
+- **Moving `STAMP_DIR` into the cache would NOT have fixed this** — it only relocates the race to two
+  worktrees configuring for the first time simultaneously.
+- **Still unsafe: two worktrees running their FIRST USD build concurrently** (one shared binary dir).
+  Same rule as the msvc/clangcl trees in
+  [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) — sequence the first build; every
+  tree after it is a lock-free cache hit.
+
+`-DOLO_USD_INSTALL_DIR` expects a **flat** prefix and now **probes** for `tbb12` vs `tbb12_debug`
+rather than assuming release. It previously hardcoded `tbb12.lib`, so pointing it at a Debug prefix
+(e.g. one config of the cache above) configured cleanly and then failed at link on a missing lib —
+which made the documented escape hatch useless for exactly the Debug build that hit the C2859 above.
+
 **Do NOT vendor OpenUSD via FetchContent `add_subdirectory`.** USD's CMake is install-centric: the
 runtime `plugInfo.json` resource tree it needs to open *even a plain `.usda`* is produced by the
 **install step**, and its `pxr_*` macros pollute the parent project — hence ExternalProject

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -1532,7 +1532,7 @@ payload that is already a sentence, the second rendering is pure noise — leave
 Blanket adoption across the surface would be bloat, not spec parity.
 
 The re-shaping is guarded, so opting in never loses content: it fires only on a successful
-single-block typed result. A handler that returns free text (the `format:"dot"` path of
+single-block typed result. A handler that returns free text (the `format:"mermaid"` path of
 `olo_render_graph_topology_export`), errors, or appends its own extra block (a
 `resource_link`) is passed through untouched.
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -178,6 +178,10 @@ deliberate: `olo_log_tail` returns raw log lines (free text an `outputSchema` ca
 constrain), and the `format:"markdown"`/`"mermaid"` paths of the dual-format tools stay
 text-only (their schemas describe the json format).
 
+Eleven table-shaped tools additionally return **audience-tagged content blocks** — see
+[Audience-tagged content blocks](#audience-tagged-content-blocks-673-tier-2) for the list
+and for what to do when adding a tool.
+
 | Tool | What it returns |
 |---|---|
 | `olo_log_tail` | recent engine log lines, filterable by `minLevel` and `tag` |
@@ -1484,6 +1488,61 @@ so keep a write-tier tool's description honest about what it changes.
   `capabilities.resources.listChanged` is `true`, and every publish/eviction emits
   `notifications/resources/list_changed` on the live SSE stream, so re-list after it.
   Inline base64 stays the default — opt into links for high-res captures.
+
+### Audience-tagged content blocks (#673 Tier 2)
+
+MCP 2025-06-18 lets each **content block** carry
+`annotations: { audience: ["user"|"assistant"], priority: <0..1> }`. A client that honours
+them shows each side only what it asked for; one that ignores them shows every block.
+
+For a table-shaped diagnostic that split is real, so those tools return their payload
+**twice** in one result:
+
+| block | `audience` | `priority` | content |
+|---|---|---|---|
+| `content[0]` | `["assistant"]` | 1.0 | the payload as **compact** JSON — same data as `structuredContent` |
+| `content[1]` | `["user"]` | 0.3 | a **Markdown report**: scalars as a `field`/`value` table, each array of objects as its own table |
+
+`structuredContent` is unchanged, so the `outputSchema` contract is identical — only the
+`content` array differs. `content[0]` is still the machine-readable JSON mirror, so a client
+that only reads the first block sees exactly what it used to. The mirror is emitted compact
+precisely because an annotation-blind client renders both: the pair then costs about what
+the single pretty-printed block did.
+
+The report is a **glanceable summary, not the archive** — tables cap at 24 rows, cells at 64
+characters, inline lists at 12 items, each stating what it elided. The full payload is always
+in the assistant block and in `structuredContent`. Path redaction, when enabled, scrubs both
+blocks identically.
+
+**Current adopters (11):** `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_pass_timings`,
+`olo_perf_cpu_scopes`, `olo_render_frame_breakdown`, `olo_render_graph_topology_export`,
+`olo_render_why_not_visible`, `olo_render_target_stats`, `olo_cluster_grid_stats`,
+`olo_shadow_atlas_layout`, `olo_physics_why_no_collision`.
+
+#### Adding a tool — which side of the line are you on?
+
+Set `tool.DualAudienceContent = true` at registration, next to `Title` / `OutputSchema` /
+`Annotations`; the handler stays a plain `ToolResult::Structured(...)` and the dispatcher does
+the re-shaping, headed by `Title`. That is the whole change.
+
+Opt in **only** when a human watching the session would genuinely read the payload
+differently from how the model parses it: the result is multi-field or tabular **and** it's
+something you'd stare at while debugging. For a one-scalar result, a status echo, or a
+payload that is already a sentence, the second rendering is pure noise — leave it false.
+Blanket adoption across the surface would be bloat, not spec parity.
+
+The re-shaping is guarded, so opting in never loses content: it fires only on a successful
+single-block typed result. A handler that returns free text (the `format:"dot"` path of
+`olo_render_graph_topology_export`), errors, or appends its own extra block (a
+`resource_link`) is passed through untouched.
+
+`McpAudienceBlocksTest.cpp` ratchets the adopter set **in both directions** — a new tool that
+opts in without being considered fails it, and an adopter that silently loses the flag fails
+it too. Update the expected list there deliberately, not to make the test pass.
+
+> Not to be confused with **tool-level** `ToolDef::Annotations` (`readOnlyHint`,
+> `openWorldHint`, …). Those annotate the tool *declaration* in `tools/list`; these annotate
+> content blocks inside a tool *result*. Different spec field, different object.
 
 ### Outbound MCP servers (stdio) — composing external tools in (issue #673 Tier 1)
 


### PR DESCRIPTION
Closes #673 — the two remaining items on the UE6-parity MCP roadmap. Tier 1 shipped in #676.

## Tier 2 — audience-tagged content blocks

MCP spec 2025-06-18 lets each **content block** carry `annotations: { audience, priority }`. Eleven table-shaped tools now return their payload twice:

| block | `audience` | `priority` | content |
|---|---|---|---|
| `content[0]` | `["assistant"]` | 1.0 | the payload as **compact** JSON — same data as `structuredContent` |
| `content[1]` | `["user"]` | 0.3 | a **Markdown report**: scalars as a `field`/`value` table, each array of objects as its own table |

`structuredContent` is unchanged, so the `outputSchema` contract is identical — only `content` differs. `content[0]` stays the machine-readable JSON mirror, so a client reading only the first block sees exactly what it used to. The mirror is emitted **compact** precisely because an annotation-blind client renders both: the pair then costs about what the single pretty-printed block did.

> Not to be confused with **tool-level** `ToolDef::Annotations` (`readOnlyHint`/`openWorldHint`), which `McpToolAnnotationsTest` guards. Different spec field, different object — those annotate the tool *declaration*, these annotate blocks inside a tool *result*.

### Adoption is declared at registration, not chosen in the handler

`tool.DualAudienceContent = true` sits next to `Title`/`OutputSchema`/`Annotations`; the dispatcher re-shapes the result. Handlers stay plain `ToolResult::Structured(...)`.

This was the pivotal design call. Coverage of "these tools actually emit both audiences" is otherwise observable *only* through a `tools/call` — which needs a GL context and a pumped game thread, so it can't run in CI. Declaring it on the `ToolDef` makes the adopter set readable straight off the registry, so the ratchet test is **registration-only and headless**, exactly like `McpOutputSchemaCoverageTest`.

The re-shaping is guarded so opting in can never lose content — it fires only on a successful single-block typed result. Free-text results (the `format:"dot"` path of `olo_render_graph_topology_export`), errors, and handlers that append their own block (a `resource_link`) pass through untouched. It runs **before** redaction, so both blocks are scrubbed identically.

### The adopters (11) — and the rule

Multi-field or tabular **and** something you'd stare at while debugging. A one-scalar result, a status echo, or an already-prose payload stays single-block; blanket adoption across all 66 tools would be bloat, not parity.

`olo_memory_report`, `olo_perf_snapshot`, `olo_perf_pass_timings`, `olo_perf_cpu_scopes`, `olo_render_frame_breakdown`, `olo_render_graph_topology_export`, `olo_render_why_not_visible`, `olo_render_target_stats`, `olo_cluster_grid_stats`, `olo_shadow_atlas_layout`, `olo_physics_why_no_collision`.

Each carries its reason at its registration site. `olo_memory_report` and `olo_perf_cpu_scopes` are beyond the roadmap's suggested list because both are *literally* rendered as tables in the editor's own UI — the strongest evidence a human wants them back as tables.

### The renderer

`MCP/McpAudienceReport.h` is engine-free (nlohmann + std only), so it unit-tests against synthetic payloads like `McpPassTimings.h`. Two decisions worth flagging:

- **Markdown, not space-aligned text.** A client rendering the user block as Markdown collapses runs of spaces and soft line breaks, which would destroy an aligned table. Cells are *also* padded, so it still reads as a tidy table raw.
- **Truncation is UTF-8-boundary-safe.** `nlohmann::json::dump()` throws on invalid UTF-8, so a byte-wise cut through a multi-byte codepoint (an entity name, an asset path) would turn a cosmetic bound into a *failed tool response*. Bounds: 24 rows/table, 64 chars/cell, 12 items/inline list — each stating what it elided. The full payload is always in the assistant block and `structuredContent`.

Sample of the emitted user block (`olo_perf_pass_timings`, captured live):

```
### Per-pass GPU timings

| field               | value |
| ------------------- | ----- |
| gpuResultsAgeFrames | 1     |
| gpuResultsStale     | false |
| passGpuTotalMs      | 1.623 |

**passes** (15)

| cpuMs | gpuMs | pass                   | subPasses |
| ----- | ----- | ---------------------- | --------- |
| 0.002 | 0.0   | ShadowPass             | -         |
| 0.337 | 0.283 | ScenePass              | [{"gpuMs":0.063,"name":"DepthPrepass"},... |
```

## Tier 3 — ADR, not implementation

The issue is explicit: *"worth a design doc before building, not now"*, *"Don't build opportunistically."* Honoured — **no runtime endpoint is built**, and no scaffolding is added toward one.

`docs/adr/0008-no-mcp-endpoint-in-cooked-builds.md` walks the editor server's five stated security properties through the cooked-build context. Four break outright. The fifth is the interesting one: **"read-only with respect to the project" is protecting the wrong asset.** Read-only bounds what an attacker can *break*, not what they can *learn* — `olo_scene_list_entities` against a live multiplayer client is a wallhack oracle. Read-only is a safety property, never a fairness one.

Plus two risks with no editor analogue: the binary is **distributed** (every copy is an offline attack sample), and `MarshalRead` parks a worker until a frame boundary, making a marshal-heavy tool a remote hitch primitive behind a pre-auth cpp-httplib + nlohmann parse.

Records seven preconditions for revisiting, and notes **dial-out rather than listen** as the only defensible interactive shape — Tier 1 already shipped the client half (`McpClient.{h,cpp}`).

## Unrelated: an OpenUSD build trap, hit while verifying this branch

Included at the maintainer's request rather than split out.

USD's `ExternalProject` keeps its source/binary/install trees **machine-global**, but `STAMP_DIR` defaults to the **consuming** build tree. So a fresh worktree saw no stamps, re-ran the build inside another worktree's `usd-build`, and died with `error C2859: ...arch.pdb is not the pdb file that was used when this precompiled header was created` — `BUILD_COMMAND` is `--config Release` *then* `--config Debug` in one binary dir, so re-entering a finished tree isn't idempotent. It shared the expensive artifacts but not the "already done" record.

Now **short-circuits when the cache is complete for both configs**, skipping `ExternalProject_Add` entirely, so no worktree after the first ever writes to the shared tree. A partial cache still falls through and resumes the real build. Moving `STAMP_DIR` into the cache would only relocate the race to two first-time configures, so it deliberately isn't the fix; the residual "two worktrees building USD for the first time concurrently" hazard is documented alongside the existing msvc/clangcl rule.

Separately, the `OLO_USD_INSTALL_DIR` fast path hardcoded `tbb12.lib` and so could never consume a Debug prefix (which ships `tbb12_debug.lib`) — it now probes, and hard-errors at configure time instead of deferring to a link failure.

## Verification

- **`McpAudienceBlocksTest.cpp` (17 tests, `unit`)** — annotation shape and dispatcher guards over fake tools; the pure renderer (escaping, elision, UTF-8 bounds); and the adopter ratchet **in both directions**, so a tool that opts in without being considered fails, and an adopter that silently loses the flag fails too.
- **`Mcp*` + `MeshInterchange*`: 602 passed, 0 failed, 1 skipped** (`McpHeadlessAttachTest.HostUntilDetached`, pre-existing, needs an attached editor) — in the **default USD-on config**, linking the cached `usd_m`.
- **Live over real MCP against a running editor** — the thing the unit tests can't reach, since the dispatch tests use fake tools and the real-surface test is registration-only: `olo_perf_snapshot` → `[0] audience=assistant priority=1`, `[1] audience=user priority=0.3`; `olo_scene_summary`/`olo_perf_bottlenecks` unchanged at one un-annotated block; `content[0]`-as-JSON still parses (so the existing smoke test isn't broken); every emitted table measured well-formed.

Not a rendering change, so the screenshot-evidence rule doesn't apply — this is protocol/JSON-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-tagged MCP responses, rendering structured payloads into human-friendly Markdown alongside machine-readable data.
  * Introduced dual-audience tool output for selected diagnostics tools (performance, physics, rendering) via a new opt-in flag.
* **Bug Fixes**
  * Improved reshaping behavior to avoid altering results before redaction; preserves extra blocks and skips error/text cases.
  * Added priority clamping for audience annotations.
* **Documentation**
  * Documented audience-tagged content blocks and the deferred cooked-build MCP approach.
* **Tests**
  * Added unit tests covering annotation behavior, dual-audience packaging, Markdown rendering, redaction, and adopter tool compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->