### PR TITLE
docs(agent-rules): document the WinAsanYamlThrow.h guard in build-trees §4

### DIFF
--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -320,26 +320,69 @@ yaml-cpp throwing `ParserException` on malformed input, but the input
 shape and the catch type are both irrelevant (experimentally eliminated),
 and which call paths crash is frame-layout and clang-version dependent.
 
-Mitigation pattern (see
-`OloEngine/tests/Gameplay/ExperienceCurveTest.cpp::SerializerRejectsMalformedYAML`):
-guard ONLY the throwing sub-assertion with
-`#if !(OLO_ASAN_ENABLED && defined(_WIN32))` (`OLO_ASAN_ENABLED` lives in
-`OloEngine/Memory/Platform.h`), keep every non-throwing assertion active,
-and note which still-passing test carries the Windows-ASan coverage of
-the same throw/catch plumbing. Do NOT "fix" this by changing the
-malformed input or widening the catch — both were tried and both still
-crash; input-shuffling is version roulette. Track state and the list of
-known-vulnerable tests in issue #661.
+### The guard: `OLO_SKIP_YAML_THROW_UNDER_WIN_ASAN`
+
+**Do not hand-roll `#if !(OLO_ASAN_ENABLED && defined(_WIN32))` any more.** The
+fourth occurrence (#458, guarded in PR #802) was the point at which #661's own
+follow-up list said to centralise, so the guard now lives in
+`OloEngine/tests/WinAsanYamlThrow.h`, which owns the macro *and* the single
+evidence trail — the "what does SEH 0xc0000005 with no ASan report and no stack
+mean" explanation is written down once, in the header, rather than re-derived
+each time. Include it and guard **only** the sub-assertion that makes the
+third-party library throw:
+
+```cpp
+#include "WinAsanYamlThrow.h"
+...
+#if !OLO_SKIP_YAML_THROW_UNDER_WIN_ASAN
+    EXPECT_FALSE(Parse("key: [unclosed"));      // the throwing case
+#endif
+    EXPECT_FALSE(Parse("WrongRootKey: 1\n"));   // ours, always runs
+```
+
+Keep every non-throwing assertion active, and note which still-passing test
+carries the Windows-ASan coverage of the same throw/catch plumbing. Do NOT
+"fix" this by changing the malformed input or widening the catch — both were
+tried and both still crash; input-shuffling is version roulette. Track state and
+the list of known-vulnerable tests in issue #661; the header carries the
+retirement criteria (delete it and every use once the upstream LLVM fix lands).
+
+**Both polarities are in the tree, deliberately — read the sign before copying.**
+`#if !OLO_SKIP_…` wraps a branch that is simply *dropped* under the guard;
+`#if OLO_SKIP_…` selects a **substitute** non-throwing branch. Which one you want
+depends on the next trap:
+
+> **A skipped throw can leave the rest of the test vacuously true.** In
+> `AccessibilitySettingsTest` the assertion after the load is "the previous
+> settings survived" — but the test *set* those settings two lines earlier, so
+> skipping the load outright reduces it to re-reading the value it just wrote:
+> green, and proving nothing. The fix is to substitute a **well-formed file with
+> the wrong root key**, which takes the same `LoadFromFile` rejection path
+> *without* throwing, so the preservation assertion still means something under
+> ASan. Before you guard, check what the surviving assertions are still resting
+> on.
 
 **Expect this to bite whenever you add the FIRST test that throws through a
 given entry point**, not only when you touch known-vulnerable code. The
 guarded set so far:
 
-| Test | Throwing entry point |
-| --- | --- |
-| `ExperienceCurveTest.SerializerRejectsMalformedYAML` | `ExperienceCurveSerializer::TestDeserializeFromYAML` |
-| `CharacterClassDatabaseTest` (malformed-YAML branch) | `CharacterClassDatabaseSerializer` |
-| `SceneTransitionTest.AMissingOrMalformedTargetFailsWithoutASceneAndWithAReason` | `SceneSerializer::Deserialize` → `YAML::LoadFile` (issue #642) |
+| Test | Throwing entry point | Guard |
+| --- | --- | --- |
+| `ExperienceCurveTest.SerializerRejectsMalformedYAML` | `ExperienceCurveSerializer::TestDeserializeFromYAML` | helper |
+| `CharacterClassDatabaseTest` (malformed-YAML branch) | `CharacterClassDatabaseSerializer` | helper |
+| `AccessibilitySettingsTest.LoadOfACorruptFileFailsWithoutCorruptingSettings` | `Accessibility::LoadFromFile` → `YAML::LoadFile` (issue #458) | helper (substitute branch) |
+| `SceneTransitionTest.AMissingOrMalformedTargetFailsWithoutASceneAndWithAReason` | `SceneSerializer::Deserialize` → `YAML::LoadFile` (issue #642) | **still hand-rolled** |
+
+The `SceneTransitionTest` row is the one straggler: PR #802 migrated the two
+`Gameplay/` sites onto the helper but left this one on the raw
+`#if !(OLO_ASAN_ENABLED && defined(_WIN32))`. It is not broken — the condition is
+identical — but it is the copy a future author is most likely to find and clone.
+Migrate it the next time that file is touched.
+
+Note that not every `OLO_ASAN_ENABLED` in the test tree belongs to this bug:
+`ServerAuthoritativeLoopTest` guards on it for the unrelated
+GameNetworkingSockets stack-buffer-overflow (issue #317). Grepping the macro
+over-reports the guarded set; grep `OLO_SKIP_YAML_THROW_UNDER_WIN_ASAN` instead.
 
 The #642 case is instructive about how the bug hides: the suite already had
 `SceneSerializerFuzzRegressionTest` firing a dozen malformed payloads at


### PR DESCRIPTION
§4 of `docs/agent-rules/build-trees-and-windows-asan.md` still prescribed hand-rolling
`#if !(OLO_ASAN_ENABLED && defined(_WIN32))` and listed three guarded tests. PR #802 centralised
that guard into `OloEngine/tests/WinAsanYamlThrow.h` (`OLO_SKIP_YAML_THROW_UNDER_WIN_ASAN`) when
the fourth occurrence appeared — per #661's own follow-up list, which asked to "centralize a helper
macro if a third case appears". So the doc was teaching a pattern the tree had already moved off,
in the one file an agent reads *before* writing a new malformed-input test.

Docs only; no code or test changes.

## What changed

- **Mitigation prose → the helper.** Replaced the hand-rolled `#if` instruction with the helper
  plus a usage snippet, pointing at the header for the evidence trail and the retirement criteria.
- **Guarded-set table is now 4 rows + a Guard column.** Adds
  `AccessibilitySettingsTest.LoadOfACorruptFileFailsWithoutCorruptingSettings` (#458).
- **Flagged the straggler.** #802 migrated the two `Gameplay/` sites onto the helper but left
  `SceneTransitionTest` on the raw condition. Not broken — identical semantics — but it is the copy
  a future author is likeliest to find and clone, so the table marks it and the text says to migrate
  it next time that file is touched.
- **Wrote down the vacuous-assertion trap.** In the Accessibility case, skipping the throw outright
  would leave "the previous settings survived" merely re-reading a value the test `Set()` two lines
  earlier — green, proving nothing. That is *why* the guard substitutes a well-formed wrong-root-key
  file, which takes the same `LoadFromFile` rejection path without throwing. The reasoning existed
  only as a code comment; it generalises to any guard of this shape.
- **Noted a grep footgun.** `OLO_ASAN_ENABLED` over-reports the guarded set —
  `ServerAuthoritativeLoopTest` guards on it for the unrelated GameNetworkingSockets
  stack-buffer-overflow (#317). Grep `OLO_SKIP_YAML_THROW_UNDER_WIN_ASAN` instead.

## Verification

Every claim was checked against the tree at `29c642f00`, not against issue text:

- three helper users (`AccessibilitySettingsTest`, `CharacterClassDatabaseTest`,
  `ExperienceCurveTest`) and one hand-rolled site (`SceneTransitionTest.cpp:268`), by grep;
- `EngineSubsystemSmoke.ProjectLoadMalformedYAMLFailsCleanly`, named as the surviving
  Windows-ASan coverage carrier, still exists (`EngineSubsystemSmokeTest.cpp:102`);
- the `ax_check_compile_flag.m4` / polarity / substitute-branch details read off
  `WinAsanYamlThrow.h` and the call sites themselves.

Found while sweeping merged worktrees — #802's helper landed without the doc catching up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
