### PR TITLE
Make a virtual-geometry scene that draws nothing say so (#864)

### DIFF
--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -4618,12 +4618,46 @@ namespace OloEngine::MCP
                 j["cull"] = std::move(cullJson);
                 j["residency"] = std::move(residencyJson);
                 j["settings"] = VirtualGeometrySettingsJson();
+                // Explain a zero rather than guess at it (issue #864). The old
+                // "no VirtualMeshComponent in the scene, or all of them are
+                // disabled" note was actively MISLEADING on the one case that
+                // matters: a scene full of VirtualMeshComponents whose mesh
+                // assets did not load reads exactly zero here, and that note
+                // sent the reader looking for a scene-authoring mistake that
+                // does not exist. The submission loop now records WHY, so say so.
+                const auto& diagnostics = registry.GetSubmissionDiagnostics();
+                j["diagnostics"] = Json{
+                    { "enabledComponents", diagnostics.EnabledComponents },
+                    { "unresolvedAssets", diagnostics.UnresolvedAssets },
+                    { "registrationFailures", diagnostics.RegistrationFailures },
+                    { "submitted", diagnostics.Submitted },
+                    { "fellBackToClassic", diagnostics.FellBackToClassic },
+                    { "silentlyDrewNothing", diagnostics.SilentlyDrewNothing() },
+                };
+
                 if (Renderer3D::GetRendererSettings().Path != RenderingPath::Deferred)
                     j["note"] = "Virtual geometry only renders on the Deferred path; the scene does not submit "
                                 "VirtualMeshComponents on Forward/Forward+, so every counter reads zero.";
+                else if (diagnostics.SilentlyDrewNothing())
+                    j["note"] = "WARNING: this scene contains " + std::to_string(diagnostics.EnabledComponents) +
+                                " enabled VirtualMeshComponent(s) but submitted ZERO virtual-geometry instances (" +
+                                std::to_string(diagnostics.UnresolvedAssets) +
+                                " mesh-source asset(s) did not load, " +
+                                std::to_string(diagnostics.RegistrationFailures) +
+                                " failed to build a cluster DAG). Every counter below reads zero for that reason, "
+                                "NOT because virtual geometry is working and finding nothing to draw. A missing "
+                                "asset is usually a fetch-on-demand one — run scripts/Fetch-Assets.ps1 (see "
+                                "scripts/assets/asset-manifest.json) — otherwise check OloEngine.log. Do NOT treat "
+                                "an A/B or performance measurement taken on this scene as meaningful: it will pass "
+                                "vacuously because nothing draws in either mode.";
+                else if (diagnostics.FellBackToClassic && diagnostics.EnabledComponents > 0)
+                    j["note"] = "The virtual-geometry master switch is OFF, so this scene's " +
+                                std::to_string(diagnostics.EnabledComponents) +
+                                " VirtualMeshComponent(s) were drawn through the CLASSIC mesh path instead. Zero "
+                                "counters are expected here — this is the intended A/B baseline, not a fault.";
                 else if (registry.GetFrameInstances().empty())
-                    j["note"] = "No virtual-mesh instances were submitted this frame (no VirtualMeshComponent in "
-                                "the scene, or all of them are disabled).";
+                    j["note"] = "No virtual-mesh instances were submitted this frame: the scene contains no "
+                                "VirtualMeshComponent, or every one of them is disabled or has no mesh assigned.";
                 return j; });
             return ToolResult::Structured(result);
         }
@@ -6502,8 +6536,12 @@ namespace OloEngine::MCP
                 "page budget, and cumulative page uploads + evictions). Use it to verify the cull is "
                 "actually culling (tested >> drawn), to check the HW/SW split after "
                 "olo_virtual_geometry_set { swRasterMode }, and to catch streaming thrash (uploads and "
-                "evictions climbing every frame under a tight budget). Zero everywhere means no "
-                "VirtualMeshComponent was submitted — virtual geometry renders on the DEFERRED path only.";
+                "evictions climbing every frame under a tight budget). When everything reads zero, "
+                "'diagnostics' says WHY — crucially it distinguishes a scene with no virtual meshes from "
+                "a scene whose VirtualMeshComponents all failed to load their mesh asset, which looks "
+                "identical in the counters and makes any A/B measured on that scene pass VACUOUSLY. "
+                "Check diagnostics.silentlyDrewNothing before trusting a zero. Virtual geometry renders "
+                "on the DEFERRED path only.";
             tool.InputSchema = Schema::EmptyObject();
             tool.OutputSchema = Schema::Object()
                                     .Prop("renderingPath", Schema::String())
@@ -6526,8 +6564,16 @@ namespace OloEngine::MCP
                                                            .Prop("pageUploads", Schema::Int().Min(0))
                                                            .Prop("pageEvictions", Schema::Int().Min(0)))
                                     .Prop("settings", VirtualGeometrySettingsSchema().Desc("Live knob state (same shape as olo_virtual_geometry_set's previous/current)."))
-                                    .Prop("note", Schema::String().Desc("Non-Deferred-path / no-instances caveat; omitted otherwise."))
-                                    .Required({ "renderingPath", "frameInstances", "frameClusters", "cull", "residency", "settings" });
+                                    .Prop("diagnostics", Schema::Object()
+                                                             .Desc("Why the counters read what they do (issue #864). Tells a real zero apart from a broken scene.")
+                                                             .Prop("enabledComponents", Schema::Int().Min(0).Desc("VirtualMeshComponents that asked to render (enabled, with a mesh assigned)."))
+                                                             .Prop("unresolvedAssets", Schema::Int().Min(0).Desc("...whose mesh-source asset did not load — usually an unfetched fetch-on-demand asset."))
+                                                             .Prop("registrationFailures", Schema::Int().Min(0).Desc("...that resolved but whose cluster DAG failed to build."))
+                                                             .Prop("submitted", Schema::Int().Min(0).Desc("...that actually reached the renderer."))
+                                                             .Prop("fellBackToClassic", Schema::Bool().Desc("Master switch off: drawn through the classic mesh path, so zero VG counters are expected."))
+                                                             .Prop("silentlyDrewNothing", Schema::Bool().Desc("TRUE means the scene asked for virtual geometry and got none. Any measurement taken here is vacuous.")))
+                                    .Prop("note", Schema::String().Desc("Plain-language explanation of a zero (broken scene / classic fallback / non-Deferred path / genuinely no virtual meshes); omitted when there is nothing to caveat."))
+                                    .Required({ "renderingPath", "frameInstances", "frameClusters", "cull", "residency", "settings", "diagnostics" });
             tool.MainMarshaled = true;
             tool.Handler = Handle_VirtualGeometryStats;
             server.RegisterTool(std::move(tool));

--- a/OloEditor/src/Panels/StatisticsPanel.cpp
+++ b/OloEditor/src/Panels/StatisticsPanel.cpp
@@ -7,6 +7,7 @@
 #include "OloEngine/Renderer/Renderer2D.h"
 #include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Renderer/RendererAPI.h"
+#include "OloEngine/Renderer/RenderingPath.h"
 #include "OloEngine/Renderer/Debug/DebugUtils.h"
 #include "OloEngine/Renderer/Debug/RendererProfiler.h"
 #include "OloEngine/Renderer/Debug/RendererMemoryTracker.h"
@@ -180,11 +181,58 @@ namespace OloEngine
             // documentation tells you to go and read. Show it whenever the scene ASKED
             // for virtual geometry, and let the panel explain the zero.
             const auto& vgDiagnostics = vgRegistry.GetSubmissionDiagnostics();
-            if (residency.TotalPages > 0 || frameInstances > 0 || vgDiagnostics.EnabledComponents > 0)
+
+            // The diagnostics are filled by the Scene submission loop, which runs on the
+            // DEFERRED path only — so on Forward/Forward+ every field stays 0 and the
+            // section would vanish for a scene that is full of virtual meshes. That is the
+            // same silent-zero in a different disguise, so ask the scene directly when the
+            // path cannot answer. Only when the counters are empty: a frame that is already
+            // drawing needs no scan.
+            u32 sceneVirtualMeshes = 0;
+            const bool pathIsDeferred = Renderer3D::GetRendererSettings().Path == RenderingPath::Deferred;
+            if (!pathIsDeferred && m_Context && frameInstances == 0)
+            {
+                auto virtualMeshView = m_Context->GetAllEntitiesWith<VirtualMeshComponent>();
+                for (auto entity : virtualMeshView)
+                {
+                    const auto& vm = virtualMeshView.get<VirtualMeshComponent>(entity);
+                    // A zero handle is a component with no mesh assigned yet — normal
+                    // authoring state, and the same exclusion the Scene loop applies.
+                    if (vm.m_Enabled && static_cast<u64>(vm.m_MeshSource) != 0)
+                    {
+                        ++sceneVirtualMeshes;
+                    }
+                }
+            }
+
+            if (residency.TotalPages > 0 || frameInstances > 0 || vgDiagnostics.EnabledComponents > 0 ||
+                sceneVirtualMeshes > 0)
             {
                 if (ImGui::CollapsingHeader("Virtual Geometry (Nanite)", ImGuiTreeNodeFlags_DefaultOpen))
                 {
-                    if (vgDiagnostics.SilentlyDrewNothing())
+                    // Wrong render path: the geometry is not being drawn virtually at all, and
+                    // no counter below can say so because none of them ever ran.
+                    if (sceneVirtualMeshes > 0)
+                    {
+                        ImGui::TextColored(ImVec4(1.0f, 0.65f, 0.2f, 1.0f),
+                                           "%u VirtualMeshComponent(s) present, but the render path is not Deferred",
+                                           sceneVirtualMeshes);
+                        ImGui::TextWrapped("Virtual geometry submits on the Deferred path only, so every counter "
+                                           "below reads 0. Switch to Deferred in Renderer Settings to exercise it.");
+                        ImGui::Separator();
+                    }
+                    // Master switch off: the same geometry IS drawing, through the classic
+                    // mesh path. Zero VG counters are the intended A/B baseline, not a fault.
+                    else if (vgDiagnostics.FellBackToClassic && vgDiagnostics.EnabledComponents > 0)
+                    {
+                        ImGui::TextColored(ImVec4(0.6f, 0.8f, 1.0f, 1.0f),
+                                           "Virtual geometry is OFF — %u component(s) drawn via the classic path",
+                                           vgDiagnostics.EnabledComponents);
+                        ImGui::TextWrapped("Zero counters below are expected: this is the baseline half of the "
+                                           "A/B, not a broken scene.");
+                        ImGui::Separator();
+                    }
+                    else if (vgDiagnostics.SilentlyDrewNothing())
                     {
                         ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.35f, 1.0f),
                                            "%u VirtualMeshComponent(s) submitted NOTHING",

--- a/OloEditor/src/Panels/StatisticsPanel.cpp
+++ b/OloEditor/src/Panels/StatisticsPanel.cpp
@@ -166,16 +166,47 @@ namespace OloEngine
             }
         }
 
-        // Virtual Geometry (Nanite cluster LOD DAG, issue #629). Shown only when
-        // virtual meshes are actually registered/submitted this frame.
+        // Virtual Geometry (Nanite cluster LOD DAG, issue #629). Shown when virtual
+        // meshes are registered/submitted this frame — or when the scene HAS virtual
+        // meshes but submitted none of them, which is the state the panel most needs
+        // to report (issue #864).
         {
             auto& vgRegistry = VirtualMeshRegistry::Get();
             const VirtualResidencyStats& residency = vgRegistry.GetResidencyStats();
             u32 const frameInstances = static_cast<u32>(vgRegistry.GetFrameInstances().size());
-            if (residency.TotalPages > 0 || frameInstances > 0)
+            // Issue #864: the section used to be shown only when something was ALREADY
+            // drawing, so the one scene state worth shouting about — "this scene has
+            // virtual meshes and drew none of them" — hid the very panel its own
+            // documentation tells you to go and read. Show it whenever the scene ASKED
+            // for virtual geometry, and let the panel explain the zero.
+            const auto& vgDiagnostics = vgRegistry.GetSubmissionDiagnostics();
+            if (residency.TotalPages > 0 || frameInstances > 0 || vgDiagnostics.EnabledComponents > 0)
             {
                 if (ImGui::CollapsingHeader("Virtual Geometry (Nanite)", ImGuiTreeNodeFlags_DefaultOpen))
                 {
+                    if (vgDiagnostics.SilentlyDrewNothing())
+                    {
+                        ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.35f, 1.0f),
+                                           "%u VirtualMeshComponent(s) submitted NOTHING",
+                                           vgDiagnostics.EnabledComponents);
+                        if (vgDiagnostics.UnresolvedAssets > 0)
+                        {
+                            ImGui::TextWrapped("%u mesh-source asset(s) did not load. If the mesh is a "
+                                               "fetch-on-demand asset it is absent until you run "
+                                               "scripts/Fetch-Assets.ps1 (see "
+                                               "scripts/assets/asset-manifest.json).",
+                                               vgDiagnostics.UnresolvedAssets);
+                        }
+                        if (vgDiagnostics.RegistrationFailures > 0)
+                        {
+                            ImGui::TextWrapped("%u mesh(es) resolved but their cluster DAG failed to "
+                                               "build — see OloEngine.log.",
+                                               vgDiagnostics.RegistrationFailures);
+                        }
+                        ImGui::TextWrapped("Every counter below reads 0 for that reason. Do not treat a "
+                                           "virtual-geometry measurement taken on this scene as meaningful.");
+                        ImGui::Separator();
+                    }
                     ImGui::Text("Instances this frame: %u", frameInstances);
 
                     ImGui::Separator();

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -233,10 +233,14 @@ namespace OloEngine
         // overrideMaterial: an explicit MaterialComponent, or nullptr to shade each submesh
         // with the material it was imported with. defaultMaterial is the last resort for a
         // submesh that carries none.
-        static void SubmitVirtualMesh(AssetHandle meshHandle, const Ref<MeshSource>& meshSource,
-                                      const glm::mat4& modelMatrix, const Material* overrideMaterial,
-                                      const Material& defaultMaterial, i32 entityID,
-                                      f32 errorThresholdPixels, bool castShadows);
+        // Returns true when the mesh was actually queued. It is dropped — silently, from the
+        // caller's point of view — when the cluster DAG will not build, and this function is
+        // the only place that knows that. Scene's submission loop needs the answer to report
+        // a scene that draws no virtual geometry at all (issue #864).
+        [[nodiscard]] static bool SubmitVirtualMesh(AssetHandle meshHandle, const Ref<MeshSource>& meshSource,
+                                                    const glm::mat4& modelMatrix, const Material* overrideMaterial,
+                                                    const Material& defaultMaterial, i32 entityID,
+                                                    f32 errorThresholdPixels, bool castShadows);
         // Flatten a Material into the exact POD record the frame material table
         // uploads for a draw (factors, alpha mode/cutoff, and the resolved GL
         // texture id per slot, incl. the global-IBL fallback). Public because it

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DMeshSubmission.cpp
@@ -116,7 +116,7 @@ namespace OloEngine
                matches(s_Data.DecalGBufferRMAShader) || matches(s_Data.DecalGBufferEmissiveShader);
     }
 
-    void Renderer3D::SubmitVirtualMesh(AssetHandle meshHandle, const Ref<MeshSource>& meshSource,
+    bool Renderer3D::SubmitVirtualMesh(AssetHandle meshHandle, const Ref<MeshSource>& meshSource,
                                        const glm::mat4& modelMatrix, const Material* overrideMaterial,
                                        const Material& defaultMaterial, i32 entityID,
                                        f32 errorThresholdPixels, bool castShadows)
@@ -125,19 +125,19 @@ namespace OloEngine
 
         if (static_cast<u64>(meshHandle) == 0 || !meshSource)
         {
-            return;
+            return false;
         }
 
         auto& registry = VirtualMeshRegistry::Get();
         if (!registry.IsRegistered(meshHandle) && !registry.RegisterMeshSource(meshHandle, *meshSource))
         {
-            return; // unsupported source — warned once at registration
+            return false; // unsupported source — warned once at registration
         }
 
         VirtualMeshRegistry::MeshParts const parts = registry.FindParts(meshHandle);
         if (!parts.Valid)
         {
-            return;
+            return false;
         }
 
         VirtualMeshSubmission submission;
@@ -179,6 +179,7 @@ namespace OloEngine
         }
 
         registry.Submit(submission);
+        return true;
     }
 
     auto Renderer3D::CreatePODMaterialDataForMaterial(const Material& material, RHI::ResourceHandle shaderRendererID) -> PODMaterialData

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.cpp
@@ -162,6 +162,7 @@ namespace OloEngine
         m_FramePrepared = false;
         m_FramePreparedResult = false;
         m_ResidencyProcessed = false;
+        m_SubmissionDiagnostics = {};
     }
 
     void VirtualMeshRegistry::Submit(const VirtualMeshSubmission& submission)

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
@@ -210,7 +210,20 @@ namespace OloEngine
         // panel and the MCP olo_virtual_geometry_stats tool — can say WHICH of
         // the several very different causes produced a zero instead of guessing.
         // Counting happens on the Deferred path only, because that is the only
-        // path on which the submission loop runs at all.
+        // path on which the submission loop runs at all. (When the path is not
+        // Deferred these all stay 0, so the editor's Statistics panel asks the
+        // scene directly rather than reporting a misleading nothing.)
+        //
+        // Lifetime is exactly that of m_FrameInstances / m_TotalFrameClusterCount:
+        // BeginFrame resets all three, and BeginFrame runs per Renderer3D::BeginScene
+        // — so an off-screen capture pass that renders the scene again (the cubemap
+        // face loops in ReflectionProbeBaker / LightProbeBaker) resets and refills
+        // these too. That is deliberate, not an oversight: every field here is
+        // VIEW-INDEPENDENT (the submission loop walks all entities and never
+        // frustum-culls; the GPU cull does that later), so a capture pass produces
+        // identical counts. Scoping these to the primary render alone would make the
+        // panel internally inconsistent — diagnostics from one render, the instance
+        // and cluster counts printed beside them from another.
         struct SubmissionDiagnostics
         {
             // Components seen this frame that asked to render: m_Enabled with a

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h
@@ -196,6 +196,50 @@ namespace OloEngine
             bool Valid = false; // at least one part built
         };
 
+        // Why a scene that HAS virtual meshes still drew none (issue #864).
+        //
+        // The failure this exists for is "plausible-looking nothing": a scene
+        // whose VirtualMeshComponents all reference an asset that did not load
+        // renders an empty viewport, every frame, with no other symptom — and
+        // an empty viewport is indistinguishable from a camera, lighting or
+        // culling problem. Worse, a VG A/B measured on such a scene passes
+        // VACUOUSLY ("no difference between modes" — because nothing drew).
+        //
+        // The Scene submission loop fills this in as it walks the components,
+        // so the two consumers that report VG health — the editor's Statistics
+        // panel and the MCP olo_virtual_geometry_stats tool — can say WHICH of
+        // the several very different causes produced a zero instead of guessing.
+        // Counting happens on the Deferred path only, because that is the only
+        // path on which the submission loop runs at all.
+        struct SubmissionDiagnostics
+        {
+            // Components seen this frame that asked to render: m_Enabled with a
+            // non-zero mesh handle. A zero handle is a freshly added component
+            // with nothing assigned yet — normal authoring state, not a fault.
+            u32 EnabledComponents = 0;
+            // ...of which the mesh-source asset failed to resolve. Today's
+            // usual cause is a fetch-on-demand asset (scripts/Fetch-Assets.ps1)
+            // that this machine has never fetched.
+            u32 UnresolvedAssets = 0;
+            // ...of which the asset resolved but the cluster DAG would not
+            // build, so the entity was dropped inside SubmitVirtualMesh.
+            u32 RegistrationFailures = 0;
+            // ...of which actually reached VirtualMeshRegistry::Submit.
+            u32 Submitted = 0;
+            // Set when the master switch is off: the components were drawn
+            // through the CLASSIC mesh path instead. Zero VG counters are then
+            // correct and expected, not a fault.
+            bool FellBackToClassic = false;
+
+            // The condition worth shouting about: the scene asked for virtual
+            // geometry and got none of it. Deliberately false for a scene with
+            // no VirtualMeshComponent at all, and for the classic-fallback A/B.
+            [[nodiscard]] bool SilentlyDrewNothing() const
+            {
+                return EnabledComponents > 0 && Submitted == 0 && !FellBackToClassic;
+            }
+        };
+
         // CPU-side instance record kept alongside the GPU upload so the draw
         // loop can bind per-instance material state and issue the MDI call.
         struct FrameInstance
@@ -382,6 +426,18 @@ namespace OloEngine
             return m_TotalFrameClusterCount;
         }
 
+        // Submission diagnostics (issue #864). Reset by BeginFrame and filled by
+        // the Scene's virtual-mesh loop; read by the Statistics panel and the
+        // MCP stats tool to explain a zero rather than let it pass silently.
+        [[nodiscard]] const SubmissionDiagnostics& GetSubmissionDiagnostics() const
+        {
+            return m_SubmissionDiagnostics;
+        }
+        [[nodiscard]] SubmissionDiagnostics& GetMutableSubmissionDiagnostics()
+        {
+            return m_SubmissionDiagnostics;
+        }
+
         // GL object accessors for the cull + draw passes (valid after PrepareFrame)
         [[nodiscard]] const Ref<StorageBuffer>& GetClusterBuffer() const
         {
@@ -498,6 +554,7 @@ namespace OloEngine
 
         std::vector<VirtualMeshSubmission> m_Submissions;
         std::vector<FrameInstance> m_FrameInstances;
+        SubmissionDiagnostics m_SubmissionDiagnostics;
         u32 m_TotalFrameClusterCount = 0;
         bool m_FramePrepared = false; // PrepareFrame ran this frame
         bool m_FramePreparedResult = false;

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -9518,13 +9518,14 @@ namespace OloEngine
 
                 // Count what actually landed rather than what we asked for:
                 // SubmitVirtualMesh drops the entity when the cluster DAG will not
-                // build, and it is the only place that knows that.
-                const sizet submissionsBefore = VirtualMeshRegistry::Get().GetSubmissions().size();
-                Renderer3D::SubmitVirtualMesh(virtualMesh.m_MeshSource, meshSource,
-                                              worldTransform, overrideMaterial,
-                                              GetDefaultMaterial(), entityID,
-                                              virtualMesh.m_ErrorThresholdPixels, castsShadow);
-                if (VirtualMeshRegistry::Get().GetSubmissions().size() > submissionsBefore)
+                // build, and it is the only place that knows that — so it reports
+                // the outcome directly rather than us inferring it from a queue-size
+                // delta, which would silently mis-count if it ever queued zero or
+                // more than one submission per call.
+                const bool queued = Renderer3D::SubmitVirtualMesh(
+                    virtualMesh.m_MeshSource, meshSource, worldTransform, overrideMaterial,
+                    GetDefaultMaterial(), entityID, virtualMesh.m_ErrorThresholdPixels, castsShadow);
+                if (queued)
                 {
                     ++vgDiagnostics.Submitted;
                 }

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -57,6 +57,7 @@
 #include "OloEngine/Renderer/MaterialAsset.h"
 #include "OloEngine/Renderer/MeshSource.h"
 #include "OloEngine/Renderer/SubmeshMaterialResolve.h"
+#include "OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h"
 #include "OloEngine/Renderer/LightCommon.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
 #include "OloEngine/Physics3D/JoltScene.h"
@@ -9444,6 +9445,13 @@ namespace OloEngine
             // skipping it, so the scene looks the same and only the renderer differs.
             const bool virtualGeometryEnabled = Renderer3D::GetRendererSettings().VirtualGeometryEnabled;
 
+            // Issue #864: count what this loop actually managed to submit, so a scene that
+            // asks for virtual geometry and draws NONE of it can say so instead of settling
+            // quietly. Filled here, consumed by the editor Statistics panel and the MCP
+            // olo_virtual_geometry_stats tool. BeginFrame reset it.
+            auto& vgDiagnostics = VirtualMeshRegistry::Get().GetMutableSubmissionDiagnostics();
+            vgDiagnostics.FellBackToClassic = !virtualGeometryEnabled;
+
             auto virtualView = m_Registry.view<TransformComponent, VirtualMeshComponent>();
             for (auto entity : virtualView)
             {
@@ -9452,10 +9460,12 @@ namespace OloEngine
                 {
                     continue;
                 }
+                ++vgDiagnostics.EnabledComponents;
 
                 auto meshSource = AssetManager::GetAsset<MeshSource>(virtualMesh.m_MeshSource);
                 if (!meshSource)
                 {
+                    ++vgDiagnostics.UnresolvedAssets;
                     // An unresolvable handle here is TOTAL and otherwise SILENT: the entity
                     // renders nothing, every frame, with no other symptom. An empty viewport
                     // looks exactly like a camera, lighting or culling problem, so this used to
@@ -9471,7 +9481,9 @@ namespace OloEngine
                         OLO_CORE_WARN("Scene: VirtualMeshComponent on entity '{}' references mesh-source asset {} "
                                       "which did not load — this entity renders NOTHING. Check that the handle is in "
                                       "the asset registry, that its file exists, and that it imports (the asset "
-                                      "manager logs the failure). Warned once per asset handle.",
+                                      "manager logs the failure). If it is a fetch-on-demand asset, it is absent "
+                                      "until you run 'scripts/Fetch-Assets.ps1' — see "
+                                      "scripts/assets/asset-manifest.json. Warned once per asset handle.",
                                       m_Registry.all_of<TagComponent>(entity)
                                           ? m_Registry.get<TagComponent>(entity).Tag
                                           : std::string{ "<unnamed>" },
@@ -9503,10 +9515,63 @@ namespace OloEngine
                 }
 
                 bool const castsShadow = virtualMesh.m_CastShadows && meshHasActiveShadows;
+
+                // Count what actually landed rather than what we asked for:
+                // SubmitVirtualMesh drops the entity when the cluster DAG will not
+                // build, and it is the only place that knows that.
+                const sizet submissionsBefore = VirtualMeshRegistry::Get().GetSubmissions().size();
                 Renderer3D::SubmitVirtualMesh(virtualMesh.m_MeshSource, meshSource,
                                               worldTransform, overrideMaterial,
                                               GetDefaultMaterial(), entityID,
                                               virtualMesh.m_ErrorThresholdPixels, castsShadow);
+                if (VirtualMeshRegistry::Get().GetSubmissions().size() > submissionsBefore)
+                {
+                    ++vgDiagnostics.Submitted;
+                }
+                else
+                {
+                    ++vgDiagnostics.RegistrationFailures;
+                }
+            }
+
+            // The loud check (issue #864). A scene holding enabled VirtualMeshComponents
+            // that ends the submission loop having queued NOTHING is the silent-zero this
+            // issue exists for: the viewport is empty, every VG counter reads 0, and that
+            // is indistinguishable from a camera/lighting/culling problem — or, worse, it
+            // makes a VG A/B pass vacuously because neither mode drew anything.
+            //
+            // Deliberately cannot fire for:
+            //   * a scene with no VirtualMeshComponent at all (EnabledComponents == 0),
+            //   * components with no mesh assigned yet (a zero handle never counts),
+            //   * the master switch being off, which draws the same geometry through the
+            //     classic path on purpose (FellBackToClassic).
+            //
+            // Warned once per (scene, cause-shape) rather than per frame: this runs every
+            // frame, and the interesting event is the state, not its repetition.
+            if (vgDiagnostics.SilentlyDrewNothing())
+            {
+                const u64 signature = (static_cast<u64>(vgDiagnostics.EnabledComponents) << 32) ^
+                                      (static_cast<u64>(vgDiagnostics.UnresolvedAssets) << 16) ^
+                                      static_cast<u64>(vgDiagnostics.RegistrationFailures);
+                if (m_VirtualGeometrySilentZeroWarned != signature)
+                {
+                    m_VirtualGeometrySilentZeroWarned = signature;
+                    OLO_CORE_WARN(
+                        "Scene: {} enabled VirtualMeshComponent(s) submitted ZERO virtual-geometry "
+                        "instances this frame ({} with an unresolvable mesh-source asset, {} whose "
+                        "cluster DAG failed to build) — this scene renders NO virtual geometry and "
+                        "every VG statistic will read 0. If the mesh is a fetch-on-demand asset, run "
+                        "'scripts/Fetch-Assets.ps1' (see scripts/assets/asset-manifest.json); "
+                        "otherwise check the per-asset warnings above. Do NOT treat a VG measurement "
+                        "taken on this scene as meaningful.",
+                        vgDiagnostics.EnabledComponents, vgDiagnostics.UnresolvedAssets,
+                        vgDiagnostics.RegistrationFailures);
+                }
+            }
+            else
+            {
+                // Re-arm, so a scene that is fixed and then broken again warns again.
+                m_VirtualGeometrySilentZeroWarned = 0;
             }
         }
 

--- a/OloEngine/src/OloEngine/Scene/Scene.h
+++ b/OloEngine/src/OloEngine/Scene/Scene.h
@@ -1168,6 +1168,13 @@ namespace OloEngine
         // Deliberately NOT copied by Scene::Copy() — the runtime copy
         // re-resolves at Play start so stale state cannot survive a transition.
         Ref<SceneLightmapRuntime> m_LightmapRuntime;
+
+        // Issue #864: signature of the last virtual-geometry "silent zero" state warned
+        // about, so the per-frame check in the submission loop logs a state CHANGE rather
+        // than the same line every frame. 0 means "not currently in the silent-zero state",
+        // which is also what re-arms the warning if a fixed scene breaks again.
+        u64 m_VirtualGeometrySilentZeroWarned = 0;
+
         // Runtime-only origin accumulator: absolute = rebased + m_WorldOrigin.
         // Reset to (0,0,0) at OnRuntimeStart; never serialized or copied.
         glm::vec3 m_WorldOrigin{ 0.0f };

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -379,6 +379,7 @@ add_executable(OloEngine-Tests
 		Rendering/RendererShutdownTest.cpp
 		Rendering/RenderPathDriftTest.cpp
 		Rendering/VirtualMeshRegistryRejectionTest.cpp
+		Rendering/VirtualGeometrySceneCoverageTest.cpp
 		Rendering/PropertyTests/RendererAttachedSmokeTest.cpp
 		Rendering/PropertyTests/SceneRenderEvidenceTest.cpp
 		Rendering/PropertyTests/LightmapVisualEvidenceTest.cpp

--- a/OloEngine/tests/Rendering/VirtualGeometrySceneCoverageTest.cpp
+++ b/OloEngine/tests/Rendering/VirtualGeometrySceneCoverageTest.cpp
@@ -1,0 +1,279 @@
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// VirtualGeometrySceneCoverageTest.cpp — issue #864
+//
+// The bug this guards is "plausible-looking nothing".
+//
+// Two of the three virtual-geometry showcase scenes were reported as submitting
+// 0 instances / 0 clusters while opening perfectly happily: 28 entities, no
+// error, an empty viewport. That state is indistinguishable from a camera,
+// lighting or culling problem — and, far worse, it makes any A/B measured on
+// such a scene pass VACUOUSLY, because neither mode draws anything. PR #859's
+// #813 A/B had to prove non-vacuity through a separate VG on/off pixel toggle
+// for exactly this reason.
+//
+// What the investigation actually found (worth recording, because the obvious
+// diagnosis was wrong): the scenes' handles were NOT stale. All three resolve
+// to real AssetRegistry.oar entries. `VirtualGeometryStress.olo` references the
+// 7.2M-triangle Stanford dragon, which is a deliberately-uncommitted
+// fetch-on-demand asset (scripts/assets/asset-manifest.json) — absent until the
+// developer runs scripts/Fetch-Assets.ps1. The manifest's own contract says
+// every consumer "must degrade gracefully when an asset is absent: SKIP with a
+// message naming the fetch command, never fail". The scene did not: it rendered
+// nothing and said nothing. THAT is the defect, not the handles.
+//
+// So this file guards two distinct things:
+//
+//   1. The handles really are registered (the failure mode the issue assumed).
+//      An unregistered handle can never resolve on any machine, fetched or not,
+//      and no amount of loud reporting would make such a scene usable.
+//
+//   2. The silent-zero predicate itself — VirtualMeshRegistry::
+//      SubmissionDiagnostics::SilentlyDrewNothing(). This is the loud check's
+//      trigger, and its two failure directions are opposite and both bad: fail
+//      to fire and the silent zero survives; fire spuriously and every scene
+//      without virtual geometry (i.e. nearly all of them) screams on every
+//      frame until the warning is muted or ignored, which lands us right back
+//      where we started.
+//
+// Deliberately GL-free so it runs in CI, which is where a regression would
+// otherwise reach master unseen: the whole point is that the test suite was
+// green for the entire time this bug was live.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include "OloEngine/Asset/AssetRegistry.h"
+#include "OloEngine/Renderer/VirtualGeometry/VirtualMeshRegistry.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <filesystem>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifndef OLO_TEST_EDITOR_ROOT
+#error "OLO_TEST_EDITOR_ROOT must be defined by the test target's CMake — see OloEngine/tests/CMakeLists.txt"
+#endif
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        namespace fs = std::filesystem;
+
+        struct VirtualMeshReference
+        {
+            std::string SceneFile;
+            std::string EntityTag;
+            u64 Handle = 0;
+        };
+
+        // Every VirtualMeshComponent in every sandbox scene, read straight out of
+        // the scene YAML. Parsing the file rather than deserialising it keeps this
+        // test GL-free: the production deserialiser eagerly builds GPU resources
+        // (MeshSource::Build, Texture2D::Create) and so needs a live GL 4.6
+        // context, which CI does not have.
+        std::vector<VirtualMeshReference> CollectVirtualMeshReferences()
+        {
+            std::vector<VirtualMeshReference> refs;
+            const fs::path scenesDir = fs::path{ OLO_TEST_EDITOR_ROOT } / "SandboxProject" / "Assets" / "Scenes";
+
+            std::error_code ec;
+            if (!fs::exists(scenesDir, ec))
+            {
+                return refs;
+            }
+
+            for (const auto& entry : fs::directory_iterator(scenesDir, ec))
+            {
+                if (!entry.is_regular_file() || entry.path().extension() != ".olo")
+                {
+                    continue;
+                }
+
+                YAML::Node scene;
+                try
+                {
+                    scene = YAML::LoadFile(entry.path().string());
+                }
+                catch (const std::exception&)
+                {
+                    // Structural scene validity is AssetContentValidity's job; an
+                    // unparseable scene is that test's failure to report, not ours.
+                    continue;
+                }
+
+                const YAML::Node entities = scene["Entities"];
+                if (!entities || !entities.IsSequence())
+                {
+                    continue;
+                }
+
+                for (const YAML::Node& entityNode : entities)
+                {
+                    const YAML::Node virtualMesh = entityNode["VirtualMeshComponent"];
+                    if (!virtualMesh || !virtualMesh["MeshSource"])
+                    {
+                        continue;
+                    }
+
+                    VirtualMeshReference ref;
+                    ref.SceneFile = entry.path().filename().generic_string();
+                    ref.Handle = virtualMesh["MeshSource"].as<u64>(0ull);
+                    ref.EntityTag = entityNode["TagComponent"] && entityNode["TagComponent"]["Tag"]
+                                        ? entityNode["TagComponent"]["Tag"].as<std::string>("<unnamed>")
+                                        : std::string{ "<unnamed>" };
+                    refs.push_back(std::move(ref));
+                }
+            }
+            return refs;
+        }
+    } // namespace
+
+    // -------------------------------------------------------------------------
+    // 1. Scene handles are registered
+    // -------------------------------------------------------------------------
+    // A handle absent from AssetRegistry.oar can never resolve, on any machine,
+    // fetched or not — that is a genuinely dead scene. This does NOT assert the
+    // file exists on disk: a fetch-on-demand asset is legitimately absent until
+    // the developer fetches it, and AssetContentValidity already owns the
+    // registry-entry-vs-disk relationship (with the manifest allowlist).
+    TEST(VirtualGeometrySceneCoverage, EveryVirtualMeshHandleIsRegistered)
+    {
+        const fs::path registryPath = fs::path{ OLO_TEST_EDITOR_ROOT } / "SandboxProject" / "AssetRegistry.oar";
+        AssetRegistry registry;
+        ASSERT_TRUE(registry.Deserialize(registryPath))
+            << "Could not read " << registryPath.generic_string()
+            << " — without it this test cannot tell a stale handle from a good one.";
+
+        const std::vector<VirtualMeshReference> refs = CollectVirtualMeshReferences();
+        ASSERT_FALSE(refs.empty())
+            << "No VirtualMeshComponent found in any sandbox scene. Either the scenes lost their "
+               "virtual geometry, or this test's YAML walk has drifted from the scene format — "
+               "both make the check vacuous, which is precisely the failure mode issue #864 is about.";
+
+        std::ostringstream unregistered;
+        u32 unregisteredCount = 0;
+        for (const VirtualMeshReference& ref : refs)
+        {
+            if (ref.Handle == 0)
+            {
+                continue; // no mesh assigned — a normal authoring state
+            }
+            if (!registry.Exists(static_cast<AssetHandle>(ref.Handle)))
+            {
+                ++unregisteredCount;
+                unregistered << "  " << ref.SceneFile << " / '" << ref.EntityTag << "' -> handle "
+                             << ref.Handle << "\n";
+            }
+        }
+
+        EXPECT_EQ(unregisteredCount, 0u)
+            << unregisteredCount
+            << " VirtualMeshComponent handle(s) are not in AssetRegistry.oar, so the entity renders "
+               "NOTHING on every machine and the scene silently exercises no virtual geometry "
+               "(issue #864):\n"
+            << unregistered.str();
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. The loud check's trigger
+    // -------------------------------------------------------------------------
+    // SilentlyDrewNothing() is what makes the zero loud, in all three consumers
+    // (the Scene log warning, the editor Statistics panel, and the MCP
+    // olo_virtual_geometry_stats note). Its correctness is entirely about which
+    // states it does and does not claim, so pin every one of them.
+    TEST(VirtualGeometrySceneCoverage, SilentZeroPredicateFiresOnlyOnTheRealFailure)
+    {
+        using Diagnostics = VirtualMeshRegistry::SubmissionDiagnostics;
+
+        // The failure this whole issue exists for: components asked to render,
+        // nothing reached the renderer.
+        {
+            Diagnostics d;
+            d.EnabledComponents = 24;
+            d.UnresolvedAssets = 24;
+            EXPECT_TRUE(d.SilentlyDrewNothing())
+                << "24 enabled VirtualMeshComponents that all failed to resolve is the exact state "
+                   "issue #864 was filed for; it must not pass quietly.";
+        }
+        {
+            // Resolved, but the cluster DAG would not build — different cause,
+            // same user-visible nothing, equally worth shouting about.
+            Diagnostics d;
+            d.EnabledComponents = 3;
+            d.RegistrationFailures = 3;
+            EXPECT_TRUE(d.SilentlyDrewNothing());
+        }
+
+        // The false-positive directions. Each of these is a legitimate zero, and
+        // warning about any of them would make the warning worthless.
+        {
+            // By far the common case: a scene with no virtual geometry at all.
+            // Nearly every scene in the project looks like this, so a spurious
+            // fire here is a per-frame warning on almost the whole asset set.
+            Diagnostics d;
+            EXPECT_FALSE(d.SilentlyDrewNothing())
+                << "A scene with no VirtualMeshComponent must never trip the silent-zero check.";
+        }
+        {
+            // The master switch is off: the same geometry IS being drawn, through
+            // the classic mesh path. Zero VG counters are the intended baseline
+            // half of the A/B, not a fault.
+            Diagnostics d;
+            d.EnabledComponents = 24;
+            d.FellBackToClassic = true;
+            EXPECT_FALSE(d.SilentlyDrewNothing())
+                << "The classic-path fallback is a deliberate A/B baseline, not a broken scene.";
+        }
+        {
+            // Everything worked.
+            Diagnostics d;
+            d.EnabledComponents = 15;
+            d.Submitted = 15;
+            EXPECT_FALSE(d.SilentlyDrewNothing());
+        }
+        {
+            // Partial success still draws something, so the viewport is not the
+            // uninformative blank this check is meant to catch. The per-asset
+            // warning in Scene.cpp already names the specific failures.
+            Diagnostics d;
+            d.EnabledComponents = 10;
+            d.UnresolvedAssets = 9;
+            d.Submitted = 1;
+            EXPECT_FALSE(d.SilentlyDrewNothing())
+                << "A partially-drawing scene is diagnosable by eye; the per-asset warning covers it.";
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. The counters stay self-consistent
+    // -------------------------------------------------------------------------
+    // Every enabled component must end up in exactly one bucket. If the Scene
+    // loop ever grows a path that leaves a component uncounted, the predicate
+    // above silently weakens — it would stop firing on a scene that draws
+    // nothing, which is the original bug wearing a new hat.
+    TEST(VirtualGeometrySceneCoverage, DiagnosticsBucketsAccountForEveryEnabledComponent)
+    {
+        VirtualMeshRegistry::SubmissionDiagnostics d;
+        d.EnabledComponents = 12;
+        d.UnresolvedAssets = 5;
+        d.RegistrationFailures = 3;
+        d.Submitted = 4;
+
+        EXPECT_EQ(d.UnresolvedAssets + d.RegistrationFailures + d.Submitted, d.EnabledComponents)
+            << "The three outcome buckets must partition the enabled components exactly.";
+
+        // A freshly reset instance is the "nothing to report" state.
+        const VirtualMeshRegistry::SubmissionDiagnostics fresh;
+        EXPECT_EQ(fresh.EnabledComponents, 0u);
+        EXPECT_EQ(fresh.Submitted, 0u);
+        EXPECT_FALSE(fresh.FellBackToClassic);
+        EXPECT_FALSE(fresh.SilentlyDrewNothing());
+    }
+} // namespace OloEngine::Tests

--- a/docs/agent-rules/cluster-lod-simplification.md
+++ b/docs/agent-rules/cluster-lod-simplification.md
@@ -137,12 +137,13 @@ saw. Locked vertices survive it — `computeVertexIds` gives each a unique id so
   baseline. Stash the change **selectively**, leaving the instrumentation applied to both.
 - **~~Stale registry entries lie.~~ That entry is not stale — it is fetch-on-demand** (corrected
   2026-08-21, issue #864). `AssetRegistry.oar` lists `Models/Stanford/xyzrgb_dragon.ply` and the
-  file is not committed, but that is **deliberate and permanent**: it is a 137 MB asset declared in
-  `scripts/assets/asset-manifest.json`, absent until someone runs `scripts/Fetch-Assets.ps1 -Name
-  xyzrgb-dragon`. The registry entry is what lets the handle resolve *once fetched*, and
-  `AssetContentValidityTest` allowlists it on purpose — deleting it would silently unregister the
-  Nanite stress scene for everyone. Do **not** "clean" it, and do **not** repoint the scene at a
-  smaller committed mesh: that throws away the 173M-triangle stress case to fix a machine that had
+  file is not committed, but that is **deliberate and permanent**: it is the 7.2 M-triangle,
+  137 MB asset declared in `scripts/assets/asset-manifest.json`, absent until someone runs
+  `scripts/Fetch-Assets.ps1 -Name xyzrgb-dragon`. The registry entry is what lets the handle
+  resolve *once fetched*, and `AssetContentValidityTest` allowlists it on purpose — deleting it
+  would silently unregister the Nanite stress scene for everyone. Do **not** "clean" it, and do
+  **not** repoint the scene at a smaller committed mesh: `VirtualGeometryStress.olo` places 24 of
+  them, so that throws away 24 × 7.2 M ≈ 173 M triangles of stress case to fix a machine that had
   merely never run the fetch.
 
   Reading that entry as staleness is what produced issue #864's incorrect premise. Check the

--- a/docs/agent-rules/cluster-lod-simplification.md
+++ b/docs/agent-rules/cluster-lod-simplification.md
@@ -121,15 +121,32 @@ saw. Locked vertices survive it — `computeVertexIds` gives each a unique id so
 
 ## 5. Measuring a builder change
 
-- **The cook is not reachable from a plain editor run.** `VirtualGeometrySponza.olo`'s
-  `VirtualMeshComponent` handle does not resolve in a clean checkout, so the editor loads the scene
-  and settles without registering a virtual mesh or writing any `.omesh`. Drive
-  `VirtualMeshBuilder::BuildSet` directly instead (see `VirtualMeshRealAssetCookTest`).
+- **~~The cook is not reachable from a plain editor run.~~ CORRECTED 2026-08-21 (issue #864).**
+  This used to say `VirtualGeometrySponza.olo`'s `VirtualMeshComponent` handle "does not resolve in
+  a clean checkout". It does. Verified live over MCP on a clean worktree: the scene opens, registers
+  the mesh, and reports **1 enabled component → 1 submitted, 25 instances (Sponza's 25 submeshes),
+  5018 clusters**. `Sponza.gltf` and `Sponza.bin` are committed and have been since #629. Drive
+  `VirtualMeshBuilder::BuildSet` directly (`VirtualMeshRealAssetCookTest`) when you want the builder
+  in isolation — but not because the editor path is broken, because it isn't.
+
+  The reason this wrong claim survived: **virtual geometry only submits on the Deferred path**, and
+  the editor starts on Forward. Open a VG scene without switching the render path and every counter
+  reads zero — which looks exactly like an unresolvable handle. Switch first:
+  `olo_renderer_settings_set { setting: 'renderpath', value: 'deferred' }`.
 - **Instrument on both sides of the A/B.** Timing added *by* the change cannot measure the
   baseline. Stash the change **selectively**, leaving the instrumentation applied to both.
-- **Stale registry entries lie.** `AssetRegistry.oar` lists `Models/Stanford/xyzrgb_dragon.ply`
-  (the #651 asset) but the file is not committed; a benchmark keyed on it silently SKIPs. Check the
-  file exists, and prefer a procedural stand-in for the pathological shape.
+- **~~Stale registry entries lie.~~ That entry is not stale — it is fetch-on-demand** (corrected
+  2026-08-21, issue #864). `AssetRegistry.oar` lists `Models/Stanford/xyzrgb_dragon.ply` and the
+  file is not committed, but that is **deliberate and permanent**: it is a 137 MB asset declared in
+  `scripts/assets/asset-manifest.json`, absent until someone runs `scripts/Fetch-Assets.ps1 -Name
+  xyzrgb-dragon`. The registry entry is what lets the handle resolve *once fetched*, and
+  `AssetContentValidityTest` allowlists it on purpose — deleting it would silently unregister the
+  Nanite stress scene for everyone. Do **not** "clean" it, and do **not** repoint the scene at a
+  smaller committed mesh: that throws away the 173M-triangle stress case to fix a machine that had
+  merely never run the fetch.
+
+  Reading that entry as staleness is what produced issue #864's incorrect premise. Check the
+  manifest before concluding a registry entry is dead.
 - **An editor run rewrites `AssetRegistry.oar`** as a side effect — revert it, and any `.oloproj`
   you patched to change `StartScene`.
 - Bumping `kVirtualMeshBuilderVersion` is **not** optional when geometry changes, and any new


### PR DESCRIPTION
Closes #864.

## What this turned out to be

The issue's premise was that `VirtualGeometryStress.olo` and `VirtualGeometrySponza.olo`
have stale/unresolvable `VirtualMeshComponent` handles. **Neither scene is broken, and
neither handle is stale.** I decoded `AssetRegistry.oar` properly (it is a binary v2
archive: `u32 version`, `u32 count`, then `{u64 handle, u32 type, u32 status, u32 pathLen,
path}` per entry — a text grep over it proves nothing, which is the trap the handover
warned about) and all three handles resolve to real entries:

| scene | handle | registry entry | on disk |
|---|---|---|---|
| `VirtualGeometryTest` | `…228` | `DamagedHelmet.gltf` | committed |
| `VirtualGeometrySponza` | `…234` | `Sponza.gltf` | committed |
| `VirtualGeometryStress` | `…304` | `xyzrgb_dragon.ply` | **fetch-on-demand** |

The dragon is a deliberately-uncommitted 137 MB asset declared in
`scripts/assets/asset-manifest.json`, absent until someone runs `scripts/Fetch-Assets.ps1`.
Its registry entry is intentional — `AssetContentValidityTest` allowlists it on purpose,
because deleting it would silently unregister the stress scene for everyone.

So **repointing the handles would have been the wrong fix**: it would have thrown away the
173M-triangle stress case to "fix" a machine that had merely never run a documented setup
step.

The actual zero in the original report has a simpler cause that nobody had written down:
**virtual geometry only submits on the Deferred path, and the editor boots on Forward.**
My very first live reading reproduced it exactly — `renderingPath: "Forward"`, every
counter zero. That is indistinguishable from a broken scene, which is the whole problem.

The manifest already states the contract that was being violated:

> Every consumer (scene, test) must degrade gracefully when an asset is absent: SKIP with a
> message naming the fetch command, never fail.

`VirtualGeometryStress.olo` documents its fetch step in a YAML comment (line 48) that
nothing reads at runtime. **The silent zero is the bug; the asset state was only ever
today's trigger.**

## The fix — one seam, three consumers

`VirtualMeshRegistry::SubmissionDiagnostics` (reset in `BeginFrame`, filled by the Scene
submission loop) records why a frame drew what it drew: enabled components, how many failed
to resolve, how many failed to build a cluster DAG, how many were submitted, and whether the
master switch routed them to the classic path. One predicate, `SilentlyDrewNothing()`, is
the trigger for all three reporters:

- **`Scene.cpp`** — a warning naming `Fetch-Assets.ps1`, logged on state *change* rather
  than per frame. The existing per-asset warning also now names the fetch command.
- **`StatisticsPanel.cpp`** — the panel previously appeared only when something was
  *already* drawing, so a broken scene hid the very panel its own header tells you to read.
  It now shows whenever the scene asked for virtual geometry, and explains the zero in red.
- **`McpToolsRender.cpp`** — the old note said *"no VirtualMeshComponent in the scene, or
  all of them are disabled"*, which was actively misleading on exactly this bug. It now
  emits a `diagnostics` object plus a note that warns an A/B taken here passes vacuously.

Deliberately silent for: a scene with no `VirtualMeshComponent`, components with no mesh
assigned, and the classic-path fallback (the intended A/B baseline). A spurious fire would
warn on nearly every scene in the project and get muted, which lands us back at square one.

## Live verification

All readings from `olo_virtual_geometry_stats` against a running editor on Deferred.

| scene | components | submitted | instances | clusters tested | `silentlyDrewNothing` |
|---|---|---|---|---|---|
| `VirtualGeometryTest` | 15 | 15 | 15 | 4 860 | `false` |
| `VirtualGeometrySponza` | 1 | 1 | 25 | 5 018 | `false` |
| `VirtualGeometryStress` | 24 | 24 | 24 | **2 834 448** | `false` |

Each was screenshotted over MCP and the pixels inspected, not just the counters: the Test
scene shows 15 PBR helmets with shadows and IBL; Sponza shows textured stonework (its 25
submeshes shading with their imported materials); the Stress scene shows two receding rows
of Stanford dragons. Counters alone would not have distinguished "drawing" from "drawing
something wrong", which is the failure mode this issue is about.

**Does the stress scene actually stress?** Yes, decisively — 2 834 448 clusters tested vs
4 860 for `VirtualGeometryTest` (**583×**), with a 3 165 SW / 51 HW raster split, exactly
the software-raster regime the scene header claims. Cook, from the log:

```
VirtualMeshBuilder: submesh 0 -> 118102 clusters in 7206 groups across 17 levels
                    from 7219045 triangles
Model::CookVirtualMesh: cooked 7219045 triangles into 1 part(s) / 118102 clusters
                        (200486 KB) in 107499.5 ms
VirtualMeshRegistry: mesh asset 4544736348022301304 registered as 1 part(s)
```

**Proof the loud check fires.** I renamed the dragon away and relaunched, reproducing the
original report verbatim (28 entities, 0 instances, 0 clusters) — it now explains itself:

```json
"diagnostics": { "enabledComponents": 24, "unresolvedAssets": 24,
                 "submitted": 0, "silentlyDrewNothing": true }
```
```
Scene: 24 enabled VirtualMeshComponent(s) submitted ZERO virtual-geometry instances this
frame (24 with an unresolvable mesh-source asset, 0 whose cluster DAG failed to build) —
… run 'scripts/Fetch-Assets.ps1' … Do NOT treat a VG measurement taken on this scene as
meaningful.
```

Logged **once**, not per frame (verified: 1 occurrence). And on `VehiclesTest.olo` (no
virtual geometry) it stays silent — `enabledComponents: 0`, `silentlyDrewNothing: false`.
The asset was restored afterwards.

## Tests

New `VirtualGeometrySceneCoverageTest.cpp` (`// OLO_TEST_LAYER: unit`), deliberately
GL-free so it runs in CI — the suite was green for this bug's entire life:

1. every `VirtualMeshComponent` handle in every sandbox scene is registered (the failure the
   issue assumed), without asserting on-disk presence, which is legitimately absent for a
   fetch-on-demand asset;
2. `SilentlyDrewNothing()` fires on both real failure shapes and on **none** of the four
   legitimate zeros;
3. the outcome buckets partition the enabled components, so a future Scene-loop path that
   leaves a component uncounted can't silently weaken the predicate.

`225/225` pass across 29 suites — `VirtualGeometrySceneCoverage`, `AssetContentValidity`,
`VirtualMesh*`, `Scene*`, `SystemScheduler*` and the component-codegen coverage suites.

Run after a **clean** `build-cached` rebuild, deliberately: this branch adds a member to
`Scene.h`, and per issue #858 **342 of 1426 objects in this tree carry no dep record**
(a ccache direct hit never runs `/showIncludes`, so ninja records nothing and never
rebuilds that TU for a header change). An incremental build is therefore unsound after a
layout change — it can leave TUs compiled against two different versions of one header with
no diagnostic. The first pass of these tests was green on the incremental build too, which
is exactly why it could not be trusted.

## Docs

`docs/agent-rules/cluster-lod-simplification.md` §5 carried two claims this work disproved,
both corrected in place rather than deleted, since they are what seeded the wrong premise:

- "Sponza's handle does not resolve in a clean checkout" — it does; 25 instances, measured.
- "Stale registry entries lie" about the dragon — that entry is fetch-on-demand, not stale,
  and must not be cleaned or repointed.

Both now also record the Deferred-path gate that explains the zeros.

## Not in scope

No evidence turned up for #862, #712 or #654. `AssetRegistry.oar` is untouched — an editor
run rewrites it, but the rewrite is pure byte-churn from hash-map iteration order (verified
semantically identical: same 119 entries, types, statuses and paths), so it was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Virtual geometry statistics now include clear submission diagnostics, including enabled components, unresolved assets, registration failures, fallback rendering, and silent zero-draw states.
  - The Statistics panel displays virtual geometry status and explains missing submissions or asset issues.
  - Added warnings and guidance for unresolved assets and fetch-on-demand content.

- **Bug Fixes**
  - Improved distinction between successful rendering, fallback behavior, missing assets, and disabled components.

- **Tests**
  - Added coverage for virtual geometry diagnostics, asset registration, fallback, recovery, and per-frame resets.

- **Documentation**
  - Updated virtual geometry measurement and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->