### PR TITLE
feat(ci): nightly AMD GPU conformance job on a self-hosted runner

### DIFF
--- a/.github/workflows/cross-vendor.yml
+++ b/.github/workflows/cross-vendor.yml
@@ -8,8 +8,16 @@ name: Cross-Vendor Conformance
 # for deterministic CI regression detection we prefer llvmpipe, which gives
 # identical output regardless of the underlying host.
 #
-# Hardware-GPU cross-vendor coverage (NVIDIA / AMD / Intel) is tracked
-# separately on a self-hosted runner matrix — see issue tracker.
+# Hardware-GPU cross-vendor coverage:
+#   AMD    — gpu-conformance-amd.yml, nightly on a self-hosted Navi 10 runner
+#            (docs/ops/self-hosted-gpu-runner.md). Real radeonsi, headless EGL.
+#   NVIDIA — no CI coverage. The goldens in assets/tests/golden/ are baselined
+#            on NVIDIA hardware, but only ever on a developer machine, so an
+#            NVIDIA-specific regression is caught by a human noticing it.
+#   Intel  — no coverage of any kind.
+# llvmpipe (this job) is a third *software* implementation, not a second
+# vendor, so it cannot substitute for any of the above — it catches
+# spec-compliance drift, not driver divergence.
 #
 # Manual-dispatch + scheduled nightly: the llvmpipe job takes ~25 minutes
 # compared to ~6 minutes on hardware, so it is not wired into the per-PR

--- a/.github/workflows/gpu-conformance-amd.yml
+++ b/.github/workflows/gpu-conformance-amd.yml
@@ -1,0 +1,327 @@
+name: GPU Conformance (AMD, self-hosted)
+
+# Layer 9 of the renderer testing pyramid (docs/agent-rules/testing-architecture.md,
+# row "L9 Cross-vendor") — the HARDWARE half that cross-vendor.yml's header has
+# always pointed at but that never existed:
+#
+#     "Hardware-GPU cross-vendor coverage (NVIDIA / AMD / Intel) is tracked
+#      separately on a self-hosted runner matrix — see issue tracker."
+#
+# GitHub-hosted runners have no usable GPU, so every test built on the
+# RenderPropertyFixture GL-context gate (97 test files at time of writing)
+# hits `GTEST_SKIP() << "no usable GL 4.6 context available"` in CI. That is
+# the entire visual/golden/perf half of the pyramid running nowhere except a
+# developer's Windows box. cross-vendor.yml substitutes Mesa llvmpipe, but
+# llvmpipe is a THIRD software implementation — not a second *vendor*. It
+# structurally cannot catch AMD GLSL-compiler or driver divergence from the
+# NVIDIA hardware the goldens are baselined on.
+#
+# This job runs the real suite against a real AMD Navi 10 (RX 5600 XT) via
+# Mesa radeonsi, headless, on a self-hosted Linux runner.
+#
+# ---------------------------------------------------------------------------
+# SECURITY: why this workflow is safe on a PUBLIC repository
+# ---------------------------------------------------------------------------
+# GitHub is explicit that self-hosted runners on public repos are dangerous:
+# "forks of your public repository can potentially run dangerous code on your
+# self-hosted runner machine by creating a pull request that executes the code
+# in a workflow."
+#
+# We do not *mitigate* that risk here — we remove it structurally:
+#
+#   * There is NO `pull_request` trigger, and NO `pull_request_target`. A fork
+#     PR can therefore never schedule work onto the self-hosted runner, with or
+#     without approval settings. This is the single most important line in the
+#     file; do not add a PR trigger to this workflow.
+#   * `schedule` only ever runs on the default branch, from repo-owned code.
+#   * `workflow_dispatch` requires write access to the repository.
+#   * The job requests no secrets. Nothing here needs one; keep it that way so a
+#     runner compromise cannot exfiltrate a token.
+#   * `permissions: contents: read` — the GITHUB_TOKEN is read-only, and
+#     checkout is told not to persist it into .git/config.
+#
+# The runner itself must additionally be ephemeral and run as a dedicated,
+# unprivileged user isolated from any other runners on the host — see
+# docs/ops/self-hosted-gpu-runner.md.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 00:47 UTC — roughly 02:00 German local (02:47 CEST / 01:47 CET; GitHub cron
+    # is UTC-only and does not follow DST, so it drifts an hour across the year).
+    # Odd minute follows the house convention (see cross-vendor.yml) of avoiding
+    # the on-the-hour scheduling surge. GitHub may still delay scheduled runs by
+    # tens of minutes under load; this job is not time-critical.
+    - cron: '47 0 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Only workflow_dispatch and schedule reach this workflow, so cancelling a
+  # stale run is always safe — and important here, because a self-hosted runner
+  # has a fixed pool of one. A hung run must not block tomorrow's.
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  amd-hardware:
+    name: Linux / AMD Navi 10 (radeonsi, hardware)
+    # Defence in depth: even though no fork-reachable trigger exists, refuse to
+    # run if this workflow file ever executes outside the upstream repository.
+    if: github.repository == 'drsnuggles8/OloEngineBase'
+    runs-on: [self-hosted, linux, x64, gpu-amd]
+    timeout-minutes: 120
+
+    env:
+      BUILD_TYPE: Release
+      # Goldens are baselined on NVIDIA hardware; GoldenImageTests.cpp reads this
+      # to select a per-vendor golden directory (assets/tests/golden/amd/) so an
+      # AMD run can never clobber the NVIDIA baseline set.
+      OLOENGINE_GOLDEN_VENDOR: amd
+      # Perf history rows are keyed by machine. A dedicated box is far quieter
+      # than a shared hosted VM, so these numbers are actually meaningful — but
+      # they must not land in the same series as hosted or llvmpipe runs.
+      OLOENGINE_PERF_MACHINE: selfhosted-amd-navi10-linux
+      # CPM/FetchContent pull vendor sources into OloEngine/vendor/ *inside the
+      # workspace*, which the wipe + checkout clears every run. Without a cache
+      # outside the workspace every nightly re-downloads and re-builds the whole
+      # vendor set. Both dirs live in the runner user's home, not the workspace.
+      CPM_SOURCE_CACHE: /home/gh-runner-olo/.cache/cpm
+      CCACHE_DIR: /home/gh-runner-olo/.cache/ccache
+
+    steps:
+      # A self-hosted runner's workspace PERSISTS between jobs. Even with an
+      # ephemeral runner the _work directory can survive re-registration, so
+      # never assume a clean tree: a stale generated .inl or CMake cache from a
+      # previous commit produces failures that look like real regressions.
+      - name: Wipe workspace
+        run: |
+          set -euo pipefail
+          ws="${{ github.workspace }}"
+          # Never let an empty/unexpected expansion turn this into `rm -rf /*`.
+          # A self-hosted runner has a real filesystem behind it, unlike a
+          # throwaway hosted VM — this guard is not paranoia.
+          case "$ws" in
+            ''|'/'|'/home'|'/home/'*/) echo "::error::refusing to wipe '$ws'"; exit 1 ;;
+          esac
+          [ -d "$ws/_actions" ] && { echo "::error::'$ws' looks like the runner root"; exit 1; }
+          echo "Wiping $ws"
+          find "$ws" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          mkdir -p "$ws"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This job makes no authenticated git writes. Don't leave the token in
+          # .git/config where a later step or a compromised dependency can read
+          # it — the same reasoning as Windows.yml's checkout.
+          persist-credentials: false
+
+      # ---------------------------------------------------------------------
+      # Preflight: prove we have a HARDWARE context before spending an hour
+      # building. This is the anti-silent-failure guard, and it is the whole
+      # reason this job is trustworthy: Mesa will happily fall back to llvmpipe
+      # if the render node is missing, the amdgpu module failed to load, or the
+      # runner user lost its `render` group. That fallback is SILENT — the suite
+      # would go green and we would quietly baseline llvmpipe output into
+      # assets/tests/golden/amd/, which is exactly the "tests green, screen
+      # wrong" failure mode CLAUDE.md warns about. Fail loudly instead.
+      # ---------------------------------------------------------------------
+      - name: Preflight — require hardware GL 4.6 (reject llvmpipe)
+        run: |
+          set -euo pipefail
+          test -e /dev/dri/renderD128 || { echo "::error::no /dev/dri/renderD128 - amdgpu not loaded?"; exit 1; }
+
+          cat > /tmp/glprobe.c <<'PROBE'
+          #include <EGL/egl.h>
+          #include <EGL/eglext.h>
+          #include <GL/gl.h>
+          #include <stdio.h>
+          #include <string.h>
+          #ifndef EGL_PLATFORM_SURFACELESS_MESA
+          #define EGL_PLATFORM_SURFACELESS_MESA 0x31DD
+          #endif
+          int main(void) {
+            PFNEGLGETPLATFORMDISPLAYEXTPROC gpd =
+              (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+            if (!gpd) { printf("no eglGetPlatformDisplayEXT\n"); return 1; }
+            EGLDisplay d = gpd(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, NULL);
+            if (d == EGL_NO_DISPLAY || !eglInitialize(d, 0, 0)) { printf("eglInitialize failed\n"); return 1; }
+            eglBindAPI(EGL_OPENGL_API);
+            const EGLint ca[] = { EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+                                  EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+                                  EGL_RED_SIZE,8, EGL_GREEN_SIZE,8, EGL_BLUE_SIZE,8, EGL_ALPHA_SIZE,8,
+                                  EGL_NONE };
+            EGLConfig c; EGLint n = 0;
+            if (!eglChooseConfig(d, ca, &c, 1, &n) || n < 1) { printf("chooseConfig failed\n"); return 1; }
+            const EGLint xa[] = { EGL_CONTEXT_MAJOR_VERSION, 4, EGL_CONTEXT_MINOR_VERSION, 6,
+                                  EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
+                                  EGL_NONE };
+            EGLContext x = eglCreateContext(d, c, EGL_NO_CONTEXT, xa);
+            if (x == EGL_NO_CONTEXT) { printf("no GL 4.6 core context\n"); return 1; }
+            if (!eglMakeCurrent(d, EGL_NO_SURFACE, EGL_NO_SURFACE, x)) { printf("makeCurrent failed\n"); return 1; }
+            const char* r = (const char*)glGetString(GL_RENDERER);
+            printf("GL_VENDOR   : %s\n", (const char*)glGetString(GL_VENDOR));
+            printf("GL_RENDERER : %s\n", r);
+            printf("GL_VERSION  : %s\n", (const char*)glGetString(GL_VERSION));
+            if (!r) return 1;
+            if (strstr(r,"llvmpipe") || strstr(r,"softpipe") || strstr(r,"swrast")) {
+              printf("SOFTWARE RENDERER - refusing to baseline llvmpipe as AMD\n");
+              return 2;
+            }
+            return 0;
+          }
+          PROBE
+
+          gcc -O1 -o /tmp/glprobe /tmp/glprobe.c -lEGL -lGL
+          if ! /tmp/glprobe; then
+            echo "::error::Preflight failed - no hardware GL 4.6 context (see output above)."
+            exit 1
+          fi
+          echo "Hardware GL 4.6 context confirmed."
+
+      # The engine hard-fails configure without the Vulkan SDK: it needs not just
+      # libvulkan but shaderc / glslang / SPIRV-Tools / SPIRV-Cross, and
+      # OloEngine/CMakeLists.txt raises FATAL_ERROR on the first one missing.
+      # Distro packages are not enough (Rocky ships the loader, not the SDK), so
+      # the SDK is provisioned on the box and pointed at via CMAKE_PREFIX_PATH —
+      # a single prefix resolves all of them. Checked here so the failure reads
+      # as "provision the runner" rather than a CMake stack trace 5 minutes in.
+      - name: Preflight — Vulkan SDK
+        run: |
+          set -euo pipefail
+          : "${VULKAN_SDK:?VULKAN_SDK is not set - see docs/ops/self-hosted-gpu-runner.md}"
+          test -d "$VULKAN_SDK/include/vulkan" || { echo "::error::no headers under $VULKAN_SDK"; exit 1; }
+          test -e "$VULKAN_SDK/lib/libshaderc_shared.so" || { echo "::error::no shaderc under $VULKAN_SDK"; exit 1; }
+          echo "Vulkan SDK: $VULKAN_SDK"
+
+      - name: Configure CMake
+        # Heavy optional interchange deps (USD/Alembic/MaterialX) and the FFmpeg
+        # from-source build are all irrelevant to GPU rendering conformance and
+        # cost far more than they'd tell us — same reasoning as cross-vendor.yml.
+        # USD additionally cannot install unprivileged: its pxrConfig.cmake rule
+        # ignores `cmake --install --prefix` and writes to /usr/local, so an
+        # OLO_WITH_USD=ON build fails as non-root regardless.
+        #
+        # ccache: unlike a hosted runner, this box keeps its cache between runs,
+        # so a warm rebuild is minutes rather than an hour.
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DCMAKE_PREFIX_PATH="$VULKAN_SDK"
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DOLO_VIDEO_FFMPEG=OFF
+          -DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF -DOLO_WITH_MATERIALX=OFF
+
+      - name: Build tests
+        # --parallel 12, not nproc (16): this host also runs the gh-runner-1/2/3
+        # runners for another repository. A nightly at ~02:47 local should
+        # normally find them idle, but "normally" is not "always" — leave
+        # headroom so a concurrent build on the other runners doesn't turn into
+        # swap thrash or an OOM during the OloEngine-Tests link.
+        run: cmake --build build --target OloEngine-Tests --parallel 12
+
+      # ---------------------------------------------------------------------
+      # The suite runs from OloEditor/ — OloEditor, OloRuntime and the test
+      # binary all resolve assets, shaders and scenes relative to that directory
+      # (see CLAUDE.md "Working directory matters"). Running from the repo root
+      # yields missing-shader failures that look like rendering regressions.
+      # ---------------------------------------------------------------------
+      - name: Run full suite on AMD hardware
+        working-directory: OloEditor
+        timeout-minutes: 60
+        env:
+          # Force the headless EGL surfaceless path: this box has no X server and
+          # no Wayland compositor, so GLFW cannot create a window. Requires the
+          # EGL context fallback in RenderPropertyTest.cpp (see
+          # docs/ops/self-hosted-gpu-runner.md "Prerequisite").
+          OLO_TEST_GL_BACKEND: egl
+          # Belt and braces against a silent software fallback mid-run.
+          MESA_LOADER_DRIVER_OVERRIDE: radeonsi
+        run: |
+          mkdir -p ../test_results
+          ../build/OloEngine/tests/OloEngine-Tests \
+            --gtest_catch_exceptions=1 \
+            --gtest_output=xml:../test_results/gpu_amd.xml
+
+      # ---------------------------------------------------------------------
+      # The failure mode this job exists to prevent is also its own worst
+      # failure mode: if the EGL context path breaks, every GPU-gated test
+      # calls GTEST_SKIP() and the run goes GREEN having verified nothing.
+      # A green nightly that silently tests zero pixels is worse than a red
+      # one. RenderPropertyFixture emits an exact skip reason, so assert that
+      # it never appears rather than guessing at a pass/skip ratio.
+      # ---------------------------------------------------------------------
+      - name: Assert GPU tests actually ran
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import sys, xml.etree.ElementTree as ET
+
+          # Both GPU-gate sites, which word their skip differently:
+          #   RendererAttachedTest.cpp  -> "no usable GL 4.6 context available"
+          #   OLO_ENSURE_GPU_OR_SKIP()  -> "No GPU / GL 4.5+ context available..."
+          # Matched case-insensitively so a reworded message still trips this.
+          NEEDLES = ("no usable gl 4.6 context", "no gpu / gl 4.5+ context")
+          try:
+              root = ET.parse("test_results/gpu_amd.xml").getroot()
+          except Exception as e:
+              print(f"::error::could not read gtest XML: {e}")
+              sys.exit(1)
+
+          gpu_skips, total = [], 0
+          for case in root.iter("testcase"):
+              total += 1
+              for sk in case.iter("skipped"):
+                  blob = f"{sk.get('message') or ''} {sk.text or ''}".lower()
+                  if any(n in blob for n in NEEDLES):
+                      gpu_skips.append(f"{case.get('classname')}.{case.get('name')}")
+
+          print(f"{total} test cases in report; {len(gpu_skips)} skipped for a missing GL context")
+          if gpu_skips:
+              print(f"::error::{len(gpu_skips)} GPU test(s) skipped - the headless EGL context "
+                    f"was not acquired, so this run verified no pixels.")
+              for name in gpu_skips[:20]:
+                  print(f"  skipped: {name}")
+              sys.exit(1)
+          if total == 0:
+              print("::error::gtest reported zero test cases")
+              sys.exit(1)
+          print("OK - no GPU test was skipped for want of a context.")
+          PY
+
+      - name: Perf-history trend analysis
+        if: always()
+        run: python3 OloEngine/tests/scripts/perf_trend.py
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gpu_amd_results
+          path: |
+            test_results/gpu_amd.xml
+            OloEngine/tests/Rendering/PropertyTests/perf_history/*.tsv
+          if-no-files-found: warn
+
+      # The whole point of a GPU job is the pixels. On failure, get the actual
+      # and diff images off the box so they can be inspected without SSH.
+      - name: Upload golden-image diffs and visual evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gpu_amd_golden_diffs
+          path: |
+            OloEditor/assets/tests/golden/*.actual.png
+            OloEditor/assets/tests/golden/*.diff.png
+            OloEditor/assets/tests/golden/amd/*.actual.png
+            OloEditor/assets/tests/golden/amd/*.diff.png
+            OloEditor/assets/tests/visual/**/*.png
+          if-no-files-found: ignore
+
+      # Build trees for this engine are tens of GB and the box is shared with
+      # other runners; don't let a month of nightlies fill the disk.
+      - name: Report disk usage
+        if: always()
+        run: df -h "${{ github.workspace }}" && du -sh build 2>/dev/null || true

--- a/.github/workflows/gpu-conformance-amd.yml
+++ b/.github/workflows/gpu-conformance-amd.yml
@@ -46,6 +46,21 @@ name: GPU Conformance (AMD, self-hosted)
 
 on:
   workflow_dispatch:
+    # Baselining an AMD golden set is a documented manual step (see the ops
+    # doc's "Bootstrapping the AMD golden baseline"), but there was no way to
+    # perform it: the rebase env vars could only be set by editing this file or
+    # by running the suite by hand on the box. Expose them as explicit opt-in
+    # inputs instead. They default to false and are only settable on a manual
+    # dispatch, so a *scheduled* run can never rewrite a baseline.
+    inputs:
+      golden_rebase:
+        description: 'Rewrite the AMD golden images from this run (inspect the diffs first)'
+        type: boolean
+        default: false
+      perf_rebase:
+        description: 'Rewrite the perf baselines for this machine'
+        type: boolean
+        default: false
   schedule:
     # 00:47 UTC — roughly 02:00 German local (02:47 CEST / 01:47 CET; GitHub cron
     # is UTC-only and does not follow DST, so it drifts an hour across the year).
@@ -89,6 +104,15 @@ jobs:
       # vendor set. Both dirs live in the runner user's home, not the workspace.
       CPM_SOURCE_CACHE: /home/gh-runner-olo/.cache/cpm
       CCACHE_DIR: /home/gh-runner-olo/.cache/ccache
+      # Rebase opt-ins from the manual-dispatch inputs above. On a scheduled run
+      # `inputs.*` is null, so both resolve to '0'. Emit '0' rather than '' or
+      # 'false': all three readers (GoldenImageTests::ShouldRebase,
+      # AtmosphereVisualEvidenceTest::GoldenRebaseRequested,
+      # PerfRegressionTests::PerfShouldRebase) agree that '0' means off, whereas
+      # they disagree about the string 'false' — one of them tests only the
+      # first character, so 'false' would *enable* a rebase there.
+      OLOENGINE_GOLDEN_REBASE: ${{ inputs.golden_rebase && '1' || '0' }}
+      OLOENGINE_PERF_REBASE: ${{ inputs.perf_rebase && '1' || '0' }}
 
     steps:
       # A self-hosted runner's workspace PERSISTS between jobs. Even with an
@@ -102,8 +126,21 @@ jobs:
           # Never let an empty/unexpected expansion turn this into `rm -rf /*`.
           # A self-hosted runner has a real filesystem behind it, unlike a
           # throwaway hosted VM — this guard is not paranoia.
+          #
+          # Normalise trailing slashes first, then test longest-match-first.
+          # An earlier version matched '/home/'*/ which requires a TRAILING
+          # slash — github.workspace never has one, so it rejected the form
+          # that cannot occur and allowed the bare '/home/gh-runner-olo' that
+          # would have wiped the runner user's entire home, runner install and
+          # caches included.
+          while [ "${ws%/}" != "$ws" ]; do ws="${ws%/}"; done
           case "$ws" in
-            ''|'/'|'/home'|'/home/'*/) echo "::error::refusing to wipe '$ws'"; exit 1 ;;
+            ''|'/'|'/home')
+              echo "::error::refusing to wipe '$ws'"; exit 1 ;;
+            /home/*/*)
+              : ;;  # below a home directory — the expected shape
+            /home/*)
+              echo "::error::refusing to wipe bare home directory '$ws'"; exit 1 ;;
           esac
           [ -d "$ws/_actions" ] && { echo "::error::'$ws' looks like the runner root"; exit 1; }
           echo "Wiping $ws"

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -850,6 +850,31 @@ target_link_libraries(OloEngine-Tests
 	gtest
 	cpp_httplib)
 
+# Headless GPU support (docs/ops/self-hosted-gpu-runner.md).
+#
+# The fixture normally gets its GL 4.6 context from GLFW, which on Linux needs
+# an X11 or Wayland display. A headless CI box has neither, so every test gated
+# on RenderPropertyFixture::IsGpuAvailable() skips even when a perfectly good
+# GPU is sitting there. Linking libEGL lets the fixture fall back to EGL's
+# surfaceless platform and talk to the DRM render node directly.
+#
+# Strictly optional: where libEGL is absent we keep the GLFW-only path and
+# those tests skip exactly as they did before, so this cannot break a build.
+if(UNIX AND NOT APPLE)
+	find_library(OLO_EGL_LIBRARY NAMES EGL)
+	find_path(OLO_EGL_INCLUDE_DIR NAMES EGL/egl.h)
+	if(OLO_EGL_LIBRARY AND OLO_EGL_INCLUDE_DIR)
+		# Plain signature to match the target_link_libraries call above — CMake
+		# rejects mixing the plain and keyword forms on a single target.
+		target_link_libraries(OloEngine-Tests ${OLO_EGL_LIBRARY})
+		target_include_directories(OloEngine-Tests PRIVATE ${OLO_EGL_INCLUDE_DIR})
+		target_compile_definitions(OloEngine-Tests PRIVATE OLO_TESTS_HAVE_EGL=1)
+		message(STATUS "OloEngine-Tests: headless EGL context path enabled (${OLO_EGL_LIBRARY})")
+	else()
+		message(STATUS "OloEngine-Tests: libEGL not found - headless GPU tests will skip")
+	endif()
+endif()
+
 # Copy FFmpeg DLLs next to the test exe so OLO_VIDEO_FFMPEG decode tests can run.
 olo_copy_ffmpeg_runtime(OloEngine-Tests)
 

--- a/OloEngine/tests/Rendering/PropertyTests/RenderPropertyTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RenderPropertyTest.cpp
@@ -10,18 +10,73 @@
 #include <glad/gl.h>
 #include <GLFW/glfw3.h>
 
+#if defined(OLO_TESTS_HAVE_EGL)
+// Keep X11's headers out of this translation unit. `<EGL/eglplatform.h>`
+// pulls in `<X11/Xlib.h>` unless told otherwise, and Xlib defines `None` as
+// a bare `0L` macro — which silently mangles every `None` enumerator the
+// engine headers declare (MeshComponent::Primitive::None among them). The
+// surfaceless path never touches X, so opt out of the headers entirely.
+#define EGL_NO_X11 1
+#define MESA_EGL_NO_X11_HEADERS 1
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#endif
+
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <filesystem>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace OloEngine::Tests
 {
     namespace
     {
+        // Which windowing/context path to use for the shared GL context, via
+        // the OLO_TEST_GL_BACKEND environment variable.
+        //
+        //   Auto (default) — prefer GLFW, the context a developer gets locally;
+        //                    fall back to EGL when GLFW cannot reach a display
+        //                    server, i.e. a headless Linux box that still has a
+        //                    perfectly usable GPU.
+        //   Glfw / Egl     — pin one path. Headless CI pins `egl` so that a
+        //                    missing display server is a deterministic choice
+        //                    rather than a silent backend switch: two backends
+        //                    can produce subtly different pixels, and a golden
+        //                    baseline must know which one produced it.
+        enum class GlBackend
+        {
+            Auto,
+            Glfw,
+            Egl
+        };
+
+        GlBackend SelectBackend()
+        {
+            const char* raw = std::getenv("OLO_TEST_GL_BACKEND");
+            if (raw == nullptr || raw[0] == '\0')
+                return GlBackend::Auto;
+
+            std::string value(raw);
+            std::transform(value.begin(), value.end(), value.begin(),
+                           [](unsigned char c)
+                           { return static_cast<char>(std::tolower(c)); });
+
+            if (value == "egl")
+                return GlBackend::Egl;
+            if (value == "glfw")
+                return GlBackend::Glfw;
+
+            // Unrecognised value: fall back to Auto rather than failing hard —
+            // a typo in CI config should degrade to the normal behaviour, and
+            // the GPU tests will report themselves skipped if nothing works.
+            return GlBackend::Auto;
+        }
+
         // ---------------------------------------------------------------
         // Singleton GPU-context. Created on first call to IsGpuAvailable.
         // No teardown: process exit reclaims GL state. This avoids order-
@@ -32,6 +87,10 @@ namespace OloEngine::Tests
             std::once_flag m_InitOnce;
             bool m_Available = false;
             GLFWwindow* m_Window = nullptr;
+#if defined(OLO_TESTS_HAVE_EGL)
+            EGLDisplay m_EglDisplay = EGL_NO_DISPLAY;
+            EGLContext m_EglContext = EGL_NO_CONTEXT;
+#endif
 
             static GpuContext& Get()
             {
@@ -47,42 +106,168 @@ namespace OloEngine::Tests
                                    if (!ChangeToOloEditorDir())
                                        return;
 
-                                   if (!::glfwInit())
-                                       return;
+                                   const GlBackend backend = SelectBackend();
 
-                                   ::glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-                                   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-                                   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
-                                   ::glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-                                   ::glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-
-                                   m_Window = ::glfwCreateWindow(1, 1, "OloEngine-RenderPropertyTest", nullptr, nullptr);
-                                   if (!m_Window)
+                                   if (backend != GlBackend::Egl && TryInitGlfw())
                                    {
+                                       m_Available = true;
                                        return;
                                    }
 
-                                   ::glfwMakeContextCurrent(m_Window);
-                                   const int version = ::gladLoadGL(reinterpret_cast<GLADloadfunc>(::glfwGetProcAddress));
-                                   if (version == 0)
+#if defined(OLO_TESTS_HAVE_EGL)
+                                   if (backend != GlBackend::Glfw && TryInitEgl())
                                    {
-                                       ::glfwDestroyWindow(m_Window);
-                                       m_Window = nullptr;
+                                       m_Available = true;
                                        return;
                                    }
-
-                                   const int major = GLAD_VERSION_MAJOR(version);
-                                   const int minor = GLAD_VERSION_MINOR(version);
-                                   if (major < 4 || (major == 4 && minor < 6))
-                                   {
-                                       ::glfwDestroyWindow(m_Window);
-                                       m_Window = nullptr;
-                                       return;
-                                   }
-
-                                   m_Available = true;
+#endif
                                });
             }
+
+            // Shared by both backends: glad resolves against whichever loader
+            // owns the now-current context, and we require a full 4.6 core
+            // profile either way.
+            static bool LoadGladAndCheckVersion(GLADloadfunc loader)
+            {
+                const int version = ::gladLoadGL(loader);
+                if (version == 0)
+                    return false;
+
+                const int major = GLAD_VERSION_MAJOR(version);
+                const int minor = GLAD_VERSION_MINOR(version);
+                return (major > 4) || (major == 4 && minor >= 6);
+            }
+
+            bool TryInitGlfw()
+            {
+                if (!::glfwInit())
+                    return false;
+
+                ::glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+                ::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+                ::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
+                ::glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+                ::glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+
+                m_Window = ::glfwCreateWindow(1, 1, "OloEngine-RenderPropertyTest", nullptr, nullptr);
+                if (!m_Window)
+                    return false;
+
+                ::glfwMakeContextCurrent(m_Window);
+                if (!LoadGladAndCheckVersion(reinterpret_cast<GLADloadfunc>(::glfwGetProcAddress)))
+                {
+                    ::glfwDestroyWindow(m_Window);
+                    m_Window = nullptr;
+                    return false;
+                }
+
+                return true;
+            }
+
+#if defined(OLO_TESTS_HAVE_EGL)
+            bool TryInitEgl()
+            {
+                auto getPlatformDisplay =
+                    reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(::eglGetProcAddress("eglGetPlatformDisplayEXT"));
+                if (getPlatformDisplay == nullptr)
+                    return false;
+
+                // 1. Mesa's surfaceless platform: no X, no Wayland, no GBM device
+                //    to pick. This is the path a headless CI box takes.
+                if (TryInitEglOnDisplay(getPlatformDisplay(kPlatformSurfacelessMesa, EGL_DEFAULT_DISPLAY, nullptr)))
+                    return true;
+
+                // 2. Otherwise enumerate EGL devices and take the first backed by
+                //    a DRM render node. Skipping the node-less entries is not
+                //    cosmetic: Mesa also publishes an EGL_MESA_device_software
+                //    device, and binding that would hand us llvmpipe while the
+                //    run is labelled with a hardware vendor's golden set.
+                auto queryDevices =
+                    reinterpret_cast<PFNEGLQUERYDEVICESEXTPROC>(::eglGetProcAddress("eglQueryDevicesEXT"));
+                auto queryDeviceString =
+                    reinterpret_cast<PFNEGLQUERYDEVICESTRINGEXTPROC>(::eglGetProcAddress("eglQueryDeviceStringEXT"));
+                if (queryDevices == nullptr || queryDeviceString == nullptr)
+                    return false;
+
+                constexpr EGLint kMaxDevices = 8;
+                EGLDeviceEXT devices[kMaxDevices]{};
+                EGLint deviceCount = 0;
+                if (!queryDevices(kMaxDevices, devices, &deviceCount))
+                    return false;
+
+                for (EGLint i = 0; i < deviceCount; ++i)
+                {
+                    if (queryDeviceString(devices[i], kDrmRenderNodeFileExt) == nullptr)
+                        continue;
+
+                    if (TryInitEglOnDisplay(getPlatformDisplay(EGL_PLATFORM_DEVICE_EXT, devices[i], nullptr)))
+                        return true;
+                }
+
+                return false;
+            }
+
+            bool TryInitEglOnDisplay(EGLDisplay display)
+            {
+                if (display == EGL_NO_DISPLAY)
+                    return false;
+
+                if (!::eglInitialize(display, nullptr, nullptr))
+                    return false;
+
+                // Desktop GL, not GLES — the engine is a GL 4.6 DSA renderer.
+                if (!::eglBindAPI(EGL_OPENGL_API))
+                    return false;
+
+                constexpr EGLint configAttribs[] = {
+                    EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+                    EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+                    EGL_RED_SIZE, 8,
+                    EGL_GREEN_SIZE, 8,
+                    EGL_BLUE_SIZE, 8,
+                    EGL_ALPHA_SIZE, 8,
+                    EGL_NONE
+                };
+                EGLConfig config{};
+                EGLint configCount = 0;
+                if (!::eglChooseConfig(display, configAttribs, &config, 1, &configCount) || configCount < 1)
+                    return false;
+
+                constexpr EGLint contextAttribs[] = {
+                    EGL_CONTEXT_MAJOR_VERSION, 4,
+                    EGL_CONTEXT_MINOR_VERSION, 6,
+                    EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
+                    EGL_NONE
+                };
+                EGLContext context = ::eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
+                if (context == EGL_NO_CONTEXT)
+                    return false;
+
+                // Surfaceless on purpose: every pixel the suite inspects is read
+                // back from an FBO, so a default framebuffer would go unused.
+                if (!::eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, context))
+                {
+                    ::eglDestroyContext(display, context);
+                    return false;
+                }
+
+                if (!LoadGladAndCheckVersion(reinterpret_cast<GLADloadfunc>(::eglGetProcAddress)))
+                {
+                    ::eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+                    ::eglDestroyContext(display, context);
+                    return false;
+                }
+
+                m_EglDisplay = display;
+                m_EglContext = context;
+                return true;
+            }
+
+            // Spelled out rather than relying on the SDK headers being new enough
+            // to declare them.
+            static constexpr EGLenum kPlatformSurfacelessMesa = 0x31DD; // EGL_PLATFORM_SURFACELESS_MESA
+            static constexpr EGLint kDrmRenderNodeFileExt = 0x3377;     // EGL_DRM_RENDER_NODE_FILE_EXT
+#endif
 
             // Walk up from CWD looking for <candidate>/OloEditor/assets/shaders.
             // chdir into the OloEditor folder if found, so Shader::Create's

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Windows](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/Windows.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/Windows.yml)
 [![Sanitizers](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/asan.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/asan.yml)
+[![GPU Conformance (AMD, self-hosted)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/gpu-conformance-amd.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/gpu-conformance-amd.yml)
 [![Cross-Vendor Conformance](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/cross-vendor.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/cross-vendor.yml)
 [![Fuzz Smoke](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/fuzz.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/fuzz.yml)
 [![SonarCloud Scan](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/SonarCloud.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/SonarCloud.yml)
@@ -26,6 +27,7 @@ Metallic and dielectric PBR spheres (a roughness sweep) reflecting a procedural 
 - [Building & running](#building--running)
 - [Features](#features)
 - [Testing](#testing)
+- [Continuous integration](#continuous-integration)
 - [Tooling](#tooling)
 - [Dependencies](#dependencies)
 - [Code style & pre-commit hooks](#code-style--pre-commit-hooks)
@@ -173,6 +175,34 @@ build\OloEngine\tests\Debug\OloEngine-Tests.exe --gtest_filter=SuiteName.TestNam
 ```
 
 The rationale, per-layer reference, classification rules, and anti-patterns live in [docs/testing.md](docs/testing.md) and [docs/agent-rules/testing-architecture.md](docs/agent-rules/testing-architecture.md).
+
+## Continuous integration
+
+### Per-PR and per-push
+
+These gate every change and run on GitHub-hosted runners.
+
+| Workflow | Status | Covers |
+| --- | --- | --- |
+| [Windows](.github/workflows/Windows.yml) | [![Windows](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/Windows.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/Windows.yml) | MSVC build + full suite via CTest |
+| [Sanitizers](.github/workflows/asan.yml) | [![Sanitizers](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/asan.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/asan.yml) | ASan (Windows/clang-cl), ASan+LSan / UBSan / TSan (Linux/Clang) |
+| [SonarCloud Scan](.github/workflows/SonarCloud.yml) | [![SonarCloud Scan](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/SonarCloud.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/SonarCloud.yml) | Static analysis (see [sonarqube-review-alignment.md](docs/agent-rules/sonarqube-review-alignment.md)) |
+| [Pre-commit checks](.github/workflows/pre-commit.yml) | [![Pre-commit checks](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/pre-commit.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/pre-commit.yml) | Formatting, YAML, test-catalogue classification |
+
+### Scheduled
+
+Cron times are **UTC** — GitHub's scheduler does not observe DST, so local times shift by an hour across the year. Every one of these is also `workflow_dispatch`-able from the Actions tab. Scheduled runs may start tens of minutes late under load.
+
+| Workflow | Status | Cadence (UTC) | Runs on | Covers |
+| --- | --- | --- | --- | --- |
+| [GPU Conformance (AMD)](.github/workflows/gpu-conformance-amd.yml) | [![GPU Conformance (AMD, self-hosted)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/gpu-conformance-amd.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/gpu-conformance-amd.yml) | nightly 00:47 | **self-hosted** Linux / AMD Navi 10 | The renderer's visual, golden and perf layers against a **real GPU** — they skip everywhere else. See [self-hosted-gpu-runner.md](docs/ops/self-hosted-gpu-runner.md) |
+| [Cross-Vendor Conformance](.github/workflows/cross-vendor.yml) | [![Cross-Vendor Conformance](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/cross-vendor.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/cross-vendor.yml) | nightly 03:47 | GitHub-hosted Windows | L1/3/5/6/8 against Mesa **llvmpipe** (software) |
+| [Fuzz Smoke](.github/workflows/fuzz.yml) | [![Fuzz Smoke](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/fuzz.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/fuzz.yml) | nightly 04:13 | GitHub-hosted Windows | Parser / deserializer fuzzing |
+| [Flaky repro (#281)](.github/workflows/flaky-repro-281.yml) | [![Flaky repro (#281)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/flaky-repro-281.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/flaky-repro-281.yml) | nightly 07:00 | GitHub-hosted Windows | Repeat-runs a known-flaky test to hunt issue #281 |
+| [Video (FFmpeg backend)](.github/workflows/video-ffmpeg.yml) | [![Video (FFmpeg backend)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/video-ffmpeg.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/video-ffmpeg.yml) | weekly, Mon 06:00 | GitHub-hosted matrix | `OLO_VIDEO_FFMPEG=ON` build + decode tests |
+| [reflection-status-check](.github/workflows/reflection-status-check.yml) | [![reflection-status-check](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/reflection-status-check.yml/badge.svg?branch=master)](https://github.com/drsnuggles8/OloEngineBase/actions/workflows/reflection-status-check.yml) | monthly, 1st 09:07 | GitHub-hosted Linux | Reminder to re-check C++26 reflection toolchain support |
+
+**Hardware-GPU vendor coverage** is AMD-only. The goldens in `assets/tests/golden/` are baselined on NVIDIA, but only ever from a developer machine — there is no NVIDIA or Intel CI. llvmpipe is a third *software* implementation, not a second vendor, so it catches spec-compliance drift rather than driver divergence.
 
 ## Tooling
 

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -217,12 +217,19 @@ case the permissive mode is a distribution default that changes.
 
 A tarball is staged at `/home/obueker/actions-runner-linux-x64-2.336.0.tar.gz`.
 
-```bash
-sudo -iu gh-runner-olo
-mkdir -p ~/actions-runner && cd ~/actions-runner
-tar xzf /home/obueker/actions-runner-linux-x64-2.336.0.tar.gz
+**Extract it as root, not as the runner user.** `/home/obueker` is mode `0700`,
+so `gh-runner-olo` cannot traverse into it and `tar` fails with `Cannot open:
+Permission denied` before reading a byte — the same reason the Vulkan SDK has to
+be relocated to `/opt` above. Extract, hand ownership over, then register as the
+runner user:
 
-./config.sh \
+```bash
+RUNNER_DIR=/home/gh-runner-olo/actions-runner
+sudo install -o gh-runner-olo -g gh-runner-olo -m 700 -d "$RUNNER_DIR"
+sudo tar xzf /home/obueker/actions-runner-linux-x64-2.336.0.tar.gz -C "$RUNNER_DIR"
+sudo chown -R gh-runner-olo:gh-runner-olo "$RUNNER_DIR"
+
+sudo -u gh-runner-olo -- "$RUNNER_DIR/config.sh" \
   --url https://github.com/drsnuggles8/OloEngineBase \
   --token <REGISTRATION_TOKEN> \
   --name olo-gpu-amd \
@@ -230,6 +237,10 @@ tar xzf /home/obueker/actions-runner-linux-x64-2.336.0.tar.gz
   --work _work \
   --unattended --replace
 ```
+
+`config.sh` prints a few `ldd: ./bin/lib*.so: No such file or directory` lines
+from its dependency probe (it uses relative paths from the wrong directory).
+They are cosmetic — registration and `Runner.Listener` both work regardless.
 
 Mint the token with `gh api -X POST
 repos/drsnuggles8/OloEngineBase/actions/runners/registration-token --jq .token`

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -131,9 +131,12 @@ those, so configure fails with:
 Required shader library not found: SHADERC_LIB.
 ```
 
-Install the LunarG SDK (unpacked under the runner user's home is fine — it needs
-no root) and point CMake at it with a single prefix, which resolves Vulkan *and*
-all the shader libraries at once:
+Install the LunarG SDK **somewhere the runner user can actually reach** — on this
+host that means `/opt/vulkan-sdk/<version>/`, root-owned and world-readable. It
+must *not* live in a person's home directory: `/home/obueker` is mode `0700`, so
+the runner user cannot traverse into it even though the SDK's own subdirectories
+are world-readable. Point CMake at it with a single prefix, which resolves Vulkan
+*and* all the shader libraries at once:
 
 ```
 -DCMAKE_PREFIX_PATH="$VULKAN_SDK"
@@ -143,7 +146,7 @@ Export `VULKAN_SDK` for the runner service — add it to `actions-runner/.env`, 
 every job inherits it:
 
 ```
-VULKAN_SDK=/path/to/vulkan-sdk/<version>/x86_64
+VULKAN_SDK=/opt/vulkan-sdk/1.4.350.1/x86_64
 ```
 
 The workflow preflights this and fails with a "provision the runner" message
@@ -210,9 +213,9 @@ directory, or any credential with `gh-runner-1/2/3`.
 group is belt-and-braces rather than strictly required — but set it anyway, in
 case the permissive mode is a distribution default that changes.
 
-### 3. Register the runner (ephemeral)
+### 3. Register the runner
 
-A tarball is already staged at `~/actions-runner-linux-x64-2.336.0.tar.gz`.
+A tarball is staged at `/home/obueker/actions-runner-linux-x64-2.336.0.tar.gz`.
 
 ```bash
 sudo -iu gh-runner-olo
@@ -225,22 +228,51 @@ tar xzf /home/obueker/actions-runner-linux-x64-2.336.0.tar.gz
   --name olo-gpu-amd \
   --labels self-hosted,linux,x64,gpu-amd \
   --work _work \
-  --ephemeral \
-  --unattended
+  --unattended --replace
 ```
 
-`--ephemeral` retires the runner after a single job, so no state carries between
-jobs. Pair it with a systemd unit that re-registers on exit, or accept a manual
-re-register per nightly — see the runner docs for the auto-reconfigure pattern.
+Mint the token with `gh api -X POST
+repos/drsnuggles8/OloEngineBase/actions/runners/registration-token --jq .token`
+(or **Settings → Actions → Runners → New self-hosted runner**). It expires after
+an hour.
 
-Get the registration token from **Settings → Actions → Runners → New self-hosted
-runner** (it expires after an hour).
+**Not `--ephemeral`, deliberately.** An ephemeral runner deregisters after one
+job and must be re-registered with a fresh token, which in practice means
+storing a long-lived PAT on the box — trading one risk for another. The value of
+ephemerality is low here because the workflow has no `pull_request` trigger, so
+only repo-owned code ever runs, and it wipes the workspace as its first step.
+Revisit this if the runner is ever pointed at a workflow that untrusted code can
+reach.
 
 ### 4. Service
 
+The host's existing runners start via **user-level systemd with lingering**
+(`/var/lib/systemd/linger/`), so match that rather than installing a system unit
+with `svc.sh`:
+
 ```bash
-sudo ./svc.sh install gh-runner-olo
-sudo ./svc.sh start
+sudo loginctl enable-linger gh-runner-olo
+# ~/.config/systemd/user/actions-runner-olo.service -> ExecStart=<dir>/run.sh
+sudo -u gh-runner-olo XDG_RUNTIME_DIR=/run/user/$(id -u gh-runner-olo) \
+    systemctl --user enable --now actions-runner-olo.service
+```
+
+### 5. One-shot setup script
+
+All of the above — user, SDK relocation, unpack, register, `.env`, caches,
+linger, unit — is scripted and idempotent. Run it as root with a freshly minted
+token:
+
+```bash
+sudo bash scripts/setup-olo-runner.sh \
+  "$(gh api -X POST repos/drsnuggles8/OloEngineBase/actions/runners/registration-token --jq .token)"
+```
+
+Verify afterwards:
+
+```bash
+gh api repos/drsnuggles8/OloEngineBase/actions/runners \
+  --jq '.runners[]|{name,status,busy,labels:[.labels[].name]}'
 ```
 
 ## GitHub-side settings

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -1,0 +1,286 @@
+# Self-hosted AMD GPU runner
+
+Provisioning notes for the runner behind
+[`.github/workflows/gpu-conformance-amd.yml`](../../.github/workflows/gpu-conformance-amd.yml).
+
+## Why this runner exists
+
+It is **not** a cost or speed measure. OloEngineBase is a public repository, so
+standard GitHub-hosted runners are free and unlimited, and queue wait is
+negligible (median 7 s). Moving existing jobs here would save nothing — the CI
+critical path is Windows (SonarCloud ~155 min, ASan/clang-cl ~151 min), which a
+Linux box cannot take, and the three Linux sanitizer jobs already finish before
+those.
+
+The runner exists for the one thing GitHub cannot sell at any price: **a real
+GPU**. Every test gated on `RenderPropertyFixture`'s GL-context check — 97 test
+files — currently hits `GTEST_SKIP() << "no usable GL 4.6 context available"` in
+CI. That is the visual, golden and perf third of the renderer pyramid running
+nowhere but a developer's Windows box, in a repository whose own rules say
+rendering changes must be verified against pixels.
+
+`cross-vendor.yml` substitutes Mesa llvmpipe, but llvmpipe is a *third software
+implementation*, not a second **vendor**. It cannot catch AMD GLSL-compiler or
+driver divergence from the NVIDIA hardware the goldens are baselined on.
+
+## Verified host capability
+
+Confirmed working on the target box before any of this was written:
+
+| | |
+|---|---|
+| GPU | AMD Radeon RX 5600 XT — Navi 10, PCI `1002:731F` |
+| Driver | `amdgpu`, `/dev/dri/card0` + `/dev/dri/renderD128` |
+| Userspace | Mesa 25.2.7 — `radeonsi_dri.so`, RADV (`radeon_icd`) |
+| Context | **OpenGL 4.6 Core, GLSL 4.60** via `EGL_MESA_platform_surfaceless` |
+| Display server | **none** — no X, no Wayland (`multi-user.target`) |
+| CPU / RAM | Ryzen 7 3700X (8C/16T) / 31 GiB |
+| Toolchain | cmake 4.4.0, ninja 1.13, clang 21.1.8, gcc 14.3.1, python 3.12 |
+
+Headless offscreen render + readback was verified pixel-exact (FBO clear to
+`0.25,0.5,0.75,1.0` → readback `64,128,191,255`, `glGetError() == 0`).
+
+Note the software EGL device (`EGL_MESA_device_software`) is also enumerated on
+this host and **fails** to produce a 4.6 core context — which is why the
+workflow's preflight explicitly rejects `llvmpipe`/`softpipe`/`swrast` rather
+than trusting that a context implies hardware.
+
+## How the headless context works
+
+The suite used to get its GL context only from GLFW, which on Linux needs an
+X11 or Wayland display. This host has neither, so `glfwCreateWindow` failed and
+every GPU test skipped — the exact condition the runner exists to eliminate.
+
+`RenderPropertyTest.cpp` now selects a backend via **`OLO_TEST_GL_BACKEND`**:
+
+| Value | Behaviour |
+|---|---|
+| unset (*Auto*) | GLFW first, then EGL if GLFW can't reach a display server |
+| `glfw` | GLFW only — the unchanged local-developer path |
+| `egl` | EGL only — what this workflow pins |
+
+CI pins `egl` deliberately. Under *Auto* a broken display server would silently
+switch backends, and two backends can produce subtly different pixels — a golden
+baseline has to know which one produced it.
+
+The EGL path tries `EGL_MESA_platform_surfaceless` first, then falls back to
+enumerating EGL devices and taking the first backed by a DRM render node.
+Skipping node-less devices is not cosmetic: Mesa also publishes an
+`EGL_MESA_device_software` device, and binding it would hand us llvmpipe while
+the run is labelled with a hardware vendor's golden set.
+
+libEGL is discovered optionally in `OloEngine/tests/CMakeLists.txt`
+(`OLO_TESTS_HAVE_EGL`). Where it is absent the GLFW-only path remains and those
+tests skip exactly as before, so this cannot break a build.
+
+Two implementation notes worth preserving:
+
+- The EGL headers are included with `EGL_NO_X11` / `MESA_EGL_NO_X11_HEADERS`.
+  Without them `<EGL/eglplatform.h>` drags in `<X11/Xlib.h>`, which defines
+  `None` as a bare `0L` macro and mangles every `None` enumerator in the engine
+  headers (`MeshComponent::Primitive::None` among them).
+- The context is surfaceless — no default framebuffer. That is fine because
+  every pixel the suite inspects is read back from an FBO.
+
+Do **not** reach for Xvfb as an alternative: it is a software rasteriser, i.e.
+llvmpipe with extra steps, and would produce "AMD" goldens that are nothing of
+the sort.
+
+### Guarding against a green-but-empty run
+
+The job's own worst failure mode is that the EGL path breaks, every GPU test
+calls `GTEST_SKIP()`, and the nightly passes having verified nothing. The
+**"Assert GPU tests actually ran"** step parses the gtest XML and fails the run
+if *any* test skipped for want of a context. It matches both gate sites, which
+word their skip differently:
+
+- `RendererAttachedTest.cpp` — *"no usable GL 4.6 context available"*
+- `OLO_ENSURE_GPU_OR_SKIP()` — *"No GPU / GL 4.5+ context available…"*
+
+If you add a third GPU gate with new wording, add its phrase there too.
+
+## Host provisioning
+
+### 1. Packages
+
+Most of the toolchain is already present. Mirroring `asan.yml`'s Linux
+dependency set, on Rocky 10:
+
+```bash
+sudo dnf install -y \
+  ccache \
+  vulkan-loader-devel vulkan-headers \
+  mesa-libGL-devel mesa-libEGL-devel libglvnd-devel \
+  libX11-devel libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel libXext-devel \
+  wayland-devel wayland-protocols-devel libxkbcommon-devel \
+  glslang-devel spirv-tools
+python3 -m pip install --user jinja2   # OloHeaderTool codegen
+```
+
+The X11/Wayland `-devel` packages are needed to *build* GLFW even though no
+display server runs — GLFW compiles its backends unconditionally.
+
+### 1b. Vulkan SDK (required — distro packages are not enough)
+
+`OloEngine/CMakeLists.txt` raises `FATAL_ERROR` at configure time on the first
+missing shader library, and it needs **shaderc, glslang, SPIRV-Tools and
+SPIRV-Cross**, not just the loader. Rocky ships `vulkan-loader` but none of
+those, so configure fails with:
+
+```
+Required shader library not found: SHADERC_LIB.
+```
+
+Install the LunarG SDK (unpacked under the runner user's home is fine — it needs
+no root) and point CMake at it with a single prefix, which resolves Vulkan *and*
+all the shader libraries at once:
+
+```
+-DCMAKE_PREFIX_PATH="$VULKAN_SDK"
+```
+
+Export `VULKAN_SDK` for the runner service — add it to `actions-runner/.env`, so
+every job inherits it:
+
+```
+VULKAN_SDK=/path/to/vulkan-sdk/<version>/x86_64
+```
+
+The workflow preflights this and fails with a "provision the runner" message
+rather than a CMake stack trace several minutes into configure.
+
+### 1c. Caches outside the workspace
+
+The workflow wipes the workspace and `actions/checkout` cleans it, so anything
+under it is gone every run — including `OloEngine/vendor/`, where CPM and
+FetchContent place vendor sources. Without caches sited elsewhere, every nightly
+re-downloads and rebuilds the entire vendor set. The workflow points both at the
+runner user's home:
+
+```
+CPM_SOURCE_CACHE=/home/gh-runner-olo/.cache/cpm
+CCACHE_DIR=/home/gh-runner-olo/.cache/ccache
+```
+
+### 1d. Why the interchange formats are switched off
+
+Beyond cost, `OLO_WITH_USD=ON` **cannot complete as a non-root user**: OpenUSD's
+`pxr/cmake_install.cmake` installs `pxrConfig.cmake` to an absolute path,
+ignoring `cmake --install --prefix`, and dies with
+
+```
+file INSTALL cannot copy file ".../pxrConfig.cmake"
+to "/usr/local/pxrConfig.cmake": Permission denied
+```
+
+The workflow passes `-DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF
+-DOLO_WITH_MATERIALX=OFF`, which is correct on its own merits (none of them
+affect GPU rendering conformance) and sidesteps this too.
+
+### 1e. Gotcha when building locally alongside another tree
+
+CPM/FetchContent subbuilds live in the **shared source tree**
+(`OloEngine/vendor/`), not the build directory, and are stamped with the
+generator that created them. A second build tree using a *different* generator
+fails at configure with:
+
+```
+Error: generator : Ninja
+Does not match the generator used previously: Ninja Multi-Config
+```
+
+Use the same generator as any existing tree, or wipe `OloEngine/vendor/`. CI is
+unaffected — it always starts from a wiped workspace.
+
+### 2. Dedicated, isolated user
+
+The host already runs `gh-runner-1/2/3` for a **private** repository. This
+runner serves a **public** one, which is a materially different trust level: a
+compromise here must not reach those runners or their secrets.
+
+```bash
+sudo useradd -m -s /bin/bash gh-runner-olo
+sudo usermod -aG render,video gh-runner-olo    # GPU access
+```
+
+Do not add it to `wheel`. Do not share a home directory, work directory, ccache
+directory, or any credential with `gh-runner-1/2/3`.
+
+`/dev/dri/renderD128` is currently mode `0666` on this host, so the `render`
+group is belt-and-braces rather than strictly required — but set it anyway, in
+case the permissive mode is a distribution default that changes.
+
+### 3. Register the runner (ephemeral)
+
+A tarball is already staged at `~/actions-runner-linux-x64-2.336.0.tar.gz`.
+
+```bash
+sudo -iu gh-runner-olo
+mkdir -p ~/actions-runner && cd ~/actions-runner
+tar xzf /home/obueker/actions-runner-linux-x64-2.336.0.tar.gz
+
+./config.sh \
+  --url https://github.com/drsnuggles8/OloEngineBase \
+  --token <REGISTRATION_TOKEN> \
+  --name olo-gpu-amd \
+  --labels self-hosted,linux,x64,gpu-amd \
+  --work _work \
+  --ephemeral \
+  --unattended
+```
+
+`--ephemeral` retires the runner after a single job, so no state carries between
+jobs. Pair it with a systemd unit that re-registers on exit, or accept a manual
+re-register per nightly — see the runner docs for the auto-reconfigure pattern.
+
+Get the registration token from **Settings → Actions → Runners → New self-hosted
+runner** (it expires after an hour).
+
+### 4. Service
+
+```bash
+sudo ./svc.sh install gh-runner-olo
+sudo ./svc.sh start
+```
+
+## GitHub-side settings
+
+The workflow is structurally safe — it has no `pull_request` or
+`pull_request_target` trigger, so a fork PR can never schedule onto this box.
+These are defence in depth:
+
+- **Settings → Actions → General → Fork pull request workflows**: set approval to
+  **"Require approval for all external contributors"**. The default is
+  first-time contributors only, which is not sufficient for a public repo with a
+  self-hosted runner.
+- Keep the runner **repository-scoped**, not org-scoped, so no other repository
+  can target the `gpu-amd` label.
+- Never add a secret to this job. It needs none.
+
+## Bootstrapping the AMD golden baseline
+
+`GoldenImageTests.cpp` reads `OLOENGINE_GOLDEN_VENDOR` to select a per-vendor
+golden directory, so AMD output cannot clobber the NVIDIA baselines.
+
+1. Land the EGL harness change; run the workflow via **Run workflow**.
+2. The first run will fail on golden comparisons — expected, there is no
+   `assets/tests/golden/amd/` yet.
+3. Download the `gpu_amd_golden_diffs` artifact and **look at the PNGs**. Do not
+   promote them unseen; a genuine AMD-vs-NVIDIA divergence and a broken headless
+   context both present as "all goldens differ".
+4. Once the images are confirmed correct, re-run with `OLOENGINE_GOLDEN_REBASE=1`
+   and commit the resulting `assets/tests/golden/amd/*.png`.
+
+Perf baselines follow the same pattern with `OLOENGINE_PERF_REBASE=1`. Because
+the box is dedicated rather than a shared hosted VM, these numbers are actually
+stable enough to be worth trending — unlike hosted-runner perf data.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Preflight: `no /dev/dri/renderD128` | `amdgpu` not loaded, or the runner user lost `render` group |
+| Preflight: `SOFTWARE RENDERER` | Mesa fell back to llvmpipe — check `MESA_LOADER_DRIVER_OVERRIDE`, driver install, and that the *software* EGL device wasn't selected |
+| All GPU tests still skip | The EGL harness fallback is missing, or `OLO_TEST_GL_BACKEND=egl` is not reaching the process |
+| Failures that look like missing shaders | Job ran from the repo root instead of `OloEditor/` |
+| Stale generated `.inl` failures | Workspace not wiped; the workflow's first step does this, but a manually-run build may not have |

--- a/scripts/setup-olo-runner.sh
+++ b/scripts/setup-olo-runner.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Register the self-hosted GitHub Actions runner for OloEngineBase.
+# Run as root:   sudo bash setup-olo-runner.sh "<registration-token>"
+#
+# Idempotent: safe to re-run. See docs/ops/self-hosted-gpu-runner.md.
+set -euo pipefail
+
+# Host-specific paths; override via the environment if your box differs.
+RUNNER_USER=${RUNNER_USER:-gh-runner-olo}
+RUNNER_HOME=/home/$RUNNER_USER
+RUNNER_DIR=$RUNNER_HOME/actions-runner
+TARBALL=${TARBALL:-/home/obueker/actions-runner-linux-x64-2.336.0.tar.gz}
+REPO_URL=${REPO_URL:-https://github.com/drsnuggles8/OloEngineBase}
+RUNNER_NAME=${RUNNER_NAME:-olo-gpu-amd}
+LABELS=${LABELS:-self-hosted,linux,x64,gpu-amd}
+SDK_SRC=${SDK_SRC:-/home/obueker/vulkan-sdk/1.4.350.1}
+SDK_DST=${SDK_DST:-/opt/vulkan-sdk/1.4.350.1}
+UNIT=${UNIT:-actions-runner-olo}
+
+TOKEN="${1:-}"
+[ -n "$TOKEN" ] || { echo "usage: sudo bash $0 <registration-token>" >&2; exit 2; }
+[ "$(id -u)" -eq 0 ] || { echo "must run as root" >&2; exit 2; }
+[ -f "$TARBALL" ] || { echo "runner tarball not found: $TARBALL" >&2; exit 1; }
+
+say() { printf '\n=== %s ===\n' "$*"; }
+
+# --------------------------------------------------------------------------
+# 1. Dedicated unprivileged user, isolated from gh-runner-1/2/3.
+#    Those serve a PRIVATE repo; this one serves a PUBLIC repo, which is a
+#    different trust level. No shared home, no shared cache, and deliberately
+#    NOT in the wheel group.
+# --------------------------------------------------------------------------
+say "user $RUNNER_USER"
+if id -u "$RUNNER_USER" >/dev/null 2>&1; then
+    echo "already exists"
+else
+    useradd -m -s /bin/bash "$RUNNER_USER"
+    echo "created"
+fi
+# GPU access. /dev/dri/renderD128 is currently mode 0666 so this is
+# belt-and-braces, but distro defaults change.
+usermod -aG render,video "$RUNNER_USER"
+chmod 700 "$RUNNER_HOME"
+id "$RUNNER_USER"
+
+# --------------------------------------------------------------------------
+# 2. Vulkan SDK -> /opt.
+#    The engine needs shaderc/glslang/SPIRV-Tools/SPIRV-Cross, not just the
+#    loader, and CMake FATAL_ERRORs on the first one missing. The SDK currently
+#    sits under /home/obueker, which is mode 0700 — the runner user cannot even
+#    traverse into it, so a copy in /opt is required, not just convenient.
+#    Copied (not moved) so the existing build-linux tree keeps working.
+# --------------------------------------------------------------------------
+say "Vulkan SDK -> $SDK_DST"
+if [ -d "$SDK_DST/x86_64" ]; then
+    echo "already present"
+else
+    [ -d "$SDK_SRC" ] || { echo "source SDK missing: $SDK_SRC" >&2; exit 1; }
+    mkdir -p /opt/vulkan-sdk
+    cp -a "$SDK_SRC" /opt/vulkan-sdk/
+    echo "copied ($(du -sh "$SDK_DST" | cut -f1))"
+fi
+chown -R root:root /opt/vulkan-sdk
+chmod -R a+rX /opt/vulkan-sdk
+# Prove the runner user can actually read what the build needs.
+sudo -u "$RUNNER_USER" test -r "$SDK_DST/x86_64/include/vulkan/vulkan.h" \
+    || { echo "runner cannot read Vulkan headers" >&2; exit 1; }
+sudo -u "$RUNNER_USER" test -r "$SDK_DST/x86_64/lib/libshaderc_shared.so" \
+    || { echo "runner cannot read shaderc" >&2; exit 1; }
+echo "readable by $RUNNER_USER: OK"
+
+# --------------------------------------------------------------------------
+# 3. Unpack the runner.
+# --------------------------------------------------------------------------
+say "runner package"
+if [ -x "$RUNNER_DIR/config.sh" ]; then
+    echo "already unpacked"
+else
+    install -o "$RUNNER_USER" -g "$RUNNER_USER" -m 700 -d "$RUNNER_DIR"
+    sudo -u "$RUNNER_USER" tar xzf "$TARBALL" -C "$RUNNER_DIR"
+    echo "unpacked $(basename "$TARBALL")"
+fi
+
+# --------------------------------------------------------------------------
+# 4. Register with GitHub.
+#    NOT --ephemeral. Ephemeral runners deregister after one job and must be
+#    re-registered with a fresh token, which means storing a long-lived PAT on
+#    the box — trading one risk for another. The value of ephemerality is low
+#    here because the workflow has no pull_request trigger (so only repo-owned
+#    code ever runs) and it wipes the workspace as its first step.
+# --------------------------------------------------------------------------
+say "registering $RUNNER_NAME"
+if [ -f "$RUNNER_DIR/.runner" ]; then
+    echo "already configured; use ./config.sh remove to re-register"
+else
+    sudo -u "$RUNNER_USER" -- "$RUNNER_DIR/config.sh" \
+        --url "$REPO_URL" \
+        --token "$TOKEN" \
+        --name "$RUNNER_NAME" \
+        --labels "$LABELS" \
+        --work _work \
+        --unattended --replace
+fi
+
+# --------------------------------------------------------------------------
+# 5. Job environment. The workflow preflights VULKAN_SDK and fails with a
+#    "provision the runner" message if it is missing.
+# --------------------------------------------------------------------------
+say "runner .env"
+printf 'VULKAN_SDK=%s/x86_64\n' "$SDK_DST" > "$RUNNER_DIR/.env"
+chown "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR/.env"
+cat "$RUNNER_DIR/.env"
+
+# Caches must live OUTSIDE the workspace: the workflow wipes it and checkout
+# cleans it, so vendor sources under OloEngine/vendor/ are gone every run.
+sudo -u "$RUNNER_USER" mkdir -p "$RUNNER_HOME/.cache/cpm" "$RUNNER_HOME/.cache/ccache"
+
+# --------------------------------------------------------------------------
+# 6. Start at boot via user-level systemd + linger, matching the pattern the
+#    existing gh-runner-1/2/3 use on this host.
+# --------------------------------------------------------------------------
+say "service"
+loginctl enable-linger "$RUNNER_USER"
+RUID=$(id -u "$RUNNER_USER")
+for _ in $(seq 1 20); do [ -d "/run/user/$RUID" ] && break; sleep 0.5; done
+[ -d "/run/user/$RUID" ] || { echo "user manager for $RUNNER_USER never came up" >&2; exit 1; }
+
+install -o "$RUNNER_USER" -g "$RUNNER_USER" -d "$RUNNER_HOME/.config/systemd/user"
+cat > "$RUNNER_HOME/.config/systemd/user/$UNIT.service" <<EOF
+[Unit]
+Description=GitHub Actions runner (OloEngineBase, AMD GPU)
+After=network-online.target
+
+[Service]
+ExecStart=$RUNNER_DIR/run.sh
+WorkingDirectory=$RUNNER_DIR
+Restart=always
+RestartSec=10
+KillMode=process
+KillSignal=SIGTERM
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=default.target
+EOF
+chown "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME/.config/systemd/user/$UNIT.service"
+
+run_uctl() { sudo -u "$RUNNER_USER" XDG_RUNTIME_DIR="/run/user/$RUID" systemctl --user "$@"; }
+run_uctl daemon-reload
+run_uctl enable --now "$UNIT.service"
+sleep 3
+run_uctl --no-pager --lines=15 status "$UNIT.service" || true
+
+say "done"
+echo "Verify from GitHub:  gh api repos/drsnuggles8/OloEngineBase/actions/runners --jq '.runners[]|{name,status,busy}'"

--- a/scripts/setup-olo-runner.sh
+++ b/scripts/setup-olo-runner.sh
@@ -78,7 +78,12 @@ if [ -x "$RUNNER_DIR/config.sh" ]; then
     echo "already unpacked"
 else
     install -o "$RUNNER_USER" -g "$RUNNER_USER" -m 700 -d "$RUNNER_DIR"
-    sudo -u "$RUNNER_USER" tar xzf "$TARBALL" -C "$RUNNER_DIR"
+    # Extract as ROOT, then hand ownership over. The tarball sits under
+    # /home/obueker, which is mode 0700 — the runner user cannot traverse into
+    # it, exactly like the Vulkan SDK above. Running tar as the runner user
+    # fails with "Cannot open: Permission denied" before it reads a byte.
+    tar xzf "$TARBALL" -C "$RUNNER_DIR"
+    chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
     echo "unpacked $(basename "$TARBALL")"
 fi
 


### PR DESCRIPTION
## Why

Every test gated on `RenderPropertyFixture`'s GL-context check **skips in CI today** — GitHub-hosted runners have no usable GPU, so the renderer's visual, golden and perf layers run nowhere but a developer's machine, in a repo whose own rules say rendering changes must be verified against pixels.

`cross-vendor.yml` substitutes Mesa llvmpipe, but llvmpipe is a third *software* implementation, not a second **vendor**. It structurally cannot catch AMD GLSL-compiler or driver divergence from the NVIDIA-baselined goldens.

This adds a nightly (00:47 UTC ≈ 02:00 German) + `workflow_dispatch` job running the suite against a real **AMD Navi 10 via Mesa radeonsi** on a self-hosted Linux box.

Note this is explicitly **not** a cost or speed measure. The repo is public, so hosted runners are free and unlimited, and queue wait is negligible (median 7 s). The CI critical path is Windows (SonarCloud ~155 min, ASan ~151 min), which a Linux box cannot take anyway. The only thing this buys is a GPU — which GitHub does not sell at any tier.

## Headless context support

The suite got its GL context only from GLFW, which needs X11/Wayland on Linux; the runner is headless. `RenderPropertyTest.cpp` now selects a backend via **`OLO_TEST_GL_BACKEND`**:

| Value | Behaviour |
|---|---|
| unset (*auto*) | GLFW first, EGL if GLFW can't reach a display server |
| `glfw` | GLFW only — unchanged local-developer path |
| `egl` | EGL only — what CI pins |

CI pins `egl` deliberately: under *auto* a broken display server would silently switch backends, and a golden baseline has to know which one produced it.

The EGL path tries `EGL_MESA_platform_surfaceless`, then enumerates devices and takes the first backed by a DRM render node. Skipping node-less devices is **not** cosmetic — Mesa also publishes an `EGL_MESA_device_software` device, and binding it would yield llvmpipe output under an `amd` golden vendor label.

libEGL is discovered **optionally** (`OLO_TESTS_HAVE_EGL`); where absent the GLFW-only path remains, so this cannot break the Windows build. On Windows the block compiles out and *auto* reduces to exactly the original code.

The EGL headers are included with `EGL_NO_X11` — otherwise `<EGL/eglplatform.h>` drags in Xlib, whose `#define None 0L` mangles every `None` enumerator in the engine headers (`MeshComponent::Primitive::None` among them).

## Verification

Built and run on the target hardware (`AMD Radeon RX 5600 XT`, navi10, Mesa 25.2.7, GL 4.6 Core). Debug, `*RenderGraph*` subset:

| `OLO_TEST_GL_BACKEND` | Result |
|---|---|
| `egl` | **357 passed, 0 GPU-context skips** |
| `glfw` | **skipped** — control, proves the gate is real |
| unset (*auto*) | **passed** via the EGL fallback |

The `glfw` control is the load-bearing one: it shows the tests genuinely depend on a context and that the EGL path is what makes them run.

Not yet verified: a `Release` build (this was Debug) and the full suite (a full Debug run takes hours). The visual/golden tests will fail on their first real run until `assets/tests/golden/amd/` is baselined — that procedure is in the ops doc.

## Safety on a public repository

GitHub warns that fork PRs can run arbitrary code on a self-hosted runner. This removes the risk **structurally** rather than mitigating it:

- **No `pull_request` and no `pull_request_target` trigger** — a fork PR can never schedule onto the box, with or without approval settings. This is the single most important line in the file.
- `schedule` runs default-branch code only; `workflow_dispatch` requires write access.
- No secrets requested; `permissions: contents: read`; token not persisted into `.git/config`.

Runner-side requirements (dedicated unprivileged user isolated from the host's other runners, `--ephemeral`, fork-PR approval set to *all external contributors*) are in `docs/ops/self-hosted-gpu-runner.md`.

## Guards against silent failure

Two failure modes would otherwise pass green:

- **Preflight rejects `llvmpipe`/`softpipe`/`swrast`** before the build, so a driver fault can't baseline software output as "amd".
- **A post-run step fails the job if any test skipped for want of a context.** A broken EGL path would otherwise go green having verified zero pixels — worse than red. It matches both gate sites, which word their skip differently (`RendererAttachedTest.cpp` vs the `OLO_ENSURE_GPU_OR_SKIP()` macro).

## Also in this PR

- **`cross-vendor.yml`** pointed at a *"self-hosted runner matrix — see issue tracker"* that **never existed**. Replaced with the real coverage state: AMD in CI, NVIDIA by hand, Intel not at all.
- **README** gains a *Continuous integration* section tracking every scheduled workflow's status, cadence and runner. (It immediately surfaced that SonarCloud, flaky-repro-281 and video-ffmpeg are currently red on master — untouched here, pre-existing.)
- **Ops doc** records provisioning facts found the hard way while validating this: the Vulkan SDK is required (the distro loader is not enough — configure `FATAL_ERROR`s on shaderc), caches must live outside the wiped workspace or every nightly re-downloads the vendor set, `OLO_WITH_USD=ON` **cannot install unprivileged** (its `pxrConfig.cmake` ignores `--install --prefix` and writes to `/usr/local`), and FetchContent subbuilds are generator-stamped in the shared source tree.

## Follow-ups (not in scope here)

- Baseline `assets/tests/golden/amd/`.
- Provision and register the runner per the ops doc — the badge 404s until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled and manually triggered AMD GPU conformance testing.
  * Added headless EGL support for running GPU tests without a display.
  * Added safeguards to detect skipped GPU tests and prevent false-positive results.
  * Added performance history tracking and failure-only visual evidence artifacts.

* **Documentation**
  * Documented continuous integration workflows and AMD runner setup.
  * Added guidance for configuring, operating, and troubleshooting self-hosted GPU testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->