### PR TITLE
fix(build): resolve the Steamworks SDK paths before any add_subdirectory (#828)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ you are in.
 - [build-trees-and-windows-asan.md](docs/agent-rules/build-trees-and-windows-asan.md) — never build the msvc and clangcl trees concurrently; plus per-user `mspdbsrv` stalls, the codegen build-graph wiring, the local ASan recipe, and (§5e) why both memory job pools vanish on Linux CI so a bare `--parallel` is a runaway there and nowhere else.
 - [static-archive-4gib-ceiling.md](docs/agent-rules/static-archive-4gib-ceiling.md) — a .lib cannot exceed 4 GiB, `LNK1248` under-reports the overshoot, and no CI job had ever built a `/GL` object.
 - [vcpkg-dependency-management.md](docs/agent-rules/vcpkg-dependency-management.md) — read before adding, bumping or removing a dep: the CRT triplet mismatch is heap corruption, and three of the five traps are silent.
+- [configure-time-variable-visibility.md](docs/agent-rules/configure-time-variable-visibility.md) — a CMake variable resolved *below* the `add_subdirectory()` that consumes it, behind a guard that reads "unset" as "nothing to do": correct on every configure but the first.
 - [asset-import-usd-alembic.md](docs/agent-rules/asset-import-usd-alembic.md) — the importer/exporter registry seam, and vendoring OpenUSD / Alembic / MaterialX into a static-everything build.
 
 **Renderer**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,13 @@ endif()
 # Includes
 include(cmake/SetupConfigurations.cmake)
 include(cmake/CommonProperties.cmake)
+# Resolves OLO_STEAM_{SDK_ROOT,INCLUDE_DIR,IMPORT_LIB,RUNTIME_DLL} from the two options above.
+# MUST stay ABOVE every add_subdirectory() below — those variables are read from four different
+# subdirectories (OloEngine/tests, OloEditor/src, OloRuntime/src, OloServer/src) and a variable
+# set after a subdirectory is added is invisible inside it. That ordering trap is issue #828; the
+# file's header comment carries the full story. It touches no targets, so it has no ordering
+# requirement of its own and can sit here with the other pure-configuration includes.
+include(cmake/Steamworks.cmake)
 include(cmake/Sanitizers.cmake)
 # Must come AFTER SetupConfigurations.cmake (it overrides that file's MSVC
 # debug-info default) and BEFORE the target subdirectories below (it sets the

--- a/OloEngine/CMakeLists.txt
+++ b/OloEngine/CMakeLists.txt
@@ -279,74 +279,12 @@ endif()
 # macro, compiling to empty TUs when OFF — the same convention as OLO_WITH_VULKAN above and the
 # OLO_WITH_* import formats.
 #
-# The API surface comes from exactly one of two mutually exclusive places:
-#   * the REAL SDK, resolved from $ENV{STEAMWORKS_SDK_ROOT}. Never vendored: the licence forbids
-#     redistribution and this repo is public, so developers install it themselves (it is free —
-#     see docs/ops/build.md). This mirrors how the Vulkan SDK is found above, NOT how Mono is
-#     vendored in-tree at :432 — Mono may live in-tree only because it is redistributable.
-#   * our hand-written STUBS (OLO_WITH_STEAM_STUB_SDK), which let CI compile, link and RUN the
-#     ON path that the real SDK can never reach. See the root CMakeLists for why that matters.
+# Only the TARGET WIRING lives here. Resolving the SDK paths themselves
+# (OLO_STEAM_{SDK_ROOT,INCLUDE_DIR,IMPORT_LIB,RUNTIME_DLL}) moved to cmake/Steamworks.cmake,
+# included from the root CMakeLists ABOVE every add_subdirectory() — because those variables are
+# consumed by subdirectories, and this file adds tests/ near its top, long before this line.
+# See issue #828 and that file's header comment; do not move the resolution back down here.
 if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK)
-	# Both halves matter. WIN32 is TRUE for 32-bit Windows too, and everything below hard-codes
-	# the x64 redistributables (steam_api64.lib / steam_api64.dll) — so a 32-bit configure would
-	# sail past a WIN32-only guard and fail much later at link, with an error that says nothing
-	# about pointer size. Reject it here, where the message can.
-	if(NOT WIN32 OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-		message(FATAL_ERROR
-			"OLO_WITH_STEAM=ON is only wired for 64-bit Windows, the stated target for issue #644 "
-			"(this configure: WIN32=${WIN32}, pointer size=${CMAKE_SIZEOF_VOID_P} bytes). "
-			"The paths below use the SDK's win64 redistributables exclusively. The SDK does ship "
-			"win32/linux64/osx variants, so extending this is a small change — but none of it is "
-			"tested here, and silently disabling would hide that. "
-			"Use -DOLO_WITH_STEAM=OFF, or -DOLO_WITH_STEAM_STUB_SDK=ON to compile the Steam path "
-			"without any SDK at all.")
-	endif()
-
-	if(NOT DEFINED ENV{STEAMWORKS_SDK_ROOT})
-		message(FATAL_ERROR
-			"OLO_WITH_STEAM=ON but STEAMWORKS_SDK_ROOT is not set. Download the Steamworks SDK "
-			"(free, needs only an ordinary Steam account — the $100 Steam Direct fee is for "
-			"publishing, not building) and point the variable at the directory containing "
-			"public/ and redistributable_bin/. Full instructions: docs/ops/build.md.")
-	endif()
-
-	# Point at the inner `sdk` directory — the one DIRECTLY containing public/ and
-	# redistributable_bin/. Pointing one level out is the obvious mistake and would otherwise
-	# surface as an unhelpful "cannot open include file: steam/steam_api.h" much later.
-	set(OLO_STEAM_SDK_ROOT "$ENV{STEAMWORKS_SDK_ROOT}")
-
-	# The include dir is the SDK ROOT, NOT root/public — and the one TU that uses it includes
-	# "public/steam/steam_api.h" rather than "steam/steam_api.h".
-	#
-	# THIS IS NOT A STYLE CHOICE. Adding …/public would put a directory with a `steam/` child on
-	# the engine include path, and every `#include <steam/…>` in the NETWORKING code would then
-	# resolve against Valve's SDK instead of GameNetworkingSockets'. The Steamworks SDK ships its
-	# own isteamnetworkingutils.h / steamnetworkingtypes.h / isteamnetworkingsockets.h /
-	# steam_api_common.h / steamtypes.h, so the netcode ends up with Valve's
-	# <steam/isteamnetworkingutils.h> (which Valve HAS) alongside GNS's
-	# <steam/steamnetworkingsockets.h> (which Valve does NOT) — half of each SDK in one TU, dying
-	# with 12 × "C2365: 'k_iSteamNetworkingSocketsCallbacks': redefinition" reported inside a
-	# Steamworks header from Networking files that never mention Steam.
-	#
-	# Rooting one level higher makes the hijack impossible by construction. See
-	# docs/agent-rules/steamworks-platform-integration.md.
-	set(OLO_STEAM_INCLUDE_DIR "${OLO_STEAM_SDK_ROOT}")
-	set(OLO_STEAM_IMPORT_LIB  "${OLO_STEAM_SDK_ROOT}/redistributable_bin/win64/steam_api64.lib")
-	set(OLO_STEAM_RUNTIME_DLL "${OLO_STEAM_SDK_ROOT}/redistributable_bin/win64/steam_api64.dll")
-
-	foreach(_olo_steam_path
-			"${OLO_STEAM_SDK_ROOT}/public/steam/steam_api.h"
-			"${OLO_STEAM_IMPORT_LIB}"
-			"${OLO_STEAM_RUNTIME_DLL}")
-		if(NOT EXISTS "${_olo_steam_path}")
-			message(FATAL_ERROR
-				"STEAMWORKS_SDK_ROOT=${OLO_STEAM_SDK_ROOT} does not look like a Steamworks SDK: "
-				"missing ${_olo_steam_path}. It must point at the directory DIRECTLY containing "
-				"public/ and redistributable_bin/ (i.e. the inner 'sdk' folder of the zip), not "
-				"its parent. See docs/ops/build.md.")
-		endif()
-	endforeach()
-
 	# steam_api64.lib is an IMPORT LIBRARY for a DLL, not a static lib — it carries no CRT of its
 	# own, so it links cleanly against this project's x64-windows-static-md triplet. The
 	# CRT-triplet mismatch that docs/agent-rules/vcpkg-dependency-management.md calls out as
@@ -363,11 +301,6 @@ if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK)
 	# around the #include in SteamworksBackend.cpp itself, NOT here — set_source_files_properties
 	# is directory-scoped and silently does nothing from the wrong CMakeLists, which is a trap
 	# worth not re-walking into (see the comment in that file).
-
-	# Consumed by the executable targets, which copy it next to their .exe — the DLL must sit
-	# beside the binary (or in the working directory) at runtime or the process fails to start.
-	set(OLO_STEAM_RUNTIME_DLL "${OLO_STEAM_RUNTIME_DLL}" CACHE INTERNAL "steam_api64.dll to stage next to the executables")
-	message(STATUS "Steamworks: using SDK at ${OLO_STEAM_SDK_ROOT}")
 endif()
 
 if(OLO_WITH_STEAM AND OLO_WITH_STEAM_STUB_SDK)

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -178,8 +178,25 @@ endfunction()
 #
 # Same directory-scope rule as olo_copy_ffmpeg_runtime above: add_custom_command(TARGET ...) must
 # run in the directory that created the target, so call this next to each add_executable.
+#
+# The DEFINED check used to be part of the `if` condition, so an unset variable meant this
+# function quietly staged nothing — issue #828: OLO_STEAM_RUNTIME_DLL was resolved BELOW
+# add_subdirectory(tests), so on a fresh configure OloEngine-Tests silently shipped without the
+# DLL and died hours later at gtest discovery with 0xC0000135, an error naming nothing about
+# Steam. It is now a FATAL_ERROR: if Steam is on with the real SDK, there is no legitimate way to
+# reach here without the path, and a configure-time sentence naming Steam beats an opaque runtime
+# status code. Safe in CI, which is Steam-OFF (or stub) and never enters this branch at all.
 function(olo_copy_steam_runtime target_name)
-    if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK AND DEFINED OLO_STEAM_RUNTIME_DLL)
+    if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK)
+        if(NOT OLO_STEAM_RUNTIME_DLL)
+            message(FATAL_ERROR
+                "olo_copy_steam_runtime(${target_name}): OLO_WITH_STEAM is ON with the real SDK, "
+                "but OLO_STEAM_RUNTIME_DLL is not set, so steam_api64.dll would not be staged "
+                "next to ${target_name} and the executable would fail to start with 0xC0000135 "
+                "(STATUS_DLL_NOT_FOUND). This is an ordering bug: cmake/Steamworks.cmake resolves "
+                "that variable and MUST be included from the root CMakeLists before the "
+                "add_subdirectory() that created ${target_name}. See issue #828.")
+        endif()
         add_custom_command(TARGET ${target_name} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                     "${OLO_STEAM_RUNTIME_DLL}" "$<TARGET_FILE_DIR:${target_name}>"

--- a/cmake/Steamworks.cmake
+++ b/cmake/Steamworks.cmake
@@ -1,0 +1,99 @@
+# Steamworks SDK path resolution (#644), gated on OLO_WITH_STEAM (root CMakeLists).
+#
+# WHY THIS LIVES AT THE ROOT AND NOT IN OloEngine/CMakeLists.txt (issue #828).
+#
+# These are plain variables consumed by SUBDIRECTORIES — OLO_STEAM_RUNTIME_DLL in particular is
+# read by olo_copy_steam_runtime() (cmake/CommonProperties.cmake) from four different directories:
+# OloEngine/tests, OloEditor/src, OloRuntime/src and OloServer/src. A CMake variable is only
+# visible to a subdirectory added AFTER it is set, so resolving these anywhere other than before
+# the first add_subdirectory() makes correctness depend on directory-processing order.
+#
+# That is exactly the bug this file was extracted to kill. The block used to sit at the bottom of
+# OloEngine/CMakeLists.txt, which processes add_subdirectory(tests) near its top — so on a FRESH
+# configure OLO_STEAM_RUNTIME_DLL was still undefined when OloEngine-Tests asked for it, the copy
+# step was silently skipped, and the test executable shipped without steam_api64.dll. It then died
+# at gtest discovery with 0xC0000135 (STATUS_DLL_NOT_FOUND) — an error naming nothing about Steam.
+# The second configure "fixed" it only because the CACHE INTERNAL write from the first run was
+# still there, which is why it read as "works on my machine".
+#
+# So: keep this include ABOVE every add_subdirectory() in the root CMakeLists. Everything here is
+# pure path resolution and validation — no targets are touched, deliberately, so it has no
+# ordering requirement of its own. The target wiring (include dirs, the import library, the
+# compile definitions) stays in OloEngine/CMakeLists.txt where the OloEngine target exists.
+#
+# The API surface comes from exactly one of two mutually exclusive places:
+#   * the REAL SDK, resolved from $ENV{STEAMWORKS_SDK_ROOT}. Never vendored: the licence forbids
+#     redistribution and this repo is public, so developers install it themselves (it is free —
+#     see docs/ops/build.md). This mirrors how the Vulkan SDK is found, NOT how Mono is vendored
+#     in-tree — Mono may live in-tree only because it is redistributable.
+#   * our hand-written STUBS (OLO_WITH_STEAM_STUB_SDK), which let CI compile, link and RUN the
+#     ON path that the real SDK can never reach. See the root CMakeLists for why that matters.
+#     That path resolves no external paths at all, so it does nothing here.
+if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK)
+	# Both halves matter. WIN32 is TRUE for 32-bit Windows too, and everything below hard-codes
+	# the x64 redistributables (steam_api64.lib / steam_api64.dll) — so a 32-bit configure would
+	# sail past a WIN32-only guard and fail much later at link, with an error that says nothing
+	# about pointer size. Reject it here, where the message can.
+	if(NOT WIN32 OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+		message(FATAL_ERROR
+			"OLO_WITH_STEAM=ON is only wired for 64-bit Windows, the stated target for issue #644 "
+			"(this configure: WIN32=${WIN32}, pointer size=${CMAKE_SIZEOF_VOID_P} bytes). "
+			"The paths below use the SDK's win64 redistributables exclusively. The SDK does ship "
+			"win32/linux64/osx variants, so extending this is a small change — but none of it is "
+			"tested here, and silently disabling would hide that. "
+			"Use -DOLO_WITH_STEAM=OFF, or -DOLO_WITH_STEAM_STUB_SDK=ON to compile the Steam path "
+			"without any SDK at all.")
+	endif()
+
+	if(NOT DEFINED ENV{STEAMWORKS_SDK_ROOT})
+		message(FATAL_ERROR
+			"OLO_WITH_STEAM=ON but STEAMWORKS_SDK_ROOT is not set. Download the Steamworks SDK "
+			"(free, needs only an ordinary Steam account — the $100 Steam Direct fee is for "
+			"publishing, not building) and point the variable at the directory containing "
+			"public/ and redistributable_bin/. Full instructions: docs/ops/build.md.")
+	endif()
+
+	# Point at the inner `sdk` directory — the one DIRECTLY containing public/ and
+	# redistributable_bin/. Pointing one level out is the obvious mistake and would otherwise
+	# surface as an unhelpful "cannot open include file: steam/steam_api.h" much later.
+	set(OLO_STEAM_SDK_ROOT "$ENV{STEAMWORKS_SDK_ROOT}")
+
+	# The include dir is the SDK ROOT, NOT root/public — and the one TU that uses it includes
+	# "public/steam/steam_api.h" rather than "steam/steam_api.h".
+	#
+	# THIS IS NOT A STYLE CHOICE. Adding …/public would put a directory with a `steam/` child on
+	# the engine include path, and every `#include <steam/…>` in the NETWORKING code would then
+	# resolve against Valve's SDK instead of GameNetworkingSockets'. The Steamworks SDK ships its
+	# own isteamnetworkingutils.h / steamnetworkingtypes.h / isteamnetworkingsockets.h /
+	# steam_api_common.h / steamtypes.h, so the netcode ends up with Valve's
+	# <steam/isteamnetworkingutils.h> (which Valve HAS) alongside GNS's
+	# <steam/steamnetworkingsockets.h> (which Valve does NOT) — half of each SDK in one TU, dying
+	# with 12 × "C2365: 'k_iSteamNetworkingSocketsCallbacks': redefinition" reported inside a
+	# Steamworks header from Networking files that never mention Steam.
+	#
+	# Rooting one level higher makes the hijack impossible by construction. See
+	# docs/agent-rules/steamworks-platform-integration.md.
+	set(OLO_STEAM_INCLUDE_DIR "${OLO_STEAM_SDK_ROOT}")
+	set(OLO_STEAM_IMPORT_LIB  "${OLO_STEAM_SDK_ROOT}/redistributable_bin/win64/steam_api64.lib")
+	set(OLO_STEAM_RUNTIME_DLL "${OLO_STEAM_SDK_ROOT}/redistributable_bin/win64/steam_api64.dll")
+
+	foreach(_olo_steam_path
+			"${OLO_STEAM_SDK_ROOT}/public/steam/steam_api.h"
+			"${OLO_STEAM_IMPORT_LIB}"
+			"${OLO_STEAM_RUNTIME_DLL}")
+		if(NOT EXISTS "${_olo_steam_path}")
+			message(FATAL_ERROR
+				"STEAMWORKS_SDK_ROOT=${OLO_STEAM_SDK_ROOT} does not look like a Steamworks SDK: "
+				"missing ${_olo_steam_path}. It must point at the directory DIRECTLY containing "
+				"public/ and redistributable_bin/ (i.e. the inner 'sdk' folder of the zip), not "
+				"its parent. See docs/ops/build.md.")
+		endif()
+	endforeach()
+
+	# Consumed by the executable and test targets, which copy it next to their binary — the DLL
+	# must sit beside the .exe (or in the working directory) at runtime or the process fails to
+	# start with 0xC0000135. CACHE INTERNAL so it also survives into a re-configure; the plain
+	# set() above is what makes the FIRST configure correct, which is the whole point of #828.
+	set(OLO_STEAM_RUNTIME_DLL "${OLO_STEAM_RUNTIME_DLL}" CACHE INTERNAL "steam_api64.dll to stage next to the executables")
+	message(STATUS "Steamworks: using SDK at ${OLO_STEAM_SDK_ROOT}")
+endif()

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -92,6 +92,10 @@ not instead of it) ·
 [steamworks-platform-integration.md](steamworks-platform-integration.md) (an SDK path set one level
 too high drops the whole feature — the build succeeds with Steam quietly switched off, and the error
 explaining the correct layout is the one thing that never fires) ·
+[configure-time-variable-visibility.md](configure-time-variable-visibility.md) (a DLL, from the test
+executable — a configure-time guard that could not tell "does not apply here" from "not computed
+yet", so the copy step was never generated and the exe died at gtest discovery with an error naming
+nothing about Steam) ·
 [cache-stored-unresolvable-reference.md](cache-stored-unresolvable-reference.md) (a texture, from the
 SECOND load onward — an empty reference in a cache is indistinguishable from a slot that was never
 set, so every step downstream handles it "correctly")
@@ -152,7 +156,10 @@ between two recorded draws is GL command order; a life-stable Vulkan address mak
 last-write-wins) · [gpu-scan-compaction.md](gpu-scan-compaction.md) (a `barrier()` only some
 invocations reach — the early-return habit in front of a work-group scan) ·
 [lazy-static-release-ownership.md](lazy-static-release-ownership.md) (a shared lazy static released
-from a *conditional* teardown — fine until a session creates it without running that teardown)
+from a *conditional* teardown — fine until a session creates it without running that teardown) ·
+[configure-time-variable-visibility.md](configure-time-variable-visibility.md) (a CMake variable read
+by a subdirectory processed *before* the line that sets it — correct on every configure but the
+first, which is the only one that matters)
 
 ## 6. It was never actually called
 
@@ -213,6 +220,7 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 
 **Build & deps** — [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) ·
 [static-archive-4gib-ceiling.md](static-archive-4gib-ceiling.md) ·
+[configure-time-variable-visibility.md](configure-time-variable-visibility.md) ·
 [vcpkg-dependency-management.md](vcpkg-dependency-management.md) ·
 [asset-import-usd-alembic.md](asset-import-usd-alembic.md)
 

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -205,6 +205,10 @@ because of three non-obvious choices you must replicate locally:
   is NOT interchangeable — standalone-LLVM-built binaries fail against it
   with `0xC0000139` (entry point not found). Match the runtime to the
   compiler in `build-clang/CMakeCache.txt` (`CMAKE_CXX_COMPILER`).
+  (`0xC0000135` has a second, unrelated cause on this repo: a missing
+  `steam_api64.dll` next to the executable — see
+  [configure-time-variable-visibility.md](configure-time-variable-visibility.md).
+  Tell them apart with `dumpbin /DEPENDENTS` on the exe.)
 - **To see an ASan crash report instead of gtest's opaque
   `SEH exception with code 0xc0000005 thrown in the test body`**, run the
   failing test with `--gtest_catch_exceptions=0`. gtest's SEH catcher

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -208,7 +208,14 @@ because of three non-obvious choices you must replicate locally:
   (`0xC0000135` has a second, unrelated cause on this repo: a missing
   `steam_api64.dll` next to the executable — see
   [configure-time-variable-visibility.md](configure-time-variable-visibility.md).
-  Tell them apart with `dumpbin /DEPENDENTS` on the exe.)
+  To tell them apart, start with `dumpbin /DEPENDENTS` on the exe — but note
+  it only lists the DLL names the image *imports*, statically. It does not
+  say which one failed to load, and both names appear whether or not they
+  resolve at run time. So use it to see which of the two candidates the
+  binary even imports, then check each one's resolution separately:
+  `steam_api64.dll` must sit **beside the executable**, and
+  `clang_rt.asan_dynamic-x86_64.dll` must be reachable **through `PATH`**.
+  An ASan build can be missing both at once.)
 - **To see an ASan crash report instead of gtest's opaque
   `SEH exception with code 0xc0000005 thrown in the test body`**, run the
   failing test with `--gtest_catch_exceptions=0`. gtest's SEH catcher

--- a/docs/agent-rules/configure-time-variable-visibility.md
+++ b/docs/agent-rules/configure-time-variable-visibility.md
@@ -1,0 +1,102 @@
+# A configure-time guard that no-ops when its input is unset
+
+**Postmortem of issue #828.** A fresh CMake configure on a machine with `STEAMWORKS_SDK_ROOT` set
+produced an `OloEngine-Tests.exe` that would not start. The build only failed at the very end, in
+gtest discovery:
+
+```
+CMake Error at .../GoogleTestAddTests.cmake:233 (message):
+  Error running test executable.
+    Path: .../build/OloEngine/tests/Debug/OloEngine-Tests.exe
+    Result: Exit code 0xc0000135
+```
+
+`0xC0000135` is `STATUS_DLL_NOT_FOUND`. Run by hand the exe printed nothing and exited with that
+code. **Nothing in the failure named Steam**, which is what made it expensive — and the known
+workaround, *configure twice*, made it read as "works on my machine".
+
+## The mechanism
+
+Two independent facts combined.
+
+**1. A CMake variable is only visible to a subdirectory added after it is set.** `OloEngine/CMakeLists.txt`
+processed `add_subdirectory(tests)` near its top (line 49) but resolved `OLO_STEAM_RUNTIME_DLL`
+near its bottom (line 335/369). So when `OloEngine/tests/CMakeLists.txt` called
+`olo_copy_steam_runtime(OloEngine-Tests)`, the variable did not exist yet.
+
+**2. The guard treated "unset" as "nothing to do."**
+
+```cmake
+if(OLO_WITH_STEAM AND NOT OLO_WITH_STEAM_STUB_SDK AND DEFINED OLO_STEAM_RUNTIME_DLL)
+```
+
+That `DEFINED` term was meant to say *"a stub build has no DLL to stage."* It also silently
+absorbed *"the path has not been computed yet"* — a completely different situation, and a bug.
+The copy step was simply never generated, the exe linked against `steam_api64.lib` (an **import**
+library) with no DLL beside it, and the failure surfaced hours later wearing an unrelated face.
+
+**Why only a fresh configure.** The final `set(... CACHE INTERNAL ...)` persists the path. On the
+second configure the cache entry already exists when `tests/` is processed, the guard passes, and
+the DLL gets staged. The bug is invisible to anyone with a warm build tree — which is everyone,
+most of the time.
+
+**Why CI never caught it.** The runners have no Steamworks SDK, so `OLO_WITH_STEAM` is OFF there
+and the branch is never entered. This class of bug is only reachable on a developer machine.
+
+## The fix
+
+Two changes, one for the ordering and one for the silence.
+
+**Move the resolution above every `add_subdirectory()`.** The path resolution and validation moved
+out of `OloEngine/CMakeLists.txt` into `cmake/Steamworks.cmake`, included from the root
+`CMakeLists.txt` alongside the other configuration modules. The **target wiring** — include
+directories, the import library, the compile definitions — stayed in `OloEngine/CMakeLists.txt`,
+because it needs the `OloEngine` target to exist.
+
+That split is the durable part. A block that only computes variables has no ordering requirement of
+its own, so it can be hoisted to the earliest point that makes every consumer correct. A block that
+touches targets cannot. Keeping them together is what forced the resolution down to where the
+target lived, and the consumers were four directories away.
+
+Merely reordering within `OloEngine/CMakeLists.txt` would have fixed the symptom and left the trap
+armed: any subdirectory added above the Steam block later would reintroduce it.
+
+**Make the silent case loud.** `olo_copy_steam_runtime` now `message(FATAL_ERROR ...)`s when Steam
+is on with the real SDK and the path is unset — naming Steam, naming `0xC0000135`, and naming the
+ordering requirement. If someone re-arms this, they get a sentence at configure instead of a status
+code at test discovery. It is safe in CI, which never enters that branch.
+
+## The general rule
+
+Ask of every `if(DEFINED X)` guard: **does the code distinguish "X does not apply here" from "X has
+not been computed yet"?** If a single condition covers both, one of them is a silent failure waiting
+for an ordering change. The two remedies compose:
+
+- **Hoist pure-variable computation** above every consumer, so ordering cannot go wrong.
+- **Make the impossible case fatal**, so if it does go wrong it says so where the cause is, not
+  where the consequence is.
+
+This is not specific to CMake, but CMake makes it especially easy: directory-scoped variables mean
+"visible" is a property of *where* a line sits in the include/subdirectory graph, and nothing warns
+you when you read one that is not there yet — an undefined variable expands to the empty string.
+
+Related: `olo_copy_ffmpeg_runtime` in the same file carries the sibling constraint (an
+`add_custom_command(TARGET ...)` must run in the directory that created the target), and
+[steamworks-platform-integration.md](steamworks-platform-integration.md) covers the Steamworks
+seam itself — including the *other* silent-drop in this area, an SDK path set one level too high.
+
+## Verifying a fix in this area
+
+A rebuild in an already-configured tree proves nothing, because the cache papers over the bug.
+**Delete the build tree and configure from scratch.** The cheap check does not need a build at all:
+grep the generated project for the staging step.
+
+```powershell
+cmake --preset msvc
+Select-String -Path build\OloEngine\tests\OloEngine-Tests.vcxproj -Pattern steam_api64.dll
+```
+
+Zero matches on a fresh configure is the bug; matches in all four consumers (`OloEngine-Tests`,
+`OloEditor`, `OloRuntime`, `OloServer`) is the fix. Check the Steam-OFF and
+`OLO_WITH_STEAM_STUB_SDK=ON` configures too — a new fatal guard is exactly the kind of change that
+fires where it should not.


### PR DESCRIPTION
Closes #828

A fresh configure on a machine with `STEAMWORKS_SDK_ROOT` set produced an `OloEngine-Tests.exe` that would not start. The build only failed at the very end, in gtest discovery, with exit `0xC0000135` (`STATUS_DLL_NOT_FOUND`) — an error naming nothing about Steam, which is what made it expensive. The missing DLL was `steam_api64.dll`.

## Root cause

Two independent facts combined.

**A CMake variable is only visible to a subdirectory added after it is set.** `OloEngine/CMakeLists.txt` processed `add_subdirectory(tests)` at line 49 but resolved `OLO_STEAM_RUNTIME_DLL` at line 335/369. So when `OloEngine/tests/CMakeLists.txt` called `olo_copy_steam_runtime(OloEngine-Tests)`, the variable did not exist yet.

**The guard read "unset" as "nothing to do."** Its `DEFINED OLO_STEAM_RUNTIME_DLL` term was meant to say *"a stub build has no DLL to stage"* — it also silently absorbed *"the path has not been computed yet"*, a completely different situation. The copy step was simply never generated.

Only a **fresh** configure was affected: the `CACHE INTERNAL` write from a previous run made the second configure pass, which is why this read as "works on my machine" and why the known local workaround was to configure twice. CI never caught it because the runners have no Steamworks SDK, so `OLO_WITH_STEAM` is OFF there and the branch is never entered.

## The fix — two parts

**1. Move the resolution above every `add_subdirectory()`.** The path resolution and validation moved out of `OloEngine/CMakeLists.txt` into a new `cmake/Steamworks.cmake`, included from the root `CMakeLists.txt` alongside the other configuration modules. The **target wiring** — include directories, the import library, the compile definitions — stays in `OloEngine/CMakeLists.txt`, because it needs the `OloEngine` target to exist.

I weighed this against simply reordering within `OloEngine/CMakeLists.txt` and chose the split deliberately: reordering fixes the symptom and leaves the trap armed, since any subdirectory added above the Steam block later reintroduces it. A block that only computes variables has no ordering requirement of its own, so it can be hoisted to the earliest point that makes all four consumers (`OloEngine/tests`, `OloEditor/src`, `OloRuntime/src`, `OloServer/src`) correct. A generator-expression approach was considered and rejected — the DLL is a plain file path, not a target, so making it an imported target would still need that target defined before `tests/`, which is the same ordering problem wearing a different hat.

**2. Make the silent case loud.** `olo_copy_steam_runtime` now `message(FATAL_ERROR ...)`s when Steam is on with the real SDK and the path is unset, naming Steam, `0xC0000135`, and the ordering requirement. If someone re-arms this, they get a sentence at configure instead of a status code at test discovery. It is safe in CI, which never enters that branch.

## Verification — from a clean configure

**A rebuild in an already-configured tree proves nothing here**, because the cache papers over the bug. Everything below is from a deleted or separate build tree.

The cheap check needs no build at all — grep the generated project for the staging step:

| target | before fix | after fix |
|---|---|---|
| `OloEngine-Tests.vcxproj` | **0** refs | 6 refs |
| `OloEditor.vcxproj` | 6 refs | 6 refs |
| `OloRuntime.vcxproj` | 6 refs | 6 refs |
| `OloServer.vcxproj` | 6 refs | 6 refs |

All four call sites of the shared function were checked, not just `OloEngine-Tests`.

Three configures, each from a deleted or separate tree:

| configure | result |
|---|---|
| `msvc`, Steam ON, `build/` **deleted first** | all four targets stage the DLL |
| `-DOLO_WITH_STEAM=OFF` | no staging, no warnings, no fatal |
| `-DOLO_WITH_STEAM_STUB_SDK=ON` (the CI path) | stub message, no staging, no fatal |

Then the end-to-end check, built from that clean-configured tree through the build mutex:

- `cmake --build build --target OloEngine-Tests --config Debug --parallel 6` — exit 0, log shows `Staging steam_api64.dll next to OloEngine-Tests`
- `steam_api64.dll` present next to `OloEngine-Tests.exe`
- `dumpbin /DEPENDENTS` → **30** dependents including `steam_api64.dll`, matching the figure in the issue (a Steam-OFF build has 29, without it)
- the exe **starts**: `--gtest_list_tests` exits 0 and enumerates 7183 lines. That is the same operation that previously died with `0xC0000135`, since gtest discovery works by running the executable.

## ⚠ Coordination with #811

Per the handover, `feature/vulkan-off-build-coverage-811` is editing `OloEngine/CMakeLists.txt` concurrently. **Lines this PR touches in that file: the Steamworks block at 277-372, which becomes 277-303** (target wiring only — the resolution half moved out). Nothing else in that file is touched, and the Vulkan region is untouched, so whichever lands second should rebase cleanly.

Root `CMakeLists.txt` gains exactly one `include(cmake/Steamworks.cmake)` plus its comment, in the existing includes block.

## Docs

New `docs/agent-rules/configure-time-variable-visibility.md`, since the shape generalises past Steam: a guard whose single condition cannot distinguish *"this does not apply here"* from *"this has not been computed yet"*. Linked from both indexes (`docs/agent-rules/README.md` under "it silently drops something" and "ordering and lifetime", plus the Build & deps roster; and `CLAUDE.md`'s companion guides). Cross-linked from `build-trees-and-windows-asan.md`, which documents the **other** cause of `0xC0000135` in this repo (a missing ASan runtime on PATH) — a reader who hits that code can now tell the two apart with `dumpbin /DEPENDENTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steamworks setup during configuration to ensure required runtime files are correctly found and staged.
  * Configuration now reports clear errors for unsupported platforms, missing SDK settings, or incomplete SDK installations.
  * Prevented builds from silently omitting required Steamworks runtime files.

* **Documentation**
  * Added troubleshooting guidance for missing Steamworks runtime DLLs and related Windows startup errors.
  * Documented configuration requirements and verification steps for fresh builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->