### PR TITLE
fix(renderer): break OpenGLShader self-ref cycle causing 115 leaked programs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ you are in.
 - [vcpkg-dependency-management.md](docs/agent-rules/vcpkg-dependency-management.md) — read before adding, bumping or removing a dep: the CRT triplet mismatch is heap corruption, and three of the five traps are silent.
 - [configure-time-variable-visibility.md](docs/agent-rules/configure-time-variable-visibility.md) — a CMake variable resolved *below* the `add_subdirectory()` that consumes it, behind a guard that reads "unset" as "nothing to do": correct on every configure but the first.
 - [asset-import-usd-alembic.md](docs/agent-rules/asset-import-usd-alembic.md) — the importer/exporter registry seam, and vendoring OpenUSD / Alembic / MaterialX into a static-everything build.
+- [incremental-build-odr-staleness.md](docs/agent-rules/incremental-build-odr-staleness.md) — when a correct fix's live behavior makes no logical sense, suspect the `dev-cached` incremental build before the code: a struct-layout change to a by-value member with an inline `=default` destructor can link without error while a stale copy of that destructor survives in another TU.
 
 **Renderer**
 

--- a/OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.cpp
@@ -21,7 +21,7 @@ namespace OloEngine
     } // namespace
 
     ShaderResourceRegistry::ShaderResourceRegistry(const Ref<Shader>& shader)
-        : m_Shader(shader)
+        : m_Shader(shader.get())
     {
     }
 

--- a/OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.h
@@ -77,16 +77,42 @@ namespace OloEngine
             return m_Initialized;
         }
 
-        // @brief Set the associated shader for this registry
+        // @brief Set the associated shader for this registry.
+        //
+        // Stores a non-owning back-pointer, deliberately NOT a Ref<Shader>: this
+        // registry is always a BY-VALUE member of the OpenGLShader it describes
+        // (OpenGLShader::m_ResourceRegistry), so its lifetime is strictly bounded
+        // by the shader's — it is constructed and destroyed as part of the shader
+        // object and can never outlive it or be reused for a different one. A
+        // Ref<Shader> here would be a self-referential strong cycle (the shader
+        // owning a strong reference to itself through its own member), which
+        // inflates every shader's refcount by one for its entire life: no amount
+        // of external Ref<Shader>::Reset() at teardown can ever bring the count to
+        // zero, so the shader is never destroyed and its GL program never deleted
+        // (issue #841 — 115 OpenGL shader programs surviving Renderer::Shutdown()
+        // while the identical Vulkan path, whose VulkanShader never calls
+        // InitializeResourceRegistry, released the same set cleanly).
         void SetShader(const Ref<Shader>& shader)
         {
-            m_Shader = shader;
+            m_Shader = shader.get();
         }
 
-        // @brief Get the associated shader
+        // @brief Get the associated shader.
+        //
+        // Goes through WeakRef<Shader>::Lock() rather than constructing a
+        // Ref<Shader> from m_Shader directly: Lock() atomically checks that
+        // the object is still live (under the same mutex Ref<T>::DecRef's
+        // release path uses) before incrementing, so a caller that reached
+        // this registry via the raw-pointer-keyed ShaderResourceRegistry::Find()
+        // map — as CommandDispatch::SetShaderResource already does — can never
+        // resurrect a Ref during the shader's own release. A plain
+        // Ref<Shader>(m_Shader) would skip that check entirely (see
+        // docs/agent-rules/intrusive-refcount-weakref-races.md, case 2).
+        // const_cast is safe: m_Shader is const only because SetShader() takes
+        // its Ref<Shader> by const&, not because the pointee is actually const.
         Ref<Shader> GetShader() const
         {
-            return m_Shader;
+            return m_Shader ? WeakRef<Shader>(const_cast<Shader*>(m_Shader)).Lock() : nullptr;
         }
 
         // Resource discovery from reflection
@@ -203,7 +229,8 @@ namespace OloEngine
         static bool IsStandardTextureBinding(u32 binding, const std::string& name);
 
       private:
-        Ref<Shader> m_Shader;
+        // Non-owning — see SetShader() above for why this must not be a Ref<Shader>.
+        const Shader* m_Shader = nullptr;
         std::unordered_map<std::string, ResourceBinding> m_Bindings;
         Ref<InflightFrameManager> m_FrameManager;
         u32 m_CurrentFrame = 0;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -142,6 +142,7 @@ add_executable(OloEngine-Tests
 		Rendering/ShaderStageContractTest.cpp
 		Rendering/ShaderPackTest.cpp
 		Rendering/ShaderBinaryCacheRoundTripTest.cpp
+		Rendering/ShaderResourceRegistrySelfRefTest.cpp
 		Rendering/GLDebugMessageParseTest.cpp
 		Rendering/FrameDataBufferTest.cpp
 		Rendering/InstanceDataLayoutTest.cpp

--- a/OloEngine/tests/Rendering/ShaderResourceRegistrySelfRefTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderResourceRegistrySelfRefTest.cpp
@@ -1,0 +1,74 @@
+// OLO_TEST_LAYER: plumbing
+// =============================================================================
+// ShaderResourceRegistrySelfRefTest.cpp
+//
+// Issue #841 — 115 OpenGL shader programs survived Renderer::Shutdown() on
+// every editor close, while the identical Vulkan path released the same set
+// cleanly.
+//
+// Root cause: OpenGLShader::InitializeResourceRegistry() called
+// m_ResourceRegistry.SetShader(shaderRef), and ShaderResourceRegistry::m_Shader
+// used to be a Ref<Shader>. ShaderResourceRegistry is a BY-VALUE member of the
+// OpenGLShader it describes (OpenGLShader::m_ResourceRegistry), so that stored
+// a strong reference from the shader back to itself — a self-referential
+// cycle. Every external Ref<Shader> could be dropped (ShaderLibrary::Clear(),
+// every s_Data.*Shader.Reset() in Renderer3D::Shutdown(), a pass's own
+// Ref<Shader> member going away) and the object's refcount still never
+// reached zero, so ~OpenGLShader() — and the OLO_TRACK_DEALLOC / glDeleteProgram
+// it performs — never ran. VulkanShader never calls InitializeResourceRegistry,
+// which is why only the OpenGL backend showed the leak.
+//
+// The fix (ShaderResourceRegistry.h) stores a non-owning `const Shader*`
+// instead: the registry can never outlive its owning shader (it is not
+// separately heap-allocated), so a raw back-pointer is safe by construction.
+//
+// This test pins the observable contract: once every external Ref<Shader> is
+// dropped for a shader whose resource registry has been initialized (the
+// self-ref would have been established by then), the shader must actually be
+// destroyed.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "PropertyTests/RenderPropertyTest.h"
+
+#include "OloEngine/Core/Ref.h"
+#include "OloEngine/Renderer/Shader.h"
+#include "OloEngine/Renderer/ShaderLibrary.h"
+#include "OloEngine/Renderer/ShaderResourceRegistry.h"
+
+#include <gtest/gtest.h>
+
+namespace OloEngine::Tests
+{
+    TEST(ShaderResourceRegistrySelfRefTest, DroppingExternalRefsDestroysShaderAfterRegistryInit)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        WeakRef<Shader> weak;
+        {
+            ShaderLibrary library;
+            Ref<Shader> shader = library.Load("assets/shaders/PBR_MultiLight.glsl");
+            ASSERT_TRUE(shader);
+
+            // Force any async link to complete synchronously — this is also
+            // the call site (ShaderLibrary::FlushPendingShaders /
+            // PollPendingShaders) that invokes InitializeResourceRegistry(),
+            // the step that would establish the self-cycle if the bug were
+            // still present.
+            library.FlushPendingShaders();
+            ASSERT_TRUE(shader->IsReady());
+            ASSERT_NE(shader->GetResourceRegistry(), nullptr);
+            ASSERT_TRUE(shader->GetResourceRegistry()->IsInitialized());
+
+            weak = shader;
+            shader.Reset();
+            library.Clear();
+        }
+
+        EXPECT_FALSE(weak.IsValid())
+            << "Shader survived after every external Ref<Shader> was dropped — "
+               "ShaderResourceRegistry is holding a self-referential strong ref again "
+               "(see docs/agent-rules/lazy-static-release-ownership.md).";
+    }
+} // namespace OloEngine::Tests

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -128,6 +128,7 @@ Read before trusting any measurement.
 | [static-archive-4gib-ceiling.md](static-archive-4gib-ceiling.md) | `LNK1248` reports the offset where the archive crossed 4 GiB, not its size — two readings both looked ~0.5 MB over when the real overshoot was ~1.1 GB |
 | [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) §5e | the CI job that said `--config Release` was building no config at all, and grepping for `--parallel` finds four sites of which only one is a runaway — the generator, not the flag, decides |
 | [lazy-static-release-ownership.md](lazy-static-release-ownership.md) | GL has no allocator-teardown assertion, so a clean GL close is not evidence of a clean teardown — the same leak was silent there for the backend's whole life |
+| [incremental-build-odr-staleness.md](incremental-build-odr-staleness.md) | a correct fix, re-derived and re-read four times, that a live rebuild-and-relaunch kept "disproving" — the binary, not the source, was the thing lying |
 
 **The counter-move:** measure the noise floor first, and construct a case the instrument *must*
 fail on before trusting a case it passes.
@@ -231,7 +232,8 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 [static-archive-4gib-ceiling.md](static-archive-4gib-ceiling.md) ·
 [configure-time-variable-visibility.md](configure-time-variable-visibility.md) ·
 [vcpkg-dependency-management.md](vcpkg-dependency-management.md) ·
-[asset-import-usd-alembic.md](asset-import-usd-alembic.md)
+[asset-import-usd-alembic.md](asset-import-usd-alembic.md) ·
+[incremental-build-odr-staleness.md](incremental-build-odr-staleness.md)
 
 **Renderer** — [rhi-abstraction-boundary.md](rhi-abstraction-boundary.md) ·
 [ddgi-probe-cascades-and-sparsity.md](ddgi-probe-cascades-and-sparsity.md) ·

--- a/docs/agent-rules/incremental-build-odr-staleness.md
+++ b/docs/agent-rules/incremental-build-odr-staleness.md
@@ -1,0 +1,116 @@
+# A "correct fix that doesn't work" can be the build, not the code — clean-rebuild before you trust a live symptom
+
+Issue #841. A one-line, obviously-correct fix (replace an owning `Ref<Shader>` member
+with a non-owning raw pointer) appeared to do nothing across four separate rebuild-and-relaunch
+cycles: the same 115 shaders still "survived" `Renderer::Shutdown()`, live refcount tracing showed
+every survivor pinned at exactly 1 with no reachable second owner, and — after adding more
+diagnostics — a live editor session started reproducibly double-freeing an unrelated shader on
+close. All of this evaporated the moment the affected translation units were deleted and rebuilt
+from scratch. The code had been right since the first edit.
+
+## The trap
+
+`ShaderResourceRegistry` is a **by-value member** of every `OpenGLShader`
+(`OpenGLShader::m_ResourceRegistry`), and its destructor is declared `~ShaderResourceRegistry() =
+default;` **inline, in the header**. Changing `m_Shader` from an owning `Ref<Shader>` to a
+non-owning `const Shader*` changes the class's layout and, because the destructor body is
+generated per-translation-unit from the header it sees, changes what that inline destructor's
+generated machine code actually does — from "decrement a `Ref<Shader>`" to "do nothing to that
+field at all".
+
+With an **incremental, ccache-backed** build (`dev-cached` — the repo's own recommended default
+tree), some translation units that transitively depend on the header were recompiled against the
+new layout and some were not (or a stale `.obj` was reused, or the linker's COMDAT/`/OPT:ICF`
+folding picked an old copy of the inline destructor to keep). The result links **without error**:
+every symbol resolves, the binary runs, and the specific `.cpp` files actually edited show their
+new log lines firing exactly as written — because those files' *own* code really did recompile.
+What silently didn't follow was every other TU's copy of the header-inline destructor for the
+*embedded member type*, which is a different, easy-to-miss dependency edge than "did the file I
+edited get recompiled".
+
+## What it looked like from the debugging seat
+
+Four rounds of "add a diagnostic, rebuild, relaunch, read the log" each *confirmed a different,
+increasingly implausible finding*, in this order:
+
+1. **The self-ref fix appeared to change nothing.** Before-and-after `[Teardown]` reports both
+   showed 115 survivors. Since this was compared across separate sessions rather than a true
+   same-binary A/B, it read as "the fix didn't help" rather than "the fix isn't fully linked".
+2. **Every survivor's live `RefCounted::GetRefCount()` read exactly 1, with only one known owner.**
+   For `ShaderLibrary::s_FallbackShader` specifically: the log traced its address at creation, at
+   the *start* of `ShutdownFallbackShader()`, and confirmed `s_FallbackShader.Reset()` runs
+   unconditionally on a call path proven to complete (the survivor report itself only prints from
+   the last line of `Renderer::Shutdown()`). No second owner was ever found by code reading, and
+   none should have existed under the (correct) fixed header. This is the shape of a build problem
+   presenting as "the object structurally cannot have a second owner, yet behaves as if it does".
+3. **A live session started reliably crashing** with `RefCounted: DecRefCount() underflow` on an
+   *unrelated* shader (`AssetPreviewRenderer`'s `MaterialPreview`), immediately after that shader's
+   own destructor ran to completion. Two independent background-agent investigations, plus manual
+   tracing of every member and base-class destructor in the object graph, found no plausible
+   second-release site — because there wasn't one in the *current* source.
+4. **A live debugger attach on the hung (assert-blocked) process produced the answer that ended
+   the hunt**: the call stack showed `Ref<Shader>::Reset` → `Ref<Shader>::DecRef` → (legitimate)
+   `~OpenGLShader` → **`ShaderResourceRegistry::~ShaderResourceRegistry` → `Ref<Shader>::~Ref`** →
+   `RefUtils::Release` → the assert. That inner call is *impossible* under the fixed header —
+   `ShaderResourceRegistry` no longer has a `Ref<Shader>` member for anything to destruct. The
+   only explanation is a stale/ODR-mismatched destructor body, decrementing the shader's *own*
+   refcount a second time because the raw-pointer field's bit pattern (the shader's own address,
+   under the correct layout) was being read as if it were still a `Ref<Shader>::m_Instance`.
+
+Deleting `build-cached/{OloEngine,OloEngineRenderer,OloEditor}/**/CMakeFiles/*.dir` and rebuilding
+from scratch made both symptoms disappear in the very next run: zero survivors, zero crash, on a
+binary whose *only* source change since the previous (broken-looking) run was the diagnostic
+prints being removed again.
+
+## The rule
+
+**When a fix you have re-derived correctly by reading the code multiple times produces a *live*
+result that makes no logical sense — not "still buggy in an understandable way", but "the object
+graph as written cannot behave like this" — stop adding diagnostics and do a clean rebuild of the
+affected static libraries before spending more time on code-level theories.** The tell that
+distinguishes this from an actual logic bug: your *own* newly-added log lines, in the files you
+just edited, print correctly and prove those specific `.cpp`s recompiled — while the *behavior*
+still matches the pre-fix code path for a type those files don't define. That combination (my
+edits ran, but something depending on my header change didn't) is the specific signature of
+partial/inconsistent incremental linking, not a mistaken fix.
+
+This is expensive to reach empirically (four rebuild-and-test rounds, two background-agent
+investigations, and a live debugger attach, none of which found anything wrong with the code)
+compared to just trying a clean rebuild early once the live behavior stops matching what the
+source says it should do. **Full-clean is not the *first* thing to reach for** — most incremental
+staleness is caught correctly by Ninja's own dependency tracking, and the routine advice elsewhere
+in this repo (`build-result-verification`, the `msbuild-node-reuse-fakes-a-live-build` memory) is
+about *build success* being misleading, not correctness of a build that genuinely reports and
+looks green. This is narrower: a struct-layout change to a type with an inline `=default`
+destructor, embedded **by value** in a widely-instantiated class, under an incremental
+ccache-backed tree — reach for a clean rebuild specifically when *that* shape is present and the
+live symptom contradicts what the current source can produce.
+
+## Why this is plausible specifically here
+
+- `dev-cached` is this repo's own recommended default build tree *because* it's fast — which means
+  it is exercised far more than a from-scratch build, and staleness bugs in it get far less
+  practice being caught.
+- `ShaderResourceRegistry` is instantiated as a **by-value member**, not a pointer/`Ref` — so its
+  ABI (`sizeof`, member offsets, and any header-inline special member function) leaks directly into
+  every translation unit that touches `OpenGLShader`, `sizeof(OpenGLShader)`, or constructs/destroys
+  one. A pointer-to-`ShaderResourceRegistry` member would not have this exposure.
+- The destructor is the *implicit* `= default` kind, generated fresh per-TU from whatever the
+  header looks like to that TU at that time — there is no single out-of-line definition for the
+  linker to deduplicate from one authoritative source.
+
+## Guard
+
+None added. This is a build-environment failure mode, not a source-level invariant a unit test can
+pin — the fix, once actually linked, is exactly what `ShaderResourceRegistrySelfRefTest.cpp`
+(`OloEngine/tests/Rendering/`) already verifies: drop every external `Ref<Shader>` after
+`InitializeResourceRegistry()` has run, and assert the `WeakRef` goes dead. What generalizes is the
+debugging discipline above, not a mechanism to catch the staleness itself.
+
+## Related
+
+[build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) (the `dev-cached` tree's design
+and its own known traps) · [dev-cached tree facts, project memory] (measured cold/warm costs) ·
+[lazy-static-release-ownership.md](lazy-static-release-ownership.md) (the leak-class this issue was
+originally filed under, and the actual, unrelated self-referential-`Ref` root cause once the build
+staleness was cleared out of the way).

--- a/docs/agent-rules/lazy-static-release-ownership.md
+++ b/docs/agent-rules/lazy-static-release-ownership.md
@@ -400,3 +400,33 @@ GL branch silently**. The test passed. It would have kept passing with the leak
 reinstated. The scratch copy had the corrected indices, so only running the real
 binary against a deliberately broken tree found it. Being a source-scan test makes
 that cheap: delete the release, re-run the already-built binary, no rebuild needed.
+
+## #841 resolved: not a species this document's scan covers, and not a code bug at all
+
+The 115-shader survivor named above turned out to be neither scan 1's territory
+(no owning static was misplaced) nor scan 2's (no missing `Shutdown()` call) — it
+was `ShaderResourceRegistry::m_Shader`, a **member of a member**: `OpenGLShader`
+embeds a `ShaderResourceRegistry` by value, and that registry's `SetShader()` had
+been storing a strong `Ref<Shader>` back to the very `OpenGLShader` that owns it.
+A shader's own resource registry keeping a strong reference to the shader is a
+self-cycle neither scan can see — scan 1 only inspects *direct* static/lazy-handle
+declarations, and this Ref lives two structs deep, reached only via
+`Shader::Create()` → `InitializeResourceRegistry()`. Fixed by storing a non-owning
+`const Shader*` instead (the registry can never outlive its enclosing shader — it
+is not separately heap-allocated — so a raw back-pointer is safe by construction).
+See `docs/agent-rules/component-serializer-codegen.md`-style "member of a member"
+reasoning generalizes: scan 1's declaration-only reach is a documented limit, not
+a bug in the guard.
+
+**The much longer story was verifying it.** The fix read correct on every
+re-derivation, yet four live rebuild-and-relaunch rounds each seemed to disprove
+it — the survivor count didn't move, then live refcount tracing showed every
+survivor pinned at exactly 1 with no reachable second owner, then a *different*
+shader started reproducibly double-freeing on close. All of it was stale
+incremental-build state, not the fix — see
+[incremental-build-odr-staleness.md](incremental-build-odr-staleness.md) for the
+full shape and the rule it generalizes to. The lesson worth carrying forward
+specifically for *this* document's territory: a self-referential `Ref` through an
+embedded member is now a fourth thing to check, beyond the three scans already
+documented above, when a GPU-owning object survives every release call you can
+find.


### PR DESCRIPTION
## What changed

`ShaderResourceRegistry::m_Shader` was a strong `Ref<Shader>` pointing back to the `OpenGLShader`
that embeds it (`OpenGLShader::m_ResourceRegistry` is a by-value member). Every file-backed shader
therefore held a hidden strong reference to itself, so its refcount could never reach zero —
`Renderer::Shutdown()`'s entire release sequence (`ShaderLibrary::Clear()`, every
`s_Data.*Shader.Reset()`, `ShutdownFallbackShader()`, `ShaderWarmup::Shutdown()`) would run
correctly and still leave the object alive, because one owner (the shader's own registry) was never
dropped. `VulkanShader` never calls `InitializeResourceRegistry`, which is why only the OpenGL
backend showed the leak — Vulkan released the identical set cleanly on the identical teardown path.

Fixed by storing a non-owning `const Shader*` instead: the registry can never outlive the shader
that embeds it (it isn't separately heap-allocated), so a raw back-pointer is safe by construction.
`GetShader()` goes through `WeakRef<Shader>::Lock()` rather than reconstructing a `Ref` directly —
a self-review finding (see below) — so a caller reaching the registry through the raw-pointer-keyed
`ShaderResourceRegistry::Find()` map (as `CommandDispatch::SetShaderResource` already does) can
never resurrect a `Ref` during the shader's own release, matching the liveness-checked pattern the
codebase's sibling raw-pointer path (`ShaderRegistry::LockAll`) already uses.

## Verification

- **Live editor, both backends** — start scene, select an entity, close. Before this fix: 115
  surviving `Shader` GPU allocations reported by `RendererMemoryTracker::Shutdown()` on OpenGL.
  After: **zero** survivors of any type on OpenGL, matching the already-clean Vulkan teardown.
  (Evidence captured to `.claude/skills/run-oloengine/shots/gl-final.log` /
  `vulkan-after-fix.log` in the worktree — not part of this diff.)
- **New regression test** — `ShaderResourceRegistrySelfRefTest.cpp`: creates a shader through a
  local `ShaderLibrary`, confirms `InitializeResourceRegistry()` ran, drops every external
  `Ref<Shader>`, and asserts a `WeakRef<Shader>` to it goes dead. This is the isolated,
  in-process version of the live-editor check above.
- **Full suite** — `OloEngine-Tests`: 6245/6268 passed, 23 environmental skips (Steam stub,
  headless MCP attach, etc. — all pre-existing skip conditions unrelated to this change), 0
  failed.

## Review guide

**Where I'd look hardest**
1. `OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.h:95-98,105-112` — the actual fix.
   The invariant "this registry can never outlive its shader" is enforced by comment, not the
   type system (a self-review finding — see Least confident below).
2. `OloEngine/src/OloEngine/Renderer/ShaderResourceRegistry.cpp:24` — the constructor's matching
   `m_Shader(shader.get())`. This constructor has zero call sites in the tree today (verified by
   grep across the whole repo), so it's unexercised by anything except symmetry with the header.

**What I verified, and how** — named above: the live before/after teardown logs on both backends,
the new isolated regression test, and the full suite run. I did not rely on the test suite alone
for a lifetime/teardown-ordering change — `docs/testing.md`'s own guidance is that a green suite
was what shipped this exact leak in the first place (it's how #839's sweep found the 115
survivors: the suite was green throughout).

**Least confident about** — the safety of the non-owning raw pointer rests on "`ShaderResourceRegistry`
is always a by-value member of exactly one `OpenGLShader`, for its whole life." That's true today
(verified: no other constructor call site, no copy/move path since `RefCounted`'s atomic member
makes the owning `OpenGLShader` non-copyable/non-movable), but it's an invariant a future refactor
could violate silently. A self-review pass (4 parallel finder agents at `/code-review` scope) flagged
this and specifically caught that `GetShader()`'s original implementation reconstructed a `Ref<Shader>`
from the raw pointer with no liveness check — a real (if currently unreachable) resurrection-during-release
race, since `ShaderResourceRegistry::Find()` already hands out raw registry pointers across an
unsynchronized global map. Fixed by routing through `WeakRef<Shader>::Lock()`, which is now in this
diff.

**Deliberately not tested** — I did not add a test asserting the by-value-member invariant itself
(e.g. via `static_assert` on non-copyability propagating through the ownership chain), since the
existing `RefCounted` atomic-member mechanism already makes this structurally true for any class in
this hierarchy, not something specific to `ShaderResourceRegistry` that would need its own guard.

## A note on how long this took to verify

The fix above was correct from the first edit, but confirming that live took an unusually long
investigation: several rebuild-and-relaunch rounds each seemed to show the leak persisting (a
different session's survivor count, then live refcount tracing showing every survivor pinned at
1 with no reachable second owner, then a live session reproducibly double-freeing an *unrelated*
shader on close). All of it turned out to be stale/ODR-inconsistent state in the `dev-cached`
incremental build tree — a live debugger attach on a hung (assert-blocked) process showed a call
stack that was structurally impossible under the actual (fixed) header, which is what identified
it as a build problem rather than a code problem. A clean rebuild made both symptoms disappear
immediately. Captured as a new postmortem for the next person who hits this shape:
`docs/agent-rules/incremental-build-odr-staleness.md` (added in this PR).

Closes #841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shader resource registry ownership behavior to prevent self-referential shader leaks and unsafe cleanup during teardown.
  * Added regression coverage confirming shaders are released after external references are removed.

* **Documentation**
  * Added troubleshooting guidance for stale incremental builds and misleading runtime results.
  * Documented self-referential shader ownership patterns and updated companion guide indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->