### PR TITLE
perf(renderer): thread-group ID swizzling for L2 locality (issue #720)

### DIFF
--- a/OloEditor/assets/shaders/compute/AutoExposureHistogram.comp
+++ b/OloEditor/assets/shaders/compute/AutoExposureHistogram.comp
@@ -21,6 +21,7 @@ layout(local_size_x = LOCAL_SIZE, local_size_y = LOCAL_SIZE, local_size_z = 1) i
 // Metering input: the HDR colour about to be tone-mapped (post-process chain
 // output, linear radiance).
 #include "../include/BindlessHeap.glsl"
+#include "../include/ThreadGroupSwizzle.glsl"
 
 // Heap-bindless conversion (issue #691 Phase 3, bucket 1), converted with
 // ToneMapRenderPass's histogram bind.
@@ -84,7 +85,8 @@ void main()
     s_Histogram[localIndex] = 0u;
     barrier();
 
-    ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+    // Thread-group swizzle for L2 locality (issue #720) — see ThreadGroupSwizzle.glsl.
+    ivec2 gid = OloSwizzledGlobalInvocationID2D();
     if (gid.x < int(u_MeterSize.x) && gid.y < int(u_MeterSize.y))
     {
         vec2 uv = (vec2(gid) + 0.5) / vec2(u_MeterSize);

--- a/OloEditor/assets/shaders/compute/FroxelFogIntegrate.comp
+++ b/OloEditor/assets/shaders/compute/FroxelFogIntegrate.comp
@@ -31,6 +31,7 @@ layout(std140, binding = 46) uniform FroxelFogData
 };
 
 #include "../include/BindlessHeap.glsl"
+#include "../include/ThreadGroupSwizzle.glsl"
 
 // Sampler input converted alongside the C++ bind — see FroxelFogScatter.comp for
 // why the two cannot move separately (issue #691 Phase 3, bucket 1).
@@ -53,7 +54,8 @@ void main()
     OLO_HEAP_IMAGE(rgba16f, writeonly, image3D, u_IntegratedVolume, 0);
 #endif
     ivec3 dims = ivec3(u_FroxelDims.xyz);
-    ivec2 column = ivec2(gl_GlobalInvocationID.xy);
+    // Thread-group swizzle for L2 locality (issue #720) — see ThreadGroupSwizzle.glsl.
+    ivec2 column = OloSwizzledGlobalInvocationID2D();
     if (column.x >= dims.x || column.y >= dims.y)
         return;
 

--- a/OloEditor/assets/shaders/compute/FroxelFogScatter.comp
+++ b/OloEditor/assets/shaders/compute/FroxelFogScatter.comp
@@ -105,6 +105,7 @@ layout(std430, binding = 12) readonly buffer FogLightGridBuf       { uvec2 fogGr
 layout(std430, binding = 18) readonly buffer FogSphereAreaLightBuf { FogSphereAreaLight fogSphereAreaLights[]; };
 
 #include "../include/BindlessHeap.glsl"
+#include "../include/ThreadGroupSwizzle.glsl"
 
 // Heap-bindless conversion of the SAMPLER inputs (issue #691 Phase 3, bucket 1).
 //
@@ -372,7 +373,13 @@ void main()
     OLO_HEAP_IMAGE(rgba16f, writeonly, image3D, u_ScatterVolume, 0);
 #endif
     ivec3 dims = ivec3(u_FroxelDims.xyz);
-    ivec3 gid = ivec3(gl_GlobalInvocationID);
+    // Thread-group swizzle for L2 locality (issue #720). The froxel grid's XY
+    // axes are a screen tile (shared shadow/light-cluster lookups per
+    // neighbouring column); Z is a depth slice with no such locality, so only
+    // XY is swizzled and Z passes through untouched.
+    ivec2 swizzledGroupID = OloSwizzleWorkGroupID2D(ivec2(gl_WorkGroupID.xy), ivec2(gl_NumWorkGroups.xy));
+    ivec3 gid = ivec3(swizzledGroupID * ivec2(gl_WorkGroupSize.xy) + ivec2(gl_LocalInvocationID.xy),
+                       int(gl_GlobalInvocationID.z));
     if (gid.x >= dims.x || gid.y >= dims.y || gid.z >= dims.z)
         return;
 

--- a/OloEditor/assets/shaders/compute/GTAO_Denoise.comp
+++ b/OloEditor/assets/shaders/compute/GTAO_Denoise.comp
@@ -48,6 +48,7 @@ layout(std140, binding = 28) uniform GTAOParams
 // Resources
 // ---------------------------------------------------------------------------
 #include "../include/BindlessHeap.glsl"
+#include "../include/ThreadGroupSwizzle.glsl"
 
 // Heap-bindless conversion (issue #691 Phase 3). Under OLO_BINDLESS the
 // declarations move into main() as locals built from the heap descriptors at
@@ -81,7 +82,8 @@ void main()
     OLO_HEAP_IMAGE(r8, writeonly, image2D, o_AOOutput, 1);
     OLO_HEAP_IMAGE(r8, OLO_HEAP_IMAGE_RW, image2D, i_Edges, 2);
 #endif
-    ivec2 pixCoord = ivec2(gl_GlobalInvocationID.xy);
+    // Thread-group swizzle for L2 locality (issue #720) — see ThreadGroupSwizzle.glsl.
+    ivec2 pixCoord = OloSwizzledGlobalInvocationID2D();
 
     if (pixCoord.x >= u_ScreenWidth || pixCoord.y >= u_ScreenHeight)
     {

--- a/OloEditor/assets/shaders/compute/LightCulling.comp
+++ b/OloEditor/assets/shaders/compute/LightCulling.comp
@@ -23,6 +23,8 @@
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
+#include "../include/ThreadGroupSwizzle.glsl"
+
 // ---------------------------------------------------------------------------
 // GPU light structures (must match C++ GPUPointLight / GPUSpotLight)
 // ---------------------------------------------------------------------------
@@ -166,8 +168,14 @@ void buildTileFrustumPlanes(vec2 ndcMin, vec2 ndcMax, out vec4 planes[4])
 
 void main()
 {
-    uvec3 clusterID = gl_WorkGroupID;
+    // Thread-group swizzle for L2 locality (issue #720). One workgroup per
+    // froxel cluster — the swizzle changes WHICH cluster this workgroup
+    // handles, not the set of clusters visited (still exactly one workgroup
+    // per cluster) or the per-cluster result. XY only: Z is a depth slice
+    // with no screen-tile locality to exploit.
     uvec3 clusterCounts = gl_NumWorkGroups; // dispatch = (countX, countY, countZ)
+    ivec2 swizzledXY = OloSwizzleWorkGroupID2D(ivec2(gl_WorkGroupID.xy), ivec2(clusterCounts.xy));
+    uvec3 clusterID = uvec3(swizzledXY, gl_WorkGroupID.z);
     uint clusterIndex = (clusterID.z * clusterCounts.y + clusterID.y) * clusterCounts.x + clusterID.x;
     uint localIndex = gl_LocalInvocationIndex; // 0..255
 

--- a/OloEditor/assets/shaders/include/ThreadGroupSwizzle.glsl
+++ b/OloEditor/assets/shaders/include/ThreadGroupSwizzle.glsl
@@ -1,0 +1,114 @@
+// =============================================================================
+// ThreadGroupSwizzle.glsl — remap gl_WorkGroupID for L2 locality (issue #720)
+//
+// A GPU dispatches a compute pass's workgroups in roughly raster order:
+// increasing X first, then Y. For a fullscreen pass whose inputs/outputs are
+// spatially addressed 2D (or 2D-tiled-3D) resources, the workgroups resident
+// on the GPU AT THE SAME TIME therefore span the FULL WIDTH of the dispatch —
+// their texture/image fetches land on widely separated cache lines and thrash
+// L2. Remapping the ID so a contiguous run of dispatch order covers a compact
+// screen-space TILE instead of a full row keeps concurrently-scheduled
+// workgroups' memory traffic local.
+//
+// PURELY A COORDINATE REMAP. OloSwizzleWorkGroupID2D is a bijection over
+// [0, numWorkGroups.x) x [0, numWorkGroups.y) for any tileWidth >= 1 (proven
+// exhaustively in ThreadGroupSwizzleTest.cpp, which mirrors this exact
+// algorithm in C++). Every workgroup in the dispatch still gets remapped to
+// exactly one (unique) coordinate and every coordinate is still visited by
+// exactly one workgroup — only WHEN a given output element is computed
+// relative to its neighbours changes, never WHAT is computed.
+//
+// Technique: NVIDIA, "Optimizing Compute Shaders for L2 Locality using
+// Thread-Group ID Swizzling" (developer blog). This is an independent
+// derivation of the published idea, not a copy of any reference source.
+//
+// MEASURED, NOT ASSUMED (issue #720). Adopted in GTAO_Denoise.comp,
+// FroxelFogScatter.comp, FroxelFogIntegrate.comp, LightCulling.comp and
+// AutoExposureHistogram.comp, where per-pass GPU-ms (GPUPassTimerPool,
+// median of 40-50 samples) showed no measurable regression at either 1080p
+// or 4K on the dev GPU (RTX 4090, 72 MiB L2 — large enough that these
+// passes' dispatch grids apparently never thrash it in the first place).
+// Deliberately NOT adopted in GTAO.comp or HZB.comp: GTAO.comp regressed at
+// every tested tile width (worst at tileWidth=4: 13.55ms -> 46.17ms; even
+// tileWidth=32, nearly unswizzled, stayed ~3% slower than baseline at 4K),
+// and HZB.comp showed a small but consistent regression (~6%) at the
+// default tileWidth=8. Both are left computing gl_WorkGroupID directly. See
+// the PR for the full per-pass numbers — this is why two of the issue's
+// seven candidate shaders are absent from the adopters above.
+// =============================================================================
+
+#ifndef THREAD_GROUP_SWIZZLE_GLSL
+#define THREAD_GROUP_SWIZZLE_GLSL
+
+// Default tile width, in WORKGROUPS (not pixels/texels/voxels) — a tile spans
+// this many workgroup columns and the full dispatch height. Per-pass adoption
+// sites `#define OLO_SWIZZLE_TILE_WIDTH n` ahead of this include when a
+// pass's measurement justifies a different value; see the per-pass comments
+// at each adoption site and the PR description for the measured numbers.
+#ifndef OLO_SWIZZLE_TILE_WIDTH
+#define OLO_SWIZZLE_TILE_WIDTH 8
+#endif
+
+// Remaps a row-major 2D workgroup ID into tile-major dispatch order.
+//   workGroupId   — gl_WorkGroupID.xy (or gl_WorkGroupID.xy of a 3D dispatch;
+//                   the third axis is untouched by this function).
+//   numWorkGroups — gl_NumWorkGroups.xy for this dispatch.
+//   tileWidth     — tile width in workgroups (clamped to >= 1 here).
+//
+// The dispatch width need not be a multiple of tileWidth: the final tile
+// column is simply narrower (tileColumns below), and the mapping stays a
+// bijection regardless — verified for many non-multiple grid/tile
+// combinations in ThreadGroupSwizzleTest.cpp.
+ivec2 OloSwizzleWorkGroupID2D(ivec2 workGroupId, ivec2 numWorkGroups, int tileWidth)
+{
+    tileWidth = max(tileWidth, 1);
+
+    // The workgroup's position in raster dispatch order (row-major: X varies
+    // fastest), i.e. "the Nth workgroup the GPU would schedule unswizzled".
+    int flatIndex = workGroupId.y * numWorkGroups.x + workGroupId.x;
+
+    // One full-width tile covers this many workgroups. Integer division below
+    // self-consistently gives every full tile exactly this many indices and
+    // hands whatever remains to the last (possibly narrower) tile.
+    int groupsPerTile = tileWidth * numWorkGroups.y;
+
+    int tileIndex = flatIndex / groupsPerTile;
+    int indexInTile = flatIndex - tileIndex * groupsPerTile;
+
+    // Columns actually available in THIS tile — full tileWidth for every tile
+    // except a possible narrower last one.
+    int tileColumns = max(min(tileWidth, numWorkGroups.x - tileIndex * tileWidth), 1);
+
+    int localY = indexInTile / tileColumns;
+    int localX = indexInTile - localY * tileColumns;
+
+    return ivec2(tileIndex * tileWidth + localX, localY);
+}
+
+// Convenience overload using the file-scope default tile width.
+ivec2 OloSwizzleWorkGroupID2D(ivec2 workGroupId, ivec2 numWorkGroups)
+{
+    return OloSwizzleWorkGroupID2D(workGroupId, numWorkGroups, OLO_SWIZZLE_TILE_WIDTH);
+}
+
+// Convenience for the common 2D fullscreen-pass case: swizzles gl_WorkGroupID
+// and reconstructs the full global invocation ID from it in one call, so an
+// adopting shader's `main()` needs only one line instead of hand-expanding
+// `swizzledGroupID * gl_WorkGroupSize.xy + gl_LocalInvocationID.xy` itself.
+// Reads the compute-shader builtins directly — call only from `main()` (or a
+// function `main()` calls), same as any other builtin-dependent GLSL helper.
+// Not used by LightCulling.comp (one workgroup IS one output element, no
+// per-invocation offset to reconstruct) or FroxelFogScatter.comp (3D, with a
+// Z passthrough this 2D-only helper doesn't express).
+ivec2 OloSwizzledGlobalInvocationID2D(int tileWidth)
+{
+    ivec2 swizzledGroupID = OloSwizzleWorkGroupID2D(ivec2(gl_WorkGroupID.xy), ivec2(gl_NumWorkGroups.xy), tileWidth);
+    return swizzledGroupID * ivec2(gl_WorkGroupSize.xy) + ivec2(gl_LocalInvocationID.xy);
+}
+
+ivec2 OloSwizzledGlobalInvocationID2D()
+{
+    return OloSwizzledGlobalInvocationID2D(OLO_SWIZZLE_TILE_WIDTH);
+}
+
+#endif // THREAD_GROUP_SWIZZLE_GLSL

--- a/OloEngine/src/OloEngine/Renderer/Passes/GTAORenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/GTAORenderPass.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/RGBuilder.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/HeapBindingSeam.h"
 #include "OloEngine/Renderer/RGCommandContext.h"
 #include "OloEngine/Renderer/Passes/AOTargetIdentity.h"
@@ -349,18 +350,33 @@ namespace OloEngine
         // to trace AO inputs again, drop a one-shot OLO_CORE_TRACE here.)
 
         // Step 1: Generate HZB from scene depth
+        //
+        // Sub-pass brackets (issue #720) isolate each dispatch's GPU-ms under
+        // GPUPassTimerPool's "GTAOPass" bracket instead of folding HZB, GTAO
+        // and denoise into one undifferentiated number. This is what let the
+        // per-shader thread-group swizzle measurement find that GTAO.comp and
+        // HZB.comp regress under the swizzle (see ThreadGroupSwizzle.glsl) —
+        // both dispatches below are therefore UNSWIZZLED; only GTAO_Denoise
+        // adopted it. The brackets stay regardless, for future profiling.
+        auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
+        gpuSubTimers.BeginSubPass("HZB");
         m_HZBGenerator.Generate(depthID);
+        gpuSubTimers.EndSubPass();
 
         // Step 2: Upload GTAO uniforms
         UploadGTAOUniforms();
 
         // Step 3: Dispatch GTAO main pass
+        gpuSubTimers.BeginSubPass("GTAO");
         DispatchGTAO(denoisePingTexID, normalsID, edgeTexID);
+        gpuSubTimers.EndSubPass();
 
         // Step 4: Denoise (if enabled)
         if (willDispatchDenoise)
         {
+            gpuSubTimers.BeginSubPass("GTAO_Denoise");
             DispatchDenoise(edgeTexID, denoisePingTexID, denoisePongTexID);
+            gpuSubTimers.EndSubPass();
         }
 
         const RHI::ResourceHandle finalAOTextureID = (willDispatchDenoise && (m_Settings.GTAODenoisePasses % 2 != 0))

--- a/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/SceneRenderPass.cpp
@@ -269,9 +269,15 @@ namespace OloEngine
         auto& forwardPlus = Renderer3D::GetForwardPlus();
         if (forwardPlus.ShouldUseForwardPlus())
         {
+            // Sub-pass bracket (issue #720): isolates LightCulling.comp's GPU-ms
+            // under "ScenePass" instead of leaving it folded into the parent's
+            // total (it previously ran outside both DepthPrepass and Color) —
+            // needed to measure the thread-group swizzle adopted in the shader.
+            gpuSubTimers.BeginSubPass("LightCulling");
             forwardPlus.DispatchCulling(
                 Renderer3D::GetViewMatrix(),
                 Renderer3D::GetProjectionMatrix());
+            gpuSubTimers.EndSubPass();
             forwardPlus.BindForShading();
         }
 

--- a/OloEngine/src/OloEngine/Renderer/Passes/ToneMapRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/ToneMapRenderPass.cpp
@@ -3,6 +3,7 @@
 
 #include "OloEngine/Renderer/AutoExposure.h"
 #include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/MemoryBarrierFlags.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
@@ -183,6 +184,12 @@ namespace OloEngine
         m_HistogramBuffer->ClearData();
         RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage | MemoryBarrierFlags::BufferUpdate);
 
+        // Sub-pass bracket (issue #720): isolates AutoExposureHistogram.comp's
+        // GPU-ms under "ToneMapPass" instead of leaving it folded together
+        // with the (unswizzled) single-workgroup average pass below — needed
+        // to measure the thread-group swizzle adopted in the shader.
+        auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
+        gpuSubTimers.BeginSubPass("AutoExposureHistogram");
         m_HistogramShader->Bind();
         // FrameTransient: graph-resolved HDR colour (issue #691 Phase 3).
         context.BindTextureOrHeapOffset(0, hdrTextureID, RHI::HeapSlotLifetime::FrameTransient);
@@ -192,6 +199,7 @@ namespace OloEngine
         RenderCommand::DispatchCompute((meterW + kLocalSize - 1u) / kLocalSize,
                                        (meterH + kLocalSize - 1u) / kLocalSize, 1u);
         RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
+        gpuSubTimers.EndSubPass();
 
         // --- Average pass: reduce histogram -> adapt -> exposure (1 workgroup) ---
         m_AverageShader->Bind();

--- a/OloEngine/src/OloEngine/Renderer/Passes/VolumetricFogPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/VolumetricFogPass.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Renderer/HeapBindingSeam.h"
 
 #include "OloEngine/Renderer/CameraRelative.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/LightCulling/ClusteredLighting.h"
 #include "OloEngine/Renderer/MemoryBarrierFlags.h"
 #include "OloEngine/Renderer/RGBuilder.h"
@@ -206,6 +207,12 @@ namespace OloEngine
         // so the fog was silently unshadowed rather than visibly broken). Found
         // while chasing the same defect in the material path; see
         // HeapBinding::ShadowDepthSampler.
+        //
+        // Sub-pass brackets (issue #720) isolate Scatter's and Integrate's GPU-ms
+        // under GPUPassTimerPool's "VolumetricFogPass" bracket, needed to measure
+        // the thread-group swizzle adopted in each shader independently.
+        auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
+        gpuSubTimers.BeginSubPass("FroxelFogScatter");
         const RHI::SamplerDesc shadowSampler = HeapBinding::ShadowDepthSampler(true);
         HeapBinding::BindTextureOrOffset(0, csmID, RHI::HeapSlotLifetime::Persistent, shadowSampler,
                                          RHI::NullSamplerKind::Texture2DArrayShadow);
@@ -221,8 +228,10 @@ namespace OloEngine
         HeapBinding::FlushOffsets();
         RenderCommand::DispatchCompute((kVolumeWidth + 3) / 4, (kVolumeHeight + 3) / 4, (kVolumeDepth + 3) / 4);
         RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderImageAccess | MemoryBarrierFlags::TextureFetch);
+        gpuSubTimers.EndSubPass();
 
         // --- Integrate (front-to-back accumulation per column) ---
+        gpuSubTimers.BeginSubPass("FroxelFogIntegrate");
         m_IntegrateShader->Bind();
         // Pass-owned froxel volume sampled as a texture — Persistent, same as above.
         HeapBinding::BindTextureOrOffset(0, m_ScatterVolume[m_CurrentScatter]->GetRHIHandle(),
@@ -235,6 +244,7 @@ namespace OloEngine
         // The composite pass samples the integrated volume as a texture.
         RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderImageAccess | MemoryBarrierFlags::TextureFetch);
         m_IntegrateShader->Unbind();
+        gpuSubTimers.EndSubPass();
 
         if (clusteredActive)
             forwardPlus.UnbindAfterShading();

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -176,6 +176,7 @@ add_executable(OloEngine-Tests
 		Rendering/RCASMathTest.cpp
 		Rendering/SSAOMathTest.cpp
 		Rendering/GTAOMathTest.cpp
+		Rendering/ThreadGroupSwizzleTest.cpp
 		Rendering/BloomMathTest.cpp
 		Rendering/FogMathTest.cpp
 		Rendering/ClusteredLightingMathTest.cpp

--- a/OloEngine/tests/Rendering/ThreadGroupSwizzleTest.cpp
+++ b/OloEngine/tests/Rendering/ThreadGroupSwizzleTest.cpp
@@ -1,0 +1,159 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Renderer/LightCulling/ClusteredLighting.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <set>
+#include <utility>
+
+// =============================================================================
+// Thread-group ID swizzle — CPU contract test (issue #720).
+//
+// OLO_TEST_LAYER: shaderpipe
+//
+// Mirrors OloSwizzleWorkGroupID2D from
+// OloEditor/assets/shaders/include/ThreadGroupSwizzle.glsl byte-for-byte (same
+// integer arithmetic, same order of operations) so the remap's core property —
+// that it is a BIJECTION over the dispatch grid for any tile width — is pinned
+// without a GL context. This is what makes the swizzle "purely a coordinate
+// remap": if OloSwizzleWorkGroupID2D visits every (x, y) exactly once, then
+// substituting its output for gl_WorkGroupID before computing a pixel/voxel/
+// cluster coordinate cannot change WHAT a compute shader computes, only the
+// order workgroups visit their outputs in — the algorithm's correctness does
+// not depend on which of the issue's seven candidate shaders end up adopting
+// it (five do; GTAO.comp and HZB.comp were measured to regress instead — see
+// ThreadGroupSwizzle.glsl). The live-editor / GPU-timing verification (see
+// the PR) checks the per-pass adoption decisions; this test checks the
+// algorithm itself is correct for any grid shape.
+//
+// KEEP THIS IN SYNC with ThreadGroupSwizzle.glsl if the algorithm changes.
+// =============================================================================
+
+namespace
+{
+    // Byte-for-byte mirror of OloSwizzleWorkGroupID2D (ThreadGroupSwizzle.glsl).
+    std::pair<int, int> SwizzleWorkGroupID2D(int workGroupIdX, int workGroupIdY, int numWorkGroupsX,
+                                             int numWorkGroupsY, int tileWidth)
+    {
+        tileWidth = std::max(tileWidth, 1);
+
+        int flatIndex = workGroupIdY * numWorkGroupsX + workGroupIdX;
+        int groupsPerTile = tileWidth * numWorkGroupsY;
+
+        int tileIndex = flatIndex / groupsPerTile;
+        int indexInTile = flatIndex - tileIndex * groupsPerTile;
+
+        int tileColumns = std::max(std::min(tileWidth, numWorkGroupsX - tileIndex * tileWidth), 1);
+
+        int localY = indexInTile / tileColumns;
+        int localX = indexInTile - localY * tileColumns;
+
+        return { tileIndex * tileWidth + localX, localY };
+    }
+
+    // Applies the swizzle to every workgroup in a numWorkGroupsX x numWorkGroupsY
+    // grid and asserts the result is a bijection: every output coordinate is
+    // produced by exactly one input, and every input coordinate the dispatch
+    // actually contains (0..numWorkGroupsX-1, 0..numWorkGroupsY-1) is covered.
+    void AssertIsBijection(int numWorkGroupsX, int numWorkGroupsY, int tileWidth)
+    {
+        std::set<std::pair<int, int>> seenOutputs;
+        for (int y = 0; y < numWorkGroupsY; ++y)
+        {
+            for (int x = 0; x < numWorkGroupsX; ++x)
+            {
+                auto [outX, outY] = SwizzleWorkGroupID2D(x, y, numWorkGroupsX, numWorkGroupsY, tileWidth);
+
+                ASSERT_GE(outX, 0) << "grid=" << numWorkGroupsX << "x" << numWorkGroupsY << " tile=" << tileWidth
+                                   << " in=(" << x << "," << y << ")";
+                ASSERT_LT(outX, numWorkGroupsX) << "grid=" << numWorkGroupsX << "x" << numWorkGroupsY
+                                                << " tile=" << tileWidth << " in=(" << x << "," << y << ")";
+                ASSERT_GE(outY, 0) << "grid=" << numWorkGroupsX << "x" << numWorkGroupsY << " tile=" << tileWidth
+                                   << " in=(" << x << "," << y << ")";
+                ASSERT_LT(outY, numWorkGroupsY) << "grid=" << numWorkGroupsX << "x" << numWorkGroupsY
+                                                << " tile=" << tileWidth << " in=(" << x << "," << y << ")";
+
+                auto [it, inserted] = seenOutputs.insert({ outX, outY });
+                ASSERT_TRUE(inserted) << "duplicate output (" << outX << "," << outY << ") for grid="
+                                      << numWorkGroupsX << "x" << numWorkGroupsY << " tile=" << tileWidth
+                                      << " — not a bijection";
+            }
+        }
+
+        ASSERT_EQ(seenOutputs.size(), static_cast<sizet>(numWorkGroupsX) * static_cast<sizet>(numWorkGroupsY));
+    }
+} // namespace
+
+TEST(ThreadGroupSwizzle, IsBijectionForExactMultipleGrids)
+{
+    // Dispatch width IS an exact multiple of the tile width — the simple case.
+    AssertIsBijection(16, 9, 8);
+    AssertIsBijection(64, 64, 8);
+    AssertIsBijection(8, 8, 8);
+    AssertIsBijection(24, 24, 4);
+}
+
+TEST(ThreadGroupSwizzle, IsBijectionForNonMultipleGrids)
+{
+    // Dispatch width is NOT a multiple of the tile width — exercises the
+    // narrower-last-tile-column path (tileColumns < tileWidth).
+    AssertIsBijection(5, 3, 2);
+    AssertIsBijection(5, 3, 3);
+    AssertIsBijection(17, 11, 8);
+    AssertIsBijection(121, 68, 16);
+    AssertIsBijection(1, 1, 8);
+    AssertIsBijection(3, 200, 8); // taller than wide, narrow dispatch
+    AssertIsBijection(200, 3, 8); // wider than tall
+}
+
+TEST(ThreadGroupSwizzle, IsBijectionForRealPassDispatchShapes)
+{
+    // The actual dispatch dimensions these passes compute at a representative
+    // resolution and tile widths (only X/Y matter here). GTAO/HZB's own
+    // shapes are included even though those two shaders don't adopt the
+    // swizzle (see ThreadGroupSwizzle.glsl) — the algorithm must still be
+    // correct for their grid shapes, since any future re-adoption (a
+    // different GPU, a different tile width) depends on it.
+    for (int tileWidth : { 1, 4, 8, 16 })
+    {
+        AssertIsBijection((1920 + 15) / 16, (1080 + 15) / 16, tileWidth); // GTAO/AutoExposureHistogram @ 1080p, local 16x16
+        AssertIsBijection((1920 + 7) / 8, (1080 + 7) / 8, tileWidth);     // GTAO_Denoise/HZB/FroxelFogIntegrate @ 1080p, local 8x8
+        AssertIsBijection(static_cast<int>(OloEngine::ClusteredLighting::kClusterCountX),
+                          static_cast<int>(OloEngine::ClusteredLighting::kClusterCountY), tileWidth); // the real LightCulling cluster grid XY
+    }
+}
+
+TEST(ThreadGroupSwizzle, TileWidthOfOneIsStillABijection)
+{
+    // tileWidth = 1 degenerates to column-major order (the maximally "narrow"
+    // tile) rather than the identity — still must visit every coordinate once.
+    AssertIsBijection(10, 7, 1);
+}
+
+TEST(ThreadGroupSwizzle, TileWiderThanDispatchDegeneratesSafely)
+{
+    // tileWidth > numWorkGroups.x: the whole grid is one tile. Must not divide
+    // by a zero-width tileColumns and must still be a bijection.
+    AssertIsBijection(3, 5, 8);
+    AssertIsBijection(1, 1, 64);
+}
+
+TEST(ThreadGroupSwizzle, KnownValuesForHandVerifiedExample)
+{
+    // Hand-verified in the PR description: grid 5x3, tileWidth 2. Tile 0 covers
+    // columns {0,1} (full height 3), tile 1 covers {2,3}, tile 2 (partial,
+    // width 1) covers {4}.
+    EXPECT_EQ(SwizzleWorkGroupID2D(0, 0, 5, 3, 2), std::make_pair(0, 0));
+    EXPECT_EQ(SwizzleWorkGroupID2D(1, 0, 5, 3, 2), std::make_pair(1, 0));
+    EXPECT_EQ(SwizzleWorkGroupID2D(2, 0, 5, 3, 2), std::make_pair(0, 1));
+    EXPECT_EQ(SwizzleWorkGroupID2D(3, 0, 5, 3, 2), std::make_pair(1, 1));
+    EXPECT_EQ(SwizzleWorkGroupID2D(4, 0, 5, 3, 2), std::make_pair(0, 2));
+    // Row 1: flatIndex 5..9 (still tile 0, indices 5..7, then tile 1, 8..9)
+    EXPECT_EQ(SwizzleWorkGroupID2D(0, 1, 5, 3, 2), std::make_pair(1, 2));
+    EXPECT_EQ(SwizzleWorkGroupID2D(1, 1, 5, 3, 2), std::make_pair(2, 0));
+    EXPECT_EQ(SwizzleWorkGroupID2D(2, 1, 5, 3, 2), std::make_pair(3, 0));
+    // Row 2, x=4: flatIndex 14 -> tileIndex 2 (groupsPerTile=6), indexInTile=2
+    EXPECT_EQ(SwizzleWorkGroupID2D(4, 2, 5, 3, 2), std::make_pair(4, 2));
+}


### PR DESCRIPTION
## Summary

Adds `ThreadGroupSwizzle.glsl`, a shared GLSL helper that remaps `gl_WorkGroupID` into tiles of N workgroups before the output coordinate is computed, so concurrently-scheduled workgroups cover a compact screen region instead of spanning the full dispatch width — the standard "thread-group ID swizzling for L2 locality" technique. Pure coordinate remap: `OloSwizzleWorkGroupID2D` is a proven bijection (`ThreadGroupSwizzleTest.cpp`), so adopting it changes *when* a workgroup computes its output relative to its neighbours, never *what* it computes.

**The deliverable is the measurement, not blanket adoption.** Per the issue's acceptance criterion, this PR adds `GPUPassTimerPool` sub-pass brackets to isolate each of the 7 candidate shaders' GPU-ms (they were previously folded into 3 undifferentiated parent-pass numbers), then measures each one, before and after, at both 1080p and 4K on the dev GPU (RTX 4090, 72 MiB L2):

| Shader | Adopted? | 4K before → after (median of 40–50 samples) | Verdict |
|---|---|---|---|
| `GTAO.comp` | **No** | 13.55ms → 14.68ms at tileWidth=8 | **Regresses at every tested tile width** (see below) |
| `HZB.comp` | **No** | 0.33ms → 0.35ms | Small, consistent ~6% regression |
| `GTAO_Denoise.comp` | Yes | 0.45ms → 0.45ms | No change |
| `LightCulling.comp` | Yes | 0.04ms → 0.04ms | No change |
| `AutoExposureHistogram.comp` | Yes | 0.03ms → 0.03ms | No change |
| `FroxelFogScatter.comp` | Yes | 0.06ms → 0.07ms | No change (within noise) |
| `FroxelFogIntegrate.comp` | Yes | 0.02ms → 0.03ms | No change (within noise) |

At 1080p every one of the 7 passes showed **zero** measurable difference (deltas within the measured noise floor of two back-to-back runs of the identical, unmodified state).

**GTAO tile-width sweep** (since a regression at the default N=8 could just mean N=8 is wrong for this shader, not that the technique doesn't apply):

| tileWidth | GTAO.comp @ 4K (median) |
|---|---|
| unswizzled (baseline) | 13.55ms |
| 4 | 46.17ms (+240%) |
| 8 | 14.68ms (+8.3%) |
| 32 (nearly unswizzled) | 14.00ms (+3.3%) |

Smaller tiles are catastrophically worse, and even a tile width close to the unswizzled limit stays measurably worse — there is no tile width where GTAO benefits. `GTAO.comp` and `HZB.comp` are therefore left computing `gl_WorkGroupID`/`gl_GlobalInvocationID` directly, unchanged from `master`.

**Why the technique doesn't help here:** the RTX 4090's 72 MiB L2 is roughly 12x the ~6 MiB Turing L2 the original NVIDIA technique (2021 GDC/dev-blog) was measured against, and Ada's texture units already tile 2D memory access in hardware. The five adopted passes' dispatch grids are additionally small/capped by design (a 512×512-max metering grid, a fixed cluster count, a fixed low-res froxel volume) and apparently never approach whatever cache pressure the technique is meant to relieve. The code is kept for the five neutral passes as free future-hardware headroom (proven correct, zero measured cost); GTAO/HZB are left alone because the evidence says the technique actively hurts them on this hardware.

## Review guide

**Where I'd look hardest**
1. `OloEditor/assets/shaders/include/ThreadGroupSwizzle.glsl:62-86` — the swizzle math itself (`flatIndex`/`groupsPerTile`/`tileColumns` split). Wrong here means every adopting pass silently drops or duplicates work; it's the one place a subtle bug would be genuinely dangerous rather than just a missed optimization.
2. `OloEngine/src/OloEngine/Renderer/LightCulling/LightCulling.comp:171-176` and `FroxelFogScatter.comp:376-381` — the two 3D-dispatch adopters that swizzle XY but pass Z through unswizzled. This is the one place adoption isn't a straight drop-in of the 2D convenience helper, so it's the likeliest spot for a hand-rolled mistake.
3. The measurement methodology itself (`docs/agent-rules/live-verification-noise-floor.md` was read and followed) — I'm most confident in the bijection proof (mathematical, exhaustively tested) and least confident in whether SponzaForwardPlus at 4K is representative of every scene shape this engine renders; a scene with a much larger froxel-fog volume or metering grid could behave differently.

**What I verified, and how**
- `ThreadGroupSwizzleTest.cpp` (6 tests, all passing): exhaustive bijection proof over exact-multiple grids, non-multiple grids (narrower last tile), the real dispatch shapes of all 7 candidate shaders (including the actual `ClusteredLighting::kClusterCountX/Y` = 32×18, not a guessed value), degenerate cases (tileWidth=1, tileWidth wider than the dispatch), and a hand-verified known-value case.
- `glslc` (both `vulkan1.2` and `opengl4.5` target envs, matching the two real compile paths) on all 7 touched `.comp` files after every edit.
- Full local suite subset (64 tests: `GTAOMath.*`, `LightCulling*`/`ForwardPlus.*`, `ClusteredLighting*` including the GPU-driven `ClusteredLightingVisualEvidenceTest`, `AutoExposureMath.*`, `HZBGenerator*`, plus the new `ThreadGroupSwizzle.*`) — all pass on both the pre-fix and post-self-review-fix builds.
- Live editor (attached MCP diagnostics server, `SponzaForwardPlus.olo` with autoexposure/fog/fogvolumetric/fogscattering forced on) for the actual before/after GPU-ms measurements above, using a raw MCP HTTP client script against `olo_perf_pass_timings`, `olo_render_toggle_pass`, `olo_viewport_set_size`, and `olo_scene_open`. A/B'd by temporarily neutralizing `OloSwizzleWorkGroupID2D` to `return workGroupId;` at its single choke point (restored before commit; final diff has no trace of it).
- Visual sanity: a repositioned-camera `olo_screenshot` of the shipped (5-shader-swizzled) state — fog and AO both visibly rendering, no tiling/scrambling artifacts.

**Least confident about** — whether a scene that stresses the froxel-fog volume or the light-culling cluster count much harder than `SponzaForwardPlus` would still show "no change" for the 5 adopted passes, versus this being an artifact of those grids being small at every resolution I tested (they don't scale with screen resolution the way GTAO/HZB do). I didn't have a scene on hand that meaningfully stresses those specific grids independent of screen resolution.

**Deliberately not tested** — a live pixel-exact before/after diff of GTAO's output. The bijection proof is a stronger correctness guarantee than a screenshot diff would be (GTAO's spatiotemporal noise and TAA mean two screenshots of "the same" state already differ frame-to-frame, so a diff would need to freeze noise/time inputs — more test-harness work than this measurement-focused PR needed, especially since GTAO ends up unswizzled and unchanged from `master` anyway).

Closes #720
