### PR TITLE
fix(renderer): sweep the lazy-static release class — eight more members (#839)

### DIFF
--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -4686,7 +4686,12 @@ namespace OloEngine::MCP
                 // The engine's stand-in when neither an override nor an imported
                 // material exists. Constructed exactly like Scene's cached default
                 // (Scene.cpp::GetDefaultMaterial), which is file-static there.
-                static const Ref<Material> s_EngineDefault =
+                //
+                // Deliberately NOT static: this is a per-call temporary. As a function
+                // static it was a process-wide Ref<Material> with no release site — the
+                // same shape as everything #839 swept — and caching buys nothing here,
+                // since an MCP tool handler runs at agent speed, not per frame.
+                const Ref<Material> engineDefault =
                     Material::CreatePBR("Default", glm::vec3(0.8f, 0.8f, 0.8f), 0.0f, 0.5f);
 
                 const Material* overrideMaterial = entity.HasComponent<MaterialComponent>()
@@ -4739,14 +4744,14 @@ namespace OloEngine::MCP
                     // rule the renderer no longer follows would make this tool lie to the
                     // next person debugging a material.
                     const Material& resolved =
-                        ResolveSubmeshMaterial(overrideMaterial, meshSource.get(), index, *s_EngineDefault);
+                        ResolveSubmeshMaterial(overrideMaterial, meshSource.get(), index, *engineDefault);
                     const Material* material = &resolved;
                     std::string_view source = "engine default material";
                     if (material == overrideMaterial)
                     {
                         source = "MaterialComponent (override)";
                     }
-                    else if (material != s_EngineDefault.get())
+                    else if (material != engineDefault.get())
                     {
                         source = "MeshSource imported material (per-submesh)";
                     }

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -4746,7 +4746,7 @@ namespace OloEngine::MCP
                     const Material& resolved =
                         ResolveSubmeshMaterial(overrideMaterial, meshSource.get(), index, *engineDefault);
                     const Material* material = &resolved;
-                    std::string_view source = "engine default material";
+                    std::string_view source;
                     if (material == overrideMaterial)
                     {
                         source = "MaterialComponent (override)";
@@ -4754,6 +4754,10 @@ namespace OloEngine::MCP
                     else if (material != engineDefault.get())
                     {
                         source = "MeshSource imported material (per-submesh)";
+                    }
+                    else
+                    {
+                        source = "engine default material";
                     }
 
                     const PODMaterialData data = Renderer3D::CreatePODMaterialDataForMaterial(*material, RHI::NullResource);

--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -81,9 +81,41 @@ namespace
 
 namespace OloEngine
 {
+    // Every DrawComponent<T> instantiation owns its own static map of undo snapshots, and a
+    // snapshot is a COPY of the component — so the ModelComponent one owns a Ref<Model> and
+    // the texture-bearing ones own Ref<Texture2D>. There is no way to reach a function-local
+    // static of a template from outside, so each instantiation registers a clearer here the
+    // first time it runs, and ClearComponentEditSnapshots() calls them all.
+    //
+    // Note this is the same leak species as s_DrawComponentScene further down this file, but
+    // wrapped in a container: a scan that looks for `static Ref<GpuType>` declarations cannot
+    // see a Ref that lives inside a std::unordered_map's mapped_type. It was the last object
+    // still alive at vmaDestroyAllocator after the rest of the #839 sweep landed.
+    static std::vector<void (*)()>& DrawComponentSnapshotClearers()
+    {
+        static std::vector<void (*)()> clearers;
+        return clearers;
+    }
+
     SceneHierarchyPanel::SceneHierarchyPanel(const Ref<Scene>& context)
     {
         SetContext(context);
+    }
+
+    SceneHierarchyPanel::~SceneHierarchyPanel()
+    {
+        // The panel dies with EditorLayer during Application's m_LayerStack.Clear(), i.e.
+        // before Renderer::Shutdown() — so anything the snapshots pin is released while
+        // the graphics context is still alive, which is the deadline that matters (#839).
+        ClearComponentEditSnapshots();
+    }
+
+    void SceneHierarchyPanel::ClearComponentEditSnapshots()
+    {
+        for (void (*clear)() : DrawComponentSnapshotClearers())
+        {
+            clear();
+        }
     }
 
     void SceneHierarchyPanel::SetContext(const Ref<Scene>& context)
@@ -91,6 +123,11 @@ namespace OloEngine
         m_Context = context;
         m_SelectionContext = {};
         m_SelectedEntities.clear();
+        // The snapshots are keyed by entity UUID and hold copies of the OUTGOING scene's
+        // components; keeping them across a scene swap both leaks that scene's GPU
+        // resources and lets a stale "before" state feed the undo stack of a UUID that
+        // happens to repeat in the new scene.
+        ClearComponentEditSnapshots();
     }
 
     void SceneHierarchyPanel::OnImGuiRender()
@@ -1107,9 +1144,42 @@ namespace OloEngine
         return modified;
     }
 
-    // File-scope state for undo integration in DrawComponent (set by DrawComponents)
+    // File-scope state for undo integration in DrawComponent (set by DrawComponents).
+    //
+    // Scoped to ONE DrawComponents() call by DrawComponentStateScope below, and that
+    // matters: s_DrawComponentScene is a strong Ref, and leaving it set between frames
+    // pinned the last scene the Properties panel drew for the rest of the process —
+    // every MeshSource, texture and cubemap in it — long past m_LayerStack.Clear().
+    // On Vulkan that made closing the editor ABORT rather than exit — every MeshSource
+    // and texture in the scene was still live at vmaDestroyAllocator (measured: 12 vertex
+    // arrays, 6 textures, 147 MB on the sandbox start scene; 64 vertex arrays on the
+    // scene in #839). On GL it was silent. Note the leak only happens once an entity has
+    // been selected, because that is what makes the Properties panel call DrawComponents
+    // at all. A Ref parked in file-scope state "until the next frame overwrites it" is a
+    // leak on the frame that never comes.
     static CommandHistory* s_DrawComponentCmdHistory = nullptr;
     static Ref<Scene> s_DrawComponentScene = nullptr;
+
+    // Clears both on every exit path from DrawComponents(), so the invariant "these are
+    // live only for the duration of the call" is enforced by the type system rather than
+    // by a trailing assignment somebody can jump over.
+    struct DrawComponentStateScope
+    {
+        DrawComponentStateScope(CommandHistory* history, const Ref<Scene>& scene)
+        {
+            s_DrawComponentCmdHistory = history;
+            s_DrawComponentScene = scene;
+        }
+        ~DrawComponentStateScope()
+        {
+            s_DrawComponentCmdHistory = nullptr;
+            s_DrawComponentScene = nullptr;
+        }
+        DrawComponentStateScope(const DrawComponentStateScope&) = delete;
+        DrawComponentStateScope& operator=(const DrawComponentStateScope&) = delete;
+        DrawComponentStateScope(DrawComponentStateScope&&) = delete;
+        DrawComponentStateScope& operator=(DrawComponentStateScope&&) = delete;
+    };
 
     // Compile-time stable component name extraction (no RTTI dependency).
     // Uses a probe type in the OloEngine namespace to calibrate __FUNCSIG__/__PRETTY_FUNCTION__.
@@ -1503,6 +1573,16 @@ namespace OloEngine
                         alignas(alignof(T)) unsigned char snapshotBytes[sizeof(T)]{};
                     };
                     static std::unordered_map<u64, EditState> s_EditStates;
+                    // Register this instantiation's map for bulk clearing exactly once. A
+                    // capture-less lambda can name an enclosing function's static directly
+                    // (statics are not captured), so it converts to the plain function
+                    // pointer the registry holds. See DrawComponentSnapshotClearers (#839).
+                    [[maybe_unused]] static const bool s_ClearerRegistered = []
+                    {
+                        DrawComponentSnapshotClearers().push_back([]
+                                                                  { s_EditStates.clear(); });
+                        return true;
+                    }();
                     auto& editState = s_EditStates[static_cast<u64>(entity.GetUUID()) ^ typeid(T).hash_code()];
 
                     // Take a snapshot once per idle→edit cycle (not every frame)
@@ -1923,9 +2003,9 @@ namespace OloEngine
 
     void SceneHierarchyPanel::DrawComponents(Entity entity)
     {
-        // Set file-scope state for DrawComponent undo integration
-        s_DrawComponentCmdHistory = m_CommandHistory;
-        s_DrawComponentScene = m_Context;
+        // Set file-scope state for DrawComponent undo integration, and drop it again on
+        // the way out — the Ref<Scene> must not outlive this call (see the declaration).
+        const DrawComponentStateScope drawComponentState(m_CommandHistory, m_Context);
 
         if (entity.HasComponent<TagComponent>())
         {

--- a/OloEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -91,9 +91,11 @@ namespace OloEngine
     // wrapped in a container: a scan that looks for `static Ref<GpuType>` declarations cannot
     // see a Ref that lives inside a std::unordered_map's mapped_type. It was the last object
     // still alive at vmaDestroyAllocator after the rest of the #839 sweep landed.
-    static std::vector<void (*)()>& DrawComponentSnapshotClearers()
+    using SnapshotClearer = void (*)();
+
+    [[nodiscard]] static std::vector<SnapshotClearer>& DrawComponentSnapshotClearers()
     {
-        static std::vector<void (*)()> clearers;
+        static std::vector<SnapshotClearer> clearers;
         return clearers;
     }
 
@@ -112,7 +114,7 @@ namespace OloEngine
 
     void SceneHierarchyPanel::ClearComponentEditSnapshots()
     {
-        for (void (*clear)() : DrawComponentSnapshotClearers())
+        for (const SnapshotClearer clear : DrawComponentSnapshotClearers())
         {
             clear();
         }

--- a/OloEditor/src/Panels/SceneHierarchyPanel.h
+++ b/OloEditor/src/Panels/SceneHierarchyPanel.h
@@ -18,8 +18,20 @@ namespace OloEngine
       public:
         SceneHierarchyPanel() = default;
         SceneHierarchyPanel(const Ref<Scene>& context);
+        ~SceneHierarchyPanel();
 
         void SetContext(const Ref<Scene>& context);
+
+        // Drop every DrawComponent<T> undo snapshot. Each instantiation keeps a static
+        // map of "component as it looked before this edit" keyed by entity, and a
+        // snapshot is a COPY of the component — so for ModelComponent it owns a
+        // Ref<Model>, and for the texture-bearing components a Ref<Texture2D>. Nothing
+        // cleared those maps, so drawing an entity in the inspector once pinned its GPU
+        // resources for the life of the process (#839: the last survivor at
+        // vmaDestroyAllocator after the rest of that sweep landed). Called on every scene
+        // swap — the snapshots belong to the outgoing scene's entities — and from the
+        // destructor, which runs while the renderer is still alive.
+        static void ClearComponentEditSnapshots();
         void SetCommandHistory(CommandHistory* history)
         {
             m_CommandHistory = history;

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -19,8 +19,10 @@
 #include "OloEngine/Renderer/Debug/GPUResourceInspector.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Debug/ShaderDebugger.h"
+#include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scripting/C#/ScriptEngine.h"
 #include "OloEngine/Scripting/Lua/LuaScriptEngine.h"
+#include "OloEngine/Video/VideoSystem.h"
 #include "OloEngine/Utils/PlatformUtils.h"
 #include "OloEngine/Task/Scheduler.h"
 #include "OloEngine/Task/NamedThreads.h"
@@ -268,6 +270,15 @@ namespace OloEngine
             m_LayerStack.Clear();
             m_ImGuiLayer = nullptr;
 
+            // Same two GPU-owning caches the destructor path releases, and for the same
+            // reason: a layer that ran OnAttach before the throw can already have created
+            // them. OloRuntime puts up a studio-logo splash through
+            // VideoSystem::ShowFullscreenImage() from its layer attach, so this is a real
+            // path, not symmetry for its own sake. Both are no-ops when nothing was
+            // created (#839).
+            VideoSystem::Shutdown();
+            Scene::ReleaseSharedRenderDefaults();
+
             // Unwind subsystems in reverse initialization order.
             // Each Shutdown() is safe to call even if its Init() wasn't reached.
             if (!m_Specification.IsHeadless)
@@ -321,6 +332,26 @@ namespace OloEngine
         // which vmaDestroyAllocator answers with an "allocations not freed"
         // abort on Vulkan (#691 Phase 8, the close-button crash).
         Project::Unload();
+
+        // Two process-wide caches that own GPU memory but do NOT live under Renderer/,
+        // so releasing them from Renderer::Shutdown() would invert the layering. This is
+        // the narrowest teardown that is unconditional for every session that can create
+        // them AND still runs while the graphics context is alive, which is the rule
+        // (#814/#839, docs/agent-rules/lazy-static-release-ownership.md) one level up
+        // from "release it from Renderer::Shutdown()".
+        //
+        // VideoSystem's global fullscreen player holds a decoded-frame GPU texture. Its
+        // Shutdown() was written with the comment "Call on engine/scene shutdown" and had
+        // ZERO callers, so a splash/cutscene overlay leaked for the life of the process —
+        // a shipped OloRuntime showing a studio logo hit this on every launch.
+        //
+        // Scene's cached default material is a plain PBR stand-in that owns no textures
+        // today, but Material can own five Texture2Ds and three cubemaps, so the shape is
+        // one ConfigureIBL() call away from being a real leak. Released here rather than
+        // left to static destruction, where a Ref's destructor runs after the Meyer's
+        // singletons it frees through are already gone.
+        VideoSystem::Shutdown();
+        Scene::ReleaseSharedRenderDefaults();
 
         if (!m_Specification.IsHeadless)
         {

--- a/OloEngine/src/OloEngine/Renderer/Debug/RendererMemoryTracker.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/RendererMemoryTracker.cpp
@@ -76,6 +76,68 @@ namespace OloEngine
 
         TUniqueLock<FMutex> lock(m_Mutex);
 
+        // Anything still tracked here outlived the renderer, which is the entire
+        // lazy-static-release bug class (#814, #839). This used to clear() the map
+        // without looking at it — so the ONE instrument that is backend-independent, and
+        // that already knew every survivor's type, size, name and creation site, threw
+        // that away at exactly the moment it had the answer. That is why "GL is quiet"
+        // read as "GL is clean" for the whole life of the backend while Vulkan aborted at
+        // vmaDestroyAllocator over the same objects.
+        //
+        // Reported at ERROR because it always indicates a real defect: by the time
+        // Renderer::Shutdown() reaches here the layers are detached and Project::Unload()
+        // has dropped every loaded asset, so a live GPU allocation has no legitimate
+        // owner left. Its limit, stated so nobody over-trusts it: TrackAllocation() is
+        // called from the OpenGL resource classes only, so on Vulkan this is silent and
+        // the #794 teardown forensics remain the instrument there.
+        // See docs/agent-rules/lazy-static-release-ownership.md.
+        {
+            // Deliberately terse: ONE error line with the totals and a per-type breakdown,
+            // then a handful of examples at warning level. The first run of this reporter
+            // found 115 survivors on OpenGL, and a two-dozen-line dump on every editor exit
+            // — and at the end of every test run, since OloEngineTest calls
+            // Renderer::Shutdown() — is noise nobody reads. The count and the type tell you
+            // whether to care; the examples tell you where to start looking.
+            constexpr u32 kMaxSurvivorExamples = 6;
+            sizet gpuBytes = 0;
+            u32 gpuCount = 0;
+            std::array<u32, static_cast<sizet>(std::to_underlying(ResourceType::COUNT))> byType{};
+            for (const auto& [address, info] : m_Allocations)
+            {
+                if (!info.m_IsGPU)
+                    continue;
+                ++gpuCount;
+                gpuBytes += info.m_Size;
+                ++byType[static_cast<sizet>(std::to_underlying(info.m_Type))];
+            }
+            if (gpuCount > 0)
+            {
+                std::string breakdown;
+                for (u32 i = 0; i < static_cast<u32>(std::to_underlying(ResourceType::COUNT)); ++i)
+                {
+                    if (byType[i] == 0)
+                        continue;
+                    if (!breakdown.empty())
+                        breakdown += ", ";
+                    breakdown += std::to_string(byType[i]) + " " + GetResourceTypeName(static_cast<ResourceType>(i));
+                }
+                OLO_CORE_ERROR("[Teardown] {} GPU allocation(s) ({} bytes) survived the renderer — {}. Each is a "
+                               "process static, or a Ref that outlived Renderer::Shutdown(). See "
+                               "docs/agent-rules/lazy-static-release-ownership.md",
+                               gpuCount, gpuBytes, breakdown);
+                u32 listed = 0;
+                for (const auto& [address, info] : m_Allocations)
+                {
+                    if (!info.m_IsGPU || listed == kMaxSurvivorExamples)
+                        continue;
+                    ++listed;
+                    OLO_CORE_WARN("[Teardown]   e.g. {} '{}' ({} bytes) created at {}:{}",
+                                  GetResourceTypeName(info.m_Type), info.m_Name, info.m_Size,
+                                  info.m_File, info.m_Line);
+                }
+            }
+        }
+
         m_Allocations.clear();
         m_TypeUsage.fill(0);
         m_TypeCounts.fill(0);

--- a/OloEngine/src/OloEngine/Renderer/Font.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Font.cpp
@@ -243,12 +243,23 @@ namespace OloEngine
         return m_Data->BandTexture;
     }
 
+    namespace
+    {
+        // The process-wide default font. File-scope rather than function-local so
+        // ShutdownDefault() below can reach it: its curve + band atlas textures are GPU
+        // objects, and until #839 nothing released them in any session, on any backend —
+        // Font.cpp had a getter and no reset at all. They are created from an ECS
+        // component's default member initializer (UITextComponent / TextComponent
+        // `= Font::GetDefault()`), so the creating session need not have touched the 3D
+        // renderer, or any renderer. See docs/agent-rules/lazy-static-release-ownership.md.
+        Ref<Font> s_DefaultFont;
+    } // namespace
+
     Ref<Font> Font::GetDefault()
     {
-        static Ref<Font> DefaultFont;
-        if (DefaultFont && DefaultFont->IsLoaded())
+        if (s_DefaultFont && s_DefaultFont->IsLoaded())
         {
-            return DefaultFont;
+            return s_DefaultFont;
         }
 
         // Search a small list of well-known locations. Production code runs
@@ -270,19 +281,26 @@ namespace OloEngine
             auto candidateFont = Font::Create(candidate);
             if (candidateFont && candidateFont->IsLoaded())
             {
-                DefaultFont = candidateFont;
-                return DefaultFont;
+                s_DefaultFont = candidateFont;
+                return s_DefaultFont;
             }
         }
 
         // Nothing on disk loaded. Cache whatever the last attempt produced
         // (an unloaded Font sentinel) so accessors can null-check via
         // IsLoaded() without infinite re-load attempts.
-        if (!DefaultFont)
+        if (!s_DefaultFont)
         {
-            DefaultFont = Font::Create(kCandidates[0]);
+            s_DefaultFont = Font::Create(kCandidates[0]);
         }
-        return DefaultFont;
+        return s_DefaultFont;
+    }
+
+    void Font::ShutdownDefault()
+    {
+        // Idempotent, and a later GetDefault() simply reloads — nothing holds a raw
+        // pointer into the font, and every component that wanted it kept its own Ref.
+        s_DefaultFont.Reset();
     }
 
     Ref<Font> Font::Create(const std::filesystem::path& font)

--- a/OloEngine/src/OloEngine/Renderer/Font.h
+++ b/OloEngine/src/OloEngine/Renderer/Font.h
@@ -105,6 +105,18 @@ namespace OloEngine
         }
 
         static Ref<Font> GetDefault();
+
+        // Release the process-wide default font cached by GetDefault(). Called from
+        // Renderer::Shutdown() — the teardown that always runs — because the default
+        // font is built from an ECS component's default member initializer, so any
+        // session that constructs a UITextComponent/TextComponent creates it, 3D or
+        // not. Before #839 it had no release site at all and its two Slug atlas
+        // textures survived every session on every backend (Vulkan reported them at
+        // vmaDestroyAllocator; GL, having no allocator assertion, said nothing).
+        // Idempotent; a later GetDefault() reloads.
+        // See docs/agent-rules/lazy-static-release-ownership.md.
+        static void ShutdownDefault();
+
         static Ref<Font> Create(const std::filesystem::path& font);
         static Ref<Font> Create(const std::filesystem::path& font, const std::vector<FontCodepointRange>& ranges);
 

--- a/OloEngine/src/OloEngine/Renderer/Renderer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Renderer.h"
 
+#include "OloEngine/Renderer/Font.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
 #include "OloEngine/Renderer/Renderer2D.h"
 #include "OloEngine/Renderer/Renderer3D.h"
@@ -20,6 +21,17 @@ namespace OloEngine
 
         RenderCommand::Init();
         s_RendererType = type;
+
+        // Symmetric with the Shutdown() call at the bottom of Renderer::Shutdown(),
+        // which is the only half that existed: Initialize() had NO callers, so the
+        // tracker never sized its history buffers and — worse — never cleared the
+        // m_IsShutdown latch its own comment says it exists to clear. After the first
+        // Renderer::Shutdown() in a process, TrackDeallocation() early-returned while
+        // TrackAllocation() kept recording, so every resource type read as a phantom
+        // leaker across an Init/Shutdown/Init cycle (the test binary and the editor's
+        // project reload both do exactly that). Needed here because Shutdown() now
+        // REPORTS what is still tracked (#839) rather than silently clearing it.
+        RendererMemoryTracker::GetInstance().Initialize();
 
         // Initialize boot + fallback shaders BEFORE any renderer loads shaders.
         // This ensures the warmup progress bar is available during all shader
@@ -93,6 +105,16 @@ namespace OloEngine
         // enqueue into VulkanDeferredReclaim, which VulkanContext::Shutdown
         // drains a final time just before VulkanDevice::Shutdown.
         MeshPrimitives::Shutdown();
+
+        // The process-wide default font's two Slug atlas textures. Same class as the
+        // triangle above and the same reason it belongs here rather than in
+        // Renderer3D::Shutdown(): Font::GetDefault() is reached from an ECS component's
+        // default member initializer (`Ref<Font> m_FontAsset = Font::GetDefault()` on
+        // UITextComponent / TextComponent), so merely deserialising a scene with a text
+        // component creates it — in a 2D session, a 3D session, or a headless one. Until
+        // #839 it had NO release site anywhere; the atlases survived every session on
+        // every backend, and only Vulkan's allocator teardown ever said so.
+        Font::ShutdownDefault();
 
         // Release the descriptor heap and its backend WHILE THE CONTEXT IS STILL
         // CURRENT. ~OpenGLRendererAPI cannot do this: it runs from the static

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -48,6 +48,7 @@
 #include <chrono>
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
 #include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
+#include "OloEngine/Renderer/Debug/GPUTimerQueryPool.h"
 #include "OloEngine/Renderer/Debug/RenderGraphDebugRuntime.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Occlusion/OcclusionQueryPool.h"
@@ -709,6 +710,14 @@ namespace OloEngine
         // (both are idempotent, but no need to call them twice).
 
         GPUPassTimerPool::GetInstance().Shutdown();
+        // Its neighbour, and a different species of the same bug (#839): this pool has
+        // had a correct Shutdown() since it was written and NOTHING called it. Grepping
+        // "is this released?" finds the function and stops; the question that finds the
+        // leak is "who calls it?". CommandBucket::ExecuteWithGPUTiming lazily
+        // Initialize()s it on the first GPU-timed frame from SceneRenderPass, so it is
+        // 3D-only by construction and Renderer3D::Shutdown() is unconditional for every
+        // session that can create it. See docs/agent-rules/lazy-static-release-ownership.md.
+        GPUTimerQueryPool::GetInstance().Shutdown();
         RendererProfiler::GetInstance().Shutdown();
 
         s_Data.CoreInitialized = false;

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -6342,6 +6342,14 @@ namespace OloEngine
         return *s_DefaultMaterial;
     }
 
+    void Scene::ReleaseSharedRenderDefaults()
+    {
+        // Idempotent; GetDefaultMaterial() rebuilds on next use. Nothing keeps a
+        // Material* across frames — every consumer takes the reference and submits
+        // within the same call — so dropping it here cannot dangle.
+        s_DefaultMaterial.Reset();
+    }
+
     void Scene::LoadAndRenderSkybox()
     {
         OLO_PROFILE_FUNCTION();

--- a/OloEngine/src/OloEngine/Scene/Scene.h
+++ b/OloEngine/src/OloEngine/Scene/Scene.h
@@ -83,6 +83,15 @@ namespace OloEngine
         static Ref<Scene> Create();
         static Ref<Scene> Copy(Ref<Scene>& other);
 
+        // Release the process-wide render defaults Scene.cpp caches lazily (currently
+        // the fallback PBR material every un-materialed submesh draws with). Not
+        // per-scene state, so ~Scene() is the wrong place; called from
+        // ~Application after Project::Unload() and before Renderer::Shutdown(), i.e.
+        // the narrowest teardown that is unconditional for every session that can
+        // create them and still has a live graphics context (#839).
+        // See docs/agent-rules/lazy-static-release-ownership.md.
+        static void ReleaseSharedRenderDefaults();
+
         [[nodiscard("Store this!")]] Entity CreateEntity(const std::string& name = std::string());
         [[nodiscard("Store this!")]] Entity CreateEntityWithUUID(UUID uuid, const std::string& name = std::string());
         void DestroyEntity(Entity entity);

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -3,6 +3,7 @@
 #include "Platform/OpenGL/OpenGLDebug.h"
 #include "Platform/OpenGL/OpenGLUtilities.h"
 #include "Platform/OpenGL/OpenGLRHIConversions.h"
+#include "Platform/OpenGL/OpenGLTextureCubemap.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Shader.h"
 #include "OloEngine/Renderer/ShaderBindingLayout.h"
@@ -58,6 +59,21 @@ namespace OloEngine
         }
         RHI::DescriptorHeap::Get().Shutdown();
         m_DescriptorHeapBackend.Shutdown();
+        // The cubemap face-upload staging PBO: a lazily created GL buffer that
+        // glNamedBufferData grows to the largest face the session ever uploaded (tens of
+        // MB for a 2048² HDR skybox) and that nothing ever deleted (#839). GL-only, so
+        // the Vulkan teardown forensics that found the rest of that leak class could not
+        // see it, and GL has no allocator-teardown assertion to complain.
+        //
+        // Released HERE rather than from Renderer::Shutdown() for a boundary reason:
+        // OpenGLTextureCubemap.h includes <glad/gl.h>, so calling it from Renderer.cpp
+        // would drag the GL loader into an engine-core translation unit and undo the
+        // `sweep_glad_includes == 0` property RHIBoundaryRatchetTest pins. This entry
+        // point is already the GL-only teardown that always runs — Renderer::Shutdown()
+        // reaches it through RenderCommand::ShutdownGpuResources(), which the Vulkan path
+        // inherits as the empty RendererAPI base default — and it runs while the context
+        // is still current, which is exactly the deadline a GL delete has.
+        OpenGLTextureCubemap::ShutdownSharedResources();
         m_GpuResourcesReleased = true;
     }
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.cpp
@@ -9,6 +9,26 @@
 
 namespace OloEngine
 {
+    namespace
+    {
+        // The persistent GL_PIXEL_UNPACK_BUFFER staging buffer UploadFace() uploads
+        // through (see the rationale at its use site). It was a function-local static
+        // with no release site of any kind: created on the first cubemap face upload,
+        // grown by glNamedBufferData to the largest face the session ever uploaded, and
+        // still owning that storage at process exit. File-scope so
+        // ShutdownSharedResources() can delete it while the context is current (#839).
+        GLuint s_UnpackStagingPBO = 0;
+    } // namespace
+
+    void OpenGLTextureCubemap::ShutdownSharedResources()
+    {
+        if (s_UnpackStagingPBO != 0)
+        {
+            glDeleteBuffers(1, &s_UnpackStagingPBO);
+            s_UnpackStagingPBO = 0;
+        }
+    }
+
     namespace Utils
     {
         [[nodiscard("Store this!")]] static GLenum OloEngineImageFormatToGLDataFormat(ImageFormat format)
@@ -483,7 +503,6 @@ namespace OloEngine
         // create/delete, so it adds no buffer-id churn; a single GL context on the main thread
         // makes the shared static race-free. GL_UNPACK_ALIGNMENT (set above) still applies to
         // the PBO read.
-        static GLuint s_UnpackStagingPBO = 0;
         if (s_UnpackStagingPBO == 0)
             glCreateBuffers(1, &s_UnpackStagingPBO);
         // Save + restore whatever was bound to GL_PIXEL_UNPACK_BUFFER rather than assume 0,

--- a/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTextureCubemap.h
@@ -15,6 +15,12 @@ namespace OloEngine
         explicit OpenGLTextureCubemap(const std::vector<std::string>& facePaths);
         ~OpenGLTextureCubemap() override;
 
+        // Delete the shared face-upload staging PBO (see OpenGLTextureCubemap.cpp).
+        // Called from Renderer::Shutdown()'s OpenGL branch, alongside
+        // OpenGLFramebuffer::ShutdownSharedResources(), so the buffer dies while the
+        // context is still current. Idempotent; the next upload recreates it (#839).
+        static void ShutdownSharedResources();
+
         // Texture interface implementation
         const TextureSpecification& GetSpecification() const override
         {

--- a/OloEngine/tests/Rendering/RendererShutdownTest.cpp
+++ b/OloEngine/tests/Rendering/RendererShutdownTest.cpp
@@ -176,6 +176,108 @@ namespace OloEngine::Tests
             return s_StartCwd / relative; // report the path we looked for
         }
 
+        // ------------------------------------------------------------------------------
+        // #839 sweep guard helpers.
+        // ------------------------------------------------------------------------------
+
+        // The repo root. Derived from one of the scan roots below rather than by counting
+        // parent_path() hops up from a source file — that count is silent if the file
+        // moves, and this one is wrong only if the directory the scan already depends on
+        // is wrong, which the scan's own non-vacuity assertion catches.
+        [[nodiscard]] std::filesystem::path RepoRoot()
+        {
+            return RepoFile("OloEngine/src").parent_path().parent_path();
+        }
+
+        // Types whose Ref<> owns GPU memory, or transitively owns something that does.
+        // SEEDED deliberately rather than discovered: a scan that discovers what to check
+        // can stop checking, which is the lesson #814's guard learned the hard way. Adding a
+        // new GPU-resource class means adding it here.
+        constexpr const char* kGpuOwningRefTypes[] = {
+            "VertexArray", "VertexBuffer", "IndexBuffer", "UniformBuffer", "StorageBuffer",
+            "Texture", "Texture2D", "Texture3D", "TextureCubemap", "Texture2DArray",
+            "TextureCubemapArray", "Framebuffer", "Shader", "ComputeShader",
+            "Mesh", "MeshSource", "StaticMesh", "Material", "Font", "EnvironmentMap",
+            "Scene", "VideoPlayer", "RenderGraph", "Model", "AnimatedModel"
+        };
+
+        // Statics released through a SETTER called with nullptr rather than by an assignment
+        // the scan can see. Keep the justification with the entry; an unexplained name here
+        // is how a roster turns into a place to hide a leak.
+        struct IndirectRelease
+        {
+            const char* Name;
+            const char* Where;
+        };
+        constexpr IndirectRelease kReleasedIndirectly[] = {
+            { "s_ActiveGraph",
+              "RenderGraphDebugRuntime::SetActiveGraph(nullptr), called from Renderer3D::Shutdown(); it is "
+              "also only ever SET from Renderer3D::Init(), so the 3D-only teardown is unconditional for it" }
+        };
+
+        [[nodiscard]] std::vector<std::filesystem::path> EngineSourceFiles()
+        {
+            std::vector<std::filesystem::path> files;
+            for (const char* root : { "OloEngine/src", "OloEditor/src" })
+            {
+                const std::filesystem::path dir = RepoFile(root);
+                std::error_code ec;
+                if (!std::filesystem::is_directory(dir, ec))
+                {
+                    continue;
+                }
+                for (std::filesystem::recursive_directory_iterator it(dir, ec), end; it != end; it.increment(ec))
+                {
+                    if (ec)
+                    {
+                        break;
+                    }
+                    if (const std::string ext = it->path().extension().string(); ext == ".cpp" || ext == ".h")
+                    {
+                        files.push_back(it->path());
+                    }
+                }
+            }
+            std::sort(files.begin(), files.end());
+            return files;
+        }
+
+        // An out-of-class static member DEFINITION: `Ref<Shader> ShaderLibrary::s_Fallback
+        // = nullptr;` in the .cpp that pairs with `static Ref<Shader> s_Fallback;` in the
+        // .h. It textually contains `= nullptr` but is not a release, and declRe does not
+        // match it (the `Class::` qualifier), so without this the sibling-file search would
+        // accept every class static as "released" by its own definition — a silent false
+        // negative on exactly the species this test exists to catch.
+        const std::regex kStaticMemberDefinitionRe(
+            R"RX(^[ \t]*(?:Ref|Scope)<[ \t]*[A-Za-z_][A-Za-z0-9_]*[ \t]*>[ \t]+[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*[ \t]*(?:=[^;]*)?;)RX");
+
+        // Is `name` reset anywhere in `scope`? A declaration with an initializer
+        // (`Ref<Font> s_DefaultFont = nullptr;`) textually contains `= nullptr`, so lines
+        // that are themselves declarations or definitions do not count — without that,
+        // giving a static an explicit null initializer would be enough to "release" it.
+        [[nodiscard]] bool HasReleaseSite(const std::string& scope, const std::string& name,
+                                          const std::regex& declRe)
+        {
+            const std::regex releaseRe(
+                "\\b" + name +
+                "[ \\t]*(\\.Reset\\(\\)|\\.Release\\(\\)|=[ \\t]*nullptr[ \\t]*;|=[ \\t]*\\{[ \\t]*\\}[ \\t]*;)");
+            for (auto it = std::sregex_iterator(scope.begin(), scope.end(), releaseRe);
+                 it != std::sregex_iterator(); ++it)
+            {
+                const sizet at = static_cast<sizet>(it->position());
+                const sizet before = scope.rfind('\n', at);
+                const sizet lineStart = (before == std::string::npos) ? 0 : before + 1;
+                const sizet after = scope.find('\n', at);
+                const std::string hit =
+                    scope.substr(lineStart, (after == std::string::npos ? scope.size() : after) - lineStart);
+                if (!std::regex_search(hit, declRe) && !std::regex_search(hit, kStaticMemberDefinitionRe))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         // Every `Foo::Shutdown*()` / `Foo::Get().Shutdown*()` / `Foo::GetInstance().Shutdown*()`
         // in a teardown body, reduced to the bare facility name `Foo`. `Release*` and `Clear*`
         // are matched too — `TerrainGPUQuadtree::ReleaseSharedPatchMesh()` and
@@ -387,5 +489,190 @@ namespace OloEngine::Tests
                "Call `<Facility>::Shutdown();` from a teardown that ALWAYS runs — Renderer::Shutdown() in\n"
                "Renderer.cpp (it owns both sub-renderers), or the Renderer2D / ShaderWarmup teardown that\n"
                "created the resource in the first place.";
+    }
+
+    // #839: the sweep guard. The two tests above both start from a teardown BODY and ask
+    // "is this facility released from the right place?". That only sees facilities somebody
+    // already thought to release. The sweep behind #839 found seven more members of the
+    // class, and the largest ones were not misfiled releases at all — they were statics with
+    // no release site of ANY kind, which a teardown-body scan is structurally blind to:
+    //
+    //   * Font::GetDefault()'s cached default font — two Slug atlas textures, created from an
+    //     ECS component's default member initializer, released by nothing on any backend.
+    //   * SceneHierarchyPanel's s_DrawComponentScene — a Ref<Scene> set every inspector frame
+    //     and never cleared, pinning the whole scene (64 vertex arrays, ~133 MB) forever.
+    //   * Scene.cpp's cached default Material.
+    //   * OpenGLTextureCubemap's face-upload staging PBO — a raw GLuint, so not even a Ref.
+    //
+    // So this test starts from the DECLARATION instead: every process static that holds a
+    // GPU-owning Ref (or a lazily created raw GL object) must be reset somewhere in its own
+    // translation unit. Where that reset is CALLED from is the other two tests' business;
+    // this one only insists that it exists at all.
+    //
+    // LIMITS, stated so nobody over-trusts it. TWO species are out of reach.
+    //
+    // 1. A release site that exists and correctly resets the static, which nothing ever calls
+    //    (VideoSystem::Shutdown() and GPUTimerQueryPool::Shutdown() were both like that, the
+    //    former carrying a comment saying "Call on engine/scene shutdown"). A prototype that
+    //    tried to resolve callers textually through singleton accessors, aliases and
+    //    delegating bodies produced enough false positives to be noise, and a curated roster
+    //    of "teardowns that must be called" drifts by construction.
+    //
+    // 2. A GPU-owning Ref that is not DECLARED as one — because it sits inside a container or
+    //    a struct. The #839 sweep's last survivor was exactly this: DrawComponent<T> keeps a
+    //    `static std::unordered_map<u64, EditState>` of undo snapshots, and EditState::snapshot
+    //    is a COPY of the component, so the ModelComponent instantiation owns a Ref<Model>
+    //    three type layers below anything this regex can see. Chasing it would mean deciding
+    //    whether an arbitrary static's type TRANSITIVELY owns GPU memory, which is a
+    //    type-system question, not a text one. This test covers direct declarations only.
+    //
+    // Both are caught empirically instead: the Vulkan teardown forensics (#794), and
+    // RendererMemoryTracker::Shutdown(), which now reports its live allocations instead of
+    // clear()ing them unseen. Note when reading that output that the VMA leak assert ABORTS,
+    // and an abort discards the log's buffered tail — so the forensics may be missing from
+    // OloEngine.log while present on the console. Run the editor under cdb if in doubt.
+    TEST(RendererShutdown, EveryProcessStaticGpuResourceHasAReleaseSite)
+    {
+        const std::vector<std::filesystem::path> files = EngineSourceFiles();
+        ASSERT_GT(files.size(), 500u)
+            << "found only " << files.size()
+            << " engine sources — the scan roots are wrong (is the cwd inside the repo?), which would make "
+               "this test silently vacuous";
+
+        // Ref<T>/Scope<T> declaration at namespace, class or function scope. `static` is
+        // explicit at class/function scope; an anonymous-namespace global carries no keyword,
+        // so an `s_`-prefixed name at shallow indent counts too (the repo's convention, and
+        // how VideoSystem's leaked player was declared).
+        const std::regex declRe(
+            R"RX(^([ \t]*)(?:inline[ \t]+)?(static[ \t]+)?(?:Ref|Scope)<[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]*>[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*(?:=[^;]*)?;)RX");
+        // A lazily created raw GL object: `GLuint s_Foo = 0;` handed to glCreate*/glGen*.
+        // Same static-storage rule as above — the `static` keyword is optional because
+        // moving such a handle into an anonymous namespace (which is what fixing one looks
+        // like) must not drop it out of this test's coverage.
+        const std::regex glHandleRe(
+            R"RX(^([ \t]*)(static[ \t]+)?(?:GLuint|u32)[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*0[ \t]*;)RX");
+
+        std::vector<std::string> unreleased;
+        u32 examined = 0;
+
+        for (const std::filesystem::path& path : files)
+        {
+            const std::string raw = ReadFile(path);
+            if (raw.empty())
+            {
+                continue;
+            }
+            const std::string text = StripLineComments(raw);
+
+            // A class static declared in Foo.h is defined — and released — in Foo.cpp, so the
+            // sibling translation unit is part of the search scope.
+            std::string scope = text;
+            if (const std::filesystem::path sibling =
+                    std::filesystem::path(path).replace_extension(path.extension() == ".h" ? ".cpp" : ".h");
+                std::filesystem::exists(sibling))
+            {
+                scope += '\n';
+                scope += StripLineComments(ReadFile(sibling));
+            }
+
+            const std::string relative = std::filesystem::relative(path, RepoRoot()).generic_string();
+
+            std::istringstream in(text);
+            std::string line;
+            while (std::getline(in, line))
+            {
+                // Cheap pre-filter before any regex: a static-storage declaration either
+                // says `static` or carries the repo's `s_` prefix. Two substring finds per
+                // line instead of two regex_searches over ~700k lines — 10.5s -> 3.0s in a
+                // Debug build, same findings.
+                if (line.find("s_") == std::string::npos && line.find("static") == std::string::npos)
+                {
+                    continue;
+                }
+
+                std::smatch match;
+                if ((line.find("Ref<") != std::string::npos || line.find("Scope<") != std::string::npos) &&
+                    std::regex_search(line, match, declRe))
+                {
+                    const std::string indent = match[1].str();
+                    const bool explicitStatic = match[2].matched;
+                    const std::string type = match[3].str();
+                    const std::string name = match[4].str();
+
+                    const bool gpuOwning =
+                        std::find_if(std::begin(kGpuOwningRefTypes), std::end(kGpuOwningRefTypes),
+                                     [&](const char* t)
+                                     { return type == t; }) != std::end(kGpuOwningRefTypes);
+                    const bool staticStorage = explicitStatic || (name.starts_with("s_") && indent.size() <= 8);
+                    const bool indirect =
+                        std::find_if(std::begin(kReleasedIndirectly), std::end(kReleasedIndirectly),
+                                     [&](const IndirectRelease& e)
+                                     { return name == e.Name; }) !=
+                        std::end(kReleasedIndirectly);
+
+                    if (gpuOwning && staticStorage && !indirect)
+                    {
+                        ++examined;
+                        if (!HasReleaseSite(scope, name, declRe))
+                        {
+                            unreleased.push_back("Ref<" + type + "> " + name + "  (" + relative + ")");
+                        }
+                    }
+                }
+
+                if (std::regex_search(line, match, glHandleRe))
+                {
+                    const std::string glIndent = match[1].str();
+                    const bool glExplicitStatic = match[2].matched;
+                    const std::string name = match[3].str();
+                    // Same static-storage rule as the Ref scan above.
+                    if (glExplicitStatic || (name.starts_with("s_") && glIndent.size() <= 8))
+                    {
+                        const bool created =
+                            std::regex_search(text, std::regex("gl(Create|Gen)[A-Za-z]*\\([^;]*&" + name));
+                        if (created)
+                        {
+                            ++examined;
+                            if (!std::regex_search(text, std::regex("glDelete[A-Za-z]*\\([^;]*&?" + name)))
+                            {
+                                unreleased.push_back("GLuint " + name + "  (" + relative + ")");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Non-vacuity: the seeded type roster means a deleted DECLARATION cannot quietly
+        // shrink what this test covers, but a drifted regex can. The engine has dozens of
+        // these statics; finding none at all means the scan stopped working.
+        ASSERT_GT(examined, 15u)
+            << "the declaration scan matched only " << examined
+            << " process statics of a GPU-owning type. The engine has far more than that, so the regex has "
+               "drifted from the code and this test is no longer checking anything.";
+
+        std::string names;
+        for (const std::string& n : unreleased)
+        {
+            names += "\n  - " + n;
+        }
+
+        EXPECT_TRUE(unreleased.empty())
+            << "these process statics own GPU memory and NOTHING in their translation unit ever releases "
+               "them:"
+            << names
+            << "\n\nA lazily created GPU object with no release site survives every session on every backend.\n"
+               "Vulkan reports it at vmaDestroyAllocator (and in Debug the assertion is a HANG, not a log\n"
+               "line); OpenGL, having no allocator-teardown assertion, says nothing at all — which is exactly\n"
+               "why this class went unnoticed for the whole life of the GL backend (#814, #839).\n\n"
+               "Give the static a release function and call it from the narrowest teardown that is\n"
+               "unconditional for every session that can CREATE it, and that still runs while the graphics\n"
+               "context is alive:\n"
+               "  * 3D-only facility            -> Renderer3D::Shutdown()\n"
+               "  * anything else under Renderer/ -> Renderer::Shutdown()\n"
+               "  * a non-renderer subsystem    -> ~Application, after Project::Unload()\n"
+               "If the static exists only for the duration of one call (like the inspector's\n"
+               "s_DrawComponentScene), clear it at the end of that call instead.\n\n"
+               "See docs/agent-rules/lazy-static-release-ownership.md.";
     }
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/RendererShutdownTest.cpp
+++ b/OloEngine/tests/Rendering/RendererShutdownTest.cpp
@@ -215,6 +215,26 @@ namespace OloEngine::Tests
               "also only ever SET from Renderer3D::Init(), so the 3D-only teardown is unconditional for it" }
         };
 
+        // The extensions this scan reads. THIS LIST IS THE COVERAGE BOUNDARY: a GPU-owning
+        // static in a file whose extension is missing here is never examined, and the test
+        // passes anyway — the same "a scan that stops checking" failure the seeded type
+        // roster above exists to prevent. `.inl` is in the list because this repo has 15 of
+        // them under the scanned roots (the OloHeaderTool-generated component lists, plus
+        // hand-written ones like DebugLevers.inl); the rest are here so a future file using
+        // a conventional C++ extension cannot silently escape.
+        constexpr const char* kHeaderExtensions[] = { ".h", ".hpp", ".hh", ".inl" };
+        constexpr const char* kImplementationExtensions[] = { ".cpp", ".cc", ".cxx" };
+
+        [[nodiscard]] bool IsScannedExtension(const std::string& ext)
+        {
+            return std::find_if(std::begin(kHeaderExtensions), std::end(kHeaderExtensions),
+                                [&](const char* e)
+                                { return ext == e; }) != std::end(kHeaderExtensions) ||
+                   std::find_if(std::begin(kImplementationExtensions), std::end(kImplementationExtensions),
+                                [&](const char* e)
+                                { return ext == e; }) != std::end(kImplementationExtensions);
+        }
+
         [[nodiscard]] std::vector<std::filesystem::path> EngineSourceFiles()
         {
             std::vector<std::filesystem::path> files;
@@ -232,7 +252,7 @@ namespace OloEngine::Tests
                     {
                         break;
                     }
-                    if (const std::string ext = it->path().extension().string(); ext == ".cpp" || ext == ".h")
+                    if (IsScannedExtension(it->path().extension().string()))
                     {
                         files.push_back(it->path());
                     }
@@ -240,6 +260,48 @@ namespace OloEngine::Tests
             }
             std::sort(files.begin(), files.end());
             return files;
+        }
+
+        // Every counterpart a class static's declaration and its definition could be split
+        // across: a `static Ref<Shader> s_Fallback;` in Foo.h is defined and released in
+        // Foo.cpp (or Foo.cc), so the search scope has to span both. Returns the paths that
+        // exist, never the file itself.
+        [[nodiscard]] std::vector<std::filesystem::path> SiblingTranslationUnits(const std::filesystem::path& path)
+        {
+            const std::string ext = path.extension().string();
+            const bool isHeader = std::find_if(std::begin(kHeaderExtensions), std::end(kHeaderExtensions),
+                                               [&](const char* e)
+                                               { return ext == e; }) != std::end(kHeaderExtensions);
+
+            std::vector<std::filesystem::path> siblings;
+            const auto probe = [&](const char* candidateExt)
+            {
+                std::filesystem::path candidate = path;
+                candidate.replace_extension(candidateExt);
+                std::error_code ec;
+                if (candidate != path && std::filesystem::exists(candidate, ec))
+                {
+                    siblings.push_back(std::move(candidate));
+                }
+            };
+
+            // A header's release lives in an implementation file and vice versa. `.inl` is
+            // treated as a header: it is #included, never compiled on its own.
+            if (isHeader)
+            {
+                for (const char* implExt : kImplementationExtensions)
+                {
+                    probe(implExt);
+                }
+            }
+            else
+            {
+                for (const char* headerExt : kHeaderExtensions)
+                {
+                    probe(headerExt);
+                }
+            }
+            return siblings;
         }
 
         // An out-of-class static member DEFINITION: `Ref<Shader> ShaderLibrary::s_Fallback
@@ -564,12 +626,12 @@ namespace OloEngine::Tests
             }
             const std::string text = StripLineComments(raw);
 
-            // A class static declared in Foo.h is defined — and released — in Foo.cpp, so the
-            // sibling translation unit is part of the search scope.
+            // A class static declared in Foo.h is defined — and released — in Foo.cpp, so
+            // every sibling translation unit is part of the search scope. All counterparts
+            // are probed, not just the .h/.cpp pair, so a release that lives in a .cc (or a
+            // declaration in a .hpp/.inl) is still found.
             std::string scope = text;
-            if (const std::filesystem::path sibling =
-                    std::filesystem::path(path).replace_extension(path.extension() == ".h" ? ".cpp" : ".h");
-                std::filesystem::exists(sibling))
+            for (const std::filesystem::path& sibling : SiblingTranslationUnits(path))
             {
                 scope += '\n';
                 scope += StripLineComments(ReadFile(sibling));

--- a/docs/agent-rules/lazy-static-release-ownership.md
+++ b/docs/agent-rules/lazy-static-release-ownership.md
@@ -166,3 +166,230 @@ fullscreen-triangle cache "is a process STATIC now holding Vulkan VMA buffers �
 released here or the allocator teardown asserts on the leak". A test that has to
 reach past a subsystem's teardown to release something is evidence the release
 site is in the wrong place; it read as a test-fixture quirk for a whole phase.
+
+---
+
+# The sweep (#839): what the rest of the class looked like
+
+#814 fixed one member and this document predicted there were others. There were
+eight, and the part worth carrying forward is that **they were not all the same
+shape**. "The release site is in the wrong teardown" turned out to be the
+*rarest* of three species:
+
+| species | what it looks like | members found |
+|---|---|---|
+| **(a) release in a conditional teardown** | a release call exists and runs, just not in every session that can create the object | the fullscreen triangle (#814) — and nothing else |
+| **(b) no release site at all** | nobody ever wrote one; the object is simply immortal | the default font, the GL cubemap staging PBO, the inspector's scene reference, the inspector's undo-snapshot maps, the scene's default material |
+| **(c) a release site nothing calls** | someone wrote the teardown — one of them with a comment saying when to call it — and never wired it up | `VideoSystem::Shutdown()`, `GPUTimerQueryPool::Shutdown()` |
+
+Species (c) is the one to internalise. Both instances read as *finished* code: a
+public `Shutdown()`, a correct body, and in `VideoSystem`'s case a doc comment
+reading "Release the global fullscreen player. Call on engine/scene shutdown."
+Grepping for "is this released?" finds the function and stops. The question that
+finds the bug is **"who calls it?"**, and it has to be asked separately.
+
+So the sweep is three scans, not one:
+
+1. every process static holding a `Ref<T>` where `T` owns GPU memory — does its
+   own translation unit reset it anywhere?
+2. every `Shutdown()` / `Release*()` on a static or singleton facility — does
+   anything call it?
+3. every raw `static GLuint` / `static Vk*` in the platform layers — is there a
+   matching delete?
+
+Scan 3 is not garnish. It found a persistent `GL_PIXEL_UNPACK_BUFFER` staging
+buffer in `OpenGLTextureCubemap`'s face upload, created on first use, grown by
+`glNamedBufferData` to the largest cubemap face the session ever uploaded, and
+never deleted. It is **GL-only**, so the Vulkan forensics that found everything
+else were blind to it, and GL has no allocator assertion to complain. *A leak
+class found on Vulkan still needs a GL-side pass.*
+
+## The big one was not a teardown-placement bug at all
+
+The headline number — 64 surviving vertex arrays, two per mesh, plus the BRDF LUT
+— was not a misplaced release. Every one of those `MeshSource`s was owned by the
+deserialised scene through `MeshComponent::m_MeshSource`, the BRDF LUT through
+`EnvironmentMapComponent`, and the surviving albedo textures through the model
+components. They survived because **the scene survived**, and the scene survived
+because `SceneHierarchyPanel.cpp` kept a file-scope `Ref<Scene>`:
+
+```cpp
+// File-scope state for undo integration in DrawComponent (set by DrawComponents)
+static CommandHistory* s_DrawComponentCmdHistory = nullptr;
+static Ref<Scene>      s_DrawComponentScene      = nullptr;
+```
+
+`DrawComponents()` sets it every inspector frame so the templated
+`DrawComponent<T>` helpers can build undo commands without threading two extra
+parameters through ~95 call sites. That is a reasonable trick, and the comment
+even scopes it to the call. Nothing ever unset it, so the last scene the
+Properties panel drew was pinned for the rest of the process.
+
+**The A/B that proves it**, same binary, same scene, `--rhi=vulkan`, close the
+window:
+
+| | vertex arrays | textures | VMA allocations | bytes | exit |
+|---|---|---|---|---|---|
+| no entity selected | 0 | 0 | 0 | 0 | 0, "Context shut down cleanly" |
+| one entity selected | 12 | 6 | 30 | 147,330,896 | **3 (abort)** |
+
+Selecting an entity is the whole difference: it is what makes the Properties
+panel call `DrawComponents()` at all. Worth knowing when reading a teardown-leak
+report — **this class of bug can be conditional on a UI interaction**, so "I
+couldn't reproduce it" may only mean you did not click the same thing. It also
+means the failure is worse than a leak: with a selection, closing the Vulkan
+editor **aborts** rather than exiting.
+
+Two things this rules out. `~Application` *already* detaches the layers and calls
+`Project::Unload()` before `Renderer::Shutdown()`, deliberately, with a comment
+explaining that the asset manager's Refs would otherwise outlive the graphics
+context (#691 Phase 8). **The teardown order was right; the object had one more
+owner than the order accounted for.** When a survivor is a whole aggregate — a
+scene, a model, an asset pack — rather than a single cached resource, look for
+the extra owner before you reach for the teardown order: reordering teardown to
+"fix" a stray strong reference just converts a leak into a use-after-free
+somewhere less visible.
+
+The general rule for a scratch static like this one: **if a static exists only
+for the duration of a call, clear it at the end of that call** — with a scope
+guard, not a trailing assignment somebody can jump over. A `Ref<>` parked in
+file-scope state "until next frame overwrites it" is a leak on the frame that
+never comes.
+
+
+## The one the guard cannot see, and how it was found
+
+The sweep above got the Vulkan teardown from 12 vertex arrays / 6 textures / 30 VMA
+allocations / 147 MB down to **1 vertex array and 2 allocations (18 KB)** — and the
+acceptance bar is zero, so that last one mattered. Its creation stack named a `Model`
+built by `ModelComponent::Reload` during scene deserialisation, and it only appeared
+when an entity had been selected in the inspector.
+
+The owner is an **eighth** member, and it is species (b) wearing a disguise:
+
+```cpp
+struct EditState { bool isEditing; bool snapshotValid; T snapshot{}; ... };
+static std::unordered_map<u64, EditState> s_EditStates;   // inside DrawComponent<T>
+```
+
+`snapshot` is a **copy of the component**, so the `ModelComponent` instantiation of that
+template owns a `Ref<Model>` and the texture-bearing ones own `Ref<Texture2D>`. Nothing
+ever cleared the maps, so drawing an entity in the inspector once pinned its GPU
+resources for the life of the process.
+
+Two things to take from it.
+
+**A declaration scan cannot find a Ref inside a container.** The guard looks for
+`static Ref<GpuOwningType> name;`. Here the Ref is a member of a struct that is the
+`mapped_type` of a static map, three type layers down — invisible, and deliberately not
+chased, because "recursively decide whether an arbitrary static's type transitively owns
+GPU memory" is a type-system question a regex cannot answer. **The guard covers direct
+declarations only. Say so; do not let it imply coverage it does not have.**
+
+**Run the teardown under a debugger before believing a leak count.** The VMA leak assert
+*aborts*, and an abort discards spdlog's buffered tail — so `OloEngine.log` stopped at
+"Pipeline cache saved", several lines before the forensics that name the survivors, and
+the run looked like it might be a fresh crash in `~VulkanContext`. Under `cdb` the
+inherited console showed the whole report and `sxe av` proved there was no access
+violation at all: same old leak assert, far fewer survivors. Without that, the last
+member would have been missed and the leak reported as fixed.
+
+Also worth knowing when reading a teardown log: **a nonzero exit code with a log that
+stops early is the abort, not a second bug.** Check the console, not the file.
+
+## The rule, one level up
+
+#814 phrased it as "for anything under `Renderer/` that is not exclusively 3D,
+release from `Renderer::Shutdown()`". Two of #839's members live outside
+`Renderer/`, and releasing them from `Renderer::Shutdown()` would have inverted
+the layering. The rule generalises:
+
+> Release from the **narrowest teardown that is unconditional for every session
+> that can create the object**, and that still runs **while the graphics context
+> is alive**.
+
+which resolves, in widening order, to:
+
+| creator | release from |
+|---|---|
+| a 3D-only facility | `Renderer3D::Shutdown()` |
+| anything else under `Renderer/` | `Renderer::Shutdown()` |
+| a backend-private object under `Platform/OpenGL/` | `OpenGLRendererAPI::ShutdownGpuResources()` |
+| a non-renderer subsystem that can own GPU memory (video, scene defaults) | `Application::~Application()`, after `Project::Unload()` and before `Renderer::Shutdown()` |
+| state that lives for one call | the end of that call |
+
+That third row has a trap worth knowing. The obvious home for the GL staging PBO
+was the `if (GetAPI() == OpenGL)` branch already sitting in `Renderer::Shutdown()`
+next to `OpenGLFramebuffer::ShutdownSharedResources()` — but `OpenGLTextureCubemap.h`
+includes `<glad/gl.h>` (that framebuffer header does not), so calling it from
+`Renderer.cpp` would drag the GL loader into an engine-core translation unit and
+undo the `sweep_glad_includes == 0` property `RHIBoundaryRatchetTest` pins.
+**And the ratchet would not have caught it**: it counts *direct* `#include` lines
+naming `glad/gl.h`, so an indirect one through a backend header breaks the
+property while the counter stays at zero. `OpenGLRendererAPI::ShutdownGpuResources()`
+is the correct home instead — it is inside the backend, it is GL-only by
+construction (`Renderer::Shutdown()` reaches it through
+`RenderCommand::ShutdownGpuResources()`, which the Vulkan path inherits as the
+empty `RendererAPI` base default), and it already runs while the context is
+current, which is exactly the deadline a `glDelete*` has.
+
+## The guard, and what it deliberately does not cover
+
+`RendererShutdown.EveryProcessStaticGpuResourceHasAReleaseSite` implements scans
+1 and 3. The two older tests in that file both start from a teardown *body* and
+ask "is this facility released from the right place?", which only ever sees
+facilities somebody already thought to release — structurally blind to species
+(b). So this one starts from the **declaration**: every process static holding a
+GPU-owning `Ref` (seeded roster, `kGpuOwningRefTypes`) and every lazily created
+raw GL handle must be reset somewhere in its own translation unit. Where that
+reset is *called* from is the other two tests' business.
+
+It does **not** implement scan 2. A prototype was written and thrown away:
+resolving `Foo::GetInstance().Shutdown()` through aliases, member calls and
+delegating bodies textually produced enough false positives to be noise, and a
+curated roster of "teardowns that must be called" drifts by construction.
+**Species (c) has no cheap static guard.** It is caught empirically, by:
+
+- the Vulkan teardown forensics (#794), which name every survivor with its
+  creation stack; and
+- `RendererMemoryTracker::Shutdown()`, which used to `clear()` its live-allocation
+  map without looking at it and now reports what is in it first. That map already
+  held the type, size, name, file and line of every survivor — so the one
+  backend-independent instrument threw the answer away at exactly the moment it
+  had it. Its limit: `TrackAllocation` is called from the **OpenGL** resource
+  classes only, so on Vulkan the report is empty and #794 remains the instrument
+  there. (`RendererMemoryTracker::Initialize()` had no callers either, which left
+  the `m_IsShutdown` latch its own comment exists to clear permanently set after
+  the first `Renderer::Shutdown()` in a process; `Renderer::Init()` now calls it.)
+
+  **It earned its keep on the first run.** With this sweep complete and Vulkan at zero
+  survivors, the very first OpenGL session reported **115 surviving shader programs**
+  (3.2 MB) — and nothing else: no textures, no buffers, no vertex arrays. `OpenGLShader`
+  pairs its alloc/dealloc tracking correctly, so those are 115 objects genuinely still
+  alive after `ShaderLibrary::Clear()`, `ShutdownFallbackShader()`,
+  `ShaderWarmup::Shutdown()` and every `s_Data.*Shader.Reset()` have run — while the
+  Vulkan backend releases the same set cleanly on the identical path. Filed as **#841**:
+  a backend divergence in shader lifetime, not one of this class's scene-owned families.
+  The instrument had been recording that answer for the whole life of the GL backend and
+  discarding it at the one moment it mattered.
+
+Red-checked against every way scan 1 can break: it reports exactly the four
+species-(b) members against the unfixed tree and none against the fixed one, and
+neither a declaration's own `= nullptr` initializer **nor an out-of-class static
+member definition** (`Ref<Shader> ShaderLibrary::s_Fallback = nullptr;` in the
+.cpp that pairs with the `static Ref<Shader> s_Fallback;` in the .h) counts as a
+release. Both textually contain `= nullptr`; without excluding them, giving a
+static an explicit null initializer — or simply *defining* a class static — would
+be enough to "release" it, which would have made the check silently vacuous for
+every class static in the engine.
+
+And red-check it **in the compiled binary**, not only in a scratch copy of the
+scan. Both halves of this guard were validated standalone first, but the *test's*
+GL-handle branch still shipped broken: widening its regex to accept an
+anonymous-namespace declaration (which is exactly what fixing the PBO looks like)
+shifted the capture groups, and the body still read `match[1]` as the name — so it
+searched for `glCreate...&<whitespace>`, matched nothing, and **skipped the entire
+GL branch silently**. The test passed. It would have kept passing with the leak
+reinstated. The scratch copy had the corrected indices, so only running the real
+binary against a deliberately broken tree found it. Being a source-scan test makes
+that cheap: delete the release, re-run the already-built binary, no rebuild needed.

--- a/docs/agent-rules/lazy-static-release-ownership.md
+++ b/docs/agent-rules/lazy-static-release-ownership.md
@@ -341,7 +341,14 @@ ask "is this facility released from the right place?", which only ever sees
 facilities somebody already thought to release — structurally blind to species
 (b). So this one starts from the **declaration**: every process static holding a
 GPU-owning `Ref` (seeded roster, `kGpuOwningRefTypes`) and every lazily created
-raw GL handle must be reset somewhere in its own translation unit. Where that
+raw GL handle must be reset somewhere in its own translation unit. A third seeded
+roster sits alongside the type list and is just as load-bearing: **the file
+extensions the scan reads**. It walks `.cpp/.cc/.cxx` and `.h/.hpp/.hh/.inl`
+(the repo has 15 `.inl` files under those roots), because a static in a file
+whose extension is missing from that list is never examined and the test passes
+regardless — the same silent-coverage-loss failure the type roster exists to
+prevent, one level down. CodeRabbit caught the `.cpp`/`.h`-only version of this
+on review. Where that
 reset is *called* from is the other two tests' business.
 
 It does **not** implement scan 2. A prototype was written and thrown away:


### PR DESCRIPTION
Closes #839.

#814 fixed one member of the lazy-static release class and
[the write-up it produced](docs/agent-rules/lazy-static-release-ownership.md)
predicted there were others. There were **eight**, and the useful finding is that
they were not all the same shape. "The release site is in the wrong teardown" —
the shape #814 documented — turned out to be the *rarest* of three species.

| species | what it looks like | members found here |
|---|---|---|
| **(a)** release in a **conditional** teardown | a release call exists and runs, just not in every session that can create the object | the fullscreen triangle (#814) — and nothing else |
| **(b)** **no release site at all** | nobody ever wrote one; the object is immortal | the default font's two Slug atlas textures, the GL cubemap staging PBO, `SceneHierarchyPanel`'s `Ref<Scene>` **and its per-component undo-snapshot maps**, `Scene`'s cached default `Material` |
| **(c)** a release site **nothing calls** | someone wrote the teardown — one with a comment saying when to call it — and never wired it up | `VideoSystem::Shutdown()`, `GPUTimerQueryPool::Shutdown()` |

Species (c) is the one worth internalising. Both read as *finished* code: a public
`Shutdown()`, a correct body, and in `VideoSystem`'s case the comment *"Release the
global fullscreen player. Call on engine/scene shutdown."* Grepping "is this
released?" finds the function and stops. The question that finds the bug is
**"who calls it?"**, and it has to be asked separately.

## The big one was not a teardown-ordering bug

The issue's headline — 64 vertex arrays, two per mesh, plus the BRDF LUT — is not a
misplaced release. Those `MeshSource`s are owned by the deserialised scene through
`MeshComponent::m_MeshSource`, the BRDF LUT through `EnvironmentMapComponent`, the
albedo maps through the model components. They survived because **the scene
survived** — `SceneHierarchyPanel.cpp` kept a file-scope `Ref<Scene>` that
`DrawComponents()` set on every inspector frame and nothing ever cleared.

**The A/B that proves it.** Same binary, same scene, `--rhi=vulkan`, close the window;
the only variable is whether an entity is selected in the inspector:

| | vertex arrays | textures | VMA allocations | bytes | exit |
|---|---|---|---|---|---|
| no entity selected | 0 | 0 | 0 | 0 | 0 — *"Context shut down cleanly"* |
| one entity selected | 12 | 6 | 30 | 147,330,896 | **3 — abort** |

Selecting an entity is the entire difference: it is what makes the Properties panel
call `DrawComponents()` at all. Two consequences the issue did not have:

* the failure is **worse than a leak** — closing the Vulkan editor *aborts*
  (`vmaDestroyAllocator`), it does not merely leak and exit;
* it is **conditional on a UI interaction**, so "I couldn't reproduce it" may only
  mean you did not click the same thing. The no-selection run looks perfectly clean.

This also settles the ownership question the issue asked to decide explicitly, and
the answer is **not** teardown ordering. `~Application` already detaches the layers
and calls `Project::Unload()` *before* `Renderer::Shutdown()`, deliberately and with
a comment saying why (#691 Phase 8). The order was right; the object had one more
owner than the order accounted for. Reordering teardown to "fix" a stray strong
reference would have converted a leak into a use-after-free — the failure direction
the issue warned about.

## Where each release went

Each at the narrowest teardown that is unconditional for every session that can
create the object, and that still runs while the graphics context is alive:

| release site | member |
|---|---|
| `Renderer::Shutdown()` | `Font::ShutdownDefault()` |
| `OpenGLRendererAPI::ShutdownGpuResources()` | `OpenGLTextureCubemap::ShutdownSharedResources()` |
| `Renderer3D::Shutdown()` | `GPUTimerQueryPool` (3D-only by construction) |
| `~Application` (both the destructor and the exception path) | `VideoSystem::Shutdown()`, `Scene::ReleaseSharedRenderDefaults()` |
| the end of the call | `SceneHierarchyPanel`'s file-scope state, via a scope guard rather than a trailing assignment |
| `SceneHierarchyPanel::SetContext` + its new destructor | `DrawComponent<T>`'s per-instantiation undo-snapshot maps |
| deleted outright | `McpToolsRender`'s duplicate static default `Material` |

### One of these has a trap worth reading

The GL staging PBO is a persistent `GL_PIXEL_UNPACK_BUFFER` that `glNamedBufferData`
grows to the largest cubemap face the session ever uploaded, and that nothing ever
deleted. It is **GL-only**, so the Vulkan forensics that found everything else were
blind to it — *a leak class found on Vulkan still needs a GL-side pass*.

Its release does **not** go in the `if (GetAPI() == OpenGL)` branch already sitting in
`Renderer::Shutdown()` next to `OpenGLFramebuffer::ShutdownSharedResources()`, which is
where it obviously belongs. `OpenGLTextureCubemap.h` includes `<glad/gl.h>` (that
framebuffer header does not), so calling it from `Renderer.cpp` would pull the GL loader
into an engine-core translation unit and undo the `sweep_glad_includes == 0` property
`RHIBoundaryRatchetTest` pins — **and the ratchet would not have caught it**, because it
counts *direct* `#include` lines naming `glad/gl.h`. An indirect one through a backend
header breaks the property with the counter still reading zero.

## Guard

`RendererShutdown.EveryProcessStaticGpuResourceHasAReleaseSite`. The two existing tests
in that file both start from a teardown *body*, so they only ever see facilities somebody
already thought to release — structurally blind to species (b). This one starts from the
**declaration**: every process static holding a GPU-owning `Ref` (seeded roster) and every
lazily created raw GL handle must be reset somewhere in its own translation unit.

Red-checked: **4 findings against the unfixed tree, 0 against the fixed one.** Neither a
declaration's own `= nullptr` initializer nor an out-of-class static member *definition*
(`Ref<Shader> ShaderLibrary::s_Fallback = nullptr;`) counts as a release — both textually
contain `= nullptr`, and without excluding them the check would have been silently vacuous
for every class static in the engine.

It deliberately does **not** cover species (c). A prototype that tried to resolve callers
textually through singleton accessors, aliases and delegating bodies was too noisy to keep,
and a curated roster of "teardowns that must be called" drifts by construction. That is
said out loud in the test and the doc rather than left as an implied guarantee.

Species (c) is caught empirically instead — and **GL now has an instrument for it**.
`RendererMemoryTracker::Shutdown()` used to `clear()` its live-allocation map without
looking at it, discarding the type, size, name, file and line of every survivor at exactly
the moment it had them. It now reports first. (`Initialize()` had no callers either, which
left the `m_IsShutdown` latch *its own comment exists to clear* permanently set after the
first `Renderer::Shutdown()` in a process; `Renderer::Init()` now calls it.) Limit stated
in the code: `TrackAllocation` is called from the OpenGL resource classes only, so on
Vulkan the report is empty and the #794 forensics remain the instrument there.

### The eighth member, and the guard's blind spot

With the other seven fixed, Vulkan still reported **1 surviving vertex array and 2
allocations (18 KB)** — a `Ref<Model>` held by `DrawComponent<T>`'s
`static std::unordered_map<u64, EditState>` of undo snapshots, whose `EditState::snapshot`
is a **copy of the component**. Drawing an entity in the inspector once pinned its GPU
resources for the life of the process. Each instantiation now registers a clearer (a
function-local static of a template is otherwise unreachable from outside), invoked from
`SetContext` — which also drops stale cross-scene undo state — and from a new panel
destructor that runs while the renderer is still alive.

**The guard cannot catch this one, by construction.** It looks for
`static Ref<GpuOwningType> name;`; here the Ref is a member of a struct that is the
`mapped_type` of a static map, three type layers down. Deciding whether an arbitrary
static's type *transitively* owns GPU memory is a type-system question, not a text one.
The test and the doc both say so rather than implying coverage they do not have.

## Verification

`OloEditor.exe --rhi=vulkan`, start scene, **entity selected** (the reproducing condition),
window closed with WM_CLOSE so the real `~Application` → `Renderer::Shutdown` →
`~VulkanContext` path runs:

| | vertex arrays | textures | VMA allocations | bytes | shutdown |
|---|---|---|---|---|---|
| baseline | 12 | 6 | 30 | 147,330,896 | **abort** |
| after the first seven members | 1 | 0 | 2 | 18,208 | **abort** |
| **this PR** | **0** | **0** | **0** | **0** | `[Vulkan] Context shut down cleanly`, exit 0 |

Run under `cdb` with `sxe av` armed: **no access violation**, and the run reaches the #794
forensics, which print nothing. That last point matters — see below.

**GL does not regress.** Same scene and interaction on `--rhi=opengl`: exit 0, and the new
`RendererMemoryTracker` report shows **zero** surviving textures, buffers or vertex arrays.

**Test suite:** `RendererShutdown.*` green (3/3), including the new guard; full suite result
below.

### Two things that cost time and are worth knowing

**The VMA leak assert aborts, and an abort discards spdlog's buffered tail.** So
`OloEngine.log` stopped several lines *before* the forensics that name the survivors, and an
intermediate run looked like a possible fresh crash in `~VulkanContext`. It was not: `cdb`
showed the full report on the inherited console and proved there was no AV. A nonzero exit
with a log that stops early is the abort — read the console, not the file. Had I trusted the
log, the eighth member would have been missed and this reported as fixed at "1 surviving
vertex array".

**A dirty scene blocks WM_CLOSE on a native MessageBox** (`OnWindowClose` →
`ConfirmDiscardChanges` → `MessagePrompt::YesNoCancel`), which no headless session can click
— a 12-minute "hang" until diagnosed. The engine already ships `OLO_EDITOR_UNSAVED_PROMPT`
for it, the same way `OLO_EDITOR_AUTOSAVE_RECOVERY` covers the other modal; the repro
harness just was not setting it.

## Found while verifying, filed separately

The new GL-side report immediately paid for itself: the first OpenGL session showed **115
shader programs surviving `Renderer::Shutdown()`** (3.2 MB) — and nothing else, no textures
or buffers. `OpenGLShader` pairs its alloc/dealloc tracking correctly and the survivors
include `__WarmupBoot`, `__Fallback` and the `Renderer2D_*` set whose teardowns had all
already run, while **Vulkan releases the identical set cleanly**. That is a backend
divergence in shader lifetime rather than one of this issue's scene-owned families, so it is
**#841** rather than more scope here.

The report was deliberately made terse before shipping — one ERROR summary with a per-type
breakdown plus six WARN examples — because two dozen ERROR lines on every editor exit, and at
the end of every test run (`OloEngineTest` calls `Renderer::Shutdown()`), is noise nobody
reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of graphics resources during normal shutdown and error recovery.
  * Prevented lingering editor undo data when panels are closed or scenes change.
  * Added diagnostics for GPU allocations that remain active during shutdown.
  * Improved cleanup of shared textures, fonts, materials, timers, and rendering resources.

* **Documentation**
  * Added guidance for identifying and safely releasing lazily created graphics resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->