### PR TITLE
ci(tsan): suppress Jolt's assert-build mutex-bookkeeping race (vendored, benign by design)

### DIFF
--- a/.github/sanitizer-suppressions/tsan.txt
+++ b/.github/sanitizer-suppressions/tsan.txt
@@ -1,0 +1,22 @@
+# ThreadSanitizer runtime suppressions. Referenced from the TSan job's
+# TSAN_OPTIONS in .github/workflows/asan.yml (same pattern as lsan.txt).
+#
+# Jolt's JPH_ENABLE_ASSERTS lock-ownership bookkeeping (vendored code, so we
+# suppress rather than patch). JPH::Mutex / JPH::SharedMutex wrap the STL
+# mutexes and, in assert builds only (the TSan job builds Debug), track the
+# owning thread in an mLockedThreadID field as a best-effort recursive-lock
+# detector. try_lock() reads that field in its assert BEFORE acquiring the
+# mutex, racing unlock()'s clear of it (Jolt/Core/Mutex.h:126 vs :148, and the
+# SharedMutex twins). The mutex itself synchronizes correctly — only the
+# diagnostic field races. A true positive against the C++ memory model, benign
+# on x86-64, shipped knowingly by upstream in assert builds (same verdict
+# family as #350's allocator race). First seen: master Sanitizers run
+# 31188714433, PhysicsJoint3DTest.PathPositionMotorSettlesAtTargetFraction —
+# but any test that overlaps Jolt jobs with the stepping thread can trip it.
+#
+# File-based on purpose: it covers all six bookkeeping functions across both
+# mutex classes, and a genuine engine-side race cannot have its RACING ACCESS
+# inside this header — the only memory these inline wrappers themselves touch
+# is the mutex's own bookkeeping field. Races merely *guarded* by Jolt mutexes
+# still report normally (their racing frames are elsewhere).
+race:Jolt/Core/Mutex.h

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -773,7 +773,10 @@ jobs:
       # object reachability, so it cannot see either guarantee. See #636.
       run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.'
       env:
-        TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+        # suppressions: vendored-code races we accept rather than patch — see
+        # the rationale comments in tsan.txt (currently: Jolt's assert-build
+        # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
+        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Test report


### PR DESCRIPTION
Fixes the master **Sanitizers / TSan (Linux/Clang)** failure ([run 31188714433](https://github.com/drsnuggles8/OloEngineBase/actions/runs/31188714433), `PhysicsJoint3DTest.PathPositionMotorSettlesAtTargetFraction`).

## Diagnosis

TSan flagged a read in `JPH::Mutex::try_lock` racing a write in `JPH::Mutex::unlock` — both frames are **Jolt's `JPH_ENABLE_ASSERTS` lock-ownership bookkeeping** (`mLockedThreadID`, `Jolt/Core/Mutex.h:126` vs `:148`). `try_lock`'s assert deliberately reads the field *before* acquiring, as a best-effort recursive-lock detector; the mutex itself synchronizes correctly, only the diagnostic field races. True positive against the C++ memory model, benign on x86-64, shipped knowingly by upstream in assert builds — the TSan job builds `Debug`, which turns them on. `SharedMutex` carries the identical pattern.

**Latent flake, not a regression**: the previous master run (`da854ebf`) executed TSan and passed, and the first-failing commit (`bb090041`) is a shader-only PR with zero physics surface. The report needs the `try_lock` read to land inside `unlock`'s few-instruction write window while a Jolt job (here `JobSoftBodyPrepare`) overlaps the stepping thread's `ValidateActiveBodyBounds` — both Debug-only paths, pure scheduling luck.

## Why a runtime suppression (and not the alternatives)

- **Disabling Jolt asserts under TSan** would drop real assert coverage from the one job most likely to catch cross-thread misuse.
- **`-fno-sanitize=thread` on Jolt** would blind TSan to happens-before edges through Jolt locks and manufacture false positives in *engine* code.
- **Patching vendored sources** — we don't (recast/UBSan precedent, #613: de-instrument/except, never edit `vendor/`).

The suppression is deliberately **file-based** (`race:Jolt/Core/Mutex.h`): it covers all six bookkeeping functions across both mutex classes, while a genuine engine-side race still reports — its racing frames cannot be inside that header, whose inline wrappers touch only the mutex's own bookkeeping field. Same mechanism as the existing `lsan.txt`; full rationale lives as comments in the new `tsan.txt`.

Once merged, PR CI on open branches (e.g. #755) picks this up automatically via the merge ref — no rebases needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)