### PR TITLE
feat(renderer): general GPU-visible paged cache + lock-free GPU hash map (#704)

### DIFF
--- a/OloEditor/assets/shaders/include/GPUCacheResolve.glsl
+++ b/OloEditor/assets/shaders/include/GPUCacheResolve.glsl
@@ -1,0 +1,112 @@
+// =============================================================================
+// GPUCacheResolve.glsl — shader-side residency lookup for GPUPagedCache (#704).
+//
+// The CPU side (OloEngine/Renderer/GPUCache/) keeps two GPU-readable
+// structures when created with the HostMirrored backing:
+//
+//   * the object directory — GPUHashMap<u64, ObjectAllocation>: one flat
+//     std430 array of { key, value } entries, linear-probed, power-of-two
+//     capacity, key sentinels for empty/tombstone;
+//   * the page-node table — u32 next-pointers, one per page, kInvalidPage
+//     (0xFFFFFFFF) terminating each object's chain.
+//
+// With those two bound, a compute shader resolves "is object X resident, and
+// which pages hold it?" entirely on the GPU — no CPU round trip. That is
+// acceptance criterion 2 of issue #704, proven by
+// tests/GPUCacheResolve_Probe.comp + GPUCacheShaderResolveTest.cpp.
+//
+// THE CONTRACT (all of it checked by that test):
+//
+// 1. The consumer declares the entry struct and both buffers BEFORE including
+//    this file (GLSL includes are textual; binding points are the consumer's
+//    business). The entry struct must mirror the C++ instantiation EXACTLY —
+//    for GPUPagedCache<u64, Atom, LRUPolicy> that is:
+//
+//        struct OloGpuCacheEntry
+//        {
+//            uint64_t Key;               // GPUHashMap entry key
+//            uint TotalElementCount;     // ObjectAllocation begins here
+//            uint StartPage;
+//            uint EndPage;
+//            uint PolicyHandle;          // LRUPolicy<u64>::Handle (one u32)
+//        };                              // std430: size 24, align 8
+//
+//    A policy with a different Handle size changes the stride — re-derive it.
+//
+// 2. `#extension GL_ARB_gpu_shader_int64 : require` at the top of the
+//    consumer (extensions cannot live in an include). Keys are 64-bit, and
+//    the hash below does 64-bit multiplies. Ask the driver for the extension
+//    BEFORE creating the shader — a failed compute compile is a modal assert
+//    dialog in Debug, not a return value (gpu-scan-compaction.md §6).
+//
+// 3. The hash and sentinels below must stay bit-identical to the C++ side:
+//    the hash is the engine's canonical MurmurHash3 finalizer Hash::Hash64
+//    (Core/Hash.h, reached through GPUHashMap::HashKey), the sentinels are
+//    GPUHashMap::kEmptyKey / kTombstoneKey. GPUHashMapTest's
+//    GlslResolveContractMatchesCppConstants pins this file against them.
+//
+// 4. Capacity is a power of two; the start slot is hash & (capacity - 1).
+//
+// Use OLO_GPU_CACHE_DEFINE_FIND to stamp out the probe function against your
+// buffer declarations:
+//
+//     OLO_GPU_CACHE_DEFINE_FIND(OloGpuCacheFind, u_Entries)
+//     ...
+//     uint count, startPage, endPage;
+//     if (OloGpuCacheFind(objectKey, count, startPage, endPage)) { ... }
+//
+// and walk the chain with the page-node array:
+//
+//     for (uint page = startPage; page != OLO_GPU_CACHE_INVALID_PAGE;
+//          page = u_PageNodes[page]) { ... }
+// =============================================================================
+
+const uint64_t OLO_GPU_CACHE_EMPTY_KEY = 0xFFFFFFFFFFFFFFFFUL;
+const uint64_t OLO_GPU_CACHE_TOMBSTONE_KEY = 0xFFFFFFFFFFFFFFFEUL;
+const uint OLO_GPU_CACHE_INVALID_PAGE = 0xFFFFFFFFu;
+
+// MurmurHash3 finalizer — bit-identical to Hash::Hash64 (Core/Hash.h), the
+// hash GPUHashMap::HashKey uses for its start slot.
+uint64_t OloGpuCacheHash64(uint64_t x)
+{
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdUL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53UL;
+    x ^= x >> 33;
+    return x;
+}
+
+uint OloGpuCacheStartSlot(uint64_t key, uint capacity)
+{
+    return uint(OloGpuCacheHash64(key) & uint64_t(capacity - 1u));
+}
+
+// Stamps out `bool FuncName(uint64_t key, out uint outTotalElementCount,
+// out uint outStartPage, out uint outEndPage)` probing `EntriesArray`
+// (an OloGpuCacheEntry[] as specified in the header comment). Linear probe:
+// an empty slot ends the search; tombstones are skipped implicitly (their key
+// matches nothing).
+#define OLO_GPU_CACHE_DEFINE_FIND(FuncName, EntriesArray)                                          \
+    bool FuncName(uint64_t key, out uint outTotalElementCount, out uint outStartPage,              \
+                  out uint outEndPage)                                                             \
+    {                                                                                              \
+        uint capacity = uint(EntriesArray.length());                                               \
+        uint start = OloGpuCacheStartSlot(key, capacity);                                          \
+        for (uint probe = 0u; probe < capacity; ++probe)                                           \
+        {                                                                                          \
+            uint slot = (start + probe) & (capacity - 1u);                                         \
+            if (EntriesArray[slot].Key == OLO_GPU_CACHE_EMPTY_KEY)                                 \
+            {                                                                                      \
+                return false;                                                                      \
+            }                                                                                      \
+            if (EntriesArray[slot].Key == key)                                                     \
+            {                                                                                      \
+                outTotalElementCount = EntriesArray[slot].TotalElementCount;                       \
+                outStartPage = EntriesArray[slot].StartPage;                                       \
+                outEndPage = EntriesArray[slot].EndPage;                                           \
+                return true;                                                                       \
+            }                                                                                      \
+        }                                                                                          \
+        return false;                                                                              \
+    }

--- a/OloEditor/assets/shaders/tests/GPUCacheResolve_Probe.comp
+++ b/OloEditor/assets/shaders/tests/GPUCacheResolve_Probe.comp
@@ -1,0 +1,114 @@
+// NOTE: single-file compute shader (no `#type` prefix — the compute-shader
+// loader in this project uses a plain `#version ... core` header directly).
+#version 460 core
+#extension GL_ARB_gpu_shader_int64 : require
+
+// =============================================================================
+// GPUCacheResolve_Probe.comp — issue #704 acceptance criterion 2.
+//
+// One thread per query key: probe the GPUPagedCache object directory
+// (GPUHashMap layout, binding 0), then walk the page-node chain (binding 1),
+// writing everything the CPU can cross-check into binding 2 — hit/miss, the
+// allocation fields, the chain length, and an ORDER-SENSITIVE chain checksum.
+// The checksum is deliberately position-dependent (h = h * 33 + page): a
+// set-style comparison would pass on a walk that visits the right pages in the
+// wrong order, which is exactly the bug class
+// docs/agent-rules/gpu-scan-compaction.md §2 warns about.
+//
+// Driven by GPUCacheShaderResolveTest.cpp against a live GPUPagedCache in
+// HostMirrored backing; the CPU computes the same tuple through
+// GPUPagedCache::Find + a CPU chain walk and requires exact equality.
+// =============================================================================
+
+layout(local_size_x = 64) in;
+
+// Must mirror GPUHashMap<u64, GPUPagedCache<u64, Atom, LRUPolicy>::ObjectAllocation>::Entry
+// — see the contract in ../include/GPUCacheResolve.glsl.
+struct OloGpuCacheEntry
+{
+    uint64_t Key;
+    uint TotalElementCount;
+    uint StartPage;
+    uint EndPage;
+    uint PolicyHandle;
+};
+
+layout(std430, binding = 0) readonly buffer GpuCacheEntries
+{
+    OloGpuCacheEntry u_Entries[];
+};
+
+layout(std430, binding = 1) readonly buffer GpuCachePageNodes
+{
+    uint u_PageNodes[];
+};
+
+struct ResolveResult
+{
+    uint Found;
+    uint TotalElementCount;
+    uint StartPage;
+    uint EndPage;
+    uint PageCount;      // chain length walked on the GPU
+    uint LastPage;       // final page reached by the walk (must equal EndPage)
+    uint ChainChecksum;  // h = h * 33 + page, per chain step — order-sensitive
+    uint Pad;
+};
+
+layout(std430, binding = 2) buffer ResolveIO
+{
+    uint u_QueryCount;
+    uint u_Pad0;
+    uint u_Pad1;
+    uint u_Pad2;
+    uint64_t u_QueryKeys[256];
+    ResolveResult u_Results[256];
+};
+
+#include "../include/GPUCacheResolve.glsl"
+
+OLO_GPU_CACHE_DEFINE_FIND(OloGpuCacheFind, u_Entries)
+
+void main()
+{
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= u_QueryCount)
+    {
+        return;
+    }
+
+    ResolveResult result;
+    result.Found = 0u;
+    result.TotalElementCount = 0u;
+    result.StartPage = OLO_GPU_CACHE_INVALID_PAGE;
+    result.EndPage = OLO_GPU_CACHE_INVALID_PAGE;
+    result.PageCount = 0u;
+    result.LastPage = OLO_GPU_CACHE_INVALID_PAGE;
+    result.ChainChecksum = 0u;
+    result.Pad = 0u;
+
+    uint totalElementCount;
+    uint startPage;
+    uint endPage;
+    if (OloGpuCacheFind(u_QueryKeys[idx], totalElementCount, startPage, endPage))
+    {
+        result.Found = 1u;
+        result.TotalElementCount = totalElementCount;
+        result.StartPage = startPage;
+        result.EndPage = endPage;
+
+        // Chain walk, bounded by the page-node table size so a corrupt chain
+        // cannot hang the dispatch.
+        uint maxSteps = uint(u_PageNodes.length());
+        uint current = startPage;
+        for (uint step = 0u; step < maxSteps && current != OLO_GPU_CACHE_INVALID_PAGE; ++step)
+        {
+            result.ChainChecksum = result.ChainChecksum * 33u + current;
+            result.LastPage = current;
+            ++result.PageCount;
+            current = u_PageNodes[current];
+        }
+    }
+
+    u_Results[idx] = result;
+}

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -842,6 +842,15 @@
 		"OloEngine/Renderer/LightCulling/TiledForwardPlus.h"
 		"OloEngine/Renderer/LightCulling/TiledForwardPlus.cpp"
 
+		"OloEngine/Renderer/GPUCache/GPUBufferLock.h"
+		"OloEngine/Renderer/GPUCache/GPUBufferLock.cpp"
+		"OloEngine/Renderer/GPUCache/GPUCachePolicy.h"
+		"OloEngine/Renderer/GPUCache/GPUCacheStorage.h"
+		"OloEngine/Renderer/GPUCache/GPUCircularBuffer.h"
+		"OloEngine/Renderer/GPUCache/GPUHashMap.h"
+		"OloEngine/Renderer/GPUCache/GPUPagedBuffer.h"
+		"OloEngine/Renderer/GPUCache/GPUPagedCache.h"
+
 		"OloEngine/Renderer/VirtualGeometry/VirtualMesh.h"
 		"OloEngine/Renderer/VirtualGeometry/VirtualMesh.cpp"
 		"OloEngine/Renderer/VirtualGeometry/VirtualMeshBuilder.h"

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.cpp
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.cpp
@@ -1,0 +1,104 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/GPUCache/GPUBufferLock.h"
+
+#include "OloEngine/Renderer/RenderCommand.h"
+
+#include <algorithm>
+
+namespace OloEngine
+{
+    namespace
+    {
+        constexpr u64 kOneSecondInNanoseconds = 1'000'000'000ull;
+    }
+
+    GPUBufferLockManager::~GPUBufferLockManager()
+    {
+        Reset();
+    }
+
+    void GPUBufferLockManager::WaitForLockedRange(sizet lockBeginBytes, sizet lockLengthBytes)
+    {
+        const GPUBufferRange testRange{ lockBeginBytes, lockLengthBytes };
+
+        auto overlapping = std::partition(m_BufferLocks.begin(), m_BufferLocks.end(),
+                                          [&testRange](const BufferLock& lock)
+                                          { return !testRange.Overlaps(lock.m_Range); });
+        for (auto it = overlapping; it != m_BufferLocks.end(); ++it)
+        {
+            Wait(it->m_Fence);
+            RenderCommand::DestroyFence(it->m_Fence);
+        }
+        m_BufferLocks.erase(overlapping, m_BufferLocks.end());
+    }
+
+    void GPUBufferLockManager::LockRange(sizet lockBeginBytes, sizet lockLengthBytes)
+    {
+        // Reap locks whose fences have already signaled (GPU work done — the
+        // range is safe to rewrite, so the lock carries no information).
+        // Without this, a ring that wraps rarely accumulates one live GLsync
+        // per Commit until the head comes back around — thousands of driver
+        // sync objects, and an ever-longer overlap scan in WaitForLockedRange.
+        std::erase_if(m_BufferLocks,
+                      [](const BufferLock& lock)
+                      {
+                          if (RenderCommand::IsFenceSignaled(lock.m_Fence))
+                          {
+                              RenderCommand::DestroyFence(lock.m_Fence);
+                              return true;
+                          }
+                          return false;
+                      });
+
+        const u64 fence = RenderCommand::CreateFence();
+        m_BufferLocks.push_back({ { lockBeginBytes, lockLengthBytes }, fence });
+    }
+
+    void GPUBufferLockManager::Reset()
+    {
+        // Guarded so a destructor reached at static teardown (rendering device
+        // already gone) degrades to leaking the fences — as the pre-#704 code
+        // did — instead of calling into a dead RendererAPI.
+        if (!m_BufferLocks.empty() && RenderCommand::IsDeviceAvailable())
+        {
+            for (const BufferLock& lock : m_BufferLocks)
+            {
+                RenderCommand::DestroyFence(lock.m_Fence);
+            }
+        }
+        m_BufferLocks.clear();
+    }
+
+    void GPUBufferLockManager::Wait(u64 fence) const
+    {
+        // ClientWaitFence flushes on the OpenGL backend (GL_SYNC_FLUSH_COMMANDS_BIT
+        // inside the wait), so a fence whose commands were never submitted still
+        // completes. NOTE for a future Vulkan enablement: VulkanRendererAPI stages
+        // its CreateFence signal for the NEXT queue submit, so an intra-frame wait
+        // with no submit in between would spin here — currently unreachable
+        // (Vulkan's AllocatePersistentUploadStorage is a stub returning null, so
+        // no persistent-mapped consumer of this class can exist there), but audit
+        // this loop when that stub is implemented. The periodic error keeps any
+        // such regression loud instead of a silent hang.
+        u32 timeouts = 0;
+        while (true)
+        {
+            const RHI::FenceStatus status = RenderCommand::ClientWaitFence(fence, kOneSecondInNanoseconds);
+            if (status == RHI::FenceStatus::AlreadySignaled || status == RHI::FenceStatus::ConditionSatisfied)
+            {
+                return;
+            }
+            if (status == RHI::FenceStatus::Failed)
+            {
+                OLO_CORE_WARN("GPUBufferLockManager: ClientWaitFence failed — treating the range as unlocked");
+                return;
+            }
+            if (++timeouts == 5)
+            {
+                OLO_CORE_ERROR("GPUBufferLockManager: a range fence has not signaled after {} seconds — "
+                               "still waiting (GPU stall or a backend that never submitted the fence?)",
+                               timeouts);
+            }
+        }
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.cpp
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.cpp
@@ -9,8 +9,12 @@ namespace OloEngine
 {
     namespace
     {
-        constexpr u64 kOneSecondInNanoseconds = 1'000'000'000ull;
-    }
+        constexpr u64 kNanosecondsPerSecond = 1'000'000'000ull;
+        // How long each ClientWaitFence call blocks before we re-check.
+        constexpr u64 kFenceWaitChunkNanoseconds = kNanosecondsPerSecond;
+        // Re-log every N chunks so a never-signalling fence stays loud.
+        constexpr u32 kFenceWaitLogEveryChunks = 5;
+    } // namespace
 
     GPUBufferLockManager::~GPUBufferLockManager()
     {
@@ -83,7 +87,7 @@ namespace OloEngine
         u32 timeouts = 0;
         while (true)
         {
-            const RHI::FenceStatus status = RenderCommand::ClientWaitFence(fence, kOneSecondInNanoseconds);
+            const RHI::FenceStatus status = RenderCommand::ClientWaitFence(fence, kFenceWaitChunkNanoseconds);
             if (status == RHI::FenceStatus::AlreadySignaled || status == RHI::FenceStatus::ConditionSatisfied)
             {
                 return;
@@ -93,11 +97,13 @@ namespace OloEngine
                 OLO_CORE_WARN("GPUBufferLockManager: ClientWaitFence failed — treating the range as unlocked");
                 return;
             }
-            if (++timeouts == 5)
+            // Periodic, not once: a fence that never signals must keep saying so,
+            // or the "loud instead of silent" guarantee above lasts one message.
+            if (++timeouts % kFenceWaitLogEveryChunks == 0)
             {
                 OLO_CORE_ERROR("GPUBufferLockManager: a range fence has not signaled after {} seconds — "
                                "still waiting (GPU stall or a backend that never submitted the fence?)",
-                               timeouts);
+                               (static_cast<u64>(timeouts) * kFenceWaitChunkNanoseconds) / kNanosecondsPerSecond);
             }
         }
     }

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUBufferLock.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <vector>
+
+namespace OloEngine
+{
+    // @brief Byte range of a GPU buffer, used to track in-flight GPU reads over
+    // persistent-mapped memory (issue #704, ported from the VoxelEngine
+    // reference's gpu_buffer_lock.h).
+    struct GPUBufferRange
+    {
+        sizet m_StartOffset = 0;
+        sizet m_Length = 0;
+
+        [[nodiscard]] bool Overlaps(const GPUBufferRange& rhs) const
+        {
+            return m_StartOffset < (rhs.m_StartOffset + rhs.m_Length) &&
+                   rhs.m_StartOffset < (m_StartOffset + m_Length);
+        }
+    };
+
+    // @brief Fence-based range locking for persistent-mapped buffer writes.
+    //
+    // LockRange inserts a fence (RenderCommand::CreateFence) covering the byte
+    // range just handed to the GPU; WaitForLockedRange client-waits every fence
+    // whose range overlaps the bytes about to be rewritten, so the CPU never
+    // scribbles over memory a still-executing command is reading. Requires a
+    // live rendering device; single-threaded (render-thread) use only, same
+    // contract as the rest of the renderer.
+    class GPUBufferLockManager
+    {
+      public:
+        GPUBufferLockManager() = default;
+        ~GPUBufferLockManager();
+        GPUBufferLockManager(const GPUBufferLockManager&) = delete;
+        GPUBufferLockManager& operator=(const GPUBufferLockManager&) = delete;
+
+        void WaitForLockedRange(sizet lockBeginBytes, sizet lockLengthBytes);
+        void LockRange(sizet lockBeginBytes, sizet lockLengthBytes);
+
+        // Drops every outstanding fence without waiting (buffer destroyed).
+        void Reset();
+
+      private:
+        struct BufferLock
+        {
+            GPUBufferRange m_Range;
+            u64 m_Fence = 0;
+        };
+
+        void Wait(u64 fence) const;
+
+        std::vector<BufferLock> m_BufferLocks;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCachePolicy.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCachePolicy.h
@@ -1,0 +1,310 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <concepts>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace OloEngine
+{
+    // @brief Pluggable eviction for GPUPagedCache (issue #704, ported from the
+    // VoxelEngine reference's gpu_cache_policy.h).
+    //
+    // Divergence from the reference: SelectVictim() (assert-on-empty) became
+    // TrySelectVictim(exclude, out) -> bool. The cache calls it in a loop under
+    // memory pressure, and two situations the reference could not express are
+    // routine there: the policy has no evictable entry left (allocation must
+    // FAIL, not hang), and the only candidate is the requesting object itself
+    // (evicting it would free pages the allocation is about to chain).
+    template<typename Policy, typename ObjectID>
+    concept EvictionPolicy =
+        requires(Policy policy, const ObjectID& objectID, ObjectID& outVictim, u32 capacity) {
+            typename Policy::Handle;
+
+            Policy(capacity);
+
+            { policy.OnAccess(std::declval<typename Policy::Handle&>()) } noexcept -> std::same_as<void>;
+            { policy.OnInsert(objectID) } noexcept -> std::same_as<typename Policy::Handle>;
+            { policy.OnRemove(std::declval<typename Policy::Handle&>()) } noexcept -> std::same_as<void>;
+            { policy.TrySelectVictim(objectID, outVictim) } noexcept -> std::same_as<bool>;
+        };
+
+    // @brief Strict least-recently-used: intrusive doubly-linked list, OnAccess
+    // moves to front, victim is the tail.
+    template<typename ObjectID>
+    class LRUPolicy
+    {
+      public:
+        using Index = u32;
+        static constexpr Index kNullIndex = std::numeric_limits<Index>::max();
+
+        struct Handle
+        {
+            Index m_Index = kNullIndex;
+        };
+
+        explicit LRUPolicy(u32 capacity)
+        {
+            m_Nodes.reserve(capacity);
+            m_FreeList.reserve(capacity);
+        }
+
+        void OnAccess(Handle& handle) noexcept
+        {
+            OLO_CORE_ASSERT(IsValid(handle.m_Index), "LRUPolicy::OnAccess on an invalid handle");
+            MoveToFront(handle.m_Index);
+        }
+
+        [[nodiscard]] Handle OnInsert(const ObjectID& id) noexcept
+        {
+            const Index idx = AllocateNode();
+            Node& node = m_Nodes[idx];
+            node.m_Id = id;
+            node.m_Prev = kNullIndex;
+            node.m_Next = kNullIndex;
+            InsertFront(idx);
+            return Handle{ idx };
+        }
+
+        void OnRemove(Handle& handle) noexcept
+        {
+            if (!IsValid(handle.m_Index))
+            {
+                return;
+            }
+            RemoveNode(handle.m_Index);
+            m_FreeList.push_back(handle.m_Index);
+            handle.m_Index = kNullIndex;
+        }
+
+        [[nodiscard]] bool TrySelectVictim(const ObjectID& exclude, ObjectID& outVictim) noexcept
+        {
+            for (Index idx = m_Tail; idx != kNullIndex; idx = m_Nodes[idx].m_Prev)
+            {
+                if (!(m_Nodes[idx].m_Id == exclude))
+                {
+                    outVictim = m_Nodes[idx].m_Id;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+      private:
+        struct Node
+        {
+            ObjectID m_Id{};
+            Index m_Prev = kNullIndex;
+            Index m_Next = kNullIndex;
+        };
+
+        [[nodiscard]] bool IsValid(Index i) const noexcept
+        {
+            return i != kNullIndex && i < m_Nodes.size();
+        }
+
+        [[nodiscard]] Index AllocateNode() noexcept
+        {
+            if (!m_FreeList.empty())
+            {
+                const Index idx = m_FreeList.back();
+                m_FreeList.pop_back();
+                return idx;
+            }
+            m_Nodes.emplace_back();
+            return static_cast<Index>(m_Nodes.size() - 1);
+        }
+
+        void InsertFront(Index idx) noexcept
+        {
+            Node& node = m_Nodes[idx];
+            node.m_Prev = kNullIndex;
+            node.m_Next = m_Head;
+            if (m_Head != kNullIndex)
+            {
+                m_Nodes[m_Head].m_Prev = idx;
+            }
+            m_Head = idx;
+            if (m_Tail == kNullIndex)
+            {
+                m_Tail = idx;
+            }
+        }
+
+        void RemoveNode(Index idx) noexcept
+        {
+            Node& node = m_Nodes[idx];
+            if (node.m_Prev != kNullIndex)
+            {
+                m_Nodes[node.m_Prev].m_Next = node.m_Next;
+            }
+            else
+            {
+                m_Head = node.m_Next;
+            }
+            if (node.m_Next != kNullIndex)
+            {
+                m_Nodes[node.m_Next].m_Prev = node.m_Prev;
+            }
+            else
+            {
+                m_Tail = node.m_Prev;
+            }
+            node.m_Prev = kNullIndex;
+            node.m_Next = kNullIndex;
+        }
+
+        void MoveToFront(Index idx) noexcept
+        {
+            if (idx == m_Head)
+            {
+                return;
+            }
+            RemoveNode(idx);
+            InsertFront(idx);
+        }
+
+        std::vector<Node> m_Nodes;
+        std::vector<Index> m_FreeList;
+        Index m_Head = kNullIndex;
+        Index m_Tail = kNullIndex;
+    };
+
+    // @brief First-in-first-out: exactly the LRU list with accesses ignored,
+    // so the victim is always the least-recently-INSERTED entry.
+    //
+    // The reference implemented FIFO as a lock-free Vyukov MPMC ring, which
+    // cannot remove a mid-queue entry — every DeallocateObject left a stale
+    // entry that only drained under eviction pressure, so deallocate-heavy
+    // churn without pressure grew the queue without bound. The policies run
+    // under GPUPagedCache's single-writer mutation contract, so the ring's
+    // lock-freedom bought nothing; the intrusive list gives O(1) removal and
+    // no stale entries at all.
+    template<typename ObjectID>
+    class FIFOPolicy : private LRUPolicy<ObjectID>
+    {
+        using Base = LRUPolicy<ObjectID>;
+
+      public:
+        using Handle = typename Base::Handle;
+        using Base::Base;
+        using Base::OnInsert;
+        using Base::OnRemove;
+        using Base::TrySelectVictim;
+
+        void OnAccess(Handle&) noexcept
+        {
+            // FIFO ignores accesses — insertion order is eviction order.
+        }
+    };
+
+    // @brief Second-chance ("clock") eviction: entries sit on a ring with a
+    // referenced bit that OnAccess sets; the hand clears bits as it sweeps and
+    // evicts the first entry found unreferenced. LRU-approximating at O(1)
+    // bookkeeping per access — the classic page-cache compromise, named by the
+    // issue alongside FIFO and LRU.
+    template<typename ObjectID>
+    class ClockPolicy
+    {
+      public:
+        using Index = u32;
+        static constexpr Index kNullIndex = std::numeric_limits<Index>::max();
+
+        struct Handle
+        {
+            Index m_Index = kNullIndex;
+        };
+
+        explicit ClockPolicy(u32 capacity)
+        {
+            m_Entries.reserve(capacity);
+            m_FreeList.reserve(capacity);
+        }
+
+        void OnAccess(Handle& handle) noexcept
+        {
+            OLO_CORE_ASSERT(handle.m_Index != kNullIndex && handle.m_Index < m_Entries.size() &&
+                                m_Entries[handle.m_Index].m_Live,
+                            "ClockPolicy::OnAccess on an invalid handle");
+            m_Entries[handle.m_Index].m_Referenced = true;
+        }
+
+        [[nodiscard]] Handle OnInsert(const ObjectID& id) noexcept
+        {
+            Index idx;
+            if (!m_FreeList.empty())
+            {
+                idx = m_FreeList.back();
+                m_FreeList.pop_back();
+            }
+            else
+            {
+                m_Entries.emplace_back();
+                idx = static_cast<Index>(m_Entries.size() - 1);
+            }
+            Entry& entry = m_Entries[idx];
+            entry.m_Id = id;
+            entry.m_Referenced = true; // a fresh insert gets its second chance
+            entry.m_Live = true;
+            ++m_LiveCount;
+            return Handle{ idx };
+        }
+
+        void OnRemove(Handle& handle) noexcept
+        {
+            if (handle.m_Index == kNullIndex || handle.m_Index >= m_Entries.size() ||
+                !m_Entries[handle.m_Index].m_Live)
+            {
+                return;
+            }
+            m_Entries[handle.m_Index].m_Live = false;
+            m_FreeList.push_back(handle.m_Index);
+            --m_LiveCount;
+            handle.m_Index = kNullIndex;
+        }
+
+        [[nodiscard]] bool TrySelectVictim(const ObjectID& exclude, ObjectID& outVictim) noexcept
+        {
+            if (m_LiveCount == 0 || m_Entries.empty())
+            {
+                return false;
+            }
+            // Two full sweeps suffice: the first clears every referenced bit the
+            // hand passes, so the second must find an unreferenced entry —
+            // unless every live entry is the excluded object.
+            const sizet entryCount = m_Entries.size();
+            for (sizet step = 0; step < entryCount * 2; ++step)
+            {
+                Entry& entry = m_Entries[m_Hand];
+                m_Hand = (m_Hand + 1) % entryCount;
+                if (!entry.m_Live || entry.m_Id == exclude)
+                {
+                    continue;
+                }
+                if (entry.m_Referenced)
+                {
+                    entry.m_Referenced = false;
+                    continue;
+                }
+                outVictim = entry.m_Id;
+                return true;
+            }
+            return false;
+        }
+
+      private:
+        struct Entry
+        {
+            ObjectID m_Id{};
+            bool m_Referenced = false;
+            bool m_Live = false;
+        };
+
+        std::vector<Entry> m_Entries;
+        std::vector<Index> m_FreeList;
+        sizet m_Hand = 0;
+        sizet m_LiveCount = 0;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCacheStorage.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCacheStorage.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/RHI/RHITypes.h"
+#include "OloEngine/Renderer/RenderCommand.h"
+
+#include <cstring>
+#include <memory>
+#include <type_traits>
+
+namespace OloEngine
+{
+    // @brief A struct that is safe to place in GPU-visible memory byte-for-byte.
+    template<typename T>
+    concept GPUSafeStruct = std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T> &&
+                            !std::is_polymorphic_v<T> && !std::is_reference_v<T> && !std::is_pointer_v<T>;
+
+    // Where a GPU-cache data structure keeps its bytes (issue #704).
+    //
+    // The whole substrate runs its allocation/probing logic on a plain CPU
+    // pointer, so the SAME code serves all three backings — which is what makes
+    // the allocate/evict/split/collision tests runnable headless (HostOnly)
+    // while the shipped configuration is GPU-visible.
+    enum class GPUCacheBacking : u8
+    {
+        // Heap memory only. No rendering device required — headless tests, and
+        // consumers (like VirtualMeshRegistry) whose shaders don't read the
+        // directory.
+        HostOnly,
+        // Heap memory is the authority for every CPU read/write; each mutation
+        // is mirrored into a persistent-mapped device buffer so shaders can
+        // read the structure. The RHI's persistent mapping is WRITE-only
+        // (GL_MAP_WRITE_BIT without READ — see
+        // OpenGLRendererAPI::AllocatePersistentUploadStorage), so reading it
+        // back from the CPU would be undefined; the host copy exists precisely
+        // so no CPU read ever touches the mapping.
+        HostMirrored,
+        // Persistent-mapped device buffer only, no host copy. CPU access is
+        // WRITE-only (bulk payload staging); CPU-side reads must go through
+        // ReadbackRange, which round-trips via the device.
+        DeviceMapped
+    };
+
+    // @brief Typed storage for the GPU-cache substrate with selectable backing.
+    //
+    // NOT a general buffer abstraction: it exists so GPUHashMap / GPUPagedBuffer
+    // / GPUPagedCache can run identically with or without a rendering device.
+    // Single render-thread mutation contract for the device mirror; the host
+    // pointer itself supports the lock-free (std::atomic_ref) access the hash
+    // map and page bitset perform.
+    template<typename Atom>
+        requires GPUSafeStruct<Atom>
+    class GPUCacheStorage
+    {
+      public:
+        GPUCacheStorage() = default;
+        ~GPUCacheStorage()
+        {
+            Destroy();
+        }
+        GPUCacheStorage(const GPUCacheStorage&) = delete;
+        GPUCacheStorage& operator=(const GPUCacheStorage&) = delete;
+
+        [[nodiscard]] bool Create(u32 count, GPUCacheBacking backing)
+        {
+            if (m_Count != 0 || count == 0)
+            {
+                return false;
+            }
+
+            m_Backing = backing;
+
+            if (backing != GPUCacheBacking::DeviceMapped)
+            {
+                m_HostData = std::make_unique<Atom[]>(count);
+            }
+
+            if (backing != GPUCacheBacking::HostOnly)
+            {
+                if (!RenderCommand::IsDeviceAvailable())
+                {
+                    m_HostData.reset();
+                    return false;
+                }
+                m_DeviceBuffer = RenderCommand::CreateBufferHandle();
+                m_MappedPtr = static_cast<Atom*>(RenderCommand::AllocatePersistentUploadStorage(
+                    m_DeviceBuffer, static_cast<u64>(count) * sizeof(Atom)));
+                if (m_MappedPtr == nullptr)
+                {
+                    RenderCommand::DeleteBuffer(m_DeviceBuffer);
+                    m_DeviceBuffer = RHI::NullResource;
+                    m_HostData.reset();
+                    return false;
+                }
+            }
+
+            m_Count = count;
+            return true;
+        }
+
+        void Destroy()
+        {
+            if (m_DeviceBuffer.IsValid())
+            {
+                // Reached at static teardown when an owner's explicit Shutdown
+                // was skipped: with the RendererAPI gone, leak the device
+                // buffer (as pre-#704 code did) rather than call into it.
+                if (RenderCommand::IsDeviceAvailable())
+                {
+                    if (m_MappedPtr != nullptr)
+                    {
+                        RenderCommand::UnmapBuffer(m_DeviceBuffer);
+                    }
+                    RenderCommand::DeleteBuffer(m_DeviceBuffer);
+                }
+                m_MappedPtr = nullptr;
+                m_DeviceBuffer = RHI::NullResource;
+            }
+            m_HostData.reset();
+            m_Count = 0;
+        }
+
+        // The authority pointer the substrate's logic operates on. DeviceMapped
+        // storage hands back the mapped pointer, which is WRITE-only — callers
+        // in that mode must never read through it (see GPUCacheBacking).
+        [[nodiscard]] Atom* Data()
+        {
+            return m_HostData ? m_HostData.get() : m_MappedPtr;
+        }
+        [[nodiscard]] const Atom* Data() const
+        {
+            return m_HostData ? m_HostData.get() : m_MappedPtr;
+        }
+
+        // HostMirrored: republish [first, first+count) of the host copy into the
+        // device mapping. No-op for the other backings, so mutation sites can
+        // call it unconditionally.
+        void MirrorWrite(u32 first, u32 count)
+        {
+            if (m_Backing != GPUCacheBacking::HostMirrored || count == 0)
+            {
+                return;
+            }
+            OLO_CORE_ASSERT(first + count <= m_Count, "GPUCacheStorage::MirrorWrite out of range");
+            std::memcpy(m_MappedPtr + first, m_HostData.get() + first, static_cast<sizet>(count) * sizeof(Atom));
+        }
+
+        // DeviceMapped test/inspection path: read a range back through the
+        // device (the mapping itself is not CPU-readable). Host-backed storage
+        // copies straight from the authority.
+        [[nodiscard]] bool ReadbackRange(u32 first, u32 count, Atom* out) const
+        {
+            if (first + count > m_Count)
+            {
+                return false;
+            }
+            if (m_HostData)
+            {
+                std::memcpy(out, m_HostData.get() + first, static_cast<sizet>(count) * sizeof(Atom));
+                return true;
+            }
+            RenderCommand::ReadBufferSubData(m_DeviceBuffer, static_cast<u64>(first) * sizeof(Atom),
+                                             static_cast<u64>(count) * sizeof(Atom), out);
+            return true;
+        }
+
+        void Bind(u32 bindingPoint) const
+        {
+            OLO_CORE_ASSERT(m_DeviceBuffer.IsValid(), "GPUCacheStorage::Bind on host-only storage");
+            RenderCommand::BindStorageBuffer(bindingPoint, m_DeviceBuffer);
+        }
+
+        [[nodiscard]] u32 GetCount() const
+        {
+            return m_Count;
+        }
+        [[nodiscard]] GPUCacheBacking GetBacking() const
+        {
+            return m_Backing;
+        }
+        [[nodiscard]] bool IsCreated() const
+        {
+            return m_Count != 0;
+        }
+        [[nodiscard]] bool IsDeviceBacked() const
+        {
+            return m_DeviceBuffer.IsValid();
+        }
+        [[nodiscard]] RHI::ResourceHandle GetDeviceHandle() const
+        {
+            return m_DeviceBuffer;
+        }
+
+      private:
+        std::unique_ptr<Atom[]> m_HostData;
+        Atom* m_MappedPtr = nullptr;
+        RHI::ResourceHandle m_DeviceBuffer{};
+        u32 m_Count = 0;
+        GPUCacheBacking m_Backing = GPUCacheBacking::HostOnly;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCircularBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCircularBuffer.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/GPUCache/GPUBufferLock.h"
+#include "OloEngine/Renderer/RHI/RHITypes.h"
+#include "OloEngine/Renderer/RenderCommand.h"
+
+namespace OloEngine
+{
+    // @brief Fence-locked persistent-mapped upload ring (issue #704, ported
+    // from the VoxelEngine reference's GPUCircularBuffer).
+    //
+    // The classic streaming pattern: the CPU writes into a persistent-mapped
+    // buffer at a moving head, the GPU copies/reads from it, and fence range
+    // locks keep the writer from scribbling over bytes a still-executing
+    // command needs. Byte-granular on purpose — its one engine consumer stages
+    // heterogeneous payloads (VirtualMeshRegistry page uploads).
+    //
+    // Usage per staged payload, on the render thread:
+    //   1. u64 offset; u8* dst = ring.Reserve(bytes, offset);   // waits on overlapping fences
+    //   2. memcpy(dst, payload, bytes);
+    //   3. enqueue the GPU command that consumes [offset, offset+bytes)
+    //   4. ring.Commit(bytes);                                  // fences the range, advances head
+    //
+    // A Reserve that cannot fit before the end of the buffer wraps to 0 (the
+    // remainder tail is skipped, never split). A payload larger than the whole
+    // ring returns nullptr — the caller falls back to a direct upload.
+    class GPUCircularBuffer
+    {
+      public:
+        GPUCircularBuffer() = default;
+        ~GPUCircularBuffer()
+        {
+            Destroy();
+        }
+        GPUCircularBuffer(const GPUCircularBuffer&) = delete;
+        GPUCircularBuffer& operator=(const GPUCircularBuffer&) = delete;
+
+        [[nodiscard]] bool Create(u64 sizeBytes)
+        {
+            if (m_SizeBytes != 0 || sizeBytes == 0 || !RenderCommand::IsDeviceAvailable())
+            {
+                return false;
+            }
+            m_Buffer = RenderCommand::CreateBufferHandle();
+            m_MappedPtr = static_cast<u8*>(RenderCommand::AllocatePersistentUploadStorage(m_Buffer, sizeBytes));
+            if (m_MappedPtr == nullptr)
+            {
+                RenderCommand::DeleteBuffer(m_Buffer);
+                m_Buffer = RHI::NullResource;
+                return false;
+            }
+            m_SizeBytes = sizeBytes;
+            m_Head = 0;
+            return true;
+        }
+
+        void Destroy()
+        {
+            m_LockManager.Reset();
+            if (m_Buffer.IsValid())
+            {
+                // Device guard: this destructor can be reached at static
+                // teardown through an owner whose explicit Shutdown was
+                // skipped (VirtualMeshRegistry is a function-local static).
+                // With the RendererAPI gone, leak — the pre-#704 hand-rolled
+                // ring leaked on that path too — rather than call into it.
+                if (RenderCommand::IsDeviceAvailable())
+                {
+                    if (m_MappedPtr != nullptr)
+                    {
+                        RenderCommand::UnmapBuffer(m_Buffer);
+                    }
+                    RenderCommand::DeleteBuffer(m_Buffer);
+                }
+                m_MappedPtr = nullptr;
+                m_Buffer = RHI::NullResource;
+            }
+            m_SizeBytes = 0;
+            m_Head = 0;
+        }
+
+        // Returns a write pointer for `bytes` contiguous bytes and the ring
+        // offset it corresponds to, waiting out any fence still covering that
+        // range. Wraps to offset 0 when the tail cannot fit. nullptr when
+        // `bytes` exceeds the ring (or the ring was never created).
+        [[nodiscard]] u8* Reserve(u64 bytes, u64& outOffset)
+        {
+            if (m_MappedPtr == nullptr || bytes == 0 || bytes > m_SizeBytes)
+            {
+                return nullptr;
+            }
+            if (m_Head + bytes > m_SizeBytes)
+            {
+                m_Head = 0;
+            }
+            m_LockManager.WaitForLockedRange(m_Head, bytes);
+            outOffset = m_Head;
+            return m_MappedPtr + m_Head;
+        }
+
+        // Fences the range handed out by the matching Reserve and advances the
+        // head past it. Call AFTER enqueueing the GPU command that consumes it.
+        void Commit(u64 bytes)
+        {
+            OLO_CORE_ASSERT(m_Head + bytes <= m_SizeBytes, "GPUCircularBuffer::Commit past the reserved range");
+            m_LockManager.LockRange(m_Head, bytes);
+            m_Head += bytes;
+            if (m_Head == m_SizeBytes)
+            {
+                m_Head = 0;
+            }
+        }
+
+        [[nodiscard]] u64 GetSize() const
+        {
+            return m_SizeBytes;
+        }
+        [[nodiscard]] u64 GetHead() const
+        {
+            return m_Head;
+        }
+        [[nodiscard]] bool IsCreated() const
+        {
+            return m_SizeBytes != 0;
+        }
+        [[nodiscard]] RHI::ResourceHandle GetDeviceHandle() const
+        {
+            return m_Buffer;
+        }
+
+      private:
+        GPUBufferLockManager m_LockManager;
+        RHI::ResourceHandle m_Buffer{};
+        u8* m_MappedPtr = nullptr;
+        u64 m_SizeBytes = 0;
+        u64 m_Head = 0;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCircularBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUCircularBuffer.h
@@ -52,6 +52,7 @@ namespace OloEngine
             }
             m_SizeBytes = sizeBytes;
             m_Head = 0;
+            m_ReservedBytes = 0;
             return true;
         }
 
@@ -78,12 +79,16 @@ namespace OloEngine
             }
             m_SizeBytes = 0;
             m_Head = 0;
+            m_ReservedBytes = 0;
         }
 
         // Returns a write pointer for `bytes` contiguous bytes and the ring
         // offset it corresponds to, waiting out any fence still covering that
         // range. Wraps to offset 0 when the tail cannot fit. nullptr when
         // `bytes` exceeds the ring (or the ring was never created).
+        //
+        // An uncommitted reservation is simply superseded by the next Reserve —
+        // the head has not moved, so nothing is lost.
         [[nodiscard]] u8* Reserve(u64 bytes, u64& outOffset)
         {
             if (m_MappedPtr == nullptr || bytes == 0 || bytes > m_SizeBytes)
@@ -96,16 +101,32 @@ namespace OloEngine
             }
             m_LockManager.WaitForLockedRange(m_Head, bytes);
             outOffset = m_Head;
+            m_ReservedBytes = bytes;
             return m_MappedPtr + m_Head;
         }
 
         // Fences the range handed out by the matching Reserve and advances the
         // head past it. Call AFTER enqueueing the GPU command that consumes it.
+        //
+        // `bytes` must equal the outstanding reservation: the fence and the head
+        // advance both cover the range Reserve handed out, so committing a
+        // SHORTER length would leave the tail of that range unfenced and
+        // re-handable while the GPU is still reading it. The reservation length
+        // is therefore authoritative and `bytes` is the cross-check.
         void Commit(u64 bytes)
         {
-            OLO_CORE_ASSERT(m_Head + bytes <= m_SizeBytes, "GPUCircularBuffer::Commit past the reserved range");
-            m_LockManager.LockRange(m_Head, bytes);
-            m_Head += bytes;
+            OLO_CORE_ASSERT(m_ReservedBytes != 0, "GPUCircularBuffer::Commit without a matching Reserve");
+            OLO_CORE_ASSERT(bytes == m_ReservedBytes,
+                            "GPUCircularBuffer::Commit length differs from the reserved length");
+            if (m_ReservedBytes == 0)
+            {
+                return;
+            }
+            OLO_CORE_ASSERT(m_Head + m_ReservedBytes <= m_SizeBytes,
+                            "GPUCircularBuffer::Commit past the end of the ring");
+            m_LockManager.LockRange(m_Head, m_ReservedBytes);
+            m_Head += m_ReservedBytes;
+            m_ReservedBytes = 0;
             if (m_Head == m_SizeBytes)
             {
                 m_Head = 0;
@@ -135,5 +156,6 @@ namespace OloEngine
         u8* m_MappedPtr = nullptr;
         u64 m_SizeBytes = 0;
         u64 m_Head = 0;
+        u64 m_ReservedBytes = 0; // outstanding Reserve, cleared by Commit
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUHashMap.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUHashMap.h
@@ -25,12 +25,23 @@ namespace OloEngine
     // The table is one flat array of { key, value } entries, linear-probed,
     // power-of-two capacity, with two reserved key sentinels — which is exactly
     // the layout a compute shader can probe in ~25 lines of GLSL (see
-    // assets/shaders/include/GPUCacheResolve.glsl). Keys are claimed with a CAS
-    // through std::atomic_ref, so concurrent CPU inserts of DISTINCT keys are
-    // lock-free-safe; concurrent writes to the SAME key are last-writer-wins
-    // with no value-tearing guarantee (the value store is not atomic — the
-    // reference has the same contract). CompactTombstones is the one
-    // SINGLE-WRITER-only operation, and says so.
+    // assets/shaders/include/GPUCacheResolve.glsl).
+    //
+    // THREADING CONTRACT. Keys are claimed with a CAS through std::atomic_ref,
+    // so concurrent Insert / Erase / Find of **distinct** keys is safe and
+    // lock-free — including keys that collide on the same slot, which is the
+    // interesting case and the one the tests hammer.
+    //
+    // Concurrent mutation of the **same** key from multiple threads is NOT
+    // supported: the value store is a plain write (V is caller-supplied and can
+    // be wider than any lock-free atomic), so two threads writing one key is a
+    // data race — undefined behaviour, and TSan reports it as one. The
+    // reference's "last-writer-wins" wording claimed otherwise; it was wrong,
+    // and it cost a red TSan job to find out. Serialize externally if you need
+    // it. Every engine consumer is single-writer, so nothing pays for this.
+    //
+    // Mutate, CompactTombstones and the HostMirrored device mirror are all
+    // single-writer-only for the same reason.
     //
     // Divergence from the reference: Insert is tombstone-aware. The reference
     // claimed the first empty-or-tombstone slot it probed, so updating a key
@@ -178,8 +189,11 @@ namespace OloEngine
                 }
                 if (expected == key)
                 {
-                    // Another thread claimed the slot with OUR key first —
-                    // last-writer-wins on the value, per the class contract.
+                    // Another thread claimed the slot with OUR key first. Only
+                    // reachable when two threads insert the SAME key, which the
+                    // threading contract above excludes — so this write is not
+                    // a supported concurrent path, it just keeps the
+                    // single-threaded semantics (insert-or-update) intact.
                     claimed.m_Value = value;
                     m_Table.MirrorWrite(static_cast<u32>(claimIndex), 1);
                     return true;
@@ -233,7 +247,15 @@ namespace OloEngine
             for (sizet probe = 0; probe < capacity; ++probe)
             {
                 const Entry& entry = table[(start + probe) & (capacity - 1)];
-                const std::atomic_ref<const K> atomicKey(entry.m_Key);
+                // atomic_ref over a CV-QUALIFIED type is a later addition
+                // (P3323R1) than the C++23 this repo targets, so whether
+                // atomic_ref<const K> compiles depends on the standard library
+                // — and this builds under both MSVC's STL and libstdc++ in CI.
+                // Take the portable non-const form. The const_cast is sound:
+                // only the ACCESS path is const here — the table storage itself
+                // is mutable heap/mapped memory owned by GPUCacheStorage — and
+                // this reference is only ever loaded from, never stored to.
+                const std::atomic_ref<K> atomicKey(const_cast<K&>(entry.m_Key));
                 const K current = atomicKey.load(std::memory_order_acquire);
                 if (current == kEmptyKey)
                 {

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUHashMap.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUHashMap.h
@@ -1,0 +1,381 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/Hash.h"
+#include "OloEngine/Renderer/GPUCache/GPUCacheStorage.h"
+
+#include <atomic>
+#include <bit>
+#include <concepts>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace OloEngine
+{
+    template<typename K>
+    concept GPUHashMapKey = std::integral<K> && GPUSafeStruct<K>;
+
+    template<typename V>
+    concept GPUHashMapValue = GPUSafeStruct<V>;
+
+    // @brief Open-addressed hash map with a GPU-readable layout (issue #704,
+    // ported from the VoxelEngine reference's gpu_hashmap_allocator.h).
+    //
+    // The table is one flat array of { key, value } entries, linear-probed,
+    // power-of-two capacity, with two reserved key sentinels — which is exactly
+    // the layout a compute shader can probe in ~25 lines of GLSL (see
+    // assets/shaders/include/GPUCacheResolve.glsl). Keys are claimed with a CAS
+    // through std::atomic_ref, so concurrent CPU inserts of DISTINCT keys are
+    // lock-free-safe; concurrent writes to the SAME key are last-writer-wins
+    // with no value-tearing guarantee (the value store is not atomic — the
+    // reference has the same contract). CompactTombstones is the one
+    // SINGLE-WRITER-only operation, and says so.
+    //
+    // Divergence from the reference: Insert is tombstone-aware. The reference
+    // claimed the first empty-or-tombstone slot it probed, so updating a key
+    // whose probe chain crossed a later-erased slot created a DUPLICATE entry
+    // — Erase then removed only the first copy and lookups resurrected the
+    // stale second one. Insert here probes the full chain for the key before
+    // claiming the earliest tombstone.
+    //
+    // Backing (GPUCacheBacking):
+    //  - HostOnly:     heap table, no device. Headless tests, CPU-only callers.
+    //  - HostMirrored: heap table is the authority; every committed mutation is
+    //    mirrored into a persistent-mapped device buffer for shader-side
+    //    lookup. GPU reads must be frame-synchronized with CPU mutation (mutate,
+    //    then dispatch) — the mirror memcpy is not atomic against an in-flight
+    //    shader.
+    //  - DeviceMapped is NOT supported: probing reads the table, and the
+    //    persistent mapping is write-only.
+    template<typename K, typename V>
+        requires GPUHashMapKey<K> && GPUHashMapValue<V>
+    class GPUHashMap
+    {
+      public:
+        static constexpr K kEmptyKey = std::numeric_limits<K>::max();
+        static constexpr K kTombstoneKey = std::numeric_limits<K>::max() - 1;
+
+        struct Entry
+        {
+            K m_Key;
+            V m_Value;
+        };
+
+        GPUHashMap() = default;
+
+        // `capacity` is rounded up to the next power of two. Load factor is the
+        // caller's business (GPUPagedCache creates it at 2x its page count).
+        [[nodiscard]] bool Create(u32 capacity, GPUCacheBacking backing = GPUCacheBacking::HostOnly)
+        {
+            OLO_CORE_ASSERT(backing != GPUCacheBacking::DeviceMapped,
+                            "GPUHashMap probing reads the table; the write-only device mapping cannot back it");
+            if (capacity == 0)
+            {
+                return false;
+            }
+            const u32 actualCapacity = std::bit_ceil(capacity);
+            if (!m_Table.Create(actualCapacity, backing))
+            {
+                return false;
+            }
+            // The WHOLE rounded-up table must be initialised, not just the first
+            // `capacity` entries — the reference initialised [0, capacity) and
+            // left the rounded tail as uninitialised memory a probe could read.
+            Entry* table = m_Table.Data();
+            for (u32 i = 0; i < actualCapacity; ++i)
+            {
+                table[i].m_Key = kEmptyKey;
+            }
+            m_Table.MirrorWrite(0, actualCapacity);
+            m_TombstoneCount.store(0, std::memory_order_relaxed);
+            return true;
+        }
+
+        void Destroy()
+        {
+            m_Table.Destroy();
+            m_TombstoneCount.store(0, std::memory_order_relaxed);
+        }
+
+        // Insert-or-update. Returns false only when the table has no claimable
+        // slot for this key (full of other live keys, or pathological CAS
+        // contention). See the class comment for the tombstone-aware contract.
+        [[nodiscard]] bool Insert(const K& key, const V& value)
+        {
+            Entry* table = m_Table.Data();
+            OLO_CORE_ASSERT(table != nullptr, "GPUHashMap used before Create / after Destroy");
+            OLO_CORE_ASSERT(key != kEmptyKey && key != kTombstoneKey, "GPUHashMap key collides with a sentinel");
+
+            const sizet capacity = m_Table.GetCount();
+            const sizet start = HashIndex(key);
+
+            // A lost claim-CAS means another thread just rewrote the slot we
+            // decided on; the probe state is stale, so restart the whole probe.
+            // Bounded: contention on the same few slots resolves in a handful
+            // of rounds, and the single-writer consumers never restart at all.
+            constexpr int kMaxRestarts = 16;
+            for (int restart = 0; restart < kMaxRestarts; ++restart)
+            {
+                sizet firstTombstone = capacity; // "none seen"
+                sizet claimIndex = capacity;
+                K claimExpected = kEmptyKey;
+
+                for (sizet probe = 0; probe < capacity; ++probe)
+                {
+                    const auto index = static_cast<sizet>((start + probe) & (capacity - 1));
+                    Entry& entry = table[index];
+                    const std::atomic_ref<K> atomicKey(entry.m_Key);
+                    const K current = atomicKey.load(std::memory_order_acquire);
+
+                    if (current == key)
+                    {
+                        entry.m_Value = value;
+                        m_Table.MirrorWrite(static_cast<u32>(index), 1);
+                        return true;
+                    }
+                    if (current == kTombstoneKey)
+                    {
+                        if (firstTombstone == capacity)
+                        {
+                            firstTombstone = index;
+                        }
+                        continue;
+                    }
+                    if (current == kEmptyKey)
+                    {
+                        // The key is nowhere in its probe chain (an empty slot
+                        // ends every lookup) — claim the earliest reusable slot.
+                        claimIndex = (firstTombstone != capacity) ? firstTombstone : index;
+                        claimExpected = (firstTombstone != capacity) ? kTombstoneKey : kEmptyKey;
+                        break;
+                    }
+                    // A different live key: probe on.
+                }
+
+                if (claimIndex == capacity)
+                {
+                    if (firstTombstone == capacity)
+                    {
+                        return false; // full of live keys
+                    }
+                    claimIndex = firstTombstone;
+                    claimExpected = kTombstoneKey;
+                }
+
+                Entry& claimed = table[claimIndex];
+                const std::atomic_ref<K> atomicKey(claimed.m_Key);
+                K expected = claimExpected;
+                if (atomicKey.compare_exchange_strong(expected, key, std::memory_order_acq_rel))
+                {
+                    if (claimExpected == kTombstoneKey)
+                    {
+                        m_TombstoneCount.fetch_sub(1, std::memory_order_relaxed);
+                    }
+                    claimed.m_Value = value;
+                    m_Table.MirrorWrite(static_cast<u32>(claimIndex), 1);
+                    return true;
+                }
+                if (expected == key)
+                {
+                    // Another thread claimed the slot with OUR key first —
+                    // last-writer-wins on the value, per the class contract.
+                    claimed.m_Value = value;
+                    m_Table.MirrorWrite(static_cast<u32>(claimIndex), 1);
+                    return true;
+                }
+            }
+            OLO_CORE_ERROR("GPUHashMap: Insert gave up after {} contended restarts", 16);
+            return false;
+        }
+
+        // Single-probe in-place update of a PRESENT key: `mutate` receives the
+        // stored value by reference (policy-handle mutations included), and the
+        // entry is re-mirrored afterwards. Returns false when the key is absent
+        // — nothing is called then.
+        template<typename F>
+        [[nodiscard]] bool Mutate(const K& key, F&& mutate)
+        {
+            Entry* table = m_Table.Data();
+            OLO_CORE_ASSERT(table != nullptr, "GPUHashMap used before Create / after Destroy");
+            OLO_CORE_ASSERT(key != kEmptyKey && key != kTombstoneKey, "GPUHashMap key collides with a sentinel");
+
+            const sizet capacity = m_Table.GetCount();
+            const sizet start = HashIndex(key);
+            for (sizet probe = 0; probe < capacity; ++probe)
+            {
+                const auto index = static_cast<sizet>((start + probe) & (capacity - 1));
+                Entry& entry = table[index];
+                const std::atomic_ref<K> atomicKey(entry.m_Key);
+                const K current = atomicKey.load(std::memory_order_acquire);
+                if (current == kEmptyKey)
+                {
+                    return false;
+                }
+                if (current == key)
+                {
+                    std::forward<F>(mutate)(entry.m_Value);
+                    m_Table.MirrorWrite(static_cast<u32>(index), 1);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool Find(const K& key, V& out) const
+        {
+            const Entry* table = m_Table.Data();
+            OLO_CORE_ASSERT(table != nullptr, "GPUHashMap used before Create / after Destroy");
+            OLO_CORE_ASSERT(key != kEmptyKey && key != kTombstoneKey, "GPUHashMap key collides with a sentinel");
+
+            const sizet capacity = m_Table.GetCount();
+            const sizet start = HashIndex(key);
+            for (sizet probe = 0; probe < capacity; ++probe)
+            {
+                const Entry& entry = table[(start + probe) & (capacity - 1)];
+                const std::atomic_ref<const K> atomicKey(entry.m_Key);
+                const K current = atomicKey.load(std::memory_order_acquire);
+                if (current == kEmptyKey)
+                {
+                    return false;
+                }
+                if (current == key)
+                {
+                    out = entry.m_Value;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool Contains(const K& key) const
+        {
+            V ignored;
+            return Find(key, ignored);
+        }
+
+        bool Erase(const K& key)
+        {
+            Entry* table = m_Table.Data();
+            OLO_CORE_ASSERT(table != nullptr, "GPUHashMap used before Create / after Destroy");
+            OLO_CORE_ASSERT(key != kEmptyKey && key != kTombstoneKey, "GPUHashMap key collides with a sentinel");
+
+            const sizet capacity = m_Table.GetCount();
+            const sizet start = HashIndex(key);
+            for (sizet probe = 0; probe < capacity; ++probe)
+            {
+                const auto index = static_cast<u32>((start + probe) & (capacity - 1));
+                Entry& entry = table[index];
+                const std::atomic_ref<K> atomicKey(entry.m_Key);
+                const K current = atomicKey.load(std::memory_order_acquire);
+                if (current == kEmptyKey)
+                {
+                    return false;
+                }
+                if (current == key)
+                {
+                    K expected = key;
+                    if (atomicKey.compare_exchange_strong(expected, kTombstoneKey, std::memory_order_acq_rel))
+                    {
+                        m_TombstoneCount.fetch_add(1, std::memory_order_relaxed);
+                        m_Table.MirrorWrite(index, 1);
+                        return true;
+                    }
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        // Tombstones are only reclaimed when an Insert's own probe chain
+        // crosses one, so erase-heavy churn monotonically consumes the empty
+        // slots that terminate probes — in the limit every miss degrades to a
+        // full-table scan (CPU and GPU alike). Single-writer consumers
+        // (GPUPagedCache) rebuild the table in place when the count crosses a
+        // quarter of the capacity.
+        [[nodiscard]] bool NeedsCompaction() const
+        {
+            return m_TombstoneCount.load(std::memory_order_relaxed) > m_Table.GetCount() / 4;
+        }
+
+        [[nodiscard]] u32 GetTombstoneCount() const
+        {
+            return m_TombstoneCount.load(std::memory_order_relaxed);
+        }
+
+        // Rebuilds the table without tombstones. SINGLE-WRITER ONLY: concurrent
+        // readers would observe live keys vanishing mid-rebuild, and GPU
+        // consumers must not be probing the mirror while it runs (call between
+        // frames, exactly where cache mutation already happens).
+        void CompactTombstones()
+        {
+            Entry* table = m_Table.Data();
+            OLO_CORE_ASSERT(table != nullptr, "GPUHashMap used before Create / after Destroy");
+
+            const u32 capacity = m_Table.GetCount();
+            std::vector<Entry> live;
+            live.reserve(capacity / 2);
+            for (u32 i = 0; i < capacity; ++i)
+            {
+                if (table[i].m_Key != kEmptyKey && table[i].m_Key != kTombstoneKey)
+                {
+                    live.push_back(table[i]);
+                }
+                table[i].m_Key = kEmptyKey;
+            }
+            for (const Entry& entry : live)
+            {
+                // No tombstones exist mid-rebuild, so plain first-empty
+                // placement reproduces exactly what Insert would do.
+                const sizet start = HashIndex(entry.m_Key);
+                for (sizet probe = 0; probe < capacity; ++probe)
+                {
+                    Entry& slot = table[(start + probe) & (capacity - 1)];
+                    if (slot.m_Key == kEmptyKey)
+                    {
+                        slot = entry;
+                        break;
+                    }
+                }
+            }
+            m_TombstoneCount.store(0, std::memory_order_relaxed);
+            m_Table.MirrorWrite(0, capacity);
+        }
+
+        void Bind(u32 bindingPoint) const
+        {
+            m_Table.Bind(bindingPoint);
+        }
+
+        [[nodiscard]] u32 GetCapacity() const
+        {
+            return m_Table.GetCount();
+        }
+        [[nodiscard]] bool IsCreated() const
+        {
+            return m_Table.IsCreated();
+        }
+        [[nodiscard]] RHI::ResourceHandle GetDeviceHandle() const
+        {
+            return m_Table.GetDeviceHandle();
+        }
+
+        // The start slot the GLSL side must reproduce: the engine's canonical
+        // MurmurHash3 finalizer (Hash::Hash64, Core/Hash.h) masked to the
+        // power-of-two capacity. GPUCacheResolve.glsl mirrors those constants;
+        // GPUHashMapTest pins the two files against each other.
+        [[nodiscard]] static constexpr u64 HashKey(u64 key)
+        {
+            return Hash::Hash64(key);
+        }
+
+      private:
+        [[nodiscard]] sizet HashIndex(const K& key) const
+        {
+            return static_cast<sizet>(HashKey(static_cast<u64>(key)) & (m_Table.GetCount() - 1));
+        }
+
+        GPUCacheStorage<Entry> m_Table;
+        std::atomic<u32> m_TombstoneCount{ 0 };
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedBuffer.h
@@ -138,7 +138,10 @@ namespace OloEngine
                     {
                         break;
                     }
-                    const int bit = std::countr_zero(old);
+                    // Unsigned shift count: countr_zero returns int, and shifting
+                    // by a signed operand is a defect class in its own right
+                    // (cpp:S874) even when the value is provably in range.
+                    const auto bit = static_cast<u32>(std::countr_zero(old));
                     const u64 mask = 1ull << bit;
                     const u64 desired = old & ~mask;
                     if (word.compare_exchange_weak(old, desired, std::memory_order_acq_rel,

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedBuffer.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/GPUCache/GPUCacheStorage.h"
+
+#include <atomic>
+#include <bit>
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace OloEngine
+{
+    // @brief Page-granular buffer: a flat atom array carved into fixed-size
+    // pages, with a lock-free free-page bitset (issue #704, ported from the
+    // VoxelEngine reference's GPUPagedBuffer).
+    //
+    // The bitset always lives on the CPU heap (the GPU never consults it); the
+    // atom storage backing is the caller's choice — HostOnly for headless use,
+    // DeviceMapped for a real GPU arena the CPU stages payloads into.
+    //
+    // Directory-only mode: Create with pageSizeAtoms == 0 allocates NO atom
+    // storage — the object is purely a page-index allocator. That is how a
+    // consumer whose payload lives in its own buffers (VirtualMeshRegistry's
+    // vertex/index slot arenas) reuses the allocation machinery without
+    // adopting this class's storage.
+    template<typename Atom>
+        requires GPUSafeStruct<Atom>
+    class GPUPagedBuffer
+    {
+      public:
+        static constexpr u32 kInvalidPage = std::numeric_limits<u32>::max();
+
+        GPUPagedBuffer() = default;
+        GPUPagedBuffer(const GPUPagedBuffer&) = delete;
+        GPUPagedBuffer& operator=(const GPUPagedBuffer&) = delete;
+
+        [[nodiscard]] bool Create(sizet pageSizeAtoms, u32 pageCount, GPUCacheBacking backing)
+        {
+            if (m_PageCount != 0 || pageCount == 0 || pageCount >= kInvalidPage)
+            {
+                return false;
+            }
+
+            if (pageSizeAtoms > 0)
+            {
+                const u64 totalAtoms = static_cast<u64>(pageSizeAtoms) * pageCount;
+                if (totalAtoms > std::numeric_limits<u32>::max() ||
+                    !m_Storage.Create(static_cast<u32>(totalAtoms), backing))
+                {
+                    return false;
+                }
+            }
+
+            m_PageSize = pageSizeAtoms;
+            m_PageCount = pageCount;
+
+            const sizet wordCount = (pageCount + kWordBits - 1) / kWordBits;
+            m_FreePages = std::make_unique<std::atomic<u64>[]>(wordCount);
+            for (sizet i = 0; i < wordCount; ++i)
+            {
+                m_FreePages[i].store(std::numeric_limits<u64>::max(), std::memory_order_relaxed);
+            }
+            // Ghost pages past pageCount in the last word are marked reserved so
+            // the scan can never hand them out.
+            if (pageCount % kWordBits != 0)
+            {
+                const u64 usedBits = pageCount % kWordBits;
+                const u64 ghostMask = ~((1ull << usedBits) - 1);
+                m_FreePages[wordCount - 1].store(~ghostMask, std::memory_order_relaxed);
+            }
+            m_FreePageCount.store(pageCount, std::memory_order_relaxed);
+            return true;
+        }
+
+        void Destroy()
+        {
+            m_Storage.Destroy();
+            m_FreePages.reset();
+            m_FreePageCount.store(0, std::memory_order_relaxed);
+            m_PageSize = 0;
+            m_PageCount = 0;
+        }
+
+        // Write-side pointer to a page's atoms. HostOnly: normal memory.
+        // DeviceMapped: WRITE-only mapped memory — never read through it.
+        [[nodiscard]] Atom* PageData(u32 pageIndex)
+        {
+            OLO_CORE_ASSERT(m_PageSize > 0, "GPUPagedBuffer is directory-only (pageSizeAtoms == 0)");
+            OLO_CORE_ASSERT(pageIndex < m_PageCount, "GPUPagedBuffer page index out of range");
+            return m_Storage.Data() + static_cast<sizet>(pageIndex) * m_PageSize;
+        }
+
+        // Readback of a page's atoms that is safe in every backing (device
+        // round-trip when the storage is DeviceMapped). Test/inspection path.
+        [[nodiscard]] bool ReadbackPage(u32 pageIndex, Atom* out) const
+        {
+            if (m_PageSize == 0 || pageIndex >= m_PageCount)
+            {
+                return false;
+            }
+            return m_Storage.ReadbackRange(static_cast<u32>(static_cast<sizet>(pageIndex) * m_PageSize),
+                                           static_cast<u32>(m_PageSize), out);
+        }
+
+        // Claims as many of `count` free pages as exist, appending them to
+        // outPages. Returns the number claimed — the caller decides whether a
+        // partial claim is progress (eviction makes up the difference) or must
+        // be rolled back.
+        //
+        // LOWEST INDEX FIRST is a documented guarantee, not an accident of the
+        // word scan: consumers rely on it for deterministic layout
+        // (VirtualMeshRegistry's slot assignment reproduces its pre-#704
+        // free-list order because of it), and a test pins it. An optimisation
+        // that reorders the scan is a behaviour change.
+        [[nodiscard]] u32 ReserveUpToPages(u32 count, std::vector<u32>& outPages)
+        {
+            OLO_CORE_ASSERT(m_FreePages != nullptr, "GPUPagedBuffer used before Create");
+
+            // Advisory early-out: a residency cache at budget spends most
+            // frames with zero free pages, and scanning the all-zero bitset
+            // per allocation is pure waste. Exact under the single-writer
+            // usage; concurrent racers merely fall through to the scan.
+            if (count == 0 || m_FreePageCount.load(std::memory_order_relaxed) == 0)
+            {
+                return 0;
+            }
+
+            const sizet wordCount = (m_PageCount + kWordBits - 1) / kWordBits;
+            u32 remaining = count;
+            for (sizet i = 0; i < wordCount && remaining > 0; ++i)
+            {
+                std::atomic<u64>& word = m_FreePages[i];
+                while (remaining > 0)
+                {
+                    u64 old = word.load(std::memory_order_relaxed);
+                    if (old == 0)
+                    {
+                        break;
+                    }
+                    const int bit = std::countr_zero(old);
+                    const u64 mask = 1ull << bit;
+                    const u64 desired = old & ~mask;
+                    if (word.compare_exchange_weak(old, desired, std::memory_order_acq_rel,
+                                                   std::memory_order_relaxed))
+                    {
+                        m_FreePageCount.fetch_sub(1, std::memory_order_relaxed);
+                        outPages.push_back(static_cast<u32>(i * kWordBits + static_cast<sizet>(bit)));
+                        --remaining;
+                    }
+                }
+            }
+            return count - remaining;
+        }
+
+        void FreePage(u32 pageIndex)
+        {
+            OLO_CORE_ASSERT(pageIndex < m_PageCount, "GPUPagedBuffer page index out of range");
+            const u64 mask = 1ull << (pageIndex % kWordBits);
+            std::atomic<u64>& word = m_FreePages[pageIndex / kWordBits];
+            u64 old = word.load(std::memory_order_relaxed);
+            while (true)
+            {
+                OLO_CORE_ASSERT((old & mask) == 0, "GPUPagedBuffer: freeing a page that is already free — "
+                                                   "two chains claim the same page");
+                if (word.compare_exchange_weak(old, old | mask, std::memory_order_release,
+                                               std::memory_order_relaxed))
+                {
+                    m_FreePageCount.fetch_add(1, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        }
+
+        [[nodiscard]] bool IsPageReserved(u32 pageIndex) const
+        {
+            OLO_CORE_ASSERT(pageIndex < m_PageCount, "GPUPagedBuffer page index out of range");
+            const u64 word = m_FreePages[pageIndex / kWordBits].load(std::memory_order_relaxed);
+            return (word & (1ull << (pageIndex % kWordBits))) == 0;
+        }
+
+        void Bind(u32 bindingPoint) const
+        {
+            m_Storage.Bind(bindingPoint);
+        }
+
+        [[nodiscard]] sizet GetPageSize() const
+        {
+            return m_PageSize;
+        }
+        [[nodiscard]] u32 GetPageCount() const
+        {
+            return m_PageCount;
+        }
+        [[nodiscard]] bool IsCreated() const
+        {
+            return m_PageCount != 0;
+        }
+        [[nodiscard]] bool IsDirectoryOnly() const
+        {
+            return m_PageCount != 0 && m_PageSize == 0;
+        }
+        [[nodiscard]] RHI::ResourceHandle GetDeviceHandle() const
+        {
+            return m_Storage.GetDeviceHandle();
+        }
+
+      private:
+        static constexpr sizet kWordBits = 64;
+
+        GPUCacheStorage<Atom> m_Storage;
+        std::unique_ptr<std::atomic<u64>[]> m_FreePages;
+        // Advisory mirror of the bitset's population for the empty fast path;
+        // exact whenever mutation is single-writer.
+        std::atomic<u32> m_FreePageCount{ 0 };
+        sizet m_PageSize = 0;
+        u32 m_PageCount = 0;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedCache.h
+++ b/OloEngine/src/OloEngine/Renderer/GPUCache/GPUPagedCache.h
@@ -1,0 +1,751 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Debug/Instrumentor.h"
+#include "OloEngine/Renderer/GPUCache/GPUCachePolicy.h"
+#include "OloEngine/Renderer/GPUCache/GPUCacheStorage.h"
+#include "OloEngine/Renderer/GPUCache/GPUHashMap.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedBuffer.h"
+
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace OloEngine
+{
+    template<typename Cache>
+    class GPUPagedCacheInspector; // test-only white-box access (tests/Rendering/GPUCacheInspector.h)
+
+    // @brief General GPU-visible paged cache: page-chain allocation over one
+    // large buffer, an open-addressed object directory a compute shader can
+    // probe, and pluggable eviction (issue #704, ported from the VoxelEngine
+    // reference's gpu_cache_allocator.h).
+    //
+    // Objects are variable-sized atom runs stored as CHAINS of fixed-size
+    // pages; the page-node table (singly-linked next indices) and the
+    // object->allocation hash map are both GPU-readable when created with the
+    // HostMirrored backing, so a shader resolves "is object X resident, and
+    // where?" inline — see assets/shaders/include/GPUCacheResolve.glsl.
+    //
+    // Divergences from the reference, all deliberate:
+    //  - Allocation is FALLIBLE. The reference looped `while (short) evict()`
+    //    with no exit, which hangs the render thread the moment the policy has
+    //    no evictable victim (everything pinned/in-use). AllocatePages returns
+    //    false instead and rolls the object back to its pre-call allocation
+    //    (evictions already performed on its behalf stand — they cannot be
+    //    undone).
+    //  - Eviction notifies an optional listener with the victim id, so a
+    //    consumer whose payload lives outside this cache (VirtualMeshRegistry)
+    //    can reclaim its side of the state.
+    //  - MoveObject re-registers the surviving object with the policy and
+    //    Swap exchanges allocation contents while each object KEEPS its own
+    //    policy handle — the reference leaked/aliased policy nodes in both.
+    //  - No ThreadMode parameter: mutation is render-thread-only (matching
+    //    every engine consumer); the underlying bitset/hash-map primitives are
+    //    lock-free regardless.
+    //
+    // Backing:
+    //  - GPUCacheBacking::HostOnly — no rendering device touched at all;
+    //    headless tests and CPU-only directories.
+    //  - GPUCacheBacking::HostMirrored — the directory (hash map + page nodes)
+    //    is mirrored into persistent-mapped device buffers for shader lookup,
+    //    and the atom store (when present) is a DeviceMapped arena.
+    template<typename TObjectID, typename TAtom, template<typename> typename Policy>
+        requires EvictionPolicy<Policy<TObjectID>, TObjectID> && GPUHashMapKey<TObjectID> && GPUSafeStruct<TAtom>
+    class GPUPagedCache
+    {
+      public:
+        using ObjectID = TObjectID;
+        using Atom = TAtom;
+
+        static constexpr u32 kInvalidPage = GPUPagedBuffer<TAtom>::kInvalidPage;
+
+        // GPU-visible page-chain link. kInvalidPage terminates a chain.
+        struct PageNode
+        {
+            u32 m_Next = kInvalidPage;
+        };
+
+        // The hash-map value: where an object's atoms live. The policy handle
+        // rides along so the map is the single source of truth per object.
+        // GPU-visible layout — a shader mirroring this struct must match the
+        // concrete instantiation (Policy handle size included).
+        struct ObjectAllocation
+        {
+            u32 m_TotalElementCount = 0;
+            u32 m_StartPage = kInvalidPage;
+            u32 m_EndPage = kInvalidPage;
+            Policy<TObjectID>::Handle m_PolicyHandle;
+
+            [[nodiscard]] bool IsEmpty() const
+            {
+                return m_StartPage == kInvalidPage;
+            }
+        };
+
+        // Contiguous atom span inside the paged buffer (element units).
+        struct BufferRange
+        {
+            sizet m_StartAtom = 0;
+            sizet m_AtomCount = 0;
+
+            bool operator==(const BufferRange&) const = default;
+        };
+
+        using EvictionListener = std::function<void(const ObjectID&)>;
+
+        GPUPagedCache() = default;
+        ~GPUPagedCache()
+        {
+            Destroy();
+        }
+        GPUPagedCache(const GPUPagedCache&) = delete;
+        GPUPagedCache& operator=(const GPUPagedCache&) = delete;
+
+        // pageSizeAtoms == 0 creates a DIRECTORY-ONLY cache: page chains, hash
+        // map and eviction, but no atom storage — the consumer owns the payload
+        // and maps page indices to its own buffers (VirtualMeshRegistry mode).
+        // AllocateObject / PushBackToObject / ReadObject are unavailable then.
+        [[nodiscard]] bool Create(sizet pageSizeAtoms, u32 pageCount,
+                                  GPUCacheBacking backing = GPUCacheBacking::HostOnly)
+        {
+            OLO_CORE_ASSERT(backing != GPUCacheBacking::DeviceMapped,
+                            "GPUPagedCache backing selects HostOnly or HostMirrored (the atom arena becomes "
+                            "DeviceMapped internally)");
+            // The upper bound keeps every derived capacity (2x map, 4x policy)
+            // inside u32 — and is still absurdly beyond any real cache.
+            if (IsCreated() || pageCount == 0 || pageCount >= kInvalidPage / 4)
+            {
+                return false;
+            }
+
+            const GPUCacheBacking atomBacking =
+                (backing == GPUCacheBacking::HostOnly) ? GPUCacheBacking::HostOnly : GPUCacheBacking::DeviceMapped;
+            if (!m_PagedBuffer.Create(pageSizeAtoms, pageCount, atomBacking))
+            {
+                return false;
+            }
+
+            // MAX_LOAD 0.5, as in the reference: the map is created at twice the
+            // page count (an object occupies at least one page, so live objects
+            // can never exceed half the capacity).
+            if (!m_ObjectPages.Create(pageCount * 2, backing) || !m_PageNodes.Create(pageCount, backing))
+            {
+                Destroy();
+                return false;
+            }
+
+            PageNode* nodes = m_PageNodes.Data();
+            for (u32 i = 0; i < pageCount; ++i)
+            {
+                nodes[i].m_Next = kInvalidPage;
+            }
+            m_PageNodes.MirrorWrite(0, pageCount);
+
+            // Capacity is a reservation hint only — every shipped policy grows
+            // its node storage on demand, and live objects never exceed the
+            // page count (each holds at least one page).
+            m_Policy.emplace(pageCount);
+            return true;
+        }
+
+        void Destroy()
+        {
+            m_ObjectPages.Destroy();
+            m_PageNodes.Destroy();
+            m_PagedBuffer.Destroy();
+            m_Policy.reset();
+        }
+
+        // Reclaim pages under pressure through the policy until `pageCount`
+        // pages back `obj` (appending to any existing chain). On success the
+        // returned allocation is also committed to the directory. On failure
+        // the object keeps exactly its pre-call allocation and false is
+        // returned — never a hang (see class comment).
+        [[nodiscard]] bool AllocatePages(const ObjectID& obj, u32 pageCount, ObjectAllocation& outAlloc)
+        {
+            OLO_PROFILE_FUNCTION();
+            OLO_CORE_ASSERT(pageCount > 0, "GPUPagedCache::AllocatePages of zero pages");
+            OLO_CORE_ASSERT(IsCreated(), "GPUPagedCache used before Create");
+
+            ObjectAllocation alloc;
+            const bool isCached = m_ObjectPages.Find(obj, alloc);
+            const ObjectAllocation before = alloc;
+
+            u32 allocated = TryReservePages(alloc, pageCount);
+            // A Retry outcome consumed a policy entry the directory no longer
+            // knows. The shipped list-based policies never produce one, but a
+            // consumer-supplied policy could keep re-deriving the same unknown
+            // victim — cap consecutive retries so that bug degrades to a loud
+            // failed allocation instead of a render-thread hang (the exact
+            // hang class this method's fallibility exists to eliminate).
+            u32 consecutiveRetries = 0;
+            const u32 maxConsecutiveRetries = m_PagedBuffer.GetPageCount() + 16;
+            while (allocated < pageCount)
+            {
+                u32 taken = 0;
+                const EvictOutcome outcome = EvictAndTakePages(obj, alloc, pageCount - allocated, taken);
+                if (outcome == EvictOutcome::Exhausted ||
+                    (outcome == EvictOutcome::Retry && ++consecutiveRetries > maxConsecutiveRetries))
+                {
+                    if (outcome == EvictOutcome::Retry)
+                    {
+                        OLO_CORE_ERROR("GPUPagedCache: eviction policy kept naming victims the directory "
+                                       "does not hold — failing the allocation instead of spinning");
+                    }
+                    RollBackAppendedPages(alloc, isCached ? &before : nullptr);
+                    return false;
+                }
+                if (outcome == EvictOutcome::Progress)
+                {
+                    consecutiveRetries = 0;
+                }
+                allocated += taken;
+            }
+
+            if (isCached)
+            {
+                m_Policy->OnAccess(alloc.m_PolicyHandle);
+            }
+            else
+            {
+                alloc.m_PolicyHandle = m_Policy->OnInsert(obj);
+            }
+
+            if (!m_ObjectPages.Insert(obj, alloc))
+            {
+                OLO_CORE_ERROR("GPUPagedCache: object directory full — rolling back allocation");
+                if (!isCached)
+                {
+                    m_Policy->OnRemove(alloc.m_PolicyHandle);
+                }
+                RollBackAppendedPages(alloc, isCached ? &before : nullptr);
+                return false;
+            }
+
+            outAlloc = alloc;
+            return true;
+        }
+
+        // Replaces the object's contents with `count` atoms (freeing any prior
+        // allocation first, as the reference does). count == 0 still allocates
+        // one page so the object exists. Returns false when the pages could not
+        // be reclaimed — the object is then absent from the cache.
+        [[nodiscard]] bool AllocateObject(const ObjectID& obj, const Atom* data, sizet count)
+        {
+            OLO_CORE_ASSERT(!m_PagedBuffer.IsDirectoryOnly(),
+                            "GPUPagedCache is directory-only — the consumer owns the payload");
+            if (m_PagedBuffer.IsDirectoryOnly())
+            {
+                return false; // Release: refuse rather than write through a null atom store
+            }
+            DeallocateObject(obj);
+
+            ObjectAllocation alloc;
+            if (count == 0)
+            {
+                return AllocatePages(obj, 1, alloc);
+            }
+
+            const sizet pageSize = m_PagedBuffer.GetPageSize();
+            const auto pagesNeeded = static_cast<u32>((count + pageSize - 1) / pageSize);
+            if (!AllocatePages(obj, pagesNeeded, alloc))
+            {
+                return false;
+            }
+
+            u32 current = alloc.m_StartPage;
+            sizet remaining = count;
+            sizet srcIndex = 0;
+            while (current != kInvalidPage && remaining > 0)
+            {
+                const sizet copyCount = std::min(remaining, pageSize);
+                std::memcpy(m_PagedBuffer.PageData(current), data + srcIndex, copyCount * sizeof(Atom));
+                srcIndex += copyCount;
+                remaining -= copyCount;
+                current = m_PageNodes.Data()[current].m_Next;
+            }
+
+            [[maybe_unused]] const bool updated =
+                m_ObjectPages.Mutate(obj, [count](ObjectAllocation& stored)
+                                     { stored.m_TotalElementCount = static_cast<u32>(count); });
+            OLO_CORE_ASSERT(updated, "GPUPagedCache: updating a just-inserted key cannot fail");
+            return true;
+        }
+
+        // Appends one atom, allocating a page when the current chain is full.
+        // Returns false when a needed page could not be reclaimed.
+        [[nodiscard]] bool PushBackToObject(const ObjectID& obj, const Atom& data)
+        {
+            OLO_PROFILE_FUNCTION();
+            OLO_CORE_ASSERT(!m_PagedBuffer.IsDirectoryOnly(),
+                            "GPUPagedCache is directory-only — the consumer owns the payload");
+            if (m_PagedBuffer.IsDirectoryOnly())
+            {
+                return false; // Release: refuse rather than write through a null atom store
+            }
+
+            ObjectAllocation alloc;
+            if (!m_ObjectPages.Find(obj, alloc) && !AllocatePages(obj, 1, alloc))
+            {
+                return false;
+            }
+
+            const sizet pageSize = m_PagedBuffer.GetPageSize();
+            const auto pageIndex = static_cast<u32>(alloc.m_TotalElementCount / pageSize);
+            const sizet pageElemOffset = alloc.m_TotalElementCount % pageSize;
+
+            if (pageIndex >= CountAllocatedPages(alloc) && !AllocatePages(obj, 1, alloc))
+            {
+                return false;
+            }
+
+            // The write lands in the chain page at ordinal `pageIndex` — NOT
+            // necessarily the end page: after ClearObject the element count
+            // rewinds while the chain keeps its pages, so the reference's
+            // "write to endPage" put post-clear appends in the wrong page.
+            const u32 targetPage = ChainPageAt(alloc, pageIndex);
+            OLO_CORE_ASSERT(targetPage != kInvalidPage, "GPUPagedCache: chain shorter than its element count");
+            m_PagedBuffer.PageData(targetPage)[pageElemOffset] = data;
+
+            const bool updated = m_ObjectPages.Mutate(obj,
+                                                      [this](ObjectAllocation& stored)
+                                                      {
+                                                          ++stored.m_TotalElementCount;
+                                                          m_Policy->OnAccess(stored.m_PolicyHandle);
+                                                      });
+            OLO_CORE_ASSERT(updated, "GPUPagedCache: updating a present key cannot fail");
+            return updated;
+        }
+
+        // Renames src to dst. An existing dst is overwritten (its chain freed,
+        // its policy node removed). The surviving object is re-registered with
+        // the policy under its new identity — FIFO's handle carries the id, so
+        // keeping the old node (as the reference did) would leave the object
+        // unevictable.
+        void MoveObject(const ObjectID& src, const ObjectID& dst)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            if (src == dst)
+            {
+                // Without this, the dst-exists branch below would free the
+                // object's own live chain and OnRemove its policy node twice.
+                return;
+            }
+
+            ObjectAllocation srcAlloc;
+            if (!m_ObjectPages.Find(src, srcAlloc))
+            {
+                OLO_CORE_WARN("GPUPagedCache: MoveObject source not found");
+                return;
+            }
+            if (ObjectAllocation dstAlloc; m_ObjectPages.Find(dst, dstAlloc))
+            {
+                FreeChain(dstAlloc.m_StartPage);
+                m_Policy->OnRemove(dstAlloc.m_PolicyHandle);
+            }
+
+            m_Policy->OnRemove(srcAlloc.m_PolicyHandle);
+            srcAlloc.m_PolicyHandle = m_Policy->OnInsert(dst);
+
+            [[maybe_unused]] const bool inserted = m_ObjectPages.Insert(dst, srcAlloc);
+            OLO_CORE_ASSERT(inserted, "GPUPagedCache: object directory full during MoveObject");
+            m_ObjectPages.Erase(src);
+            MaintainDirectory();
+        }
+
+        // Exchanges the two objects' allocation CONTENTS. Each object keeps its
+        // own policy handle — handles are bound to object identity, and the
+        // identities don't move here, only the data does.
+        void Swap(const ObjectID& obj1, const ObjectID& obj2)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            if (obj1 == obj2)
+            {
+                return;
+            }
+            ObjectAllocation alloc1;
+            ObjectAllocation alloc2;
+            if (!m_ObjectPages.Find(obj1, alloc1) || !m_ObjectPages.Find(obj2, alloc2))
+            {
+                OLO_CORE_WARN("GPUPagedCache: Swap with a missing object");
+                return;
+            }
+
+            // Exchange contents in place; each object keeps its own policy
+            // handle (handles are bound to identity, and identities stay put).
+            auto writeContents = [this](const ObjectAllocation& from)
+            {
+                return [this, &from](ObjectAllocation& stored)
+                {
+                    stored.m_TotalElementCount = from.m_TotalElementCount;
+                    stored.m_StartPage = from.m_StartPage;
+                    stored.m_EndPage = from.m_EndPage;
+                    m_Policy->OnAccess(stored.m_PolicyHandle);
+                };
+            };
+            [[maybe_unused]] bool updated = m_ObjectPages.Mutate(obj1, writeContents(alloc2));
+            updated = m_ObjectPages.Mutate(obj2, writeContents(alloc1)) && updated;
+            OLO_CORE_ASSERT(updated, "GPUPagedCache: updating present keys cannot fail");
+        }
+
+        void DeallocateObject(const ObjectID& obj)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            ObjectAllocation alloc;
+            if (!m_ObjectPages.Find(obj, alloc))
+            {
+                return;
+            }
+            FreeChain(alloc.m_StartPage);
+            m_Policy->OnRemove(alloc.m_PolicyHandle);
+            m_ObjectPages.Erase(obj);
+            MaintainDirectory();
+        }
+
+        // Rewinds the element count to zero; the chain keeps its pages.
+        void ClearObject(const ObjectID& obj)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            [[maybe_unused]] const bool updated = m_ObjectPages.Mutate(obj,
+                                                                       [this](ObjectAllocation& stored)
+                                                                       {
+                                                                           stored.m_TotalElementCount = 0;
+                                                                           m_Policy->OnAccess(stored.m_PolicyHandle);
+                                                                       });
+            // Clearing a non-existing object is a no-op, as in the reference.
+        }
+
+        // The object's atoms as contiguous spans of the paged buffer, in
+        // ascending address order (element units). Chain pages are full except
+        // the one holding the data tail, so a range never spans the garbage
+        // beyond the tail — a partially-used page always ends its range.
+        [[nodiscard]] std::vector<BufferRange> GetObjectBufferRanges(const ObjectID& obj)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            std::vector<BufferRange> result;
+            ObjectAllocation alloc;
+            const bool found = m_ObjectPages.Mutate(obj,
+                                                    [this, &alloc](ObjectAllocation& stored)
+                                                    {
+                                                        m_Policy->OnAccess(stored.m_PolicyHandle);
+                                                        alloc = stored;
+                                                    });
+            if (!found)
+            {
+                return result;
+            }
+
+            const sizet pageSize = m_PagedBuffer.GetPageSize();
+            if (pageSize == 0 || alloc.m_TotalElementCount == 0 || alloc.IsEmpty())
+            {
+                return result;
+            }
+
+            // (page index, atoms used) per chain page, in CHAIN order — every
+            // page full except the last one data reaches.
+            std::vector<std::pair<u32, sizet>> usedPages;
+            sizet remaining = alloc.m_TotalElementCount;
+            for (u32 current = alloc.m_StartPage; current != kInvalidPage && remaining > 0;
+                 current = m_PageNodes.Data()[current].m_Next)
+            {
+                const sizet used = std::min(remaining, pageSize);
+                usedPages.emplace_back(current, used);
+                remaining -= used;
+            }
+
+            std::ranges::sort(usedPages);
+            for (sizet i = 0; i < usedPages.size();)
+            {
+                const sizet rangeStartAtom = static_cast<sizet>(usedPages[i].first) * pageSize;
+                sizet rangeAtoms = 0;
+                // Extend while pages are address-adjacent AND the previous page
+                // was completely full (a partial page ends the readable run).
+                sizet j = i;
+                while (true)
+                {
+                    rangeAtoms += usedPages[j].second;
+                    const bool partial = usedPages[j].second < pageSize;
+                    ++j;
+                    if (partial || j >= usedPages.size() || usedPages[j].first != usedPages[j - 1].first + 1)
+                    {
+                        break;
+                    }
+                }
+                result.push_back({ rangeStartAtom, rangeAtoms });
+                i = j;
+            }
+            return result;
+        }
+
+        [[nodiscard]] bool Has(const ObjectID& obj) const
+        {
+            return m_ObjectPages.Contains(obj);
+        }
+
+        [[nodiscard]] bool Find(const ObjectID& obj, ObjectAllocation& out) const
+        {
+            return m_ObjectPages.Find(obj, out);
+        }
+
+        // Fires whenever the POLICY reclaims a victim under memory pressure
+        // (never for explicit DeallocateObject/MoveObject calls) — the hook an
+        // external-payload consumer uses to drop its side of the object. The
+        // listener runs mid-allocation and must NOT call back into this cache.
+        void SetEvictionListener(EvictionListener listener)
+        {
+            m_EvictionListener = std::move(listener);
+        }
+
+        // Access for consumers whose policy needs configuration beyond its
+        // capacity constructor (e.g. a context pointer).
+        [[nodiscard]] Policy<TObjectID>& GetPolicy()
+        {
+            OLO_CORE_ASSERT(m_Policy.has_value(), "GPUPagedCache used before Create");
+            return *m_Policy;
+        }
+
+        void BindAtomData(u32 bindingPoint) const
+        {
+            m_PagedBuffer.Bind(bindingPoint);
+        }
+        void BindLookup(u32 hashMapBinding, u32 pageNodesBinding) const
+        {
+            m_ObjectPages.Bind(hashMapBinding);
+            m_PageNodes.Bind(pageNodesBinding);
+        }
+
+        [[nodiscard]] bool IsCreated() const
+        {
+            return m_PagedBuffer.IsCreated();
+        }
+        [[nodiscard]] sizet GetPageSize() const
+        {
+            return m_PagedBuffer.GetPageSize();
+        }
+        [[nodiscard]] u32 GetPageCount() const
+        {
+            return m_PagedBuffer.GetPageCount();
+        }
+
+      private:
+        template<typename Cache>
+        friend class GPUPagedCacheInspector; // validation, debugging and unit tests
+
+        enum class EvictOutcome : u8
+        {
+            Progress,  // pages were taken from a victim
+            Retry,     // a stale policy entry was consumed; ask again
+            Exhausted, // the policy has nothing evictable — allocation fails
+        };
+
+        void SetNodeNext(u32 page, u32 next)
+        {
+            m_PageNodes.Data()[page].m_Next = next;
+            m_PageNodes.MirrorWrite(page, 1);
+        }
+
+        // Claims whatever free pages exist (no eviction) and appends them to
+        // the chain; eviction makes up any shortfall in the caller's loop.
+        // Greedy on purpose: an all-or-nothing reserve would leave free pages
+        // idle while a victim is evicted for the whole request.
+        [[nodiscard]] u32 TryReservePages(ObjectAllocation& alloc, u32 pageCount)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            // Member scratch: the pre-#704 free list allocated nothing per
+            // page load, so this path shouldn't either. Safe because cache
+            // mutation is single-writer and the eviction listener is forbidden
+            // from re-entering the cache.
+            m_ScratchPages.clear();
+            const u32 reserved = m_PagedBuffer.ReserveUpToPages(pageCount, m_ScratchPages);
+            AppendChain(alloc, m_ScratchPages);
+            return reserved;
+        }
+
+        void AppendChain(ObjectAllocation& alloc, const std::vector<u32>& pages)
+        {
+            if (pages.empty())
+            {
+                return;
+            }
+            if (alloc.IsEmpty())
+            {
+                alloc.m_StartPage = pages.front();
+            }
+            else
+            {
+                SetNodeNext(alloc.m_EndPage, pages.front());
+            }
+            const sizet pageCount = pages.size();
+            for (sizet i = 0; i + 1 < pageCount; ++i)
+            {
+                SetNodeNext(pages[i], pages[i + 1]);
+            }
+            SetNodeNext(pages.back(), kInvalidPage);
+            alloc.m_EndPage = pages.back();
+        }
+
+        [[nodiscard]] EvictOutcome EvictAndTakePages(const ObjectID& obj, ObjectAllocation& targetAlloc,
+                                                     u32 pagesNeeded, u32& outTaken)
+        {
+            OLO_PROFILE_FUNCTION();
+
+            outTaken = 0;
+            ObjectID victimID{};
+            if (!m_Policy->TrySelectVictim(obj, victimID))
+            {
+                return EvictOutcome::Exhausted;
+            }
+
+            ObjectAllocation victimAlloc;
+            if (!m_ObjectPages.Find(victimID, victimAlloc))
+            {
+                // The policy named an object the directory no longer holds.
+                // None of the shipped list-based policies can produce this
+                // (OnRemove unlinks eagerly), but a consumer-supplied policy
+                // might — the caller bounds consecutive retries.
+                return EvictOutcome::Retry;
+            }
+
+            const u32 victimPages = CountAllocatedPages(victimAlloc);
+            const u32 pagesToTake = std::min(victimPages, pagesNeeded);
+            if (pagesToTake == 0)
+            {
+                // A cached object with no pages cannot arise today, but a
+                // zero-take must not report Progress or the caller spins.
+                m_Policy->OnRemove(victimAlloc.m_PolicyHandle);
+                m_ObjectPages.Erase(victimID);
+                NotifyEviction(victimID);
+                return EvictOutcome::Retry;
+            }
+
+            // Split the victim's chain: the first pagesToTake pages transfer to
+            // the requester, the remainder is freed outright.
+            u32 current = victimAlloc.m_StartPage;
+            u32 prev = kInvalidPage;
+            for (u32 i = 0; i < pagesToTake; ++i)
+            {
+                prev = current;
+                current = m_PageNodes.Data()[current].m_Next;
+            }
+            const u32 takeStart = victimAlloc.m_StartPage;
+            const u32 takeEnd = prev;
+            const u32 remainingStart = current;
+            SetNodeNext(takeEnd, kInvalidPage);
+
+            AttachPages(targetAlloc, takeStart, takeEnd);
+            FreeChain(remainingStart);
+
+            m_Policy->OnRemove(victimAlloc.m_PolicyHandle);
+            m_ObjectPages.Erase(victimID);
+            MaintainDirectory();
+            NotifyEviction(victimID);
+
+            outTaken = pagesToTake;
+            return EvictOutcome::Progress;
+        }
+
+        // Every Erase mints a tombstone, and tombstones are what turn misses
+        // into full-table scans over time (see GPUHashMap::NeedsCompaction).
+        // The cache is the single-writer context the map's compaction demands,
+        // so it amortises the rebuild across its own erase sites.
+        void MaintainDirectory()
+        {
+            if (m_ObjectPages.NeedsCompaction())
+            {
+                m_ObjectPages.CompactTombstones();
+            }
+        }
+
+        // Attach an already-linked chain segment [start, end] to the target.
+        void AttachPages(ObjectAllocation& target, u32 start, u32 end)
+        {
+            OLO_CORE_ASSERT(end != kInvalidPage, "GPUPagedCache: attaching an empty segment");
+            if (target.IsEmpty())
+            {
+                target.m_StartPage = start;
+            }
+            else
+            {
+                SetNodeNext(target.m_EndPage, start);
+            }
+            target.m_EndPage = end;
+            SetNodeNext(end, kInvalidPage);
+        }
+
+        // Frees every page from `startPage` to the chain end, resetting links.
+        void FreeChain(u32 startPage)
+        {
+            u32 current = startPage;
+            while (current != kInvalidPage)
+            {
+                const u32 next = m_PageNodes.Data()[current].m_Next;
+                SetNodeNext(current, kInvalidPage);
+                m_PagedBuffer.FreePage(current);
+                current = next;
+            }
+        }
+
+        // Undo the pages AllocatePages appended past the pre-call allocation.
+        // `before` is null when the object had no allocation at all.
+        void RollBackAppendedPages(ObjectAllocation& alloc, const ObjectAllocation* before)
+        {
+            if (before == nullptr || before->IsEmpty())
+            {
+                FreeChain(alloc.m_StartPage);
+                alloc = (before != nullptr) ? *before : ObjectAllocation{};
+                return;
+            }
+            const u32 appendedStart = m_PageNodes.Data()[before->m_EndPage].m_Next;
+            FreeChain(appendedStart);
+            SetNodeNext(before->m_EndPage, kInvalidPage);
+            alloc = *before;
+        }
+
+        [[nodiscard]] u32 CountAllocatedPages(const ObjectAllocation& alloc) const
+        {
+            u32 count = 0;
+            for (u32 current = alloc.m_StartPage; current != kInvalidPage;
+                 current = m_PageNodes.Data()[current].m_Next)
+            {
+                ++count;
+            }
+            return count;
+        }
+
+        // The chain page at ordinal `index` (0 = start page).
+        [[nodiscard]] u32 ChainPageAt(const ObjectAllocation& alloc, u32 index) const
+        {
+            u32 current = alloc.m_StartPage;
+            for (u32 i = 0; i < index && current != kInvalidPage; ++i)
+            {
+                current = m_PageNodes.Data()[current].m_Next;
+            }
+            return current;
+        }
+
+        void NotifyEviction(const ObjectID& victim)
+        {
+            if (m_EvictionListener)
+            {
+                m_EvictionListener(victim);
+            }
+        }
+
+        std::optional<Policy<TObjectID>> m_Policy;
+        GPUHashMap<TObjectID, ObjectAllocation> m_ObjectPages;
+        GPUCacheStorage<PageNode> m_PageNodes;
+        GPUPagedBuffer<TAtom> m_PagedBuffer;
+        EvictionListener m_EvictionListener;
+        std::vector<u32> m_ScratchPages; // TryReservePages scratch (single-writer)
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.cpp
@@ -171,35 +171,30 @@ namespace OloEngine
         }
     }
 
-    bool VirtualMeshRegistry::CopyThroughRing(RHI::ResourceHandle targetBuffer, u64 targetOffset,
+    void VirtualMeshRegistry::CopyThroughRing(RHI::ResourceHandle targetBuffer, u64 targetOffset,
                                               const void* payload, u64 bytes)
     {
         if (bytes == 0)
         {
-            return true;
+            return;
         }
-        if (m_RingPtr == nullptr || bytes > m_RingSize)
+
+        // Reserve waits out only the fences still covering the reused range
+        // (GPUCircularBuffer, #704) — the old hand-rolled ring stalled the
+        // whole device on wrap. nullptr means the payload exceeds the ring (or
+        // the ring never mapped): direct upload.
+        u64 ringOffset = 0;
+        u8* dst = m_UploadRing.IsCreated() ? m_UploadRing.Reserve(bytes, ringOffset) : nullptr;
+        if (dst == nullptr)
         {
-            // Payload larger than the ring (pathological page size): direct upload.
             RenderCommand::UploadBufferSubData(targetBuffer, targetOffset, bytes, payload);
-            return true;
+            return;
         }
 
-        if (m_RingHead + bytes > m_RingSize)
-        {
-            // Wrap. The ring is written strictly before the GPU consumes the
-            // copies this frame (copies are enqueued immediately after the
-            // memcpy), so a wrap only conflicts with copies still in flight
-            // from EARLIER offsets this frame — wait them out. Rare at the
-            // 8 MB ring size vs the per-frame upload cap.
-            RenderCommand::WaitForDeviceIdle();
-            m_RingHead = 0;
-        }
-
-        std::memcpy(m_RingPtr + m_RingHead, payload, bytes);
-        RenderCommand::CopyBufferSubData(m_RingBuffer, targetBuffer, m_RingHead, targetOffset, bytes);
-        m_RingHead += bytes;
-        return true;
+        std::memcpy(dst, payload, bytes);
+        RenderCommand::CopyBufferSubData(m_UploadRing.GetDeviceHandle(), targetBuffer, ringOffset, targetOffset,
+                                         bytes);
+        m_UploadRing.Commit(bytes);
     }
 
     bool VirtualMeshRegistry::LoadPage(u32 pageIndex)
@@ -210,34 +205,18 @@ namespace OloEngine
             return true;
         }
 
-        // Allocate a slot: free list first, then LRU eviction of a non-pinned
-        // resident page that was not touched this frame.
-        if (m_FreeSlots.empty())
+        // Allocate a slot through the shared paged-cache substrate (#704):
+        // free slot first, else the policy delegates back to
+        // SelectResidencyVictim (the exact pre-#704 LRU scan) and the victim's
+        // slot transfers to this page — OnResidencyEvicted does the victim's
+        // bookkeeping via the eviction listener. Failure means the budget is
+        // exhausted by pinned/in-use pages; the coarser cut keeps rendering.
+        SlotCache::ObjectAllocation slotAlloc;
+        if (!m_SlotCache.AllocatePages(static_cast<u64>(pageIndex), 1, slotAlloc))
         {
-            u32 victim = kNoSlot;
-            u64 oldestUse = ~0ull;
-            for (u32 p = 0; p < m_Pages.size(); ++p)
-            {
-                const PageRuntime& candidate = m_Pages[p];
-                if (!candidate.Resident || candidate.Pinned || candidate.LastUsedFrame >= m_FrameCounter)
-                {
-                    continue;
-                }
-                if (candidate.LastUsedFrame < oldestUse)
-                {
-                    oldestUse = candidate.LastUsedFrame;
-                    victim = p;
-                }
-            }
-            if (victim == kNoSlot)
-            {
-                return false; // budget exhausted by pinned/in-use pages — the coarser cut keeps rendering
-            }
-            EvictPage(victim);
+            return false;
         }
-
-        u32 const slot = m_FreeSlots.back();
-        m_FreeSlots.pop_back();
+        u32 const slot = slotAlloc.m_StartPage;
 
         const MeshEntry& entry = m_Entries[page.MeshEntryIndex];
         const VirtualMeshGpuData& packed = entry.Packed;
@@ -275,19 +254,47 @@ namespace OloEngine
         return true;
     }
 
-    void VirtualMeshRegistry::EvictPage(u32 pageIndex)
+    void VirtualMeshRegistry::OnResidencyEvicted(u32 pageIndex)
     {
+        // The slot itself has already been reclaimed by the cache (transferred
+        // to the requesting page); this is only the registry-side bookkeeping.
         PageRuntime& page = m_Pages[pageIndex];
         if (!page.Resident)
         {
             return;
         }
-        m_FreeSlots.push_back(page.SlotIndex);
         page.SlotIndex = kNoSlot;
         page.Resident = false;
         m_GroupStatesCpu[page.PooledGroup] &= ~kStateResident;
         ++m_ResidencyStats.PageEvictions;
         --m_ResidencyStats.ResidentPages;
+    }
+
+    bool VirtualMeshRegistry::SelectResidencyVictim(u64 excludePage, u64& outPage) const
+    {
+        u32 victim = kNoSlot;
+        u64 oldestUse = ~0ull;
+        auto const pageCount = static_cast<u32>(m_Pages.size());
+        for (u32 p = 0; p < pageCount; ++p)
+        {
+            const PageRuntime& candidate = m_Pages[p];
+            if (p == excludePage || !candidate.Resident || candidate.Pinned ||
+                candidate.LastUsedFrame >= m_FrameCounter)
+            {
+                continue;
+            }
+            if (candidate.LastUsedFrame < oldestUse)
+            {
+                oldestUse = candidate.LastUsedFrame;
+                victim = p;
+            }
+        }
+        if (victim == kNoSlot)
+        {
+            return false;
+        }
+        outPage = victim;
+        return true;
     }
 
     void VirtualMeshRegistry::RebuildPools()
@@ -298,7 +305,7 @@ namespace OloEngine
         m_PooledClusters.clear();
         m_Pages.clear();
         m_PageOfPooledGroup.clear();
-        m_FreeSlots.clear();
+        m_SlotCache.Destroy();
         m_ResidencyStats = {};
 
         u32 maxPageVertices = 0;
@@ -373,10 +380,20 @@ namespace OloEngine
         m_ResidencyStats.PinnedPages = pinnedPages;
         m_ResidencyStats.BudgetSlots = slotCount;
 
-        m_FreeSlots.resize(slotCount);
-        for (u32 s = 0; s < slotCount; ++s)
+        // The slot arena's residency directory (#704). Directory-only (no atom
+        // storage — the payload arenas are below) and HostOnly (no shader reads
+        // it). The substrate hands out free slots lowest-index-first, matching
+        // the ascending order the old hand-rolled free list produced. A zero
+        // page count (a registered mesh set with no streamable pages) leaves
+        // the cache uncreated — LoadPage is unreachable then.
+        if (slotCount > 0)
         {
-            m_FreeSlots[s] = slotCount - 1 - s; // pop from the back -> ascending slot order
+            bool const cacheCreated = m_SlotCache.Create(0, slotCount, GPUCacheBacking::HostOnly);
+            OLO_CORE_ASSERT(cacheCreated, "VirtualMeshRegistry: slot cache creation cannot fail host-side");
+            m_SlotCache.GetPolicy().SetVictimSelector([this](u64 excludePage, u64& outPage)
+                                                      { return SelectResidencyVictim(excludePage, outPage); });
+            m_SlotCache.SetEvictionListener([this](const u64& victimPage)
+                                            { OnResidencyEvicted(static_cast<u32>(victimPage)); });
         }
 
         auto uploadPool = [](Ref<StorageBuffer>& buffer, u32 binding, const void* dataPtr, sizet bytes)
@@ -424,14 +441,12 @@ namespace OloEngine
         }
         RenderCommand::SetVertexArrayIndexBuffer(m_Vao, m_IndexBuffer);
 
-        // Persistent-mapped upload ring
-        if (!m_RingBuffer.IsValid())
+        // Persistent-mapped upload ring (fence-locked, #704). A failed create
+        // (no device / mapping failure) degrades to direct uploads inside
+        // CopyThroughRing, exactly as the old null-m_RingPtr path did.
+        if (!m_UploadRing.IsCreated())
         {
-            m_RingBuffer = RenderCommand::CreateBufferHandle();
-            m_RingPtr = static_cast<u8*>(
-                RenderCommand::AllocatePersistentUploadStorage(m_RingBuffer, kUploadRingBytes));
-            m_RingSize = (m_RingPtr != nullptr) ? kUploadRingBytes : 0;
-            m_RingHead = 0;
+            [[maybe_unused]] bool const ringCreated = m_UploadRing.Create(kUploadRingBytes);
         }
 
         // Residency reset: nothing resident, then load pinned pages (always) and
@@ -909,18 +924,7 @@ namespace OloEngine
             m_ArgsReadback = RHI::NullResource;
             m_ArgsReadbackBytes = 0;
         }
-        if (m_RingBuffer.IsValid())
-        {
-            if (m_RingPtr != nullptr)
-            {
-                RenderCommand::UnmapBuffer(m_RingBuffer);
-                m_RingPtr = nullptr;
-            }
-            RenderCommand::DeleteBuffer(m_RingBuffer);
-            m_RingBuffer = RHI::NullResource;
-            m_RingSize = 0;
-            m_RingHead = 0;
-        }
+        m_UploadRing.Destroy();
         if (m_Vao.IsValid())
         {
             RenderCommand::DeleteVertexArray(m_Vao);
@@ -952,7 +956,7 @@ namespace OloEngine
         m_PageOfPooledGroup.clear();
         m_PooledClusters.clear();
         m_GroupStatesCpu.clear();
-        m_FreeSlots.clear();
+        m_SlotCache.Destroy();
         m_ResidencyStats = {};
         m_FrameCounter = 0;
         m_PoolsDirty = false;

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
@@ -4,6 +4,8 @@
 #include "OloEngine/Asset/Asset.h"
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/GPUCache/GPUCircularBuffer.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedCache.h"
 #include "OloEngine/Renderer/VirtualGeometry/VirtualMesh.h"
 #include "OloEngine/Renderer/VirtualGeometry/VirtualMeshGpuData.h"
 
@@ -12,6 +14,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -20,6 +23,49 @@ namespace OloEngine
 {
     class MeshSource;
     class StorageBuffer;
+
+    // @brief Eviction policy adapter that lets VirtualMeshRegistry keep its
+    // exact residency semantics (pinning, touched-this-frame protection,
+    // frame-stamped LRU with lowest-page-index tie-break) while the slot
+    // arena itself is managed by the shared GPUPagedCache substrate (#704).
+    // The registry owns the page metadata the decision needs, so victim
+    // selection is delegated back to it through m_SelectVictim; the per-object
+    // bookkeeping hooks are no-ops because the registry stamps LastUsedFrame
+    // itself in LoadPage/ProcessResidency.
+    template<typename ObjectID>
+    class VirtualPageEvictionPolicy
+    {
+      public:
+        struct Handle
+        {
+        };
+
+        explicit VirtualPageEvictionPolicy(u32 /*capacity*/) {}
+
+        void SetVictimSelector(std::function<bool(ObjectID, ObjectID&)> selector)
+        {
+            m_SelectVictim = std::move(selector);
+        }
+
+        void OnAccess(Handle&) noexcept {}
+        [[nodiscard]] Handle OnInsert(const ObjectID&) noexcept
+        {
+            return {};
+        }
+        void OnRemove(Handle&) noexcept {}
+
+        [[nodiscard]] bool TrySelectVictim(const ObjectID& exclude, ObjectID& outVictim) noexcept
+        {
+            // An unwired selector would silently pin the cache at its current
+            // contents (every allocation under pressure fails, geometry stays
+            // at the coarse cut with no error anywhere) — fail loudly instead.
+            OLO_CORE_ASSERT(m_SelectVictim, "VirtualPageEvictionPolicy used before SetVictimSelector");
+            return m_SelectVictim && m_SelectVictim(exclude, outVictim);
+        }
+
+      private:
+        std::function<bool(ObjectID, ObjectID&)> m_SelectVictim;
+    };
 
     // Debug / test routing control for the compute software rasterizer.
     enum class VirtualSwRasterMode : u8
@@ -366,6 +412,12 @@ namespace OloEngine
 
         static constexpr u32 kNoSlot = 0xFFFFFFFFu;
 
+        // The slot-arena residency directory type (#704): objects are pooled
+        // page indices, each holding exactly one substrate page (= one slot of
+        // the uniform vertex/index arenas). The Atom type is irrelevant — the
+        // cache runs directory-only; payloads live in the arenas.
+        using SlotCache = GPUPagedCache<u64, u8, VirtualPageEvictionPolicy>;
+
         // Runtime state of one streamable page (pooled numbering).
         struct PageRuntime
         {
@@ -382,9 +434,19 @@ namespace OloEngine
         void RebuildPools();
         void EnsureFrameBuffers();
         bool LoadPage(u32 pageIndex);
-        void EvictPage(u32 pageIndex);
-        [[nodiscard]] bool CopyThroughRing(RHI::ResourceHandle targetBuffer, u64 targetOffset,
-                                           const void* payload, u64 bytes);
+        // Bookkeeping when the slot cache's policy reclaims a page's slot under
+        // budget pressure (the GPUPagedCache eviction listener — issue #704).
+        void OnResidencyEvicted(u32 pageIndex);
+        // The exact pre-#704 LRU victim scan, now invoked THROUGH the slot
+        // cache's policy: resident, not pinned, not touched this frame (or
+        // loaded this frame), oldest LastUsedFrame wins, lowest page index
+        // breaks ties.
+        [[nodiscard]] bool SelectResidencyVictim(u64 excludePage, u64& outPage) const;
+        // Stages `payload` through the fence-locked upload ring into the target
+        // buffer, degrading to a direct upload when the ring is unavailable or
+        // too small — every path succeeds, hence no result.
+        void CopyThroughRing(RHI::ResourceHandle targetBuffer, u64 targetOffset,
+                             const void* payload, u64 bytes);
 
         std::unordered_map<AssetHandle, MeshParts> m_EntryLookup;
         std::vector<MeshEntry> m_Entries; // stable order => deterministic pool layout
@@ -414,7 +476,13 @@ namespace OloEngine
         std::vector<u32> m_PageOfPooledGroup;                  // pooled group -> page index
         std::vector<VirtualClusterGpuRecord> m_PooledClusters; // CPU mirror, mesh-local bases
         std::vector<u32> m_GroupStatesCpu;
-        std::vector<u32> m_FreeSlots;
+        // Slot-arena residency directory (#704): one GPUPagedCache "page" per
+        // slot, one single-page object per RESIDENT VirtualMeshRegistry page
+        // (keyed by pooled page index). Directory-only + HostOnly: the payload
+        // stays in the device-local vertex/index arenas below, and no shader
+        // consults this map (the cull reads SSBO_VIRTUAL_GROUP_STATES), so no
+        // GPU mirror is paid for.
+        SlotCache m_SlotCache;
         u32 m_SlotVertexCapacity = 0;
         u32 m_SlotIndexCapacity = 0;
         u32 m_SlotCount = 0;
@@ -423,11 +491,11 @@ namespace OloEngine
         u64 m_FrameCounter = 0;
         VirtualResidencyStats m_ResidencyStats;
 
-        // Persistent-mapped upload ring (CPU staging -> arena copies)
-        RHI::ResourceHandle m_RingBuffer{};
-        u8* m_RingPtr = nullptr;
-        u64 m_RingSize = 0;
-        u64 m_RingHead = 0;
+        // Persistent-mapped upload ring (CPU staging -> arena copies). The
+        // substrate's fence-locked ring (#704): a wrap now waits only on the
+        // fences still covering the reused range, where the old hand-rolled
+        // ring stalled the whole device (WaitForDeviceIdle).
+        GPUCircularBuffer m_UploadRing;
 
         // Per-frame buffers (grow-only)
         Ref<StorageBuffer> m_InstanceBuffer; // SSBO_VIRTUAL_INSTANCES

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
@@ -17,6 +17,7 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace OloEngine

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -147,6 +147,9 @@ add_executable(OloEngine-Tests
 		Rendering/GPUFrustumCullParityTest.cpp
 		Rendering/GPUPrefixSumTest.cpp
 		Rendering/GPUPrefixSumPerfProbe.cpp
+		Rendering/GPUHashMapTest.cpp
+		Rendering/GPUPagedCacheTest.cpp
+		Rendering/GPUCacheShaderResolveTest.cpp
 		Rendering/GPUParticleCompactionTest.cpp
 		Rendering/ShaderDebugDrawContractTest.cpp
 		Rendering/ShaderDebugDrawExpansionTest.cpp

--- a/OloEngine/tests/Rendering/GPUCacheInspector.h
+++ b/OloEngine/tests/Rendering/GPUCacheInspector.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// White-box access to GPUPagedCache internals for validation, debugging and
+// unit tests (issue #704 — port of the VoxelEngine reference's
+// Tests/Helpers/gpu_cache_inspector.h). Test helper only; the friend
+// declaration lives in GPUPagedCache.h.
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedCache.h"
+
+#include <vector>
+
+namespace OloEngine
+{
+    template<typename Cache>
+    class GPUPagedCacheInspector
+    {
+      public:
+        using ObjectID = typename Cache::ObjectID;
+        using Atom = typename Cache::Atom;
+        using ObjectAllocation = typename Cache::ObjectAllocation;
+
+        // The object's atoms in CHAIN order — the order AllocateObject wrote
+        // them. Uses the backing-safe readback path, so it works against a
+        // DeviceMapped atom arena too.
+        static std::vector<Atom> ReadObjectData(const Cache& cache, const ObjectID& id)
+        {
+            std::vector<Atom> result;
+
+            ObjectAllocation alloc;
+            if (!cache.m_ObjectPages.Find(id, alloc) || alloc.m_TotalElementCount == 0 || alloc.IsEmpty())
+            {
+                return result;
+            }
+
+            const sizet pageSize = cache.m_PagedBuffer.GetPageSize();
+            std::vector<Atom> pageAtoms(pageSize);
+            sizet remaining = alloc.m_TotalElementCount;
+            for (u32 current = alloc.m_StartPage; current != Cache::kInvalidPage && remaining > 0;
+                 current = cache.m_PageNodes.Data()[current].m_Next)
+            {
+                if (!cache.m_PagedBuffer.ReadbackPage(current, pageAtoms.data()))
+                {
+                    return result;
+                }
+                const sizet count = std::min(pageSize, remaining);
+                result.insert(result.end(), pageAtoms.begin(), pageAtoms.begin() + count);
+                remaining -= count;
+            }
+            return result;
+        }
+
+        static u32 GetFreePagesCount(const Cache& cache)
+        {
+            u32 freePages = 0;
+            const u32 pageCount = cache.m_PagedBuffer.GetPageCount();
+            for (u32 i = 0; i < pageCount; ++i)
+            {
+                if (!cache.m_PagedBuffer.IsPageReserved(i))
+                {
+                    ++freePages;
+                }
+            }
+            return freePages;
+        }
+
+        static u32 CountAllocatedPages(const Cache& cache, const ObjectAllocation& alloc)
+        {
+            return cache.CountAllocatedPages(alloc);
+        }
+
+        // The object's page indices in CHAIN order.
+        static std::vector<u32> ChainPages(const Cache& cache, const ObjectID& id)
+        {
+            std::vector<u32> pages;
+            ObjectAllocation alloc;
+            if (!cache.m_ObjectPages.Find(id, alloc))
+            {
+                return pages;
+            }
+            for (u32 current = alloc.m_StartPage; current != Cache::kInvalidPage;
+                 current = cache.m_PageNodes.Data()[current].m_Next)
+            {
+                pages.push_back(current);
+            }
+            return pages;
+        }
+    };
+} // namespace OloEngine

--- a/OloEngine/tests/Rendering/GPUCacheInspector.h
+++ b/OloEngine/tests/Rendering/GPUCacheInspector.h
@@ -8,6 +8,7 @@
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Renderer/GPUCache/GPUPagedCache.h"
 
+#include <algorithm>
 #include <vector>
 
 namespace OloEngine

--- a/OloEngine/tests/Rendering/GPUCacheShaderResolveTest.cpp
+++ b/OloEngine/tests/Rendering/GPUCacheShaderResolveTest.cpp
@@ -151,9 +151,11 @@ TEST(GPUCacheShaderResolveTest, ComputeShaderResolvesAllocationsWithNoCpuRoundTr
         << "HostMirrored backing failed on a live device";
 
     // A population with every directory state the shader can meet: single- and
-    // multi-page objects, an out-of-address-order chain (eviction transfer), a
-    // cleared-but-resident object, tombstones from explicit erases, and a
-    // policy eviction.
+    // multi-page objects, an out-of-address-order chain (built below by reusing
+    // freed pages), a cleared-but-present object, and a tombstone from an
+    // explicit erase. Note this deliberately stays well inside the 32-page
+    // capacity, so no policy eviction occurs — eviction's effect on the
+    // directory is covered headless by GPUPagedCacheTest.
     const std::vector<u32> small = { 1, 2, 3 };
     const std::vector<u32> large(11, 7); // 3 pages
     ASSERT_TRUE(cache.AllocateObject(100, small.data(), small.size()));
@@ -161,7 +163,7 @@ TEST(GPUCacheShaderResolveTest, ComputeShaderResolvesAllocationsWithNoCpuRoundTr
     ASSERT_TRUE(cache.AllocateObject(300, small.data(), small.size()));
     ASSERT_TRUE(cache.AllocateObject(400, large.data(), large.size()));
     cache.ClearObject(300);      // present, zero elements, chain kept
-    cache.DeallocateObject(100); // tombstone
+    cache.DeallocateObject(100); // tombstone + frees a page for the reuse below
     // Reuse the freed pages out of order so at least one chain is not
     // address-ascending — the order-sensitive checksum has to prove the GPU
     // walks CHAIN order, not index order.

--- a/OloEngine/tests/Rendering/GPUCacheShaderResolveTest.cpp
+++ b/OloEngine/tests/Rendering/GPUCacheShaderResolveTest.cpp
@@ -1,0 +1,302 @@
+// OLO_TEST_LAYER: shaderpipe
+// =============================================================================
+// GPUCacheShaderResolveTest.cpp — the GPU-visible half of the paged-cache
+// substrate (issue #704).
+//
+// Three contracts, each needing a real GL 4.6 device (SKIPs cleanly headless):
+//
+//  1. Acceptance criterion 2: a compute shader resolves an object's allocation
+//     with NO CPU involvement. A GPUPagedCache in HostMirrored backing is
+//     populated/evicted/cleared on the CPU; GPUCacheResolve_Probe.comp then
+//     probes the mirrored hash table and walks the mirrored page-node chains
+//     for a mixed batch of present / absent / erased keys, and every field it
+//     reports — including an ORDER-SENSITIVE chain checksum — must equal the
+//     CPU-side ground truth. The checksum matters: a set-style comparison
+//     passes on a walk that visits the right pages in the wrong order
+//     (docs/agent-rules/gpu-scan-compaction.md §2), and chain order IS the
+//     data layout.
+//
+//  2. The DeviceMapped atom arena: AllocateObject's payload writes land in
+//     device memory and read back bit-identical through the device path.
+//
+//  3. GPUCircularBuffer: staged copies survive wrap-around under fence range
+//     locks (the substrate's persistent-mapped upload ring, which
+//     VirtualMeshRegistry's page uploads now ride).
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "GPUCacheInspector.h"
+#include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/GPUCache/GPUCachePolicy.h"
+#include "OloEngine/Renderer/GPUCache/GPUCircularBuffer.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedCache.h"
+#include "OloEngine/Renderer/MemoryBarrierFlags.h"
+#include "OloEngine/Renderer/RenderCommand.h"
+#include "OloEngine/Renderer/StorageBuffer.h"
+#include "PropertyTests/RenderPropertyTest.h"
+
+#define GLFW_INCLUDE_NONE
+#include <glad/gl.h>
+
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    using Cache = GPUPagedCache<u64, u32, LRUPolicy>;
+    using Inspector = GPUPagedCacheInspector<Cache>;
+
+    // The probe shader needs 64-bit integer arithmetic. Ask the driver BEFORE
+    // creating the shader: a failed compute compile is a modal assert dialog
+    // in Debug, not a return value (gpu-scan-compaction.md §6).
+    bool DriverSupportsInt64()
+    {
+        GLint extensionCount = 0;
+        glGetIntegerv(GL_NUM_EXTENSIONS, &extensionCount);
+        for (GLint i = 0; i < extensionCount; ++i)
+        {
+            const auto* name = reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, static_cast<GLuint>(i)));
+            if (name != nullptr && std::string_view(name) == "GL_ARB_gpu_shader_int64")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // CPU mirror of the probe shader's binding-2 block. The static_asserts pin
+    // the std430 contract GPUCacheResolve.glsl documents — if the Entry layout
+    // drifts (a policy with a differently-sized Handle, a reordered field),
+    // they fail the BUILD instead of the dispatch silently misreading memory.
+    inline constexpr u32 kMaxQueries = 256;
+
+    struct GpuResolveResult
+    {
+        u32 m_Found;
+        u32 m_TotalElementCount;
+        u32 m_StartPage;
+        u32 m_EndPage;
+        u32 m_PageCount;
+        u32 m_LastPage;
+        u32 m_ChainChecksum;
+        u32 m_Pad;
+    };
+
+    struct ResolveIoBlock
+    {
+        u32 m_QueryCount;
+        u32 m_Pad0;
+        u32 m_Pad1;
+        u32 m_Pad2;
+        u64 m_QueryKeys[kMaxQueries];
+        GpuResolveResult m_Results[kMaxQueries];
+    };
+
+    static_assert(sizeof(GpuResolveResult) == 32);
+    static_assert(sizeof(ResolveIoBlock) == 16 + kMaxQueries * 8 + kMaxQueries * 32);
+    static_assert(offsetof(ResolveIoBlock, m_QueryKeys) == 16);
+    static_assert(offsetof(ResolveIoBlock, m_Results) == 16 + kMaxQueries * 8);
+    static_assert(sizeof(Cache::ObjectAllocation) == 16,
+                  "the GLSL OloGpuCacheEntry mirror assumes a 4-byte LRU policy handle");
+    static_assert(sizeof(GPUHashMap<u64, Cache::ObjectAllocation>::Entry) == 24,
+                  "the GLSL OloGpuCacheEntry mirror assumes an 8-byte key + 16-byte allocation");
+
+    // The CPU-side ground truth the GPU must reproduce, computed through the
+    // cache's public lookup + the inspector's chain walk.
+    GpuResolveResult CpuResolve(Cache& cache, u64 key)
+    {
+        GpuResolveResult expected{};
+        expected.m_StartPage = Cache::kInvalidPage;
+        expected.m_EndPage = Cache::kInvalidPage;
+        expected.m_LastPage = Cache::kInvalidPage;
+
+        Cache::ObjectAllocation alloc;
+        if (!cache.Find(key, alloc))
+        {
+            return expected;
+        }
+        expected.m_Found = 1;
+        expected.m_TotalElementCount = alloc.m_TotalElementCount;
+        expected.m_StartPage = alloc.m_StartPage;
+        expected.m_EndPage = alloc.m_EndPage;
+        for (const u32 page : Inspector::ChainPages(cache, key))
+        {
+            expected.m_ChainChecksum = expected.m_ChainChecksum * 33u + page;
+            expected.m_LastPage = page;
+            ++expected.m_PageCount;
+        }
+        return expected;
+    }
+} // namespace
+
+TEST(GPUCacheShaderResolveTest, ComputeShaderResolvesAllocationsWithNoCpuRoundTrip)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+    if (!DriverSupportsInt64())
+    {
+        GTEST_SKIP() << "GL_ARB_gpu_shader_int64 not supported by this driver";
+    }
+
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 32, GPUCacheBacking::HostMirrored))
+        << "HostMirrored backing failed on a live device";
+
+    // A population with every directory state the shader can meet: single- and
+    // multi-page objects, an out-of-address-order chain (eviction transfer), a
+    // cleared-but-resident object, tombstones from explicit erases, and a
+    // policy eviction.
+    const std::vector<u32> small = { 1, 2, 3 };
+    const std::vector<u32> large(11, 7); // 3 pages
+    ASSERT_TRUE(cache.AllocateObject(100, small.data(), small.size()));
+    ASSERT_TRUE(cache.AllocateObject(200, large.data(), large.size()));
+    ASSERT_TRUE(cache.AllocateObject(300, small.data(), small.size()));
+    ASSERT_TRUE(cache.AllocateObject(400, large.data(), large.size()));
+    cache.ClearObject(300);      // present, zero elements, chain kept
+    cache.DeallocateObject(100); // tombstone
+    // Reuse the freed pages out of order so at least one chain is not
+    // address-ascending — the order-sensitive checksum has to prove the GPU
+    // walks CHAIN order, not index order.
+    const std::vector<u32> reuse(6, 9); // 2 pages from the freed/fragmented set
+    ASSERT_TRUE(cache.AllocateObject(500, reuse.data(), reuse.size()));
+
+    std::vector<u64> queries;
+    for (const u64 key : { 100ull, 200ull, 300ull, 400ull, 500ull }) // live + tombstoned
+    {
+        queries.push_back(key);
+    }
+    for (u64 key = 9000; key < 9040; ++key) // never inserted
+    {
+        queries.push_back(key);
+    }
+    ASSERT_LE(queries.size(), static_cast<sizet>(kMaxQueries));
+
+    auto io = std::make_unique<ResolveIoBlock>();
+    std::memset(io.get(), 0, sizeof(ResolveIoBlock));
+    io->m_QueryCount = static_cast<u32>(queries.size());
+    std::memcpy(io->m_QueryKeys, queries.data(), queries.size() * sizeof(u64));
+
+    auto ioBuffer = StorageBuffer::Create(static_cast<u32>(sizeof(ResolveIoBlock)), 2,
+                                          StorageBufferUsage::DynamicCopy);
+    ioBuffer->SetData(io.get(), static_cast<u32>(sizeof(ResolveIoBlock)), 0);
+
+    auto probe = ComputeShader::Create("assets/shaders/tests/GPUCacheResolve_Probe.comp");
+    ASSERT_TRUE(probe && probe->IsValid()) << "GPUCacheResolve_Probe.comp failed to compile";
+
+    probe->Bind();
+    cache.BindLookup(/*hashMapBinding=*/0, /*pageNodesBinding=*/1);
+    ioBuffer->Bind();
+    const u32 groups = (io->m_QueryCount + 63u) / 64u;
+    RenderCommand::DispatchCompute(groups, 1, 1);
+    RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage | MemoryBarrierFlags::BufferUpdate);
+
+    auto readback = std::make_unique<ResolveIoBlock>();
+    ioBuffer->GetData(readback.get(), static_cast<u32>(sizeof(ResolveIoBlock)), 0);
+
+    for (sizet i = 0; i < queries.size(); ++i)
+    {
+        const GpuResolveResult& actual = readback->m_Results[i];
+        const GpuResolveResult expected = CpuResolve(cache, queries[i]);
+        EXPECT_EQ(actual.m_Found, expected.m_Found) << "key " << queries[i];
+        EXPECT_EQ(actual.m_TotalElementCount, expected.m_TotalElementCount) << "key " << queries[i];
+        EXPECT_EQ(actual.m_StartPage, expected.m_StartPage) << "key " << queries[i];
+        EXPECT_EQ(actual.m_EndPage, expected.m_EndPage) << "key " << queries[i];
+        EXPECT_EQ(actual.m_PageCount, expected.m_PageCount) << "key " << queries[i];
+        EXPECT_EQ(actual.m_LastPage, expected.m_LastPage) << "key " << queries[i];
+        EXPECT_EQ(actual.m_ChainChecksum, expected.m_ChainChecksum)
+            << "key " << queries[i] << " — the GPU walked a different page ORDER than the CPU chain";
+    }
+
+    // At least one queried chain must be genuinely out of address order, or
+    // the checksum assertion above proved nothing about walk order.
+    bool sawNonAscendingChain = false;
+    for (const u64 key : { 200ull, 300ull, 400ull, 500ull })
+    {
+        const std::vector<u32> chain = Inspector::ChainPages(cache, key);
+        for (sizet i = 1; i < chain.size(); ++i)
+        {
+            sawNonAscendingChain = sawNonAscendingChain || chain[i] != chain[i - 1] + 1;
+        }
+    }
+    EXPECT_TRUE(sawNonAscendingChain) << "test population never produced a fragmented chain — "
+                                         "the order-sensitive checksum was exercised vacuously";
+
+    // GL hygiene (§6.4): leave no SSBO of ours on a shared binding point.
+    ioBuffer->Unbind();
+    probe->Unbind();
+    cache.Destroy(); // deleting the buffers detaches them from bindings 0/1
+}
+
+TEST(GPUCacheShaderResolveTest, DeviceArenaRoundTripsObjectData)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    Cache cache;
+    ASSERT_TRUE(cache.Create(8, 16, GPUCacheBacking::HostMirrored));
+
+    const std::vector<u32> data = { 0xDEAD0001u, 0xDEAD0002u, 0xDEAD0003u, 0xDEAD0004u, 0xDEAD0005u,
+                                    0xDEAD0006u, 0xDEAD0007u, 0xDEAD0008u, 0xDEAD0009u, 0xDEAD000Au };
+    ASSERT_TRUE(cache.AllocateObject(7, data.data(), data.size()));
+
+    // The mapped arena is write-only for the CPU; the inspector reads back
+    // through the device, so equality proves the payload actually landed in
+    // the device buffer — not in some host shadow.
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 7), data);
+
+    cache.Destroy();
+}
+
+TEST(GPUCacheShaderResolveTest, CircularBufferCopiesSurviveWrapUnderFences)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    constexpr u64 kRingBytes = 64;
+    constexpr u32 kChunkBytes = 16;
+    constexpr u32 kChunkCount = 32; // 8x the ring: forces 7 wrap-arounds
+
+    GPUCircularBuffer ring;
+    ASSERT_TRUE(ring.Create(kRingBytes));
+
+    auto destination = StorageBuffer::Create(kChunkCount * kChunkBytes, 3, StorageBufferUsage::DynamicCopy);
+
+    for (u32 chunk = 0; chunk < kChunkCount; ++chunk)
+    {
+        u32 payload[kChunkBytes / sizeof(u32)];
+        for (u32 word = 0; word < std::size(payload); ++word)
+        {
+            payload[word] = chunk * 1000u + word;
+        }
+
+        u64 ringOffset = 0;
+        u8* dst = ring.Reserve(kChunkBytes, ringOffset);
+        ASSERT_NE(dst, nullptr);
+        std::memcpy(dst, payload, kChunkBytes);
+        RenderCommand::CopyBufferSubData(ring.GetDeviceHandle(), destination->GetRHIHandle(), ringOffset,
+                                         static_cast<u64>(chunk) * kChunkBytes, kChunkBytes);
+        ring.Commit(kChunkBytes);
+    }
+
+    std::vector<u32> readback(kChunkCount * kChunkBytes / sizeof(u32));
+    destination->GetData(readback.data(), static_cast<u32>(readback.size() * sizeof(u32)), 0);
+
+    for (u32 chunk = 0; chunk < kChunkCount; ++chunk)
+    {
+        for (u32 word = 0; word < kChunkBytes / sizeof(u32); ++word)
+        {
+            ASSERT_EQ(readback[chunk * (kChunkBytes / sizeof(u32)) + word], chunk * 1000u + word)
+                << "chunk " << chunk << " word " << word
+                << " — a wrap overwrote bytes an in-flight copy still needed";
+        }
+    }
+
+    destination->Unbind();
+    ring.Destroy();
+}

--- a/OloEngine/tests/Rendering/GPUHashMapTest.cpp
+++ b/OloEngine/tests/Rendering/GPUHashMapTest.cpp
@@ -1,0 +1,551 @@
+// OLO_TEST_LAYER: plumbing
+// =============================================================================
+// GPUHashMapTest.cpp — the lock-free, GPU-layout hash map of the paged-cache
+// substrate (issue #704, acceptance criterion 3: "hash collision" coverage,
+// headless).
+//
+// Every test here runs with the HostOnly backing — the probing/CAS logic is
+// byte-identical to what the GPU-visible (HostMirrored) configuration runs,
+// the bytes just live on the heap, so no GL context is needed and nothing
+// skips. The shader-side view of the same table is covered by
+// GPUCacheShaderResolveTest.cpp (shaderpipe).
+//
+// Ported from the VoxelEngine reference's Tests/gpu_lockfree_hash_map_tests.cpp,
+// plus regression tests for the sharp edges the port fixed:
+//   * a non-power-of-two capacity left the rounded-up tail of the table
+//     UNINITIALISED in the reference (Create initialised [0, capacity) but
+//     allocated bit_ceil(capacity) entries);
+//   * an Insert whose CAS lost the race to another thread claiming the SAME
+//     key missed the duplicate and inserted a second entry further down the
+//     probe sequence;
+//   * an update-Insert that claimed a tombstone AHEAD of the key's live entry,
+//     duplicating it (one Erase then resurrected the stale copy);
+//   * tombstone accumulation, answered by NeedsCompaction/CompactTombstones.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Renderer/GPUCache/GPUHashMap.h"
+
+#include <algorithm>
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    using Map = GPUHashMap<u64, u32>;
+} // namespace
+
+TEST(GPUHashMapTest, CreateRoundsCapacityToPowerOfTwo)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(96));
+    EXPECT_EQ(map.GetCapacity(), 128u);
+}
+
+TEST(GPUHashMapTest, CreateWithZeroCapacityFails)
+{
+    Map map;
+    EXPECT_FALSE(map.Create(0));
+    EXPECT_FALSE(map.IsCreated());
+}
+
+TEST(GPUHashMapTest, InsertAndFind)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(128));
+
+    EXPECT_TRUE(map.Insert(1, 42));
+
+    u32 value = 0;
+    EXPECT_TRUE(map.Find(1, value));
+    EXPECT_EQ(value, 42u);
+}
+
+TEST(GPUHashMapTest, ContainsKey)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(128));
+
+    EXPECT_FALSE(map.Contains(5));
+    EXPECT_TRUE(map.Insert(5, 99));
+    EXPECT_TRUE(map.Contains(5));
+}
+
+TEST(GPUHashMapTest, FindNonExistentKey)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    u32 value = 0;
+    EXPECT_FALSE(map.Find(999, value));
+}
+
+// Regression for the reference's uninitialised-tail bug: with capacity 96 the
+// table is 128 entries, and entries [96, 128) must read as EMPTY, not as
+// whatever the allocation held. Nothing is inserted, so every lookup must
+// miss — including keys whose probe sequence starts inside the rounded tail.
+TEST(GPUHashMapTest, NonPowerOfTwoCapacityTailReadsEmpty)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(96));
+
+    for (u64 key = 0; key < 4096; ++key)
+    {
+        EXPECT_FALSE(map.Contains(key)) << "phantom entry for key " << key;
+    }
+}
+
+TEST(GPUHashMapTest, EraseKey)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(128));
+
+    EXPECT_TRUE(map.Insert(7, 77));
+    EXPECT_TRUE(map.Contains(7));
+
+    EXPECT_TRUE(map.Erase(7));
+    EXPECT_FALSE(map.Contains(7));
+
+    u32 value = 0;
+    EXPECT_FALSE(map.Find(7, value));
+}
+
+TEST(GPUHashMapTest, EraseNonExistentKeyReturnsFalse)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    EXPECT_FALSE(map.Erase(123));
+}
+
+TEST(GPUHashMapTest, InsertMultipleKeys)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(256));
+
+    for (u64 i = 0; i < 100; ++i)
+    {
+        EXPECT_TRUE(map.Insert(i, static_cast<u32>(i * 10)));
+    }
+    for (u64 i = 0; i < 100; ++i)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(i, value));
+        EXPECT_EQ(value, static_cast<u32>(i * 10));
+    }
+}
+
+TEST(GPUHashMapTest, InsertEraseInsert)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    EXPECT_TRUE(map.Insert(1, 10));
+    EXPECT_TRUE(map.Erase(1));
+    EXPECT_TRUE(map.Insert(1, 20));
+
+    u32 value = 0;
+    EXPECT_TRUE(map.Find(1, value));
+    EXPECT_EQ(value, 20u);
+}
+
+TEST(GPUHashMapTest, DuplicateInsertOverwrites)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(128));
+
+    EXPECT_TRUE(map.Insert(10, 1));
+    EXPECT_TRUE(map.Insert(10, 2));
+
+    u32 value = 0;
+    EXPECT_TRUE(map.Find(10, value));
+    EXPECT_EQ(value, 2u);
+}
+
+// A probe that crosses a tombstone must keep going: erase a key, and every
+// key inserted after/around it must still be findable. Exercised densely so
+// probe sequences genuinely cross the tombstones.
+TEST(GPUHashMapTest, LookupsCrossTombstones)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(16)); // small: probes collide constantly
+
+    for (u64 i = 0; i < 12; ++i)
+    {
+        ASSERT_TRUE(map.Insert(i, static_cast<u32>(i)));
+    }
+    // Punch holes.
+    for (u64 i = 0; i < 12; i += 3)
+    {
+        ASSERT_TRUE(map.Erase(i));
+    }
+    for (u64 i = 0; i < 12; ++i)
+    {
+        u32 value = 0;
+        if (i % 3 == 0)
+        {
+            EXPECT_FALSE(map.Find(i, value)) << "erased key " << i << " resurfaced";
+        }
+        else
+        {
+            EXPECT_TRUE(map.Find(i, value)) << "key " << i << " lost behind a tombstone";
+            EXPECT_EQ(value, static_cast<u32>(i));
+        }
+    }
+    // Tombstoned slots are reusable.
+    for (u64 i = 0; i < 12; i += 3)
+    {
+        EXPECT_TRUE(map.Insert(i, static_cast<u32>(i + 100)));
+    }
+    for (u64 i = 0; i < 12; i += 3)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(i, value));
+        EXPECT_EQ(value, static_cast<u32>(i + 100));
+    }
+}
+
+TEST(GPUHashMapTest, InsertIntoFullTableReturnsFalse)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(8));
+    ASSERT_EQ(map.GetCapacity(), 8u);
+
+    for (u64 i = 0; i < 8; ++i)
+    {
+        EXPECT_TRUE(map.Insert(i, static_cast<u32>(i)));
+    }
+    EXPECT_FALSE(map.Insert(1000, 0)) << "a full table must refuse, not spin or overwrite";
+
+    // Nothing was disturbed.
+    for (u64 i = 0; i < 8; ++i)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(i, value));
+        EXPECT_EQ(value, static_cast<u32>(i));
+    }
+}
+
+TEST(GPUHashMapTest, DenseFillForcesCollisions)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    // 60 of 64 slots occupied: nearly every probe sequence collides multiple
+    // times, so this exercises wrap-around and long probe runs.
+    for (u64 i = 0; i < 60; ++i)
+    {
+        EXPECT_TRUE(map.Insert(i * 7919, static_cast<u32>(i)));
+    }
+    for (u64 i = 0; i < 60; ++i)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(i * 7919, value));
+        EXPECT_EQ(value, static_cast<u32>(i));
+    }
+}
+
+// NOTE for all the multi-threaded tests below: gtest assertions are NOT
+// thread-safe on Windows, so worker threads only count failures into an
+// atomic; the main thread asserts the count.
+TEST(GPUHashMapTest, MultiThreadedInsertDistinctKeys)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(16384));
+
+    constexpr int kThreadCount = 8;
+    constexpr int kInsertsPerThread = 500;
+    std::atomic<int> workerFailures{ 0 };
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (int t = 0; t < kThreadCount; ++t)
+    {
+        threads.emplace_back(
+            [&map, &workerFailures, t]()
+            {
+                for (int i = 0; i < kInsertsPerThread; ++i)
+                {
+                    const auto key = static_cast<u64>(t * kInsertsPerThread + i);
+                    if (!map.Insert(key, static_cast<u32>(key * 10)))
+                    {
+                        workerFailures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+    EXPECT_EQ(workerFailures.load(), 0);
+
+    for (u64 i = 0; i < static_cast<u64>(kThreadCount) * kInsertsPerThread; ++i)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(i, value));
+        EXPECT_EQ(value, static_cast<u32>(i * 10));
+    }
+}
+
+// All threads hammer the SAME key. The claim CAS must produce exactly one
+// live entry (any thread's value) — the reference could produce a duplicate
+// entry when the claiming CAS lost the race to another thread inserting the
+// same key. Verified by erasing once: a duplicate would still be findable.
+TEST(GPUHashMapTest, MultiThreadedDuplicateInsertLeavesOneEntry)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(512));
+
+    constexpr int kThreadCount = 16;
+    std::atomic<int> workerFailures{ 0 };
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (int t = 0; t < kThreadCount; ++t)
+    {
+        threads.emplace_back(
+            [&map, &workerFailures, t]()
+            {
+                for (int i = 0; i < 100; ++i)
+                {
+                    if (!map.Insert(42, static_cast<u32>(t)))
+                    {
+                        workerFailures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+    EXPECT_EQ(workerFailures.load(), 0);
+
+    u32 value = 0;
+    EXPECT_TRUE(map.Find(42, value));
+    EXPECT_LT(value, static_cast<u32>(kThreadCount));
+
+    EXPECT_TRUE(map.Erase(42));
+    EXPECT_FALSE(map.Contains(42)) << "duplicate entry for the contended key survived one erase";
+}
+
+TEST(GPUHashMapTest, MultiThreadedStressWithErases)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(16384));
+
+    const int threadCount = static_cast<int>(std::max(2u, std::thread::hardware_concurrency()));
+    constexpr int kOperations = 20000;
+    constexpr int kKeySpace = 2000;
+    std::atomic<int> workerFailures{ 0 };
+
+    std::vector<std::thread> threads;
+    threads.reserve(static_cast<sizet>(threadCount));
+    for (int t = 0; t < threadCount; ++t)
+    {
+        threads.emplace_back(
+            [&map, &workerFailures, t]()
+            {
+                std::mt19937 rng(static_cast<u32>(t));
+                std::uniform_int_distribution<int> dist(0, kKeySpace);
+                for (int i = 0; i < kOperations; ++i)
+                {
+                    const auto key = static_cast<u64>(dist(rng));
+                    (void)map.Insert(key, static_cast<u32>(key * 2));
+                    if (u32 value = 0; map.Find(key, value) && value != static_cast<u32>(key * 2))
+                    {
+                        workerFailures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    if (i % 5 == 0)
+                    {
+                        (void)map.Erase(key);
+                    }
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+    EXPECT_EQ(workerFailures.load(), 0);
+
+    // Final consistency: every surviving key still maps to its derived value.
+    for (u64 key = 0; key <= kKeySpace; ++key)
+    {
+        if (u32 value = 0; map.Find(key, value))
+        {
+            EXPECT_EQ(value, static_cast<u32>(key * 2));
+        }
+    }
+}
+
+// =============================================================================
+// Regressions for the tombstone-aware Insert (the reference claimed the first
+// tombstone it probed WITHOUT checking whether the key already lived further
+// along the chain — an update-insert then created a duplicate entry, and Erase
+// removed only the first copy, resurrecting the stale one).
+// =============================================================================
+
+namespace
+{
+    // Two distinct keys whose probe sequences START in the same slot of a
+    // `capacity`-entry table, found by brute force over the real hash — the
+    // scenario needs a genuine collision, not an assumed one.
+    std::pair<u64, u64> FindCollidingKeys(u32 capacity)
+    {
+        const u64 mask = capacity - 1;
+        std::vector<u64> firstKeyForSlot(capacity, 0);
+        for (u64 key = 1;; ++key)
+        {
+            const auto slot = static_cast<sizet>(Map::HashKey(key) & mask);
+            if (firstKeyForSlot[slot] != 0)
+            {
+                return { firstKeyForSlot[slot], key };
+            }
+            firstKeyForSlot[slot] = key;
+        }
+    }
+} // namespace
+
+TEST(GPUHashMapTest, UpdateInsertAcrossTombstoneDoesNotDuplicate)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(8));
+    const auto [k1, k2] = FindCollidingKeys(map.GetCapacity());
+
+    ASSERT_TRUE(map.Insert(k1, 1)); // lands at the shared start slot
+    ASSERT_TRUE(map.Insert(k2, 2)); // probes past k1
+    ASSERT_TRUE(map.Erase(k1));     // tombstone AHEAD of k2's entry
+
+    // The update-insert must find k2 beyond the tombstone, not claim the
+    // tombstone as a second home for it.
+    ASSERT_TRUE(map.Insert(k2, 22));
+    u32 value = 0;
+    ASSERT_TRUE(map.Find(k2, value));
+    EXPECT_EQ(value, 22u);
+
+    // One erase must remove the key entirely — a duplicate would survive it.
+    ASSERT_TRUE(map.Erase(k2));
+    EXPECT_FALSE(map.Contains(k2)) << "a duplicate entry resurrected the erased key";
+}
+
+TEST(GPUHashMapTest, MutateUpdatesInPlaceAndSkipsAbsentKeys)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    ASSERT_TRUE(map.Insert(7, 70));
+    EXPECT_TRUE(map.Mutate(7, [](u32& value)
+                           { value += 1; }));
+
+    u32 value = 0;
+    ASSERT_TRUE(map.Find(7, value));
+    EXPECT_EQ(value, 71u);
+
+    bool called = false;
+    EXPECT_FALSE(map.Mutate(8, [&called](u32&)
+                            { called = true; }));
+    EXPECT_FALSE(called) << "Mutate must not invoke the callback for an absent key";
+}
+
+// Tombstones are a non-renewable poison for probe lengths (misses only stop at
+// EMPTY slots); CompactTombstones rebuilds the table without them, preserving
+// every live entry.
+TEST(GPUHashMapTest, CompactTombstonesPreservesLiveEntries)
+{
+    Map map;
+    ASSERT_TRUE(map.Create(64));
+
+    // Persistent residents that must survive the rebuild.
+    for (u64 key = 5000; key < 5010; ++key)
+    {
+        ASSERT_TRUE(map.Insert(key, static_cast<u32>(key)));
+    }
+
+    // Insert/erase churn mints tombstones faster than probe paths reuse them.
+    bool sawNeedsCompaction = false;
+    for (u64 key = 0; key < 1000; ++key)
+    {
+        ASSERT_TRUE(map.Insert(key, static_cast<u32>(key * 3)));
+        ASSERT_TRUE(map.Erase(key));
+        sawNeedsCompaction = sawNeedsCompaction || map.NeedsCompaction();
+    }
+    EXPECT_TRUE(sawNeedsCompaction) << "churn never tripped the compaction threshold — the test is vacuous";
+
+    map.CompactTombstones();
+    EXPECT_EQ(map.GetTombstoneCount(), 0u);
+
+    for (u64 key = 5000; key < 5010; ++key)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(key, value)) << "live key " << key << " lost in compaction";
+        EXPECT_EQ(value, static_cast<u32>(key));
+    }
+    for (u64 key = 0; key < 1000; ++key)
+    {
+        EXPECT_FALSE(map.Contains(key)) << "erased key " << key << " resurrected by compaction";
+    }
+}
+
+// The GLSL side of the lookup contract is a hand-mirrored file, and the GPU
+// test that executes it needs a device — so this HEADLESS text pin is what
+// keeps CI honest about drift: the include must carry the exact hash constants
+// and sentinels the C++ side uses.
+TEST(GPUHashMapTest, GlslResolveContractMatchesCppConstants)
+{
+    namespace fs = std::filesystem;
+    fs::path candidate = fs::current_path();
+    fs::path includePath;
+    for (int depth = 0; depth < 6; ++depth)
+    {
+        // The GPU fixtures chdir into OloEditor/, so probe both spellings.
+        for (const char* relative : { "assets/shaders/include/GPUCacheResolve.glsl",
+                                      "OloEditor/assets/shaders/include/GPUCacheResolve.glsl" })
+        {
+            if (fs::exists(candidate / relative))
+            {
+                includePath = candidate / relative;
+                break;
+            }
+        }
+        if (!includePath.empty() || !candidate.has_parent_path() || candidate == candidate.parent_path())
+        {
+            break;
+        }
+        candidate = candidate.parent_path();
+    }
+    ASSERT_FALSE(includePath.empty()) << "GPUCacheResolve.glsl not found from " << fs::current_path();
+
+    std::ifstream file(includePath);
+    ASSERT_TRUE(file.is_open());
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    const std::string source = buffer.str();
+
+    // The MurmurHash3 finalizer, exactly as Hash::Hash64 (Core/Hash.h) has it.
+    EXPECT_NE(source.find("0xff51afd7ed558ccdUL"), std::string::npos);
+    EXPECT_NE(source.find("0xc4ceb9fe1a85ec53UL"), std::string::npos);
+    EXPECT_NE(source.find(">> 33"), std::string::npos);
+
+    // The key sentinels and the chain terminator, as literals the GLSL uses.
+    static_assert(Map::kEmptyKey == 0xFFFFFFFFFFFFFFFFull);
+    static_assert(Map::kTombstoneKey == 0xFFFFFFFFFFFFFFFEull);
+    EXPECT_NE(source.find("0xFFFFFFFFFFFFFFFFUL"), std::string::npos);
+    EXPECT_NE(source.find("0xFFFFFFFFFFFFFFFEUL"), std::string::npos);
+    EXPECT_NE(source.find("OLO_GPU_CACHE_INVALID_PAGE = 0xFFFFFFFFu"), std::string::npos);
+
+    // And the C++ hash really is the canonical engine one.
+    EXPECT_EQ(Map::HashKey(0x0123456789ABCDEFull), Hash::Hash64(0x0123456789ABCDEFull));
+}

--- a/OloEngine/tests/Rendering/GPUHashMapTest.cpp
+++ b/OloEngine/tests/Rendering/GPUHashMapTest.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -45,6 +46,26 @@ using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file
 namespace
 {
     using Map = GPUHashMap<u64, u32>;
+
+    // `count` distinct keys whose probe sequences all START in the same slot of
+    // a `capacity`-entry table, found by brute force over the real hash. Maximal
+    // claim-CAS contention without any two threads touching the same key — the
+    // shape the threading contract supports (see GPUHashMap.h).
+    std::vector<u64> FindKeysInSameSlot(u32 capacity, sizet count)
+    {
+        const u64 mask = capacity - 1;
+        std::unordered_map<u64, std::vector<u64>> bySlot;
+        for (u64 key = 1; key < 4'000'000; ++key)
+        {
+            auto& keys = bySlot[Map::HashKey(key) & mask];
+            keys.push_back(key);
+            if (keys.size() == count)
+            {
+                return keys;
+            }
+        }
+        return {};
+    }
 } // namespace
 
 TEST(GPUHashMapTest, CreateRoundsCapacityToPowerOfTwo)
@@ -300,29 +321,44 @@ TEST(GPUHashMapTest, MultiThreadedInsertDistinctKeys)
     }
 }
 
-// All threads hammer the SAME key. The claim CAS must produce exactly one
-// live entry (any thread's value) — the reference could produce a duplicate
-// entry when the claiming CAS lost the race to another thread inserting the
-// same key. Verified by erasing once: a duplicate would still be findable.
-TEST(GPUHashMapTest, MultiThreadedDuplicateInsertLeavesOneEntry)
+// Maximal claim-CAS contention: every thread inserts DISTINCT keys that all
+// hash to the SAME start slot, so the threads fight over the same entries
+// while never writing the same key — exactly what the threading contract
+// supports. Each key must end up present exactly once with its own value; a
+// claim that dropped an insert or duplicated an entry fails this.
+//
+// (This replaced a version where 16 threads hammered one shared key. That
+// raced on the non-atomic value store — a real data race TSan caught in CI,
+// not a test artefact — and the contract now says so explicitly.)
+TEST(GPUHashMapTest, MultiThreadedCollidingClaimsKeepEveryKey)
 {
     Map map;
     ASSERT_TRUE(map.Create(512));
 
     constexpr int kThreadCount = 16;
+    constexpr sizet kKeysPerThread = 8;
+    const std::vector<u64> keys = FindKeysInSameSlot(map.GetCapacity(), kThreadCount * kKeysPerThread);
+    ASSERT_EQ(keys.size(), static_cast<sizet>(kThreadCount) * kKeysPerThread);
+
     std::atomic<int> workerFailures{ 0 };
     std::vector<std::thread> threads;
     threads.reserve(kThreadCount);
     for (int t = 0; t < kThreadCount; ++t)
     {
         threads.emplace_back(
-            [&map, &workerFailures, t]()
+            [&map, &keys, &workerFailures, t]()
             {
-                for (int i = 0; i < 100; ++i)
+                for (sizet i = 0; i < kKeysPerThread; ++i)
                 {
-                    if (!map.Insert(42, static_cast<u32>(t)))
+                    const u64 key = keys[static_cast<sizet>(t) * kKeysPerThread + i];
+                    // Insert repeatedly: re-inserting a key this thread alone
+                    // owns keeps re-running the probe across the contended run.
+                    for (int repeat = 0; repeat < 8; ++repeat)
                     {
-                        workerFailures.fetch_add(1, std::memory_order_relaxed);
+                        if (!map.Insert(key, static_cast<u32>(key)))
+                        {
+                            workerFailures.fetch_add(1, std::memory_order_relaxed);
+                        }
                     }
                 }
             });
@@ -333,14 +369,26 @@ TEST(GPUHashMapTest, MultiThreadedDuplicateInsertLeavesOneEntry)
     }
     EXPECT_EQ(workerFailures.load(), 0);
 
-    u32 value = 0;
-    EXPECT_TRUE(map.Find(42, value));
-    EXPECT_LT(value, static_cast<u32>(kThreadCount));
-
-    EXPECT_TRUE(map.Erase(42));
-    EXPECT_FALSE(map.Contains(42)) << "duplicate entry for the contended key survived one erase";
+    for (const u64 key : keys)
+    {
+        u32 value = 0;
+        EXPECT_TRUE(map.Find(key, value)) << "key " << key << " lost under claim contention";
+        EXPECT_EQ(value, static_cast<u32>(key));
+    }
+    // One erase must remove each key completely — a duplicate entry created by
+    // a lost claim would still be findable afterwards.
+    for (const u64 key : keys)
+    {
+        EXPECT_TRUE(map.Erase(key));
+        EXPECT_FALSE(map.Contains(key)) << "duplicate entry for key " << key << " survived one erase";
+    }
 }
 
+// Insert / find / erase churn from every core at once. The key space is
+// PARTITIONED per thread (thread t owns keys where key % threadCount == t), so
+// threads share the table and collide on probe runs without ever mutating the
+// same key — the concurrency the contract supports. A shared key space here
+// was the second data race TSan caught.
 TEST(GPUHashMapTest, MultiThreadedStressWithErases)
 {
     Map map;
@@ -348,7 +396,7 @@ TEST(GPUHashMapTest, MultiThreadedStressWithErases)
 
     const int threadCount = static_cast<int>(std::max(2u, std::thread::hardware_concurrency()));
     constexpr int kOperations = 20000;
-    constexpr int kKeySpace = 2000;
+    constexpr int kKeysPerThread = 250;
     std::atomic<int> workerFailures{ 0 };
 
     std::vector<std::thread> threads;
@@ -356,13 +404,15 @@ TEST(GPUHashMapTest, MultiThreadedStressWithErases)
     for (int t = 0; t < threadCount; ++t)
     {
         threads.emplace_back(
-            [&map, &workerFailures, t]()
+            [&map, &workerFailures, t, threadCount]()
             {
                 std::mt19937 rng(static_cast<u32>(t));
-                std::uniform_int_distribution<int> dist(0, kKeySpace);
+                std::uniform_int_distribution<int> dist(0, kKeysPerThread - 1);
                 for (int i = 0; i < kOperations; ++i)
                 {
-                    const auto key = static_cast<u64>(dist(rng));
+                    // Owned exclusively by this thread: no other thread ever
+                    // writes or erases it.
+                    const auto key = static_cast<u64>(dist(rng) * threadCount + t);
                     (void)map.Insert(key, static_cast<u32>(key * 2));
                     if (u32 value = 0; map.Find(key, value) && value != static_cast<u32>(key * 2))
                     {
@@ -382,7 +432,7 @@ TEST(GPUHashMapTest, MultiThreadedStressWithErases)
     EXPECT_EQ(workerFailures.load(), 0);
 
     // Final consistency: every surviving key still maps to its derived value.
-    for (u64 key = 0; key <= kKeySpace; ++key)
+    for (u64 key = 0; key < static_cast<u64>(kKeysPerThread) * threadCount; ++key)
     {
         if (u32 value = 0; map.Find(key, value))
         {
@@ -398,32 +448,15 @@ TEST(GPUHashMapTest, MultiThreadedStressWithErases)
 // removed only the first copy, resurrecting the stale one).
 // =============================================================================
 
-namespace
-{
-    // Two distinct keys whose probe sequences START in the same slot of a
-    // `capacity`-entry table, found by brute force over the real hash — the
-    // scenario needs a genuine collision, not an assumed one.
-    std::pair<u64, u64> FindCollidingKeys(u32 capacity)
-    {
-        const u64 mask = capacity - 1;
-        std::vector<u64> firstKeyForSlot(capacity, 0);
-        for (u64 key = 1;; ++key)
-        {
-            const auto slot = static_cast<sizet>(Map::HashKey(key) & mask);
-            if (firstKeyForSlot[slot] != 0)
-            {
-                return { firstKeyForSlot[slot], key };
-            }
-            firstKeyForSlot[slot] = key;
-        }
-    }
-} // namespace
-
 TEST(GPUHashMapTest, UpdateInsertAcrossTombstoneDoesNotDuplicate)
 {
     Map map;
     ASSERT_TRUE(map.Create(8));
-    const auto [k1, k2] = FindCollidingKeys(map.GetCapacity());
+    // Two keys that genuinely collide under the real hash, not an assumed pair.
+    const std::vector<u64> colliding = FindKeysInSameSlot(map.GetCapacity(), 2);
+    ASSERT_EQ(colliding.size(), 2u);
+    const u64 k1 = colliding[0];
+    const u64 k2 = colliding[1];
 
     ASSERT_TRUE(map.Insert(k1, 1)); // lands at the shared start slot
     ASSERT_TRUE(map.Insert(k2, 2)); // probes past k1
@@ -506,11 +539,24 @@ TEST(GPUHashMapTest, CompactTombstonesPreservesLiveEntries)
 TEST(GPUHashMapTest, GlslResolveContractMatchesCppConstants)
 {
     namespace fs = std::filesystem;
-    fs::path candidate = fs::current_path();
     fs::path includePath;
-    for (int depth = 0; depth < 6; ++depth)
+
+    // The repo's idiom for "a source-tree path, independent of the binary's
+    // cwd" (ADR 0003). The cwd walk below stays only as a fallback, because
+    // the GPU fixtures chdir into OloEditor/ and a standalone harness may not
+    // define the macro at all.
+#ifdef OLO_TEST_EDITOR_ROOT
+    if (const fs::path fromRoot =
+            fs::path{ OLO_TEST_EDITOR_ROOT } / "assets" / "shaders" / "include" / "GPUCacheResolve.glsl";
+        fs::exists(fromRoot))
     {
-        // The GPU fixtures chdir into OloEditor/, so probe both spellings.
+        includePath = fromRoot;
+    }
+#endif
+
+    fs::path candidate = fs::current_path();
+    for (int depth = 0; includePath.empty() && depth < 6; ++depth)
+    {
         for (const char* relative : { "assets/shaders/include/GPUCacheResolve.glsl",
                                       "OloEditor/assets/shaders/include/GPUCacheResolve.glsl" })
         {

--- a/OloEngine/tests/Rendering/GPUPagedCacheTest.cpp
+++ b/OloEngine/tests/Rendering/GPUPagedCacheTest.cpp
@@ -1,0 +1,951 @@
+// OLO_TEST_LAYER: plumbing
+// =============================================================================
+// GPUPagedCacheTest.cpp — the paged-cache substrate's allocation machinery
+// (issue #704, acceptance criterion 3: allocate / evict / split-chain,
+// headless).
+//
+// Everything here runs with the HostOnly backing: the page-chain, bitset and
+// eviction logic is byte-identical to the GPU-visible configuration — the
+// bytes just live on the heap — so nothing needs a GL context and nothing
+// skips. The GPU-visible side (device arena writes, shader-side lookup) is
+// covered by GPUCacheShaderResolveTest.cpp (shaderpipe).
+//
+// Ported from the VoxelEngine reference's Tests/gpu_paged_cache_tests.cpp,
+// plus regression tests for behaviour the port deliberately changed:
+//   * allocation FAILS (with rollback) instead of hanging when the policy has
+//     no evictable victim — the reference looped forever;
+//   * a partial page reservation is either completed by eviction or rolled
+//     back — the reference leaked the partially-claimed pages;
+//   * PushBackToObject after ClearObject writes to the chain page the element
+//     count says, not blindly to the end page;
+//   * GetObjectBufferRanges reports content-exact spans (a partially-used
+//     page ends its range) — asserted on VALUES, not just range counts,
+//     because a count-only comparison passes on the very bugs it should catch
+//     (docs/agent-rules/gpu-scan-compaction.md §2).
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "GPUCacheInspector.h"
+#include "OloEngine/Renderer/GPUCache/GPUCachePolicy.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedBuffer.h"
+#include "OloEngine/Renderer/GPUCache/GPUPagedCache.h"
+
+#include <array>
+#include <random>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    using Cache = GPUPagedCache<u32, int, FIFOPolicy>;
+    using LruCache = GPUPagedCache<u32, int, LRUPolicy>;
+    using ClockCache = GPUPagedCache<u32, int, ClockPolicy>;
+    using Inspector = GPUPagedCacheInspector<Cache>;
+
+    constexpr sizet kPageSize = 5;
+    constexpr u32 kPageCount = 10;
+} // namespace
+
+// ---------------------------------------------------------------- lifecycle
+
+TEST(GPUPagedCacheTest, CreateCache)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+    EXPECT_TRUE(cache.IsCreated());
+}
+
+TEST(GPUPagedCacheTest, CreateWithZeroPageCountFails)
+{
+    Cache cache;
+    ASSERT_FALSE(cache.Create(kPageSize, 0));
+    EXPECT_FALSE(cache.IsCreated());
+}
+
+TEST(GPUPagedCacheTest, CreateTwiceFailsAndKeepsOriginal)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+    ASSERT_FALSE(cache.Create(kPageSize, kPageCount));
+    EXPECT_TRUE(cache.IsCreated());
+    EXPECT_EQ(cache.GetPageCount(), kPageCount);
+}
+
+TEST(GPUPagedCacheTest, DestroyEmptyCache)
+{
+    Cache cache;
+    ASSERT_NO_THROW(cache.Destroy());
+    EXPECT_FALSE(cache.IsCreated());
+}
+
+TEST(GPUPagedCacheTest, DestroyPopulatedCache)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const int data[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data, std::size(data)));
+    ASSERT_TRUE(cache.Has(1));
+
+    ASSERT_NO_THROW(cache.Destroy());
+    EXPECT_FALSE(cache.IsCreated());
+}
+
+// ------------------------------------------------------------ AllocatePages
+
+TEST(GPUPagedCacheTest, AllocatePagesSinglePage)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 32));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 1, alloc));
+
+    EXPECT_EQ(alloc.m_StartPage, alloc.m_EndPage);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 31u);
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesExactRemainingCapacity)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 4, alloc));
+
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 0u);
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc), 4u);
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesSingleEviction)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 2, alloc));
+    ASSERT_TRUE(cache.AllocatePages(2, 2, alloc));
+    ASSERT_EQ(Inspector::GetFreePagesCount(cache), 0u);
+
+    // This must evict exactly one object (FIFO: object 1).
+    ASSERT_TRUE(cache.AllocatePages(3, 2, alloc));
+
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc), 2u);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 0u);
+    EXPECT_FALSE(cache.Has(1));
+    EXPECT_TRUE(cache.Has(2));
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesMultipleEvictions)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    Cache::ObjectAllocation alloc;
+    for (u32 obj = 1; obj <= 4; ++obj)
+    {
+        ASSERT_TRUE(cache.AllocatePages(obj, 1, alloc));
+    }
+    ASSERT_EQ(Inspector::GetFreePagesCount(cache), 0u);
+
+    // Needs 3 pages -> must evict 3 single-page objects.
+    ASSERT_TRUE(cache.AllocatePages(5, 3, alloc));
+
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc), 3u);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 0u);
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesFragmentedAllocation)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 8));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 2, alloc));
+    ASSERT_TRUE(cache.AllocatePages(2, 2, alloc));
+    ASSERT_TRUE(cache.AllocatePages(3, 2, alloc));
+    ASSERT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+
+    // Free the middle allocation -> fragmentation.
+    cache.DeallocateObject(2);
+    ASSERT_EQ(Inspector::GetFreePagesCount(cache), 4u);
+
+    ASSERT_TRUE(cache.AllocatePages(4, 3, alloc));
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc), 3u);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 1u);
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesReusesFreedPages)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 8));
+
+    Cache::ObjectAllocation alloc1;
+    ASSERT_TRUE(cache.AllocatePages(1, 2, alloc1));
+    const u32 firstStart = alloc1.m_StartPage;
+
+    cache.DeallocateObject(1);
+    ASSERT_EQ(Inspector::GetFreePagesCount(cache), 8u);
+
+    Cache::ObjectAllocation alloc2;
+    ASSERT_TRUE(cache.AllocatePages(2, 2, alloc2));
+    EXPECT_EQ(alloc2.m_StartPage, firstStart); // lowest-first: must reuse the same pages
+}
+
+TEST(GPUPagedCacheTest, AllocatePagesAppendsToExistingAllocation)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 8));
+
+    Cache::ObjectAllocation alloc1;
+    ASSERT_TRUE(cache.AllocatePages(1, 1, alloc1));
+    const u32 first = alloc1.m_StartPage;
+
+    Cache::ObjectAllocation alloc2;
+    ASSERT_TRUE(cache.AllocatePages(1, 2, alloc2)); // append 2 more pages
+
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc2), 3u);
+    EXPECT_EQ(alloc2.m_StartPage, first);
+}
+
+// -------------------------------------------------- failure instead of hang
+
+// The reference's eviction loop had no exit: with nothing evictable it spun
+// forever on the render thread. The port must FAIL the allocation and leave
+// the cache untouched.
+TEST(GPUPagedCacheTest, AllocationBeyondCapacityFailsCleanly)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_FALSE(cache.AllocatePages(1, 5, alloc)) << "5 pages can never fit in a 4-page cache";
+
+    EXPECT_FALSE(cache.Has(1));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 4u) << "partially-reserved pages leaked on failure";
+}
+
+// The only evictable candidate is the requester itself: the policy must skip
+// it (evicting it would free the very chain being grown) and the allocation
+// must fail rather than hang or self-cannibalise.
+TEST(GPUPagedCacheTest, RequesterIsNeverItsOwnVictim)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 4, alloc));
+
+    ASSERT_FALSE(cache.AllocatePages(1, 1, alloc)) << "no victim exists besides the requester";
+    EXPECT_TRUE(cache.Has(1));
+
+    Cache::ObjectAllocation surviving;
+    ASSERT_TRUE(cache.Find(1, surviving));
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, surviving), 4u);
+}
+
+// A failed grow of an EXISTING object must restore its exact prior chain and
+// contents — and the evictions performed on its behalf stand (documented
+// contract; they cannot be undone).
+TEST(GPUPagedCacheTest, FailedGrowRollsBackToPriorAllocation)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(2, 4));
+
+    const int data[] = { 10, 20, 30, 40 }; // 2 pages
+    ASSERT_TRUE(cache.AllocateObject(1, data, std::size(data)));
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_FALSE(cache.AllocatePages(1, 3, alloc)) << "2 existing + 3 more exceeds the 4-page capacity";
+
+    ASSERT_TRUE(cache.Has(1));
+    Cache::ObjectAllocation after;
+    ASSERT_TRUE(cache.Find(1, after));
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, after), 2u) << "appended pages were not rolled back";
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), std::vector<int>(data, data + std::size(data)));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+}
+
+TEST(GPUPagedCacheTest, EvictionListenerReportsPolicyVictimsOnly)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 4));
+
+    std::vector<u32> evicted;
+    cache.SetEvictionListener([&evicted](const u32& victim)
+                              { evicted.push_back(victim); });
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.AllocatePages(1, 2, alloc));
+    ASSERT_TRUE(cache.AllocatePages(2, 2, alloc));
+
+    cache.DeallocateObject(2); // explicit — must NOT notify
+    EXPECT_TRUE(evicted.empty());
+
+    ASSERT_TRUE(cache.AllocatePages(3, 2, alloc)); // free pages exist — no eviction
+    EXPECT_TRUE(evicted.empty());
+
+    ASSERT_TRUE(cache.AllocatePages(4, 2, alloc)); // pressure — FIFO evicts object 1
+    EXPECT_EQ(evicted, std::vector<u32>{ 1u });
+}
+
+// ---------------------------------------------------------- DeallocateObject
+
+TEST(GPUPagedCacheTest, DeallocateObjectBasic)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    ASSERT_TRUE(cache.Has(1));
+    const u32 freePagesBefore = Inspector::GetFreePagesCount(cache);
+
+    cache.DeallocateObject(1);
+    EXPECT_FALSE(cache.Has(1));
+    EXPECT_GT(Inspector::GetFreePagesCount(cache), freePagesBefore);
+    EXPECT_TRUE(Inspector::ReadObjectData(cache, 1).empty());
+}
+
+TEST(GPUPagedCacheTest, DeallocateObjectNonExisting)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const u32 freePagesBefore = Inspector::GetFreePagesCount(cache);
+    EXPECT_NO_THROW(cache.DeallocateObject(9999));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), freePagesBefore);
+}
+
+TEST(GPUPagedCacheTest, DeallocateObjectEmptyObject)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    ASSERT_TRUE(cache.AllocateObject(7, nullptr, 0));
+    ASSERT_TRUE(cache.Has(7));
+    const u32 freePagesBefore = Inspector::GetFreePagesCount(cache);
+
+    EXPECT_NO_THROW(cache.DeallocateObject(7));
+    EXPECT_FALSE(cache.Has(7));
+    EXPECT_GT(Inspector::GetFreePagesCount(cache), freePagesBefore);
+}
+
+TEST(GPUPagedCacheTest, DeallocateObjectTwiceIsIdempotent)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data = { 10, 20, 30, 40, 50 };
+    ASSERT_TRUE(cache.AllocateObject(42, data.data(), data.size()));
+    cache.DeallocateObject(42);
+    EXPECT_FALSE(cache.Has(42));
+    const u32 freePagesAfterFirst = Inspector::GetFreePagesCount(cache);
+
+    EXPECT_NO_THROW(cache.DeallocateObject(42));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), freePagesAfterFirst);
+}
+
+TEST(GPUPagedCacheTest, DeallocateObjectFragmentedAllocation)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> dataA = { 1, 2, 3, 4, 5 };
+    const std::vector<int> dataB = { 10, 11, 12, 13 };
+    const std::vector<int> dataC = { 20, 21, 22, 23 };
+    ASSERT_TRUE(cache.AllocateObject(1, dataA.data(), dataA.size()));
+    ASSERT_TRUE(cache.AllocateObject(2, dataB.data(), dataB.size()));
+    ASSERT_TRUE(cache.AllocateObject(3, dataC.data(), dataC.size()));
+
+    cache.DeallocateObject(2);
+    EXPECT_FALSE(cache.Has(2));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), dataA);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 3), dataC);
+
+    // The freed hole is reusable by a larger, now-fragmented object.
+    const std::vector<int> dataD = { 100, 101, 102, 103, 104, 105 };
+    ASSERT_TRUE(cache.AllocateObject(4, dataD.data(), dataD.size()));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 4), dataD);
+
+    cache.DeallocateObject(4);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 8u);
+}
+
+// ------------------------------------------------------------ AllocateObject
+
+TEST(GPUPagedCacheTest, AllocateObjectSinglePage)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data = { 1, 2, 3 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    ASSERT_TRUE(cache.Has(1));
+
+    const auto ranges = cache.GetObjectBufferRanges(1);
+    ASSERT_EQ(ranges.size(), 1u);
+    EXPECT_EQ(ranges[0].m_AtomCount, 3u);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectTwiceReplacesContents)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    std::vector<int> data = { 1, 2, 3 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+
+    data.push_back(4);
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectExactPageBoundary)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(2, data.data(), data.size()));
+
+    const auto ranges = cache.GetObjectBufferRanges(2);
+    ASSERT_EQ(ranges.size(), 1u);
+    EXPECT_EQ(ranges[0].m_AtomCount, 5u);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 2), data);
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectOverMultiplePagesContiguous)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data(12, 42); // 3 pages
+    ASSERT_TRUE(cache.AllocateObject(3, data.data(), data.size()));
+
+    const auto ranges = cache.GetObjectBufferRanges(3);
+    ASSERT_EQ(ranges.size(), 1u);
+    EXPECT_EQ(ranges[0].m_AtomCount, 12u);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 3), data);
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectOverMultiplePagesFragmented)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 6));
+
+    const std::array<int, 5> pageData{ 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData.data(), pageData.size()));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData.data(), pageData.size()));
+    ASSERT_TRUE(cache.AllocateObject(3, pageData.data(), pageData.size()));
+    cache.DeallocateObject(2); // hole at page 1
+
+    const std::vector<int> largeData(7, 7); // 2 pages: the hole + a tail page
+    ASSERT_TRUE(cache.AllocateObject(4, largeData.data(), largeData.size()));
+
+    const auto ranges = cache.GetObjectBufferRanges(4);
+    ASSERT_EQ(ranges.size(), 2u);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 4), largeData);
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectWithNoElements)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    ASSERT_TRUE(cache.AllocateObject(5, nullptr, 0));
+    EXPECT_TRUE(cache.Has(5));
+    EXPECT_TRUE(cache.GetObjectBufferRanges(5).empty());
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectCausesSingleEviction)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5)); // requires eviction
+    ASSERT_TRUE(cache.Has(3));
+
+    const bool obj1Alive = cache.Has(1);
+    const bool obj2Alive = cache.Has(2);
+    EXPECT_NE(obj1Alive, obj2Alive) << "exactly one prior object should have been evicted";
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectCausesMultipleEvictions)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 3));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5));
+
+    const std::vector<int> largeData(10, 9); // 2 pages
+    ASSERT_TRUE(cache.AllocateObject(4, largeData.data(), largeData.size()));
+    ASSERT_TRUE(cache.Has(4));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 4), largeData);
+
+    const int survivors = (cache.Has(1) ? 1 : 0) + (cache.Has(2) ? 1 : 0) + (cache.Has(3) ? 1 : 0);
+    EXPECT_EQ(survivors, 1) << "only one old object should remain";
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectAfterDeallocationReusesFreedPages)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+
+    cache.DeallocateObject(1);
+
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5)); // reuses the freed page, no eviction
+    EXPECT_TRUE(cache.Has(2));
+    EXPECT_TRUE(cache.Has(3));
+}
+
+// ---------------------------------------------------------------- ClearObject
+
+TEST(GPUPagedCacheTest, ClearObjectKeepsObjectAlive)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const int data[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data, 5));
+
+    cache.ClearObject(1);
+    EXPECT_TRUE(cache.Has(1));
+    EXPECT_TRUE(Inspector::ReadObjectData(cache, 1).empty());
+
+    // Clearing an already-empty object is safe.
+    cache.ClearObject(1);
+    EXPECT_TRUE(cache.Has(1));
+}
+
+TEST(GPUPagedCacheTest, ClearObjectNonExisting)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    EXPECT_NO_THROW(cache.ClearObject(999));
+    EXPECT_FALSE(cache.Has(999));
+}
+
+TEST(GPUPagedCacheTest, AllocateObjectAfterClearObject)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const int initialData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, initialData, 5));
+    cache.ClearObject(1);
+
+    const int newData[] = { 9, 8, 7 };
+    ASSERT_TRUE(cache.AllocateObject(1, newData, 3));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), std::vector<int>({ 9, 8, 7 }));
+    ASSERT_EQ(cache.GetObjectBufferRanges(1).size(), 1u);
+}
+
+// ------------------------------------------------------------- PushBackToObject
+
+TEST(GPUPagedCacheTest, PushBackCreatesMissingObject)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    ASSERT_TRUE(cache.PushBackToObject(1, 11));
+    ASSERT_TRUE(cache.Has(1));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), std::vector<int>({ 11 }));
+}
+
+TEST(GPUPagedCacheTest, PushBackGrowsAcrossPageBoundary)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(2, 4)); // tiny pages: boundary every 2 atoms
+
+    std::vector<int> expected;
+    for (int i = 0; i < 7; ++i) // 4 pages worth minus one atom
+    {
+        ASSERT_TRUE(cache.PushBackToObject(1, i));
+        expected.push_back(i);
+    }
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), expected);
+
+    Cache::ObjectAllocation alloc;
+    ASSERT_TRUE(cache.Find(1, alloc));
+    EXPECT_EQ(Inspector::CountAllocatedPages(cache, alloc), 4u);
+}
+
+// Regression: after ClearObject the element count rewinds but the chain keeps
+// its pages, so the next PushBack must land in the FIRST chain page. The
+// reference wrote to the end page — the appended element vanished from
+// ReadObjectData (it read chain-ordered) while `Has` stayed true.
+TEST(GPUPagedCacheTest, PushBackAfterClearWritesChainStart)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, kPageCount));
+
+    const std::vector<int> data(7, 3); // 2 pages
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    cache.ClearObject(1);
+
+    ASSERT_TRUE(cache.PushBackToObject(1, 77));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), std::vector<int>({ 77 }));
+}
+
+// ---------------------------------------------------------------- Move / Swap
+
+TEST(GPUPagedCacheTest, MoveObjectBasic)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+
+    cache.MoveObject(1, 2);
+    EXPECT_FALSE(cache.Has(1));
+    ASSERT_TRUE(cache.Has(2));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 2), data);
+}
+
+TEST(GPUPagedCacheTest, MoveObjectNonExistingSource)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    cache.MoveObject(123, 456);
+    EXPECT_FALSE(cache.Has(123));
+    EXPECT_FALSE(cache.Has(456));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+}
+
+TEST(GPUPagedCacheTest, MoveObjectOntoExistingDestination)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 3));
+
+    const std::vector<int> srcData = { 1, 2, 3, 4, 5 };
+    const std::vector<int> dstData = { 9, 8, 7 };
+    ASSERT_TRUE(cache.AllocateObject(1, srcData.data(), srcData.size()));
+    ASSERT_TRUE(cache.AllocateObject(2, dstData.data(), dstData.size()));
+
+    cache.MoveObject(1, 2);
+    EXPECT_FALSE(cache.Has(1));
+    ASSERT_TRUE(cache.Has(2));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 2), srcData);
+    // The overwritten destination's page was freed.
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+}
+
+// A moved object must stay evictable under FIFO. The reference kept the
+// source's policy handle, whose queue entry named the OLD id — after the move
+// nothing in the queue named the survivor, so it could never be evicted.
+TEST(GPUPagedCacheTest, MovedObjectRemainsEvictable)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    cache.MoveObject(1, 2);
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5));
+
+    // Pressure: someone must be evicted, and object 2 is the only candidate
+    // besides the requester.
+    ASSERT_TRUE(cache.AllocateObject(4, pageData, 5));
+    EXPECT_FALSE(cache.Has(2)) << "the moved object was invisible to the eviction policy";
+    EXPECT_TRUE(cache.Has(4));
+}
+
+TEST(GPUPagedCacheTest, SwapSinglePageObjects)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const std::vector<int> data1 = { 1, 2, 3, 4, 5 };
+    const std::vector<int> data2 = { 9, 8, 7 };
+    ASSERT_TRUE(cache.AllocateObject(1, data1.data(), data1.size()));
+    ASSERT_TRUE(cache.AllocateObject(2, data2.data(), data2.size()));
+
+    cache.Swap(1, 2);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data2);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 2), data1);
+}
+
+TEST(GPUPagedCacheTest, SwapMultiPageObjects)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 6));
+
+    const std::vector<int> data1(10, 1); // 2 pages
+    const std::vector<int> data2(15, 2); // 3 pages
+    ASSERT_TRUE(cache.AllocateObject(1, data1.data(), data1.size()));
+    ASSERT_TRUE(cache.AllocateObject(2, data2.data(), data2.size()));
+
+    cache.Swap(1, 2);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data2);
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 2), data1);
+}
+
+TEST(GPUPagedCacheTest, SwapNonExistingObject)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 3));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+
+    cache.Swap(1, 999);
+    ASSERT_TRUE(cache.Has(1));
+    EXPECT_FALSE(cache.Has(999));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+}
+
+TEST(GPUPagedCacheTest, SwapBothNonExistingObjects)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    cache.Swap(111, 222);
+    EXPECT_FALSE(cache.Has(111));
+    EXPECT_FALSE(cache.Has(222));
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), 2u);
+}
+
+TEST(GPUPagedCacheTest, SwapObjectWithItself)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+
+    cache.Swap(1, 1);
+    ASSERT_TRUE(cache.Has(1));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+}
+
+// -------------------------------------------------------- GetObjectBufferRanges
+
+// Content-exact spans, not just counts: chain [1, 2, 0] where page 0 holds the
+// PARTIAL data tail. Pages 0..2 are address-adjacent, so a naive contiguous
+// merge reports one 5-atom span [0, 5) — but atoms 1..2 of page 0 are garbage
+// (the tail wrote only one atom there). The partial page must END its span.
+TEST(GPUPagedCacheTest, BufferRangesSplitAtThePartialPage)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(2, 3)); // pageSize 2, 3 pages
+
+    // Object 1 takes page 0; object 2 then needs 3 pages: reserves {1, 2} and
+    // evicts object 1 to take page 0 — chain [1, 2, 0].
+    const int seed[] = { 7, 7 };
+    ASSERT_TRUE(cache.AllocateObject(1, seed, 2));
+    const std::vector<int> data = { 10, 11, 12, 13, 14 }; // 5 atoms = 2 full pages + 1
+    ASSERT_TRUE(cache.AllocateObject(2, data.data(), data.size()));
+    ASSERT_FALSE(cache.Has(1));
+    ASSERT_EQ(Inspector::ChainPages(cache, 2), std::vector<u32>({ 1, 2, 0 }));
+
+    using Range = Cache::BufferRange;
+    const auto ranges = cache.GetObjectBufferRanges(2);
+    const std::vector<Range> expected = {
+        Range{ 0, 1 }, // page 0: the 1-atom data tail
+        Range{ 2, 4 }, // pages 1-2: full, address-adjacent
+    };
+    EXPECT_EQ(ranges, expected);
+}
+
+TEST(GPUPagedCacheTest, BufferRangesForNonExistingObjectAreEmpty)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+    EXPECT_TRUE(cache.GetObjectBufferRanges(404).empty());
+}
+
+// ------------------------------------------------------------- other policies
+
+TEST(GPUPagedCacheTest, LruPolicyEvictsTheLeastRecentlyUsed)
+{
+    LruCache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 3));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5));
+
+    // Touch 1 (the current LRU tail) so 2 becomes the coldest.
+    (void)cache.GetObjectBufferRanges(1);
+
+    ASSERT_TRUE(cache.AllocateObject(4, pageData, 5));
+    EXPECT_TRUE(cache.Has(1));
+    EXPECT_FALSE(cache.Has(2)) << "LRU must evict the coldest object";
+    EXPECT_TRUE(cache.Has(3));
+}
+
+TEST(GPUPagedCacheTest, ClockPolicyEvictsAnUnreferencedObject)
+{
+    ClockCache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 3));
+
+    const int pageData[] = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5));
+
+    ASSERT_TRUE(cache.AllocateObject(4, pageData, 5));
+    ASSERT_TRUE(cache.Has(4));
+
+    const int survivors = (cache.Has(1) ? 1 : 0) + (cache.Has(2) ? 1 : 0) + (cache.Has(3) ? 1 : 0);
+    EXPECT_EQ(survivors, 2) << "clock must evict exactly one object";
+}
+
+// -------------------------------------------------------------- stress tests
+
+TEST(GPUPagedCacheTest, FullCacheChurnStressTest)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(4, 32));
+
+    std::mt19937 rng(555);
+    for (int cycle = 0; cycle < 100; ++cycle)
+    {
+        for (u32 i = 0; i < 64; ++i)
+        {
+            std::vector<int> data((rng() % 8) + 1);
+            for (int& v : data)
+            {
+                v = static_cast<int>(rng());
+            }
+            ASSERT_TRUE(cache.AllocateObject(i, data.data(), data.size()));
+            ASSERT_TRUE(cache.Has(i));
+        }
+        for (u32 i = 0; i < 64; ++i)
+        {
+            cache.DeallocateObject(i);
+            ASSERT_FALSE(cache.Has(i));
+        }
+        ASSERT_EQ(Inspector::GetFreePagesCount(cache), 32u);
+    }
+}
+
+TEST(GPUPagedCacheTest, RepeatedFragmentationReuseStressTest)
+{
+    Cache cache;
+    constexpr sizet kStressPageSize = 8;
+    constexpr u32 kStressPageCount = 64;
+    ASSERT_TRUE(cache.Create(kStressPageSize, kStressPageCount));
+
+    std::mt19937 rng(777);
+    for (int iteration = 0; iteration < 1000; ++iteration)
+    {
+        const u32 objectID = rng() % 128;
+        if ((rng() % 3) == 0)
+        {
+            cache.DeallocateObject(objectID);
+            ASSERT_FALSE(cache.Has(objectID));
+        }
+        else
+        {
+            std::vector<int> data((rng() % (kStressPageSize * 5)) + 1);
+            for (int& v : data)
+            {
+                v = static_cast<int>(rng());
+            }
+            ASSERT_TRUE(cache.AllocateObject(objectID, data.data(), data.size()));
+            ASSERT_TRUE(cache.Has(objectID));
+            ASSERT_EQ(Inspector::ReadObjectData(cache, objectID), data);
+        }
+    }
+    ASSERT_LE(Inspector::GetFreePagesCount(cache), kStressPageCount);
+}
+
+TEST(GPUPagedCacheTest, LargeObjectChurnStressTest)
+{
+    Cache cache;
+    constexpr sizet kStressPageSize = 64;
+    ASSERT_TRUE(cache.Create(kStressPageSize, 256));
+
+    std::mt19937 rng(9001);
+    for (int iteration = 0; iteration < 1000; ++iteration)
+    {
+        const u32 objectID = static_cast<u32>(iteration % 32);
+        std::vector<int> data(kStressPageSize * ((rng() % 16) + 1));
+        for (int& v : data)
+        {
+            v = static_cast<int>(rng());
+        }
+        ASSERT_TRUE(cache.AllocateObject(objectID, data.data(), data.size()));
+        ASSERT_EQ(Inspector::ReadObjectData(cache, objectID), data);
+
+        if ((iteration % 3) == 0)
+        {
+            cache.DeallocateObject(objectID);
+            ASSERT_FALSE(cache.Has(objectID));
+        }
+    }
+}
+
+// The dst-exists branch of MoveObject frees the destination's chain — without
+// a self-move guard that chain is the object's OWN live chain, and the policy
+// node gets removed twice.
+TEST(GPUPagedCacheTest, MoveObjectOntoItselfIsANoOp)
+{
+    Cache cache;
+    ASSERT_TRUE(cache.Create(kPageSize, 2));
+
+    const std::vector<int> data = { 1, 2, 3, 4, 5 };
+    ASSERT_TRUE(cache.AllocateObject(1, data.data(), data.size()));
+    const u32 freeBefore = Inspector::GetFreePagesCount(cache);
+
+    cache.MoveObject(1, 1);
+
+    ASSERT_TRUE(cache.Has(1));
+    EXPECT_EQ(Inspector::ReadObjectData(cache, 1), data);
+    EXPECT_EQ(Inspector::GetFreePagesCount(cache), freeBefore);
+
+    // The policy must still see the object: pressure evicts it, not a hang.
+    const int pageData[] = { 9, 9, 9, 9, 9 };
+    ASSERT_TRUE(cache.AllocateObject(2, pageData, 5));
+    ASSERT_TRUE(cache.AllocateObject(3, pageData, 5));
+    EXPECT_FALSE(cache.Has(1)) << "self-move corrupted the eviction policy's view of the object";
+}
+
+// Lowest-index-first is a DOCUMENTED guarantee of ReserveUpToPages (consumers
+// derive deterministic layout from it — VirtualMeshRegistry's slot order), so
+// it gets pinned here against scan "optimisations" that would reorder it.
+TEST(GPUPagedCacheTest, ReserveUpToPagesClaimsLowestIndicesFirst)
+{
+    GPUPagedBuffer<int> buffer;
+    ASSERT_TRUE(buffer.Create(1, 8, GPUCacheBacking::HostOnly));
+
+    std::vector<u32> pages;
+    ASSERT_EQ(buffer.ReserveUpToPages(5, pages), 5u);
+    EXPECT_EQ(pages, std::vector<u32>({ 0, 1, 2, 3, 4 }));
+
+    buffer.FreePage(3);
+    buffer.FreePage(1);
+
+    pages.clear();
+    ASSERT_EQ(buffer.ReserveUpToPages(2, pages), 2u);
+    EXPECT_EQ(pages, std::vector<u32>({ 1, 3 })) << "freed pages must be re-claimed in ascending order";
+
+    // A short claim reports how much it got and keeps the claim.
+    pages.clear();
+    EXPECT_EQ(buffer.ReserveUpToPages(9, pages), 3u); // only 5..7 remain
+    EXPECT_EQ(pages, std::vector<u32>({ 5, 6, 7 }));
+}

--- a/docs/agent-rules/notes-core-and-threading.md
+++ b/docs/agent-rules/notes-core-and-threading.md
@@ -380,3 +380,45 @@ So: **any new modal asks `IsNonInteractive()` first**, and the automated path
 takes the *least destructive* answer — "cancel", "keep what is on disk" — never
 the convenient one. A host that knows it is automated calls
 `SetNonInteractive(true)` at startup (the test binary already does).
+
+## 15. A "benign" data race you documented is still a failed TSan job
+
+Issue #704's `GPUHashMap` shipped its first round with this in the class comment:
+
+> concurrent writes to the SAME key are last-writer-wins with no value-tearing
+> guarantee (the value store is not atomic — the reference has the same contract).
+
+That is a data race described in prose. The keys were claimed with a CAS through
+`std::atomic_ref`, but the *value* store next to it was a plain write, so two
+threads inserting one key wrote the same bytes unsynchronized. Writing the
+consequence down does not make it defined: C++ has no "benign race", and the
+gating `tsan-linux` job failed on exactly the two tests that exercised it — while
+the full 6100-test suite passed clean on Windows, where **no TSan exists**
+(neither MSVC nor clang-cl ships it).
+
+Two things generalise:
+
+**Narrow the contract instead of documenting the race.** The fix was not to make
+the value atomic — `V` is caller-supplied and `ObjectAllocation` is 16 bytes, so
+`atomic_ref<V>` would take a lock and tax the single-writer path every engine
+consumer actually uses. It was to state what is genuinely supported and true:
+concurrent `Insert`/`Erase`/`Find` of **distinct** keys is lock-free-safe
+(including keys colliding on one slot), and same-key mutation is unsupported.
+Ask what concurrency the consumers need before paying for concurrency nobody
+asked for.
+
+**Then make the tests contend the thing you actually claim.** The old test had 16
+threads hammering one key — which only exercised the race. The replacement gives
+each thread its own keys, all chosen (by brute force over the real hash) to land
+in the **same start slot**: maximal contention on the claim CAS, zero shared
+value writes. That tests the guarantee the class now makes, and it is a stronger
+test than the one it replaced, not a weaker one. The general trap: when a
+sanitizer flags a test, check whether the test is asserting a property the code
+should not have been offering — deleting or muting it is the wrong repair, and so
+is loosening the code to match a bad test.
+
+Corollary for planning: any change adding atomics or a multithreaded test should
+assume a CI round is spent on TSan alone, because it cannot be reproduced on this
+platform. Get the report from `gh api repos/<o>/<r>/actions/jobs/<id>/logs` and
+grep `WARNING: ThreadSanitizer` — the `SUMMARY:` line names both conflicting
+accesses by file:line, which is usually enough to fix without reproducing.

--- a/docs/agent-rules/notes-renderer.md
+++ b/docs/agent-rules/notes-renderer.md
@@ -399,3 +399,27 @@ own stage and every differential assertion passes vacuously against itself.
 > **Rule of thumb:** grep `ResolveFrameGraphFramebuffer(ResourceNames::` before
 > adding anything to the tail of the post chain. Every hit is a consumer that
 > has hard-coded "the last stage" by name.
+
+## 18. The RHI's persistent mapping is WRITE-only — a GPU-visible CPU structure needs host authority, not mapped reads
+
+`RenderCommand::AllocatePersistentUploadStorage` maps with
+`GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT` and **no read
+bit** (`OpenGLRendererAPI.cpp`), so a CPU read through the returned pointer is
+undefined behaviour — and would be a WC-memory perf trap even where it happens
+to work. This matters the moment a CPU-maintained structure must also be
+readable by shaders: a hash table or link table the CPU probes cannot live *in*
+the mapping.
+
+The `Renderer/GPUCache/` substrate (#704) is the worked example of the correct
+shape: `GPUCacheStorage`'s `HostMirrored` backing keeps the heap copy as the
+single authority for every CPU read/write and write-through-mirrors each
+committed mutation into the mapping for shader-side lookup. Two dividends
+beyond correctness: CPU probes hit cacheable heap memory instead of uncached
+WC pages, and the identical logic runs with `HostOnly` backing — which is what
+lets the allocate/evict/split-chain/collision tests run **headless** instead of
+skipping without a GL context. Bulk payloads that the CPU only ever writes
+(`DeviceMapped` backing) are the one case the raw mapping serves directly.
+
+If you find yourself wanting a READ|WRITE persistent mapping instead, that is a
+new RHI entry point across both backends — weigh it against the mirror pattern
+first.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -75,7 +75,7 @@ sonar.cpd.exclusions=OloEngine/tests/**/*
 #   ecs_*/   templates, ECS predicate chains, X-macro template-arg pasting),
 #   xmacro_* scoped as narrowly as the offending location allows.
 # ---------------------------------------------------------------------------
-sonar.issue.ignore.multicriteria=tst_s5443,tst_s3656,tst_s997,tst_s1001,fp_s5000,ecs_s1067,xmacro_s963,cmp_s1244_components,cmp_s1244_rendercmd,env_s990,lever_s963,lever_s958,lever_s960,lever_m23042,lever_s1820,interactivity_s5421
+sonar.issue.ignore.multicriteria=tst_s5443,tst_s3656,tst_s997,tst_s1001,fp_s5000,ecs_s1067,xmacro_s963,cmp_s1244_components,cmp_s1244_rendercmd,env_s990,lever_s963,lever_s958,lever_s960,lever_m23042,lever_s1820,interactivity_s5421,gpucache_s8417
 
 # S5443 "avoid publicly writable directories": GoogleTest fixtures legitimately
 # use std::filesystem::temp_directory_path() for isolated, self-cleaning artefacts;
@@ -189,3 +189,18 @@ sonar.issue.ignore.multicriteria.lever_s1820.resourceKey=OloEngine/src/OloEngine
 # job is to be atomically mutable state".
 sonar.issue.ignore.multicriteria.interactivity_s5421.ruleKey=cpp:S5421
 sonar.issue.ignore.multicriteria.interactivity_s5421.resourceKey=OloEngine/src/OloEngine/Core/Interactivity.cpp
+
+# S8417 "use seq_cst" on Renderer/GPUCache/**: this directory IS the engine's
+# lock-free residency substrate (issue #704) — an open-addressed hash map whose
+# keys are claimed by CAS, and a free-page bitset. Explicit acquire/release/
+# relaxed orders are the entire design, chosen per operation and documented at
+# each site; "fixing" them to seq_cst would be a silent behaviour and
+# performance change to the most concurrency-sensitive code in the renderer.
+# This matches the standing project position on S8417 — "deliberately defer,
+# don't fight" (docs/agent-rules/sonarqube-review-alignment.md) — but has to be
+# a scoped exclusion rather than a note, because on NEW code the rule sinks the
+# quality gate's reliability rating instead of just adding backlog noise.
+# Scoped to this one directory so a stray non-seq_cst atomic anywhere else in
+# the engine is still reported.
+sonar.issue.ignore.multicriteria.gpucache_s8417.ruleKey=cpp:S8417
+sonar.issue.ignore.multicriteria.gpucache_s8417.resourceKey=OloEngine/src/OloEngine/Renderer/GPUCache/**/*


### PR DESCRIPTION
# feat(renderer): general GPU-visible paged cache + lock-free GPU hash map (#704)

Ports the VoxelEngine residency substrate (MIT, same stack: C++23 / GL 4.6) into
`OloEngine/Renderer/GPUCache/` and reimplements `VirtualMeshRegistry`'s slot-arena
residency on top of it, per the three acceptance criteria of #704.

## What landed

**The substrate** — seven headers + one .cpp under `Renderer/GPUCache/`, no raw GL
anywhere (everything routes through `RenderCommand`, so the RHI boundary stays
intact):

- `GPUPagedCache<ObjectID, Atom, Policy>` — page-chain allocation over one large
  buffer, victim-chain split on eviction, object allocate/append/move/swap/clear,
  plus a **directory-only mode** (no atom storage) for consumers whose payload
  lives in their own buffers — which is exactly what VirtualMeshRegistry needs and
  what Adaptive Virtual Texturing (#715) will need.
- `GPUHashMap<K, V>` — open-addressed, power-of-two capacity, 64-bit keys,
  `EMPTY_KEY`/`TOMBSTONE_KEY` sentinels, lock-free CPU inserts via
  `std::atomic_ref` CAS, **GPU-readable layout**.
- `EvictionPolicy` concept + `LRUPolicy` / `FIFOPolicy` / `ClockPolicy`.
- `GPUBufferLockManager` + `GPUCircularBuffer` — fence-based range locking for
  persistent-mapped writes, and the upload ring built on it.
- `assets/shaders/include/GPUCacheResolve.glsl` — the shader-side lookup contract
  (hash + sentinels + a `OLO_GPU_CACHE_DEFINE_FIND` macro), bit-identical to the
  C++ side.

**The storage design** (the one real divergence from the reference): the RHI's
persistent mapping is WRITE-only (`GL_MAP_WRITE_BIT` without READ — see
`OpenGLRendererAPI::AllocatePersistentUploadStorage`), so the reference's
"CPU probes the mapped table" approach would be UB here. Instead
`GPUCacheStorage<T>` keeps a **host-authority copy** for every CPU read/write and
write-through-mirrors committed mutations into the mapping (`HostMirrored`), with
`HostOnly` (no device at all) and `DeviceMapped` (bulk write-only payloads)
variants. Dividends: CPU probes hit cacheable heap memory instead of uncached WC
pages, and the identical logic runs headless — which is how criterion 3's tests
run instead of skipping. Captured as `docs/agent-rules/notes-renderer.md` §18.

**Reference bugs fixed in the port** (each has a regression test):

1. The eviction loop had **no exit** — nothing evictable meant an infinite loop
   on the render thread. Allocation is now fallible: it fails cleanly and rolls
   the object back to its pre-call allocation (and a consecutive-retry cap makes
   the no-hang guarantee hold even against a misbehaving consumer policy).
2. A partial page reservation on failure **leaked the claimed pages**.
3. `GPUHashMap::Create` initialised only `[0, capacity)` of the
   power-of-two-rounded table — the tail was uninitialised memory a probe could
   read.
4. An `Insert` whose claim-CAS lost the race to another thread inserting the
   *same* key missed the duplicate and inserted a second entry.
5. **`Insert` claimed the first tombstone in the probe chain without checking
   whether the key already lived further along it** — an update-insert whose
   chain crossed a later-erased slot duplicated the entry; one `Erase` then
   removed only the first copy and lookups resurrected the stale allocation
   (two objects sharing pages). Insert now probes the full chain before
   claiming the earliest tombstone.
6. `PushBackToObject` after `ClearObject` wrote to the end page instead of the
   chain page the element count implies.
7. `MoveObject` left the moved object's FIFO policy entry naming the *old* id —
   the survivor became permanently unevictable — and had no self-move guard
   (`MoveObject(X, X)` freed X's own live chain).
8. `Swap` exchanged policy handles along with contents, aliasing policy nodes.
9. The requesting object could be selected as its own eviction victim
   (self-cannibalisation → infinite loop); victim selection now excludes it.
10. The reference's FIFO was a Vyukov MPMC ring that could not remove mid-queue
    entries, so every deallocation left a stale entry that only drained under
    eviction pressure — deallocate-heavy churn without pressure grew it without
    bound. FIFO is now the LRU intrusive list with accesses ignored: exact FIFO
    order, O(1) removal, no stale entries (the policies run under the cache's
    single-writer contract, so the ring's lock-freedom bought nothing).

**Self-review hardening beyond the reference's bug set** (from the Phase 3
review, high effort — every finding verified against the code before acting):

- **Tombstone decay**: erases mint tombstones and only probe-path reuse ever
  reclaimed them, so long-session churn degrades every miss to an O(capacity)
  scan (CPU and GPU). `NeedsCompaction`/`CompactTombstones` (single-writer,
  documented) rebuild the table in place; `GPUPagedCache` amortises it across
  its erase sites.
- `GPUHashMap::Mutate` — single-probe in-place update; the cache's
  find-then-reinsert sites (double probe each) now use it.
- Fence hygiene: `GPUBufferLockManager` reaps already-signaled fences on every
  `LockRange` — previously a rarely-wrapping ring accumulated one live sync
  object per commit until the head came back around.
- Free-page fast path: an atomic free-count early-out spares the
  steady-state-full residency cache a full bitset scan per allocation.
- Allocation-free hot path: `TryReservePages` uses a member scratch vector
  (the pre-#704 free list allocated nothing per page load; now this doesn't
  either).
- Static-teardown safety: destructors reached with the RendererAPI gone
  (skipped `Shutdown`) now leak — as the pre-#704 code did — instead of
  calling into a dead device.
- An unwired `VirtualPageEvictionPolicy` selector asserts loudly instead of
  silently pinning the cache at the coarse cut.
- A headless text-parse test pins `GPUCacheResolve.glsl`'s hash constants and
  sentinels against the C++ side, so contract drift fails CI even where the
  GPU test skips; the hash itself now delegates to the engine's canonical
  `Hash::Hash64` (`Core/Hash.h`) instead of a third hand-rolled copy.
- Lowest-index-first page claiming is promoted from incidental scan order to a
  documented, test-pinned guarantee (VirtualMeshRegistry's deterministic slot
  layout relies on it).
- Dead reference-port surface deleted: `ReserveFirstAvailablePages`,
  `ReservePage`, `Emplace`, the speculative `BufferLockManagerLike` concept and
  `NullBufferLockManager`.

**Review findings deliberately not taken** (each verified, then dismissed with
reasoning): replacing the VMR integration with a bare bitset (criterion 1 says
"reimplemented on top of it", and the substrate is the point); deleting
`MoveObject`/`Swap` as unconsumed (the issue text names append/move/swap/clear
as the required API shape); a composition split of the directory-only mode
(right direction for #715, out of proportion here — Release-mode guards added
instead); caching chain length in `ObjectAllocation` to speed `PushBackToObject`
(no hot consumer; it would change the GPU-visible struct); emitting the GLSL
contract from C++ codegen (follow-up material — the text-pin test covers the
drift risk); and a Vulkan fence-wait deadlock scenario that is unreachable
today because Vulkan's `AllocatePersistentUploadStorage` is a stub returning
null, so no persistent-mapped consumer can exist there (documented at the wait
loop for whoever implements the stub).

## Criterion 1 — VirtualMeshRegistry residency, no behaviour change

The slot arena is now a directory-only, host-backed
`GPUPagedCache<u64, u8, VirtualPageEvictionPolicy>`: objects are pooled page
indices, one substrate page per slot. The policy delegates victim selection back
to the registry (`SelectResidencyVictim`) so the *exact* pre-#704 semantics are
preserved: pinned pages never evict, pages touched or loaded this frame are
protected, oldest `LastUsedFrame` wins, lowest page index breaks ties. The
eviction listener does the registry-side bookkeeping the old `EvictPage` did.
Free slots come out lowest-index-first, matching the old free-list order, and
all `VirtualResidencyStats` counters are fed at the same points as before.

The upload ring moved onto `GPUCircularBuffer`: same reserve/copy semantics, but
a wrap now waits only on the fences covering the reused range where the old ring
called `WaitForDeviceIdle()` (a full pipeline stall).

**Evidence it is unchanged**: `VirtualGeometryVisualEvidence.StreamingResidencyConvergesUnderTightBudget`
was run **on master's binary built at this branch's base commit (`1aa7fe975`)**
and on this branch — green both times, same scene, same 4-slot budget, same
assertions (resident ≤ budget every frame across 20 streaming frames, uploads >
the pinned set, LRU evictions actually occurring, and no pixel dropout: the
sphere never falls below half the coarse-cut baseline while streaming).

## Criterion 2 — shader-side resolve with no CPU round trip

`GPUCacheResolve_Probe.comp` + `GPUCacheShaderResolveTest` (shaderpipe): a live
`GPUPagedCache` in `HostMirrored` backing is populated/evicted/cleared on the
CPU; one compute thread per query key probes the mirrored hash table and walks
the mirrored page-node chains for present / absent / erased keys. Every reported
field must equal the CPU ground truth, including an **order-sensitive** chain
checksum (h = h·33 + page) — a set-style comparison would pass on a walk that
visits the right pages in the wrong order (`gpu-scan-compaction.md` §2), and
chain order *is* the data layout. The test asserts its own population produced a
fragmented chain, so the order check cannot pass vacuously.

## Criterion 3 — headless unit tests

69 headless tests (`plumbing`): allocate / evict / split-chain across all three
policies, hash insert / lookup / collision / tombstone / full-table, lock-free
multithreaded insert & erase stress, the 8 regression tests above, and 3 ported
churn/fragmentation stress suites. All run without a GL context — nothing skips.

## Binding-space impact

**Zero new UBO or SSBO slots.** The substrate takes binding points as
parameters at bind time; the probe shader lives under `assets/shaders/tests/`
(outside the reflection sweep) and uses local bindings 0–2. Slot 83 remains
untouched for #723.

## VSM allocator — recommendation: do NOT migrate (deliberate, criterion "state it either way")

`VirtualShadowMap`'s page allocator runs **entirely on the GPU** by design
("Allocation, freeing and marking all run ON THE GPU", VirtualShadowMap.h §) —
requests, free-list build, allocation and eviction are compute passes over
SSBOs, with the CPU only reading stats a frame late. This substrate is the
opposite family: CPU-authority allocation with GPU-readable lookup. Migrating
VSM onto it would move allocation back to the CPU and re-introduce the round
trip #702 deliberately removed. The two consumers that fit the substrate are
CPU-driven residency systems: VirtualMeshRegistry (done here) and AVT (#715).

## Review guide

**Where I'd look hardest**

1. `GPUPagedCache.h` `AllocatePages`/`RollBackAppendedPages`/`EvictAndTakePages`
   — the fallible-allocation rework of the reference's infinite loop. The
   rollback restores the pre-call chain; evictions already performed stand
   (documented). This is the highest-consequence divergence from the reference.
2. `VirtualMeshRegistry.cpp` `LoadPage`/`OnResidencyEvicted`/`SelectResidencyVictim`
   — the "no behaviour change" criterion lives here. Compare the victim scan
   against the pre-diff LoadPage loop: same predicate, same tie-break.
3. `GPUHashMap.h` `InsertImpl` — the CAS-loss-same-key branch (reference bug 4)
   and the mirror-write ordering for GPU readers.

**What I verified, and how**

- **Full suite green**: 6094 tests, 25 skips — byte-identical skip list to the
  pre-change run on master's binary (all environmental: no Steam SDK, no video
  fixture, app-launch smokes).
- **78 substrate tests** (`GPUHashMapTest`, `GPUPagedCacheTest`,
  `GPUCacheShaderResolveTest`): 75 headless + 3 device. The headless ones need
  no GL context, so they are real CI coverage rather than skips.
- **Residency unchanged**: the master-baseline-vs-branch comparison above.
- **Pixels, looked at — not just asserted**: re-ran
  `VirtualGeometryVisualEvidence.HardwarePathRendersTheDagCutFromMultipleAngles`
  and `DebugCaptureTargetsRenderClusterLodAndOverdraw` and opened the PNGs.
  `VirtualGeometry_Front.png` / `_Above.png` show a complete, smoothly shaded
  sphere from both angles; `VirtualGeometry_Debug_ClusterId.png` shows the
  sphere fully tiled with distinct cluster patches and **no holes or stale
  regions** — which is the picture a starved or mis-rebased page would break
  first. (These PNGs are regenerated evidence, not committed — the suite churns
  them on every run.)
- **The check that would have failed if this were wrong**: the shader-resolve
  test's order-sensitive chain checksum, plus its own assertion that the test
  population actually produced a fragmented (non-address-ascending) chain, so
  the order check cannot pass vacuously.

**Least confident about** — the `GPUHashMap` CAS paths under *genuine* CPU
concurrency. The multithreaded tests hammer distinct keys, the same key, and
mixed insert/erase churn, and they pass — but a linear-probe table with
tombstones has interleavings no test enumerates, and the engine's only consumer
today is single-writer. If you read one thing closely, make it `InsertImpl`'s
restart-on-lost-CAS loop: I convinced myself a lost claim invalidates the probe
state and must restart rather than continue, but that is the argument I would
most like a second pair of eyes on.

**Deliberately not tested**

- The `GPUBufferLockManager` under a driver that defers copy execution long
  enough for the fences to be load-bearing: the ring-wrap test exercises the
  fence path but cannot force the driver to defer, so it would also pass on an
  implementation with broken waits.
- The Vulkan backend, at all: its `AllocatePersistentUploadStorage` is a stub
  returning null, so no persistent-mapped consumer of this substrate can exist
  there yet. The fence-wait loop carries a comment for whoever implements that
  stub, because Vulkan's `CreateFence` stages its signal for the next queue
  submit and an intra-frame wait would need re-examining.
- A **live editor session**: the OloEditor binary is not built in this worktree
  and the build mutex is currently held by a sibling worktree. The rendering
  evidence above is the automated pipeline (real render passes, real readback,
  PNGs I opened) rather than a hand-driven editor frame — worth knowing when
  weighing the visual claim.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU cache support for storage, paging, hashing, eviction, synchronization, and circular-buffer uploads.
  * Improved virtual geometry residency management and staged GPU uploads.
  * Added shader-based cache resolution with allocation and page-chain reporting.

* **Bug Fixes**
  * Improved fragmented-chain handling, eviction, allocation rollback, and upload synchronization.

* **Tests**
  * Added broad coverage for GPU caches, hash maps, shader resolution, eviction, and repeated buffer wrapping.

* **Documentation**
  * Documented persistent GPU mapping limitations and supported storage modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->