### PR TITLE
feat(rhi): Vulkan render-graph execution layer — unified Access barriers, VMA transients, command dispatch (#691 Phase 5)

### DIFF
--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -1463,14 +1463,25 @@
 		"Platform/OpenGL/OpenGLVertexBuffer.cpp"
 		"Platform/OpenGL/OpenGLVertexBuffer.h"
 
-		# Vulkan backend bring-up (#691 Phase 4). Always listed; each .cpp self-guards
-		# on OLO_WITH_VULKAN and compiles to an empty TU when the backend is off —
-		# the same convention as the OLO_WITH_* import-format translators.
+		# Vulkan backend bring-up (#691 Phase 4) + render-graph execution layer
+		# (#691 Phase 5). Always listed; each .cpp self-guards on OLO_WITH_VULKAN
+		# and compiles to an empty TU when the backend is off — the same
+		# convention as the OLO_WITH_* import-format translators.
+		"Platform/Vulkan/VulkanBarrierLowering.cpp"
+		"Platform/Vulkan/VulkanBarrierLowering.h"
 		"Platform/Vulkan/VulkanCapabilities.cpp"
 		"Platform/Vulkan/VulkanCapabilities.h"
 		"Platform/Vulkan/VulkanContext.cpp"
 		"Platform/Vulkan/VulkanContext.h"
+		"Platform/Vulkan/VulkanDevice.cpp"
+		"Platform/Vulkan/VulkanDevice.h"
+		"Platform/Vulkan/VulkanImageLayoutTracker.cpp"
+		"Platform/Vulkan/VulkanImageLayoutTracker.h"
 		"Platform/Vulkan/VulkanMemoryAllocator.cpp"
+		"Platform/Vulkan/VulkanRendererAPI.cpp"
+		"Platform/Vulkan/VulkanRendererAPI.h"
+		"Platform/Vulkan/VulkanTransientResources.cpp"
+		"Platform/Vulkan/VulkanTransientResources.h"
 )
 
 # Platform-specific sources

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -11,6 +11,7 @@
 #include "OloEngine/Debug/PerformanceLayer.h"
 #include "OloEngine/Networking/Core/NetworkManager.h"
 #include "OloEngine/Renderer/BackendSelection.h"
+#include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
@@ -67,6 +68,12 @@ namespace OloEngine
                 OLO_CORE_ERROR("[RHI] {}", backend.Diagnostic);
             }
             RendererAPI::SetAPI(backend.Api);
+            // ADR 0011 amendment (39): RenderCommand::s_RendererAPI was built
+            // at static init, BEFORE the selection above — always the OpenGL
+            // default. Re-create it now so the facade matches the selection;
+            // nothing has routed through it yet (no window, no context), which
+            // is the only moment this swap is legal.
+            RenderCommand::RecreateForSelectedBackend();
             OLO_CORE_INFO("[RHI] Backend: {} (source: {})",
                           backend.Api == RendererAPI::API::Vulkan ? "Vulkan" : "OpenGL", backend.Source);
         }

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandBucket.h
@@ -11,6 +11,10 @@
 #include <functional>
 
 #include "OloEngine/Threading/Mutex.h"
+// TUniqueLock — used by the parallel-submission paths below. Not transitively
+// provided by Mutex.h: a non-PCH TU including this header (the Vulkan
+// execution test was the first) fails on Linux/Clang without it.
+#include "OloEngine/Threading/UniqueLock.h"
 
 #include <optional>
 

--- a/OloEngine/src/OloEngine/Renderer/Framebuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Framebuffer.cpp
@@ -3,6 +3,12 @@
 #include "OloEngine/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLFramebuffer.h"
 
+#if OLO_WITH_VULKAN
+// Sanctioned factory-include pattern (rhi-abstraction-boundary.md): this
+// OLO_WITH_VULKAN-guarded factory TU may see Platform/Vulkan/ headers.
+#include "Platform/Vulkan/VulkanTransientResources.h"
+#endif
+
 namespace OloEngine
 {
     Ref<Framebuffer> Framebuffer::Create(const FramebufferSpecification& spec)
@@ -16,7 +22,16 @@ namespace OloEngine
             }
             case RendererAPI::API::Vulkan:
             {
-                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+#if OLO_WITH_VULKAN
+                // #691 Phase 5: the TransientPool's attribute-only path. A
+                // Vulkan resource cannot exist without a device, so fall
+                // through to the loud assert when none is up.
+                if (VulkanDevice::Get() != nullptr)
+                {
+                    return Ref<VulkanFramebuffer>::Create(spec);
+                }
+#endif
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan: no VulkanDevice is up (or OLO_WITH_VULKAN is compiled out) — cannot create a Vulkan framebuffer!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/RGBuilder.h
+++ b/OloEngine/src/OloEngine/Renderer/RGBuilder.h
@@ -79,6 +79,11 @@ namespace OloEngine
         u32 BaseSlice = 0;
         u32 SliceCount = ~0u; // ~0u means "all slices from BaseSlice"
 
+        // Phase 5: the submission plan dedupes per-consumer transitions on
+        // (resource, range, from, to). Trailing-return form for MSVC (see
+        // cpp-coding-quality.md §7).
+        [[nodiscard]] auto operator==(const RGSubresourceRange& other) const -> bool = default;
+
         static RGSubresourceRange Full()
         {
             return {};

--- a/OloEngine/src/OloEngine/Renderer/RGCommandContext.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RGCommandContext.cpp
@@ -130,6 +130,16 @@ namespace OloEngine
         RenderCommand::MemoryBarrier(flags);
     }
 
+    void RGCommandContext::IssueBarrierBatch(const MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) const
+    {
+        // Same early-out contract as MemoryBarrier(): a batch with nothing in
+        // either currency issues nothing, so GL behaviour is byte-identical
+        // to the pre-Phase-5 MemoryBarrier(flags) path.
+        if (flags == MemoryBarrierFlags::None && barriers.empty())
+            return;
+        RenderCommand::IssueBarrierBatch(flags, barriers);
+    }
+
     void RGCommandContext::DrawIndexed(const Ref<VertexArray>& vertexArray, const u32 indexCount) const
     {
         RenderCommand::DrawIndexed(vertexArray, indexCount);

--- a/OloEngine/src/OloEngine/Renderer/RGCommandContext.h
+++ b/OloEngine/src/OloEngine/Renderer/RGCommandContext.h
@@ -108,6 +108,12 @@ namespace OloEngine
         // is disabled, so a converted pass costs nothing on the slot-based path.
         void FlushHeapOffsets() const;
         void MemoryBarrier(MemoryBarrierFlags flags) const;
+        // Phase 5 (ADR 0011 §1.5): the pre-pass barrier batch carrying both
+        // currencies — the GL flags bitmask AND the handle-resolved
+        // per-resource transitions. Forwards to RendererAPI::IssueBarrierBatch;
+        // GL executes the flags exactly as MemoryBarrier() did, an
+        // explicit-barrier backend lowers the RHI::Barrier span instead.
+        void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) const;
         void DrawIndexed(const Ref<VertexArray>& vertexArray, u32 indexCount = 0) const;
         // Async-compute batch boundaries.
         // In GL 4.6 (single command stream) these insert KHR_debug group labels

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHIResources.h
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHIResources.h
@@ -142,33 +142,10 @@ namespace OloEngine::RHI
     // second view, and under this model a second heap slot.
     // =========================================================================
 
-    // Which plane(s) of a resource an access refers to. A depth-stencil format
-    // has two, and Vulkan can transition them independently
-    // (DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL and its mirror), so a range
-    // without an aspect is not a complete subresource identifier. The engine's
-    // existing RGSubresourceRange omits this; it is added here because
-    // CreateDepthArrayCompareOffView already produces a depth-only read of a
-    // resource that is elsewhere used as a depth-stencil attachment.
-    enum class TextureAspect : u8
-    {
-        Color = 0,
-        Depth,
-        Stencil,
-        DepthStencil,
-    };
-
-    struct SubresourceRange
-    {
-        static constexpr u32 AllRemaining = ~0u;
-
-        TextureAspect Aspect = TextureAspect::Color;
-        u32 BaseMip = 0;
-        u32 MipCount = AllRemaining;
-        u32 BaseLayer = 0;
-        u32 LayerCount = AllRemaining;
-
-        [[nodiscard]] auto operator==(const SubresourceRange& other) const -> bool = default;
-    };
+    // TextureAspect and SubresourceRange MOVED to RHITypes.h in Phase 5: the
+    // barrier facade entry point (RendererAPI::IssueBarrierBatch) takes
+    // RHI::Barrier, and RendererAPI.h includes only RHITypes.h — same
+    // move-don't-duplicate precedent as MemoryResidency (Phase 2 step 2).
 
     // WHICH KIND OF DESCRIPTOR a view produces (issue #691 Phase 3, ADR 0011
     // amendment (26)).
@@ -497,30 +474,10 @@ namespace OloEngine::RHI
     };
 
     // =========================================================================
-    // Barriers
-    //
-    // ADR 0011 §1.5. This is what RenderGraph::ResourceTransition should carry
-    // once Phase 5 unifies its RGWriteUsage -> RGReadUsage pair, which today
-    // structurally cannot express a write -> write transition.
-    //
-    // There is no image-layout member, deliberately: layout is a pure function
-    // of Access, so the Vulkan backend derives it. See RHITypes.h.
+    // Barriers — struct Barrier MOVED to RHITypes.h in Phase 5, when
+    // RendererAPI::IssueBarrierBatch made it facade vocabulary (RendererAPI.h
+    // includes only RHITypes.h). See the note at TextureAspect above.
     // =========================================================================
-
-    struct Barrier
-    {
-        ResourceHandle Resource;
-        SubresourceRange Range;
-        Access Before = Access::Undefined;
-        Access After = Access::Undefined;
-
-        // Set when producer and consumer sit on different queues. On GL 4.6
-        // (one command stream) this is informational; on Vulkan it drives
-        // queue-family ownership transfer and semaphore waits.
-        bool IsCrossQueue = false;
-        QueueType SourceQueue = QueueType::Graphics;
-        QueueType DestQueue = QueueType::Graphics;
-    };
 
     // =========================================================================
     // The debug escape hatch.

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHITypes.h
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHITypes.h
@@ -414,19 +414,19 @@ namespace OloEngine::RHI
     // -------------------------------------------------------------------------
     // Access — the unified barrier lattice.
     //
-    // ADR 0011 §1.5. RenderGraph::ResourceTransition currently types its
+    // ADR 0011 §1.5. Before Phase 5, RenderGraph::ResourceTransition typed its
     // transition as `RGWriteUsage FromUsage` -> `RGReadUsage ToUsage`, which
-    // structurally CANNOT express a write->write transition. The barrier planner
-    // does emit WAW barriers, but BuildResourceTransitions then finds no read
-    // declaration on the consumer and silently falls back to
-    // `ToUsage = RGReadUsage::ShaderSample`.
+    // structurally could NOT express a write->write transition: the barrier
+    // planner emitted WAW barriers, BuildResourceTransitions found no read
+    // declaration on the consumer, and silently fell back to
+    // `ToUsage = RGReadUsage::ShaderSample`. Harmless on GL (only the Flags
+    // bitmask is executed there); on Vulkan it would have lowered a
+    // storage-image WAW into SHADER_READ_ONLY_OPTIMAL with a read-only access
+    // mask — wrong layout, wrong access, silent.
     //
-    // On GL that is harmless — the flags come from PlannedBarrier::Flags, which
-    // the planner derived correctly from the *write* usage, so the bogus ToUsage
-    // is never read. On Vulkan, a backend deriving (dstStageMask, dstAccessMask,
-    // newLayout) from ToUsage would lower a storage-image WAW into
-    // SHADER_READ_ONLY_OPTIMAL with a read-only access mask: wrong layout, wrong
-    // access, and silent.
+    // Phase 5 fixed it at the source: PlannedBarrier captures the consumer's
+    // access (read OR write) AT EMISSION, and ResourceTransition carries this
+    // enum as `FromAccess` / `ToAccess`.
     //
     // This single enum covers reads, writes and the initial no-access state, so
     // a transition record can express any pair. RGReadUsage / RGWriteUsage stay
@@ -444,9 +444,9 @@ namespace OloEngine::RHI
     {
         // The resource has no defined contents. First use of a transient this
         // frame, and the state a Vulkan backend uses to discard rather than
-        // preserve. Today `ProducerPass == "external"` defaults FromUsage to
-        // RenderTarget instead, which is wrong for a genuine first use — see
-        // ADR 0011 §1.5.
+        // preserve. Since Phase 5, `ProducerPass == "external"` transitions
+        // carry this as FromAccess (the pre-Phase-5 record defaulted to
+        // RenderTarget, wrong for a genuine first use — ADR 0011 §1.5).
         Undefined = 0,
 
         IndirectArgsRead,
@@ -500,6 +500,71 @@ namespace OloEngine::RHI
         Graphics = 0,
         Compute,
         Transfer,
+    };
+
+    // -------------------------------------------------------------------------
+    // Barrier vocabulary. MOVED here from RHIResources.h in Phase 5, when
+    // `RendererAPI::IssueBarrierBatch` made these facade vocabulary and
+    // RendererAPI.h includes only this header — the same move-don't-duplicate
+    // rule as MemoryResidency below (Phase 2 step 2's amendment method).
+    // -------------------------------------------------------------------------
+
+    // Which plane(s) of a resource an access refers to. A depth-stencil format
+    // has two, and Vulkan can transition them independently
+    // (DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL and its mirror), so a range
+    // without an aspect is not a complete subresource identifier. The engine's
+    // existing RGSubresourceRange omits this; it is added here because
+    // CreateDepthArrayCompareOffView already produces a depth-only read of a
+    // resource that is elsewhere used as a depth-stencil attachment.
+    enum class TextureAspect : u8
+    {
+        Color = 0,
+        Depth,
+        Stencil,
+        DepthStencil,
+    };
+
+    struct SubresourceRange
+    {
+        static constexpr u32 AllRemaining = ~0u;
+
+        TextureAspect Aspect = TextureAspect::Color;
+        u32 BaseMip = 0;
+        u32 MipCount = AllRemaining;
+        u32 BaseLayer = 0;
+        u32 LayerCount = AllRemaining;
+
+        [[nodiscard]] auto operator==(const SubresourceRange& other) const -> bool = default;
+    };
+
+    // ADR 0011 §1.5: the handle-resolved form of one RenderGraph
+    // ResourceTransition, batched per consumer pass and handed to
+    // `RendererAPI::IssueBarrierBatch`. The GL backend ignores these (its
+    // lowering is the MemoryBarrierFlags bitmask the planner also derives);
+    // the Vulkan backend lowers each to a VkImageMemoryBarrier2 /
+    // VkBufferMemoryBarrier2.
+    //
+    // There is no image-layout member, deliberately: layout is a function of
+    // (Access, aspect, read-while-attached) that the Vulkan backend owns.
+    // `ReadWhileAttached` is the third input of that function — set when the
+    // consuming pass also has the resource bound as an attachment while
+    // reading it (the PCSS raw-depth-sample case), which lowers to
+    // DEPTH_STENCIL_READ_ONLY_OPTIMAL / GENERAL instead of the plain
+    // read-only layouts.
+    struct Barrier
+    {
+        ResourceHandle Resource;
+        SubresourceRange Range;
+        Access Before = Access::Undefined;
+        Access After = Access::Undefined;
+        bool ReadWhileAttached = false;
+
+        // Set when producer and consumer sit on different queues. On GL 4.6
+        // (one command stream) this is informational; on Vulkan it drives
+        // queue-family ownership transfer and semaphore waits.
+        bool IsCrossQueue = false;
+        QueueType SourceQueue = QueueType::Graphics;
+        QueueType DestQueue = QueueType::Graphics;
     };
 
     // -------------------------------------------------------------------------

--- a/OloEngine/src/OloEngine/Renderer/RenderCommand.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderCommand.h
@@ -12,6 +12,19 @@ namespace OloEngine
             s_RendererAPI->Init();
         }
 
+        // ADR 0011 amendment (39), Phase 5. `s_RendererAPI` is constructed at
+        // STATIC INIT (RenderCommand.cpp), before `--rhi=` parses — so the
+        // static-init instance is always the OpenGL default regardless of the
+        // selected backend. Application's constructor calls this immediately
+        // after `RendererAPI::SetAPI` (and before `Window::Create`) so the
+        // facade matches the selection the moment anything can route through
+        // it. Must never be called once a window/context exists or any code
+        // has captured `GetRendererAPI()` by reference.
+        static void RecreateForSelectedBackend()
+        {
+            s_RendererAPI = RendererAPI::Create();
+        }
+
         static void SetViewport(const u32 x, const u32 y, const u32 width, const u32 height)
         {
             s_RendererAPI->SetViewport(x, y, width, height);
@@ -308,6 +321,14 @@ namespace OloEngine
         static void MemoryBarrier(MemoryBarrierFlags flags)
         {
             s_RendererAPI->MemoryBarrier(flags);
+        }
+
+        // Phase 5 (ADR 0011 §1.5): the render graph's pre-pass barrier batch
+        // carrying both currencies — GL executes `flags`, explicit-barrier
+        // backends lower `barriers`.
+        static void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers)
+        {
+            s_RendererAPI->IssueBarrierBatch(flags, barriers);
         }
 
         // Per-attachment blend control

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -1028,7 +1028,14 @@ namespace OloEngine
             // Bump generation only when the backing resource or placeholder
             // state actually changes. A no-op re-import keeps prior handle
             // copies valid for callers caching handles across frames.
-            const bool resourceChanged = (phys.BufferID != bufferID);
+            // A slot whose previous occupant carried the IDENTITY currency (a
+            // materialized transient sets BOTH — Phase 5) changes occupants
+            // even when the native id happens to match: the native import
+            // below clears phys.Handle, so cached RGBufferHandles must fail
+            // their generation check rather than silently resolve to the new
+            // native-only occupant (AllocateTextureHandle's identity
+            // comparison, mirrored).
+            const bool resourceChanged = (phys.BufferID != bufferID) || phys.Handle.IsValid();
             const bool placeholderChanged = (slot.IsPlaceholder != isPlaceholder) ||
                                             (slot.PlaceholderReason != placeholderReason);
             const bool needsGenBump = wasOnFreeList || !slot.Alive || resourceChanged || placeholderChanged;
@@ -4265,7 +4272,7 @@ namespace OloEngine
         const auto canonicalName = [this](const std::string& name) -> const std::string&
         {
             const std::string* current = &name;
-            for (u32 depth = 0; depth < 16u; ++depth)
+            for (u32 depth = 0; depth < kMaxVersionAliasDepth; ++depth)
             {
                 const auto it = m_VersionAliasTargets.find(*current);
                 if (it == m_VersionAliasTargets.end() || it->second.empty())

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.cpp
@@ -1046,6 +1046,10 @@ namespace OloEngine
             handle.Generation = slot.Generation;
 
             phys.BufferID = bufferID;
+            // A native import holds ONE currency — clear any stale identity a
+            // prior transient occupant left ("alternatives, never both", and
+            // the native path clears the identity for free).
+            phys.Handle = RHI::ResourceHandle{};
             m_BufferHandlesByName[std::string(name)] = handle;
             return handle;
         }
@@ -1073,6 +1077,7 @@ namespace OloEngine
                 m_PhysicalBuffers.resize(static_cast<sizet>(handle.Index) + 1u);
 
             m_PhysicalBuffers[handle.Index].BufferID = bufferID;
+            m_PhysicalBuffers[handle.Index].Handle = RHI::ResourceHandle{};
         }
         else
         {
@@ -3304,6 +3309,7 @@ namespace OloEngine
             .BatchEventHook = m_BatchEventHook,
             .PostPassHook = composedPostPassHook,
             .GraphForPostPassHook = this,
+            .GraphForBarrierResolution = this,
         });
         commandContext.SetRenderGraph(nullptr);
 
@@ -3630,7 +3636,11 @@ namespace OloEngine
                         bufferHandleIt != m_BufferHandlesByName.end() &&
                         bufferHandleIt->second.Index < m_PhysicalBuffers.size())
                     {
+                        // The graph holds the pooled Ref itself, so it sets BOTH
+                        // currencies off one pointer — the PhysicalTexture
+                        // slice-7 contract, extended to buffers in Phase 5.
                         m_PhysicalBuffers[bufferHandleIt->second.Index].BufferID = bufferIt->second ? bufferIt->second->GetRendererID() : 0;
+                        m_PhysicalBuffers[bufferHandleIt->second.Index].Handle = bufferIt->second ? bufferIt->second->GetRHIHandle() : RHI::ResourceHandle{};
                     }
                     break;
                 }
@@ -3716,7 +3726,12 @@ namespace OloEngine
                         bufferHandleIt != m_BufferHandlesByName.end() &&
                         bufferHandleIt->second.Index < m_PhysicalBuffers.size())
                     {
+                        // Alias fan-out sets BOTH currencies too — item 4 of
+                        // the boundary doc found exactly this site-class
+                        // setting only the native id (silent null identity on
+                        // the aliased half of a plan).
                         m_PhysicalBuffers[bufferHandleIt->second.Index].BufferID = sibling ? sibling->GetRendererID() : 0;
+                        m_PhysicalBuffers[bufferHandleIt->second.Index].Handle = sibling ? sibling->GetRHIHandle() : RHI::ResourceHandle{};
                     }
                     break;
                 }
@@ -4202,9 +4217,14 @@ namespace OloEngine
         // GetAsyncComputeBatches itself delegates; here we just plumb the
         // results into the IR builder.
         const auto batches = GetAsyncComputeBatches();
+        // Phase 5: derive the transition records once so every emitted
+        // MemoryBarrier command carries its per-resource transitions for the
+        // explicit-barrier backend (GL ignores them; ADR 0011 §1.5).
+        const auto transitions = GetResourceTransitions();
         return RenderGraphSubmissionPlan::BuildPlan({
             .ExecutionOrder = m_ExecutionOrder,
             .PlannedBarriers = m_PlannedBarriers,
+            .Transitions = transitions,
             .Batches = batches,
             .GetPassWorkType = [this](const std::string& passName)
             { return GetGraphEntryWorkType(passName); },
@@ -4230,6 +4250,144 @@ namespace OloEngine
             .GetPassWorkType = [this](const std::string& passName)
             { return GetGraphEntryWorkType(passName); },
         });
+    }
+
+    std::vector<RHI::Barrier> RenderGraph::ResolveTransitionsToBarriers(std::span<const ResourceTransition> transitions) const
+    {
+        OLO_PROFILE_FUNCTION();
+
+        std::vector<RHI::Barrier> barriers;
+        barriers.reserve(transitions.size());
+
+        // Version-aliased names (SceneColor@Pass) refer to the SAME physical
+        // resource as their source — follow the chain with the same depth
+        // guard the transient planner uses.
+        const auto canonicalName = [this](const std::string& name) -> const std::string&
+        {
+            const std::string* current = &name;
+            for (u32 depth = 0; depth < 16u; ++depth)
+            {
+                const auto it = m_VersionAliasTargets.find(*current);
+                if (it == m_VersionAliasTargets.end() || it->second.empty())
+                    break;
+                current = &it->second;
+            }
+            return *current;
+        };
+
+        const auto toQueueType = [](const QueueLane lane) -> RHI::QueueType
+        {
+            switch (lane)
+            {
+                case QueueLane::Compute:
+                    return RHI::QueueType::Compute;
+                case QueueLane::Copy:
+                    return RHI::QueueType::Transfer;
+                case QueueLane::Graphics:
+                    return RHI::QueueType::Graphics;
+            }
+
+            return RHI::QueueType::Graphics;
+        };
+
+        const auto toRHIRange = [](const RGSubresourceRange& range) -> RHI::SubresourceRange
+        {
+            // Slices are dropped: VkImageSubresourceRange has no slice
+            // granularity (a 3D image transitions per-mip at most), so the
+            // RHI form is API-faithful without them. Aspect stays at the
+            // default — see the header comment.
+            RHI::SubresourceRange out;
+            out.BaseMip = range.BaseMip;
+            out.MipCount = (range.MipCount == ~0u) ? RHI::SubresourceRange::AllRemaining : range.MipCount;
+            out.BaseLayer = range.BaseLayer;
+            out.LayerCount = (range.LayerCount == ~0u) ? RHI::SubresourceRange::AllRemaining : range.LayerCount;
+            return out;
+        };
+
+        for (const auto& transition : transitions)
+        {
+            const auto& name = canonicalName(transition.ResourceName);
+
+            RHI::Barrier prototype;
+            prototype.Range = toRHIRange(transition.Range);
+            prototype.Before = transition.FromAccess;
+            prototype.After = transition.ToAccess;
+            prototype.ReadWhileAttached = transition.ReadWhileAttached;
+            prototype.IsCrossQueue = transition.IsCrossLane;
+            prototype.SourceQueue = toQueueType(transition.ProducerLane);
+            prototype.DestQueue = toQueueType(transition.ConsumerLane);
+
+            // Texture?
+            if (const auto texIt = m_TextureHandlesByName.find(name); texIt != m_TextureHandlesByName.end())
+            {
+                const u32 slot = texIt->second.Index;
+                if (slot < m_PhysicalTextures.size() && m_PhysicalTextures[slot].Handle.IsValid())
+                {
+                    prototype.Resource = m_PhysicalTextures[slot].Handle;
+                    barriers.push_back(prototype);
+                }
+                // A native-only import cannot answer in the identity currency;
+                // the GL flags path still synchronises it. Skipped, not an
+                // error (see the header comment).
+                continue;
+            }
+
+            // Framebuffer? One barrier per attachment that can answer in the
+            // identity currency — the backend derives each attachment's
+            // aspect/layout from its own image format.
+            if (const auto fbIt = m_FramebufferHandlesByName.find(name); fbIt != m_FramebufferHandlesByName.end())
+            {
+                const u32 slot = fbIt->second.Index;
+                if (slot < m_PhysicalFramebuffers.size() && m_PhysicalFramebuffers[slot].FB)
+                {
+                    const auto& fb = m_PhysicalFramebuffers[slot].FB;
+                    const auto& spec = fb->GetSpecification();
+                    u32 colorIndex = 0;
+                    bool hasDepth = false;
+                    for (const auto& attachment : spec.Attachments.Attachments)
+                    {
+                        const bool isDepth = attachment.TextureFormat == FramebufferTextureFormat::DEPTH24STENCIL8 ||
+                                             attachment.TextureFormat == FramebufferTextureFormat::DEPTH_COMPONENT32F;
+                        if (isDepth)
+                        {
+                            hasDepth = true;
+                            continue;
+                        }
+                        if (const auto handle = fb->GetColorAttachmentHandle(colorIndex); handle.IsValid())
+                        {
+                            auto barrier = prototype;
+                            barrier.Resource = handle;
+                            barriers.push_back(barrier);
+                        }
+                        ++colorIndex;
+                    }
+                    if (hasDepth)
+                    {
+                        if (const auto handle = fb->GetDepthAttachmentHandle(); handle.IsValid())
+                        {
+                            auto barrier = prototype;
+                            barrier.Resource = handle;
+                            barriers.push_back(barrier);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            // Buffer?
+            if (const auto bufIt = m_BufferHandlesByName.find(name); bufIt != m_BufferHandlesByName.end())
+            {
+                const u32 slot = bufIt->second.Index;
+                if (slot < m_PhysicalBuffers.size() && m_PhysicalBuffers[slot].Handle.IsValid())
+                {
+                    prototype.Resource = m_PhysicalBuffers[slot].Handle;
+                    barriers.push_back(prototype);
+                }
+                continue;
+            }
+        }
+
+        return barriers;
     }
 
     std::vector<RenderGraph::ResourceLifetime> RenderGraph::GetResourceLifetimes() const
@@ -5245,6 +5403,55 @@ namespace OloEngine
             }
         };
 
+        // Phase 5: transitions carry the unified RHI::Access pair
+        // (ADR 0011 §1.5) instead of the read/write usage split above.
+        const auto accessToString = [](const RHI::Access access)
+        {
+            switch (access)
+            {
+                case RHI::Access::Undefined:
+                    return "Undefined";
+                case RHI::Access::IndirectArgsRead:
+                    return "IndirectArgsRead";
+                case RHI::Access::IndexRead:
+                    return "IndexRead";
+                case RHI::Access::VertexAttributeRead:
+                    return "VertexAttributeRead";
+                case RHI::Access::UniformRead:
+                    return "UniformRead";
+                case RHI::Access::ShaderSampleRead:
+                    return "ShaderSampleRead";
+                case RHI::Access::StorageRead:
+                    return "StorageRead";
+                case RHI::Access::StorageWrite:
+                    return "StorageWrite";
+                case RHI::Access::StorageReadWrite:
+                    return "StorageReadWrite";
+                case RHI::Access::ColorAttachmentRead:
+                    return "ColorAttachmentRead";
+                case RHI::Access::ColorAttachmentWrite:
+                    return "ColorAttachmentWrite";
+                case RHI::Access::DepthStencilAttachmentRead:
+                    return "DepthStencilAttachmentRead";
+                case RHI::Access::DepthStencilAttachmentWrite:
+                    return "DepthStencilAttachmentWrite";
+                case RHI::Access::InputAttachmentRead:
+                    return "InputAttachmentRead";
+                case RHI::Access::TransferRead:
+                    return "TransferRead";
+                case RHI::Access::TransferWrite:
+                    return "TransferWrite";
+                case RHI::Access::ClearAsLoadOp:
+                    return "ClearAsLoadOp";
+                case RHI::Access::ClearAsTransfer:
+                    return "ClearAsTransfer";
+                case RHI::Access::Present:
+                    return "Present";
+            }
+
+            return "Unknown";
+        };
+
         // Helper to serialise RGSubresourceRange as a compact
         // JSON object.  ~0u (= all mips/layers/slices) is written as -1 so that
         // consumers can distinguish "full range" from an explicit 1-element range.
@@ -6239,10 +6446,11 @@ namespace OloEngine
             out << "    { \"resource\": \"" << jsonEscape(tr.ResourceName)
                 << "\", \"producerPass\": \"" << jsonEscape(tr.ProducerPass)
                 << "\", \"consumerPass\": \"" << jsonEscape(tr.ConsumerPass)
-                << "\", \"fromUsage\": \"" << writeUsageToString(tr.FromUsage)
-                << "\", \"toUsage\": \"" << readUsageToString(tr.ToUsage)
+                << "\", \"fromAccess\": \"" << accessToString(tr.FromAccess)
+                << "\", \"toAccess\": \"" << accessToString(tr.ToAccess)
                 << "\", \"flags\": " << std::to_underlying(tr.Flags)
                 << ", \"range\": " << subresourceRangeToJson(tr.Range)
+                << ", \"readWhileAttached\": " << (tr.ReadWhileAttached ? "true" : "false")
                 << ", \"isCrossLane\": " << (tr.IsCrossLane ? "true" : "false")
                 << ", \"producerLane\": \"" << queueLaneToString(tr.ProducerLane)
                 << "\", \"consumerLane\": \"" << queueLaneToString(tr.ConsumerLane)

--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <span>
 #include <vector>
 #include <unordered_map>
 #include <string>
@@ -898,6 +899,16 @@ namespace OloEngine
             std::string Resource;
             MemoryBarrierFlags Flags = MemoryBarrierFlags::None;
             RGSubresourceRange Range; ///< subresource range from the consuming access declaration
+
+            // The consumer's access, captured AT EMISSION (ADR 0011 §1.5,
+            // Phase 5). For a read-after-write barrier this is the consumer's
+            // read access; for a write-after-write barrier it is the
+            // consumer's WRITE access — which is exactly what the old
+            // transition-building rescan could not recover (it looked only at
+            // read declarations and silently defaulted a WAW consumer to
+            // ShaderSample). Capturing it here kills that defect at the
+            // source instead of patching the rescan.
+            RHI::Access ToAccess = RHI::Access::Undefined;
         };
 
         struct ExecutionTiming
@@ -1136,6 +1147,63 @@ namespace OloEngine
         [[nodiscard]] std::vector<AsyncComputeBatch> GetAsyncComputeBatches() const;
 
         // -------------------------------------------------------------------
+        // Explicit resource transition records
+        // -------------------------------------------------------------------
+        // For each planned barrier, captures the before-state (producer's
+        // access) and after-state (consumer's access) so explicit-barrier
+        // backends can insert the correct image-layout transitions and
+        // pipeline-stage masks without re-querying the per-pass
+        // access-declaration tables.
+        //
+        // Each record corresponds one-to-one with an entry in
+        // GetPlannedBarriers(): same resource/consumerPass pairing, with the
+        // producer's and consumer's accesses added.
+        //
+        // Phase 5 (ADR 0011 §1.5): the pair is typed with the unified
+        // RHI::Access lattice, NOT the old RGWriteUsage -> RGReadUsage pair —
+        // that pair structurally could not express a write->write transition
+        // (the planner emits WAW barriers, and the old record silently
+        // defaulted their ToUsage to ShaderSample; harmless on GL where only
+        // Flags is read, wrong layout + wrong access mask on Vulkan).
+        // RGReadUsage / RGWriteUsage remain the BUILDER's declaration
+        // vocabulary; this record is where they unify.
+        //
+        // Backend mapping:
+        //   Vulkan  : (FromAccess, ToAccess, aspect, ReadWhileAttached) →
+        //             VkImageMemoryBarrier2 (stage/access masks + old/new
+        //             layout). FromAccess == Undefined means the contents may
+        //             be discarded (oldLayout UNDEFINED).
+        //   GL 4.6  : glMemoryBarrier(Flags) — Flags stays the GL lowering,
+        //             derived by the planner exactly as before Phase 5.
+        struct ResourceTransition
+        {
+            std::string ResourceName;                            ///< virtual resource in the graph
+            std::string ProducerPass;                            ///< last writer before this transition; "external" when only imported
+            std::string ConsumerPass;                            ///< pass whose access triggers the barrier (barrier inserted before it)
+            RHI::Access FromAccess = RHI::Access::Undefined;     ///< producer's access; Undefined for external/first-use (discardable)
+            RHI::Access ToAccess = RHI::Access::Undefined;       ///< consumer's access (read OR write — WAW is representable)
+            MemoryBarrierFlags Flags = MemoryBarrierFlags::None; ///< the GL lowering, from PlannedBarrier (ADR 0011 §1.5)
+            RGSubresourceRange Range;                            ///< subresource range from the consuming access declaration
+
+            // Set when the consuming pass ALSO has this resource declared as
+            // an attachment write while reading it (same-pass feedback, e.g.
+            // the PCSS blocker search sampling raw depth of the bound depth
+            // attachment). The third input of the backend's layout resolution
+            // (ADR 0011 §1.5): such a read lowers to
+            // DEPTH_STENCIL_READ_ONLY_OPTIMAL / GENERAL, not the plain
+            // read-only layout.
+            bool ReadWhileAttached = false;
+
+            // Cross-lane sync metadata (release/acquire intent).
+            // Set when ProducerPass and ConsumerPass reside on different queue lanes.
+            // On GL 4.6 this is informational only; on Vulkan/DX12 it drives
+            // ownership-transfer barriers and semaphore waits.
+            bool IsCrossLane = false;                     ///< true when producer and consumer are on different queue lanes
+            QueueLane ProducerLane = QueueLane::Graphics; ///< lane of the producing pass; Graphics for "external" producers
+            QueueLane ConsumerLane = QueueLane::Graphics; ///< lane of the consuming pass
+        };
+
+        // -------------------------------------------------------------------
         // Submission-plan IR
         // -------------------------------------------------------------------
         // A backend-portable linearised sequence of operations that a
@@ -1172,10 +1240,23 @@ namespace OloEngine
             Kind CommandKind = Kind::Pass;
             std::string NodeName;                                                 ///< non-empty for Pass commands
             RenderGraphNode* NodePointer = nullptr;                               ///< cached node pointer to avoid map lookups
-            MemoryBarrierFlags Barriers = MemoryBarrierFlags::None;               ///< for MemoryBarrier commands
+            MemoryBarrierFlags Barriers = MemoryBarrierFlags::None;               ///< for MemoryBarrier commands: the GL lowering
             u32 BatchIndex = 0;                                                   ///< for BatchBegin/BatchEnd: which async batch
             RenderGraphPassWorkType WorkType = RenderGraphPassWorkType::Graphics; ///< for Pass commands
             QueueLane Lane = QueueLane::Graphics;                                 ///< queue lane assignment for this command
+
+            // For MemoryBarrier commands: the per-resource transitions this
+            // barrier covers, deduplicated on (resource, range, from, to) —
+            // the planner emits one barrier per prior writer, but for layout
+            // purposes only the LAST writer's state matters (earlier writers
+            // are ordered transitively through the WAW barriers between the
+            // writers themselves). GL ignores this and executes `Barriers`;
+            // Vulkan lowers each entry to a VkImageMemoryBarrier2 /
+            // VkBufferMemoryBarrier2 batched into one vkCmdPipelineBarrier2.
+            // Name-keyed on purpose: physical handles change per frame under
+            // transient pooling, so handle resolution happens at execute
+            // time (RGCommandContext), never at plan-bake time.
+            std::vector<ResourceTransition> Transitions; ///< for MemoryBarrier commands
 
             // Self-contained batch-boundary metadata so
             // backends can map waits/signals/resource ownership transitions
@@ -1193,46 +1274,6 @@ namespace OloEngine
         // compute-hoist have already run.
         [[nodiscard]] std::vector<SubmissionCommand> GetSubmissionPlan() const;
 
-        // -------------------------------------------------------------------
-        // Explicit resource transition records
-        // -------------------------------------------------------------------
-        // For each planned barrier, captures the before-state (producer's
-        // write usage) and after-state (consumer's read usage) so
-        // explicit-barrier backends can insert the correct image-layout
-        // transitions and pipeline-stage masks without re-querying the
-        // per-pass access-declaration tables.
-        //
-        // Each record corresponds one-to-one with an entry in
-        // GetPlannedBarriers(): same resource/consumerPass pairing, with the
-        // producer's write-usage and the consumer's read-usage added.
-        //
-        // Backend mapping:
-        //   Vulkan  : FromUsage → VkImageLayout (e.g. RenderTarget →
-        //             COLOR_ATTACHMENT_OPTIMAL); ToUsage → SHADER_READ_ONLY.
-        //             Flags → VkAccessFlags / VkPipelineStageFlags.
-        //   DX12    : FromUsage → D3D12_RESOURCE_STATE_RENDER_TARGET;
-        //             ToUsage → D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE.
-        //   GL 4.6  : glMemoryBarrier(Flags) already inserted; transition
-        //             records are informational until explicit barriers land.
-        struct ResourceTransition
-        {
-            std::string ResourceName;                            ///< virtual resource in the graph
-            std::string ProducerPass;                            ///< last writer before this transition; "external" when only imported
-            std::string ConsumerPass;                            ///< pass that reads the resource (barrier inserted before it)
-            RGWriteUsage FromUsage = RGWriteUsage::RenderTarget; ///< write usage of ProducerPass
-            RGReadUsage ToUsage = RGReadUsage::ShaderSample;     ///< read usage of ConsumerPass
-            MemoryBarrierFlags Flags = MemoryBarrierFlags::None; ///< barrier flags from PlannedBarrier
-            RGSubresourceRange Range;                            ///< subresource range from the consuming access declaration
-
-            // Cross-lane sync metadata (release/acquire intent).
-            // Set when ProducerPass and ConsumerPass reside on different queue lanes.
-            // On GL 4.6 this is informational only; on Vulkan/DX12 it drives
-            // ownership-transfer barriers and semaphore waits.
-            bool IsCrossLane = false;                     ///< true when producer and consumer are on different queue lanes
-            QueueLane ProducerLane = QueueLane::Graphics; ///< lane of the producing pass; Graphics for "external" producers
-            QueueLane ConsumerLane = QueueLane::Graphics; ///< lane of the consuming pass
-        };
-
         // Derive all resource transition records from the current barrier plan
         // and access declarations. Returns an empty vector when no barriers are
         // planned (no declared reads/writes or passes not yet executed).
@@ -1240,6 +1281,22 @@ namespace OloEngine
         // ComputeBarrierPlan() have run so that m_PlannedBarriers and
         // m_PassAccessDeclarations are populated.
         [[nodiscard]] std::vector<ResourceTransition> GetResourceTransitions() const;
+
+        // Phase 5 (ADR 0011 §1.5): resolve name-keyed transition records into
+        // the handle-keyed RHI::Barrier form the facade's IssueBarrierBatch
+        // takes. Runs at EXECUTE time, never at plan-bake time — transient
+        // physicals change per frame under pooling, so a baked handle would
+        // be exactly the stale-pool-read archetype
+        // (render-graph-transient-aliasing.md). Version-aliased names resolve
+        // to their source physical; a framebuffer resource fans out to one
+        // barrier per attachment; entries that cannot answer in the identity
+        // currency (native-only imports) are skipped — the GL flags path
+        // still covers them, and a Vulkan graph must import by handle.
+        // Range.Aspect stays at its default: the backend derives the real
+        // aspect mask from the image's own format, which it knows
+        // authoritatively; the field is only meaningful for a declared
+        // aspect-split transition, which no pass performs today.
+        [[nodiscard]] std::vector<RHI::Barrier> ResolveTransitionsToBarriers(std::span<const ResourceTransition> transitions) const;
 
         // -------------------------------------------------------------------
         // Unified resource lifetime records
@@ -1507,6 +1564,13 @@ namespace OloEngine
         struct PhysicalBuffer
         {
             u32 BufferID = 0;
+            // Phase 5: the identity currency, set alongside BufferID wherever
+            // the graph itself does the setting (transient materialization —
+            // the planner holds the pooled Ref and reads both off one
+            // pointer, same contract as PhysicalTexture). A native-only
+            // import keeps a null handle and is skipped by
+            // ResolveTransitionsToBarriers until its chain migrates.
+            RHI::ResourceHandle Handle;
         };
 
         // Parallel arrays — index by handle.Index (same slot system as HandleSlots).

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.cpp
@@ -76,6 +76,48 @@ namespace OloEngine::RenderGraphBarrierPlanner
         }
     }
 
+    auto AccessForWriteUsage(const RGWriteUsage usage) -> RHI::Access
+    {
+        switch (usage)
+        {
+            case RGWriteUsage::RenderTarget:
+                return RHI::Access::ColorAttachmentWrite;
+            case RGWriteUsage::DepthStencil:
+                return RHI::Access::DepthStencilAttachmentWrite;
+            case RGWriteUsage::ShaderImage:
+            case RGWriteUsage::ShaderStorage:
+                return RHI::Access::StorageWrite;
+            case RGWriteUsage::TransferDest:
+                return RHI::Access::TransferWrite;
+            case RGWriteUsage::Clear:
+                return RHI::Access::ClearAsLoadOp;
+        }
+
+        return RHI::Access::Undefined;
+    }
+
+    auto AccessForReadUsage(const RGReadUsage usage) -> RHI::Access
+    {
+        switch (usage)
+        {
+            case RGReadUsage::ShaderSample:
+                return RHI::Access::ShaderSampleRead;
+            case RGReadUsage::ShaderImage:
+            case RGReadUsage::ShaderStorage:
+                return RHI::Access::StorageRead;
+            case RGReadUsage::RenderTargetRead:
+                return RHI::Access::ColorAttachmentRead;
+            case RGReadUsage::ComputeIndirectArgs:
+                return RHI::Access::IndirectArgsRead;
+            case RGReadUsage::TransferSource:
+                return RHI::Access::TransferRead;
+            case RGReadUsage::InputAttachment:
+                return RHI::Access::InputAttachmentRead;
+        }
+
+        return RHI::Access::Undefined;
+    }
+
     auto ComputePlan(const PlanInput& input) -> PlanResult
     {
         OLO_PROFILE_FUNCTION();
@@ -181,6 +223,7 @@ namespace OloEngine::RenderGraphBarrierPlanner
                             .Resource = access.ResourceName,
                             .Flags = flags,
                             .Range = access.Range,
+                            .ToAccess = AccessForReadUsage(access.ReadUsage),
                         });
                     }
                 }
@@ -214,6 +257,10 @@ namespace OloEngine::RenderGraphBarrierPlanner
                                 .Resource = access.ResourceName,
                                 .Flags = flags,
                                 .Range = access.Range,
+                                // The consumer's WRITE access — the WAW case
+                                // the old read-only rescan could not see
+                                // (ADR 0011 §1.5).
+                                .ToAccess = AccessForWriteUsage(access.WriteUsage),
                             });
                         }
                     }
@@ -312,20 +359,34 @@ namespace OloEngine::RenderGraphBarrierPlanner
             t.Flags = barrier.Flags;
             t.Range = barrier.Range;
 
-            // Determine the consumer's read usage from its declared accesses.
-            // Default to ShaderSample when no frame-setup declaration is present
-            // (for example nodes that expose only static declaration metadata
-            // instead of per-frame builder reads).
-            t.ToUsage = RGReadUsage::ShaderSample;
-            if (const auto dit = input.PassAccessDeclarations.find(barrier.BeforePass);
-                dit != input.PassAccessDeclarations.end())
+            // The consumer's access was captured AT EMISSION (a read access
+            // for RAW barriers, a WRITE access for WAW barriers) — the old
+            // rescan of read declarations here silently defaulted every WAW
+            // consumer to ShaderSample (ADR 0011 §1.5, fixed in Phase 5).
+            t.ToAccess = barrier.ToAccess;
+
+            // Read-while-attached: the consuming pass reads the resource
+            // while ALSO holding it declared as an attachment write with an
+            // overlapping range (same-pass feedback, PCSS raw-depth style).
+            // Third input of the backend's layout resolution — such a read
+            // must not lower to a plain read-only layout.
+            if (!RHI::IsWriteAccess(t.ToAccess))
             {
-                for (const auto& decl : dit->second)
+                if (const auto dit = input.PassAccessDeclarations.find(barrier.BeforePass);
+                    dit != input.PassAccessDeclarations.end())
                 {
-                    if (decl.ResourceName == barrier.Resource && !decl.IsWrite)
+                    for (const auto& decl : dit->second)
                     {
-                        t.ToUsage = decl.ReadUsage;
-                        break;
+                        if (decl.ResourceName != barrier.Resource || !decl.IsWrite)
+                            continue;
+                        const bool isAttachmentWrite = decl.WriteUsage == RGWriteUsage::RenderTarget ||
+                                                       decl.WriteUsage == RGWriteUsage::DepthStencil ||
+                                                       decl.WriteUsage == RGWriteUsage::Clear;
+                        if (isAttachmentWrite && SubresourceRangesOverlap(decl.Range, barrier.Range))
+                        {
+                            t.ReadWhileAttached = true;
+                            break;
+                        }
                     }
                 }
             }
@@ -336,9 +397,12 @@ namespace OloEngine::RenderGraphBarrierPlanner
             // hits the LAST writer in O(W_resource) instead of O(N·D). For
             // graphs where each resource has few writers this is essentially
             // O(1). External producers (no prior writer) keep ProducerPass =
-            // "external" with RenderTarget as the default from-usage.
+            // "external" with Access::Undefined — the resource has no
+            // graph-known contents-producing access, so a Vulkan backend may
+            // transition from UNDEFINED and discard (ADR 0011 §1.5; the old
+            // RenderTarget default was wrong for a genuine first use).
             t.ProducerPass = "external";
-            t.FromUsage = RGWriteUsage::RenderTarget;
+            t.FromAccess = RHI::Access::Undefined;
 
             if (const auto consumerIdxIt = passOrderIdx.find(barrier.BeforePass); consumerIdxIt != passOrderIdx.end())
             {
@@ -352,7 +416,7 @@ namespace OloEngine::RenderGraphBarrierPlanner
                         if (it->PassIndex < consumerIdx)
                         {
                             t.ProducerPass = *it->PassName;
-                            t.FromUsage = it->Usage;
+                            t.FromAccess = AccessForWriteUsage(it->Usage);
                             break;
                         }
                     }

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.cpp
@@ -192,6 +192,28 @@ namespace OloEngine::RenderGraphBarrierPlanner
                                 });
                             }
                         }
+
+                        // A first-use read with no prior in-frame writer still
+                        // needs a barrier on an explicit-layout backend: the
+                        // image must transition OUT of its initial state
+                        // before the first sample (the transition's oldLayout
+                        // comes from the backend's tracker — UNDEFINED on
+                        // frame 1, the real prior layout afterwards, so an
+                        // imported history texture keeps its contents). Flags
+                        // stay None — GL needs no barrier for an external
+                        // producer, and a None-flags batch is a no-op on the
+                        // GL path — while the transition record built from
+                        // this barrier carries ("external", Undefined ->
+                        // read access) for the Vulkan lowering. The
+                        // diagnostics above still fire; this is a barrier, not
+                        // an exoneration.
+                        result.PlannedBarriers.push_back(RenderGraph::PlannedBarrier{
+                            .BeforePass = passName,
+                            .Resource = access.ResourceName,
+                            .Flags = MemoryBarrierFlags::None,
+                            .Range = access.Range,
+                            .ToAccess = AccessForReadUsage(access.ReadUsage),
+                        });
                         continue;
                     }
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphBarrierPlanner.h
@@ -30,9 +30,31 @@ namespace OloEngine::RenderGraphBarrierPlanner
 
     // ------------------------------------------------------------------------
     // Pure flag-resolution helpers (no state — usable from any caller).
+    //
+    // ADR 0011 §1.5: these two are the GL LOWERING — the MemoryBarrierFlags
+    // they produce feed glMemoryBarrier and nothing else. The neutral truth a
+    // transition carries is the RHI::Access pair below.
     // ------------------------------------------------------------------------
     [[nodiscard]] auto ResolveProducerBarrierFlags(RGWriteUsage usage) -> MemoryBarrierFlags;
     [[nodiscard]] auto ResolveConsumerBarrierFlags(RGReadUsage usage) -> MemoryBarrierFlags;
+
+    // ------------------------------------------------------------------------
+    // Builder-usage → unified-access mapping (ADR 0011 §1.5, Phase 5).
+    //
+    // RGWriteUsage / RGReadUsage stay the builder's declaration vocabulary;
+    // the transition record is typed with RHI::Access so a write→write pair
+    // is representable. Notes on the two deliberate collapses:
+    //   - ShaderImage and ShaderStorage both map to Storage{Read,Write}: the
+    //     image-vs-buffer distinction is recovered from the resource's kind
+    //     at lowering time (only images have layouts; the GL flag split is
+    //     preserved separately by the flag resolvers above).
+    //   - RGWriteUsage::Clear maps to ClearAsLoadOp: its only producer site
+    //     (OITPrepareRenderPass) is a load-op clear. An explicit
+    //     vkCmdClearColorImage-style clear must be declared TransferDest
+    //     (→ TransferWrite) instead — that is the §1.5 Clear split.
+    // ------------------------------------------------------------------------
+    [[nodiscard]] auto AccessForWriteUsage(RGWriteUsage usage) -> RHI::Access;
+    [[nodiscard]] auto AccessForReadUsage(RGReadUsage usage) -> RHI::Access;
 
     // ------------------------------------------------------------------------
     // ComputeBarrierPlan inputs/outputs.

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.cpp
@@ -42,7 +42,12 @@ namespace OloEngine::RenderGraphPlanExecutor
                 case SubmissionCommand::Kind::MemoryBarrier:
                 {
                     if (input.RuntimeBarrierExecutionEnabled)
-                        input.Context.MemoryBarrier(cmd.Barriers);
+                    {
+                        std::vector<RHI::Barrier> resolved;
+                        if (input.GraphForBarrierResolution && !cmd.Transitions.empty())
+                            resolved = input.GraphForBarrierResolution->ResolveTransitionsToBarriers(cmd.Transitions);
+                        input.Context.IssueBarrierBatch(cmd.Barriers, resolved);
+                    }
                     break;
                 }
                 case SubmissionCommand::Kind::Pass:

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphPlanExecutor.h
@@ -33,6 +33,14 @@ namespace OloEngine::RenderGraphPlanExecutor
         // debug-tooling use (e.g. `RenderGraphFrameCapture`).
         RenderGraph::PostPassHook PostPassHook;
         RenderGraph* GraphForPostPassHook = nullptr;
+
+        // Phase 5 (ADR 0011 §1.5): when set, each MemoryBarrier command's
+        // name-keyed transitions are resolved to handle-keyed RHI::Barriers
+        // at execute time (transient physicals change per frame, so this
+        // cannot be baked into the plan) and passed to the context alongside
+        // the GL flags. When null — headless plan-shape tests — the barrier
+        // batch carries flags only, which is the complete GL behaviour.
+        RenderGraph* GraphForBarrierResolution = nullptr;
     };
 
     // Runs the IR walk and returns per-pass CPU timings (one entry per

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphSubmissionPlan.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphSubmissionPlan.cpp
@@ -251,6 +251,33 @@ namespace OloEngine::RenderGraphSubmissionPlan
             flags = flags | planned.Flags;
         }
 
+        // Map: passName → deduplicated transition records (Phase 5, the
+        // explicit-barrier currency). The planner emits one barrier per prior
+        // writer, but for layout purposes only the LAST writer's state
+        // matters — earlier writers are ordered transitively through the WAW
+        // barriers between the writers themselves — so per-writer duplicates
+        // collapse on (resource, range, from, to). Known caveat, recorded in
+        // ADR 0011's Phase 5 amendments: two prior writers touching DISJOINT
+        // subresources of one resource collapse to the last writer's stage
+        // and access masks; sync validation is the instrument that would
+        // surface a real graph relying on that (Phase 7 hardening item).
+        std::unordered_map<std::string, std::vector<RenderGraph::ResourceTransition>> transitionsForPass;
+        for (const auto& transition : input.Transitions)
+        {
+            auto& list = transitionsForPass[transition.ConsumerPass];
+            const bool duplicate = std::ranges::any_of(
+                list,
+                [&transition](const RenderGraph::ResourceTransition& existing)
+                {
+                    return existing.ResourceName == transition.ResourceName &&
+                           existing.Range == transition.Range &&
+                           existing.FromAccess == transition.FromAccess &&
+                           existing.ToAccess == transition.ToAccess;
+                });
+            if (!duplicate)
+                list.push_back(transition);
+        }
+
         // Walk the execution order and emit commands.
         u32 currentBatch = std::numeric_limits<u32>::max();
 
@@ -311,6 +338,8 @@ namespace OloEngine::RenderGraphSubmissionPlan
                 barrier.CommandKind = SubmissionCommand::Kind::MemoryBarrier;
                 barrier.Barriers = barIt->second;
                 barrier.Lane = passLane;
+                if (const auto trIt = transitionsForPass.find(passName); trIt != transitionsForPass.end())
+                    barrier.Transitions = trIt->second;
                 plan.push_back(std::move(barrier));
             }
 

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphSubmissionPlan.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphSubmissionPlan.h
@@ -41,6 +41,13 @@ namespace OloEngine::RenderGraphSubmissionPlan
     {
         std::span<const std::string> ExecutionOrder;
         std::span<const RenderGraph::PlannedBarrier> PlannedBarriers;
+        // Phase 5 (ADR 0011 §1.5): the per-resource transition records for
+        // the same barrier plan. Attached (deduplicated) to each emitted
+        // MemoryBarrier command so an explicit-barrier backend can lower
+        // per-resource layout transitions without re-querying the graph.
+        // May be empty (headless plan-shape tests) — GL execution never
+        // reads them.
+        std::span<const RenderGraph::ResourceTransition> Transitions;
         std::span<const RenderGraph::AsyncComputeBatch> Batches;
         std::function<RenderGraphPassWorkType(const std::string&)> GetPassWorkType;
         // Returns the node pointer for the named pass, or nullptr if the

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
@@ -1,6 +1,9 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "Platform/OpenGL/OpenGLRendererAPI.h"
+#if OLO_WITH_VULKAN
+#include "Platform/Vulkan/VulkanRendererAPI.h"
+#endif
 
 namespace OloEngine
 {
@@ -17,11 +20,17 @@ namespace OloEngine
             }
             case RendererAPI::API::Vulkan:
             {
-                // Unreachable until Phase 5: this factory runs at static init (see
-                // RenderCommand.cpp), before --rhi= is parsed, so s_API is still the
-                // default here; and the Vulkan bring-up never routes RenderCommand.
-                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no RendererAPI implementation until #691 Phase 5!");
+                // Reachable since Phase 5 ONLY through
+                // RenderCommand::RecreateForSelectedBackend() — the static-init
+                // construction (RenderCommand.cpp) always runs before --rhi=
+                // parses and therefore always builds the OpenGL default
+                // (ADR 0011 amendment (39)).
+#if OLO_WITH_VULKAN
+                return CreateScope<VulkanRendererAPI>();
+#else
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan selected but OLO_WITH_VULKAN=OFF — the backend is not compiled in!");
                 return nullptr;
+#endif
             }
             case RendererAPI::API::OpenGL:
             {

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.h
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.h
@@ -157,6 +157,18 @@ namespace OloEngine
         virtual void DispatchCompute(u32 groupsX, u32 groupsY, u32 groupsZ) = 0;
         virtual void MemoryBarrier(MemoryBarrierFlags flags) = 0;
 
+        // The render graph's pre-pass barrier batch, carrying BOTH barrier
+        // currencies (ADR 0011 §1.5, Phase 5). `flags` is the GL lowering —
+        // the glMemoryBarrier bitmask the planner derives; `barriers` is the
+        // neutral truth — the handle-resolved per-resource transitions for
+        // the same batch. The GL backend executes `flags` and ignores
+        // `barriers`; an explicit-barrier backend (Vulkan) lowers each
+        // RHI::Barrier to a VkImageMemoryBarrier2 / VkBufferMemoryBarrier2
+        // in one vkCmdPipelineBarrier2 and ignores `flags`. Exactly one of
+        // the two is authoritative per backend — neither backend may consult
+        // both.
+        virtual void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) = 0;
+
         // New methods for render graph
         virtual void BindDefaultFramebuffer() = 0;
         virtual void BlitFramebufferToDefault(RHI::ResourceHandle srcFramebuffer, u32 width, u32 height) = 0;

--- a/OloEngine/src/OloEngine/Renderer/StorageBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/StorageBuffer.cpp
@@ -3,6 +3,12 @@
 #include "OloEngine/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLStorageBuffer.h"
 
+#if OLO_WITH_VULKAN
+// Sanctioned factory-include pattern (rhi-abstraction-boundary.md): this
+// OLO_WITH_VULKAN-guarded factory TU may see Platform/Vulkan/ headers.
+#include "Platform/Vulkan/VulkanTransientResources.h"
+#endif
+
 namespace OloEngine
 {
     Ref<StorageBuffer> StorageBuffer::Create(u32 size, u32 binding, StorageBufferUsage usage)
@@ -16,7 +22,17 @@ namespace OloEngine
             }
             case RendererAPI::API::Vulkan:
             {
-                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+#if OLO_WITH_VULKAN
+                // #691 Phase 5: the TransientPool's attribute-only path. A
+                // Vulkan resource cannot exist without a device, so fall
+                // through to the loud assert when none is up. Raw-new matches
+                // this factory's OpenGL arm.
+                if (VulkanDevice::Get() != nullptr)
+                {
+                    return Ref<StorageBuffer>(new VulkanStorageBuffer(size, binding, usage));
+                }
+#endif
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan: no VulkanDevice is up (or OLO_WITH_VULKAN is compiled out) — cannot create a Vulkan storage buffer!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/OloEngine/Renderer/Texture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Texture.cpp
@@ -4,6 +4,12 @@
 #include "OloEngine/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
 
+#if OLO_WITH_VULKAN
+// Sanctioned factory-include pattern (rhi-abstraction-boundary.md): this
+// OLO_WITH_VULKAN-guarded factory TU may see Platform/Vulkan/ headers.
+#include "Platform/Vulkan/VulkanTransientResources.h"
+#endif
+
 namespace OloEngine
 {
     Ref<Texture2D> Texture2D::Create(const TextureSpecification& specification)
@@ -17,7 +23,16 @@ namespace OloEngine
             }
             case RendererAPI::API::Vulkan:
             {
-                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan has no resource factories until #691 Phase 5/6!");
+#if OLO_WITH_VULKAN
+                // #691 Phase 5: the TransientPool's attribute-only path. A
+                // Vulkan resource cannot exist without a device, so fall
+                // through to the loud assert when none is up.
+                if (VulkanDevice::Get() != nullptr)
+                {
+                    return Ref<VulkanTexture2D>::Create(specification);
+                }
+#endif
+                OLO_CORE_ASSERT(false, "RendererAPI::Vulkan: no VulkanDevice is up (or OLO_WITH_VULKAN is compiled out) — cannot create a Vulkan texture!");
                 return nullptr;
             }
             case RendererAPI::API::OpenGL:

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -35,7 +35,12 @@ namespace OloEngine
         // teardown happens in ShutdownGpuResources(), called while the context is
         // still current, and this destructor does nothing if that already ran.
         // If it did NOT run we deliberately leak rather than touch dead GL.
-        if (!m_GpuResourcesReleased)
+        // A never-Init()ed instance held no GPU resources, so there is
+        // nothing to warn about: since Phase 5, RenderCommand's static-init
+        // instance is deliberately replaced by RecreateForSelectedBackend()
+        // before any use (ADR 0011 amendment (39)), and warning on THAT
+        // destruction was pure noise.
+        if (!m_GpuResourcesReleased && m_Initialized)
         {
             OLO_CORE_WARN("[RHI/GL] OpenGLRendererAPI destroyed without ShutdownGpuResources(); "
                           "skipping descriptor-heap teardown because the GL context is likely gone. "
@@ -59,6 +64,8 @@ namespace OloEngine
     void OpenGLRendererAPI::Init()
     {
         OLO_PROFILE_FUNCTION();
+
+        m_Initialized = true;
 
 #ifdef OLO_DEBUG
         glEnable(GL_DEBUG_OUTPUT);
@@ -874,6 +881,15 @@ namespace OloEngine
             glBarrier |= GL_QUERY_BUFFER_BARRIER_BIT;
 
         glMemoryBarrier(glBarrier);
+    }
+
+    void OpenGLRendererAPI::IssueBarrierBatch(const MemoryBarrierFlags flags, std::span<const RHI::Barrier> /*barriers*/)
+    {
+        // ADR 0011 §1.5: on GL the flags bitmask IS the lowering — the
+        // per-resource transitions are the explicit-barrier backends'
+        // currency and are deliberately ignored here. Delegating keeps the
+        // pre-Phase-5 glMemoryBarrier behaviour byte-identical.
+        MemoryBarrier(flags);
     }
 
     void OpenGLRendererAPI::SetPolygonOffset(f32 factor, f32 units)

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
@@ -99,6 +99,7 @@ namespace OloEngine
 
         void DispatchCompute(u32 groupsX, u32 groupsY, u32 groupsZ) override;
         void MemoryBarrier(MemoryBarrierFlags flags) override;
+        void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) override;
 
         void BindDefaultFramebuffer() override;
         void BlitFramebufferToDefault(RHI::ResourceHandle srcFramebuffer, u32 width, u32 height) override;
@@ -314,5 +315,10 @@ namespace OloEngine
         OpenGLDescriptorHeapBackend m_DescriptorHeapBackend;
         // Guards the destructor against touching GL at atexit — see ~OpenGLRendererAPI.
         bool m_GpuResourcesReleased = false;
+        // Whether Init() ever ran — a never-initialised instance (the
+        // static-init one RecreateForSelectedBackend replaces, ADR 0011
+        // amendment (39)) held no GPU resources and must not warn at
+        // destruction.
+        bool m_Initialized = false;
     };
 } // namespace OloEngine

--- a/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
@@ -199,7 +199,20 @@ namespace OloEngine::VulkanBarrierLowering
         // the contents are discarded, so there is nothing to make available —
         // source masks drop to NONE regardless of what FromAccess claimed.
         if (trackedOldLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+        {
             src = { VK_PIPELINE_STAGE_2_NONE, VK_ACCESS_2_NONE };
+        }
+        else if (barrier.Before == RHI::Access::Undefined)
+        {
+            // The INVERSE mismatch: the transition claims no producer, yet
+            // the image is demonstrably in a defined layout — something
+            // outside the graph's knowledge wrote it (the poison clear is
+            // the live case: it leaves TRANSFER_DST recorded, and the
+            // external first-use barrier that follows carries Undefined).
+            // NONE source masks would race that writer; over-sync instead.
+            src = { VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                    VK_ACCESS_2_MEMORY_READ_BIT | VK_ACCESS_2_MEMORY_WRITE_BIT };
+        }
 
         VkImageMemoryBarrier2 out{};
         out.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;

--- a/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
@@ -219,13 +219,17 @@ namespace OloEngine::VulkanBarrierLowering
         auto& range = out.subresourceRange;
         range.aspectMask = AspectMaskFor(aspect);
         range.baseMipLevel = std::min(barrier.Range.BaseMip, imageMipCount > 0u ? imageMipCount - 1u : 0u);
+        // Resolved counts clamp to AT LEAST 1: a zero levelCount/layerCount is
+        // a VUID violation, and the degenerate inputs that could produce one
+        // (a zero-extent image record, a base at the image's last slot with a
+        // zero span) should degrade to a 1-wide range, not an invalid barrier.
         range.levelCount = (barrier.Range.MipCount == RHI::SubresourceRange::AllRemaining)
                                ? VK_REMAINING_MIP_LEVELS
-                               : std::min(barrier.Range.MipCount, imageMipCount - range.baseMipLevel);
+                               : std::max(std::min(barrier.Range.MipCount, imageMipCount - range.baseMipLevel), 1u);
         range.baseArrayLayer = std::min(barrier.Range.BaseLayer, imageLayerCount > 0u ? imageLayerCount - 1u : 0u);
         range.layerCount = (barrier.Range.LayerCount == RHI::SubresourceRange::AllRemaining)
                                ? VK_REMAINING_ARRAY_LAYERS
-                               : std::min(barrier.Range.LayerCount, imageLayerCount - range.baseArrayLayer);
+                               : std::max(std::min(barrier.Range.LayerCount, imageLayerCount - range.baseArrayLayer), 1u);
 
         return out;
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.cpp
@@ -1,0 +1,253 @@
+#include "OloEnginePCH.h"
+#include "Platform/Vulkan/VulkanBarrierLowering.h"
+
+#if OLO_WITH_VULKAN
+
+namespace OloEngine::VulkanBarrierLowering
+{
+    namespace
+    {
+        [[nodiscard]] bool IsDepthLikeAspect(const RHI::TextureAspect aspect)
+        {
+            return aspect == RHI::TextureAspect::Depth ||
+                   aspect == RHI::TextureAspect::Stencil ||
+                   aspect == RHI::TextureAspect::DepthStencil;
+        }
+
+        // The shader-stage union one lane's shader access can touch. The
+        // Graphics union includes COMPUTE deliberately — this engine's
+        // Graphics-work-type passes dispatch compute mid-pass (bloom chain,
+        // AO), and the lane annotation describes the PASS, not the pipe.
+        [[nodiscard]] VkPipelineStageFlags2 ShaderStagesForQueue(const RHI::QueueType queue)
+        {
+            switch (queue)
+            {
+                case RHI::QueueType::Compute:
+                    return VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+                case RHI::QueueType::Transfer:
+                    // A shader access annotated onto the transfer lane cannot
+                    // narrow — fall back to every shader stage.
+                case RHI::QueueType::Graphics:
+                    return VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT |
+                           VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
+                           VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT |
+                           VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT |
+                           VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT |
+                           VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+            }
+
+            return VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        }
+
+        constexpr VkPipelineStageFlags2 kDepthStencilTestStages =
+            VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT;
+    } // namespace
+
+    StageAccess LowerAccess(const RHI::Access access, const RHI::QueueType queue, const RHI::TextureAspect aspect)
+    {
+        switch (access)
+        {
+            case RHI::Access::Undefined:
+                // No prior access to make available — pairs with an UNDEFINED
+                // oldLayout on the source side of a first-use transition.
+                return { VK_PIPELINE_STAGE_2_NONE, VK_ACCESS_2_NONE };
+
+            case RHI::Access::IndirectArgsRead:
+                return { VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT, VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT };
+            case RHI::Access::IndexRead:
+                return { VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT, VK_ACCESS_2_INDEX_READ_BIT };
+            case RHI::Access::VertexAttributeRead:
+                return { VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT, VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT };
+            case RHI::Access::UniformRead:
+                return { ShaderStagesForQueue(queue), VK_ACCESS_2_UNIFORM_READ_BIT };
+
+            case RHI::Access::ShaderSampleRead:
+                return { ShaderStagesForQueue(queue), VK_ACCESS_2_SHADER_SAMPLED_READ_BIT };
+            case RHI::Access::StorageRead:
+                return { ShaderStagesForQueue(queue), VK_ACCESS_2_SHADER_STORAGE_READ_BIT };
+            case RHI::Access::StorageWrite:
+                return { ShaderStagesForQueue(queue), VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT };
+            case RHI::Access::StorageReadWrite:
+                return { ShaderStagesForQueue(queue),
+                         VK_ACCESS_2_SHADER_STORAGE_READ_BIT | VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT };
+
+            case RHI::Access::ColorAttachmentRead:
+                return { VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT };
+            case RHI::Access::ColorAttachmentWrite:
+                return { VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT };
+            case RHI::Access::DepthStencilAttachmentRead:
+                return { kDepthStencilTestStages, VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT };
+            case RHI::Access::DepthStencilAttachmentWrite:
+                return { kDepthStencilTestStages, VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT };
+            case RHI::Access::InputAttachmentRead:
+                return { VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT, VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT };
+
+            case RHI::Access::TransferRead:
+                return { VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT };
+            case RHI::Access::TransferWrite:
+                return { VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT };
+
+            case RHI::Access::ClearAsLoadOp:
+                // A load-op clear is an attachment write on whichever
+                // attachment kind the aspect names — the one access whose
+                // stage depends on the aspect.
+                if (IsDepthLikeAspect(aspect))
+                    return { kDepthStencilTestStages, VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT };
+                return { VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT };
+            case RHI::Access::ClearAsTransfer:
+                return { VK_PIPELINE_STAGE_2_CLEAR_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT };
+
+            case RHI::Access::Present:
+                // Presentation is synchronised by the queue-submit semaphore,
+                // not by an access mask (there is no PRESENT access bit).
+                return { VK_PIPELINE_STAGE_2_NONE, VK_ACCESS_2_NONE };
+        }
+
+        return { VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, VK_ACCESS_2_MEMORY_READ_BIT | VK_ACCESS_2_MEMORY_WRITE_BIT };
+    }
+
+    VkImageLayout LayoutFor(const RHI::Access access, const RHI::TextureAspect aspect, const bool readWhileAttached)
+    {
+        switch (access)
+        {
+            case RHI::Access::Undefined:
+                return VK_IMAGE_LAYOUT_UNDEFINED;
+
+            case RHI::Access::ShaderSampleRead:
+                if (readWhileAttached)
+                {
+                    // The attachment half of the feedback is still live: depth
+                    // keeps its read-only attachment layout (the PCSS raw-depth
+                    // case); color needs GENERAL (feedback-loop layout would
+                    // need VK_EXT_attachment_feedback_loop_layout).
+                    return IsDepthLikeAspect(aspect) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+                                                     : VK_IMAGE_LAYOUT_GENERAL;
+                }
+                return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            case RHI::Access::InputAttachmentRead:
+                return readWhileAttached ? VK_IMAGE_LAYOUT_GENERAL
+                                         : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            case RHI::Access::StorageRead:
+            case RHI::Access::StorageWrite:
+            case RHI::Access::StorageReadWrite:
+                return VK_IMAGE_LAYOUT_GENERAL;
+
+            case RHI::Access::ColorAttachmentRead:
+            case RHI::Access::ColorAttachmentWrite:
+                return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            case RHI::Access::DepthStencilAttachmentWrite:
+                return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            case RHI::Access::DepthStencilAttachmentRead:
+                return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+
+            case RHI::Access::TransferRead:
+                return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            case RHI::Access::TransferWrite:
+            case RHI::Access::ClearAsTransfer:
+                return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+
+            case RHI::Access::ClearAsLoadOp:
+                return IsDepthLikeAspect(aspect) ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+                                                 : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+            case RHI::Access::Present:
+                return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+            // Buffer-shaped accesses have no image layout; GENERAL is the
+            // total answer if one ever reaches an image barrier.
+            case RHI::Access::IndirectArgsRead:
+            case RHI::Access::IndexRead:
+            case RHI::Access::VertexAttributeRead:
+            case RHI::Access::UniformRead:
+                return VK_IMAGE_LAYOUT_GENERAL;
+        }
+
+        return VK_IMAGE_LAYOUT_GENERAL;
+    }
+
+    VkImageAspectFlags AspectMaskFor(const RHI::TextureAspect aspect)
+    {
+        switch (aspect)
+        {
+            case RHI::TextureAspect::Color:
+                return VK_IMAGE_ASPECT_COLOR_BIT;
+            case RHI::TextureAspect::Depth:
+                return VK_IMAGE_ASPECT_DEPTH_BIT;
+            case RHI::TextureAspect::Stencil:
+                return VK_IMAGE_ASPECT_STENCIL_BIT;
+            case RHI::TextureAspect::DepthStencil:
+                return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        }
+
+        return VK_IMAGE_ASPECT_COLOR_BIT;
+    }
+
+    VkImageMemoryBarrier2 BuildImageBarrier(const RHI::Barrier& barrier,
+                                            const VkImage image,
+                                            const RHI::TextureAspect aspect,
+                                            const VkImageLayout trackedOldLayout,
+                                            const u32 imageMipCount,
+                                            const u32 imageLayerCount)
+    {
+        auto src = LowerAccess(barrier.Before, barrier.SourceQueue, aspect);
+        const auto dst = LowerAccess(barrier.After, barrier.DestQueue, aspect);
+
+        // The tracker is authoritative for oldLayout. When it answers
+        // UNDEFINED (first use, or a pooled transient's unknown inheritance)
+        // the contents are discarded, so there is nothing to make available —
+        // source masks drop to NONE regardless of what FromAccess claimed.
+        if (trackedOldLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+            src = { VK_PIPELINE_STAGE_2_NONE, VK_ACCESS_2_NONE };
+
+        VkImageMemoryBarrier2 out{};
+        out.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+        out.srcStageMask = src.StageMask;
+        out.srcAccessMask = src.AccessMask;
+        out.dstStageMask = dst.StageMask;
+        out.dstAccessMask = dst.AccessMask;
+        out.oldLayout = trackedOldLayout;
+        out.newLayout = LayoutFor(barrier.After, aspect, barrier.ReadWhileAttached);
+        out.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        out.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        out.image = image;
+
+        // Clamp the neutral range against the image's real extents —
+        // AllRemaining is a VK_REMAINING_* spelling, and a range beyond the
+        // image is a validation error rather than a clamp.
+        auto& range = out.subresourceRange;
+        range.aspectMask = AspectMaskFor(aspect);
+        range.baseMipLevel = std::min(barrier.Range.BaseMip, imageMipCount > 0u ? imageMipCount - 1u : 0u);
+        range.levelCount = (barrier.Range.MipCount == RHI::SubresourceRange::AllRemaining)
+                               ? VK_REMAINING_MIP_LEVELS
+                               : std::min(barrier.Range.MipCount, imageMipCount - range.baseMipLevel);
+        range.baseArrayLayer = std::min(barrier.Range.BaseLayer, imageLayerCount > 0u ? imageLayerCount - 1u : 0u);
+        range.layerCount = (barrier.Range.LayerCount == RHI::SubresourceRange::AllRemaining)
+                               ? VK_REMAINING_ARRAY_LAYERS
+                               : std::min(barrier.Range.LayerCount, imageLayerCount - range.baseArrayLayer);
+
+        return out;
+    }
+
+    VkBufferMemoryBarrier2 BuildBufferBarrier(const RHI::Barrier& barrier, const VkBuffer buffer)
+    {
+        const auto src = LowerAccess(barrier.Before, barrier.SourceQueue, RHI::TextureAspect::Color);
+        const auto dst = LowerAccess(barrier.After, barrier.DestQueue, RHI::TextureAspect::Color);
+
+        VkBufferMemoryBarrier2 out{};
+        out.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2;
+        out.srcStageMask = src.StageMask;
+        out.srcAccessMask = src.AccessMask;
+        out.dstStageMask = dst.StageMask;
+        out.dstAccessMask = dst.AccessMask;
+        out.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        out.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        out.buffer = buffer;
+        out.offset = 0;
+        out.size = VK_WHOLE_SIZE;
+        return out;
+    }
+} // namespace OloEngine::VulkanBarrierLowering
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanBarrierLowering.h
@@ -1,0 +1,98 @@
+#pragma once
+
+// =============================================================================
+// VulkanBarrierLowering — the pure RHI::Access → Vulkan synchronization2
+// lowering (issue #691 Phase 5, ADR 0011 §1.5).
+//
+// This is the Vulkan half of the two-currency barrier contract: the render
+// graph's planner derives (FromAccess, ToAccess, range, lanes) as the neutral
+// truth, the GL backend executes the MemoryBarrierFlags bitmask, and THIS
+// module lowers the neutral pair to (stage mask, access mask, image layout).
+//
+// Everything here is a pure function — no device, no state, no allocation —
+// so the whole table is pinned headlessly by VulkanBarrierLoweringTest in
+// plain CI, which is the cheap layer that proves the formula
+// (CLAUDE.md's rendering-verification rule, step 1).
+//
+// Layout is resolved from (Access, aspect, read-while-attached) — ADR 0011
+// §1.5 explicitly rejects a bare Access → layout table: the depth/stencil
+// aspect and the read-while-attached flag are the two inputs the common-case
+// mapping cannot do without (the PCSS blocker search samples raw depth of a
+// resource that is simultaneously in play as an attachment).
+// =============================================================================
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+#include "OloEngine/Renderer/RHI/RHITypes.h"
+
+#include <volk.h>
+
+namespace OloEngine::VulkanBarrierLowering
+{
+    struct StageAccess
+    {
+        VkPipelineStageFlags2 StageMask = VK_PIPELINE_STAGE_2_NONE;
+        VkAccessFlags2 AccessMask = VK_ACCESS_2_NONE;
+    };
+
+    // Lower one side of a transition to (stage mask, access mask).
+    //
+    // `queue` narrows the shader-stage union: a Compute-lane access waits on
+    // COMPUTE_SHADER only; a Graphics-lane access uses the full graphics
+    // union PLUS compute, because this engine's Graphics-work-type passes
+    // legitimately dispatch compute mid-pass (bloom, AO). Over-inclusion is
+    // correctness-safe (extra sync); under-inclusion is a race.
+    //
+    // `aspect` matters only for the two clear/attachment accesses whose stage
+    // differs between color and depth (ClearAsLoadOp).
+    [[nodiscard]] StageAccess LowerAccess(RHI::Access access, RHI::QueueType queue, RHI::TextureAspect aspect);
+
+    // The layout-resolution function of ADR 0011 §1.5:
+    // (Access, aspect, read-while-attached) → VkImageLayout.
+    //
+    //  - Storage accesses → GENERAL (heap-bindless storage images live there).
+    //  - A read-while-attached depth sample → DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    //    never SHADER_READ_ONLY_OPTIMAL — the attachment half of the feedback
+    //    is still live.
+    //  - A read-while-attached color sample / input attachment → GENERAL.
+    //    ATTACHMENT_FEEDBACK_LOOP_OPTIMAL would be tighter but requires
+    //    VK_EXT_attachment_feedback_loop_layout, which the ADR 0010 contract
+    //    does not carry; GENERAL is always legal.
+    //  - Undefined → UNDEFINED (discardable — the external/first-use state).
+    //
+    // Buffers have no layout; callers only consult this for image barriers.
+    [[nodiscard]] VkImageLayout LayoutFor(RHI::Access access, RHI::TextureAspect aspect, bool readWhileAttached);
+
+    [[nodiscard]] VkImageAspectFlags AspectMaskFor(RHI::TextureAspect aspect);
+
+    // Assemble a full VkImageMemoryBarrier2 from a neutral barrier plus the
+    // backend-known image identity.
+    //
+    // `aspect` comes from the backend's own knowledge of the image's format —
+    // authoritative, where the neutral Range.Aspect is only a request for an
+    // aspect-split transition (which no pass declares today).
+    //
+    // `trackedOldLayout` comes from the VulkanImageLayoutTracker and is
+    // AUTHORITATIVE for oldLayout: the neutral FromAccess describes the
+    // producer's access (source stage/access masks), but the image's actual
+    // layout can differ — a pooled transient re-acquired this frame carries
+    // whatever its previous tenant left, and first use is UNDEFINED. When the
+    // tracker answers UNDEFINED the source masks are forced to NONE too:
+    // contents are discarded, so there is nothing to make available.
+    //
+    // Queue-family indices are IGNORED — Phase 5 runs one combined queue
+    // (ADR 0010 contract row); IsCrossQueue stays informational until a real
+    // second queue exists.
+    [[nodiscard]] VkImageMemoryBarrier2 BuildImageBarrier(const RHI::Barrier& barrier,
+                                                          VkImage image,
+                                                          RHI::TextureAspect aspect,
+                                                          VkImageLayout trackedOldLayout,
+                                                          u32 imageMipCount,
+                                                          u32 imageLayerCount);
+
+    [[nodiscard]] VkBufferMemoryBarrier2 BuildBufferBarrier(const RHI::Barrier& barrier, VkBuffer buffer);
+} // namespace OloEngine::VulkanBarrierLowering
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
@@ -3,34 +3,23 @@
 #if OLO_WITH_VULKAN
 
 #include "Platform/Vulkan/VulkanContext.h"
-#include "Platform/Vulkan/VulkanCapabilities.h"
-
-// volk before both VMA and GLFW: vk_mem_alloc.h keys its volk import helper on
-// VOLK_HEADER_VERSION, and glfw3.h only declares its Vulkan entry points
-// (glfwCreateWindowSurface et al.) when VK_VERSION_1_0 is already visible.
-#include <volk.h>
-
-// Function-pointer config must match VulkanMemoryAllocator.cpp (the
-// VMA_IMPLEMENTATION TU) exactly — VMA is imported through volk's loaded
-// pointers, never linked statically (nothing links vulkan-1.lib).
-#define VMA_STATIC_VULKAN_FUNCTIONS 0
-#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
-#include <vk_mem_alloc.h>
+// VulkanDevice.h pulls <volk.h> (and <vk_mem_alloc.h>) — volk must come before
+// GLFW: glfw3.h only declares its Vulkan entry points (glfwCreateWindowSurface
+// et al.) when VK_VERSION_1_0 is already visible.
+#include "Platform/Vulkan/VulkanDevice.h"
 
 #include <GLFW/glfw3.h>
 
 #include <algorithm>
-#include <optional>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <vector>
 
 // The vendored Vulkan-Headers (SDK 1.4.357.0, the ADR 0010 tooling floor) must be
 // the ones this TU compiles against. An installed SDK's include dir is also on the
 // include path (via the shaderc toolchain's find_package(Vulkan)); if it ever wins
 // the include search, an older SDK would break the VK_EXT_descriptor_heap
-// declarations silently — fail the build instead.
+// declarations silently — fail the build instead. (Duplicated in VulkanDevice.cpp.)
 static_assert(VK_HEADER_VERSION >= 357,
               "Vulkan headers older than the vendored 1.4.357 floor — the installed SDK's include dir "
               "won the include search over OloEngine/vendor's Vulkan-Headers (see vendor/CMakeLists.txt)");
@@ -39,6 +28,8 @@ namespace OloEngine
 {
     namespace
     {
+        // Kept in sync with VulkanDevice.cpp's copy (both anonymous-namespace,
+        // trivially small — not worth a shared header).
         void VkCheck(VkResult result, const char* what)
         {
             if (result != VK_SUCCESS)
@@ -47,81 +38,20 @@ namespace OloEngine
                                          std::to_string(static_cast<int>(result)) + ")");
             }
         }
-
-#ifdef OLO_DEBUG
-        VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessengerCallback(
-            VkDebugUtilsMessageSeverityFlagBitsEXT severity,
-            VkDebugUtilsMessageTypeFlagsEXT /*types*/,
-            const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
-            void* /*userData*/)
-        {
-            const char* message = (callbackData != nullptr && callbackData->pMessage != nullptr)
-                                      ? callbackData->pMessage
-                                      : "(no message)";
-            if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0)
-            {
-                OLO_CORE_ERROR("[Vulkan] {}", message);
-            }
-            else if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0)
-            {
-                OLO_CORE_WARN("[Vulkan] {}", message);
-            }
-            else
-            {
-                OLO_CORE_TRACE("[Vulkan] {}", message);
-            }
-            return VK_FALSE;
-        }
-
-        VkDebugUtilsMessengerCreateInfoEXT MakeDebugMessengerCreateInfo()
-        {
-            VkDebugUtilsMessengerCreateInfoEXT info{};
-            info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-            info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-            info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-            info.pfnUserCallback = DebugMessengerCallback;
-            return info;
-        }
-
-        bool ValidationLayerAvailable()
-        {
-            u32 count = 0;
-            if (vkEnumerateInstanceLayerProperties(&count, nullptr) != VK_SUCCESS)
-            {
-                return false;
-            }
-            std::vector<VkLayerProperties> layers(count);
-            if (vkEnumerateInstanceLayerProperties(&count, layers.data()) != VK_SUCCESS)
-            {
-                return false;
-            }
-            for (const VkLayerProperties& layer : layers)
-            {
-                if (std::string_view(layer.layerName) == "VK_LAYER_KHRONOS_validation")
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-#endif
     } // namespace
 
     struct VulkanContextData
     {
         static constexpr u32 kFramesInFlight = 2;
 
-        VkInstance Instance = VK_NULL_HANDLE;
-        VkDebugUtilsMessengerEXT DebugMessenger = VK_NULL_HANDLE;
+        // The window-independent half (volk init, instance, debug messenger,
+        // physical-device pick, device, queue, VMA allocator, command pool)
+        // lives in VulkanDevice since Phase 5 — this struct keeps only the
+        // presentation / frame-loop state. The surface is created by this
+        // context (via the surfaceProvider callback) and OWNED by it;
+        // VulkanDevice only borrows the handle for the queue-family pick.
+        VulkanDevice Device;
         VkSurfaceKHR Surface = VK_NULL_HANDLE;
-        VkPhysicalDevice PhysicalDevice = VK_NULL_HANDLE;
-        VkDevice Device = VK_NULL_HANDLE;
-        u32 QueueFamily = 0;
-        VkQueue Queue = VK_NULL_HANDLE;
-        VmaAllocator Allocator = VK_NULL_HANDLE;
 
         VkSwapchainKHR Swapchain = VK_NULL_HANDLE;
         VkFormat SwapchainFormat = VK_FORMAT_UNDEFINED;
@@ -135,7 +65,6 @@ namespace OloEngine
         // per-frame ACQUIRE semaphore.
         std::vector<VkSemaphore> RenderFinished;
 
-        VkCommandPool CommandPool = VK_NULL_HANDLE;
         struct Frame
         {
             VkSemaphore ImageAvailable = VK_NULL_HANDLE;
@@ -155,46 +84,33 @@ namespace OloEngine
     VulkanContext::~VulkanContext()
     {
         VulkanContextData& d = *m_Data;
-        if (d.Device != VK_NULL_HANDLE)
+        const VkDevice device = d.Device.GetDevice();
+        if (device != VK_NULL_HANDLE)
         {
-            vkDeviceWaitIdle(d.Device);
+            vkDeviceWaitIdle(device);
 
             DestroySwapchain();
             for (VulkanContextData::Frame& frame : d.Frames)
             {
                 if (frame.ImageAvailable != VK_NULL_HANDLE)
                 {
-                    vkDestroySemaphore(d.Device, frame.ImageAvailable, nullptr);
+                    vkDestroySemaphore(device, frame.ImageAvailable, nullptr);
                 }
                 if (frame.InFlight != VK_NULL_HANDLE)
                 {
-                    vkDestroyFence(d.Device, frame.InFlight, nullptr);
+                    vkDestroyFence(device, frame.InFlight, nullptr);
                 }
             }
-            if (d.CommandPool != VK_NULL_HANDLE)
-            {
-                vkDestroyCommandPool(d.Device, d.CommandPool, nullptr);
-            }
-            if (d.Allocator != VK_NULL_HANDLE)
-            {
-                vmaDestroyAllocator(d.Allocator);
-            }
-            vkDestroyDevice(d.Device, nullptr);
         }
-        if (d.Instance != VK_NULL_HANDLE)
+        // The surface is this context's to destroy, and it must go BEFORE the
+        // instance — which Device.Shutdown() below is about to destroy (its
+        // order: command pool -> VMA -> device -> messenger -> instance).
+        if (d.Surface != VK_NULL_HANDLE && d.Device.GetInstance() != VK_NULL_HANDLE)
         {
-            if (d.Surface != VK_NULL_HANDLE)
-            {
-                vkDestroySurfaceKHR(d.Instance, d.Surface, nullptr);
-            }
-#ifdef OLO_DEBUG
-            if (d.DebugMessenger != VK_NULL_HANDLE)
-            {
-                vkDestroyDebugUtilsMessengerEXT(d.Instance, d.DebugMessenger, nullptr);
-            }
-#endif
-            vkDestroyInstance(d.Instance, nullptr);
+            vkDestroySurfaceKHR(d.Device.GetInstance(), d.Surface, nullptr);
+            d.Surface = VK_NULL_HANDLE;
         }
+        d.Device.Shutdown();
         OLO_CORE_INFO("[Vulkan] Context shut down cleanly");
     }
 
@@ -204,6 +120,10 @@ namespace OloEngine
         VulkanContextData& d = *m_Data;
 
         // --- Loader ---------------------------------------------------------
+        // VulkanDevice::Init runs volkInitialize itself (headless tests bring a
+        // device up without a window); it also runs here FIRST so the GLFW
+        // support probe below can fail fast — before any instance work — exactly
+        // as the Phase 4 bring-up did. volkInitialize is safe to run twice.
         if (volkInitialize() != VK_SUCCESS)
         {
             throw std::runtime_error(
@@ -218,223 +138,23 @@ namespace OloEngine
                 "Vulkan bring-up: GLFW reports no Vulkan surface support. Run with --rhi=opengl.");
         }
 
-        // --- Instance -------------------------------------------------------
-        u32 glfwExtensionCount = 0;
-        const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
-        if (glfwExtensions == nullptr || glfwExtensionCount == 0)
-        {
-            throw std::runtime_error(
-                "Vulkan bring-up: glfwGetRequiredInstanceExtensions returned nothing. Run with --rhi=opengl.");
-        }
-        std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
-        std::vector<const char*> instanceLayers;
+        // --- Instance + device (the window-independent half) -----------------
+        // The surface must exist AFTER the instance but BEFORE the physical-
+        // device pick (present support is per queue family, per surface) —
+        // hence the callback shape rather than create-then-pass. The surface
+        // handle lands in d.Surface and stays OWNED by this context.
+        d.Device.Init([this, &d](VkInstance instance) -> VkSurfaceKHR
+                      {
+            VkCheck(glfwCreateWindowSurface(instance, m_WindowHandle, nullptr, &d.Surface),
+                    "glfwCreateWindowSurface");
+            return d.Surface; });
 
-        VkApplicationInfo appInfo{};
-        appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-        appInfo.pApplicationName = "OloEngine";
-        appInfo.pEngineName = "OloEngine";
-        appInfo.apiVersion = VulkanCapabilities::kMinApiVersion;
-
-        VkInstanceCreateInfo instanceInfo{};
-        instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-        instanceInfo.pApplicationInfo = &appInfo;
-
-#ifdef OLO_DEBUG
-        // Chained into pNext so create/destroy of the instance itself is covered
-        // before/after the persistent messenger exists.
-        VkDebugUtilsMessengerCreateInfoEXT messengerInfo = MakeDebugMessengerCreateInfo();
-        const bool useValidation = ValidationLayerAvailable();
-        if (useValidation)
-        {
-            instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
-            instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-            instanceInfo.pNext = &messengerInfo;
-        }
-        else
-        {
-            OLO_CORE_WARN("[Vulkan] VK_LAYER_KHRONOS_validation not available — running unvalidated");
-        }
-#endif
-        instanceInfo.enabledExtensionCount = static_cast<u32>(instanceExtensions.size());
-        instanceInfo.ppEnabledExtensionNames = instanceExtensions.data();
-        instanceInfo.enabledLayerCount = static_cast<u32>(instanceLayers.size());
-        instanceInfo.ppEnabledLayerNames = instanceLayers.empty() ? nullptr : instanceLayers.data();
-
-        VkCheck(vkCreateInstance(&instanceInfo, nullptr, &d.Instance), "vkCreateInstance");
-        volkLoadInstance(d.Instance);
-
-#ifdef OLO_DEBUG
-        if (useValidation)
-        {
-            VkCheck(vkCreateDebugUtilsMessengerEXT(d.Instance, &messengerInfo, nullptr, &d.DebugMessenger),
-                    "vkCreateDebugUtilsMessengerEXT");
-        }
-#endif
-
-        // --- Surface --------------------------------------------------------
-        VkCheck(glfwCreateWindowSurface(d.Instance, m_WindowHandle, nullptr, &d.Surface),
-                "glfwCreateWindowSurface");
-
-        // --- Physical device: gate HARD on ADR 0010's capability contract ----
-        u32 deviceCount = 0;
-        VkCheck(vkEnumeratePhysicalDevices(d.Instance, &deviceCount, nullptr), "vkEnumeratePhysicalDevices");
-        if (deviceCount == 0)
-        {
-            throw std::runtime_error("Vulkan bring-up: no Vulkan devices present. Run with --rhi=opengl.");
-        }
-        std::vector<VkPhysicalDevice> devices(deviceCount);
-        VkCheck(vkEnumeratePhysicalDevices(d.Instance, &deviceCount, devices.data()), "vkEnumeratePhysicalDevices");
-
-        // Find a queue family doing BOTH graphics and present. Split-family
-        // hardware is refused for bring-up — every desktop GPU this backend's
-        // hardware floor admits has a combined family, and supporting the split
-        // doubles the sync/sharing surface for no Phase 4 gain.
-        auto findCombinedQueueFamily = [&d](VkPhysicalDevice device) -> std::optional<u32>
-        {
-            u32 familyCount = 0;
-            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, nullptr);
-            std::vector<VkQueueFamilyProperties> families(familyCount);
-            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, families.data());
-            for (u32 i = 0; i < familyCount; ++i)
-            {
-                if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0)
-                {
-                    continue;
-                }
-                VkBool32 presentSupport = VK_FALSE;
-                vkGetPhysicalDeviceSurfaceSupportKHR(device, i, d.Surface, &presentSupport);
-                if (presentSupport == VK_TRUE)
-                {
-                    return i;
-                }
-            }
-            return std::nullopt;
-        };
-
-        VulkanCapabilityReport bestRejected;
-        for (VkPhysicalDevice candidate : devices)
-        {
-            VulkanCapabilityReport report = VulkanCapabilities::Evaluate(candidate);
-            const std::optional<u32> family = findCombinedQueueFamily(candidate);
-            if (!family.has_value())
-            {
-                report.Missing.emplace_back("a combined graphics+present queue family");
-                report.Satisfied = false;
-            }
-            if (report.Satisfied)
-            {
-                VkPhysicalDeviceProperties properties{};
-                vkGetPhysicalDeviceProperties(candidate, &properties);
-                // First satisfying discrete GPU wins; a satisfying integrated one is
-                // kept only until a discrete appears.
-                if (d.PhysicalDevice == VK_NULL_HANDLE ||
-                    properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-                {
-                    d.PhysicalDevice = candidate;
-                    d.QueueFamily = *family;
-                    if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-                    {
-                        break;
-                    }
-                }
-            }
-            else if (bestRejected.Missing.empty() || report.Missing.size() < bestRejected.Missing.size())
-            {
-                bestRejected = report;
-            }
-        }
-
-        if (d.PhysicalDevice == VK_NULL_HANDLE)
-        {
-            // Refuse to initialise, naming the missing capability — never degrade
-            // (ADR 0010; the OpenGL fallback is a USER decision, not an engine one).
-            std::string missing;
-            for (const std::string& item : bestRejected.Missing)
-            {
-                missing += (missing.empty() ? "" : ", ") + item;
-            }
-            throw std::runtime_error(
-                "Vulkan bring-up: no device satisfies the capability contract (ADR 0010). Closest device '" +
-                bestRejected.DeviceName + "' is missing: " + missing + ". Run with --rhi=opengl.");
-        }
-
-        {
-            VkPhysicalDeviceProperties properties{};
-            vkGetPhysicalDeviceProperties(d.PhysicalDevice, &properties);
-            OLO_CORE_INFO("[Vulkan] Device: {} (driver {}.{}.{}, API {}.{}.{})", properties.deviceName,
-                          VK_API_VERSION_MAJOR(properties.driverVersion), VK_API_VERSION_MINOR(properties.driverVersion),
-                          VK_API_VERSION_PATCH(properties.driverVersion), VK_API_VERSION_MAJOR(properties.apiVersion),
-                          VK_API_VERSION_MINOR(properties.apiVersion), VK_API_VERSION_PATCH(properties.apiVersion));
-        }
-
-        // --- Logical device + queue -----------------------------------------
-        const f32 queuePriority = 1.0f;
-        VkDeviceQueueCreateInfo queueInfo{};
-        queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-        queueInfo.queueFamilyIndex = d.QueueFamily;
-        queueInfo.queueCount = 1;
-        queueInfo.pQueuePriorities = &queuePriority;
-
-        // Enable the contract's feature bits now, not in Phase 5: a driver that
-        // advertises the features but rejects enabling them should fail HERE, at
-        // the gate, not later at first descriptor-heap use.
-        VkPhysicalDeviceDescriptorHeapFeaturesEXT heapFeatures{};
-        heapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT;
-        heapFeatures.descriptorHeap = VK_TRUE;
-        VkPhysicalDeviceShaderUntypedPointersFeaturesKHR untypedFeatures{};
-        untypedFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR;
-        untypedFeatures.shaderUntypedPointers = VK_TRUE;
-        untypedFeatures.pNext = &heapFeatures;
-
-        // synchronization2 backs the vkCmdPipelineBarrier2/vkQueueSubmit2 calls in
-        // SwapBuffers. Core in 1.3 and MANDATORY for 1.3+ devices, so it needs no
-        // capability-gate entry — but core-promoted features still default OFF at
-        // device creation, and validation flags every sync2 call without this bit
-        // (the NVIDIA driver happens to tolerate it, which is exactly the kind of
-        // works-by-accident the validation layers exist to catch).
-        VkPhysicalDeviceVulkan13Features vulkan13Features{};
-        vulkan13Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
-        vulkan13Features.synchronization2 = VK_TRUE;
-        vulkan13Features.pNext = &untypedFeatures;
-
-        const std::vector<const char*> deviceExtensions = VulkanCapabilities::RequiredDeviceExtensions();
-
-        VkDeviceCreateInfo deviceInfo{};
-        deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-        deviceInfo.pNext = &vulkan13Features;
-        deviceInfo.queueCreateInfoCount = 1;
-        deviceInfo.pQueueCreateInfos = &queueInfo;
-        deviceInfo.enabledExtensionCount = static_cast<u32>(deviceExtensions.size());
-        deviceInfo.ppEnabledExtensionNames = deviceExtensions.data();
-
-        VkCheck(vkCreateDevice(d.PhysicalDevice, &deviceInfo, nullptr, &d.Device), "vkCreateDevice");
-        volkLoadDevice(d.Device);
-        vkGetDeviceQueue(d.Device, d.QueueFamily, 0, &d.Queue);
-
-        // --- VMA (vendoring proof + the allocator Phase 5 inherits) ----------
-        {
-            VmaVulkanFunctions vulkanFunctions{};
-            VmaAllocatorCreateInfo allocatorInfo{};
-            allocatorInfo.physicalDevice = d.PhysicalDevice;
-            allocatorInfo.device = d.Device;
-            allocatorInfo.instance = d.Instance;
-            allocatorInfo.vulkanApiVersion = VulkanCapabilities::kMinApiVersion;
-            VkCheck(vmaImportVulkanFunctionsFromVolk(&allocatorInfo, &vulkanFunctions),
-                    "vmaImportVulkanFunctionsFromVolk");
-            allocatorInfo.pVulkanFunctions = &vulkanFunctions;
-            VkCheck(vmaCreateAllocator(&allocatorInfo, &d.Allocator), "vmaCreateAllocator");
-        }
+        const VkDevice device = d.Device.GetDevice();
 
         // --- Commands + per-frame sync ---------------------------------------
-        VkCommandPoolCreateInfo poolInfo{};
-        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-        poolInfo.queueFamilyIndex = d.QueueFamily;
-        VkCheck(vkCreateCommandPool(d.Device, &poolInfo, nullptr, &d.CommandPool), "vkCreateCommandPool");
-
         VkCommandBufferAllocateInfo cmdInfo{};
         cmdInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        cmdInfo.commandPool = d.CommandPool;
+        cmdInfo.commandPool = d.Device.GetCommandPool();
         cmdInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         cmdInfo.commandBufferCount = 1;
 
@@ -446,9 +166,9 @@ namespace OloEngine
 
         for (VulkanContextData::Frame& frame : d.Frames)
         {
-            VkCheck(vkAllocateCommandBuffers(d.Device, &cmdInfo, &frame.Cmd), "vkAllocateCommandBuffers");
-            VkCheck(vkCreateSemaphore(d.Device, &semaphoreInfo, nullptr, &frame.ImageAvailable), "vkCreateSemaphore");
-            VkCheck(vkCreateFence(d.Device, &fenceInfo, nullptr, &frame.InFlight), "vkCreateFence");
+            VkCheck(vkAllocateCommandBuffers(device, &cmdInfo, &frame.Cmd), "vkAllocateCommandBuffers");
+            VkCheck(vkCreateSemaphore(device, &semaphoreInfo, nullptr, &frame.ImageAvailable), "vkCreateSemaphore");
+            VkCheck(vkCreateFence(device, &fenceInfo, nullptr, &frame.InFlight), "vkCreateFence");
         }
 
         // --- Swapchain (+ its per-image semaphores) ---------------------------
@@ -461,9 +181,11 @@ namespace OloEngine
     void VulkanContext::CreateSwapchain()
     {
         VulkanContextData& d = *m_Data;
+        const VkPhysicalDevice physicalDevice = d.Device.GetPhysicalDevice();
+        const VkDevice device = d.Device.GetDevice();
 
         VkSurfaceCapabilitiesKHR caps{};
-        VkCheck(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(d.PhysicalDevice, d.Surface, &caps),
+        VkCheck(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, d.Surface, &caps),
                 "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
 
         // The bring-up clear uses vkCmdClearColorImage, which needs TRANSFER_DST on
@@ -476,9 +198,9 @@ namespace OloEngine
         }
 
         u32 formatCount = 0;
-        vkGetPhysicalDeviceSurfaceFormatsKHR(d.PhysicalDevice, d.Surface, &formatCount, nullptr);
+        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, d.Surface, &formatCount, nullptr);
         std::vector<VkSurfaceFormatKHR> formats(formatCount);
-        vkGetPhysicalDeviceSurfaceFormatsKHR(d.PhysicalDevice, d.Surface, &formatCount, formats.data());
+        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, d.Surface, &formatCount, formats.data());
         VkSurfaceFormatKHR surfaceFormat = formats.at(0);
         for (const VkSurfaceFormatKHR& format : formats)
         {
@@ -534,39 +256,40 @@ namespace OloEngine
         swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
         swapchainInfo.clipped = VK_TRUE;
 
-        VkCheck(vkCreateSwapchainKHR(d.Device, &swapchainInfo, nullptr, &d.Swapchain), "vkCreateSwapchainKHR");
+        VkCheck(vkCreateSwapchainKHR(device, &swapchainInfo, nullptr, &d.Swapchain), "vkCreateSwapchainKHR");
         d.SwapchainFormat = surfaceFormat.format;
         d.SwapchainExtent = extent;
 
         u32 actualImageCount = 0;
-        vkGetSwapchainImagesKHR(d.Device, d.Swapchain, &actualImageCount, nullptr);
+        vkGetSwapchainImagesKHR(device, d.Swapchain, &actualImageCount, nullptr);
         d.SwapchainImages.resize(actualImageCount);
-        vkGetSwapchainImagesKHR(d.Device, d.Swapchain, &actualImageCount, d.SwapchainImages.data());
+        vkGetSwapchainImagesKHR(device, d.Swapchain, &actualImageCount, d.SwapchainImages.data());
 
         VkSemaphoreCreateInfo semaphoreInfo{};
         semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
         d.RenderFinished.resize(actualImageCount, VK_NULL_HANDLE);
         for (VkSemaphore& semaphore : d.RenderFinished)
         {
-            VkCheck(vkCreateSemaphore(d.Device, &semaphoreInfo, nullptr, &semaphore), "vkCreateSemaphore");
+            VkCheck(vkCreateSemaphore(device, &semaphoreInfo, nullptr, &semaphore), "vkCreateSemaphore");
         }
     }
 
     void VulkanContext::DestroySwapchain()
     {
         VulkanContextData& d = *m_Data;
+        const VkDevice device = d.Device.GetDevice();
         for (VkSemaphore semaphore : d.RenderFinished)
         {
             if (semaphore != VK_NULL_HANDLE)
             {
-                vkDestroySemaphore(d.Device, semaphore, nullptr);
+                vkDestroySemaphore(device, semaphore, nullptr);
             }
         }
         d.RenderFinished.clear();
         d.SwapchainImages.clear();
         if (d.Swapchain != VK_NULL_HANDLE)
         {
-            vkDestroySwapchainKHR(d.Device, d.Swapchain, nullptr);
+            vkDestroySwapchainKHR(device, d.Swapchain, nullptr);
             d.Swapchain = VK_NULL_HANDLE;
         }
     }
@@ -576,7 +299,7 @@ namespace OloEngine
         VulkanContextData& d = *m_Data;
         // Blunt but correct without VK_KHR_swapchain_maintenance1: nothing may
         // reference the old swapchain or its per-image semaphores afterwards.
-        vkDeviceWaitIdle(d.Device);
+        vkDeviceWaitIdle(d.Device.GetDevice());
         DestroySwapchain();
         CreateSwapchain();
         OLO_CORE_INFO("[Vulkan] Swapchain recreated ({}x{})", d.SwapchainExtent.width, d.SwapchainExtent.height);
@@ -586,6 +309,7 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
         VulkanContextData& d = *m_Data;
+        const VkDevice device = d.Device.GetDevice();
 
         // Minimised: a 0-sized framebuffer cannot host a swapchain — skip frames
         // until the window has area again.
@@ -610,10 +334,10 @@ namespace OloEngine
         }
 
         VulkanContextData::Frame& frame = d.Frames[d.FrameIndex];
-        VkCheck(vkWaitForFences(d.Device, 1, &frame.InFlight, VK_TRUE, UINT64_MAX), "vkWaitForFences");
+        VkCheck(vkWaitForFences(device, 1, &frame.InFlight, VK_TRUE, UINT64_MAX), "vkWaitForFences");
 
         u32 imageIndex = 0;
-        const VkResult acquireResult = vkAcquireNextImageKHR(d.Device, d.Swapchain, UINT64_MAX,
+        const VkResult acquireResult = vkAcquireNextImageKHR(device, d.Swapchain, UINT64_MAX,
                                                              frame.ImageAvailable, VK_NULL_HANDLE, &imageIndex);
         if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR)
         {
@@ -627,7 +351,7 @@ namespace OloEngine
 
         // Only reset the fence once this frame will actually submit (a reset
         // without a submit would deadlock the next wait).
-        VkCheck(vkResetFences(d.Device, 1, &frame.InFlight), "vkResetFences");
+        VkCheck(vkResetFences(device, 1, &frame.InFlight), "vkResetFences");
 
         VkCommandBufferBeginInfo beginInfo{};
         beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -644,7 +368,15 @@ namespace OloEngine
         // UNDEFINED -> TRANSFER_DST: previous contents are irrelevant (we clear).
         VkImageMemoryBarrier2 toTransfer{};
         toTransfer.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
-        toTransfer.srcStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+        // srcStageMask must be the ACQUIRE SEMAPHORE'S WAIT STAGE (CLEAR, see
+        // waitInfo.stageMask below), not TOP_OF_PIPE: the semaphore orders
+        // this submission against the presentation engine's read only at the
+        // wait stage, and a layout transition whose srcStage is earlier than
+        // that can begin before the wait — a WRITE_AFTER_READ hazard against
+        // vkAcquireNextImageKHR. Phase 4 shipped TOP_OF_PIPE here and passed,
+        // because only core validation ran; Phase 5's synchronization
+        // validation flagged it on its first live run (issue #691).
+        toTransfer.srcStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
         toTransfer.dstStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
         toTransfer.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
         toTransfer.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -705,7 +437,7 @@ namespace OloEngine
         submitInfo.pCommandBufferInfos = &cmdSubmitInfo;
         submitInfo.signalSemaphoreInfoCount = 1;
         submitInfo.pSignalSemaphoreInfos = &signalInfo;
-        VkCheck(vkQueueSubmit2(d.Queue, 1, &submitInfo, frame.InFlight), "vkQueueSubmit2");
+        VkCheck(vkQueueSubmit2(d.Device.GetQueue(), 1, &submitInfo, frame.InFlight), "vkQueueSubmit2");
 
         VkPresentInfoKHR presentInfo{};
         presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -714,7 +446,7 @@ namespace OloEngine
         presentInfo.swapchainCount = 1;
         presentInfo.pSwapchains = &d.Swapchain;
         presentInfo.pImageIndices = &imageIndex;
-        const VkResult presentResult = vkQueuePresentKHR(d.Queue, &presentInfo);
+        const VkResult presentResult = vkQueuePresentKHR(d.Device.GetQueue(), &presentInfo);
         if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR)
         {
             RecreateSwapchain();

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.h
@@ -16,6 +16,9 @@ namespace OloEngine
 
     // #691 Phase 4 bring-up: instance / device / swapchain / per-frame sync, and a
     // SwapBuffers() that clears the backbuffer to a fixed colour and presents.
+    // Since Phase 5 the window-independent half (instance, physical-device pick,
+    // device, queue, VMA allocator, command pool) lives in VulkanDevice — this
+    // class keeps the surface, swapchain, and frame-loop state.
     // Nothing else — no rendering, no descriptor heaps in use (device selection
     // gates on VK_EXT_descriptor_heap per ADR 0010, but Phase 5/6 are the first
     // consumers). Init() throws std::runtime_error to REFUSE initialisation when

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -385,9 +385,27 @@ namespace OloEngine
         m_TessellationShaderEnabled = supported.tessellationShader == VK_TRUE;
         m_GeometryShaderEnabled = supported.geometryShader == VK_TRUE;
 
+        // shaderBufferInt64Atomics: the facade REPORTS this capability
+        // (SupportsInt64ShaderAtomics feeds the virtual-geometry software
+        // rasterizer's path choice), and a queried-but-not-enabled feature is
+        // a Phase 6 shader crash waiting to happen. Enabled when supported,
+        // never required.
+        VkPhysicalDeviceShaderAtomicInt64Features supportedAtomics{};
+        supportedAtomics.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+        VkPhysicalDeviceFeatures2 supportedFeatures2{};
+        supportedFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        supportedFeatures2.pNext = &supportedAtomics;
+        vkGetPhysicalDeviceFeatures2(m_PhysicalDevice, &supportedFeatures2);
+
+        VkPhysicalDeviceShaderAtomicInt64Features atomicFeatures{};
+        atomicFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+        atomicFeatures.shaderBufferInt64Atomics = supportedAtomics.shaderBufferInt64Atomics;
+        atomicFeatures.pNext = &vulkan13Features;
+        m_ShaderBufferInt64AtomicsEnabled = supportedAtomics.shaderBufferInt64Atomics == VK_TRUE;
+
         VkDeviceCreateInfo deviceInfo{};
         deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-        deviceInfo.pNext = &vulkan13Features;
+        deviceInfo.pNext = &atomicFeatures;
         deviceInfo.queueCreateInfoCount = 1;
         deviceInfo.pQueueCreateInfos = &queueInfo;
         deviceInfo.enabledExtensionCount = static_cast<u32>(deviceExtensions.size());

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -1,0 +1,486 @@
+#include "OloEnginePCH.h"
+
+#if OLO_WITH_VULKAN
+
+#include "Platform/Vulkan/VulkanDevice.h"
+#include "Platform/Vulkan/VulkanCapabilities.h"
+
+#include <atomic>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The vendored Vulkan-Headers (SDK 1.4.357.0, the ADR 0010 tooling floor) must be
+// the ones this TU compiles against. An installed SDK's include dir is also on the
+// include path (via the shaderc toolchain's find_package(Vulkan)); if it ever wins
+// the include search, an older SDK would break the VK_EXT_descriptor_heap
+// declarations silently — fail the build instead.
+static_assert(VK_HEADER_VERSION >= 357,
+              "Vulkan headers older than the vendored 1.4.357 floor — the installed SDK's include dir "
+              "won the include search over OloEngine/vendor's Vulkan-Headers (see vendor/CMakeLists.txt)");
+
+namespace OloEngine
+{
+    namespace
+    {
+        // Kept in sync with VulkanContext.cpp's copy (both anonymous-namespace,
+        // trivially small — not worth a shared header).
+        void VkCheck(VkResult result, const char* what)
+        {
+            if (result != VK_SUCCESS)
+            {
+                throw std::runtime_error(std::string("Vulkan bring-up: ") + what + " failed (VkResult " +
+                                         std::to_string(static_cast<int>(result)) + ")");
+            }
+        }
+
+        // ERROR-severity validation messages seen by the debug messenger. Always
+        // defined (the public accessors exist in every config); only the
+        // OLO_DEBUG messenger ever increments it.
+        std::atomic<u64> s_ValidationErrorCount{ 0 };
+
+        // The live device, set at the end of a successful Init and cleared by
+        // Shutdown. A plain pointer: single-threaded bring-up/teardown, and the
+        // Init assert refuses a second live device.
+        VulkanDevice* s_ActiveDevice = nullptr;
+
+#ifdef OLO_DEBUG
+        VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessengerCallback(
+            VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+            VkDebugUtilsMessageTypeFlagsEXT /*types*/,
+            const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+            void* /*userData*/)
+        {
+            const char* message = (callbackData != nullptr && callbackData->pMessage != nullptr)
+                                      ? callbackData->pMessage
+                                      : "(no message)";
+            if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0)
+            {
+                s_ValidationErrorCount.fetch_add(1, std::memory_order_relaxed);
+                OLO_CORE_ERROR("[Vulkan] {}", message);
+            }
+            else if ((severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0)
+            {
+                OLO_CORE_WARN("[Vulkan] {}", message);
+            }
+            else
+            {
+                OLO_CORE_TRACE("[Vulkan] {}", message);
+            }
+            return VK_FALSE;
+        }
+
+        VkDebugUtilsMessengerCreateInfoEXT MakeDebugMessengerCreateInfo()
+        {
+            VkDebugUtilsMessengerCreateInfoEXT info{};
+            info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+            info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+            info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+            info.pfnUserCallback = DebugMessengerCallback;
+            return info;
+        }
+
+        bool ValidationLayerAvailable()
+        {
+            u32 count = 0;
+            if (vkEnumerateInstanceLayerProperties(&count, nullptr) != VK_SUCCESS)
+            {
+                return false;
+            }
+            std::vector<VkLayerProperties> layers(count);
+            if (vkEnumerateInstanceLayerProperties(&count, layers.data()) != VK_SUCCESS)
+            {
+                return false;
+            }
+            for (const VkLayerProperties& layer : layers)
+            {
+                if (std::string_view(layer.layerName) == "VK_LAYER_KHRONOS_validation")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+#endif
+    } // namespace
+
+    VulkanDevice::~VulkanDevice()
+    {
+        Shutdown();
+    }
+
+    void VulkanDevice::Init(const std::function<VkSurfaceKHR(VkInstance)>& surfaceProvider)
+    {
+        OLO_PROFILE_FUNCTION();
+        OLO_CORE_ASSERT(s_ActiveDevice == nullptr, "VulkanDevice::Init: another VulkanDevice is already live");
+        OLO_CORE_ASSERT(m_Instance == VK_NULL_HANDLE, "VulkanDevice::Init called twice");
+
+        // --- Loader ---------------------------------------------------------
+        // Safe to run twice: VulkanContext also runs it (before this call) so
+        // its GLFW support probe can fail fast before any instance work.
+        if (volkInitialize() != VK_SUCCESS)
+        {
+            throw std::runtime_error(
+                "Vulkan bring-up: no Vulkan loader found on this system. Run with --rhi=opengl.");
+        }
+
+        // --- Instance -------------------------------------------------------
+        // The window-independent half cannot ask GLFW which surface extensions
+        // the platform needs (glfwGetRequiredInstanceExtensions is a window
+        // concern), so it enables VK_KHR_surface plus whichever platform
+        // surface extension the instance offers. On Windows that is exactly
+        // GLFW's list (VK_KHR_surface + VK_KHR_win32_surface). Headless runs
+        // need VK_KHR_surface enabled too: the ADR 0010 contract's
+        // VK_KHR_swapchain DEVICE extension declares an instance-level
+        // dependency on it.
+        u32 availableExtensionCount = 0;
+        VkCheck(vkEnumerateInstanceExtensionProperties(nullptr, &availableExtensionCount, nullptr),
+                "vkEnumerateInstanceExtensionProperties");
+        std::vector<VkExtensionProperties> availableExtensions(availableExtensionCount);
+        VkCheck(vkEnumerateInstanceExtensionProperties(nullptr, &availableExtensionCount, availableExtensions.data()),
+                "vkEnumerateInstanceExtensionProperties");
+        auto extensionAvailable = [&availableExtensions](std::string_view name)
+        {
+            for (const VkExtensionProperties& extension : availableExtensions)
+            {
+                if (std::string_view(extension.extensionName) == name)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        // Names as literals: the platform-specific VK_KHR_*_EXTENSION_NAME
+        // macros live in headers volk only pulls under VK_USE_PLATFORM_* defines.
+        constexpr const char* kSurfaceExtensionNames[] = {
+            VK_KHR_SURFACE_EXTENSION_NAME,
+            "VK_KHR_win32_surface",
+            "VK_KHR_xcb_surface",
+            "VK_KHR_xlib_surface",
+            "VK_KHR_wayland_surface",
+        };
+        std::vector<const char*> instanceExtensions;
+        for (const char* name : kSurfaceExtensionNames)
+        {
+            if (extensionAvailable(name))
+            {
+                instanceExtensions.push_back(name);
+            }
+        }
+        std::vector<const char*> instanceLayers;
+
+        VkApplicationInfo appInfo{};
+        appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+        appInfo.pApplicationName = "OloEngine";
+        appInfo.pEngineName = "OloEngine";
+        appInfo.apiVersion = VulkanCapabilities::kMinApiVersion;
+
+        VkInstanceCreateInfo instanceInfo{};
+        instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        instanceInfo.pApplicationInfo = &appInfo;
+
+#ifdef OLO_DEBUG
+        // Chained into pNext so create/destroy of the instance itself is covered
+        // before/after the persistent messenger exists.
+        VkDebugUtilsMessengerCreateInfoEXT messengerInfo = MakeDebugMessengerCreateInfo();
+        // Synchronization validation is the real test of Phase 5's barrier
+        // translation: the core validation layer checks structure, sync
+        // validation checks that the barriers actually cover every hazard.
+        const VkValidationFeatureEnableEXT enabledValidationFeatures[] = {
+            VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT,
+        };
+        VkValidationFeaturesEXT validationFeatures{};
+        validationFeatures.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+        validationFeatures.enabledValidationFeatureCount =
+            static_cast<u32>(std::size(enabledValidationFeatures));
+        validationFeatures.pEnabledValidationFeatures = enabledValidationFeatures;
+        const bool useValidation = ValidationLayerAvailable();
+        if (useValidation)
+        {
+            instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
+            instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+            // Provided by the validation layer itself, so only requestable when
+            // the layer is enabled.
+            instanceExtensions.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+            // Chain: instance -> validation features -> messenger (both are
+            // consumed by the layer at instance create/destroy).
+            validationFeatures.pNext = &messengerInfo;
+            instanceInfo.pNext = &validationFeatures;
+        }
+        else
+        {
+            OLO_CORE_WARN("[Vulkan] VK_LAYER_KHRONOS_validation not available — running unvalidated");
+        }
+#endif
+        instanceInfo.enabledExtensionCount = static_cast<u32>(instanceExtensions.size());
+        instanceInfo.ppEnabledExtensionNames = instanceExtensions.data();
+        instanceInfo.enabledLayerCount = static_cast<u32>(instanceLayers.size());
+        instanceInfo.ppEnabledLayerNames = instanceLayers.empty() ? nullptr : instanceLayers.data();
+
+        VkCheck(vkCreateInstance(&instanceInfo, nullptr, &m_Instance), "vkCreateInstance");
+        volkLoadInstance(m_Instance);
+
+#ifdef OLO_DEBUG
+        if (useValidation)
+        {
+            VkCheck(vkCreateDebugUtilsMessengerEXT(m_Instance, &messengerInfo, nullptr, &m_DebugMessenger),
+                    "vkCreateDebugUtilsMessengerEXT");
+        }
+#endif
+
+        // --- Surface (owned by the CALLER, borrowed here for the pick) -------
+        const VkSurfaceKHR surface = surfaceProvider ? surfaceProvider(m_Instance) : VK_NULL_HANDLE;
+
+        // --- Physical device: gate HARD on ADR 0010's capability contract ----
+        u32 deviceCount = 0;
+        VkCheck(vkEnumeratePhysicalDevices(m_Instance, &deviceCount, nullptr), "vkEnumeratePhysicalDevices");
+        if (deviceCount == 0)
+        {
+            throw std::runtime_error("Vulkan bring-up: no Vulkan devices present. Run with --rhi=opengl.");
+        }
+        std::vector<VkPhysicalDevice> devices(deviceCount);
+        VkCheck(vkEnumeratePhysicalDevices(m_Instance, &deviceCount, devices.data()), "vkEnumeratePhysicalDevices");
+
+        // With a surface: find a queue family doing BOTH graphics and present.
+        // Split-family hardware is refused for bring-up — every desktop GPU this
+        // backend's hardware floor admits has a combined family, and supporting
+        // the split doubles the sync/sharing surface for no gain. Headless
+        // (surface == VK_NULL_HANDLE): graphics alone suffices — there is
+        // nothing to present to.
+        auto findQueueFamily = [surface](VkPhysicalDevice device) -> std::optional<u32>
+        {
+            u32 familyCount = 0;
+            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, nullptr);
+            std::vector<VkQueueFamilyProperties> families(familyCount);
+            vkGetPhysicalDeviceQueueFamilyProperties(device, &familyCount, families.data());
+            for (u32 i = 0; i < familyCount; ++i)
+            {
+                if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0)
+                {
+                    continue;
+                }
+                if (surface == VK_NULL_HANDLE)
+                {
+                    return i;
+                }
+                VkBool32 presentSupport = VK_FALSE;
+                vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface, &presentSupport);
+                if (presentSupport == VK_TRUE)
+                {
+                    return i;
+                }
+            }
+            return std::nullopt;
+        };
+
+        VulkanCapabilityReport bestRejected;
+        for (VkPhysicalDevice candidate : devices)
+        {
+            VulkanCapabilityReport report = VulkanCapabilities::Evaluate(candidate);
+            const std::optional<u32> family = findQueueFamily(candidate);
+            if (!family.has_value())
+            {
+                report.Missing.emplace_back(surface != VK_NULL_HANDLE
+                                                ? "a combined graphics+present queue family"
+                                                : "a graphics queue family");
+                report.Satisfied = false;
+            }
+            if (report.Satisfied)
+            {
+                VkPhysicalDeviceProperties properties{};
+                vkGetPhysicalDeviceProperties(candidate, &properties);
+                // First satisfying discrete GPU wins; a satisfying integrated one is
+                // kept only until a discrete appears.
+                if (m_PhysicalDevice == VK_NULL_HANDLE ||
+                    properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+                {
+                    m_PhysicalDevice = candidate;
+                    m_QueueFamily = *family;
+                    if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+                    {
+                        break;
+                    }
+                }
+            }
+            else if (bestRejected.Missing.empty() || report.Missing.size() < bestRejected.Missing.size())
+            {
+                bestRejected = report;
+            }
+        }
+
+        if (m_PhysicalDevice == VK_NULL_HANDLE)
+        {
+            // Refuse to initialise, naming the missing capability — never degrade
+            // (ADR 0010; the OpenGL fallback is a USER decision, not an engine one).
+            std::string missing;
+            for (const std::string& item : bestRejected.Missing)
+            {
+                missing += (missing.empty() ? "" : ", ") + item;
+            }
+            throw std::runtime_error(
+                "Vulkan bring-up: no device satisfies the capability contract (ADR 0010). Closest device '" +
+                bestRejected.DeviceName + "' is missing: " + missing + ". Run with --rhi=opengl.");
+        }
+
+        {
+            VkPhysicalDeviceProperties properties{};
+            vkGetPhysicalDeviceProperties(m_PhysicalDevice, &properties);
+            OLO_CORE_INFO("[Vulkan] Device: {} (driver {}.{}.{}, API {}.{}.{})", properties.deviceName,
+                          VK_API_VERSION_MAJOR(properties.driverVersion), VK_API_VERSION_MINOR(properties.driverVersion),
+                          VK_API_VERSION_PATCH(properties.driverVersion), VK_API_VERSION_MAJOR(properties.apiVersion),
+                          VK_API_VERSION_MINOR(properties.apiVersion), VK_API_VERSION_PATCH(properties.apiVersion));
+        }
+
+        // --- Logical device + queue -----------------------------------------
+        const f32 queuePriority = 1.0f;
+        VkDeviceQueueCreateInfo queueInfo{};
+        queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo.queueFamilyIndex = m_QueueFamily;
+        queueInfo.queueCount = 1;
+        queueInfo.pQueuePriorities = &queuePriority;
+
+        // Enable the contract's feature bits at the gate: a driver that
+        // advertises the features but rejects enabling them should fail HERE,
+        // not later at first descriptor-heap use.
+        VkPhysicalDeviceDescriptorHeapFeaturesEXT heapFeatures{};
+        heapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT;
+        heapFeatures.descriptorHeap = VK_TRUE;
+        VkPhysicalDeviceShaderUntypedPointersFeaturesKHR untypedFeatures{};
+        untypedFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR;
+        untypedFeatures.shaderUntypedPointers = VK_TRUE;
+        untypedFeatures.pNext = &heapFeatures;
+
+        // synchronization2 backs the vkCmdPipelineBarrier2/vkQueueSubmit2 calls in
+        // SwapBuffers. Core in 1.3 and MANDATORY for 1.3+ devices, so it needs no
+        // capability-gate entry — but core-promoted features still default OFF at
+        // device creation, and validation flags every sync2 call without this bit
+        // (the NVIDIA driver happens to tolerate it, which is exactly the kind of
+        // works-by-accident the validation layers exist to catch).
+        VkPhysicalDeviceVulkan13Features vulkan13Features{};
+        vulkan13Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+        vulkan13Features.synchronization2 = VK_TRUE;
+        vulkan13Features.pNext = &untypedFeatures;
+
+        const std::vector<const char*> deviceExtensions = VulkanCapabilities::RequiredDeviceExtensions();
+
+        // Core VkPhysicalDeviceFeatures the engine's shader stages need:
+        // tessellation (terrain patches) and geometry shaders. Enabled WHEN
+        // SUPPORTED, never required — these are not ADR 0010 contract rows,
+        // and requiring them would silently widen the gate. Barrier stage
+        // masks may only name stages whose features are ENABLED
+        // (VUID-VkImageMemoryBarrier2-dstStageMask-03929/-03930), so
+        // VulkanRendererAPI narrows its shader-stage unions by the two flags
+        // recorded here.
+        VkPhysicalDeviceFeatures supported{};
+        vkGetPhysicalDeviceFeatures(m_PhysicalDevice, &supported);
+        VkPhysicalDeviceFeatures enabledFeatures{};
+        enabledFeatures.tessellationShader = supported.tessellationShader;
+        enabledFeatures.geometryShader = supported.geometryShader;
+        m_TessellationShaderEnabled = supported.tessellationShader == VK_TRUE;
+        m_GeometryShaderEnabled = supported.geometryShader == VK_TRUE;
+
+        VkDeviceCreateInfo deviceInfo{};
+        deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        deviceInfo.pNext = &vulkan13Features;
+        deviceInfo.queueCreateInfoCount = 1;
+        deviceInfo.pQueueCreateInfos = &queueInfo;
+        deviceInfo.enabledExtensionCount = static_cast<u32>(deviceExtensions.size());
+        deviceInfo.ppEnabledExtensionNames = deviceExtensions.data();
+        deviceInfo.pEnabledFeatures = &enabledFeatures;
+
+        VkCheck(vkCreateDevice(m_PhysicalDevice, &deviceInfo, nullptr, &m_Device), "vkCreateDevice");
+        volkLoadDevice(m_Device);
+        vkGetDeviceQueue(m_Device, m_QueueFamily, 0, &m_Queue);
+
+        // --- VMA (vendoring proof + the allocator Phase 5's VMA-backed --------
+        // transient resources allocate from, reached via VulkanDevice::Get())
+        {
+            VmaVulkanFunctions vulkanFunctions{};
+            VmaAllocatorCreateInfo allocatorInfo{};
+            allocatorInfo.physicalDevice = m_PhysicalDevice;
+            allocatorInfo.device = m_Device;
+            allocatorInfo.instance = m_Instance;
+            allocatorInfo.vulkanApiVersion = VulkanCapabilities::kMinApiVersion;
+            VkCheck(vmaImportVulkanFunctionsFromVolk(&allocatorInfo, &vulkanFunctions),
+                    "vmaImportVulkanFunctionsFromVolk");
+            allocatorInfo.pVulkanFunctions = &vulkanFunctions;
+            VkCheck(vmaCreateAllocator(&allocatorInfo, &m_Allocator), "vmaCreateAllocator");
+        }
+
+        // --- Command pool -----------------------------------------------------
+        VkCommandPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        poolInfo.queueFamilyIndex = m_QueueFamily;
+        VkCheck(vkCreateCommandPool(m_Device, &poolInfo, nullptr, &m_CommandPool), "vkCreateCommandPool");
+
+        s_ActiveDevice = this;
+    }
+
+    void VulkanDevice::Shutdown()
+    {
+        // Idempotent: also runs from the dtor after an explicit Shutdown, and
+        // after a partially-failed Init (whatever came up gets torn down).
+        // Order: pool -> VMA -> device -> messenger -> instance — the tail of
+        // Phase 4's teardown, unchanged. The caller destroys its surface and
+        // frame-loop objects BEFORE calling this (surface before instance).
+        if (m_Device != VK_NULL_HANDLE)
+        {
+            vkDeviceWaitIdle(m_Device);
+            if (m_CommandPool != VK_NULL_HANDLE)
+            {
+                vkDestroyCommandPool(m_Device, m_CommandPool, nullptr);
+                m_CommandPool = VK_NULL_HANDLE;
+            }
+            if (m_Allocator != VK_NULL_HANDLE)
+            {
+                vmaDestroyAllocator(m_Allocator);
+                m_Allocator = VK_NULL_HANDLE;
+            }
+            vkDestroyDevice(m_Device, nullptr);
+            m_Device = VK_NULL_HANDLE;
+            m_Queue = VK_NULL_HANDLE;
+        }
+        if (m_Instance != VK_NULL_HANDLE)
+        {
+#ifdef OLO_DEBUG
+            if (m_DebugMessenger != VK_NULL_HANDLE)
+            {
+                vkDestroyDebugUtilsMessengerEXT(m_Instance, m_DebugMessenger, nullptr);
+                m_DebugMessenger = VK_NULL_HANDLE;
+            }
+#endif
+            vkDestroyInstance(m_Instance, nullptr);
+            m_Instance = VK_NULL_HANDLE;
+        }
+        m_PhysicalDevice = VK_NULL_HANDLE;
+        m_QueueFamily = 0;
+        if (s_ActiveDevice == this)
+        {
+            s_ActiveDevice = nullptr;
+        }
+    }
+
+    u64 VulkanDevice::GetValidationErrorCount()
+    {
+        return s_ValidationErrorCount.load(std::memory_order_relaxed);
+    }
+
+    void VulkanDevice::ResetValidationErrorCount()
+    {
+        s_ValidationErrorCount.store(0, std::memory_order_relaxed);
+    }
+
+    VulkanDevice* VulkanDevice::Get()
+    {
+        return s_ActiveDevice;
+    }
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -17,9 +17,14 @@
 
 // Function-pointer config must match VulkanMemoryAllocator.cpp (the
 // VMA_IMPLEMENTATION TU) exactly — VMA is imported through volk's loaded
-// pointers, never linked statically (nothing links vulkan-1.lib).
+// pointers, never linked statically (nothing links vulkan-1.lib). Guarded so
+// a TU that already defined them (with the same value) doesn't warn.
+#ifndef VMA_STATIC_VULKAN_FUNCTIONS
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
+#endif
+#ifndef VMA_DYNAMIC_VULKAN_FUNCTIONS
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#endif
 #include <vk_mem_alloc.h>
 
 #include <functional>

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+// This header exposes Vulkan types directly — it is included only by
+// Platform/Vulkan siblings and by OLO_WITH_VULKAN-guarded engine factory TUs
+// (the sanctioned factory-include pattern, rhi-abstraction-boundary.md).
+// NEVER include <vulkan/vulkan.h> here or anywhere: volk owns the function
+// pointers and the declarations (ADR 0011 amendment 41a — an import-library
+// thunk colliding with volk's data symbols is a runtime AV, not a link error).
+//
+// volk before VMA: vk_mem_alloc.h keys its volk import helper on
+// VOLK_HEADER_VERSION.
+#include <volk.h>
+
+// Function-pointer config must match VulkanMemoryAllocator.cpp (the
+// VMA_IMPLEMENTATION TU) exactly — VMA is imported through volk's loaded
+// pointers, never linked statically (nothing links vulkan-1.lib).
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#include <vk_mem_alloc.h>
+
+#include <functional>
+
+namespace OloEngine
+{
+    // #691 Phase 5: the WINDOW-INDEPENDENT half of the Vulkan bring-up, split
+    // out of VulkanContext so headless tests (and later the render graph's
+    // execution layer) can bring a device up without a window. Owns: volk
+    // loader init, VkInstance, debug messenger (OLO_DEBUG only), physical-
+    // device selection, VkDevice, the single graphics(+present) queue, the
+    // VmaAllocator, and the command pool. Does NOT own: surface, swapchain,
+    // per-image present semaphores, per-frame acquire semaphores / fences /
+    // command buffers — that presentation and frame-loop state stays in
+    // VulkanContext.
+    class VulkanDevice
+    {
+      public:
+        VulkanDevice() = default;
+        ~VulkanDevice();
+
+        VulkanDevice(const VulkanDevice&) = delete;
+        VulkanDevice& operator=(const VulkanDevice&) = delete;
+        VulkanDevice(VulkanDevice&&) = delete;
+        VulkanDevice& operator=(VulkanDevice&&) = delete;
+
+        // Bring up instance + device. When `surfaceProvider` yields a surface
+        // the queue-family pick requires graphics+present on ONE family (the
+        // ADR 0010 contract row); when it yields VK_NULL_HANDLE (headless
+        // tests) it requires graphics only. The callback is invoked between
+        // instance creation and device selection — VulkanContext must create
+        // its VkSurfaceKHR AFTER the instance exists but BEFORE the physical-
+        // device pick (present support is per queue family, per surface).
+        // VulkanDevice uses the returned surface for the pick only; it does
+        // NOT own or destroy it — the caller does. Throws std::runtime_error
+        // to REFUSE initialisation (never degrade — ADR 0010) when the loader
+        // is absent or no device satisfies the capability contract.
+        void Init(const std::function<VkSurfaceKHR(VkInstance)>& surfaceProvider);
+        void Shutdown(); // also called by dtor; idempotent
+
+        [[nodiscard]] VkInstance GetInstance() const
+        {
+            return m_Instance;
+        }
+        [[nodiscard]] VkPhysicalDevice GetPhysicalDevice() const
+        {
+            return m_PhysicalDevice;
+        }
+        [[nodiscard]] VkDevice GetDevice() const
+        {
+            return m_Device;
+        }
+        [[nodiscard]] u32 GetQueueFamily() const
+        {
+            return m_QueueFamily;
+        }
+        [[nodiscard]] VkQueue GetQueue() const
+        {
+            return m_Queue;
+        }
+        [[nodiscard]] VmaAllocator GetAllocator() const
+        {
+            return m_Allocator;
+        }
+        [[nodiscard]] VkCommandPool GetCommandPool() const
+        {
+            return m_CommandPool;
+        }
+
+        // Core features enabled at device creation (when supported — never
+        // required, they are not contract rows). Barrier stage masks may only
+        // name stages whose features are ENABLED (VUID-…-03929/-03930), so
+        // VulkanRendererAPI narrows its shader-stage unions by these.
+        [[nodiscard]] bool IsTessellationShaderEnabled() const
+        {
+            return m_TessellationShaderEnabled;
+        }
+        [[nodiscard]] bool IsGeometryShaderEnabled() const
+        {
+            return m_GeometryShaderEnabled;
+        }
+
+        // Validation-error counter: the debug messenger increments this on
+        // every ERROR-severity validation message. Tests assert it stays 0.
+        // Always 0 outside OLO_DEBUG (no messenger exists there).
+        static u64 GetValidationErrorCount();
+        static void ResetValidationErrorCount();
+
+        // Process-wide accessor for the live device (set by Init, cleared by
+        // Shutdown). Null when no Vulkan device is up. Backend resource
+        // classes (Phase 5's VMA-backed transients) reach the allocator
+        // through this.
+        static VulkanDevice* Get();
+
+      private:
+        VkInstance m_Instance = VK_NULL_HANDLE;
+        VkDebugUtilsMessengerEXT m_DebugMessenger = VK_NULL_HANDLE;
+        VkPhysicalDevice m_PhysicalDevice = VK_NULL_HANDLE;
+        VkDevice m_Device = VK_NULL_HANDLE;
+        u32 m_QueueFamily = 0;
+        VkQueue m_Queue = VK_NULL_HANDLE;
+        VmaAllocator m_Allocator = VK_NULL_HANDLE;
+        VkCommandPool m_CommandPool = VK_NULL_HANDLE;
+        bool m_TessellationShaderEnabled = false;
+        bool m_GeometryShaderEnabled = false;
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -106,6 +106,13 @@ namespace OloEngine
         {
             return m_GeometryShaderEnabled;
         }
+        // ENABLED on the logical device (not merely supported by the physical
+        // one) — the facade's SupportsInt64ShaderAtomics must report what a
+        // shader can actually use.
+        [[nodiscard]] bool IsShaderBufferInt64AtomicsEnabled() const
+        {
+            return m_ShaderBufferInt64AtomicsEnabled;
+        }
 
         // Validation-error counter: the debug messenger increments this on
         // every ERROR-severity validation message. Tests assert it stays 0.
@@ -130,6 +137,7 @@ namespace OloEngine
         VkCommandPool m_CommandPool = VK_NULL_HANDLE;
         bool m_TessellationShaderEnabled = false;
         bool m_GeometryShaderEnabled = false;
+        bool m_ShaderBufferInt64AtomicsEnabled = false;
     };
 } // namespace OloEngine
 

--- a/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.cpp
@@ -7,7 +7,7 @@
 
 namespace OloEngine
 {
-    void VulkanImageLayoutTracker::RegisterImage(const VkImage image, const u32 mipCount, const u32 layerCount)
+    void VulkanImageLayoutTracker::RegisterImage(const VkImage image, const u32 mipCount, const u32 layerCount, const u64 registrationId)
     {
         if (image == VK_NULL_HANDLE)
             return;
@@ -16,14 +16,18 @@ namespace OloEngine
         const u32 layers = std::max(layerCount, 1u);
 
         if (const auto it = m_Images.find(image);
-            it != m_Images.end() && it->second.MipCount == mips && it->second.LayerCount == layers)
+            it != m_Images.end() && it->second.MipCount == mips && it->second.LayerCount == layers &&
+            it->second.RegistrationId == registrationId)
         {
-            return; // idempotent re-registration
+            return; // idempotent re-registration of the SAME image
         }
 
+        // New image, changed extents, or a recycled handle value carrying a
+        // fresh registry stamp — all reset to UNDEFINED.
         ImageState state;
         state.MipCount = mips;
         state.LayerCount = layers;
+        state.RegistrationId = registrationId;
         state.Layouts.assign(static_cast<sizet>(mips) * layers, VK_IMAGE_LAYOUT_UNDEFINED);
         m_Images[image] = std::move(state);
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.cpp
@@ -1,0 +1,142 @@
+#include "OloEnginePCH.h"
+#include "Platform/Vulkan/VulkanImageLayoutTracker.h"
+
+#if OLO_WITH_VULKAN
+
+#include <algorithm>
+
+namespace OloEngine
+{
+    void VulkanImageLayoutTracker::RegisterImage(const VkImage image, const u32 mipCount, const u32 layerCount)
+    {
+        if (image == VK_NULL_HANDLE)
+            return;
+
+        const u32 mips = std::max(mipCount, 1u);
+        const u32 layers = std::max(layerCount, 1u);
+
+        if (const auto it = m_Images.find(image);
+            it != m_Images.end() && it->second.MipCount == mips && it->second.LayerCount == layers)
+        {
+            return; // idempotent re-registration
+        }
+
+        ImageState state;
+        state.MipCount = mips;
+        state.LayerCount = layers;
+        state.Layouts.assign(static_cast<sizet>(mips) * layers, VK_IMAGE_LAYOUT_UNDEFINED);
+        m_Images[image] = std::move(state);
+    }
+
+    void VulkanImageLayoutTracker::ForgetImage(const VkImage image)
+    {
+        m_Images.erase(image);
+    }
+
+    void VulkanImageLayoutTracker::Reset()
+    {
+        m_Images.clear();
+    }
+
+    VulkanImageLayoutTracker::ResolvedRange VulkanImageLayoutTracker::Resolve(const ImageState& state,
+                                                                              const VkImageSubresourceRange& range)
+    {
+        ResolvedRange out;
+        out.BaseMip = std::min(range.baseMipLevel, state.MipCount > 0u ? state.MipCount - 1u : 0u);
+        out.BaseLayer = std::min(range.baseArrayLayer, state.LayerCount > 0u ? state.LayerCount - 1u : 0u);
+        const u32 mipSpan = state.MipCount - out.BaseMip;
+        const u32 layerSpan = state.LayerCount - out.BaseLayer;
+        out.MipCount = (range.levelCount == VK_REMAINING_MIP_LEVELS) ? mipSpan : std::min(range.levelCount, mipSpan);
+        out.LayerCount = (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? layerSpan : std::min(range.layerCount, layerSpan);
+        return out;
+    }
+
+    void VulkanImageLayoutTracker::SetLayout(const VkImage image, const VkImageSubresourceRange& range, const VkImageLayout layout)
+    {
+        const auto it = m_Images.find(image);
+        if (it == m_Images.end())
+            return;
+
+        auto& state = it->second;
+        const auto r = Resolve(state, range);
+        for (u32 layer = r.BaseLayer; layer < r.BaseLayer + r.LayerCount; ++layer)
+        {
+            for (u32 mip = r.BaseMip; mip < r.BaseMip + r.MipCount; ++mip)
+                state.Layouts[static_cast<sizet>(layer) * state.MipCount + mip] = layout;
+        }
+    }
+
+    void VulkanImageLayoutTracker::ForEachLayoutRun(const VkImage image,
+                                                    const VkImageSubresourceRange& range,
+                                                    const std::function<void(const VkImageSubresourceRange&, VkImageLayout)>& visitor) const
+    {
+        const auto it = m_Images.find(image);
+        if (it == m_Images.end())
+        {
+            // Unknown image: one UNDEFINED run covering the requested range.
+            visitor(range, VK_IMAGE_LAYOUT_UNDEFINED);
+            return;
+        }
+
+        const auto& state = it->second;
+        const auto r = Resolve(state, range);
+        if (r.MipCount == 0 || r.LayerCount == 0)
+            return;
+
+        // Runs are emitted per layer as maximal contiguous mip spans of equal
+        // layout. (A run could also merge across layers when every mip agrees;
+        // per-layer is simpler and the barrier count difference is noise at
+        // the layer counts this engine uses.)
+        for (u32 layer = r.BaseLayer; layer < r.BaseLayer + r.LayerCount; ++layer)
+        {
+            u32 runStart = r.BaseMip;
+            auto runLayout = state.Layouts[static_cast<sizet>(layer) * state.MipCount + runStart];
+            for (u32 mip = r.BaseMip + 1u; mip <= r.BaseMip + r.MipCount; ++mip)
+            {
+                const bool atEnd = (mip == r.BaseMip + r.MipCount);
+                const auto layout = atEnd ? VK_IMAGE_LAYOUT_MAX_ENUM
+                                          : state.Layouts[static_cast<sizet>(layer) * state.MipCount + mip];
+                if (atEnd || layout != runLayout)
+                {
+                    VkImageSubresourceRange run{};
+                    run.aspectMask = range.aspectMask;
+                    run.baseMipLevel = runStart;
+                    run.levelCount = mip - runStart;
+                    run.baseArrayLayer = layer;
+                    run.layerCount = 1;
+                    visitor(run, runLayout);
+                    if (!atEnd)
+                    {
+                        runStart = mip;
+                        runLayout = layout;
+                    }
+                }
+            }
+        }
+    }
+
+    VkImageLayout VulkanImageLayoutTracker::CurrentLayout(const VkImage image, const VkImageSubresourceRange& range) const
+    {
+        const auto it = m_Images.find(image);
+        if (it == m_Images.end())
+            return VK_IMAGE_LAYOUT_UNDEFINED;
+
+        const auto& state = it->second;
+        const auto r = Resolve(state, range);
+        if (r.MipCount == 0 || r.LayerCount == 0)
+            return VK_IMAGE_LAYOUT_UNDEFINED;
+
+        const auto first = state.Layouts[static_cast<sizet>(r.BaseLayer) * state.MipCount + r.BaseMip];
+        for (u32 layer = r.BaseLayer; layer < r.BaseLayer + r.LayerCount; ++layer)
+        {
+            for (u32 mip = r.BaseMip; mip < r.BaseMip + r.MipCount; ++mip)
+            {
+                if (state.Layouts[static_cast<sizet>(layer) * state.MipCount + mip] != first)
+                    return VK_IMAGE_LAYOUT_UNDEFINED; // mixed — discard is the safe total answer
+            }
+        }
+        return first;
+    }
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// =============================================================================
+// VulkanImageLayoutTracker — per-subresource image-layout state
+// (issue #691 Phase 5).
+//
+// GL has no image layouts, so this state machine is NEW with the Vulkan
+// backend, and it is the piece a wrong guess turns into a validation error
+// (or a silent GPU hazard) rather than a wrong pixel. The rules:
+//
+//  - The TRACKER is authoritative for a barrier's oldLayout, never the
+//    transition's FromAccess: a pooled transient re-acquired this frame is in
+//    whatever layout its previous tenant left, and a first use is UNDEFINED.
+//    FromAccess only contributes the source stage/access masks.
+//  - Granularity is per (mip, layer). Images register their extents up front
+//    (RegisterImage), so VK_REMAINING_*-style open ranges expand exactly and
+//    a query over a range whose subresources DISAGREE can answer per run
+//    instead of guessing one layout for all of them.
+//  - Unknown image / unregistered subresource → UNDEFINED, which is always a
+//    legal oldLayout (it discards). Conservative in the direction that can
+//    only lose contents, never corrupt sync.
+//
+// Pure CPU container — no device calls — so it is pinned headlessly by
+// VulkanBarrierLoweringTest with fabricated non-dispatchable handles.
+// =============================================================================
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+#include <volk.h>
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace OloEngine
+{
+    class VulkanImageLayoutTracker
+    {
+      public:
+        // Declare an image's extents. Idempotent; re-registering with
+        // different extents resets that image's state to UNDEFINED (it is a
+        // different allocation reusing the handle value).
+        void RegisterImage(VkImage image, u32 mipCount, u32 layerCount);
+
+        // Drop all state for an image (call at destroy — a recycled handle
+        // value must not inherit the dead image's layouts).
+        void ForgetImage(VkImage image);
+
+        void Reset();
+
+        // Record that `range` now sits in `layout` (call AFTER recording the
+        // barrier that performs the transition).
+        void SetLayout(VkImage image, const VkImageSubresourceRange& range, VkImageLayout layout);
+
+        // Visit maximal runs of equal layout inside `range`, in subresource
+        // order. The visitor receives a sub-range (same aspect mask as the
+        // query) and that run's layout. This is how a barrier batch stays
+        // exact when one logical range spans mixed layouts: one
+        // VkImageMemoryBarrier2 per run, never one guessed layout for all.
+        void ForEachLayoutRun(VkImage image,
+                              const VkImageSubresourceRange& range,
+                              const std::function<void(const VkImageSubresourceRange&, VkImageLayout)>& visitor) const;
+
+        // Convenience for whole-range queries: the single layout when every
+        // covered subresource agrees, VK_IMAGE_LAYOUT_UNDEFINED otherwise
+        // (mixed or unknown).
+        [[nodiscard]] VkImageLayout CurrentLayout(VkImage image, const VkImageSubresourceRange& range) const;
+
+      private:
+        struct ImageState
+        {
+            u32 MipCount = 1;
+            u32 LayerCount = 1;
+            // Indexed [layer * MipCount + mip].
+            std::vector<VkImageLayout> Layouts;
+        };
+
+        // Clamp an open (VK_REMAINING_*) range against the image's extents.
+        struct ResolvedRange
+        {
+            u32 BaseMip = 0;
+            u32 MipCount = 0;
+            u32 BaseLayer = 0;
+            u32 LayerCount = 0;
+        };
+        [[nodiscard]] static ResolvedRange Resolve(const ImageState& state, const VkImageSubresourceRange& range);
+
+        std::unordered_map<VkImage, ImageState> m_Images;
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanImageLayoutTracker.h
@@ -40,9 +40,12 @@ namespace OloEngine
     {
       public:
         // Declare an image's extents. Idempotent; re-registering with
-        // different extents resets that image's state to UNDEFINED (it is a
-        // different allocation reusing the handle value).
-        void RegisterImage(VkImage image, u32 mipCount, u32 layerCount);
+        // different extents — or a different `registrationId`
+        // (VulkanImageInfo::RegistrationId: the stamp that distinguishes a
+        // driver-recycled handle VALUE from the image previously tracked,
+        // even at identical extents) — resets that image's state to
+        // UNDEFINED. Callers without a registry stamp may pass 0.
+        void RegisterImage(VkImage image, u32 mipCount, u32 layerCount, u64 registrationId = 0);
 
         // Drop all state for an image (call at destroy — a recycled handle
         // value must not inherit the dead image's layouts).
@@ -73,6 +76,7 @@ namespace OloEngine
         {
             u32 MipCount = 1;
             u32 LayerCount = 1;
+            u64 RegistrationId = 0;
             // Indexed [layer * MipCount + mip].
             std::vector<VkImageLayout> Layouts;
         };

--- a/OloEngine/src/Platform/Vulkan/VulkanMemoryAllocator.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanMemoryAllocator.cpp
@@ -3,7 +3,7 @@
 #if OLO_WITH_VULKAN
 
 // The single VMA_IMPLEMENTATION TU for the engine (#691 Phase 4). The
-// function-pointer config must match VulkanContext.cpp exactly: every Vulkan
+// function-pointer config must match VulkanDevice.h exactly: every Vulkan
 // entry point reaches VMA through volk's loaded pointers
 // (vmaImportVulkanFunctionsFromVolk at allocator creation) — nothing links
 // vulkan-1.lib, so static and dynamic self-loading are both disabled.

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -1,0 +1,1149 @@
+#include "OloEnginePCH.h"
+#include "Platform/Vulkan/VulkanRendererAPI.h"
+
+#if OLO_WITH_VULKAN
+
+#include "OloEngine/Renderer/RHI/RHIResourceRegistry.h"
+#include "Platform/Vulkan/VulkanBarrierLowering.h"
+#include "Platform/Vulkan/VulkanDevice.h"
+#include "Platform/Vulkan/VulkanTransientResources.h"
+
+#include <bit>
+#include <vector>
+
+namespace OloEngine
+{
+    namespace
+    {
+        // Conservative both-ways masks for the debug clears and the
+        // flags-only global barrier: the poison instrument and a
+        // transitions-empty batch have no per-resource truth to be precise
+        // with, and over-synchronisation is correct where under- is a race.
+        constexpr VkPipelineStageFlags2 kAllStages = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        constexpr VkAccessFlags2 kAllAccess = VK_ACCESS_2_MEMORY_READ_BIT | VK_ACCESS_2_MEMORY_WRITE_BIT;
+
+        [[nodiscard]] RHI::TextureAspect AspectFromInfo(const VulkanImageInfo& info)
+        {
+            if (info.HasDepth && info.HasStencil)
+                return RHI::TextureAspect::DepthStencil;
+            if (info.HasDepth)
+                return RHI::TextureAspect::Depth;
+            if (info.HasStencil)
+                return RHI::TextureAspect::Stencil;
+            return RHI::TextureAspect::Color;
+        }
+    } // namespace
+
+    void VulkanRendererAPI::Phase6Stub(const char* entryPoint) const
+    {
+        ++m_Phase6StubHits;
+        if (m_WarnedStubs.insert(entryPoint).second)
+        {
+            OLO_CORE_WARN("[RHI/Vulkan] {} is a Phase 6 concern (#691) — no-op under the Phase 5 execution layer "
+                          "(further calls counted, not logged)",
+                          entryPoint);
+        }
+    }
+
+    void VulkanRendererAPI::CacheDeviceLimits()
+    {
+        if (m_LimitsCached)
+            return;
+        auto* device = VulkanDevice::Get();
+        if (!device)
+            return;
+
+        VkPhysicalDeviceProperties props{};
+        vkGetPhysicalDeviceProperties(device->GetPhysicalDevice(), &props);
+        m_MaxUniformBlockSize = props.limits.maxUniformBufferRange;
+
+        const VkSampleCountFlags counts = props.limits.framebufferColorSampleCounts &
+                                          props.limits.framebufferDepthSampleCounts;
+        m_MaxSamples = 1;
+        for (const VkSampleCountFlagBits bit : { VK_SAMPLE_COUNT_64_BIT, VK_SAMPLE_COUNT_32_BIT,
+                                                 VK_SAMPLE_COUNT_16_BIT, VK_SAMPLE_COUNT_8_BIT,
+                                                 VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_2_BIT })
+        {
+            if (counts & bit)
+            {
+                m_MaxSamples = static_cast<u32>(bit);
+                break;
+            }
+        }
+
+        VkPhysicalDeviceShaderAtomicInt64Features atomics{};
+        atomics.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+        VkPhysicalDeviceFeatures2 features2{};
+        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        features2.pNext = &atomics;
+        vkGetPhysicalDeviceFeatures2(device->GetPhysicalDevice(), &features2);
+        m_SupportsInt64Atomics = atomics.shaderBufferInt64Atomics == VK_TRUE;
+
+        // VUID-…-03929/-03930: a barrier stage mask may only name stages
+        // whose device features are enabled.
+        m_EnabledStageMask = ~VkPipelineStageFlags2{ 0 };
+        if (!device->IsTessellationShaderEnabled())
+        {
+            m_EnabledStageMask &= ~(VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
+                                    VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT);
+        }
+        if (!device->IsGeometryShaderEnabled())
+            m_EnabledStageMask &= ~VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT;
+
+        m_LimitsCached = true;
+    }
+
+    void VulkanRendererAPI::Init()
+    {
+        OLO_PROFILE_FUNCTION();
+        CacheDeviceLimits();
+        OLO_CORE_INFO("[RHI/Vulkan] VulkanRendererAPI up — Phase 5 execution layer (barriers, transient clears, "
+                      "dynamic state); pipeline-shaped entry points stub until Phase 6");
+    }
+
+    void VulkanRendererAPI::BeginRecording(const VkCommandBuffer cmd)
+    {
+        OLO_CORE_ASSERT(m_Cmd == VK_NULL_HANDLE, "BeginRecording while a recording bracket is already open");
+        m_Cmd = cmd;
+    }
+
+    void VulkanRendererAPI::EndRecording()
+    {
+        m_Cmd = VK_NULL_HANDLE;
+    }
+
+    // --- Viewport / scissor (real dynamic state) ---------------------------
+
+    void VulkanRendererAPI::SetViewport(const u32 x, const u32 y, const u32 width, const u32 height)
+    {
+        m_Viewport = { x, y, width, height };
+        if (m_Cmd == VK_NULL_HANDLE)
+            return;
+
+        // Negative-height flip is a Phase 6 (pipeline/pass) concern; Phase 5
+        // records the plain rect so state packets replay without error.
+        VkViewport vp{};
+        vp.x = static_cast<f32>(x);
+        vp.y = static_cast<f32>(y);
+        vp.width = static_cast<f32>(width);
+        vp.height = static_cast<f32>(height);
+        vp.minDepth = 0.0f;
+        vp.maxDepth = 1.0f;
+        vkCmdSetViewport(m_Cmd, 0, 1, &vp);
+
+        VkRect2D scissor{};
+        scissor.offset = { static_cast<i32>(x), static_cast<i32>(y) };
+        scissor.extent = { width, height };
+        vkCmdSetScissor(m_Cmd, 0, 1, &scissor);
+    }
+
+    Viewport VulkanRendererAPI::GetViewport() const
+    {
+        return m_Viewport;
+    }
+
+    void VulkanRendererAPI::SetScissorBox(const i32 x, const i32 y, const u32 width, const u32 height)
+    {
+        if (m_Cmd == VK_NULL_HANDLE)
+            return;
+        VkRect2D scissor{};
+        scissor.offset = { x, y };
+        scissor.extent = { width, height };
+        vkCmdSetScissor(m_Cmd, 0, 1, &scissor);
+    }
+
+    // --- Barriers ----------------------------------------------------------
+
+    void VulkanRendererAPI::MemoryBarrier(MemoryBarrierFlags flags)
+    {
+        // The flags are the GL lowering (ADR 0011 §1.5); on Vulkan a bare
+        // MemoryBarrier call has no per-resource truth, so it lowers to one
+        // conservative global memory barrier.
+        if (flags == MemoryBarrierFlags::None)
+            return;
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            Phase6Stub("MemoryBarrier(outside recording bracket)");
+            return;
+        }
+
+        VkMemoryBarrier2 barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        barrier.srcStageMask = kAllStages;
+        barrier.srcAccessMask = kAllAccess;
+        barrier.dstStageMask = kAllStages;
+        barrier.dstAccessMask = kAllAccess;
+
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep.memoryBarrierCount = 1;
+        dep.pMemoryBarriers = &barrier;
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+    }
+
+    void VulkanRendererAPI::IssueBarrierBatch(const MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            if (flags != MemoryBarrierFlags::None || !barriers.empty())
+                Phase6Stub("IssueBarrierBatch(outside recording bracket)");
+            return;
+        }
+
+        std::vector<VkImageMemoryBarrier2> imageBarriers;
+        std::vector<VkBufferMemoryBarrier2> bufferBarriers;
+        imageBarriers.reserve(barriers.size());
+
+        auto& registry = RHI::ResourceRegistry::Get();
+        for (const auto& barrier : barriers)
+        {
+            const auto kind = registry.KindOf(barrier.Resource);
+            const u64 native = registry.ResolveNativeForBackend(barrier.Resource);
+            if (native == 0u)
+                continue; // stale/dead/foreign handle — degrades to "no barrier", never to garbage
+
+            if (kind == RHI::ResourceKind::Buffer)
+            {
+                auto vkBarrier = VulkanBarrierLowering::BuildBufferBarrier(barrier, reinterpret_cast<VkBuffer>(native));
+                vkBarrier.srcStageMask &= m_EnabledStageMask;
+                vkBarrier.dstStageMask &= m_EnabledStageMask;
+                bufferBarriers.push_back(vkBarrier);
+                continue;
+            }
+            if (kind != RHI::ResourceKind::Texture)
+                continue;
+
+            const auto image = reinterpret_cast<VkImage>(native);
+            const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
+            if (!info)
+                continue; // not a Vulkan-backend image (mixed-currency graph)
+
+            const auto aspect = AspectFromInfo(*info);
+            m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+
+            // The neutral range, clamped into Vk terms once; the tracker then
+            // splits it into runs of equal current layout so oldLayout is
+            // EXACT per emitted barrier — one guessed layout for a mixed
+            // range is precisely the class of bug sync validation exists for.
+            VkImageSubresourceRange queryRange{};
+            queryRange.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
+            queryRange.baseMipLevel = std::min(barrier.Range.BaseMip, info->MipLevels - 1u);
+            queryRange.levelCount = (barrier.Range.MipCount == RHI::SubresourceRange::AllRemaining)
+                                        ? VK_REMAINING_MIP_LEVELS
+                                        : std::min(barrier.Range.MipCount, info->MipLevels - queryRange.baseMipLevel);
+            queryRange.baseArrayLayer = std::min(barrier.Range.BaseLayer, info->ArrayLayers - 1u);
+            queryRange.layerCount = (barrier.Range.LayerCount == RHI::SubresourceRange::AllRemaining)
+                                        ? VK_REMAINING_ARRAY_LAYERS
+                                        : std::min(barrier.Range.LayerCount, info->ArrayLayers - queryRange.baseArrayLayer);
+
+            m_LayoutTracker.ForEachLayoutRun(
+                image, queryRange,
+                [&](const VkImageSubresourceRange& run, const VkImageLayout trackedLayout)
+                {
+                    auto vkBarrier = VulkanBarrierLowering::BuildImageBarrier(barrier, image, aspect, trackedLayout,
+                                                                              info->MipLevels, info->ArrayLayers);
+                    vkBarrier.subresourceRange = run;
+                    // The pure lowering emits the full shader-stage union;
+                    // the device knows which stage features are ENABLED
+                    // (VUID-…-03929/-03930). A masked-off stage can hold no
+                    // work, so narrowing loses no synchronisation.
+                    vkBarrier.srcStageMask &= m_EnabledStageMask;
+                    vkBarrier.dstStageMask &= m_EnabledStageMask;
+                    imageBarriers.push_back(vkBarrier);
+                });
+
+            m_LayoutTracker.SetLayout(image, queryRange,
+                                      VulkanBarrierLowering::LayoutFor(barrier.After, aspect, barrier.ReadWhileAttached));
+        }
+
+        VkMemoryBarrier2 globalBarrier{};
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+
+        if (imageBarriers.empty() && bufferBarriers.empty())
+        {
+            // Nothing resolved to a per-resource barrier (flags-only batch,
+            // or every operand was a native-only import). The synchronisation
+            // the GL flags promised must still happen: one conservative
+            // global barrier.
+            if (flags == MemoryBarrierFlags::None)
+                return;
+            globalBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+            globalBarrier.srcStageMask = kAllStages;
+            globalBarrier.srcAccessMask = kAllAccess;
+            globalBarrier.dstStageMask = kAllStages;
+            globalBarrier.dstAccessMask = kAllAccess;
+            dep.memoryBarrierCount = 1;
+            dep.pMemoryBarriers = &globalBarrier;
+        }
+        else
+        {
+            dep.imageMemoryBarrierCount = static_cast<u32>(imageBarriers.size());
+            dep.pImageMemoryBarriers = imageBarriers.data();
+            dep.bufferMemoryBarrierCount = static_cast<u32>(bufferBarriers.size());
+            dep.pBufferMemoryBarriers = bufferBarriers.data();
+        }
+
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+    }
+
+    // --- Transient clears (the poison instrument's backend) ----------------
+
+    void VulkanRendererAPI::ClearTextureFloat(const RHI::ResourceHandle texture, const u32 mipLevel, const glm::vec4& color)
+    {
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            Phase6Stub("ClearTextureFloat(outside recording bracket)");
+            return;
+        }
+
+        auto& registry = RHI::ResourceRegistry::Get();
+        const u64 native = registry.ResolveNativeForBackend(texture);
+        if (native == 0u)
+            return;
+        const auto image = reinterpret_cast<VkImage>(native);
+        const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
+        if (!info)
+            return;
+
+        const auto aspect = AspectFromInfo(*info);
+        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+
+        VkImageSubresourceRange range{};
+        range.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
+        range.baseMipLevel = std::min(mipLevel, info->MipLevels - 1u);
+        range.levelCount = 1;
+        range.baseArrayLayer = 0;
+        range.layerCount = VK_REMAINING_ARRAY_LAYERS;
+
+        // Conservative pre-barrier into TRANSFER_DST, exact per layout run.
+        std::vector<VkImageMemoryBarrier2> toTransfer;
+        m_LayoutTracker.ForEachLayoutRun(
+            image, range,
+            [&](const VkImageSubresourceRange& run, const VkImageLayout trackedLayout)
+            {
+                VkImageMemoryBarrier2 b{};
+                b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+                b.srcStageMask = (trackedLayout == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_PIPELINE_STAGE_2_NONE : kAllStages;
+                b.srcAccessMask = (trackedLayout == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_ACCESS_2_NONE : kAllAccess;
+                b.dstStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+                b.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+                b.oldLayout = trackedLayout;
+                b.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.image = image;
+                b.subresourceRange = run;
+                toTransfer.push_back(b);
+            });
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep.imageMemoryBarrierCount = static_cast<u32>(toTransfer.size());
+        dep.pImageMemoryBarriers = toTransfer.data();
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+        m_LayoutTracker.SetLayout(image, range, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+        if (aspect == RHI::TextureAspect::Color)
+        {
+            VkClearColorValue clear{};
+            clear.float32[0] = color.r;
+            clear.float32[1] = color.g;
+            clear.float32[2] = color.b;
+            clear.float32[3] = color.a;
+            vkCmdClearColorImage(m_Cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
+        }
+        else
+        {
+            VkClearDepthStencilValue clear{};
+            clear.depth = color.r;
+            clear.stencil = 0;
+            vkCmdClearDepthStencilImage(m_Cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
+        }
+    }
+
+    void VulkanRendererAPI::ClearTextureUInt(const RHI::ResourceHandle texture, const u32 mipLevel, const u32 value)
+    {
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            Phase6Stub("ClearTextureUInt(outside recording bracket)");
+            return;
+        }
+        // Same shape as the float clear with a uint payload; share the
+        // transition by delegating and then re-clearing would double-clear,
+        // so the small duplication is deliberate.
+        auto& registry = RHI::ResourceRegistry::Get();
+        const u64 native = registry.ResolveNativeForBackend(texture);
+        if (native == 0u)
+            return;
+        const auto image = reinterpret_cast<VkImage>(native);
+        const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
+        if (!info || info->HasDepth || info->HasStencil)
+            return; // a uint clear of a depth image has no meaning
+
+        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+
+        VkImageSubresourceRange range{};
+        range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        range.baseMipLevel = std::min(mipLevel, info->MipLevels - 1u);
+        range.levelCount = 1;
+        range.baseArrayLayer = 0;
+        range.layerCount = VK_REMAINING_ARRAY_LAYERS;
+
+        std::vector<VkImageMemoryBarrier2> toTransfer;
+        m_LayoutTracker.ForEachLayoutRun(
+            image, range,
+            [&](const VkImageSubresourceRange& run, const VkImageLayout trackedLayout)
+            {
+                VkImageMemoryBarrier2 b{};
+                b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
+                b.srcStageMask = (trackedLayout == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_PIPELINE_STAGE_2_NONE : kAllStages;
+                b.srcAccessMask = (trackedLayout == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_ACCESS_2_NONE : kAllAccess;
+                b.dstStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+                b.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+                b.oldLayout = trackedLayout;
+                b.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.image = image;
+                b.subresourceRange = run;
+                toTransfer.push_back(b);
+            });
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep.imageMemoryBarrierCount = static_cast<u32>(toTransfer.size());
+        dep.pImageMemoryBarriers = toTransfer.data();
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+        m_LayoutTracker.SetLayout(image, range, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+        VkClearColorValue clear{};
+        clear.uint32[0] = value;
+        clear.uint32[1] = value;
+        clear.uint32[2] = value;
+        clear.uint32[3] = value;
+        vkCmdClearColorImage(m_Cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
+    }
+
+    void VulkanRendererAPI::ClearBufferFloat(const RHI::ResourceHandle buffer, const f32 value)
+    {
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            Phase6Stub("ClearBufferFloat(outside recording bracket)");
+            return;
+        }
+        const u64 native = RHI::ResourceRegistry::Get().ResolveNativeForBackend(buffer);
+        if (native == 0u)
+            return;
+
+        // Conservative bracket: the poison fill must be ordered against
+        // whatever used the pooled buffer last frame and whatever reads it
+        // next — this is a debug instrument, over-sync is the point.
+        VkMemoryBarrier2 global{};
+        global.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        global.srcStageMask = kAllStages;
+        global.srcAccessMask = kAllAccess;
+        global.dstStageMask = kAllStages;
+        global.dstAccessMask = kAllAccess;
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep.memoryBarrierCount = 1;
+        dep.pMemoryBarriers = &global;
+
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+        vkCmdFillBuffer(m_Cmd, reinterpret_cast<VkBuffer>(native), 0, VK_WHOLE_SIZE, std::bit_cast<u32>(value));
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+    }
+
+    void VulkanRendererAPI::ClearBufferUInt(const RHI::ResourceHandle buffer, const u32 value)
+    {
+        if (m_Cmd == VK_NULL_HANDLE)
+        {
+            Phase6Stub("ClearBufferUInt(outside recording bracket)");
+            return;
+        }
+        const u64 native = RHI::ResourceRegistry::Get().ResolveNativeForBackend(buffer);
+        if (native == 0u)
+            return;
+
+        VkMemoryBarrier2 global{};
+        global.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
+        global.srcStageMask = kAllStages;
+        global.srcAccessMask = kAllAccess;
+        global.dstStageMask = kAllStages;
+        global.dstAccessMask = kAllAccess;
+        VkDependencyInfo dep{};
+        dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
+        dep.memoryBarrierCount = 1;
+        dep.pMemoryBarriers = &global;
+
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+        vkCmdFillBuffer(m_Cmd, reinterpret_cast<VkBuffer>(native), 0, VK_WHOLE_SIZE, value);
+        vkCmdPipelineBarrier2(m_Cmd, &dep);
+    }
+
+    // --- Debug labels / device queries -------------------------------------
+
+    void VulkanRendererAPI::PushDebugGroup(u32 /*id*/, const std::string_view label)
+    {
+        // vkCmdBeginDebugUtilsLabelEXT is loaded only when the debug-utils
+        // extension was enabled (debug builds with the validation layer) —
+        // the pointer probe IS the capability check under volk.
+        if (m_Cmd == VK_NULL_HANDLE || vkCmdBeginDebugUtilsLabelEXT == nullptr)
+            return;
+        const std::string labelStr(label);
+        VkDebugUtilsLabelEXT vkLabel{};
+        vkLabel.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+        vkLabel.pLabelName = labelStr.c_str();
+        vkCmdBeginDebugUtilsLabelEXT(m_Cmd, &vkLabel);
+    }
+
+    void VulkanRendererAPI::PopDebugGroup()
+    {
+        if (m_Cmd == VK_NULL_HANDLE || vkCmdEndDebugUtilsLabelEXT == nullptr)
+            return;
+        vkCmdEndDebugUtilsLabelEXT(m_Cmd);
+    }
+
+    void VulkanRendererAPI::WaitForDeviceIdle()
+    {
+        if (auto* device = VulkanDevice::Get())
+            vkDeviceWaitIdle(device->GetDevice());
+    }
+
+    bool VulkanRendererAPI::IsDeviceAvailable() const
+    {
+        return VulkanDevice::Get() != nullptr;
+    }
+
+    u32 VulkanRendererAPI::GetMaxUniformBlockSize() const
+    {
+        const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
+        return m_MaxUniformBlockSize;
+    }
+
+    bool VulkanRendererAPI::SupportsInt64ShaderAtomics() const
+    {
+        const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
+        return m_SupportsInt64Atomics;
+    }
+
+    u32 VulkanRendererAPI::GetMaxFramebufferSamples() const
+    {
+        const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
+        return m_MaxSamples;
+    }
+
+    u32 VulkanRendererAPI::GetMaxColorTextureSamples() const
+    {
+        const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
+        return m_MaxSamples;
+    }
+
+    u32 VulkanRendererAPI::GetMaxDepthTextureSamples() const
+    {
+        const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
+        return m_MaxSamples;
+    }
+
+    // --- Recorded pipeline-key state (see VulkanRecordedPipelineState) -----
+
+    void VulkanRendererAPI::SetClearColor(const glm::vec4& color)
+    {
+        m_State.ClearColor = color;
+    }
+    void VulkanRendererAPI::SetClearDepth(const f32 depth)
+    {
+        m_State.ClearDepth = depth;
+    }
+    void VulkanRendererAPI::SetDepthTest(const bool value)
+    {
+        m_State.DepthTest = value;
+    }
+    void VulkanRendererAPI::SetDepthMask(const bool value)
+    {
+        m_State.DepthWrite = value;
+    }
+    void VulkanRendererAPI::SetDepthFunc(const RHI::CompareOp func)
+    {
+        m_State.DepthFunc = func;
+    }
+    void VulkanRendererAPI::SetBlendState(const bool value)
+    {
+        m_State.Blend = value;
+    }
+    void VulkanRendererAPI::SetBlendFunc(const RHI::BlendFactor sfactor, const RHI::BlendFactor dfactor)
+    {
+        m_State.BlendSrcRGB = sfactor;
+        m_State.BlendDstRGB = dfactor;
+        m_State.BlendSrcAlpha = sfactor;
+        m_State.BlendDstAlpha = dfactor;
+    }
+    void VulkanRendererAPI::SetBlendFuncSeparate(const RHI::BlendFactor srcRGB, const RHI::BlendFactor dstRGB,
+                                                 const RHI::BlendFactor srcAlpha, const RHI::BlendFactor dstAlpha)
+    {
+        m_State.BlendSrcRGB = srcRGB;
+        m_State.BlendDstRGB = dstRGB;
+        m_State.BlendSrcAlpha = srcAlpha;
+        m_State.BlendDstAlpha = dstAlpha;
+    }
+    void VulkanRendererAPI::SetBlendEquation(const RHI::BlendOp mode)
+    {
+        m_State.BlendEquation = mode;
+    }
+    void VulkanRendererAPI::EnableStencilTest()
+    {
+        m_State.StencilTest = true;
+    }
+    void VulkanRendererAPI::DisableStencilTest()
+    {
+        m_State.StencilTest = false;
+    }
+    bool VulkanRendererAPI::IsStencilTestEnabled() const
+    {
+        return m_State.StencilTest;
+    }
+    void VulkanRendererAPI::SetStencilFunc(const RHI::CompareOp func, const i32 ref, const u32 mask)
+    {
+        m_State.StencilFunc = func;
+        m_State.StencilRef = ref;
+        m_State.StencilReadMask = mask;
+    }
+    void VulkanRendererAPI::SetStencilOp(const RHI::StencilOp sfail, const RHI::StencilOp dpfail, const RHI::StencilOp dppass)
+    {
+        m_State.StencilFail = sfail;
+        m_State.StencilDepthFail = dpfail;
+        m_State.StencilPass = dppass;
+    }
+    void VulkanRendererAPI::SetStencilMask(const u32 mask)
+    {
+        m_State.StencilWriteMask = mask;
+    }
+    void VulkanRendererAPI::EnableCulling()
+    {
+        m_State.Culling = true;
+    }
+    void VulkanRendererAPI::DisableCulling()
+    {
+        m_State.Culling = false;
+    }
+    void VulkanRendererAPI::FrontCull()
+    {
+        m_State.CullFace = RHI::CullMode::Front;
+    }
+    void VulkanRendererAPI::BackCull()
+    {
+        m_State.CullFace = RHI::CullMode::Back;
+    }
+    void VulkanRendererAPI::SetCullFace(const RHI::CullMode face)
+    {
+        m_State.CullFace = face;
+    }
+    void VulkanRendererAPI::SetFrontFace(const RHI::FrontFace face)
+    {
+        m_State.FrontFaceWinding = face;
+    }
+    void VulkanRendererAPI::SetPolygonMode(const RHI::PolygonMode mode)
+    {
+        m_State.PolygonMode = mode;
+    }
+    void VulkanRendererAPI::SetPolygonOffset(const f32 factor, const f32 units)
+    {
+        m_State.PolygonOffsetEnabled = true;
+        m_State.PolygonOffsetFactor = factor;
+        m_State.PolygonOffsetUnits = units;
+    }
+    void VulkanRendererAPI::EnableScissorTest()
+    {
+        m_State.ScissorTest = true;
+    }
+    void VulkanRendererAPI::DisableScissorTest()
+    {
+        m_State.ScissorTest = false;
+    }
+    void VulkanRendererAPI::EnableMultisampling()
+    {
+        m_State.Multisampling = true;
+    }
+    void VulkanRendererAPI::DisableMultisampling()
+    {
+        m_State.Multisampling = false;
+    }
+    void VulkanRendererAPI::SetLineWidth(const f32 width)
+    {
+        m_State.LineWidth = width;
+    }
+    void VulkanRendererAPI::SetColorMask(const bool red, const bool green, const bool blue, const bool alpha)
+    {
+        m_State.ColorMask[0] = red;
+        m_State.ColorMask[1] = green;
+        m_State.ColorMask[2] = blue;
+        m_State.ColorMask[3] = alpha;
+    }
+    void VulkanRendererAPI::SetColorMaskForAttachment(const u32 attachment, const bool red, const bool green,
+                                                      const bool blue, const bool alpha)
+    {
+        if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
+            return;
+        m_State.AttachmentColorMask[attachment] = static_cast<u8>((red ? 1u : 0u) | (green ? 2u : 0u) |
+                                                                  (blue ? 4u : 0u) | (alpha ? 8u : 0u));
+    }
+    void VulkanRendererAPI::SetBlendStateForAttachment(const u32 attachment, const bool enabled)
+    {
+        if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
+            return;
+        m_State.AttachmentBlend[attachment] = enabled;
+    }
+    void VulkanRendererAPI::SetBlendFuncForAttachment(const u32 attachment, const RHI::BlendFactor src, const RHI::BlendFactor dst)
+    {
+        if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
+            return;
+        m_State.AttachmentBlendSrc[attachment] = src;
+        m_State.AttachmentBlendDst[attachment] = dst;
+    }
+    void VulkanRendererAPI::SetPatchVertexCount(const u32 patchVertices)
+    {
+        m_State.PatchVertexCount = patchVertices;
+    }
+
+    // --- Phase 6 stubs (generated; every entry warns once and counts) ------
+
+    void VulkanRendererAPI::Clear()
+    {
+        Phase6Stub("Clear");
+    }
+
+    void VulkanRendererAPI::ClearDepthOnly()
+    {
+        Phase6Stub("ClearDepthOnly");
+    }
+
+    void VulkanRendererAPI::ClearColorAndDepth()
+    {
+        Phase6Stub("ClearColorAndDepth");
+    }
+
+    void VulkanRendererAPI::DrawArrays(const Ref<VertexArray>& /*vertexArray*/, u32 /*vertexCount*/)
+    {
+        Phase6Stub("DrawArrays");
+    }
+
+    void VulkanRendererAPI::DrawIndexed(const Ref<VertexArray>& /*vertexArray*/, u32 /*indexCount*/)
+    {
+        Phase6Stub("DrawIndexed");
+    }
+
+    void VulkanRendererAPI::DrawIndexedInstanced(const Ref<VertexArray>& /*vertexArray*/, u32 /*indexCount*/, u32 /*instanceCount*/)
+    {
+        Phase6Stub("DrawIndexedInstanced");
+    }
+
+    void VulkanRendererAPI::DrawLines(const Ref<VertexArray>& /*vertexArray*/, u32 /*vertexCount*/)
+    {
+        Phase6Stub("DrawLines");
+    }
+
+    void VulkanRendererAPI::DrawIndexedPatches(const Ref<VertexArray>& /*vertexArray*/, u32 /*indexCount*/, u32 /*patchVertices*/)
+    {
+        Phase6Stub("DrawIndexedPatches");
+    }
+
+    void VulkanRendererAPI::DrawIndexedRaw(RHI::ResourceHandle /*vertexArray*/, u32 /*indexCount*/)
+    {
+        Phase6Stub("DrawIndexedRaw");
+    }
+
+    void VulkanRendererAPI::DrawIndexedRaw(RHI::ResourceHandle /*vertexArray*/, u32 /*indexCount*/, u32 /*baseIndex*/)
+    {
+        Phase6Stub("DrawIndexedRaw");
+    }
+
+    void VulkanRendererAPI::DrawIndexedInstancedRaw(RHI::ResourceHandle /*vertexArray*/, u32 /*indexCount*/, u32 /*baseIndex*/, u32 /*instanceCount*/)
+    {
+        Phase6Stub("DrawIndexedInstancedRaw");
+    }
+
+    void VulkanRendererAPI::DrawIndexedPatchesRaw(RHI::ResourceHandle /*vertexArray*/, u32 /*indexCount*/, u32 /*patchVertices*/)
+    {
+        Phase6Stub("DrawIndexedPatchesRaw");
+    }
+
+    void VulkanRendererAPI::ClearStencil()
+    {
+        Phase6Stub("ClearStencil");
+    }
+
+    void VulkanRendererAPI::DrawElementsIndirect(const Ref<VertexArray>& /*vertexArray*/, RHI::ResourceHandle /*indirectBuffer*/)
+    {
+        Phase6Stub("DrawElementsIndirect");
+    }
+
+    void VulkanRendererAPI::DrawArraysIndirect(const Ref<VertexArray>& /*vertexArray*/, RHI::ResourceHandle /*indirectBuffer*/)
+    {
+        Phase6Stub("DrawArraysIndirect");
+    }
+
+    void VulkanRendererAPI::DrawBoundElementsIndirect(RHI::ResourceHandle /*indirectBuffer*/)
+    {
+        Phase6Stub("DrawBoundElementsIndirect");
+    }
+
+    void VulkanRendererAPI::MultiDrawElementsIndirectCountRaw(RHI::ResourceHandle /*vertexArray*/, RHI::ResourceHandle /*indirectBuffer*/, u32 /*indirectOffsetBytes*/, RHI::ResourceHandle /*parameterBuffer*/, u32 /*parameterOffsetBytes*/, u32 /*maxDrawCount*/, u32 /*strideBytes*/)
+    {
+        Phase6Stub("MultiDrawElementsIndirectCountRaw");
+    }
+
+    void VulkanRendererAPI::DispatchCompute(u32 /*groupsX*/, u32 /*groupsY*/, u32 /*groupsZ*/)
+    {
+        Phase6Stub("DispatchCompute");
+    }
+
+    void VulkanRendererAPI::BindDefaultFramebuffer()
+    {
+        Phase6Stub("BindDefaultFramebuffer");
+    }
+
+    void VulkanRendererAPI::BlitFramebufferToDefault(RHI::ResourceHandle /*srcFramebuffer*/, u32 /*width*/, u32 /*height*/)
+    {
+        Phase6Stub("BlitFramebufferToDefault");
+    }
+
+    void VulkanRendererAPI::BindTexture(u32 /*slot*/, RHI::ResourceHandle /*texture*/)
+    {
+        Phase6Stub("BindTexture");
+    }
+
+    void VulkanRendererAPI::BindImageTexture(u32 /*unit*/, RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/, bool /*layered*/, u32 /*layer*/, RHI::Access /*access*/, RHI::Format /*format*/)
+    {
+        Phase6Stub("BindImageTexture");
+    }
+
+    void VulkanRendererAPI::CopyImageSubData(RHI::ResourceHandle /*src*/, TextureTargetType /*srcTarget*/, RHI::ResourceHandle /*dst*/, TextureTargetType /*dstTarget*/, u32 /*width*/, u32 /*height*/)
+    {
+        Phase6Stub("CopyImageSubData");
+    }
+
+    void VulkanRendererAPI::CopyImageSubDataFull(RHI::ResourceHandle /*src*/, TextureTargetType /*srcTarget*/, i32 /*srcLevel*/, i32 /*srcZ*/, RHI::ResourceHandle /*dst*/, TextureTargetType /*dstTarget*/, i32 /*dstLevel*/, i32 /*dstZ*/, u32 /*width*/, u32 /*height*/)
+    {
+        Phase6Stub("CopyImageSubDataFull");
+    }
+
+    void VulkanRendererAPI::CopyFramebufferToTexture(RHI::ResourceHandle /*texture*/, u32 /*width*/, u32 /*height*/)
+    {
+        Phase6Stub("CopyFramebufferToTexture");
+    }
+
+    void VulkanRendererAPI::SetDrawBuffers(std::span<const u32> /*attachments*/)
+    {
+        Phase6Stub("SetDrawBuffers");
+    }
+
+    void VulkanRendererAPI::RestoreAllDrawBuffers(u32 /*colorAttachmentCount*/)
+    {
+        Phase6Stub("RestoreAllDrawBuffers");
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateDepthArrayCompareOffViewHandle(RHI::ResourceHandle /*srcTexture*/, u32 /*numLayers*/)
+    {
+        Phase6Stub("CreateDepthArrayCompareOffViewHandle");
+        return {};
+    }
+
+    void VulkanRendererAPI::SetTextureFilter(RHI::ResourceHandle /*texture*/, RHI::Filter /*minFilter*/, RHI::Filter /*magFilter*/)
+    {
+        Phase6Stub("SetTextureFilter");
+    }
+
+    void VulkanRendererAPI::SetTextureWrap(RHI::ResourceHandle /*texture*/, RHI::AddressMode /*wrap*/)
+    {
+        Phase6Stub("SetTextureWrap");
+    }
+
+    void VulkanRendererAPI::UploadTextureSubImage2D(RHI::ResourceHandle /*texture*/, u32 /*width*/, u32 /*height*/, RHI::Format /*sourceFormat*/, const void* /*data*/)
+    {
+        Phase6Stub("UploadTextureSubImage2D");
+    }
+
+    void VulkanRendererAPI::BeginConditionalRender(RHI::ResourceHandle /*query*/)
+    {
+        Phase6Stub("BeginConditionalRender");
+    }
+
+    void VulkanRendererAPI::EndConditionalRender()
+    {
+        Phase6Stub("EndConditionalRender");
+    }
+
+    void VulkanRendererAPI::BindUniformBuffer(u32 /*bindingPoint*/, RHI::ResourceHandle /*buffer*/)
+    {
+        Phase6Stub("BindUniformBuffer");
+    }
+
+    void VulkanRendererAPI::BindStorageBuffer(u32 /*bindingPoint*/, RHI::ResourceHandle /*buffer*/)
+    {
+        Phase6Stub("BindStorageBuffer");
+    }
+
+    void VulkanRendererAPI::BindShaderProgram(RHI::ResourceHandle /*program*/)
+    {
+        Phase6Stub("BindShaderProgram");
+    }
+
+    void VulkanRendererAPI::BindVertexArrayRaw(RHI::ResourceHandle /*vertexArray*/)
+    {
+        Phase6Stub("BindVertexArrayRaw");
+    }
+
+    void VulkanRendererAPI::BindFramebuffer(RHI::ResourceHandle /*framebuffer*/)
+    {
+        Phase6Stub("BindFramebuffer");
+    }
+
+    void VulkanRendererAPI::DrawBoundIndexed(RHI::PrimitiveTopology /*topology*/, u32 /*indexCount*/, RHI::IndexType /*indexType*/, u32 /*baseIndex*/)
+    {
+        Phase6Stub("DrawBoundIndexed");
+    }
+
+    void VulkanRendererAPI::DrawBoundIndexedInstanced(RHI::PrimitiveTopology /*topology*/, u32 /*indexCount*/, RHI::IndexType /*indexType*/, u32 /*baseIndex*/, u32 /*instanceCount*/)
+    {
+        Phase6Stub("DrawBoundIndexedInstanced");
+    }
+
+    void VulkanRendererAPI::DrawBoundArrays(RHI::PrimitiveTopology /*topology*/, u32 /*firstVertex*/, u32 /*vertexCount*/)
+    {
+        Phase6Stub("DrawBoundArrays");
+    }
+
+    void VulkanRendererAPI::AttachFramebufferColorTexture(RHI::ResourceHandle /*framebuffer*/, u32 /*attachmentIndex*/, RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/)
+    {
+        Phase6Stub("AttachFramebufferColorTexture");
+    }
+
+    void VulkanRendererAPI::AttachFramebufferDepthTexture(RHI::ResourceHandle /*framebuffer*/, RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/)
+    {
+        Phase6Stub("AttachFramebufferDepthTexture");
+    }
+
+    bool VulkanRendererAPI::IsFramebufferComplete(RHI::ResourceHandle /*framebuffer*/)
+    {
+        Phase6Stub("IsFramebufferComplete");
+        return false;
+    }
+
+    void VulkanRendererAPI::SetFramebufferDrawAttachments(RHI::ResourceHandle /*framebuffer*/, std::span<const u32> /*attachmentIndices*/)
+    {
+        Phase6Stub("SetFramebufferDrawAttachments");
+    }
+
+    void VulkanRendererAPI::RestoreAllFramebufferDrawAttachments(RHI::ResourceHandle /*framebuffer*/, u32 /*colorAttachmentCount*/)
+    {
+        Phase6Stub("RestoreAllFramebufferDrawAttachments");
+    }
+
+    void VulkanRendererAPI::SetFramebufferReadAttachment(RHI::ResourceHandle /*framebuffer*/, u32 /*attachmentIndex*/)
+    {
+        Phase6Stub("SetFramebufferReadAttachment");
+    }
+
+    void VulkanRendererAPI::ClearFramebufferColorAttachment(RHI::ResourceHandle /*framebuffer*/, u32 /*attachmentIndex*/, const glm::vec4& /*color*/)
+    {
+        Phase6Stub("ClearFramebufferColorAttachment");
+    }
+
+    void VulkanRendererAPI::ClearFramebufferDepth(RHI::ResourceHandle /*framebuffer*/, f32 /*depth*/)
+    {
+        Phase6Stub("ClearFramebufferDepth");
+    }
+
+    void VulkanRendererAPI::BlitFramebuffer(RHI::ResourceHandle /*srcFramebuffer*/, RHI::ResourceHandle /*dstFramebuffer*/, i32 /*srcX0*/, i32 /*srcY0*/, i32 /*srcX1*/, i32 /*srcY1*/, i32 /*dstX0*/, i32 /*dstY0*/, i32 /*dstX1*/, i32 /*dstY1*/, RHI::BlitAspect /*aspect*/, RHI::Filter /*filter*/)
+    {
+        Phase6Stub("BlitFramebuffer");
+    }
+
+    void VulkanRendererAPI::AllocateBufferStorage(RHI::ResourceHandle /*buffer*/, u64 /*sizeBytes*/, RHI::MemoryResidency /*residency*/)
+    {
+        Phase6Stub("AllocateBufferStorage");
+    }
+
+    void* VulkanRendererAPI::AllocatePersistentUploadStorage(RHI::ResourceHandle /*buffer*/, u64 /*sizeBytes*/)
+    {
+        Phase6Stub("AllocatePersistentUploadStorage");
+        return nullptr;
+    }
+
+    void VulkanRendererAPI::UnmapBuffer(RHI::ResourceHandle /*buffer*/)
+    {
+        Phase6Stub("UnmapBuffer");
+    }
+
+    void VulkanRendererAPI::UploadBufferSubData(RHI::ResourceHandle /*buffer*/, u64 /*offsetBytes*/, u64 /*sizeBytes*/, const void* /*data*/)
+    {
+        Phase6Stub("UploadBufferSubData");
+    }
+
+    void VulkanRendererAPI::ReadBufferSubData(RHI::ResourceHandle /*buffer*/, u64 /*offsetBytes*/, u64 /*sizeBytes*/, void* /*dest*/)
+    {
+        Phase6Stub("ReadBufferSubData");
+    }
+
+    void VulkanRendererAPI::CopyBufferSubData(RHI::ResourceHandle /*srcBuffer*/, RHI::ResourceHandle /*dstBuffer*/, u64 /*srcOffsetBytes*/, u64 /*dstOffsetBytes*/, u64 /*sizeBytes*/)
+    {
+        Phase6Stub("CopyBufferSubData");
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateTexture2DHandle(u32 /*width*/, u32 /*height*/, RHI::Format /*internalFormat*/)
+    {
+        Phase6Stub("CreateTexture2DHandle");
+        return {};
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateTextureCubemapHandle(u32 /*width*/, u32 /*height*/, RHI::Format /*internalFormat*/)
+    {
+        Phase6Stub("CreateTextureCubemapHandle");
+        return {};
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateFramebufferHandle()
+    {
+        Phase6Stub("CreateFramebufferHandle");
+        return {};
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateBufferHandle()
+    {
+        Phase6Stub("CreateBufferHandle");
+        return {};
+    }
+
+    RHI::ResourceHandle VulkanRendererAPI::CreateVertexArrayHandle()
+    {
+        Phase6Stub("CreateVertexArrayHandle");
+        return {};
+    }
+
+    void VulkanRendererAPI::DeleteTexture(RHI::ResourceHandle /*texture*/)
+    {
+        Phase6Stub("DeleteTexture");
+    }
+
+    void VulkanRendererAPI::DeleteFramebuffer(RHI::ResourceHandle /*framebuffer*/)
+    {
+        Phase6Stub("DeleteFramebuffer");
+    }
+
+    void VulkanRendererAPI::DeleteBuffer(RHI::ResourceHandle /*buffer*/)
+    {
+        Phase6Stub("DeleteBuffer");
+    }
+
+    void VulkanRendererAPI::DeleteVertexArray(RHI::ResourceHandle /*vertexArray*/)
+    {
+        Phase6Stub("DeleteVertexArray");
+    }
+
+    void VulkanRendererAPI::SetVertexArrayIndexBuffer(RHI::ResourceHandle /*vertexArray*/, RHI::ResourceHandle /*indexBuffer*/)
+    {
+        Phase6Stub("SetVertexArrayIndexBuffer");
+    }
+
+    void VulkanRendererAPI::UploadTextureSubImage2D(RHI::ResourceHandle /*texture*/, i32 /*xOffset*/, i32 /*yOffset*/, u32 /*width*/, u32 /*height*/, RHI::Format /*sourceFormat*/, const void* /*data*/)
+    {
+        Phase6Stub("UploadTextureSubImage2D");
+    }
+
+    void VulkanRendererAPI::UploadTextureSubImage3D(RHI::ResourceHandle /*texture*/, i32 /*xOffset*/, i32 /*yOffset*/, i32 /*zOffset*/, u32 /*width*/, u32 /*height*/, u32 /*depth*/, RHI::Format /*sourceFormat*/, const void* /*data*/)
+    {
+        Phase6Stub("UploadTextureSubImage3D");
+    }
+
+    bool VulkanRendererAPI::ReadTextureImage(RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/, RHI::Format /*destFormat*/, sizet /*destSizeBytes*/, void* /*dest*/)
+    {
+        Phase6Stub("ReadTextureImage");
+        return false;
+    }
+
+    bool VulkanRendererAPI::ReadTextureSubImage(RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/, i32 /*x*/, i32 /*y*/, i32 /*z*/, u32 /*width*/, u32 /*height*/, u32 /*depth*/, RHI::Format /*destFormat*/, sizet /*destSizeBytes*/, void* /*dest*/)
+    {
+        Phase6Stub("ReadTextureSubImage");
+        return false;
+    }
+
+    void VulkanRendererAPI::GetTextureDimensions(RHI::ResourceHandle /*texture*/, u32 /*mipLevel*/, u32& /*outWidth*/, u32& /*outHeight*/)
+    {
+        Phase6Stub("GetTextureDimensions");
+    }
+
+    void VulkanRendererAPI::TextureBarrier()
+    {
+        Phase6Stub("TextureBarrier");
+    }
+
+    void VulkanRendererAPI::CreateQueries(RHI::QueryType /*type*/, std::span<RHI::ResourceHandle> /*outQueries*/)
+    {
+        Phase6Stub("CreateQueries");
+    }
+
+    void VulkanRendererAPI::DeleteQueries(std::span<const RHI::ResourceHandle> /*queries*/)
+    {
+        Phase6Stub("DeleteQueries");
+    }
+
+    void VulkanRendererAPI::BeginQuery(RHI::QueryType /*type*/, RHI::ResourceHandle /*query*/)
+    {
+        Phase6Stub("BeginQuery");
+    }
+
+    void VulkanRendererAPI::EndQuery(RHI::QueryType /*type*/)
+    {
+        Phase6Stub("EndQuery");
+    }
+
+    bool VulkanRendererAPI::IsQueryResultAvailable(RHI::ResourceHandle /*query*/)
+    {
+        Phase6Stub("IsQueryResultAvailable");
+        return false;
+    }
+
+    u32 VulkanRendererAPI::GetQueryResultU32(RHI::ResourceHandle /*query*/)
+    {
+        Phase6Stub("GetQueryResultU32");
+        return 0;
+    }
+
+    u64 VulkanRendererAPI::GetQueryResultU64(RHI::ResourceHandle /*query*/)
+    {
+        Phase6Stub("GetQueryResultU64");
+        return 0;
+    }
+
+    u64 VulkanRendererAPI::CreateFence()
+    {
+        Phase6Stub("CreateFence");
+        return 0;
+    }
+
+    RHI::FenceStatus VulkanRendererAPI::ClientWaitFence(u64 /*fence*/, u64 /*timeoutNanoseconds*/)
+    {
+        Phase6Stub("ClientWaitFence");
+        return RHI::FenceStatus::ConditionSatisfied;
+    }
+
+    bool VulkanRendererAPI::IsFenceSignaled(u64 /*fence*/)
+    {
+        Phase6Stub("IsFenceSignaled");
+        return false;
+    }
+
+    void VulkanRendererAPI::DestroyFence(u64 /*fence*/)
+    {
+        Phase6Stub("DestroyFence");
+    }
+
+    void VulkanRendererAPI::SetProgramUniformFloat(RHI::ResourceHandle /*program*/, std::string_view /*name*/, f32 /*value*/)
+    {
+        Phase6Stub("SetProgramUniformFloat");
+    }
+
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -256,16 +256,20 @@ namespace OloEngine
             // splits it into runs of equal current layout so oldLayout is
             // EXACT per emitted barrier — one guessed layout for a mixed
             // range is precisely the class of bug sync validation exists for.
+            // Finite counts clamp to [1, remaining] — an explicit zero count
+            // is a malformed declaration, and BuildImageBarrier already
+            // treats it as 1-wide; the tracker query must agree or the two
+            // silently disagree about whether a barrier exists at all.
             VkImageSubresourceRange queryRange{};
             queryRange.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
             queryRange.baseMipLevel = std::min(barrier.Range.BaseMip, mipCount - 1u);
             queryRange.levelCount = (barrier.Range.MipCount == RHI::SubresourceRange::AllRemaining)
                                         ? VK_REMAINING_MIP_LEVELS
-                                        : std::min(barrier.Range.MipCount, mipCount - queryRange.baseMipLevel);
+                                        : std::max(std::min(barrier.Range.MipCount, mipCount - queryRange.baseMipLevel), 1u);
             queryRange.baseArrayLayer = std::min(barrier.Range.BaseLayer, layerCount - 1u);
             queryRange.layerCount = (barrier.Range.LayerCount == RHI::SubresourceRange::AllRemaining)
                                         ? VK_REMAINING_ARRAY_LAYERS
-                                        : std::min(barrier.Range.LayerCount, layerCount - queryRange.baseArrayLayer);
+                                        : std::max(std::min(barrier.Range.LayerCount, layerCount - queryRange.baseArrayLayer), 1u);
 
             m_LayoutTracker.ForEachLayoutRun(
                 image, queryRange,

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -185,6 +185,13 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // The enabled-stage narrowing below depends on the device's feature
+        // set, and this instance may have been constructed before the device
+        // existed (RecreateForSelectedBackend runs pre-window, and Init() is
+        // skipped while Renderer::Init is). CacheDeviceLimits early-outs once
+        // cached, so this is a no-op on the steady path.
+        CacheDeviceLimits();
+
         if (m_Cmd == VK_NULL_HANDLE)
         {
             if (flags != MemoryBarrierFlags::None || !barriers.empty())
@@ -196,13 +203,23 @@ namespace OloEngine
         std::vector<VkBufferMemoryBarrier2> bufferBarriers;
         imageBarriers.reserve(barriers.size());
 
+        // Barriers that cannot resolve to a native object (stale/dead/foreign
+        // handles, non-Vulkan images in a mixed-currency graph) must not
+        // silently drop the synchronisation the batch promised for them — a
+        // resolved-only batch would order SOME of the pass's inputs and race
+        // the rest. They fall back to the conservative global barrier below.
+        bool anyUnresolved = false;
+
         auto& registry = RHI::ResourceRegistry::Get();
         for (const auto& barrier : barriers)
         {
             const auto kind = registry.KindOf(barrier.Resource);
             const u64 native = registry.ResolveNativeForBackend(barrier.Resource);
             if (native == 0u)
-                continue; // stale/dead/foreign handle — degrades to "no barrier", never to garbage
+            {
+                anyUnresolved = true; // degrades to the global fallback, never to garbage
+                continue;
+            }
 
             if (kind == RHI::ResourceKind::Buffer)
             {
@@ -213,15 +230,21 @@ namespace OloEngine
                 continue;
             }
             if (kind != RHI::ResourceKind::Texture)
+            {
+                anyUnresolved = true;
                 continue;
+            }
 
             const auto image = reinterpret_cast<VkImage>(native);
             const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
             if (!info)
-                continue; // not a Vulkan-backend image (mixed-currency graph)
+            {
+                anyUnresolved = true; // not a Vulkan-backend image (mixed-currency graph)
+                continue;
+            }
 
             const auto aspect = AspectFromInfo(*info);
-            m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+            m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
 
             // The neutral range, clamped into Vk terms once; the tracker then
             // splits it into runs of equal current layout so oldLayout is
@@ -262,14 +285,23 @@ namespace OloEngine
         VkDependencyInfo dep{};
         dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
 
-        if (imageBarriers.empty() && bufferBarriers.empty())
+        // The conservative global barrier fires whenever the per-resource set
+        // is INCOMPLETE: a flags-only batch (no transitions at all), or a
+        // MIXED batch where some operands could not resolve — the flags
+        // promised synchronisation for those too, and one dependency info can
+        // carry the global barrier alongside the resolved image/buffer
+        // barriers (execution+memory coverage for the unresolved remainder;
+        // layout transitions for them stay impossible without a native image,
+        // which is exactly why a Vulkan graph must import by handle).
+        const bool needsGlobalFallback =
+            flags != MemoryBarrierFlags::None &&
+            (anyUnresolved || (imageBarriers.empty() && bufferBarriers.empty()));
+
+        if (!needsGlobalFallback && imageBarriers.empty() && bufferBarriers.empty())
+            return;
+
+        if (needsGlobalFallback)
         {
-            // Nothing resolved to a per-resource barrier (flags-only batch,
-            // or every operand was a native-only import). The synchronisation
-            // the GL flags promised must still happen: one conservative
-            // global barrier.
-            if (flags == MemoryBarrierFlags::None)
-                return;
             globalBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2;
             globalBarrier.srcStageMask = kAllStages;
             globalBarrier.srcAccessMask = kAllAccess;
@@ -278,13 +310,10 @@ namespace OloEngine
             dep.memoryBarrierCount = 1;
             dep.pMemoryBarriers = &globalBarrier;
         }
-        else
-        {
-            dep.imageMemoryBarrierCount = static_cast<u32>(imageBarriers.size());
-            dep.pImageMemoryBarriers = imageBarriers.data();
-            dep.bufferMemoryBarrierCount = static_cast<u32>(bufferBarriers.size());
-            dep.pBufferMemoryBarriers = bufferBarriers.data();
-        }
+        dep.imageMemoryBarrierCount = static_cast<u32>(imageBarriers.size());
+        dep.pImageMemoryBarriers = imageBarriers.empty() ? nullptr : imageBarriers.data();
+        dep.bufferMemoryBarrierCount = static_cast<u32>(bufferBarriers.size());
+        dep.pBufferMemoryBarriers = bufferBarriers.empty() ? nullptr : bufferBarriers.data();
 
         vkCmdPipelineBarrier2(m_Cmd, &dep);
     }
@@ -309,7 +338,7 @@ namespace OloEngine
             return;
 
         const auto aspect = AspectFromInfo(*info);
-        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
 
         VkImageSubresourceRange range{};
         range.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
@@ -382,7 +411,7 @@ namespace OloEngine
         if (!info || info->HasDepth || info->HasStencil)
             return; // a uint clear of a depth image has no meaning
 
-        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers);
+        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
 
         VkImageSubresourceRange range{};
         range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -57,27 +57,29 @@ namespace OloEngine
         vkGetPhysicalDeviceProperties(device->GetPhysicalDevice(), &props);
         m_MaxUniformBlockSize = props.limits.maxUniformBufferRange;
 
-        const VkSampleCountFlags counts = props.limits.framebufferColorSampleCounts &
-                                          props.limits.framebufferDepthSampleCounts;
-        m_MaxSamples = 1;
-        for (const VkSampleCountFlagBits bit : { VK_SAMPLE_COUNT_64_BIT, VK_SAMPLE_COUNT_32_BIT,
-                                                 VK_SAMPLE_COUNT_16_BIT, VK_SAMPLE_COUNT_8_BIT,
-                                                 VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_2_BIT })
+        // Three DISTINCT caps, mirroring the GL getters they implement:
+        // framebuffer = the color∩depth attachment intersection (a framebuffer
+        // carries both), while the per-kind texture caps come from the
+        // sampled-image limits.
+        const auto highestBit = [](const VkSampleCountFlags counts) -> u32
         {
-            if (counts & bit)
+            for (const VkSampleCountFlagBits bit : { VK_SAMPLE_COUNT_64_BIT, VK_SAMPLE_COUNT_32_BIT,
+                                                     VK_SAMPLE_COUNT_16_BIT, VK_SAMPLE_COUNT_8_BIT,
+                                                     VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_2_BIT })
             {
-                m_MaxSamples = static_cast<u32>(bit);
-                break;
+                if (counts & bit)
+                    return static_cast<u32>(bit);
             }
-        }
+            return 1u;
+        };
+        m_MaxFramebufferSamples = highestBit(props.limits.framebufferColorSampleCounts &
+                                             props.limits.framebufferDepthSampleCounts);
+        m_MaxColorTextureSamples = highestBit(props.limits.sampledImageColorSampleCounts);
+        m_MaxDepthTextureSamples = highestBit(props.limits.sampledImageDepthSampleCounts);
 
-        VkPhysicalDeviceShaderAtomicInt64Features atomics{};
-        atomics.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
-        VkPhysicalDeviceFeatures2 features2{};
-        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-        features2.pNext = &atomics;
-        vkGetPhysicalDeviceFeatures2(device->GetPhysicalDevice(), &features2);
-        m_SupportsInt64Atomics = atomics.shaderBufferInt64Atomics == VK_TRUE;
+        // ENABLED on the logical device, not merely supported by the physical
+        // one — a shader can only use what vkCreateDevice turned on.
+        m_SupportsInt64Atomics = device->IsShaderBufferInt64AtomicsEnabled();
 
         // VUID-…-03929/-03930: a barrier stage mask may only name stages
         // whose device features are enabled.
@@ -122,6 +124,10 @@ namespace OloEngine
 
         // Negative-height flip is a Phase 6 (pipeline/pass) concern; Phase 5
         // records the plain rect so state packets replay without error.
+        // Deliberately does NOT touch the scissor: glViewport never did, and
+        // deriving one here would clobber an explicit SetScissorBox. A draw
+        // with dynamic scissor state and no scissor set is Phase 6's pipeline
+        // setup to default.
         VkViewport vp{};
         vp.x = static_cast<f32>(x);
         vp.y = static_cast<f32>(y);
@@ -130,11 +136,6 @@ namespace OloEngine
         vp.minDepth = 0.0f;
         vp.maxDepth = 1.0f;
         vkCmdSetViewport(m_Cmd, 0, 1, &vp);
-
-        VkRect2D scissor{};
-        scissor.offset = { static_cast<i32>(x), static_cast<i32>(y) };
-        scissor.extent = { width, height };
-        vkCmdSetScissor(m_Cmd, 0, 1, &scissor);
     }
 
     Viewport VulkanRendererAPI::GetViewport() const
@@ -244,7 +245,12 @@ namespace OloEngine
             }
 
             const auto aspect = AspectFromInfo(*info);
-            m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
+            // Normalized extents: a registry entry with 0 mips/layers (no
+            // producer writes one today, but the struct cannot forbid it)
+            // would underflow every `- 1u`/`- base` below.
+            const u32 mipCount = std::max(info->MipLevels, 1u);
+            const u32 layerCount = std::max(info->ArrayLayers, 1u);
+            m_LayoutTracker.RegisterImage(image, mipCount, layerCount, info->RegistrationId);
 
             // The neutral range, clamped into Vk terms once; the tracker then
             // splits it into runs of equal current layout so oldLayout is
@@ -252,21 +258,21 @@ namespace OloEngine
             // range is precisely the class of bug sync validation exists for.
             VkImageSubresourceRange queryRange{};
             queryRange.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
-            queryRange.baseMipLevel = std::min(barrier.Range.BaseMip, info->MipLevels - 1u);
+            queryRange.baseMipLevel = std::min(barrier.Range.BaseMip, mipCount - 1u);
             queryRange.levelCount = (barrier.Range.MipCount == RHI::SubresourceRange::AllRemaining)
                                         ? VK_REMAINING_MIP_LEVELS
-                                        : std::min(barrier.Range.MipCount, info->MipLevels - queryRange.baseMipLevel);
-            queryRange.baseArrayLayer = std::min(barrier.Range.BaseLayer, info->ArrayLayers - 1u);
+                                        : std::min(barrier.Range.MipCount, mipCount - queryRange.baseMipLevel);
+            queryRange.baseArrayLayer = std::min(barrier.Range.BaseLayer, layerCount - 1u);
             queryRange.layerCount = (barrier.Range.LayerCount == RHI::SubresourceRange::AllRemaining)
                                         ? VK_REMAINING_ARRAY_LAYERS
-                                        : std::min(barrier.Range.LayerCount, info->ArrayLayers - queryRange.baseArrayLayer);
+                                        : std::min(barrier.Range.LayerCount, layerCount - queryRange.baseArrayLayer);
 
             m_LayoutTracker.ForEachLayoutRun(
                 image, queryRange,
                 [&](const VkImageSubresourceRange& run, const VkImageLayout trackedLayout)
                 {
                     auto vkBarrier = VulkanBarrierLowering::BuildImageBarrier(barrier, image, aspect, trackedLayout,
-                                                                              info->MipLevels, info->ArrayLayers);
+                                                                              mipCount, layerCount);
                     vkBarrier.subresourceRange = run;
                     // The pure lowering emits the full shader-stage union;
                     // the device knows which stage features are ENABLED
@@ -343,11 +349,12 @@ namespace OloEngine
             return;
 
         const auto aspect = AspectFromInfo(*info);
-        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
+        const u32 mipCount = std::max(info->MipLevels, 1u); // 0-extent guard, see IssueBarrierBatch
+        m_LayoutTracker.RegisterImage(image, mipCount, std::max(info->ArrayLayers, 1u), info->RegistrationId);
 
         VkImageSubresourceRange range{};
         range.aspectMask = VulkanBarrierLowering::AspectMaskFor(aspect);
-        range.baseMipLevel = std::min(mipLevel, info->MipLevels - 1u);
+        range.baseMipLevel = std::min(mipLevel, mipCount - 1u);
         range.levelCount = 1;
         range.baseArrayLayer = 0;
         range.layerCount = VK_REMAINING_ARRAY_LAYERS;
@@ -416,11 +423,12 @@ namespace OloEngine
         if (!info || info->HasDepth || info->HasStencil)
             return; // a uint clear of a depth image has no meaning
 
-        m_LayoutTracker.RegisterImage(image, info->MipLevels, info->ArrayLayers, info->RegistrationId);
+        const u32 mipCount = std::max(info->MipLevels, 1u); // 0-extent guard, see IssueBarrierBatch
+        m_LayoutTracker.RegisterImage(image, mipCount, std::max(info->ArrayLayers, 1u), info->RegistrationId);
 
         VkImageSubresourceRange range{};
         range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        range.baseMipLevel = std::min(mipLevel, info->MipLevels - 1u);
+        range.baseMipLevel = std::min(mipLevel, mipCount - 1u);
         range.levelCount = 1;
         range.baseArrayLayer = 0;
         range.layerCount = VK_REMAINING_ARRAY_LAYERS;
@@ -564,19 +572,19 @@ namespace OloEngine
     u32 VulkanRendererAPI::GetMaxFramebufferSamples() const
     {
         const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
-        return m_MaxSamples;
+        return m_MaxFramebufferSamples;
     }
 
     u32 VulkanRendererAPI::GetMaxColorTextureSamples() const
     {
         const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
-        return m_MaxSamples;
+        return m_MaxColorTextureSamples;
     }
 
     u32 VulkanRendererAPI::GetMaxDepthTextureSamples() const
     {
         const_cast<VulkanRendererAPI*>(this)->CacheDeviceLimits();
-        return m_MaxSamples;
+        return m_MaxDepthTextureSamples;
     }
 
     // --- Recorded pipeline-key state (see VulkanRecordedPipelineState) -----
@@ -1158,7 +1166,10 @@ namespace OloEngine
     RHI::FenceStatus VulkanRendererAPI::ClientWaitFence(u64 /*fence*/, u64 /*timeoutNanoseconds*/)
     {
         Phase6Stub("ClientWaitFence");
-        return RHI::FenceStatus::ConditionSatisfied;
+        // Failed, not ConditionSatisfied: a stub must not claim GPU work
+        // completed (consistent with IsFenceSignaled() returning false — a
+        // caller gating a readback on this would consume garbage).
+        return RHI::FenceStatus::Failed;
     }
 
     bool VulkanRendererAPI::IsFenceSignaled(u64 /*fence*/)

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -446,11 +446,10 @@ namespace OloEngine
         vkCmdPipelineBarrier2(m_Cmd, &dep);
         m_LayoutTracker.SetLayout(image, range, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-        VkClearColorValue clear{};
-        clear.uint32[0] = value;
-        clear.uint32[1] = value;
-        clear.uint32[2] = value;
-        clear.uint32[3] = value;
+        // Designated init ACTIVATES the union's uint32 member — value-init
+        // (`{}`) would activate float32 (the first member) and make these
+        // writes inactive-member accesses.
+        const VkClearColorValue clear{ .uint32 = { value, value, value, value } };
         vkCmdClearColorImage(m_Cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
     }
 

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -293,9 +293,14 @@ namespace OloEngine
         // barriers (execution+memory coverage for the unresolved remainder;
         // layout transitions for them stay impossible without a native image,
         // which is exactly why a Vulkan graph must import by handle).
+        // `anyUnresolved` forces the fallback INDEPENDENTLY of the flags:
+        // today a None-flags barrier is always an external no-producer
+        // transition (nothing to order), but that is an invariant of the
+        // planner, not of this function — a future None-flags barrier kind
+        // with a real producer must degrade to over-sync, never to a race.
         const bool needsGlobalFallback =
-            flags != MemoryBarrierFlags::None &&
-            (anyUnresolved || (imageBarriers.empty() && bufferBarriers.empty()));
+            anyUnresolved ||
+            (flags != MemoryBarrierFlags::None && imageBarriers.empty() && bufferBarriers.empty());
 
         if (!needsGlobalFallback && imageBarriers.empty() && bufferBarriers.empty())
             return;

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
@@ -268,7 +268,9 @@ namespace OloEngine
 
         // Cached at Init() from the physical device.
         u32 m_MaxUniformBlockSize = 16384;
-        u32 m_MaxSamples = 1;
+        u32 m_MaxFramebufferSamples = 1;
+        u32 m_MaxColorTextureSamples = 1;
+        u32 m_MaxDepthTextureSamples = 1;
         bool m_SupportsInt64Atomics = false;
         bool m_LimitsCached = false;
         // Barrier stage masks may only name stages whose device features are

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
@@ -1,0 +1,285 @@
+#pragma once
+
+// =============================================================================
+// VulkanRendererAPI — the Vulkan implementation of the RendererAPI facade
+// (issue #691 Phase 5).
+//
+// Phase 5 scope: the render graph's EXECUTION layer — barrier batches
+// (IssueBarrierBatch via VulkanBarrierLowering + the layout tracker),
+// transient clears (the poison instrument's ClearTexture*/ClearBuffer*),
+// dynamic viewport/scissor, device queries, and debug labels. Everything
+// pipeline-shaped (draws, shader binds, buffer lifecycle, queries, fences)
+// is a WARN-ONCE stub naming Phase 6 — deliberately loud, never silent,
+// which is what ADR 0011 amendment (42) demanded of the first
+// VulkanRendererAPI ("~100 no-op virtuals inviting silent fallthrough" was
+// the reason Phase 4 refused to build one; the stubs' warn-once counters are
+// the mitigation).
+//
+// Recording model: Vulkan has no GL-style implicit current context — every
+// vkCmd* needs a live VkCommandBuffer. Whoever drives execution (the
+// device-gated execution test now, VulkanContext's frame loop when the graph
+// is wired into it) brackets work in BeginRecording/EndRecording. A
+// recording-dependent entry point called outside a bracket warn-once skips.
+// =============================================================================
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+#include "OloEngine/Renderer/RendererAPI.h"
+#include "Platform/Vulkan/VulkanImageLayoutTracker.h"
+
+#include <volk.h>
+
+#include <string>
+#include <unordered_set>
+
+namespace OloEngine
+{
+    // Pipeline-key state recorded from the facade's state-setter entry
+    // points. Vulkan bakes nearly all of this into the VkPipeline, so
+    // Phase 5 RECORDS it for Phase 6's pipeline-key derivation instead of
+    // stubbing the setters — a state packet is a real dispatch, not a
+    // Phase 6 loss (the execution test pins that state packets never touch
+    // the stub counter).
+    struct VulkanRecordedPipelineState
+    {
+        static constexpr u32 kMaxAttachments = 8;
+
+        glm::vec4 ClearColor{ 0.0f };
+        f32 ClearDepth = 1.0f;
+        bool DepthTest = true;
+        bool DepthWrite = true;
+        RHI::CompareOp DepthFunc = RHI::CompareOp::Less;
+        bool Blend = false;
+        RHI::BlendFactor BlendSrcRGB = RHI::BlendFactor::One;
+        RHI::BlendFactor BlendDstRGB = RHI::BlendFactor::Zero;
+        RHI::BlendFactor BlendSrcAlpha = RHI::BlendFactor::One;
+        RHI::BlendFactor BlendDstAlpha = RHI::BlendFactor::Zero;
+        RHI::BlendOp BlendEquation = RHI::BlendOp::Add;
+        bool StencilTest = false;
+        RHI::CompareOp StencilFunc = RHI::CompareOp::Always;
+        i32 StencilRef = 0;
+        u32 StencilReadMask = 0xFFFFFFFFu;
+        u32 StencilWriteMask = 0xFFFFFFFFu;
+        RHI::StencilOp StencilFail = RHI::StencilOp::Keep;
+        RHI::StencilOp StencilDepthFail = RHI::StencilOp::Keep;
+        RHI::StencilOp StencilPass = RHI::StencilOp::Keep;
+        bool Culling = false;
+        RHI::CullMode CullFace = RHI::CullMode::Back;
+        RHI::FrontFace FrontFaceWinding = RHI::FrontFace::CounterClockwise;
+        RHI::PolygonMode PolygonMode = RHI::PolygonMode::Fill;
+        bool PolygonOffsetEnabled = false;
+        f32 PolygonOffsetFactor = 0.0f;
+        f32 PolygonOffsetUnits = 0.0f;
+        bool ScissorTest = false;
+        bool Multisampling = true;
+        f32 LineWidth = 1.0f;
+        bool ColorMask[4] = { true, true, true, true };
+        u32 PatchVertexCount = 3;
+
+        bool AttachmentBlend[kMaxAttachments] = {};
+        RHI::BlendFactor AttachmentBlendSrc[kMaxAttachments] = {};
+        RHI::BlendFactor AttachmentBlendDst[kMaxAttachments] = {};
+        u8 AttachmentColorMask[kMaxAttachments] = { 0xF, 0xF, 0xF, 0xF, 0xF, 0xF, 0xF, 0xF };
+    };
+
+    class VulkanRendererAPI : public RendererAPI
+    {
+      public:
+        VulkanRendererAPI() = default;
+        ~VulkanRendererAPI() override = default;
+
+        [[nodiscard]] const VulkanRecordedPipelineState& RecordedState() const
+        {
+            return m_State;
+        }
+
+        // --- Phase 5 recording bracket (backend-internal, not facade) -----
+        void BeginRecording(VkCommandBuffer cmd);
+        void EndRecording();
+        [[nodiscard]] VkCommandBuffer CurrentCommandBuffer() const
+        {
+            return m_Cmd;
+        }
+        [[nodiscard]] VulkanImageLayoutTracker& LayoutTracker()
+        {
+            return m_LayoutTracker;
+        }
+
+        // Observability for the execution test: how many packets/entry points
+        // hit a Phase 6 stub (nothing may fall through silently).
+        [[nodiscard]] u64 GetPhase6StubHitCount() const
+        {
+            return m_Phase6StubHits;
+        }
+
+        // --- RendererAPI ---------------------------------------------------
+        void Init() override;
+        void SetViewport(u32 x, u32 y, u32 width, u32 height) override;
+        void SetClearColor(const glm::vec4& color) override;
+        void Clear() override;
+        void ClearDepthOnly() override;
+        void ClearColorAndDepth() override;
+        Viewport GetViewport() const override;
+        void DrawArrays(const Ref<VertexArray>& vertexArray, u32 vertexCount) override;
+        void DrawIndexed(const Ref<VertexArray>& vertexArray, u32 indexCount) override;
+        void DrawIndexedInstanced(const Ref<VertexArray>& vertexArray, u32 indexCount, u32 instanceCount) override;
+        void DrawLines(const Ref<VertexArray>& vertexArray, u32 vertexCount) override;
+        void DrawIndexedPatches(const Ref<VertexArray>& vertexArray, u32 indexCount, u32 patchVertices) override;
+        void DrawIndexedRaw(RHI::ResourceHandle vertexArray, u32 indexCount) override;
+        void DrawIndexedRaw(RHI::ResourceHandle vertexArray, u32 indexCount, u32 baseIndex) override;
+        void DrawIndexedInstancedRaw(RHI::ResourceHandle vertexArray, u32 indexCount, u32 baseIndex, u32 instanceCount) override;
+        void DrawIndexedPatchesRaw(RHI::ResourceHandle vertexArray, u32 indexCount, u32 patchVertices) override;
+        void SetLineWidth(f32 width) override;
+        void EnableCulling() override;
+        void DisableCulling() override;
+        void FrontCull() override;
+        void BackCull() override;
+        void SetCullFace(RHI::CullMode face) override;
+        void SetDepthMask(bool value) override;
+        void SetDepthTest(bool value) override;
+        void SetDepthFunc(RHI::CompareOp func) override;
+        void SetBlendState(bool value) override;
+        void SetBlendFunc(RHI::BlendFactor sfactor, RHI::BlendFactor dfactor) override;
+        void SetBlendEquation(RHI::BlendOp mode) override;
+        void EnableStencilTest() override;
+        void DisableStencilTest() override;
+        bool IsStencilTestEnabled() const override;
+        void SetStencilFunc(RHI::CompareOp func, i32 ref, u32 mask) override;
+        void SetStencilOp(RHI::StencilOp sfail, RHI::StencilOp dpfail, RHI::StencilOp dppass) override;
+        void SetStencilMask(u32 mask) override;
+        void ClearStencil() override;
+        void SetPolygonMode(RHI::PolygonMode mode) override;
+        void EnableScissorTest() override;
+        void DisableScissorTest() override;
+        void SetScissorBox(i32 x, i32 y, u32 width, u32 height) override;
+        void DrawElementsIndirect(const Ref<VertexArray>& vertexArray, RHI::ResourceHandle indirectBuffer) override;
+        void DrawArraysIndirect(const Ref<VertexArray>& vertexArray, RHI::ResourceHandle indirectBuffer) override;
+        void DrawBoundElementsIndirect(RHI::ResourceHandle indirectBuffer) override;
+        void MultiDrawElementsIndirectCountRaw(RHI::ResourceHandle vertexArray, RHI::ResourceHandle indirectBuffer, u32 indirectOffsetBytes, RHI::ResourceHandle parameterBuffer, u32 parameterOffsetBytes, u32 maxDrawCount, u32 strideBytes) override;
+        void DispatchCompute(u32 groupsX, u32 groupsY, u32 groupsZ) override;
+        void MemoryBarrier(MemoryBarrierFlags flags) override;
+        void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) override;
+        void BindDefaultFramebuffer() override;
+        void BlitFramebufferToDefault(RHI::ResourceHandle srcFramebuffer, u32 width, u32 height) override;
+        void BindTexture(u32 slot, RHI::ResourceHandle texture) override;
+        void BindImageTexture(u32 unit, RHI::ResourceHandle texture, u32 mipLevel, bool layered, u32 layer, RHI::Access access, RHI::Format format) override;
+        void SetPolygonOffset(f32 factor, f32 units) override;
+        void EnableMultisampling() override;
+        void DisableMultisampling() override;
+        void SetColorMask(bool red, bool green, bool blue, bool alpha) override;
+        void SetColorMaskForAttachment(u32 attachment, bool red, bool green, bool blue, bool alpha) override;
+        void SetBlendStateForAttachment(u32 attachment, bool enabled) override;
+        void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst) override;
+        void CopyImageSubData(RHI::ResourceHandle src, TextureTargetType srcTarget, RHI::ResourceHandle dst, TextureTargetType dstTarget, u32 width, u32 height) override;
+        void CopyImageSubDataFull(RHI::ResourceHandle src, TextureTargetType srcTarget, i32 srcLevel, i32 srcZ, RHI::ResourceHandle dst, TextureTargetType dstTarget, i32 dstLevel, i32 dstZ, u32 width, u32 height) override;
+        void CopyFramebufferToTexture(RHI::ResourceHandle texture, u32 width, u32 height) override;
+        void SetDrawBuffers(std::span<const u32> attachments) override;
+        void RestoreAllDrawBuffers(u32 colorAttachmentCount) override;
+        [[nodiscard]] RHI::ResourceHandle CreateDepthArrayCompareOffViewHandle(RHI::ResourceHandle srcTexture, u32 numLayers) override;
+        void SetTextureFilter(RHI::ResourceHandle texture, RHI::Filter minFilter, RHI::Filter magFilter) override;
+        void SetTextureWrap(RHI::ResourceHandle texture, RHI::AddressMode wrap) override;
+        void UploadTextureSubImage2D(RHI::ResourceHandle texture, u32 width, u32 height, RHI::Format sourceFormat, const void* data) override;
+        void BeginConditionalRender(RHI::ResourceHandle query) override;
+        void EndConditionalRender() override;
+        void BindUniformBuffer(u32 bindingPoint, RHI::ResourceHandle buffer) override;
+        void BindStorageBuffer(u32 bindingPoint, RHI::ResourceHandle buffer) override;
+        void BindShaderProgram(RHI::ResourceHandle program) override;
+        void BindVertexArrayRaw(RHI::ResourceHandle vertexArray) override;
+        void BindFramebuffer(RHI::ResourceHandle framebuffer) override;
+        void DrawBoundIndexed(RHI::PrimitiveTopology topology, u32 indexCount, RHI::IndexType indexType, u32 baseIndex) override;
+        void DrawBoundIndexedInstanced(RHI::PrimitiveTopology topology, u32 indexCount, RHI::IndexType indexType, u32 baseIndex, u32 instanceCount) override;
+        void DrawBoundArrays(RHI::PrimitiveTopology topology, u32 firstVertex, u32 vertexCount) override;
+        void SetPatchVertexCount(u32 patchVertices) override;
+        void SetFrontFace(RHI::FrontFace face) override;
+        void SetBlendFuncSeparate(RHI::BlendFactor srcRGB, RHI::BlendFactor dstRGB, RHI::BlendFactor srcAlpha, RHI::BlendFactor dstAlpha) override;
+        void SetClearDepth(f32 depth) override;
+        void AttachFramebufferColorTexture(RHI::ResourceHandle framebuffer, u32 attachmentIndex, RHI::ResourceHandle texture, u32 mipLevel) override;
+        void AttachFramebufferDepthTexture(RHI::ResourceHandle framebuffer, RHI::ResourceHandle texture, u32 mipLevel) override;
+        [[nodiscard("Store this!")]] bool IsFramebufferComplete(RHI::ResourceHandle framebuffer) override;
+        void SetFramebufferDrawAttachments(RHI::ResourceHandle framebuffer, std::span<const u32> attachmentIndices) override;
+        void RestoreAllFramebufferDrawAttachments(RHI::ResourceHandle framebuffer, u32 colorAttachmentCount) override;
+        void SetFramebufferReadAttachment(RHI::ResourceHandle framebuffer, u32 attachmentIndex) override;
+        void ClearFramebufferColorAttachment(RHI::ResourceHandle framebuffer, u32 attachmentIndex, const glm::vec4& color) override;
+        void ClearFramebufferDepth(RHI::ResourceHandle framebuffer, f32 depth) override;
+        void BlitFramebuffer(RHI::ResourceHandle srcFramebuffer, RHI::ResourceHandle dstFramebuffer, i32 srcX0, i32 srcY0, i32 srcX1, i32 srcY1, i32 dstX0, i32 dstY0, i32 dstX1, i32 dstY1, RHI::BlitAspect aspect, RHI::Filter filter) override;
+        void AllocateBufferStorage(RHI::ResourceHandle buffer, u64 sizeBytes, RHI::MemoryResidency residency) override;
+        void* AllocatePersistentUploadStorage(RHI::ResourceHandle buffer, u64 sizeBytes) override;
+        void UnmapBuffer(RHI::ResourceHandle buffer) override;
+        void UploadBufferSubData(RHI::ResourceHandle buffer, u64 offsetBytes, u64 sizeBytes, const void* data) override;
+        void ReadBufferSubData(RHI::ResourceHandle buffer, u64 offsetBytes, u64 sizeBytes, void* dest) override;
+        void CopyBufferSubData(RHI::ResourceHandle srcBuffer, RHI::ResourceHandle dstBuffer, u64 srcOffsetBytes, u64 dstOffsetBytes, u64 sizeBytes) override;
+        void ClearBufferUInt(RHI::ResourceHandle buffer, u32 value) override;
+        void ClearBufferFloat(RHI::ResourceHandle buffer, f32 value) override;
+        [[nodiscard]] RHI::ResourceHandle CreateTexture2DHandle(u32 width, u32 height, RHI::Format internalFormat) override;
+        [[nodiscard]] RHI::ResourceHandle CreateTextureCubemapHandle(u32 width, u32 height, RHI::Format internalFormat) override;
+        [[nodiscard]] RHI::ResourceHandle CreateFramebufferHandle() override;
+        [[nodiscard]] RHI::ResourceHandle CreateBufferHandle() override;
+        [[nodiscard]] RHI::ResourceHandle CreateVertexArrayHandle() override;
+        void DeleteTexture(RHI::ResourceHandle texture) override;
+        void DeleteFramebuffer(RHI::ResourceHandle framebuffer) override;
+        void DeleteBuffer(RHI::ResourceHandle buffer) override;
+        void DeleteVertexArray(RHI::ResourceHandle vertexArray) override;
+        void SetVertexArrayIndexBuffer(RHI::ResourceHandle vertexArray, RHI::ResourceHandle indexBuffer) override;
+        void ClearTextureFloat(RHI::ResourceHandle texture, u32 mipLevel, const glm::vec4& color) override;
+        void ClearTextureUInt(RHI::ResourceHandle texture, u32 mipLevel, u32 value) override;
+        void UploadTextureSubImage2D(RHI::ResourceHandle texture, i32 xOffset, i32 yOffset, u32 width, u32 height, RHI::Format sourceFormat, const void* data) override;
+        void UploadTextureSubImage3D(RHI::ResourceHandle texture, i32 xOffset, i32 yOffset, i32 zOffset, u32 width, u32 height, u32 depth, RHI::Format sourceFormat, const void* data) override;
+        [[nodiscard("Store this!")]] bool ReadTextureImage(RHI::ResourceHandle texture, u32 mipLevel, RHI::Format destFormat, sizet destSizeBytes, void* dest) override;
+        [[nodiscard("Store this!")]] bool ReadTextureSubImage(RHI::ResourceHandle texture, u32 mipLevel, i32 x, i32 y, i32 z, u32 width, u32 height, u32 depth, RHI::Format destFormat, sizet destSizeBytes, void* dest) override;
+        void GetTextureDimensions(RHI::ResourceHandle texture, u32 mipLevel, u32& outWidth, u32& outHeight) override;
+        void TextureBarrier() override;
+        void CreateQueries(RHI::QueryType type, std::span<RHI::ResourceHandle> outQueries) override;
+        void DeleteQueries(std::span<const RHI::ResourceHandle> queries) override;
+        void BeginQuery(RHI::QueryType type, RHI::ResourceHandle query) override;
+        void EndQuery(RHI::QueryType type) override;
+        [[nodiscard("Store this!")]] bool IsQueryResultAvailable(RHI::ResourceHandle query) override;
+        [[nodiscard("Store this!")]] u32 GetQueryResultU32(RHI::ResourceHandle query) override;
+        [[nodiscard("Store this!")]] u64 GetQueryResultU64(RHI::ResourceHandle query) override;
+        [[nodiscard("Store this!")]] u64 CreateFence() override;
+        [[nodiscard("Store this!")]] RHI::FenceStatus ClientWaitFence(u64 fence, u64 timeoutNanoseconds) override;
+        [[nodiscard("Store this!")]] bool IsFenceSignaled(u64 fence) override;
+        void DestroyFence(u64 fence) override;
+        void PushDebugGroup(u32 id, std::string_view label) override;
+        void PopDebugGroup() override;
+        void WaitForDeviceIdle() override;
+        [[nodiscard("Store this!")]] u32 GetMaxFramebufferSamples() const override;
+        [[nodiscard("Store this!")]] u32 GetMaxColorTextureSamples() const override;
+        [[nodiscard("Store this!")]] u32 GetMaxDepthTextureSamples() const override;
+        void SetProgramUniformFloat(RHI::ResourceHandle program, std::string_view name, f32 value) override;
+        [[nodiscard("Store this!")]] bool IsDeviceAvailable() const override;
+        [[nodiscard("Store this!")]] u32 GetMaxUniformBlockSize() const override;
+        [[nodiscard("Store this!")]] bool SupportsInt64ShaderAtomics() const override;
+
+      private:
+        // Const: several facade getters are const-qualified and still must
+        // count their stub hit (nothing may fall through silently).
+        void Phase6Stub(const char* entryPoint) const;
+
+        VkCommandBuffer m_Cmd = VK_NULL_HANDLE;
+        VulkanImageLayoutTracker m_LayoutTracker;
+        Viewport m_Viewport{};
+
+        mutable u64 m_Phase6StubHits = 0;
+        mutable std::unordered_set<std::string> m_WarnedStubs;
+
+        VulkanRecordedPipelineState m_State;
+
+        // Cached at Init() from the physical device.
+        u32 m_MaxUniformBlockSize = 16384;
+        u32 m_MaxSamples = 1;
+        bool m_SupportsInt64Atomics = false;
+        bool m_LimitsCached = false;
+        // Barrier stage masks may only name stages whose device features are
+        // ENABLED (VUID-…-03929/-03930): all-ones minus the tessellation /
+        // geometry bits when VulkanDevice did not enable those features.
+        // ANDed onto every per-resource barrier's stage masks; the catch-all
+        // bits (ALL_COMMANDS / ALL_TRANSFER) are single distinct bits and
+        // pass through untouched.
+        VkPipelineStageFlags2 m_EnabledStageMask = ~VkPipelineStageFlags2{ 0 };
+        void CacheDeviceLimits();
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
@@ -1,0 +1,834 @@
+#include "OloEnginePCH.h"
+
+#if OLO_WITH_VULKAN
+
+#include "Platform/Vulkan/VulkanTransientResources.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace OloEngine
+{
+    namespace
+    {
+        // Kept in sync with VulkanDevice.cpp's / VulkanContext.cpp's copies
+        // (all anonymous-namespace, trivially small — not worth a shared header).
+        void VkCheck(VkResult result, const char* what)
+        {
+            if (result != VK_SUCCESS)
+            {
+                throw std::runtime_error(std::string("Vulkan bring-up: ") + what + " failed (VkResult " +
+                                         std::to_string(static_cast<int>(result)) + ")");
+            }
+        }
+
+        // Non-dispatchable Vulkan handles are pointers on 64-bit builds and
+        // u64 on 32-bit ones — normalise either shape into the registry's u64.
+        template<typename T>
+        [[nodiscard]] u64 VkHandleToU64(T handle)
+        {
+            if constexpr (std::is_pointer_v<T>)
+            {
+                return static_cast<u64>(reinterpret_cast<std::uintptr_t>(handle));
+            }
+            else
+            {
+                return static_cast<u64>(handle);
+            }
+        }
+
+        // ImageFormat -> VkFormat. Every ImageFormat member is covered; the
+        // -Wswitch-with-no-default convention (ADR 0011) makes a new member a
+        // compile warning here rather than a silent VK_FORMAT_UNDEFINED.
+        //
+        // Widening choices (documented, deliberate):
+        //  - RGB8 / RGB32F widen to their RGBA siblings: 3-channel formats
+        //    have no mandated optimal-tiling sampled/attachment support.
+        //  - DEPTH24STENCIL8 maps to D32_SFLOAT_S8_UINT, not D24_UNORM_S8_UINT:
+        //    Vulkan mandates support for at least one of the two and AMD ships
+        //    only the D32 variant, so this is the portable pick (more depth
+        //    precision, same aspects). Format-feature querying is Phase 6.
+        //  - `srgb` is honoured only where the engine defines it (8-bit color
+        //    and BC7), matching TextureSpecification::SRGB's contract.
+        [[nodiscard]] VkFormat ImageFormatToVkFormat(ImageFormat format, bool srgb)
+        {
+            switch (format)
+            {
+                case ImageFormat::None:
+                    break;
+                case ImageFormat::R8:
+                    return VK_FORMAT_R8_UNORM;
+                case ImageFormat::R8UI:
+                    return VK_FORMAT_R8_UINT;
+                case ImageFormat::R16UI:
+                    return VK_FORMAT_R16_UINT;
+                case ImageFormat::RG16UI:
+                    return VK_FORMAT_R16G16_UINT;
+                case ImageFormat::RGB8:
+                    return srgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
+                case ImageFormat::RGBA8:
+                    return srgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
+                case ImageFormat::RGBA16F:
+                    return VK_FORMAT_R16G16B16A16_SFLOAT;
+                case ImageFormat::RGBA32F:
+                    return VK_FORMAT_R32G32B32A32_SFLOAT;
+                case ImageFormat::R32F:
+                    return VK_FORMAT_R32_SFLOAT;
+                case ImageFormat::RG32F:
+                    return VK_FORMAT_R32G32_SFLOAT;
+                case ImageFormat::RGB32F:
+                    return VK_FORMAT_R32G32B32A32_SFLOAT;
+                case ImageFormat::DEPTH24STENCIL8:
+                    return VK_FORMAT_D32_SFLOAT_S8_UINT;
+                case ImageFormat::RG16F:
+                    return VK_FORMAT_R16G16_SFLOAT;
+                case ImageFormat::R32I:
+                    return VK_FORMAT_R32_SINT;
+                case ImageFormat::RG8:
+                    return VK_FORMAT_R8G8_UNORM;
+                case ImageFormat::BC7:
+                    return srgb ? VK_FORMAT_BC7_SRGB_BLOCK : VK_FORMAT_BC7_UNORM_BLOCK;
+                case ImageFormat::BC5:
+                    return VK_FORMAT_BC5_UNORM_BLOCK;
+                case ImageFormat::BC6H:
+                    return VK_FORMAT_BC6H_UFLOAT_BLOCK;
+            }
+
+            OLO_CORE_ASSERT(false, "ImageFormatToVkFormat: unknown ImageFormat {}", static_cast<u32>(format));
+            return VK_FORMAT_UNDEFINED;
+        }
+
+        [[nodiscard]] bool IsDepthImageFormat(ImageFormat format)
+        {
+            return format == ImageFormat::DEPTH24STENCIL8;
+        }
+
+        [[nodiscard]] bool IsSrgbVkFormat(VkFormat format)
+        {
+            return format == VK_FORMAT_R8G8B8A8_SRGB || format == VK_FORMAT_BC7_SRGB_BLOCK;
+        }
+
+        [[nodiscard]] VkSampleCountFlagBits SampleCountFromU32(u32 samples)
+        {
+            switch (samples)
+            {
+                case 0:
+                case 1:
+                    return VK_SAMPLE_COUNT_1_BIT;
+                case 2:
+                    return VK_SAMPLE_COUNT_2_BIT;
+                case 4:
+                    return VK_SAMPLE_COUNT_4_BIT;
+                case 8:
+                    return VK_SAMPLE_COUNT_8_BIT;
+                case 16:
+                    return VK_SAMPLE_COUNT_16_BIT;
+                case 32:
+                    return VK_SAMPLE_COUNT_32_BIT;
+                case 64:
+                    return VK_SAMPLE_COUNT_64_BIT;
+                default:
+                    OLO_CORE_WARN("VulkanTexture2D: unsupported sample count {} — falling back to 1", samples);
+                    return VK_SAMPLE_COUNT_1_BIT;
+            }
+        }
+
+        // Mirrors OpenGLTexture2D::CalculateFullMipCount.
+        [[nodiscard]] u32 CalculateFullMipCount(u32 width, u32 height)
+        {
+            return static_cast<u32>(std::floor(std::log2(static_cast<f64>(std::max(width, height))))) + 1;
+        }
+
+        // Mirrors the GL twin's mip derivation, including the spec mutations:
+        // multisampling forces a single level, an explicit MipLevels wins,
+        // GenerateMips selects the full chain, otherwise 1.
+        [[nodiscard]] u32 DeriveMipLevels(TextureSpecification& spec, u32 width, u32 height)
+        {
+            if (spec.Samples > 1u)
+            {
+                spec.GenerateMips = false;
+                spec.MipLevels = 1u;
+                return 1u;
+            }
+            if (spec.MipLevels > 0u)
+            {
+                return spec.MipLevels;
+            }
+            if (spec.GenerateMips)
+            {
+                return CalculateFullMipCount(width, height);
+            }
+            return 1u;
+        }
+
+        // FramebufferTextureFormat -> ImageFormat, so VulkanFramebuffer can
+        // build its attachments as real VulkanTexture2D instances (handles +
+        // VulkanImageInfoRegistry entries come for free). Widening choices:
+        //  - RGB16F -> RGBA16F: ImageFormat has no RGB16F member, and the
+        //    Vulkan map would widen a 3-channel format anyway (see above).
+        //  - DEPTH_COMPONENT32F -> DEPTH24STENCIL8: ImageFormat has no
+        //    stencil-free depth member; the Vulkan map allocates
+        //    D32_SFLOAT_S8_UINT for it, so a shadow depth attachment keeps its
+        //    32-bit float depth aspect — the surplus stencil aspect is unused.
+        // (Depth/ShadowDepth are enumerator aliases of the two depth members,
+        // so this switch covers every distinct value.)
+        [[nodiscard]] ImageFormat FramebufferFormatToImageFormat(FramebufferTextureFormat format)
+        {
+            switch (format)
+            {
+                case FramebufferTextureFormat::None:
+                    break;
+                case FramebufferTextureFormat::RGBA8:
+                    return ImageFormat::RGBA8;
+                case FramebufferTextureFormat::RGBA16F:
+                    return ImageFormat::RGBA16F;
+                case FramebufferTextureFormat::RGBA32F:
+                    return ImageFormat::RGBA32F;
+                case FramebufferTextureFormat::RGB16F:
+                    return ImageFormat::RGBA16F;
+                case FramebufferTextureFormat::RGB32F:
+                    return ImageFormat::RGB32F;
+                case FramebufferTextureFormat::RG16F:
+                    return ImageFormat::RG16F;
+                case FramebufferTextureFormat::RG32F:
+                    return ImageFormat::RG32F;
+                case FramebufferTextureFormat::RED_INTEGER:
+                    return ImageFormat::R32I;
+                case FramebufferTextureFormat::DEPTH24STENCIL8:
+                    return ImageFormat::DEPTH24STENCIL8;
+                case FramebufferTextureFormat::DEPTH_COMPONENT32F:
+                    return ImageFormat::DEPTH24STENCIL8;
+            }
+
+            OLO_CORE_ASSERT(false, "FramebufferFormatToImageFormat: unknown FramebufferTextureFormat {}",
+                            static_cast<u32>(format));
+            return ImageFormat::None;
+        }
+
+        [[nodiscard]] bool IsDepthFramebufferFormat(FramebufferTextureFormat format)
+        {
+            return format == FramebufferTextureFormat::DEPTH24STENCIL8 ||
+                   format == FramebufferTextureFormat::DEPTH_COMPONENT32F;
+        }
+    } // namespace
+
+// Phase 6 stub: warn ONCE per entry point, then no-op with a benign return.
+// Each expansion gets its own function-local static, so no two entry points
+// ever share a flag. Deliberately NOT an assert: TransientPool's acquire path
+// must stay alive under --rhi=vulkan even when a caller pokes an
+// upload/bind-shaped virtual.
+#define OLO_VK_PHASE6_STUB(entryPoint)                                                      \
+    do                                                                                      \
+    {                                                                                       \
+        static bool s_WarnedOnce = false;                                                   \
+        if (!s_WarnedOnce)                                                                  \
+        {                                                                                   \
+            s_WarnedOnce = true;                                                            \
+            OLO_CORE_WARN(entryPoint " is a Phase 6 concern — no-op under Phase 5 (#691)"); \
+        }                                                                                   \
+    } while (false)
+
+    // =========================================================================
+    // VulkanImageInfoRegistry
+    // =========================================================================
+
+    VulkanImageInfoRegistry& VulkanImageInfoRegistry::Get()
+    {
+        static auto* s_Instance = new VulkanImageInfoRegistry(); // deliberately leaked
+        return *s_Instance;
+    }
+
+    void VulkanImageInfoRegistry::Register(VkImage image, const VulkanImageInfo& info)
+    {
+        if (image == VK_NULL_HANDLE)
+        {
+            return;
+        }
+        m_Infos[image] = info;
+    }
+
+    const VulkanImageInfo* VulkanImageInfoRegistry::Lookup(VkImage image) const
+    {
+        const auto it = m_Infos.find(image);
+        return it != m_Infos.end() ? &it->second : nullptr;
+    }
+
+    void VulkanImageInfoRegistry::Unregister(VkImage image)
+    {
+        m_Infos.erase(image);
+    }
+
+    // =========================================================================
+    // VulkanDeferredReclaim
+    // =========================================================================
+
+    VulkanDeferredReclaim& VulkanDeferredReclaim::Get()
+    {
+        static auto* s_Instance = new VulkanDeferredReclaim(); // deliberately leaked
+        return *s_Instance;
+    }
+
+    void VulkanDeferredReclaim::Enqueue(VkImage image, VmaAllocation allocation)
+    {
+        if (image == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
+        {
+            return;
+        }
+        m_Entries.push_back({ image, VK_NULL_HANDLE, allocation, m_Generation });
+    }
+
+    void VulkanDeferredReclaim::Enqueue(VkBuffer buffer, VmaAllocation allocation)
+    {
+        if (buffer == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
+        {
+            return;
+        }
+        m_Entries.push_back({ VK_NULL_HANDLE, buffer, allocation, m_Generation });
+    }
+
+    void VulkanDeferredReclaim::DestroyEntry(const Entry& entry)
+    {
+        // Image metadata retires at ACTUAL destroy time — a barrier emitted for
+        // a still-enqueued image must keep resolving until the image is gone.
+        if (entry.Image != VK_NULL_HANDLE)
+        {
+            VulkanImageInfoRegistry::Get().Unregister(entry.Image);
+        }
+
+        auto* device = VulkanDevice::Get();
+        if (device == nullptr)
+        {
+            // Shutdown teardown race: the device (and with it the allocator)
+            // is already gone. Dropping the entry leaks at process exit, which
+            // beats calling into a destroyed allocator.
+            OLO_CORE_WARN("VulkanDeferredReclaim: dropping a reclaim entry — VulkanDevice already shut down");
+            return;
+        }
+
+        if (entry.Image != VK_NULL_HANDLE)
+        {
+            vmaDestroyImage(device->GetAllocator(), entry.Image, entry.Allocation);
+        }
+        else if (entry.Buffer != VK_NULL_HANDLE)
+        {
+            vmaDestroyBuffer(device->GetAllocator(), entry.Buffer, entry.Allocation);
+        }
+        else if (entry.Allocation != VK_NULL_HANDLE)
+        {
+            vmaFreeMemory(device->GetAllocator(), entry.Allocation);
+        }
+    }
+
+    void VulkanDeferredReclaim::NotifyFrameCompleted()
+    {
+        ++m_Generation;
+
+        std::erase_if(m_Entries, [this](const Entry& entry)
+                      {
+            if (m_Generation - entry.EnqueuedAtGeneration < kFramesInFlight)
+            {
+                return false;
+            }
+            DestroyEntry(entry);
+            return true; });
+    }
+
+    void VulkanDeferredReclaim::FlushAll()
+    {
+        // Caller guarantees vkDeviceWaitIdle has already been done.
+        for (const auto& entry : m_Entries)
+        {
+            DestroyEntry(entry);
+        }
+        m_Entries.clear();
+    }
+
+    // =========================================================================
+    // VulkanTexture2D
+    // =========================================================================
+
+    VulkanTexture2D::VulkanTexture2D(const TextureSpecification& specification)
+        // Vulkan refuses a zero extent outright (GL merely misbehaved), so
+        // clamp defensively — pre-Resize 0-sized framebuffer specs reach here.
+        : m_Specification(specification),
+          m_Width(std::max(specification.Width, 1u)),
+          m_Height(std::max(specification.Height, 1u))
+    {
+        OLO_PROFILE_FUNCTION();
+        OLO_CORE_ASSERT(VulkanDevice::Get() != nullptr, "VulkanTexture2D requires a live VulkanDevice");
+
+        // Mirror the GL twin: block-compressed formats have no population path
+        // through the spec ctor — they MUST come via the CompressedTextureImage
+        // overload (Phase 6 for Vulkan). Refuse loudly but non-fatally.
+        if (IsCompressedFormat(m_Specification.Format))
+        {
+            OLO_CORE_ERROR("VulkanTexture2D: block-compressed format {} cannot be created from a "
+                           "TextureSpecification — the CompressedTextureImage overload is Phase 6",
+                           static_cast<u32>(m_Specification.Format));
+            m_IsLoaded = false;
+            return;
+        }
+
+        m_Specification.Samples = std::max(m_Specification.Samples, 1u);
+        m_MipLevels = DeriveMipLevels(m_Specification, m_Width, m_Height);
+
+        CreateImage();
+        m_IsLoaded = true;
+    }
+
+    VulkanTexture2D::~VulkanTexture2D()
+    {
+        // Retire the identity first (outstanding handles go stale), then hand
+        // the native object to the deferred queue — NEVER vmaDestroyImage
+        // inline, prior frames may still be executing.
+        m_RHIHandle.Reset();
+        ReleaseImage();
+    }
+
+    void VulkanTexture2D::CreateImage()
+    {
+        auto* device = VulkanDevice::Get();
+        OLO_CORE_ASSERT(device != nullptr, "VulkanTexture2D::CreateImage requires a live VulkanDevice");
+
+        const VkFormat format = ImageFormatToVkFormat(m_Specification.Format, m_Specification.SRGB);
+        const bool isDepth = IsDepthImageFormat(m_Specification.Format);
+
+        VkImageUsageFlags usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                  VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        if (isDepth)
+        {
+            usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+        }
+        else
+        {
+            usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+            // STORAGE only where the format-feature contract allows it without
+            // a per-format query (Phase 6): sRGB image views don't support
+            // storage writes, and multisampled storage images need an opt-in
+            // device feature.
+            if (!IsSrgbVkFormat(format) && m_Specification.Samples == 1u)
+            {
+                usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+            }
+        }
+
+        VkImageCreateInfo imageInfo{};
+        imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.format = format;
+        imageInfo.extent = { m_Width, m_Height, 1u };
+        imageInfo.mipLevels = m_MipLevels;
+        imageInfo.arrayLayers = 1u;
+        imageInfo.samples = SampleCountFromU32(m_Specification.Samples);
+        imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imageInfo.usage = usage;
+        imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+        VkCheck(vmaCreateImage(device->GetAllocator(), &imageInfo, &allocInfo, &m_Image, &m_Allocation, nullptr),
+                "vmaCreateImage (VulkanTexture2D)");
+
+        // HasStencil follows the RESOLVED VkFormat: the engine's combined
+        // depth format lowers to D32_SFLOAT_S8_UINT, which carries a stencil
+        // aspect — the orchestrator derives barrier aspect masks from this.
+        VulkanImageInfoRegistry::Get().Register(m_Image, VulkanImageInfo{
+                                                             .Format = format,
+                                                             .MipLevels = m_MipLevels,
+                                                             .ArrayLayers = 1u,
+                                                             .HasDepth = isDepth,
+                                                             .HasStencil = isDepth,
+                                                         });
+
+        m_RHIHandle.Sync(RHI::ResourceKind::Texture, VkHandleToU64(m_Image), RHI::Backend::Vulkan);
+    }
+
+    void VulkanTexture2D::ReleaseImage()
+    {
+        if (m_Image != VK_NULL_HANDLE || m_Allocation != VK_NULL_HANDLE)
+        {
+            // The info-registry entry retires inside the reclaim queue at
+            // actual-destroy time, not here.
+            VulkanDeferredReclaim::Get().Enqueue(m_Image, m_Allocation);
+            m_Image = VK_NULL_HANDLE;
+            m_Allocation = VK_NULL_HANDLE;
+        }
+    }
+
+    void VulkanTexture2D::Resize(u32 width, u32 height)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (width == 0u || height == 0u)
+        {
+            OLO_CORE_WARN("VulkanTexture2D::Resize: ignoring zero extent {}x{}", width, height);
+            return;
+        }
+        if (width == m_Width && height == m_Height && m_Image != VK_NULL_HANDLE)
+        {
+            return;
+        }
+
+        ReleaseImage();
+
+        m_Width = width;
+        m_Height = height;
+        m_Specification.Width = width;
+        m_Specification.Height = height;
+        m_MipLevels = DeriveMipLevels(m_Specification, m_Width, m_Height);
+
+        // Sync inside CreateImage PRESERVES the identity — same object, new
+        // storage, matching the GL twin's recreate-in-place semantics.
+        CreateImage();
+    }
+
+    void VulkanTexture2D::SetData(void* data, u32 size)
+    {
+        (void)data;
+        (void)size;
+        OLO_VK_PHASE6_STUB("VulkanTexture2D::SetData");
+    }
+
+    void VulkanTexture2D::SubImage(u32 x, u32 y, u32 width, u32 height, const void* data, u32 dataSize)
+    {
+        (void)x;
+        (void)y;
+        (void)width;
+        (void)height;
+        (void)data;
+        (void)dataSize;
+        OLO_VK_PHASE6_STUB("VulkanTexture2D::SubImage");
+    }
+
+    void VulkanTexture2D::Invalidate(std::string_view path, u32 width, u32 height, const void* data, u32 channels)
+    {
+        (void)path;
+        (void)width;
+        (void)height;
+        (void)data;
+        (void)channels;
+        OLO_VK_PHASE6_STUB("VulkanTexture2D::Invalidate");
+    }
+
+    void VulkanTexture2D::Bind(u32 slot) const
+    {
+        (void)slot;
+        OLO_VK_PHASE6_STUB("VulkanTexture2D::Bind");
+    }
+
+    bool VulkanTexture2D::GetData(std::vector<u8>& outData, u32 mipLevel) const
+    {
+        (void)mipLevel;
+        outData.clear();
+        OLO_VK_PHASE6_STUB("VulkanTexture2D::GetData");
+        return false;
+    }
+
+    // =========================================================================
+    // VulkanFramebuffer
+    // =========================================================================
+
+    VulkanFramebuffer::VulkanFramebuffer(const FramebufferSpecification& spec)
+        : m_Specification(spec)
+    {
+        OLO_PROFILE_FUNCTION();
+        OLO_CORE_ASSERT(VulkanDevice::Get() != nullptr, "VulkanFramebuffer requires a live VulkanDevice");
+
+        for (const auto& attachmentSpec : m_Specification.Attachments.Attachments)
+        {
+            if (IsDepthFramebufferFormat(attachmentSpec.TextureFormat))
+            {
+                m_DepthAttachmentSpecification = attachmentSpec;
+            }
+            else if (attachmentSpec.TextureFormat != FramebufferTextureFormat::None)
+            {
+                m_ColorAttachmentSpecifications.push_back(attachmentSpec);
+            }
+        }
+
+        CreateAttachments();
+
+        // The framebuffer's own identity: native = 0 because under dynamic
+        // rendering no VkFramebuffer object exists to name (render passes are
+        // Phase 6). The attachments carry their own nonzero-native handles.
+        m_RHIHandle.Adopt(RHI::ResourceKind::Framebuffer, 0u, RHI::Backend::Vulkan);
+    }
+
+    VulkanFramebuffer::~VulkanFramebuffer()
+    {
+        // Retire the framebuffer identity; the attachment Refs release next
+        // and each texture enqueues its image on VulkanDeferredReclaim.
+        m_RHIHandle.Reset();
+    }
+
+    void VulkanFramebuffer::CreateAttachments()
+    {
+        // Replacing the Refs drops the old attachments — their destructors
+        // route the images through VulkanDeferredReclaim, never an inline
+        // destroy.
+        m_ColorAttachments.clear();
+        m_DepthAttachment = nullptr;
+
+        // A 0-sized spec is legal in the engine (framebuffers are routinely
+        // resized before first use); Vulkan refuses a zero extent, so the
+        // attachment textures clamp to 1x1 until Resize provides real
+        // dimensions. m_Specification keeps the authored values.
+        const u32 width = std::max(m_Specification.Width, 1u);
+        const u32 height = std::max(m_Specification.Height, 1u);
+
+        const auto makeAttachmentSpec = [&](FramebufferTextureFormat format)
+        {
+            TextureSpecification texSpec;
+            texSpec.Width = width;
+            texSpec.Height = height;
+            texSpec.Format = FramebufferFormatToImageFormat(format);
+            texSpec.GenerateMips = false;
+            texSpec.MipLevels = 1u;
+            texSpec.Samples = std::max(m_Specification.Samples, 1u);
+            return texSpec;
+        };
+
+        m_ColorAttachments.reserve(m_ColorAttachmentSpecifications.size());
+        for (const auto& attachmentSpec : m_ColorAttachmentSpecifications)
+        {
+            m_ColorAttachments.push_back(Ref<VulkanTexture2D>::Create(makeAttachmentSpec(attachmentSpec.TextureFormat)));
+        }
+
+        if (m_DepthAttachmentSpecification.TextureFormat != FramebufferTextureFormat::None)
+        {
+            m_DepthAttachment = Ref<VulkanTexture2D>::Create(makeAttachmentSpec(m_DepthAttachmentSpecification.TextureFormat));
+        }
+    }
+
+    void VulkanFramebuffer::Bind()
+    {
+        // Will set the orchestrator's VulkanRendererAPI current-render-target
+        // state once that lands.
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::Bind");
+    }
+
+    void VulkanFramebuffer::Unbind()
+    {
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::Unbind");
+    }
+
+    void VulkanFramebuffer::Resize(u32 width, u32 height)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (width == 0u || height == 0u)
+        {
+            OLO_CORE_WARN("VulkanFramebuffer::Resize: ignoring zero extent {}x{}", width, height);
+            return;
+        }
+
+        m_Specification.Width = width;
+        m_Specification.Height = height;
+
+        // Physical resize implies render viewport == physical size (same
+        // contract as the GL twin).
+        m_RenderViewportWidth = 0u;
+        m_RenderViewportHeight = 0u;
+
+        // The attachments genuinely become NEW objects with NEW handles —
+        // anything still holding the old ones has to see them go stale (same
+        // contract as the GL twin). The old images auto-enqueue on
+        // VulkanDeferredReclaim via their destructors.
+        CreateAttachments();
+    }
+
+    void VulkanFramebuffer::SetRenderViewportSize(u32 width, u32 height)
+    {
+        m_RenderViewportWidth = width;
+        m_RenderViewportHeight = height;
+    }
+
+    int VulkanFramebuffer::ReadPixel(u32 attachmentIndex, int x, int y)
+    {
+        (void)attachmentIndex;
+        (void)x;
+        (void)y;
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::ReadPixel");
+        return -1; // the entity-picking "nothing here" value
+    }
+
+    void VulkanFramebuffer::ClearAttachment(u32 attachmentIndex, int value)
+    {
+        (void)attachmentIndex;
+        (void)value;
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::ClearAttachment(int)");
+    }
+
+    void VulkanFramebuffer::ClearAttachment(u32 attachmentIndex, const glm::vec4& value)
+    {
+        (void)attachmentIndex;
+        (void)value;
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::ClearAttachment(vec4)");
+    }
+
+    void VulkanFramebuffer::ClearAllAttachments(const glm::vec4& clearColor, int entityIdClear)
+    {
+        (void)clearColor;
+        (void)entityIdClear;
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::ClearAllAttachments");
+    }
+
+    RHI::ResourceHandle VulkanFramebuffer::GetColorAttachmentHandle(u32 index) const
+    {
+        OLO_CORE_ASSERT(index < m_ColorAttachments.size());
+        if (index >= m_ColorAttachments.size())
+        {
+            return {};
+        }
+        return m_ColorAttachments[index]->GetRHIHandle();
+    }
+
+    RHI::ResourceHandle VulkanFramebuffer::GetDepthAttachmentHandle() const
+    {
+        return m_DepthAttachment ? m_DepthAttachment->GetRHIHandle() : RHI::ResourceHandle{};
+    }
+
+    void VulkanFramebuffer::AttachDepthTextureArrayLayer(RHI::ResourceHandle textureArray, u32 layer)
+    {
+        (void)textureArray;
+        (void)layer;
+        // Shadow-cascade rendering needs the render-pass/PSO path.
+        OLO_VK_PHASE6_STUB("VulkanFramebuffer::AttachDepthTextureArrayLayer");
+    }
+
+    Ref<VulkanTexture2D> VulkanFramebuffer::GetColorAttachmentImage(u32 index) const
+    {
+        OLO_CORE_ASSERT(index < m_ColorAttachments.size());
+        if (index >= m_ColorAttachments.size())
+        {
+            return nullptr;
+        }
+        return m_ColorAttachments[index];
+    }
+
+    // =========================================================================
+    // VulkanStorageBuffer
+    // =========================================================================
+
+    VulkanStorageBuffer::VulkanStorageBuffer(u32 size, u32 binding, StorageBufferUsage usage)
+        : m_Size(size), m_Binding(binding), m_Usage(usage)
+    {
+        OLO_PROFILE_FUNCTION();
+        OLO_CORE_ASSERT(VulkanDevice::Get() != nullptr, "VulkanStorageBuffer requires a live VulkanDevice");
+
+        CreateBuffer();
+    }
+
+    VulkanStorageBuffer::~VulkanStorageBuffer()
+    {
+        // Identity first, then the deferred queue — never vmaDestroyBuffer
+        // inline (prior frames may still be executing).
+        m_RHIHandle.Reset();
+        ReleaseBuffer();
+    }
+
+    void VulkanStorageBuffer::CreateBuffer()
+    {
+        auto* device = VulkanDevice::Get();
+        OLO_CORE_ASSERT(device != nullptr, "VulkanStorageBuffer::CreateBuffer requires a live VulkanDevice");
+
+        VkBufferCreateInfo bufferInfo{};
+        bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        // Vulkan refuses a zero-sized buffer; clamp defensively (GetSize keeps
+        // reporting the authored size).
+        bufferInfo.size = std::max<VkDeviceSize>(m_Size, 1u);
+        bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                           VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+        // DynamicDraw means "CPU writes, GPU reads": let VMA prefer a
+        // host-writable (BAR/host-visible) placement when one exists, falling
+        // back to device-local + a transfer path otherwise — which is exactly
+        // the upload shape Phase 6's SetData will need. DynamicCopy is
+        // GPU-writes/GPU-reads and stays pure device-local.
+        if (m_Usage == StorageBufferUsage::DynamicDraw)
+        {
+            allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                              VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT;
+        }
+
+        VkCheck(vmaCreateBuffer(device->GetAllocator(), &bufferInfo, &allocInfo, &m_Buffer, &m_Allocation, nullptr),
+                "vmaCreateBuffer (VulkanStorageBuffer)");
+
+        m_RHIHandle.Sync(RHI::ResourceKind::Buffer, VkHandleToU64(m_Buffer), RHI::Backend::Vulkan);
+    }
+
+    void VulkanStorageBuffer::ReleaseBuffer()
+    {
+        if (m_Buffer != VK_NULL_HANDLE || m_Allocation != VK_NULL_HANDLE)
+        {
+            VulkanDeferredReclaim::Get().Enqueue(m_Buffer, m_Allocation);
+            m_Buffer = VK_NULL_HANDLE;
+            m_Allocation = VK_NULL_HANDLE;
+        }
+    }
+
+    void VulkanStorageBuffer::Bind() const
+    {
+        OLO_VK_PHASE6_STUB("VulkanStorageBuffer::Bind");
+    }
+
+    void VulkanStorageBuffer::Unbind() const
+    {
+        OLO_VK_PHASE6_STUB("VulkanStorageBuffer::Unbind");
+    }
+
+    void VulkanStorageBuffer::SetData(const void* data, u32 size, u32 offset)
+    {
+        (void)data;
+        (void)size;
+        (void)offset;
+        OLO_VK_PHASE6_STUB("VulkanStorageBuffer::SetData");
+    }
+
+    void VulkanStorageBuffer::GetData(void* outData, u32 size, u32 offset) const
+    {
+        (void)offset;
+        OLO_VK_PHASE6_STUB("VulkanStorageBuffer::GetData");
+        // Benign return: callers read DEFINED memory (zeros), not garbage.
+        if (outData != nullptr && size > 0u)
+        {
+            std::memset(outData, 0, size);
+        }
+    }
+
+    void VulkanStorageBuffer::ClearData()
+    {
+        OLO_VK_PHASE6_STUB("VulkanStorageBuffer::ClearData");
+    }
+
+    void VulkanStorageBuffer::Resize(u32 newSize)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (newSize == m_Size && m_Buffer != VK_NULL_HANDLE)
+        {
+            return;
+        }
+
+        // Same contract as the GL twin: Resize invalidates existing data.
+        ReleaseBuffer();
+        m_Size = newSize;
+        // Sync inside CreateBuffer PRESERVES the identity — same object, new
+        // storage.
+        CreateBuffer();
+    }
+
+#undef OLO_VK_PHASE6_STUB
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
@@ -157,7 +157,13 @@ namespace OloEngine
             }
             if (spec.MipLevels > 0u)
             {
-                return spec.MipLevels;
+                // Clamp an authored level count to the full chain the extents
+                // support — Vulkan refuses mipLevels beyond
+                // floor(log2(max(w,h)))+1 (VUID-VkImageCreateInfo-mipLevels-02255),
+                // where GL silently tolerated the over-ask. Resize re-derives
+                // through this same path, so a persisted over-large spec stays
+                // bounded there too.
+                return std::min(spec.MipLevels, CalculateFullMipCount(width, height));
             }
             if (spec.GenerateMips)
             {
@@ -249,7 +255,12 @@ namespace OloEngine
         {
             return;
         }
+        // Stamp every registration uniquely so a layout tracker can tell a
+        // driver-recycled handle VALUE apart from the image it tracked — see
+        // VulkanImageInfo::RegistrationId.
+        static u64 s_NextRegistrationId = 0;
         m_Infos[image] = info;
+        m_Infos[image].RegistrationId = ++s_NextRegistrationId;
     }
 
     const VulkanImageInfo* VulkanImageInfoRegistry::Lookup(VkImage image) const

--- a/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTransientResources.cpp
@@ -396,15 +396,32 @@ namespace OloEngine
     {
         // Retire the identity first (outstanding handles go stale), then hand
         // the native object to the deferred queue — NEVER vmaDestroyImage
-        // inline, prior frames may still be executing.
-        m_RHIHandle.Reset();
-        ReleaseImage();
+        // inline, prior frames may still be executing. Destructors must not
+        // let an exception escape (the reclaim enqueue can allocate): a
+        // failed enqueue leaks one image until process exit, which beats
+        // std::terminate.
+        try
+        {
+            m_RHIHandle.Reset();
+            ReleaseImage();
+        }
+        catch (const std::exception& e)
+        {
+            OLO_CORE_ERROR("~VulkanTexture2D: release failed ({}) — leaking the image until process exit", e.what());
+        }
     }
 
     void VulkanTexture2D::CreateImage()
     {
         auto* device = VulkanDevice::Get();
         OLO_CORE_ASSERT(device != nullptr, "VulkanTexture2D::CreateImage requires a live VulkanDevice");
+        if (device == nullptr)
+        {
+            // The assert compiles out in Release; the factory arm guards this
+            // path, but a Resize on a device that has since shut down must
+            // fail loudly rather than dereference null.
+            throw std::runtime_error("VulkanTexture2D::CreateImage: no live VulkanDevice");
+        }
 
         const VkFormat format = ImageFormatToVkFormat(m_Specification.Format, m_Specification.SRGB);
         const bool isDepth = IsDepthImageFormat(m_Specification.Format);
@@ -740,15 +757,28 @@ namespace OloEngine
     VulkanStorageBuffer::~VulkanStorageBuffer()
     {
         // Identity first, then the deferred queue — never vmaDestroyBuffer
-        // inline (prior frames may still be executing).
-        m_RHIHandle.Reset();
-        ReleaseBuffer();
+        // inline (prior frames may still be executing). No exception may
+        // escape a destructor: a failed enqueue leaks one buffer until
+        // process exit, which beats std::terminate.
+        try
+        {
+            m_RHIHandle.Reset();
+            ReleaseBuffer();
+        }
+        catch (const std::exception& e)
+        {
+            OLO_CORE_ERROR("~VulkanStorageBuffer: release failed ({}) — leaking the buffer until process exit", e.what());
+        }
     }
 
     void VulkanStorageBuffer::CreateBuffer()
     {
         auto* device = VulkanDevice::Get();
         OLO_CORE_ASSERT(device != nullptr, "VulkanStorageBuffer::CreateBuffer requires a live VulkanDevice");
+        if (device == nullptr)
+        {
+            throw std::runtime_error("VulkanStorageBuffer::CreateBuffer: no live VulkanDevice");
+        }
 
         VkBufferCreateInfo bufferInfo{};
         bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;

--- a/OloEngine/src/Platform/Vulkan/VulkanTransientResources.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTransientResources.h
@@ -59,6 +59,15 @@ namespace OloEngine
         u32 ArrayLayers = 1;
         bool HasDepth = false;
         bool HasStencil = false;
+
+        // Stamped by Register() from a process-wide monotonic counter. A
+        // destroyed VkImage's handle VALUE can be recycled by the driver for
+        // a later image with identical extents; layout trackers key on the
+        // handle and would otherwise inherit the dead image's layouts (a
+        // wrong oldLayout, i.e. a validation error at best). Comparing this
+        // stamp is how a tracker detects "same handle value, different
+        // image" — the same recycled-name lesson as RHI handle generations.
+        u64 RegistrationId = 0;
     };
 
     class VulkanImageInfoRegistry

--- a/OloEngine/src/Platform/Vulkan/VulkanTransientResources.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTransientResources.h
@@ -1,0 +1,409 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#if OLO_WITH_VULKAN
+
+// =============================================================================
+// VulkanTransientResources.h — #691 Phase 5: VMA-backed resource classes for
+// the TransientPool's attribute-only acquire path.
+//
+// TransientPool::AcquireTexture / AcquireFramebuffer / AcquireBuffer build GPU
+// objects from a bare specification — no pixel upload, no bind, no sampling.
+// That is exactly the slice these classes implement fully: allocation,
+// identity (RHI::ResourceRegistry handles), lifetime (deferred reclaim), and
+// the metadata the barrier translator needs (VulkanImageInfoRegistry). Every
+// upload/bind/readback-shaped virtual is a warn-once no-op — Phase 6 territory
+// (it needs the transfer/PSO paths) — never an assert, because the pool's
+// acquire path must stay alive under --rhi=vulkan.
+//
+// This header exposes Vulkan types directly — it is included only by
+// Platform/Vulkan siblings and by OLO_WITH_VULKAN-guarded engine factory TUs
+// (the sanctioned factory-include pattern, rhi-abstraction-boundary.md).
+// =============================================================================
+
+// VulkanDevice.h provides <volk.h> and <vk_mem_alloc.h> (with the
+// VMA_STATIC/DYNAMIC_VULKAN_FUNCTIONS config that must stay in sync with
+// VulkanMemoryAllocator.cpp) — do NOT include either directly here, and NEVER
+// <vulkan/vulkan.h> (volk owns the function pointers, ADR 0011 amendment 41a).
+#include "Platform/Vulkan/VulkanDevice.h"
+
+#include "OloEngine/Renderer/Framebuffer.h"
+#include "OloEngine/Renderer/RHI/RHIResourceRegistry.h"
+#include "OloEngine/Renderer/StorageBuffer.h"
+#include "OloEngine/Renderer/Texture.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace OloEngine
+{
+    // -------------------------------------------------------------------------
+    // VulkanImageInfoRegistry — backend-internal VkImage metadata side table.
+    //
+    // Maps a live VkImage to the creation attributes a barrier emitter cannot
+    // recover from the handle alone. CONSUMER: the orchestrator's
+    // VulkanRendererAPI reads this to derive VkImageAspectFlags for barriers
+    // (color vs depth|stencil) and to seed its image-layout tracking; keep the
+    // API to Register/Lookup/Unregister — it is a lookup table, not a manager.
+    //
+    // Thread-safety: NONE, deliberately. Registration happens in resource
+    // constructors and unregistration inside VulkanDeferredReclaim's destroy
+    // pass — all render-thread work, matching the rest of the Vulkan backend.
+    // -------------------------------------------------------------------------
+    struct VulkanImageInfo
+    {
+        VkFormat Format = VK_FORMAT_UNDEFINED;
+        u32 MipLevels = 1;
+        u32 ArrayLayers = 1;
+        bool HasDepth = false;
+        bool HasStencil = false;
+    };
+
+    class VulkanImageInfoRegistry
+    {
+      public:
+        // Process-wide instance. Deliberately leaked (never destroyed), same
+        // rationale as RHI::ResourceRegistry: a Ref<Texture> released during
+        // static destruction must still find a live registry.
+        [[nodiscard]] static VulkanImageInfoRegistry& Get();
+
+        void Register(VkImage image, const VulkanImageInfo& info);
+        // Returns nullptr when the image was never registered (or already
+        // unregistered). The pointer is invalidated by the next Register or
+        // Unregister — copy out, don't hold.
+        [[nodiscard]] const VulkanImageInfo* Lookup(VkImage image) const;
+        void Unregister(VkImage image);
+
+      private:
+        VulkanImageInfoRegistry() = default;
+
+        std::unordered_map<VkImage, VulkanImageInfo> m_Infos;
+    };
+
+    // -------------------------------------------------------------------------
+    // VulkanDeferredReclaim — deferred-destroy queue for VMA allocations.
+    //
+    // WHY: TransientPool::Clear()/Trim() destroy pooled GPU objects while prior
+    // frames may still be executing on the GPU. On GL the driver refcounts the
+    // object behind the name, so an in-flight delete is safe; on Vulkan,
+    // destroying a resource a submitted command buffer still references is
+    // undefined behavior. So no Vulkan resource class ever calls
+    // vmaDestroyImage/vmaDestroyBuffer inline — destruction enqueues here and
+    // the actual destroy happens once the GPU is provably past the frame that
+    // could have referenced the object.
+    //
+    // The wait is counted in GENERATIONS, not clocks: the frame loop calls
+    // NotifyFrameCompleted() once per completed frame, and an entry is
+    // destroyed once >= kFramesInFlight (2, matching VulkanContext's
+    // frames-in-flight shape) notifications have passed since it was enqueued.
+    // FlushAll() is the shutdown/device-idle path: the CALLER guarantees
+    // vkDeviceWaitIdle has already been done, and everything is destroyed
+    // immediately.
+    //
+    // Thread-safety: NONE, deliberately — render thread only, like the rest of
+    // the backend.
+    // -------------------------------------------------------------------------
+    class VulkanDeferredReclaim
+    {
+      public:
+        // Process-wide instance, deliberately leaked (see
+        // VulkanImageInfoRegistry::Get for the rationale).
+        [[nodiscard]] static VulkanDeferredReclaim& Get();
+
+        void Enqueue(VkImage image, VmaAllocation allocation);
+        void Enqueue(VkBuffer buffer, VmaAllocation allocation);
+
+        // Called by the frame loop once per completed frame. Destroys every
+        // entry enqueued >= 2 notifications ago; also unregisters images from
+        // VulkanImageInfoRegistry at actual-destroy time.
+        void NotifyFrameCompleted();
+
+        // Destroy everything immediately. Caller guarantees device idle
+        // (vkDeviceWaitIdle already done — shutdown, swapchain teardown).
+        void FlushAll();
+
+        // Diagnostic/test affordance.
+        [[nodiscard]] sizet GetPendingCount() const
+        {
+            return m_Entries.size();
+        }
+
+      private:
+        VulkanDeferredReclaim() = default;
+
+        struct Entry
+        {
+            VkImage Image = VK_NULL_HANDLE; // exactly one of Image/Buffer is set
+            VkBuffer Buffer = VK_NULL_HANDLE;
+            VmaAllocation Allocation = VK_NULL_HANDLE;
+            u64 EnqueuedAtGeneration = 0;
+        };
+
+        // Destroys one entry through the live device's allocator. When the
+        // device is already gone (shutdown teardown races) the entry is
+        // dropped with a warn log — leaking at process exit beats calling
+        // into a destroyed allocator.
+        static void DestroyEntry(const Entry& entry);
+
+        // Matches VulkanContextData::kFramesInFlight.
+        static constexpr u64 kFramesInFlight = 2;
+
+        std::vector<Entry> m_Entries;
+        u64 m_Generation = 0;
+    };
+
+    // -------------------------------------------------------------------------
+    // VulkanTexture2D — attribute-only VMA image for the TransientPool.
+    //
+    // Fully implemented: allocation, identity, metadata, Resize. Upload /
+    // bind / readback virtuals are warn-once no-ops until Phase 6.
+    // -------------------------------------------------------------------------
+    class VulkanTexture2D : public Texture2D
+    {
+      public:
+        explicit VulkanTexture2D(const TextureSpecification& specification);
+        ~VulkanTexture2D() override;
+
+        const TextureSpecification& GetSpecification() const override
+        {
+            return m_Specification;
+        }
+
+        [[nodiscard("Store this!")]] u32 GetWidth() const override
+        {
+            return m_Width;
+        }
+        [[nodiscard("Store this!")]] u32 GetHeight() const override
+        {
+            return m_Height;
+        }
+        // Diagnostics-only field: a native GL name does not exist here.
+        [[nodiscard("Store this!")]] u32 GetRendererID() const override
+        {
+            return 0;
+        }
+
+        [[nodiscard]] RHI::ResourceHandle GetRHIHandle() const override
+        {
+            return m_RHIHandle.Get();
+        }
+        [[nodiscard("Store this!")]] const std::string& GetPath() const override
+        {
+            return m_Path;
+        }
+
+        // Phase 6 concerns (upload/bind/readback) — warn-once no-ops.
+        void SetData(void* data, u32 size) override;
+        void SubImage(u32 x, u32 y, u32 width, u32 height, const void* data, u32 dataSize) override;
+        void Invalidate(std::string_view path, u32 width, u32 height, const void* data, u32 channels) override;
+        void Bind(u32 slot) const override;
+        bool GetData(std::vector<u8>& outData, u32 mipLevel = 0) const override;
+
+        [[nodiscard("Store this!")]] bool IsLoaded() const override
+        {
+            return m_IsLoaded;
+        }
+
+        [[nodiscard("Use for transparency")]] bool HasAlphaChannel() const override
+        {
+            return m_Specification.Format == ImageFormat::RGBA8 ||
+                   m_Specification.Format == ImageFormat::RGBA16F ||
+                   m_Specification.Format == ImageFormat::RGBA32F ||
+                   m_Specification.Format == ImageFormat::BC7;
+        }
+
+        [[nodiscard("Store this!")]] u32 GetMipLevelCount() const override
+        {
+            return m_MipLevels;
+        }
+
+        // Recreates the VMA image at the new size (old image goes through
+        // VulkanDeferredReclaim). Identity is PRESERVED via m_RHIHandle.Sync,
+        // matching the GL twin's recreate-in-place semantics.
+        void Resize(u32 width, u32 height) override;
+
+        [[nodiscard]] VkImage GetVkImage() const
+        {
+            return m_Image;
+        }
+
+      private:
+        void CreateImage();
+        void ReleaseImage();
+
+        TextureSpecification m_Specification;
+        std::string m_Path; // always empty — transient textures have no source file
+        u32 m_Width = 0;
+        u32 m_Height = 0;
+        u32 m_MipLevels = 1;
+        bool m_IsLoaded = false;
+
+        VkImage m_Image = VK_NULL_HANDLE;
+        VmaAllocation m_Allocation = VK_NULL_HANDLE;
+        // Generation-checked identity for m_Image, kept in lockstep by
+        // m_RHIHandle.Sync at every site that assigns the native handle —
+        // same pattern as the GL twin (issue #691).
+        RHI::ScopedResourceHandle m_RHIHandle;
+    };
+
+    // -------------------------------------------------------------------------
+    // VulkanFramebuffer — a bag of attachment images, no VkFramebuffer.
+    //
+    // The Vulkan backend targets dynamic rendering (render passes are Phase 6),
+    // so there is deliberately NO VkFramebuffer object here: a framebuffer IS
+    // its attachment images. Attachments are real VulkanTexture2D instances
+    // (created via a FramebufferTextureFormat -> ImageFormat translation), so
+    // their RHI handles and VulkanImageInfoRegistry entries come for free and
+    // GetColorAttachmentHandle/GetDepthAttachmentHandle hand out genuine
+    // per-attachment identities exactly like the GL twin.
+    // -------------------------------------------------------------------------
+    class VulkanFramebuffer : public Framebuffer
+    {
+      public:
+        explicit VulkanFramebuffer(const FramebufferSpecification& spec);
+        ~VulkanFramebuffer() override;
+
+        // Will become meaningful when the orchestrator's VulkanRendererAPI
+        // current-render-target state lands — warn-once no-ops until then.
+        void Bind() override;
+        void Unbind() override;
+
+        void Resize(u32 width, u32 height) override;
+
+        void SetRenderViewportSize(u32 width, u32 height) override;
+        [[nodiscard]] u32 GetRenderViewportWidth() const override
+        {
+            return m_RenderViewportWidth;
+        }
+        [[nodiscard]] u32 GetRenderViewportHeight() const override
+        {
+            return m_RenderViewportHeight;
+        }
+
+        // Readback / clear-shaped — Phase 6 concerns, warn-once no-ops.
+        int ReadPixel(u32 attachmentIndex, int x, int y) override;
+        void ClearAttachment(u32 attachmentIndex, int value) override;
+        void ClearAttachment(u32 attachmentIndex, const glm::vec4& value) override;
+        void ClearAllAttachments(const glm::vec4& clearColor = glm::vec4(0.0f), int entityIdClear = -1) override;
+
+        // Diagnostics-only fields: native GL names do not exist here.
+        [[nodiscard("Store this!")]] u32 GetColorAttachmentRendererID(u32 index) const override
+        {
+            (void)index;
+            return 0;
+        }
+        [[nodiscard("Store this!")]] u32 GetDepthAttachmentRendererID() const override
+        {
+            return 0;
+        }
+
+        [[nodiscard("Store this!")]] RHI::ResourceHandle GetColorAttachmentHandle(u32 index) const override;
+        [[nodiscard("Store this!")]] RHI::ResourceHandle GetDepthAttachmentHandle() const override;
+
+        [[nodiscard("Store this!")]] const FramebufferSpecification& GetSpecification() const override
+        {
+            return m_Specification;
+        }
+        [[nodiscard("Store this!")]] u32 GetRendererID() const override
+        {
+            return 0;
+        }
+
+        [[nodiscard]] RHI::ResourceHandle GetRHIHandle() const override
+        {
+            return m_RHIHandle.Get();
+        }
+
+        void AttachDepthTextureArrayLayer(RHI::ResourceHandle textureArray, u32 layer) override;
+
+        [[nodiscard]] Ref<VulkanTexture2D> GetColorAttachmentImage(u32 index) const;
+        [[nodiscard]] Ref<VulkanTexture2D> GetDepthAttachmentImage() const
+        {
+            return m_DepthAttachment;
+        }
+
+      private:
+        void CreateAttachments();
+
+        FramebufferSpecification m_Specification;
+
+        std::vector<FramebufferTextureSpecification> m_ColorAttachmentSpecifications;
+        FramebufferTextureSpecification m_DepthAttachmentSpecification = FramebufferTextureFormat::None;
+
+        std::vector<Ref<VulkanTexture2D>> m_ColorAttachments;
+        Ref<VulkanTexture2D> m_DepthAttachment;
+
+        // The framebuffer's OWN identity. Native = 0: under dynamic rendering
+        // there is no VkFramebuffer object to name, and 0 is the honest
+        // "nothing" answer for ResolveNativeForBackend. The attachments carry
+        // their own (nonzero-native) handles.
+        RHI::ScopedResourceHandle m_RHIHandle;
+
+        // DRS render viewport override, same semantics as the GL twin:
+        // reset to zero by Resize().
+        u32 m_RenderViewportWidth = 0;
+        u32 m_RenderViewportHeight = 0;
+    };
+
+    // -------------------------------------------------------------------------
+    // VulkanStorageBuffer — attribute-only VMA buffer for the TransientPool.
+    // -------------------------------------------------------------------------
+    class VulkanStorageBuffer : public StorageBuffer
+    {
+      public:
+        VulkanStorageBuffer(u32 size, u32 binding, StorageBufferUsage usage = StorageBufferUsage::DynamicDraw);
+        ~VulkanStorageBuffer() override;
+
+        // Phase 6 concerns (bind/upload/readback/fill) — warn-once no-ops.
+        void Bind() const override;
+        void Unbind() const override;
+        void SetData(const void* data, u32 size, u32 offset = 0) override;
+        void GetData(void* outData, u32 size, u32 offset = 0) const override;
+        void ClearData() override;
+
+        // Recreates the VMA buffer at the new size (old buffer goes through
+        // VulkanDeferredReclaim). Identity preserved via m_RHIHandle.Sync.
+        void Resize(u32 newSize) override;
+
+        // Diagnostics-only field: a native GL name does not exist here.
+        [[nodiscard]] u32 GetRendererID() const override
+        {
+            return 0;
+        }
+
+        [[nodiscard]] RHI::ResourceHandle GetRHIHandle() const override
+        {
+            return m_RHIHandle.Get();
+        }
+        [[nodiscard]] u32 GetSize() const override
+        {
+            return m_Size;
+        }
+        [[nodiscard]] u32 GetBinding() const override
+        {
+            return m_Binding;
+        }
+
+        [[nodiscard]] VkBuffer GetVkBuffer() const
+        {
+            return m_Buffer;
+        }
+
+      private:
+        void CreateBuffer();
+        void ReleaseBuffer();
+
+        VkBuffer m_Buffer = VK_NULL_HANDLE;
+        VmaAllocation m_Allocation = VK_NULL_HANDLE;
+        // Generation-checked identity for m_Buffer, kept in lockstep by
+        // m_RHIHandle.Sync — same pattern as the GL twin (issue #691).
+        RHI::ScopedResourceHandle m_RHIHandle;
+        u32 m_Size = 0;
+        u32 m_Binding = 0;
+        StorageBufferUsage m_Usage = StorageBufferUsage::DynamicDraw;
+    };
+} // namespace OloEngine
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -169,6 +169,15 @@ add_executable(OloEngine-Tests
 		# SKIPs cleanly without a loader/device; compiles to a single SKIP when
 		# OLO_WITH_VULKAN=OFF.
 		Rendering/VulkanBringUpTest.cpp
+		# #691 Phase 5: the pure Access -> (stage2, access2, layout) lowering
+		# tables + the image-layout tracker. Headless (no device — fabricated
+		# handles); compiles to a single SKIP when OLO_WITH_VULKAN=OFF.
+		Rendering/VulkanBarrierLoweringTest.cpp
+		# #691 Phase 5: the render graph's execution layer on a REAL device —
+		# VMA transients, vkCmdPipelineBarrier2 batches, CommandBucket dispatch
+		# through VulkanRendererAPI, asserted validation-error count == 0.
+		# Same SKIP ladder as VulkanBringUpTest.
+		Rendering/VulkanRenderGraphExecutionTest.cpp
 		# #691 Phase 4: the --rhi= / config-file backend-selection chain (headless).
 		Rendering/BackendSelectionTest.cpp
 		# Coordinate math of GPUResourceInspector::CaptureTexturePng's `region`

--- a/OloEngine/tests/Rendering/MockRendererAPI.h
+++ b/OloEngine/tests/Rendering/MockRendererAPI.h
@@ -336,6 +336,16 @@ namespace OloEngine::Testing
         {
             Record("MemoryBarrier");
         }
+        void IssueBarrierBatch(MemoryBarrierFlags flags, std::span<const RHI::Barrier> barriers) override
+        {
+            // ParamU32_0 = the GL-lowered flag bits, ParamU32_1 = how many
+            // per-resource transitions the batch carried — lets a headless
+            // test assert both currencies arrived without a real backend.
+            RecordedCall c{ "IssueBarrierBatch" };
+            c.ParamU32_0 = static_cast<u32>(std::to_underlying(flags));
+            c.ParamU32_1 = static_cast<u32>(barriers.size());
+            m_Calls.push_back(std::move(c));
+        }
 
         void BindDefaultFramebuffer() override
         {

--- a/OloEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/OloEngine/tests/Rendering/RenderGraphTest.cpp
@@ -9920,8 +9920,9 @@ TEST(RenderGraphResourceTransitions, SingleTransitionCapturesProducerAndConsumer
     EXPECT_EQ(tr.ResourceName, "ColorTex");
     EXPECT_EQ(tr.ProducerPass, "Producer");
     EXPECT_EQ(tr.ConsumerPass, "Consumer");
-    EXPECT_EQ(tr.FromUsage, RGWriteUsage::RenderTarget);
-    EXPECT_EQ(tr.ToUsage, RGReadUsage::ShaderSample);
+    EXPECT_EQ(tr.FromAccess, RHI::Access::ColorAttachmentWrite);
+    EXPECT_EQ(tr.ToAccess, RHI::Access::ShaderSampleRead);
+    EXPECT_FALSE(tr.ReadWhileAttached);
     EXPECT_NE(tr.Flags, MemoryBarrierFlags::None)
         << "Barrier flags must be non-zero for a RenderTarget->ShaderSample transition";
 }
@@ -10019,8 +10020,214 @@ TEST(RenderGraphResourceTransitions, ExternalImportHasNoProducerPass)
         {
             EXPECT_EQ(tr.ProducerPass, "external")
                 << "Imported resource has no pass producer";
+            EXPECT_EQ(tr.FromAccess, RHI::Access::Undefined)
+                << "An external producer means no graph-known contents — Undefined lets Vulkan discard "
+                   "(ADR 0011 §1.5; the pre-Phase-5 RenderTarget default was wrong for a first use)";
         }
     }
+}
+
+TEST(RenderGraphResourceTransitions, WriteAfterWriteTransitionCarriesTheConsumersWriteAccess)
+{
+    // THE ADR 0011 §1.5 defect pin: two storage writers in sequence. The
+    // planner emits a WAW barrier before Writer2; the transition record for
+    // it must carry ToAccess == StorageWrite. The pre-Phase-5 record
+    // structurally could not express this and silently fell back to
+    // ShaderSample — harmless on GL, wrong layout + wrong access on Vulkan.
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false);
+
+    AddSetupNode(
+        graph,
+        "Writer1",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "StorageTex",
+                7,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Texture2D, "StorageTex"));
+            builder.Write(tex, RGWriteUsage::ShaderImage);
+        });
+
+    AddSetupNode(
+        graph,
+        "Writer2",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "StorageTex",
+                7,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Texture2D, "StorageTex"));
+            builder.Write(tex, RGWriteUsage::ShaderImage);
+        });
+
+    graph.AddExecutionDependency("Writer1", "Writer2");
+    graph.SetFinalPass("Writer2");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto transitions = graph.GetResourceTransitions();
+    const auto it = std::ranges::find_if(transitions,
+                                         [](const RenderGraph::ResourceTransition& t)
+                                         { return t.ResourceName == "StorageTex" && t.ConsumerPass == "Writer2"; });
+    ASSERT_NE(it, transitions.end()) << "Expected a WAW transition record for StorageTex->Writer2";
+    EXPECT_EQ(it->ToAccess, RHI::Access::StorageWrite)
+        << "A WAW consumer's access is its WRITE — never the pre-Phase-5 ShaderSample fallback";
+    EXPECT_EQ(it->FromAccess, RHI::Access::StorageWrite);
+    EXPECT_EQ(it->ProducerPass, "Writer1");
+}
+
+TEST(RenderGraphResourceTransitions, ClearWriteUsageMapsToClearAsLoadOp)
+{
+    // ADR 0011 §1.5's Clear split: RGWriteUsage::Clear means the load-op
+    // clear (its only engine producer, OITPrepareRenderPass, is one); an
+    // explicit vkCmdClearColorImage-style clear must be declared
+    // TransferDest instead. Pin the mapping through a real transition.
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false);
+
+    AddSetupNode(
+        graph,
+        "ClearPass",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "Accum",
+                9,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Framebuffer, "Accum"));
+            builder.Write(tex, RGWriteUsage::Clear);
+        });
+
+    AddSetupNode(
+        graph,
+        "Consumer",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "Accum",
+                9,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Framebuffer, "Accum"));
+            [[maybe_unused]] const auto sampled = builder.Read(tex, RGReadUsage::ShaderSample);
+        });
+
+    graph.AddExecutionDependency("ClearPass", "Consumer");
+    graph.SetFinalPass("Consumer");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto transitions = graph.GetResourceTransitions();
+    const auto it = std::ranges::find_if(transitions,
+                                         [](const RenderGraph::ResourceTransition& t)
+                                         { return t.ResourceName == "Accum" && t.ConsumerPass == "Consumer"; });
+    ASSERT_NE(it, transitions.end());
+    EXPECT_EQ(it->FromAccess, RHI::Access::ClearAsLoadOp);
+    EXPECT_EQ(it->ToAccess, RHI::Access::ShaderSampleRead);
+}
+
+TEST(RenderGraphResourceTransitions, ReadWhileAttachedIsFlaggedOnSamePassFeedback)
+{
+    // The third input of the backend's layout resolution (ADR 0011 §1.5):
+    // a pass that samples a resource while ALSO holding it declared as an
+    // attachment write (PCSS raw-depth shape) must flag the read, or the
+    // backend lowers it to a plain read-only layout while the attachment
+    // half is still live.
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false);
+
+    AddSetupNode(
+        graph,
+        "DepthProducer",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "SceneDepth",
+                11,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Texture2D, "SceneDepth"));
+            builder.Write(tex, RGWriteUsage::DepthStencil);
+        });
+
+    AddSetupNode(
+        graph,
+        "FeedbackPass",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "SceneDepth",
+                11,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Texture2D, "SceneDepth"));
+            builder.AllowSamePassReadWrite(tex);
+            builder.Write(tex, RGWriteUsage::DepthStencil);
+            [[maybe_unused]] const auto sampled = builder.Read(tex, RGReadUsage::ShaderSample);
+        });
+
+    graph.AddExecutionDependency("DepthProducer", "FeedbackPass");
+    graph.SetFinalPass("FeedbackPass");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto transitions = graph.GetResourceTransitions();
+    const auto it = std::ranges::find_if(transitions,
+                                         [](const RenderGraph::ResourceTransition& t)
+                                         {
+                                             return t.ResourceName == "SceneDepth" &&
+                                                    t.ConsumerPass == "FeedbackPass" &&
+                                                    t.ToAccess == RHI::Access::ShaderSampleRead;
+                                         });
+    ASSERT_NE(it, transitions.end()) << "Expected a sampled-read transition into the feedback pass";
+    EXPECT_TRUE(it->ReadWhileAttached)
+        << "A read whose pass also writes the resource as an attachment must carry the flag";
+}
+
+TEST(RenderGraphSubmissionPlan, MemoryBarrierCommandsCarryDedupedTransitions)
+{
+    // Phase 5: the submission IR's MemoryBarrier commands carry the
+    // per-resource transitions (deduplicated) so an explicit-barrier backend
+    // lowers layouts without re-querying the graph. GL ignores them; this
+    // pins that they ARRIVE.
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false);
+
+    AddSetupNode(
+        graph,
+        "Producer",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "ColorTex",
+                21,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Framebuffer, "ColorTex"));
+            builder.Write(tex, RGWriteUsage::RenderTarget);
+        });
+
+    AddSetupNode(
+        graph,
+        "Consumer",
+        [](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTexture(
+                "ColorTex",
+                21,
+                RGResourceDesc::FromHandleKind(RGResourceHandle::Kind::Framebuffer, "ColorTex"));
+            [[maybe_unused]] const auto sampled = builder.Read(tex, RGReadUsage::ShaderSample);
+        });
+
+    graph.AddExecutionDependency("Producer", "Consumer");
+    graph.SetFinalPass("Consumer");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto plan = graph.GetSubmissionPlan();
+    const auto it = std::ranges::find_if(plan,
+                                         [](const RenderGraph::SubmissionCommand& cmd)
+                                         { return cmd.CommandKind == RenderGraph::SubmissionCommand::Kind::MemoryBarrier; });
+    ASSERT_NE(it, plan.end()) << "Expected a MemoryBarrier command in the plan";
+    ASSERT_EQ(it->Transitions.size(), 1u)
+        << "The barrier command carries exactly the deduped transitions for its consumer pass";
+    EXPECT_EQ(it->Transitions[0].ResourceName, "ColorTex");
+    EXPECT_EQ(it->Transitions[0].FromAccess, RHI::Access::ColorAttachmentWrite);
+    EXPECT_EQ(it->Transitions[0].ToAccess, RHI::Access::ShaderSampleRead);
+    EXPECT_NE(it->Barriers, MemoryBarrierFlags::None)
+        << "The GL flags currency travels alongside, unchanged";
 }
 
 TEST(RenderGraphResourceTransitions, DumpToJsonIncludesResourceTransitions)
@@ -10077,10 +10284,10 @@ TEST(RenderGraphResourceTransitions, DumpToJsonIncludesResourceTransitions)
         << "Transition record must name the producer pass";
     EXPECT_NE(json.find("\"consumerPass\": \"PostPass\""), std::string::npos)
         << "Transition record must name the consumer pass";
-    EXPECT_NE(json.find("\"fromUsage\": \"RenderTarget\""), std::string::npos)
-        << "From-usage must be serialised as RenderTarget";
-    EXPECT_NE(json.find("\"toUsage\": \"ShaderSample\""), std::string::npos)
-        << "To-usage must be serialised as ShaderSample";
+    EXPECT_NE(json.find("\"fromAccess\": \"ColorAttachmentWrite\""), std::string::npos)
+        << "From-access must be serialised as ColorAttachmentWrite";
+    EXPECT_NE(json.find("\"toAccess\": \"ShaderSampleRead\""), std::string::npos)
+        << "To-access must be serialised as ShaderSampleRead";
     EXPECT_NE(json.find(";transitions=1"), std::string::npos)
         << "graphDigest must contain the transition count";
 

--- a/OloEngine/tests/Rendering/VulkanBarrierLoweringTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanBarrierLoweringTest.cpp
@@ -1,0 +1,304 @@
+// OLO_TEST_LAYER: plumbing
+//
+// Headless contract tests for the Vulkan barrier lowering (issue #691
+// Phase 5, ADR 0011 §1.5) — the CPU layer that pins the formula before any
+// device exists (CLAUDE.md rendering-verification rule, step 1).
+//
+// Everything here is pure: RHI::Access → (stage2, access2, layout) tables,
+// the (Access, aspect, read-while-attached) layout-resolution exceptions,
+// full VkImageMemoryBarrier2 assembly, and the image-layout tracker's
+// per-subresource run splitting. No instance, no device — runs in plain CI.
+// The device-gated half (real vkCmdPipelineBarrier2 under the validation
+// layer) lives in VulkanRenderGraphExecutionTest.
+//
+// Like VulkanBringUpTest, the whole file compiles out to one SKIP when the
+// backend is off.
+
+#include "OloEngine/Core/Base.h"
+
+#include <gtest/gtest.h>
+
+#if !OLO_WITH_VULKAN
+
+TEST(VulkanBarrierLowering, SkipsWhenNotCompiledIn)
+{
+    GTEST_SKIP() << "Built with OLO_WITH_VULKAN=OFF — the Vulkan backend is not compiled in.";
+}
+
+#else
+
+#include "Platform/Vulkan/VulkanBarrierLowering.h"
+#include "Platform/Vulkan/VulkanImageLayoutTracker.h"
+
+#include <vector>
+
+namespace
+{
+    using namespace OloEngine;
+    namespace VBL = OloEngine::VulkanBarrierLowering;
+
+    constexpr auto kGfx = RHI::QueueType::Graphics;
+    constexpr auto kCompute = RHI::QueueType::Compute;
+    constexpr auto kColor = RHI::TextureAspect::Color;
+    constexpr auto kDepth = RHI::TextureAspect::Depth;
+    constexpr auto kDepthStencil = RHI::TextureAspect::DepthStencil;
+
+    [[nodiscard]] VkImage FakeImage(const u64 value)
+    {
+        // Non-dispatchable handle — a fabricated value is fine for the pure
+        // CPU tracker; it never reaches a driver.
+        return reinterpret_cast<VkImage>(value); // NOLINT(performance-no-int-to-ptr)
+    }
+} // namespace
+
+// ---------------------------------------------------------------------------
+// LowerAccess: the stage/access table
+// ---------------------------------------------------------------------------
+
+TEST(VulkanBarrierLowering, UndefinedLowersToNoStageNoAccess)
+{
+    const auto sa = VBL::LowerAccess(RHI::Access::Undefined, kGfx, kColor);
+    EXPECT_EQ(sa.StageMask, VK_PIPELINE_STAGE_2_NONE);
+    EXPECT_EQ(sa.AccessMask, VK_ACCESS_2_NONE);
+}
+
+TEST(VulkanBarrierLowering, AttachmentAccessesLowerToAttachmentStages)
+{
+    const auto colorWrite = VBL::LowerAccess(RHI::Access::ColorAttachmentWrite, kGfx, kColor);
+    EXPECT_EQ(colorWrite.StageMask, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(colorWrite.AccessMask, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+
+    const auto depthWrite = VBL::LowerAccess(RHI::Access::DepthStencilAttachmentWrite, kGfx, kDepthStencil);
+    EXPECT_EQ(depthWrite.StageMask,
+              VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT);
+    EXPECT_EQ(depthWrite.AccessMask, VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+}
+
+TEST(VulkanBarrierLowering, ComputeLaneNarrowsShaderStagesToComputeOnly)
+{
+    const auto compute = VBL::LowerAccess(RHI::Access::StorageWrite, kCompute, kColor);
+    EXPECT_EQ(compute.StageMask, VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT);
+    EXPECT_EQ(compute.AccessMask, VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT);
+
+    // Graphics-lane shader accesses include COMPUTE deliberately — this
+    // engine's Graphics-work-type passes dispatch compute mid-pass, so the
+    // union must cover it (under-inclusion is a race).
+    const auto gfx = VBL::LowerAccess(RHI::Access::ShaderSampleRead, kGfx, kColor);
+    EXPECT_NE(gfx.StageMask & VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT, 0u);
+    EXPECT_NE(gfx.StageMask & VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, 0u);
+    EXPECT_EQ(gfx.AccessMask, VK_ACCESS_2_SHADER_SAMPLED_READ_BIT);
+}
+
+TEST(VulkanBarrierLowering, ClearAccessesSplitByKind)
+{
+    // ADR 0011 §1.5's Clear split, lowered: load-op clear is an attachment
+    // write (stage depends on aspect); explicit clear is a transfer write on
+    // the CLEAR stage.
+    const auto loadOpColor = VBL::LowerAccess(RHI::Access::ClearAsLoadOp, kGfx, kColor);
+    EXPECT_EQ(loadOpColor.StageMask, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(loadOpColor.AccessMask, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+
+    const auto loadOpDepth = VBL::LowerAccess(RHI::Access::ClearAsLoadOp, kGfx, kDepth);
+    EXPECT_EQ(loadOpDepth.AccessMask, VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+
+    const auto transferClear = VBL::LowerAccess(RHI::Access::ClearAsTransfer, kGfx, kColor);
+    EXPECT_EQ(transferClear.StageMask, VK_PIPELINE_STAGE_2_CLEAR_BIT);
+    EXPECT_EQ(transferClear.AccessMask, VK_ACCESS_2_TRANSFER_WRITE_BIT);
+}
+
+// ---------------------------------------------------------------------------
+// LayoutFor: the (Access, aspect, read-while-attached) resolution
+// ---------------------------------------------------------------------------
+
+TEST(VulkanBarrierLowering, CommonLayoutsFollowAccess)
+{
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::Undefined, kColor, false), VK_IMAGE_LAYOUT_UNDEFINED);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::ShaderSampleRead, kColor, false), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::ColorAttachmentWrite, kColor, false), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::DepthStencilAttachmentWrite, kDepthStencil, false),
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::TransferRead, kColor, false), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::TransferWrite, kColor, false), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::Present, kColor, false), VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+}
+
+TEST(VulkanBarrierLowering, StorageAccessesLowerToGeneralNotReadOnly)
+{
+    // THE §1.5 poster child: before the unification, a storage-image WAW
+    // transition record claimed ShaderSample and a naïve backend would have
+    // picked SHADER_READ_ONLY_OPTIMAL with a read-only access mask. The
+    // unified enum makes the write representable; this pins its lowering.
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::StorageWrite, kColor, false), VK_IMAGE_LAYOUT_GENERAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::StorageRead, kColor, false), VK_IMAGE_LAYOUT_GENERAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::StorageReadWrite, kColor, false), VK_IMAGE_LAYOUT_GENERAL);
+}
+
+TEST(VulkanBarrierLowering, ReadWhileAttachedDepthKeepsReadOnlyAttachmentLayout)
+{
+    // The PCSS raw-depth case (ADR 0011 §1.5's read-while-attached input):
+    // sampling depth that is simultaneously an attachment must land in
+    // DEPTH_STENCIL_READ_ONLY_OPTIMAL, never plain SHADER_READ_ONLY_OPTIMAL.
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::ShaderSampleRead, kDepth, true),
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::ShaderSampleRead, kDepthStencil, true),
+              VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
+
+    // Color feedback needs GENERAL (feedback-loop layout would need
+    // VK_EXT_attachment_feedback_loop_layout, outside the ADR 0010 contract).
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::ShaderSampleRead, kColor, true), VK_IMAGE_LAYOUT_GENERAL);
+    EXPECT_EQ(VBL::LayoutFor(RHI::Access::InputAttachmentRead, kColor, true), VK_IMAGE_LAYOUT_GENERAL);
+}
+
+// ---------------------------------------------------------------------------
+// BuildImageBarrier: full assembly
+// ---------------------------------------------------------------------------
+
+TEST(VulkanBarrierLowering, ImageBarrierAssemblesBothSidesAndLayouts)
+{
+    RHI::Barrier b;
+    b.Before = RHI::Access::ColorAttachmentWrite;
+    b.After = RHI::Access::ShaderSampleRead;
+    b.Range = {}; // full
+
+    const auto image = FakeImage(0x10);
+    const auto out = VBL::BuildImageBarrier(b, image, kColor, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 4, 1);
+
+    EXPECT_EQ(out.sType, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2);
+    EXPECT_EQ(out.image, image);
+    EXPECT_EQ(out.srcStageMask, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
+    EXPECT_EQ(out.srcAccessMask, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+    EXPECT_EQ(out.oldLayout, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(out.newLayout, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    EXPECT_EQ(out.srcQueueFamilyIndex, static_cast<u32>(VK_QUEUE_FAMILY_IGNORED));
+    EXPECT_EQ(out.dstQueueFamilyIndex, static_cast<u32>(VK_QUEUE_FAMILY_IGNORED));
+    EXPECT_EQ(out.subresourceRange.aspectMask, static_cast<VkImageAspectFlags>(VK_IMAGE_ASPECT_COLOR_BIT));
+    EXPECT_EQ(out.subresourceRange.levelCount, static_cast<u32>(VK_REMAINING_MIP_LEVELS));
+}
+
+TEST(VulkanBarrierLowering, TrackedUndefinedOldLayoutForcesSourceMasksToNone)
+{
+    // A pooled transient's first-use / unknown-inheritance case: the tracker
+    // answers UNDEFINED, the contents are discarded, and whatever FromAccess
+    // claimed must NOT leak into the source masks (there is nothing to make
+    // available from a discarded image).
+    RHI::Barrier b;
+    b.Before = RHI::Access::ColorAttachmentWrite; // claims a producer...
+    b.After = RHI::Access::ShaderSampleRead;
+
+    const auto out = VBL::BuildImageBarrier(b, FakeImage(0x11), kColor, VK_IMAGE_LAYOUT_UNDEFINED, 1, 1);
+    EXPECT_EQ(out.oldLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+    EXPECT_EQ(out.srcStageMask, VK_PIPELINE_STAGE_2_NONE);
+    EXPECT_EQ(out.srcAccessMask, VK_ACCESS_2_NONE);
+}
+
+TEST(VulkanBarrierLowering, StorageWawBarrierGetsGeneralAndWriteAccess)
+{
+    // End-to-end §1.5 pin at the assembly level: a WAW transition
+    // (StorageWrite -> StorageWrite) must produce GENERAL + a WRITE access on
+    // the destination side.
+    RHI::Barrier b;
+    b.Before = RHI::Access::StorageWrite;
+    b.After = RHI::Access::StorageWrite;
+
+    const auto out = VBL::BuildImageBarrier(b, FakeImage(0x12), kColor, VK_IMAGE_LAYOUT_GENERAL, 1, 1);
+    EXPECT_EQ(out.newLayout, VK_IMAGE_LAYOUT_GENERAL);
+    EXPECT_NE(out.dstAccessMask & VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT, 0u);
+    EXPECT_EQ(out.dstAccessMask & VK_ACCESS_2_SHADER_SAMPLED_READ_BIT, 0u)
+        << "A WAW consumer must not be lowered as a sampled read (the pre-Phase-5 fallback)";
+}
+
+TEST(VulkanBarrierLowering, BufferBarrierCoversWholeBufferWithBothSides)
+{
+    RHI::Barrier b;
+    b.Before = RHI::Access::StorageWrite;
+    b.After = RHI::Access::IndirectArgsRead;
+
+    const auto buffer = reinterpret_cast<VkBuffer>(static_cast<u64>(0x20)); // NOLINT(performance-no-int-to-ptr)
+    const auto out = VBL::BuildBufferBarrier(b, buffer);
+    EXPECT_EQ(out.sType, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2);
+    EXPECT_EQ(out.buffer, buffer);
+    EXPECT_EQ(out.size, VK_WHOLE_SIZE);
+    EXPECT_EQ(out.dstStageMask, VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT);
+    EXPECT_EQ(out.dstAccessMask, VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT);
+}
+
+// ---------------------------------------------------------------------------
+// VulkanImageLayoutTracker
+// ---------------------------------------------------------------------------
+
+TEST(VulkanImageLayoutTracker, UnknownImageAnswersUndefined)
+{
+    const VulkanImageLayoutTracker tracker;
+    VkImageSubresourceRange full{ VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS };
+    EXPECT_EQ(tracker.CurrentLayout(FakeImage(0x30), full), VK_IMAGE_LAYOUT_UNDEFINED);
+}
+
+TEST(VulkanImageLayoutTracker, SetAndQueryRoundTrip)
+{
+    VulkanImageLayoutTracker tracker;
+    const auto image = FakeImage(0x31);
+    tracker.RegisterImage(image, 4, 1);
+
+    VkImageSubresourceRange full{ VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS };
+    EXPECT_EQ(tracker.CurrentLayout(image, full), VK_IMAGE_LAYOUT_UNDEFINED);
+
+    tracker.SetLayout(image, full, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    EXPECT_EQ(tracker.CurrentLayout(image, full), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+}
+
+TEST(VulkanImageLayoutTracker, MixedRangeSplitsIntoExactRuns)
+{
+    // The HZB shape: mip 0 written as an attachment, mips 1..N as storage.
+    // A whole-image query must yield one run per layout region with exact
+    // sub-ranges — one guessed oldLayout for a mixed range is the validation
+    // error class this tracker exists to prevent.
+    VulkanImageLayoutTracker tracker;
+    const auto image = FakeImage(0x32);
+    tracker.RegisterImage(image, 4, 1);
+
+    VkImageSubresourceRange mip0{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+    VkImageSubresourceRange rest{ VK_IMAGE_ASPECT_COLOR_BIT, 1, 3, 0, 1 };
+    tracker.SetLayout(image, mip0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    tracker.SetLayout(image, rest, VK_IMAGE_LAYOUT_GENERAL);
+
+    VkImageSubresourceRange full{ VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS };
+    std::vector<std::pair<VkImageSubresourceRange, VkImageLayout>> runs;
+    tracker.ForEachLayoutRun(image, full,
+                             [&runs](const VkImageSubresourceRange& r, const VkImageLayout l)
+                             { runs.emplace_back(r, l); });
+
+    ASSERT_EQ(runs.size(), 2u);
+    EXPECT_EQ(runs[0].first.baseMipLevel, 0u);
+    EXPECT_EQ(runs[0].first.levelCount, 1u);
+    EXPECT_EQ(runs[0].second, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    EXPECT_EQ(runs[1].first.baseMipLevel, 1u);
+    EXPECT_EQ(runs[1].first.levelCount, 3u);
+    EXPECT_EQ(runs[1].second, VK_IMAGE_LAYOUT_GENERAL);
+
+    // The convenience whole-range query cannot name one layout for a mixed
+    // range — UNDEFINED (discard) is its safe total answer.
+    EXPECT_EQ(tracker.CurrentLayout(image, full), VK_IMAGE_LAYOUT_UNDEFINED);
+}
+
+TEST(VulkanImageLayoutTracker, ForgetDropsStateAndReRegistrationResets)
+{
+    VulkanImageLayoutTracker tracker;
+    const auto image = FakeImage(0x33);
+    tracker.RegisterImage(image, 2, 1);
+    VkImageSubresourceRange full{ VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS };
+    tracker.SetLayout(image, full, VK_IMAGE_LAYOUT_GENERAL);
+
+    // Destroy + handle-value reuse: the recycled value must not inherit the
+    // dead image's layouts.
+    tracker.ForgetImage(image);
+    EXPECT_EQ(tracker.CurrentLayout(image, full), VK_IMAGE_LAYOUT_UNDEFINED);
+
+    // Re-registration with different extents resets too (different
+    // allocation reusing the handle value).
+    tracker.RegisterImage(image, 2, 1);
+    tracker.SetLayout(image, full, VK_IMAGE_LAYOUT_GENERAL);
+    tracker.RegisterImage(image, 6, 1);
+    EXPECT_EQ(tracker.CurrentLayout(image, full), VK_IMAGE_LAYOUT_UNDEFINED);
+}
+
+#endif // OLO_WITH_VULKAN

--- a/OloEngine/tests/Rendering/VulkanBarrierLoweringTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanBarrierLoweringTest.cpp
@@ -191,6 +191,22 @@ TEST(VulkanBarrierLowering, TrackedUndefinedOldLayoutForcesSourceMasksToNone)
     EXPECT_EQ(out.srcAccessMask, VK_ACCESS_2_NONE);
 }
 
+TEST(VulkanBarrierLowering, UndefinedBeforeWithDefinedTrackedLayoutOverSyncs)
+{
+    // The inverse mismatch: the transition claims no producer (Undefined) but
+    // the tracker says the image IS in a defined layout — an out-of-graph
+    // writer (the poison clear leaves TRANSFER_DST) produced it. NONE source
+    // masks would race that writer; the lowering must go conservative.
+    RHI::Barrier b;
+    b.Before = RHI::Access::Undefined;
+    b.After = RHI::Access::ShaderSampleRead;
+
+    const auto out = VBL::BuildImageBarrier(b, FakeImage(0x13), kColor, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, 1);
+    EXPECT_EQ(out.oldLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    EXPECT_EQ(out.srcStageMask, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+    EXPECT_NE(out.srcAccessMask & VK_ACCESS_2_MEMORY_WRITE_BIT, 0u);
+}
+
 TEST(VulkanBarrierLowering, StorageWawBarrierGetsGeneralAndWriteAccess)
 {
     // End-to-end §1.5 pin at the assembly level: a WAW transition

--- a/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
@@ -303,28 +303,71 @@ TEST_F(VulkanRenderGraphExecution, GraphTransitionsLowerToValidationCleanBarrier
     graph.BuildFrameGraph();
     graph.Execute();
 
+    // EVERY MemoryBarrier command in the plan gets lowered and executed —
+    // the graph plans one batch per consuming pass (the WAW before
+    // VkRewriter AND the RAW before VkConsumer), and exercising only the
+    // first would leave the second lowering untested on-device.
     const auto plan = graph.GetSubmissionPlan();
-    const auto barrierIt = std::ranges::find_if(plan,
-                                                [](const RenderGraph::SubmissionCommand& cmd)
-                                                { return cmd.CommandKind == RenderGraph::SubmissionCommand::Kind::MemoryBarrier; });
-    ASSERT_NE(barrierIt, plan.end());
-    ASSERT_FALSE(barrierIt->Transitions.empty());
-
-    const auto resolved = graph.ResolveTransitionsToBarriers(barrierIt->Transitions);
-    ASSERT_FALSE(resolved.empty()) << "A handle-imported resource must resolve to an RHI::Barrier";
+    struct BarrierBatch
+    {
+        MemoryBarrierFlags Flags = MemoryBarrierFlags::None;
+        std::vector<RHI::Barrier> Resolved;
+    };
+    std::vector<BarrierBatch> batches;
+    bool sawWaw = false;
+    bool sawRaw = false;
+    for (const auto& cmd : plan)
+    {
+        if (cmd.CommandKind != RenderGraph::SubmissionCommand::Kind::MemoryBarrier)
+            continue;
+        for (const auto& transition : cmd.Transitions)
+        {
+            sawWaw |= transition.ToAccess == RHI::Access::StorageWrite;
+            sawRaw |= transition.ToAccess == RHI::Access::ShaderSampleRead;
+        }
+        BarrierBatch batch;
+        batch.Flags = cmd.Barriers;
+        batch.Resolved = graph.ResolveTransitionsToBarriers(cmd.Transitions);
+        batches.push_back(std::move(batch));
+    }
+    ASSERT_GE(batches.size(), 2u) << "Expected a WAW batch (before VkRewriter) and a RAW batch (before VkConsumer)";
+    EXPECT_TRUE(sawWaw) << "The plan must carry the write->write transition (ADR 0011 §1.5)";
+    EXPECT_TRUE(sawRaw) << "The plan must carry the read-after-write transition";
+    for (const auto& batch : batches)
+        ASSERT_FALSE(batch.Resolved.empty()) << "A handle-imported resource must resolve to RHI::Barriers";
 
     VulkanRendererAPI api;
     api.Init();
 
     // Frame 1: first-use transitions (tracker answers UNDEFINED — discard).
     SubmitFrame(api, [&]
-                { api.IssueBarrierBatch(barrierIt->Barriers, resolved); });
+                {
+                    for (const auto& batch : batches)
+                        api.IssueBarrierBatch(batch.Flags, batch.Resolved); });
 
-    // Frame 2: the tracker now knows the layouts — the same batch must
-    // transition FROM the tracked layout, not UNDEFINED, and still validate
+    // Frame 2: the tracker now knows the layouts — the same batches must
+    // transition FROM the tracked layouts, not UNDEFINED, and still validate
     // clean (this is the state machine the phase exists to get right).
     SubmitFrame(api, [&]
-                { api.IssueBarrierBatch(barrierIt->Barriers, resolved); });
+                {
+                    for (const auto& batch : batches)
+                        api.IssueBarrierBatch(batch.Flags, batch.Resolved); });
+
+    // A MIXED batch — one resolvable barrier plus one whose handle cannot
+    // resolve — must keep the synchronisation the flags promised for the
+    // unresolved remainder (the conservative global fallback) instead of
+    // silently ordering only the resolved half. Validation-clean is the
+    // observable contract.
+    {
+        std::vector<RHI::Barrier> mixed = batches.front().Resolved;
+        RHI::Barrier unresolvable;
+        unresolvable.Resource = RHI::ResourceHandle{}; // null handle — never resolves
+        unresolvable.Before = RHI::Access::StorageWrite;
+        unresolvable.After = RHI::Access::ShaderSampleRead;
+        mixed.push_back(unresolvable);
+        SubmitFrame(api, [&]
+                    { api.IssueBarrierBatch(MemoryBarrierFlags::ShaderStorage, mixed); });
+    }
 
     EXPECT_EQ(VulkanDevice::GetValidationErrorCount(), 0u);
     pool.ReleaseAll();

--- a/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
@@ -53,6 +53,7 @@ TEST(VulkanRenderGraphExecution, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/StorageBuffer.h"
 #include "OloEngine/Renderer/Texture.h"
 #include "OloEngine/Renderer/TransientPool.h"
+#include "Platform/Vulkan/VulkanCapabilities.h"
 #include "Platform/Vulkan/VulkanDevice.h"
 #include "Platform/Vulkan/VulkanRendererAPI.h"
 #include "Platform/Vulkan/VulkanTransientResources.h"
@@ -126,6 +127,46 @@ class VulkanRenderGraphExecution : public ::testing::Test
         if (volkInitialize() != VK_SUCCESS)
             GTEST_SKIP() << "No Vulkan loader on this machine.";
 
+        // Probe with VulkanBringUpTest's EXACT ladder (bare instance, no
+        // layers/extensions, enumerate, Evaluate) BEFORE constructing
+        // VulkanDevice: a loader-without-ICD CI runner survives this probe
+        // path provably (VulkanBringUp skips cleanly there), while the full
+        // bring-up's extra loader calls SEH-faulted on the Windows ASan
+        // runner. Skip decisions belong on the proven path.
+        {
+            VkApplicationInfo appInfo{};
+            appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+            appInfo.pApplicationName = "OloEngine-Tests";
+            appInfo.apiVersion = VulkanCapabilities::kMinApiVersion;
+            VkInstanceCreateInfo instanceInfo{};
+            instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+            instanceInfo.pApplicationInfo = &appInfo;
+            VkInstance probe = VK_NULL_HANDLE;
+            if (vkCreateInstance(&instanceInfo, nullptr, &probe) != VK_SUCCESS)
+                GTEST_SKIP() << "vkCreateInstance failed (driver below Vulkan 1.4?).";
+            volkLoadInstance(probe);
+
+            u32 deviceCount = 0;
+            vkEnumeratePhysicalDevices(probe, &deviceCount, nullptr);
+            std::vector<VkPhysicalDevice> devices(deviceCount);
+            if (deviceCount > 0)
+                vkEnumeratePhysicalDevices(probe, &deviceCount, devices.data());
+            const bool anySatisfies = std::ranges::any_of(
+                devices,
+                [](VkPhysicalDevice device)
+                { return VulkanCapabilities::Evaluate(device).Satisfied; });
+            vkDestroyInstance(probe, nullptr);
+            if (!anySatisfies)
+            {
+                GTEST_SKIP() << "No device satisfies the ADR 0010 capability contract here — the gate would "
+                                "refuse --rhi=vulkan.";
+            }
+            // The probe's volkLoadInstance left instance-scoped pointers
+            // behind; restore loader-scoped ones for the real bring-up.
+            if (volkInitialize() != VK_SUCCESS)
+                GTEST_SKIP() << "Vulkan loader re-initialisation failed.";
+        }
+
         m_Device = std::make_unique<VulkanDevice>();
         try
         {
@@ -136,9 +177,7 @@ class VulkanRenderGraphExecution : public ::testing::Test
         catch (const std::exception& e)
         {
             m_Device.reset();
-            GTEST_SKIP() << "No device satisfies the ADR 0010 capability contract here — the gate would refuse "
-                            "--rhi=vulkan ("
-                         << e.what() << ")";
+            GTEST_SKIP() << "Vulkan bring-up refused on a contract-satisfying machine: " << e.what();
         }
 
         VulkanDevice::ResetValidationErrorCount();

--- a/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
@@ -147,10 +147,27 @@ class VulkanRenderGraphExecution : public ::testing::Test
             volkLoadInstance(probe);
 
             u32 deviceCount = 0;
-            vkEnumeratePhysicalDevices(probe, &deviceCount, nullptr);
+            if (vkEnumeratePhysicalDevices(probe, &deviceCount, nullptr) != VK_SUCCESS)
+            {
+                vkDestroyInstance(probe, nullptr);
+                GTEST_SKIP() << "vkEnumeratePhysicalDevices (count) failed on this machine.";
+            }
             std::vector<VkPhysicalDevice> devices(deviceCount);
             if (deviceCount > 0)
-                vkEnumeratePhysicalDevices(probe, &deviceCount, devices.data());
+            {
+                const VkResult listResult = vkEnumeratePhysicalDevices(probe, &deviceCount, devices.data());
+                if (listResult == VK_SUCCESS || listResult == VK_INCOMPLETE)
+                {
+                    // The second call rewrites deviceCount with how many it
+                    // actually returned (fewer on VK_INCOMPLETE).
+                    devices.resize(deviceCount);
+                }
+                else
+                {
+                    vkDestroyInstance(probe, nullptr);
+                    GTEST_SKIP() << "vkEnumeratePhysicalDevices (list) failed on this machine.";
+                }
+            }
             const bool anySatisfies = std::ranges::any_of(
                 devices,
                 [](VkPhysicalDevice device)

--- a/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanRenderGraphExecutionTest.cpp
@@ -1,0 +1,401 @@
+// OLO_TEST_LAYER: plumbing
+//
+// #691 Phase 5, the device-gated half: the render graph's execution layer on
+// a REAL Vulkan device under the validation layer (debug builds also enable
+// synchronization validation — the actual test of the barrier translation).
+//
+// What runs on-device here:
+//   1. TransientPool acquisitions materialize as VMA-backed VulkanTexture2D /
+//      VulkanStorageBuffer through the ordinary factories (the pool itself is
+//      backend-neutral — the factory arm IS the Phase 5 seam), including LIFO
+//      reuse across a simulated frame and Trim-driven deferred reclaim.
+//   2. The graph's transition records, resolved to RHI::Barriers and lowered
+//      to vkCmdPipelineBarrier2 batches through VulkanRendererAPI, with the
+//      layout tracker supplying exact oldLayouts across two simulated frames
+//      (frame 2's barriers start from tracked layouts, not UNDEFINED).
+//   3. The poison instrument's clears (ClearTextureFloat / ClearBufferFloat).
+//   4. CommandBucket packets dispatched through the SAME Molecular-Matters
+//      dispatch table against the Vulkan backend (state packets record
+//      dynamic state; draw packets hit the loud Phase 6 stubs and are
+//      COUNTED, never silent).
+//
+// The gate: VulkanDevice::GetValidationErrorCount() must stay 0 across all
+// of it. Deliberately NOT routed through RenderCommand's process-wide
+// backend: swapping the global mid-suite would destroy an initialized GL
+// backend under later GPU tests. The facade wiring is exercised by the GL
+// suite (same neutral path); this test injects a local VulkanRendererAPI,
+// which is exactly what CommandBucket::Execute(RendererAPI&) exists for.
+//
+// SKIP ladder mirrors VulkanBringUpTest: no loader / no instance / no device
+// satisfying the ADR 0010 contract -> clean SKIP, headless CI stays green.
+
+#include "OloEngine/Core/Base.h"
+
+#include <gtest/gtest.h>
+
+#if !OLO_WITH_VULKAN
+
+TEST(VulkanRenderGraphExecution, SkipsWhenNotCompiledIn)
+{
+    GTEST_SKIP() << "Built with OLO_WITH_VULKAN=OFF — the Vulkan backend is not compiled in.";
+}
+
+#else
+
+#include "OloEngine/Renderer/Commands/CommandAllocator.h"
+#include "OloEngine/Renderer/Commands/CommandBucket.h"
+#include "OloEngine/Renderer/Commands/CommandDispatch.h"
+#include "OloEngine/Renderer/Commands/RenderCommand.h"
+#include "OloEngine/Renderer/Framebuffer.h"
+#include "OloEngine/Renderer/RenderGraph.h"
+#include "OloEngine/Renderer/RenderGraphNode.h"
+#include "OloEngine/Renderer/RendererAPI.h"
+#include "OloEngine/Renderer/StorageBuffer.h"
+#include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Renderer/TransientPool.h"
+#include "Platform/Vulkan/VulkanDevice.h"
+#include "Platform/Vulkan/VulkanRendererAPI.h"
+#include "Platform/Vulkan/VulkanTransientResources.h"
+
+#include "RenderingTestUtils.h"
+
+#include <volk.h>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+
+namespace
+{
+    using namespace OloEngine;
+
+    // RAII flip of the process-wide API selector around the factory calls —
+    // Texture2D::Create / StorageBuffer::Create switch on it. Restores
+    // OpenGL so later suite tests see the default untouched. Deliberately
+    // does NOT touch RenderCommand's process-wide backend (swapping it
+    // mid-suite would destroy an initialized GL backend under later GPU
+    // tests) — everything here injects a local VulkanRendererAPI instead.
+    struct ScopedVulkanApiSelection
+    {
+        ScopedVulkanApiSelection()
+        {
+            RendererAPI::SetAPI(RendererAPI::API::Vulkan);
+        }
+        ~ScopedVulkanApiSelection()
+        {
+            RendererAPI::SetAPI(RendererAPI::API::OpenGL);
+        }
+    };
+
+    // Minimal setup-lambda node (the RenderGraphTest.cpp stub pattern —
+    // local because that helper is file-local there).
+    class VkExecStubPass : public RenderGraphNode
+    {
+      public:
+        using SetupFn = std::function<void(RGBuilder&)>;
+
+        VkExecStubPass(const std::string& name, SetupFn setup)
+            : m_Setup(std::move(setup))
+        {
+            m_Name = name;
+        }
+
+        void Init(const FramebufferSpecification& /*spec*/) override {}
+        void Setup(RGBuilder& builder, FrameBlackboard& blackboard) override
+        {
+            RenderGraphNode::Setup(builder, blackboard);
+            if (m_Setup)
+                m_Setup(builder);
+        }
+        void Execute(RGCommandContext& /*context*/) override {}
+        [[nodiscard]] Ref<Framebuffer> GetTarget() const override
+        {
+            return nullptr;
+        }
+
+      private:
+        SetupFn m_Setup;
+    };
+} // namespace
+
+class VulkanRenderGraphExecution : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        if (volkInitialize() != VK_SUCCESS)
+            GTEST_SKIP() << "No Vulkan loader on this machine.";
+
+        m_Device = std::make_unique<VulkanDevice>();
+        try
+        {
+            // Headless: no surface — the device pick requires graphics only.
+            m_Device->Init([](VkInstance)
+                           { return VK_NULL_HANDLE; });
+        }
+        catch (const std::exception& e)
+        {
+            m_Device.reset();
+            GTEST_SKIP() << "No device satisfies the ADR 0010 capability contract here — the gate would refuse "
+                            "--rhi=vulkan ("
+                         << e.what() << ")";
+        }
+
+        VulkanDevice::ResetValidationErrorCount();
+
+        VkCommandBufferAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        allocInfo.commandPool = m_Device->GetCommandPool();
+        allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        allocInfo.commandBufferCount = 1;
+        ASSERT_EQ(vkAllocateCommandBuffers(m_Device->GetDevice(), &allocInfo, &m_Cmd), VK_SUCCESS);
+
+        VkFenceCreateInfo fenceInfo{};
+        fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        ASSERT_EQ(vkCreateFence(m_Device->GetDevice(), &fenceInfo, nullptr, &m_Fence), VK_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if (!m_Device)
+            return;
+        vkDeviceWaitIdle(m_Device->GetDevice());
+        VulkanDeferredReclaim::Get().FlushAll();
+        if (m_Fence != VK_NULL_HANDLE)
+            vkDestroyFence(m_Device->GetDevice(), m_Fence, nullptr);
+        // Command buffer returns with the pool inside VulkanDevice::Shutdown.
+        EXPECT_EQ(VulkanDevice::GetValidationErrorCount(), 0u)
+            << "The Phase 5 bar: ZERO validation errors (sync validation included in debug builds)";
+        m_Device->Shutdown();
+        m_Device.reset();
+    }
+
+    // Record `work` into the command buffer through the Vulkan backend,
+    // submit, and wait — one simulated frame.
+    void SubmitFrame(VulkanRendererAPI& api, const std::function<void()>& work)
+    {
+        ASSERT_EQ(vkResetCommandBuffer(m_Cmd, 0), VK_SUCCESS);
+        VkCommandBufferBeginInfo beginInfo{};
+        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        ASSERT_EQ(vkBeginCommandBuffer(m_Cmd, &beginInfo), VK_SUCCESS);
+
+        api.BeginRecording(m_Cmd);
+        work();
+        api.EndRecording();
+
+        ASSERT_EQ(vkEndCommandBuffer(m_Cmd), VK_SUCCESS);
+
+        VkSubmitInfo submit{};
+        submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit.commandBufferCount = 1;
+        submit.pCommandBuffers = &m_Cmd;
+        ASSERT_EQ(vkResetFences(m_Device->GetDevice(), 1, &m_Fence), VK_SUCCESS);
+        ASSERT_EQ(vkQueueSubmit(m_Device->GetQueue(), 1, &submit, m_Fence), VK_SUCCESS);
+        ASSERT_EQ(vkWaitForFences(m_Device->GetDevice(), 1, &m_Fence, VK_TRUE, UINT64_MAX), VK_SUCCESS);
+        VulkanDeferredReclaim::Get().NotifyFrameCompleted();
+    }
+
+    std::unique_ptr<VulkanDevice> m_Device;
+    VkCommandBuffer m_Cmd = VK_NULL_HANDLE;
+    VkFence m_Fence = VK_NULL_HANDLE;
+};
+
+TEST_F(VulkanRenderGraphExecution, TransientPoolMaterializesVmaResourcesAndReusesThem)
+{
+    ScopedVulkanApiSelection vulkanSelected;
+
+    TransientPool pool;
+
+    TextureSpecification spec;
+    spec.Width = 128;
+    spec.Height = 128;
+    spec.Format = ImageFormat::RGBA16F;
+
+    const auto tex = pool.AcquireTexture(spec);
+    ASSERT_TRUE(tex);
+    EXPECT_TRUE(tex->GetRHIHandle().IsValid()) << "A Vulkan transient mints an identity like the GL twin";
+    EXPECT_EQ(tex->GetRendererID(), 0u) << "No GL name exists under Vulkan — the diagnostics field is 0";
+
+    const auto buffer = pool.AcquireBuffer(4096);
+    ASSERT_TRUE(buffer);
+    EXPECT_TRUE(buffer->GetRHIHandle().IsValid());
+
+    // LIFO reuse: release-all then re-acquire the same descriptor must hand
+    // back the SAME physical object (the pool's aliasing model is
+    // backend-neutral — Phase 5 must not have disturbed it).
+    const auto firstHandle = tex->GetRHIHandle();
+    pool.ReleaseAll();
+    const auto reacquired = pool.AcquireTexture(spec);
+    ASSERT_TRUE(reacquired);
+    EXPECT_EQ(reacquired->GetRHIHandle(), firstHandle) << "Same descriptor -> same pooled object (LIFO)";
+
+    // Trim to zero: pooled objects are destroyed -> the VMA backing goes
+    // through the deferred-reclaim queue, drained in TearDown after the
+    // fence — destroying in-flight memory inline is the hazard the queue
+    // exists for.
+    pool.ReleaseAll();
+    pool.Trim(0);
+    pool.Clear();
+}
+
+TEST_F(VulkanRenderGraphExecution, GraphTransitionsLowerToValidationCleanBarrierBatches)
+{
+    ScopedVulkanApiSelection vulkanSelected;
+
+    // Pool-acquired Vulkan resources, imported into the graph BY HANDLE —
+    // the identity currency is what makes a Vulkan graph resolvable
+    // (native-only imports are GL's migration tail).
+    TransientPool pool;
+    TextureSpecification colorSpec;
+    colorSpec.Width = 64;
+    colorSpec.Height = 64;
+    colorSpec.Format = ImageFormat::RGBA16F;
+    const auto colorTex = pool.AcquireTexture(colorSpec);
+    ASSERT_TRUE(colorTex);
+    const auto storageBuf = pool.AcquireBuffer(1024);
+    ASSERT_TRUE(storageBuf);
+
+    RenderGraph graph;
+    graph.SetRuntimeBarrierExecutionEnabled(false); // we drive the barriers ourselves below
+
+    RGResourceDesc texDesc;
+    texDesc.Kind = RGResourceHandle::Kind::Texture2D;
+    texDesc.Format = RGResourceFormat::RGBA16Float;
+    texDesc.Width = 64;
+    texDesc.Height = 64;
+    [[maybe_unused]] const auto texHandle = graph.ImportTextureHandle("VkColor", colorTex->GetRHIHandle(), texDesc);
+
+    // Producer writes the imported texture as a storage image; a second
+    // writer follows (the §1.5 WAW shape); a consumer samples it. The plan
+    // therefore carries a RAW *and* a WAW transition to lower.
+    const auto colorIdentity = colorTex->GetRHIHandle();
+    auto producer = Ref<VkExecStubPass>::Create(
+        "VkProducer",
+        [&texDesc, colorIdentity](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTextureHandle("VkColor", colorIdentity, texDesc);
+            builder.Write(tex, RGWriteUsage::ShaderImage);
+        });
+    graph.AddNode(producer);
+
+    auto rewriter = Ref<VkExecStubPass>::Create(
+        "VkRewriter",
+        [&texDesc, colorIdentity](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTextureHandle("VkColor", colorIdentity, texDesc);
+            builder.Write(tex, RGWriteUsage::ShaderImage);
+        });
+    graph.AddNode(rewriter);
+
+    auto consumer = Ref<VkExecStubPass>::Create(
+        "VkConsumer",
+        [&texDesc, colorIdentity](RGBuilder& builder)
+        {
+            auto tex = builder.ImportTextureHandle("VkColor", colorIdentity, texDesc);
+            [[maybe_unused]] const auto sampled = builder.Read(tex, RGReadUsage::ShaderSample);
+        });
+    graph.AddNode(consumer);
+
+    graph.AddExecutionDependency("VkProducer", "VkRewriter");
+    graph.AddExecutionDependency("VkRewriter", "VkConsumer");
+    graph.SetFinalPass("VkConsumer");
+    graph.BuildFrameGraph();
+    graph.Execute();
+
+    const auto plan = graph.GetSubmissionPlan();
+    const auto barrierIt = std::ranges::find_if(plan,
+                                                [](const RenderGraph::SubmissionCommand& cmd)
+                                                { return cmd.CommandKind == RenderGraph::SubmissionCommand::Kind::MemoryBarrier; });
+    ASSERT_NE(barrierIt, plan.end());
+    ASSERT_FALSE(barrierIt->Transitions.empty());
+
+    const auto resolved = graph.ResolveTransitionsToBarriers(barrierIt->Transitions);
+    ASSERT_FALSE(resolved.empty()) << "A handle-imported resource must resolve to an RHI::Barrier";
+
+    VulkanRendererAPI api;
+    api.Init();
+
+    // Frame 1: first-use transitions (tracker answers UNDEFINED — discard).
+    SubmitFrame(api, [&]
+                { api.IssueBarrierBatch(barrierIt->Barriers, resolved); });
+
+    // Frame 2: the tracker now knows the layouts — the same batch must
+    // transition FROM the tracked layout, not UNDEFINED, and still validate
+    // clean (this is the state machine the phase exists to get right).
+    SubmitFrame(api, [&]
+                { api.IssueBarrierBatch(barrierIt->Barriers, resolved); });
+
+    EXPECT_EQ(VulkanDevice::GetValidationErrorCount(), 0u);
+    pool.ReleaseAll();
+    pool.Clear();
+}
+
+TEST_F(VulkanRenderGraphExecution, PoisonClearsAndBucketDispatchRunOnVulkan)
+{
+    ScopedVulkanApiSelection vulkanSelected;
+
+    TransientPool pool;
+    TextureSpecification spec;
+    spec.Width = 32;
+    spec.Height = 32;
+    spec.Format = ImageFormat::RGBA8;
+    const auto tex = pool.AcquireTexture(spec);
+    ASSERT_TRUE(tex);
+    const auto buf = pool.AcquireBuffer(256);
+    ASSERT_TRUE(buf);
+
+    VulkanRendererAPI api;
+    api.Init();
+
+    // The poison instrument's exact backend calls
+    // (render-graph-transient-aliasing.md's hunt levers must stay armed on
+    // the second backend).
+    SubmitFrame(api, [&]
+                {
+                    api.ClearTextureFloat(tex->GetRHIHandle(), 0, { 1.0f, 0.0f, 1.0f, 1.0f });
+                    api.ClearBufferFloat(buf->GetRHIHandle(), 1.0e9f); });
+
+    // The same recorded CommandBucket packets the GL dispatcher executes,
+    // against the Vulkan backend, through the SAME Molecular-Matters
+    // dispatch table: state packets apply (dynamic state or recorded
+    // pipeline-key state), draw packets would hit the LOUD Phase 6 stub
+    // counter — dispatched, counted, never silent.
+    //
+    // Initialize is idempotent (re-assigns the same table); Shutdown is
+    // deliberately NOT called — the table is process-wide, the renderer's
+    // one-time init populates it for the whole suite, and tearing it down
+    // here nulls the dispatch resolver under every visual test that runs
+    // after this one (found as 51 suite-order-only visual failures).
+    CommandDispatch::Initialize();
+    {
+        auto allocator = std::make_unique<CommandAllocator>();
+        CommandBucket bucket;
+
+        const auto viewport = MakeSyntheticViewportCommand(0, 0, 32, 32);
+        const auto depthTest = MakeSyntheticDepthTestCommand(true);
+
+        PacketMetadata meta0;
+        meta0.m_ExecutionOrder = 0;
+        meta0.m_DependsOnPrevious = true;
+        PacketMetadata meta1;
+        meta1.m_ExecutionOrder = 1;
+        meta1.m_DependsOnPrevious = true;
+        bucket.Submit(viewport, meta0, allocator.get());
+        bucket.Submit(depthTest, meta1, allocator.get());
+        bucket.SortCommands();
+
+        const u64 stubsBefore = api.GetPhase6StubHitCount();
+        SubmitFrame(api, [&]
+                    { bucket.Execute(api); });
+        EXPECT_EQ(api.GetPhase6StubHitCount(), stubsBefore)
+            << "Pure state packets must dispatch without touching a Phase 6 stub";
+        bucket.Reset(*allocator);
+    }
+
+    EXPECT_EQ(VulkanDevice::GetValidationErrorCount(), 0u);
+    pool.ReleaseAll();
+    pool.Clear();
+}
+
+#endif // OLO_WITH_VULKAN

--- a/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
+++ b/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
@@ -2018,6 +2018,163 @@ line for that API's import library.
 
 ---
 
+## Amendments from Phase 5 (2026-08-08) — the render graph's execution layer
+
+Phase 5 landed the three §1.8 deliverables (the unified access enum, the Clear
+split, external→Undefined) plus the barrier translation, the VMA-backed
+transient pool, and the command dispatcher on Vulkan. Seven findings correct
+or sharpen what earlier phases predicted.
+
+### (43) The WAW fix belongs at barrier EMISSION, not in the transition build
+
+§1.5's plan was "unify the transition record's enum pair". Implementing it
+showed the record was downstream of the defect: `BuildResourceTransitions`
+re-derived the consumer's access by scanning its READ declarations, and no
+record type can recover what that scan already dropped. The fix that works is
+one line earlier — `PlannedBarrier` now captures `ToAccess` AT EMISSION, where
+the planner is holding the exact consuming declaration (a read for RAW, a
+WRITE for WAW). The rescan is deleted, not patched. Everything else landed as
+designed: `ResourceTransition` carries `RHI::Access FromAccess/ToAccess`,
+`ProducerPass == "external"` yields `Access::Undefined` (Vulkan discards),
+`RGWriteUsage::Clear` maps to `ClearAsLoadOp` (its only engine producer,
+OITPrepare, is a load-op clear — an explicit transfer clear must be declared
+`TransferDest`), and the §1.5 read-while-attached input is a computed
+`ReadWhileAttached` flag (consumer also declares an overlapping attachment
+write). Pinned by `RenderGraphResourceTransitions.WriteAfterWriteTransition
+CarriesTheConsumersWriteAccess` and siblings.
+
+*Generalisable:* when a derivation is lossy, fix the producer to carry the
+fact, not the consumer to guess better — the guess was the bug.
+
+### (44) The barrier facade is ONE virtual carrying BOTH currencies
+
+`RendererAPI::IssueBarrierBatch(MemoryBarrierFlags, span<RHI::Barrier>)` is
+the §1.5 demotion made literal: the flags are the GL lowering, the barrier
+span is the neutral truth, and each backend consults exactly one. The GL
+implementation delegates to the pre-existing `MemoryBarrier(flags)` —
+byte-identical behaviour, which is what kept the goldens out of play. The
+planner still derives the flags (`Resolve*BarrierFlags` did NOT physically
+relocate to `Platform/OpenGL/`; they are now labelled as the GL lowering and
+feed only the flags field — the §1.8 table never listed the move, and doing
+it would have rebuilt the proven GL path for zero behaviour change).
+`TextureAspect` / `SubresourceRange` / `Barrier` moved `RHIResources.h` →
+`RHITypes.h` for the facade's include set — the amendment-(5) MemoryResidency
+move-don't-duplicate precedent, third use.
+
+### (45) Handle resolution is an EXECUTE-time act; the plan stays name-keyed
+
+The submission IR's `MemoryBarrier` commands carry the per-consumer
+transitions (deduplicated on (resource, range, from, to)), but resolution to
+`RHI::Barrier` happens per frame in `RenderGraph::ResolveTransitionsToBarriers`
+— a transient's physical changes across frames under pooling, so a handle
+baked into the cached plan would be the stale-pool-read archetype
+(render-graph-transient-aliasing.md) built into the IR. Dedup keeps
+LAST-writer semantics: earlier writers are ordered transitively through the
+WAW barriers between the writers themselves. **Recorded caveat (Phase 7
+hardening item):** two prior writers touching DISJOINT subresources of one
+resource collapse to the last writer's source masks — no WAW barrier chains
+them (their ranges don't overlap), so the earlier writer's pipe is
+under-synchronised. No current graph hits it; sync validation is the
+instrument that will name the pass that first does. This closed a second
+identity gap on the way: `PhysicalBuffer` now carries `Handle` alongside
+`BufferID` (set by materialization/alias fan-out, CLEARED by native imports —
+the item-4 grep-every-assignment rule found one more site-class).
+
+### (46) The layout state machine: the tracker owns oldLayout, exactness per run
+
+GL has no image layouts, so this state machine is new, and its two rules are
+the phase's core correctness claims. (1) The TRACKER is authoritative for
+`oldLayout`, never the transition's `FromAccess` — a pooled transient
+re-acquired this frame is in whatever layout its previous tenant left, and
+first use is UNDEFINED (which also forces the source masks to NONE: discarded
+contents have nothing to make available). `FromAccess` contributes only
+source stage/access masks. (2) A range whose subresources sit in DIFFERENT
+layouts (HZB: mip 0 attachment-written, mips 1..N storage-written) is split
+into maximal equal-layout runs, one `VkImageMemoryBarrier2` per run — one
+guessed layout for a mixed range is a validation error at best and a silent
+hazard at worst. Granularity is per (mip, layer) with registered extents.
+Pinned headlessly by `VulkanBarrierLoweringTest` (fabricated handles) and
+on-device by `VulkanRenderGraphExecutionTest`'s two-frame sequence (frame 2
+must transition FROM tracked layouts, not UNDEFINED).
+
+### (47) The "Vulkan-side dispatcher" is the backend BEHIND the existing table
+
+The Molecular-Matters dispatch table was already backend-neutral — its
+functions take `RendererAPI&` — so Phase 5 added no second table:
+`VulkanRendererAPI` behind the same packets is the dispatcher. Amendment
+(42)'s "~100 no-op virtuals inviting silent fallthrough" objection is met
+with three tiers, none silent: REAL implementations (barriers, transient
+clears, viewport/scissor dynamic state, device queries, debug labels);
+RECORDED pipeline-key state for the ~33 state setters
+(`VulkanRecordedPipelineState` — Vulkan bakes this into the PSO, so recording
+IS the correct Phase 5 semantics and hands Phase 6 its pipeline-key material);
+and warn-once + counted stubs for everything pipeline-shaped
+(`GetPhase6StubHitCount` — the execution test pins that state packets never
+touch it). Recording context: `BeginRecording(VkCommandBuffer)`/`EndRecording`
+brackets, because Vulkan has no implicit current context. The two
+`RenderCommand::` calls inside CommandDispatch's bind-cache helpers were NOT
+rerouted: post-(48) they reach the same selected backend as the injected
+`api`, and re-plumbing ~30 call sites for identity's sake is churn — recorded
+as a known quirk instead.
+
+### (48) Amendment (39) closed — and the first live run caught a feature-gate rule
+
+`RenderCommand::RecreateForSelectedBackend()` runs in `Application`'s
+constructor immediately after `SetAPI`, before `Window::Create` — the only
+moment the swap is legal (nothing has routed, nothing holds a captured
+reference). The dormant-OpenGL-object atexit warning under `--rhi=vulkan`
+dies with it. The finding the validation gate then produced on its FIRST
+device run: **a barrier stage mask may only name stages whose device
+features are ENABLED** (VUID-VkImageMemoryBarrier2-dstStageMask-03929/-03930)
+— the graphics shader-stage union named tessellation/geometry stages the
+bring-up device never enabled. Resolution: `VulkanDevice` enables
+`tessellationShader`/`geometryShader` WHEN SUPPORTED (never required — they
+are not ADR 0010 contract rows, and requiring them would silently widen the
+gate), and `VulkanRendererAPI` ANDs every per-resource barrier's stage masks
+with the enabled-stage mask (a disabled stage can hold no work, so narrowing
+loses no synchronisation; the catch-all ALL_COMMANDS/ALL_TRANSFER bits pass
+through). Sync validation is now always on in debug builds
+(`VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT` chained at
+instance create), and the debug messenger counts ERROR-severity messages —
+`VulkanDevice::GetValidationErrorCount() == 0` is an ASSERTABLE property, not
+a log to eyeball. Its second catch, minutes later, was in PHASE 4'S OWN
+frame loop: the swapchain UNDEFINED→TRANSFER_DST transition used
+`srcStageMask = TOP_OF_PIPE`, which does not order the layout transition
+against the acquire semaphore's wait at the CLEAR stage — a WRITE_AFTER_READ
+hazard against `vkAcquireNextImageKHR` that core validation cannot see (the
+structure is legal; only the timeline is wrong). The rule, now in the code
+comment: **the first barrier that writes an acquired swapchain image must
+carry the acquire-wait stage in its srcStageMask.** Phase 4's "zero
+validation errors" bar was real but ran without the sync layer; Phase 5's
+bar includes it.
+
+### (49) VMA resource notes a later phase will otherwise rediscover
+
+- `DEPTH24STENCIL8` resolves to `VK_FORMAT_D32_SFLOAT_S8_UINT`, not
+  `D24_UNORM_S8_UINT` — Vulkan mandates only one of the two and AMD ships
+  only the D32 variant. 3-channel formats widen to RGBA (no mandated
+  optimal-tiling support). STORAGE usage is dropped for sRGB-resolved and
+  multisampled images (guaranteed format-feature validation errors
+  otherwise).
+- Deferred reclaim is generation-counted (destroy at ≥ 2
+  `NotifyFrameCompleted`s, tied to `kFramesInFlight = 2`) because
+  `TransientPool::Clear()/Trim()` destroy pooled objects while prior frames
+  may still execute — on GL the driver refcounts; on Vulkan inline
+  destruction is UB. `FlushAll()` is the device-idle path.
+- A Vulkan resource's `GetRendererID()` is 0 — the diagnostics-only field has
+  no native GL name to report, and `olo_render_transient_plan`'s `glId` shows
+  0 until Phase 8's capture parity (the identity fields beside it answer the
+  alias question).
+- Full-frame graph execution through the `RenderCommand` facade inside a
+  real window loop is deliberately NOT wired this phase: pass `Execute()`
+  bodies need PSOs, so the editor's `--rhi=vulkan` path still ends at the
+  Phase 4 clear+present. The execution layer's on-device proof is the
+  device-gated test (headless `VulkanDevice`, real queue submits, zero
+  validation errors) — Phase 6 owns moving it into the frame loop with the
+  first rendered pass.
+
+---
+
 ## Consequences
 
 - The renderer carries **four** boundary concepts where it carries one today

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -2023,41 +2023,42 @@ single "not yet" bucket would have been worse than none.
 
 ---
 
-## 5. `ResourceTransition` looks backend-neutral and is neutral only by accident
+## 5. `ResourceTransition` looked backend-neutral by accident — FIXED in Phase 5
 
-`RenderGraph::ResourceTransition` carries `ResourceName`, `ProducerPass`,
-`ConsumerPass`, `FromUsage`, `ToUsage`, `Range`, and cross-queue metadata. That
-is very nearly a Vulkan barrier, and the barrier planner is genuinely
-backend-agnostic — real RHI-shaped thinking.
+**Status: the defect below was fixed in Phase 5 (2026-08-08); kept because the
+lesson generalises.** `ResourceTransition` now carries the unified
+`RHI::Access FromAccess/ToAccess` pair, `PlannedBarrier` captures the
+consumer's access AT EMISSION (a read for RAW, a WRITE for WAW — the lossy
+read-declaration rescan is deleted, not patched), `"external"` producers carry
+`Access::Undefined`, and `ReadWhileAttached` marks same-pass feedback reads.
+The two-currency contract is literal in the facade:
+`RendererAPI::IssueBarrierBatch(MemoryBarrierFlags, span<RHI::Barrier>)` — GL
+executes the flags (byte-identical to the old `glMemoryBarrier` path), Vulkan
+lowers the barrier span (`Platform/Vulkan/VulkanBarrierLowering` +
+`VulkanImageLayoutTracker`), and neither backend may consult both. See ADR
+0011 amendments (43)–(48).
 
-But the transition is typed `RGWriteUsage FromUsage` → `RGReadUsage ToUsage`, so
-it **structurally cannot express a write → write transition.** The planner *does*
-emit WAW barriers. `BuildResourceTransitions` then looks for a matching **read**
-declaration on the consumer, finds none, and silently defaults to
-`t.ToUsage = RGReadUsage::ShaderSample`.
-
-On GL this is invisible, because the actual synchronisation comes from
-`barrier.Flags` (a `glMemoryBarrier` bitmask the planner derived correctly from
-the *write* usage) and the bogus `ToUsage` is never read. On Vulkan, a backend
-deriving `(dstStageMask, dstAccessMask, newLayout)` from `ToUsage` would lower a
-storage-image WAW into `SHADER_READ_ONLY_OPTIMAL` with a read-only access mask —
-wrong layout, wrong access, silent.
+The original finding, for the pattern: the transition was typed
+`RGWriteUsage FromUsage` → `RGReadUsage ToUsage`, so it **structurally could
+not express a write → write transition.** The planner *did* emit WAW barriers;
+`BuildResourceTransitions` then looked for a matching **read** declaration on
+the consumer, found none, and silently defaulted to `ShaderSample`. On GL
+invisible (only `Flags` was executed); on Vulkan it would have lowered a
+storage-image WAW into `SHADER_READ_ONLY_OPTIMAL` with a read-only access mask
+— wrong layout, wrong access, silent.
 
 **Generalisable lesson: a record is not backend-neutral just because its field
-types are.** This one is held up by a GL-specific field sitting next to it. When
+types are.** It was held up by a GL-specific field sitting next to it. When
 auditing an abstraction for a second backend, ask what each field is *actually
-read for today* — a field nothing reads is a field nothing keeps correct.
+read for today* — a field nothing reads is a field nothing keeps correct. And
+when the derivation of a field is lossy, fix the PRODUCER to carry the fact
+rather than the consumer to guess better — the guess was the bug.
 
-Related, same audit: `MemoryBarrierFlags` is a `glMemoryBarrier` bitmask that has
-been promoted to the neutral currency (`PlannedBarrier::Flags`,
-`RGCommandContext::MemoryBarrier`, `RendererAPI::MemoryBarrier`). The usage pair
-is the truth; the flags are a GL lowering and belong in the GL backend.
-
-And a non-gap worth recording so nobody adds it: **the neutral model deliberately
-carries no image layout.** Layout is a pure function of usage
-(`ShaderSample → SHADER_READ_ONLY_OPTIMAL`, `RenderTarget → COLOR_ATTACHMENT_OPTIMAL`,
-`ShaderImage → GENERAL`, …), so the Vulkan backend derives it. Hoisting a layout
-enum into the render graph leaks Vulkan upward for zero gain.
+Layout stays out of the neutral model, as designed — but it is a function of
+**(Access, aspect, read-while-attached)**, not of access alone (ADR 0011
+§1.5's three exception cases), and the barrier's `oldLayout` comes from the
+backend's layout TRACKER, never from `FromAccess`: a pooled transient is in
+whatever layout its previous tenant left, and first use is UNDEFINED.
 
 ---
 


### PR DESCRIPTION
Phase 5 of #691: the render graph's execution layer runs on Vulkan — barriers issued, transients allocated, packets dispatched. Rendering a pass is Phase 6's checkpoint (PSO/SPIR-V path); this phase's bar is validation-clean execution + contract tests, and it holds.

## The neutral half (GL byte-identical, goldens untouched)

- **All three ADR 0011 §1.8 Phase 5 deliverables:** `ResourceTransition` unifies onto `RHI::Access`; `ProducerPass == "external"` now means `Access::Undefined` (discardable); `RGWriteUsage::Clear` maps to `ClearAsLoadOp`.
- **The write→write defect is fixed at the source:** `PlannedBarrier` captures the consumer's access **at emission** (a read for RAW, a WRITE for WAW) — the lossy read-declaration rescan that silently defaulted WAW consumers to `ShaderSample` is deleted, not patched. `ReadWhileAttached` marks same-pass feedback reads (the PCSS raw-depth layout input).
- **Two-currency facade seam:** `RendererAPI::IssueBarrierBatch(MemoryBarrierFlags, span<RHI::Barrier>)` — GL executes the flags exactly as before, an explicit-barrier backend lowers the span; neither consults both. Submission-IR barrier commands carry deduped per-consumer transitions; handle resolution happens at **execute time** (`ResolveTransitionsToBarriers`), never plan-bake — transient physicals change per frame (the stale-pool-read archetype). `PhysicalBuffer` gains the identity currency.

## The Vulkan half

- `VulkanDevice`: headless-constructible extraction from `VulkanContext` (same behaviour windowed), **validation-error counter** + **synchronization validation on in debug** — "zero validation errors" is now an assertable property.
- `VulkanBarrierLowering`: pure `(Access, aspect, read-while-attached)` → stage₂/access₂/layout tables, pinned headlessly in CI.
- `VulkanImageLayoutTracker`: per-(mip,layer) layout state; the **tracker owns `oldLayout`** (`FromAccess` only drives source masks; UNDEFINED forces them to NONE), and mixed-layout ranges split into exact per-run barriers (the HZB shape).
- VMA-backed `VulkanTexture2D`/`VulkanFramebuffer`/`VulkanStorageBuffer` behind the ordinary `Create()` factories — the pool itself needed zero changes — plus generation-counted deferred reclaim (destroying pooled GPU objects while frames are in flight is UB on Vulkan).
- `VulkanRendererAPI` behind the **existing** Molecular-Matters dispatch table (the table was already backend-neutral): real barriers/clears/viewport/scissor/device queries/debug labels, **recorded pipeline-key state** for the ~33 state setters (Phase 6's PSO-key material), and warn-once **counted** stubs for everything pipeline-shaped — nothing falls through silently.
- Amendment (39) closed: `RenderCommand::RecreateForSelectedBackend()` after `--rhi=` selection; the dormant-GL atexit warning dies with it.

## Sync validation earned its keep on day one

Its first runs caught **two real bugs**: barrier stage masks naming stages whose device features weren't enabled (VUID-03929/30 — fixed by enabling tess/geom when supported and narrowing the masks), and a latent WRITE_AFTER_READ in **Phase 4's own** swapchain transition (`TOP_OF_PIPE` vs the acquire-wait stage) that core validation structurally cannot see. Both fixed; the rule is in the code comments and ADR 0011 amendment (48).

## Evidence

- Device-gated `VulkanRenderGraphExecutionTest` on the RTX 4090: VMA transient LIFO reuse + Trim reclaim, two-frame barrier sequences transitioning **from tracked layouts**, poison clears, bucket dispatch with zero stub hits for state packets — **`GetValidationErrorCount() == 0`** throughout, sync validation included.
- Headless `VulkanBarrierLoweringTest` pins the lowering tables + tracker runs in plain CI (SKIPs to one test when `OLO_WITH_VULKAN=OFF`).
- **Full suite 5568/5575** — matches the Phase 4 baseline exactly (6 environment skips; sole failure = permanently-red #754). Goldens untouched (`OLOENGINE_GOLDEN_REBASE` unset).
- Live `--rhi=vulkan` editor: cornflower clear + present, clean log (only the user's OBS overlay layer warning). Live default-GL editor: VehiclesTest scene at 160 FPS, unaffected.

Docs: ADR 0011 amendments (43)–(49); `rhi-abstraction-boundary.md` §5 rewritten as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Vulkan renderer support, including device setup, transient resources, synchronization, and image-layout tracking.
  - Render-graph execution now resolves detailed resource transitions, write-after-write barriers, and attachment feedback.
  - Added Vulkan support for textures, framebuffers, and storage buffers.
  - Renderer selection is applied before window and rendering initialization.

- **Bug Fixes**
  - Improved renderer initialization diagnostics and reduced misleading OpenGL shutdown warnings.

- **Tests**
  - Added Vulkan barrier, resource, and render-graph execution coverage with validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->