### PR TITLE
fix(build): full-path /WHOLEARCHIVE unbreaks the clangcl link (#697) + property guards for the four smoke goldens (#734)

### DIFF
--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -259,8 +259,18 @@ if(OLO_WITH_USD)
 	target_compile_definitions(OloEngine PUBLIC OLO_WITH_USD=1)
 	# USD registers Sdf file formats + schemas via static-init side effects; without a
 	# whole-archive force-link the linker discards those objects and UsdStage::Open fails.
+	#
+	# FULL PATH, not the bare `usd_m` (#697). CMake sets MSVC TRUE for clang-cl too, so
+	# this branch is taken under the clangcl / clangcl-asan presets — and lld-link, unlike
+	# link.exe, will NOT resolve a bare /WHOLEARCHIVE: name against /LIBPATH. It killed
+	# every clangcl link with `could not open 'usd_m': no such file or directory`. A full
+	# path force-links under both linkers (verified LLD 21.1.8 / link.exe 14.51), and
+	# OloEngine_USD_LIB's $<CONFIG> genexpr makes it config-matched into the bargain.
+	# Do NOT delete the option to "fix" a whole-archive error — it is load-bearing under
+	# both linkers, silently at runtime for link.exe and loudly at link for lld-link.
+	# Full linker matrix + failure modes: docs/agent-rules/asset-import-usd-alembic.md.
 	if(MSVC)
-		target_link_options(OloEngine PUBLIC "/WHOLEARCHIVE:usd_m")
+		target_link_options(OloEngine PUBLIC "/WHOLEARCHIVE:${OloEngine_USD_LIB}")
 	endif()
 	# Ship USD's plugInfo resource tree next to every consuming executable — PlugRegistry needs
 	# it at runtime to map .usda/.usdc/.usdz -> file-format plugin (see UsdMeshImporter). The exe

--- a/OloEngine/tests/Rendering/PropertyTests/GoldenImageTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/GoldenImageTests.cpp
@@ -55,6 +55,7 @@
 #include <stb_image/stb_image_write.h>
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>
@@ -62,6 +63,7 @@
 #include <filesystem>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace OloEngine::Tests
@@ -633,6 +635,94 @@ namespace OloEngine::Tests
             }
             return out;
         }
+
+        // =====================================================================
+        // Property guards (#734)
+        //
+        // CompareOrBootstrap answers "does this frame still match its
+        // baseline?". It cannot answer "is the effect still doing its job?".
+        // A *partial* regression — FXAA blending only one side of an edge, a
+        // tone map that clips, a shadow that lost its penumbra, a splatmap
+        // whose layer weights got renormalised — can sit comfortably inside
+        // the RMSE/SSIM pass band while the invariant the effect exists to
+        // uphold is gone. And a baseline is only ever a recording of one
+        // machine: where a vendor baseline was baked separately (#735,
+        // assets/tests/golden/amd) the compare can pass on a frame nobody has
+        // verified is *correct*.
+        //
+        // So each golden below also asserts a property derived from the
+        // readback it already holds — one extra pass over the image, and a
+        // failure that says what broke instead of "the image moved".
+        //
+        // Index alignment used by the guards: glTextureSubImage2D uploads and
+        // glGetTextureImage reads back in the same GL row order, and a
+        // fullscreen quad drawn at the texture's own resolution samples texel
+        // centres 1:1 — so a CPU-authored input array and a readback of the
+        // frame it produced share the same texel index. Guards that cannot
+        // rely on that (the shadow mask, whose regions are placed by the
+        // authored depth map) are written to be orientation-free instead, so
+        // a flipped readback can never satisfy them by accident.
+        // =====================================================================
+
+        static f32 Rec601Luma(u8 r, u8 g, u8 b)
+        {
+            return 0.299f * static_cast<f32>(r) + 0.587f * static_cast<f32>(g) + 0.114f * static_cast<f32>(b);
+        }
+
+        struct ColorPopulation
+        {
+            u32 m_Rgb = 0; // packed 0x00RRGGBB
+            u32 m_Count = 0;
+        };
+
+        // Distinct-colour histogram, most populous first. Lets a guard find
+        // flat regions by population rather than by sampling a hard-coded
+        // screen position — which would bake a readback orientation into the
+        // assertion and quietly pass on a vertically flipped frame.
+        static std::vector<ColorPopulation> RankColorsByPopulation(const std::vector<u8>& rgba)
+        {
+            std::unordered_map<u32, u32> counts;
+            for (std::size_t i = 0; i + 3 < rgba.size(); i += 4)
+            {
+                const u32 key = (static_cast<u32>(rgba[i + 0]) << 16) |
+                                (static_cast<u32>(rgba[i + 1]) << 8) |
+                                static_cast<u32>(rgba[i + 2]);
+                ++counts[key];
+            }
+            std::vector<ColorPopulation> ranked;
+            ranked.reserve(counts.size());
+            for (const auto& [rgb, count] : counts)
+                ranked.push_back(ColorPopulation{ rgb, count });
+            std::sort(ranked.begin(), ranked.end(),
+                      [](const ColorPopulation& a, const ColorPopulation& b)
+                      { return a.m_Count > b.m_Count; });
+            return ranked;
+        }
+
+        // Mean RGB of a square patch centred on (cx, cy), in the readback's own
+        // index space (so it lines up with whatever CPU array authored the input).
+        static std::array<f32, 3> PatchMeanRgb(const std::vector<u8>& rgba, u32 width, u32 height,
+                                               u32 cx, u32 cy, u32 radius)
+        {
+            std::array<f64, 3> sum{ 0.0, 0.0, 0.0 };
+            u32 taps = 0;
+            const u32 x0 = cx > radius ? cx - radius : 0u;
+            const u32 y0 = cy > radius ? cy - radius : 0u;
+            const u32 x1 = std::min(cx + radius, width - 1u);
+            const u32 y1 = std::min(cy + radius, height - 1u);
+            for (u32 y = y0; y <= y1; ++y)
+            {
+                for (u32 x = x0; x <= x1; ++x)
+                {
+                    const std::size_t idx = (static_cast<std::size_t>(y) * width + x) * 4;
+                    for (u32 c = 0; c < 3; ++c)
+                        sum[c] += static_cast<f64>(rgba[idx + c]);
+                    ++taps;
+                }
+            }
+            const f64 n = taps > 0 ? static_cast<f64>(taps) : 1.0;
+            return { static_cast<f32>(sum[0] / n), static_cast<f32>(sum[1] / n), static_cast<f32>(sum[2] / n) };
+        }
     } // namespace
 
     // =========================================================================
@@ -760,6 +850,69 @@ namespace OloEngine::Tests
         {
             RecordProperty("result", result.m_Message);
         }
+
+        // --- Property guards (#734) ------------------------------------------
+        // Reinhard is x/(1+x): it approaches 1 asymptotically and never reaches
+        // it, so a correct frame CANNOT contain a saturated channel no matter
+        // how bright the input. That makes "peak < 255" the strongest of the
+        // four goldens' invariants, and it was entirely unasserted. A
+        // passthrough (u_TonemapOperator ignored / UBO unbound), a clipping
+        // operator substituted for Reinhard, or an exposure blowout all pin the
+        // top of this 0..4 luminance ramp at 255 — and because the bottom of
+        // the ramp is unaffected, the frame-wide RMSE can stay inside the band.
+        //
+        // Theoretical peak for the brightest channel of this ramp:
+        //     pow(4 / (1 + 4), 1 / 2.2) * 255 = 230.4
+        // so the ceiling sits just above it. The floor matters just as much:
+        // without it a black or dim frame would satisfy "never saturates"
+        // vacuously — an assertion that cannot fail is the anti-pattern here.
+        u32 peakChannel = 0;
+        for (std::size_t i = 0; i + 3 < output.size(); i += 4)
+        {
+            peakChannel = std::max({ peakChannel,
+                                     static_cast<u32>(output[i + 0]),
+                                     static_cast<u32>(output[i + 1]),
+                                     static_cast<u32>(output[i + 2]) });
+        }
+        EXPECT_LT(peakChannel, 245u)
+            << "peak output channel is " << peakChannel
+            << " — x/(1+x) is asymptotic to 1, so a (near-)saturated channel means the frame did not go "
+               "through Reinhard (passthrough / clipping operator / exposure blowout)";
+        EXPECT_GT(peakChannel, 200u)
+            << "peak output channel is only " << peakChannel
+            << " — the ramp never reaches the shoulder of the curve, so the ceiling assertion above would "
+               "pass vacuously; the input ramp or the exposure has changed";
+
+        // Monotonicity: input luminance rises with x and every per-channel
+        // coefficient in the ramp is positive, so each row must be
+        // non-decreasing left to right in every channel. A decreasing step
+        // means the curve inverted, the ramp got mirrored, or the operator
+        // stopped being a function of the input alone. Deband dither would
+        // break this, which is why the UBO leaves u_DitherAmplitude at 0 —
+        // one LSB of tolerance covers plain quantisation only.
+        constexpr u32 kMonotonicityTolerance = 1;
+        u32 monotonicityViolations = 0;
+        u32 worstDrop = 0;
+        for (u32 y = 0; y < kHeight; ++y)
+        {
+            for (u32 c = 0; c < 3; ++c)
+            {
+                u32 previous = output[(static_cast<std::size_t>(y) * kWidth) * 4 + c];
+                for (u32 x = 1; x < kWidth; ++x)
+                {
+                    const u32 current = output[((static_cast<std::size_t>(y) * kWidth) + x) * 4 + c];
+                    if (current + kMonotonicityTolerance < previous)
+                    {
+                        ++monotonicityViolations;
+                        worstDrop = std::max(worstDrop, previous - current);
+                    }
+                    previous = current;
+                }
+            }
+        }
+        EXPECT_EQ(monotonicityViolations, 0u)
+            << monotonicityViolations << " decreasing steps along the ramp (worst drop " << worstDrop
+            << " LSB) — the tone curve is no longer monotone increasing in input luminance";
     }
 
     // =========================================================================
@@ -795,6 +948,80 @@ namespace OloEngine::Tests
         h.ReadOutputRgba8(output);
         const auto result = CompareOrBootstrap("fxaa_hard_edge", kSize, kSize, output);
         EXPECT_TRUE(result.m_Passed) << result.m_Message;
+
+        // --- Property guards (#734) ------------------------------------------
+        // FXAA's entire job on this fixture is to soften the zig-zag edge, and
+        // the golden compare asserts nothing about that. Two properties do.
+        //
+        // 1. It must blend a real fraction of the frame — but only near the
+        //    edge. A no-op FXAA (edge threshold wrong, input never bound, early
+        //    exit always taken) leaves a pure 0/255 image; a runaway one (search
+        //    span or sub-pixel factor blown out) smears everything. Both can
+        //    land inside the RMSE band when only part of the frame moves.
+        //
+        // 2. The blends must be COMPLEMENTARY. Every altered pixel is a bilinear
+        //    tap taken some fraction t of a texel across a black/white edge, so
+        //    a black pixel is lifted to t and the white pixel mirrored across
+        //    the same edge is dropped to 1 - t. Pairing the sorted multiset of
+        //    dark outputs against the sorted-descending multiset of bright ones
+        //    must therefore sum to 255 everywhere. That is a genuine invariant
+        //    of blending a two-tone edge and a far sharper signal than RMSE: a
+        //    filter that blends one side harder than the other (a sign error in
+        //    stepLength, a mis-clamped finalOffset) breaks the pairing at once
+        //    while the mean image barely moves.
+        ASSERT_EQ(output.size(), static_cast<std::size_t>(kSize) * kSize * 4);
+        constexpr u32 kFxaaLsbTolerance = 1; // ignore pure float->RGBA8 rounding
+        std::vector<u32> darkBlends;         // outputs of pixels whose input was black
+        std::vector<u32> brightBlends;       // outputs of pixels whose input was white
+        for (std::size_t p = 0; p < static_cast<std::size_t>(kSize) * kSize; ++p)
+        {
+            const u32 outValue = output[p * 4];
+            if (pixels[p * 4] > 0.5f)
+            {
+                if (outValue + kFxaaLsbTolerance < 255u)
+                    brightBlends.push_back(outValue);
+            }
+            else if (outValue > kFxaaLsbTolerance)
+            {
+                darkBlends.push_back(outValue);
+            }
+        }
+
+        const u32 alteredCount = static_cast<u32>(darkBlends.size() + brightBlends.size());
+        const f32 alteredFraction = static_cast<f32>(alteredCount) / static_cast<f32>(kSize * kSize);
+        EXPECT_GT(alteredFraction, 0.005f)
+            << "FXAA altered only " << alteredCount << " of " << (kSize * kSize)
+            << " pixels — the edge is not being anti-aliased at all";
+        EXPECT_LT(alteredFraction, 0.10f)
+            << "FXAA altered " << alteredCount << " of " << (kSize * kSize)
+            << " pixels — that is a whole-frame smear, not edge anti-aliasing";
+
+        ASSERT_EQ(darkBlends.size(), brightBlends.size())
+            << "FXAA blended " << darkBlends.size() << " dark pixels but " << brightBlends.size()
+            << " bright ones — the filter is not symmetric across the edge";
+
+        std::sort(darkBlends.begin(), darkBlends.end());
+        std::sort(brightBlends.begin(), brightBlends.end());
+        u32 worstPairDeviation = 0;
+        std::size_t worstPairIndex = 0;
+        for (std::size_t i = 0; i < darkBlends.size(); ++i)
+        {
+            // darkBlends ascending against brightBlends descending.
+            const u32 sum = darkBlends[i] + brightBlends[brightBlends.size() - 1 - i];
+            if (const u32 deviation = sum > 255u ? sum - 255u : 255u - sum; deviation > worstPairDeviation)
+            {
+                worstPairDeviation = deviation;
+                worstPairIndex = i;
+            }
+        }
+        if (!darkBlends.empty())
+        {
+            EXPECT_LE(worstPairDeviation, 2u)
+                << "FXAA blend pair " << worstPairIndex << " is not complementary: dark->"
+                << darkBlends[worstPairIndex] << ", bright->"
+                << brightBlends[brightBlends.size() - 1 - worstPairIndex]
+                << " (should sum to 255, off by " << worstPairDeviation << ")";
+        }
     }
 
     // =========================================================================
@@ -972,6 +1199,67 @@ namespace OloEngine::Tests
         {
             RecordProperty("result", result.m_Message);
         }
+
+        // --- Property guards (#734) ------------------------------------------
+        // This frame is two flat regions with a PCF penumbra between them, and
+        // the golden asserted nothing about either. An implementation that lost
+        // the 3x3 kernel — a single tap, a compare-mode misconfiguration, a
+        // texelSize collapsed to zero — still produces two flat regions in the
+        // right places at nearly the right brightness, stays inside the RMSE
+        // band, and has silently thrown away the entire point of PCF.
+        //
+        // Both guards are deliberately orientation-free: they never sample a
+        // hard-coded screen position, because the shadowed region's location
+        // comes from the authored depth map and a flipped readback would then
+        // satisfy the assertion for the wrong reason.
+        const std::vector<ColorPopulation> shadowColors = RankColorsByPopulation(output);
+        ASSERT_GE(shadowColors.size(), 2u) << "shadow frame has fewer than two distinct colours";
+        EXPECT_GE(shadowColors.size(), 4u)
+            << "shadow frame has only " << shadowColors.size()
+            << " distinct colours — a 3x3 PCF kernel produces intermediate shadow factors (k/9), so this "
+               "looks like a single-tap hard shadow";
+
+        const auto unpackRgb = [](u32 rgb)
+        {
+            return std::array<u8, 3>{ static_cast<u8>(rgb >> 16),
+                                      static_cast<u8>((rgb >> 8) & 0xFFu),
+                                      static_cast<u8>(rgb & 0xFFu) };
+        };
+        const std::array<u8, 3> flatA = unpackRgb(shadowColors[0].m_Rgb);
+        const std::array<u8, 3> flatB = unpackRgb(shadowColors[1].m_Rgb);
+        const f32 lumaA = Rec601Luma(flatA[0], flatA[1], flatA[2]);
+        const f32 lumaB = Rec601Luma(flatB[0], flatB[1], flatB[2]);
+        const f32 litLuma = std::max(lumaA, lumaB);
+        const f32 shadowedLuma = std::min(lumaA, lumaB);
+        ASSERT_GT(litLuma, 0.0f) << "both flat regions are black — nothing was lit";
+
+        // Attenuation: ambient is 0.15 of full lighting, and the Reinhard +
+        // gamma chain compresses that up into the low 0.6s. A shadow that
+        // crushed to black (ambient dropped) and one that barely attenuates
+        // (shadow factor stuck near 1, or the light term not applied) both
+        // leave this ratio, and both are invisible to a threshold on RMSE.
+        const f32 attenuation = shadowedLuma / litLuma;
+        EXPECT_GT(attenuation, 0.50f)
+            << "shadowed/lit luma ratio " << attenuation << " (" << shadowedLuma << " / " << litLuma
+            << ") — the shadowed region is darker than the 0.15 ambient floor allows";
+        EXPECT_LT(attenuation, 0.75f)
+            << "shadowed/lit luma ratio " << attenuation << " (" << shadowedLuma << " / " << litLuma
+            << ") — the shadow barely attenuates; the light term or the shadow factor is not being applied";
+
+        // Penumbra width: every pixel outside the two flat populations is the
+        // PCF transition band. Requiring it to be non-empty is what makes
+        // "lost the penumbra" fail loudly; the upper bound keeps a frame that
+        // is nothing but gradient (no flat lit/shadowed regions at all) from
+        // passing.
+        const u32 shadowPixelCount = kFrameW * kFrameH;
+        const f32 flatFraction = static_cast<f32>(shadowColors[0].m_Count + shadowColors[1].m_Count) /
+                                 static_cast<f32>(shadowPixelCount);
+        EXPECT_GT(flatFraction, 0.80f)
+            << "the two most populous colours cover only " << (flatFraction * 100.0f)
+            << "% of the frame — the flat lit/shadowed regions have broken up";
+        EXPECT_LT(flatFraction, 0.98f)
+            << "the two most populous colours cover " << (flatFraction * 100.0f)
+            << "% of the frame — the PCF penumbra between them is gone (hard shadow edge)";
     }
 
     // =========================================================================
@@ -1133,5 +1421,89 @@ namespace OloEngine::Tests
         {
             RecordProperty("result", result.m_Message);
         }
+
+        // --- Property guards (#734) ------------------------------------------
+        // The golden's failure mode here is the subtle one: a channel swizzle
+        // (w.g driving layer 2), an array-layer off-by-one, or a
+        // re-normalisation inside the shader all keep this frame a smooth
+        // four-way gradient. It still *looks* like a splatmap blend, it still
+        // compares fine against a baseline recorded while the bug was present,
+        // and nothing asserts the weights are actually being applied to the
+        // layers they belong to.
+        //
+        // Guard 1 closes that completely: the blended HDR must equal
+        // Σ w_i · layer_i for the exact weights this test uploaded, texel by
+        // texel. splatPixels[i] and hdrReadback[i] are the same texel (see the
+        // index-alignment note on the guard helpers), and at 128x128 into a
+        // 128x128 target the fullscreen quad samples texel centres 1:1, so the
+        // comparison is exact rather than approximate.
+        f32 worstBlendError = 0.0f;
+        std::size_t worstBlendTexel = 0;
+        u32 worstBlendChannel = 0;
+        for (std::size_t i = 0; i < static_cast<std::size_t>(kSize) * kSize; ++i)
+        {
+            for (u32 c = 0; c < 3; ++c)
+            {
+                f32 expected = 0.0f;
+                for (u32 layer = 0; layer < 4; ++layer)
+                    expected += splatPixels[i * 4 + layer] * kLayerColors[layer][c];
+                if (const f32 error = std::abs(hdrReadback[i * 4 + c] - expected); error > worstBlendError)
+                {
+                    worstBlendError = error;
+                    worstBlendTexel = i;
+                    worstBlendChannel = c;
+                }
+            }
+        }
+        // RGBA16F carries ~3 decimal digits at these magnitudes, so 0.01 sits
+        // two orders above the fp16 quantum and an order below the smallest
+        // separation between layer colours (0.15 vs 1.8) — tight enough to
+        // catch a swizzle, loose enough not to flake on a different GPU.
+        EXPECT_LT(worstBlendError, 0.01f)
+            << "blended terrain disagrees with the CPU-authored sum(w_i * layer_i) by " << worstBlendError
+            << " at texel " << worstBlendTexel << " channel " << worstBlendChannel
+            << " — check splatmap channel->layer mapping, array layer indices, and weight normalisation";
+
+        // Guard 2 states the same invariant on the *final* tone-mapped image,
+        // which is what the golden actually compares: each edge midpoint is
+        // ~99% one layer (only the opposite-edge weight is non-zero there), so
+        // it must carry that layer's colour signature all the way through the
+        // blend + tone-map chain. Red rock and warm sand share a dominant red
+        // channel, so they are separated by their green content instead.
+        struct EdgeDominance
+        {
+            const char* m_Name;
+            u32 m_X;
+            u32 m_Y;
+            u32 m_DominantChannel; // 0=R, 1=G, 2=B
+        };
+        constexpr u32 kEdgeInset = 3;
+        constexpr u32 kEdgeRadius = 2;
+        const EdgeDominance kEdges[4] = {
+            { "layer 0 (red rock), u->0", kEdgeInset, kSize / 2, 0 },
+            { "layer 1 (grass), v->0", kSize / 2, kEdgeInset, 1 },
+            { "layer 2 (water blue), u->1", kSize - 1 - kEdgeInset, kSize / 2, 2 },
+            { "layer 3 (warm sand), v->1", kSize / 2, kSize - 1 - kEdgeInset, 0 },
+        };
+        for (const EdgeDominance& edge : kEdges)
+        {
+            const std::array<f32, 3> mean = PatchMeanRgb(output, kSize, kSize, edge.m_X, edge.m_Y, kEdgeRadius);
+            const u32 dominant = static_cast<u32>(std::distance(
+                mean.begin(), std::max_element(mean.begin(), mean.end())));
+            EXPECT_EQ(dominant, edge.m_DominantChannel)
+                << edge.m_Name << " is not dominated by its own layer at (" << edge.m_X << "," << edge.m_Y
+                << "): rgb(" << mean[0] << ", " << mean[1] << ", " << mean[2] << ")";
+        }
+        // Rock (1.8, 0.25, 0.2) tone-maps to a green/red ratio near 0.59; sand
+        // (1.7, 1.4, 0.25) to near 0.97. Anything between means the two red
+        // layers have been confused for each other.
+        const std::array<f32, 3> rockMean = PatchMeanRgb(output, kSize, kSize, kEdgeInset, kSize / 2, kEdgeRadius);
+        const std::array<f32, 3> sandMean = PatchMeanRgb(output, kSize, kSize, kSize / 2, kSize - 1 - kEdgeInset, kEdgeRadius);
+        EXPECT_LT(rockMean[1] / rockMean[0], 0.75f)
+            << "the u->0 edge has too much green for layer 0 (red rock): rgb(" << rockMean[0] << ", "
+            << rockMean[1] << ", " << rockMean[2] << ")";
+        EXPECT_GT(sandMean[1] / sandMean[0], 0.85f)
+            << "the v->1 edge has too little green for layer 3 (warm sand): rgb(" << sandMean[0] << ", "
+            << sandMean[1] << ", " << sandMean[2] << ")";
     }
 } // namespace OloEngine::Tests

--- a/docs/agent-rules/asset-import-usd-alembic.md
+++ b/docs/agent-rules/asset-import-usd-alembic.md
@@ -122,8 +122,9 @@ ExternalProject_Add(openusd DEPENDS onetbb GIT_REPOSITORY .../OpenUSD.git GIT_TA
    static monolithic build needs the installed `lib/usd/**/plugInfo.json` tree at runtime AND the
    objects force-linked. `UsdMeshImporter` calls `PlugRegistry::RegisterPlugins` on
    `OLO_USD_PLUGIN_PATH` (env, for the headless smoke test) or `<exe>/usd` (the tree CMake stages next
-   to the editor). The engine link adds `/WHOLEARCHIVE:usd_m` or the Sdf/schema static-init
-   registrations are dropped and `UsdStage::Open` returns null.
+   to the editor). The engine link force-links the archive with `/WHOLEARCHIVE:` or the Sdf/schema
+   static-init registrations are dropped and `UsdStage::Open` returns null. Pass it the **full
+   path**, not the bare `usd_m` — see gotcha 7.
 5. **Cost.** `usd_m.lib` ≈ **2.1 GB** Release / **2.4 GB** Debug (static archive — dead-stripped at
    the final exe link). Cold build ≈ 8–15 min per config. Config-matched builds both.
 6. **oneTBB static-Debug teardown assert.** A static Debug oneTBB trips a benign worker-teardown
@@ -133,6 +134,52 @@ ExternalProject_Add(openusd DEPENDS onetbb GIT_REPOSITORY .../OpenUSD.git GIT_TA
    respects a command-line define; disables `__TBB_ASSERT` in the compiled lib; Release already has
    it off via `NDEBUG`). Verify a fix took by grepping the assert string out of `tbb12_debug.lib`
    AND clean-relinking the consumer (MSBuild won't relink on a same-path `.lib` content change).
+7. **`/WHOLEARCHIVE:` needs a FULL PATH — a bare library name is not portable across the two
+   Windows linkers** (#697). `link.exe` resolves a bare `/WHOLEARCHIVE:usd_m` against `/LIBPATH`;
+   **`lld-link` does not** — it opens the argument as a path relative to the working directory only,
+   and kills the whole link with
+
+   ```
+   lld-link: error: could not open 'usd_m': no such file or directory
+   ```
+
+   even though `usd_m.lib` is already on the link line by full path and its directory is in
+   `/LIBPATH`. This is not a niche path: **CMake sets `MSVC` TRUE for clang-cl** (it targets the MSVC
+   ABI), so an `if(MSVC)` guard is taken under the `clangcl` / `clangcl-asan` presets too. The result
+   was that both of those presets could not link *at all* with the default `OLO_WITH_USD=ON`, while
+   the msvc preset was perfectly green — everything compiled, so it looked like a link-config problem
+   rather than an option-spelling one.
+
+   The fix is to spell the option with the full path CMake already has
+   (`target_link_options(OloEngine PUBLIC "/WHOLEARCHIVE:${OloEngine_USD_LIB}")`), which is accepted
+   by **both** linkers. Verified against **LLD 21.1.8** and **MSVC `link.exe` 14.51** with a minimal
+   force-link probe (a static lib whose only content is a static-init side effect, and a `main` that
+   never references it):
+
+   | `/WHOLEARCHIVE:` argument                   | `link.exe` | `lld-link` |
+   | ------------------------------------------ | ---------- | ---------- |
+   | bare name, lib reachable via `/LIBPATH`     | force-links | **link fails** |
+   | full path, lib also on the link line        | force-links | force-links |
+   | full path, lib *not* on the link line       | force-links | force-links |
+   | full path containing spaces                 | force-links | force-links |
+   | *(control)* no `/WHOLEARCHIVE` at all       | object dropped | object dropped |
+
+   The control row is the part worth keeping: it is what proves the probe measures force-linking
+   rather than incidental reachability.
+
+   Do **not** "fix" a `/WHOLEARCHIVE` failure by deleting the option. It is load-bearing under both
+   linkers, but in *different* ways — measured by relinking the engine with the option commented out:
+   under `link.exe` the link succeeds and USD fails at **runtime** (gotcha 4), while under `lld-link`
+   the link fails outright with
+   `undefined symbol: __declspec(dllimport) ... UsdGeomGetStageUpAxis` — because `usd_m`'s headers
+   declare its symbols `dllimport` (the `/IGNORE:4217` flood) and lld-link will not satisfy a
+   dllimport-declared symbol from the archive without the whole-archive pull. So "it linked after I
+   removed the flag" is a *link.exe-only* observation, and it is the silent-at-link,
+   broken-at-runtime case.
+
+   `OloEngine_USD_LIB` carries a `$<CONFIG>` genexpr and `target_link_options` expands
+   it per config, so the full-path spelling is also config-matched where the bare name depended on
+   `/LIBPATH` search order to land on the right one.
 
 Silent-correctness handling in `UsdMeshImporter`: stage up-axis (Z-up → -90° X rotation),
 `metersPerUnit` scale, `orientation` (leftHanded → reversed winding), primvar interpolation

--- a/docs/agent-rules/asset-import-usd-alembic.md
+++ b/docs/agent-rules/asset-import-usd-alembic.md
@@ -139,7 +139,7 @@ ExternalProject_Add(openusd DEPENDS onetbb GIT_REPOSITORY .../OpenUSD.git GIT_TA
    **`lld-link` does not** — it opens the argument as a path relative to the working directory only,
    and kills the whole link with
 
-   ```
+   ```text
    lld-link: error: could not open 'usd_m': no such file or directory
    ```
 

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -30,6 +30,18 @@ processes first.
 
 ## 2. Building and running the `clangcl-asan` preset locally
 
+**Before #697, this whole section was unrunnable locally.** `clangcl-asan`
+inherits `clangcl`, and with the default `OLO_WITH_USD=ON` neither preset
+could reach a successful link: the engine force-linked OpenUSD with a bare
+`/WHOLEARCHIVE:usd_m`, which `lld-link` (unlike `link.exe`) will not resolve
+against `/LIBPATH`, so every executable died with
+`lld-link: error: could not open 'usd_m': no such file or directory`. The
+workaround was to configure with `-DOLO_WITH_USD=OFF`; that is **no longer
+needed** — the option now carries the full path and links under both linkers.
+If you see a bare-name `/WHOLEARCHIVE` failure again, see gotcha 7 in
+[asset-import-usd-alembic.md](asset-import-usd-alembic.md) before deleting
+the option (deleting it moves the failure to runtime).
+
 The CI job (`.github/workflows/asan.yml`, "ASan (Windows/clang-cl)") works
 because of three non-obvious choices you must replicate locally:
 
@@ -39,7 +51,9 @@ because of three non-obvious choices you must replicate locally:
   ("AddressSanitizer doesn't support linking with debug runtime libraries
   yet"). The CI build/ctest steps select Release; do the same:
   `cmake --preset clangcl-asan` then
-  `cmake --build build-clang --target OloEngine-Tests --config Release --parallel`.
+  `cmake --build build-clang --target OloEngine-Tests --config Release --parallel 6`.
+  (Bare `--parallel` forwards the omission to Ninja, whose default here is
+  `cores + 2` = 18 — see CLAUDE.md; always give it a number.)
 - **Put the LLVM-matched ASan runtime directory on PATH** before running
   anything ASan-instrumented (including `OloHeaderTool.exe`, which the
   build itself executes):


### PR DESCRIPTION
Two small, unrelated issues batched into one branch because neither justifies its own PR. They share no files — one commit each.

Closes #697
Closes #734

---

## #697 — `clangcl` could not link at all

`clangcl` (and `clangcl-asan`, which inherits it) failed every link with the default `OLO_WITH_USD=ON`:

```
lld-link: error: could not open 'usd_m': no such file or directory
```

Everything compiled. The error names a library that *is* present on disk, which sends you looking in the wrong place.

**Cause.** CMake sets `MSVC` TRUE for clang-cl (it targets the MSVC ABI), so the `if(MSVC)` guard around the USD force-link is taken under the clangcl presets too — and the two linkers resolve a bare `/WHOLEARCHIVE:` name differently. `link.exe` looks it up against `/LIBPATH`; `lld-link` opens it as a path relative to the working directory only, even when the archive is already on the link line by full path.

**Fix.** `OloEngine_USD_LIB` is already the full path, so it's a one-liner.

**Verified against both linkers, not assumed.** An isolated force-link probe — a static lib whose only content is a static-init side effect, plus a `main` that never references it — on LLD 21.1.8 and MSVC `link.exe` 14.51:

| `/WHOLEARCHIVE:` argument | `link.exe` | `lld-link` |
| --- | --- | --- |
| bare name, reachable via `/LIBPATH` | force-links | **link fails** |
| full path, lib also on the link line | force-links | force-links |
| full path, lib *not* on the link line | force-links | force-links |
| full path containing spaces | force-links | force-links |
| *(control)* no `/WHOLEARCHIVE` | object dropped | object dropped |

The control row is what proves the probe measures force-linking rather than incidental reachability.

Then confirmed end-to-end in the real tree, both directions: with the bare name the clangcl link reproduces the exact error above; with the full path, **clangcl and msvc both link `OloEngine-Tests` with USD on**.

**The force-link stays, and is load-bearing under both linkers in _different_ ways** — measured by relinking with the option removed:

- `link.exe` — links fine, `UsdStage::Open` then fails at **runtime**.
- `lld-link` — fails the link outright on `undefined symbol: __declspec(dllimport) ... UsdGeomGetStageUpAxis`, because `usd_m`'s headers declare its symbols `dllimport`.

So "it linked after I removed the flag" is a link.exe-only observation, and it's the silent-at-link/broken-at-runtime case. Worth knowing before anyone "fixes" a future whole-archive error by deleting the option.

Bonus: `OloEngine_USD_LIB` carries a `$<CONFIG>` genexpr that `target_link_options` expands per config, so the force-link is now config-matched instead of depending on `/LIBPATH` search order.

Docs: new gotcha 7 in `asset-import-usd-alembic.md` (linker matrix + both failure modes); a note in `build-trees-and-windows-asan.md` that its ASan recipe was unrunnable until this fix and no longer needs the `-DOLO_WITH_USD=OFF` workaround (and that its example build command needs an explicit `-jN`).

---

## #734 — the four smoke goldens were weak guards

They asserted one thing: "the image still matches the baseline within an RMSE/SSIM band". That catches an effect failing *completely* and little else. A baseline is also only ever a recording of one machine, so where a vendor baseline was baked separately (#735) the compare can pass on a frame nobody has verified is *correct*.

Each golden now also pins the property the effect exists to provide, computed from the readback it already holds. **Additive** — goldens unchanged, no engine or shader code touched.

| golden | property pinned |
| --- | --- |
| **Reinhard** | peak channel `< 245` **and** `> 200`, plus per-row monotonicity. `x/(1+x)` is asymptotic to 1 and can never reach it, so a correct frame *cannot* saturate; the floor stops a dim frame passing vacuously. |
| **FXAA** | bounded fraction of pixels blended, and blends are **complementary** — a black pixel lifts to `t`, its mirror drops to `1-t`, so the sorted multisets must pair to 255. |
| **Shadow** | lit/shadowed attenuation in range, ≥4 distinct colours, and the two flat regions must not cover the whole frame (the PCF penumbra has non-zero width). Orientation-free: regions are found by population, never by a hard-coded screen position. |
| **Splatmap** | blended HDR must equal `Σ wᵢ·layerᵢ` for the exact uploaded weights, texel by texel, plus edge dominance and a green:red separation of the two red-dominant layers. |

**Thresholds were measured, not guessed** — and each independently reproduces the numbers in the issue: peak 230 (theory 230.4), FXAA 1.3672% of 16384 px as 112 dark + 112 bright, shadow 8 colours / attenuation 0.619 / 93.85% flat, splatmap worst blend error 0.00135 against an fp16 quantum of ~0.0009.

**Every guard was confirmed to actually fail** — an assertion that can't fail is the anti-pattern here — by breaking the property in the real pipeline (scaffolding not committed):

| mutation | guard that fired |
| --- | --- |
| passthrough tone map | peak 255 vs 245 |
| V-shaped ramp | 8914 decreasing steps |
| zero texel size | 0% blended vs 0.5% floor |
| halved dark blends | pair 97 off by 68 |
| single-tap PCF kernel | 2 colours vs 4; 100% flat vs 98% |
| washed-out ambient | attenuation 0.906 vs 0.75 |
| swizzled splatmap channels | blend error 1.60 vs 0.01; all 4 edges mis-dominated |

Note the single-tap mutation left attenuation at **0.619** — losing the penumbra doesn't move the ratio at all. That's exactly why both shadow guards exist, and it's the issue's argument in miniature.

---

## Verification

- **clangcl** — configures, compiles and links `OloEngine-Tests` with `OLO_WITH_USD=ON`; new test code compiles clean under clang-cl (no new warnings).
- **msvc** — builds and links; goldens green.
- **Full suite: 5247/5254 passed**, 2 skipped, 10 disabled.
- **One pre-existing failure, unrelated to this branch:** `AtmosphereVisualEvidenceTest.DayNightWeatherMatrixRendersAndHoldsContracts` — `NightClear` RMSE 13.08 and `NightOvercast` 9.40 against a threshold of 8. Deterministic (identical values in isolation, so not a test-order state leak), and this branch touches only `GoldenImageTests.cpp`, one CMake link option and two docs. It looks like the GPU-baseline drift #735 is about. **No baseline was rebaked here**, per the handover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenUSD linking for MSVC and lld-link builds, including configurations using clang-cl.
  - Enabled reliable USD plugin registration and reduced related build or runtime failures.

- **Tests**
  - Added validation for tone mapping, anti-aliasing, shadows, and splatmap blending to improve rendering quality checks.

- **Documentation**
  - Updated USD linking guidance and Windows AddressSanitizer build instructions, including explicit parallel build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->