### PR TITLE
build: give OLO_WITH_VULKAN=OFF a CI job, fix what had rotted, and delete the escape-valve claim

### DIFF
--- a/.github/workflows/vulkan-off.yml
+++ b/.github/workflows/vulkan-off.yml
@@ -19,12 +19,17 @@
 # gpu-conformance-amd nightly are for. This job answers exactly one question: does the GL-only
 # configuration still compile, link and skip cleanly?
 #
-# NOTE the SDK is still required. `OLO_WITH_VULKAN=OFF` is NOT "build without a Vulkan SDK":
-# `find_package(Vulkan REQUIRED ...)` in OloEngine/CMakeLists.txt is deliberately ungated because
-# the SDK is also where the SHADER toolchain lives (shaderc / glslang / SPIRV-Tools /
-# SPIRV-Cross), which every build needs regardless of backend. See ADR 0011 amendment (86). The
-# option is about link weight and port count, not about the SDK — so this job installs the SDK
-# like every other build job here.
+# NOTE Vulkan dev packages are still required. `OLO_WITH_VULKAN=OFF` is NOT "build without
+# Vulkan installed": `find_package(Vulkan REQUIRED ...)` in OloEngine/CMakeLists.txt is
+# deliberately ungated because the SHADER toolchain (shaderc / glslang / SPIRV-Tools /
+# SPIRV-Cross) is needed by every build regardless of backend. See ADR 0011 amendment (86). The
+# option is about link weight and port count, not about Vulkan discovery.
+#
+# On MSVC that means the LunarG SDK specifically (the COMPONENTS branch). This job is Linux, which
+# takes the plain `find_package(Vulkan REQUIRED)` branch and could likely be satisfied by the apt
+# packages installed below alone — but it runs setup-vulkan anyway, matching every other build job
+# here. Dropping that step is a plausible minute or two of savings; it is untested, so it is left
+# in rather than traded for a red nightly.
 name: Vulkan OFF (GL-only build)
 
 # TRIGGER RATIONALE — a full engine build is not cheap, so the cadence is deliberately mixed
@@ -61,6 +66,19 @@ on:
       - 'OloEngine/src/OloEngine/Renderer/RHI/**'
       - 'OloEngine/tests/Rendering/Vulkan*'
       - 'OloEngine/tests/Rendering/BackendSelectionTest.cpp'
+      # The two files that carry the ON/OFF *contract* rather than the option. The break #811
+      # actually found was in VirtualShadowMapLocalTest.cpp — a GL-path test that had reached into
+      # a Platform/Vulkan header — and none of the patterns above would have caught the PR that
+      # introduced it. ShaderBindingLayout.h is the other half: it now defines
+      # MIN_GUARANTEED_BUFFER_BINDINGS, which VulkanBindingState::kMaxBufferBindings aliases, so a
+      # change there lands on both sides of the guard at once.
+      #
+      # Naming two files is narrow, and deliberately so — but it is also the weakest link here:
+      # any OTHER GL-only TU could acquire the same dependency and slip past. The durable guard
+      # for that class is a cheap grep job (the shape steam-stub.yml's single-valve-tu uses),
+      # which would run on every PR in seconds. Worth adding if this ever recurs.
+      - 'OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h'
+      - 'OloEngine/tests/Rendering/VirtualShadowMapLocalTest.cpp'
   schedule:
     - cron: '0 5 * * 4' # weekly, Thursday 05:00 UTC (off steam-stub's Wednesday and video-ffmpeg's Monday slots)
   workflow_dispatch:

--- a/.github/workflows/vulkan-off.yml
+++ b/.github/workflows/vulkan-off.yml
@@ -1,0 +1,266 @@
+# Anti-rot gate for the OLO_WITH_VULKAN=OFF build configuration (#811).
+#
+# WHY THIS WORKFLOW EXISTS
+# ------------------------
+# `OLO_WITH_VULKAN=OFF` is a real, documented build configuration: it drops the volk /
+# vulkan-headers / VulkanMemoryAllocator vcpkg ports and compiles every `Platform/Vulkan` TU to an
+# empty object. Before this workflow, NO CI job set the option — every workflow in this repo built
+# the default ON path. That left two things compiled nowhere but on a developer's machine:
+#
+#   * the `#if OLO_WITH_VULKAN` self-guards in the ~40 `Platform/Vulkan/*.cpp` TUs, which is
+#     exactly the "guarded code bitrots because nothing compiles it" shape that Trap 3 in
+#     docs/agent-rules/vcpkg-dependency-management.md describes, and
+#   * the `#if !OLO_WITH_VULKAN` GTEST_SKIP branches in seven Vulkan test files plus the `#else`
+#     arms in Rendering/BackendSelectionTest.cpp, which had presumably never executed.
+#
+# WHAT IT DOES NOT PROVE
+# ----------------------
+# Nothing about the Vulkan backend itself — that is what the ON builds and the device-gated
+# gpu-conformance-amd nightly are for. This job answers exactly one question: does the GL-only
+# configuration still compile, link and skip cleanly?
+#
+# NOTE the SDK is still required. `OLO_WITH_VULKAN=OFF` is NOT "build without a Vulkan SDK":
+# `find_package(Vulkan REQUIRED ...)` in OloEngine/CMakeLists.txt is deliberately ungated because
+# the SDK is also where the SHADER toolchain lives (shaderc / glslang / SPIRV-Tools /
+# SPIRV-Cross), which every build needs regardless of backend. See ADR 0011 amendment (86). The
+# option is about link weight and port count, not about the SDK — so this job installs the SDK
+# like every other build job here.
+name: Vulkan OFF (GL-only build)
+
+# TRIGGER RATIONALE — a full engine build is not cheap, so the cadence is deliberately mixed
+# rather than "every PR" or "weekly only":
+#
+#   * pull_request WITH A PATHS FILTER. Anything that can break OFF-but-not-ON has to live in a
+#     Vulkan-guarded region, in a consumer of the Vulkan targets, or in the option plumbing
+#     itself — so the paths below are where the risk actually concentrates, and a PR touching
+#     them gets the check while the PRs that do not touch them pay nothing.
+#   * push to master + weekly. The paths filter is a heuristic, not a proof: an include-graph
+#     change somewhere else can still reach a guarded region. The unfiltered runs catch that with
+#     a bounded blast radius (discovered on the next master/weekly run rather than in review),
+#     which is the same trade steam-stub.yml documents for its stub-build job.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - '.github/workflows/vulkan-off.yml'
+      - '.github/actions/**'
+      # The option plumbing, listed file by file rather than as **/CMakeLists.txt.
+      # Nearly every renderer PR in this repo touches SOME CMakeLists (source lists), and a
+      # wildcard would hand each of them a full engine build for a change that cannot affect the
+      # option. These four files are where OLO_WITH_VULKAN actually lives: the root option() and
+      # the vcpkg manifest-feature mirror, the compile definition and the ungated
+      # find_package(Vulkan), and the port/pinned-header block.
+      - 'CMakeLists.txt'
+      - 'OloEngine/CMakeLists.txt'
+      - 'OloEngine/vendor/CMakeLists.txt'
+      - 'cmake/**'
+      - 'CMakePresets.json'
+      - 'vcpkg.json'
+      - 'OloEngine/src/Platform/Vulkan/**'
+      - 'OloEngine/src/OloEngine/Renderer/RHI/**'
+      - 'OloEngine/tests/Rendering/Vulkan*'
+      - 'OloEngine/tests/Rendering/BackendSelectionTest.cpp'
+  schedule:
+    - cron: '0 5 * * 4' # weekly, Thursday 05:00 UTC (off steam-stub's Wednesday and video-ffmpeg's Monday slots)
+  workflow_dispatch:
+
+# Read-only: this job builds and runs tests, it never comments, labels or publishes. Declared
+# explicitly rather than inherited so a future step cannot quietly acquire write scopes.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
+jobs:
+  build-vulkan-off:
+    name: Configure + build OLO_WITH_VULKAN=OFF
+    # Linux deliberately, for the same reason steam-stub.yml uses it: hosted Linux minutes bill at
+    # 1x against Windows' 2x, and nothing about this configuration is Windows-specific — the
+    # option, the guards and the SKIP branches are all platform-agnostic.
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Python 3.10
+        id: py
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+
+      # Pinned (SonarCloud githubactions:S8544). jinja2 is used only by the glad2 GL-loader
+      # generator; bump it deliberately rather than floating. Same treatment as steam-stub.yml.
+      - name: Python deps (OloHeaderTool)
+        run: python -m pip install jinja2==3.1.6
+
+      # Installed even though the Vulkan BACKEND is off — see the note at the top of this file.
+      - name: Setup Vulkan SDK
+        uses: ./.github/actions/setup-vulkan
+
+      # The engine needs a C++23 STANDARD LIBRARY, not just a C++23 compiler: Core/Reflection uses
+      # std::forward_like, which ubuntu-24.04's default libstdc++ does not provide. Every Linux
+      # job in this repo pins clang-19 from apt.llvm.org for that reason — see asan.yml.
+      - name: Add LLVM apt repository
+        uses: ./.github/actions/setup-llvm-apt
+
+      - name: Install Linux deps
+        run: |
+          # The ubuntu runner image ships Microsoft apt repos (azure-cli, prod) that periodically
+          # return 403 Forbidden; we never use them, and `apt-get update` fails hard on any single
+          # repo error. Drop them so a Microsoft-side outage cannot break our update.
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-19 lld-19 \
+            libgl-dev libglu1-mesa-dev \
+            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev \
+            glslang-dev libshaderc-dev libspirv-cross-c-shared-dev spirv-tools
+
+      - name: Setup vcpkg
+        id: vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-linux
+
+      # The heavy optional importers and FFmpeg are off: this job's question is "does the GL-only
+      # configuration still build", not "does the whole engine still work" — the main Windows /
+      # Linux workflows already answer that, and every minute spent building OpenUSD here is a
+      # minute not spent on the thing under test.
+      - name: Configure (OLO_WITH_VULKAN=OFF)
+        run: |
+          cmake -S . -B build \
+            -DOLO_WITH_VULKAN=OFF \
+            -DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF -DOLO_WITH_MATERIALX=OFF \
+            -DOLO_VIDEO_FFMPEG=OFF \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
+            -DCMAKE_C_COMPILER=clang-19 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
+            ${{ steps.vcpkg.outputs.toolchain-args }} \
+            -DPython_EXECUTABLE="${{ steps.py.outputs.python-path }}"
+
+      # Fail loudly if the option plumbing did not take. Without this the job could pass green
+      # while quietly building the default ON path — which would make the whole workflow a
+      # reassuring no-op, the precise failure it exists to prevent. Same guard shape as
+      # steam-stub.yml's "Verify the ON path is actually enabled".
+      - name: Verify the OFF path is actually selected
+        run: |
+          if ! grep -q '^OLO_WITH_VULKAN:BOOL=OFF' build/CMakeCache.txt; then
+            echo "::error::OLO_WITH_VULKAN did not resolve to OFF — the option plumbing is broken."
+            grep -E '^OLO_WITH_VULKAN' build/CMakeCache.txt || true
+            exit 1
+          fi
+
+          # The vcpkg manifest feature is mirrored from the option in the root CMakeLists BEFORE
+          # project(), and that mirroring is easy to break silently (the comment there says so).
+          # If the `vulkan` feature still resolved, the ports are installed and OFF is only half
+          # applied — the object code would be gone but the ports still built, so the job would
+          # stop measuring what it claims to.
+          if [ -d build/vcpkg_installed/x64-linux/include/volk ] \
+             || [ -f build/vcpkg_installed/x64-linux/include/volk.h ] \
+             || [ -f build/vcpkg_installed/x64-linux/include/vk_mem_alloc.h ]; then
+            echo "::error::Vulkan backend ports were installed despite OLO_WITH_VULKAN=OFF —"
+            echo "the vcpkg manifest-feature mirror in the root CMakeLists has drifted from the option."
+            exit 1
+          fi
+          echo "OK: building the GL-only configuration (backend object code and Vulkan ports both out)."
+
+      # Capped parallelism, per CLAUDE.md — a bare --parallel forwards the omission to the native
+      # tool and takes ITS default, which is wider, not narrower.
+      #
+      # No --config: single-config generator, so the build type came from CMAKE_BUILD_TYPE.
+      #
+      # OloServer and OloRuntime are built alongside the tests on purpose. #762/#834 split
+      # OloEngine into three static archives, and the OFF configuration changes what lands in
+      # them — a link-order or missing-symbol regression can hit one consumer and not another.
+      - name: Build (engine, tests, runtime, server)
+        run: cmake --build build --target OloEngine-Tests OloRuntime OloServer --parallel 4
+
+      # Resolved once and exported rather than re-found per step: two lookups can disagree, and a
+      # single failure point is easier to read in the log. Same as steam-stub.yml.
+      - name: Locate the test binary
+        run: |
+          BIN=$(find build/OloEngine/tests -type f \( -name OloEngine-Tests -o -name OloEngine-Tests.exe \) | head -1)
+          if [ -z "$BIN" ]; then
+            echo "::error::OloEngine-Tests binary not found under build/OloEngine/tests."
+            exit 1
+          fi
+          echo "OLO_TESTS_BIN=${GITHUB_WORKSPACE}/${BIN}" >> "$GITHUB_ENV"
+          echo "Test binary: ${BIN}"
+
+      # The issue (#811) only asked for configure+build. Running the two OFF-specific suites costs
+      # a few seconds on top of a build that already happened, and it is the only thing that
+      # proves the `#if !OLO_WITH_VULKAN` branches do what they say rather than merely compiling.
+      #
+      # Runs from OloEditor/ to match the suite's working-directory contract.
+      - name: Assert the Vulkan suites SKIP rather than fail or vanish
+        run: |
+          cd OloEditor
+
+          # Capture the status explicitly. GitHub runs `run:` under `bash -e`, so `OUT=$(cmd)`
+          # with a failing cmd aborts before the echo and the job reports a failure whose output
+          # was never printed — exactly when the log matters most.
+          set +e
+          OUTPUT=$("$OLO_TESTS_BIN" --gtest_filter='Vulkan*' 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::The Vulkan* suites exited with status $STATUS in an OLO_WITH_VULKAN=OFF build."
+            exit "$STATUS"
+          fi
+          if echo "$OUTPUT" | grep -qE '\[  FAILED  \]'; then
+            echo "::error::A Vulkan test FAILED in an OFF build; the OFF branch should SKIP."
+            exit 1
+          fi
+
+          # The filter must match something. A renamed suite otherwise yields "0 tests ran" and a
+          # zero exit — a green step that tested nothing.
+          if echo "$OUTPUT" | grep -qE '^\[==========\] Running 0 tests'; then
+            echo "::error::The Vulkan* filter matched no tests — suite names changed?"
+            exit 1
+          fi
+
+          # And they must actually SKIP. If a future refactor compiled the ON body into an OFF
+          # build, these would PASS instead, and this job would silently stop testing the guards.
+          SKIPPED=$(echo "$OUTPUT" | sed -nE 's/^\[  SKIPPED \] ([0-9]+) tests?.*/\1/p' | tail -1)
+          if [ -z "${SKIPPED:-}" ] || [ "$SKIPPED" -eq 0 ]; then
+            echo "::error::No Vulkan test SKIPPED in an OFF build — the #if !OLO_WITH_VULKAN branches did not run."
+            exit 1
+          fi
+          echo "OK: $SKIPPED Vulkan test(s) skipped cleanly with the backend compiled out."
+
+      # BackendSelectionTest is the other half: its `#else` arms assert that `--rhi=vulkan` in an
+      # OFF binary degrades to OpenGL *with a diagnostic* — never silently. Those arms must PASS,
+      # not skip, so this is a separate step with a different assertion.
+      - name: Assert --rhi=vulkan degrades loudly, not silently
+        run: |
+          cd OloEditor
+
+          set +e
+          OUTPUT=$("$OLO_TESTS_BIN" --gtest_filter='BackendSelection.*' 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::BackendSelection exited with status $STATUS."
+            exit "$STATUS"
+          fi
+          if echo "$OUTPUT" | grep -qE '\[  FAILED  \]'; then
+            echo "::error::BackendSelection reported failures in an OFF build."
+            exit 1
+          fi
+
+          PASSED=$(echo "$OUTPUT" | sed -nE 's/^\[  PASSED  \] ([0-9]+) tests?.*/\1/p' | tail -1)
+          if [ -z "${PASSED:-}" ] || [ "$PASSED" -eq 0 ]; then
+            echo "::error::BackendSelection matched no passing tests — filter or suite name changed?"
+            exit 1
+          fi
+          echo "OK: $PASSED backend-selection tests passed against the OFF binary."

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -1664,7 +1664,17 @@ namespace OloEngine
                           UBO_VIRTUAL_SHADOW < UBO_BINDING_LIMIT &&
                           UBO_VIRTUAL_SHADOW_DRAW < UBO_BINDING_LIMIT,
                       "UBO_BINDING_LIMIT must stay one past the highest engine UBO binding");
-        static_assert(UBO_BINDING_LIMIT <= 84,
+        // GL 4.6's MINIMUM guarantee for GL_MAX_UNIFORM_BUFFER_BINDINGS — the floor every
+        // conforming implementation must meet, so it is the largest binding number the engine
+        // may hand out and still be portable. Backend-neutral on purpose: it is a GL-derived
+        // bound that the Vulkan bind-state mirror also sizes its arrays to
+        // (VulkanBindingState::kMaxBufferBindings aliases this), and it used to be spelled as a
+        // bare 84 in both places. Naming it here rather than there is what lets a GL-only test
+        // assert against it — VirtualShadowMapLocalTest reached into
+        // Platform/Vulkan/VulkanBindingState.h for the constant and stopped compiling under
+        // OLO_WITH_VULKAN=OFF, which nothing built until #811 added the CI job.
+        static constexpr u32 MIN_GUARANTEED_BUFFER_BINDINGS = 84;
+        static_assert(UBO_BINDING_LIMIT <= MIN_GUARANTEED_BUFFER_BINDINGS,
                       "Engine UBO binding points exceed the GL 4.6 minimum GL_MAX_UNIFORM_BUFFER_BINDINGS");
 
         // =============================================================================

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -1665,8 +1665,11 @@ namespace OloEngine
                           UBO_VIRTUAL_SHADOW_DRAW < UBO_BINDING_LIMIT,
                       "UBO_BINDING_LIMIT must stay one past the highest engine UBO binding");
         // GL 4.6's MINIMUM guarantee for GL_MAX_UNIFORM_BUFFER_BINDINGS — the floor every
-        // conforming implementation must meet, so it is the largest binding number the engine
-        // may hand out and still be portable. Backend-neutral on purpose: it is a GL-derived
+        // conforming implementation must meet. It is a COUNT, so it is an EXCLUSIVE upper bound:
+        // the portable binding indices are 0..83, and 84 itself must never be handed out. Compare
+        // against it with `<` (an array sized by it, like the bind-state mirror's, makes that
+        // automatic); `<=` is only correct for a value that is itself a count, which is why the
+        // UBO_BINDING_LIMIT assert above uses one. Backend-neutral on purpose: it is a GL-derived
         // bound that the Vulkan bind-state mirror also sizes its arrays to
         // (VulkanBindingState::kMaxBufferBindings aliases this), and it used to be spelled as a
         // bare 84 in both places. Naming it here rather than there is what lets a GL-only test

--- a/OloEngine/src/Platform/Vulkan/VulkanBindingState.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanBindingState.h
@@ -56,8 +56,15 @@ namespace OloEngine
         // frame (#691 Phase 7: the auto-exposure block moving to 72 on the
         // #705 merge, and the A2 renumber pushing TEX_DDGI_VISIBILITY to 64
         // and TEX_SHADER_GRAPH_0 to 65, both walked past the old 64).
-        static constexpr u32 kMaxBufferBindings = 84; // GL_MAX_UNIFORM_BUFFER_BINDINGS' minimum guarantee
-        static constexpr u32 kMaxTextureSlots = 96;   // engine slots + shader-graph user slots, with headroom
+        //
+        // kMaxBufferBindings ALIASES the backend-neutral constant rather than repeating the
+        // literal: the bound is GL_MAX_UNIFORM_BUFFER_BINDINGS' minimum guarantee, a property of
+        // the binding NUMBERS the engine hands out and not of Vulkan. Defining it in
+        // ShaderBindingLayout.h is what lets a GL-only TU assert against it without reaching into
+        // this header, which vanishes entirely under OLO_WITH_VULKAN=OFF — VirtualShadowMapLocalTest
+        // did exactly that and had stopped compiling in that configuration (#811).
+        static constexpr u32 kMaxBufferBindings = ShaderBindingLayout::MIN_GUARANTEED_BUFFER_BINDINGS;
+        static constexpr u32 kMaxTextureSlots = 96; // engine slots + shader-graph user slots, with headroom
         static constexpr u32 kNoHeapSlot = 0xFFFFFFFFu;
 
         static_assert(ShaderBindingLayout::UBO_BINDING_LIMIT <= kMaxBufferBindings,

--- a/OloEngine/tests/Rendering/VirtualShadowMapLocalTest.cpp
+++ b/OloEngine/tests/Rendering/VirtualShadowMapLocalTest.cpp
@@ -26,10 +26,12 @@
 // It also brings in ShadowAtlas.h for the 16-light budget this beats.
 #include "OloEngine/Renderer/Shadow/ShadowMap.h"
 #include "OloEngine/Renderer/Shadow/VirtualShadowMap.h"
+// Also for MIN_GUARANTEED_BUFFER_BINDINGS — the 84 this file used to spell as a
+// literal. It reached into Platform/Vulkan/VulkanBindingState.h for that constant
+// until #811, which does not compile under OLO_WITH_VULKAN=OFF (the whole header is
+// behind the guard) — and nothing built that configuration, so it went unnoticed.
+// The bound is a GL binding-number property, so it now lives in the neutral header.
 #include "OloEngine/Renderer/ShaderBindingLayout.h"
-// For kMaxBufferBindings — the 84 this file used to spell as a literal. Including
-// a Platform header from a renderer test follows VulkanDrawPathTest.cpp.
-#include "Platform/Vulkan/VulkanBindingState.h"
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -171,7 +173,7 @@ TEST(VirtualShadowMapLocal, ConstantsMirrorTheShaderContract)
     // streams and the GL 4.6 minimum, the same two checks #702's bindings got.
     EXPECT_NE(ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS, ShaderBindingLayout::SSBO_VERTEX_PULL);
     EXPECT_NE(ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS, ShaderBindingLayout::SSBO_BONE_PULL);
-    EXPECT_LT(ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS, VulkanBindingState::kMaxBufferBindings)
+    EXPECT_LT(ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS, ShaderBindingLayout::MIN_GUARANTEED_BUFFER_BINDINGS)
         << "past the GL_MAX_UNIFORM_BUFFER_BINDINGS minimum guarantee (84), which is the bound the "
            "Vulkan backend sizes its binding tables to — not a shader-storage limit, which is where "
            "the previous message pointed";

--- a/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
+++ b/docs/adr/0011-rhi-neutral-resource-and-binding-model.md
@@ -465,9 +465,11 @@ genuinely separate axes, and this ADR separates them:
 - **Build-time — `OLO_WITH_VULKAN` (CMake option, default `ON` on desktop):**
   *is the Vulkan backend compiled in at all?* This is needed, because the SDK +
   volk + VMA vendoring is heavy, and `docs/agent-rules/asset-import-usd-alembic.md`
-  already records what heavyweight vendored dependencies cost this build. It
-  also lets `OloServer` (the WSL2/headless target) and a lean CI configuration
-  build without a Vulkan SDK present. This is an *availability* switch.
+  already records what heavyweight vendored dependencies cost this build. This
+  is an *availability* switch, and it is **whole-tree**: `OloServer`, the editor
+  and the runtime are configured together, so it cannot be set "for the server".
+  It also does **not** remove the Vulkan SDK requirement — see amendment (86)
+  and the Consequences bullet, corrected by #811.
 - **Run-time — `--rhi=`:** *which compiled-in backend does this process use?*
   This is a *selection* switch, and it is the one the user interacts with.
 
@@ -1023,7 +1025,17 @@ changes the model in §1.1–§1.5; all four are corrections to the *vocabulary*
   Vulkan (§1.5) — fixed in Phase 5 by (43): the transition record is unified
   onto `RHI::Access`, with the WAW fix applied at barrier emission.
 - One binary ships both backends. Binary size and link time grow; `OLO_WITH_VULKAN=OFF`
-  is the escape valve for `OloServer` and lean CI.
+  drops the volk / vulkan-headers / VulkanMemoryAllocator ports and compiles the
+  backend object code out. **It is not an escape valve from the Vulkan SDK, and
+  not a per-target one.** `find_package(Vulkan REQUIRED)` is deliberately ungated
+  (the *shader* toolchain — shaderc / glslang / SPIRV-Tools / SPIRV-Cross — lives
+  in the same SDK and every build needs it), and the option is whole-tree, so
+  `OloServer` cannot be configured lean while the editor is not. Corrected in
+  place by amendment (86); #811 then decided the follow-on question — **an
+  SDK-free lean server build is not a goal** (the server is already backend-less
+  per (86), and its deployment image needs no GPU stack) — and added the
+  `vulkan-off.yml` CI job so the OFF configuration is compiled somewhere other
+  than a developer's machine.
 - Vulkan adds exactly one new on-disk cache artefact (`pipeline_cache.vkpc`) and
   changes the *name* of an existing one (the target-env-keyed SPIR-V). Existing
   caches are invalidated once, at the version that lands (b); this is a

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -2171,8 +2171,33 @@ including its font atlas.
 Also note the separate axis: `OLO_WITH_VULKAN` (build-time, "is the backend
 compiled in") is **not** the selection mechanism. Both backends ship in one
 binary so a machine below Vulkan's hardware floor (ADR 0010: Intel ANV is still
-experimental) can fall back at runtime. `OLO_WITH_VULKAN=OFF` exists for
-`OloServer`/WSL2 and lean CI, where no Vulkan SDK is present.
+experimental) can fall back at runtime.
+
+`OLO_WITH_VULKAN=OFF` does **not** mean "no Vulkan SDK". That claim was wrong
+from the start and #811 removed it here and from ADR 0011: OFF drops the volk /
+vulkan-headers / VulkanMemoryAllocator ports and compiles every
+`Platform/Vulkan` TU to an empty object, but `find_package(Vulkan REQUIRED ...)`
+in `OloEngine/CMakeLists.txt` is deliberately **ungated** — the SDK is also
+where the *shader* toolchain lives (shaderc, glslang, SPIRV-Tools,
+SPIRV-Cross), which every build needs regardless of backend. The valve is about
+link weight and port count.
+
+It is also **whole-tree**, not per-target: `OloServer` is configured from the
+same tree as the editor and the runtime, so "OFF for the server" is not a thing
+a single configure can express. #811 decided explicitly that a lean, SDK-free
+server build is **not** a goal — the server is backend-less anyway (ADR 0011
+amendment (86)) and its deployment image (ubuntu + libstdc++6, no libGL, no
+libvulkan) needs no GPU stack — so the capability was deleted from the docs
+rather than built.
+
+**If you touch a `#if OLO_WITH_VULKAN` guard, the OFF path has a CI job now:**
+`.github/workflows/vulkan-off.yml` configures and builds the GL-only
+configuration on Linux and asserts the seven Vulkan suites SKIP while
+`BackendSelection`'s `#else` arms pass. It runs on every PR that touches the
+paths where OFF-only breakage can live (CMake, `Platform/Vulkan/`,
+`Renderer/RHI/`, the Vulkan tests), and unfiltered on master and weekly. Before
+#811 nothing set the option anywhere in CI, and the guards had gone
+uncompiled — and the SKIP branches unexecuted — for the whole epic.
 
 ---
 

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -2194,10 +2194,22 @@ rather than built.
 `.github/workflows/vulkan-off.yml` configures and builds the GL-only
 configuration on Linux and asserts the seven Vulkan suites SKIP while
 `BackendSelection`'s `#else` arms pass. It runs on every PR that touches the
-paths where OFF-only breakage can live (CMake, `Platform/Vulkan/`,
-`Renderer/RHI/`, the Vulkan tests), and unfiltered on master and weekly. Before
+paths where OFF-only breakage can live — the option plumbing (the root /
+`OloEngine/` / `OloEngine/vendor/` `CMakeLists.txt`, `cmake/`,
+`CMakePresets.json`, `vcpkg.json`), `Platform/Vulkan/`, `Renderer/RHI/`, the
+Vulkan tests, and the two ON/OFF *contract* files (`ShaderBindingLayout.h` and
+`VirtualShadowMapLocalTest.cpp`) — and unfiltered on master and weekly. Before
 #811 nothing set the option anywhere in CI, and the guards had gone
 uncompiled — and the SKIP branches unexecuted — for the whole epic.
+
+**The filter is a heuristic, and here is its known hole:** it names two contract
+files because those are the ones that broke, but *any* GL-only TU that acquires
+an include of a `Platform/Vulkan` header inherits the same failure and would
+slip past on the PR that introduced it (master/weekly still catch it, one merge
+later). If that recurs, the right answer is not a longer path list but a cheap
+grep job in the shape of `steam-stub.yml`'s `single-valve-tu` — assert that no
+TU outside `Platform/Vulkan/` and the Vulkan tests includes a
+`Platform/Vulkan/` header — which runs on every PR in seconds.
 
 ---
 

--- a/docs/ops/build.md
+++ b/docs/ops/build.md
@@ -392,11 +392,19 @@ binary ships the OpenGL backend only.
 
 Two things it is **not**, both of which the docs claimed until #811:
 
-- **It is not "build without a Vulkan SDK."** `find_package(Vulkan REQUIRED ...)`
-  in `OloEngine/CMakeLists.txt` is ungated on purpose — the SDK is where the
-  *shader* toolchain lives (shaderc, glslang, SPIRV-Tools, SPIRV-Cross) and every
-  build needs it. Configuring without `VULKAN_SDK` fails at `find_package`
-  whichever way this option is set.
+- **It is not "build without Vulkan development packages."**
+  `find_package(Vulkan REQUIRED ...)` in `OloEngine/CMakeLists.txt` is ungated on
+  purpose, because the *shader* toolchain (shaderc, glslang, SPIRV-Tools,
+  SPIRV-Cross) is needed by every build regardless of backend. Turning the option
+  off does not relax that, but what satisfies it differs by platform:
+  - **MSVC** takes the `COMPONENTS glslc glslang SPIRV-Tools` branch, which in
+    practice means the LunarG SDK — configuring without `VULKAN_SDK` fails at
+    `find_package`, whichever way this option is set.
+  - **Everywhere else** takes a plain `find_package(Vulkan REQUIRED)`, so any
+    discoverable Vulkan installation will do and the shader tooling can come from
+    system packages instead (`glslang-dev`, `libshaderc-dev`,
+    `libspirv-cross-c-shared-dev`, `spirv-tools` on Debian/Ubuntu — the same set
+    the Linux CI jobs install). No LunarG SDK is strictly required there.
 - **It is not per-target.** `OloServer`, `OloEditor` and `OloRuntime` come out of
   one configure, so there is no "OFF for the server, ON for the editor". A lean,
   SDK-free server build was considered in #811 and explicitly **rejected**: the

--- a/docs/ops/build.md
+++ b/docs/ops/build.md
@@ -383,6 +383,40 @@ backend is logged at startup and, when it isn't the GL default, shown in the
 window title. `OloServer` is headless and selects no backend at all (ADR
 0011 amendment (86)).
 
+### `OLO_WITH_VULKAN=OFF` — what it does and does not do
+
+The *build-time* axis, distinct from `--rhi=` above. `-DOLO_WITH_VULKAN=OFF`
+drops the `volk` / `vulkan-headers` / `vulkan-memory-allocator` vcpkg ports and
+compiles every `OloEngine/src/Platform/Vulkan/*.cpp` to an empty object, so the
+binary ships the OpenGL backend only.
+
+Two things it is **not**, both of which the docs claimed until #811:
+
+- **It is not "build without a Vulkan SDK."** `find_package(Vulkan REQUIRED ...)`
+  in `OloEngine/CMakeLists.txt` is ungated on purpose — the SDK is where the
+  *shader* toolchain lives (shaderc, glslang, SPIRV-Tools, SPIRV-Cross) and every
+  build needs it. Configuring without `VULKAN_SDK` fails at `find_package`
+  whichever way this option is set.
+- **It is not per-target.** `OloServer`, `OloEditor` and `OloRuntime` come out of
+  one configure, so there is no "OFF for the server, ON for the editor". A lean,
+  SDK-free server build was considered in #811 and explicitly **rejected**: the
+  server is backend-less already, and its deployment image (ubuntu +
+  libstdc++6 — see [deployment.md](deployment.md)) carries no GPU stack, so the
+  build weight the valve saves buys nothing there.
+
+What it *is* good for: cutting three ports and the backend object code out of a
+GL-only build. It is exercised in CI by
+[`.github/workflows/vulkan-off.yml`](../../.github/workflows/vulkan-off.yml),
+which configures + builds it on Linux and asserts the Vulkan test suites SKIP
+cleanly. Run it locally with a separate build directory so it does not clobber
+the default tree:
+
+```powershell
+cmake --preset msvc -B build-vkoff -DOLO_WITH_VULKAN=OFF
+pwsh -NoProfile -File .claude/skills/run-oloengine/build-lock.ps1 -Command `
+  'cmake --build build-vkoff --target OloEngine-Tests --config Debug --parallel 6'
+```
+
 ---
 
 ## Build speed options


### PR DESCRIPTION
Closes #811.

`OLO_WITH_VULKAN=OFF` is a documented build configuration that **no CI job had ever built** and that
the docs described wrongly. This PR gives it a CI job, fixes the one thing that had rotted, and
resolves the part-2 question the issue left open.

## Was it already broken? Yes — but only in one place, and not where we expected

The issue and the handover both flagged #762/#834 (the split of `OloEngine` into three static
archives) as the change most likely to have broken this path. **It did not.** With
`-DOLO_WITH_VULKAN=OFF`, `OloEngineContent.lib`, `OloEngineRenderer.lib` and `OloEngine.lib` all
build and archive cleanly, and `OloEditor` / `OloRuntime` / `OloServer` all link.

The one real break is in the test target:

```
OloEngine/tests/Rendering/VirtualShadowMapLocalTest.cpp(174,5):
  error C2653: 'VulkanBindingState': is not a class or namespace name
  error C2065: 'kMaxBufferBindings': undeclared identifier
```

`VirtualShadowMapLocalTest` is a GL-path test that reached into
`Platform/Vulkan/VulkanBindingState.h` for `kMaxBufferBindings`. That whole header sits behind
`#if OLO_WITH_VULKAN`, so under OFF it compiles to nothing and the test stops building. The comment
at the include site even says the reach-in was deliberate ("follows VulkanDrawPathTest.cpp") — but
`VulkanDrawPathTest` is itself guarded, and this one is not.

**Fix:** the constant is a property of the *binding numbers the engine hands out*, not of Vulkan —
it is GL 4.6's minimum guarantee for `GL_MAX_UNIFORM_BUFFER_BINDINGS`, and it was already spelled as
a bare `84` in `ShaderBindingLayout.h`'s own `static_assert`. So it is now named there as
`ShaderBindingLayout::MIN_GUARANTEED_BUFFER_BINDINGS`, `VulkanBindingState::kMaxBufferBindings`
aliases it, and the test asserts against the neutral name. One literal fewer in two places, and a
GL-only TU no longer depends on a backend header.

## Part 1 — the CI job

New `.github/workflows/vulkan-off.yml`: configure + build the GL-only configuration on
`ubuntu-24.04` with clang-19, heavy optional subsystems off (USD / Alembic / MaterialX / FFmpeg), so
the job's cost is the thing under test rather than the importer stack.

Choices worth stating, since the issue asked for the runner cost to be weighed honestly:

- **Linux, not Windows.** Hosted Linux bills at 1x against Windows' 2x, and nothing about this
  configuration is Windows-specific. Same reasoning `steam-stub.yml` records.
- **Cadence is mixed, not "every PR".** `pull_request` **with a paths filter** covering the places
  OFF-only breakage can actually live (the four CMake files that carry the option, `cmake/`,
  `vcpkg.json`, `Platform/Vulkan/**`, `Renderer/RHI/**`, the Vulkan tests), plus unfiltered runs on
  master and weekly. The filter is deliberately file-by-file rather than `**/CMakeLists.txt`:
  nearly every renderer PR here touches *some* `CMakeLists.txt` for a source-list addition, and a
  wildcard would hand each of them a full engine build for a change that cannot affect the option.
- **It builds `OloServer` and `OloRuntime` too**, not just the tests — post-#834 a link regression
  can hit one consumer of the archives and not another.
- **It goes slightly past "configure + build".** The issue said no tests needed; running the two
  OFF-specific filters costs seconds on top of a build that already happened, and it is the only
  thing that proves the guards *behave* rather than merely compile. See part 1b.
- **Two anti-vacuity guards**, in the shape `steam-stub.yml` established: the job fails if
  `OLO_WITH_VULKAN` did not resolve to `OFF` in the cache, and fails if the vcpkg Vulkan ports got
  installed anyway (the manifest-feature mirror in the root `CMakeLists.txt` runs before
  `project()` and its own comment warns that it drifts silently). Without those, a broken option
  could make the whole workflow a reassuring no-op.

### Part 1b — the SKIP branches

The issue said three test files carry OFF branches. It is **seven** — `VulkanBringUpTest`,
`VulkanBarrierLoweringTest`, `VulkanDrawPathTest`, `VulkanPassSuiteTest`,
`VulkanRenderGraphExecutionTest`, `VulkanResourceFactoryTest`, `VulkanShaderPipelineTest` — plus
three `#else` arms in `BackendSelectionTest` that are a different kind: they must **pass**, not
skip, because they assert that `--rhi=vulkan` against an OFF binary degrades to OpenGL *with a
diagnostic*. The job asserts both shapes separately, and asserts a non-zero SKIP count, so a future
refactor that accidentally compiled the ON body into an OFF build fails here instead of silently
un-testing the guards.

## Part 2 — the lean server build: **not a goal**, so the language is deleted

`OLO_WITH_VULKAN` is whole-tree: `OloServer`, `OloEditor` and `OloRuntime` come out of one
configure, so "OFF for the server" is not something a single configure can express. The question the
issue posed is whether to *build* that capability or *delete the claim*. Deleting it:

- The server is already **backend-less** — ADR 0011 amendment (86) decided that, and `IsHeadless`
  skips backend selection entirely.
- Its deployment image (ubuntu + libstdc++6, no libGL, no libvulkan) carries no GPU stack, so the
  link weight the valve saves buys nothing there.
- The SDK requirement it was supposed to escape is not escapable by this option at all:
  `find_package(Vulkan REQUIRED ...)` is ungated on purpose, because the *shader* toolchain lives in
  the same SDK. Decoupling that is technically feasible on Linux (glslang / shaderc / SPIRV-Cross
  are separately packaged, and this repo's Linux jobs already apt-install them) — but there is no
  customer for it, and installing the SDK is one composite-action step in CI and a free download
  locally.

So no follow-up issue is filed: there is nothing left scoped. If someone later *does* want an
SDK-free configure, that is a fresh decision with a real customer behind it, not a leftover from
this one.

### One thing the issue got slightly wrong, worth recording

The issue says amendment (86) "corrected the ADR text". The amendment *body* says the Consequences
bullet "is corrected in place" — but the edit never landed. Both the §2 bullet and the Consequences
bullet in `0011-rhi-neutral-resource-and-binding-model.md` still carried "build without a Vulkan SDK
present" and "escape valve for `OloServer` and lean CI". They are corrected now, along with
`docs/agent-rules/rhi-abstraction-boundary.md`, and `docs/ops/build.md` gains a short section saying
exactly what the option does, what it does not do, and how to build it locally.

## Verification

- **OFF build, locally, green** — `cmake --preset msvc -B build-vkoff -DOLO_WITH_VULKAN=OFF`, then
  `OloEngine-Tests` / `OloEditor` / `OloRuntime` / `OloServer` at Debug through the build mutex.
- **Default ON build unaffected** — the only engine-side change is one `static constexpr` moving
  from a Vulkan header to the neutral header it already included, with the Vulkan name kept as an
  alias, so every existing `VulkanBindingState::kMaxBufferBindings` use compiles unchanged. The ON
  side of `VulkanBindingState.h` was additionally syntax-checked directly (`clang-cl
  -DOLO_WITH_VULKAN=1 -fsyntax-only`, with a `static_assert` pinning the alias at 84) — that header
  pulls in no Vulkan headers of its own, so it verifies standalone in seconds; the ON tree builds
  in CI as usual.
- **The CI job green on this branch**, not merely present — and not vacuously: its own log shows
  `OK: building the GL-only configuration`, `OK: 7 Vulkan test(s) skipped cleanly`, and
  `OK: 12 backend-selection tests passed against the OFF binary`, matching the local run exactly.
- **Measured runner cost**, since the cadence argument above rests on it: **~45 min** end to end on
  `ubuntu-24.04` (~2 min setup, ~41 min configure+build, seconds for the two test steps). That is
  the number to weigh if anyone later wants to widen the paths filter.

## Structural changes worth flagging to the sibling branches

Only one, and it is small: `ShaderBindingLayout.h` gains
`MIN_GUARANTEED_BUFFER_BINDINGS`. No source lists were touched, so this should not collide with
`feature/ddgi-v2-cascades-707` or `feature/terrain-virtual-texturing-715`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for builds with Vulkan backend support disabled, including OpenGL fallback checks.
  * Standardized the guaranteed buffer-binding limit across rendering components.

* **Documentation**
  * Clarified Vulkan-disabled build behavior, SDK requirements, configuration scope, and CI coverage.
  * Added local build guidance for Vulkan-disabled configurations.

* **Tests**
  * Updated rendering validation to use the shared binding-limit definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->