### PR TITLE
ci(setup-vcpkg): verify vcpkg's own bootstrap prerequisites, not just autotools

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -74,12 +74,23 @@ runs:
           echo "autotools + vcpkg bootstrap prerequisites already provisioned; nothing to install"
           exit 0
         fi
-        if command -v apt-get >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        # Gate the install on runner.environment, not merely on "apt-get exists
+        # and sudo works". Those two are a PROXY for github-hosted, and the proxy
+        # is wrong for a self-hosted Debian/Ubuntu host with passwordless sudo --
+        # a common setup -- which would silently take the install path and mutate
+        # a machine that is provisioned system-wide, ahead of time. It only held
+        # here because the one self-hosted runner is Rocky (no apt-get). Assert
+        # the actual condition; keep the apt-get/sudo checks as a fallback so a
+        # hosted image that ever lacks them lands on the message, not on a
+        # sudo error.
+        if [ "${{ runner.environment }}" = "github-hosted" ] \
+           && command -v apt-get >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             autoconf autoconf-archive automake libtool pkg-config curl zip unzip tar
         else
-          echo "::error::build prerequisites missing (${missing[*]}) and this runner has no apt-get with passwordless sudo."
+          echo "::error::build prerequisites missing (${missing[*]}) on a ${{ runner.environment }} runner."
+          echo "::error::Self-hosted runners are provisioned system-wide, ahead of time -- this step verifies, never installs."
           echo "::error::Provision the runner system-wide: sudo dnf install -y autoconf autoconf-archive automake libtool pkgconf-pkg-config curl zip unzip tar"
           echo "::error::See docs/ops/self-hosted-gpu-runner.md (Host provisioning)."
           exit 1

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -39,13 +39,28 @@ runs:
     # — a workflow step must verify, not install. GitHub-hosted Ubuntu images keep
     # the install path: passwordless sudo + apt-get are guaranteed there, and
     # autoconf-archive genuinely is missing from the stock image.
-    - name: Install autotools (Linux)
+    #
+    # curl/zip/unzip/tar are vcpkg's OWN bootstrap prerequisites (scripts/
+    # bootstrap.sh checks for them before it will build vcpkg-tool), not port
+    # dependencies -- but they belong in the same check for the same reason:
+    # every GitHub-hosted image ships them, so a self-hosted host is the only
+    # place their absence shows up. Rocky 10 turned out to have neither `zip`
+    # nor `unzip`, and because bootstrap.sh reports only the FIRST missing one,
+    # installing just the name it printed would have failed again on the next.
+    # Hence: check them as a SET here, so one provisioning message names
+    # everything at once instead of costing a round trip per package.
+    #
+    # Checking them here also stops the bootstrap retry loop below from burning
+    # three attempts (45s) on a deterministic failure -- that retry exists for
+    # transient network drops during the tool download, and it printed vcpkg's
+    # 20-line "Could not find zip" help text three times before failing.
+    - name: Verify build prerequisites (Linux)
       if: runner.os == 'Linux'
       shell: bash
       run: |
         set -euo pipefail
         missing=()
-        for tool in autoconf autoreconf automake libtoolize pkg-config; do
+        for tool in autoconf autoreconf automake libtoolize pkg-config curl zip unzip tar; do
           command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
         done
         # autoconf-archive ships m4 macros, not a binary; probe a canonical
@@ -56,16 +71,16 @@ runs:
         done
         [ "$have_archive" = true ] || missing+=("autoconf-archive")
         if [ ${#missing[@]} -eq 0 ]; then
-          echo "autotools already provisioned; nothing to install"
+          echo "autotools + vcpkg bootstrap prerequisites already provisioned; nothing to install"
           exit 0
         fi
         if command -v apt-get >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            autoconf autoconf-archive automake libtool pkg-config
+            autoconf autoconf-archive automake libtool pkg-config curl zip unzip tar
         else
-          echo "::error::autotools missing (${missing[*]}) and this runner has no apt-get with passwordless sudo."
-          echo "::error::Provision the runner system-wide: sudo dnf install -y autoconf autoconf-archive automake libtool pkgconf-pkg-config"
+          echo "::error::build prerequisites missing (${missing[*]}) and this runner has no apt-get with passwordless sudo."
+          echo "::error::Provision the runner system-wide: sudo dnf install -y autoconf autoconf-archive automake libtool pkgconf-pkg-config curl zip unzip tar"
           echo "::error::See docs/ops/self-hosted-gpu-runner.md (Host provisioning)."
           exit 1
         fi

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -123,18 +123,35 @@ sudo dnf install -y \
   wayland-devel wayland-protocols-devel libxkbcommon-devel \
   glslang-devel spirv-tools \
   python3-jinja2 \
-  autoconf autoconf-archive automake libtool pkgconf-pkg-config
+  autoconf autoconf-archive automake libtool pkgconf-pkg-config \
+  curl zip unzip tar
 ```
 
-**The autotools row is required since the vcpkg manifest migration (#773/#781).**
-Ports with an autotools Linux build (libsodium is the one in this manifest) need
-`autoconf`/`automake`/`libtoolize`/`autoconf-archive`/`pkg-config` from the
-system. The `setup-vcpkg` composite action *verifies* these on a self-hosted
-runner and fails with a provisioning message naming this section — it only
-auto-installs on GitHub-hosted images, where passwordless sudo + apt-get exist.
-(An earlier version ran `sudo apt-get` unconditionally, which died on this
-Rocky host with "sudo: a terminal is required to read the password" and kept
-the nightly red for days before the suite ever built.)
+**The last two rows are required since the vcpkg manifest migration (#773/#781)**,
+and they are separate requirements that fail at different stages:
+
+- **autotools** — ports with an autotools Linux build (libsodium is the one in
+  this manifest) need `autoconf`/`automake`/`libtoolize`/`autoconf-archive`/
+  `pkg-config` from the system. Fails during the port build.
+- **`curl zip unzip tar`** — vcpkg's *own* `scripts/bootstrap.sh` requires these
+  before it will build `vcpkg-tool`, so a miss here fails earlier than any port,
+  with vcpkg's own "Could not find zip" help text rather than our message. This
+  host had neither `zip` nor `unzip` on a fresh Rocky 10 install. **Install all
+  four together**: bootstrap.sh reports only the *first* missing one, so fixing
+  the name it prints just surfaces the next on the following run.
+
+The `setup-vcpkg` composite action *verifies* both sets on a self-hosted runner
+and fails with a provisioning message naming this section — it only auto-installs
+on GitHub-hosted images, where passwordless sudo + apt-get exist. (An earlier
+version ran `sudo apt-get` unconditionally, which died on this Rocky host with
+"sudo: a terminal is required to read the password" and kept the nightly red for
+days before the suite ever built.)
+
+Both gaps share one root cause worth remembering when adding any new build
+dependency: **GitHub-hosted images ship a large implicit toolchain**, so a
+requirement that is invisible on `ubuntu-latest` is a hard provisioning step
+here. This box is the only place such a gap can surface, and it surfaces as a
+red nightly nobody reads.
 
 **`python3-jinja2` from dnf, not `pip install --user`.** glad2's code generation
 imports jinja2, and `--user` installs it into the *installing* user's home —


### PR DESCRIPTION
The `gpu-conformance-amd` nightly failed on the self-hosted Rocky 10 host with vcpkg's raw
`Could not find zip` help text — printed **three times** — immediately after the autotools
provisioning gap (#801) was cleared. `zip` *and* `unzip` were both absent from that host;
GitHub-hosted images ship them, so this can only ever surface on the self-hosted runner.

Same root cause as the autotools gap, one stage later: **a requirement that is invisible on
`ubuntu-latest` is a hard provisioning step on a self-hosted box.**

## Two defects

- **The action verified the autotools set but not `curl`/`zip`/`unzip`/`tar`**, which vcpkg's own
  `scripts/bootstrap.sh` requires before it will build `vcpkg-tool`. A miss therefore failed later,
  opaquely, and without naming the ops doc — the opposite of what #801 set up for autotools.
- **`docs/ops/self-hosted-gpu-runner.md`'s provisioning command omitted all four packages**, so a
  host provisioned *exactly per the doc* still could not bootstrap vcpkg. That is how this one got
  missed: the box was correctly provisioned against an incomplete list.

## Changes

- Extend the existing detect-first/install-second step to cover both sets; rename it from
  "Install autotools (Linux)" to "Verify build prerequisites (Linux)", which is what it does on a
  self-hosted runner.
- Add `curl zip unzip tar` to the ops doc's `dnf` command, and split the note into the two distinct
  failure stages (autotools fail during a *port* build; the bootstrap set fails *before any port*).

## The load-bearing detail

**Check them as a set.** `bootstrap.sh` reports only the **first** missing name, so installing what
it printed just surfaces the next one on the following run — which is exactly what would have
happened here (`zip`, then `unzip`, two round trips at ~20 min each). One provisioning message now
names everything at once.

Checking here also stops the bootstrap retry loop burning three attempts (45s) on a deterministic
failure; that retry exists for transient network drops during the tool download, and it buried the
one useful line under three copies of a 20-line help text.

## Verification

Fix applied to the live runner and re-dispatched
([run 31945622740](https://github.com/drsnuggles8/OloEngineBase/actions/runs/31945622740)):
`Setup vcpkg` **success**, `Configure CMake` **success**, now building — the furthest this lane has
reached in 12+ consecutive nightly failures. `check yaml` passes; `action.yml` re-parsed locally.

Note the fixed action itself is only exercised on the *next* run against this branch — the runner
was provisioned by hand for the run above, which is what the doc change now makes reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted GPU runner setup guidance to include required archive utilities for vcpkg.
  * Clarified which tools are needed for manifest ports versus vcpkg bootstrapping.
  * Documented that dependency checks are performed automatically and unsupported automatic installation is not attempted.

* **Bug Fixes**
  * Improved prerequisite validation and error messages for missing runner tools, making setup failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->