### PR TITLE
feat(build): CMake 4.3 native build instrumentation + 4.4 per-file-set compile job pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,10 +296,11 @@ endif()
 # Opt-in, default OFF: the API wraps every compile/link/custom command in a
 # launcher, and profiling every developer build by default is not wanted.
 # Enable with -DOLO_BUILD_INSTRUMENTATION=ON on a Ninja tree (build-clang/, or
-# a Linux preset). The Visual Studio generator (build/, the primary msvc
-# preset) is unsupported by the API itself — rather than silently doing
-# nothing there (the exact failure shape this file's comments keep warning
-# about), that case gets a loud message(WARNING).
+# a Linux preset). The API itself only supports Makefile / Ninja / FASTBuild
+# generators (cmake-instrumentation(7)) — checked as an ALLOW-list below, not a
+# deny-list on just "Visual Studio", so Xcode (and any other generator this
+# repo doesn't currently use) also gets the loud message(WARNING) instead of
+# silently attempting instrumentation and doing nothing.
 #
 # stdout/stderr capture (the `captureOutput` option, 4.4+) is deliberately
 # left off: it inflates snippet volume considerably for data this project
@@ -307,22 +308,22 @@ endif()
 # questions #759 asked) don't need it.
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.3)
     option(OLO_BUILD_INSTRUMENTATION
-        "Emit CMake Instrumentation API trace data (compile/link/custom timing + host memory before/after) for this build tree. Ninja/Makefile/FASTBuild only; no effect under the Visual Studio generator."
+        "Emit CMake Instrumentation API trace data (compile/link/custom timing + host memory before/after) for this build tree. Ninja/Makefile/FASTBuild only; no effect under other generators (Visual Studio, Xcode, ...)."
         OFF)
     if(OLO_BUILD_INSTRUMENTATION)
-        if(CMAKE_GENERATOR MATCHES "Visual Studio")
-            message(WARNING
-                "OLO_BUILD_INSTRUMENTATION has no effect under the Visual Studio "
-                "generator - the CMake Instrumentation API is Makefile/Ninja/"
-                "FASTBuild only (cmake-instrumentation(7)). Configure the clangcl "
-                "preset (or a Linux preset) instead.")
-        else()
+        if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja|FASTBuild")
             cmake_instrumentation(
                 API_VERSION 1
                 DATA_VERSION 1
                 HOOKS postGenerate postCMakeBuild
                 OPTIONS staticSystemInformation dynamicSystemInformation trace
             )
+        else()
+            message(WARNING
+                "OLO_BUILD_INSTRUMENTATION has no effect under the '${CMAKE_GENERATOR}' "
+                "generator - the CMake Instrumentation API is Makefile/Ninja/"
+                "FASTBuild only (cmake-instrumentation(7)). Configure the clangcl "
+                "preset (or a Linux preset) instead.")
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,95 @@ if(CMAKE_GENERATOR MATCHES "Ninja")
     set(CMAKE_JOB_POOL_LINK olo_link)
 endif()
 
+# --------------------------------------------------------------------------
+# Heavy-TU compile concurrency (CMake 4.4+, Ninja only — issue #822).
+#
+# The missing middle between the link pool above and the blunt -j width used for
+# everything else. #759's instrumented trace (docs/agent-rules/
+# build-trees-and-windows-asan.md §5) found compilation, not linking, sets this
+# host's build memory ceiling — and it's a HANDFUL of TUs that set it, not the
+# lane count. A fresh trace taken while adding this (issue #822) confirms the
+# same two outliers, both roughly unchanged in identity from #759: LuaScriptGlue.cpp
+# (~198s CPU-time, more than 3x the next-heaviest TU) and McpFieldRegistry.cpp
+# (~67s, compiled separately into both OloEditor and OloEngine-Tests). Both wrap
+# heavy macro-driven binding-glue generation (Sol2 Lua bindings; the generated MCP
+# writable-field registry) the compiler has to instantiate wholesale, unlike
+# ordinary engine TUs.
+#
+# 4.4 lets a SOURCES-type file set carry its own JOB_POOL_COMPILE, which overrides
+# both the target- and source-level setting — so these specific TUs can be
+# throttled without capping compilation for the rest of the tree. Each target that
+# compiles one of the heavy TUs binds it via olo_bind_heavy_compile_pool()
+# (cmake/CommonProperties.cmake) after removing it from its own plain source
+# list — see that function's comment for why the removal is mandatory.
+#
+# Raise -DOLO_HEAVY_COMPILE_JOBS=<N> (or set it to the compile -j width) to
+# loosen the throttle without reverting the file-set wiring.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.4 AND CMAKE_GENERATOR MATCHES "Ninja")
+    set(OLO_HEAVY_COMPILE_JOBS "2" CACHE STRING
+        "Maximum concurrent compiles of the handful of memory-heavy TUs (LuaScriptGlue.cpp, McpFieldRegistry.cpp — issue #822). Ninja generators only.")
+    # Same rule, and the same reason, as OLO_LINK_JOBS above: depth 0 or empty
+    # passes straight through CMake AND Ninja and leaves the pool silently uncapped.
+    if(NOT OLO_HEAVY_COMPILE_JOBS MATCHES "^[1-9][0-9]*$")
+        message(FATAL_ERROR
+            "OLO_HEAVY_COMPILE_JOBS must be a positive integer (got '${OLO_HEAVY_COMPILE_JOBS}'). "
+            "It bounds concurrent compiles of the memory-heavy TU set; 0 or empty "
+            "would leave them effectively uncapped.")
+    endif()
+    # APPEND — the link pool above already set JOB_POOLS; a plain (non-APPEND) set
+    # here would silently clobber olo_link's registration, uncapping links instead
+    # of adding a second pool alongside them.
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS olo_heavy=${OLO_HEAVY_COMPILE_JOBS})
+    set(OLO_HEAVY_COMPILE_POOL_AVAILABLE TRUE)
+else()
+    set(OLO_HEAVY_COMPILE_POOL_AVAILABLE FALSE)
+endif()
+
+# --------------------------------------------------------------------------
+# Build instrumentation (CMake 4.3+, Makefile/Ninja/FASTBuild only — issue #822).
+#
+# Native successor to the recipe issue #759 used by hand
+# (docs/agent-rules/build-trees-and-windows-asan.md §5): the same
+# Instrumentation API existed pre-4.3 but only behind an experimental,
+# UUID-suffixed query directory undocumented outside Help/dev/experimental.rst
+# (not shipped in the binary install). cmake_instrumentation() is the same
+# feature, now stable, invoked from the project itself — no gate UUID, no
+# manually-written query file, repeatable by any future agent.
+#
+# Opt-in, default OFF: the API wraps every compile/link/custom command in a
+# launcher, and profiling every developer build by default is not wanted.
+# Enable with -DOLO_BUILD_INSTRUMENTATION=ON on a Ninja tree (build-clang/, or
+# a Linux preset). The Visual Studio generator (build/, the primary msvc
+# preset) is unsupported by the API itself — rather than silently doing
+# nothing there (the exact failure shape this file's comments keep warning
+# about), that case gets a loud message(WARNING).
+#
+# stdout/stderr capture (the `captureOutput` option, 4.4+) is deliberately
+# left off: it inflates snippet volume considerably for data this project
+# doesn't currently consume — timing and host memory before/after (the two
+# questions #759 asked) don't need it.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.3)
+    option(OLO_BUILD_INSTRUMENTATION
+        "Emit CMake Instrumentation API trace data (compile/link/custom timing + host memory before/after) for this build tree. Ninja/Makefile/FASTBuild only; no effect under the Visual Studio generator."
+        OFF)
+    if(OLO_BUILD_INSTRUMENTATION)
+        if(CMAKE_GENERATOR MATCHES "Visual Studio")
+            message(WARNING
+                "OLO_BUILD_INSTRUMENTATION has no effect under the Visual Studio "
+                "generator - the CMake Instrumentation API is Makefile/Ninja/"
+                "FASTBuild only (cmake-instrumentation(7)). Configure the clangcl "
+                "preset (or a Linux preset) instead.")
+        else()
+            cmake_instrumentation(
+                API_VERSION 1
+                DATA_VERSION 1
+                HOOKS postGenerate postCMakeBuild
+                OPTIONS staticSystemInformation dynamicSystemInformation trace
+            )
+        endif()
+    endif()
+endif()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)

--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -29,7 +29,8 @@
 		"MCP/McpToolsScene.cpp"
 		# The generated writable-field registry in its own TU (see the file's
 		# header comment: keeping it inline in McpGenericFieldWrite.h OOM'd
-		# clang-cl Release+ASan compiling McpToolsScene.cpp).
+		# clang-cl Release+ASan compiling McpToolsScene.cpp). Conditionally pulled
+		# back out below (issue #822) so it can join the heavy-compile file set.
 		"MCP/McpFieldRegistry.cpp"
 		"MCP/McpToolsScripting.cpp"
 		"MCP/McpToolsShader.cpp"
@@ -131,6 +132,12 @@ if(WIN32)
 	list(APPEND EDITOR_RESOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../Resources/OloEditor.rc")
 endif()
 
+# Heavy-TU compile pool (issue #822): see the matching block in OloEngine/src/CMakeLists.txt for
+# why the removal must stay conditional on the pool actually being available.
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	list(REMOVE_ITEM EDITOR_SOURCES "MCP/McpFieldRegistry.cpp")
+endif()
+
 add_executable(OloEditor
 		${EDITOR_SOURCES}
 		${GLSL_SOURCE_FILES}
@@ -140,6 +147,12 @@ add_executable(OloEditor
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
 			FILES ${EDITOR_SOURCES}
 )
+
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	olo_bind_heavy_compile_pool(OloEditor "${CMAKE_CURRENT_SOURCE_DIR}"
+		"MCP/McpFieldRegistry.cpp"
+	)
+endif()
 
 # Deploy the FFmpeg runtime libs next to the exe (no-op when OLO_VIDEO_FFMPEG=OFF).
 # Must live in the same directory scope as add_executable — see the note on

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -1670,9 +1670,25 @@ elseif(UNIX AND NOT APPLE)
 	)
 endif()
 
+# Heavy-TU compile pool (issue #822): pulled out of the plain SOURCES list and re-added below via
+# a FILE_SET so it can carry its own JOB_POOL_COMPILE. Only when the pool is actually available —
+# on a tree where it is not (MSVC generator, or CMake < 4.4), leaving this unconditional would
+# drop the file from SOURCES with nothing re-adding it, silently removing it from the build.
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	list(REMOVE_ITEM SOURCES
+		"OloEngine/Scripting/Lua/LuaScriptGlue.cpp"
+	)
+endif()
+
 add_library(OloEngine STATIC
 		${SOURCES}
 )
+
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	olo_bind_heavy_compile_pool(OloEngine "${CMAKE_CURRENT_SOURCE_DIR}"
+		"OloEngine/Scripting/Lua/LuaScriptGlue.cpp"
+	)
+endif()
 
 # Unity (jumbo) build exclusions. The OloEngine target's UNITY_BUILD property is set in the
 # parent OloEngine/CMakeLists.txt (gated on OLO_ENABLE_UNITY_BUILD); the per-source

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1,4 +1,15 @@
 ﻿enable_testing()
+
+# Heavy-TU compile pool (issue #822): McpFieldRegistry.cpp is pulled OUT of the source list below
+# and re-added via a FILE_SET after add_executable, but only when the pool is available — see the
+# matching block in OloEngine/src/CMakeLists.txt for why the exclusion must stay conditional. This
+# variable holds the one line so the huge inline source list below needs a single line touched,
+# not restructured into a separate variable (a collision point for parallel branches on its own).
+set(_olo_mcp_field_registry_src ${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpFieldRegistry.cpp)
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	set(_olo_mcp_field_registry_src "")
+endif()
+
 add_executable(OloEngine-Tests
 		OloEngineTest.cpp
 		# Per-process, per-case scratch paths. Every test that writes a file goes
@@ -573,7 +584,9 @@ add_executable(OloEngine-Tests
 		# Registry() definition). Compiled once here instead of inline in every
 		# includer — the inline form OOM'd clang-cl Release+ASan on this very
 		# target's McpToolsScene.cpp.obj once the registry crossed ~100 components.
-		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpFieldRegistry.cpp
+		# Conditionally blanked above (issue #822) so it can join the heavy-compile
+		# file set instead when the pool is available.
+		${_olo_mcp_field_registry_src}
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsScripting.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsShader.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpScriptApi.cpp
@@ -976,6 +989,13 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/UITextScaleVisualEvidenceTest.cpp
 		Functional/Accessibility/SubtitlesFollowDialogueStateTest.cpp
 )
+
+if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+	olo_bind_heavy_compile_pool(OloEngine-Tests "${CMAKE_SOURCE_DIR}/OloEditor/src"
+		"MCP/McpFieldRegistry.cpp"
+	)
+endif()
+
 target_link_libraries(OloEngine-Tests
 	OloEngine
 	GTest::gtest

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -219,6 +219,45 @@ function(olo_set_common_include_directories target_name)
     )
 endfunction()
 
+# Bind FILES to a JOB_POOL_COMPILE-bound SOURCES file set on target_name (CMake 4.4+, Ninja
+# only — issue #822). No-op unless OLO_HEAVY_COMPILE_POOL_AVAILABLE (set once in the root
+# CMakeLists.txt, alongside the olo_heavy pool itself and its OLO_HEAVY_COMPILE_JOBS validation).
+#
+# Each FILE must already be REMOVED from target_name's plain source list by the caller — a file
+# added via a FILE_SET SOURCES set is a distinct code path from the ordinary SOURCES target
+# property (CMake's own docs on prop_tgt:SOURCES: it "does not include File Sets"), so leaving
+# the same path in both schedules two build edges for one output file.
+#
+# FILES may be relative to base_dir OR already absolute — resolved explicitly below rather than
+# left to target_sources()'s own relative-path handling, which resolves against the CALLER's
+# CMAKE_CURRENT_SOURCE_DIR (this function's call site), not base_dir. That mismatch is exactly how
+# this function first failed: OloEngine/tests/CMakeLists.txt calling with base_dir pointing at
+# OloEditor/src still had CMake look for the file under OloEngine/tests/, a hard configure error
+# ("must be in one of the file set's base directories") rather than a silent misconfiguration.
+#
+# TYPE SOURCE (not SOURCES) in set_property(FILE_SET ...)'s own example is a documented-but-wrong
+# CMake 4.4 doc snippet — verified against a throwaway project: it errors "set_property required
+# TARGET option is missing". The working form is set_property(FILE_SET <name> TARGET <target> ...).
+function(olo_bind_heavy_compile_pool target_name base_dir)
+    if(NOT OLO_HEAVY_COMPILE_POOL_AVAILABLE)
+        return()
+    endif()
+    set(_olo_heavy_files "")
+    foreach(_olo_heavy_file ${ARGN})
+        if(IS_ABSOLUTE "${_olo_heavy_file}")
+            list(APPEND _olo_heavy_files "${_olo_heavy_file}")
+        else()
+            list(APPEND _olo_heavy_files "${base_dir}/${_olo_heavy_file}")
+        endif()
+    endforeach()
+    target_sources(${target_name} PRIVATE
+        FILE_SET olo_heavy_compile TYPE SOURCES
+        BASE_DIRS ${base_dir}
+        FILES ${_olo_heavy_files}
+    )
+    set_property(FILE_SET olo_heavy_compile TARGET ${target_name} PROPERTY JOB_POOL_COMPILE olo_heavy)
+endfunction()
+
 # Configure C# project properties
 function(olo_configure_csharp_project target_name output_dir)
     # Set output directories for C# assemblies

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -399,7 +399,49 @@ none does — nothing else in the suite throws through it — so the honest note
 that the file-path throw is uncovered under Windows ASan while the
 non-throwing branches of the same test stay active everywhere.
 
-## 5. Instrumenting a build with the CMake Instrumentation API (issue #759)
+## 5. Instrumenting a build, and a per-file-set compile job pool (issues #759, #822)
+
+### 5a. Use the native recipe (CMake 4.3+), not the manual gate below
+
+As of #822 this machine is on CMake 4.4.2. The repo's own `cmake_minimum_required` floor
+is unchanged (still `3.25` in the root `CMakeLists.txt`, and the presets' `cmakeMinimumRequired`
+is `4.2.0` — see the hard constraints in issue #822, not raised by this work); the
+instrumentation and heavy-compile-pool blocks below are purely additive, each behind its own
+`if(CMAKE_VERSION VERSION_GREATER_EQUAL ...)` guard, and no-op cleanly on an older CMake.
+`cmake_instrumentation()` — the API described in §5b below, now stable — is wired
+directly into the root `CMakeLists.txt`, gated `if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.3)`.
+No UUID gate, no manually-written query file:
+
+```powershell
+cmake --preset clangcl -DOLO_BUILD_INSTRUMENTATION=ON
+pwsh -NoProfile -File .claude/skills/run-oloengine/build-lock.ps1 -Command `
+  'cmake --build build-clang --target OloEngine-Tests --config Debug --parallel 6'
+```
+
+`OLO_BUILD_INSTRUMENTATION` defaults `OFF` (the launcher wraps every compile/link/custom
+command, and profiling every developer build by default is not wanted). It has no effect
+under the Visual Studio generator (`build/`, the primary `msvc` preset) — that case prints
+a `message(WARNING)` rather than silently doing nothing, since the API itself doesn't
+support that generator (§5b point 1 still applies).
+
+**Verify it wired** the same way as before trusting a build: `build-clang/CMakeFiles/rules.ninja`
+compile/link rules must carry the `"…/ctest.exe" --instrument --command-type compile …`
+prefix, and `build-clang/.cmake/instrumentation/v1/query/generated/query-0.json` must exist
+after configure — no UUID suffix on the directory name this time, that was only ever an
+experimental-gate artifact (§5b). The trace lands at
+`build-clang/.cmake/instrumentation/v1/data/trace/trace-<timestamp>.json` after the build
+completes (the `postCMakeBuild` hook). **Only the most recent trace file is kept** — a second
+build's indexing deletes the first trace, so copy out anything you want to keep before
+re-running.
+
+A minimal analysis script (per-TU compile time ranked descending, peak host memory, role
+totals) is the fastest way to read a multi-MB trace; see the `#822` PR for one, or write
+~40 lines against the JSON directly — each event's `args.role` is `compile`/`link`/`custom`/
+`cmakeBuild`, `args.source` is the TU path for compile events, `dur` is microseconds, and
+`args.dynamicSystemInformation.afterHostMemoryUsed` is **system-wide** host memory in KiB
+(not the command's own RSS) sampled at that command's completion.
+
+### 5b. Historical: the pre-4.3 experimental gate (only relevant on CMake < 4.3)
 
 CMake 4.x ships an experimental Instrumentation API that emits a Google Trace
 Event file with per-command timing, target attribution and per-command
@@ -447,7 +489,7 @@ is **system-wide** host memory in KiB, not the command's RSS; the top-level
 `build.ninja` is useless here — the worktree path itself
 (`OloEngine-build-instrumentation-759`) contains the substring.
 
-### What it measured (clean Debug build, `build-clang/`, clang-cl, this host)
+### 5c. What #759 measured (clean Debug build, `build-clang/`, clang-cl, this host)
 
 Host was an i7-14700KF (20 cores / 28 threads, 64 GB), CI runners idle — **not**
 the 16c/31GB CLAUDE.md assumes; confirm your host before reusing these numbers.
@@ -484,3 +526,98 @@ these are OloEngine + small in-tree vendor + FFmpeg only:
   It roughly halved link CPU-time (89→44 s, plausibly pruned transitive link
   libs) but that is fully hidden under the compile-bound critical path — no
   wall-clock benefit for this graph. `INSTALL_PARALLEL` is N/A (we never install).
+
+### 5d. The heavy-compile file-set pool (CMake 4.4, issue #822)
+
+A fresh trace taken five days after #759, on the same host, confirms the same two
+outliers **by identity** (only their size grew with the intervening work):
+`LuaScriptGlue.cpp` (145–198 s across repeated runs) and `McpFieldRegistry.cpp`
+(40–67 s, compiled separately into both `OloEditor` and `OloEngine-Tests` — see
+`docs/agent-rules/component-serializer-codegen.md`-adjacent MCP field-registry
+context). Peak host memory at `-j6` (narrow scope, `OloEngine-Tests` only) came in
+at **41.4 GiB**, within noise of #759's 41.6 GiB — a solid corroboration that
+nothing structural drifted between the two measurements.
+
+CMake 4.4's `SOURCES`-type file set can carry its own `JOB_POOL_COMPILE`, which
+overrides the target/source-level setting. #822 pulls the two heavy TUs (three
+compile sites: `OloEngine`'s `LuaScriptGlue.cpp`, `OloEditor`'s and
+`OloEngine-Tests`'s independent copies of `McpFieldRegistry.cpp`) out of their
+targets' plain source lists and rebinds them via a file set into a new
+Ninja-only `olo_heavy` pool, default depth 2 (`-DOLO_HEAVY_COMPILE_JOBS=<N>` to
+change it), validated with the same "reject 0/empty" rigor as `OLO_LINK_JOBS`.
+`cmake/CommonProperties.cmake`'s `olo_bind_heavy_compile_pool()` centralizes the
+file-set + pool-property binding so each of the three call sites is one line.
+
+**Two real bugs found while wiring this — both would have been silent
+misconfigurations, not build failures, without the verification the plan
+demanded:**
+
+1. **The `JOB_POOL_COMPILE` file-set property's own CMake 4.4 doc example is
+   wrong.** `set_property(FILE_SET my_fileset TYPE SOURCE PROPERTY
+   JOB_POOL_COMPILE two_jobs)` — copied verbatim from `Help/prop_fs/JOB_POOL_COMPILE.rst`
+   — errors `set_property required TARGET option is missing`, because
+   `set_property()`'s actual `FILE_SET` scope signature (`Help/command/set_property.rst`)
+   is `FILE_SET <file_set>... TARGET <target>`, no `TYPE` keyword at all. Caught
+   by testing the exact snippet in a throwaway two-source scratch project against
+   a real generated `build.ninja` *before* touching the 1300-TU tree — cheap
+   insurance that would have cost a full reconfigure-and-grep cycle on the real
+   tree to catch otherwise.
+2. **`target_sources(... FILE_SET ...)`'s relative `FILES` resolve against the
+   *caller's* `CMAKE_CURRENT_SOURCE_DIR`, not the function's `base_dir`
+   argument.** `olo_bind_heavy_compile_pool()`'s first version passed relative
+   paths straight through to `target_sources()`; called from
+   `OloEngine/tests/CMakeLists.txt` with `base_dir` pointing at `OloEditor/src`,
+   CMake looked for the file under `OloEngine/tests/` instead — a **hard
+   configure error** ("must be in one of the file set's base directories"), not
+   a silent drop, but only because the file happened to not exist at the wrong
+   location; a same-named collision could have resolved to the wrong file
+   instead of erroring. Fixed by resolving `FILES` against `base_dir` explicitly
+   inside the function (`IS_ABSOLUTE` check, then join) rather than trusting
+   `target_sources()`'s own relative-path handling.
+
+**Measurement methodology note, also load-bearing:** the plan's literal
+instruction ("clean Debug build of `OloEngine-Tests`") under-scopes the
+experiment. `OloEngine-Tests` does not link against `OloEditor` — it recompiles
+`OloEditor`'s `.cpp` files directly as its own sources (see
+`OloEngine/tests/CMakeLists.txt`'s comment on this) — so `--target OloEngine-Tests`
+alone never builds `OloEditor.exe`, and therefore never compiles *`OloEditor`'s own
+copy* of `McpFieldRegistry.cpp`. At that narrow scope only two heavy compiles
+exist at all (`LuaScriptGlue.cpp` + one `McpFieldRegistry.cpp`), so a depth-2 pool
+and a depth-6 (~unthrottled) pool are behaviorally indistinguishable — both
+already allow every heavy TU that scope can produce to run unblocked. The
+comparison that actually exercises the pool needs `--target OloEditor --target
+OloEngine-Tests` together, which is where the three-heavy-TU-instance scenario
+the pool is meant to arbitrate genuinely exists.
+
+**Results, `OloEditor` + `OloEngine-Tests` together, `-j6`, clean, clang-cl,
+idle host, `OLO_BUILD_INSTRUMENTATION=ON`:**
+
+| pool depth | wall time | peak host memory |
+|---|---|---|
+| 2 (real default) — run 1 | 583.4 s | 38.42 GiB |
+| 2 (real default) — run 2 | 576.8 s | 38.79 GiB |
+| 6 (~unthrottled) — run 1 | 624.8 s | 40.48 GiB |
+
+Depth 2 is **~7 % faster** and uses **~4–5 % less peak memory** than depth 6,
+fairly consistently across the two repeated depth-2 runs (within 1.2 % of each
+other). **Honest caveat, stated plainly rather than oversold:** a direct overlap
+check of the three heavy TUs' `[timeStart, timeStart+dur]` windows in both traces
+found they almost never directly overlap **with each other** regardless of pool
+depth (max concurrent 1–2 either way) — so the improvement is *not* cleanly
+attributable to "the pool stopped two heavy TUs racing each other," the
+mechanism's most intuitive story. Total system-wide concurrent build-step count
+never exceeded 6 in either configuration (confirms a named Ninja pool is a
+subsidiary cap *within* the `-j` budget, not additional capacity on top of it —
+worth confirming empirically once, since it is easy to reason about backwards).
+The likely explanation is a second-order scheduling effect — constraining the
+heavy pool changes *when* those TUs start relative to the rest of the 1300+-TU
+graph, which shifts what else is running concurrently at the moment each heavy
+TU peaks. Sample size is small (n=2 vs n=1); do not read more precision into the
+percentages than that supports.
+
+**Decision:** ship the pool at its structurally-conservative default (depth 2),
+same framing #759 used for `OLO_LINK_JOBS` itself — cheap, verified-real
+insurance against the documented worst case, not a headline win. The `-j6`
+compile-width guidance in `CLAUDE.md` is **not** revisited by this data; the
+measured deltas here are too modest and the sample too small to move that
+needle in either direction.

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -419,10 +419,13 @@ pwsh -NoProfile -File .claude/skills/run-oloengine/build-lock.ps1 -Command `
 ```
 
 `OLO_BUILD_INSTRUMENTATION` defaults `OFF` (the launcher wraps every compile/link/custom
-command, and profiling every developer build by default is not wanted). It has no effect
-under the Visual Studio generator (`build/`, the primary `msvc` preset) — that case prints
-a `message(WARNING)` rather than silently doing nothing, since the API itself doesn't
-support that generator (§5b point 1 still applies).
+command, and profiling every developer build by default is not wanted). It has no effect under
+any generator the API itself doesn't support — Makefile/Ninja/FASTBuild only (§5b point 1 still
+applies), checked as an **allow-list** in the root `CMakeLists.txt`, not a deny-list on just
+"Visual Studio". That matters for the primary `msvc` preset (`build/`, Visual Studio 18 2026,
+this repo's actual unsupported case) **and** for Xcode or any other generator this repo doesn't
+currently use — every one of them prints a `message(WARNING)` naming the actual generator in use,
+rather than silently attempting instrumentation and doing nothing.
 
 **Verify it wired** the same way as before trusting a build: `build-clang/CMakeFiles/rules.ninja`
 compile/link rules must carry the `"…/ctest.exe" --instrument --command-type compile …`


### PR DESCRIPTION
## Summary

Adopts two CMake features that shipped past our 4.2 floor (this machine upgraded to 4.4.2 as
step 0, per issue #822):

1. **`cmake_instrumentation()` (4.3)** — native successor to issue #759's hand-rolled recipe
   (an experimental, UUID-gated query directory undocumented outside `Help/dev/experimental.rst`).
   Opt-in via `-DOLO_BUILD_INSTRUMENTATION=ON` (default `OFF`), gated `CMAKE_VERSION >= 4.3`.
2. **File-set `JOB_POOL_COMPILE` (4.4)** — a `SOURCES`-type file set can carry its own
   `JOB_POOL_COMPILE`, overriding both target- and source-level settings. Used to throttle the
   two TUs a fresh instrumented trace confirmed are this tree's memory-heavy outliers —
   `LuaScriptGlue.cpp` and `McpFieldRegistry.cpp` (same identity as #759's finding, just grown
   with five days of intervening work). Default pool depth 2, `-DOLO_HEAVY_COMPILE_JOBS=<N>` to
   change it, validated with the same "reject 0/empty" rigor as the existing `OLO_LINK_JOBS`
   link pool it's modeled on.

**Both are Ninja-only.** This affects the `clangcl` preset (`build-clang/`) and Linux presets —
**not** the primary `msvc` preset (`build/`, Visual Studio 18 2026), which the Instrumentation
API doesn't support at all and which has no `JOB_POOL_COMPILE`/`JOB_POOLS` mechanism to hook
into. Per CLAUDE.md's own measured numbers, MSVC's peak memory is *higher* than clang-cl's at
`-j6` (~47 GiB vs ~42 GiB), so the tree with the larger OOM exposure gets **no mitigation from
this PR** — flagging this plainly so it isn't assumed to have gotten faster/safer too.

`cmake_minimum_required` is unchanged (still `3.25`; presets' `cmakeMinimumRequired` still
`4.2.0`) — every new block is behind its own `CMAKE_VERSION VERSION_GREATER_EQUAL` guard and
no-ops cleanly below its threshold.

## What I measured, and how

Full methodology + numbers are in
[`docs/agent-rules/build-trees-and-windows-asan.md` §5](docs/agent-rules/build-trees-and-windows-asan.md#5-instrumenting-a-build-and-a-per-file-set-compile-job-pool-issues-759-822)
(§5a: native recipe; §5d: the pool's measurement). Short version:

- **The plan's literal scope (`--target OloEngine-Tests` alone) under-tests the pool.**
  `OloEngine-Tests` recompiles `OloEditor`'s `.cpp` files directly rather than linking against
  it, so that target alone never builds `OloEditor.exe` — meaning `OloEditor`'s own copy of
  `McpFieldRegistry.cpp` never compiles, and at most 2 heavy TUs ever exist to contend for a
  depth-2 pool (which doesn't throttle 2). Found this by comparing depth-2 vs depth-6 runs at
  that narrow scope and seeing no consistent difference — the real comparison needs
  `--target OloEditor --target OloEngine-Tests` together, where 3 heavy-TU instances exist.
- **At that corrected scope** (`-j6`, clean, clang-cl, idle host, instrumented): pool depth 2
  (the real default) averaged **~580 s / ~38.6 GiB peak** across 2 repeated runs; depth 6
  (~unthrottled) measured **624.8 s / 40.48 GiB** in 1 run. Depth 2 is **~7% faster** and
  **~4-5% less peak memory**, fairly consistently across the repeated depth-2 runs.
- **Honest caveat, not oversold:** a direct `[timeStart, timeStart+dur]` overlap check on the
  three heavy-TU compile events in both traces found they almost never directly collide with
  *each other* regardless of pool depth (max concurrent 1-2 either way). So the improvement
  isn't cleanly attributable to "the pool stopped two heavy TUs racing" — the mechanism's most
  intuitive story doesn't hold up under the data. Total system-wide concurrent build-step count
  never exceeded 6 in either configuration either (confirms a named Ninja pool is a subsidiary
  cap *within* the `-j` budget, not additive on top — worth confirming empirically since it's
  easy to reason backwards). Likely explanation: a second-order scheduling effect on *when* the
  heavy TUs start relative to the rest of the 1300+-TU graph. Sample size is small (n=2 vs n=1);
  the percentages shouldn't be read with more precision than that supports.
- **Decision:** ship at the conservative default (depth 2) as cheap, structurally-verified
  insurance — same framing #759 used for `OLO_LINK_JOBS` itself. The `-j6` compile-width
  guidance in `CLAUDE.md` is **not** revisited by this data; the deltas are too modest and the
  sample too small to move that needle either way.

**Mechanism verified real, not just configured** (the plan's explicit top risk — a cap that
configures cleanly and does nothing): grepped the generated `build.ninja`/`rules.ninja` for the
`olo_heavy` pool declaration *and* `pool = olo_heavy` on the three specific heavy-TU compile
edges, confirmed an ordinary neighboring TU (`Scene.cpp`) carries no pool line, and confirmed
the existing `olo_link` pool survives alongside it (the `JOB_POOLS` global property needs
`APPEND` on the second `set_property` call, or it silently clobbers the first).

## Two real CMake bugs found while wiring this

1. **CMake 4.4's own doc example for the file-set `JOB_POOL_COMPILE` property is wrong.**
   `set_property(FILE_SET my_fileset TYPE SOURCE PROPERTY JOB_POOL_COMPILE two_jobs)` — copied
   verbatim from `Help/prop_fs/JOB_POOL_COMPILE.rst` — errors `set_property required TARGET
   option is missing`, because `set_property()`'s actual `FILE_SET` scope signature is
   `FILE_SET <file_set>... TARGET <target>`, no `TYPE` keyword at all. Caught by testing the
   exact snippet in a throwaway two-source scratch project *before* touching the 1300-TU tree.
2. **`target_sources(... FILE_SET ...)`'s relative `FILES` resolve against the *caller's*
   `CMAKE_CURRENT_SOURCE_DIR`, not a helper function's `base_dir` parameter.** First version of
   `olo_bind_heavy_compile_pool()` passed relative paths straight through; called from
   `OloEngine/tests/CMakeLists.txt` with `base_dir` pointing at `OloEditor/src`, CMake looked for
   the file under `OloEngine/tests/` instead — a hard configure error, not a silent drop, but
   only because the file didn't happen to exist at the wrong location. Fixed by resolving
   `FILES` against `base_dir` explicitly inside the function.

## Ride-along considered, not included

The handover's suggested ride-along — `CMAKE_EP_GIT_CLONE_RETRY_COUNT`/`_DELAY` (also 4.4) for
CI clone-flake resilience — turned out to contradict CMake's own docs: both variables are
explicitly documented as "should not be set by a project, it is intended for the user to set."
Hardcoding a project default would silently override a user who deliberately configured a
different value. Skipped rather than fought against the upstream API's stated contract.

Filed a **separate**, smaller follow-up instead: #824, documenting a real ~15-minute
`HTTP 429` this task hit from glad's uncached, retry-less configure-time spec fetch
(`raw.githubusercontent.com`) — unrelated to this PR's scope, but genuinely encountered while
measuring, with a concrete one-line fix (`glad_add_library(... REPRODUCIBLE)`) verified locally.

## Review guide

**Where I'd look hardest**
1. `CMakeLists.txt` (the `JOB_POOLS` `APPEND` line) — the one line where getting this wrong
   silently disables the *existing* link pool, not just the new one. Verified by grep against
   the generated `rules.ninja` (both `pool olo_link` and `pool olo_heavy` present), not just by
   reading the CMake source.
2. `cmake/CommonProperties.cmake`'s `olo_bind_heavy_compile_pool()` — the `base_dir`-relative
   path resolution (bug #2 above). Fixed, but it's exactly the kind of thing that looks right
   until a fourth call site with a different relative-path shape exercises it differently.
3. The measurement scope correction in §5d — I initially measured the wrong thing
   (`--target OloEngine-Tests` alone never exercises 3-way heavy-TU contention) and only caught
   it by noticing depth-2 vs depth-6 showed no consistent difference at that scope. Worth a
   second read of whether the corrected (`OloEditor` + `OloEngine-Tests`) scope is itself the
   *right* proxy for "what a full build experiences," or whether `OloRuntime`/`OloServer` add a
   fourth contender I didn't measure.

**What I verified, and how** — mechanism reality: direct `build.ninja`/`rules.ninja` grep
(pool declared, bound to exactly the 3 intended edges, not bound to a neighboring TU, link pool
undisturbed) both before and after a `--fresh` reconfigure. Correctness under two real
generator/version combinations: confirmed `OLO_HEAVY_COMPILE_POOL_AVAILABLE` is `FALSE` under
the `msvc` (Visual Studio) preset regardless of CMake version, so the `REMOVE_ITEM` blocks never
fire there and both heavy TUs stay in their original plain source lists, unaffected — verified
by reading the preset's generator string, not assumed. Functional correctness of the moved TUs:
targeted test run (`--gtest_filter="McpFieldRegistry*:*Lua*"`, 208 tests, all passed) plus the
**full suite** (5925 tests, 0 failures, run against the real-default-config build — no
instrumentation, no glad workaround — after reverting both). Self-reviewed with `/code-review
high` (5 independent angles: reuse/simplification, altitude/conventions, cross-file trace,
removed-behavior audit, line-by-line diff scan) — no functional bugs found; one angle
independently re-derived and confirmed the unity-build/file-set interaction I'd already checked
empirically (a `FILE_SET`-added source with `SKIP_UNITY_BUILD_INCLUSION` set stays correctly
excluded from unity batching and keeps its pool assignment — verified on the real 1300-TU tree
with `-DOLO_ENABLE_UNITY_BUILD=ON`, configure-only, not built).

**Least confident about** — the small sample size on the wall-time/memory numbers (n=2 depth-2
runs, n=1 depth-6 run) given how much build-cycle time each full clean rebuild costs. The
*direction* (depth 2 faster and lower-memory) was consistent across repeats; the *magnitude*
(~7%, ~4-5%) could easily be +/-2-3 points of that just from run-to-run noise on a shared
20-core host. I'd want a third depth-6 run before treating the percentages as load-bearing for
anything beyond "ship the conservative default."

**Deliberately not tested** — the Linux presets (this machine is Windows-only) and the
`clangcl-asan` preset specifically (inherits `clangcl`, so the same wiring applies, but ASan's
memory overhead changes the absolute numbers enough that I didn't want to imply the measured
percentages transfer). Also did not attempt to measure `OloRuntime`/`OloServer` in the same
build — per the review guide above, a fourth contender I didn't check.

Closes #822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional CMake build instrumentation for supported generators, with configuration and trace output to help analyze build performance.
  - Added configurable throttling for memory-intensive compilation when using recent CMake and Ninja versions.
  - Added validation for positive concurrency settings.

- **Bug Fixes**
  - Reduced peak memory usage and improved build reliability by scheduling resource-heavy compilation more carefully.

- **Documentation**
  - Expanded Windows AddressSanitizer and build-performance guidance, including setup, verification, limitations, and measurement results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->