### PR TITLE
fix(asset): cook embedded textures without a project so the mesh cache can persist them (#791)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ you are in.
 - [component-serializer-codegen.md](docs/agent-rules/component-serializer-codegen.md) — when a component round-trips for free, when to annotate a field, and when to hand-write *and* exclude.
 - [scene-binary-sidecar.md](docs/agent-rules/scene-binary-sidecar.md) — the `.scenebin` fast path: generated, hybrid-covered, and how it gets invalidated.
 - [binary-format-versioning.md](docs/agent-rules/binary-format-versioning.md) — versioning a fixed-order binary archive: gate each new field, don't trust the header check to exclude old data.
+- [cache-stored-unresolvable-reference.md](docs/agent-rules/cache-stored-unresolvable-reference.md) — a cache that stores a *name* (handle, path) must refuse to store one nothing can resolve; the failure only shows on the second load, so CI never sees it.
 - [scene-copy-must-carry-scene-level-settings.md](docs/agent-rules/scene-copy-must-carry-scene-level-settings.md) — `Scene::Copy()` drops scene-level settings structs the instant Play starts, invisibly to headless tests.
 - [floating-origin-rebase-subsystems.md](docs/agent-rules/floating-origin-rebase-subsystems.md) — the four subsystems holding world-space state outside the rebased set, each needing a different fix.
 - [asset-degradation-and-constructor-preconditions.md](docs/agent-rules/asset-degradation-and-constructor-preconditions.md) — a precondition asserted in a constructor delegates safety to ~30 call sites, and they will disagree.

--- a/OloEngine/src/OloEngine/Asset/MeshCache.cpp
+++ b/OloEngine/src/OloEngine/Asset/MeshCache.cpp
@@ -263,6 +263,23 @@ namespace OloEngine
                     OLO_CORE_INFO("MeshCache: Cleared animation cache");
                 }
             }
+
+            // The cooked-texture cache is derived data like the other two: every file in it is
+            // reproducible from the model that produced it. Leaving it behind would make "clear
+            // cache" silently partial — and the .omesh files that reference these textures by
+            // path are being deleted right above, so keeping them would strand them anyway.
+            if (auto embeddedDir = GetAssetRoot() / kEmbeddedTextureCacheSubdir; std::filesystem::exists(embeddedDir, ec))
+            {
+                std::filesystem::remove_all(embeddedDir, ec);
+                if (ec)
+                {
+                    OLO_CORE_ERROR("MeshCache: Failed to clear embedded-texture cache: {}", ec.message());
+                }
+                else
+                {
+                    OLO_CORE_INFO("MeshCache: Cleared embedded-texture cache");
+                }
+            }
         }
 
         void InvalidateCache(const std::filesystem::path& sourcePath, const std::string& prefix)
@@ -398,6 +415,7 @@ namespace OloEngine
 
             accumulateDirectorySize(GetAssetRoot() / kMeshCacheSubdir);
             accumulateDirectorySize(GetAssetRoot() / kAnimationCacheSubdir);
+            accumulateDirectorySize(GetAssetRoot() / kEmbeddedTextureCacheSubdir);
 
             return totalSize;
         }

--- a/OloEngine/src/OloEngine/Asset/MeshCache.cpp
+++ b/OloEngine/src/OloEngine/Asset/MeshCache.cpp
@@ -17,6 +17,7 @@ namespace OloEngine
     {
         constexpr const char* kMeshCacheSubdir = "cache/mesh";
         constexpr const char* kAnimationCacheSubdir = "cache/animation";
+        constexpr const char* kEmbeddedTextureCacheSubdir = "cache/embedded";
 
         // Returns the project asset directory if a project is active, or falls back
         // to the CWD-relative "assets/" for headless / test scenarios.
@@ -89,6 +90,13 @@ namespace OloEngine
         std::filesystem::path GetAnimationCacheDirectory()
         {
             auto dir = GetAssetRoot() / kAnimationCacheSubdir;
+            EnsureDirectoryExists(dir);
+            return dir;
+        }
+
+        std::filesystem::path GetEmbeddedTextureCacheDirectory()
+        {
+            auto dir = GetAssetRoot() / kEmbeddedTextureCacheSubdir;
             EnsureDirectoryExists(dir);
             return dir;
         }

--- a/OloEngine/src/OloEngine/Asset/MeshCache.h
+++ b/OloEngine/src/OloEngine/Asset/MeshCache.h
@@ -23,6 +23,18 @@ namespace OloEngine
         // Returns the animation cache directory path (assets/cache/animation/).
         std::filesystem::path GetAnimationCacheDirectory();
 
+        // Returns the embedded-texture cache directory path (assets/cache/embedded/),
+        // where Model cooks a glTF/FBX embedded bitmap into a real .png so it gains a
+        // path (and, when a project is mounted, a registry handle).
+        //
+        // It lives here — next to the mesh cache rather than in Model — because the two
+        // must resolve the SAME asset root. A .omesh written under this root references
+        // a cooked texture by path; if the texture root were derived differently (say,
+        // only from an active project) the two would disagree the moment there is no
+        // project, and the warm load would read a cache whose texture paths point
+        // nowhere. That divergence was issue #791.
+        std::filesystem::path GetEmbeddedTextureCacheDirectory();
+
         // Compute cache file path from source file path.
         // e.g. "models/fox.gltf" → "assets/cache/mesh/<hash>.omesh"
         // Optional prefix differentiates cache namespaces (e.g. "anim_" for animated models).

--- a/OloEngine/src/OloEngine/Asset/MeshCache.h
+++ b/OloEngine/src/OloEngine/Asset/MeshCache.h
@@ -58,13 +58,15 @@ namespace OloEngine
         // Save AnimationClips to cache after import.
         bool SaveAnimationsToCache(const std::filesystem::path& sourcePath, const std::vector<Ref<AnimationClip>>& clips);
 
-        // Delete all cached files (e.g. for "clear cache" editor action).
+        // Delete all cached files — mesh, animation and cooked embedded textures
+        // (e.g. for the "clear cache" editor action).
         void ClearCache();
 
         // Delete the cached files for a specific source file (reimport trigger).
         void InvalidateCache(const std::filesystem::path& sourcePath, const std::string& prefix = {});
 
-        // Returns the total size of all cached mesh + animation files in bytes.
+        // Returns the total size of all cached mesh + animation + cooked embedded-texture
+        // files in bytes.
         u64 GetTotalCacheSize();
 
     } // namespace MeshCache

--- a/OloEngine/src/OloEngine/Renderer/Model.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Model.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
+#include <functional>
 #include <initializer_list>
 #include <limits>
 #include <memory>
@@ -29,6 +30,7 @@
 #include "OloEngine/Asset/MeshCache.h"
 #include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
 #include "OloEngine/Project/Project.h"
+#include "OloEngine/Serialization/ImportedMaterialCodec.h"
 #include "OloEngine/Task/ParallelFor.h"
 
 #include <assimp/GltfMaterial.h>
@@ -200,10 +202,16 @@ namespace OloEngine
             i32 height = 0;
             i32 channels = 0;
 
-            // Match Texture2D::Create(path), which flips file-backed images for OpenGL.
-            ::stbi_set_flip_vertically_on_load_thread(1);
+            // TOP-DOWN (file row order), deliberately NOT flipped for OpenGL.
+            //
+            // This used to flip, to match Texture2D::Create(path), because the packed
+            // result was uploaded straight to the GPU and so had to arrive already in
+            // OpenGL's bottom-left origin. The packed result is now written out as a .png
+            // first and loaded back through Texture2D::Create(path), which applies that
+            // flip itself — flipping here as well would invert the metallic-roughness map
+            // relative to every other map on the material. One flip, at load, same as any
+            // image file: that is what DecodedBitmap's TOP-DOWN contract buys.
             stbi_uc* pixels = ::stbi_load(path.string().c_str(), &width, &height, &channels, 1);
-            ::stbi_set_flip_vertically_on_load_thread(0); // reset thread-local flag to avoid polluting later stbi calls
             if (!pixels)
             {
                 OLO_CORE_WARN("Model: Failed to load single-channel material texture '{}'", path.string());
@@ -227,7 +235,27 @@ namespace OloEngine
             return image.Pixels.get()[static_cast<sizet>(sourceY) * static_cast<sizet>(image.Width) + sourceX];
         }
 
-        Ref<Texture2D> CreatePackedMetallicRoughnessTexture(
+        // A bitmap in RGBA8, TOP-DOWN (image-file) row order — i.e. exactly the
+        // orientation a .png on disk stores. Every consumer starts from this: a cook
+        // writes it straight out as a PNG, and an in-memory upload flips it into
+        // OpenGL's bottom-left origin (which is what the on-disk loader does too, via
+        // stbi's flip-on-load). Produced both by decoding an embedded texture and by
+        // packing two single-channel maps into one.
+        struct DecodedBitmap
+        {
+            std::vector<u8> RGBA;
+            u32 Width = 0;
+            u32 Height = 0;
+        };
+
+        // The legacy/specular workflow ships metallic and roughness as two separate
+        // single-channel files; the PBR shader wants them packed into one texture. The
+        // packed result exists only in memory, which used to mean it had no path and no
+        // asset handle — so ImportedMaterialCodec recorded an empty reference and the
+        // .omesh silently came back without a metallic-roughness map, the same defect
+        // issue #791 fixed for embedded textures. It is now cooked to a real file too,
+        // so this returns PIXELS and the caller cooks them.
+        std::optional<DecodedBitmap> BuildPackedMetallicRoughnessPixels(
             const std::filesystem::path& metallicPath,
             const std::filesystem::path& roughnessPath,
             f32 metallicFallback,
@@ -238,18 +266,18 @@ namespace OloEngine
             auto metallicImage = LoadSingleChannelImage(metallicPath);
             auto roughnessImage = LoadSingleChannelImage(roughnessPath);
             if (!metallicImage.IsValid() && !roughnessImage.IsValid())
-                return nullptr;
+                return std::nullopt;
 
             const auto width = static_cast<u32>(metallicImage.IsValid() ? metallicImage.Width : roughnessImage.Width);
             const auto height = static_cast<u32>(metallicImage.IsValid() ? metallicImage.Height : roughnessImage.Height);
             if (width == 0 || height == 0)
-                return nullptr;
+                return std::nullopt;
 
             const auto pixelCount = static_cast<sizet>(width) * static_cast<sizet>(height);
             if (pixelCount > (std::numeric_limits<u32>::max() / 4u))
             {
                 OLO_CORE_WARN("Model: Refusing to pack oversized metallic-roughness texture ({}x{})", width, height);
-                return nullptr;
+                return std::nullopt;
             }
 
             std::vector<u8> packed(pixelCount * 4u);
@@ -272,19 +300,11 @@ namespace OloEngine
                 }
             }
 
-            TextureSpecification spec;
-            spec.Width = width;
-            spec.Height = height;
-            spec.Format = ImageFormat::RGBA8;
-            spec.GenerateMips = false;
-            spec.MipLevels = 1;
-
-            auto texture = Texture2D::Create(spec);
-            if (!texture || !texture->IsLoaded())
-                return nullptr;
-
-            texture->SetData(packed.data(), static_cast<u32>(packed.size()));
-            return texture;
+            // TOP-DOWN, matching DecodedBitmap's contract: LoadSingleChannelImage reads
+            // rows in file order and this loop preserves them, so the cook can write these
+            // bytes straight out as a .png and Texture2D::Create(path) flips them on load
+            // exactly as it would for any other image file.
+            return DecodedBitmap{ std::move(packed), width, height };
         }
 
         // Sanity cap on embedded textures. A hostile (or just thoughtlessly
@@ -298,28 +318,16 @@ namespace OloEngine
                       "Embedded-texture pixel cap must keep the RGBA byte count within u32 — "
                       "Texture2D::SetData takes the size as u32.");
 
-        // An embedded bitmap decoded to RGBA8, in TOP-DOWN (image-file) row order —
-        // i.e. exactly the orientation a .png on disk stores. Both consumers below
-        // start from this: the cook writes it straight out as a PNG, and the
-        // in-memory upload flips it into OpenGL's bottom-left origin (which is what
-        // the on-disk loader does too, via stbi's flip-on-load).
-        struct DecodedEmbeddedTexture
-        {
-            std::vector<u8> RGBA;
-            u32 Width = 0;
-            u32 Height = 0;
-        };
-
         // Decode an Assimp embedded texture. glTF / FBX may embed the bitmap either
         // as compressed bytes (PNG/JPG in pcData, mHeight==0, mWidth=byte-length —
         // this covers both a GLB binary chunk and a base64 data URI, which Assimp has
         // already decoded) or as raw BGRA aiTexel pixels (mWidth/mHeight = dimensions).
-        std::optional<DecodedEmbeddedTexture> DecodeEmbeddedTopDown(const aiTexture* embedded)
+        std::optional<DecodedBitmap> DecodeEmbeddedTopDown(const aiTexture* embedded)
         {
             if (!embedded || !embedded->pcData)
                 return std::nullopt;
 
-            DecodedEmbeddedTexture out;
+            DecodedBitmap out;
 
             if (embedded->mHeight == 0)
             {
@@ -406,13 +414,14 @@ namespace OloEngine
         // srgb mirrors Texture2D::Create(path, srgb) — pass true for albedo /
         // base-color / emissive so the GPU converts samples to linear.
         //
-        // This is the FALLBACK now: CookEmbeddedTexture (below) turns an embedded
-        // bitmap into a real Texture asset on disk whenever a project is mounted, so
-        // that it gains an AssetHandle and a path and therefore survives the .omesh
-        // cache and the asset pack. This path still runs when there is no project (a
-        // packed runtime never imports from source; a headless test may not mount one)
-        // or when the cook fails — the mesh then renders correctly for this session,
-        // it just cannot persist the texture.
+        // This is the FALLBACK now: CookEmbeddedTexture (below) writes an embedded
+        // bitmap out as a real .png under the asset cache, so that it gains a path —
+        // and, when a project is mounted, an AssetHandle too — and therefore survives
+        // the .omesh cache and the asset pack. Since issue #791 the cook no longer
+        // requires a project, so this path only runs when the cook genuinely FAILS (no
+        // writable cache directory, an undecodable bitmap). The mesh then renders
+        // correctly for this session but the texture cannot persist — which is why the
+        // cache-write site refuses to store a material table containing one.
         Ref<Texture2D> CreateTextureFromEmbedded(const aiTexture* embedded, bool srgb = false)
         {
             auto decoded = DecodeEmbeddedTopDown(embedded);
@@ -461,10 +470,21 @@ namespace OloEngine
         // every model that embeds them — which is most GLB files.
         //
         // The fix is upstream of the codec, not inside it: give the texture a real
-        // identity at import time. We decode it once, write it into the project's asset
-        // cache as a plain .png, and ImportAsset it, after which it is an ordinary
-        // Texture2D asset — a path, a registry handle, an asset-pack entry — and BOTH
-        // containers already work with zero codec changes.
+        // identity at import time. We decode it once, write it into the asset cache as a
+        // plain .png, and (when there is an editor asset manager) ImportAsset it, after
+        // which it is an ordinary Texture2D asset — a path, a registry handle, an
+        // asset-pack entry — and BOTH containers already work with zero codec changes.
+        //
+        // NO PROJECT REQUIRED (issue #791). The cook originally bailed out unless a
+        // project with an EditorAssetManager was mounted, which quietly reintroduced the
+        // very bug it was written to fix for every project-less load: the texture stayed
+        // an in-memory decode with no path and no handle, and the .omesh written right
+        // after recorded an EMPTY reference for the slot. Cold load: textured. Warm load:
+        // no albedo map, no error. The two halves are now separated — the cache
+        // DIRECTORY comes from MeshCache (which falls back to a CWD-relative "assets"
+        // exactly as the .omesh itself does), and asset REGISTRATION is best-effort on
+        // top. A path alone is enough for the .omesh, because ImportedMaterialCodec's
+        // RealizeTexture resolves the recorded path before it ever consults the handle.
         //
         // STABILITY (the property that matters): the cooked filename is derived from
         // FNV-1a-64(canonical model path + '|' + the Assimp texture reference) plus the
@@ -487,72 +507,135 @@ namespace OloEngine
         // the cooked path is constructed by the engine from a hash, never from a string
         // in the model file, so no attacker-controlled component reaches the filesystem.
         // ────────────────────────────────────────────────────────────────────────
-        std::optional<std::filesystem::path> CookEmbeddedTexture(const aiTexture* embedded,
-                                                                 const std::string& modelSourcePath,
-                                                                 const std::string& assimpTextureRef,
-                                                                 bool srgb)
+        // An RGBA8 bitmap the importer synthesised rather than read off disk, ready to be
+        // written out. `Produce` is only invoked when the cooked file is not already there,
+        // so a warm cook never pays for the decode/pack it would throw away.
+        using RgbaProducer = std::function<std::optional<DecodedBitmap>()>;
+
+        // Writes a synthesised bitmap into the asset cache under a name derived from
+        // `identity`, registers it as an asset where that is possible, and hands back the
+        // path. Shared by every texture the importer builds in memory — see the two callers
+        // below — because they all face the same problem: a Texture2D with no file behind it
+        // has no identity, and ImportedMaterialCodec can only persist an identity.
+        std::optional<std::filesystem::path> CookRgbaToAssetCache(std::string_view namePrefix,
+                                                                  const std::string& identity,
+                                                                  bool srgb,
+                                                                  const RgbaProducer& produce)
         {
-            // No project => no asset directory and no registry to hand out a handle.
-            // (A packed runtime never imports from source, so this is the editor path.)
-            Ref<Project> project = Project::GetActive();
-            if (!project)
-                return std::nullopt;
-
-            Ref<AssetManagerBase> managerBase = Project::GetAssetManager();
-            auto* editor = dynamic_cast<EditorAssetManager*>(managerBase.Raw());
-            if (!editor)
-                return std::nullopt;
-
+            // The cook does NOT require a project (issue #791). It used to bail out when
+            // there was no active project or no EditorAssetManager, which left the texture
+            // as a GPU-only decode with neither a path nor a handle — and the .omesh written
+            // moments later therefore recorded an EMPTY texture reference for that slot. The
+            // cold load looked right, the warm load came back with no map at all, and nothing
+            // said so. A registry handle is a bonus (it is what puts the texture in the asset
+            // pack); the PATH is what the .omesh actually needs, and a path can be produced
+            // with no project at all.
+            //
+            // MeshCache owns the asset-root fallback (project asset dir, else CWD-relative
+            // "assets") so the cooked texture lands under the SAME root as the .omesh that
+            // will reference it — see GetEmbeddedTextureCacheDirectory.
             std::error_code ec;
-            const std::filesystem::path cacheDir = Project::GetAssetDirectory() / "cache" / "embedded";
-            std::filesystem::create_directories(cacheDir, ec);
-            if (ec)
+            const std::filesystem::path cacheDir = MeshCache::GetEmbeddedTextureCacheDirectory();
+            if (!std::filesystem::is_directory(cacheDir, ec))
             {
-                OLO_CORE_WARN("Model: Could not create embedded-texture cache dir '{}': {}",
-                              cacheDir.string(), ec.message());
+                OLO_CORE_WARN("Model: Texture cache dir '{}' is unavailable — the texture cannot be persisted",
+                              cacheDir.string());
                 return std::nullopt;
             }
 
             // Stable, deterministic identity — see STABILITY above.
-            const std::filesystem::path canonicalModel = std::filesystem::weakly_canonical(modelSourcePath, ec);
-            const std::string modelKey = ec ? modelSourcePath : canonicalModel.generic_string();
-            const u64 hash = HashString(modelKey + "|" + assimpTextureRef);
-
             std::ostringstream name;
-            name << "emb_" << std::hex << std::setw(16) << std::setfill('0') << hash
+            name << namePrefix << std::hex << std::setw(16) << std::setfill('0') << HashString(identity)
                  << (srgb ? "_basecolor" : "_linear") << ".png";
             const std::filesystem::path cookedPath = cacheDir / name.str();
 
             if (!std::filesystem::exists(cookedPath, ec))
             {
-                auto decoded = DecodeEmbeddedTopDown(embedded);
+                auto decoded = produce();
                 if (!decoded)
                     return std::nullopt;
 
                 // Written TOP-DOWN, like any image file: Texture2D::Create(path) flips it
-                // on load, so an embedded texture and the same bitmap shipped loose end up
-                // with identical orientation on the GPU.
+                // on load, so a cooked bitmap and the same bitmap shipped loose end up with
+                // identical orientation on the GPU.
                 const int written = ::stbi_write_png(
                     cookedPath.string().c_str(),
                     static_cast<int>(decoded->Width), static_cast<int>(decoded->Height), 4,
                     decoded->RGBA.data(), static_cast<int>(decoded->Width * 4u));
                 if (written == 0)
                 {
-                    OLO_CORE_WARN("Model: Failed to write cooked embedded texture '{}'", cookedPath.string());
+                    OLO_CORE_WARN("Model: Failed to write cooked texture '{}'", cookedPath.string());
                     return std::nullopt;
                 }
-                OLO_CORE_TRACE("Model: Cooked embedded texture '{}' -> {}", assimpTextureRef, cookedPath.string());
+                OLO_CORE_TRACE("Model: Cooked texture '{}' -> {}", identity, cookedPath.string());
             }
 
-            // Registers the file (or returns the handle it already has), which is what
-            // puts it in the asset registry and therefore in the asset pack.
-            if (static_cast<u64>(editor->ImportAsset(cookedPath)) == 0)
+            // Registering the file (or fetching the handle it already has) is what puts the
+            // texture in the asset registry and therefore in the ASSET PACK. That needs an
+            // EditorAssetManager, which only exists in an editor session with a project
+            // mounted — so it is best-effort, NOT a precondition. Failing it costs the packed
+            // runtime its handle; returning nullopt here would additionally cost the .omesh
+            // its path, which is the strictly worse outcome the cook exists to prevent.
+            Ref<AssetManagerBase> managerBase = Project::GetActive() ? Project::GetAssetManager() : nullptr;
+            if (auto* editor = dynamic_cast<EditorAssetManager*>(managerBase.Raw()))
             {
-                OLO_CORE_WARN("Model: Could not register cooked embedded texture '{}'", cookedPath.string());
-                return std::nullopt;
+                if (static_cast<u64>(editor->ImportAsset(cookedPath)) == 0)
+                {
+                    OLO_CORE_WARN("Model: Could not register cooked texture '{}' as an asset — it will round-trip "
+                                  "the .omesh cache by path but will be missing from the asset pack",
+                                  cookedPath.string());
+                }
             }
 
             return cookedPath;
+        }
+
+        std::optional<std::filesystem::path> CookEmbeddedTexture(const aiTexture* embedded,
+                                                                 const std::string& modelSourcePath,
+                                                                 const std::string& assimpTextureRef,
+                                                                 bool srgb)
+        {
+            std::error_code ec;
+            const std::filesystem::path canonicalModel = std::filesystem::weakly_canonical(modelSourcePath, ec);
+            const std::string modelKey = ec ? modelSourcePath : canonicalModel.generic_string();
+
+            return CookRgbaToAssetCache("emb_", modelKey + "|" + assimpTextureRef, srgb,
+                                        [embedded]
+                                        { return DecodeEmbeddedTopDown(embedded); });
+        }
+
+        // The packed metallic-roughness map, cooked to a real file for the same reason an
+        // embedded texture is: it is synthesised in memory, so without a file it has no
+        // identity and cannot survive the .omesh. Always LINEAR — it is data, not colour —
+        // so the cooked name carries the "_linear" intent and the pack/runtime loaders read
+        // it back as linear too.
+        //
+        // The identity is the same tuple that keys the in-session cache: both source paths
+        // plus both scalar factors. Change any one and the packed pixels change, so a
+        // different file must be cooked; change none and the existing file is reused, which
+        // keeps its timestamp — and the asset registry's LastWriteTime — stable.
+        std::optional<std::filesystem::path> CookPackedMetallicRoughnessTexture(
+            const std::filesystem::path& metallicPath,
+            const std::filesystem::path& roughnessPath,
+            f32 metallicFallback,
+            f32 roughnessFallback,
+            f32 metallicScale,
+            f32 roughnessScale)
+        {
+            const std::string identity = "packed_mr|" + metallicPath.generic_string() + "|" +
+                                         roughnessPath.generic_string() + "|" +
+                                         std::to_string(metallicFallback) + "|" +
+                                         std::to_string(roughnessFallback) + "|" +
+                                         std::to_string(metallicScale) + "|" +
+                                         std::to_string(roughnessScale);
+
+            return CookRgbaToAssetCache("mr_", identity, /*srgb*/ false,
+                                        [&]
+                                        {
+                                            return BuildPackedMetallicRoughnessPixels(
+                                                metallicPath, roughnessPath, metallicFallback,
+                                                roughnessFallback, metallicScale, roughnessScale);
+                                        });
         }
     } // namespace
 
@@ -872,8 +955,25 @@ namespace OloEngine
                 // omit the materials; that load then re-imports them from the source file (the
                 // pre-v4 behaviour) instead of inheriting someone else's textures.
                 // The MeshSource here is a cache-only copy on this path, so clearing is local.
+                //
+                // The second reason to omit them is a texture the codec cannot REFERENCE
+                // (issue #791). ImportedMaterialCodec describes a texture by asset handle or
+                // source path; one that has neither — an embedded bitmap whose cook failed —
+                // encodes as an empty slot, so the warm load silently comes back with fewer
+                // maps than the cold import produced. Dropping the table sends the next load
+                // down the Assimp re-import branch above: slower, but it reproduces the cold
+                // result exactly. A cache that is slow is a cost; a cache that is wrong on
+                // the second run only is a bug that reads as a flaky test.
                 if (m_TextureOverride)
                 {
+                    combinedMeshSource->SetImportedMaterials({});
+                }
+                else if (!ImportedMaterialCodec::CanPersistEveryTexture(combinedMeshSource->GetImportedMaterials()))
+                {
+                    OLO_CORE_WARN("Model::LoadModel: '{}' has a material texture with no asset handle and no source "
+                                  "path, so the imported-material table cannot round-trip the .omesh cache — writing "
+                                  "the geometry only; the next load re-imports its materials from source",
+                                  path);
                     combinedMeshSource->SetImportedMaterials({});
                 }
                 MeshCache::SaveMeshToCache(sourcePath, *combinedMeshSource, cachePrefix);
@@ -1135,10 +1235,11 @@ namespace OloEngine
                         continue;
                     }
 
-                    // COOK FIRST: an embedded texture written into the project's asset
-                    // cache gains a path AND an AssetHandle, so ImportedMaterialCodec can
-                    // persist it through both the .omesh cache and the asset pack. Without
-                    // this the material comes back from either container with no maps.
+                    // COOK FIRST: an embedded texture written into the asset cache gains a
+                    // path (and, where a project is mounted, an AssetHandle), so
+                    // ImportedMaterialCodec can persist it through both the .omesh cache and
+                    // the asset pack. Without this the material comes back from either
+                    // container with no maps.
                     // Loading it back off the cooked file (rather than keeping the
                     // in-memory decode) is deliberate: the texture we hand out is then
                     // byte-for-byte the one the codec will resolve later, so the editor
@@ -1150,8 +1251,10 @@ namespace OloEngine
                         if (texture && !texture->IsLoaded())
                             texture = nullptr;
                     }
-                    // No project mounted (or the cook failed): fall back to the GPU-only
-                    // decode. Renders correctly this session; simply cannot persist.
+                    // The cook failed (no writable cache directory, or an undecodable
+                    // bitmap): fall back to the GPU-only decode. Renders correctly this
+                    // session; simply cannot persist — and the cache-write site drops the
+                    // whole material table rather than storing a reference to it.
                     if (!texture)
                         texture = CreateTextureFromEmbedded(embedded, srgb);
 
@@ -1477,13 +1580,23 @@ namespace OloEngine
                     }
                     else
                     {
-                        packedTexture = CreatePackedMetallicRoughnessTexture(
-                            metallicSourcePath,
-                            roughnessSourcePath,
-                            metallic,
-                            roughness,
-                            metallicScale,
-                            roughnessScale);
+                        // Cook to a real file, then load it back — deliberately, and for the
+                        // same reason the embedded path does it: the texture we hand the
+                        // material is then byte-for-byte the one ImportedMaterialCodec will
+                        // resolve out of the .omesh later, so this session and a warm reload
+                        // cannot disagree. Uploading the packed bytes straight to the GPU (what
+                        // this did before) left the texture with no path, so the cache recorded
+                        // an empty reference and the warm load lost the map entirely.
+                        if (auto cooked = CookPackedMetallicRoughnessTexture(
+                                metallicSourcePath,
+                                roughnessSourcePath,
+                                metallic,
+                                roughness,
+                                metallicScale,
+                                roughnessScale))
+                        {
+                            packedTexture = Texture2D::Create(cooked->string(), /*srgb*/ false);
+                        }
                         if (packedTexture && packedTexture->IsLoaded())
                         {
                             m_LoadedTextures[cacheKey] = packedTexture;

--- a/OloEngine/src/OloEngine/Renderer/Model.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Model.cpp
@@ -16,6 +16,7 @@
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <random>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -555,17 +556,54 @@ namespace OloEngine
                 if (!decoded)
                     return std::nullopt;
 
+                // WRITE TO A TEMPORARY, THEN RENAME. The existence check above is the only
+                // thing standing between a warm load and a re-cook, so a half-written file is
+                // permanent: it exists, so nothing ever rewrites it, and every later load hands
+                // the material a truncated or empty texture. Writing in place makes that the
+                // outcome of any crash mid-write — and of two processes cooking the same
+                // texture at once, which is routine here, because ctest runs each case in its
+                // own process against one shared repo-relative cache directory.
+                //
+                // A rename within a directory is atomic, so a reader sees either no file or the
+                // whole file. The temp name carries a random token so two processes cooking the
+                // same texture never collide on the temporary itself (there is no portable
+                // process-id accessor in the engine's HAL, and uniqueness only has to hold
+                // among concurrent cooks in one directory).
+                std::random_device rd;
+                const u64 token = (static_cast<u64>(rd()) << 32) ^ rd();
+                std::ostringstream tempName;
+                tempName << cookedPath.stem().string() << ".tmp"
+                         << std::hex << std::setw(16) << std::setfill('0') << token << ".png";
+                const std::filesystem::path tempPath = cookedPath.parent_path() / tempName.str();
+
                 // Written TOP-DOWN, like any image file: Texture2D::Create(path) flips it
                 // on load, so a cooked bitmap and the same bitmap shipped loose end up with
                 // identical orientation on the GPU.
                 const int written = ::stbi_write_png(
-                    cookedPath.string().c_str(),
+                    tempPath.string().c_str(),
                     static_cast<int>(decoded->Width), static_cast<int>(decoded->Height), 4,
                     decoded->RGBA.data(), static_cast<int>(decoded->Width * 4u));
                 if (written == 0)
                 {
-                    OLO_CORE_WARN("Model: Failed to write cooked texture '{}'", cookedPath.string());
+                    OLO_CORE_WARN("Model: Failed to write cooked texture '{}'", tempPath.string());
+                    std::filesystem::remove(tempPath, ec);
                     return std::nullopt;
+                }
+
+                std::error_code renameEc;
+                std::filesystem::rename(tempPath, cookedPath, renameEc);
+                if (renameEc)
+                {
+                    // A racing process that finished first is the expected loser-path here, and
+                    // its file is equally valid (same identity => same pixels), so treat an
+                    // existing destination as success rather than failing the cook.
+                    std::filesystem::remove(tempPath, ec);
+                    if (std::error_code existsEc; !std::filesystem::exists(cookedPath, existsEc))
+                    {
+                        OLO_CORE_WARN("Model: Failed to publish cooked texture '{}': {}",
+                                      cookedPath.string(), renameEc.message());
+                        return std::nullopt;
+                    }
                 }
                 OLO_CORE_TRACE("Model: Cooked texture '{}' -> {}", identity, cookedPath.string());
             }
@@ -614,6 +652,44 @@ namespace OloEngine
         // plus both scalar factors. Change any one and the packed pixels change, so a
         // different file must be cooked; change none and the existing file is reused, which
         // keeps its timestamp — and the asset registry's LastWriteTime — stable.
+        // THE identity of a packed metallic-roughness map — every input that changes a pixel of
+        // it, and nothing else. Used for BOTH the cooked filename and the in-session
+        // `m_LoadedTextures` key, deliberately: those two are the same question ("is this the
+        // same texture?") and answering it two ways lets them disagree. They did — the
+        // in-session key omitted the two scales, so two materials that differ only in whether
+        // a metallic/roughness FACTOR was declared (same paths, same values) shared one cache
+        // entry while cooking to two different files, and the second material silently got the
+        // first one's texture.
+        //
+        // Paths are weakly-canonicalised, matching MeshCache::HashSourcePath and
+        // CookEmbeddedTexture: the same file reached by a different spelling (relative vs
+        // absolute, `.` or `..` segments) must hash the same, or one texture cooks twice under
+        // two names. Canonicalisation can fail for a path that does not exist; fall back to the
+        // path as given rather than dropping the component.
+        std::string PackedMetallicRoughnessIdentity(const std::filesystem::path& metallicPath,
+                                                    const std::filesystem::path& roughnessPath,
+                                                    f32 metallicFallback,
+                                                    f32 roughnessFallback,
+                                                    f32 metallicScale,
+                                                    f32 roughnessScale)
+        {
+            const auto canonical = [](const std::filesystem::path& p)
+            {
+                if (p.empty())
+                    return std::string{};
+                std::error_code ec;
+                const std::filesystem::path c = std::filesystem::weakly_canonical(p, ec);
+                return ec ? p.generic_string() : c.generic_string();
+            };
+
+            return "packed_mr|" + canonical(metallicPath) + "|" +
+                   canonical(roughnessPath) + "|" +
+                   std::to_string(metallicFallback) + "|" +
+                   std::to_string(roughnessFallback) + "|" +
+                   std::to_string(metallicScale) + "|" +
+                   std::to_string(roughnessScale);
+        }
+
         std::optional<std::filesystem::path> CookPackedMetallicRoughnessTexture(
             const std::filesystem::path& metallicPath,
             const std::filesystem::path& roughnessPath,
@@ -622,12 +698,8 @@ namespace OloEngine
             f32 metallicScale,
             f32 roughnessScale)
         {
-            const std::string identity = "packed_mr|" + metallicPath.generic_string() + "|" +
-                                         roughnessPath.generic_string() + "|" +
-                                         std::to_string(metallicFallback) + "|" +
-                                         std::to_string(roughnessFallback) + "|" +
-                                         std::to_string(metallicScale) + "|" +
-                                         std::to_string(roughnessScale);
+            const std::string identity = PackedMetallicRoughnessIdentity(
+                metallicPath, roughnessPath, metallicFallback, roughnessFallback, metallicScale, roughnessScale);
 
             return CookRgbaToAssetCache("mr_", identity, /*srgb*/ false,
                                         [&]
@@ -1570,8 +1642,11 @@ namespace OloEngine
                 {
                     const auto metallicScale = metallicSourcePath.empty() ? 1.0f : (hasMetallicFactor ? metallic : 1.0f);
                     const auto roughnessScale = roughnessSourcePath.empty() ? 1.0f : (hasRoughnessFactor ? roughness : 1.0f);
-                    const auto cacheKey = std::string("packed_mr|") + metallicSourcePath.string() + "|" + roughnessSourcePath.string() + "|" +
-                                          std::to_string(metallic) + "|" + std::to_string(roughness);
+                    // Same identity the cook hashes into the filename — one definition, so the
+                    // in-session cache and the on-disk cache cannot disagree about what counts
+                    // as "the same texture".
+                    const auto cacheKey = PackedMetallicRoughnessIdentity(
+                        metallicSourcePath, roughnessSourcePath, metallic, roughness, metallicScale, roughnessScale);
 
                     Ref<Texture2D> packedTexture;
                     if (auto it = m_LoadedTextures.find(cacheKey); it != m_LoadedTextures.end())

--- a/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.cpp
+++ b/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.cpp
@@ -8,6 +8,7 @@
 #include "OloEngine/Project/Project.h"
 #include "OloEngine/Renderer/Texture.h"
 
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
@@ -365,6 +366,41 @@ namespace OloEngine::ImportedMaterialCodec
         }
 
         return materials;
+    }
+
+    bool CanPersistEveryTexture(const std::vector<Ref<Material>>& materials)
+    {
+        for (const auto& material : materials)
+        {
+            if (!material)
+            {
+                continue;
+            }
+
+            const std::array<Ref<Texture2D>, 5> slots = {
+                material->GetAlbedoMap(),
+                material->GetMetallicRoughnessMap(),
+                material->GetNormalMap(),
+                material->GetAOMap(),
+                material->GetEmissiveMap(),
+            };
+
+            for (const auto& texture : slots)
+            {
+                // An UNSET slot is nothing to lose. A SET slot whose description is empty is
+                // a texture the reader has no way of finding again — neither a handle nor a
+                // path — so persisting this table would quietly drop it.
+                if (texture && DescribeTexture(texture).IsEmpty())
+                {
+                    OLO_CORE_WARN("ImportedMaterialCodec: material '{}' carries a texture with neither an asset "
+                                  "handle nor a source path, so it cannot be persisted",
+                                  material->GetName());
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     std::vector<u8> Encode(const std::vector<MaterialDesc>& descs)

--- a/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.cpp
+++ b/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.cpp
@@ -177,6 +177,22 @@ namespace OloEngine::ImportedMaterialCodec
             return editor->GetAssetHandleFromFilePath(path);
         }
 
+        // THE set of texture slots this codec persists, in table order. Both Describe() and
+        // CanPersistEveryTexture() read it, so a slot added to the material can only be
+        // half-supported if someone edits this list and then ignores the compile error the
+        // structured binding below produces — rather than by simply forgetting the guard,
+        // which would silently reintroduce exactly the drop issue #791 was about.
+        [[nodiscard]] std::array<Ref<Texture2D>, 5> MaterialTextureSlots(const Material& material)
+        {
+            return {
+                material.GetAlbedoMap(),
+                material.GetMetallicRoughnessMap(),
+                material.GetNormalMap(),
+                material.GetAOMap(),
+                material.GetEmissiveMap(),
+            };
+        }
+
         [[nodiscard]] TextureRef DescribeTexture(const Ref<Texture2D>& texture)
         {
             TextureRef ref;
@@ -286,11 +302,14 @@ namespace OloEngine::ImportedMaterialCodec
             desc.OcclusionStrength = material->GetOcclusionStrength();
             desc.EnableIBL = material->IsIBLEnabled();
 
-            desc.Albedo = DescribeTexture(material->GetAlbedoMap());
-            desc.MetallicRoughness = DescribeTexture(material->GetMetallicRoughnessMap());
-            desc.Normal = DescribeTexture(material->GetNormalMap());
-            desc.AO = DescribeTexture(material->GetAOMap());
-            desc.Emissive = DescribeTexture(material->GetEmissiveMap());
+            // Destructured from the shared slot list rather than re-fetching each getter:
+            // adding a slot there is then a compile error here until this is updated too.
+            const auto& [albedo, metallicRoughness, normal, ao, emissive] = MaterialTextureSlots(*material);
+            desc.Albedo = DescribeTexture(albedo);
+            desc.MetallicRoughness = DescribeTexture(metallicRoughness);
+            desc.Normal = DescribeTexture(normal);
+            desc.AO = DescribeTexture(ao);
+            desc.Emissive = DescribeTexture(emissive);
 
             descs.push_back(std::move(desc));
         }
@@ -377,15 +396,7 @@ namespace OloEngine::ImportedMaterialCodec
                 continue;
             }
 
-            const std::array<Ref<Texture2D>, 5> slots = {
-                material->GetAlbedoMap(),
-                material->GetMetallicRoughnessMap(),
-                material->GetNormalMap(),
-                material->GetAOMap(),
-                material->GetEmissiveMap(),
-            };
-
-            for (const auto& texture : slots)
+            for (const auto& texture : MaterialTextureSlots(*material))
             {
                 // An UNSET slot is nothing to lose. A SET slot whose description is empty is
                 // a texture the reader has no way of finding again — neither a handle nor a

--- a/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.h
+++ b/OloEngine/src/OloEngine/Serialization/ImportedMaterialCodec.h
@@ -48,14 +48,25 @@ namespace OloEngine
     // embeds them, which is most GLB files.
     //
     // The fix is in the IMPORTER, not here: Model::LoadMaterialTextures now COOKS an embedded
-    // bitmap into a real .png asset under <AssetDir>/cache/embedded/ and ImportAsset()s it, so
-    // it gains a stable, deterministic path AND a registry handle like any other texture — after
-    // which the handle-plus-path scheme below already works, unchanged. The cooked name is
-    // derived from FNV-1a-64(model path | Assimp texture ref) plus the colour-space intent, so
-    // it is stable across re-imports (the pack does not churn and scene references do not rot),
-    // and the intent is spelled into the filename because the packed-runtime loader and the pack
-    // cook both decide sRGB from the FILENAME.
-    // Pinned by ImportedMaterialPackTest.EmbeddedTextureSurvivesThe{OmeshCache,AssetPack}.
+    // bitmap into a real .png asset under <AssetRoot>/cache/embedded/ and (where an editor
+    // asset manager exists) ImportAsset()s it, so it gains a stable, deterministic path AND a
+    // registry handle like any other texture — after which the handle-plus-path scheme below
+    // already works, unchanged. The cooked name is derived from FNV-1a-64(model path | Assimp
+    // texture ref) plus the colour-space intent, so it is stable across re-imports (the pack
+    // does not churn and scene references do not rot), and the intent is spelled into the
+    // filename because the packed-runtime loader and the pack cook both decide sRGB from the
+    // FILENAME.
+    //
+    // The cook is NOT conditional on a project (issue #791). It was, and that made the gap
+    // above reappear for every load with no project mounted: no cook, so no path and no
+    // handle, so an empty TextureRef in the .omesh, so a warm load with no albedo map. The
+    // asset ROOT falls back to a CWD-relative "assets" (MeshCache owns that rule, so the
+    // texture lands beside the .omesh that references it) and only the registry half needs an
+    // editor asset manager. Realize() resolves the path before the handle, so the path alone
+    // carries the .omesh round-trip.
+    // Pinned by ImportedMaterialPackTest.EmbeddedTextureSurvivesThe{OmeshCache,AssetPack} and,
+    // for the project-less path this codec is most often driven from, by
+    // DeccerCubesLoaderFixture.SurvivesAWarmMeshCacheRoundTrip.
     //
     // STILL OPEN: AnimatedModel::LoadMaterialTextures (the rigged/skinned importer) never had
     // embedded-texture support at all — it does not take the aiScene and never calls
@@ -126,6 +137,23 @@ namespace OloEngine
         // is unknown but the file exists. A slot that resolves to nothing is simply
         // left unset (the consumer's own default applies), never a hard failure.
         [[nodiscard]] std::vector<Ref<Material>> Realize(const std::vector<MaterialDesc>& descs);
+
+        // True when every texture slot that is actually SET on `materials` describes to a
+        // reference a reader could resolve — an asset handle, a source path, or both.
+        //
+        // Describe() cannot fail: a texture with neither identity yields an empty TextureRef
+        // and the encoded material simply comes back mapless. That is the correct behaviour
+        // for a slot that was always empty, and silent data loss for one that was not. A
+        // caller writing a PERSISTENT cache must tell the two apart, because a cache entry
+        // that resolves to fewer textures than a fresh import is worse than no cache entry
+        // at all: the fresh import is merely slow, the cache entry is wrong, and it is wrong
+        // only on the second run — which is what made issue #791 read as a flaky test.
+        //
+        // Call this before persisting a material table and omit the table when it returns
+        // false; the reader then re-imports the materials from source, which is slower and
+        // correct. This is a backstop, not the fix: the importer's job is to give every
+        // texture an identity in the first place (Model::CookEmbeddedTexture).
+        [[nodiscard]] bool CanPersistEveryTexture(const std::vector<Ref<Material>>& materials);
 
         // Wire format (self-describing; own magic + version).
         [[nodiscard]] std::vector<u8> Encode(const std::vector<MaterialDesc>& descs);

--- a/OloEngine/src/OloEngine/Serialization/MeshBinaryFormat.h
+++ b/OloEngine/src/OloEngine/Serialization/MeshBinaryFormat.h
@@ -9,7 +9,7 @@
 namespace OloEngine
 {
     // ============================================================================
-    // .omesh Binary Mesh Format — Version 2
+    // .omesh Binary Mesh Format — Version 5
     //
     // Layout:
     //   [FileHeader]
@@ -49,7 +49,17 @@ namespace OloEngine
         // with, so a warm cache load no longer has to re-run a full Assimp import of the
         // source file just to rebuild them (and so the asset-pack cook, which reads the
         // MeshSource, has materials to ship at all — issue #629).
-        constexpr u32 CurrentVersion = 4; // v4: imported-material table
+        //
+        // v5 adds no sections either. Like v3 it exists purely to INVALIDATE the caches
+        // written before it (issue #791). A v4 file produced without a project mounted
+        // recorded an EMPTY texture reference for every EMBEDDED texture — the importer
+        // only cooked those into real .png assets when there was a project, so they had
+        // neither a handle nor a path to record. Such a file reads back cleanly and
+        // resolves materials with no albedo map, which looks like a flaky test rather
+        // than a corrupt cache (the first, cold run of the day always passes). The
+        // writer is fixed, but every .omesh already on a developer's disk still holds
+        // the empty references, so the version must move for them to be re-imported.
+        constexpr u32 CurrentVersion = 5; // v5: invalidates v4 caches with unpersisted embedded textures
 
         constexpr u32 MinSupportedVersion = 1;
         constexpr u32 FlagCompressed = 1;   // Payload is zlib-compressed
@@ -368,6 +378,7 @@ namespace OloEngine
     static_assert(OMeshFormat::SectionCountForVersion(1) == 7);
     static_assert(OMeshFormat::SectionCountForVersion(2) == 8);
     static_assert(OMeshFormat::SectionCountForVersion(3) == 8);
+    static_assert(OMeshFormat::SectionCountForVersion(4) == OMeshFormat::kSectionCount);
     static_assert(OMeshFormat::SectionCountForVersion(OMeshFormat::CurrentVersion) == OMeshFormat::kSectionCount);
 
     static_assert(std::is_trivially_copyable_v<OMeshFormat::GeometryHeader>);

--- a/OloEngine/tests/AssetContentValidityTest.cpp
+++ b/OloEngine/tests/AssetContentValidityTest.cpp
@@ -998,6 +998,23 @@ namespace OloEngine::Tests
             if (ec)
                 continue;
 
+            // `Assets/cache/` is DERIVED data, not authored content: every file under it is
+            // regenerated on demand from something else, and the whole tree is git-ignored
+            // (`**/cache/**`). It is validated by AllCacheFilesMatchKnownPattern below — by
+            // filename pattern, which is the meaningful contract for a cache — rather than by
+            // registry membership.
+            //
+            // This only started to matter with issue #791. Cache files never had a *supported
+            // asset extension* before, so the scan skipped them all on the extension check
+            // above; the cooked embedded/packed textures are real `.png` files, so they are the
+            // first cache artifacts to reach this point. Registering them is a runtime
+            // side-effect of loading a model, and the registry is tracked while the files
+            // themselves are ignored — so requiring the two to agree here would fail on any
+            // machine that had run the editor, and committing the entries would leave a fresh
+            // clone pointing at files that do not exist.
+            if (relative.starts_with("Assets/cache/"))
+                continue;
+
             if (!registeredPaths.contains(relative))
             {
                 unregistered.push_back({

--- a/OloEngine/tests/AssetContentValidityTest.cpp
+++ b/OloEngine/tests/AssetContentValidityTest.cpp
@@ -1430,6 +1430,28 @@ namespace OloEngine::Tests
             { "animation",
               std::regex(R"([0-9A-F]{16}\.oanim)"),
               "<path-hash>.oanim" },
+            // Cooked-texture cache (MeshCache::GetEmbeddedTextureCacheDirectory).
+            // Textures the importer SYNTHESISES rather than reads off disk, written
+            // out as real .png files so they have a path and can therefore survive
+            // the .omesh cache and the asset pack (issue #791 — before that a
+            // synthesised texture had no identity and the warm load silently lost
+            // the map). Two producers, one directory:
+            //   `emb_` — a bitmap embedded in a glTF/GLB/FBX (Model::CookEmbeddedTexture)
+            //   `mr_`  — the legacy/specular workflow's separate metallic + roughness
+            //            files packed into one map (Model::CookPackedMetallicRoughnessTexture)
+            // The name is `<prefix><identity-hash><colour-space>.png`: 16 LOWERCASE hex
+            // digits (std::hex), then the colour-space intent, which is part of the
+            // filename because the packed-runtime loader and the pack cook both decide
+            // sRGB from the name (TextureCompression::IsLikelyColorTexture).
+            //
+            // No orphan detection: unlike a shader, whose source file is the obvious
+            // referent, deciding whether one of these is still reachable means
+            // re-importing every model and re-deriving its texture hashes. They are
+            // small, content-addressed and stable across re-imports, so a stale one is
+            // dead weight rather than a hazard.
+            { "embedded",
+              std::regex(R"((emb|mr)_[0-9a-f]{16}_(basecolor|linear)\.png)"),
+              "{emb|mr}_<identity-hash>_{basecolor|linear}.png" },
             // physics/ and shapes/ are reserved for future caches. Until they
             // grow content with a stable filename pattern, any file appearing
             // there is unclassified and fails the test below.

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1110,8 +1110,15 @@ include(GoogleTest)
 # we serialize these offenders against EACH OTHER with a shared RESOURCE_LOCK;
 # they still overlap freely with every unrelated test. Keep this list in sync if
 # a new test loads + invalidates a shared model cache.
+#
+# DeccerCubesLoaderFixture joins the list for the same reason (issue #791): its
+# SurvivesAWarmMeshCacheRoundTrip case invalidates a variant's .omesh, writes it
+# cold, then reads it warm. LoadsWithMeshesAndFiniteBounds loads the SAME source
+# files, so under --parallel the two cases race over one cache entry — the
+# round-trip's invalidate can land between the other case's write and read. Both
+# cases are matched with one wildcard.
 set(OLO_MESH_CACHE_TESTS
-	"ModelLoadDeterminism.Backpack_FreshVsCache:DataRoundTripTest.BackpackLegacyObjImportsPbrCompanionMaps:DataRoundTripTest.BackpackLegacyObjFlipsUvsToMatchTextureUploads")
+	"ModelLoadDeterminism.Backpack_FreshVsCache:DataRoundTripTest.BackpackLegacyObjImportsPbrCompanionMaps:DataRoundTripTest.BackpackLegacyObjFlipsUvsToMatchTextureUploads:AllVariants/DeccerCubesLoaderFixture.*")
 
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor

--- a/OloEngine/tests/Rendering/DeccerCubesLoadingTest.cpp
+++ b/OloEngine/tests/Rendering/DeccerCubesLoadingTest.cpp
@@ -42,6 +42,7 @@
 
 #include "OloEngine/Asset/MeshCache.h"
 #include "OloEngine/Renderer/Material.h"
+#include "OloEngine/Renderer/MeshSource.h"
 #include "OloEngine/Renderer/Model.h"
 #include "OloEngine/Renderer/Texture.h"
 
@@ -253,6 +254,26 @@ namespace OloEngine::Tests
             ASSERT_TRUE(MeshCache::IsMeshCacheValid(absolutePath))
                 << "the cold load wrote no .omesh for " << param.Name
                 << ", so the warm half below would silently re-run the cold path and prove nothing";
+
+            // The .omesh must carry the MATERIALS, not just the geometry.
+            //
+            // Without this the test has a hole big enough to pass on the bug it exists to
+            // catch: Model::LoadModel drops the imported-material table when a texture cannot
+            // be referenced, and a table-less cache sends the warm load down the Assimp
+            // re-import branch — which rebuilds the materials from source and restores the
+            // albedo. The pixel comparison below would then be comparing two *cold* imports
+            // and would pass with the cache contributing nothing. Read the cached MeshSource
+            // directly and require a non-empty table, so "warm" means what it says.
+            if (param.ExpectsAlbedoTexture)
+            {
+                Ref<MeshSource> const cached = MeshCache::LoadMeshFromCache(absolutePath);
+                ASSERT_TRUE(cached) << "the .omesh for " << param.Name << " reports valid but did not load";
+                EXPECT_FALSE(cached->GetImportedMaterials().empty())
+                    << "the .omesh for " << param.Name << " carries geometry but NO imported-material table, so the "
+                                                          "warm load below will re-import materials from source and the albedo assertions would pass "
+                                                          "without the cache ever round-tripping a texture. Model::LoadModel drops the table when "
+                                                          "ImportedMaterialCodec cannot reference one of the material's textures.";
+            }
 
             // -- Warm: geometry and materials come back out of the .omesh. --
             Model warm{ absolutePath.string() };

--- a/OloEngine/tests/Rendering/DeccerCubesLoadingTest.cpp
+++ b/OloEngine/tests/Rendering/DeccerCubesLoadingTest.cpp
@@ -40,11 +40,15 @@
 
 #include "PropertyTests/RenderPropertyTest.h"
 
+#include "OloEngine/Asset/MeshCache.h"
 #include "OloEngine/Renderer/Material.h"
 #include "OloEngine/Renderer/Model.h"
+#include "OloEngine/Renderer/Texture.h"
 
+#include <glad/gl.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <string>
 #include <string_view>
@@ -146,6 +150,143 @@ namespace OloEngine::Tests
                                                           "feeding '*N' URIs to the filesystem texture loader instead "
                                                           "of resolving them via aiScene::GetEmbeddedTexture.";
             }
+        }
+
+        // The texture's ACTUAL contents off the GPU (level 0, RGBA8). Reading the GPU
+        // rather than a file compares what the renderer will sample, whichever route
+        // the material resolved through — cooked file, registry handle or in-memory
+        // decode. A warm load that produced SOME texture but the wrong one would
+        // satisfy a bare "has an albedo map" assertion; this does not.
+        std::vector<u8> ReadTexturePixels(const Ref<Texture2D>& texture)
+        {
+            if (!texture || texture->GetWidth() == 0 || texture->GetHeight() == 0)
+            {
+                return {};
+            }
+            std::vector<u8> pixels(static_cast<sizet>(texture->GetWidth()) * texture->GetHeight() * 4u);
+            ::glGetTextureImage(texture->GetRendererID(), 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                                static_cast<GLsizei>(pixels.size()), pixels.data());
+            return pixels;
+        }
+
+        // The first albedo map any material in the model carries, or null.
+        Ref<Texture2D> FirstAlbedoMap(const Model& model)
+        {
+            for (sizet i = 0; i < model.GetMaterialCount(); ++i)
+            {
+                if (auto material = model.GetMaterial(i); material && material->GetAlbedoMap())
+                {
+                    return material->GetAlbedoMap();
+                }
+            }
+            return nullptr;
+        }
+
+        // =====================================================================
+        // The WARM half of the loader contract (issue #791).
+        //
+        // Everything above loads each variant exactly once, which only ever
+        // exercises the COLD path: a fresh checkout has no
+        // OloEditor/assets/cache/mesh/. That is precisely why CI could never
+        // see this bug — a runner is cold by construction and always passes.
+        // It bit a developer or an agent running the suite twice on one
+        // machine, where the second run reads back the .omesh the first run
+        // wrote, and it presented as a FLAKY test because the first run of the
+        // day was green.
+        //
+        // What broke: an embedded texture (TexturedComplex and TexturedEmbedded
+        // store their images in glTF bufferViews rather than as sidecar URIs)
+        // has no file and no asset handle, so Model cooks it into a real .png
+        // to give it an identity. That cook used to require an active project.
+        // With no project — which is every load in this fixture — there was no
+        // cook, so ImportedMaterialCodec recorded an EMPTY texture reference
+        // into the .omesh and the warm load resolved a material with no albedo
+        // map at all. No error, no warning: just fewer textures on run 2.
+        //
+        // So this case loads twice on purpose. Run 2 is a different experiment
+        // than run 1, not a repeat of it.
+        // =====================================================================
+        TEST_P(DeccerCubesLoaderFixture, SurvivesAWarmMeshCacheRoundTrip)
+        {
+            OLO_ENSURE_GPU_OR_SKIP();
+
+            const auto param = GetParam();
+            const auto absolutePath = EditorRoot() / param.RelativePath;
+
+            ASSERT_TRUE(std::filesystem::exists(absolutePath))
+                << "Fixture file missing: " << absolutePath.string();
+
+            // Start cold whatever the machine's cache state is, so the two halves below
+            // are genuinely cold-then-warm rather than warm-then-warm. Both prefixes:
+            // "static_uvflip_v1" is the default-flipped-UV namespace OBJ takes, and a
+            // stale entry in the one we are not about to write would go unnoticed.
+            MeshCache::InvalidateCache(absolutePath);
+            MeshCache::InvalidateCache(absolutePath, "static_uvflip_v1");
+
+            // -- Cold: straight from the source file via Assimp. Ground truth. --
+            sizet coldMeshCount = 0;
+            glm::vec3 coldExtent{ 0.0f };
+            std::vector<u8> coldAlbedoPixels;
+            {
+                Model cold{ absolutePath.string() };
+                coldMeshCount = cold.GetMeshCount();
+                ASSERT_GT(coldMeshCount, 0u) << "the cold load produced no meshes for " << param.Name;
+                coldExtent = cold.GetBoundingBox().GetSize();
+
+                if (param.ExpectsAlbedoTexture)
+                {
+                    Ref<Texture2D> const albedo = FirstAlbedoMap(cold);
+                    ASSERT_TRUE(albedo)
+                        << "the COLD load of " << param.Name << " already has no albedo map, so the warm "
+                                                                "comparison below would be vacuous — fix the importer before reading anything "
+                                                                "into the cache half of this test";
+                    coldAlbedoPixels = ReadTexturePixels(albedo);
+                    ASSERT_FALSE(coldAlbedoPixels.empty());
+                    ASSERT_TRUE(std::ranges::any_of(coldAlbedoPixels,
+                                                    [&](u8 b)
+                                                    { return b != coldAlbedoPixels[0]; }))
+                        << "the cold albedo is a uniform block — comparing it to anything proves nothing";
+                }
+            }
+
+            // A .gltf/.glb is not an OBJ, so it takes the un-prefixed cache namespace.
+            ASSERT_TRUE(MeshCache::IsMeshCacheValid(absolutePath))
+                << "the cold load wrote no .omesh for " << param.Name
+                << ", so the warm half below would silently re-run the cold path and prove nothing";
+
+            // -- Warm: geometry and materials come back out of the .omesh. --
+            Model warm{ absolutePath.string() };
+
+            EXPECT_EQ(warm.GetMeshCount(), coldMeshCount)
+                << "the warm load produced a different number of meshes for " << param.Name;
+
+            const glm::vec3 warmExtent = warm.GetBoundingBox().GetSize();
+            EXPECT_TRUE(std::isfinite(warmExtent.x) && std::isfinite(warmExtent.y) && std::isfinite(warmExtent.z))
+                << "the warm bounding box contains NaN/Inf for " << param.Name;
+            EXPECT_NEAR(warmExtent.x, coldExtent.x, 1e-3f) << "warm bounds drifted for " << param.Name;
+            EXPECT_NEAR(warmExtent.y, coldExtent.y, 1e-3f) << "warm bounds drifted for " << param.Name;
+            EXPECT_NEAR(warmExtent.z, coldExtent.z, 1e-3f) << "warm bounds drifted for " << param.Name;
+
+            if (!param.ExpectsAlbedoTexture)
+            {
+                return;
+            }
+
+            Ref<Texture2D> const warmAlbedo = FirstAlbedoMap(warm);
+            ASSERT_TRUE(warmAlbedo)
+                << "No material in " << param.Name << " carries an albedo map after a WARM cache load, "
+                                                      "though the cold load a moment ago did. The .omesh is storing a texture reference "
+                                                      "nothing can resolve — for an *Embedded/*Complex variant that means the embedded "
+                                                      "bitmap was never cooked to a real file, so ImportedMaterialCodec had neither an "
+                                                      "asset handle nor a path to write.";
+
+            // Not merely SOME texture: the same pixels. A material holding a handle to the
+            // wrong texture would pass the assertion above.
+            const std::vector<u8> warmAlbedoPixels = ReadTexturePixels(warmAlbedo);
+            EXPECT_EQ(warmAlbedoPixels, coldAlbedoPixels)
+                << "the albedo survived the .omesh for " << param.Name << " but its CONTENT differs from "
+                                                                          "the cold import — the cache round-trip must reproduce the exact pixels, orientation "
+                                                                          "included, not merely produce a texture";
         }
 
         // Every shipped .gltf/.glb under OloEditor/assets/models/DeccerCubes/.

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -39,6 +39,7 @@ run is **not** evidence.
 | [gpu-scan-compaction.md](gpu-scan-compaction.md) | a compaction test that sorts both sides passes identically on `atomicAdd` and on the scan meant to replace it — the *set* was never the broken thing |
 | [vendor-golden-baseline-crosscheck.md](vendor-golden-baseline-crosscheck.md) | every glyph in the engine invisible on AMD, with the font loaded, 189 glyphs packed and 852 quads submitted — bake that and the nightly defends a blank UI forever |
 | [binary-greedy-voxel-meshing.md](binary-greedy-voxel-meshing.md) | a merged quad with U and V swapped, or width and height transposed, still merges and still draws — five of the six face directions look right |
+| [cache-stored-unresolvable-reference.md](cache-stored-unresolvable-reference.md) | 7/7 green on every CI run and every clean checkout — a runner never has a warm cache, so the failing path is the one nothing runs twice |
 
 **The counter-move:** name the observation that *would* have failed. Usually it's a moving target
 instead of a static one, an edge instead of a steady state, a second camera angle, or the physical
@@ -88,7 +89,10 @@ pushes that nothing reports missing — which is why the new carrier runs *besid
 not instead of it) ·
 [steamworks-platform-integration.md](steamworks-platform-integration.md) (an SDK path set one level
 too high drops the whole feature — the build succeeds with Steam quietly switched off, and the error
-explaining the correct layout is the one thing that never fires)
+explaining the correct layout is the one thing that never fires) ·
+[cache-stored-unresolvable-reference.md](cache-stored-unresolvable-reference.md) (a texture, from the
+SECOND load onward — an empty reference in a cache is indistinguishable from a slot that was never
+set, so every step downstream handles it "correctly")
 
 **The counter-move:** ask what the *absence* would look like, and whether anything in the system
 would be different. If the answer is "nothing", you need a coverage test, not a unit test.
@@ -231,6 +235,7 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 **Scene, ECS & serialization** — [component-serializer-codegen.md](component-serializer-codegen.md) ·
 [scene-binary-sidecar.md](scene-binary-sidecar.md) ·
 [binary-format-versioning.md](binary-format-versioning.md) ·
+[cache-stored-unresolvable-reference.md](cache-stored-unresolvable-reference.md) ·
 [scene-copy-must-carry-scene-level-settings.md](scene-copy-must-carry-scene-level-settings.md) ·
 [floating-origin-rebase-subsystems.md](floating-origin-rebase-subsystems.md) ·
 [asset-degradation-and-constructor-preconditions.md](asset-degradation-and-constructor-preconditions.md)

--- a/docs/agent-rules/cache-stored-unresolvable-reference.md
+++ b/docs/agent-rules/cache-stored-unresolvable-reference.md
@@ -1,0 +1,112 @@
+# A disk cache must not store a reference its reader cannot resolve
+
+Issue #791. The `.omesh` mesh cache recorded a texture reference that pointed at nothing, so the
+**second** load of a model came back with fewer textures than the first. Nothing errored. The first
+run of the day always passed, which is why it read as a flaky test rather than as a broken cache.
+
+Read this before adding a field to any persisted format that **names** something rather than
+containing it — an asset handle, a file path, a URI, an index into another file.
+
+## What stayed green
+
+Everything. `AllVariants/DeccerCubesLoaderFixture.LoadsWithMeshesAndFiniteBounds` passed 7/7 on
+every CI run and on every clean checkout, because a runner starts with no
+`OloEditor/assets/cache/mesh/` and therefore only ever exercises the **cold** path. The failure
+needed two loads in one working tree:
+
+```
+run 1 (cold cache)  -> [  PASSED  ] 7 tests.
+run 2 (warm cache)  -> [  PASSED  ] 5 tests.  [  FAILED  ] 2  (TexturedComplex, TexturedEmbedded)
+```
+
+**Run 2 is a different experiment than run 1, not a repeat of it.** A test that only ever runs once
+per checkout cannot see any cache bug, and every cache in this repo has that blind spot by
+construction.
+
+## The mechanism
+
+`ImportedMaterialCodec` persists a material's textures **by reference** — an `AssetHandle`, with the
+source path as a fallback — never by pixels. That is the right design (a texture shared by 40
+materials costs 40 handles, not 40 copies). It has one precondition: every texture must *have* one
+of those identities.
+
+A texture embedded in a glTF/GLB has neither. It is bytes inside the model file: no file of its own,
+no registry entry. So `Model::CookEmbeddedTexture` writes it out as a real `.png` and imports it,
+after which it is an ordinary texture with a path and a handle, and the codec works unchanged.
+
+The cook required an active project with an `EditorAssetManager`. Without one it returned early, the
+texture stayed an in-memory decode with no path and no handle, and then:
+
+1. `Describe()` produced an **empty** `TextureRef` for the slot — which is also, exactly, what it
+   produces for a slot that was legitimately never set;
+2. `Encode()` wrote that empty reference into the `.omesh`, reporting success;
+3. `Realize()` on the next load resolved it to nothing and left the slot unset — which is also,
+   exactly, the correct handling of a slot that was legitimately never set.
+
+Every step behaved correctly in isolation. The information that the slot *had* held a texture was
+destroyed at step 1, so no later step could notice.
+
+## The three rules
+
+**1. A cook that gives a thing its identity must not be conditional on something unrelated.**
+The cook needed a *directory to write to*; it was gated on *an asset registry to register with*.
+Those are separate capabilities and only the first is required for the cache to work — the reader
+resolves the recorded path before it ever consults the handle. Splitting them was the fix: the
+directory comes from `MeshCache::GetEmbeddedTextureCacheDirectory()` (which falls back to a
+CWD-relative `assets/` exactly as the `.omesh` itself does, so the texture always lands under the
+same root as the file referencing it), and registration is best-effort on top.
+
+Note the asymmetry that hid this: with a project mounted the whole path worked, and
+`ImportedMaterialPackTest.EmbeddedTextureSurvivesTheOmeshCache` proved it. The test mounted a
+project because that was the realistic editor case. The *un*realistic case was the one every
+headless load actually took.
+
+**2. Refuse to persist what you cannot resolve.** `Describe()` cannot fail — an unrepresentable
+texture degrades to an empty slot rather than an error, which is correct for a codec. So the
+**writer** must ask the question instead. `ImportedMaterialCodec::CanPersistEveryTexture()` reports
+whether every slot that is *set* describes to something resolvable, and `Model::LoadModel` omits the
+material table entirely when it does not — sending the next load down the re-import branch.
+
+That trade is not close. A cache that is slow is a cost; a cache that is wrong is a bug, and one
+that is wrong *only on the second run* is a bug that will be diagnosed as flakiness. Degrade to slow.
+
+**3. A writer fix does not fix the files already on disk.** Every machine that had run the suite
+held `.omesh` files containing the empty references, written by the old code and still perfectly
+valid by the header check. Fixing only the writer produces the worst possible symptom — "works on a
+clean machine, still broken on mine" — which is precisely the shape that made this hard to see in
+the first place. `OMeshFormat::CurrentVersion` was bumped 4 → 5 with no new sections, purely to
+invalidate them, exactly as v3 had been bumped before it. `ReadTimestamp` gates cache validity on
+`Version == CurrentVersion` (strict), so the bump costs one cold re-import and nothing else.
+
+## Where else this shape lives
+
+The same defect was sitting one function away, unreported: `Model` packs the legacy/specular
+workflow's separate metallic and roughness files into one texture **in memory**, so that texture had
+no path either and every warm load of `backpack.obj` silently lost its metallic-roughness map. It is
+now cooked to a file through the same helper. Grep for a `Texture2D` built from a
+`TextureSpecification` rather than a path and ask what persists it.
+
+More generally, look for anything that is **synthesised at import time and then referenced by name**:
+a runtime-generated atlas, a procedurally-built LUT, a merged or remapped buffer. If a consumer
+persists it by identity, the importer owes it an identity — a real file — not just pixels on the GPU.
+
+Distinct from the staleness species (a cache keyed on path + config that never notices the source
+changed — issues #505, #530, #542). There the cached artifact is *out of date*; here it was fully
+up to date and internally consistent, and a field inside it pointed at nothing.
+
+## The test that would have caught it
+
+`DeccerCubesLoaderFixture.SurvivesAWarmMeshCacheRoundTrip` — invalidate, load cold, assert the
+`.omesh` was written, load warm, and compare. It compares **pixels read back off the GPU**, not just
+"is there an albedo map": a material holding a handle to the *wrong* texture satisfies the weaker
+assertion.
+
+Two things to copy when writing one for another cache:
+
+- **Assert the cache was actually written** between the halves (`MeshCache::IsMeshCacheValid`).
+  Without that, a warm half that silently re-ran the cold path passes while proving nothing — the
+  most likely way this kind of test rots.
+- **Take the `RESOURCE_LOCK`.** The mesh cache is a real repo-relative directory, not a
+  process-isolated temp dir, so a test that invalidates it races every other test loading the same
+  model under `ctest --parallel`. Add the case to `OLO_MESH_CACHE_TESTS` in
+  `OloEngine/tests/CMakeLists.txt`.


### PR DESCRIPTION
Closes #791.

`AllVariants/DeccerCubesLoaderFixture.LoadsWithMeshesAndFiniteBounds` failed for
`TexturedComplex` and `TexturedEmbedded` whenever `OloEditor/assets/cache/mesh/` was warm.
The first run of the day passed, so it read as a flaky test — and **CI can never catch this
class**, because a runner starts from a clean checkout and is always cold.

## Root cause

`Model::CookEmbeddedTexture` returned early unless an active project *with an
`EditorAssetManager`* was mounted. Those two variants are exactly the ones whose images live
in glTF **bufferViews** rather than sidecar URIs:

| variant | `images[]` | warm result (before) |
|---|---|---|
| `Textured`, `MergedAtlas` | `uri: T_*.png` | fine |
| `TexturedComplex`, `TexturedEmbedded` | `bufferView: N` | **albedo dropped** |

Without the cook the texture stayed an in-memory decode with no path and no handle, so
`ImportedMaterialCodec::Describe` wrote an **empty `TextureRef`** into the `.omesh` —
indistinguishable from a slot that was legitimately never set. The warm load resolved a
material with no albedo map. Every step was individually correct; the information was
destroyed at the first one.

The cook needed a **directory to write to** but was gated on a **registry to register with**.
Only the first is required, because `RealizeTexture` resolves the recorded path *before* it
consults the handle. The two are now separated:

* directory ← `MeshCache::GetEmbeddedTextureCacheDirectory()`, which uses the same asset-root
  fallback as the `.omesh` itself (project asset dir, else CWD-relative `assets`), so a cooked
  texture always lands under the root that references it;
* registration ← best-effort. Losing it costs the packed runtime a handle; returning early
  additionally cost the `.omesh` its path, the strictly worse outcome.

With a project mounted the cooked path is byte-identical to before, so handle stability across
re-imports is unchanged.

## Also in this PR

**A writer-side guard.** `ImportedMaterialCodec::CanPersistEveryTexture()` + a check at the
cache-write site. `Describe()` cannot fail, so the *writer* must ask whether every texture that
is set describes to something resolvable; if not the material table is omitted and the next load
re-imports from source. A cache that is slow is a cost; a cache that is wrong on the second run
only is a bug that gets diagnosed as flakiness.

**`.omesh` v4 → v5**, no new sections — purely to invalidate existing files, same as the v3 bump.
A writer fix does not repair what is already on disk: every machine that had run the suite held
`.omesh` files with the empty references, still valid by the header check. That is the
"fixed on a clean machine, still broken on mine" shape. Costs one cold re-import.

**Ride-along: the packed metallic-roughness map had the same defect.** `Model` packs the
legacy/specular workflow's separate metallic + roughness files into one texture in memory, so it
had no path either and **every warm load of `backpack.obj` silently lost its MR map**. Now cooked
through the same extracted helper.

> Kept in the same commit rather than split out (contrary to the usual ride-along rule) because it
> shares the extracted `CookRgbaToAssetCache` helper — splitting would leave an intermediate commit
> that was never built. Named explicitly in the commit message. Happy to reconstruct the split
> history if preferred.

This moves **where the stbi row-flip happens**: `LoadSingleChannelImage` no longer flips, because
the cooked `.png` is flipped again by `Texture2D::Create(path)` on load. **This is the part of the
diff worth reviewing hardest** — verified quantitatively below.

## Verification

Every set run **twice** (cold then warm) — run 2 is a different experiment than run 1.

**The reproduction, before and after:**

| | run 1 (cold) | run 2 (warm) |
|---|---|---|
| baseline (fix reverted, test kept) | 7/7 pass | **5 pass, 2 FAILED** |
| with fix | 7/7 pass | **7/7 pass** |

Warm run with the fix: **7 loads from cache, 0 Assimp re-imports, 0 unresolved-texture warnings,
0 dropped material tables** — so it resolves through the cooked path, not via the new guard's
slow fallback.

**Full suite: 6038 passed / 0 failed, identical cold and warm** (6063 run, 25 skipped GPU/Steam).
The warm full-suite run is the one that matters here and had never been done before.

**Live editor over MCP** (`DeccerCubesTest.olo`, `ModelLoadingTest.olo`), cold vs warm:

| entity | cold vs warm frame |
|---|---|
| `DeccerCubes_Textured` | SHA256 **identical** |
| `DeccerCubes_Textured_Complex` | SHA256 **identical** |
| `DeccerCubes_Textured_Embedded` | SHA256 **identical** |
| `DeccerCubes_Merged_Atlas` | SHA256 **identical** |
| `Backpack` | SHA256 **identical** |

The backpack renders with metal reading as metal (canteen, axe head) and leather/canvas as rough —
an inverted MR map would swap those.

**MR orientation, checked against the source maps rather than trusting the render:**

| comparison | mean abs diff |
|---|---|
| cooked MR **G** vs `roughness.jpg` as-is | **0.004** |
| …vs vertically flipped | 54.703 |
| cooked MR **B** vs `specular.jpg` as-is | **0.004** |
| …vs vertically flipped | 62.717 |

R=0, A=255 per the packing convention. The cooked file is genuinely top-down; the single GL flip
happens at load, as for any image file. No double flip.

## Tests

* **`DeccerCubesLoaderFixture.SurvivesAWarmMeshCacheRoundTrip`** — invalidate, load cold, assert the
  `.omesh` was written, load warm, compare **GPU pixel readback** (a handle to the *wrong* texture
  would satisfy a bare "has an albedo map" check). Reproduces the failure **in one process**, so CI
  can finally see this class. Verified to fail on the unfixed engine and pass with it.
* **`AssetContentValidity` gained an `embedded` cache-kind entry.** It caught the new `mr_` file
  immediately — which also revealed the directory had **no entry at all**: the pre-existing `emb_`
  files never reached the repo tree before, because the old cook only ran with a project and wrote
  into the project's asset dir.
* Both DeccerCubes cases joined `OLO_MESH_CACHE_TESTS` (`RESOURCE_LOCK`) — the new case invalidates
  a shared repo-relative cache entry the other case reads. Note `OloEngine/tests/CMakeLists.txt` is
  a known collision point for parallel branches; the change there is two lines.

## Docs

`docs/agent-rules/cache-stored-unresolvable-reference.md` — the generalizable rule: a cache that
stores a **name** (handle, path, URI, cross-file index) must refuse to store one nothing can
resolve. Covers why CI is structurally blind to this, and the two things to copy when writing a
warm-path test for another cache. Linked from both indexes and `CLAUDE.md` as
`docs/agent-rules/README.md` requires. Distinct from the staleness species (#505/#530/#542), where
the artifact is *out of date*; here it was current and internally consistent, with a field pointing
at nothing.

## Note for reviewers

Loading a model with embedded textures in the editor adds cooked-texture entries to
`SandboxProject/AssetRegistry.oar`, which point at git-ignored `cache/` files. That churn is
pre-existing (#629) and deliberately **not** committed here — committing it would give a fresh
clone dangling entries. This PR adds the two `mr_*` entries to that same pre-existing churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded and packed metallic-roughness textures are now cached as reusable PNG assets.
  * Texture processing works even when no project is mounted.

* **Bug Fixes**
  * Prevented cached models from silently losing unresolved textures.
  * Improved consistency between first-time imports and cached reloads.
  * Corrected texture orientation handling for single-channel images.

* **Compatibility**
  * Updated the mesh cache format; existing version 4 caches will be regenerated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->