### PR TITLE
feat(mcp): cacheable list results (ttlMs + cacheScope)

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -102,11 +102,38 @@ runs:
         # Bootstrap unconditionally: the tool version is pinned per registry commit
         # (scripts/vcpkg-tool-metadata.txt), so the image's prebuilt binary can be
         # older than the baseline expects. The script no-ops when it already matches.
+        #
+        # Retried with backoff: when the pinned tool version does NOT match, the
+        # script downloads vcpkg.exe straight from the vcpkg-tool GitHub release —
+        # the one network hop in this action with no cache or retry in front of it,
+        # and a hard `throw` on the first failed response. Observed dying a job at
+        # the 3-minute mark, before configure:
+        #
+        #   Downloading https://github.com/microsoft/vcpkg-tool/releases/download/…/vcpkg.exe
+        #     -> While calling Windows API function WinHttpReceiveResponse got error
+        #        0x00002F78: The server returned an invalid or unrecognized response
+        #
+        # Bootstrapping is idempotent (it re-checks the version and re-downloads into
+        # a temp path before moving it into place), so re-running it after a truncated
+        # transfer is safe. Three attempts, 15s then 30s apart; a genuine breakage —
+        # a bad baseline, a deleted release — still fails, just 45s later.
         if [ "$RUNNER_OS" = "Windows" ]; then
-          "$VCPKG_ROOT/bootstrap-vcpkg.bat" -disableMetrics
+          bootstrap="$VCPKG_ROOT/bootstrap-vcpkg.bat"
         else
-          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+          bootstrap="$VCPKG_ROOT/bootstrap-vcpkg.sh"
         fi
+        for attempt in 1 2 3; do
+          if "$bootstrap" -disableMetrics; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::vcpkg bootstrap failed after 3 attempts. See .github/actions/setup-vcpkg."
+            exit 1
+          fi
+          delay=$((attempt * 15))
+          echo "::warning::vcpkg bootstrap attempt ${attempt} failed; retrying in ${delay}s"
+          sleep "$delay"
+        done
 
     # BINARY CACHING. `x-gha` is NOT usable: vcpkg-tool removed the provider in
     # microsoft/vcpkg-tool#1662 (merged 2025-04-29), and the tool release this

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -372,6 +372,66 @@ namespace OloEngine::MCP
                    kSupportedProtocolVersions.end();
         }
 
+        // ---- cacheable list results (spec 2026-07-28, server/utilities/caching) ----
+        //
+        // tools/list, prompts/list, resources/list and resources/read attach two
+        // optional freshness hints so a client can avoid re-fetching a result it
+        // already holds:
+        //   * ttlMs      — integer milliseconds (MUST be >= 0) the client MAY treat
+        //                  the result as fresh; semantics mirror HTTP
+        //                  Cache-Control: max-age (0 == immediately stale).
+        //   * cacheScope — "public" (no user-specific data; any cache/proxy MAY share
+        //                  it) or "private" (per-authorization-context; MUST NOT be
+        //                  shared across auth contexts).
+        //
+        // This is ADDITIVE and version-NEUTRAL: we do NOT advertise the 2026-07-28
+        // protocol (that requires the whole stateless core — server/discover, _meta
+        // identity, routing headers, resultType — explicitly out of scope for
+        // issue #777). The spec only *requires* these hints on results tagged
+        // resultType: "complete", but emitting them unconditionally is spec-compatible
+        // and harmless: older clients ignore both unknown fields, so every existing
+        // result shape is unchanged. The two fields sit at the top level of the result
+        // object, beside `tools` / `prompts` / `resources` / `contents`.
+        void AddCacheHints(Json& result, i64 ttlMs, const char* cacheScope)
+        {
+            result["ttlMs"] = ttlMs;
+            result["cacheScope"] = cacheScope;
+        }
+
+        // tools/list: the catalogue is static for a server run EXCEPT
+        // olo_script_tools_reload (issue #607), which rescans <project>/McpTools and
+        // fires notifications/tools/list_changed on every live SSE stream. Because that
+        // push is the authoritative invalidation (capabilities.tools.listChanged is
+        // true), a generous TTL is honest — it only bridges the gap between reloads.
+        // 5 min matches the spec's own worked example.
+        constexpr i64 kToolsListTtlMs = 300000;
+
+        // resources/list: the base catalogue is static, but capture tools publish and
+        // evict ephemeral resources while serving (issue #673 Tier 1), also pushed via
+        // notifications/resources/list_changed. Shorter than tools/list because that
+        // ephemeral churn is more frequent; the push again bounds staleness.
+        constexpr i64 kResourcesListTtlMs = 60000;
+
+        // prompts/list: prompts are compiled in and FIXED for the whole server run
+        // (capabilities.prompts.listChanged is false — there is no push invalidation),
+        // so the TTL is the only freshness signal. A long TTL is fully honest precisely
+        // because the list is immutable within a run; a reconnecting client
+        // re-initializes into a fresh process.
+        constexpr i64 kPromptsListTtlMs = 3600000;
+
+        // resources/read: a read reflects LIVE editor state (current frame / scene /
+        // log) and may be path-redacted per the session's redaction setting, so caching
+        // it is NOT honest — ttlMs 0 tells the client to treat it as immediately stale
+        // and re-read on demand.
+        constexpr i64 kResourcesReadTtlMs = 0;
+
+        // The three catalogues carry no user-specific data and are identical for every
+        // caller, so they are "public". A resources/read payload can depend on the
+        // redaction setting and on host-local paths, so it is "private" — it MUST NOT
+        // be shared across authorization contexts.
+        constexpr const char* kCacheScopePublic = "public";
+        constexpr const char* kCacheScopePrivate = "private";
+
         // True when `body` is a single (non-batch) tools/call that opted into
         // progress via params._meta.progressToken (string or integer per spec) —
         // the gate for upgrading the POST response to an SSE stream. Parsing here
@@ -1991,7 +2051,9 @@ namespace OloEngine::MCP
         Json tools = Json::array();
         for (const auto& tool : *snapshot)
             tools.push_back(BuildToolEntry(tool));
-        return MakeResult(id, Json{ { "tools", std::move(tools) } });
+        Json result{ { "tools", std::move(tools) } };
+        AddCacheHints(result, kToolsListTtlMs, kCacheScopePublic);
+        return MakeResult(id, std::move(result));
     }
 
     Json McpServer::HandleToolsSearch(const Json& id, const Json& params) const
@@ -2293,7 +2355,9 @@ namespace OloEngine::MCP
                 entry["size"] = resource.SizeBytes;
             resources.push_back(std::move(entry));
         }
-        return MakeResult(id, Json{ { "resources", std::move(resources) } });
+        Json result{ { "resources", std::move(resources) } };
+        AddCacheHints(result, kResourcesListTtlMs, kCacheScopePublic);
+        return MakeResult(id, std::move(result));
     }
 
     Json McpServer::HandleResourcesRead(const Json& id, const Json& params)
@@ -2323,10 +2387,12 @@ namespace OloEngine::MCP
             {
                 return MakeError(id, kInvalidRequest, std::string("Failed to read resource: ") + e.what());
             }
-            return MakeResult(id, Json{ { "contents",
-                                          Json::array({ Json{ { "uri", uri },
-                                                              { "mimeType", resource->MimeType },
-                                                              { "blob", Base64Encode(bytes) } } }) } });
+            Json result{ { "contents",
+                           Json::array({ Json{ { "uri", uri },
+                                               { "mimeType", resource->MimeType },
+                                               { "blob", Base64Encode(bytes) } } }) } };
+            AddCacheHints(result, kResourcesReadTtlMs, kCacheScopePrivate);
+            return MakeResult(id, std::move(result));
         }
 
         std::string text;
@@ -2342,10 +2408,12 @@ namespace OloEngine::MCP
         if (RedactPaths())
             text = RedactPathsInText(text);
 
-        return MakeResult(id, Json{ { "contents",
-                                      Json::array({ Json{ { "uri", uri },
-                                                          { "mimeType", resource->MimeType },
-                                                          { "text", std::move(text) } } }) } });
+        Json result{ { "contents",
+                       Json::array({ Json{ { "uri", uri },
+                                           { "mimeType", resource->MimeType },
+                                           { "text", std::move(text) } } }) } };
+        AddCacheHints(result, kResourcesReadTtlMs, kCacheScopePrivate);
+        return MakeResult(id, std::move(result));
     }
 
     const ResourceDef* McpServer::FindResource(const ResourceList& resources, const std::string& uri)
@@ -2367,7 +2435,9 @@ namespace OloEngine::MCP
                                     { "title", prompt.Title },
                                     { "description", prompt.Description } });
         }
-        return MakeResult(id, Json{ { "prompts", std::move(prompts) } });
+        Json result{ { "prompts", std::move(prompts) } };
+        AddCacheHints(result, kPromptsListTtlMs, kCacheScopePublic);
+        return MakeResult(id, std::move(result));
     }
 
     Json McpServer::HandlePromptsGet(const Json& id, const Json& params) const

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -507,6 +507,95 @@ TEST_F(McpDispatchTest, ResourcesReadMissingUriIsInvalidParams)
     EXPECT_EQ(resp["error"]["code"], -32602);
 }
 
+// ---- cacheable list results (spec 2026-07-28 server/utilities/caching) ------
+//
+// tools/list, prompts/list, resources/list and resources/read now carry the
+// `ttlMs` (integer ms, >= 0) + `cacheScope` ("public"|"private") freshness hints.
+// The change is additive and version-neutral (we do NOT advertise 2026-07-28), so
+// these tests also pin backward compatibility: the pre-existing result keys must
+// still be present and unchanged alongside the two new fields.
+
+namespace
+{
+    // Assert the two cache-hint fields are well-formed: ttlMs is a non-negative
+    // integer (the spec forbids negatives; a fractional value would be malformed)
+    // and cacheScope is exactly one of the two spec-defined string values.
+    void ExpectWellFormedCacheHints(const Json& result)
+    {
+        ASSERT_TRUE(result.contains("ttlMs")) << "cacheable result missing ttlMs";
+        ASSERT_TRUE(result["ttlMs"].is_number_integer()) << "ttlMs must be an integer";
+        EXPECT_GE(result["ttlMs"].get<long long>(), 0) << "ttlMs must be >= 0";
+
+        ASSERT_TRUE(result.contains("cacheScope")) << "cacheable result missing cacheScope";
+        ASSERT_TRUE(result["cacheScope"].is_string());
+        const std::string scope = result["cacheScope"].get<std::string>();
+        EXPECT_TRUE(scope == "public" || scope == "private") << "unexpected cacheScope: " << scope;
+    }
+} // namespace
+
+TEST_F(McpDispatchTest, ToolsListCarriesCacheHints)
+{
+    // Store the response BY VALUE: binding a reference to ["result"] of the returned
+    // temporary would dangle (lifetime extension doesn't reach through operator[]).
+    const Json resp = m_Server.HandleMessage(MakeRequest(40, "tools/list"));
+    const Json& result = resp["result"];
+    ExpectWellFormedCacheHints(result);
+    // The catalogue is non-user-specific and identical for every caller.
+    EXPECT_EQ(result["cacheScope"], "public");
+    // Static-for-a-run + push invalidation (tools/list_changed) -> a positive TTL.
+    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    // Backward compatibility: the original `tools` array is still present.
+    EXPECT_TRUE(result.contains("tools"));
+    EXPECT_TRUE(result["tools"].is_array());
+}
+
+TEST_F(McpDispatchTest, ResourcesListCarriesCacheHints)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(41, "resources/list"));
+    const Json& result = resp["result"];
+    ExpectWellFormedCacheHints(result);
+    EXPECT_EQ(result["cacheScope"], "public");
+    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    EXPECT_TRUE(result.contains("resources"));
+    EXPECT_TRUE(result["resources"].is_array());
+}
+
+TEST_F(McpDispatchTest, PromptsListCarriesCacheHints)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(42, "prompts/list"));
+    const Json& result = resp["result"];
+    ExpectWellFormedCacheHints(result);
+    EXPECT_EQ(result["cacheScope"], "public");
+    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    EXPECT_TRUE(result.contains("prompts"));
+    EXPECT_TRUE(result["prompts"].is_array());
+}
+
+// A read reflects live editor state and may be path-redacted, so it is
+// non-cacheable (ttlMs 0) and per-authorization-context (private).
+TEST_F(McpDispatchTest, ResourcesReadCarriesPrivateNonCacheableHints)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(43, "resources/read", Json{ { "uri", "olo://fake" } }));
+    const Json& result = resp["result"];
+    ExpectWellFormedCacheHints(result);
+    EXPECT_EQ(result["cacheScope"], "private");
+    EXPECT_EQ(result["ttlMs"].get<long long>(), 0);
+    // Backward compatibility: the original `contents` array is untouched.
+    EXPECT_TRUE(result.contains("contents"));
+    EXPECT_EQ(result["contents"][0]["text"], "resource-body");
+}
+
+// An *error* result (unknown resource) is not a cacheable "complete" result and
+// must NOT carry the hints — they belong on the success envelope only.
+TEST_F(McpDispatchTest, ResourcesReadErrorHasNoCacheHints)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(44, "resources/read", Json{ { "uri", "olo://nope" } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_FALSE(resp.contains("result"));
+    EXPECT_FALSE(resp["error"].contains("ttlMs"));
+    EXPECT_FALSE(resp["error"].contains("cacheScope"));
+}
+
 // ---- prompts/get -----------------------------------------------------------
 
 TEST_F(McpDispatchTest, PromptsGetHappyPathExpandsToUserMessage)

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -542,8 +542,12 @@ TEST_F(McpDispatchTest, ToolsListCarriesCacheHints)
     ExpectWellFormedCacheHints(result);
     // The catalogue is non-user-specific and identical for every caller.
     EXPECT_EQ(result["cacheScope"], "public");
-    // Static-for-a-run + push invalidation (tools/list_changed) -> a positive TTL.
-    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    // Static-for-a-run + push invalidation (tools/list_changed) -> a generous TTL.
+    // Pinned to the exact configured value (kToolsListTtlMs, 5 min — the spec's own
+    // worked example) rather than just "> 0": the three catalogues carry three
+    // deliberately DIFFERENT TTLs, so a positivity check would pass even if two of
+    // the constants were swapped at the call site.
+    EXPECT_EQ(result["ttlMs"].get<long long>(), 300000);
     // Backward compatibility: the original `tools` array is still present.
     EXPECT_TRUE(result.contains("tools"));
     EXPECT_TRUE(result["tools"].is_array());
@@ -555,7 +559,9 @@ TEST_F(McpDispatchTest, ResourcesListCarriesCacheHints)
     const Json& result = resp["result"];
     ExpectWellFormedCacheHints(result);
     EXPECT_EQ(result["cacheScope"], "public");
-    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    // kResourcesListTtlMs, 1 min — shorter than tools/list because capture tools
+    // publish/evict ephemeral resources while serving.
+    EXPECT_EQ(result["ttlMs"].get<long long>(), 60000);
     EXPECT_TRUE(result.contains("resources"));
     EXPECT_TRUE(result["resources"].is_array());
 }
@@ -566,7 +572,10 @@ TEST_F(McpDispatchTest, PromptsListCarriesCacheHints)
     const Json& result = resp["result"];
     ExpectWellFormedCacheHints(result);
     EXPECT_EQ(result["cacheScope"], "public");
-    EXPECT_GT(result["ttlMs"].get<long long>(), 0);
+    // kPromptsListTtlMs, 1 h — the longest of the three: prompts are compiled in and
+    // immutable within a run, and there is no list_changed push to bound staleness,
+    // so the TTL is the only freshness signal.
+    EXPECT_EQ(result["ttlMs"].get<long long>(), 3600000);
     EXPECT_TRUE(result.contains("prompts"));
     EXPECT_TRUE(result["prompts"].is_array());
 }

--- a/OloEngine/tests/Rendering/BackendSelectionTest.cpp
+++ b/OloEngine/tests/Rendering/BackendSelectionTest.cpp
@@ -15,9 +15,24 @@
 #include <filesystem>
 #include <fstream>
 
+#ifdef _WIN32
+#include <process.h> // _getpid()
+#else
+#include <unistd.h>
+#endif
+
 namespace
 {
     using namespace OloEngine;
+
+    [[nodiscard]] long long CurrentPid()
+    {
+#ifdef _WIN32
+        return static_cast<long long>(::_getpid());
+#else
+        return static_cast<long long>(::getpid());
+#endif
+    }
 
     // argv helper: string literals are never written through, and GLFW-style
     // main() argv is char**, so the const_cast mirrors what EntryPoint passes.
@@ -35,10 +50,17 @@ namespace
     class ScopedConfigFile
     {
       public:
+        // Keyed by PID, not by gtest's random_seed: gtest only randomises that seed
+        // when --gtest_shuffle is set, so it is 0 in every process here. Since
+        // gtest_discover_tests gives each case its own ctest entry (its own process,
+        // each starting the counter at 0), a seed-keyed name collided across the four
+        // config-file cases the moment ctest ran them in parallel — one case then read
+        // (or raced the deletion of) another's file. PID + counter is the repo-wide
+        // convention for exactly this reason.
         explicit ScopedConfigFile(const std::string& contents)
             : m_Path(std::filesystem::temp_directory_path() /
-                     ("olo-backend-selection-test-" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) +
-                      "-" + std::to_string(s_Counter++) + ".yaml"))
+                     ("olo-backend-selection-test-" + std::to_string(CurrentPid()) + "-" +
+                      std::to_string(s_Counter++) + ".yaml"))
         {
             std::ofstream out(m_Path);
             out << contents;

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -1764,13 +1764,15 @@ freshness hints at the **top level of the result object**, beside `tools` /
 - **`cacheScope`** — `"public"` (no user-specific data; any cache/proxy MAY share
   it) or `"private"` (per-authorization-context; MUST NOT be shared).
 
-The values are chosen per endpoint (see the constants + comments in
-`McpServer.cpp`): the three catalogues are `public` with a positive TTL (they are
-static for a run, and their live-mutation paths — script-tool reload, ephemeral
-resource publish — already push a `list_changed` notification as the authoritative
-invalidation, so the TTL only bridges the gaps); `resources/read` is
-`private` + `ttlMs: 0`, because a read reflects **live** editor state and may be
-path-redacted, so it is never honestly cacheable.
+The values are chosen per endpoint (the constants + their full rationale live in
+`McpServer.cpp`; `McpDispatchTest` pins each one exactly):
+
+| Endpoint | `ttlMs` | `cacheScope` | Why |
+| --- | --- | --- | --- |
+| `tools/list` | `300000` (5 min) | `public` | Static for a run except `olo_script_tools_reload`, which pushes `notifications/tools/list_changed` as the authoritative invalidation — the TTL only bridges the gap. Matches the spec's own worked example. |
+| `resources/list` | `60000` (1 min) | `public` | Base catalogue is static, but capture tools publish/evict ephemeral resources while serving (also pushed via `list_changed`); shorter than `tools/list` because that churn is more frequent. |
+| `prompts/list` | `3600000` (1 h) | `public` | Prompts are compiled in and immutable within a run, and `capabilities.prompts.listChanged` is `false` — with no push invalidation the TTL is the only freshness signal, and a long one is honest precisely because the list cannot change. |
+| `resources/read` | `0` | `private` | Reflects **live** editor state and may be path-redacted, so it is never honestly cacheable and MUST NOT be shared across authorization contexts. |
 
 Two gotchas worth carrying forward:
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -1751,6 +1751,40 @@ running against the tools they started with. The server then emits a
 advertises `capabilities.tools.listChanged: true`), so **call `tools/list` again
 after a reload**.
 
+#### Cacheable list results — `ttlMs` + `cacheScope` (issue #777)
+
+`tools/list`, `prompts/list`, `resources/list` and `resources/read` each attach
+the [2026-07-28 caching](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching)
+freshness hints at the **top level of the result object**, beside `tools` /
+`prompts` / `resources` / `contents`:
+
+- **`ttlMs`** — integer milliseconds (always `>= 0`) the client MAY treat the
+  result as fresh; semantics mirror HTTP `Cache-Control: max-age` (`0` = re-fetch
+  every time).
+- **`cacheScope`** — `"public"` (no user-specific data; any cache/proxy MAY share
+  it) or `"private"` (per-authorization-context; MUST NOT be shared).
+
+The values are chosen per endpoint (see the constants + comments in
+`McpServer.cpp`): the three catalogues are `public` with a positive TTL (they are
+static for a run, and their live-mutation paths — script-tool reload, ephemeral
+resource publish — already push a `list_changed` notification as the authoritative
+invalidation, so the TTL only bridges the gaps); `resources/read` is
+`private` + `ttlMs: 0`, because a read reflects **live** editor state and may be
+path-redacted, so it is never honestly cacheable.
+
+Two gotchas worth carrying forward:
+
+- **Additive and version-neutral.** We do **not** advertise the `2026-07-28`
+  protocol (that needs the whole stateless core — `server/discover`, `_meta`
+  identity, `resultType`), and the spec technically only *requires* these hints on
+  results tagged `resultType: "complete"`. Emitting them unconditionally is
+  spec-compatible and safe: older clients ignore the two unknown fields, so every
+  existing result shape is unchanged. Backward compatibility here means *adding*
+  fields, never reshaping.
+- **Success envelope only.** The hints live on the `result`, so an *error*
+  response (unknown URI, etc.) carries none — an error is not a cacheable
+  "complete" result.
+
 #### Write-tier script tools (`writes = true`)
 
 A script tool that declares `writes = true` becomes a project-write tool:


### PR DESCRIPTION
Implements the single **"✅ Actionable now"** bullet of the #777 tracker — the 2026-07-28 spec's [cacheable list results](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching). Refs #777 (leaving the tracker open for its deprecation clocks).

## What

`tools/list`, `prompts/list`, `resources/list` and `resources/read` now attach the two freshness hints at the top level of the result object:

| Endpoint | `ttlMs` | `cacheScope` | Why |
|---|---|---|---|
| `tools/list` | 300000 (5 min) | `public` | Static per run; `tools/list_changed` push is the real invalidation, TTL bridges reloads |
| `resources/list` | 60000 (1 min) | `public` | Static + ephemeral-resource churn, also `list_changed`-pushed |
| `prompts/list` | 3600000 (1 hr) | `public` | Compiled-in, immutable for the run; no push, so TTL is the only signal |
| `resources/read` | 0 | `private` | Live editor state, may be path-redacted → never honestly cacheable |

Each value is justified in a comment next to its constant in `McpServer.cpp`.

## Backward compatibility

**Additive and version-neutral.** The advertised `protocolVersion` is unchanged — advertising `2026-07-28` would require the whole stateless core (`server/discover`, `_meta` identity, `resultType`), which is explicitly out of scope. The spec only *requires* these hints on `resultType: "complete"` results; emitting them unconditionally is spec-compatible, and older clients ignore the two unknown fields, so every existing result shape is unchanged. Error envelopes carry no hints.

## Tests

5 new tests in `McpDispatchTest.cpp` (well-formedness, per-endpoint scope/TTL, old-shape preservation, error-envelope exclusion). Full `Mcp*` suite: **654 passed, 0 failed, 1 skipped** (a GL-gated visual test, by design).

## Out of scope (left for the tracker)

The stateless-core transport rework and every deprecation-clock watch item — untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache hints to MCP tool, resource, and prompt listings, including freshness duration and visibility scope.
  * Resource reads are marked private and non-cacheable to protect live response data.
  * Existing response payloads remain available alongside the new metadata.

* **Documentation**
  * Documented cache-hint behavior, caching semantics, and backward compatibility for MCP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->