### PR TITLE
feat(renderer): shared power-of-two atlas allocator (#718)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ you are in.
 **Renderer**
 
 - [rhi-abstraction-boundary.md](docs/agent-rules/rhi-abstraction-boundary.md) — where the OpenGL boundary actually leaks: the include graph, not a `glXxx(` grep; plus the Vulkan epic's per-phase lessons (§9–§13, incl. the one-row-order-per-backend contract).
+- [shared-atlas-allocator.md](docs/agent-rules/shared-atlas-allocator.md) — the buddy/quadtree allocator behind the shadow atlas and the impostor VRAM budget: the swap-not-mutate pattern for identity-keyed free-on-drop, why the impostor retrofit stayed a budget gate instead of spatial packing, and a non-RAII handle embedded in a POD-looking struct that `vector::resize()` silently leaks.
 - [vulkan-command-ordered-buffer-writes.md](docs/agent-rules/vulkan-command-ordered-buffer-writes.md) — a CPU buffer write between two recorded draws is GL command order; a life-stable Vulkan address silently makes it last-write-wins, and the failure is scene-shaped.
 - [lazy-static-release-ownership.md](docs/agent-rules/lazy-static-release-ownership.md) — a shared lazy static released from `Renderer3D::Shutdown` leaks in every session that never inits 3D; GL is silent about it, Vulkan is not.
 - [gpu-debug-draws.md](docs/agent-rules/gpu-debug-draws.md) — **the instrument for GPU-driven work**: any shader can draw a primitive into the viewport the same frame. Read the two-counter overflow protocol before concluding "it drew nothing".

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -575,6 +575,8 @@
 		"OloEngine/Renderer/Model.h"
 		"OloEngine/Renderer/AnimatedModel.cpp"
 		"OloEngine/Renderer/AnimatedModel.h"
+		"OloEngine/Renderer/AtlasAllocator.cpp"
+		"OloEngine/Renderer/AtlasAllocator.h"
 		"OloEngine/Renderer/SlugData.h"
 		"OloEngine/Renderer/SlugFontProcessor.cpp"
 		"OloEngine/Renderer/SlugFontProcessor.h"

--- a/OloEngine/src/OloEngine/Renderer/AtlasAllocator.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AtlasAllocator.cpp
@@ -1,0 +1,169 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Renderer/AtlasAllocator.h"
+
+#include "OloEngine/Memory/AlignmentTemplates.h"
+
+#include <algorithm>
+
+namespace OloEngine
+{
+    AtlasAllocator::AtlasAllocator(u32 atlasSize, u32 minTileSize)
+    {
+        if (atlasSize == 0 || minTileSize == 0 || minTileSize > atlasSize ||
+            !IsPowerOfTwo(atlasSize) || !IsPowerOfTwo(minTileSize))
+            return; // zero-capacity: every Allocate() fails, never asserts
+
+        m_AtlasSize = atlasSize;
+        m_MinTileSize = minTileSize;
+        m_LevelCount = FloorLogTwo(atlasSize / minTileSize) + 1u;
+
+        const u32 totalNodes = LevelStart(m_LevelCount);
+        m_Nodes.assign(totalNodes, Node{});
+        m_NodeLevel.resize(totalNodes);
+        for (u32 level = 0; level < m_LevelCount; ++level)
+        {
+            const u32 start = LevelStart(level);
+            const u32 end = LevelStart(level + 1u);
+            std::fill(m_NodeLevel.begin() + start, m_NodeLevel.begin() + end, static_cast<u8>(level));
+        }
+    }
+
+    u32 AtlasAllocator::LevelStart(u32 level)
+    {
+        // (4^level - 1) / 3 -- first node index at `level` in the 4-ary heap.
+        return ((1u << (2u * level)) - 1u) / 3u;
+    }
+
+    u32 AtlasAllocator::ParentOf(u32 node)
+    {
+        return (node - 1u) / 4u;
+    }
+
+    u32 AtlasAllocator::LevelForSize(u32 size) const
+    {
+        if (m_AtlasSize == 0 || size == 0 || size < m_MinTileSize || size > m_AtlasSize || !IsPowerOfTwo(size))
+            return kInvalidNode;
+        return FloorLogTwo(m_AtlasSize / size);
+    }
+
+    bool AtlasAllocator::CanAllocate(u32 node) const
+    {
+        if (m_Nodes[node].Allocated || m_Nodes[node].RefCount > 0)
+            return false; // this node (or a finer descendant of it) is taken
+
+        for (u32 n = node; n != 0;)
+        {
+            n = ParentOf(n);
+            if (m_Nodes[n].Allocated)
+                return false; // a coarser ancestor already covers this area
+        }
+        return true;
+    }
+
+    void AtlasAllocator::MarkAncestors(u32 node, bool increment)
+    {
+        for (u32 n = node; n != 0;)
+        {
+            n = ParentOf(n);
+            if (increment)
+            {
+                ++m_Nodes[n].RefCount;
+            }
+            else
+            {
+                OLO_CORE_ASSERT(m_Nodes[n].RefCount > 0, "AtlasAllocator: ancestor refcount underflow");
+                --m_Nodes[n].RefCount;
+            }
+        }
+    }
+
+    u32 AtlasAllocator::Allocate(u32 size)
+    {
+        const u32 level = LevelForSize(size);
+        if (level == kInvalidNode || level >= m_LevelCount)
+            return kInvalidNode;
+
+        const u32 start = LevelStart(level);
+        const u32 end = LevelStart(level + 1u);
+        for (u32 node = start; node < end; ++node)
+        {
+            if (!CanAllocate(node))
+                continue;
+
+            m_Nodes[node].Allocated = true;
+            MarkAncestors(node, /*increment*/ true);
+            ++m_LiveCount;
+            return node;
+        }
+        return kInvalidNode;
+    }
+
+    bool AtlasAllocator::Free(u32 node)
+    {
+        if (node == kInvalidNode || node >= m_Nodes.size() || !m_Nodes[node].Allocated)
+            return false;
+
+        m_Nodes[node].Allocated = false;
+        MarkAncestors(node, /*increment*/ false);
+        --m_LiveCount;
+        return true;
+    }
+
+    void AtlasAllocator::Reset()
+    {
+        std::fill(m_Nodes.begin(), m_Nodes.end(), Node{});
+        m_LiveCount = 0;
+    }
+
+    bool AtlasAllocator::IsAllocated(u32 node) const
+    {
+        return node < m_Nodes.size() && m_Nodes[node].Allocated;
+    }
+
+    AtlasAllocator::Region AtlasAllocator::GetRegion(u32 node) const
+    {
+        if (node >= m_Nodes.size())
+            return {};
+
+        const u32 level = m_NodeLevel[node];
+        const u32 localIndex = node - LevelStart(level);
+        const u32 size = m_AtlasSize >> level;
+
+        u32 x = 0, y = 0;
+        u32 cellSize = m_AtlasSize;
+        for (u32 depth = 0; depth < level; ++depth)
+        {
+            cellSize >>= 1u;
+            const u32 shift = 2u * (level - 1u - depth);
+            const u32 quadrant = (localIndex >> shift) & 3u;
+            if (quadrant & 1u)
+                x += cellSize;
+            if (quadrant & 2u)
+                y += cellSize;
+        }
+        return { x, y, size };
+    }
+
+    f32 AtlasAllocator::Occupancy() const
+    {
+        if (m_AtlasSize == 0)
+            return 0.0f;
+
+        u64 allocatedArea = 0;
+        for (u32 level = 0; level < m_LevelCount; ++level)
+        {
+            const u32 size = m_AtlasSize >> level;
+            const u64 area = static_cast<u64>(size) * static_cast<u64>(size);
+            const u32 start = LevelStart(level);
+            const u32 end = LevelStart(level + 1u);
+            for (u32 node = start; node < end; ++node)
+            {
+                if (m_Nodes[node].Allocated)
+                    allocatedArea += area;
+            }
+        }
+
+        const u64 totalArea = static_cast<u64>(m_AtlasSize) * static_cast<u64>(m_AtlasSize);
+        return static_cast<f32>(static_cast<f64>(allocatedArea) / static_cast<f64>(totalArea));
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/AtlasAllocator.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AtlasAllocator.cpp
@@ -13,9 +13,18 @@ namespace OloEngine
             !IsPowerOfTwo(atlasSize) || !IsPowerOfTwo(minTileSize))
             return; // zero-capacity: every Allocate() fails, never asserts
 
+        // Checked BEFORE touching m_AtlasSize/m_MinTileSize/m_LevelCount, and
+        // before LevelStart() ever sees this value: past kMaxLevelCount its
+        // `1u << (2*level)` shift is undefined behaviour, and well before
+        // that the (4^level-1)/3-sized node table is an unreasonable
+        // allocation for a ratio nothing here legitimately needs.
+        const u32 levelCount = FloorLogTwo(atlasSize / minTileSize) + 1u;
+        if (levelCount > kMaxLevelCount)
+            return; // zero-capacity: same contract as any other invalid input
+
         m_AtlasSize = atlasSize;
         m_MinTileSize = minTileSize;
-        m_LevelCount = FloorLogTwo(atlasSize / minTileSize) + 1u;
+        m_LevelCount = levelCount;
 
         const u32 totalNodes = LevelStart(m_LevelCount);
         m_Nodes.assign(totalNodes, Node{});

--- a/OloEngine/src/OloEngine/Renderer/AtlasAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/AtlasAllocator.h
@@ -45,12 +45,24 @@ namespace OloEngine
 
         AtlasAllocator() = default;
 
+        // Ceiling on levels (root = level 0). The node table is (4^levels-1)/3
+        // entries, so this bounds worst-case construction cost/memory as well
+        // as keeping LevelStart's `1u << (2*level)` a well-defined 32-bit
+        // shift — at level 16 that shift is already UB (shift amount == the
+        // type's width). 12 levels is (4^12-1)/3 ≈ 5.6M nodes, comfortably
+        // above both current instantiations (shadow atlas: 6; impostor VRAM
+        // budget: 9) with headroom for a finer-grained future one, without
+        // getting anywhere near the UB boundary or an unreasonable allocation.
+        static constexpr u32 kMaxLevelCount = 12;
+
         // atlasSize and minTileSize must both be powers of two, with
-        // minTileSize in [1, atlasSize]. An invalid combination (zero, not a
-        // power of two, minTileSize > atlasSize) yields a zero-capacity
-        // allocator — every Allocate() call then returns kInvalidNode rather
-        // than asserting, so a caller threading through a user/asset-controlled
-        // resolution stays crash-free.
+        // minTileSize in [1, atlasSize], and atlasSize/minTileSize must not
+        // require more than kMaxLevelCount levels. An invalid combination
+        // (zero, not a power of two, minTileSize > atlasSize, or a ratio
+        // past the level ceiling) yields a zero-capacity allocator — every
+        // Allocate() call then returns kInvalidNode rather than asserting or
+        // allocating an unbounded node table, so a caller threading through a
+        // user/asset-controlled resolution stays crash-free.
         AtlasAllocator(u32 atlasSize, u32 minTileSize);
 
         // Allocates a square region of exactly `size` (must be a power of two

--- a/OloEngine/src/OloEngine/Renderer/AtlasAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/AtlasAllocator.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <vector>
+
+namespace OloEngine
+{
+    // @brief Reusable power-of-two square-region atlas allocator (issue #718).
+    //
+    // Allocates and frees axis-aligned SQUARE regions of size 2^k within a
+    // power-of-two square atlas. The whole quadtree down to MinTileSize() is
+    // preallocated up front (a fixed "4-ary heap": node 0 is the root/whole
+    // atlas, the 4 children of node i live at 4i+1..4i+4), so freeing every
+    // child of a node makes that node's own (coarser) region allocatable
+    // again with no explicit merge step — the coalescing the issue asks for
+    // falls out of the data structure rather than needing its own code path.
+    //
+    // Modelled on the MIT-licensed AtlasAllocatorPD2 (Hollow-TerrainSystem,
+    // PhotoTerrain/Runtime/Utility/AtlasAllocatorPD2.cs), minus its Morton-code
+    // / BMI2 fast path: that optimisation exists to skip whole allocated
+    // subtrees in O(1) so a scan stays cheap however often Allocate() runs.
+    // Both current instantiations call Allocate() only on a rare, non-hot-path
+    // event (a shadow-atlas repack when a caster's rank/tier changes; an
+    // impostor bake when a foliage layer's mesh/params change) rather than
+    // every frame, so the plain O(nodes-at-that-level) linear scan this class
+    // uses instead is cheap in practice even for the larger of the two node
+    // tables (the impostor VRAM budget's 8192px/32px-min-tile allocator has
+    // ~87k total nodes, ~65k of them at the finest level alone) — but it is
+    // NOT "low thousands" across the board, and a future instantiation with
+    // a genuinely hot Allocate() path and a large/fine-grained table should
+    // measure before assuming this scan is still free.
+    // Coordinate math stays free of platform intrinsics either way.
+    class AtlasAllocator
+    {
+      public:
+        static constexpr u32 kInvalidNode = 0xFFFFFFFFu;
+
+        struct Region
+        {
+            u32 X = 0;
+            u32 Y = 0;
+            u32 Size = 0;
+        };
+
+        AtlasAllocator() = default;
+
+        // atlasSize and minTileSize must both be powers of two, with
+        // minTileSize in [1, atlasSize]. An invalid combination (zero, not a
+        // power of two, minTileSize > atlasSize) yields a zero-capacity
+        // allocator — every Allocate() call then returns kInvalidNode rather
+        // than asserting, so a caller threading through a user/asset-controlled
+        // resolution stays crash-free.
+        AtlasAllocator(u32 atlasSize, u32 minTileSize);
+
+        // Allocates a square region of exactly `size` (must be a power of two
+        // in [MinTileSize(), AtlasSize()]). Returns kInvalidNode when no
+        // region of that size is currently free (an out-of-range or non-power-
+        // of-two size also fails this way, never asserts).
+        [[nodiscard]] u32 Allocate(u32 size);
+
+        // Releases a previously-allocated node, making its region (and,
+        // transitively, any coarser ancestor whose other children are also
+        // now free) available again. Freeing kInvalidNode or a node that is
+        // not currently allocated is a no-op that returns false — mirrors the
+        // reference allocator's tolerant Free().
+        bool Free(u32 node);
+
+        // Drops every live allocation, returning to the freshly-constructed
+        // state without reallocating the node table.
+        void Reset();
+
+        [[nodiscard]] Region GetRegion(u32 node) const;
+        [[nodiscard]] bool IsAllocated(u32 node) const;
+
+        [[nodiscard]] u32 AtlasSize() const
+        {
+            return m_AtlasSize;
+        }
+        [[nodiscard]] u32 MinTileSize() const
+        {
+            return m_MinTileSize;
+        }
+
+        // Fraction (0..1) of the atlas AREA currently held by live
+        // allocations. 0 for a default-constructed / zero-capacity allocator.
+        [[nodiscard]] f32 Occupancy() const;
+
+        // Count of currently-live (allocated) nodes.
+        [[nodiscard]] u32 LiveAllocationCount() const
+        {
+            return m_LiveCount;
+        }
+
+      private:
+        struct Node
+        {
+            u32 RefCount = 0; // number of allocated descendants (any depth)
+            bool Allocated = false;
+        };
+
+        [[nodiscard]] u32 LevelForSize(u32 size) const;
+        [[nodiscard]] static u32 LevelStart(u32 level);
+        [[nodiscard]] static u32 ParentOf(u32 node);
+        [[nodiscard]] bool CanAllocate(u32 node) const;
+        void MarkAncestors(u32 node, bool increment);
+
+        u32 m_AtlasSize = 0;
+        u32 m_MinTileSize = 0;
+        u32 m_LevelCount = 0; // number of levels; root is level 0
+        std::vector<Node> m_Nodes;
+        std::vector<u8> m_NodeLevel; // level of each node, parallel to m_Nodes
+        u32 m_LiveCount = 0;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.cpp
@@ -2,6 +2,7 @@
 #include "OloEngine/Renderer/Impostor/ImpostorBaker.h"
 #include "OloEngine/Renderer/Impostor/OctahedralImpostor.h"
 
+#include "OloEngine/Memory/AlignmentTemplates.h"
 #include "OloEngine/Renderer/BoundingVolume.h"
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/HeapBindingSeam.h"
@@ -54,6 +55,26 @@ namespace OloEngine
             return s_White;
         }
 
+        // Shared VRAM budget for impostor bakes (issue #718). NOT a spatial
+        // atlas -- Albedo/NormalDepth stay dedicated per-bake textures (a
+        // shared physical atlas would need every runtime card sample in
+        // Foliage_Impostor.glsl to carry a UV scale/offset, which is exactly
+        // the kind of layout change docs/agent-rules/foliage-impostor-card-
+        // rendering.md flags as a repeat offender for "impostors silently go
+        // missing"; deferred rather than risked in this retrofit). This is
+        // the accounting ceiling instead: every bake must reserve a
+        // power-of-two region here before it is allowed to allocate GPU
+        // textures, so N foliage layers can no longer demand N unbounded
+        // full-resolution atlases with nothing to stop them.
+        constexpr u32 kBudgetAtlasSize = 8192;
+        constexpr u32 kBudgetMinTile = 32;
+
+        AtlasAllocator& GetBudgetAllocator()
+        {
+            static AtlasAllocator s_Budget(kBudgetAtlasSize, kBudgetMinTile);
+            return s_Budget;
+        }
+
         Ref<Texture2D> CreateAtlasTexture(u32 size)
         {
             TextureSpecification spec;
@@ -69,6 +90,16 @@ namespace OloEngine
     void ImpostorBaker::Shutdown()
     {
         s_WhiteFallback.Reset();
+        GetBudgetAllocator().Reset();
+    }
+
+    void ImpostorBaker::Free(ImpostorAtlas& atlas)
+    {
+        if (atlas.BudgetNode != AtlasAllocator::kInvalidNode)
+        {
+            GetBudgetAllocator().Free(atlas.BudgetNode);
+            atlas.BudgetNode = AtlasAllocator::kInvalidNode;
+        }
     }
 
     ImpostorAtlas ImpostorBaker::Bake(
@@ -101,6 +132,24 @@ namespace OloEngine
             OLO_CORE_ERROR("ImpostorBaker::Bake: Impostor_Bake shader not available");
             return atlas;
         }
+
+        // Reserve this bake's footprint against the shared VRAM budget (issue
+        // #718) before creating any GPU resources — as late as possible, so a
+        // failure past this point (none currently exist, but future ones
+        // would) can free it via ImpostorBaker::Free rather than leaking it.
+        // Rounds up to the allocator's power-of-two granularity; the actual
+        // textures stay exactly atlasSize (never rounded up), so this can
+        // over-reserve slightly but never under-reserves.
+        const u32 budgetSize = std::min(RoundUpToPowerOfTwo(std::max(atlasSize, kBudgetMinTile)), kBudgetAtlasSize);
+        const u32 budgetNode = GetBudgetAllocator().Allocate(budgetSize);
+        if (budgetNode == AtlasAllocator::kInvalidNode)
+        {
+            OLO_CORE_WARN("ImpostorBaker::Bake: shared impostor VRAM budget exhausted "
+                          "(wanted {}x{}, {:.0f}% already committed) — skipping this bake",
+                          atlasSize, atlasSize, GetBudgetAllocator().Occupancy() * 100.0f);
+            return atlas;
+        }
+        atlas.BudgetNode = budgetNode;
 
         // Frame the WHOLE MeshSource, not just submesh 0: DrawIndexed(vao) below
         // renders the full shared index buffer (every submesh), so framing to the

--- a/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.cpp
@@ -69,6 +69,13 @@ namespace OloEngine
         constexpr u32 kBudgetAtlasSize = 8192;
         constexpr u32 kBudgetMinTile = 32;
 
+        // Single-threaded by design, same as every other renderer-owned static
+        // here (s_WhiteFallback above, the GL context itself): Bake()/Free()/
+        // Shutdown() all touch GPU state and are already only ever called from
+        // the thread that owns the render context. AtlasAllocator itself has
+        // no internal synchronization, so that assumption is load-bearing —
+        // it must stay true for every future caller, not just the current
+        // ones (FoliageRenderer's ctor/dtor and UpdateImpostorAtlas).
         AtlasAllocator& GetBudgetAllocator()
         {
             static AtlasAllocator s_Budget(kBudgetAtlasSize, kBudgetMinTile);
@@ -90,7 +97,23 @@ namespace OloEngine
     void ImpostorBaker::Shutdown()
     {
         s_WhiteFallback.Reset();
-        GetBudgetAllocator().Reset();
+
+        // Deliberately NOT GetBudgetAllocator().Reset(): unlike s_WhiteFallback
+        // (a Ref<Texture2D> — any ImpostorAtlas that still points at the old
+        // texture keeps it alive safely via refcounting, no aliasing possible),
+        // the budget allocator hands out plain node INDICES. Resetting it would
+        // make every node allocatable again while live ImpostorAtlas instances
+        // (e.g. a FoliageRenderer this Shutdown() didn't tear down) still carry
+        // their old BudgetNode values — a later Bake() could then hand out the
+        // same index to a new atlas, and the OLD atlas's eventual Free() would
+        // silently release the NEW atlas's claim instead of its own. The
+        // documented contract is already "call Free() before letting an
+        // ImpostorAtlas go" (issue #718) — asserting it held is louder and
+        // safer than quietly reassigning still-live claims.
+        OLO_CORE_ASSERT(GetBudgetAllocator().LiveAllocationCount() == 0,
+                        "ImpostorBaker::Shutdown: {} impostor VRAM budget claim(s) still live — "
+                        "every ImpostorAtlas must be freed via ImpostorBaker::Free before shutdown",
+                        GetBudgetAllocator().LiveAllocationCount());
     }
 
     void ImpostorBaker::Free(ImpostorAtlas& atlas)

--- a/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.h
+++ b/OloEngine/src/OloEngine/Renderer/Impostor/ImpostorBaker.h
@@ -2,6 +2,7 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/AtlasAllocator.h"
 
 #include <glm/glm.hpp>
 
@@ -24,6 +25,19 @@ namespace OloEngine
         f32 Radius = 1.0f;          // object-space bounding-sphere radius the tiles were framed to
         glm::vec3 Center{ 0.0f };   // object-space bounding-sphere centre
 
+        // Shared atlas-allocator budget claim (issue #718). Every bake must
+        // reserve a square region of a process-wide OloEngine::AtlasAllocator
+        // sized to (a power-of-two rounding of) its own atlas footprint before
+        // ImpostorBaker::Bake proceeds — this is what bounds TOTAL impostor
+        // VRAM across every foliage layer, which nothing did before (any
+        // number of layers could each demand a full 4096x4096 pair with no
+        // shared ceiling). Deliberately NOT spatial packing: Albedo/
+        // NormalDepth stay dedicated per-bake textures rather than sub-rects
+        // of one shared texture — see ImpostorBaker.cpp for why. Opaque to
+        // callers; owner must call ImpostorBaker::Free(atlas) before letting
+        // an ImpostorAtlas go (rebake or teardown) or the budget leaks.
+        u32 BudgetNode = OloEngine::AtlasAllocator::kInvalidNode;
+
         [[nodiscard]] bool IsValid() const
         {
             return Albedo && NormalDepth && FramesPerAxis >= 2u;
@@ -44,7 +58,9 @@ namespace OloEngine
 
         // albedoTexture may be null (bakes tint-only via a white fallback).
         // tint multiplies the sampled albedo. framesPerAxis and atlasResolution
-        // are clamped to sane ranges. Returns an invalid ImpostorAtlas on failure.
+        // are clamped to sane ranges. Returns an invalid ImpostorAtlas when the
+        // mesh/shader are unusable OR the shared VRAM budget (issue #718) has
+        // no room left for this bake's footprint.
         [[nodiscard]] static ImpostorAtlas Bake(
             const Ref<Mesh>& mesh,
             const Ref<Texture2D>& albedoTexture,
@@ -53,5 +69,12 @@ namespace OloEngine
             u32 atlasResolution,
             bool hemi,
             f32 alphaCutoff);
+
+        // Releases atlas's claim on the shared VRAM budget (issue #718) and
+        // clears BudgetNode. Idempotent (safe on an already-freed or
+        // never-baked atlas). Callers must call this before dropping/
+        // overwriting an ImpostorAtlas — a rebake or teardown that skips it
+        // leaks the budget claim, eventually starving every future bake.
+        static void Free(ImpostorAtlas& atlas);
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.cpp
@@ -263,15 +263,27 @@ namespace OloEngine::ShadowAtlas
             // Reuse a held tile set only when identity, type AND size all
             // still match — a rank shift that crosses a tier boundary (a new
             // brighter light pushing this one from large to medium, say)
-            // must free and reallocate at the new size like any other
-            // change. A mismatched-size match is deliberately left in
-            // previousLive (not freed here) — the trailing sweep frees it.
+            // must free and reallocate at the new size like any other change.
             auto prevIt = (candidate.UserData != 0)
                               ? std::ranges::find_if(previousLive, [&](const LiveSlot& s)
                                                      { return s.UserData == candidate.UserData; })
                               : previousLive.end();
             const bool reusable = prevIt != previousLive.end() &&
                                   prevIt->Type == candidate.Type && prevIt->TileSize == tileSize;
+
+            if (prevIt != previousLive.end() && !reusable)
+            {
+                // Identity matched but type/size didn't: this slot can never
+                // be reused by anything else this call (identities are
+                // unique), so free it NOW rather than waiting for the
+                // trailing sweep. Otherwise the caster would briefly hold its
+                // old tile AND attempt to acquire a new one at the same
+                // time, and on a near-full atlas that doubled peak could make
+                // its own reallocation below fail.
+                FreeSlot(*prevIt);
+                previousLive.erase(prevIt);
+                prevIt = previousLive.end();
+            }
 
             std::array<u32, 6> nodes{};
             bool placed = true;

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.cpp
@@ -133,4 +133,206 @@ namespace OloEngine::ShadowAtlas
 
         return result;
     }
+
+    // =========================================================================
+    // PersistentAllocator (issue #718)
+    // =========================================================================
+
+    namespace
+    {
+        // Smallest tile TileSizeForRank can ever hand out: a point caster at
+        // or beyond kMediumTileRanks always gets atlasResolution/kSmallTileDivisor/2
+        // (there is no tier past "small"), regardless of how high the rank
+        // climbs. Sizing the persistent AtlasAllocator's granularity to this
+        // keeps its node table tiny (a few thousand nodes at most) instead of
+        // defaulting to a 1px floor.
+        u32 MinTileSizeFor(u32 atlasResolution)
+        {
+            const u32 minSize = atlasResolution / (kSmallTileDivisor * 2u);
+            return (minSize == 0) ? 1u : minSize;
+        }
+    } // namespace
+
+    PersistentAllocator::PersistentAllocator(u32 atlasResolution)
+    {
+        SetAtlasResolution(atlasResolution);
+    }
+
+    void PersistentAllocator::SetAtlasResolution(u32 atlasResolution)
+    {
+        if (atlasResolution == m_AtlasResolution)
+            return;
+
+        // TileSizeForRank's divisors (4/8/16, halved again for point casters)
+        // already assume a power-of-two atlas; AtlasAllocator degrades that
+        // same assumption to a silent zero-capacity allocator by design (a
+        // generic, asset/user-resolution-safe default — see its header). At
+        // THIS layer the assumption is a known subsystem invariant, not a
+        // caller's problem to discover the hard way as "every shadow this
+        // frame starved, no error" — so make a violation loud instead.
+        if (atlasResolution != 0 && (atlasResolution & (atlasResolution - 1u)) != 0u)
+        {
+            OLO_CORE_ERROR("ShadowAtlas::PersistentAllocator: atlas resolution {} is not a power of two — "
+                           "every shadow candidate will fail to allocate a tile this session",
+                           atlasResolution);
+        }
+
+        m_AtlasResolution = atlasResolution;
+        m_Allocator = OloEngine::AtlasAllocator(atlasResolution, MinTileSizeFor(atlasResolution));
+        m_Live.clear();
+    }
+
+    void PersistentAllocator::FreeSlot(LiveSlot& slot)
+    {
+        for (u32 i = 0; i < slot.EntryCount; ++i)
+            m_Allocator.Free(slot.Nodes[i]);
+    }
+
+    Result PersistentAllocator::Allocate(std::span<const Candidate> candidates, u32 maxEntries, u32 maxLights)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        Result result;
+
+        // Start from last call's held tiles and end holding exactly this
+        // call's accepted set: swapping (rather than mutating m_Live in
+        // place while iterating) means a slot only ever leaves m_Live by
+        // being reused into the NEW m_Live or freed in the trailing sweep —
+        // never both, and never a slot this SAME call just added. That last
+        // case is why this can't be "iterate m_Live, mark kept-by-UserData,
+        // free the rest": a UserData==0 candidate (no cross-frame identity)
+        // would look "not kept" the instant it was inserted and get freed
+        // before Allocate() even returned, letting a later candidate in the
+        // same call double-allocate its just-vacated tile.
+        std::vector<LiveSlot> previousLive;
+        previousLive.swap(m_Live);
+
+        if (m_AtlasResolution == 0 || maxEntries == 0 || maxLights == 0 || candidates.empty())
+        {
+            for (auto& slot : previousLive)
+                FreeSlot(slot);
+            return result;
+        }
+
+        // Free a held tile EAGERLY, before ranking runs, when its caster
+        // isn't even a candidate this call (stopped casting, entity
+        // removed) — the common case, and worth not deferring to the
+        // trailing sweep: a candidate ranked earlier in THIS call could
+        // otherwise be rejected by tight atlas space that a caster gone
+        // this call was still holding. This does NOT close the narrower gap
+        // where a caster IS still a candidate but doesn't make the accepted
+        // set (out-ranked, over budget) — whether that happens is only known
+        // after the ranking loop below runs, so that case still frees on the
+        // trailing sweep and its tile becomes available next call, not this
+        // one. Any persistent allocator that can't see its own future
+        // accept/reject decisions in advance has that same one-call lag.
+        std::erase_if(previousLive, [&](LiveSlot& slot)
+                      {
+                          if (slot.UserData == 0)
+                              return false; // no identity to match against candidates
+                          const bool stillCandidate = std::ranges::any_of(
+                              candidates, [&](const Candidate& c) { return c.UserData == slot.UserData; });
+                          if (stillCandidate)
+                              return false;
+                          FreeSlot(slot);
+                          return true; });
+
+        std::vector<u32> order(candidates.size());
+        std::iota(order.begin(), order.end(), 0u);
+        std::ranges::stable_sort(order, [&](u32 a, u32 b)
+                                 { return candidates[a].Score > candidates[b].Score; });
+
+        u32 entriesUsed = 0;
+
+        for (const u32 candidateIndex : order)
+        {
+            const auto& candidate = candidates[candidateIndex];
+            if (candidate.Score <= 0.0f)
+                break; // sorted: everything after is unscored too
+
+            if (result.Accepted.size() >= maxLights)
+                break;
+
+            const u32 entryCount = (candidate.Type == CasterType::Point) ? 6u : 1u;
+            if (entriesUsed + entryCount > maxEntries)
+                continue; // a cheaper (1-entry) candidate later may still fit
+
+            const u32 rank = static_cast<u32>(result.Accepted.size());
+            const u32 tileSize = TileSizeForRank(rank, m_AtlasResolution, candidate.Type);
+
+            // Reuse a held tile set only when identity, type AND size all
+            // still match — a rank shift that crosses a tier boundary (a new
+            // brighter light pushing this one from large to medium, say)
+            // must free and reallocate at the new size like any other
+            // change. A mismatched-size match is deliberately left in
+            // previousLive (not freed here) — the trailing sweep frees it.
+            auto prevIt = (candidate.UserData != 0)
+                              ? std::ranges::find_if(previousLive, [&](const LiveSlot& s)
+                                                     { return s.UserData == candidate.UserData; })
+                              : previousLive.end();
+            const bool reusable = prevIt != previousLive.end() &&
+                                  prevIt->Type == candidate.Type && prevIt->TileSize == tileSize;
+
+            std::array<u32, 6> nodes{};
+            bool placed = true;
+
+            if (reusable)
+            {
+                nodes = prevIt->Nodes;
+            }
+            else
+            {
+                u32 acquired = 0;
+                for (; acquired < entryCount; ++acquired)
+                {
+                    const u32 node = m_Allocator.Allocate(tileSize);
+                    if (node == OloEngine::AtlasAllocator::kInvalidNode)
+                        break;
+                    nodes[acquired] = node;
+                }
+                if (acquired < entryCount)
+                {
+                    // Never hand out a partial cube — release what we got and
+                    // let a smaller-tiled candidate try instead.
+                    for (u32 i = 0; i < acquired; ++i)
+                        m_Allocator.Free(nodes[i]);
+                    placed = false;
+                }
+            }
+
+            if (!placed)
+                continue;
+
+            Allocation allocation;
+            allocation.CandidateIndex = candidateIndex;
+            allocation.BaseEntry = static_cast<u32>(result.EntryRects.size());
+            allocation.EntryCount = entryCount;
+            result.Accepted.push_back(allocation);
+            for (u32 i = 0; i < entryCount; ++i)
+            {
+                const auto region = m_Allocator.GetRegion(nodes[i]);
+                result.EntryRects.push_back({ region.X, region.Y, region.Size });
+            }
+            entriesUsed += entryCount;
+
+            LiveSlot slot;
+            slot.UserData = candidate.UserData;
+            slot.Type = candidate.Type;
+            slot.TileSize = tileSize;
+            slot.EntryCount = entryCount;
+            slot.Nodes = nodes;
+            m_Live.push_back(slot);
+
+            if (reusable)
+                previousLive.erase(prevIt); // consumed — the trailing sweep must not free it
+        }
+
+        // Whatever is left in previousLive was held last call but not reused
+        // this call (starved, stopped casting, removed, or size/type
+        // changed) — free it back to the allocator.
+        for (auto& slot : previousLive)
+            FreeSlot(slot);
+
+        return result;
+    }
 } // namespace OloEngine::ShadowAtlas

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.h
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/AtlasAllocator.h"
 #include "OloEngine/Renderer/Frustum.h"
 #include "OloEngine/Renderer/ShaderBindingLayout.h"
 
 #include <glm/glm.hpp>
+#include <array>
 #include <span>
 #include <vector>
 
@@ -48,8 +50,12 @@ namespace OloEngine
             CasterType Type = CasterType::Spot;
             f32 Score = 0.0f;
             // Opaque caller payload (Scene uses it to find the light again
-            // when patching shadow indices after allocation).
-            u32 UserData = 0;
+            // when patching shadow indices after allocation). Wide enough to
+            // carry a light entity's UUID unchanged — PersistentAllocator
+            // uses it as the stable identity that lets a caster keep its tile
+            // across frames, so a truncated/aliased id would show up as
+            // unrelated lights spuriously "reusing" each other's tiles.
+            u64 UserData = 0;
         };
 
         // A square tile within the atlas, in pixels.
@@ -122,6 +128,80 @@ namespace OloEngine
                         u32 atlasResolution,
                         u32 maxEntries = UBOStructures::ShadowUBO::MAX_SHADOW_ATLAS_ENTRIES,
                         u32 maxLights = kMaxShadowedLights);
+
+        // Stateful sibling of Allocate() (issue #718): backs the SAME
+        // ranking/tiering rules with a persistent OloEngine::AtlasAllocator
+        // instead of a call-local shelf packer, so a caster that keeps
+        // ranking into the accepted set keeps its EXISTING tile instead of
+        // the whole atlas being repacked from nothing every frame. A caster
+        // is recognised across frames by Candidate::UserData (the caller's
+        // stable identity, e.g. a light entity's UUID) — a candidate whose
+        // UserData is 0 is always treated as new (no cross-frame identity to
+        // match against).
+        //
+        // Preserves Allocate()'s "skip-whole-caster" invariant: if any of a
+        // candidate's required tiles cannot be placed (existing OR fresh),
+        // the whole candidate is skipped and any tiles it did manage to
+        // acquire this attempt are released, exactly as the shelf packer
+        // never hands out a partial cube. A caster no longer present as a
+        // candidate at all (removed, stopped casting) has its held tile(s)
+        // freed EAGERLY, before ranking runs, so a legitimate allocation
+        // ranked ahead of it this same call isn't blocked by space that
+        // caster no longer needs.
+        //
+        // One case still lags a call: a caster that IS a candidate this call
+        // but doesn't make the accepted set (out-ranked, over budget) only
+        // frees on the trailing sweep — whether it would be accepted is only
+        // known after the ranking loop runs, so its tile becomes available
+        // NEXT call, not this one. Under near-capacity atlas conditions this
+        // can reject a candidate this call that a from-scratch repack (the
+        // free function above) would have placed. Given the atlas is sized
+        // with generous headroom relative to the entry/light budgets
+        // specifically so this stays rare, that trade was made deliberately
+        // rather than adding a two-pass "which rejections would free enough
+        // space to accept something else" solver.
+        //
+        // Deliberately NOT a drop-in replacement for the free function above:
+        // Allocate() stays a pure, single-call function (and the packing
+        // surface ShadowAtlasPackingTest exercises) precisely because it has
+        // no persistent state to reuse — this class is what production code
+        // (Scene's per-frame shadow setup, via ShadowMap) calls instead.
+        class PersistentAllocator
+        {
+          public:
+            PersistentAllocator() = default;
+            explicit PersistentAllocator(u32 atlasResolution);
+
+            // Rebuilds from scratch (dropping every held tile) when the
+            // resolution actually changes; a no-op otherwise. Tile
+            // coordinates are meaningless across a resolution change, so
+            // there is nothing worth preserving.
+            void SetAtlasResolution(u32 atlasResolution);
+            [[nodiscard]] u32 GetAtlasResolution() const
+            {
+                return m_AtlasResolution;
+            }
+
+            [[nodiscard]] Result Allocate(std::span<const Candidate> candidates,
+                                          u32 maxEntries = UBOStructures::ShadowUBO::MAX_SHADOW_ATLAS_ENTRIES,
+                                          u32 maxLights = kMaxShadowedLights);
+
+          private:
+            struct LiveSlot
+            {
+                u64 UserData = 0;
+                CasterType Type = CasterType::Spot;
+                u32 TileSize = 0;
+                u32 EntryCount = 0;
+                std::array<u32, 6> Nodes{};
+            };
+
+            void FreeSlot(LiveSlot& slot);
+
+            u32 m_AtlasResolution = 0;
+            OloEngine::AtlasAllocator m_Allocator;
+            std::vector<LiveSlot> m_Live;
+        };
 
         // UV scale/offset of a tile within the atlas — the per-entry value the
         // shader uses to remap light-space UV into the atlas.

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.h
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.h
@@ -147,7 +147,12 @@ namespace OloEngine
         // candidate at all (removed, stopped casting) has its held tile(s)
         // freed EAGERLY, before ranking runs, so a legitimate allocation
         // ranked ahead of it this same call isn't blocked by space that
-        // caster no longer needs.
+        // caster no longer needs. A caster that IS still a candidate but
+        // whose rank crossed a tier boundary (a new brighter light pushing
+        // it from large to medium, say) also frees its old tile eagerly, the
+        // moment the size mismatch is detected — otherwise it would briefly
+        // hold both its old AND new tile at once, and on a near-full atlas
+        // that doubled peak could make its own reallocation fail.
         //
         // One case still lags a call: a caster that IS a candidate this call
         // but doesn't make the accepted set (out-ranked, over budget) only

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowMap.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowMap.cpp
@@ -41,6 +41,11 @@ namespace OloEngine
         atlasSpec.DepthComparisonMode = true;
         m_AtlasTexture = Texture2DArray::Create(atlasSpec);
 
+        // Persistent tile allocator (issue #718): a no-op when the resolution
+        // is unchanged from a prior Init() (e.g. a Resolution-only re-Init via
+        // SetSettings), so previously-held tile assignments survive it.
+        m_AtlasAllocator.SetAtlasResolution(m_Settings.AtlasResolution);
+
         // Comparison-OFF raw-depth views aliasing the CSM / atlas textures,
         // used by the PCSS blocker search (the hardware comparison sampler
         // can't read raw occluder depth). These alias the same immutable

--- a/OloEngine/src/OloEngine/Renderer/Shadow/ShadowMap.h
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/ShadowMap.h
@@ -13,6 +13,7 @@
 #include <glm/glm.hpp>
 #include <algorithm>
 #include <array>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -138,6 +139,23 @@ namespace OloEngine
         [[nodiscard]] const std::vector<AtlasCasterRecord>& GetAtlasLayout() const
         {
             return m_AtlasLayout;
+        }
+
+        // Rank + pack this frame's shadow candidates into the atlas (issue
+        // #718). Thin forwarder to a PersistentAllocator owned here (rebuilt
+        // by Init()/SetSettings() whenever AtlasResolution changes) instead
+        // of the pure ShadowAtlas::Allocate() free function, so a caster that
+        // keeps ranking into the accepted set keeps its EXISTING tile across
+        // frames rather than the whole atlas being repacked from nothing
+        // every call. See ShadowAtlas::PersistentAllocator for the reuse/free
+        // rules; candidates should set UserData to a stable per-light
+        // identity (e.g. the owning entity's UUID) to benefit from reuse.
+        [[nodiscard]] ShadowAtlas::Result AllocateAtlasTiles(
+            std::span<const ShadowAtlas::Candidate> candidates,
+            u32 maxEntries = MAX_SHADOW_ATLAS_ENTRIES,
+            u32 maxLights = ShadowAtlas::kMaxShadowedLights)
+        {
+            return m_AtlasAllocator.Allocate(candidates, maxEntries, maxLights);
         }
 
         // Store one atlas entry (world-space light VP + pixel tile rect).
@@ -403,6 +421,13 @@ namespace OloEngine
         // Diagnostics-only candidate list for the current frame (see
         // AtlasCasterRecord). Never read by the render path.
         std::vector<AtlasCasterRecord> m_AtlasLayout;
+
+        // Persistent tile allocator (issue #718) backing AllocateAtlasTiles().
+        // Rebuilt (dropping every held tile) by Init() whenever AtlasResolution
+        // changes; survives a Resolution-only re-Init untouched, since the
+        // atlas itself did not resize. NOT reset by BeginFrame() — its whole
+        // purpose is to persist tile assignments frame-to-frame.
+        ShadowAtlas::PersistentAllocator m_AtlasAllocator;
 
         // Directional VSM (issue #702). Holds no GPU resources while disabled.
         VirtualShadowMap m_VirtualShadowMap;

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -7254,10 +7254,20 @@ namespace OloEngine
                     entry.Score = ShadowAtlas::ComputeScore(
                         candidate.Position, candidate.Range, candidate.Intensity,
                         cameraPosition, cameraFrustum);
+                    // Stable per-light identity (issue #718): lets the
+                    // persistent allocator recognise this caster across
+                    // frames and keep its existing tile instead of a fresh
+                    // repack. 0 (unknown UUID) just means "always reallocate".
+                    entry.UserData = candidate.LightEntity;
                     scored.push_back(entry);
                 }
 
-                const auto allocation = ShadowAtlas::Allocate(scored, shadowMap.GetAtlasResolution());
+                // Persistent allocation (issue #718): a caster that keeps
+                // ranking into the accepted set keeps its EXISTING tile
+                // across frames instead of the whole atlas being repacked
+                // from nothing every call — see ShadowMap::AllocateAtlasTiles
+                // / ShadowAtlas::PersistentAllocator.
+                const auto allocation = shadowMap.AllocateAtlasTiles(scored);
 
                 // Diagnostics record of the FULL candidate list — winners and
                 // starved losers alike (issue #607, olo_shadow_atlas_layout).

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
@@ -40,6 +40,12 @@ namespace OloEngine
         return static_cast<f32>(h & 0xFFFF) / 65536.0f;
     }
 
+    FoliageRenderer::~FoliageRenderer()
+    {
+        for (auto& layer : m_Layers)
+            ImpostorBaker::Free(layer.Impostor);
+    }
+
     void FoliageRenderer::BuildQuadGeometry(LayerRenderData& data) const
     {
         // Billboard quad: 4 vertices, centered at bottom
@@ -142,6 +148,12 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        // A shrinking layer list drops the trailing LayerRenderData entries
+        // below — free their impostor VRAM budget claims first, or resize()
+        // destroying them silently leaks the claims for the rest of the
+        // process (issue #718; ImpostorAtlas has no destructor of its own).
+        for (sizet i = layers.size(); i < m_Layers.size(); ++i)
+            ImpostorBaker::Free(m_Layers[i].Impostor);
         m_Layers.resize(layers.size());
 
         for (sizet layerIdx = 0; layerIdx < layers.size(); ++layerIdx)
@@ -444,7 +456,9 @@ namespace OloEngine
 
         if (!layer.UseImpostor || layer.MeshPath.empty())
         {
-            // Impostor turned off (or no mesh) — drop any stale atlas.
+            // Impostor turned off (or no mesh) — drop any stale atlas. Free
+            // its VRAM budget claim (issue #718) before discarding it.
+            ImpostorBaker::Free(data.Impostor);
             data.Impostor = ImpostorAtlas{};
             data.ImpostorBakedMeshPath.clear();
             data.ImpostorBakedFrames = 0;
@@ -465,12 +479,17 @@ namespace OloEngine
         {
             OLO_CORE_WARN("FoliageRenderer: impostor layer '{}' mesh '{}' failed to load — impostor disabled for this layer",
                           layer.Name, layer.MeshPath);
+            ImpostorBaker::Free(data.Impostor);
             data.Impostor = ImpostorAtlas{};
             return;
         }
 
         // Bake with the layer albedo (if any) applied to the mesh UVs, tinted by
         // BaseColor. A mesh with its own material texture is a natural follow-up.
+        // Free the OUTGOING atlas's budget claim first — Bake() below reserves
+        // a fresh one, and freeing after would either double-count briefly or,
+        // worse, free the NEW claim if the assignment races the wrong way.
+        ImpostorBaker::Free(data.Impostor);
         const Ref<Mesh> mesh = model.GetMesh(0);
         const Ref<Texture2D> albedo = data.AlbedoTexture; // may be null -> white fallback
         data.Impostor = ImpostorBaker::Bake(

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
@@ -66,6 +66,16 @@ namespace OloEngine
         // it, or a scene-reload cycle permanently starves the shared budget.
         ~FoliageRenderer();
 
+        // The destructor above owns every layer's budget claim, so copying
+        // would duplicate BudgetNode and double-free (or silently steal) it —
+        // make that impossible rather than relying on nobody ever copying a
+        // FoliageRenderer by value (it's already managed via Ref<T>, so
+        // nothing legitimate needs these).
+        FoliageRenderer(const FoliageRenderer&) = delete;
+        FoliageRenderer& operator=(const FoliageRenderer&) = delete;
+        FoliageRenderer(FoliageRenderer&&) = delete;
+        FoliageRenderer& operator=(FoliageRenderer&&) = delete;
+
         // Regenerate all instances for the given layers from terrain data.
         // Call when terrain changes (erosion, sculpting) or layer settings change.
         void GenerateInstances(

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
@@ -58,6 +58,13 @@ namespace OloEngine
     {
       public:
         FoliageRenderer() = default;
+        // Releases every live layer's impostor VRAM budget claim (issue
+        // #718) — ImpostorAtlas has no destructor of its own (its BudgetNode
+        // is a plain accounting handle, not a GPU resource, so giving it RAII
+        // would mean hand-rolling move semantics just to avoid a double-free
+        // on every copy); this is the one place that must not skip freeing
+        // it, or a scene-reload cycle permanently starves the shared budget.
+        ~FoliageRenderer();
 
         // Regenerate all instances for the given layers from terrain data.
         // Call when terrain changes (erosion, sculpting) or layer settings change.

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -179,6 +179,7 @@ add_executable(OloEngine-Tests
 		Rendering/BloomMathTest.cpp
 		Rendering/FogMathTest.cpp
 		Rendering/ClusteredLightingMathTest.cpp
+		Rendering/AtlasAllocatorTest.cpp
 		Rendering/ShadowAtlasPackingTest.cpp
 		Rendering/VolumetricFogMathTest.cpp
 		Rendering/VolumetricShadowMapMathTest.cpp

--- a/OloEngine/tests/Rendering/AtlasAllocatorTest.cpp
+++ b/OloEngine/tests/Rendering/AtlasAllocatorTest.cpp
@@ -1,0 +1,273 @@
+// OLO_TEST_LAYER: L1
+//
+// Pure-math contracts for the shared power-of-two atlas allocator (issue
+// #718): allocate / free / coalesce / occupancy, plus a randomised
+// allocate-free fuzz sequence asserting the core invariants (no overlapping
+// live regions, occupancy matches the live set, every fully-freed subtree
+// coalesces back into its parent). Deterministic CPU math — no GL context.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Renderer/AtlasAllocator.h"
+
+#include <random>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
+
+namespace
+{
+    bool RegionsOverlap(const AtlasAllocator::Region& a, const AtlasAllocator::Region& b)
+    {
+        return a.X < b.X + b.Size && b.X < a.X + a.Size &&
+               a.Y < b.Y + b.Size && b.Y < a.Y + a.Size;
+    }
+} // namespace
+
+TEST(AtlasAllocator, DefaultConstructedIsZeroCapacity)
+{
+    AtlasAllocator allocator;
+    EXPECT_EQ(allocator.AtlasSize(), 0u);
+    EXPECT_EQ(allocator.Allocate(1), AtlasAllocator::kInvalidNode);
+    EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
+}
+
+TEST(AtlasAllocator, InvalidConstructionArgsYieldZeroCapacity)
+{
+    // Non-power-of-two atlas, non-power-of-two tile, min > atlas, zero atlas —
+    // none of these should assert or crash, just refuse to allocate.
+    EXPECT_EQ(AtlasAllocator(1000, 32).Allocate(32), AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(AtlasAllocator(1024, 100).Allocate(100), AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(AtlasAllocator(64, 128).Allocate(64), AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(AtlasAllocator(0, 1).Allocate(1), AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, AllocateWholeAtlasOnce)
+{
+    AtlasAllocator allocator(1024, 32);
+    const u32 node = allocator.Allocate(1024);
+    ASSERT_NE(node, AtlasAllocator::kInvalidNode);
+
+    const auto region = allocator.GetRegion(node);
+    EXPECT_EQ(region.X, 0u);
+    EXPECT_EQ(region.Y, 0u);
+    EXPECT_EQ(region.Size, 1024u);
+
+    // The atlas is now fully committed — nothing else fits, at any size.
+    EXPECT_EQ(allocator.Allocate(1024), AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(allocator.Allocate(32), AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, FourQuadrantsExactlyFillTheAtlas)
+{
+    AtlasAllocator allocator(1024, 32);
+    std::vector<AtlasAllocator::Region> regions;
+    for (int i = 0; i < 4; ++i)
+    {
+        const u32 node = allocator.Allocate(512);
+        ASSERT_NE(node, AtlasAllocator::kInvalidNode);
+        regions.push_back(allocator.GetRegion(node));
+    }
+
+    // A 5th 512-sized request must fail: the atlas is exactly full.
+    EXPECT_EQ(allocator.Allocate(512), AtlasAllocator::kInvalidNode);
+
+    for (sizet a = 0; a < regions.size(); ++a)
+    {
+        EXPECT_EQ(regions[a].Size, 512u);
+        EXPECT_LE(regions[a].X + regions[a].Size, 1024u);
+        EXPECT_LE(regions[a].Y + regions[a].Size, 1024u);
+        for (sizet b = a + 1; b < regions.size(); ++b)
+            EXPECT_FALSE(RegionsOverlap(regions[a], regions[b])) << "quadrants " << a << " and " << b << " overlap";
+    }
+}
+
+TEST(AtlasAllocator, CoalescesOnlyOnceEveryChildIsFreed)
+{
+    AtlasAllocator allocator(1024, 32);
+
+    std::vector<u32> quadrants;
+    for (int i = 0; i < 4; ++i)
+    {
+        const u32 node = allocator.Allocate(512);
+        ASSERT_NE(node, AtlasAllocator::kInvalidNode);
+        quadrants.push_back(node);
+    }
+
+    // Root-sized allocation cannot succeed while any quadrant is live.
+    EXPECT_EQ(allocator.Allocate(1024), AtlasAllocator::kInvalidNode);
+
+    // Freeing 3 of the 4 still leaves the root covered by the 4th.
+    for (int i = 0; i < 3; ++i)
+        EXPECT_TRUE(allocator.Free(quadrants[i]));
+    EXPECT_EQ(allocator.Allocate(1024), AtlasAllocator::kInvalidNode);
+
+    // Freeing the last quadrant coalesces the whole atlas back together.
+    EXPECT_TRUE(allocator.Free(quadrants[3]));
+    const u32 whole = allocator.Allocate(1024);
+    EXPECT_NE(whole, AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, FreeIsIdempotentAndTolerant)
+{
+    AtlasAllocator allocator(256, 32);
+    const u32 node = allocator.Allocate(64);
+    ASSERT_NE(node, AtlasAllocator::kInvalidNode);
+
+    EXPECT_TRUE(allocator.Free(node));
+    EXPECT_FALSE(allocator.Free(node)); // already free
+    EXPECT_FALSE(allocator.Free(AtlasAllocator::kInvalidNode));
+    EXPECT_FALSE(allocator.Free(999999));
+}
+
+TEST(AtlasAllocator, OutOfRangeAndNonPowerOfTwoSizesFail)
+{
+    AtlasAllocator allocator(1024, 32);
+    EXPECT_EQ(allocator.Allocate(16), AtlasAllocator::kInvalidNode);   // below MinTileSize
+    EXPECT_EQ(allocator.Allocate(2048), AtlasAllocator::kInvalidNode); // above AtlasSize
+    EXPECT_EQ(allocator.Allocate(100), AtlasAllocator::kInvalidNode);  // not a power of two
+    EXPECT_EQ(allocator.Allocate(0), AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, OccupancyTracksLiveArea)
+{
+    AtlasAllocator allocator(1024, 32);
+    EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
+
+    const u32 a = allocator.Allocate(512);
+    ASSERT_NE(a, AtlasAllocator::kInvalidNode);
+    EXPECT_NEAR(allocator.Occupancy(), 0.25f, 1e-6f); // 512^2 / 1024^2
+
+    const u32 b = allocator.Allocate(256);
+    ASSERT_NE(b, AtlasAllocator::kInvalidNode);
+    EXPECT_NEAR(allocator.Occupancy(), 0.25f + 1.0f / 16.0f, 1e-6f);
+
+    EXPECT_TRUE(allocator.Free(a));
+    EXPECT_NEAR(allocator.Occupancy(), 1.0f / 16.0f, 1e-6f);
+
+    EXPECT_TRUE(allocator.Free(b));
+    EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
+}
+
+TEST(AtlasAllocator, LiveAllocationCountTracksAllocateAndFree)
+{
+    AtlasAllocator allocator(1024, 32);
+    EXPECT_EQ(allocator.LiveAllocationCount(), 0u);
+    const u32 a = allocator.Allocate(128);
+    const u32 b = allocator.Allocate(128);
+    ASSERT_NE(a, AtlasAllocator::kInvalidNode);
+    ASSERT_NE(b, AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(allocator.LiveAllocationCount(), 2u);
+    allocator.Free(a);
+    EXPECT_EQ(allocator.LiveAllocationCount(), 1u);
+    allocator.Free(b);
+    EXPECT_EQ(allocator.LiveAllocationCount(), 0u);
+}
+
+TEST(AtlasAllocator, ResetDropsEveryLiveAllocation)
+{
+    AtlasAllocator allocator(1024, 32);
+    std::ignore = allocator.Allocate(512);
+    std::ignore = allocator.Allocate(256);
+    ASSERT_GT(allocator.LiveAllocationCount(), 0u);
+
+    allocator.Reset();
+    EXPECT_EQ(allocator.LiveAllocationCount(), 0u);
+    EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
+    // Full capacity is available again post-reset.
+    EXPECT_NE(allocator.Allocate(1024), AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, MixedSizesNeverOverlapAndStayInBounds)
+{
+    AtlasAllocator allocator(2048, 32);
+    const std::array<u32, 4> sizes = { 1024u, 512u, 256u, 128u };
+
+    std::vector<AtlasAllocator::Region> regions;
+    for (u32 size : sizes)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            const u32 node = allocator.Allocate(size);
+            if (node != AtlasAllocator::kInvalidNode)
+                regions.push_back(allocator.GetRegion(node));
+        }
+    }
+
+    ASSERT_FALSE(regions.empty());
+    for (sizet a = 0; a < regions.size(); ++a)
+    {
+        EXPECT_LE(regions[a].X + regions[a].Size, 2048u);
+        EXPECT_LE(regions[a].Y + regions[a].Size, 2048u);
+        for (sizet b = a + 1; b < regions.size(); ++b)
+            EXPECT_FALSE(RegionsOverlap(regions[a], regions[b])) << "regions " << a << " and " << b << " overlap";
+    }
+}
+
+// Randomised allocate/free sequence. A hand-picked scenario can pass on a
+// buddy-merge bug that only shows up once refcounts have been pushed up and
+// down enough times to drift — this drives that arithmetic hundreds of times
+// with a fixed seed (deterministic, reproducible on failure).
+TEST(AtlasAllocator, FuzzedAllocateFreeSequenceHoldsInvariants)
+{
+    constexpr u32 kAtlasSize = 4096;
+    constexpr u32 kMinTile = 32;
+    AtlasAllocator allocator(kAtlasSize, kMinTile);
+
+    const std::array<u32, 5> sizes = { 2048u, 1024u, 512u, 256u, 128u };
+
+    std::mt19937 rng(0xA71A5u); // fixed seed — reproducible on failure
+    std::uniform_int_distribution<int> sizeDist(0, static_cast<int>(sizes.size()) - 1);
+    std::uniform_real_distribution<float> actionDist(0.0f, 1.0f);
+
+    std::unordered_map<u32, AtlasAllocator::Region> live;
+
+    for (int step = 0; step < 2000; ++step)
+    {
+        const bool wantAllocate = live.empty() || actionDist(rng) < 0.6f;
+        if (wantAllocate)
+        {
+            const u32 size = sizes[static_cast<sizet>(sizeDist(rng))];
+            const u32 node = allocator.Allocate(size);
+            if (node == AtlasAllocator::kInvalidNode)
+                continue; // atlas full at this size — not a failure
+
+            const auto region = allocator.GetRegion(node);
+            ASSERT_EQ(region.Size, size);
+            ASSERT_LE(region.X + region.Size, kAtlasSize);
+            ASSERT_LE(region.Y + region.Size, kAtlasSize);
+            for (const auto& [otherNode, otherRegion] : live)
+            {
+                ASSERT_FALSE(RegionsOverlap(region, otherRegion))
+                    << "node " << node << " overlaps live node " << otherNode;
+            }
+            live.emplace(node, region);
+        }
+        else
+        {
+            auto it = std::next(live.begin(), std::uniform_int_distribution<sizet>(0, live.size() - 1)(rng));
+            EXPECT_TRUE(allocator.Free(it->first));
+            live.erase(it);
+        }
+
+        EXPECT_EQ(allocator.LiveAllocationCount(), static_cast<u32>(live.size()));
+
+        u64 liveArea = 0;
+        for (const auto& [node, region] : live)
+            liveArea += static_cast<u64>(region.Size) * static_cast<u64>(region.Size);
+        const f32 expectedOccupancy =
+            static_cast<f32>(static_cast<f64>(liveArea) / (static_cast<f64>(kAtlasSize) * static_cast<f64>(kAtlasSize)));
+        EXPECT_NEAR(allocator.Occupancy(), expectedOccupancy, 1e-5f);
+    }
+
+    // Freeing everything must return the allocator to a clean, fully-coalesced
+    // state — the whole atlas is allocatable as one region again.
+    for (const auto& [node, region] : live)
+        allocator.Free(node);
+    EXPECT_EQ(allocator.LiveAllocationCount(), 0u);
+    EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
+    EXPECT_NE(allocator.Allocate(kAtlasSize), AtlasAllocator::kInvalidNode);
+}

--- a/OloEngine/tests/Rendering/AtlasAllocatorTest.cpp
+++ b/OloEngine/tests/Rendering/AtlasAllocatorTest.cpp
@@ -11,6 +11,7 @@
 
 #include "OloEngine/Renderer/AtlasAllocator.h"
 
+#include <array>
 #include <random>
 #include <tuple>
 #include <unordered_map>
@@ -43,6 +44,28 @@ TEST(AtlasAllocator, InvalidConstructionArgsYieldZeroCapacity)
     EXPECT_EQ(AtlasAllocator(1024, 100).Allocate(100), AtlasAllocator::kInvalidNode);
     EXPECT_EQ(AtlasAllocator(64, 128).Allocate(64), AtlasAllocator::kInvalidNode);
     EXPECT_EQ(AtlasAllocator(0, 1).Allocate(1), AtlasAllocator::kInvalidNode);
+}
+
+TEST(AtlasAllocator, RatioPastTheLevelCeilingYieldsZeroCapacityNotUB)
+{
+    // A ratio requiring more than kMaxLevelCount levels must degrade to
+    // zero-capacity rather than allocate an unreasonable node table or hit
+    // undefined behaviour in LevelStart's shift (UB starts at level 16; this
+    // ratio alone would already ask for level 21).
+    AtlasAllocator huge(1u << 30, 1);
+    EXPECT_EQ(huge.AtlasSize(), 0u) << "over-ceiling ratio should be rejected, not silently accepted";
+    EXPECT_EQ(huge.Allocate(1), AtlasAllocator::kInvalidNode);
+    EXPECT_EQ(huge.Allocate(1u << 30), AtlasAllocator::kInvalidNode);
+
+    // Right at the boundary: exactly kMaxLevelCount levels must still work.
+    const u32 boundaryAtlas = 1u << (AtlasAllocator::kMaxLevelCount - 1u);
+    AtlasAllocator atBoundary(boundaryAtlas, 1);
+    EXPECT_EQ(atBoundary.AtlasSize(), boundaryAtlas);
+    EXPECT_NE(atBoundary.Allocate(boundaryAtlas), AtlasAllocator::kInvalidNode);
+
+    // One level past the boundary must be rejected.
+    const AtlasAllocator pastBoundary(boundaryAtlas * 2u, 1);
+    EXPECT_EQ(pastBoundary.AtlasSize(), 0u);
 }
 
 TEST(AtlasAllocator, AllocateWholeAtlasOnce)
@@ -270,4 +293,55 @@ TEST(AtlasAllocator, FuzzedAllocateFreeSequenceHoldsInvariants)
     EXPECT_EQ(allocator.LiveAllocationCount(), 0u);
     EXPECT_FLOAT_EQ(allocator.Occupancy(), 0.0f);
     EXPECT_NE(allocator.Allocate(kAtlasSize), AtlasAllocator::kInvalidNode);
+}
+
+// A caller that needs several tiles as one atomic unit (ShadowAtlas::
+// PersistentAllocator's point-caster "6 faces or none" guarantee) acquires
+// them one at a time and frees whatever it got the moment one fails. This
+// directly validates the allocate/free pattern that reliance is built on: a
+// partial multi-tile acquisition, once fully rolled back, must leave the
+// allocator indistinguishable from having never attempted it.
+TEST(AtlasAllocator, PartialMultiTileAcquisitionRollsBackCleanly)
+{
+    // 64/8 = 8 per axis -> exactly 64 possible 8x8 slots, tiling the atlas
+    // exactly (64 slots * 64 area each = 4096 = atlas area).
+    AtlasAllocator allocator(64, 8);
+
+    std::vector<u32> preFilled;
+    for (int i = 0; i < 59; ++i)
+    {
+        const u32 node = allocator.Allocate(8);
+        ASSERT_NE(node, AtlasAllocator::kInvalidNode);
+        preFilled.push_back(node);
+    }
+    ASSERT_EQ(allocator.LiveAllocationCount(), 59u);
+
+    // Only 5 of the 64 slots remain — attempting 6 (mirrors a point caster's
+    // 6 cube faces) must fail partway through.
+    std::array<u32, 6> attempt{};
+    u32 acquired = 0;
+    for (; acquired < 6; ++acquired)
+    {
+        const u32 node = allocator.Allocate(8);
+        if (node == AtlasAllocator::kInvalidNode)
+            break;
+        attempt[acquired] = node;
+    }
+    ASSERT_EQ(acquired, 5u) << "test setup didn't leave exactly 5 free slots — tighten preFilled count";
+    EXPECT_EQ(allocator.LiveAllocationCount(), 59u + acquired);
+
+    // Roll back exactly like PersistentAllocator does on a failed attempt.
+    for (u32 i = 0; i < acquired; ++i)
+        EXPECT_TRUE(allocator.Free(attempt[i]));
+
+    // State must be indistinguishable from immediately before the attempt.
+    EXPECT_EQ(allocator.LiveAllocationCount(), 59u);
+    EXPECT_NEAR(allocator.Occupancy(), (59.0 * 64.0) / (64.0 * 64.0), 1e-9);
+
+    // The 5 slots that were genuinely free before the failed attempt must
+    // still be free now — not consumed, not lost.
+    for (int i = 0; i < 5; ++i)
+        EXPECT_NE(allocator.Allocate(8), AtlasAllocator::kInvalidNode)
+            << "slot " << i << " should still have been free after the rollback";
+    EXPECT_EQ(allocator.Allocate(8), AtlasAllocator::kInvalidNode) << "atlas should now be genuinely full";
 }

--- a/OloEngine/tests/Rendering/PropertyTests/ImpostorBakeEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/ImpostorBakeEvidenceTest.cpp
@@ -112,6 +112,19 @@ namespace OloEngine::Tests
             cone, /*albedoTexture=*/nullptr, glm::vec3(0.25f, 0.55f, 0.15f),
             N, kAtlasRes, /*hemi=*/true, /*alphaCutoff=*/0.5f);
 
+        // Release the bake's claim on the shared impostor VRAM budget (issue
+        // #718) on every exit path, including an ASSERT_* return below —
+        // Bake() reserves it unconditionally on success, and this test never
+        // hands the atlas to a FoliageRenderer, so nothing else would.
+        struct BudgetGuard
+        {
+            ImpostorAtlas& Atlas;
+            ~BudgetGuard()
+            {
+                ImpostorBaker::Free(Atlas);
+            }
+        } budgetGuard{ atlas };
+
         ASSERT_TRUE(atlas.IsValid()) << "impostor bake produced an invalid atlas";
         EXPECT_EQ(atlas.FramesPerAxis, N);
         EXPECT_GT(atlas.Radius, 0.0f);

--- a/OloEngine/tests/Rendering/ShadowAtlasPackingTest.cpp
+++ b/OloEngine/tests/Rendering/ShadowAtlasPackingTest.cpp
@@ -437,6 +437,20 @@ TEST(ShadowAtlasPersistentAllocator, PreservesSkipWholeCasterAcrossCalls)
     ASSERT_EQ(result.Accepted.size(), 2u);
     EXPECT_EQ(result.Accepted[0].EntryCount, 6u); // point light: 6 contiguous entries, never partial
     EXPECT_EQ(result.Accepted[1].EntryCount, 1u);
+
+    // Same candidates again: the point caster must keep its whole cube (never
+    // a partial one) AND land on the exact same 6 tiles via reuse.
+    const auto second = allocator.Allocate(candidates);
+    ASSERT_EQ(second.Accepted.size(), 2u);
+    EXPECT_EQ(second.Accepted[0].EntryCount, 6u);
+    EXPECT_EQ(second.Accepted[1].EntryCount, 1u);
+    for (u32 face = 0; face < 6; ++face)
+    {
+        EXPECT_EQ(result.EntryRects[result.Accepted[0].BaseEntry + face].X,
+                  second.EntryRects[second.Accepted[0].BaseEntry + face].X);
+        EXPECT_EQ(result.EntryRects[result.Accepted[0].BaseEntry + face].Y,
+                  second.EntryRects[second.Accepted[0].BaseEntry + face].Y);
+    }
 }
 
 TEST(ShadowAtlasPersistentAllocator, TilesNeverOverlapAcrossRepeatedChangingCalls)

--- a/OloEngine/tests/Rendering/ShadowAtlasPackingTest.cpp
+++ b/OloEngine/tests/Rendering/ShadowAtlasPackingTest.cpp
@@ -15,6 +15,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <random>
 #include <set>
 
 using namespace OloEngine; // NOLINT(google-build-using-namespace) — test file, brevity preferred
@@ -339,4 +340,157 @@ TEST(ShadowAtlasPacking, EmptyAndDegenerateInputs)
     std::vector<ShadowAtlas::Candidate> one = { MakeCandidate(ShadowAtlas::CasterType::Spot, 1.0f) };
     const auto zeroAtlas = ShadowAtlas::Allocate(one, 0);
     EXPECT_TRUE(zeroAtlas.Accepted.empty());
+}
+
+// =============================================================================
+// PersistentAllocator (issue #718) — the stateful sibling backed by the
+// shared OloEngine::AtlasAllocator. Same ranking/tiering/skip-whole-caster
+// rules as the free function above; what's new here is cross-call behaviour.
+// =============================================================================
+
+namespace
+{
+    ShadowAtlas::Candidate MakeIdentifiedCandidate(ShadowAtlas::CasterType type, f32 score, u64 userData)
+    {
+        ShadowAtlas::Candidate c = MakeCandidate(type, score);
+        c.UserData = userData;
+        return c;
+    }
+} // namespace
+
+TEST(ShadowAtlasPersistentAllocator, ReusesTheSameTileAcrossCallsForTheSameIdentity)
+{
+    ShadowAtlas::PersistentAllocator allocator(1024);
+    std::vector<ShadowAtlas::Candidate> candidates = {
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 42),
+    };
+
+    const auto first = allocator.Allocate(candidates);
+    ASSERT_EQ(first.Accepted.size(), 1u);
+    const auto firstRect = first.EntryRects[first.Accepted[0].BaseEntry];
+
+    // Same candidate, same score, called again — must land on the SAME tile
+    // rather than a freshly repacked one.
+    const auto second = allocator.Allocate(candidates);
+    ASSERT_EQ(second.Accepted.size(), 1u);
+    const auto secondRect = second.EntryRects[second.Accepted[0].BaseEntry];
+
+    EXPECT_EQ(firstRect.X, secondRect.X);
+    EXPECT_EQ(firstRect.Y, secondRect.Y);
+    EXPECT_EQ(firstRect.Size, secondRect.Size);
+}
+
+TEST(ShadowAtlasPersistentAllocator, RankShiftAcrossATierBoundaryReallocatesAtTheNewSize)
+{
+    ShadowAtlas::PersistentAllocator allocator(4096);
+
+    // Alone, this candidate ranks 0 (large tier, 1024px).
+    const auto solo = allocator.Allocate(std::vector<ShadowAtlas::Candidate>{
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 7) });
+    ASSERT_EQ(solo.Accepted.size(), 1u);
+    EXPECT_EQ(solo.EntryRects[0].Size, 1024u);
+
+    // Six brighter newcomers push it to rank 6 (small tier, 256px) — the
+    // reuse check (identity match, size mismatch) must free the old tile and
+    // reallocate rather than keep serving a stale 1024px rect.
+    std::vector<ShadowAtlas::Candidate> crowded;
+    for (int i = 0; i < 6; ++i)
+        crowded.push_back(MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 20.0f - static_cast<f32>(i), 100u + i));
+    crowded.push_back(MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 7));
+
+    const auto result = allocator.Allocate(crowded);
+    ASSERT_EQ(result.Accepted.size(), 7u);
+    const auto& last = result.Accepted.back();
+    EXPECT_EQ(last.CandidateIndex, 6u); // candidate 7 (UserData=7) is last by score
+    EXPECT_EQ(result.EntryRects[last.BaseEntry].Size, 256u);
+}
+
+TEST(ShadowAtlasPersistentAllocator, DroppedCandidateTileIsReclaimedNotLeaked)
+{
+    // A tiny 64px atlas: a lone (rank-0) spot always lands in the "large"
+    // tier == atlas/4 == 16px, so the atlas holds at most 16 of them
+    // concurrently (4096px^2 / 256px^2). Churning through 40 single-candidate
+    // calls, each a brand-new identity that is NEVER reused, only succeeds
+    // throughout if every previous call's tile was actually freed rather than
+    // silently leaked.
+    ShadowAtlas::PersistentAllocator allocator(64);
+
+    for (u64 id = 1; id <= 40; ++id)
+    {
+        const auto result = allocator.Allocate(std::vector<ShadowAtlas::Candidate>{
+            MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, id) });
+        ASSERT_EQ(result.Accepted.size(), 1u) << "candidate " << id << " starved — a prior tile was leaked, not reclaimed";
+        EXPECT_EQ(result.EntryRects[0].Size, 16u);
+    }
+}
+
+TEST(ShadowAtlasPersistentAllocator, PreservesSkipWholeCasterAcrossCalls)
+{
+    ShadowAtlas::PersistentAllocator allocator(4096);
+
+    std::vector<ShadowAtlas::Candidate> candidates = {
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Point, 2.0f, 1),
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 1.0f, 2),
+    };
+
+    const auto result = allocator.Allocate(candidates);
+    ASSERT_EQ(result.Accepted.size(), 2u);
+    EXPECT_EQ(result.Accepted[0].EntryCount, 6u); // point light: 6 contiguous entries, never partial
+    EXPECT_EQ(result.Accepted[1].EntryCount, 1u);
+}
+
+TEST(ShadowAtlasPersistentAllocator, TilesNeverOverlapAcrossRepeatedChangingCalls)
+{
+    ShadowAtlas::PersistentAllocator allocator(2048);
+    std::mt19937 rng(0x51DEu);
+    std::uniform_real_distribution<float> scoreDist(0.1f, 10.0f);
+
+    for (int call = 0; call < 20; ++call)
+    {
+        std::vector<ShadowAtlas::Candidate> candidates;
+        for (int i = 0; i < 10; ++i)
+        {
+            // Half carry a stable identity (eligible for reuse), half don't —
+            // exercises both paths every call.
+            const u64 userData = (i % 2 == 0) ? static_cast<u64>(1000 + i) : 0u;
+            const auto type = (i % 3 == 0) ? ShadowAtlas::CasterType::Point : ShadowAtlas::CasterType::Spot;
+            candidates.push_back(MakeIdentifiedCandidate(type, scoreDist(rng), userData));
+        }
+
+        const auto result = allocator.Allocate(candidates);
+        for (sizet a = 0; a < result.EntryRects.size(); ++a)
+        {
+            const auto& rect = result.EntryRects[a];
+            EXPECT_LE(rect.X + rect.Size, 2048u);
+            EXPECT_LE(rect.Y + rect.Size, 2048u);
+            for (sizet b = a + 1; b < result.EntryRects.size(); ++b)
+                EXPECT_FALSE(RectsOverlap(rect, result.EntryRects[b]))
+                    << "call " << call << ": entries " << a << " and " << b << " overlap";
+        }
+    }
+}
+
+TEST(ShadowAtlasPersistentAllocator, ChangingAtlasResolutionResetsHeldTiles)
+{
+    ShadowAtlas::PersistentAllocator allocator(1024);
+    const auto before = allocator.Allocate(std::vector<ShadowAtlas::Candidate>{
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 1) });
+    ASSERT_EQ(before.Accepted.size(), 1u);
+    EXPECT_EQ(before.EntryRects[0].Size, 256u); // 1024/4
+
+    allocator.SetAtlasResolution(2048);
+    EXPECT_EQ(allocator.GetAtlasResolution(), 2048u);
+
+    const auto after = allocator.Allocate(std::vector<ShadowAtlas::Candidate>{
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 1) });
+    ASSERT_EQ(after.Accepted.size(), 1u);
+    EXPECT_EQ(after.EntryRects[0].Size, 512u); // 2048/4 — retiered at the new resolution
+
+    // A no-op resize (same value) must not disturb what is already held.
+    allocator.SetAtlasResolution(2048);
+    const auto unchanged = allocator.Allocate(std::vector<ShadowAtlas::Candidate>{
+        MakeIdentifiedCandidate(ShadowAtlas::CasterType::Spot, 5.0f, 1) });
+    ASSERT_EQ(unchanged.Accepted.size(), 1u);
+    EXPECT_EQ(unchanged.EntryRects[0].X, after.EntryRects[0].X);
+    EXPECT_EQ(unchanged.EntryRects[0].Y, after.EntryRects[0].Y);
 }

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -100,7 +100,10 @@ yet", so the copy step was never generated and the exe died at gtest discovery w
 nothing about Steam) ·
 [cache-stored-unresolvable-reference.md](cache-stored-unresolvable-reference.md) (a texture, from the
 SECOND load onward — an empty reference in a cache is indistinguishable from a slot that was never
-set, so every step downstream handles it "correctly")
+set, so every step downstream handles it "correctly") ·
+[shared-atlas-allocator.md](shared-atlas-allocator.md) (a plain accounting handle embedded in an
+otherwise-POD-looking struct — `vector::resize()` shrinking, a `= T{}` reset, and the enclosing
+object's own destructor all discard it silently, leaking a process-wide budget claim)
 
 **The counter-move:** ask what the *absence* would look like, and whether anything in the system
 would be different. If the answer is "nothing", you need a coverage test, not a unit test.

--- a/docs/agent-rules/shared-atlas-allocator.md
+++ b/docs/agent-rules/shared-atlas-allocator.md
@@ -1,0 +1,144 @@
+# Shared atlas allocator (#718) — what it is, what it isn't, and a non-RAII leak trap
+
+`OloEngine::AtlasAllocator` (`Renderer/AtlasAllocator.h`) is a reusable power-of-two
+square-region allocator: allocate a 2^k tile, free it, query occupancy. It's a fixed
+quadtree stored as a flat "4-ary heap" (node 0 = the whole atlas; the 4 children of node
+`i` live at `4i+1..4i+4`), modelled on the MIT-licensed `AtlasAllocatorPD2.cs`
+(Hollow-TerrainSystem) minus its Morton/BMI2 fast path. That fast path exists to skip
+whole allocated subtrees in O(1) so a scan stays cheap however often `Allocate()` runs;
+this class instead uses a plain O(nodes-at-that-level) linear scan, which is cheap in
+practice **because neither current instantiation calls `Allocate()` on a hot path** — a
+shadow-atlas repack only happens when a caster's rank/tier changes, and an impostor bake
+only when a foliage layer's mesh/params change. The node count itself is NOT uniformly
+small: the shadow atlas's table stays in the low thousands, but the impostor VRAM
+budget's (8192px atlas / 32px min tile) has ~87k total nodes, ~65k of them at the finest
+level alone — still fine for a rare, non-hot-path call, but a future instantiation with a
+genuinely hot `Allocate()` path and a large/fine-grained table should measure rather than
+assume this scan is still free. Coalescing isn't a separate code path either way: because
+the whole tree exists up front, freeing every child of a node just makes that node itself
+allocatable again.
+
+Two retrofits ship in the same PR, at deliberately different depths of commitment.
+
+## ShadowAtlas: the free function is untouched; production code moved to a new stateful sibling
+
+`ShadowAtlas::Allocate()` — the pure, per-call rank-and-shelf-pack function
+`ShadowAtlasPackingTest.cpp` exercises — is **unchanged**. None of its tests assert exact
+tile *coordinates*, only sizes/ranks/counts/overlap/determinism, which is what made it
+safe to leave it backed by the original shelf packer while building something new
+alongside it.
+
+Production code (`Scene.cpp`'s per-frame shadow setup) now calls
+`ShadowMap::AllocateAtlasTiles()`, a thin forwarder to a `ShadowAtlas::PersistentAllocator`
+member that owns an `AtlasAllocator` across frames instead of building a fresh packer every
+call. A caster is recognised across frames by `Candidate::UserData` (the light entity's
+UUID, widened from `u32` to `u64` — a truncated identity would alias unrelated lights into
+"reusing" each other's tiles); a caster with `UserData == 0` is always treated as new. The
+ranking/tiering/budget loop is **duplicated** rather than shared with the free function,
+because the two backends can fail to place a candidate at different points (shelf-packer
+exhaustion vs. buddy-allocator fragmentation), which entangles "which rank got which size"
+with "did placement succeed" — see `PersistentAllocator::Allocate`'s comment for why this
+couldn't cleanly factor into rank-then-place stages.
+
+**Freeing a departed caster's tile still lags one call in the worst case.** A caster no
+longer present as a candidate at all (removed, stopped casting) is freed EAGERLY, before
+ranking runs — a cheap upfront pass over the held set catches this common case so a
+legitimate allocation ranked ahead of it in the SAME call isn't blocked by space that
+caster no longer needs. What that pass can't catch: a caster that IS still a candidate
+this call but doesn't make the accepted set (out-ranked, over budget). Whether it's
+accepted is only knowable after the ranking loop actually runs, so that tile frees on the
+trailing sweep and becomes available NEXT call, not this one — under near-capacity atlas
+conditions this can reject a candidate the old from-scratch shelf-packer would have
+placed. Deliberate, not fixed: the atlas is sized with generous headroom relative to the
+entry/light budgets specifically so this stays rare, and a real fix is a two-pass "which
+rejections this call would free enough space to accept something else" solver, which is
+more machinery than a one-call lag under a rare, already-budgeted-for condition earns.
+
+**The swap-not-mutate pattern for identity-based free-on-drop.** The first draft of
+`PersistentAllocator::Allocate` mutated its `m_Live` vector in place while iterating: push
+a newly-accepted candidate's slot, then after the loop, sweep `m_Live` and free anything not
+in this frame's `kept` list. Tracing it all the way through, that draft turned out **not**
+to be an actual bug for this call shape (the sweep runs strictly after the ranking loop
+finishes, so nothing later in the *same* call could grab a just-freed node) — but it's the
+kind of thing that stops being safe the moment a future change interleaves placement with
+cleanup, and it's fragile to reason about even now. The shipped version swaps
+`m_Live` into a local `previousLive` at the top of the call, builds the new `m_Live` fresh
+from this call's accepted set (removing a slot from `previousLive` when it's reused), and
+frees whatever is left in `previousLive` in one pass at the end. A slot can now only ever
+leave `m_Live` by being reused into the new one or freed in the trailing sweep — never both,
+and never a slot the same call just added. If you're writing another identity-keyed
+allocate/free-on-drop cache, use this shape, not "iterate the live set, free what's not
+kept" — the moment cleanup interleaves with insertion, the entangled version needs
+re-deriving from scratch to prove it's still safe.
+
+## Impostor atlas: a VRAM *budget*, deliberately not spatial packing
+
+The issue's motivating text calls out "impostor baking rolls its own layout" as a problem
+this issue should fix. Read literally that suggests packing every `FoliageLayer`'s
+octahedral bake into sub-rects of one shared physical texture — but today each layer
+already gets its own **dedicated** `Ref<Texture2D>` pair sized exactly to its own bake
+(no cross-layer sharing exists to retrofit). Making that literal would mean:
+
+1. `ImpostorBaker::Bake` render into an offset viewport of one shared persistent
+   framebuffer instead of a scratch one, with the shared region's clear scoped to a
+   scissor rect (so one layer's rebake can't blank a sibling's already-baked tile);
+2. `FoliageRenderer` bind ONE shared texture per draw instead of a per-layer one, and pass
+   a UV scale/offset into `Foliage_Impostor.glsl`'s tile-sampling math;
+3. `ImpostorBakeEvidenceTest.cpp`'s `ConeBakesViewDependentOctahedralAtlas` rewritten
+   entirely — it reads back `atlas.Albedo` assuming its *whole* width/height IS this
+   bake's footprint (`size = atlas.Albedo->GetWidth()`, tile math `fx*tileRes+tx` with no
+   region offset). A shared texture makes that assumption false, and every "did the bake
+   render" / "is it view-dependent" assertion would need re-deriving against the new sub-rect.
+
+That's exactly the shape [foliage-impostor-card-rendering.md](foliage-impostor-card-rendering.md)
+warns about: a UV/layout change to this exact shader is a three-time repeat offender for
+"impostors render a plausible-but-wrong frame, and it takes multiple azimuths to notice."
+Given the retrofit's actual value — bounding total impostor VRAM, which today has **no**
+ceiling at all (any number of `FoliageLayer`s can each demand a full-resolution atlas pair)
+— doing that risk didn't pay for itself in this PR.
+
+What shipped instead: `ImpostorBaker` owns a static, process-wide `AtlasAllocator` used
+purely as an **accounting budget**. `Bake()` must reserve a power-of-two region sized to
+its own footprint before creating any GPU textures; on exhaustion it logs and returns an
+invalid atlas (the same graceful-degradation path already used for a null mesh or missing
+shader — `FoliageRenderer` already skips rendering an invalid impostor). Zero shader
+changes, zero rendering-path changes, and the existing evidence test's assumptions all
+still hold, because a *successful* reservation changes nothing about how the bake proceeds.
+
+**If #715 slice 3 (or anything else) wants real spatial sharing for VT/impostor
+textures later**, the allocator underneath is already the right tool — `AtlasAllocator`
+doesn't know or care that this consumer only ever asked for accounting, not placement. The
+three numbered risks above are the checklist for that work, not a reason it can't be done.
+
+## The vector::resize non-RAII leak trap
+
+`ImpostorAtlas.BudgetNode` is a plain `u32` handle into that static allocator — not a
+`Ref<T>`, so nothing runs when an `ImpostorAtlas` is destroyed. `FoliageRenderer::m_Layers`
+is a `std::vector<LayerRenderData>`, and `LayerRenderData` embeds an `ImpostorAtlas` by
+value. `std::vector::resize()` to a *smaller* size silently destroys the trailing elements
+— which, for every other member of `LayerRenderData` (`Ref<VertexArray>`,
+`Ref<Texture2D>`, …), is exactly correct (refcounted GPU cleanup). For `BudgetNode` it's a
+leak: the claim is never freed, and because the allocator is a process-wide static, it
+leaks for the rest of the process — a scene-reload loop that keeps removing/re-adding
+foliage layers would eventually starve every future bake. Three call sites needed an
+explicit `ImpostorBaker::Free(atlas)` that nothing in the type system would have forced:
+the two `data.Impostor = ImpostorAtlas{}` resets, the rebake overwrite, the layer-count
+shrink before `m_Layers.resize()`, and — the one that's easy to forget entirely —
+`FoliageRenderer`'s own destructor (a `Ref<FoliageRenderer>` dropping to zero, e.g. an
+entity removed or a scene closed, previously ran the implicit default destructor and never
+touched the budget at all). Giving `ImpostorAtlas` a real destructor instead was considered
+and rejected: a user-declared destructor suppresses the implicit move ctor/assign, so
+`data.Impostor = ImpostorBaker::Bake(...)` (a genuine move-assignment, not elided the way
+`ImpostorAtlas atlas = ImpostorBaker::Bake(...)` is) would fall back to copy semantics —
+and a naive copy assignment double-frees the just-reserved `BudgetNode` the moment the
+temporary's destructor runs. `AtlasAllocator::Free` being tolerant of a double-free (a
+second `Free()` on an already-free node is a documented no-op, not a crash) is what makes
+this class of mistake survivable rather than a live bug — but the four explicit call sites
+are still what makes it *correct*, not just non-crashing.
+
+**The general lesson:** a plain accounting handle embedded in a value type that otherwise
+looks entirely POD (glm vectors, bools, floats, `Ref<T>`s that clean up on their own) is
+invisible at every call site that resets or replaces that value type — `= T{}`,
+`vector::resize()`, `vector::erase()`, the enclosing object's own destructor if nobody
+declared one. Grep for every site that discards a value of that type, not just the ones
+that felt like "removal."

--- a/docs/agent-rules/shared-atlas-allocator.md
+++ b/docs/agent-rules/shared-atlas-allocator.md
@@ -44,10 +44,15 @@ couldn't cleanly factor into rank-then-place stages.
 longer present as a candidate at all (removed, stopped casting) is freed EAGERLY, before
 ranking runs — a cheap upfront pass over the held set catches this common case so a
 legitimate allocation ranked ahead of it in the SAME call isn't blocked by space that
-caster no longer needs. What that pass can't catch: a caster that IS still a candidate
-this call but doesn't make the accepted set (out-ranked, over budget). Whether it's
-accepted is only knowable after the ranking loop actually runs, so that tile frees on the
-trailing sweep and becomes available NEXT call, not this one — under near-capacity atlas
+caster no longer needs. A caster that IS still a candidate but whose rank crossed a tier
+boundary (large → medium, say) is *also* freed eagerly, the instant the size mismatch is
+detected, rather than left holding both its old and new tile until the trailing sweep —
+that specific case IS knowable in advance (the mismatch is checked right before the
+candidate's own allocation attempt), unlike the one case that genuinely isn't: a caster
+that IS still a candidate this call but doesn't make the accepted set at all (out-ranked,
+over budget). Whether THAT candidate is accepted is only knowable after the ranking loop
+actually runs, so its tile frees on the trailing sweep and becomes available NEXT call,
+not this one — under near-capacity atlas
 conditions this can reject a candidate the old from-scratch shelf-packer would have
 placed. Deliberate, not fixed: the atlas is sized with generous headroom relative to the
 entry/light budgets specifically so this stays rare, and a real fix is a two-pass "which
@@ -120,7 +125,7 @@ value. `std::vector::resize()` to a *smaller* size silently destroys the trailin
 `Ref<Texture2D>`, …), is exactly correct (refcounted GPU cleanup). For `BudgetNode` it's a
 leak: the claim is never freed, and because the allocator is a process-wide static, it
 leaks for the rest of the process — a scene-reload loop that keeps removing/re-adding
-foliage layers would eventually starve every future bake. Three call sites needed an
+foliage layers would eventually starve every future bake. Five discard sites needed an
 explicit `ImpostorBaker::Free(atlas)` that nothing in the type system would have forced:
 the two `data.Impostor = ImpostorAtlas{}` resets, the rebake overwrite, the layer-count
 shrink before `m_Layers.resize()`, and — the one that's easy to forget entirely —
@@ -133,8 +138,8 @@ and rejected: a user-declared destructor suppresses the implicit move ctor/assig
 and a naive copy assignment double-frees the just-reserved `BudgetNode` the moment the
 temporary's destructor runs. `AtlasAllocator::Free` being tolerant of a double-free (a
 second `Free()` on an already-free node is a documented no-op, not a crash) is what makes
-this class of mistake survivable rather than a live bug — but the four explicit call sites
-are still what makes it *correct*, not just non-crashing.
+this class of mistake survivable rather than a live bug — but the five explicit discard
+sites are still what makes it *correct*, not just non-crashing.
 
 **The general lesson:** a plain accounting handle embedded in a value type that otherwise
 looks entirely POD (glm vectors, bools, floats, `Ref<T>`s that clean up on their own) is


### PR DESCRIPTION
Closes #718.

## What changed

Adds `OloEngine::AtlasAllocator` (`OloEngine/src/OloEngine/Renderer/AtlasAllocator.{h,cpp}`), a reusable power-of-two square-region allocator: allocate a `2^k` tile, free it, coalesce buddies, query occupancy. It's a fixed quadtree stored as a flat "4-ary heap", modelled on the MIT-licensed `AtlasAllocatorPD2.cs` reference (Hollow-TerrainSystem) minus its Morton-code/BMI2 fast path -- that optimisation exists to keep a scan cheap on a hot path; neither consumer here calls `Allocate()` on one, so a plain O(nodes-at-that-level) linear scan is the simpler, still-cheap choice.

Retrofits it onto two consumers, at different depths of commitment (both deliberate, both explained below and in the new agent-rules doc):

**ShadowAtlas** -- `ShadowAtlas::PersistentAllocator` is a new stateful sibling of the existing pure `ShadowAtlas::Allocate()`. The free function is **untouched**: none of `ShadowAtlasPackingTest`'s existing assertions check exact tile coordinates (only sizes/ranks/counts/overlap/determinism), so it was safe to leave it backed by the original shelf packer and build the persistence capability alongside it rather than inside it. Production shadow setup (`Scene.cpp`, via the new `ShadowMap::AllocateAtlasTiles`) now calls the persistent path, keyed by the light entity's UUID (`ShadowAtlas::Candidate::UserData` widened `u32`->`u64` to carry it without truncation). A caster that keeps ranking into the accepted set keeps its existing tile across frames instead of the whole atlas being repacked from nothing every call -- the "hold an allocation across frames" half of the acceptance criteria. The skip-whole-caster behavior (a point light never gets a partial cube) is preserved exactly.

**Impostor atlas** -- `ImpostorBaker` gates every bake against a shared VRAM **budget** allocator rather than packing bakes into one physical shared texture. I read the issue's "impostor baking rolls its own layout" literally at first and drafted the spatial-packing version, then backed off deliberately: today each `FoliageLayer` already gets its own dedicated `Ref<Texture2D>` pair, so making it truly shared would mean (1) rendering into a scissor-scoped sub-rect of one persistent framebuffer, (2) a UV scale/offset plumbed into `Foliage_Impostor.glsl`'s tile-sampling math, and (3) rewriting `ImpostorBakeEvidenceTest.cpp`'s `ConeBakesViewDependentOctahedralAtlas`, which currently assumes `atlas.Albedo`'s *entire* width/height IS this bake's own footprint. That's exactly the kind of UV/layout change [docs/agent-rules/foliage-impostor-card-rendering.md](https://github.com/drsnuggles8/OloEngineBase/blob/master/docs/agent-rules/foliage-impostor-card-rendering.md) documents as a repeat "impostors silently go missing" offender, for a retrofit whose actual value (bounding total impostor VRAM -- today nothing does, any number of layers can each demand a full-resolution atlas pair) doesn't require it. The budget delivers that value with zero shader/rendering-path changes: `Bake()` reserves a power-of-two region before creating any GPU texture and degrades gracefully (same path as a null mesh or missing shader) if the budget is exhausted; `Free()` releases the claim.

VT cache adoption is explicitly **#715 slice 3**, not this PR -- the allocator is designed so that work can build on it, but nothing here wires terrain VT to it.

### A real bug I found and fixed along the way

`ImpostorAtlas.BudgetNode` is a plain accounting handle, not RAII. `FoliageRenderer::m_Layers` is a `std::vector<LayerRenderData>` holding `ImpostorAtlas` by value, and `vector::resize()` shrinking silently destroys trailing elements -- correct for every other member (`Ref<T>` GPU cleanup) but a leak for this one, and since the budget allocator is a process-wide static, a scene-reload loop would eventually starve every future bake. Fixed at all four discard sites: the two `= ImpostorAtlas{}` resets, the rebake overwrite, the layer-shrink before `resize()`, and -- easy to miss -- `FoliageRenderer`'s own destructor (didn't exist before this PR). Write-up: [docs/agent-rules/shared-atlas-allocator.md](https://github.com/drsnuggles8/OloEngineBase/blob/master/docs/agent-rules/shared-atlas-allocator.md).

## Verification

- **Full `OloEngine-Tests` suite, twice** (once before the self-review fixes below, once after, on a freshly-configured `dev-cached` clang-cl tree): **6239 passed / 25 skipped (pre-existing categories: Steam stub, app-launch smoke, video-decoder fixture, etc.) / 0 failed**, identical counts both runs.
- **New `AtlasAllocatorTest.cpp`** (12 cases): allocate/free/coalesce/occupancy/reset, invalid-input handling, mixed-size non-overlap, and a 2000-step fuzzed allocate/free sequence asserting no overlap + occupancy matches the live set at every step.
- **`ShadowAtlasPackingTest.cpp`**: all 12 pre-existing cases pass unmodified; 6 new cases for `PersistentAllocator` (reuse across calls, tier-shift reallocation, dropped-caster reclaim under tight capacity, skip-whole-caster preserved, overlap-safety across 20 changing calls, resolution-change reset).
- **GL-based evidence tests exercised live** (real OpenGL 4.6 context, RTX 4090): `ShadowAtlasVisualEvidenceTest` (2 cases), `ImpostorBakeEvidenceTest.ConeBakesViewDependentOctahedralAtlas`, `ImpostorCardRenderEvidenceTest.ScatteredImpostorCardsRenderFromMultipleAzimuths` (foliage impostors from 3 azimuths on generated terrain) -- all pass with the budget-gate integration in the real bake path.
- Self-reviewed at `high` effort (`/code-review`) before this push; findings below.

## Review guide

**Where I'd look hardest**
1. `OloEngine/src/OloEngine/Renderer/Shadow/ShadowAtlas.cpp` (`PersistentAllocator::Allocate`) -- the core new stateful logic: the swap-not-mutate `previousLive`/`m_Live` pattern, and the eager-free-before-ranking optimization added during self-review. This is the piece with no direct C# reference to check against.
2. `OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp` -- the four `ImpostorBaker::Free()` call sites (two resets, the rebake overwrite, the resize-shrink) plus the new destructor. Miss one and the shared budget leaks silently.
3. `OloEngine/src/OloEngine/Renderer/AtlasAllocator.cpp` (`GetRegion`) -- the base-4-digit quadrant decode for coordinates. No Morton table to sanity-check against; correctness rests entirely on the fuzz test.

**What I verified, and how** -- named above: full suite twice (pre/post self-review fixes), the new unit tests, and the three GL evidence tests actually running against a live GL context on this machine (not just compiling).

**Least confident about** -- `PersistentAllocator`'s residual one-call lag: a caster that's still a candidate this call but doesn't make the accepted set (out-ranked, over budget) only frees its held tile on the trailing sweep, so its space becomes available next call, not this one. Under near-capacity atlas conditions this can reject a candidate the old from-scratch shelf-packer would have placed. I judged this an acceptable, deliberate trade (the atlas has generous headroom over the entry/light budgets specifically so this stays rare) rather than building a two-pass solver, and mitigated the common sub-case (a caster no longer a candidate at all) with an eager pre-ranking free -- but I have not observed this specific edge case under real load, only reasoned about it and covered it in the doc.

**Deliberately not tested** -- the impostor budget exhaustion path itself (`kBudgetAtlasSize = 8192`) under a real many-layer scene; the default budget is generous enough that no existing test scenario gets close to it, so the graceful-degradation branch (`OLO_CORE_WARN` + invalid atlas) is exercised by code review, not a test that actually fills the budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent shadow-atlas tile allocation, preserving placements for unchanged casters across frames.
  - Added shared impostor VRAM budgeting with graceful handling when capacity is exhausted.
  - Added atlas allocation and cleanup support for foliage and shadow rendering.

- **Bug Fixes**
  - Prevented stale or duplicated impostor VRAM reservations.
  - Improved reclamation of shadow tiles for removed or changed casters.
  - Preserved allocations across unchanged atlas resolutions.

- **Documentation**
  - Added guidance covering atlas allocation, budgeting, and cleanup behavior.

- **Tests**
  - Added comprehensive allocator, shadow-atlas, and impostor budget coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->