### PR TITLE
fix(vendor): pin Jolt to the v5.6.0 release tag

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,8 +55,9 @@
       // Style 2 — pinned to a release tag, e.g. "GIT_TAG v3.0.0".
       // Tags here always contain a "." (v3.0.0, 3.4, 1.0.20-RELEASE, ...) while
       // the digest pins above are dot-free hex, so requiring a "." in the value
-      // cleanly separates the two styles (and skips bare-SHA pins like Jolt,
-      // which carry no branch hint and can't be auto-tracked — left manual).
+      // cleanly separates the two styles (and skips a bare SHA with no trailing
+      // comment at all, which carries no branch/tag hint and can't be
+      // auto-tracked — left manual; no vendored dep is pinned that way today).
       customType: "regex",
       managerFilePatterns: ["/^OloEngine/vendor/CMakeLists\\.txt$/"],
       datasourceTemplate: "github-tags",

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -81,17 +81,17 @@ FetchContent_Declare(
 # Pin Jolt to a fixed commit (not a floating branch). A floating `GIT_TAG master`
 # makes builds non-deterministic — CI can fetch a newer Jolt than any dev with zero
 # repo changes, which is exactly how the #281 flaky physics crash hid (CI and local
-# ran different Jolt commits). We can't pin to a release tag: the engine uses
-# JPH::CharacterContact (JoltCharacterController.h), a CharacterVirtual contact-listener
-# type added after the latest release (v5.5.0). 6cef2a22 is the master HEAD as of
-# 2026-06-01 that 100/100 Release runs pass against locally. Bump deliberately after
+# ran different Jolt commits). v5.6.0 is a tested release tag that carries
+# JPH::CharacterContact (JoltCharacterController.h uses it as a CharacterVirtual
+# contact-listener type) — deliberate release pin per #294 (gold-standard form:
+# SHA + "# <tag>" comment, same shape as cpp_httplib above). Bump deliberately after
 # re-testing the JoltScene/JoltJobSystemAdapter integration.
 # NOTE: GIT_SHALLOW must be FALSE when GIT_TAG is a commit SHA — a shallow fetch only
 # pulls branch tips, so it can't resolve an arbitrary historical commit.
 FetchContent_Declare(
 	joltphysics
 	GIT_REPOSITORY https://github.com/jrouwe/JoltPhysics.git
-	GIT_TAG 6cef2a2214741a77fff8771e233c84da6b875ed5
+	GIT_TAG e77f175595e64cb44218cc9d9d56fc365ad0e36a  # v5.6.0
 	GIT_SHALLOW		FALSE
 	SOURCE_SUBDIR Build
 )


### PR DESCRIPTION
## Summary
- Repoints Jolt's `GIT_TAG` from the master-snapshot SHA `6cef2a22...` to the **v5.6.0 release tag's commit** (`e77f175595e64cb44218cc9d9d56fc365ad0e36a`), and rewrites the ~10-line comment that claimed a release tag was unusable — that claim was stale, since v5.6.0 does ship `JPH::CharacterContact` (48 occurrences in `CharacterVirtual.h` vs 47 at the old snapshot).
- Fixes a knock-on stale reference in `.github/renovate.json5`: its Style-2 comment named Jolt as an example of an untracked bare-SHA pin; now that Jolt carries a `# v5.6.0` comment it matches the Style-3 release-tag manager instead (same shape as `cpp_httplib`).

Closes #776.

## Verification
Re-established the "100/100 Release runs pass" bar the previous pin was chosen for:
- Clean Debug + Release builds of `OloEditor` and `OloEngine-Tests` against v5.6.0 — no API breakage across `JoltScene`, `JoltCharacterController`, `JoltJobSystemAdapter`, or the collider/vehicle/joint code.
- Physics/Jolt/Character/Vehicle/Ragdoll filtered tests: 140/140 passed.
- Full suite: 5687/5693 passed. The 2 failures (`AtmosphereVisualEvidenceTest`, `EASUVisualEvidenceTest`) are GPU golden-image RMSE comparisons with no code-path connection to physics — one passed on retry, and the other's own source comments document known vendor/driver-dependent RMSE drift. Pre-existing flakiness, not a regression from this change.
- Re-ran `scripts/repro-flaky-test.ps1` (the #281 flaky-Jolt-race harness, 2-core CPU-affinity squeeze, Release config): 100/100 iterations, 0 failures.

No integration fix was needed against v5.6.0.

## Test plan
- [x] `cmake --preset msvc` reconfigure fetches Jolt at v5.6.0 (`git describe --tags --exact-match` confirms)
- [x] `OloEditor` + `OloEngine-Tests` build clean in Debug and Release (`--parallel 6`)
- [x] Physics/Jolt/Character/Vehicle/Ragdoll gtest filter: 140/140
- [x] Full gtest suite: 5687/5693 (2 pre-existing unrelated GPU visual-test flakes)
- [x] #281 flaky-repro harness: 100/100 iterations, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration documentation to clarify handling of unannotated commit pins.
  * Pinned Jolt Physics to the stable v5.6.0 release for improved build consistency.
  * Documented the required compatibility support for character contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->