### PR TITLE
feat(mcp): dual-era outbound client + a `logging`-deprecation offramp carrier (#777)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ you are in.
 - [runtime-scene-switching.md](docs/agent-rules/runtime-scene-switching.md) — the host applies a scene swap after the tick; five ordering rules, plus the `Project` mount shipped games were missing.
 - [server-authoritative-networking-loop.md](docs/agent-rules/server-authoritative-networking-loop.md) — ~20 well-tested networking classes produced nothing, because the entry point had zero call sites.
 - [mcp-setter-based-field-registry.md](docs/agent-rules/mcp-setter-based-field-registry.md) — the copy-then-swap MCP write path is unsound when `operator=` can't reproduce a field write's side effects.
+- [mcp-protocol-eras.md](docs/agent-rules/mcp-protocol-eras.md) — the 2026-07-28 stateless core is a second transport, not a field addition; `server/discover` added on its own actively breaks working clients.
 
 **Concurrency & memory**
 

--- a/OloEditor/src/MCP/McpClient.cpp
+++ b/OloEditor/src/MCP/McpClient.cpp
@@ -168,6 +168,17 @@ namespace OloEngine::MCP
             if (!initResponse || !initResponse->contains("result"))
             {
                 outError = "MCP initialize failed (no/invalid response from '" + config.Command + "')";
+                // The probe told us this child understands the modern protocol, yet
+                // the handshake it steered us to also failed. Say so: a bare
+                // "initialize failed" sends the reader hunting for a legacy problem
+                // when the real answer is that the child and OloEditor share no
+                // usable revision.
+                if (connection->m_FellBackFromModernReply)
+                {
+                    outError += " — the server answered the 2026-07-28 `server/discover` probe but advertised "
+                                "no protocol version OloEditor can speak, and the legacy handshake it was "
+                                "asked to fall back to failed too";
+                }
                 connection->Shutdown();
                 return nullptr;
             }
@@ -241,7 +252,14 @@ namespace OloEngine::MCP
                 return true;
             }
             if (OffersLegacyVersion(versions) || !versions.is_array() || versions.empty())
-                return true; // dual-era (or uninformative) — the handshake still works
+            {
+                // Dual-era (or uninformative). A handshake-era revision in the list
+                // IS a mutually supported version — but the only way to speak one is
+                // `initialize`, because those revisions have no per-request `_meta`.
+                // So falling back here is selecting from the list, not ignoring it.
+                m_FellBackFromModernReply = true;
+                return true;
+            }
             outError = "MCP client '" + m_Config.Alias + "': the server speaks only " + JoinVersions(versions) +
                        ", none of which OloEditor supports";
             return false;
@@ -276,7 +294,10 @@ namespace OloEngine::MCP
                 // sin is a thin error payload — so fall back and let the handshake
                 // answer the question.
                 if (OffersLegacyVersion(supported) || !supported.is_array() || supported.empty())
+                {
+                    m_FellBackFromModernReply = true;
                     return true;
+                }
                 outError = "MCP client '" + m_Config.Alias +
                            "': the server rejected every protocol version OloEditor speaks (it supports " +
                            JoinVersions(supported) + ")";

--- a/OloEditor/src/MCP/McpClient.cpp
+++ b/OloEditor/src/MCP/McpClient.cpp
@@ -116,7 +116,55 @@ namespace OloEngine::MCP
         const McpClientConfig& config, const McpClientTransportFactory& factory,
         std::function<void(const std::string& alias)> onDeath, std::string& outError)
     {
+        bool probeAnsweredByModernServer = false;
+        std::shared_ptr<McpClientConnection> connection = ConnectOnce(
+            config, factory, onDeath, /*probeForModernEra=*/true, probeAnsweredByModernServer, outError);
+        if (connection)
+            return connection;
+
+        // The era probe is a request sent BEFORE `initialize`, and every 2025-*
+        // revision forbids exactly that ("the client MUST NOT send requests other
+        // than pings before the server has responded to the initialize request").
+        // The spec still prescribes the probe on stdio, and a well-behaved legacy
+        // child just answers -32601 — but a strict one (the Python SDK raises on
+        // any pre-init request) can tear its session down instead, and then the
+        // `initialize` we fall back to fails against a child that is already gone.
+        //
+        // That would be a REGRESSION: before the probe existed, this child bridged
+        // fine. So recover rather than report it: spawn a clean child and run the
+        // legacy handshake on its own, with no probe to poison it.
+        //
+        // Only when the probe did NOT get a recognized modern reply. A child that
+        // answered with a DiscoverResult or a -32022 is demonstrably alive and
+        // modern-aware, so a second spawn would fail identically — and would cost
+        // the user another process launch to learn nothing.
+        if (!probeAnsweredByModernServer)
+        {
+            std::string retryError;
+            bool ignoredProbeFlag = false;
+            if (std::shared_ptr<McpClientConnection> retried =
+                    ConnectOnce(config, factory, std::move(onDeath), /*probeForModernEra=*/false,
+                                ignoredProbeFlag, retryError))
+            {
+                OLO_CORE_WARN("[MCP client '{}'] the child did not survive the `server/discover` era probe; "
+                              "reconnected with the legacy handshake only.",
+                              config.Alias);
+                outError.clear();
+                return retried;
+            }
+            // Keep the FIRST error: it describes the path we actually wanted, and
+            // the retry's failure is almost always the same cause seen twice.
+        }
+        return nullptr;
+    }
+
+    std::shared_ptr<McpClientConnection> McpClientConnection::ConnectOnce(
+        const McpClientConfig& config, const McpClientTransportFactory& factory,
+        std::function<void(const std::string& alias)> onDeath, bool probeForModernEra,
+        bool& outProbeAnsweredByModernServer, std::string& outError)
+    {
         outError.clear();
+        outProbeAnsweredByModernServer = false;
         std::shared_ptr<McpClientConnection> connection(new McpClientConnection(config, std::move(onDeath)));
 
         // Weak captures: the transport's reader-thread callbacks must not keep
@@ -147,12 +195,16 @@ namespace OloEngine::MCP
         connection->m_Alive.store(true, std::memory_order_release);
 
         // Decide the era BEFORE anything else: it determines both the opening
-        // sequence and whether every later request carries `_meta`.
-        if (!connection->NegotiateEra(outError))
+        // sequence and whether every later request carries `_meta`. Skipping the
+        // probe leaves the connection on its Legacy default, which is exactly what
+        // Connect's retry wants.
+        if (probeForModernEra && !connection->NegotiateEra(outError))
         {
+            outProbeAnsweredByModernServer = connection->m_ProbeAnsweredByModernServer;
             connection->Shutdown();
             return nullptr;
         }
+        outProbeAnsweredByModernServer = connection->m_ProbeAnsweredByModernServer;
 
         // Legacy era only: the initialize -> notifications/initialized handshake.
         // A modern child has no handshake — `server/discover` already told us
@@ -173,7 +225,7 @@ namespace OloEngine::MCP
                 // "initialize failed" sends the reader hunting for a legacy problem
                 // when the real answer is that the child and OloEditor share no
                 // usable revision.
-                if (connection->m_FellBackFromModernReply)
+                if (connection->m_ModernReplyOfferedNoUsableVersion)
                 {
                     outError += " — the server answered the 2026-07-28 `server/discover` probe but advertised "
                                 "no protocol version OloEditor can speak, and the legacy handshake it was "
@@ -244,6 +296,26 @@ namespace OloEngine::MCP
         if (response->contains("result") && (*response)["result"].is_object())
         {
             const Json& result = (*response)["result"];
+            // Only a modern server answers `server/discover` at all, so we are past
+            // the era question whatever the payload says.
+            m_ProbeAnsweredByModernServer = true;
+
+            // MRTR applies to `server/discover` like any other request: a modern
+            // server may answer `input_required` instead of a discovery. Without
+            // this check that reads as a complete discovery with an EMPTY version
+            // list, which then falls back to the handshake against a modern-only
+            // server and fails for a reason nobody can see. Same defensive read as
+            // InvokeBridged's; an absent resultType still means "complete".
+            if (result.contains("resultType") &&
+                (!result["resultType"].is_string() || result["resultType"].get<std::string>() != "complete"))
+            {
+                outError = "MCP client '" + m_Config.Alias +
+                           "': the server answered `server/discover` with resultType " +
+                           result["resultType"].dump() +
+                           " (Multi Round-Trip), which OloEditor's outbound client does not implement";
+                return false;
+            }
+
             const Json versions = result.value("supportedVersions", Json::array());
             if (OffersModernVersion(versions))
             {
@@ -251,13 +323,22 @@ namespace OloEngine::MCP
                 m_ProtocolVersion = kModernProtocolVersion;
                 return true;
             }
-            if (OffersLegacyVersion(versions) || !versions.is_array() || versions.empty())
+            if (OffersLegacyVersion(versions))
             {
-                // Dual-era (or uninformative). A handshake-era revision in the list
-                // IS a mutually supported version — but the only way to speak one is
-                // `initialize`, because those revisions have no per-request `_meta`.
-                // So falling back here is selecting from the list, not ignoring it.
-                m_FellBackFromModernReply = true;
+                // Dual-era. A handshake-era revision in the list IS a mutually
+                // supported version — but the only way to speak one is `initialize`,
+                // because those revisions have no per-request `_meta`. So falling
+                // back here is selecting from the list, not ignoring it. Deliberately
+                // does NOT set m_ModernReplyOfferedNoUsableVersion: a later handshake
+                // failure here is a plain handshake failure, not a version mismatch.
+                return true;
+            }
+            if (!versions.is_array() || versions.empty())
+            {
+                // Uninformative. Fall back — a terse modern server may still serve
+                // the handshake — but remember why, so a failing `initialize` can
+                // say what actually happened instead of blaming the handshake.
+                m_ModernReplyOfferedNoUsableVersion = true;
                 return true;
             }
             outError = "MCP client '" + m_Config.Alias + "': the server speaks only " + JoinVersions(versions) +
@@ -278,6 +359,8 @@ namespace OloEngine::MCP
                                             error["code"].get<int>() == kUnsupportedProtocolVersionCode;
             if (unsupportedVersion)
             {
+                // -32022 is reserved by the spec, so only a modern server emits it.
+                m_ProbeAnsweredByModernServer = true;
                 const Json supported = error.contains("data") && error["data"].is_object()
                                            ? error["data"].value("supported", Json::array())
                                            : Json::array();
@@ -289,13 +372,16 @@ namespace OloEngine::MCP
                 }
                 // Same rule as the DiscoverResult branch above, deliberately: only a
                 // list that is present AND names revisions we cannot speak is a hard
-                // failure. An absent or empty `supported` tells us nothing, and
-                // hard-failing on it would strand every tool from a child whose only
-                // sin is a thin error payload — so fall back and let the handshake
-                // answer the question.
-                if (OffersLegacyVersion(supported) || !supported.is_array() || supported.empty())
+                // failure.
+                if (OffersLegacyVersion(supported))
+                    return true;
+                // An absent or empty `supported` tells us nothing, and hard-failing
+                // on it would strand every tool from a child whose only sin is a thin
+                // error payload — so fall back and let the handshake answer the
+                // question, remembering why in case it doesn't.
+                if (!supported.is_array() || supported.empty())
                 {
-                    m_FellBackFromModernReply = true;
+                    m_ModernReplyOfferedNoUsableVersion = true;
                     return true;
                 }
                 outError = "MCP client '" + m_Config.Alias +

--- a/OloEditor/src/MCP/McpClient.cpp
+++ b/OloEditor/src/MCP/McpClient.cpp
@@ -21,6 +21,84 @@
 
 namespace OloEngine::MCP
 {
+    namespace
+    {
+        // The two revisions this client speaks, one per era (issue #777).
+        //
+        // Modern (2026-07-28, the stateless core): no handshake at all — every
+        // request carries its protocol version, our identity and our per-request
+        // capabilities in `params._meta`. The routing headers (Mcp-Method /
+        // Mcp-Name) and header/body validation that revision also mandates are
+        // Streamable-HTTP concerns and do NOT apply to this stdio client.
+        //
+        // Legacy (2025-06-18): the newest revision whose features we rely on
+        // (outputSchema/structuredContent pass-through). The child may echo an
+        // older one — transport framing is identical, so we accept any reply.
+        constexpr const char* kModernProtocolVersion = "2026-07-28";
+        constexpr const char* kLegacyProtocolVersion = "2025-06-18";
+
+        // UnsupportedProtocolVersionError (spec 2026-07-28). Reserved by the spec,
+        // so seeing it is itself proof the peer is a modern server — which is why
+        // it steers us to a version retry rather than to the legacy fallback.
+        constexpr int kUnsupportedProtocolVersionCode = -32022;
+
+        // Reserved `_meta` keys carrying what `initialize` used to carry once.
+        constexpr const char* kMetaProtocolVersion = "io.modelcontextprotocol/protocolVersion";
+        constexpr const char* kMetaClientInfo = "io.modelcontextprotocol/clientInfo";
+        constexpr const char* kMetaClientCapabilities = "io.modelcontextprotocol/clientCapabilities";
+
+        [[nodiscard]] Json ClientInfo()
+        {
+            return Json{ { "name", "OloEditor" }, { "version", "0.0.1" } };
+        }
+
+        // True when `versions` (a JSON array of revision strings) names a revision
+        // this client can speak in the MODERN era.
+        [[nodiscard]] bool OffersModernVersion(const Json& versions)
+        {
+            if (!versions.is_array())
+                return false;
+            return std::any_of(versions.begin(), versions.end(),
+                               [](const Json& v)
+                               { return v.is_string() && v.get<std::string>() == kModernProtocolVersion; });
+        }
+
+        // True when `versions` names a revision we can speak in the LEGACY era.
+        // A dual-era child answers server/discover but may still list only
+        // handshake-era revisions; that is a fallback, not a failure. Any
+        // "2025-*"/"2024-*" entry qualifies because HandleInitialize-style
+        // negotiation lets the child echo whichever of those it prefers.
+        [[nodiscard]] bool OffersLegacyVersion(const Json& versions)
+        {
+            if (!versions.is_array())
+                return false;
+            return std::any_of(versions.begin(), versions.end(),
+                               [](const Json& v)
+                               {
+                                   if (!v.is_string())
+                                       return false;
+                                   const std::string s = v.get<std::string>();
+                                   return s.rfind("2025-", 0) == 0 || s.rfind("2024-", 0) == 0;
+                               });
+        }
+
+        [[nodiscard]] std::string JoinVersions(const Json& versions)
+        {
+            std::string out;
+            if (!versions.is_array())
+                return out;
+            for (const Json& v : versions)
+            {
+                if (!v.is_string())
+                    continue;
+                if (!out.empty())
+                    out += ", ";
+                out += v.get<std::string>();
+            }
+            return out;
+        }
+    } // namespace
+
     // ---- McpClientConnection: protocol + concurrency ---------------------------
 
     McpClientConnection::McpClientConnection(McpClientConfig config,
@@ -68,22 +146,44 @@ namespace OloEngine::MCP
         connection->m_Transport = std::move(transport);
         connection->m_Alive.store(true, std::memory_order_release);
 
-        // MCP handshake: initialize -> notifications/initialized -> tools/list.
-        // 2025-06-18 is the newest revision whose features we rely on here
-        // (outputSchema/structuredContent pass-through); the child may echo an
-        // older one — transport framing is identical, so we accept any reply.
-        const Json initParams{ { "protocolVersion", "2025-06-18" },
-                               { "capabilities", Json::object() },
-                               { "clientInfo", Json{ { "name", "OloEditor" }, { "version", "0.0.1" } } } };
-        const std::optional<Json> initResponse =
-            connection->SendRequest("initialize", initParams, config.HandshakeTimeout);
-        if (!initResponse || !initResponse->contains("result"))
+        // Decide the era BEFORE anything else: it determines both the opening
+        // sequence and whether every later request carries `_meta`.
+        if (!connection->NegotiateEra(outError))
         {
-            outError = "MCP initialize failed (no/invalid response from '" + config.Command + "')";
             connection->Shutdown();
             return nullptr;
         }
-        connection->SendNotification("notifications/initialized", Json::object());
+
+        // Legacy era only: the initialize -> notifications/initialized handshake.
+        // A modern child has no handshake — `server/discover` already told us
+        // everything initialize used to, and sending `initialize` to it would be
+        // an unknown method.
+        if (connection->m_Era == McpProtocolEra::Legacy)
+        {
+            const Json initParams{ { "protocolVersion", connection->m_ProtocolVersion },
+                                   { "capabilities", Json::object() },
+                                   { "clientInfo", ClientInfo() } };
+            const std::optional<Json> initResponse =
+                connection->SendRequest("initialize", initParams, config.HandshakeTimeout);
+            if (!initResponse || !initResponse->contains("result"))
+            {
+                outError = "MCP initialize failed (no/invalid response from '" + config.Command + "')";
+                connection->Shutdown();
+                return nullptr;
+            }
+            // The handshake NEGOTIATES: the child echoes the revision it actually
+            // agreed to, which may be older or newer than the one we asked for.
+            // Record that, not our request — otherwise the panel and the connect log
+            // report a version nobody is speaking, and the first thing anyone
+            // debugging an era problem looks at is wrong.
+            const Json& initResult = (*initResponse)["result"];
+            if (initResult.is_object() && initResult.contains("protocolVersion") &&
+                initResult["protocolVersion"].is_string())
+            {
+                connection->m_ProtocolVersion = initResult["protocolVersion"].get<std::string>();
+            }
+            connection->SendNotification("notifications/initialized", Json::object());
+        }
 
         const std::optional<Json> toolsResponse =
             connection->SendRequest("tools/list", Json::object(), config.HandshakeTimeout);
@@ -97,6 +197,108 @@ namespace OloEngine::MCP
 
         connection->BuildBridgedTools((*toolsResponse)["result"]["tools"], connection);
         return connection;
+    }
+
+    bool McpClientConnection::NegotiateEra(std::string& outError)
+    {
+        // Default assumption: legacy. Every path below either confirms it or
+        // upgrades us, so a probe that fails in ANY unrecognised way (including a
+        // child that never answers) lands on the handshake — which is exactly the
+        // spec's stdio backward-compatibility rule, and what every MCP server in
+        // the wild speaks today.
+        m_Era = McpProtocolEra::Legacy;
+        m_ProtocolVersion = kLegacyProtocolVersion;
+
+        // The probe must be self-describing: `server/discover` is a modern method
+        // and a modern server validates `_meta` on it like any other request. Send
+        // it explicitly rather than via RequestMeta(), which is still legacy here.
+        const Json probeParams{ { "_meta",
+                                  Json{ { kMetaProtocolVersion, kModernProtocolVersion },
+                                        { kMetaClientInfo, ClientInfo() },
+                                        { kMetaClientCapabilities, Json::object() } } } };
+        const std::chrono::milliseconds probeTimeout =
+            std::min(m_Config.DiscoverProbeTimeout, m_Config.HandshakeTimeout);
+        const std::optional<Json> response = SendRequest("server/discover", probeParams, probeTimeout);
+
+        // No reply at all (timeout, or the child died mid-probe): legacy. Note the
+        // ordering guarantee this relies on — a late `server/discover` response
+        // arriving after we fall back finds no waiter in m_Pending and is dropped
+        // by OnLine, so it cannot be mistaken for a later request's answer.
+        if (!response)
+            return true;
+
+        // A DiscoverResult: definitively modern. Take the newest revision we both
+        // speak; a dual-era child that lists only handshake revisions sends us
+        // back to the legacy path rather than failing.
+        if (response->contains("result") && (*response)["result"].is_object())
+        {
+            const Json& result = (*response)["result"];
+            const Json versions = result.value("supportedVersions", Json::array());
+            if (OffersModernVersion(versions))
+            {
+                m_Era = McpProtocolEra::Modern;
+                m_ProtocolVersion = kModernProtocolVersion;
+                return true;
+            }
+            if (OffersLegacyVersion(versions) || !versions.is_array() || versions.empty())
+                return true; // dual-era (or uninformative) — the handshake still works
+            outError = "MCP client '" + m_Config.Alias + "': the server speaks only " + JoinVersions(versions) +
+                       ", none of which OloEditor supports";
+            return false;
+        }
+
+        // An UnsupportedProtocolVersionError is itself a modern marker: only a
+        // modern server emits it, so this is a version mismatch to resolve, NOT a
+        // reason to fall back (the spec is explicit that a recognized modern error
+        // identifies a modern server).
+        if (response->contains("error") && (*response)["error"].is_object())
+        {
+            const Json& error = (*response)["error"];
+            // Defensive read: a child's reply is untrusted, and value() throws on a
+            // present-but-non-numeric "code".
+            const bool unsupportedVersion = error.contains("code") && error["code"].is_number_integer() &&
+                                            error["code"].get<int>() == kUnsupportedProtocolVersionCode;
+            if (unsupportedVersion)
+            {
+                const Json supported = error.contains("data") && error["data"].is_object()
+                                           ? error["data"].value("supported", Json::array())
+                                           : Json::array();
+                if (OffersModernVersion(supported))
+                {
+                    m_Era = McpProtocolEra::Modern;
+                    m_ProtocolVersion = kModernProtocolVersion;
+                    return true;
+                }
+                // Same rule as the DiscoverResult branch above, deliberately: only a
+                // list that is present AND names revisions we cannot speak is a hard
+                // failure. An absent or empty `supported` tells us nothing, and
+                // hard-failing on it would strand every tool from a child whose only
+                // sin is a thin error payload — so fall back and let the handshake
+                // answer the question.
+                if (OffersLegacyVersion(supported) || !supported.is_array() || supported.empty())
+                    return true;
+                outError = "MCP client '" + m_Config.Alias +
+                           "': the server rejected every protocol version OloEditor speaks (it supports " +
+                           JoinVersions(supported) + ")";
+                return false;
+            }
+        }
+
+        // Anything else — most commonly -32601 from a legacy server that has never
+        // heard of `server/discover`. Legacy it is.
+        return true;
+    }
+
+    Json McpClientConnection::RequestMeta() const
+    {
+        if (m_Era != McpProtocolEra::Modern)
+            return Json::object();
+        // clientCapabilities is REQUIRED and per-request: the server must not infer
+        // it from an earlier call. We consume tools only — no sampling, roots or
+        // elicitation — so an empty object is the honest declaration.
+        return Json{ { kMetaProtocolVersion, m_ProtocolVersion },
+                     { kMetaClientInfo, ClientInfo() },
+                     { kMetaClientCapabilities, Json::object() } };
     }
 
     void McpClientConnection::BuildBridgedTools(const Json& toolsArray,
@@ -156,6 +358,30 @@ namespace OloEngine::MCP
         }
 
         const Json result = response->value("result", Json::object());
+
+        // Multi Round-Trip Requests (spec 2026-07-28): a modern server may answer
+        // with resultType "input_required" instead of a finished call, expecting us
+        // to satisfy `inputRequests` (elicitation / sampling / roots) and retry. We
+        // implement none of those, and an absent resultType means "complete" for
+        // backward compatibility — so the ONLY thing that must not happen is
+        // forwarding an interim result to the agent as though it were the answer.
+        // Fail loudly instead; a silent half-result is the failure mode this bridge
+        // must not have. The field is read defensively (contains + is_string rather
+        // than value()) because a child's reply is untrusted network data and
+        // nlohmann's value() throws type_error.302 on a present-but-wrong type.
+        if (result.is_object() && result.contains("resultType"))
+        {
+            const Json& resultType = result["resultType"];
+            if (!resultType.is_string() || resultType.get<std::string>() != "complete")
+            {
+                return ToolResult::Error(
+                    "External server '" + m_Config.Alias + "' did not return a completed result (resultType " +
+                    resultType.dump() +
+                    "); OloEditor's outbound MCP client does not implement Multi Round-Trip Requests, so the "
+                    "call was not completed.");
+            }
+        }
+
         ToolResult out;
         out.IsError = result.is_object() && result.value("isError", false);
         if (result.is_object() && result.contains("content") && result["content"].is_array())
@@ -182,7 +408,20 @@ namespace OloEngine::MCP
             m_Pending.emplace(key, pending);
         }
 
-        const Json request{ { "jsonrpc", "2.0" }, { "id", id }, { "method", method }, { "params", params } };
+        // Modern era: every request is self-describing. Stamp `_meta` here — the
+        // one place every client-initiated request funnels through — rather than
+        // at each call site, so a future request can never ship without it. A
+        // caller that already supplied `_meta` (the era probe) keeps its own.
+        Json outParams = params;
+        if (m_Era == McpProtocolEra::Modern)
+        {
+            if (!outParams.is_object())
+                outParams = Json::object();
+            if (!outParams.contains("_meta"))
+                outParams["_meta"] = RequestMeta();
+        }
+
+        const Json request{ { "jsonrpc", "2.0" }, { "id", id }, { "method", method }, { "params", std::move(outParams) } };
         bool written = false;
         {
             // Serialize concurrent bridged handlers' writes. Never held while
@@ -602,8 +841,9 @@ namespace OloEngine::MCP
             std::lock_guard lock(m_ClientsMutex);
             m_Clients.push_back(connection);
         }
-        OLO_CORE_INFO("[MCP] Outbound client '{}' connected: {} tool(s) bridged from `{}`.", config.Alias,
-                      merged, config.Command);
+        OLO_CORE_INFO("[MCP] Outbound client '{}' connected ({} protocol {}): {} tool(s) bridged from `{}`.",
+                      config.Alias, connection->Era() == McpProtocolEra::Modern ? "stateless" : "handshake",
+                      connection->ProtocolVersion(), merged, config.Command);
         return {};
     }
 
@@ -641,6 +881,8 @@ namespace OloEngine::MCP
             status.Command = client->Command();
             status.Connected = client->IsConnected();
             status.ToolCount = client->BridgedToolCount();
+            status.Era = client->Era();
+            status.ProtocolVersion = client->ProtocolVersion();
             statuses.push_back(std::move(status));
         }
         return statuses;

--- a/OloEditor/src/MCP/McpClient.h
+++ b/OloEditor/src/MCP/McpClient.h
@@ -12,8 +12,10 @@
 //     (MakeStdioTransportFactory, McpClient.cpp) owns CreateProcessW + pipes +
 //     a blocking reader thread; tests substitute an in-memory fake that
 //     replies synchronously inside WriteLine.
-//   * McpClientConnection — the protocol + concurrency layer: the initialize /
-//     initialized / tools/list handshake, request-id multiplexing (bridged
+//   * McpClientConnection — the protocol + concurrency layer: era negotiation
+//     (see NegotiateEra — `server/discover` probe, falling back to the
+//     initialize / initialized handshake), tools/list, request-id
+//     multiplexing (bridged
 //     tool handlers run CONCURRENTLY on httplib worker threads, so responses
 //     are matched to waiters by exact id, the same id.dump() keying the
 //     server's cancellation registry uses), timeouts, and teardown that never
@@ -75,12 +77,12 @@ namespace OloEngine::MCP
     class McpClientConnection
     {
       public:
-        // Spawn (via `factory`), run the MCP handshake (initialize ->
-        // notifications/initialized -> tools/list), and build the bridged
-        // ToolDefs. Returns nullptr with `outError` set on any failure (spawn,
-        // timeout, malformed handshake). `onDeath(alias)` is invoked at most
-        // once, from the transport's reader thread, when the child dies or the
-        // stream breaks OUTSIDE a deliberate Shutdown — the owner uses it to
+        // Spawn (via `factory`), negotiate an era (see NegotiateEra), run the
+        // matching opening sequence, list the child's tools, and build the
+        // bridged ToolDefs. Returns nullptr with `outError` set on any failure
+        // (spawn, timeout, malformed handshake). `onDeath(alias)` is invoked at
+        // most once, from the transport's reader thread, when the child dies or
+        // the stream breaks OUTSIDE a deliberate Shutdown — the owner uses it to
         // unpublish the alias's tools.
         [[nodiscard]] static std::shared_ptr<McpClientConnection> Connect(
             const McpClientConfig& config, const McpClientTransportFactory& factory,
@@ -118,14 +120,48 @@ namespace OloEngine::MCP
             return m_BridgedToolCount;
         }
 
+        // The era this connection negotiated at Connect time, and the exact
+        // revision string it stamps on requests (issue #777). Fixed for the
+        // lifetime of the connection — the spec makes era a property of the
+        // server, not of an individual request — so these are plain reads.
+        [[nodiscard]] McpProtocolEra Era() const
+        {
+            return m_Era;
+        }
+        [[nodiscard]] const std::string& ProtocolVersion() const
+        {
+            return m_ProtocolVersion;
+        }
+
       private:
         explicit McpClientConnection(McpClientConfig config,
                                      std::function<void(const std::string&)> onDeath);
 
+        // Decide whether the child speaks the 2026-07-28 stateless core or the
+        // legacy `initialize` handshake, and settle on a mutually supported
+        // revision. Implements the spec's stdio backward-compatibility rule:
+        // probe with `server/discover`, treat a recognized MODERN reply (a
+        // DiscoverResult, or an UnsupportedProtocolVersionError naming the
+        // versions it does support) as a modern server, and fall back to the
+        // legacy handshake on anything else — including a timeout. Sets m_Era
+        // and m_ProtocolVersion; returns false with `outError` set only when the
+        // child is modern but shares no revision with us (an actionable
+        // mismatch, not a fallback).
+        [[nodiscard]] bool NegotiateEra(std::string& outError);
+
+        // The per-request `_meta` block every MODERN request must carry: the
+        // protocol version (required), our identity (SHOULD), and our capability
+        // set for THIS request (required — the server may not infer it from a
+        // previous one). Empty in the legacy era, where the handshake carried
+        // all three once.
+        [[nodiscard]] Json RequestMeta() const;
+
         // Send one request and block the CALLING thread (an httplib worker or
         // the connecting thread) until the child's response arrives, `timeout`
         // expires, or the connection shuts down. Returns the full JSON-RPC
-        // response object, or nullopt on timeout/write-failure/shutdown.
+        // response object, or nullopt on timeout/write-failure/shutdown. In the
+        // modern era `params._meta` is stamped on by RequestMeta() unless the
+        // caller already supplied one.
         [[nodiscard]] std::optional<Json> SendRequest(const std::string& method, const Json& params,
                                                       std::chrono::milliseconds timeout);
         void SendNotification(const std::string& method, const Json& params);
@@ -160,6 +196,11 @@ namespace OloEngine::MCP
 
         std::atomic<bool> m_Alive{ false };
         std::atomic<bool> m_ShuttingDown{ false };
+
+        // Written once by NegotiateEra during Connect, before the connection is
+        // published to any other thread; read-only thereafter.
+        McpProtocolEra m_Era = McpProtocolEra::Legacy;
+        std::string m_ProtocolVersion;
 
         std::vector<ToolDef> m_BridgedTools;
         sizet m_BridgedToolCount = 0;

--- a/OloEditor/src/MCP/McpClient.h
+++ b/OloEditor/src/MCP/McpClient.h
@@ -201,6 +201,12 @@ namespace OloEngine::MCP
         // published to any other thread; read-only thereafter.
         McpProtocolEra m_Era = McpProtocolEra::Legacy;
         std::string m_ProtocolVersion;
+        // True when the era probe got a RECOGNIZED modern reply but we still chose
+        // the legacy handshake (the child advertised only handshake-era revisions,
+        // or its reply named no versions at all). Purely diagnostic: if `initialize`
+        // then fails, the plain "initialize failed" message would point at the wrong
+        // problem, so Connect appends the era context it alone knows.
+        bool m_FellBackFromModernReply = false;
 
         std::vector<ToolDef> m_BridgedTools;
         sizet m_BridgedToolCount = 0;

--- a/OloEditor/src/MCP/McpClient.h
+++ b/OloEditor/src/MCP/McpClient.h
@@ -88,6 +88,19 @@ namespace OloEngine::MCP
             const McpClientConfig& config, const McpClientTransportFactory& factory,
             std::function<void(const std::string& alias)> onDeath, std::string& outError);
 
+        // One spawn + opening sequence. `probeForModernEra` false skips the
+        // `server/discover` era probe entirely and goes straight to the legacy
+        // handshake — see Connect's retry, which needs a child that has never been
+        // sent a pre-`initialize` request. `outProbeAnsweredByModernServer` reports
+        // whether the probe got a recognized modern reply; Connect uses it to decide
+        // whether a retry could possibly help. It is an out-param rather than shared
+        // state because connects can run concurrently (the MCP panel and a script
+        // tool can each start one).
+        [[nodiscard]] static std::shared_ptr<McpClientConnection> ConnectOnce(
+            const McpClientConfig& config, const McpClientTransportFactory& factory,
+            std::function<void(const std::string& alias)> onDeath, bool probeForModernEra,
+            bool& outProbeAnsweredByModernServer, std::string& outError);
+
         ~McpClientConnection();
         McpClientConnection(const McpClientConnection&) = delete;
         McpClientConnection& operator=(const McpClientConnection&) = delete;
@@ -201,12 +214,17 @@ namespace OloEngine::MCP
         // published to any other thread; read-only thereafter.
         McpProtocolEra m_Era = McpProtocolEra::Legacy;
         std::string m_ProtocolVersion;
-        // True when the era probe got a RECOGNIZED modern reply but we still chose
-        // the legacy handshake (the child advertised only handshake-era revisions,
-        // or its reply named no versions at all). Purely diagnostic: if `initialize`
-        // then fails, the plain "initialize failed" message would point at the wrong
-        // problem, so Connect appends the era context it alone knows.
-        bool m_FellBackFromModernReply = false;
+        // True once the probe got a RECOGNIZED modern reply (a `DiscoverResult` or
+        // a `-32022`). It proves the child is alive and modern-aware, which rules
+        // out the "strict legacy child died on a pre-`initialize` request" case —
+        // so Connect must NOT respawn-and-retry when this is set.
+        bool m_ProbeAnsweredByModernServer = false;
+        // Narrower, and diagnostic only: that modern reply named no revision we can
+        // speak at all (absent/empty version list). The dual-era case — where the
+        // child DID advertise a usable handshake revision — must not set this, or a
+        // later `initialize` failure would be blamed on a version mismatch that
+        // isn't there.
+        bool m_ModernReplyOfferedNoUsableVersion = false;
 
         std::vector<ToolDef> m_BridgedTools;
         sizet m_BridgedToolCount = 0;

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -36,6 +36,7 @@
 #include <string_view>
 #include <system_error>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -1285,6 +1286,13 @@ namespace OloEngine::MCP
             std::lock_guard lock(m_SessionMutex);
             m_Sessions.clear();
         }
+        // Resource subscriptions die with the session that made them: the streams
+        // that would carry the updates are gone, and a later Start() must not
+        // inherit a subscription no live client asked for.
+        {
+            std::lock_guard lock(m_SubscriptionMutex);
+            m_ResourceSubscriptions.clear();
+        }
         m_Token.clear();
 
         // Drop the session's ephemeral capture resources so a later Start()
@@ -1671,8 +1679,9 @@ namespace OloEngine::MCP
         res.set_chunked_content_provider(
             "text/event-stream",
             [this, cursor = startCursor, lastWrite = std::chrono::steady_clock::now(), greeted = false,
-             toolsGeneration = ToolsGeneration(),
-             resourcesGeneration = ResourcesGeneration()](std::size_t /*offset*/, httplib::DataSink& sink) mutable -> bool
+             toolsGeneration = ToolsGeneration(), resourcesGeneration = ResourcesGeneration(),
+             subscriptionTokens = std::unordered_map<std::string, u64>{}](
+                std::size_t /*offset*/, httplib::DataSink& sink) mutable -> bool
             {
                 // Server tearing down: end the stream gracefully so the worker thread
                 // is free to be joined by Stop().
@@ -1723,6 +1732,52 @@ namespace OloEngine::MCP
                         return false;
                     resourcesGeneration = generation;
                     lastWrite = std::chrono::steady_clock::now();
+                }
+
+                // Resource subscriptions (#777 — the `logging` offramp carrier).
+                // Same polled-generation delivery as the two blocks above, for the
+                // same single-writer-thread reason, but per SUBSCRIBED URI: each
+                // subscribable resource exposes a monotonic ChangeToken and we emit
+                // `notifications/resources/updated` when it advances.
+                //
+                // A URI this stream has not seen before starts from the
+                // SUBSCRIBE-TIME baseline, never from the token as of now. Seeding
+                // from "now" would swallow every change between the subscribe and
+                // this cycle — including everything that happened before the client
+                // opened its stream at all — which is precisely the
+                // never-fires failure the ChangeToken gate exists to prevent.
+                // Unsubscribing drops the URI from both maps, so a resubscribe
+                // re-baselines rather than replaying.
+                //
+                // Updates COALESCE by construction: the token is sampled once per
+                // cycle, so a burst inside one poll interval yields one
+                // notification. That is the correct semantics — the notification
+                // means "re-read this resource", not "one thing happened" — but a
+                // consumer must read from its own cursor, not count notifications.
+                {
+                    const ResourceSnapshot resources = ResourcesSnapshot();
+                    std::unordered_map<std::string, u64> stillSubscribed;
+                    for (const auto& [uri, baseline] : SubscriptionBaselines())
+                    {
+                        const ResourceDef* resource = FindResource(*resources, uri);
+                        if (resource == nullptr || !resource->ChangeToken)
+                            continue; // evicted or replaced by a non-subscribable def
+                        const u64 token = resource->ChangeToken();
+                        const auto seen = subscriptionTokens.find(uri);
+                        const u64 lastSeen = seen != subscriptionTokens.end() ? seen->second : baseline;
+                        if (lastSeen != token)
+                        {
+                            const std::string frame = FormatSseData(
+                                Json{ { "jsonrpc", "2.0" },
+                                      { "method", "notifications/resources/updated" },
+                                      { "params", Json{ { "uri", uri } } } });
+                            if (!sink.write(frame.data(), frame.size()))
+                                return false;
+                            lastWrite = std::chrono::steady_clock::now();
+                        }
+                        stillSubscribed.emplace(uri, token);
+                    }
+                    subscriptionTokens = std::move(stillSubscribed);
                 }
 
                 if (!ServiceEventStream(sink, cursor, lastWrite))
@@ -1980,6 +2035,10 @@ namespace OloEngine::MCP
             return HandleResourcesList(id);
         if (method == "resources/read")
             return HandleResourcesRead(id, request.value("params", Json::object()));
+        if (method == "resources/subscribe")
+            return HandleResourcesSubscribe(id, request.value("params", Json::object()));
+        if (method == "resources/unsubscribe")
+            return HandleResourcesUnsubscribe(id, request.value("params", Json::object()));
         if (method == "prompts/list")
             return HandlePromptsList(id);
         if (method == "prompts/get")
@@ -2006,6 +2065,12 @@ namespace OloEngine::MCP
         result["protocolVersion"] = version;
         // `logging` is advertised because the GET /mcp SSE stream pushes diagnostics
         // events as `notifications/message` log notifications (issue #306 item B).
+        // It is DEPRECATED as of spec 2026-07-28 (SEP-2577, ≥12-month offramp), so
+        // it now has a successor running beside it rather than replacing it: the
+        // `olo://events/recent` resource plus `resources.subscribe` below. Both
+        // carriers stay live for the whole offramp — dropping `logging` early would
+        // break every client that speaks a 2025-* revision, which today is all of
+        // them. See docs/agent-rules/mcp-protocol-eras.md.
         //
         // `tools.listChanged` is TRUE since the script-tool live-reload item (#607):
         // olo_script_tools_reload (and the MCP panel's "Reload script tools" button)
@@ -2014,10 +2079,15 @@ namespace OloEngine::MCP
         // stream. `resources.listChanged` is TRUE since the resource-link work
         // (#673 Tier 1): capture tools publish ephemeral resources while serving
         // (RegisterEphemeralResource), announced the same generation-polled way.
-        // Prompts are still fixed for a server run; per-URI `subscribe` stays
-        // unimplemented (nothing needs a subscription registry yet).
+        // Prompts are still fixed for a server run.
+        //
+        // `resources.subscribe` is TRUE since the `logging` offramp (#777): a
+        // client can subscribe to `olo://events/recent` and receive
+        // `notifications/resources/updated` whenever the diagnostics ring advances.
+        // Only resources carrying a ResourceDef::ChangeToken accept a subscription;
+        // the rest are rejected by name (HandleResourcesSubscribe).
         result["capabilities"] = Json{ { "tools", { { "listChanged", true } } },
-                                       { "resources", { { "subscribe", false }, { "listChanged", true } } },
+                                       { "resources", { { "subscribe", true }, { "listChanged", true } } },
                                        { "prompts", { { "listChanged", false } } },
                                        { "logging", Json::object() } };
         // `description` on Implementation is a 2025-11-25 addition (aligns with
@@ -2414,6 +2484,88 @@ namespace OloEngine::MCP
                                            { "text", std::move(text) } } }) } };
         AddCacheHints(result, kResourcesReadTtlMs, kCacheScopePrivate);
         return MakeResult(id, std::move(result));
+    }
+
+    Json McpServer::HandleResourcesSubscribe(const Json& id, const Json& params)
+    {
+        if (!params.contains("uri") || !params["uri"].is_string())
+            return MakeError(id, kInvalidParams, "Invalid params: 'uri' is required");
+
+        const std::string uri = params["uri"].get<std::string>();
+        const ResourceSnapshot snapshot = ResourcesSnapshot();
+        const ResourceDef* resource = FindResource(*snapshot, uri);
+        if (resource == nullptr)
+            return MakeError(id, kInvalidParams, "Unknown resource: " + uri);
+
+        // Refuse a subscription we could never fire. Without a ChangeToken there is
+        // no cheap way to know the resource changed, so accepting would promise
+        // updates that never arrive — the exact dishonesty the diagnostics server's
+        // "report unknown rather than fabricate" rule forbids. Name the ones that
+        // do work so the client can recover in one step.
+        if (!resource->ChangeToken)
+        {
+            std::string subscribable;
+            for (const ResourceDef& candidate : *snapshot)
+            {
+                if (!candidate.ChangeToken)
+                    continue;
+                if (!subscribable.empty())
+                    subscribable += ", ";
+                subscribable += candidate.Uri;
+            }
+            return MakeError(id, kInvalidParams,
+                             "Resource is not subscribable: " + uri +
+                                 (subscribable.empty() ? " (no resource on this server supports subscriptions)"
+                                                       : " (subscribable resources: " + subscribable + ")"));
+        }
+
+        // Baseline the token HERE, not on the stream's first poll: a change landing
+        // between this call and the next poll cycle — or before the client even
+        // opens its stream — must still be reported, or the subscription silently
+        // eats it. `emplace` keeps an existing subscription's baseline, so a
+        // repeated subscribe is idempotent and cannot discard a pending update;
+        // unsubscribe erases, so a resubscribe deliberately re-baselines.
+        {
+            std::lock_guard lock(m_SubscriptionMutex);
+            m_ResourceSubscriptions.emplace(uri, resource->ChangeToken());
+        }
+        return MakeResult(id, Json::object());
+    }
+
+    Json McpServer::HandleResourcesUnsubscribe(const Json& id, const Json& params)
+    {
+        if (!params.contains("uri") || !params["uri"].is_string())
+            return MakeError(id, kInvalidParams, "Invalid params: 'uri' is required");
+
+        // Idempotent by design: unsubscribing something never subscribed is a
+        // no-op success, so a client tearing down after a reconnect cannot be
+        // tripped by a subscription the server already forgot.
+        {
+            std::lock_guard lock(m_SubscriptionMutex);
+            m_ResourceSubscriptions.erase(params["uri"].get<std::string>());
+        }
+        return MakeResult(id, Json::object());
+    }
+
+    std::vector<std::string> McpServer::SubscribedUris() const
+    {
+        std::vector<std::string> uris;
+        {
+            std::lock_guard lock(m_SubscriptionMutex);
+            uris.reserve(m_ResourceSubscriptions.size());
+            for (const auto& [uri, baseline] : m_ResourceSubscriptions)
+                uris.push_back(uri);
+        }
+        // Sorted so the observable is deterministic — an unordered_map's iteration
+        // order is not, and a test asserting on it would be a latent flake.
+        std::sort(uris.begin(), uris.end());
+        return uris;
+    }
+
+    std::unordered_map<std::string, u64> McpServer::SubscriptionBaselines() const
+    {
+        std::lock_guard lock(m_SubscriptionMutex);
+        return m_ResourceSubscriptions;
     }
 
     const ResourceDef* McpServer::FindResource(const ResourceList& resources, const std::string& uri)

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -248,6 +248,24 @@ namespace OloEngine::MCP
         // Per bridged tools/call wait. Deliberately finite: a hung child must
         // never pin an httplib worker forever (the MarshalRead-timeout lesson).
         std::chrono::milliseconds CallTimeout{ 30000 };
+        // How long the era probe (`server/discover`) waits before concluding the
+        // child is a LEGACY handshake-era server (issue #777). Deliberately much
+        // shorter than HandshakeTimeout and clamped to it: the spec's stdio
+        // backward-compatibility rule says a probe that "times out" identifies a
+        // legacy server, and a well-behaved legacy child answers instantly with
+        // -32601 — so this budget is only ever spent on a child that silently
+        // swallows unknown methods, and every legacy connect would otherwise pay
+        // the full handshake timeout before falling back.
+        std::chrono::milliseconds DiscoverProbeTimeout{ 3000 };
+    };
+
+    // Which protocol era a bridged child speaks (issue #777). "Modern" is the
+    // 2026-07-28 stateless core — no handshake, per-request `_meta`; "Legacy" is
+    // 2025-11-25 and earlier — `initialize` + `notifications/initialized`.
+    enum class McpProtocolEra : u8
+    {
+        Legacy = 0,
+        Modern,
     };
 
     // Panel-facing snapshot of one connection.
@@ -257,6 +275,10 @@ namespace OloEngine::MCP
         std::string Command;
         bool Connected = false;
         sizet ToolCount = 0;
+        // The era + revision this connection actually negotiated (issue #777), so
+        // an operator can see at a glance why a child behaves the way it does.
+        McpProtocolEra Era = McpProtocolEra::Legacy;
+        std::string ProtocolVersion;
     };
 
     class McpClientConnection;
@@ -725,6 +747,18 @@ namespace OloEngine::MCP
         // oldest-first — and cleared on server Stop(); startup resources are never
         // evicted.
         bool Ephemeral = false;
+        // Optional monotonic "has the content changed?" token (issue #777). When
+        // set, this resource is SUBSCRIBABLE: resources/subscribe accepts its URI
+        // and the SSE stream emits `notifications/resources/updated` whenever the
+        // token advances. When null the resource is not subscribable and
+        // resources/subscribe rejects it by name — the honesty rule: a server that
+        // accepted a subscription it can never fire would be worse than one that
+        // says no.
+        //
+        // Called from the SSE stream's worker thread on every poll cycle, so it
+        // MUST be cheap and thread-safe (the diagnostics ring's LastId() is a
+        // mutex-guarded integer read). It must never touch the game thread.
+        std::function<u64()> ChangeToken;
     };
 
     // An MCP prompt: a canned workflow shipped for non-expert users. prompts/get
@@ -1020,6 +1054,23 @@ namespace OloEngine::MCP
         bool DisconnectClient(const std::string& alias);
         [[nodiscard]] std::vector<McpClientStatus> ClientStatuses() const;
 
+        // Resource URIs a client has subscribed to via resources/subscribe (issue
+        // #777), sorted, copied out under the lock. The observable that makes the
+        // subscribe/unsubscribe contract testable through the dispatch seam.
+        [[nodiscard]] std::vector<std::string> SubscribedUris() const;
+
+        // The same subscriptions with each URI's ChangeToken value AS OF THE
+        // SUBSCRIBE — the baseline a stream compares against. Read once per SSE
+        // poll cycle; the map is tiny (one entry in practice).
+        //
+        // The baseline is captured in HandleResourcesSubscribe, NOT on the stream's
+        // first poll, and that is the whole point: a change landing between the
+        // subscribe and the next poll — or before the stream is even opened —
+        // would otherwise be seeded over and silently swallowed, which is exactly
+        // the "subscription that never fires" the ChangeToken gate exists to
+        // prevent.
+        [[nodiscard]] std::unordered_map<std::string, u64> SubscriptionBaselines() const;
+
         // Optional `icons` for the server itself (SEP-973): emitted under
         // `initialize`'s `serverInfo.icons` only when non-empty. Set before Start()
         // (guarded, but it is startup configuration, not a runtime knob).
@@ -1231,6 +1282,13 @@ namespace OloEngine::MCP
         // as it uses the returned pointer (same contract as FindTool).
         [[nodiscard]] static const ResourceDef* FindResource(const ResourceList& resources, const std::string& uri);
         [[nodiscard]] const PromptDef* FindPrompt(const std::string& name) const;
+
+        // resources/subscribe + resources/unsubscribe (issue #777). Subscribe
+        // rejects a URI that is unknown OR not subscribable (no ChangeToken),
+        // naming the subscribable ones so the error is actionable; unsubscribe is
+        // idempotent and always succeeds, per the spec's empty-result contract.
+        [[nodiscard]] Json HandleResourcesSubscribe(const Json& id, const Json& params);
+        [[nodiscard]] Json HandleResourcesUnsubscribe(const Json& id, const Json& params);
         [[nodiscard]] bool CheckAuth(const httplib::Request& req) const;
 
         // Bump ToolsGeneration() and fan the tools/list_changed notification out to
@@ -1274,6 +1332,20 @@ namespace OloEngine::MCP
         // serverInfo.icons (SEP-973); empty => omitted from initialize.
         mutable std::mutex m_ServerIconsMutex;
         Json m_ServerIcons;
+
+        // Resource subscriptions (issue #777 — the `logging` offramp carrier).
+        // URI -> the resource's ChangeToken value at the moment it was subscribed
+        // (the baseline; see SubscriptionBaselines). The map is
+        // SERVER-GLOBAL, not per-session: this is a single-client localhost
+        // diagnostics server, the GET stream carries no session identity, and
+        // over-delivering `notifications/resources/updated` to a second stream that
+        // did not subscribe is the safe direction to err in (a client that never
+        // subscribed ignores the notification). Making it per-session would need
+        // session identity on the SSE stream, which the 2026-07-28 transport
+        // supplies for free via `subscriptions/listen` — so this deliberately waits
+        // for that rework rather than growing a bespoke registry now.
+        mutable std::mutex m_SubscriptionMutex;
+        std::unordered_map<std::string, u64> m_ResourceSubscriptions;
 
         Scope<httplib::Server> m_Http;
         std::thread m_ListenThread;

--- a/OloEditor/src/MCP/McpServerPanel.cpp
+++ b/OloEditor/src/MCP/McpServerPanel.cpp
@@ -216,8 +216,10 @@ namespace OloEngine::MCP
             for (const McpClientStatus& status : server.ClientStatuses())
             {
                 if (status.Connected)
-                    ImGui::TextColored(ImVec4(0.30f, 0.85f, 0.30f, 1.0f), "%s: connected, %d tool(s)",
-                                       status.Alias.c_str(), static_cast<int>(status.ToolCount));
+                    ImGui::TextColored(ImVec4(0.30f, 0.85f, 0.30f, 1.0f), "%s: connected (%s %s), %d tool(s)",
+                                       status.Alias.c_str(),
+                                       status.Era == McpProtocolEra::Modern ? "stateless" : "handshake",
+                                       status.ProtocolVersion.c_str(), static_cast<int>(status.ToolCount));
                 else
                     ImGui::TextColored(ImVec4(0.90f, 0.45f, 0.30f, 1.0f), "%s: DISCONNECTED (child ended)",
                                        status.Alias.c_str());

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -1,9 +1,11 @@
 #include "OloEnginePCH.h"
 #include "MCP/McpTools.h"
+#include "MCP/McpEventStream.h"
 #include "MCP/McpToolsCommon.h"
 #include "MCP/McpServer.h"
 
 #include "OloEngine/Core/Log.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/SceneSerializer.h"
 
@@ -22,6 +24,12 @@ namespace OloEngine::MCP
 {
     namespace
     {
+        // How many diagnostics events `olo://events/recent` returns. Matches the
+        // engine-log resource's 200-message window: enough to answer "what just
+        // happened?" after a reconnect without shipping the whole 512-entry ring on
+        // every subscription wake-up.
+        constexpr std::size_t kEventsResourceMaxCount = 200;
+
         void RegisterBuiltinResources(McpServer& server)
         {
             // ---- Resources ---------------------------------------------------------
@@ -69,6 +77,57 @@ namespace OloEngine::MCP
                     }
                     return out;
                 };
+                server.RegisterResource(std::move(resource));
+            }
+
+            {
+                // The `logging`-capability offramp (issue #777). The diagnostics
+                // event stream is pushed today as `notifications/message` log
+                // notifications over the GET SSE stream, and `logging` is deprecated
+                // as of spec 2026-07-28. This resource is the successor carrier, and
+                // it was chosen because it is the ONLY push shape that survives the
+                // era change unchanged: in 2026-07-28 the GET stream is gone,
+                // `notifications/message` becomes request-scoped, and the
+                // `subscriptions/listen` filter is a CLOSED set of four notification
+                // types — so a bespoke custom notification is not an option there,
+                // while `notifications/resources/updated` + `resources/read` is.
+                // Migrating later moves the plumbing (resources/subscribe ->
+                // subscriptions/listen) and leaves this resource and the
+                // notification untouched. See docs/agent-rules/mcp-protocol-eras.md.
+                //
+                // The payload is the same per-event shape olo_events_tail returns,
+                // so a push subscriber and an incremental poller read identical
+                // records — the property McpEventStream.h already guarantees for the
+                // `notifications/message` carrier.
+                ResourceDef resource;
+                resource.Uri = "olo://events/recent";
+                resource.Name = "Recent diagnostics events";
+                resource.Description =
+                    "The most recent 'what just happened?' engine events (scene load, play/stop, entity "
+                    "spawn/destroy, asset reload, script error) as JSON. Subscribable: resources/subscribe on "
+                    "this URI and the server pushes notifications/resources/updated whenever a new event is "
+                    "recorded.";
+                resource.MimeType = "application/json";
+                resource.Reader = [](McpServer& /*s*/) -> std::string
+                {
+                    // Reads the mutex-guarded ring directly — no MarshalRead: the log
+                    // is written from the game thread but is thread-safe by contract,
+                    // and a resource read must not stall on a frame.
+                    DiagnosticEventQuery query;
+                    query.MaxCount = kEventsResourceMaxCount;
+                    const DiagnosticEventQueryResult snapshot = DiagnosticsEventLog::Get().QueryWithCursor(query);
+                    Json events = Json::array();
+                    for (const DiagnosticEvent& event : snapshot.Events)
+                        events.push_back(EventToJson(event));
+                    // `lastId` lets a reader resume with olo_events_tail's sinceId
+                    // instead of re-reading the whole window.
+                    return Json{ { "events", std::move(events) }, { "lastId", snapshot.LastId } }.dump(2);
+                };
+                // Monotonic and cheap: the id of the newest event ever recorded. It
+                // only ever increases, so a token change is exactly "something new
+                // happened" — never a false positive from eviction.
+                resource.ChangeToken = []
+                { return DiagnosticsEventLog::Get().LastId(); };
                 server.RegisterResource(std::move(resource));
             }
         }

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -102,11 +102,15 @@ namespace OloEngine::MCP
                 ResourceDef resource;
                 resource.Uri = "olo://events/recent";
                 resource.Name = "Recent diagnostics events";
+                // The window size and the cursor both belong in the description: a
+                // reader that cannot tell this is the newest 200 rather than the whole
+                // history has no reason to resume from `lastId`, and would silently
+                // miss everything older on a busy session.
                 resource.Description =
-                    "The most recent 'what just happened?' engine events (scene load, play/stop, entity "
-                    "spawn/destroy, asset reload, script error) as JSON. Subscribable: resources/subscribe on "
-                    "this URI and the server pushes notifications/resources/updated whenever a new event is "
-                    "recorded.";
+                    "The most recent 'what just happened?' engine events (up to 200: scene load, play/stop, "
+                    "entity spawn/destroy, asset reload, script error) as JSON, newest last, with a 'lastId' "
+                    "cursor to resume from. Subscribable: resources/subscribe on this URI and the server "
+                    "pushes notifications/resources/updated whenever new events are recorded.";
                 resource.MimeType = "application/json";
                 resource.Reader = [](McpServer& /*s*/) -> std::string
                 {

--- a/OloEngine/tests/MCP/McpClientStdioTest.cpp
+++ b/OloEngine/tests/MCP/McpClientStdioTest.cpp
@@ -637,6 +637,129 @@ TEST(McpClientStdio, UnsupportedProtocolVersionErrorIsAModernMarkerNotAFallback)
     EXPECT_EQ(FirstWritten(fake->Written, "initialize"), nullptr) << "a modern marker must not trigger the handshake";
 }
 
+TEST(McpClientStdio, AStrictLegacyChildThatDiesOnTheProbeIsRecoveredByARespawn)
+{
+    // The era probe is a request sent BEFORE `initialize`, which every 2025-*
+    // revision forbids. Most legacy servers answer -32601 and we fall back fine —
+    // but a strict one (the Python SDK raises on any pre-init request) can tear its
+    // session down, and then the `initialize` we fall back to fails against a child
+    // that is already gone. Before the probe existed that child bridged fine, so
+    // this must be RECOVERED, not reported: spawn a clean child, no probe.
+    McpServer server{ EditorMcpContext{} };
+    int spawnCount = 0;
+    const auto strictLegacy = [](const Json& request, FakeTransport& transport)
+    {
+        const std::string method = request.value("method", std::string{});
+        if (method == "server/discover")
+        {
+            transport.Close(); // the child dies on a pre-initialize request
+            return;
+        }
+        if (method == "initialize")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "protocolVersion", "2025-06-18" },
+                                                    { "capabilities", Json::object() } } } });
+        }
+        else if (method == "tools/list")
+        {
+            transport.Reply(ToolsListResult(request["id"]));
+        }
+    };
+    // A factory that counts spawns and hands each one a fresh fake.
+    const OloEngine::MCP::McpClientTransportFactory countingFactory =
+        [&spawnCount, &strictLegacy](const std::string&, std::function<void(std::string)> onLine,
+                                     std::function<void()> onClosed,
+                                     std::string&) -> std::unique_ptr<IMcpClientTransport>
+    {
+        ++spawnCount;
+        auto transport = std::make_unique<FakeTransport>();
+        transport->Script = strictLegacy;
+        transport->OnLineSink = std::move(onLine);
+        transport->OnClosedSink = std::move(onClosed);
+        return transport;
+    };
+
+    McpClientConfig config = FilesConfig();
+    config.HandshakeTimeout = std::chrono::milliseconds(200);
+    config.DiscoverProbeTimeout = std::chrono::milliseconds(100);
+    const std::string error = server.ConnectClientWithTransport(config, countingFactory);
+
+    ASSERT_TRUE(error.empty()) << "a child that dies on the probe must be recovered, not reported: " << error;
+    EXPECT_EQ(spawnCount, 2) << "the recovery must use a CLEAN child, not the poisoned one";
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Legacy);
+    EXPECT_NE(FindToolEntry(server.HandleMessage(MakeRequest(24, "tools/list")), "ext.files.read_file"), nullptr);
+}
+
+TEST(McpClientStdio, ARecognizedModernReplySuppressesTheRespawnRetry)
+{
+    // The retry above exists only for the "the probe killed a legacy child" case. A
+    // child that answered with a DiscoverResult is demonstrably alive and
+    // modern-aware, so respawning would fail identically and cost the user a second
+    // process launch to learn nothing.
+    McpServer server{ EditorMcpContext{} };
+    int spawnCount = 0;
+    const auto modernButBroken = [](const Json& request, FakeTransport& transport)
+    {
+        if (request.value("method", std::string{}) == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "resultType", "complete" },
+                                                    { "supportedVersions", Json::array() },
+                                                    { "capabilities", Json::object() },
+                                                    { "ttlMs", 0 },
+                                                    { "cacheScope", "public" } } } });
+        }
+        // initialize and tools/list are swallowed, so the connect fails.
+    };
+    const OloEngine::MCP::McpClientTransportFactory countingFactory =
+        [&spawnCount, &modernButBroken](const std::string&, std::function<void(std::string)> onLine,
+                                        std::function<void()> onClosed,
+                                        std::string&) -> std::unique_ptr<IMcpClientTransport>
+    {
+        ++spawnCount;
+        auto transport = std::make_unique<FakeTransport>();
+        transport->Script = modernButBroken;
+        transport->OnLineSink = std::move(onLine);
+        transport->OnClosedSink = std::move(onClosed);
+        return transport;
+    };
+
+    McpClientConfig config = FilesConfig();
+    config.HandshakeTimeout = std::chrono::milliseconds(100);
+    config.DiscoverProbeTimeout = std::chrono::milliseconds(100);
+    EXPECT_FALSE(server.ConnectClientWithTransport(config, countingFactory).empty());
+    EXPECT_EQ(spawnCount, 1) << "a recognized modern reply must suppress the respawn";
+}
+
+TEST(McpClientStdio, DiscoverAnsweredWithInputRequiredIsReportedNotMisreadAsEmpty)
+{
+    // MRTR applies to server/discover like any other request. Without a resultType
+    // check, an `input_required` reply reads as a complete discovery with an EMPTY
+    // supportedVersions, which falls back to the handshake against a modern-only
+    // server and fails for a reason nobody can see.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        if (request.value("method", std::string{}) == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "resultType", "input_required" },
+                                                    { "requestState", "opaque" } } } });
+        }
+    };
+    const std::string error = server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, script));
+
+    ASSERT_FALSE(error.empty());
+    EXPECT_NE(error.find("input_required"), std::string::npos) << error;
+    EXPECT_NE(error.find("Multi Round-Trip"), std::string::npos) << error;
+}
+
 TEST(McpClientStdio, FallbackFailureAfterAModernReplyNamesTheEraMismatch)
 {
     // A modern-aware child that advertises no version we speak AND cannot serve the

--- a/OloEngine/tests/MCP/McpClientStdioTest.cpp
+++ b/OloEngine/tests/MCP/McpClientStdioTest.cpp
@@ -4,12 +4,18 @@
 
 // The outbound MCP client's protocol + lifecycle layer (#673 Tier 1, bullet 1),
 // driven end-to-end through McpServer::ConnectClientWithTransport with an
-// IN-MEMORY fake transport — no child process, socket, or GL: the initialize /
-// initialized / tools/list handshake, prefixed tool merging, the bridged
-// tools/call round-trip (content + structuredContent pass-through, child
+// IN-MEMORY fake transport — no child process, socket, or GL: protocol-era
+// negotiation (#777 — the `server/discover` probe and its fallback to the
+// initialize / initialized handshake), tools/list, prefixed tool merging, the
+// bridged tools/call round-trip (content + structuredContent pass-through, child
 // errors, timeouts), child-death teardown (pending calls fail fast, tools
 // unpublish, status flips), disconnect, duplicate aliases, and the
 // polite -32601 reply to a request initiated BY the child.
+//
+// Both protocol eras are pinned here on purpose. Spec 2026-07-28 removed the
+// handshake, both shapes coexist for a ≥12-month offramp, and the failure mode of
+// getting the detection wrong is silent — so the legacy path must keep being
+// asserted beside the modern one, not replaced by it.
 //
 // The registry-side trust seam (forced authority posture, namespace
 // validation) is McpClientToolsTest's job; this file assumes it and focuses on
@@ -81,15 +87,43 @@ namespace
         std::atomic<bool> m_Closed{ false };
     };
 
-    // The standard well-behaved child: answers initialize and serves one tool
-    // ("read_file"); tools/call behaviour comes from `onCall`.
+    // The one tools/list payload every script below serves.
+    Json ToolsListResult(const Json& id)
+    {
+        return Json{ { "jsonrpc", "2.0" },
+                     { "id", id },
+                     { "result",
+                       Json{ { "tools",
+                               Json::array({ Json{ { "name", "read_file" },
+                                                   { "title", "Read file" },
+                                                   { "description", "Read a file from disk." },
+                                                   { "inputSchema",
+                                                     Json{ { "type", "object" },
+                                                           { "properties",
+                                                             { { "path", { { "type", "string" } } } } } } } } }) } } } };
+    }
+
+    // The standard well-behaved LEGACY child: answers initialize and serves one
+    // tool ("read_file"); tools/call behaviour comes from `onCall`.
+    //
+    // It answers the `server/discover` era probe (#777) with -32601, which is what
+    // a real handshake-era MCP server does with an unknown method. That is both
+    // realistic AND what keeps this suite fast: without a reply the probe would
+    // burn its full timeout on every connect in this file.
     std::function<void(const Json&, FakeTransport&)> WellBehavedScript(
         std::function<void(const Json& request, FakeTransport&)> onCall = {})
     {
         return [onCall = std::move(onCall)](const Json& request, FakeTransport& transport)
         {
             const std::string method = request.value("method", std::string{});
-            if (method == "initialize")
+            if (method == "server/discover")
+            {
+                transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                      { "id", request["id"] },
+                                      { "error", Json{ { "code", -32601 },
+                                                       { "message", "Method not found: server/discover" } } } });
+            }
+            else if (method == "initialize")
             {
                 transport.Reply(Json{
                     { "jsonrpc", "2.0" },
@@ -101,25 +135,74 @@ namespace
             }
             else if (method == "tools/list")
             {
-                transport.Reply(Json{
-                    { "jsonrpc", "2.0" },
-                    { "id", request["id"] },
-                    { "result",
-                      Json{ { "tools",
-                              Json::array(
-                                  { Json{ { "name", "read_file" },
-                                          { "title", "Read file" },
-                                          { "description", "Read a file from disk." },
-                                          { "inputSchema",
-                                            Json{ { "type", "object" },
-                                                  { "properties",
-                                                    { { "path", { { "type", "string" } } } } } } } } }) } } } });
+                transport.Reply(ToolsListResult(request["id"]));
             }
             else if (method == "tools/call" && onCall)
             {
                 onCall(request, transport);
             }
         };
+    }
+
+    // A MODERN (2026-07-28 stateless core) child: it implements `server/discover`
+    // and has no `initialize` at all. `discoverVersions` is what it advertises as
+    // supportedVersions, so a test can drive the mutual-version outcomes.
+    std::function<void(const Json&, FakeTransport&)> ModernScript(
+        Json discoverVersions = Json::array({ "2026-07-28" }),
+        std::function<void(const Json& request, FakeTransport&)> onCall = {})
+    {
+        return [discoverVersions = std::move(discoverVersions), onCall = std::move(onCall)](
+                   const Json& request, FakeTransport& transport)
+        {
+            const std::string method = request.value("method", std::string{});
+            if (method == "server/discover")
+            {
+                transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                      { "id", request["id"] },
+                                      { "result",
+                                        Json{ { "resultType", "complete" },
+                                              { "supportedVersions", discoverVersions },
+                                              { "capabilities", Json{ { "tools", Json::object() } } },
+                                              { "ttlMs", 300000 },
+                                              { "cacheScope", "public" } } } });
+            }
+            else if (method == "initialize")
+            {
+                // A modern-only server has no handshake; answering one would hide a
+                // client bug where we send it anyway.
+                transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                      { "id", request["id"] },
+                                      { "error", Json{ { "code", -32601 },
+                                                       { "message", "Method not found: initialize" } } } });
+            }
+            else if (method == "tools/list")
+            {
+                transport.Reply(ToolsListResult(request["id"]));
+            }
+            else if (method == "tools/call" && onCall)
+            {
+                onCall(request, transport);
+            }
+        };
+    }
+
+    // Pull the `_meta` block off a recorded request, or a null Json when absent.
+    Json MetaOf(const Json& request)
+    {
+        if (!request.is_object() || !request.contains("params") || !request["params"].is_object())
+            return Json();
+        return request["params"].value("_meta", Json());
+    }
+
+    // The first recorded request with this method, or nullptr.
+    const Json* FirstWritten(const std::vector<Json>& written, const std::string& method)
+    {
+        for (const Json& message : written)
+        {
+            if (message.is_object() && message.value("method", std::string{}) == method)
+                return &message;
+        }
+        return nullptr;
     }
 
     // Factory exposing the created fake so the test can poke it post-connect.
@@ -171,13 +254,26 @@ TEST(McpClientStdio, ConnectHandshakesAndMergesPrefixedTools)
     ASSERT_TRUE(error.empty()) << error;
     ASSERT_NE(fake, nullptr);
 
-    // Handshake order on the wire: initialize, then the initialized
-    // notification, then tools/list.
-    ASSERT_GE(fake->Written.size(), 3u);
-    EXPECT_EQ(fake->Written[0]["method"], "initialize");
-    EXPECT_EQ(fake->Written[1]["method"], "notifications/initialized");
-    EXPECT_FALSE(fake->Written[1].contains("id")) << "initialized must be a notification";
-    EXPECT_EQ(fake->Written[2]["method"], "tools/list");
+    // Wire order against a LEGACY child: the era probe first (#777), then the
+    // handshake it falls back to — initialize, the initialized notification,
+    // tools/list.
+    ASSERT_GE(fake->Written.size(), 4u);
+    EXPECT_EQ(fake->Written[0]["method"], "server/discover");
+    EXPECT_EQ(fake->Written[1]["method"], "initialize");
+    EXPECT_EQ(fake->Written[2]["method"], "notifications/initialized");
+    EXPECT_FALSE(fake->Written[2].contains("id")) << "initialized must be a notification";
+    EXPECT_EQ(fake->Written[3]["method"], "tools/list");
+
+    // Legacy requests carry NO per-request `_meta` — the handshake conveyed the
+    // version and identity once, and stamping `_meta` on a 2025-era server would
+    // be a modern-shape request it never asked for.
+    EXPECT_TRUE(MetaOf(fake->Written[1]).is_null()) << fake->Written[1].dump(2);
+    EXPECT_TRUE(MetaOf(fake->Written[3]).is_null()) << fake->Written[3].dump(2);
+    EXPECT_EQ(fake->Written[1]["params"]["protocolVersion"], "2025-06-18");
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Legacy);
+    EXPECT_EQ(server.ClientStatuses()[0].ProtocolVersion, "2025-06-18");
 
     const Json list = server.HandleMessage(MakeRequest(1, "tools/list"));
     const Json* entry = FindToolEntry(list, "ext.files.read_file");
@@ -332,4 +428,295 @@ TEST(McpClientStdio, StopShutsDownConnections)
 
     EXPECT_TRUE(server.ClientStatuses().empty());
     EXPECT_EQ(FindToolEntry(server.HandleMessage(MakeRequest(8, "tools/list")), "ext.files.read_file"), nullptr);
+}
+
+// ---- protocol-era negotiation (issue #777) ----------------------------------
+//
+// Spec 2026-07-28 removes the `initialize` handshake in favour of a stateless
+// core where every request is self-describing. Both eras will coexist for the
+// whole ≥12-month offramp, so this client has to detect which one a child speaks
+// and can never assume either. The rule it implements is the spec's own stdio
+// backward-compatibility rule: probe `server/discover`, treat a RECOGNIZED modern
+// reply as modern, and treat everything else — including silence — as legacy.
+//
+// The load-bearing property is that the legacy path still works untouched; the
+// tests above cover it, and these cover the modern side plus each way the probe
+// can be answered. Getting this wrong is silent: a client that guesses "modern"
+// against a legacy child sends requests it will never understand.
+
+TEST(McpClientStdio, ModernChildSkipsTheHandshakeAndStampsMetaOnEveryRequest)
+{
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, ModernScript())).empty());
+    ASSERT_NE(fake, nullptr);
+
+    // No handshake at all: `initialize` is an unknown method to a modern server,
+    // and `notifications/initialized` would be a message with nowhere to land.
+    EXPECT_EQ(FirstWritten(fake->Written, "initialize"), nullptr);
+    EXPECT_EQ(FirstWritten(fake->Written, "notifications/initialized"), nullptr);
+
+    ASSERT_GE(fake->Written.size(), 2u);
+    EXPECT_EQ(fake->Written[0]["method"], "server/discover");
+    EXPECT_EQ(fake->Written[1]["method"], "tools/list");
+
+    // Every request carries the three reserved `_meta` keys. protocolVersion and
+    // clientCapabilities are REQUIRED per-request — a modern server must not infer
+    // capabilities from an earlier call, so omitting them on the second request
+    // would be just as wrong as omitting them on the first.
+    for (const Json& sent : fake->Written)
+    {
+        const Json meta = MetaOf(sent);
+        ASSERT_TRUE(meta.is_object()) << sent.dump(2);
+        EXPECT_EQ(meta.value("io.modelcontextprotocol/protocolVersion", std::string{}), "2026-07-28");
+        EXPECT_TRUE(meta.contains("io.modelcontextprotocol/clientCapabilities")) << sent.dump(2);
+        EXPECT_TRUE(meta["io.modelcontextprotocol/clientCapabilities"].is_object());
+        EXPECT_EQ(meta["io.modelcontextprotocol/clientInfo"]["name"], "OloEditor");
+    }
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Modern);
+    EXPECT_EQ(server.ClientStatuses()[0].ProtocolVersion, "2026-07-28");
+    // The tools still bridge — era negotiation must be invisible to the registry.
+    EXPECT_NE(FindToolEntry(server.HandleMessage(MakeRequest(20, "tools/list")), "ext.files.read_file"), nullptr);
+}
+
+TEST(McpClientStdio, SilentProbeFallsBackToTheLegacyHandshake)
+{
+    // A child that swallows unknown methods entirely: no reply to server/discover.
+    // The spec's compatibility matrix says a probe that TIMES OUT identifies a
+    // legacy server, so this must fall back rather than fail the connect — and the
+    // short probe budget is what stops that fallback costing the full handshake
+    // timeout.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto silentDiscover = [](const Json& request, FakeTransport& transport)
+    {
+        const std::string method = request.value("method", std::string{});
+        if (method == "server/discover")
+            return; // no reply
+        if (method == "initialize")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "protocolVersion", "2025-06-18" },
+                                                    { "capabilities", Json::object() } } } });
+        }
+        else if (method == "tools/list")
+        {
+            transport.Reply(ToolsListResult(request["id"]));
+        }
+    };
+
+    McpClientConfig config = FilesConfig();
+    config.DiscoverProbeTimeout = std::chrono::milliseconds(50);
+    const auto started = std::chrono::steady_clock::now();
+    ASSERT_TRUE(server.ConnectClientWithTransport(config, FakeFactory(fake, silentDiscover)).empty());
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Legacy);
+    EXPECT_NE(FirstWritten(fake->Written, "initialize"), nullptr) << "the handshake must still run";
+    // The probe budget is what bounds the fallback, not HandshakeTimeout (5 s
+    // here). Asserted one-sided and generously to stay off the flake line — the
+    // point is "bounded by the probe timeout", not a precise duration.
+    EXPECT_LT(elapsed, std::chrono::seconds(3)) << "the fallback must be bounded by DiscoverProbeTimeout";
+}
+
+TEST(McpClientStdio, ModernChildOfferingOnlyLegacyVersionsFallsBackToTheHandshake)
+{
+    // A dual-era child: it answers server/discover (so it IS modern-aware) but
+    // lists only handshake-era revisions. That is a fallback, not a failure.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        const std::string method = request.value("method", std::string{});
+        if (method == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "resultType", "complete" },
+                                                    { "supportedVersions", Json::array({ "2025-11-25" }) },
+                                                    { "capabilities", Json::object() },
+                                                    { "ttlMs", 0 },
+                                                    { "cacheScope", "public" } } } });
+        }
+        else if (method == "initialize")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "protocolVersion", "2025-11-25" },
+                                                    { "capabilities", Json::object() } } } });
+        }
+        else if (method == "tools/list")
+        {
+            transport.Reply(ToolsListResult(request["id"]));
+        }
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, script)).empty());
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Legacy);
+    EXPECT_NE(FirstWritten(fake->Written, "initialize"), nullptr);
+    // The handshake NEGOTIATES — we asked for 2025-06-18 and the child answered
+    // 2025-11-25. Reporting our request rather than the agreed revision would put
+    // a version nobody speaks in the panel and the log, which is the first thing
+    // anyone debugging an era problem reads.
+    EXPECT_EQ(server.ClientStatuses()[0].ProtocolVersion, "2025-11-25");
+}
+
+TEST(McpClientStdio, ModernMarkerWithNoUsableVersionListFallsBackInsteadOfFailing)
+{
+    // A -32022 whose `data` is absent or carries an empty `supported` list tells us
+    // nothing actionable. Hard-failing on it would strand every tool from a child
+    // whose only sin is a thin error payload, so it falls back to the handshake —
+    // the same rule the DiscoverResult path uses for an uninformative version list.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        const std::string method = request.value("method", std::string{});
+        if (method == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "error", Json{ { "code", -32022 },
+                                                   { "message", "Unsupported protocol version" } } } });
+        }
+        else if (method == "initialize")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "protocolVersion", "2025-06-18" },
+                                                    { "capabilities", Json::object() } } } });
+        }
+        else if (method == "tools/list")
+        {
+            transport.Reply(ToolsListResult(request["id"]));
+        }
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, script)).empty())
+        << "an uninformative modern error must not strand the connection";
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Legacy);
+    EXPECT_NE(FindToolEntry(server.HandleMessage(MakeRequest(23, "tools/list")), "ext.files.read_file"), nullptr);
+}
+
+TEST(McpClientStdio, UnsupportedProtocolVersionErrorIsAModernMarkerNotAFallback)
+{
+    // -32022 is reserved by spec 2026-07-28, so only a modern server emits it:
+    // seeing it must resolve the VERSION, never send us back to the handshake.
+    // Here the server names 2026-07-28 in `data.supported`, which we do speak.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        const std::string method = request.value("method", std::string{});
+        if (method == "server/discover")
+        {
+            transport.Reply(Json{
+                { "jsonrpc", "2.0" },
+                { "id", request["id"] },
+                { "error",
+                  Json{ { "code", -32022 },
+                        { "message", "Unsupported protocol version" },
+                        { "data", Json{ { "supported", Json::array({ "2026-07-28" }) },
+                                        { "requested", "2027-01-01" } } } } } });
+        }
+        else if (method == "tools/list")
+        {
+            transport.Reply(ToolsListResult(request["id"]));
+        }
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, script)).empty());
+
+    ASSERT_EQ(server.ClientStatuses().size(), 1u);
+    EXPECT_EQ(server.ClientStatuses()[0].Era, OloEngine::MCP::McpProtocolEra::Modern);
+    EXPECT_EQ(FirstWritten(fake->Written, "initialize"), nullptr) << "a modern marker must not trigger the handshake";
+}
+
+TEST(McpClientStdio, NoMutuallySupportedVersionFailsWithAnActionableError)
+{
+    // A modern server that shares no revision with us. Failing loudly here is the
+    // right answer: falling back to `initialize` against a modern-only server just
+    // produces a second, less informative failure.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        if (request.value("method", std::string{}) == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "resultType", "complete" },
+                                                    { "supportedVersions", Json::array({ "2099-01-01" }) },
+                                                    { "capabilities", Json::object() },
+                                                    { "ttlMs", 0 },
+                                                    { "cacheScope", "public" } } } });
+        }
+    };
+    const std::string error = server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, script));
+
+    ASSERT_FALSE(error.empty());
+    EXPECT_NE(error.find("2099-01-01"), std::string::npos)
+        << "the error must name what the server does support: " << error;
+    EXPECT_TRUE(server.ClientStatuses().empty());
+}
+
+TEST(McpClientStdio, InputRequiredResultIsRefusedRatherThanForwarded)
+{
+    // MRTR (spec 2026-07-28): a modern server may answer a tools/call with
+    // resultType "input_required" and expect elicitation/sampling plus a retry. We
+    // implement none of that, so the ONE thing that must not happen is handing the
+    // interim result to the agent as if it were the answer — a silent half-result
+    // is exactly the failure this bridge must not have.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto onCall = [](const Json& request, FakeTransport& transport)
+    {
+        transport.Reply(Json{ { "jsonrpc", "2.0" },
+                              { "id", request["id"] },
+                              { "result",
+                                Json{ { "resultType", "input_required" },
+                                      { "inputRequests",
+                                        Json{ { "ask", Json{ { "method", "elicitation/create" } } } } } } } });
+    };
+    ASSERT_TRUE(
+        server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, ModernScript({ "2026-07-28" }, onCall)))
+            .empty());
+    server.SetAllowWrites(true);
+
+    const Json response =
+        server.HandleMessage(MakeRequest(21, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["isError"], true);
+    const std::string text = response["result"]["content"][0]["text"].get<std::string>();
+    EXPECT_NE(text.find("input_required"), std::string::npos) << text;
+}
+
+TEST(McpClientStdio, AbsentResultTypeStillCountsAsComplete)
+{
+    // Backward compatibility, stated by the spec: a result from a server on an
+    // earlier revision has no `resultType`, and the client MUST read that as
+    // "complete". Without this, the MRTR guard above would reject every legacy
+    // tool call — a regression that would look like "the bridge stopped working".
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto onCall = [](const Json& request, FakeTransport& transport)
+    {
+        transport.Reply(Json{ { "jsonrpc", "2.0" },
+                              { "id", request["id"] },
+                              { "result", Json{ { "content", Json::array({ Json{ { "type", "text" },
+                                                                                 { "text", "legacy payload" } } }) } } } });
+    };
+    ASSERT_TRUE(server.ConnectClientWithTransport(FilesConfig(), FakeFactory(fake, WellBehavedScript(onCall))).empty());
+    server.SetAllowWrites(true);
+
+    const Json response =
+        server.HandleMessage(MakeRequest(22, "tools/call", Json{ { "name", "ext.files.read_file" } }));
+    ASSERT_TRUE(response.contains("result")) << response.dump(2);
+    EXPECT_EQ(response["result"]["isError"], false);
+    EXPECT_EQ(response["result"]["content"][0]["text"], "legacy payload");
 }

--- a/OloEngine/tests/MCP/McpClientStdioTest.cpp
+++ b/OloEngine/tests/MCP/McpClientStdioTest.cpp
@@ -637,6 +637,38 @@ TEST(McpClientStdio, UnsupportedProtocolVersionErrorIsAModernMarkerNotAFallback)
     EXPECT_EQ(FirstWritten(fake->Written, "initialize"), nullptr) << "a modern marker must not trigger the handshake";
 }
 
+TEST(McpClientStdio, FallbackFailureAfterAModernReplyNamesTheEraMismatch)
+{
+    // A modern-aware child that advertises no version we speak AND cannot serve the
+    // handshake we fall back to. A bare "initialize failed" would send the reader
+    // hunting for a legacy problem, so the error must carry the era context the
+    // probe alone knew.
+    McpServer server{ EditorMcpContext{} };
+    FakeTransport* fake = nullptr;
+    const auto script = [](const Json& request, FakeTransport& transport)
+    {
+        if (request.value("method", std::string{}) == "server/discover")
+        {
+            transport.Reply(Json{ { "jsonrpc", "2.0" },
+                                  { "id", request["id"] },
+                                  { "result", Json{ { "resultType", "complete" },
+                                                    { "supportedVersions", Json::array() },
+                                                    { "capabilities", Json::object() },
+                                                    { "ttlMs", 0 },
+                                                    { "cacheScope", "public" } } } });
+        }
+        // initialize is deliberately swallowed.
+    };
+    McpClientConfig config = FilesConfig();
+    config.HandshakeTimeout = std::chrono::milliseconds(100);
+    config.DiscoverProbeTimeout = std::chrono::milliseconds(100);
+    const std::string error = server.ConnectClientWithTransport(config, FakeFactory(fake, script));
+
+    ASSERT_FALSE(error.empty());
+    EXPECT_NE(error.find("server/discover"), std::string::npos) << error;
+    EXPECT_NE(error.find("legacy handshake"), std::string::npos) << error;
+}
+
 TEST(McpClientStdio, NoMutuallySupportedVersionFailsWithAnActionableError)
 {
     // A modern server that shares no revision with us. Failing loudly here is the

--- a/OloEngine/tests/MCP/McpDispatchTest.cpp
+++ b/OloEngine/tests/MCP/McpDispatchTest.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace
 {
@@ -102,6 +103,20 @@ namespace
             { return std::string("resource-body"); };
             m_Server.RegisterResource(std::move(resource));
 
+            // A SUBSCRIBABLE resource (issue #777): a ChangeToken is what opts a
+            // resource into resources/subscribe. `olo://fake` above deliberately
+            // has none, so the two together cover both sides of the gate.
+            ResourceDef live;
+            live.Uri = "olo://fake-live";
+            live.Name = "fake-live-resource";
+            live.Description = "A fake resource that reports when it changes.";
+            live.MimeType = "text/plain";
+            live.Reader = [this](McpServer&)
+            { return std::to_string(m_ChangeToken); };
+            live.ChangeToken = [this]
+            { return m_ChangeToken; };
+            m_Server.RegisterResource(std::move(live));
+
             PromptDef prompt;
             prompt.Name = "fake-prompt";
             prompt.Title = "Fake Prompt";
@@ -111,6 +126,9 @@ namespace
         }
 
         McpServer m_Server;
+        // Backing store for olo://fake-live's ChangeToken; bump it to simulate the
+        // resource's content moving. (u64 is a GLOBAL typedef, not OloEngine::u64.)
+        u64 m_ChangeToken = 1;
     };
 } // namespace
 
@@ -137,7 +155,15 @@ TEST_F(McpDispatchTest, InitializeReturnsHandshakeShape)
     EXPECT_TRUE(caps.contains("prompts"));
     // `logging` is advertised because GET /mcp pushes diagnostics events as
     // notifications/message log notifications (#306 item B server-push stream).
+    // Spec 2026-07-28 DEPRECATED it (≥12-month offramp), so #777 added a
+    // successor carrier — resources.subscribe below — that runs BESIDE it. This
+    // assertion is the pin that stops the deprecated carrier being dropped early:
+    // every client we actually talk to speaks a 2025-* revision and would lose
+    // the live event stream.
     EXPECT_TRUE(caps.contains("logging"));
+    // The offramp carrier (#777): the server accepts resources/subscribe for any
+    // resource that can honestly report a change.
+    EXPECT_EQ(caps["resources"]["subscribe"], true);
 }
 
 TEST_F(McpDispatchTest, InitializeEchoesSupportedProtocolVersion)
@@ -410,7 +436,9 @@ TEST_F(McpDispatchTest, ResourcesListSurfacesRegisteredResources)
     const Json resp = m_Server.HandleMessage(MakeRequest(4, "resources/list"));
     const Json& resources = resp["result"]["resources"];
     ASSERT_TRUE(resources.is_array());
-    ASSERT_EQ(resources.size(), 1u);
+    // Two: the plain fake resource plus olo://fake-live, which carries a
+    // ChangeToken so the resources/subscribe gate has both sides to test.
+    ASSERT_EQ(resources.size(), 2u);
     EXPECT_EQ(resources[0]["uri"], "olo://fake");
     EXPECT_EQ(resources[0]["name"], "fake-resource");
     EXPECT_EQ(resources[0]["mimeType"], "text/plain");
@@ -503,6 +531,142 @@ TEST_F(McpDispatchTest, ResourcesReadUnknownUriIsError)
 TEST_F(McpDispatchTest, ResourcesReadMissingUriIsInvalidParams)
 {
     const Json resp = m_Server.HandleMessage(MakeRequest(13, "resources/read", Json::object()));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+}
+
+// ---- resources/subscribe + unsubscribe (the `logging` offramp, issue #777) ---
+//
+// The `logging` capability that carries the live diagnostics event stream is
+// deprecated as of spec 2026-07-28. The replacement carrier is a SUBSCRIBABLE
+// resource: subscribe, receive notifications/resources/updated, read. These tests
+// pin the dispatch-side contract; the SSE delivery itself is transport-bound and
+// is not reachable from this seam.
+//
+// The gate under test is deliberate: a resource opts in with a ChangeToken, and
+// one WITHOUT a token must be refused rather than accepted-and-never-fired.
+// Accepting it would be the silent failure this carrier exists to avoid.
+
+TEST_F(McpDispatchTest, ResourcesSubscribeAcceptsAResourceWithAChangeToken)
+{
+    const Json resp =
+        m_Server.HandleMessage(MakeRequest(40, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }));
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    EXPECT_TRUE(resp["result"].is_object());
+    EXPECT_TRUE(resp["result"].empty()) << "the spec's subscribe result is empty";
+
+    const std::vector<std::string> subscribed = m_Server.SubscribedUris();
+    ASSERT_EQ(subscribed.size(), 1u);
+    EXPECT_EQ(subscribed[0], "olo://fake-live");
+}
+
+TEST_F(McpDispatchTest, ResourcesSubscribeRejectsAResourceThatCannotReportChange)
+{
+    // olo://fake has no ChangeToken, so a subscription could never fire.
+    const Json resp = m_Server.HandleMessage(MakeRequest(41, "resources/subscribe", Json{ { "uri", "olo://fake" } }));
+    ASSERT_TRUE(resp.contains("error")) << resp.dump(2);
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    // The error must be actionable: it names the URIs that DO work, so a client
+    // recovers in one step instead of probing every resource.
+    const std::string message = resp["error"]["message"].get<std::string>();
+    EXPECT_NE(message.find("olo://fake-live"), std::string::npos) << message;
+    EXPECT_TRUE(m_Server.SubscribedUris().empty()) << "a rejected subscribe must not register anything";
+}
+
+TEST_F(McpDispatchTest, ResourcesSubscribeRejectsUnknownUri)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(42, "resources/subscribe", Json{ { "uri", "olo://nope" } }));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+    EXPECT_TRUE(m_Server.SubscribedUris().empty());
+}
+
+TEST_F(McpDispatchTest, ResourcesSubscribeMissingUriIsInvalidParams)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(43, "resources/subscribe", Json::object()));
+    ASSERT_TRUE(resp.contains("error"));
+    EXPECT_EQ(resp["error"]["code"], -32602);
+}
+
+TEST_F(McpDispatchTest, ResourcesSubscribeIsIdempotent)
+{
+    for (int i = 0; i < 3; ++i)
+    {
+        const Json resp =
+            m_Server.HandleMessage(MakeRequest(44, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }));
+        ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    }
+    EXPECT_EQ(m_Server.SubscribedUris().size(), 1u) << "re-subscribing must not duplicate the entry";
+}
+
+TEST_F(McpDispatchTest, SubscribeBaselinesTheChangeTokenAtSubscribeTime)
+{
+    // The window this closes: if the baseline were taken on the STREAM's first poll
+    // instead of here, anything that changed between the subscribe and that poll —
+    // or before the client opened its stream at all — would be seeded over and
+    // never reported. The baseline must be the value as of the subscribe.
+    m_ChangeToken = 7;
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(49, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+
+    auto baselines = m_Server.SubscriptionBaselines();
+    ASSERT_EQ(baselines.count("olo://fake-live"), 1u);
+    EXPECT_EQ(baselines["olo://fake-live"], 7u);
+
+    // A change now must leave the baseline behind, so the next stream poll sees
+    // baseline != current and fires.
+    m_ChangeToken = 8;
+    baselines = m_Server.SubscriptionBaselines();
+    EXPECT_EQ(baselines["olo://fake-live"], 7u) << "the baseline must not track the live token";
+}
+
+TEST_F(McpDispatchTest, ResubscribingKeepsTheOriginalBaselineButUnsubscribeResetsIt)
+{
+    // Idempotency must not silently discard a pending update: a client that
+    // re-sends subscribe (a retry, a reconnect) keeps its original baseline, so the
+    // change it has not been told about yet still fires. A deliberate
+    // unsubscribe/resubscribe is the opposite — it means "start fresh".
+    m_ChangeToken = 1;
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(50, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+    m_ChangeToken = 2;
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(51, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+    EXPECT_EQ(m_Server.SubscriptionBaselines()["olo://fake-live"], 1u)
+        << "a repeated subscribe must not swallow the change it has not reported yet";
+
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(52, "resources/unsubscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(53, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+    EXPECT_EQ(m_Server.SubscriptionBaselines()["olo://fake-live"], 2u)
+        << "unsubscribe then subscribe means start fresh, not replay";
+}
+
+TEST_F(McpDispatchTest, ResourcesUnsubscribeRemovesTheSubscription)
+{
+    ASSERT_TRUE(m_Server.HandleMessage(MakeRequest(45, "resources/subscribe", Json{ { "uri", "olo://fake-live" } }))
+                    .contains("result"));
+    const Json resp =
+        m_Server.HandleMessage(MakeRequest(46, "resources/unsubscribe", Json{ { "uri", "olo://fake-live" } }));
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+    EXPECT_TRUE(m_Server.SubscribedUris().empty());
+}
+
+TEST_F(McpDispatchTest, ResourcesUnsubscribeUnknownUriStillSucceeds)
+{
+    // Idempotent by design: a client tearing down after a reconnect must not be
+    // tripped by a subscription the server has already forgotten. Note this
+    // accepts URIs the server has never heard of too — unsubscribe carries no
+    // information the server needs to validate.
+    const Json resp =
+        m_Server.HandleMessage(MakeRequest(47, "resources/unsubscribe", Json{ { "uri", "olo://never" } }));
+    ASSERT_TRUE(resp.contains("result")) << resp.dump(2);
+}
+
+TEST_F(McpDispatchTest, ResourcesUnsubscribeMissingUriIsInvalidParams)
+{
+    const Json resp = m_Server.HandleMessage(MakeRequest(48, "resources/unsubscribe", Json::object()));
     ASSERT_TRUE(resp.contains("error"));
     EXPECT_EQ(resp["error"]["code"], -32602);
 }

--- a/OloEngine/tests/MCP/McpProtocolIconsTest.cpp
+++ b/OloEngine/tests/MCP/McpProtocolIconsTest.cpp
@@ -172,7 +172,12 @@ namespace
         // resource-link work (#673 Tier 1: ephemeral capture resources); only
         // prompts are still fixed for a server run.
         EXPECT_EQ(response["result"]["capabilities"]["resources"]["listChanged"], true);
-        EXPECT_EQ(response["result"]["capabilities"]["resources"]["subscribe"], false);
+        // `subscribe` flipped to true with the `logging`-capability offramp (#777):
+        // a client can subscribe to olo://events/recent and be pushed
+        // notifications/resources/updated. Only resources carrying a
+        // ResourceDef::ChangeToken accept a subscription — see McpDispatchTest's
+        // resources/subscribe cases for the gate.
+        EXPECT_EQ(response["result"]["capabilities"]["resources"]["subscribe"], true);
         EXPECT_EQ(response["result"]["capabilities"]["prompts"]["listChanged"], false);
     }
 

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -34,6 +34,7 @@ run is **not** evidence.
 | [crowd-manager-follower-parity.md](crowd-manager-follower-parity.md) | a test believed it exercised the manual path; a valid navmesh had silently switched it to the crowd follower |
 | [follow-camera-and-character-query-seams.md](follow-camera-and-character-query-seams.md) | a steady-state offset check passes with a full one-tick lag present |
 | [parallelizable-mover-systems.md](parallelizable-mover-systems.md) | a position check passes on the scheduler tie-break alone, with the dependency edge missing |
+| [mcp-protocol-eras.md](mcp-protocol-eras.md) | adding `server/discover` alone keeps every test green — and converts a *working* legacy fallback into a broken modern conversation, because answering it is a client's proof the server is modern |
 
 **The counter-move:** name the observation that *would* have failed. Usually it's a moving target
 instead of a static one, an edge instead of a steady state, a second camera angle, or the physical
@@ -73,7 +74,10 @@ shipped games only) · [crowd-manager-follower-parity.md](crowd-manager-follower
 component's teardown, when `m_Registry.destroy()` skips `OnComponentRemoved`) ·
 [vcpkg-dependency-management.md](vcpkg-dependency-management.md) (three of five traps silent —
 including a forced port option that never applied) ·
-[asset-import-usd-alembic.md](asset-import-usd-alembic.md) (winding, up-axis, unit scale, UV origin)
+[asset-import-usd-alembic.md](asset-import-usd-alembic.md) (winding, up-axis, unit scale, UV origin) ·
+[mcp-protocol-eras.md](mcp-protocol-eras.md) (swapping the event stream's notification carrier drops
+pushes that nothing reports missing — which is why the new carrier runs *beside* the deprecated one,
+not instead of it)
 
 **The counter-move:** ask what the *absence* would look like, and whether anything in the system
 would be different. If the answer is "nothing", you need a coverage test, not a unit test.
@@ -208,7 +212,8 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 [script-structural-command-safe-point.md](script-structural-command-safe-point.md) ·
 [runtime-scene-switching.md](runtime-scene-switching.md) ·
 [server-authoritative-networking-loop.md](server-authoritative-networking-loop.md) ·
-[mcp-setter-based-field-registry.md](mcp-setter-based-field-registry.md)
+[mcp-setter-based-field-registry.md](mcp-setter-based-field-registry.md) ·
+[mcp-protocol-eras.md](mcp-protocol-eras.md)
 
 **Concurrency & memory** —
 [intrusive-refcount-weakref-races.md](intrusive-refcount-weakref-races.md) ·

--- a/docs/agent-rules/mcp-protocol-eras.md
+++ b/docs/agent-rules/mcp-protocol-eras.md
@@ -1,0 +1,172 @@
+# MCP protocol eras — why the stateless core is deferred, and what shipped instead
+
+Spec `2026-07-28` splits MCP into two **eras**, and the split lands on the transport, not on a
+version string:
+
+- **Legacy** (`2025-11-25` and earlier) — a session established by an `initialize` handshake.
+- **Modern** (`2026-07-28`+) — a *stateless core*: no handshake, every request self-describing.
+
+This document is the evidence behind issue #777's decision to **not** advertise `2026-07-28` yet,
+the two pieces that did ship, and the traps waiting for whoever does the migration. Read it before
+touching `OloEditor/src/MCP/McpServer.cpp`'s version list, `HandleInitialize`, `HandleGetStream`, or
+`McpClient.cpp`'s connect sequence.
+
+Sources are normative: the spec's [`schema.ts`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2026-07-28/schema.ts),
+[Versioning and Compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning),
+and [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http).
+The blog announcement is a summary and materially under-describes the work — do not scope from it.
+
+---
+
+## 1. What advertising `2026-07-28` actually costs
+
+The issue listed four requirements (`server/discover`, `_meta` identity, routing headers,
+`resultType`). The normative spec requires all of those **and** the following, every one of which
+touches the transport this server's clients already depend on:
+
+| Requirement | Where it lands here |
+|---|---|
+| `server/discover` — servers **MUST** implement | new RPC in `DispatchRpc` |
+| `_meta` per request: `io.modelcontextprotocol/protocolVersion` **and** `/clientCapabilities` **required**, `/clientInfo` SHOULD | every handler's params |
+| `Mcp-Method` + `Mcp-Name` headers **required**, and the server **MUST** validate header↔body agreement | `HandlePost` |
+| `-32020 HeaderMismatch`, `-32021 MissingRequiredClientCapability`, `-32022 UnsupportedProtocolVersion` — each with a mandated `data` shape and a mandated HTTP status | error construction |
+| Method-not-found becomes **HTTP 404** (was 200 + JSON-RPC error) | `HandlePost` status selection |
+| **The GET SSE stream is removed** — `GET`/`DELETE` must answer `405` | `HandleGetStream` |
+| `subscriptions/listen` replaces it, and replaces `resources/subscribe` | new long-lived RPC |
+| Cancellation over HTTP becomes *closing the response stream*; `notifications/cancelled` is stdio-only | the whole `m_InFlightCalls` path |
+| `Mcp-Session-Id` ignored, never minted or echoed; `Last-Event-ID` ignored, streams not resumable | `ProcessRequestBody`, `HandleGetStream` |
+| `logging/setLevel` folded into `_meta`'s `io.modelcontextprotocol/logLevel` | logging path |
+| MRTR: `resultType: "input_required"`, `inputRequests`, `inputResponses`, `requestState` | results |
+| `resultType` on **every** result | `MakeResult` |
+
+`resources/read`'s not-found code also moves (`-32002` → `-32602`), and clients must support
+`x-mcp-header` parameter mirroring.
+
+**This is a second transport shape living beside the first**, not a field-addition. Both shapes must
+be served from one httplib endpoint for the whole ≥12-month offramp, because our actual clients all
+speak `2025-*` today.
+
+## 2. Why it is a no-go *now*
+
+1. **Zero benefit.** The stateless core exists so any request can land on any instance behind a
+   round-robin load balancer. This is a single **localhost** diagnostics server with one client, no
+   gateway, and no metering. Every listed benefit is structurally inapplicable.
+2. **The blast radius is the instrument itself.** This server is how other engine work gets verified
+   live. The failure mode of a botched dual-era transport is a server that passes a happy-path smoke
+   test and misbehaves on the paths that matter — exactly the "green but wrong" archetype.
+3. **Nothing is breaking.** Every removal has a ≥12-month offramp from 2026-07-28, and our version
+   negotiation already degrades gracefully (an unknown `protocolVersion` falls back to our latest).
+4. **No client asks for it.** A modern client talking to us gets a clean legacy handshake; the spec's
+   own compatibility matrix rates *dual-era client × legacy server* as **Works**.
+
+The spec explicitly blesses staying legacy: a dual-era **client** falls back after inspecting a
+`400`, and only a *legacy-only client × modern-only server* pairing fails outright — the direction we
+are not in.
+
+## 3. The trap: `server/discover` cannot be added on its own
+
+The obvious "cheap first slice" is to implement `server/discover` — it is additive, it is a new
+method, and it breaks no existing client.
+
+**It is actively harmful without the rest.** A modern client uses a successful `DiscoverResult` as
+proof the peer is a modern server, and then sends modern requests. A `server/discover` answered by a
+server that still requires `initialize`, has no `_meta` handling, mints session ids and serves a GET
+stream converts a *working* legacy fallback into a *broken* modern conversation. On stdio the probe
+**is** the era detector; on HTTP the era detector is a modern request's `400` body — and answering
+discover while rejecting modern requests puts a client between the two.
+
+This is why the issue's "do it as one coherent change, not piecemeal" is a correctness constraint,
+not a style preference. `server/discover` ships when `_meta`, `resultType`, the routing headers, the
+three error codes and the GET-stream removal ship — or it does not ship.
+
+## 4. What did ship (PR for #777)
+
+### 4a. The outbound client is dual-era
+
+`McpClient.cpp` used to hardcode `initialize` with `protocolVersion: "2025-06-18"`. It now runs the
+spec's stdio backward-compatibility rule (`McpClientConnection::NegotiateEra`):
+
+1. Probe `server/discover`, carrying a modern `_meta`.
+2. A `DiscoverResult`, **or** a `-32022 UnsupportedProtocolVersionError`, identifies a **modern**
+   server — a recognized modern error is a modern marker, so it triggers a version retry, never a
+   fallback.
+3. **Anything else — including no reply at all — is legacy**, and the `initialize` /
+   `notifications/initialized` handshake runs unchanged.
+4. In the modern era every request carries `_meta` (version + `clientInfo` + an empty
+   `clientCapabilities`, which is *required* and per-request: a server must not infer it from an
+   earlier call). Stamped in `SendRequest`, the single funnel, so a future request cannot ship
+   without it.
+
+Three details worth keeping:
+
+- **The probe timeout is separate and short** (`McpClientConfig::DiscoverProbeTimeout`, 3 s, clamped
+  to `HandshakeTimeout`). A well-behaved legacy child answers `-32601` instantly; this budget is only
+  spent on one that swallows unknown methods, and without it *every* legacy connect would pay the
+  full handshake timeout before falling back.
+- **A late probe response is harmless.** After the timeout the pending entry is erased, so `OnLine`
+  finds no waiter and drops it — it cannot be mistaken for a later request's answer.
+- **`resultType != "complete"` is now refused, loudly.** A modern server may answer a bridged
+  `tools/call` with `input_required` (MRTR) expecting elicitation/sampling and a retry. We implement
+  none of that, and an *absent* `resultType` means `"complete"` for backward compatibility — so the
+  only unacceptable outcome is forwarding an interim result to the agent as if it were the answer.
+  It returns a tool error instead.
+
+### 4b. The `logging` offramp has a carrier, and both run side by side
+
+`logging` is deprecated (SEP-2577). We push the entire diagnostics event stream as
+`notifications/message` over the GET SSE stream, which made this the one place OloEngine was
+structurally tied to a removed feature.
+
+**The replacement is a subscribable resource, and the choice is forced.** Under `2026-07-28`:
+
+- the GET stream is gone;
+- `notifications/message` survives but only on the response stream of the request it relates to;
+- `SubscriptionFilter` — everything `subscriptions/listen` can deliver — is a **closed set** of four
+  types (`toolsListChanged`, `promptsListChanged`, `resourcesListChanged`, `resourceSubscriptions`),
+  and the server **MUST NOT** send a type the client did not request.
+
+So a custom notification has nowhere to live in the modern era, and the extensions framework is for
+negotiated capability bundles, not a one-off push. `notifications/resources/updated` on a subscribed
+URI is the only carrier on that list that fits — and it also exists *today*. That is the property
+that made it the answer: **the same notification, resource and payload work in both eras; only the
+subscription plumbing moves** (`resources/subscribe` → `subscriptions/listen`).
+
+Shipped: `olo://events/recent` (200 newest events + `lastId`, entries byte-identical to
+`olo_events_tail`), `resources/subscribe` / `resources/unsubscribe`, and
+`capabilities.resources.subscribe: true`. `logging` and the `notifications/message` push are
+**unchanged** — dropping them early would break every client that speaks a `2025-*` revision, which
+today is all of them.
+
+Two design points to preserve:
+
+- **Only a resource with a `ResourceDef::ChangeToken` is subscribable.** Without a cheap monotonic
+  change token there is no honest way to know the content moved, so a subscription would promise
+  updates that never arrive. `resources/subscribe` rejects those with `-32602` *naming the URIs that
+  do work*. This is the same honesty rule as `olo_render_why_not_visible` reporting HZB occlusion as
+  not-observable instead of guessing.
+- **The first poll cycle after a subscribe seeds the token instead of firing.** Otherwise a client
+  gets a spurious "updated" for state it has never seen change. Unsubscribing drops the entry, so a
+  resubscribe re-seeds rather than replaying.
+
+The known simplification: the subscription set is **server-global**, because the GET stream carries
+no session identity. With two streams open, both see updates once either subscribes. It errs toward
+over-delivery (a non-subscriber ignores the notification), and it dissolves in the modern transport
+where `subscriptions/listen` makes the stream *itself* the subscription — so building a bespoke
+per-session registry now would be work thrown away by the migration.
+
+## 5. When to revisit
+
+Not on a date — on a trigger. Any one of these makes the migration real work rather than speculative:
+
+- A client we actually use (Claude Code, an SDK we bridge to) starts sending `2026-07-28` requests —
+  visible as `_meta`-carrying POSTs, or as a `400`/`405` we return to a modern probe.
+- A bridged external server goes modern-only. The client half already handles this; the *server* half
+  is what would need the rework.
+- The MCP SDKs' Tier-1 servers drop the legacy handshake, which starts the clock on the offramp
+  actually ending.
+
+When it happens, build it as one additive route: `2026-07-28` added to
+`kSupportedProtocolVersions`, `server/discover` + `_meta` + routing headers + `resultType` +
+`subscriptions/listen` served **alongside** the existing handshake, legacy path untouched and still
+tested, and the new version advertised only once the whole set works. The load-bearing test is not
+the new path — it is the legacy one still passing beside it.

--- a/docs/agent-rules/mcp-protocol-eras.md
+++ b/docs/agent-rules/mcp-protocol-eras.md
@@ -144,9 +144,13 @@ Two design points to preserve:
   updates that never arrive. `resources/subscribe` rejects those with `-32602` *naming the URIs that
   do work*. This is the same honesty rule as `olo_render_why_not_visible` reporting HZB occlusion as
   not-observable instead of guessing.
-- **The first poll cycle after a subscribe seeds the token instead of firing.** Otherwise a client
-  gets a spurious "updated" for state it has never seen change. Unsubscribing drops the entry, so a
-  resubscribe re-seeds rather than replaying.
+- **The baseline token is captured at subscribe time, in `HandleResourcesSubscribe`** — *not* seeded
+  on the stream's first poll. The first poll compares the live token against that baseline, so a
+  change that lands between the subscribe and the poll — or before the client opens its stream at
+  all — still fires. Seeding at first poll instead is the version of this that silently swallows
+  those updates, which is the failure the whole `ChangeToken` gate exists to prevent. A repeated
+  subscribe keeps the existing baseline (so a retry cannot discard a pending update); unsubscribing
+  erases it, so a resubscribe deliberately re-baselines rather than replaying.
 
 The known simplification: the subscription set is **server-global**, because the GET stream carries
 no session identity. With two streams open, both see updates once either subscribes. It errs toward

--- a/docs/agent-rules/notes-mcp-tool-authoring.md
+++ b/docs/agent-rules/notes-mcp-tool-authoring.md
@@ -22,15 +22,25 @@ the wrong destination).
 3. **Unit test** `OloEngine/tests/MCP/Mcp<Name>Test.cpp` driving the pure code directly, classified
    `// OLO_TEST_LAYER: unit` and added to the explicit source list in `tests/CMakeLists.txt`.
 
-> **Why the split is mandatory: the test binary deliberately does not link `McpTools.cpp`.** It
-> compiles the pure headers plus `McpServer.cpp` (the dispatch seam) and registers *fake* tools
-> wired to the same shared code. So all real logic must live in the pure header, or it is untested.
+> **Why the split is mandatory: a handler cannot be *run* from the test binary.** Most MCP tests
+> compile the pure headers plus `McpServer.cpp` (the dispatch seam) and register *fake* tools wired
+> to the same shared code, because a real handler needs `MarshalRead`, a game thread and usually GL.
+> So all real logic must live in the pure header, or it is untested.
+>
+> **Correction (#777):** an older version of this note said the test binary "deliberately does not
+> link `McpTools.cpp`". That is **false** — `McpTools.cpp` and the whole per-domain `McpTools*.cpp`
+> family have been in `tests/CMakeLists.txt`'s explicit source list since the `McpHeadlessAttachTest`
+> work (#316). What was never safe is *invoking* a handler, not linking one; §2 below already said as
+> much about `RegisterBuiltinTools`. Practical consequence: **registering a new built-in resource,
+> prompt or tool changes what the headless tests see**, so a `resources/list` count assertion in an
+> unrelated test can fail on your change.
 
 ## 2. A green test run does not mean your handler compiles
 
-Because `McpTools.cpp` isn't in the test binary, `OloEngine-Tests` proves the header/JSON contract
-and says **nothing** about whether the handler compiles or links. **Build the `OloEditor` target
-too** before calling a tool done — that is also what live-verify needs.
+`McpTools.cpp` links into the test binary, but no test drives a real handler end-to-end, so a green
+`OloEngine-Tests` proves the header/JSON contract and the registration shape — and says **nothing**
+about whether the handler *works*. **Build the `OloEditor` target too** before calling a tool done —
+that is also what live-verify needs.
 
 > **Registration-only testing IS safe headless.** `RegisterBuiltinTools(server)` only builds
 > `ToolDef`s (schemas, names, annotations); handlers never run, so no MarshalRead, game thread or GL

--- a/docs/agent-rules/notes-mcp-tool-authoring.md
+++ b/docs/agent-rules/notes-mcp-tool-authoring.md
@@ -35,12 +35,17 @@ the wrong destination).
 > prompt or tool changes what the headless tests see**, so a `resources/list` count assertion in an
 > unrelated test can fail on your change.
 
-## 2. A green test run does not mean your handler compiles
+## 2. A green test run does not mean your handler *works*
 
-`McpTools.cpp` links into the test binary, but no test drives a real handler end-to-end, so a green
-`OloEngine-Tests` proves the header/JSON contract and the registration shape — and says **nothing**
-about whether the handler *works*. **Build the `OloEditor` target too** before calling a tool done —
-that is also what live-verify needs.
+Building `OloEngine-Tests` **does** compile `McpTools.cpp` and every per-domain `McpTools*.cpp`, so
+a green run proves they compile and that their `ToolDef`s register. What it does **not** prove:
+
+- that the handler *runs* — nothing drives a real one end-to-end (it would need `MarshalRead`, a game
+  thread and usually GL), so the body is unexercised;
+- that the **`OloEditor` target** builds — it has its own sources (`McpServerPanel.cpp`, the editor
+  layer) and its own link step, which the test target does not cover.
+
+**Build the `OloEditor` target too** before calling a tool done — that is also what live-verify needs.
 
 > **Registration-only testing IS safe headless.** `RegisterBuiltinTools(server)` only builds
 > `ToolDef`s (schemas, names, annotations); handlers never run, so no MarshalRead, game thread or GL

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -1581,7 +1581,8 @@ in regularly never misses anything between checks.
 > **Companion (issue #306 item B, server-push half — done):** `olo_events_tail` is the
 > *poll-based* read of the ring buffer; the same buffer is now also **pushed live** over a
 > persistent SSE stream on `GET /mcp` (previously `405`). See **Live event push** below.
-> `resources/subscribe` remains the one unimplemented sub-item.
+> `resources/subscribe` landed with the `logging` offramp (#777) — see **Subscribing to
+> the event resource**.
 
 ### Live event push (server-initiated SSE stream)
 
@@ -1623,6 +1624,50 @@ surface byte-identical event records.
 //          "data":{"id":313,"category":"play","time":"14:02:11.418",
 //                  "message":"Entered Play mode","context":"MyScene"}}}
 ```
+
+### Subscribing to the event resource (the `logging` offramp — #777)
+
+The `notifications/message` push above rides the MCP **`logging`** capability, which spec
+`2026-07-28` **deprecated** (SEP-2577, ≥12-month offramp). So there is now a second,
+non-`logging` carrier for exactly the same events, and **both run side by side** for the
+whole offramp — nothing about the stream above changed:
+
+1. `resources/subscribe` with `{"uri": "olo://events/recent"}`.
+2. When new diagnostics events are recorded, the GET stream carries
+   `notifications/resources/updated` with that `uri`. It means **"this resource changed,
+   re-read it"**, not "one event happened": the stream samples the change token once per
+   ~250 ms cycle, so a burst of events coalesces into a single notification. Measured on
+   a live editor — entering Play recorded 5 events (a `play` plus 4 `entity_spawn`) and
+   produced exactly **one** `resources/updated`.
+3. `resources/read` the URI (or call `olo_events_tail` with `sinceId`) to fetch what
+   changed. The resource returns `{"events": [...], "lastId": <n>}` — the `events`
+   entries are byte-identical to `olo_events_tail`'s, and `lastId` is the cursor to pass
+   as the next `sinceId`. Because updates coalesce, always read from your last cursor
+   rather than assuming one notification means one new event.
+4. `resources/unsubscribe` to stop. It is idempotent — unsubscribing something you never
+   subscribed to succeeds.
+
+**Only resources that can honestly report a change are subscribable.** A resource opts in
+by supplying a `ResourceDef::ChangeToken` (a cheap, monotonic "has this changed?" read);
+`olo://events/recent` is currently the only one. `resources/subscribe` on any other URI is
+rejected with `-32602` **naming the subscribable URIs** rather than accepting a
+subscription that could never fire. `capabilities.resources.subscribe` is `true`.
+
+Two honest limitations, both consequences of the GET stream having no session identity:
+
+- The subscription set is **server-global**, so if two clients hold streams open, both see
+  the updates once either subscribes. Harmless (a client that did not subscribe ignores
+  the notification), and it disappears in the `2026-07-28` transport, where
+  `subscriptions/listen` makes the stream itself the subscription.
+- Subscriptions are cleared on server stop.
+
+**Why a resource and not a custom notification:** under `2026-07-28` the GET stream is
+removed, `notifications/message` becomes scoped to the request that triggered it, and the
+`subscriptions/listen` filter is a **closed set** of four notification types — so a bespoke
+notification has nowhere to live there. `notifications/resources/updated` is on that list.
+Migrating therefore moves only the plumbing (`resources/subscribe` →
+`subscriptions/listen`); the resource, the notification and the payload are unchanged. Full
+reasoning: [`docs/agent-rules/mcp-protocol-eras.md`](../agent-rules/mcp-protocol-eras.md).
 
 Attach with a streaming-capable client (the same `claude mcp add` line works — Claude
 Code opens the GET stream automatically alongside the POST channel). The threading is
@@ -1831,6 +1876,9 @@ so keep a write-tier tool's description honest about what it changes.
 
 - `olo://scene/current` — the whole active scene serialized to YAML.
 - `olo://logs/recent` — the recent engine log lines.
+- `olo://events/recent` — the most recent 200 diagnostics events as JSON
+  (`{"events": [...], "lastId": <n>}`, entries identical to `olo_events_tail`'s). The one
+  **subscribable** resource: see [Subscribing to the event resource](#subscribing-to-the-event-resource-the-logging-offramp--777).
 - `olo://capture/<seq>/<kind>.png` — **ephemeral capture resources** (issue #673 Tier 1):
   when a capture tool is called with `delivery: "resource_link"` (`olo_screenshot`,
   `olo_render_capture_target`, `olo_render_compare_golden`), the PNG is published here

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -1636,9 +1636,11 @@ whole offramp — nothing about the stream above changed:
 2. When new diagnostics events are recorded, the GET stream carries
    `notifications/resources/updated` with that `uri`. It means **"this resource changed,
    re-read it"**, not "one event happened": the stream samples the change token once per
-   ~250 ms cycle, so a burst of events coalesces into a single notification. Measured on
-   a live editor — entering Play recorded 5 events (a `play` plus 4 `entity_spawn`) and
-   produced exactly **one** `resources/updated`.
+   ~250 ms cycle, so a burst of events coalesces into a single notification. Measured on a live
+   editor: entering Play on one sandbox scene recorded 5 events within a single cycle and produced
+   exactly **one** `resources/updated`. The count is scene-specific — the `play` event plus whatever
+   entities that scene's systems spawn on start (here, 4 dialogue-UI entities); it is **not** the
+   suppressed whole-scene-copy path described above, which never reaches the ring at all.
 3. `resources/read` the URI (or call `olo_events_tail` with `sinceId`) to fetch what
    changed. The resource returns `{"events": [...], "lastId": <n>}` — the `events`
    entries are byte-identical to `olo_events_tail`'s, and `lastId` is the cursor to pass


### PR DESCRIPTION
Advances **#777** (MCP: adopt the 2026-07-28 specification). Lands the two items that stand on their own; **the server-side stateless core is deliberately deferred with evidence** — so this is intentionally *not* `Closes #777` (that tracker also carries standing deprecation clocks).

Spec `2026-07-28` splits MCP into two **eras** — legacy (`initialize` handshake) and modern (stateless core, per-request `_meta`) — and both coexist for a ≥12-month offramp.

## 1. The outbound `McpClient` is now dual-era

It hardcoded `protocolVersion: "2025-06-18"` into `initialize` (`McpClient.cpp:72-75`). `McpClientConnection::NegotiateEra` now implements the spec's stdio backward-compatibility rule:

1. Probe `server/discover` carrying a modern `_meta`.
2. A `DiscoverResult` **or** a `-32022 UnsupportedProtocolVersionError` identifies a **modern** server — a recognized modern error is a modern *marker*, so it resolves the version rather than falling back.
3. **Anything else — including no reply at all — is legacy**, and the `initialize` / `notifications/initialized` handshake runs unchanged.
4. In the modern era every request carries `_meta` (`protocolVersion` + `clientInfo` + an empty, **required**, per-request `clientCapabilities`), stamped in `SendRequest` — the single funnel — so no future request can ship without it.

Also: a separate short `DiscoverProbeTimeout` (3 s, clamped to `HandshakeTimeout`) bounds the fallback cost; the negotiated legacy revision is **read back** from the handshake rather than reporting what we asked for; and MRTR `resultType: "input_required"` is refused with a clear tool error instead of being forwarded to the agent as if it were the answer (an **absent** `resultType` still means `"complete"`, per the spec's own backward-compat rule). Era + revision surface in `ClientStatuses()`, the MCP panel and the connect log.

## 2. The `logging` capability has a successor running beside it

We push the whole diagnostics event stream as `notifications/message` over the GET SSE stream, and `logging` is deprecated (SEP-2577) — the one place OloEngine was structurally tied to a removed feature.

**The replacement carrier was forced, not preferred.** Under `2026-07-28` the GET stream is removed, `notifications/message` becomes scoped to the request that triggered it, and `SubscriptionFilter` — everything `subscriptions/listen` can deliver — is a **closed set** of four notification types with a MUST-NOT on anything the client didn't request. So a bespoke custom notification has nowhere to live in the modern era. `notifications/resources/updated` on a subscribed URI is the only carrier on that list that fits **and it exists today** — which is exactly why it's the answer: *the same notification, resource and payload work in both eras; only the subscription plumbing moves* (`resources/subscribe` → `subscriptions/listen`).

Shipped: `olo://events/recent` (200 newest events + `lastId`, entries byte-identical to `olo_events_tail`'s), `resources/subscribe` / `resources/unsubscribe`, and `capabilities.resources.subscribe: true`.

- **`logging` and the existing `notifications/message` push are unchanged and stay** for the whole offramp — dropping them early would break every client speaking a `2025-*` revision, which today is all of them. Pinned by an assertion.
- **Only a resource with a `ResourceDef::ChangeToken` is subscribable.** One that cannot honestly report a change is refused with `-32602` *naming the URIs that can*, rather than accepting a subscription that could never fire.
- **The token is baselined at subscribe time**, not on the stream's first poll — otherwise a change arriving before the client opens its stream is seeded over and silently swallowed.
- Known simplification, documented: the subscription set is server-global (the GET stream carries no session identity). It errs toward over-delivery and dissolves in the modern transport.

## 3. The stateless core: a documented no-go

[`docs/agent-rules/mcp-protocol-eras.md`](docs/agent-rules/mcp-protocol-eras.md) carries the evidence. Short version: read against the normative `schema.ts` and transport pages rather than the announcement, advertising `2026-07-28` also requires header↔body validation with `-32020`, method-not-found becoming **HTTP 404**, **removal of the GET SSE stream**, `subscriptions/listen`, cancellation-by-stream-close, `Mcp-Session-Id`/`Last-Event-ID` ignored, MRTR, and `resultType` on every result. That is a **second transport shape** served from one endpoint — with zero benefit to a single localhost instance, and with the blast radius landing on the instrument every other engine task uses to verify itself.

**The trap worth knowing:** `server/discover` **cannot be added as a cheap first slice.** A modern client treats a successful `DiscoverResult` as proof the peer is modern and then sends modern requests — so answering it while still requiring `initialize` converts a *working* legacy fallback into a broken modern conversation, and every test stays green.

## Review guide

**Where I'd look hardest**

1. `OloEditor/src/MCP/McpClient.cpp` → `NegotiateEra` — a five-way classification of an untrusted child's reply where every wrong branch is silent. The asymmetry to check: an *uninformative* version list (absent/empty) falls back to legacy on **both** the `DiscoverResult` and `-32022` paths; only a populated list naming nothing we speak hard-fails.
2. `OloEditor/src/MCP/McpServer.cpp` → the SSE subscription block — a per-stream `lastSeen` map seeded from the **server-side subscribe-time baseline**, not from the live token. Seeding from "now" is the bug that swallows updates, and it is invisible in any unit test that doesn't drive the stream.
3. `OloEditor/src/MCP/McpClient.cpp` → `SendRequest`'s `_meta` stamping — it copies `params` on every request now. Correct, but it is on the bridged-call hot path.

**What I verified, and how**

- `OloEngine-Tests` full suite: **5723/5728 passed**; MCP slice **672 passed, 1 skipped, 0 failed** (673 tests). New cases: `McpClientStdio.{ModernChildSkipsTheHandshakeAndStampsMetaOnEveryRequest, SilentProbeFallsBackToTheLegacyHandshake, ModernChildOfferingOnlyLegacyVersionsFallsBackToTheHandshake, UnsupportedProtocolVersionErrorIsAModernMarkerNotAFallback, ModernMarkerWithNoUsableVersionListFallsBackInsteadOfFailing, NoMutuallySupportedVersionFailsWithAnActionableError, InputRequiredResultIsRefusedRatherThanForwarded, AbsentResultTypeStillCountsAsComplete}` and `McpDispatchTest.{ResourcesSubscribe*, ResourcesUnsubscribe*, SubscribeBaselinesTheChangeTokenAtSubscribeTime, ResubscribingKeepsTheOriginalBaselineButUnsubscribeResetsIt}`. **Both eras are pinned side by side on purpose** — the legacy path is the load-bearing one.
- **Live end-to-end against a running editor** (`run-oloengine attach`, driven over HTTP): `initialize` returns `resources.subscribe: true` *and* still `logging`; `olo://events/recent` reads back real events; subscribe on `olo://logs/recent` is refused naming `olo://events/recent`. Then, on one open GET stream, entering Play produced **both carriers side by side** — one `notifications/resources/updated` *and* the existing `notifications/message` frames. After `resources/unsubscribe`, 5 further diagnostics events produced **zero** `resources/updated` while the `notifications/message` push kept working. That is the check that would have failed if the carrier swap were wrong.
- `OloEditor` target builds — `McpTools.cpp`'s registration is not proven by the test binary alone.

**Least confident about** — the era classification against a *real* third-party modern server. Every modern case here is driven by a fake transport, because no MCP server in the wild speaks `2026-07-28` yet. The legacy path is exercised against real children; the modern path is spec-conformance-by-reading. If a real modern server disagrees with my reading of `DiscoverResult`, the failure mode is a connect that falls back to `initialize` and fails — loud, not silent, which is why I picked that default.

**Deliberately not tested** — the SSE delivery loop has no unit test (it needs a live httplib stream); it is covered by the live check above instead. The `ResourceDef::ChangeToken` contract that it must be cheap and never touch the game thread is a comment, not a mechanism.

## Note on CI

The full local suite had one unrelated failure, `EASUVisualEvidenceTest.GTAOSurvivesRuntimeUpscaleSwitch` (upscaled frame read back black). It **passes in isolation** on the same binary, and this diff contains no renderer or engine code at all — it is confined to `OloEditor/src/MCP/**`, `OloEngine/tests/MCP/**` and docs. Flagging it rather than dismissing it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to both modern stateless and legacy MCP servers.
  * Added resource subscriptions with update notifications for changing resources.
  * Added a diagnostics event resource with cursor-based updates.
  * Displayed negotiated protocol details in MCP connection status.

* **Documentation**
  * Added guidance on protocol eras, migration, resource subscriptions, and diagnostics support.

* **Bug Fixes**
  * Improved handling of unsupported protocol versions and incomplete tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->