### PR TITLE
feat(rhi): Vulkan bring-up — device/instance/swapchain/sync, clears + presents (#691 Phase 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,16 @@ option(OLO_WITH_ALEMBIC "Import Alembic (.abc) geometry caches (vendors Imath + 
 option(OLO_WITH_MATERIALX "Import MaterialX (.mtlx) materials (vendors MaterialX)" ON)
 option(OLO_WITH_USD "Import OpenUSD stages (.usd/.usda/.usdc/.usdz); builds USD from source unless OLO_USD_INSTALL_DIR is set" ON)
 
+# Vulkan RHI backend (#691 Phase 4, ADR 0011 §2). This is the AVAILABILITY axis only —
+# "is the backend compiled in at all" — deliberately separate from the runtime SELECTION
+# axis (`--rhi=opengl|vulkan` at process start; default OpenGL). There is no `vulkan`
+# CMake preset and must never be one: one binary carries every compiled-in backend, so a
+# machine below Vulkan's hardware floor (ADR 0010) can fall back to GL at runtime.
+# The backend vendors Vulkan-Headers + volk + VMA pinned at SDK 1.4.357.0 (the ADR 0010
+# tooling floor) and volk dlopens the loader, so turning this ON adds no link-time
+# dependency on an installed Vulkan SDK beyond what the shaderc toolchain already needs.
+option(OLO_WITH_VULKAN "Compile the Vulkan RHI backend (vendors Vulkan-Headers + volk + VMA; runtime selection stays --rhi=)" ON)
+
 # Includes
 include(cmake/SetupConfigurations.cmake)
 include(cmake/CommonProperties.cmake)

--- a/OloEditor/src/OloEditorApp.cpp
+++ b/OloEditor/src/OloEditorApp.cpp
@@ -18,9 +18,20 @@ namespace OloEngine
             // In `--smoke-test` mode the EditorLayer is skipped: it drives the
             // GL/ImGui editor UI which needs a real OpenGL 4.6 context, and the
             // app runs window-less there. See CreateApplication below.
-            if (pushEditorLayer)
+            //
+            // Under `--rhi=vulkan` (#691 Phase 4 bring-up) it is skipped too — the
+            // editor UI is imgui_impl_opengl3-bound until Phase 8, so the editor
+            // legitimately shows only the Vulkan-cleared window. Checked here, not
+            // in CreateApplication: selection (flag + config fallback) resolves in
+            // the Application base constructor, which has run by this point.
+            if (pushEditorLayer && Renderer::GetAPI() == RendererAPI::API::OpenGL)
             {
                 PushLayer(std::make_unique<EditorLayer>());
+            }
+            else if (pushEditorLayer)
+            {
+                OLO_CORE_INFO("[RHI] EditorLayer skipped under --rhi=vulkan (Phase 4 bring-up: "
+                              "expect only a cleared window; editor UI returns with Phase 8)");
             }
         }
 

--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -163,6 +163,13 @@ target_include_directories(OloEngine PUBLIC
 	${recastnavigation_SOURCE_DIR}/DetourCrowd/Include
 	${recastnavigation_SOURCE_DIR}/DetourTileCache/Include
 	mono/include
+	# Vendored Vulkan 1.4.357 headers (#691 Phase 4) must come BEFORE the installed
+	# SDK's include dir on the next line — /I order decides which <vulkan/vulkan_core.h>
+	# the Vulkan backend compiles against, and an older installed SDK would otherwise
+	# break the pinned VK_EXT_descriptor_heap declarations (backstopped by the
+	# static_assert on VK_HEADER_VERSION in VulkanContext.cpp). Empty when
+	# OLO_WITH_VULKAN=OFF (the variable is only propagated when vendored).
+	$<$<BOOL:${OLO_WITH_VULKAN}>:${vulkan-headers_SOURCE_DIR}/include>
 	${Vulkan_INCLUDE_DIRS}
 	${GameNetworkingSockets_SOURCE_DIR}/include
 )
@@ -194,9 +201,19 @@ target_link_libraries(OloEngine
 	stb_image
 	yaml-cpp
 	GameNetworkingSockets_s
-	Vulkan::Vulkan
 	zlibstatic
 )
+
+# Deliberately NOT linked: Vulkan::Vulkan (vulkan-1.lib). volk's contract is that
+# vulkan-1 is never statically linked — the loader is dlopen'd at runtime. Worse
+# than redundant, the import lib is actively harmful here: its function THUNKS
+# share names with volk's function-pointer globals, and under this project's
+# /FORCE:MULTIPLE link (the assimp/MaterialX pugixml collision workaround) the
+# linker silently resolved volk-style data references to thunk code bytes —
+# every Vulkan call then jumped through garbage (#691 Phase 4). The SDK include
+# dir the shaderc toolchain needs still arrives via ${Vulkan_INCLUDE_DIRS} in
+# target_include_directories above; the glslang/SPIRV libs are linked separately
+# below. find_package(Vulkan) stays for exactly those two purposes.
 
 # FFmpeg video backend (optional). vendor/ffmpeg.cmake defines the `ffmpeg` INTERFACE
 # target (includes + import libs) and builds FFmpeg from source when OLO_VIDEO_FFMPEG=ON;
@@ -204,6 +221,21 @@ target_link_libraries(OloEngine
 if(TARGET ffmpeg)
 	target_link_libraries(OloEngine ffmpeg)
 	target_compile_definitions(OloEngine PUBLIC OLO_VIDEO_FFMPEG=1)
+endif()
+
+# Vulkan RHI backend (#691 Phase 4), gated on OLO_WITH_VULKAN (root CMakeLists).
+# The Platform/Vulkan/*.cpp sources are ALWAYS listed (src/CMakeLists.txt) and self-guard
+# on this macro, compiling to empty TUs when OFF — the same convention as the OLO_WITH_*
+# import formats. PUBLIC (both-branches form, like OLO_ENABLE_CSHARP_SCRIPTING): the
+# runtime backend-selection code and the test target's SKIP logic both branch on it, so
+# every TU must agree on its value. `volk` propagates the vendored 1.4.357 Vulkan-Headers
+# include dir (deliberately shadowing the installed SDK's — see vendor/CMakeLists.txt);
+# `vma` is the header-only VulkanMemoryAllocator.
+if(OLO_WITH_VULKAN)
+	target_link_libraries(OloEngine volk vma)
+	target_compile_definitions(OloEngine PUBLIC OLO_WITH_VULKAN=1)
+else()
+	target_compile_definitions(OloEngine PUBLIC OLO_WITH_VULKAN=0)
 endif()
 
 # Asset-import format dependencies (#655), gated on the OLO_WITH_* options (root CMakeLists).

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -603,6 +603,9 @@
 		"OloEngine/Renderer/PlanarReflection.cpp"
 		"OloEngine/Renderer/RendererAPI.cpp"
 		"OloEngine/Renderer/RendererAPI.h"
+		# Runtime backend selection (--rhi= / config fallback, ADR 0011 §2, #691 Phase 4)
+		"OloEngine/Renderer/BackendSelection.cpp"
+		"OloEngine/Renderer/BackendSelection.h"
 		# RHI vocabulary (issue #691 Phases 1-2, ADR 0011). No longer
 		# declaration-only: RHIResourceRegistry.{h,cpp} mints the generation-checked
 		# RHI::ResourceHandle (defined in RHITypes.h) that the Platform/OpenGL
@@ -1459,6 +1462,15 @@
 		"Platform/OpenGL/OpenGLVertexArray.h"
 		"Platform/OpenGL/OpenGLVertexBuffer.cpp"
 		"Platform/OpenGL/OpenGLVertexBuffer.h"
+
+		# Vulkan backend bring-up (#691 Phase 4). Always listed; each .cpp self-guards
+		# on OLO_WITH_VULKAN and compiles to an empty TU when the backend is off —
+		# the same convention as the OLO_WITH_* import-format translators.
+		"Platform/Vulkan/VulkanCapabilities.cpp"
+		"Platform/Vulkan/VulkanCapabilities.h"
+		"Platform/Vulkan/VulkanContext.cpp"
+		"Platform/Vulkan/VulkanContext.h"
+		"Platform/Vulkan/VulkanMemoryAllocator.cpp"
 )
 
 # Platform-specific sources

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -10,6 +10,7 @@
 #include "OloEngine/Debug/DebugOverlayLayer.h"
 #include "OloEngine/Debug/PerformanceLayer.h"
 #include "OloEngine/Networking/Core/NetworkManager.h"
+#include "OloEngine/Renderer/BackendSelection.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
@@ -51,6 +52,30 @@ namespace OloEngine
         // Start the task scheduler workers
         LowLevelTasks::FScheduler::Get().StartWorkers();
 
+        // RHI backend selection (ADR 0011 §2, #691 Phase 4). HARD ordering
+        // contract: this must run BEFORE the Window::Create below — WindowsWindow /
+        // LinuxWindow read Renderer::GetAPI() ahead of glfwCreateWindow to pick the
+        // window's client API. Parsed after the working-directory switch above so
+        // the config-file fallback resolves against the app's real cwd.
+        if (!m_Specification.IsHeadless)
+        {
+            const BackendSelection backend = SelectRendererBackend(
+                m_Specification.CommandLineArgs.Count, m_Specification.CommandLineArgs.Args,
+                DefaultRendererConfigPath());
+            if (!backend.Diagnostic.empty())
+            {
+                OLO_CORE_ERROR("[RHI] {}", backend.Diagnostic);
+            }
+            RendererAPI::SetAPI(backend.Api);
+            OLO_CORE_INFO("[RHI] Backend: {} (source: {})",
+                          backend.Api == RendererAPI::API::Vulkan ? "Vulkan" : "OpenGL", backend.Source);
+        }
+
+        // Phase 4 bring-up scope: under --rhi=vulkan the window clears + presents
+        // and NOTHING else — Renderer::Init, the GL debug tools and the ImGui
+        // layer (imgui_impl_opengl3, GL-bound until Phase 8) are all skipped.
+        const bool vulkanBringUp = RendererAPI::GetAPI() == RendererAPI::API::Vulkan;
+
         // Register the application name with the crash reporter
         CrashReporter::SetApplicationInfo(m_Specification.Name, OLO_ENGINE_VERSION);
         CrashReporter::SetHeadless(m_Specification.IsHeadless);
@@ -61,16 +86,25 @@ namespace OloEngine
             {
                 m_Window = Window::Create(WindowProps(m_Specification.Name));
                 m_Window->SetEventCallback(OLO_BIND_EVENT_FN(Application::OnEvent));
+
+                if (!vulkanBringUp)
+                {
 // Initialize debug tools before Renderer to catch all resource creation
 #ifdef OLO_DEBUG
-                GPUResourceInspector::GetInstance().Initialize();
-                ShaderDebugger::GetInstance().Initialize();
-                OLO_CORE_INFO("GPU Resource Inspector and Shader Debugger initialized before Renderer");
+                    GPUResourceInspector::GetInstance().Initialize();
+                    ShaderDebugger::GetInstance().Initialize();
+                    OLO_CORE_INFO("GPU Resource Inspector and Shader Debugger initialized before Renderer");
 #endif
 
-                m_Window->SetTitle(m_Specification.Name + " — Loading shaders...");
-                Renderer::Init(m_Specification.PreferredRenderer, m_Window.get());
-                m_Window->SetTitle(m_Specification.Name);
+                    m_Window->SetTitle(m_Specification.Name + " — Loading shaders...");
+                    Renderer::Init(m_Specification.PreferredRenderer, m_Window.get());
+                    m_Window->SetTitle(m_Specification.Name);
+                }
+                else
+                {
+                    OLO_CORE_INFO("[RHI] Vulkan bring-up (#691 Phase 4): Renderer::Init, GL debug tools "
+                                  "and the ImGui layer are skipped — the window clears + presents only");
+                }
 
                 if (!AudioEngine::Init())
                 {
@@ -81,14 +115,17 @@ namespace OloEngine
                 GamepadManager::Initialize();
                 InputActionManager::Init();
 
-                // Non-owning pointer — ownership is transferred to LayerStack
-                // via PushOverlay; kept here for convenient access.
-                m_ImGuiLayer = new ImGuiLayer();
-                PushOverlay(std::unique_ptr<Layer>(m_ImGuiLayer));
+                if (!vulkanBringUp)
+                {
+                    // Non-owning pointer — ownership is transferred to LayerStack
+                    // via PushOverlay; kept here for convenient access.
+                    m_ImGuiLayer = new ImGuiLayer();
+                    PushOverlay(std::unique_ptr<Layer>(m_ImGuiLayer));
 
-                // Debug/performance overlay layers (toggle with F3/F4)
-                PushOverlay(std::make_unique<DebugOverlayLayer>());
-                PushOverlay(std::make_unique<PerformanceLayer>());
+                    // Debug/performance overlay layers (toggle with F3/F4)
+                    PushOverlay(std::make_unique<DebugOverlayLayer>());
+                    PushOverlay(std::make_unique<PerformanceLayer>());
+                }
             }
             else
             {
@@ -124,12 +161,18 @@ namespace OloEngine
             if (!m_Specification.IsHeadless)
             {
                 AudioEngine::Shutdown();
-                Renderer::Shutdown();
+                // Under Vulkan bring-up neither the renderer nor the GL debug tools
+                // ever initialized — and Renderer::Shutdown routes through the
+                // never-Init'ed GL RendererAPI (null glad pointers, no context).
+                if (!vulkanBringUp)
+                {
+                    Renderer::Shutdown();
 
 #ifdef OLO_DEBUG
-                ShaderDebugger::GetInstance().Shutdown();
-                GPUResourceInspector::GetInstance().Shutdown();
+                    ShaderDebugger::GetInstance().Shutdown();
+                    GPUResourceInspector::GetInstance().Shutdown();
 #endif
+                }
 
                 m_Window.reset();
             }
@@ -161,14 +204,20 @@ namespace OloEngine
         if (!m_Specification.IsHeadless)
         {
             AudioEngine::Shutdown();
-            // Shutdown debug tools before Renderer
+            // Under Vulkan bring-up (#691 Phase 4) neither the renderer nor the GL
+            // debug tools ever initialized; Renderer::Shutdown would route through
+            // the never-Init'ed GL RendererAPI (null glad pointers, no context).
+            if (RendererAPI::GetAPI() != RendererAPI::API::Vulkan)
+            {
+                // Shutdown debug tools before Renderer
 #ifdef OLO_DEBUG
-            ShaderDebugger::GetInstance().Shutdown();
-            GPUResourceInspector::GetInstance().Shutdown();
-            OLO_CORE_INFO("GPU Resource Inspector and Shader Debugger shutdown");
+                ShaderDebugger::GetInstance().Shutdown();
+                GPUResourceInspector::GetInstance().Shutdown();
+                OLO_CORE_INFO("GPU Resource Inspector and Shader Debugger shutdown");
 #endif
 
-            Renderer::Shutdown();
+                Renderer::Shutdown();
+            }
         }
 
         // Shutdown task scheduler
@@ -325,16 +374,22 @@ namespace OloEngine
                     OLO_PROFILE_FRAMEMARK_END("LayerStack OnUpdate");
                 }
 
-                OloEngine::ImGuiLayer::Begin();
+                // Null under Vulkan bring-up (#691 Phase 4): the ImGui layer was
+                // never pushed (its backend is imgui_impl_opengl3 until Phase 8),
+                // so no ImGui context exists to Begin()/End() against.
+                if (m_ImGuiLayer != nullptr)
                 {
-                    OLO_PROFILE_FRAMEMARK_START("LayerStack OnImGuiRender");
-                    for (Layer* const layer : m_LayerStack)
+                    OloEngine::ImGuiLayer::Begin();
                     {
-                        layer->OnImGuiRender();
+                        OLO_PROFILE_FRAMEMARK_START("LayerStack OnImGuiRender");
+                        for (Layer* const layer : m_LayerStack)
+                        {
+                            layer->OnImGuiRender();
+                        }
+                        OLO_PROFILE_FRAMEMARK_END("LayerStack OnImGuiRender");
                     }
-                    OLO_PROFILE_FRAMEMARK_END("LayerStack OnImGuiRender");
+                    OloEngine::ImGuiLayer::End();
                 }
-                OloEngine::ImGuiLayer::End();
             }
 
             // Timed separately from the FRAMEMARK scope: SwapBuffers is the
@@ -480,8 +535,14 @@ namespace OloEngine
         OLO_CORE_INFO("Application::OnWindowResize - Window: {}x{}, Framebuffer: {}x{}",
                       e.GetWidth(), e.GetHeight(), fbWidth, fbHeight);
 
-        // Use framebuffer size for renderer
-        Renderer::OnWindowResize(fbWidth, fbHeight);
+        // Under Vulkan bring-up (#691 Phase 4) the renderer never initialized;
+        // the swapchain recreates itself inside VulkanContext::SwapBuffers on
+        // VK_ERROR_OUT_OF_DATE_KHR, so resize needs no engine-side plumbing yet.
+        if (RendererAPI::GetAPI() != RendererAPI::API::Vulkan)
+        {
+            // Use framebuffer size for renderer
+            Renderer::OnWindowResize(fbWidth, fbHeight);
+        }
 
         return false;
     }

--- a/OloEngine/src/OloEngine/Renderer/BackendSelection.cpp
+++ b/OloEngine/src/OloEngine/Renderer/BackendSelection.cpp
@@ -1,0 +1,127 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/BackendSelection.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <optional>
+#include <string_view>
+
+namespace OloEngine
+{
+    namespace
+    {
+        [[nodiscard]] std::string ToLower(std::string_view s)
+        {
+            std::string out(s);
+            std::ranges::transform(out, out.begin(), [](unsigned char c)
+                                   { return static_cast<char>(std::tolower(c)); });
+            return out;
+        }
+
+        // Maps a backend name to an API, or nullopt for an unrecognised name.
+        [[nodiscard]] std::optional<RendererAPI::API> ParseBackendName(std::string_view name)
+        {
+            const std::string lowered = ToLower(name);
+            if (lowered == "opengl")
+            {
+                return RendererAPI::API::OpenGL;
+            }
+            if (lowered == "vulkan")
+            {
+                return RendererAPI::API::Vulkan;
+            }
+            return std::nullopt;
+        }
+
+        // Applies the availability check to a *requested* API. The degrade here is
+        // build-time availability only ("this binary doesn't contain the backend");
+        // runtime capability failures refuse to init inside VulkanContext instead.
+        [[nodiscard]] BackendSelection Resolve(RendererAPI::API requested, std::string source, std::string_view requestedName)
+        {
+            BackendSelection selection;
+            selection.Source = std::move(source);
+#if !OLO_WITH_VULKAN
+            if (requested == RendererAPI::API::Vulkan)
+            {
+                selection.Api = RendererAPI::API::OpenGL;
+                selection.Diagnostic = std::string("'") + std::string(requestedName) +
+                                       "' was requested but this binary was built with OLO_WITH_VULKAN=OFF — "
+                                       "the Vulkan backend is not compiled in. Falling back to OpenGL.";
+                return selection;
+            }
+#else
+            (void)requestedName;
+#endif
+            selection.Api = requested;
+            return selection;
+        }
+    } // namespace
+
+    std::filesystem::path DefaultRendererConfigPath()
+    {
+        return std::filesystem::path("config") / "renderer.yaml";
+    }
+
+    BackendSelection SelectRendererBackend(int argc, char** argv, const std::filesystem::path& configFile)
+    {
+        // 1) `--rhi=<name>` on the command line (argv[0] is the program name).
+        constexpr std::string_view kFlagPrefix = "--rhi=";
+        for (int i = 1; i < argc; ++i)
+        {
+            if (argv[i] == nullptr)
+            {
+                continue;
+            }
+            const std::string_view arg(argv[i]);
+            if (!arg.starts_with(kFlagPrefix))
+            {
+                continue;
+            }
+            const std::string_view value = arg.substr(kFlagPrefix.size());
+            if (const auto api = ParseBackendName(value))
+            {
+                return Resolve(*api, "--rhi flag", value);
+            }
+            BackendSelection selection;
+            selection.Diagnostic = std::string("unknown backend '") + std::string(value) +
+                                   "' in --rhi= (expected 'opengl' or 'vulkan'). Falling back to OpenGL.";
+            return selection;
+        }
+
+        // 2) Config-file fallback: Renderer: { RHI: <name> }. Absent or malformed
+        // config is the common case (no file ships by default) and is silent.
+        if (!configFile.empty() && std::filesystem::exists(configFile))
+        {
+            try
+            {
+                std::ifstream stream(configFile);
+                const YAML::Node data = YAML::Load(stream);
+                if (const YAML::Node renderer = data["Renderer"])
+                {
+                    if (const YAML::Node rhi = renderer["RHI"])
+                    {
+                        const auto value = rhi.as<std::string>();
+                        if (const auto api = ParseBackendName(value))
+                        {
+                            return Resolve(*api, "config file", value);
+                        }
+                        BackendSelection selection;
+                        selection.Diagnostic = std::string("unknown backend '") + value + "' in " +
+                                               configFile.string() + " (expected 'opengl' or 'vulkan'). Falling back to OpenGL.";
+                        return selection;
+                    }
+                }
+            }
+            catch (const YAML::Exception&)
+            {
+                // Malformed config must not block startup; the default is safe.
+            }
+        }
+
+        // 3) Default.
+        return {};
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/BackendSelection.cpp
+++ b/OloEngine/src/OloEngine/Renderer/BackendSelection.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <optional>
 #include <string_view>
+#include <system_error>
 
 namespace OloEngine
 {
@@ -86,14 +87,19 @@ namespace OloEngine
                 return Resolve(*api, "--rhi flag", value);
             }
             BackendSelection selection;
+            // Source names where the (rejected) request came from, same as the
+            // Resolve() degrade path — the Api is the default, the origin is not.
+            selection.Source = "--rhi flag";
             selection.Diagnostic = std::string("unknown backend '") + std::string(value) +
                                    "' in --rhi= (expected 'opengl' or 'vulkan'). Falling back to OpenGL.";
             return selection;
         }
 
-        // 2) Config-file fallback: Renderer: { RHI: <name> }. Absent or malformed
-        // config is the common case (no file ships by default) and is silent.
-        if (!configFile.empty() && std::filesystem::exists(configFile))
+        // 2) Config-file fallback: Renderer: { RHI: <name> }. Absent, unreadable or
+        // malformed config is the common case (no file ships by default) and is
+        // silent — the error_code overload keeps filesystem errors non-throwing.
+        std::error_code existsError;
+        if (!configFile.empty() && std::filesystem::exists(configFile, existsError))
         {
             try
             {
@@ -109,6 +115,7 @@ namespace OloEngine
                             return Resolve(*api, "config file", value);
                         }
                         BackendSelection selection;
+                        selection.Source = "config file";
                         selection.Diagnostic = std::string("unknown backend '") + value + "' in " +
                                                configFile.string() + " (expected 'opengl' or 'vulkan'). Falling back to OpenGL.";
                         return selection;

--- a/OloEngine/src/OloEngine/Renderer/BackendSelection.h
+++ b/OloEngine/src/OloEngine/Renderer/BackendSelection.h
@@ -37,7 +37,7 @@ namespace OloEngine
     // Chain: `--rhi=<name>` among argv[1..] → a `Renderer: { RHI: <name> }` mapping in
     // `configFile` (YAML; silently skipped when absent or malformed) → OpenGL.
     // Recognised names (case-insensitive): "opengl", "vulkan".
-    BackendSelection SelectRendererBackend(int argc, char** argv, const std::filesystem::path& configFile);
+    [[nodiscard]] BackendSelection SelectRendererBackend(int argc, char** argv, const std::filesystem::path& configFile);
 
     // The config file the engine reads the fallback setting from, relative to the
     // process working directory (which Application sets from its specification

--- a/OloEngine/src/OloEngine/Renderer/BackendSelection.h
+++ b/OloEngine/src/OloEngine/Renderer/BackendSelection.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "OloEngine/Renderer/RendererAPI.h"
+
+#include <filesystem>
+#include <string>
+
+namespace OloEngine
+{
+    // Result of resolving which RHI backend this process should use (ADR 0011 §2).
+    // Selection is a RUNTIME switch: `--rhi=opengl|vulkan` at process start, falling
+    // back to a config setting, falling back to OpenGL. It is deliberately separate
+    // from the build-time OLO_WITH_VULKAN availability switch.
+    struct BackendSelection
+    {
+        RendererAPI::API Api = RendererAPI::API::OpenGL;
+
+        // Where the choice came from, for the startup log: "--rhi flag",
+        // "config file", or "default".
+        std::string Source = "default";
+
+        // Non-empty when the user's request could not be honoured (unknown backend
+        // name, or a backend that is not compiled into this binary). The selection
+        // then degrades to OpenGL — loudly, never silently: the caller must log this
+        // at error level. A runtime CAPABILITY failure (device below ADR 0010's
+        // contract) is NOT handled here — that refuses to initialise inside
+        // VulkanContext instead of degrading, per ADR 0010's no-silent-fallback rule.
+        std::string Diagnostic;
+    };
+
+    // Resolve the backend for this process. Pure and side-effect-free apart from
+    // reading `configFile` if it exists — no logging, no static writes — so it is
+    // unit-testable headlessly; the caller applies the result via RendererAPI::SetAPI
+    // and logs Source/Diagnostic. MUST be called (and applied) before Window::Create;
+    // see RendererAPI::SetAPI for the ordering contract.
+    //
+    // Chain: `--rhi=<name>` among argv[1..] → a `Renderer: { RHI: <name> }` mapping in
+    // `configFile` (YAML; silently skipped when absent or malformed) → OpenGL.
+    // Recognised names (case-insensitive): "opengl", "vulkan".
+    BackendSelection SelectRendererBackend(int argc, char** argv, const std::filesystem::path& configFile);
+
+    // The config file the engine reads the fallback setting from, relative to the
+    // process working directory (which Application sets from its specification
+    // before selection runs). A future editor settings dropdown writes this file;
+    // it applies on restart.
+    [[nodiscard]] std::filesystem::path DefaultRendererConfigPath();
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/ComputeShader.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ComputeShader.cpp
@@ -18,6 +18,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<ComputeShader>(new OpenGLComputeShader(filepath));
@@ -35,6 +40,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/Framebuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Framebuffer.cpp
@@ -14,6 +14,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLFramebuffer>::Create(spec);

--- a/OloEngine/src/OloEngine/Renderer/GraphicsContext.cpp
+++ b/OloEngine/src/OloEngine/Renderer/GraphicsContext.cpp
@@ -3,6 +3,9 @@
 
 #include "OloEngine/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLContext.h"
+#if OLO_WITH_VULKAN
+#include "Platform/Vulkan/VulkanContext.h"
+#endif
 
 namespace OloEngine
 {
@@ -18,6 +21,18 @@ namespace OloEngine
             case RendererAPI::API::OpenGL:
             {
                 return CreateScope<OpenGLContext>(static_cast<GLFWwindow*>(window));
+            }
+            case RendererAPI::API::Vulkan:
+            {
+#if OLO_WITH_VULKAN
+                return CreateScope<VulkanContext>(static_cast<GLFWwindow*>(window));
+#else
+                // Unreachable: BackendSelection degrades a Vulkan request to OpenGL
+                // (with an error) when the backend is not compiled in, so s_API can
+                // only be Vulkan in an OLO_WITH_VULKAN=1 binary.
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan selected but OLO_WITH_VULKAN=OFF!");
+                return nullptr;
+#endif
             }
         }
 

--- a/OloEngine/src/OloEngine/Renderer/IndexBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/IndexBuffer.cpp
@@ -14,6 +14,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<IndexBuffer>(new OpenGLIndexBuffer(indices, size));

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
@@ -15,6 +15,14 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                // Unreachable until Phase 5: this factory runs at static init (see
+                // RenderCommand.cpp), before --rhi= is parsed, so s_API is still the
+                // default here; and the Vulkan bring-up never routes RenderCommand.
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no RendererAPI implementation until #691 Phase 5!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return CreateScope<OpenGLRendererAPI>();

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.h
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.h
@@ -24,7 +24,14 @@ namespace OloEngine
         enum class API
         {
             None = 0,
-            OpenGL = 1
+            OpenGL = 1,
+            // Vulkan bring-up (#691 Phase 4): selectable via `--rhi=vulkan`, which routes
+            // window + context creation to Platform/Vulkan. The renderer proper does NOT
+            // run under it yet — every factory below the context switches to a loud
+            // "unsupported until Phase 5/6" assert, and Application skips Renderer::Init.
+            // The member exists even when OLO_WITH_VULKAN=0 so selection code can parse
+            // the flag and report "not compiled in" instead of "unknown backend".
+            Vulkan = 2
         };
 
         enum class RendererType
@@ -512,6 +519,21 @@ namespace OloEngine
         {
             return s_API;
         }
+
+        // Backend selection is a RUNTIME switch (ADR 0011 §2): parsed from `--rhi=` /
+        // the config fallback in Application's constructor. HARD ordering contract:
+        // this must run BEFORE Window::Create — WindowsWindow::Init reads GetAPI()
+        // ahead of glfwCreateWindow (client-API hint), so a late set selects the
+        // wrong window kind. Note RenderCommand::s_RendererAPI is ALSO created at
+        // static init from the default value; Phase 4 tolerates that because the
+        // Vulkan path never routes through RenderCommand (Renderer::Init is skipped
+        // entirely), but Phase 5 must re-create it after selection. Never call this
+        // after a window or context exists.
+        static void SetAPI(API api)
+        {
+            s_API = api;
+        }
+
         static Scope<RendererAPI> Create();
 
       private:

--- a/OloEngine/src/OloEngine/Renderer/Shader.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shader.cpp
@@ -129,6 +129,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 auto shader = Ref<OpenGLShader>::Create(filepath);
@@ -152,6 +157,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/StorageBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/StorageBuffer.cpp
@@ -14,6 +14,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<StorageBuffer>(new OpenGLStorageBuffer(size, binding, usage));

--- a/OloEngine/src/OloEngine/Renderer/Texture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Texture.cpp
@@ -15,6 +15,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLTexture2D>::Create(specification);
@@ -34,6 +39,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLTexture2D>::Create(compressedImage);
@@ -51,6 +61,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/TextureCubemap.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TextureCubemap.cpp
@@ -17,6 +17,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLTextureCubemap>::Create(facePaths);
@@ -34,6 +39,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/UniformBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/UniformBuffer.cpp
@@ -14,6 +14,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<UniformBuffer>(new OpenGLUniformBuffer(size, binding));

--- a/OloEngine/src/OloEngine/Renderer/VertexArray.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VertexArray.cpp
@@ -15,6 +15,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<VertexArray>(new OpenGLVertexArray());

--- a/OloEngine/src/OloEngine/Renderer/VertexBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VertexBuffer.cpp
@@ -15,6 +15,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLVertexBuffer>(new OpenGLVertexBuffer(size));
@@ -34,6 +39,11 @@ namespace OloEngine
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
                 return nullptr;
             }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+                return nullptr;
+            }
             case RendererAPI::API::OpenGL:
             {
                 return Ref<OpenGLVertexBuffer>(new OpenGLVertexBuffer(vertices, size));
@@ -51,6 +61,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:
@@ -75,6 +90,11 @@ namespace OloEngine
             case RendererAPI::API::None:
             {
                 OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return nullptr;
+            }
+            case RendererAPI::API::Vulkan:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/Platform/Linux/LinuxWindow.cpp
+++ b/OloEngine/src/Platform/Linux/LinuxWindow.cpp
@@ -74,6 +74,14 @@ namespace OloEngine
                 }
             }
 
+            // GLFW's client-API default is GLFW_OPENGL_API (it creates a GL context
+            // with the window). Vulkan presents through a swapchain instead, so the
+            // window must opt out BEFORE glfwCreateWindow — this read is why
+            // RendererAPI::SetAPI must run before Window::Create (ADR 0011 §2).
+            if (Renderer::GetAPI() == RendererAPI::API::Vulkan)
+            {
+                GLFWAPI::glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+            }
 #if defined(OLO_DEBUG)
             if (Renderer::GetAPI() == RendererAPI::API::OpenGL)
             {
@@ -194,6 +202,12 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Destroy the graphics context BEFORE the window: the Vulkan context owns a
+        // VkSurfaceKHR created from this window, and GLFW requires the surface to be
+        // destroyed first. (The GL context is a trivial destructor — it dies with
+        // the window either way — so this is a no-op reorder on the GL path.)
+        m_Context.reset();
+
         if (m_Window)
         {
             GLFWAPI::glfwDestroyWindow(m_Window);
@@ -233,13 +247,19 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        if (enabled)
+        // glfwSwapInterval needs a current GL context; under Vulkan (GLFW_NO_API)
+        // it would only raise a GLFW error. Present pacing there is the swapchain's
+        // present mode — fixed at FIFO (vsync) for the Phase 4 bring-up.
+        if (Renderer::GetAPI() != RendererAPI::API::Vulkan)
         {
-            GLFWAPI::glfwSwapInterval(1);
-        }
-        else
-        {
-            GLFWAPI::glfwSwapInterval(0);
+            if (enabled)
+            {
+                GLFWAPI::glfwSwapInterval(1);
+            }
+            else
+            {
+                GLFWAPI::glfwSwapInterval(0);
+            }
         }
 
         m_Data.VSync = enabled;

--- a/OloEngine/src/Platform/Vulkan/VulkanCapabilities.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanCapabilities.cpp
@@ -1,0 +1,112 @@
+#include "OloEnginePCH.h"
+
+#if OLO_WITH_VULKAN
+
+#include "Platform/Vulkan/VulkanCapabilities.h"
+
+#include <cstring>
+
+namespace OloEngine
+{
+    std::vector<const char*> VulkanCapabilities::RequiredDeviceExtensions()
+    {
+        return {
+            VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+            VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME,
+            VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME,
+        };
+    }
+
+    VulkanCapabilityReport VulkanCapabilities::Evaluate(VkPhysicalDevice device)
+    {
+        VulkanCapabilityReport report;
+
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(device, &properties);
+        report.DeviceName = properties.deviceName;
+        report.ApiVersion = properties.apiVersion;
+
+        if (properties.apiVersion < kMinApiVersion)
+        {
+            report.Missing.push_back(
+                "Vulkan API version 1.4 (device reports " +
+                std::to_string(VK_API_VERSION_MAJOR(properties.apiVersion)) + "." +
+                std::to_string(VK_API_VERSION_MINOR(properties.apiVersion)) + ")");
+        }
+
+        u32 extensionCount = 0;
+        vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
+        std::vector<VkExtensionProperties> extensions(extensionCount);
+        vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, extensions.data());
+
+        auto hasExtension = [&extensions](const char* name)
+        {
+            for (const VkExtensionProperties& ext : extensions)
+            {
+                if (std::strcmp(ext.extensionName, name) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        report.HasSwapchain = hasExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+        report.HasDescriptorHeap = hasExtension(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+        report.HasShaderUntypedPointers = hasExtension(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+
+        if (!report.HasSwapchain)
+        {
+            report.Missing.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+        }
+        if (!report.HasDescriptorHeap)
+        {
+            report.Missing.emplace_back(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+        }
+        if (!report.HasShaderUntypedPointers)
+        {
+            report.Missing.emplace_back(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+        }
+
+        // Feature bits — chained only for extensions the device actually lists, so
+        // the query never hands the driver a struct it cannot recognise.
+        VkPhysicalDeviceFeatures2 features2{};
+        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+
+        VkPhysicalDeviceDescriptorHeapFeaturesEXT heapFeatures{};
+        heapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT;
+        VkPhysicalDeviceShaderUntypedPointersFeaturesKHR untypedFeatures{};
+        untypedFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR;
+
+        void** chainTail = &features2.pNext;
+        if (report.HasDescriptorHeap)
+        {
+            *chainTail = &heapFeatures;
+            chainTail = &heapFeatures.pNext;
+        }
+        if (report.HasShaderUntypedPointers)
+        {
+            *chainTail = &untypedFeatures;
+            chainTail = &untypedFeatures.pNext;
+        }
+        vkGetPhysicalDeviceFeatures2(device, &features2);
+
+        report.DescriptorHeapFeature = report.HasDescriptorHeap && heapFeatures.descriptorHeap == VK_TRUE;
+        report.ShaderUntypedPointersFeature =
+            report.HasShaderUntypedPointers && untypedFeatures.shaderUntypedPointers == VK_TRUE;
+
+        if (report.HasDescriptorHeap && !report.DescriptorHeapFeature)
+        {
+            report.Missing.emplace_back("VkPhysicalDeviceDescriptorHeapFeaturesEXT::descriptorHeap");
+        }
+        if (report.HasShaderUntypedPointers && !report.ShaderUntypedPointersFeature)
+        {
+            report.Missing.emplace_back("VkPhysicalDeviceShaderUntypedPointersFeaturesKHR::shaderUntypedPointers");
+        }
+
+        report.Satisfied = report.Missing.empty();
+        return report;
+    }
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanCapabilities.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanCapabilities.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+#include <volk.h>
+
+#include <string>
+#include <vector>
+
+namespace OloEngine
+{
+    // ADR 0010's capability contract, evaluated for one physical device. This is the
+    // SINGLE definition both readers use — VulkanContext's device selection and the
+    // bring-up test — so the two cannot drift (an acceptance test that open-coded
+    // "is VK_EXT_descriptor_heap present?" would silently pass a device missing the
+    // shader dependency). Widening or narrowing what Evaluate() checks requires
+    // amending ADR 0010's capability-contract section, not just this file.
+    struct VulkanCapabilityReport
+    {
+        // True iff EVERY requirement below is met. The check is all-or-nothing: a
+        // device satisfying some of the contract is refused, never partially enabled.
+        bool Satisfied = false;
+
+        // One human-readable entry per unmet requirement, for the refuse-to-init
+        // error ("refuse, naming the missing capability" — ADR 0010).
+        std::vector<std::string> Missing;
+
+        std::string DeviceName;
+        u32 ApiVersion = 0;
+
+        bool HasSwapchain = false;             // VK_KHR_swapchain (needed to present at all)
+        bool HasDescriptorHeap = false;        // VK_EXT_descriptor_heap listed
+        bool DescriptorHeapFeature = false;    // ...and its descriptorHeap feature bit
+        bool HasShaderUntypedPointers = false; // VK_KHR_shader_untyped_pointers listed
+        bool ShaderUntypedPointersFeature = false;
+    };
+
+    class VulkanCapabilities
+    {
+      public:
+        // Vulkan 1.4 minimum: VK_EXT_descriptor_heap is a 1.4-era extension, and on a
+        // 1.4 device its vk.xml dependency chain is satisfied by core alone.
+        static constexpr u32 kMinApiVersion = VK_API_VERSION_1_4;
+
+        // The device extensions a satisfying device must both expose and have enabled
+        // at logical-device creation. Exposed so VulkanContext enables exactly this
+        // list — same one-list rule as the report itself.
+        [[nodiscard]] static std::vector<const char*> RequiredDeviceExtensions();
+
+        // Evaluate the full contract for `device`. Requires a live instance with volk
+        // loaded (instance-level entry points are used). Never throws; the report
+        // carries the verdict.
+        [[nodiscard]] static VulkanCapabilityReport Evaluate(VkPhysicalDevice device);
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
@@ -500,6 +500,15 @@ namespace OloEngine
             extent.height = std::clamp(static_cast<u32>(fbHeight), caps.minImageExtent.height, caps.maxImageExtent.height);
         }
 
+        // A minimised window can reach here with a 0-sized surface (Init while
+        // minimised, or an OUT_OF_DATE recreate racing a minimise) — a zero
+        // extent is invalid for vkCreateSwapchainKHR. Leave the swapchain null;
+        // SwapBuffers retries the creation once the framebuffer has area again.
+        if (extent.width == 0 || extent.height == 0)
+        {
+            return;
+        }
+
         u32 imageCount = caps.minImageCount + 1;
         if (caps.maxImageCount > 0)
         {
@@ -586,6 +595,18 @@ namespace OloEngine
         if (fbWidth == 0 || fbHeight == 0)
         {
             return;
+        }
+
+        // The window has area but no swapchain exists: creation was skipped while
+        // the surface was 0-sized (see CreateSwapchain). Recreate now; if the
+        // surface still reports zero (caps lag the framebuffer), skip the frame.
+        if (d.Swapchain == VK_NULL_HANDLE)
+        {
+            RecreateSwapchain();
+            if (d.Swapchain == VK_NULL_HANDLE)
+            {
+                return;
+            }
         }
 
         VulkanContextData::Frame& frame = d.Frames[d.FrameIndex];

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
@@ -1,0 +1,710 @@
+#include "OloEnginePCH.h"
+
+#if OLO_WITH_VULKAN
+
+#include "Platform/Vulkan/VulkanContext.h"
+#include "Platform/Vulkan/VulkanCapabilities.h"
+
+// volk before both VMA and GLFW: vk_mem_alloc.h keys its volk import helper on
+// VOLK_HEADER_VERSION, and glfw3.h only declares its Vulkan entry points
+// (glfwCreateWindowSurface et al.) when VK_VERSION_1_0 is already visible.
+#include <volk.h>
+
+// Function-pointer config must match VulkanMemoryAllocator.cpp (the
+// VMA_IMPLEMENTATION TU) exactly — VMA is imported through volk's loaded
+// pointers, never linked statically (nothing links vulkan-1.lib).
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#include <vk_mem_alloc.h>
+
+#include <GLFW/glfw3.h>
+
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The vendored Vulkan-Headers (SDK 1.4.357.0, the ADR 0010 tooling floor) must be
+// the ones this TU compiles against. An installed SDK's include dir is also on the
+// include path (via the shaderc toolchain's find_package(Vulkan)); if it ever wins
+// the include search, an older SDK would break the VK_EXT_descriptor_heap
+// declarations silently — fail the build instead.
+static_assert(VK_HEADER_VERSION >= 357,
+              "Vulkan headers older than the vendored 1.4.357 floor — the installed SDK's include dir "
+              "won the include search over OloEngine/vendor's Vulkan-Headers (see vendor/CMakeLists.txt)");
+
+namespace OloEngine
+{
+    namespace
+    {
+        void VkCheck(VkResult result, const char* what)
+        {
+            if (result != VK_SUCCESS)
+            {
+                throw std::runtime_error(std::string("Vulkan bring-up: ") + what + " failed (VkResult " +
+                                         std::to_string(static_cast<int>(result)) + ")");
+            }
+        }
+
+#ifdef OLO_DEBUG
+        VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessengerCallback(
+            VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+            VkDebugUtilsMessageTypeFlagsEXT /*types*/,
+            const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+            void* /*userData*/)
+        {
+            const char* message = (callbackData != nullptr && callbackData->pMessage != nullptr)
+                                      ? callbackData->pMessage
+                                      : "(no message)";
+            if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0)
+            {
+                OLO_CORE_ERROR("[Vulkan] {}", message);
+            }
+            else if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0)
+            {
+                OLO_CORE_WARN("[Vulkan] {}", message);
+            }
+            else
+            {
+                OLO_CORE_TRACE("[Vulkan] {}", message);
+            }
+            return VK_FALSE;
+        }
+
+        VkDebugUtilsMessengerCreateInfoEXT MakeDebugMessengerCreateInfo()
+        {
+            VkDebugUtilsMessengerCreateInfoEXT info{};
+            info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+            info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+            info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+            info.pfnUserCallback = DebugMessengerCallback;
+            return info;
+        }
+
+        bool ValidationLayerAvailable()
+        {
+            u32 count = 0;
+            if (vkEnumerateInstanceLayerProperties(&count, nullptr) != VK_SUCCESS)
+            {
+                return false;
+            }
+            std::vector<VkLayerProperties> layers(count);
+            if (vkEnumerateInstanceLayerProperties(&count, layers.data()) != VK_SUCCESS)
+            {
+                return false;
+            }
+            for (const VkLayerProperties& layer : layers)
+            {
+                if (std::string_view(layer.layerName) == "VK_LAYER_KHRONOS_validation")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+#endif
+    } // namespace
+
+    struct VulkanContextData
+    {
+        static constexpr u32 kFramesInFlight = 2;
+
+        VkInstance Instance = VK_NULL_HANDLE;
+        VkDebugUtilsMessengerEXT DebugMessenger = VK_NULL_HANDLE;
+        VkSurfaceKHR Surface = VK_NULL_HANDLE;
+        VkPhysicalDevice PhysicalDevice = VK_NULL_HANDLE;
+        VkDevice Device = VK_NULL_HANDLE;
+        u32 QueueFamily = 0;
+        VkQueue Queue = VK_NULL_HANDLE;
+        VmaAllocator Allocator = VK_NULL_HANDLE;
+
+        VkSwapchainKHR Swapchain = VK_NULL_HANDLE;
+        VkFormat SwapchainFormat = VK_FORMAT_UNDEFINED;
+        VkExtent2D SwapchainExtent{};
+        std::vector<VkImage> SwapchainImages;
+        // Present-wait semaphores are PER SWAPCHAIN IMAGE, not per frame in flight:
+        // vkQueuePresentKHR gives no way to know when its wait semaphore is done, so
+        // re-signalling a per-frame one from a later submit trips
+        // VUID-vkQueueSubmit-pSignalSemaphores-00067 (Khronos guide, "Swapchain
+        // Semaphore Reuse"). The per-frame fence below is what legalises reusing the
+        // per-frame ACQUIRE semaphore.
+        std::vector<VkSemaphore> RenderFinished;
+
+        VkCommandPool CommandPool = VK_NULL_HANDLE;
+        struct Frame
+        {
+            VkSemaphore ImageAvailable = VK_NULL_HANDLE;
+            VkFence InFlight = VK_NULL_HANDLE;
+            VkCommandBuffer Cmd = VK_NULL_HANDLE;
+        };
+        Frame Frames[kFramesInFlight]{};
+        u32 FrameIndex = 0;
+    };
+
+    VulkanContext::VulkanContext(GLFWwindow* windowHandle)
+        : m_WindowHandle(windowHandle), m_Data(CreateScope<VulkanContextData>())
+    {
+        OLO_CORE_ASSERT(windowHandle, "Window handle is null!");
+    }
+
+    VulkanContext::~VulkanContext()
+    {
+        VulkanContextData& d = *m_Data;
+        if (d.Device != VK_NULL_HANDLE)
+        {
+            vkDeviceWaitIdle(d.Device);
+
+            DestroySwapchain();
+            for (VulkanContextData::Frame& frame : d.Frames)
+            {
+                if (frame.ImageAvailable != VK_NULL_HANDLE)
+                {
+                    vkDestroySemaphore(d.Device, frame.ImageAvailable, nullptr);
+                }
+                if (frame.InFlight != VK_NULL_HANDLE)
+                {
+                    vkDestroyFence(d.Device, frame.InFlight, nullptr);
+                }
+            }
+            if (d.CommandPool != VK_NULL_HANDLE)
+            {
+                vkDestroyCommandPool(d.Device, d.CommandPool, nullptr);
+            }
+            if (d.Allocator != VK_NULL_HANDLE)
+            {
+                vmaDestroyAllocator(d.Allocator);
+            }
+            vkDestroyDevice(d.Device, nullptr);
+        }
+        if (d.Instance != VK_NULL_HANDLE)
+        {
+            if (d.Surface != VK_NULL_HANDLE)
+            {
+                vkDestroySurfaceKHR(d.Instance, d.Surface, nullptr);
+            }
+#ifdef OLO_DEBUG
+            if (d.DebugMessenger != VK_NULL_HANDLE)
+            {
+                vkDestroyDebugUtilsMessengerEXT(d.Instance, d.DebugMessenger, nullptr);
+            }
+#endif
+            vkDestroyInstance(d.Instance, nullptr);
+        }
+        OLO_CORE_INFO("[Vulkan] Context shut down cleanly");
+    }
+
+    void VulkanContext::Init()
+    {
+        OLO_PROFILE_FUNCTION();
+        VulkanContextData& d = *m_Data;
+
+        // --- Loader ---------------------------------------------------------
+        if (volkInitialize() != VK_SUCCESS)
+        {
+            throw std::runtime_error(
+                "Vulkan bring-up: no Vulkan loader found on this system. Run with --rhi=opengl.");
+        }
+        // Hand GLFW volk's loader so it doesn't LoadLibrary vulkan-1 a second time
+        // (GLFW >= 3.4 API; safe to call after glfwInit).
+        glfwInitVulkanLoader(vkGetInstanceProcAddr);
+        if (glfwVulkanSupported() != GLFW_TRUE)
+        {
+            throw std::runtime_error(
+                "Vulkan bring-up: GLFW reports no Vulkan surface support. Run with --rhi=opengl.");
+        }
+
+        // --- Instance -------------------------------------------------------
+        u32 glfwExtensionCount = 0;
+        const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+        if (glfwExtensions == nullptr || glfwExtensionCount == 0)
+        {
+            throw std::runtime_error(
+                "Vulkan bring-up: glfwGetRequiredInstanceExtensions returned nothing. Run with --rhi=opengl.");
+        }
+        std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
+        std::vector<const char*> instanceLayers;
+
+        VkApplicationInfo appInfo{};
+        appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+        appInfo.pApplicationName = "OloEngine";
+        appInfo.pEngineName = "OloEngine";
+        appInfo.apiVersion = VulkanCapabilities::kMinApiVersion;
+
+        VkInstanceCreateInfo instanceInfo{};
+        instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        instanceInfo.pApplicationInfo = &appInfo;
+
+#ifdef OLO_DEBUG
+        // Chained into pNext so create/destroy of the instance itself is covered
+        // before/after the persistent messenger exists.
+        VkDebugUtilsMessengerCreateInfoEXT messengerInfo = MakeDebugMessengerCreateInfo();
+        const bool useValidation = ValidationLayerAvailable();
+        if (useValidation)
+        {
+            instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
+            instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+            instanceInfo.pNext = &messengerInfo;
+        }
+        else
+        {
+            OLO_CORE_WARN("[Vulkan] VK_LAYER_KHRONOS_validation not available — running unvalidated");
+        }
+#endif
+        instanceInfo.enabledExtensionCount = static_cast<u32>(instanceExtensions.size());
+        instanceInfo.ppEnabledExtensionNames = instanceExtensions.data();
+        instanceInfo.enabledLayerCount = static_cast<u32>(instanceLayers.size());
+        instanceInfo.ppEnabledLayerNames = instanceLayers.empty() ? nullptr : instanceLayers.data();
+
+        VkCheck(vkCreateInstance(&instanceInfo, nullptr, &d.Instance), "vkCreateInstance");
+        volkLoadInstance(d.Instance);
+
+#ifdef OLO_DEBUG
+        if (useValidation)
+        {
+            VkCheck(vkCreateDebugUtilsMessengerEXT(d.Instance, &messengerInfo, nullptr, &d.DebugMessenger),
+                    "vkCreateDebugUtilsMessengerEXT");
+        }
+#endif
+
+        // --- Surface --------------------------------------------------------
+        VkCheck(glfwCreateWindowSurface(d.Instance, m_WindowHandle, nullptr, &d.Surface),
+                "glfwCreateWindowSurface");
+
+        // --- Physical device: gate HARD on ADR 0010's capability contract ----
+        u32 deviceCount = 0;
+        VkCheck(vkEnumeratePhysicalDevices(d.Instance, &deviceCount, nullptr), "vkEnumeratePhysicalDevices");
+        if (deviceCount == 0)
+        {
+            throw std::runtime_error("Vulkan bring-up: no Vulkan devices present. Run with --rhi=opengl.");
+        }
+        std::vector<VkPhysicalDevice> devices(deviceCount);
+        VkCheck(vkEnumeratePhysicalDevices(d.Instance, &deviceCount, devices.data()), "vkEnumeratePhysicalDevices");
+
+        // Find a queue family doing BOTH graphics and present. Split-family
+        // hardware is refused for bring-up — every desktop GPU this backend's
+        // hardware floor admits has a combined family, and supporting the split
+        // doubles the sync/sharing surface for no Phase 4 gain.
+        auto findCombinedQueueFamily = [&d](VkPhysicalDevice device) -> std::optional<u32>
+        {
+            u32 familyCount = 0;
+            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, nullptr);
+            std::vector<VkQueueFamilyProperties> families(familyCount);
+            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, families.data());
+            for (u32 i = 0; i < familyCount; ++i)
+            {
+                if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0)
+                {
+                    continue;
+                }
+                VkBool32 presentSupport = VK_FALSE;
+                vkGetPhysicalDeviceSurfaceSupportKHR(device, i, d.Surface, &presentSupport);
+                if (presentSupport == VK_TRUE)
+                {
+                    return i;
+                }
+            }
+            return std::nullopt;
+        };
+
+        VulkanCapabilityReport bestRejected;
+        for (VkPhysicalDevice candidate : devices)
+        {
+            VulkanCapabilityReport report = VulkanCapabilities::Evaluate(candidate);
+            const std::optional<u32> family = findCombinedQueueFamily(candidate);
+            if (!family.has_value())
+            {
+                report.Missing.emplace_back("a combined graphics+present queue family");
+                report.Satisfied = false;
+            }
+            if (report.Satisfied)
+            {
+                VkPhysicalDeviceProperties properties{};
+                vkGetPhysicalDeviceProperties(candidate, &properties);
+                // First satisfying discrete GPU wins; a satisfying integrated one is
+                // kept only until a discrete appears.
+                if (d.PhysicalDevice == VK_NULL_HANDLE ||
+                    properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+                {
+                    d.PhysicalDevice = candidate;
+                    d.QueueFamily = *family;
+                    if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+                    {
+                        break;
+                    }
+                }
+            }
+            else if (bestRejected.Missing.empty() || report.Missing.size() < bestRejected.Missing.size())
+            {
+                bestRejected = report;
+            }
+        }
+
+        if (d.PhysicalDevice == VK_NULL_HANDLE)
+        {
+            // Refuse to initialise, naming the missing capability — never degrade
+            // (ADR 0010; the OpenGL fallback is a USER decision, not an engine one).
+            std::string missing;
+            for (const std::string& item : bestRejected.Missing)
+            {
+                missing += (missing.empty() ? "" : ", ") + item;
+            }
+            throw std::runtime_error(
+                "Vulkan bring-up: no device satisfies the capability contract (ADR 0010). Closest device '" +
+                bestRejected.DeviceName + "' is missing: " + missing + ". Run with --rhi=opengl.");
+        }
+
+        {
+            VkPhysicalDeviceProperties properties{};
+            vkGetPhysicalDeviceProperties(d.PhysicalDevice, &properties);
+            OLO_CORE_INFO("[Vulkan] Device: {} (driver {}.{}.{}, API {}.{}.{})", properties.deviceName,
+                          VK_API_VERSION_MAJOR(properties.driverVersion), VK_API_VERSION_MINOR(properties.driverVersion),
+                          VK_API_VERSION_PATCH(properties.driverVersion), VK_API_VERSION_MAJOR(properties.apiVersion),
+                          VK_API_VERSION_MINOR(properties.apiVersion), VK_API_VERSION_PATCH(properties.apiVersion));
+        }
+
+        // --- Logical device + queue -----------------------------------------
+        const f32 queuePriority = 1.0f;
+        VkDeviceQueueCreateInfo queueInfo{};
+        queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo.queueFamilyIndex = d.QueueFamily;
+        queueInfo.queueCount = 1;
+        queueInfo.pQueuePriorities = &queuePriority;
+
+        // Enable the contract's feature bits now, not in Phase 5: a driver that
+        // advertises the features but rejects enabling them should fail HERE, at
+        // the gate, not later at first descriptor-heap use.
+        VkPhysicalDeviceDescriptorHeapFeaturesEXT heapFeatures{};
+        heapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT;
+        heapFeatures.descriptorHeap = VK_TRUE;
+        VkPhysicalDeviceShaderUntypedPointersFeaturesKHR untypedFeatures{};
+        untypedFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR;
+        untypedFeatures.shaderUntypedPointers = VK_TRUE;
+        untypedFeatures.pNext = &heapFeatures;
+
+        // synchronization2 backs the vkCmdPipelineBarrier2/vkQueueSubmit2 calls in
+        // SwapBuffers. Core in 1.3 and MANDATORY for 1.3+ devices, so it needs no
+        // capability-gate entry — but core-promoted features still default OFF at
+        // device creation, and validation flags every sync2 call without this bit
+        // (the NVIDIA driver happens to tolerate it, which is exactly the kind of
+        // works-by-accident the validation layers exist to catch).
+        VkPhysicalDeviceVulkan13Features vulkan13Features{};
+        vulkan13Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+        vulkan13Features.synchronization2 = VK_TRUE;
+        vulkan13Features.pNext = &untypedFeatures;
+
+        const std::vector<const char*> deviceExtensions = VulkanCapabilities::RequiredDeviceExtensions();
+
+        VkDeviceCreateInfo deviceInfo{};
+        deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        deviceInfo.pNext = &vulkan13Features;
+        deviceInfo.queueCreateInfoCount = 1;
+        deviceInfo.pQueueCreateInfos = &queueInfo;
+        deviceInfo.enabledExtensionCount = static_cast<u32>(deviceExtensions.size());
+        deviceInfo.ppEnabledExtensionNames = deviceExtensions.data();
+
+        VkCheck(vkCreateDevice(d.PhysicalDevice, &deviceInfo, nullptr, &d.Device), "vkCreateDevice");
+        volkLoadDevice(d.Device);
+        vkGetDeviceQueue(d.Device, d.QueueFamily, 0, &d.Queue);
+
+        // --- VMA (vendoring proof + the allocator Phase 5 inherits) ----------
+        {
+            VmaVulkanFunctions vulkanFunctions{};
+            VmaAllocatorCreateInfo allocatorInfo{};
+            allocatorInfo.physicalDevice = d.PhysicalDevice;
+            allocatorInfo.device = d.Device;
+            allocatorInfo.instance = d.Instance;
+            allocatorInfo.vulkanApiVersion = VulkanCapabilities::kMinApiVersion;
+            VkCheck(vmaImportVulkanFunctionsFromVolk(&allocatorInfo, &vulkanFunctions),
+                    "vmaImportVulkanFunctionsFromVolk");
+            allocatorInfo.pVulkanFunctions = &vulkanFunctions;
+            VkCheck(vmaCreateAllocator(&allocatorInfo, &d.Allocator), "vmaCreateAllocator");
+        }
+
+        // --- Commands + per-frame sync ---------------------------------------
+        VkCommandPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        poolInfo.queueFamilyIndex = d.QueueFamily;
+        VkCheck(vkCreateCommandPool(d.Device, &poolInfo, nullptr, &d.CommandPool), "vkCreateCommandPool");
+
+        VkCommandBufferAllocateInfo cmdInfo{};
+        cmdInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        cmdInfo.commandPool = d.CommandPool;
+        cmdInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cmdInfo.commandBufferCount = 1;
+
+        VkSemaphoreCreateInfo semaphoreInfo{};
+        semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+        VkFenceCreateInfo fenceInfo{};
+        fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT; // first wait must not block
+
+        for (VulkanContextData::Frame& frame : d.Frames)
+        {
+            VkCheck(vkAllocateCommandBuffers(d.Device, &cmdInfo, &frame.Cmd), "vkAllocateCommandBuffers");
+            VkCheck(vkCreateSemaphore(d.Device, &semaphoreInfo, nullptr, &frame.ImageAvailable), "vkCreateSemaphore");
+            VkCheck(vkCreateFence(d.Device, &fenceInfo, nullptr, &frame.InFlight), "vkCreateFence");
+        }
+
+        // --- Swapchain (+ its per-image semaphores) ---------------------------
+        CreateSwapchain();
+
+        OLO_CORE_INFO("[Vulkan] Bring-up context initialised ({} swapchain images, {}x{})",
+                      m_Data->SwapchainImages.size(), m_Data->SwapchainExtent.width, m_Data->SwapchainExtent.height);
+    }
+
+    void VulkanContext::CreateSwapchain()
+    {
+        VulkanContextData& d = *m_Data;
+
+        VkSurfaceCapabilitiesKHR caps{};
+        VkCheck(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(d.PhysicalDevice, d.Surface, &caps),
+                "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+
+        // The bring-up clear uses vkCmdClearColorImage, which needs TRANSFER_DST on
+        // the presentable images. Only COLOR_ATTACHMENT is spec-guaranteed, so this
+        // is checked, not assumed (universal on desktop in practice).
+        if ((caps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0)
+        {
+            throw std::runtime_error(
+                "Vulkan bring-up: surface does not support TRANSFER_DST presentable images. Run with --rhi=opengl.");
+        }
+
+        u32 formatCount = 0;
+        vkGetPhysicalDeviceSurfaceFormatsKHR(d.PhysicalDevice, d.Surface, &formatCount, nullptr);
+        std::vector<VkSurfaceFormatKHR> formats(formatCount);
+        vkGetPhysicalDeviceSurfaceFormatsKHR(d.PhysicalDevice, d.Surface, &formatCount, formats.data());
+        VkSurfaceFormatKHR surfaceFormat = formats.at(0);
+        for (const VkSurfaceFormatKHR& format : formats)
+        {
+            if (format.format == VK_FORMAT_B8G8R8A8_UNORM &&
+                format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+            {
+                surfaceFormat = format;
+                break;
+            }
+        }
+
+        int fbWidth = 0;
+        int fbHeight = 0;
+        glfwGetFramebufferSize(m_WindowHandle, &fbWidth, &fbHeight);
+        VkExtent2D extent = caps.currentExtent;
+        if (extent.width == 0xFFFFFFFFu)
+        {
+            extent.width = std::clamp(static_cast<u32>(fbWidth), caps.minImageExtent.width, caps.maxImageExtent.width);
+            extent.height = std::clamp(static_cast<u32>(fbHeight), caps.minImageExtent.height, caps.maxImageExtent.height);
+        }
+
+        u32 imageCount = caps.minImageCount + 1;
+        if (caps.maxImageCount > 0)
+        {
+            imageCount = std::min(imageCount, caps.maxImageCount);
+        }
+
+        VkSwapchainCreateInfoKHR swapchainInfo{};
+        swapchainInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+        swapchainInfo.surface = d.Surface;
+        swapchainInfo.minImageCount = imageCount;
+        swapchainInfo.imageFormat = surfaceFormat.format;
+        swapchainInfo.imageColorSpace = surfaceFormat.colorSpace;
+        swapchainInfo.imageExtent = extent;
+        swapchainInfo.imageArrayLayers = 1;
+        swapchainInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        swapchainInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        swapchainInfo.preTransform = caps.currentTransform;
+        swapchainInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+        // FIFO is the one mode every conformant device carries; it is also vsync,
+        // which matches the GL path's swap-interval default well enough for
+        // bring-up. Window::SetVSync is a no-op under Vulkan until a real present
+        // -mode policy exists (Phase 5+).
+        swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+        swapchainInfo.clipped = VK_TRUE;
+
+        VkCheck(vkCreateSwapchainKHR(d.Device, &swapchainInfo, nullptr, &d.Swapchain), "vkCreateSwapchainKHR");
+        d.SwapchainFormat = surfaceFormat.format;
+        d.SwapchainExtent = extent;
+
+        u32 actualImageCount = 0;
+        vkGetSwapchainImagesKHR(d.Device, d.Swapchain, &actualImageCount, nullptr);
+        d.SwapchainImages.resize(actualImageCount);
+        vkGetSwapchainImagesKHR(d.Device, d.Swapchain, &actualImageCount, d.SwapchainImages.data());
+
+        VkSemaphoreCreateInfo semaphoreInfo{};
+        semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+        d.RenderFinished.resize(actualImageCount, VK_NULL_HANDLE);
+        for (VkSemaphore& semaphore : d.RenderFinished)
+        {
+            VkCheck(vkCreateSemaphore(d.Device, &semaphoreInfo, nullptr, &semaphore), "vkCreateSemaphore");
+        }
+    }
+
+    void VulkanContext::DestroySwapchain()
+    {
+        VulkanContextData& d = *m_Data;
+        for (VkSemaphore semaphore : d.RenderFinished)
+        {
+            if (semaphore != VK_NULL_HANDLE)
+            {
+                vkDestroySemaphore(d.Device, semaphore, nullptr);
+            }
+        }
+        d.RenderFinished.clear();
+        d.SwapchainImages.clear();
+        if (d.Swapchain != VK_NULL_HANDLE)
+        {
+            vkDestroySwapchainKHR(d.Device, d.Swapchain, nullptr);
+            d.Swapchain = VK_NULL_HANDLE;
+        }
+    }
+
+    void VulkanContext::RecreateSwapchain()
+    {
+        VulkanContextData& d = *m_Data;
+        // Blunt but correct without VK_KHR_swapchain_maintenance1: nothing may
+        // reference the old swapchain or its per-image semaphores afterwards.
+        vkDeviceWaitIdle(d.Device);
+        DestroySwapchain();
+        CreateSwapchain();
+        OLO_CORE_INFO("[Vulkan] Swapchain recreated ({}x{})", d.SwapchainExtent.width, d.SwapchainExtent.height);
+    }
+
+    void VulkanContext::SwapBuffers()
+    {
+        OLO_PROFILE_FUNCTION();
+        VulkanContextData& d = *m_Data;
+
+        // Minimised: a 0-sized framebuffer cannot host a swapchain — skip frames
+        // until the window has area again.
+        int fbWidth = 0;
+        int fbHeight = 0;
+        glfwGetFramebufferSize(m_WindowHandle, &fbWidth, &fbHeight);
+        if (fbWidth == 0 || fbHeight == 0)
+        {
+            return;
+        }
+
+        VulkanContextData::Frame& frame = d.Frames[d.FrameIndex];
+        VkCheck(vkWaitForFences(d.Device, 1, &frame.InFlight, VK_TRUE, UINT64_MAX), "vkWaitForFences");
+
+        u32 imageIndex = 0;
+        const VkResult acquireResult = vkAcquireNextImageKHR(d.Device, d.Swapchain, UINT64_MAX,
+                                                             frame.ImageAvailable, VK_NULL_HANDLE, &imageIndex);
+        if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR)
+        {
+            RecreateSwapchain();
+            return;
+        }
+        if (acquireResult != VK_SUCCESS && acquireResult != VK_SUBOPTIMAL_KHR)
+        {
+            VkCheck(acquireResult, "vkAcquireNextImageKHR");
+        }
+
+        // Only reset the fence once this frame will actually submit (a reset
+        // without a submit would deadlock the next wait).
+        VkCheck(vkResetFences(d.Device, 1, &frame.InFlight), "vkResetFences");
+
+        VkCommandBufferBeginInfo beginInfo{};
+        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        VkCheck(vkResetCommandBuffer(frame.Cmd, 0), "vkResetCommandBuffer");
+        VkCheck(vkBeginCommandBuffer(frame.Cmd, &beginInfo), "vkBeginCommandBuffer");
+
+        VkImage image = d.SwapchainImages[imageIndex];
+        VkImageSubresourceRange fullColor{};
+        fullColor.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        fullColor.levelCount = 1;
+        fullColor.layerCount = 1;
+
+        // UNDEFINED -> TRANSFER_DST: previous contents are irrelevant (we clear).
+        VkImageMemoryBarrier2 toTransfer{};
+        toTransfer.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+        toTransfer.srcStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+        toTransfer.dstStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+        toTransfer.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+        toTransfer.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        toTransfer.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        toTransfer.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        toTransfer.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        toTransfer.image = image;
+        toTransfer.subresourceRange = fullColor;
+
+        VkDependencyInfo depInfo{};
+        depInfo.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        depInfo.imageMemoryBarrierCount = 1;
+        depInfo.pImageMemoryBarriers = &toTransfer;
+        vkCmdPipelineBarrier2(frame.Cmd, &depInfo);
+
+        VkClearColorValue clearColor{};
+        clearColor.float32[0] = kClearColor[0];
+        clearColor.float32[1] = kClearColor[1];
+        clearColor.float32[2] = kClearColor[2];
+        clearColor.float32[3] = kClearColor[3];
+        vkCmdClearColorImage(frame.Cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &fullColor);
+
+        // TRANSFER_DST -> PRESENT_SRC.
+        VkImageMemoryBarrier2 toPresent{};
+        toPresent.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+        toPresent.srcStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+        toPresent.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+        toPresent.dstStageMask = VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT;
+        toPresent.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        toPresent.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        toPresent.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        toPresent.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        toPresent.image = image;
+        toPresent.subresourceRange = fullColor;
+
+        depInfo.pImageMemoryBarriers = &toPresent;
+        vkCmdPipelineBarrier2(frame.Cmd, &depInfo);
+
+        VkCheck(vkEndCommandBuffer(frame.Cmd), "vkEndCommandBuffer");
+
+        VkSemaphoreSubmitInfo waitInfo{};
+        waitInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+        waitInfo.semaphore = frame.ImageAvailable;
+        waitInfo.stageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+        VkSemaphoreSubmitInfo signalInfo{};
+        signalInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+        signalInfo.semaphore = d.RenderFinished[imageIndex];
+        signalInfo.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        VkCommandBufferSubmitInfo cmdSubmitInfo{};
+        cmdSubmitInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO;
+        cmdSubmitInfo.commandBuffer = frame.Cmd;
+
+        VkSubmitInfo2 submitInfo{};
+        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2;
+        submitInfo.waitSemaphoreInfoCount = 1;
+        submitInfo.pWaitSemaphoreInfos = &waitInfo;
+        submitInfo.commandBufferInfoCount = 1;
+        submitInfo.pCommandBufferInfos = &cmdSubmitInfo;
+        submitInfo.signalSemaphoreInfoCount = 1;
+        submitInfo.pSignalSemaphoreInfos = &signalInfo;
+        VkCheck(vkQueueSubmit2(d.Queue, 1, &submitInfo, frame.InFlight), "vkQueueSubmit2");
+
+        VkPresentInfoKHR presentInfo{};
+        presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+        presentInfo.waitSemaphoreCount = 1;
+        presentInfo.pWaitSemaphores = &d.RenderFinished[imageIndex];
+        presentInfo.swapchainCount = 1;
+        presentInfo.pSwapchains = &d.Swapchain;
+        presentInfo.pImageIndices = &imageIndex;
+        const VkResult presentResult = vkQueuePresentKHR(d.Queue, &presentInfo);
+        if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR)
+        {
+            RecreateSwapchain();
+        }
+        else
+        {
+            VkCheck(presentResult, "vkQueuePresentKHR");
+        }
+
+        d.FrameIndex = (d.FrameIndex + 1) % VulkanContextData::kFramesInFlight;
+    }
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/GraphicsContext.h"
+
+#if OLO_WITH_VULKAN
+
+struct GLFWwindow;
+
+namespace OloEngine
+{
+    // All Vk handles live behind this in the .cpp: a Platform/<Backend>/ include
+    // leaks exactly as much as glad/gl.h (rhi-abstraction-boundary.md §2), and
+    // GraphicsContext.cpp — engine code — includes this header for the factory.
+    struct VulkanContextData;
+
+    // #691 Phase 4 bring-up: instance / device / swapchain / per-frame sync, and a
+    // SwapBuffers() that clears the backbuffer to a fixed colour and presents.
+    // Nothing else — no rendering, no descriptor heaps in use (device selection
+    // gates on VK_EXT_descriptor_heap per ADR 0010, but Phase 5/6 are the first
+    // consumers). Init() throws std::runtime_error to REFUSE initialisation when
+    // the loader is absent or no device satisfies the capability contract; the
+    // message names the missing capability and directs the user to --rhi=opengl.
+    class VulkanContext : public GraphicsContext
+    {
+      public:
+        explicit VulkanContext(GLFWwindow* windowHandle);
+        ~VulkanContext() override;
+
+        VulkanContext(const VulkanContext&) = delete;
+        VulkanContext& operator=(const VulkanContext&) = delete;
+        VulkanContext(VulkanContext&&) = delete;
+        VulkanContext& operator=(VulkanContext&&) = delete;
+
+        void Init() override;
+
+        // Acquire → clear (vkCmdClearColorImage) → present. Handles swapchain
+        // recreation on resize (VK_ERROR_OUT_OF_DATE_KHR / suboptimal) and skips
+        // the frame entirely while the framebuffer is 0-sized (minimised).
+        void SwapBuffers() override;
+
+        // The fixed bring-up clear colour (classic XNA cornflower blue — instantly
+        // recognisable as "a cleared backbuffer", and nothing the GL editor draws).
+        static constexpr f32 kClearColor[4] = { 0.392f, 0.584f, 0.929f, 1.0f };
+
+      private:
+        void CreateSwapchain();
+        void DestroySwapchain();
+        void RecreateSwapchain();
+
+        GLFWwindow* m_WindowHandle;
+        Scope<VulkanContextData> m_Data;
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanMemoryAllocator.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanMemoryAllocator.cpp
@@ -1,0 +1,16 @@
+#include "OloEnginePCH.h"
+
+#if OLO_WITH_VULKAN
+
+// The single VMA_IMPLEMENTATION TU for the engine (#691 Phase 4). The
+// function-pointer config must match VulkanContext.cpp exactly: every Vulkan
+// entry point reaches VMA through volk's loaded pointers
+// (vmaImportVulkanFunctionsFromVolk at allocator creation) — nothing links
+// vulkan-1.lib, so static and dynamic self-loading are both disabled.
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#include <volk.h>
+#define VMA_IMPLEMENTATION
+#include <vk_mem_alloc.h>
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Windows/WindowsWindow.cpp
+++ b/OloEngine/src/Platform/Windows/WindowsWindow.cpp
@@ -11,6 +11,8 @@
 #include <GLFW/glfw3native.h>
 #include <dwmapi.h>
 
+#include <stdexcept>
+
 namespace OloEngine
 {
 
@@ -86,6 +88,14 @@ namespace OloEngine
 #endif
 
             m_Window = GLFWAPI::glfwCreateWindow(static_cast<int>(props.Width), static_cast<int>(props.Height), m_Data.Title.c_str(), nullptr, nullptr);
+            if (!m_Window)
+            {
+                if (0 == s_GLFWWindowCount)
+                {
+                    GLFWAPI::glfwTerminate();
+                }
+                throw std::runtime_error("glfwCreateWindow failed!");
+            }
             ++s_GLFWWindowCount;
         }
 
@@ -106,8 +116,38 @@ namespace OloEngine
             }
         }
 
+        // Context creation/init can legitimately fail — the Vulkan bring-up REFUSES
+        // to initialise (throws) when the device is below ADR 0010's capability
+        // contract. The constructor must not leak the GLFW window or its refcount
+        // on that path: ~WindowsWindow never runs when Init throws.
         m_Context = GraphicsContext::Create(m_Window);
-        m_Context->Init();
+        if (!m_Context)
+        {
+            GLFWAPI::glfwDestroyWindow(m_Window);
+            m_Window = nullptr;
+            --s_GLFWWindowCount;
+            if (0 == s_GLFWWindowCount)
+            {
+                GLFWAPI::glfwTerminate();
+            }
+            throw std::runtime_error("Failed to create graphics context!");
+        }
+        try
+        {
+            m_Context->Init();
+        }
+        catch (...)
+        {
+            m_Context.reset();
+            GLFWAPI::glfwDestroyWindow(m_Window);
+            m_Window = nullptr;
+            --s_GLFWWindowCount;
+            if (0 == s_GLFWWindowCount)
+            {
+                GLFWAPI::glfwTerminate();
+            }
+            throw;
+        }
 
         GLFWAPI::glfwSetWindowUserPointer(m_Window, &m_Data);
         SetVSync(false);
@@ -210,8 +250,12 @@ namespace OloEngine
         // the window either way — so this is a no-op reorder on the GL path.)
         m_Context.reset();
 
-        GLFWAPI::glfwDestroyWindow(m_Window);
-        --s_GLFWWindowCount;
+        if (m_Window)
+        {
+            GLFWAPI::glfwDestroyWindow(m_Window);
+            m_Window = nullptr;
+            --s_GLFWWindowCount;
+        }
 
         if (0 == s_GLFWWindowCount)
         {

--- a/OloEngine/src/Platform/Windows/WindowsWindow.cpp
+++ b/OloEngine/src/Platform/Windows/WindowsWindow.cpp
@@ -70,6 +70,14 @@ namespace OloEngine
                 GLFWAPI::glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
             }
 
+            // GLFW's client-API default is GLFW_OPENGL_API (it creates a GL context
+            // with the window). Vulkan presents through a swapchain instead, so the
+            // window must opt out BEFORE glfwCreateWindow — this read is why
+            // RendererAPI::SetAPI must run before Window::Create (ADR 0011 §2).
+            if (Renderer::GetAPI() == RendererAPI::API::Vulkan)
+            {
+                GLFWAPI::glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+            }
 #if defined(OLO_DEBUG)
             if (Renderer::GetAPI() == RendererAPI::API::OpenGL)
             {
@@ -196,6 +204,12 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // Destroy the graphics context BEFORE the window: the Vulkan context owns a
+        // VkSurfaceKHR created from this window, and GLFW requires the surface to be
+        // destroyed first. (The GL context is a trivial destructor — it dies with
+        // the window either way — so this is a no-op reorder on the GL path.)
+        m_Context.reset();
+
         GLFWAPI::glfwDestroyWindow(m_Window);
         --s_GLFWWindowCount;
 
@@ -231,13 +245,19 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
-        if (enabled)
+        // glfwSwapInterval needs a current GL context; under Vulkan (GLFW_NO_API)
+        // it would only raise a GLFW error. Present pacing there is the swapchain's
+        // present mode — fixed at FIFO (vsync) for the Phase 4 bring-up.
+        if (Renderer::GetAPI() != RendererAPI::API::Vulkan)
         {
-            GLFWAPI::glfwSwapInterval(1);
-        }
-        else
-        {
-            GLFWAPI::glfwSwapInterval(0);
+            if (enabled)
+            {
+                GLFWAPI::glfwSwapInterval(1);
+            }
+            else
+            {
+                GLFWAPI::glfwSwapInterval(0);
+            }
         }
 
         m_Data.VSync = enabled;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -165,6 +165,12 @@ add_executable(OloEngine-Tests
 		Rendering/RHIResourceRegistryTest.cpp
 		Rendering/RHIDescriptorHeapTest.cpp
 		Rendering/RHIEnumLoweringTest.cpp
+		# #691 Phase 4: Vulkan device-selection gate (ADR 0010 capability contract).
+		# SKIPs cleanly without a loader/device; compiles to a single SKIP when
+		# OLO_WITH_VULKAN=OFF.
+		Rendering/VulkanBringUpTest.cpp
+		# #691 Phase 4: the --rhi= / config-file backend-selection chain (headless).
+		Rendering/BackendSelectionTest.cpp
 		# Coordinate math of GPUResourceInspector::CaptureTexturePng's `region`
 		# argument (#607 native-resolution capture): the top-left-origin rect must
 		# land on exactly those texels through GL's bottom-up rows. Needs a GL

--- a/OloEngine/tests/Rendering/BackendSelectionTest.cpp
+++ b/OloEngine/tests/Rendering/BackendSelectionTest.cpp
@@ -1,0 +1,145 @@
+// OLO_TEST_LAYER: unit
+//
+// #691 Phase 4: the runtime backend-selection chain (ADR 0011 §2) —
+// `--rhi=<name>` flag → config-file fallback → OpenGL default. Pure parse
+// logic, fully headless: SelectRendererBackend touches no GL/Vulkan state and
+// never writes RendererAPI::s_API itself (Application applies the result), so
+// these tests cannot perturb the process-wide backend other suites read.
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Renderer/BackendSelection.h"
+
+#include <array>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+
+namespace
+{
+    using namespace OloEngine;
+
+    // argv helper: string literals are never written through, and GLFW-style
+    // main() argv is char**, so the const_cast mirrors what EntryPoint passes.
+    template<sizet N>
+    BackendSelection Select(std::array<const char*, N> args, const std::filesystem::path& configFile = {})
+    {
+        std::array<char*, N> argv{};
+        for (sizet i = 0; i < N; ++i)
+        {
+            argv[i] = const_cast<char*>(args[i]);
+        }
+        return SelectRendererBackend(static_cast<int>(N), argv.data(), configFile);
+    }
+
+    class ScopedConfigFile
+    {
+      public:
+        explicit ScopedConfigFile(const std::string& contents)
+            : m_Path(std::filesystem::temp_directory_path() /
+                     ("olo-backend-selection-test-" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) +
+                      "-" + std::to_string(s_Counter++) + ".yaml"))
+        {
+            std::ofstream out(m_Path);
+            out << contents;
+        }
+        ~ScopedConfigFile()
+        {
+            std::error_code ec;
+            std::filesystem::remove(m_Path, ec);
+        }
+        [[nodiscard]] const std::filesystem::path& Path() const
+        {
+            return m_Path;
+        }
+
+      private:
+        static inline int s_Counter = 0;
+        std::filesystem::path m_Path;
+    };
+
+    TEST(BackendSelection, DefaultsToOpenGLWithNoFlagAndNoConfig)
+    {
+        const BackendSelection selection = Select<1>({ "app.exe" });
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "default");
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, FlagSelectsOpenGLExplicitly)
+    {
+        const BackendSelection selection = Select<2>({ "app.exe", "--rhi=opengl" });
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "--rhi flag");
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, FlagIsCaseInsensitive)
+    {
+        const BackendSelection selection = Select<2>({ "app.exe", "--rhi=OpenGL" });
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, VulkanRequestHonouredOrLoudlyDegraded)
+    {
+        const BackendSelection selection = Select<2>({ "app.exe", "--rhi=vulkan" });
+#if OLO_WITH_VULKAN
+        EXPECT_EQ(selection.Api, RendererAPI::API::Vulkan);
+        EXPECT_TRUE(selection.Diagnostic.empty());
+#else
+        // Not compiled in: degrade to GL, but NEVER silently — the diagnostic is
+        // what Application logs at error level.
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_FALSE(selection.Diagnostic.empty());
+#endif
+        EXPECT_EQ(selection.Source, "--rhi flag");
+    }
+
+    TEST(BackendSelection, UnknownFlagValueDegradesToOpenGLWithDiagnostic)
+    {
+        const BackendSelection selection = Select<2>({ "app.exe", "--rhi=metal" });
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_FALSE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, ConfigFileSuppliesTheFallback)
+    {
+        const ScopedConfigFile config("Renderer:\n  RHI: vulkan\n");
+        const BackendSelection selection = Select<1>({ "app.exe" }, config.Path());
+#if OLO_WITH_VULKAN
+        EXPECT_EQ(selection.Api, RendererAPI::API::Vulkan);
+        EXPECT_EQ(selection.Source, "config file");
+#else
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_FALSE(selection.Diagnostic.empty());
+#endif
+    }
+
+    TEST(BackendSelection, FlagWinsOverConfigFile)
+    {
+        const ScopedConfigFile config("Renderer:\n  RHI: vulkan\n");
+        const BackendSelection selection = Select<2>({ "app.exe", "--rhi=opengl" }, config.Path());
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "--rhi flag");
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, MalformedConfigFallsBackToDefaultSilently)
+    {
+        const ScopedConfigFile config("Renderer: [unclosed\n  nonsense: {{{\n");
+        const BackendSelection selection = Select<1>({ "app.exe" }, config.Path());
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "default");
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+
+    TEST(BackendSelection, AbsentConfigFileIsSilent)
+    {
+        const BackendSelection selection =
+            Select<1>({ "app.exe" }, std::filesystem::path("definitely") / "not" / "here.yaml");
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "default");
+        EXPECT_TRUE(selection.Diagnostic.empty());
+    }
+} // namespace

--- a/OloEngine/tests/Rendering/BackendSelectionTest.cpp
+++ b/OloEngine/tests/Rendering/BackendSelectionTest.cpp
@@ -116,6 +116,20 @@ namespace
 #endif
     }
 
+    TEST(BackendSelection, WellFormedConfigWithUnknownBackendDegradesLoudly)
+    {
+        // Distinct from the malformed-config case below: the YAML parses fine and
+        // the Renderer.RHI key exists, but names no known backend. That is a USER
+        // mistake worth a diagnostic (Application logs it at error level), with
+        // Source naming where the rejected request came from — unlike malformed
+        // YAML, which falls through silently to the default.
+        const ScopedConfigFile config("Renderer:\n  RHI: directx12\n");
+        const BackendSelection selection = Select<1>({ "app.exe" }, config.Path());
+        EXPECT_EQ(selection.Api, RendererAPI::API::OpenGL);
+        EXPECT_EQ(selection.Source, "config file");
+        EXPECT_FALSE(selection.Diagnostic.empty());
+    }
+
     TEST(BackendSelection, FlagWinsOverConfigFile)
     {
         const ScopedConfigFile config("Renderer:\n  RHI: vulkan\n");

--- a/OloEngine/tests/Rendering/VulkanBringUpTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanBringUpTest.cpp
@@ -174,11 +174,19 @@ namespace
         untypedFeatures.shaderUntypedPointers = VK_TRUE;
         untypedFeatures.pNext = &heapFeatures;
 
+        // Mirror VulkanContext::Init's chain exactly, sync2 included — this test's
+        // claim is "the gate's enables are accepted", so the enable list must not
+        // drift from the gate's.
+        VkPhysicalDeviceVulkan13Features vulkan13Features{};
+        vulkan13Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+        vulkan13Features.synchronization2 = VK_TRUE;
+        vulkan13Features.pNext = &untypedFeatures;
+
         const std::vector<const char*> extensions = VulkanCapabilities::RequiredDeviceExtensions();
 
         VkDeviceCreateInfo deviceInfo{};
         deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-        deviceInfo.pNext = &untypedFeatures;
+        deviceInfo.pNext = &vulkan13Features;
         deviceInfo.queueCreateInfoCount = 1;
         deviceInfo.pQueueCreateInfos = &queueInfo;
         deviceInfo.enabledExtensionCount = static_cast<u32>(extensions.size());

--- a/OloEngine/tests/Rendering/VulkanBringUpTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanBringUpTest.cpp
@@ -1,0 +1,199 @@
+// OLO_TEST_LAYER: plumbing
+//
+// #691 Phase 4: Vulkan bring-up. Headless (no window, no surface, no swapchain):
+// what is testable without a display is the device-selection gate — the ADR 0010
+// capability contract — and that a satisfying device actually accepts a logical
+// device created with the contract's extensions + feature bits enabled. The
+// contract is read through VulkanCapabilities::Evaluate, the SAME reader
+// VulkanContext's device pick uses ("one list, two readers" — an open-coded
+// extension check here would drift from the gate it claims to test).
+//
+// SKIP ladder mirrors the GL-4.6-context pattern (RendererAttachedTest): each
+// missing environment rung SKIPs cleanly rather than failing, so headless CI
+// passes while a GPU-equipped run gates. The clears+presents checkpoint itself
+// is verified live (OloEditor --rhi=vulkan + OS-level screenshot), not here —
+// MCP capture is GL-readback until Phase 8.
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Core/Base.h"
+
+#if !OLO_WITH_VULKAN
+
+TEST(VulkanBringUp, SkipsWhenNotCompiledIn)
+{
+    GTEST_SKIP() << "Built with OLO_WITH_VULKAN=OFF — the Vulkan backend is not compiled in.";
+}
+
+#else
+
+#include "Platform/Vulkan/VulkanCapabilities.h"
+
+#include <volk.h>
+
+#include <optional>
+#include <vector>
+
+namespace
+{
+    using namespace OloEngine;
+
+    class VulkanBringUp : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            if (volkInitialize() != VK_SUCCESS)
+            {
+                GTEST_SKIP() << "No Vulkan loader on this machine.";
+            }
+
+            VkApplicationInfo appInfo{};
+            appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+            appInfo.pApplicationName = "OloEngine-Tests";
+            appInfo.apiVersion = VulkanCapabilities::kMinApiVersion;
+
+            VkInstanceCreateInfo instanceInfo{};
+            instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+            instanceInfo.pApplicationInfo = &appInfo;
+
+            if (vkCreateInstance(&instanceInfo, nullptr, &m_Instance) != VK_SUCCESS)
+            {
+                GTEST_SKIP() << "vkCreateInstance failed (driver below Vulkan 1.4?).";
+            }
+            volkLoadInstance(m_Instance);
+
+            u32 deviceCount = 0;
+            vkEnumeratePhysicalDevices(m_Instance, &deviceCount, nullptr);
+            if (deviceCount == 0)
+            {
+                GTEST_SKIP() << "No Vulkan physical devices present.";
+            }
+            m_Devices.resize(deviceCount);
+            vkEnumeratePhysicalDevices(m_Instance, &deviceCount, m_Devices.data());
+        }
+
+        void TearDown() override
+        {
+            if (m_Instance != VK_NULL_HANDLE)
+            {
+                vkDestroyInstance(m_Instance, nullptr);
+                m_Instance = VK_NULL_HANDLE;
+            }
+        }
+
+        VkInstance m_Instance = VK_NULL_HANDLE;
+        std::vector<VkPhysicalDevice> m_Devices;
+    };
+
+    // The report must be internally consistent for EVERY device, satisfying or
+    // not — Satisfied is exactly "nothing missing", and each absent extension
+    // names itself in Missing (that list is the refuse-to-init error text).
+    TEST_F(VulkanBringUp, CapabilityReportIsInternallyConsistent)
+    {
+        for (VkPhysicalDevice device : m_Devices)
+        {
+            const VulkanCapabilityReport report = VulkanCapabilities::Evaluate(device);
+
+            EXPECT_FALSE(report.DeviceName.empty());
+            EXPECT_EQ(report.Satisfied, report.Missing.empty()) << report.DeviceName;
+
+            auto missingContains = [&report](const char* item)
+            {
+                for (const std::string& entry : report.Missing)
+                {
+                    if (entry == item)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            EXPECT_EQ(!report.HasDescriptorHeap, missingContains(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME))
+                << report.DeviceName;
+            EXPECT_EQ(!report.HasShaderUntypedPointers,
+                      missingContains(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME))
+                << report.DeviceName;
+            EXPECT_EQ(!report.HasSwapchain, missingContains(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) << report.DeviceName;
+
+            // A feature bit can only be reported true when its extension is listed.
+            EXPECT_LE(report.DescriptorHeapFeature, report.HasDescriptorHeap) << report.DeviceName;
+            EXPECT_LE(report.ShaderUntypedPointersFeature, report.HasShaderUntypedPointers) << report.DeviceName;
+        }
+    }
+
+    // A device the gate would ACCEPT must also accept the logical device the gate
+    // then creates — same extension list, contract feature bits enabled. This is
+    // the "fail at the gate, not at first descriptor-heap use" property; if the
+    // driver advertises the contract but rejects enabling it, this catches it in
+    // the suite instead of at editor launch.
+    TEST_F(VulkanBringUp, SatisfyingDeviceAcceptsTheContractEnabledLogicalDevice)
+    {
+        std::optional<VkPhysicalDevice> satisfying;
+        for (VkPhysicalDevice device : m_Devices)
+        {
+            if (VulkanCapabilities::Evaluate(device).Satisfied)
+            {
+                satisfying = device;
+                break;
+            }
+        }
+        if (!satisfying.has_value())
+        {
+            GTEST_SKIP() << "No device satisfies the ADR 0010 capability contract "
+                            "(VK_EXT_descriptor_heap et al.) — the gate would refuse --rhi=vulkan here.";
+        }
+
+        u32 familyCount = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(*satisfying, &familyCount, nullptr);
+        std::vector<VkQueueFamilyProperties> families(familyCount);
+        vkGetPhysicalDeviceQueueFamilyProperties(*satisfying, &familyCount, families.data());
+        std::optional<u32> graphicsFamily;
+        for (u32 i = 0; i < familyCount; ++i)
+        {
+            if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+            {
+                graphicsFamily = i;
+                break;
+            }
+        }
+        ASSERT_TRUE(graphicsFamily.has_value());
+
+        const f32 queuePriority = 1.0f;
+        VkDeviceQueueCreateInfo queueInfo{};
+        queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo.queueFamilyIndex = *graphicsFamily;
+        queueInfo.queueCount = 1;
+        queueInfo.pQueuePriorities = &queuePriority;
+
+        VkPhysicalDeviceDescriptorHeapFeaturesEXT heapFeatures{};
+        heapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT;
+        heapFeatures.descriptorHeap = VK_TRUE;
+        VkPhysicalDeviceShaderUntypedPointersFeaturesKHR untypedFeatures{};
+        untypedFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR;
+        untypedFeatures.shaderUntypedPointers = VK_TRUE;
+        untypedFeatures.pNext = &heapFeatures;
+
+        const std::vector<const char*> extensions = VulkanCapabilities::RequiredDeviceExtensions();
+
+        VkDeviceCreateInfo deviceInfo{};
+        deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        deviceInfo.pNext = &untypedFeatures;
+        deviceInfo.queueCreateInfoCount = 1;
+        deviceInfo.pQueueCreateInfos = &queueInfo;
+        deviceInfo.enabledExtensionCount = static_cast<u32>(extensions.size());
+        deviceInfo.ppEnabledExtensionNames = extensions.data();
+
+        VkDevice device = VK_NULL_HANDLE;
+        const VkResult result = vkCreateDevice(*satisfying, &deviceInfo, nullptr, &device);
+        EXPECT_EQ(result, VK_SUCCESS)
+            << "Device advertises the ADR 0010 contract but rejected enabling it — the gate would "
+               "accept a device the driver then refuses.";
+        if (device != VK_NULL_HANDLE)
+        {
+            vkDestroyDevice(device, nullptr);
+        }
+    }
+} // namespace
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -850,11 +850,81 @@ if(OLO_WITH_MATERIALX)
 endif()
 
 #======================================
+# Vulkan RHI backend dependencies (#691 Phase 4). Gated on OLO_WITH_VULKAN (root CMakeLists).
+#======================================
+# All three are pinned at the SDK-1.4.357.0 tag family — ADR 0010's tooling floor: the first
+# SDK whose validation layers can GPU-validate VK_EXT_descriptor_heap, and the version whose
+# vulkan_core.h the backend's device-selection gate compiles against. The vendored headers
+# deliberately shadow whatever SDK happens to be installed: the engine's find_package(Vulkan)
+# (OloEngine/CMakeLists.txt, for the shaderc toolchain) contributes the SDK's include dir too,
+# so OloEngine/CMakeLists.txt lists ${vulkan-headers_SOURCE_DIR}/include explicitly BEFORE
+# ${Vulkan_INCLUDE_DIRS} — /I order is what decides, and both are plain /I paths. The backend
+# then compiles against 1.4.357 regardless of the installed SDK's age; VulkanContext.cpp pins
+# this with a static_assert on VK_HEADER_VERSION.
+if(OLO_WITH_VULKAN)
+	FetchContent_Declare(
+		vulkan-headers
+		GIT_REPOSITORY	https://github.com/KhronosGroup/Vulkan-Headers.git
+		GIT_TAG			e3b1eec08173d6b825cd3ac88c885a63b621504a  # vulkan-sdk-1.4.357.0
+		GIT_SHALLOW		FALSE
+	)
+	FetchContent_Declare(
+		volk
+		GIT_REPOSITORY	https://github.com/zeux/volk.git
+		GIT_TAG			776893306c5d3b22b6185b5d4a258b81d94572bf  # vulkan-sdk-1.4.357.0
+		GIT_SHALLOW		FALSE
+	)
+	# VOLK_PULL_IN_VULKAN must be OFF: its default resolution order prefers
+	# find_package(Vulkan) — i.e. the INSTALLED SDK's headers — over the vendored
+	# Vulkan-Headers target, which would silently compile volk against whatever SDK
+	# version the machine happens to have. Link the vendored headers explicitly instead.
+	set(VOLK_PULL_IN_VULKAN OFF CACHE BOOL "" FORCE)
+	set(VOLK_INSTALL OFF CACHE BOOL "" FORCE)
+
+	# ORDER MATTERS: vulkan-headers before volk, so the Vulkan::Headers alias exists when
+	# the link below resolves. The alias is resolved HERE, in vendor scope, to the vendored
+	# target — so consumers of `volk`/`vma` get the 1.4.357 headers by propagation even
+	# though OloEngine/CMakeLists.txt's later find_package(Vulkan) may mint its own,
+	# SDK-pointing Vulkan::Headers in its own directory scope. Nothing engine-side may link
+	# Vulkan::Headers by name for that reason; link `volk` or `vma` instead.
+	FetchContent_MakeAvailable(vulkan-headers volk)
+	target_link_libraries(volk PUBLIC Vulkan::Headers)
+
+	# VMA: header-only (vk_mem_alloc.h); the implementation TU is
+	# Platform/Vulkan/VulkanMemoryAllocator.cpp (VMA_IMPLEMENTATION + volk import).
+	# DOWNLOAD_ONLY + hand-rolled INTERFACE target, mirroring the bcdec/cpp_httplib pattern —
+	# VMA's own CMakeLists would work, but the interface target is two lines and avoids
+	# coupling to its install/export machinery.
+	CPMAddPackage(NAME vma
+	  GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+	  GIT_TAG 3aa921224c154a0d2c43912bc88e1c42ce1f7607  # v3.4.0
+	  GIT_SHALLOW FALSE
+	  DOWNLOAD_ONLY YES)
+	if(vma_ADDED)
+		add_library(vma INTERFACE)
+		# SYSTEM so the VMA_IMPLEMENTATION expansion doesn't count against OloEngine's
+		# warning level, exactly as bcdec's IMPLEMENTATION is handled.
+		target_include_directories(vma SYSTEM INTERFACE "${vma_SOURCE_DIR}/include")
+		target_link_libraries(vma INTERFACE Vulkan::Headers)
+	endif()
+
+	set_target_properties(volk PROPERTIES FOLDER "Utilities/Vulkan")
+	if(TARGET Vulkan-Headers)
+		set_target_properties(Vulkan-Headers PROPERTIES FOLDER "Utilities/Vulkan")
+	endif()
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		target_compile_options(volk PRIVATE -Wno-error -Wno-everything)
+	endif()
+	message(STATUS "OLO_WITH_VULKAN: Vulkan backend deps enabled (Vulkan-Headers + volk @ vulkan-sdk-1.4.357.0, VMA v3.4.0)")
+endif()
+
+#======================================
 # Propagate FetchContent _SOURCE_DIR / _BINARY_DIR variables to parent scope
 # so OloEngine/CMakeLists.txt can use them in target_include_directories.
 foreach(_dep assimp atomic_queue box2d entt filewatch glad glfw glm googletest
              joltphysics meshoptimizer miniaudio pl_mpeg recastnavigation spdlog tracy yaml-cpp
-             zlib stb_image imgui imguizmo lua GameNetworkingSockets Imath alembic materialx)
+             zlib stb_image imgui imguizmo lua GameNetworkingSockets Imath alembic materialx
+             vulkan-headers)
 	if(DEFINED ${_dep}_SOURCE_DIR)
 		set(${_dep}_SOURCE_DIR "${${_dep}_SOURCE_DIR}" PARENT_SCOPE)
 	endif()

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -906,6 +906,12 @@ if(OLO_WITH_VULKAN)
 		# warning level, exactly as bcdec's IMPLEMENTATION is handled.
 		target_include_directories(vma SYSTEM INTERFACE "${vma_SOURCE_DIR}/include")
 		target_link_libraries(vma INTERFACE Vulkan::Headers)
+	else()
+		# OloEngine links `vma` unconditionally under OLO_WITH_VULKAN, via the
+		# plain target_link_libraries signature — an undefined target there is
+		# silently treated as an external library name and only fails at LINK
+		# time with a baffling "cannot open vma.lib". Fail at configure instead.
+		message(FATAL_ERROR "OLO_WITH_VULKAN=ON but CPM did not add VulkanMemoryAllocator (vma_ADDED is false) — the vma target would be undefined.")
 	endif()
 
 	set_target_properties(volk PROPERTIES FOLDER "Utilities/Vulkan")

--- a/OloRuntime/src/OloRuntimeApp.cpp
+++ b/OloRuntime/src/OloRuntimeApp.cpp
@@ -647,13 +647,22 @@ namespace OloEngine
             // needs a real OpenGL 4.6 context. ImGui isn't initialized in that
             // window-less path either, so GetIO() must not be touched. See
             // CreateApplication below.
-            if (pushRuntimeLayer)
+            //
+            // Under `--rhi=vulkan` (#691 Phase 4 bring-up) it is skipped for the
+            // same two reasons — the layer renders through GL and no ImGui context
+            // exists (the ImGui layer is not pushed in that mode).
+            if (pushRuntimeLayer && Renderer::GetAPI() == RendererAPI::API::OpenGL)
             {
                 // Disable ImGui ini persistence — the runtime doesn't need it and
                 // loading the editor's imgui.ini from CWD would cause stale state.
                 ImGui::GetIO().IniFilename = nullptr;
 
                 PushLayer(std::make_unique<RuntimeLayer>());
+            }
+            else if (pushRuntimeLayer)
+            {
+                OLO_CORE_INFO("[RHI] RuntimeLayer skipped under --rhi=vulkan (Phase 4 bring-up: "
+                              "expect only a cleared window)");
             }
         }
 

--- a/docs/adr/0010-vulkan-rhi-heap-bindless-only.md
+++ b/docs/adr/0010-vulkan-rhi-heap-bindless-only.md
@@ -62,6 +62,34 @@ would be guessing, and a wrong constant here is worse than an absent one because
 it looks authoritative. Phase 4 fills this table in and **must not** widen the
 runtime check without amending this section.
 
+**Phase 4 fill-in (2026-08-07).** The single reader is
+`VulkanCapabilities::Evaluate` (`Platform/Vulkan/VulkanCapabilities.{h,cpp}`);
+`VulkanContext`'s device pick and `VulkanBringUpTest` both call it, per the
+one-list rule above. What the gate now checks, verified against the vendored
+1.4.357 headers and the NVIDIA 610.88 driver:
+
+| Requirement | Pinned value |
+| --- | --- |
+| API version | `VK_API_VERSION_1_4` (`VulkanCapabilities::kMinApiVersion`) — also what satisfies `VK_EXT_descriptor_heap`'s whole vk.xml `depends` chain, so no companion extensions need enabling below it. |
+| `VK_EXT_descriptor_heap` | Listed **and** `VkPhysicalDeviceDescriptorHeapFeaturesEXT::descriptorHeap == VK_TRUE`. `descriptorHeapCaptureReplay` is NOT required (tooling-only). `specVersion` floor stays 1 (the only revision that exists). |
+| `VK_KHR_shader_untyped_pointers` | Listed **and** `VkPhysicalDeviceShaderUntypedPointersFeaturesKHR::shaderUntypedPointers == VK_TRUE`. |
+| `VK_KHR_swapchain` | Listed (the backend must present at all). |
+| Queue topology | One family with graphics **and** present. Split-family hardware is refused for now — nothing on the driver floor above lacks a combined family, and supporting the split doubles the sync surface for no gain. Widening this later is a narrowing-free change (it accepts *more* devices) but still belongs here first. |
+
+The gate **enables** the two feature bits at `vkCreateDevice` (not just queries
+them), so a driver that advertises the contract but rejects enabling it fails at
+the gate rather than at Phase 5/6's first heap use. (It also enables
+`VkPhysicalDeviceVulkan13Features::synchronization2` for the bring-up's
+barrier/submit calls — deliberately NOT a contract row: sync2 support is
+mandatory on every 1.3+ device, so the API-version row already covers it, but
+the enable bit still defaults off and validation flags every sync2 call without
+it.) —
+`VulkanBringUpTest.SatisfyingDeviceAcceptsTheContractEnabledLogicalDevice` pins
+that property in the suite. **Still deferred, now owned by Phase 5/6:** the
+`…PropertiesEXT` heap size / alignment / descriptor-size minima — Phase 4
+creates no heap, so pinning minima it never allocates against would be the same
+authoritative-looking guess this section warned about.
+
 **The check is all-or-nothing.** A device satisfying some but not all of the
 above is refused, with a message naming the missing capability — not degraded,
 not partially enabled. That is the same "no silent fallback" rule the binding

--- a/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
+++ b/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
@@ -1890,6 +1890,134 @@ Four things generalise:
 
 ---
 
+## Amendments from Phase 4 (2026-08-07) — Vulkan bring-up
+
+### (39) §2's "nothing reads `GetAPI()` during static init" was wrong — `RenderCommand`'s backend is constructed before the flag is parsed
+
+`RenderCommand::s_RendererAPI` is initialised at static init by calling
+`RendererAPI::Create()` (`RenderCommand.cpp:6`), which switches on `s_API` —
+i.e. the one read this section said did not exist has been there all along.
+It is benign *today* for a narrow reason: `s_API` is constant-initialised to
+`OpenGL`, so the static-init read is well-defined and always sees the default —
+which means the constructed backend is **always the OpenGL one**, regardless of
+what `--rhi=` later selects. Phase 4 tolerates this deliberately: the Vulkan
+bring-up never routes through `RenderCommand` (`Renderer::Init` is skipped
+entirely under `--rhi=vulkan`), so the dormant `OpenGLRendererAPI` object is
+never `Init()`ed and makes no GL calls. **Phase 5 must not inherit this
+silently**: the moment Vulkan routes command execution, `s_RendererAPI` has to
+be (re)created *after* selection — either lazily on first use or explicitly
+from `Application`'s constructor after `SetAPI`. The setter's doc comment
+(`RendererAPI.h`) carries the same warning at the place the next reader will
+actually look.
+
+One visible symptom, benign but worth recognising: every `--rhi=vulkan` run
+ends with `[RHI/GL] OpenGLRendererAPI destroyed without ShutdownGpuResources()`
+in the log — that is this dormant object being destroyed at atexit, tripping a
+pre-existing guard that was written for a *real* GL run shutting down out of
+order. Under Vulkan it never held resources; the message goes away when Phase 5
+fixes the construction timing.
+
+### (40) The "config setting" fallback had no home — no engine-level config is readable before `Window::Create`
+
+§2's selection chain assumes a config setting exists to fall back to. It did
+not: the editor's preferences are **project-scoped** and load inside
+`EditorLayer`, long after `Window::Create` — unusable for a decision the window
+creation itself depends on. Phase 4 introduced the minimal honest form:
+`config/renderer.yaml` (relative to the process working directory, i.e.
+`OloEditor/config/renderer.yaml` for the editor), read by
+`SelectRendererBackend` (`Renderer/BackendSelection.{h,cpp}`) — a pure function
+(no logging, no static writes) so the chain is unit-testable headlessly
+(`BackendSelectionTest`). The editor dropdown, when it lands (Phase 7+), writes
+this file and applies on restart. Two degrade rules worth restating because
+they are asymmetric on purpose: an *unavailable* backend (unknown name, or
+`OLO_WITH_VULKAN=OFF`) degrades to OpenGL **with an error logged** — the binary
+genuinely cannot honour the request; an *incapable device* (below ADR 0010's
+contract) **refuses to initialise** inside `VulkanContext::Init` — degrading
+there is what ADR 0010 forbids.
+
+### (41) Vendored Vulkan headers must out-rank the installed SDK's, and TWO defaults do the opposite
+
+The engine already carries an SDK include dir on every TU's path — the shaderc
+toolchain's `find_package(Vulkan)` — so vendoring Vulkan-Headers 1.4.357 only
+pins the backend's compile if the vendored dir reliably *wins the include
+search*. Three traps, all hit:
+
+- **volk's `VOLK_PULL_IN_VULKAN` (default ON) prefers `find_package(Vulkan)` —
+  the installed SDK — over an existing vendored `Vulkan-Headers` target.** On a
+  machine with an older SDK installed, volk (and everything including `volk.h`)
+  would silently compile against that SDK's headers. It is OFF in
+  `vendor/CMakeLists.txt` and the vendored `Vulkan::Headers` is linked
+  explicitly instead.
+- **Link-propagated INTERFACE include dirs come AFTER the target's own.** The
+  vendored dir arriving "via the volk link" loses the /I order to
+  `${Vulkan_INCLUDE_DIRS}`, which sits in `OloEngine`'s own PUBLIC include list
+  — so the SDK's `vulkan_core.h` still won. The fix is explicit:
+  `${vulkan-headers_SOURCE_DIR}/include` is listed in that same include list
+  **before** `${Vulkan_INCLUDE_DIRS}` (and the vendor propagation loop exports
+  the variable). Both are plain `/I` paths; only order decides.
+- **`Vulkan::Headers` is an ALIAS resolved per directory scope.** The vendor
+  scope resolves it to the vendored target; `OloEngine/CMakeLists.txt`'s later
+  `find_package(Vulkan)` can mint its own, SDK-pointing `Vulkan::Headers` in
+  *its* scope. Engine code must therefore link `volk`/`vma` and never
+  `Vulkan::Headers` by name.
+
+The backstop for all three is a
+`static_assert(VK_HEADER_VERSION >= 357)` in `VulkanContext.cpp` — if the SDK's
+headers ever win the search on a below-floor SDK, the build fails naming the
+mechanism instead of failing to declare `VkPhysicalDeviceDescriptorHeapFeaturesEXT`.
+
+### (41a) `vulkan-1.lib` must not be linked at all — under `/FORCE:MULTIPLE` its thunks silently REPLACE volk's globals
+
+The engine had linked `Vulkan::Vulkan` (vulkan-1.lib) since the shaderc
+toolchain arrived, harmlessly: no engine code called a Vulkan function, so no
+import-library member was ever pulled. Phase 4's first run crashed with an AV
+one millisecond into instance creation, and the mechanism is worth recording
+because every ingredient was pre-existing and individually reasonable:
+
+- volk declares the core entry points as **data** (`PFN_vkCreateInstance
+  vkCreateInstance`) and populates them at `volkInitialize`; an import library
+  declares the same names as **function thunks** (`jmp [__imp_…]`).
+- The repo links with **`/FORCE:MULTIPLE`** (the assimp/MaterialX pugixml
+  collision workaround), so this duplicate did not fail the link — the linker
+  silently picked the import thunk for the backend's data references.
+- A load through that "pointer" reads the thunk's *instruction bytes* and calls
+  the result: instant `0xc0000005`, with a useless stack.
+
+Diagnosis that worked, in order: a standalone volk repro compiled clean and ran
+clean (→ not the loader/layers/headers); `dumpbin /imports:vulkan-1.dll` on the
+test exe showed **exactly the backend's own call list imported** (→ the
+references resolved to the import lib); `dumpbin /symbols` on
+`VulkanContext.obj` showed the references were correctly data-typed (→ the
+substitution happened at link, not compile). Fix: `Vulkan::Vulkan` is removed
+from the link entirely (volk's own contract — the loader is dlopen'd);
+`find_package(Vulkan)` stays for the SDK include dir + shaderc/glslang libs.
+Generalisable: **under `/FORCE:MULTIPLE`, a name collision between a data
+symbol and an import thunk is not a link error — it is a runtime AV** — so
+every new dependency that self-loads an API (volk-style) must audit the link
+line for that API's import library.
+
+### (42) What Phase 4 deliberately did NOT build, so Phase 5 doesn't go looking
+
+- **No `VulkanRendererAPI`.** ~100 no-op virtuals inviting silent fallthrough;
+  every factory switch instead carries a loud `case API::Vulkan:` assert naming
+  Phase 5/6. The `-Wswitch`-with-no-`default:` convention (amendment table in
+  `RHIEnumLoweringTest`) is what forced every switch to take an explicit
+  position — adding the enum member was self-enforcing.
+- **No ImGui under Vulkan.** `imgui_impl_opengl3` until Phase 8; `Application`
+  skips the ImGui layer + overlays and both apps skip their main layers, so
+  `--rhi=vulkan` shows exactly the cleared window the checkpoint asks for.
+- **No split graphics/present queue families** (refused at the gate, recorded
+  in ADR 0010's contract fill-in), **no swapchain-maintenance1 present fences**
+  (recreation uses `vkDeviceWaitIdle` — fine at bring-up frame rates), **no
+  `…PropertiesEXT` heap minima** (deferred to the phase that first allocates a
+  heap; pinning unallocated minima would be ADR 0010's "authoritative-looking
+  guess").
+- **Present-sync shape that Phase 5 should keep:** per-frame acquire semaphore
+  + fence, per-swapchain-IMAGE present semaphore (the
+  `VUID-vkQueueSubmit-pSignalSemaphores-00067` reuse rule), FIFO-only.
+
+---
+
 ## Consequences
 
 - The renderer carries **four** boundary concepts where it carries one today

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -2124,8 +2124,19 @@ editor when you reorder the graphics-API list; Godot takes
 "interactive" is **choosable without recompiling, applied on restart** — a
 runtime switch, just not a live one.
 
-`RendererAPI::s_API` is today a static initialised to `OpenGL` and **never
-written by anything**. Giving it a real setter comes with a hard ordering
+**Phase 4 built this** (2026-08-07): `RendererAPI::SetAPI` exists and is called
+from `Application`'s constructor via `SelectRendererBackend`
+(`Renderer/BackendSelection.{h,cpp}`: `--rhi=` flag → `config/renderer.yaml` →
+OpenGL). One correction to the paragraph below — "never written by anything"
+was true, but "nothing reads `GetAPI()` during static init" was NOT:
+`RenderCommand::s_RendererAPI = RendererAPI::Create()` runs at static init and
+switches on `s_API`, so the constructed backend is always the default OpenGL
+one regardless of the flag. Harmless while Phase 4 never routes `RenderCommand`
+under Vulkan; Phase 5 must re-create `s_RendererAPI` after selection (ADR 0011
+amendment (39)).
+
+`RendererAPI::s_API` was, before Phase 4, a static initialised to `OpenGL` and
+never written by anything. Giving it a real setter comes with a hard ordering
 requirement:
 
 > `RendererAPI::s_API` must be set **before `Window::Create`**.

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -2142,14 +2142,17 @@ requirement:
 > `RendererAPI::s_API` must be set **before `Window::Create`**.
 
 This is not hypothetical — the seam already exists and is already used:
-`WindowsWindow::Init` calls `Renderer::GetAPI()` before `glfwCreateWindow` (to
-decide `GLFW_OPENGL_DEBUG_CONTEXT`), while `Application`'s constructor calls
-`Window::Create` at line 62 and `Renderer::Init` only at line 72. The setter
-belongs in `Application`'s constructor, before line 62, parsed from
-`ApplicationCommandLineArgs` (which already has a `Contains()` helper for
-mode flags like `--smoke-test`). Anything reading `Renderer::GetAPI()` during
-static initialisation sees `OpenGL` regardless; nothing does today, and nothing
-should start.
+`WindowsWindow::Init` calls `Renderer::GetAPI()` before `glfwCreateWindow`
+(client-API hint + `GLFW_OPENGL_DEBUG_CONTEXT`), and `Application`'s
+constructor calls `Window::Create` well before `Renderer::Init`. That is where
+the setter lives: `SelectRendererBackend` resolves the chain and
+`RendererAPI::SetAPI` applies it in `Application`'s constructor, immediately
+after the working-directory switch (so the config fallback resolves against the
+real cwd) and before `Window::Create`. Anything reading `Renderer::GetAPI()`
+during static initialisation sees the constant-initialised `OpenGL` default
+regardless of the flag — and one thing DOES read it there:
+`RenderCommand::s_RendererAPI = RendererAPI::Create()` (see the Phase 4
+correction above). Nothing else should join it.
 
 Why a live swap is genuinely out of reach here, not just unimplemented:
 `GLFW_CLIENT_API` must be set before `glfwCreateWindow` (so a swap destroys the


### PR DESCRIPTION
Phase 4 of #691: the Vulkan backend's bring-up slice — **device / instance / swapchain / sync, no rendering**. Checkpoint per the issue: *"clears + presents, nothing else"*.

## What this implements

- **Runtime backend selection (ADR 0011 §2 — deliberately NOT the issue's "new `vulkan` CMake preset", which the ADR overrides):** `--rhi=opengl|vulkan` → `config/renderer.yaml` fallback → OpenGL default, resolved in `Application`'s constructor **before** `Window::Create` (the load-bearing ordering contract: the window reads `GetAPI()` ahead of `glfwCreateWindow`). `OLO_WITH_VULKAN` (CMake, default ON) is the separate *availability* axis: a not-compiled-in request degrades to GL **loudly**; a device below the capability contract **refuses to initialise**, naming the missing capability (ADR 0010's no-silent-fallback rule).
- **Vendoring:** Vulkan-Headers + volk pinned at `vulkan-sdk-1.4.357.0` (ADR 0010's tooling floor), VMA v3.4.0 — SHA pins per #294. `VOLK_PULL_IN_VULKAN` is OFF and the vendored include dir is ordered ahead of the SDK's, so the installed SDK can never silently displace the pin (`static_assert(VK_HEADER_VERSION >= 357)` backstop).
- **`Platform/Vulkan/`:** `VulkanCapabilities` — the ADR 0010 capability contract's **single reader** (device pick and the bring-up test share it: API 1.4, `VK_EXT_descriptor_heap` + feature bit, `VK_KHR_shader_untyped_pointers` + feature bit, `VK_KHR_swapchain`, combined graphics+present family); `VulkanContext` — instance (+ validation layer & debug messenger in Debug), surface, gated device pick, logical device with the contract features **enabled at `vkCreateDevice`** (fail at the gate, not at Phase 5/6's first heap use), VMA allocator via volk import, swapchain (FIFO, TRANSFER_DST-checked), per-frame acquire-semaphore/fence + **per-image** present-semaphore sync, `vkCmdClearColorImage` cornflower blue, OUT_OF_DATE/suboptimal recreation, zero-extent (minimised) skip.
- **Scope guards:** under `--rhi=vulkan` the editor/runtime skip `Renderer::Init`, ImGui (GL-bound until Phase 8), EditorLayer/RuntimeLayer and the GL debug tools — the window clears + presents, nothing else. Every `RendererAPI` factory switch gains a loud `API::Vulkan` assert case; deliberately **no** `VulkanRendererAPI` no-op stub.

## Two defects the verification loop caught (both fixed here)

1. **`vulkan-1.lib` import thunks silently displaced volk's function-pointer globals** under the repo's pre-existing `/FORCE:MULTIPLE` link (the assimp/MaterialX pugixml workaround) — instant AV at the first Vulkan call, useless stack. The vestigial `Vulkan::Vulkan` link is removed (volk's contract: never link vulkan-1); `find_package(Vulkan)` stays for the shaderc include dir + glslang libs. Mechanism + diagnosis recorded as ADR 0011 amendment **(41a)**.
2. **`synchronization2` wasn't enabled at device creation** — mandatory-*support* on 1.3+ (so not a contract row) but the enable bit defaults off; the NVIDIA driver tolerated it, validation flagged every barrier/submit. Now chained via `VkPhysicalDeviceVulkan13Features`.

Also recorded: ADR 0011 §2's "nothing reads `GetAPI()` during static init" was wrong — `RenderCommand::s_RendererAPI` is constructed at static init from the default, so **Phase 5 must re-create it after selection** (amendment (39), warning also at the `SetAPI` declaration).

## Verification

- **GL path unchanged:** full suite **5547/5552** — sole failure is the pre-existing #754 atmosphere golden drift; 18 golden tests green with `OLOENGINE_GOLDEN_REBASE` unset; editor without `--rhi` boots the full UI/scene normally (`Backend: OpenGL (source: default)`).
- **Vulkan checkpoint (RTX 4090, driver 610.88, loader 1.4.357):** `OloEditor --rhi=vulkan` presents a uniformly cornflower-blue window with **zero validation errors**; two scripted window resizes each logged `[Vulkan] Swapchain recreated`; WM_CLOSE → `[Vulkan] Context shut down cleanly` (no validation-layer leak complaints).
- **Visual evidence is OS-level window screenshots** (run-oloengine driver, `PrintWindow`): MCP capture (`olo_screenshot` / `olo_render_capture_target`) is GL-readback-based and cannot see the Vulkan frame — that plumbing is a **Phase 8 deliverable**.
- **Tests:** `VulkanBringUpTest` (plumbing; SKIP ladder — no loader / no device / no contract → clean SKIP for headless CI; asserts contract-report consistency and that a satisfying device accepts the contract-enabled `vkCreateDevice`) and `BackendSelectionTest` (unit; the full selection chain headlessly).

## Out of scope (next phases)

Phase 5: render-graph execution/barriers (+ re-creating `RenderCommand`'s backend after selection). Phase 6: pipelines/shaders/PSO cache. Phase 8: Vulkan capture/MCP + ImGui backend. Split graphics/present queue families are refused at the gate (recorded in ADR 0010's fill-in); swapchain-maintenance1 present fences deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Vulkan renderer support, enabled by default.
  * Added runtime backend selection through `--rhi` options or configuration files, with OpenGL fallback.
  * Added Vulkan initialization, device capability checks, swapchain handling, synchronization, and memory allocation.
  * Added Vulkan bring-up support for windows and headless validation.

* **Documentation**
  * Documented Vulkan capability requirements, backend selection, and renderer abstraction updates.

* **Tests**
  * Added coverage for backend selection and Vulkan device capability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->