### PR TITLE
docs(build): record #759 build-instrumentation findings, correct host/cap guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,12 +134,14 @@ An explicit `--parallel N` overrides the environment variable, so don't set one 
 
 **`CMAKE_BUILD_PARALLEL_LEVEL` caps `cmake --build` only — `ninja` does not read it.** A direct `ninja` invocation must always carry a numeric `-jN` of its own; setting the variable and then running bare `ninja` gives you the full 18-wide default with no warning. What is never acceptable is a bare `--parallel`, or a direct `ninja` without `-jN`.
 
-This is not a style preference. The dev box is 16 cores / 31 GB and *also* hosts the `gh-runner-1/2/3` runners for another repository, so a build never has the machine to itself. Neither default is a cap:
+This is not a style preference. The dev box (an i7-14700KF, 20 cores / 28 threads / 64 GB — issue #759 corrected the earlier 16c/31GB figure) *also* hosts the `gh-runner-1/2/3` runners for another repository, so a build never has the machine to itself. Neither default is a cap:
 
 - `cmake --build … --parallel` with **no number** does not pick a number itself — it forwards the omission to the native build tool, whose own default applies (unless `CMAKE_BUILD_PARALLEL_LEVEL` is set). So the width you get depends on the generator, and it is never *lower* than the tool's default.
-- With Ninja that default is `cores + 2` — 18 on this host, confirmed by `ninja --help` reporting `[default=18 on this system]`. Dropping a `--parallel N` flag therefore *raises* the width rather than lowering it.
+- With Ninja that default is `cores + 2` — 30 on this host, confirmed by `ninja --help` reporting `[default=30 on this system]`. Dropping a `--parallel N` flag therefore *raises* the width rather than lowering it.
 
 An agent session running repeated uncapped builds — especially with a test suite running alongside — has already OOM-killed this host once. If you need it faster, use ccache (already wired in), not more jobs.
+
+**Measured headroom (issue #759).** `-j6` is a deliberately conservative *floor*, not a hard limit for this hardware. An instrumented clean Debug build on this idle 64 GB host peaks at **~47 GiB (MSVC) / ~42 GiB (clang-cl)** at `-j6` — and because a handful of heavy TUs set the peak, not the lane count, `-j12` adds only **~2 GiB** of peak while running **1.3–1.6× faster** (still ~16 GiB free). So `-j12` is a safe, faster choice **when this box is otherwise idle**. Keep `-j6` as the default: it is the value that stays safe on the smaller/shared worst case and while the CI runners are active — the constraint the pool and cap were written for is the *shared* box, not the raw memory ceiling. The link pool (`OLO_LINK_JOBS=2`) is separately confirmed correct: linking is off the compile-bound critical path, so the pool costs ~0 wall-time. Details and the trace method are in [docs/agent-rules/build-trees-and-windows-asan.md](docs/agent-rules/build-trees-and-windows-asan.md) §5.
 
 Link steps are capped separately and automatically: the root `CMakeLists.txt` puts them in a Ninja job pool (`OLO_LINK_JOBS`, default 2) because linking the full static engine is the memory spike. That pool lives in the generated `build.ninja`, so it protects a bare `ninja` too — but it does **not** cap compilation, which is what the job count above is for.
 

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -355,3 +355,89 @@ carries the coverage unless one really does. For `SceneSerializer::Deserialize`
 none does — nothing else in the suite throws through it — so the honest note is
 that the file-path throw is uncovered under Windows ASan while the
 non-throwing branches of the same test stay active everywhere.
+
+## 5. Instrumenting a build with the CMake Instrumentation API (issue #759)
+
+CMake 4.x ships an experimental Instrumentation API that emits a Google Trace
+Event file with per-command timing, target attribution and per-command
+**host-memory** samples. Getting it to actually emit anything has two
+non-obvious gates, both of which fail *silently* (a green configure, no trace):
+
+1. **It does not work under the Visual Studio generator.** The feature is
+   Makefile / Ninja / FASTBuild only (`cmake-instrumentation(7)`). So the
+   primary `build/` (VS 18 2026) tree **cannot** be instrumented at all — use
+   the `build-clang/` Ninja tree (`cmake --preset clangcl`). That is also the
+   only tree where `OLO_LINK_JOBS` exists (it is a Ninja job pool), so it is the
+   correct tree for any link-concurrency question regardless.
+2. **While experimental, the query directory name carries the gate UUID.** The
+   shipped manual (`cmake-instrumentation.7.rst`) says query files go under
+   `<build>/.cmake/instrumentation/v1/query/` — that path is **ignored**. The
+   experimental gate requires the UUID **appended to the directory name**:
+   `<build>/.cmake/instrumentation-ec7aa2dc-b87f-45a3-8022-fe01c5f59984/v1/query/`.
+   With the plain `instrumentation/` path, configure prints
+   `Manually-specified variables were not used by the project:
+   CMAKE_EXPERIMENTAL_INSTRUMENTATION` and wires no launcher. The UUID-suffixed
+   rule is documented only in `Help/dev/experimental.rst`, which is **not shipped
+   in the binary install** — read it from the release tag on gitlab.kitware.com.
+
+Recipe that works on CMake 4.2:
+
+```powershell
+$GATE = "ec7aa2dc-b87f-45a3-8022-fe01c5f59984"   # this exact UUID; 4.2-specific
+$q = "build-clang/.cmake/instrumentation-$GATE/v1/query"
+New-Item -ItemType Directory -Force $q | Out-Null
+'{ "version":1, "hooks":["postGenerate","postCMakeBuild"],
+   "options":["staticSystemInformation","dynamicSystemInformation","trace"] }' |
+   Set-Content "$q/olo.json"
+cmake --preset clangcl -DCMAKE_EXPERIMENTAL_INSTRUMENTATION=$GATE
+cmake --build build-clang --config Debug --parallel 6     # must be `cmake --build` for the hook
+```
+
+**Verify it wired** before trusting a build: the compile rule in
+`build-clang/CMakeFiles/rules.ninja` must gain a
+`"…/ctest.exe" --instrument --command-type compile … -- <compiler>` prefix, and
+`…/instrumentation-<UUID>/v1/data/` must appear after configure. The trace lands
+at `…/instrumentation-<UUID>/v1/data/trace/trace-*.json` (one event per
+compile/link/custom command; `args.dynamicSystemInformation.afterHostMemoryUsed`
+is **system-wide** host memory in KiB, not the command's RSS; the top-level
+`dur`/`ts` are microseconds). `--gtest`-style grepping for "instrument" in
+`build.ninja` is useless here — the worktree path itself
+(`OloEngine-build-instrumentation-759`) contains the substring.
+
+### What it measured (clean Debug build, `build-clang/`, clang-cl, this host)
+
+Host was an i7-14700KF (20 cores / 28 threads, 64 GB), CI runners idle — **not**
+the 16c/31GB CLAUDE.md assumes; confirm your host before reusing these numbers.
+Ports build at *configure* time (vcpkg) and are absent from the build trace, so
+these are OloEngine + small in-tree vendor + FFmpeg only:
+
+- Cold configure+generate **796 s** (dominated by the cold vcpkg install of 45
+  packages; warm reconfigure ~11 s). Build step at **-j6: 607 s**, at **-j12:
+  382 s** (1.59×).
+- Composition (-j6): **compile is 96.5 % of build CPU-work** (2569 CPU-s over
+  1314 TUs) vs 89 CPU-s of linking over 13 links. Worst single TUs:
+  `LuaScriptGlue.cpp` ~150 s, `McpFieldRegistry.cpp` ~52 s (compiled in both
+  OloEditor and OloEngine-Tests). Top targets: OloEngine-Tests (612 TU),
+  OloEngine (589 TU), OloEditor (55 TU); OloRuntime/OloServer are ~3 TU each.
+- **The `OLO_LINK_JOBS=2` pool is NOT the serialization point — compilation is.**
+  Links are off the critical path: the build ends compile-bound (OloEditor's
+  last TU finishes, then one ~10-17 s `OloEditor.exe` link). The pool only
+  briefly saturates when OloRuntime+OloServer link together; Tests then links
+  with ~0 s slot wait. Raising `OLO_LINK_JOBS` buys ~0 wall-time on a full build,
+  so keep it at 2 — it is zero-cost insurance against the link-memory spike on a
+  smaller/shared host.
+- **Peak host memory barely scales with -j** because a handful of heavy TUs set
+  the peak, not the lane count. clang-cl: **41.6 GiB at -j6, 43.6 GiB at -j12
+  (+2.0 GiB for 2× width)**. A Ninja+**MSVC** tree stood up for the same
+  measurement (real `cl.exe`/`link.exe` — the memory-hungrier toolchain the
+  folklore OOM was on): **45.7 GiB at -j6, 47.4 GiB at -j12 (+1.7 GiB)**, still
+  ~16 GiB headroom, wall 1019 s → 776 s (1.31×). Peak is a *compile* on both
+  toolchains (the pool caps links at 2). So on this host the `-j6` guidance is a
+  safety *floor* for the documented 16c/31GB + concurrent-runner worst case, not
+  a memory limit that binds here. (To instrument the MSVC compiler you need a
+  Ninja tree with cl.exe — configure/build from inside a `vcvars64.bat` shell,
+  since the VS-generator tree itself is uninstrumentable.)
+- `CMAKE_OPTIMIZE_DEPENDENCIES=ON`: clean-build wall delta **+0.6 s (noise)**.
+  It roughly halved link CPU-time (89→44 s, plausibly pruned transitive link
+  libs) but that is fully hidden under the compile-bound critical path — no
+  wall-clock benefit for this graph. `INSTALL_PARALLEL` is N/A (we never install).


### PR DESCRIPTION
Docs-only outcome of issue #759 (instrument the build, then revisit the `-j6` cap with data). The measurement summary is in the issue; this PR persists the reusable parts.

## What changed
- **`docs/agent-rules/build-trees-and-windows-asan.md` §5 (new):** how to drive the CMake Instrumentation API here, plus the two silent opt-in gotchas — it is **Ninja/Makefile/FASTBuild-only** (the VS-generator `build/` tree is uninstrumentable) and the experimental query dir must be **UUID-suffixed** (`.cmake/instrumentation-<uuid>/v1/query/`, not the plain path the shipped manual documents). Includes the measured baseline on both toolchains.
- **`CLAUDE.md`:** corrected the dev-box spec to **i7-14700KF, 20c/28t/64 GB** (was 16c/31 GB), the ninja default to **30** (was 18), and added a measured-headroom note — `-j12` is safe/faster on this idle host, `-j6` stays the default floor for the smaller/shared worst case.

## Findings (no build-system change)
- **Compilation, not the `OLO_LINK_JOBS=2` pool, is the serialization point** — the build ends compile-bound (OloEditor's `McpFieldRegistry.cpp`, then one final link); links are off the critical path, so the pool costs ~0 wall-time and stays at 2.
- **Peak memory scales weakly with `-j`** (a few heavy TUs set it, not lane count): `-j12` is 1.3–1.6× faster for only +~2 GiB peak, ~16 GiB free on this 64 GB host. MSVC peaks ~47 GiB at -j6, clang-cl ~42 GiB.
- **`OPTIMIZE_DEPENDENCIES`: rejected** — +0.6 s (noise) on a clean build; its link-CPU saving is hidden under the compile-bound path. `INSTALL_PARALLEL` N/A.

Issue #759 is already closed as *measured, no change*; this PR carries the doc updates it referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected build parallelism guidance with updated hardware details and measured performance and memory usage.
  - Documented CMake instrumentation setup, trace verification, and interpretation of timing and memory results.
  - Added benchmarks covering parallelism, compiler toolchains, link concurrency, memory usage, and dependency optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->