### PR TITLE
fix(rhi/vulkan): a global colour mask must clear per-attachment divergence (#823)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ you are in.
 
 - [rhi-abstraction-boundary.md](docs/agent-rules/rhi-abstraction-boundary.md) — where the OpenGL boundary actually leaks: the include graph, not a `glXxx(` grep; plus the Vulkan epic's per-phase lessons (§9–§13, incl. the one-row-order-per-backend contract).
 - [vulkan-command-ordered-buffer-writes.md](docs/agent-rules/vulkan-command-ordered-buffer-writes.md) — a CPU buffer write between two recorded draws is GL command order; a life-stable Vulkan address silently makes it last-write-wins, and the failure is scene-shaped.
+- [gl-global-setter-resets-indexed-state.md](docs/agent-rules/gl-global-setter-resets-indexed-state.md) — `glColorMask` / `glEnable(GL_BLEND)` are the indexed call for EVERY draw buffer; porting one as a fallback makes an indexed call permanent, and only render target 0 is ever looked at.
 - [lazy-static-release-ownership.md](docs/agent-rules/lazy-static-release-ownership.md) — a shared lazy static released from `Renderer3D::Shutdown` leaks in every session that never inits 3D; GL is silent about it, Vulkan is not.
 - [gpu-debug-draws.md](docs/agent-rules/gpu-debug-draws.md) — **the instrument for GPU-driven work**: any shader can draw a primitive into the viewport the same frame. Read the two-counter overflow protocol before concluding "it drew nothing".
 - [gpu-scan-compaction.md](docs/agent-rules/gpu-scan-compaction.md) — the `if (idx >= count) return;` habit is a hang in front of a work-group scan, and a compaction test that compares *sets* passes on the bug it is meant to catch.

--- a/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
@@ -612,6 +612,12 @@ namespace OloEngine
                 const bool useAttachmentFunc = state.AttachmentBlendFuncSet[i];
                 // Integer attachments cannot blend — see the identical mask
                 // in FlushDynamicState (the two routes must agree).
+                // The OR is deliberate and is NOT the colour-mask rule below:
+                // a per-attachment enable is an opt-in LAYERED ON TOP of the
+                // global flag, which is what lets DecalRenderPass blend RT2
+                // additively for an Emissive decal whose PODRenderState carries
+                // blendEnabled=false. Pinned by the Emissive arm of
+                // VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets.
                 attachment.blendEnable = (!IsIntegerFormat(safeTargets.ColorFormats[i]) &&
                                           (state.AttachmentBlend[i] || state.Blend))
                                              ? VK_TRUE
@@ -624,11 +630,13 @@ namespace OloEngine
                 attachment.dstAlphaBlendFactor =
                     ToVk(useAttachmentFunc ? state.AttachmentBlendDst[i] : state.BlendDstAlpha);
                 attachment.alphaBlendOp = ToVk(state.BlendEquation);
-                const VkColorComponentFlags globalMask = (state.ColorMask[0] ? VK_COLOR_COMPONENT_R_BIT : 0u) |
-                                                         (state.ColorMask[1] ? VK_COLOR_COMPONENT_G_BIT : 0u) |
-                                                         (state.ColorMask[2] ? VK_COLOR_COMPONENT_B_BIT : 0u) |
-                                                         (state.ColorMask[3] ? VK_COLOR_COMPONENT_A_BIT : 0u);
-                attachment.colorWriteMask = static_cast<VkColorComponentFlags>(state.AttachmentColorMask[i]) & globalMask;
+                // AttachmentColorMask ALONE — the opposite composition to
+                // blendEnable above, deliberately. SetColorMask fills the array
+                // for every attachment (glColorMask semantics), so ANDing the
+                // global field in on top would make a glColorMaski-shaped WIDEN
+                // after a global narrow fail to reach the attachment, which is
+                // the opposite of GL, where the indexed call wins.
+                attachment.colorWriteMask = static_cast<VkColorComponentFlags>(state.AttachmentColorMask[i]);
             }
         }
 
@@ -784,14 +792,9 @@ namespace OloEngine
         const u32 colorCount = std::min(targets.ColorCount, 8u); // same 8-wide bound as the create path
         if (device != nullptr && device->IsDynamicBlendStateEnabled() && colorCount > 0)
         {
-            // [401] The GLOBAL color mask (SetColorMask) must reach the
-            // dynamic write masks too — a pass that narrows the global mask
-            // and never touches the per-attachment API would otherwise
-            // render with the per-attachment default (all channels).
-            const VkColorComponentFlags globalMask = (state.ColorMask[0] ? VK_COLOR_COMPONENT_R_BIT : 0u) |
-                                                     (state.ColorMask[1] ? VK_COLOR_COMPONENT_G_BIT : 0u) |
-                                                     (state.ColorMask[2] ? VK_COLOR_COMPONENT_B_BIT : 0u) |
-                                                     (state.ColorMask[3] ? VK_COLOR_COMPONENT_A_BIT : 0u);
+            // [401] The GLOBAL color mask (SetColorMask) reaches the dynamic
+            // write masks by FILLING AttachmentColorMask, not by being ANDed in
+            // here — see the identical expression on the baked route.
             std::array<VkBool32, 8> enables{};
             std::array<VkColorBlendEquationEXT, 8> equations{};
             std::array<VkColorComponentFlags, 8> writeMasks{};
@@ -814,6 +817,8 @@ namespace OloEngine
                 // forward/G-buffer family — tripped this on the first live
                 // frame. Masking it here keeps GL's "just ignore it"
                 // behaviour and costs the caller nothing.
+                // Per-attachment enable ORs on top of the global flag — see the
+                // identical expression on the baked route in GetOrCreateGraphics.
                 const bool blendableFormat = !IsIntegerFormat(targets.ColorFormats[i]);
                 const bool enabled = blendableFormat && (state.AttachmentBlend[i] || state.Blend);
                 enables[i] = enabled ? VK_TRUE : VK_FALSE;
@@ -825,7 +830,7 @@ namespace OloEngine
                     .dstAlphaBlendFactor = ToVk(useAttachmentFunc ? state.AttachmentBlendDst[i] : state.BlendDstAlpha),
                     .alphaBlendOp = ToVk(state.BlendEquation),
                 };
-                writeMasks[i] = static_cast<VkColorComponentFlags>(state.AttachmentColorMask[i]) & globalMask;
+                writeMasks[i] = static_cast<VkColorComponentFlags>(state.AttachmentColorMask[i]);
             }
             vkCmdSetColorBlendEnableEXT(cmd, 0, colorCount, enables.data());
             vkCmdSetColorBlendEquationEXT(cmd, 0, colorCount, equations.data());

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -921,15 +921,6 @@ namespace OloEngine
     {
         m_State.DepthFunc = func;
     }
-    // VkColorComponentFlags' RGBA bit order, which is what the recorded
-    // per-attachment masks store — shared by the global and the indexed setter
-    // so the two can never pack the same request differently.
-    [[nodiscard]] static constexpr u8 PackColorMask(const bool red, const bool green, const bool blue,
-                                                    const bool alpha)
-    {
-        return static_cast<u8>((red ? 1u : 0u) | (green ? 2u : 0u) | (blue ? 4u : 0u) | (alpha ? 8u : 0u));
-    }
-
     void VulkanRendererAPI::SetBlendState(const bool value)
     {
         // Deliberately does NOT fill AttachmentBlend, unlike SetColorMask below.
@@ -1067,15 +1058,16 @@ namespace OloEngine
         // narrowed attachment stayed masked for the rest of the PROCESS — one
         // Renderer3D::DrawLine (colorAttachmentWriteMask = 0x01) killed every
         // G-Buffer attachment above 0 from that frame on, which is issue #823.
-        for (u8& attachmentMask : m_State.AttachmentColorMask)
-            attachmentMask = PackColorMask(red, green, blue, alpha);
+        for (u32 attachment = 0; attachment < VulkanRecordedPipelineState::kMaxAttachments; ++attachment)
+            SetColorMaskForAttachment(attachment, red, green, blue, alpha);
     }
     void VulkanRendererAPI::SetColorMaskForAttachment(const u32 attachment, const bool red, const bool green,
                                                       const bool blue, const bool alpha)
     {
         if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
             return;
-        m_State.AttachmentColorMask[attachment] = PackColorMask(red, green, blue, alpha);
+        m_State.AttachmentColorMask[attachment] = static_cast<u8>((red ? 1u : 0u) | (green ? 2u : 0u) |
+                                                                  (blue ? 4u : 0u) | (alpha ? 8u : 0u));
     }
     void VulkanRendererAPI::SetBlendStateForAttachment(const u32 attachment, const bool enabled)
     {

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -921,8 +921,27 @@ namespace OloEngine
     {
         m_State.DepthFunc = func;
     }
+    // VkColorComponentFlags' RGBA bit order, which is what the recorded
+    // per-attachment masks store — shared by the global and the indexed setter
+    // so the two can never pack the same request differently.
+    [[nodiscard]] static constexpr u8 PackColorMask(const bool red, const bool green, const bool blue,
+                                                    const bool alpha)
+    {
+        return static_cast<u8>((red ? 1u : 0u) | (green ? 2u : 0u) | (blue ? 4u : 0u) | (alpha ? 8u : 0u));
+    }
+
     void VulkanRendererAPI::SetBlendState(const bool value)
     {
+        // Deliberately does NOT fill AttachmentBlend, unlike SetColorMask below.
+        // GL's glEnable(GL_BLEND) would clear the per-buffer enables, but the
+        // engine's passes are written against OR semantics instead: DecalRenderPass
+        // turns RT2 on with SetBlendStateForAttachment(2, true) for an Emissive
+        // decal whose PODRenderState carries blendEnabled=false, and relies on the
+        // per-attachment enable surviving the global disable that
+        // ApplyPODRenderState then issues. Matching GL here would delete that
+        // additive accumulation on Vulkan without fixing it on GL, so the
+        // divergence is recorded rather than "corrected" — see the note at the
+        // AttachmentBlend declaration.
         m_State.Blend = value;
     }
     void VulkanRendererAPI::SetBlendFunc(const RHI::BlendFactor sfactor, const RHI::BlendFactor dfactor)
@@ -1039,14 +1058,24 @@ namespace OloEngine
         m_State.ColorMask[1] = green;
         m_State.ColorMask[2] = blue;
         m_State.ColorMask[3] = alpha;
+        // glColorMask writes EVERY draw buffer's mask, so it also CLEARS any
+        // divergence a previous glColorMaski installed — the same global-
+        // overwrite rule SetBlendFunc already honours, and the rule
+        // CommandDispatch::ApplyRenderState depends on: that function only ever
+        // DISABLES attachments (`if (!(colorAttachmentWriteMask & bit))`) and
+        // relies on this call to have re-enabled them first. Without the fill a
+        // narrowed attachment stayed masked for the rest of the PROCESS — one
+        // Renderer3D::DrawLine (colorAttachmentWriteMask = 0x01) killed every
+        // G-Buffer attachment above 0 from that frame on, which is issue #823.
+        for (u8& attachmentMask : m_State.AttachmentColorMask)
+            attachmentMask = PackColorMask(red, green, blue, alpha);
     }
     void VulkanRendererAPI::SetColorMaskForAttachment(const u32 attachment, const bool red, const bool green,
                                                       const bool blue, const bool alpha)
     {
         if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
             return;
-        m_State.AttachmentColorMask[attachment] = static_cast<u8>((red ? 1u : 0u) | (green ? 2u : 0u) |
-                                                                  (blue ? 4u : 0u) | (alpha ? 8u : 0u));
+        m_State.AttachmentColorMask[attachment] = PackColorMask(red, green, blue, alpha);
     }
     void VulkanRendererAPI::SetBlendStateForAttachment(const u32 attachment, const bool enabled)
     {

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
@@ -100,6 +100,29 @@ namespace OloEngine
         bool ColorMask[4] = { true, true, true, true };
         u32 PatchVertexCount = 3;
 
+        // THE COLOUR MASK AND THE BLEND ENABLE COMPOSE DIFFERENTLY HERE, on
+        // purpose — do not "make them consistent" without re-reading this.
+        //
+        // AttachmentColorMask is the lowering's ONLY input: SetColorMask
+        // overwrites every entry (glColorMask is defined as glColorMaski for
+        // every draw buffer) and an indexed call then diverges one. It has to
+        // work that way because CommandDispatch::ApplyRenderState only ever
+        // DISABLES the attachments a command names and relies on the global
+        // call to have re-enabled the rest. Before that fill existed, a
+        // narrowing indexed call was permanent for the PROCESS, and one
+        // Renderer3D::DrawLine killed every G-Buffer attachment above 0 —
+        // issue #823.
+        //
+        // AttachmentBlend does NOT work that way: it ORs on top of `Blend`, so
+        // SetBlendState deliberately leaves it alone. GL would clear it, but
+        // the engine's passes are written against the OR — DecalRenderPass
+        // enables RT2 per-attachment for an Emissive decal whose
+        // PODRenderState carries blendEnabled=false, and matching GL would
+        // delete that additive accumulation on Vulkan without fixing it on GL.
+        // The consequence is that a per-attachment blend DISABLE cannot
+        // override a global enable (OITResolveRenderPass asks for one); that
+        // asymmetry is real, is GL-divergent in the other direction, and is
+        // filed rather than changed here.
         bool AttachmentBlend[kMaxAttachments] = {};
         RHI::BlendFactor AttachmentBlendSrc[kMaxAttachments] = {};
         RHI::BlendFactor AttachmentBlendDst[kMaxAttachments] = {};

--- a/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
@@ -59,6 +59,7 @@ TEST(VulkanDrawPath, SkipsWhenNotCompiledIn)
 #include <volk.h>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -579,6 +580,219 @@ void main()
         wrongPixels += magentaPixel ? 0u : 1u;
     }
     EXPECT_EQ(wrongPixels, 0u) << "every texel must carry the UBO tint the dispatch stored";
+}
+
+// =============================================================================
+// The GL global-overwrite rule for per-attachment state (issue #823).
+//
+// glColorMask is DEFINED as glColorMaski for every draw buffer, so it clears
+// any divergence an earlier indexed call installed — and
+// CommandDispatch::ApplyRenderState leans on exactly that: it only ever
+// DISABLES attachments named by PODRenderState::colorAttachmentWriteMask and
+// never re-enables one, because the global call preceding it is supposed to
+// have. The Vulkan arm kept its own per-attachment array that the global
+// setter did not touch, so a narrowing indexed call was PERMANENT for the rest
+// of the process: one Renderer3D::DrawLine (mask 0x01) left every G-Buffer
+// attachment above 0 dead, the deferred emissive target kept its cleared
+// alpha=1 "unlit" flag, and every deferred frame came back a light-independent
+// flat grey.
+//
+// Both directions are asserted from ONE recording, because either alone
+// passes on a broken build: phase A proves the indexed mask really acts (a
+// no-op mask would satisfy phase B trivially), phase B proves the global call
+// takes it back.
+// =============================================================================
+TEST_F(VulkanDrawPath, GlobalColorMaskResetsPerAttachmentDivergence)
+{
+    ScopedVulkanApiSelection vulkanApi;
+    VulkanFrameArena::Get().BeginFrame(0);
+
+    constexpr u32 kSize = 32;
+    constexpr u32 kAttachments = 3;
+
+    // The G-Buffer's shape in miniature: more than one colour attachment, all
+    // written by one fragment stage.
+    constexpr const char* kMrtFragmentSrc = R"(
+#version 460 core
+layout(location = 0) in vec2 v_TexCoord;
+layout(location = 0) out vec4 o_Rt0;
+layout(location = 1) out vec4 o_Rt1;
+layout(location = 2) out vec4 o_Rt2;
+
+layout(std140, binding = 3) uniform TintBlock
+{
+    vec4 u_Tint;
+};
+
+void main()
+{
+    o_Rt0 = u_Tint;
+    o_Rt1 = u_Tint;
+    o_Rt2 = u_Tint;
+}
+)";
+
+    FramebufferSpecification fbSpec;
+    fbSpec.Width = kSize;
+    fbSpec.Height = kSize;
+    fbSpec.Attachments = { FramebufferTextureFormat::RGBA8, FramebufferTextureFormat::RGBA8,
+                           FramebufferTextureFormat::RGBA8 };
+    // Three targets, ONE recording — the leak was process-scoped, not
+    // scope-scoped, so the state has to be observed crossing framebuffer binds
+    // rather than reset by a fresh frame between each case.
+    auto masked = Framebuffer::Create(fbSpec);
+    ASSERT_NE(masked, nullptr);
+    auto restored = Framebuffer::Create(fbSpec);
+    ASSERT_NE(restored, nullptr);
+    // The other ordering: a global NARROW followed by an indexed WIDEN.
+    // glColorMaski wins over the preceding glColorMask, so the lowering must
+    // read the array alone — ANDing the recorded global mask on top would make
+    // this attachment stay masked.
+    auto widened = Framebuffer::Create(fbSpec);
+    ASSERT_NE(widened, nullptr);
+
+    const f32 vertices[] = { -1.0f, -1.0f, 3.0f, -1.0f, -1.0f, 3.0f };
+    auto vertexBuffer = VertexBuffer::Create(vertices, sizeof(vertices));
+    u32 indices[] = { 0, 1, 2 };
+    auto indexBuffer = IndexBuffer::Create(indices, 3);
+    auto vertexArray = VertexArray::Create();
+    vertexArray->AddVertexBuffer(vertexBuffer);
+    vertexArray->SetIndexBuffer(indexBuffer);
+
+    auto tintUbo = UniformBuffer::Create(16, 3);
+    auto shader = Ref<VulkanShader>::Create("DrawPathMrtMask", kVertexSrc, kMrtFragmentSrc);
+    ASSERT_EQ(shader->GetCompilationStatus(), ShaderCompilationStatus::Ready);
+
+    VulkanRendererAPI api;
+
+    // Clear red, first draw green, second draw blue: reading back which of the
+    // three a texel carries says exactly which draw reached that attachment.
+    constexpr f32 kGreen[4] = { 0.0f, 1.0f, 0.0f, 1.0f };
+    constexpr f32 kBlue[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
+
+    const auto transitionAll = [&api](const Ref<Framebuffer>& target, const RHI::Access before,
+                                      const RHI::Access after)
+    {
+        for (u32 i = 0; i < kAttachments; ++i)
+        {
+            RHI::Barrier barrier{};
+            barrier.Resource = target->GetColorAttachmentHandle(i);
+            barrier.Before = before;
+            barrier.After = after;
+            api.IssueBarrierBatch(MemoryBarrierFlags::None, std::span{ &barrier, 1 });
+        }
+    };
+
+    SubmitFrame(api,
+                [&]()
+                {
+                    transitionAll(masked, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+                    transitionAll(restored, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+                    transitionAll(widened, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+
+                    shader->Bind();
+                    tintUbo->Bind();
+
+                    // The narrowing indexed call, in the shape
+                    // CommandDispatch::ApplyRenderState emits for a command
+                    // whose colorAttachmentWriteMask excludes an attachment.
+                    masked->Bind();
+                    api.SetViewport(0, 0, kSize, kSize);
+                    api.SetClearColor({ 1.0f, 0.0f, 0.0f, 1.0f });
+                    api.Clear();
+                    api.SetColorMaskForAttachment(1, false, false, false, false);
+                    tintUbo->SetData(kGreen, sizeof(kGreen));
+                    api.DrawIndexed(vertexArray, 3);
+                    masked->Unbind();
+
+                    // The global call that must take the narrowing back.
+                    restored->Bind();
+                    api.SetViewport(0, 0, kSize, kSize);
+                    api.SetClearColor({ 1.0f, 0.0f, 0.0f, 1.0f });
+                    api.Clear();
+                    api.SetColorMask(true, true, true, true);
+                    tintUbo->SetData(kBlue, sizeof(kBlue));
+                    api.DrawIndexed(vertexArray, 3);
+                    restored->Unbind();
+
+                    // Global mask off for every channel, then attachment 1
+                    // widened back on its own.
+                    widened->Bind();
+                    api.SetViewport(0, 0, kSize, kSize);
+                    api.SetClearColor({ 1.0f, 0.0f, 0.0f, 1.0f });
+                    api.Clear();
+                    api.SetColorMask(false, false, false, false);
+                    api.SetColorMaskForAttachment(1, true, true, true, true);
+                    tintUbo->SetData(kGreen, sizeof(kGreen));
+                    api.DrawIndexed(vertexArray, 3);
+                    api.SetColorMask(true, true, true, true);
+                    widened->Unbind();
+
+                    transitionAll(masked, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                    transitionAll(restored, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                    transitionAll(widened, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                });
+
+    EXPECT_EQ(api.GetPhase6StubHitCount(), 0u) << "the MRT draw path must not fall through to a stub";
+
+    // `target` is deliberately NOT const: Ref<T>::Raw() const-propagates, so a
+    // const Ref hands back a const Framebuffer* and the downcast to the
+    // backend type would have to cast the qualifier away (clang-cl rejects it;
+    // MSVC let it through).
+    const auto centreTexel = [](Ref<Framebuffer>& target, u32 attachmentIndex,
+                                std::array<u8, 4>& out) -> bool
+    {
+        auto* vkFramebuffer = static_cast<VulkanFramebuffer*>(target.Raw());
+        const auto attachment = vkFramebuffer->GetColorAttachmentImage(attachmentIndex);
+        if (attachment == nullptr)
+            return false;
+        std::vector<u8> pixels;
+        if (!attachment->GetData(pixels, 0) || pixels.size() != sizet{ kSize } * kSize * 4)
+            return false;
+        const sizet offset = ((sizet{ kSize } / 2) * kSize + kSize / 2) * 4;
+        out = { pixels[offset + 0], pixels[offset + 1], pixels[offset + 2], pixels[offset + 3] };
+        return true;
+    };
+
+    constexpr std::array<u8, 4> kGreenTexel{ 0x00, 0xFF, 0x00, 0xFF };
+    constexpr std::array<u8, 4> kBlueTexel{ 0x00, 0x00, 0xFF, 0xFF };
+    constexpr std::array<u8, 4> kRedTexel{ 0xFF, 0x00, 0x00, 0xFF };
+
+    // The control: the indexed mask has to have DONE something, or the
+    // assertion below proves nothing — a no-op mask passes it trivially.
+    std::array<u8, 4> texel{};
+    ASSERT_TRUE(centreTexel(masked, 0, texel));
+    EXPECT_EQ(texel, kGreenTexel) << "attachment 0 was never masked and must carry the first draw";
+    ASSERT_TRUE(centreTexel(masked, 1, texel));
+    EXPECT_EQ(texel, kRedTexel) << "SetColorMaskForAttachment(1, false x4) did not mask attachment 1";
+    ASSERT_TRUE(centreTexel(masked, 2, texel));
+    EXPECT_EQ(texel, kGreenTexel) << "attachment 2 was never masked and must carry the first draw";
+
+    // The contract this test exists for: a global colour mask clears the
+    // per-attachment divergence an earlier indexed call installed (issue #823).
+    for (u32 i = 0; i < kAttachments; ++i)
+    {
+        ASSERT_TRUE(centreTexel(restored, i, texel)) << "attachment " << i << " readback failed";
+        EXPECT_EQ(texel, kBlueTexel)
+            << "attachment " << i
+            << " missed the draw after SetColorMask(true x4) — glColorMask is the indexed call for EVERY draw "
+               "buffer, so it must clear a narrowing SetColorMaskForAttachment (issue #823)";
+    }
+
+    // The indexed setter wins over the global one it follows, both ways round.
+    ASSERT_TRUE(centreTexel(widened, 0, texel));
+    EXPECT_EQ(texel, kRedTexel) << "attachment 0 stayed under the global SetColorMask(false x4)";
+    ASSERT_TRUE(centreTexel(widened, 1, texel));
+    EXPECT_EQ(texel, kGreenTexel)
+        << "SetColorMaskForAttachment(1, true x4) after a global SetColorMask(false x4) did not reach "
+           "attachment 1 — glColorMaski overrides the glColorMask before it, so the per-attachment array "
+           "is the lowering's only input";
+    ASSERT_TRUE(centreTexel(widened, 2, texel));
+    EXPECT_EQ(texel, kRedTexel) << "attachment 2 stayed under the global SetColorMask(false x4)";
+
+    // Leave the global mask wide, so a later test in this binary is not handed
+    // a narrowed one — the very leak this test pins.
+    api.SetColorMask(true, true, true, true);
 }
 
 #endif // OLO_WITH_VULKAN

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -36,6 +36,7 @@ run is **not** evidence.
 | [parallelizable-mover-systems.md](parallelizable-mover-systems.md) | a position check passes on the scheduler tie-break alone, with the dependency edge missing |
 | [mcp-protocol-eras.md](mcp-protocol-eras.md) | adding `server/discover` alone keeps every test green — and converts a *working* legacy fallback into a broken modern conversation, because answering it is a client's proof the server is modern |
 | [vulkan-command-ordered-buffer-writes.md](vulkan-command-ordered-buffer-writes.md) | two scenes render skybox-only, one renders perfectly, zero errors — no tenant interleaved two uploads of one SSBO with draws |
+| [gl-global-setter-resets-indexed-state.md](gl-global-setter-resets-indexed-state.md) | every Vulkan draw in the process wrote colour attachment 0 alone for a whole phase — the forward path displays only attachment 0, so the editor looked fine |
 | [gpu-scan-compaction.md](gpu-scan-compaction.md) | a compaction test that sorts both sides passes identically on `atomicAdd` and on the scan meant to replace it — the *set* was never the broken thing |
 | [vendor-golden-baseline-crosscheck.md](vendor-golden-baseline-crosscheck.md) | every glyph in the engine invisible on AMD, with the font loaded, 189 glyphs packed and 852 quads submitted — bake that and the nightly defends a blank UI forever |
 | [binary-greedy-voxel-meshing.md](binary-greedy-voxel-meshing.md) | a merged quad with U and V swapped, or width and height transposed, still merges and still draws — five of the six face directions look right |
@@ -232,6 +233,7 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 **Renderer** — [rhi-abstraction-boundary.md](rhi-abstraction-boundary.md) ·
 [ddgi-probe-cascades-and-sparsity.md](ddgi-probe-cascades-and-sparsity.md) ·
 [vulkan-command-ordered-buffer-writes.md](vulkan-command-ordered-buffer-writes.md) ·
+[gl-global-setter-resets-indexed-state.md](gl-global-setter-resets-indexed-state.md) ·
 [lazy-static-release-ownership.md](lazy-static-release-ownership.md) ·
 [gpu-debug-draws.md](gpu-debug-draws.md) ·
 [gpu-scan-compaction.md](gpu-scan-compaction.md) ·

--- a/docs/agent-rules/gl-global-setter-resets-indexed-state.md
+++ b/docs/agent-rules/gl-global-setter-resets-indexed-state.md
@@ -170,6 +170,9 @@ folded in here.
   into the array's declaration, not into the setter.
 - Grep the **callers** for a comment that states the semantic. A caller that only
   ever narrows a state is depending on something to widen it.
-- Ask which attachments a wrong answer would be **visible** on. State that only
-  render target 0 exercises is state no screenshot gate covers, on any path that
-  displays render target 0.
+- Ask which attachments a wrong answer would be **visible** on. A screenshot gate
+  covers only what the path it captures displays, and every forward path here
+  displays render target 0 alone — so a defect confined to attachments above 0
+  passes every such gate. That is the coverage condition this bug lived in for a
+  whole phase, and it is why the deferred path, where those attachments *are* the
+  picture, is the one that finally showed it.

--- a/docs/agent-rules/gl-global-setter-resets-indexed-state.md
+++ b/docs/agent-rules/gl-global-setter-resets-indexed-state.md
@@ -1,0 +1,175 @@
+# A GL global setter is the indexed setter for every draw buffer — porting it as "the fallback" is a permanent leak
+
+Postmortem of issue **#823**: on Vulkan the **deferred** editor frame was
+byte-identical no matter what you changed — the same MD5 at a given camera pose
+across light edits and across editor *processes*. The scene rendered as flat
+grey: no directional light, no shadows, no skybox, no material colour. Forward
+in the same session was perfect, and deferred on OpenGL was perfect.
+
+## The rule GL encodes, and the half that gets ported
+
+GL has three state pairs where a global entry point is *defined* as its indexed
+form applied to **every** draw buffer:
+
+| global | indexed | what the global does to divergence |
+|---|---|---|
+| `glColorMask` | `glColorMaski` | overwrites every buffer's mask |
+| `glEnable`/`glDisable(GL_BLEND)` | `glEnablei`/`glDisablei` | overwrites every buffer's enable |
+| `glBlendFunc`/`glBlendFuncSeparate` | `glBlendFunci` | overwrites every buffer's factors |
+
+A backend that keeps its own per-attachment array must therefore make the global
+setter **overwrite the whole array**. Model it as "per-attachment value, falling
+back to the global one" and you invert the relationship: nothing ever writes the
+per-attachment entry again, so **one indexed call is permanent for the rest of
+the process**.
+
+The Vulkan arm had ported exactly one of the three. `SetBlendFunc` cleared
+`AttachmentBlendFuncSet` and said why in a comment; `SetColorMask` and
+`SetBlendState` did not, and the lowering read
+`AttachmentColorMask[i] & globalMask` and `AttachmentBlend[i] || state.Blend`.
+
+## Why it stayed invisible for a whole phase
+
+Two independent reasons, and both are the general lesson:
+
+1. **The caller relies on the reset and cannot state it.**
+   `CommandDispatch::ApplyRenderState` calls the global setter and then only ever
+   *disables* the attachments a command's `colorAttachmentWriteMask` names — it
+   never re-enables one, because the global call is supposed to have. Its comment
+   says so out loud ("glColorMask above resets all buffers, then glColorMaski
+   selectively disables masked-out ones"). Read the *caller's* comment when
+   porting a facade entry point; the contract lives there, not in the signature.
+
+2. **Only attachment 0 is ever looked at on the forward path.** The forward scene
+   framebuffer's RT1/RT2/RT3 are entity-id, view normals and velocity — inputs to
+   picking, AO and TAA, none of which anyone eyeballs — the fix turned out to
+   repair forward-path screen-space AO on Vulkan as a side effect, because
+   `SceneViewNormals` had been holding its clear value and GTAO was integrating
+   from a constant bogus normal. So the whole editor looked fine while every
+   draw in the process had been writing colour attachment 0 alone ever since the
+   first narrowing command — `Renderer3D::DrawLine`, which
+   every editor gizmo built from line segments goes through, sets
+   `colorAttachmentWriteMask = 0x01`, and the infinite grid sets
+   `0xFF & ~(1 << 2)`. The deferred path is where attachments 1..3 *are* the
+   picture.
+
+The deferred symptom then falls out of one shader line. The G-Buffer clears to
+`(0.1, 0.1, 0.1, 1.0)`, and `emissiveFlags.a > 0.5` is
+`ComputeDeferredLit`'s **unlit** flag. With RT2 never written, every pixel took
+the unlit early-out and returned `emissive.rgb` — a uniform grey that is a pure
+function of geometry and camera, immune to every light, shadow, IBL and sky
+input. The geometry still visible in the viewport was the downstream AO and fog
+shaping that flat grey by depth.
+
+## The measurement that settled it
+
+Three cheap steps, in this order, and none of them a guess:
+
+1. **A hash A/B with a control on the same session.** Same pose, sun at
+   2.6 / 40 / 0 / 2.6: deferred returned one MD5 four times, forward returned
+   three different ones and reproduced its first hash exactly. That is both the
+   repro *and* the noise floor (zero) in one table, and the forward column is
+   what makes the deferred column mean anything.
+2. **Every capture carries a liveness block — read it.** The first run of this
+   A/B was taken against a window that had been minimised, where every image is
+   identical by construction. `olo_render_capture_target` and `olo_screenshot`
+   report `ticking` / `stale` / `frameIndex`; assert on them per shot, and check
+   the frame index advanced between shots. See
+   [live-verification-noise-floor.md](live-verification-noise-floor.md).
+3. **Decode the capture PNGs, do not look at them.** `GBufferAlbedo` *displayed*
+   as solid white and was misread as "the G-Buffer is empty" — its alpha
+   (metallic) is 0, so a viewer composites it against white. Counting unique
+   values per channel instead gave the real answer immediately, and made the
+   backend table decisive:
+
+   | target | OpenGL | Vulkan |
+   |---|---|---|
+   | `GBufferAlbedo` (RT0) | 7 unique/channel | 7 — identical to GL |
+   | `GBufferNormal` (RT1) | 256/188/5 | **1/1/1 — the clear value** |
+   | `GBufferEmissive` (RT2) | 85/63/46 | **1/1/1 — the clear value** |
+   | `SceneDepth` | 88 | 88 — identical to GL |
+
+   RT0 and depth matching GL byte-for-byte is what rules out "the capture path
+   resolves the wrong resource on Vulkan" — the same by-name view machinery
+   answered correctly for attachment 0 and for depth in the same call sequence.
+   Both halves of an "is my instrument lying?" question are answerable from one
+   table if it contains a channel you already trust.
+
+Three levers were also proven to *act* before anything was concluded from their
+silence (the rule from
+[render-graph-transient-aliasing.md](render-graph-transient-aliasing.md)): the
+overdraw debug view and tonemap exposure both moved the frame and returned to
+the baseline hash exactly, so "the light edits do nothing" is a statement about
+lighting, not about a dead viewport.
+
+## The fix, and its shape
+
+`SetColorMask` fills `AttachmentColorMask`, and the pipeline lowering reads that
+array as the **sole authority** on both the baked and the dynamic route — no
+`& globalMask` composed back on top, because that would stop a
+`glColorMaski`-shaped per-attachment WIDEN surviving a preceding global narrow.
+One input decides, in both directions, as in GL.
+
+**The blend twin looks identical and is not.** The obvious next step — make
+`SetBlendState` fill `AttachmentBlend` too, and drop the `|| state.Blend` from
+the lowering — was written, and the pass suite rejected it:
+`DecalRenderPass` enables RT2 per-attachment for an Emissive decal whose
+`PODRenderState` carries `blendEnabled = false`, so it needs the per-attachment
+enable to survive the global disable `ApplyPODRenderState` then issues. GL would
+clear it; the engine's passes are written against the OR. Matching GL there
+would have deleted working additive decal accumulation on Vulkan *without*
+fixing it on GL — a regression wearing parity's clothes. The change was reverted
+and the divergence recorded at the declaration instead.
+
+That is the part worth carrying away: **"same archetype" is a hypothesis, not a
+licence.** Two adjacent pieces of state with the same GL rule can have different
+callers depending on different semantics, and the only thing that separates them
+is running the suite that covers the caller.
+
+`RendererAPI` has exactly three indexed entry points —
+`SetColorMaskForAttachment`, `SetBlendStateForAttachment`,
+`SetBlendFuncForAttachment`. Two of the three globals now overwrite their array
+(`SetColorMask`, and `SetBlendFunc` which already did); `SetBlendState`
+deliberately does not, for the reason above.
+
+Pinned by `VulkanDrawPath.GlobalColorMaskResetsPerAttachmentDivergence`,
+which drives three render targets through **one recording** — because the leak
+was process-scoped, a fresh frame per case would reset the very state under
+test. It asserts that the indexed mask really masks, that a global call takes
+it back, and that an indexed widen survives a global narrow. The first of those
+is the control: a
+no-op indexed mask would satisfy the reset assertion trivially, so without it
+the test would pass on a broken build.
+
+## What this surfaced next door, and did not fix
+
+Restoring the GL semantic also takes away an accident Vulkan had been living
+off. `DecalRenderPass::ExecuteOnGBuffer` sets **channel-level** per-attachment
+masks (RT1.xy writable, RT1.zw preserved, and so on) and then calls
+`CommandDispatch::InvalidateRenderStateCache()` so the next packet re-applies
+its POD state — which runs `ApplyPODRenderState`, which calls the global
+`SetColorMask`. On GL that has always wiped those masks before the decal draw;
+on Vulkan they survived only because the global setter was inert. So the decal
+mode matrix is defeated in production on **both** backends once this lands.
+
+`VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets` does not see
+it: the tenant substitutes `FixtureDecalDispatch`, which never applies POD
+state, so it pins the *pass's* masking and not the path a real frame takes. A
+per-draw contract verified through a dispatch function the production path does
+not use is verifying the setup, not the draw.
+
+Fixing it properly means the command layer owning per-attachment channel masks —
+`PODRenderState::colorAttachmentWriteMask` is one bit per attachment and cannot
+express them — so it is a separate change with its own tenant, filed rather than
+folded in here.
+
+## The checklist for the next facade entry point
+
+- Does the GL entry point this mirrors have an **indexed sibling**? If so, decide
+  explicitly whether it overwrites the indexed state, and write that decision
+  into the array's declaration, not into the setter.
+- Grep the **callers** for a comment that states the semantic. A caller that only
+  ever narrows a state is depending on something to widen it.
+- Ask which attachments a wrong answer would be **visible** on. State that only
+  render target 0 exercises is state no screenshot gate covers, on any path that
+  displays render target 0.


### PR DESCRIPTION
On Vulkan the **deferred** editor frame was byte-identical no matter what you changed — the same
MD5 per camera pose across light edits and across editor processes, rendering as flat grey with no
directional light, no shadows and no skybox. Forward in the same session was correct, and deferred
on OpenGL was correct.

It is not a render-graph or capture-path problem. The MCP capture tools were telling the truth the
whole way through; the G-Buffer really was missing everything above colour attachment 0.

## Root cause

GL defines `glColorMask` as `glColorMaski` applied to **every** draw buffer, so it clears any
divergence an earlier indexed call installed — and `CommandDispatch::ApplyRenderState` leans on
exactly that. It only ever *disables* the attachments a command's `colorAttachmentWriteMask` names
and never re-enables one, and its own comment says why: *"glColorMask above resets all buffers, then
glColorMaski selectively disables masked-out ones"*. `OpenGLRendererAPI::SetColorMask` honours it
(`m_AttachmentColorMasks.fill(mask)`).

`VulkanRendererAPI::SetColorMask` only wrote the global field, and the lowering read
`AttachmentColorMask[i] & globalMask` — so nothing ever wrote the per-attachment entry again and a
narrowing indexed call was **permanent for the process**. `Renderer3D::DrawLine` sets
`colorAttachmentWriteMask = 0x01` on every line segment (every editor gizmo built from lines goes
through it) and the infinite grid sets `0xFF & ~(1 << 2)`. From the first such draw, every Vulkan
draw in the process wrote colour attachment 0 alone.

Forward displays only attachment 0, which is why nothing looked wrong there. Deferred's G-Buffer
RT2 (emissive) then kept its cleared `alpha = 1.0` — which is `ComputeDeferredLit`'s **unlit** flag —
so every pixel returned `emissive.rgb`. SceneColor became a uniform 0.1 grey that is a pure function
of geometry and camera, immune to every light, shadow, IBL and sky input; the geometry still visible
in the viewport was the downstream AO and fog shaping that flat grey by depth.

## What changed

`VulkanRendererAPI::SetColorMask` now fills `AttachmentColorMask` for every attachment, mirroring
`glColorMask` and the `SetBlendFunc` precedent already in that file. The pipeline lowering then reads
that array as the sole colour-mask input on both the baked and the dynamic route — the `& globalMask`
it used to compose on top is gone, because it would stop a `glColorMaski`-shaped per-attachment
*widen* surviving a preceding global narrow, which is the opposite of GL.

**The blend twin looks like the same bug and is not — I tried it and the suite said no.** Making
`SetBlendState` fill `AttachmentBlend` and dropping the `|| state.Blend` failed
`VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets`: `DecalRenderPass` enables RT2
per-attachment for an Emissive decal whose `PODRenderState` carries `blendEnabled = false`, and needs
that enable to survive the global disable `ApplyPODRenderState` issues right after. GL would clear it;
this engine's passes are written against the OR. Matching GL would have deleted working additive decal
accumulation on Vulkan without fixing it on GL, so it is reverted and the divergence is documented at
the `AttachmentBlend` declaration. The residual asymmetry — a per-attachment blend *disable* cannot
override a global enable, which `OITResolveRenderPass` asks for — is filed, not changed here.

## Found next door, deliberately not fixed here

Restoring the GL semantic takes away an accident Vulkan had been living off.
`DecalRenderPass::ExecuteOnGBuffer` sets **channel-level** per-attachment masks (RT1.xy writable,
RT1.zw preserved, …) and then calls `InvalidateRenderStateCache()` so the next packet re-applies its
POD state — which calls the global `SetColorMask`. On GL that has always wiped those masks before the
decal draw; on Vulkan they survived only because the global setter was inert. So the decal mode matrix
is defeated in production on **both** backends, and this PR does not change that on GL.

`VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets` does not catch it because the
tenant substitutes `FixtureDecalDispatch`, which never applies POD state — it pins the pass's masking,
not the path a real frame takes. Fixing it means the command layer owning per-attachment *channel*
masks (`colorAttachmentWriteMask` is one bit per attachment and cannot express them), which is a
separate change with its own tenant. Filed separately.

## Review guide

**Where I'd look hardest**

1. `OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp::SetColorMask` — the fill is only correct
   because `ApplyRenderState` re-narrows immediately afterwards. Any caller that sets an indexed
   colour mask and expects it to outlive the next global call now loses it. `DecalRenderPass` is
   exactly that shape; it survives only because its dispatch never calls `SetColorMask` — see the
   note below.
2. `OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp` — the two compositions now differ on
   purpose (colour mask reads its array alone, blend ORs the global in). That asymmetry is the thing
   most likely to look like a mistake to a reader, so it is commented at all three sites.
3. `OloEngine/tests/Rendering/VulkanDrawPathTest.cpp` — the control half. All three cases are
   asserted from one recording on purpose: a no-op indexed mask would satisfy the reset assertion
   trivially, and a fresh frame per case would reset the process-scoped state under test.

**What I verified, and how**

Live A/B on the real editor, one scene (`Scenes/VirtualShadowMapTest.olo`), one fixed pose, with
liveness asserted on every shot (`ticking=True`, `stale=False`, frame index advancing ~135 between
captures — the first attempt was against a minimised window, where every capture is identical by
construction):

| sun `Intensity` | deferred before | deferred after | forward (control) |
|---|---|---|---|
| 2.6 | `DE56DFD3` | `D6C0F6CD` | `1460999B` |
| 40 | `DE56DFD3` | `F76F3902` | `A3393A1F` |
| 0 | `DE56DFD3` | `CADDB4AF` | `591429B0` |
| 2.6 again | `DE56DFD3` | `D6C0F6CD` | `1460999B` |

Deferred was one hash four times and is now three distinct ones that return to the baseline exactly.
Before concluding anything from "the light edits do nothing", the levers were proven to act: the
overdraw debug view and tonemap exposure both moved the frame and returned to the baseline hash.

G-Buffer channel counts (unique values per channel, decoded from the captures rather than eyeballed
— `GBufferAlbedo` *displays* as solid white because its alpha is metallic=0):

| target | GL (reference) | VK before | VK after |
|---|---|---|---|
| `GBufferAlbedo` | `[7, 7, 7]` | `[7, 7, 7]` | `[7, 7, 7]` |
| `GBufferNormal` | `[256, 188, 5]` | `[1, 1, 1]` | `[256, 188, 5]` |
| `GBufferEmissive` | `[85, 63, 46]` | `[1, 1, 1]` | `[85, 63, 46]` |
| `SceneColor` | `[182, 125, 110]` | `[1, 1, 1]` | `[182, 125, 110]` |
| `SceneDepth` | `[88]` | `[88]` | `[88]` |

Vulkan now matches the OpenGL reference exactly on every channel. Screenshots confirm sun, cast
shadows and skybox are back on deferred.

`VulkanDrawPath.GlobalColorMaskResetsPerAttachmentDivergence` — new, device-gated, SKIPs headless.
Its control half (the masked attachment must read the clear) is what makes the reset half
non-vacuous. All **86** Vulkan tests pass, including the decal mode matrix.

Built and verified on the `dev-cached` (clang-cl + Ninja) tree, which caught a `Ref<T>`
const-propagation defect in the new test that the MSVC tree compiled silently. Forward and deferred
output from the clang-cl binary is byte-identical to the MSVC binary's.

**Forward's frame moved too, and that is a second fix, not a regression.** Forward's cross-backend
residual against GL went 9.1 → 10.7 mean channel delta, with the difference concentrated as a smooth
gradient over the floor and walls and near-zero on the objects — an AO signature. Measured directly:
on the fixed build the forward path's `SceneViewNormals` now carries `[256, 188]` unique values and
`AOBuffer` has 185, where the attachment had previously been masked off. Forward's screen-space AO on
Vulkan was integrating from a constant bogus normal. After the fix forward and deferred sit at the
same cross-backend residual (10.65 vs 10.62), which is what the two paths agreeing looks like.

**Least confident about**

That `SetColorMask` filling the array is safe for every existing per-attachment caller. It is safe for
the two in-tree ones (`DecalRenderPass`, `OITResolveRenderPass`) because both re-assert their masks
explicitly, and all 86 Vulkan tests pass — but the guarantee is "nobody currently relies on the leak",
not a structural one. The blend half of this change is where that assumption already proved wrong
once, which is why it is not in the diff.

**Deliberately not tested**

The decal channel-mask defect described above — it needs a tenant that dispatches through the real
`CommandDispatch::DrawDecal`, which is the separate change. And MSAA deferred (`PerSampleLighting`):
the G-Buffer resolve path has no Vulkan arm yet, so the multisample G-Buffer was out of reach.

Closes #823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Vulkan color-mask handling across multiple render-target attachments.
  - Global color-mask updates now apply consistently to all attachments, while indexed masks affect only the selected attachment.
  - Improved blending behavior for integer-format render targets.

- **Tests**
  - Added regression coverage for global and per-attachment color-mask interactions.

- **Documentation**
  - Added guidance and troubleshooting documentation for indexed rendering-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->