### PR TITLE
fix(mcp): olo_input_inject no longer reports ok for input that never landed (#854)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -729,6 +729,8 @@ namespace OloEngine
         // #607) — the overlay is process-wide static state, so a key left "down" here
         // would outlive the editor layer.
         m_McpInputQueue.clear();
+        ReleaseSyntheticMouseButtons();
+        RestoreCursorOverWindowState();
         SyntheticInput::Reset();
 
         // Properly stop the scene if still in play/simulate mode
@@ -846,6 +848,12 @@ namespace OloEngine
 
     void EditorLayer::DrainMcpInputQueue()
     {
+        // ImGui applies its event queue in NewFrame, which runs AFTER this drain, so
+        // the position fed in last tick is only observable now. Sampling here — on
+        // every tick, in flight or not — is what lets the tool answer "did the
+        // injected position actually take?" instead of guessing (issue #854).
+        SampleMcpCursorLanding();
+
         if (m_McpInputQueue.empty())
         {
             // Nothing in flight: make sure a previous plan left no key stuck down.
@@ -855,8 +863,27 @@ namespace OloEngine
                 m_McpSyntheticShift = false;
                 m_McpSyntheticAlt = false;
             }
+            // ...and hand the cursor back a few quiet frames after the plan ended, not
+            // on the frame it ended. Restoring immediately would blank ImGui's cursor
+            // (the physical mouse is elsewhere) BEFORE the tool reads the state change
+            // the injection caused, so every reply's `after.viewportHovered` /
+            // `hoveredEntity` would come back empty — trading one wrong answer for
+            // another. The countdown is short and unconditional: the plan always ends
+            // with trailing settle frames, the caller reads one frame past the plan,
+            // and this fires shortly after that. OnDetach restores without waiting.
+            if (m_McpCursorRestoreCountdown > 0 && --m_McpCursorRestoreCountdown == 0)
+                RestoreCursorOverWindowState();
             return;
         }
+        // A new plan supersedes any pending hand-back: it is about to re-assert the
+        // latch anyway, and letting the countdown fire mid-plan would drop it.
+        m_McpCursorRestoreCountdown = 0;
+
+        // Hold the backend's cursor-enter latch for as long as the plan runs, and
+        // re-assert it every frame: a real cursor-LEAVE arriving mid-plan (the human
+        // moves the physical mouse off the window) would otherwise drop it and hand
+        // the rest of the plan back to the hardware cursor half way through.
+        AssertSyntheticCursorOverWindow();
 
         const std::vector<MCP::McpInputEvent> frame = std::move(m_McpInputQueue.front());
         m_McpInputQueue.pop_front();
@@ -880,10 +907,112 @@ namespace OloEngine
             io.AddKeyEvent(ImGuiMod_Alt, true);
 
         // The last frame of the plan has drained: release the cursor override so the
-        // real mouse takes over again. Any key/button the plan left held stays held —
-        // that is the documented contract of keyAction "press".
+        // real mouse takes over again. Any KEY the plan left held stays held — that is
+        // the documented contract of keyAction "press". A mouse BUTTON is different:
+        // no action leaves one held on purpose, so one still down here means the plan
+        // was half applied, and a button ImGui believes is held pins its ActiveId and
+        // makes IsWindowHovered() false for every panel — i.e. it silently swallows
+        // every later click in the session (issue #854). Teardown restores it.
         if (m_McpInputQueue.empty())
+        {
             SyntheticInput::ClearMousePosition();
+            ReleaseSyntheticMouseButtons();
+            // Arm the hand-back rather than doing it here: see the countdown at the
+            // top of this function for why it must not land before the caller reads
+            // the state the plan produced.
+            m_McpCursorRestoreCountdown = s_McpCursorRestoreDelayFrames;
+        }
+    }
+
+    // Assert to the ImGui GLFW backend that the cursor is inside this window.
+    //
+    // Why this is needed at all (issue #854). ImGui_ImplGlfw_UpdateMouseData(), called
+    // from ImGui_ImplGlfw_NewFrame(), contains a fallback: when the window is FOCUSED
+    // and bd->MouseWindow is null — i.e. the physical mouse is not over any editor
+    // window, the normal state for an agent-driven session — it polls glfwGetCursorPos
+    // and queues the HARDWARE position. The drain above runs before ImGuiLayer::Begin,
+    // so our synthetic position is queued FIRST and the hardware one LAST, and ImGui
+    // applies its queue in order. The injected position was therefore discarded on
+    // every single frame, and the click landed wherever the physical mouse happened to
+    // be — while the tool reported ok. Both halves of #854 are that one fact: the drag
+    // never reached the pins, and every LATER injection was equally inert, because the
+    // condition is a property of where the physical mouse is sitting, not of the drag.
+    //
+    // Asserting the enter is not a fiction: InputInject::ResolvePoint has already
+    // refused any point outside this window's client area, so the synthetic cursor
+    // genuinely is inside it. The callback also queues bd->LastValidMousePos, which the
+    // position event we send immediately afterwards supersedes within the same frame.
+    void EditorLayer::AssertSyntheticCursorOverWindow()
+    {
+        auto* const window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+        if (!window)
+            return;
+        ::ImGui_ImplGlfw_CursorEnterCallback(window, GLFW_TRUE);
+        m_McpSyntheticCursorEntered = true;
+    }
+
+    // ...and hand it back when the plan ends, so an injected plan leaves the backend
+    // exactly as it found it. Left asserted, the editor would keep hovering the last
+    // injected point long after the plan finished, which is the same genre of latch
+    // this issue is about. GLFW_HOVERED is the ground truth we defer to; when it says
+    // the mouse really is outside, the leave callback's sentinel position is picked up
+    // and replaced by the fallback above on the very next frame, which IS the
+    // pre-injection behaviour.
+    void EditorLayer::RestoreCursorOverWindowState()
+    {
+        if (!m_McpSyntheticCursorEntered)
+            return;
+        m_McpSyntheticCursorEntered = false;
+
+        auto* const window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+        if (!window)
+            return;
+        if (::glfwGetWindowAttrib(window, GLFW_HOVERED) == 0)
+            ::ImGui_ImplGlfw_CursorEnterCallback(window, GLFW_FALSE);
+    }
+
+    // Release every mouse button an in-flight plan pressed and did not release.
+    // Mirrors the press into BOTH sinks the press went to, so neither the poll-based
+    // Input:: overlay nor ImGui is left believing a button is down.
+    void EditorLayer::ReleaseSyntheticMouseButtons()
+    {
+        // The two tables index the same GLFW button space; if the overlay ever grows a
+        // button this one has not, a plan could press one we never track and therefore
+        // never release.
+        static_assert(std::tuple_size_v<decltype(m_McpSyntheticButtonsDown)> == SyntheticInput::s_MouseButtonCount,
+                      "the tracked-button table must cover exactly the buttons SyntheticInput accepts");
+
+        auto* const window = static_cast<GLFWwindow*>(Application::Get().GetWindow().GetNativeWindow());
+        for (sizet button = 0; button < m_McpSyntheticButtonsDown.size(); ++button)
+        {
+            if (!m_McpSyntheticButtonsDown[button])
+                continue;
+            m_McpSyntheticButtonsDown[button] = false;
+            SyntheticInput::SetMouseButton(static_cast<MouseCode>(button), false);
+            if (window)
+            {
+                ::ImGui_ImplGlfw_MouseButtonCallback(window, static_cast<i32>(button), GLFW_RELEASE, 0);
+            }
+            OLO_CORE_WARN("[MCP] Injected plan ended with mouse button {} still down; released it.", button);
+        }
+    }
+
+    // Read back where the previous tick's injected position actually landed. ImGui's
+    // NewFrame has run since, so io.MousePos now reflects it — or does not, which is
+    // the whole point.
+    void EditorLayer::SampleMcpCursorLanding()
+    {
+        if (!m_McpCursorProbeArmed)
+            return;
+        m_McpCursorProbeArmed = false;
+
+        // Same ImGui-screen -> window-client correction GetMcpInputState applies, so
+        // asked and landed are directly comparable.
+        const MCP::McpInputViewportInfo info = GetMcpInputViewportInfo();
+        const ImVec2 mouse = ImGui::GetMousePos();
+        m_McpCursorLandedX = mouse.x - info.WindowX;
+        m_McpCursorLandedY = mouse.y - info.WindowY;
+        m_McpCursorLandingValid = true;
     }
 
     void EditorLayer::ApplyMcpInputEvent(const MCP::McpInputEvent& event)
@@ -913,6 +1042,13 @@ namespace OloEngine
                 // coordinate without us duplicating that math.
                 SyntheticInput::SetMousePosition({ event.X, event.Y });
                 ::ImGui_ImplGlfw_CursorPosCallback(window, static_cast<f64>(event.X), static_cast<f64>(event.Y));
+                // Arm the landing probe: next tick, once ImGui's NewFrame has applied
+                // its queue, SampleMcpCursorLanding checks whether this position is
+                // where the cursor actually ended up (issue #854).
+                m_McpCursorAskedX = event.X;
+                m_McpCursorAskedY = event.Y;
+                m_McpCursorProbeArmed = true;
+                m_McpCursorLandingValid = false;
                 break;
             }
             case MCP::McpInputEvent::Kind::MouseDelta:
@@ -946,6 +1082,17 @@ namespace OloEngine
             {
                 SyntheticInput::SetMouseButton(static_cast<MouseCode>(event.Code), event.Down);
                 ::ImGui_ImplGlfw_MouseButtonCallback(window, event.Code, event.Down ? GLFW_PRESS : GLFW_RELEASE, mods);
+                // Remember what this plan is holding, so its teardown can put back
+                // anything the plan itself failed to release.
+                if (event.Code >= 0 && static_cast<sizet>(event.Code) < m_McpSyntheticButtonsDown.size())
+                    m_McpSyntheticButtonsDown[static_cast<sizet>(event.Code)] = event.Down;
+                // Re-arm the landing probe WITHOUT changing what was asked for. A press
+                // trails its cursor move by several frames, so measuring only after the
+                // move would miss a cursor stolen in between — and a press that lands
+                // somewhere else is precisely the "reported ok, did nothing" this issue
+                // is about. Re-arming here makes the last measurement the one taken
+                // after the button actually acted.
+                m_McpCursorProbeArmed = true;
                 break;
             }
             case MCP::McpInputEvent::Kind::Key:
@@ -1054,6 +1201,16 @@ namespace OloEngine
         const glm::vec2 offset = SyntheticInput::GetMouseOffset();
         state.MouseOffsetX = offset.x;
         state.MouseOffsetY = offset.y;
+
+        // Where the last injected position was aimed and where it actually landed
+        // (issue #854). Reported separately from MouseX/MouseY above, which is a
+        // live read and by this point may legitimately have moved back to the
+        // hardware cursor as the plan's teardown handed hover back.
+        state.CursorLandingValid = m_McpCursorLandingValid;
+        state.CursorAskedX = m_McpCursorAskedX;
+        state.CursorAskedY = m_McpCursorAskedY;
+        state.CursorLandedX = m_McpCursorLandedX;
+        state.CursorLandedY = m_McpCursorLandedY;
         return state;
     }
 

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -39,6 +39,7 @@
 #include "OloEngine/Renderer/UniformBuffer.h"
 #include "OloEngine/Scene/SceneMeshRaycast.h"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <deque>
@@ -229,6 +230,19 @@ namespace OloEngine
         // for why this goes through the ImGui GLFW backend callbacks rather than the
         // OS or ImGuiIO alone.
         void ApplyMcpInputEvent(const MCP::McpInputEvent& event);
+        // Hold the ImGui GLFW backend's "the cursor is over this window" latch for the
+        // duration of a plan, and hand it back to physical reality when the plan ends
+        // (issue #854). Without the first, every injected position is overwritten by
+        // the hardware one; without the second, the editor is left hovering a point
+        // the physical mouse is nowhere near.
+        void AssertSyntheticCursorOverWindow();
+        void RestoreCursorOverWindowState();
+        // Release any mouse button an in-flight plan pressed but never released.
+        void ReleaseSyntheticMouseButtons();
+        // Read back where the last injected cursor position ACTUALLY landed in ImGui,
+        // one frame after it was fed in (issue #854). Called at the top of every
+        // drain, including the ones after a plan has finished.
+        void SampleMcpCursorLanding();
         [[nodiscard]] MCP::McpInputViewportInfo GetMcpInputViewportInfo() const;
         [[nodiscard]] MCP::McpInputStateSnapshot GetMcpInputState() const;
 
@@ -435,6 +449,30 @@ namespace OloEngine
         bool m_McpSyntheticCtrl = false;
         bool m_McpSyntheticShift = false;
         bool m_McpSyntheticAlt = false;
+        // True while a plan holds the backend's cursor-enter latch (issue #854), so
+        // the teardown knows it has something to hand back.
+        bool m_McpSyntheticCursorEntered = false;
+        // Quiet frames to wait after a plan ends before handing hover back to the
+        // physical mouse. Long enough that the caller's post-plan state read still
+        // sees what the injection did (it reads one frame past the plan, and the
+        // editor's entity picking is two frames latent on top of that), short enough
+        // that no human could notice. 0 = nothing pending.
+        static constexpr int s_McpCursorRestoreDelayFrames = 8;
+        int m_McpCursorRestoreCountdown = 0;
+        // Mouse buttons an in-flight plan has pressed and not yet released. A plan's
+        // teardown releases whatever is left here: unlike keyAction "press", no mouse
+        // action deliberately leaves a button held, so anything still down at the end
+        // of a plan is a half-applied plan, and a stuck button freezes ImGui's ActiveId
+        // for the rest of the session.
+        std::array<bool, 8> m_McpSyntheticButtonsDown{};
+        // The last injected cursor position (window-client logical px) and where ImGui
+        // actually put it, sampled one frame later. See McpInputStateSnapshot.
+        bool m_McpCursorProbeArmed = false;
+        bool m_McpCursorLandingValid = false;
+        f32 m_McpCursorAskedX = 0.0f;
+        f32 m_McpCursorAskedY = 0.0f;
+        f32 m_McpCursorLandedX = 0.0f;
+        f32 m_McpCursorLandedY = 0.0f;
 
         // Undo/Redo
         CommandHistory m_CommandHistory;

--- a/OloEditor/src/MCP/McpInputInject.h
+++ b/OloEditor/src/MCP/McpInputInject.h
@@ -976,6 +976,53 @@ namespace OloEngine::MCP::InputInject
             .NoAdditional();
     }
 
+    // ---- did the injected cursor actually land? ---------------------------------------
+    //
+    // The honesty backstop for issue #854. An injected position is a REQUEST to the
+    // ImGui GLFW backend, not a guarantee: the backend re-injects the hardware cursor
+    // after ours whenever the window is focused and the physical mouse is not over it,
+    // and before #854 that silently won. The editor now holds the backend's
+    // cursor-enter latch for the duration of a plan so ours wins — but "we believe it
+    // works now" is exactly the reasoning that produced a tool reporting ok for work it
+    // did not do. So the editor also MEASURES where the cursor ended up, and this
+    // compares the two. Any future way of losing the position — a backend upgrade, a
+    // second platform viewport, a human grabbing the mouse mid-plan — surfaces as a
+    // loud failure rather than a confident wrong answer.
+    //
+    // Tolerance is in window-client LOGICAL pixels. It exists only to absorb float
+    // round-tripping through ImGui's screen-space conversion (observed: sub-pixel);
+    // the failure it must catch is off by hundreds of pixels, so this is nowhere near
+    // the discrimination limit.
+    inline constexpr f32 s_CursorLandingToleranceLogicalPx = 2.0f;
+
+    [[nodiscard]] inline bool CursorLanded(f32 askedX, f32 askedY, f32 landedX, f32 landedY) noexcept
+    {
+        return std::fabs(landedX - askedX) <= s_CursorLandingToleranceLogicalPx &&
+               std::fabs(landedY - askedY) <= s_CursorLandingToleranceLogicalPx;
+    }
+
+    // True when this action injected a cursor position at all. key/text/mouseDelta
+    // deliberately do not (mouseDelta drives the poll-based Input:: API only), so
+    // there is nothing to verify for them.
+    [[nodiscard]] inline bool ActionMovesTheCursor(Action action) noexcept
+    {
+        return action == Action::Click || action == Action::Move || action == Action::Drag;
+    }
+
+    [[nodiscard]] inline std::string CursorNotLandedMessage(f32 askedX, f32 askedY, f32 landedX, f32 landedY)
+    {
+        const auto round = [](f32 value)
+        { return std::to_string(static_cast<int>(std::lround(value))); };
+        return "Injected, but the editor's cursor did not go where the injection asked: requested (" +
+               round(askedX) + ", " + round(askedY) + ") in window-client pixels, ImGui ended up at (" +
+               round(landedX) + ", " + round(landedY) +
+               "). The events were delivered, so anything they hit was hit at the WRONG place and the "
+               "state below reflects that, not your request. The usual cause is something else writing "
+               "ImGui's cursor in the same frame — a human moving the physical mouse during the call, or "
+               "a target that is not on the main platform window. Retry; if it repeats, the injected "
+               "position is being overridden and no click/drag in this session can be trusted.";
+    }
+
     // ---- result shaping ---------------------------------------------------------------
 
     [[nodiscard]] inline Json ToJson(const McpInputInjectResult& result, const McpInputStateSnapshot& state,
@@ -984,11 +1031,28 @@ namespace OloEngine::MCP::InputInject
                                      const ResolvedDelta* delta = nullptr,
                                      const std::string& stallReason = {})
     {
+        // Did the position we injected actually become ImGui's cursor? Only meaningful
+        // for the actions that inject one, only once the editor has reported a
+        // measurement, and only when the plan actually ran to completion — a timeout
+        // has its own, more specific message and the landing was never sampled.
+        // The raw comparison, reported as-is so `cursorLanding.landed` never claims a
+        // verification that did not happen (a timeout, for one, never samples).
+        const bool landedRaw = CursorLanded(state.CursorAskedX, state.CursorAskedY, state.CursorLandedX,
+                                            state.CursorLandedY);
+        const bool verifyLanding = ActionMovesTheCursor(request.Act) && state.Available &&
+                                   state.CursorLandingValid && !timedOut;
+        const bool landed = !verifyLanding || landedRaw;
+
         Json j;
         j["available"] = result.Available;
-        j["ok"] = result.Ok && !timedOut;
+        j["ok"] = result.Ok && !timedOut && landed;
         j["framesInjected"] = result.FrameCount;
         j["message"] = result.Message;
+        if (!landed)
+        {
+            j["message"] = CursorNotLandedMessage(state.CursorAskedX, state.CursorAskedY, state.CursorLandedX,
+                                                  state.CursorLandedY);
+        }
         if (timedOut)
         {
             // Name the CAUSE when the editor could tell us one. A bare "timed out" is
@@ -1038,6 +1102,17 @@ namespace OloEngine::MCP::InputInject
         // piece of injection state that OUTLIVES a call, so a session that has left it
         // non-zero should be able to see that from any injection reply.
         after["mouseOffset"] = Json{ { "x", state.MouseOffsetX }, { "y", state.MouseOffsetY } };
+        // The landing measurement behind `ok` (issue #854), so a failure can be read
+        // rather than inferred — and so a SUCCESS is visibly checked rather than
+        // asserted. Omitted for the actions that inject no position.
+        if (ActionMovesTheCursor(request.Act) && state.CursorLandingValid)
+        {
+            after["cursorLanding"] = Json{ { "askedX", state.CursorAskedX },
+                                           { "askedY", state.CursorAskedY },
+                                           { "landedX", state.CursorLandedX },
+                                           { "landedY", state.CursorLandedY },
+                                           { "landed", landedRaw } };
+        }
         after["selectedEntity"] = state.SelectedEntityId == 0
                                       ? Json(nullptr)
                                       : Json{ { "id", std::to_string(state.SelectedEntityId) },

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -563,6 +563,24 @@ namespace OloEngine::MCP
         // can leave behind, and a drifting value is how you notice you did.
         f32 MouseOffsetX = 0.0f;
         f32 MouseOffsetY = 0.0f;
+        // Where the LAST injected cursor position actually landed in ImGui (issue
+        // #854), in window-client logical pixels, alongside the position that was
+        // asked for. Sampled by the editor on the frame after the event was fed to
+        // the backend — i.e. once ImGui's NewFrame has applied its event queue —
+        // rather than read out of `MouseX` after the plan, because by then the
+        // backend may legitimately have moved the cursor back to the hardware one.
+        //
+        // This exists because "the injected position was silently discarded" used to
+        // be indistinguishable from "the click landed and the UI ignored it": the
+        // GLFW backend re-injects the HARDWARE position after ours whenever the
+        // window is focused and the physical mouse is not over it, which is the
+        // normal state for an agent-driven session. The tool compares these two and
+        // refuses to report ok when they disagree.
+        bool CursorLandingValid = false;
+        f32 CursorAskedX = 0.0f;
+        f32 CursorAskedY = 0.0f;
+        f32 CursorLandedX = 0.0f;
+        f32 CursorLandedY = 0.0f;
     };
 
     // Editor liveness + window state (issue #607) — the answer to "is the editor

--- a/OloEditor/src/MCP/McpToolsInput.cpp
+++ b/OloEditor/src/MCP/McpToolsInput.cpp
@@ -182,7 +182,14 @@ namespace OloEngine::MCP
                             { "mouseX", state.MouseX },
                             { "mouseY", state.MouseY },
                             { "mouseOffsetX", state.MouseOffsetX },
-                            { "mouseOffsetY", state.MouseOffsetY } };
+                            { "mouseOffsetY", state.MouseOffsetY },
+                            // The injected-cursor landing measurement (issue #854) —
+                            // what makes `ok` a checked claim rather than an assertion.
+                            { "cursorLandingValid", state.CursorLandingValid },
+                            { "cursorAskedX", state.CursorAskedX },
+                            { "cursorAskedY", state.CursorAskedY },
+                            { "cursorLandedX", state.CursorLandedX },
+                            { "cursorLandedY", state.CursorLandedY } };
                     if (context.GetEditorLiveness)
                     {
                         const McpEditorLiveness liveness = context.GetEditorLiveness();
@@ -211,6 +218,11 @@ namespace OloEngine::MCP
             state.MouseY = stateJson.value("mouseY", 0.0f);
             state.MouseOffsetX = stateJson.value("mouseOffsetX", 0.0f);
             state.MouseOffsetY = stateJson.value("mouseOffsetY", 0.0f);
+            state.CursorLandingValid = stateJson.value("cursorLandingValid", false);
+            state.CursorAskedX = stateJson.value("cursorAskedX", 0.0f);
+            state.CursorAskedY = stateJson.value("cursorAskedY", 0.0f);
+            state.CursorLandedX = stateJson.value("cursorLandedX", 0.0f);
+            state.CursorLandedY = stateJson.value("cursorLandedY", 0.0f);
 
             McpInputViewportInfo info;
             info.Available = true;
@@ -297,7 +309,7 @@ namespace OloEngine::MCP
         tool.InputSchema = Inject::InputSchema();
         tool.OutputSchema = Schema::Object()
                                 .Prop("available", Schema::Bool())
-                                .Prop("ok", Schema::Bool().Desc("Injection accepted AND every planned frame rendered before the settle timeout; false with a timeout warning in 'message' means the 'after' state may be stale."))
+                                .Prop("ok", Schema::Bool().Desc("Injection accepted, every planned frame rendered before the settle timeout, AND (for click/move/drag) the injected cursor position verifiably became the editor's cursor. False always means the 'after' state cannot be trusted as the result of what you asked for; 'message' says which of the three failed."))
                                 .Prop("framesInjected", Schema::Int().Min(0))
                                 .Prop("message", Schema::String())
                                 .Prop("resolved", Schema::Object().Desc("Mouse actions (click/move/drag) only; omitted for key/text. A resolved point {windowX, windowY, viewportPixelX, viewportPixelY, insideViewport} for click/move, or {from, to} of two such points for drag."))
@@ -316,8 +328,15 @@ namespace OloEngine::MCP
                                 .Prop("after", Schema::Object()
                                                    .Prop("pending", Schema::Bool().Desc("True when injected events are still queued (only after a settle timeout)."))
                                                    .Prop("viewportHovered", Schema::Bool())
-                                                   .Prop("mouseX", Schema::Number())
+                                                   .Prop("mouseX", Schema::Number().Desc("The editor cursor's CURRENT position, in window-client logical pixels. This is a live read taken after the plan finished, so it is not the place to check whether an injection landed — use 'cursorLanding' for that."))
                                                    .Prop("mouseY", Schema::Number())
+                                                   .Prop("cursorLanding", Schema::Object()
+                                                                              .Prop("askedX", Schema::Number())
+                                                                              .Prop("askedY", Schema::Number())
+                                                                              .Prop("landedX", Schema::Number())
+                                                                              .Prop("landedY", Schema::Number())
+                                                                              .Prop("landed", Schema::Bool())
+                                                                              .Desc("click/move/drag only: the last position the injection asked for and where the editor's cursor actually ended up, in window-client logical pixels. An injected position is a request to the ImGui backend, not a guarantee; when these disagree the events were delivered somewhere OTHER than where you aimed, and 'ok' is false."))
                                                    .Prop("mouseOffset", Schema::Object()
                                                                             .Prop("x", Schema::Number())
                                                                             .Prop("y", Schema::Number())

--- a/OloEngine/tests/MCP/McpInputInjectTest.cpp
+++ b/OloEngine/tests/MCP/McpInputInjectTest.cpp
@@ -154,7 +154,23 @@ namespace
                 result.Available = true;
                 result.Ok = true;
                 result.FrameCount = static_cast<u32>(plan.Frames.size());
-                const McpInputStateSnapshot state;
+
+                // Model a LIVE editor reporting back where the injected cursor landed
+                // (issue #854). By default it landed exactly where the plan asked, so
+                // every pre-existing expectation of ok == true still exercises the
+                // verification rather than skipping it. m_CursorLandingOffset makes
+                // the editor report the position being overridden, which is the real
+                // failure this test file has to keep pinned.
+                McpInputStateSnapshot state;
+                state.Available = true;
+                if (Inject::ActionMovesTheCursor(request.Act))
+                {
+                    state.CursorLandingValid = m_ReportCursorLanding;
+                    state.CursorAskedX = end.WindowX;
+                    state.CursorAskedY = end.WindowY;
+                    state.CursorLandedX = end.WindowX + m_CursorLandingOffsetX;
+                    state.CursorLandedY = end.WindowY + m_CursorLandingOffsetY;
+                }
                 return ToolResult::Text(
                     Inject::ToJson(result, state, m_ViewportInfo, request, start, end, /*timedOut*/ false).dump());
             };
@@ -162,6 +178,11 @@ namespace
         }
 
         McpInputViewportInfo m_ViewportInfo = MakeViewportInfo();
+        // How far the editor reports the cursor ACTUALLY landed from where the plan
+        // aimed it, and whether it measured at all (a host with no window does not).
+        bool m_ReportCursorLanding = true;
+        f32 m_CursorLandingOffsetX = 0.0f;
+        f32 m_CursorLandingOffsetY = 0.0f;
         int m_InjectCount = 0;
         McpInputPlan m_LastPlan;
         Inject::ResolvedPoint m_LastStart;
@@ -204,6 +225,151 @@ TEST_F(McpInputInjectTest, GateOnInjectsAndReportsResolvedPoint)
     // origin of the viewport is (300, 100); +(640, 360) => (940, 460).
     EXPECT_FLOAT_EQ(payload["resolved"]["windowX"].get<f32>(), 940.0f);
     EXPECT_FLOAT_EQ(payload["resolved"]["windowY"].get<f32>(), 460.0f);
+}
+
+// ---- issue #854: a position that did not take must never report ok ----------
+//
+// The bug this pins is not a crash, it is a CONFIDENT WRONG ANSWER, which is the most
+// expensive kind here. An injected cursor position is a REQUEST to the ImGui GLFW
+// backend, and the backend can overrule it: ImGui_ImplGlfw_UpdateMouseData()
+// re-injects the HARDWARE cursor position whenever the window is focused and the
+// physical mouse is not over it — the normal state for an agent-driven session. That
+// runs inside ImGui_ImplGlfw_NewFrame, i.e. AFTER the editor has drained the plan, so
+// the hardware position was the last word: every injected click landed wherever the
+// physical mouse happened to be, while the tool reported ok: true and echoed back a
+// resolved point it never actually used.
+//
+// Measured live before the fix, the same call twice with only the physical mouse
+// moving:
+//   physical mouse INSIDE  the window -> ImGui cursor (60, 155)   == asked, click landed
+//   physical mouse OUTSIDE the window -> ImGui cursor (927, 1313) != asked, click inert
+// Both replies said ok: true. That also explains the "latch": the condition is a
+// property of where the physical mouse is sitting, not of the drag that appeared to
+// start it, so every LATER injection in the session was equally inert.
+//
+// EditorLayer now holds the backend's cursor-enter latch for the duration of a plan so
+// the injected position wins, and MEASURES where it landed. These tests pin the second
+// half, which is the part that must survive: "we believe the first half works" is
+// exactly the reasoning that produced a lying tool, so a landing that disagrees has to
+// fail loudly no matter WHY it disagreed.
+
+TEST_F(McpInputInjectTest, CursorThatDidNotLandWhereAskedIsNotReportedOk)
+{
+    m_Server.SetAllowWrites(true);
+    // The editor reports ImGui's cursor hundreds of pixels away — the measured
+    // signature of the position being overridden by the hardware one.
+    m_CursorLandingOffsetX = 867.0f;
+    m_CursorLandingOffsetY = 853.0f;
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(70, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+
+    ASSERT_TRUE(response.contains("result"));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+
+    // The point: the events WERE injected and the frames WERE rendered, and it still
+    // must not claim success.
+    EXPECT_EQ(m_InjectCount, 1);
+    EXPECT_FALSE(payload["ok"].get<bool>());
+    EXPECT_NE(payload["message"].get<std::string>().find("did not go where the injection asked"),
+              std::string::npos)
+        << payload["message"].get<std::string>();
+
+    // ...and it must be readable rather than merely asserted, so an agent can tell
+    // this apart from "the click landed and the UI ignored it".
+    ASSERT_TRUE(payload["after"].contains("cursorLanding"));
+    const Json& landing = payload["after"]["cursorLanding"];
+    EXPECT_FALSE(landing["landed"].get<bool>());
+    EXPECT_FLOAT_EQ(landing["askedX"].get<f32>(), 940.0f);
+    EXPECT_FLOAT_EQ(landing["landedX"].get<f32>(), 1807.0f);
+}
+
+TEST_F(McpInputInjectTest, DragIsVerifiedAgainstItsEndPointNotItsStart)
+{
+    m_Server.SetAllowWrites(true);
+
+    // A drag that lands back on its start point has not dragged: the press registered
+    // and the moves did not. Verifying against the START would call that a success —
+    // which is precisely the reported symptom (ok: true, no wire created).
+    const Json arguments{ { "action", "drag" }, { "fromX", 100 }, { "fromY", 100 }, { "toX", 500 }, { "toY", 400 } };
+    m_CursorLandingOffsetX = -400.0f;
+    m_CursorLandingOffsetY = -300.0f;
+
+    const Json response = m_Server.HandleMessage(MakeCallRequest(71, "olo_input_inject", arguments));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_FALSE(payload["ok"].get<bool>());
+
+    // The same drag, landing on its end point, is the success case.
+    m_CursorLandingOffsetX = 0.0f;
+    m_CursorLandingOffsetY = 0.0f;
+    const Json good = m_Server.HandleMessage(MakeCallRequest(72, "olo_input_inject", arguments));
+    const Json goodPayload = Json::parse(good["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(goodPayload["ok"].get<bool>());
+    EXPECT_TRUE(goodPayload["after"]["cursorLanding"]["landed"].get<bool>());
+}
+
+TEST_F(McpInputInjectTest, SubPixelLandingErrorIsStillASuccess)
+{
+    m_Server.SetAllowWrites(true);
+    // Round-tripping a position through ImGui's screen-space conversion costs a
+    // fraction of a pixel (measured live: asked 880.5, landed 880.0). If that tripped
+    // the check the tool would cry wolf on every successful call, and a check nobody
+    // believes is worse than no check at all.
+    m_CursorLandingOffsetX = 0.5f;
+    m_CursorLandingOffsetY = -1.0f;
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(73, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_TRUE(payload["after"]["cursorLanding"]["landed"].get<bool>());
+}
+
+TEST_F(McpInputInjectTest, ActionsThatInjectNoPositionAreNotLandingChecked)
+{
+    m_Server.SetAllowWrites(true);
+    // key / text / mouseDelta deliberately never move ImGui's cursor (mouseDelta drives
+    // the poll-based Input:: API only), so there is nothing to verify and a stale
+    // measurement must not be turned into a failure.
+    m_CursorLandingOffsetX = 999.0f;
+    m_CursorLandingOffsetY = 999.0f;
+
+    for (const Json& arguments : { Json{ { "action", "key" }, { "key", "s" } },
+                                   Json{ { "action", "text" }, { "text", "hi" } },
+                                   Json{ { "action", "mouseDelta" }, { "dx", 40 }, { "dy", 0 } } })
+    {
+        const Json response = m_Server.HandleMessage(MakeCallRequest(74, "olo_input_inject", arguments));
+        const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+        EXPECT_TRUE(payload["ok"].get<bool>()) << arguments.dump();
+        EXPECT_FALSE(payload["after"].contains("cursorLanding")) << arguments.dump();
+    }
+}
+
+TEST_F(McpInputInjectTest, AHostThatCannotMeasureTheLandingStillReportsOk)
+{
+    m_Server.SetAllowWrites(true);
+    // A host with no editor window measures nothing. Treating "no measurement" as "did
+    // not land" would make the tool unusable there; treating it as landed is the honest
+    // reading, because nothing claimed otherwise.
+    m_ReportCursorLanding = false;
+    m_CursorLandingOffsetX = 500.0f;
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(75, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_FALSE(payload["after"].contains("cursorLanding"));
+}
+
+TEST(McpInputInjectLanding, ToleranceCatchesTheRealFailureAndForgivesFloatNoise)
+{
+    // Pin both edges, so a future widening that would let the real failure through has
+    // to change this test on purpose.
+    EXPECT_TRUE(Inject::CursorLanded(940.0f, 460.0f, 940.0f, 460.0f));
+    EXPECT_TRUE(Inject::CursorLanded(940.0f, 460.0f, 938.0f, 462.0f));
+    EXPECT_FALSE(Inject::CursorLanded(940.0f, 460.0f, 937.9f, 460.0f));
+    // The measured live failure: off by hundreds of pixels in both axes.
+    EXPECT_FALSE(Inject::CursorLanded(60.0f, 155.0f, 927.0f, 1313.0f));
 }
 
 // ---- server-side inputSchema enforcement ------------------------------------

--- a/OloEngine/tests/SyntheticInputTest.cpp
+++ b/OloEngine/tests/SyntheticInputTest.cpp
@@ -201,3 +201,78 @@ TEST_F(SyntheticInputTest, NoInjectionMeansNoOffsetAtAll)
     EXPECT_FLOAT_EQ(Input::GetMousePosition().x, 0.0f);
     EXPECT_FLOAT_EQ(Input::GetMousePosition().y, 0.0f);
 }
+
+// ---- issue #854: a drag must leave nothing behind ---------------------------
+//
+// #854 reported that after a `drag`, every later `click` in the session was inert
+// while still reporting ok, and named this overlay as the prime suspect: it carries
+// both an absolute cursor override and a persistent relative offset, and the override
+// wins outright while set, so an override left latched by a drag would explain both
+// halves at once.
+//
+// It was not the cause. The real one is a layer up, in the ImGui GLFW backend, which
+// re-injects the HARDWARE cursor position after the injected one whenever the window
+// is focused and the physical mouse is not over it — see McpInputInjectTest and
+// EditorLayer::AssertSyntheticCursorOverWindow. This test exists anyway, and says so
+// out loud, for two reasons: the suspicion is a natural one that will be raised again,
+// and the property it describes is one this overlay genuinely owes its callers. A
+// drag's whole event sequence — position, press, interpolated moves, release — must
+// leave the overlay bit-for-bit as it found it, or the next injection starts from a
+// state nobody asked for.
+
+TEST_F(SyntheticInputTest, ADragLeavesTheOverlayExactlyAsItFoundIt)
+{
+    // Snapshot the pre-plan state. With no Application the hardware fallback is a zero
+    // position, so this is exact rather than approximate.
+    const glm::vec2 before = Input::GetMousePosition();
+    ASSERT_FALSE(SyntheticInput::IsMouseButtonDown(Mouse::ButtonLeft));
+    ASSERT_FALSE(SyntheticInput::AnyKeyDown());
+
+    // Replay what a `drag` plan feeds the overlay: move to the start, press, walk the
+    // interpolated steps with the button held, release, then the plan drains.
+    SyntheticInput::SetMousePosition({ 100.0f, 200.0f });
+    SyntheticInput::SetMouseButton(Mouse::ButtonLeft, true);
+    for (int step = 1; step <= 8; ++step)
+    {
+        const auto t = static_cast<f32>(step) / 8.0f;
+        SyntheticInput::SetMousePosition({ 100.0f + (400.0f * t), 200.0f + (150.0f * t) });
+    }
+    // Mid-drag the overlay must report the button as held, or the drag is not a drag.
+    EXPECT_TRUE(SyntheticInput::IsMouseButtonDown(Mouse::ButtonLeft));
+    SyntheticInput::SetMouseButton(Mouse::ButtonLeft, false);
+    SyntheticInput::ClearMousePosition();
+
+    // State after the drag == state before it. A latched override here would make
+    // every later injected click resolve to the drag's end point instead of its own.
+    const glm::vec2 after = Input::GetMousePosition();
+    EXPECT_FLOAT_EQ(after.x, before.x);
+    EXPECT_FLOAT_EQ(after.y, before.y);
+    EXPECT_FALSE(SyntheticInput::IsMouseButtonDown(Mouse::ButtonLeft));
+    glm::vec2 position{ 0.0f };
+    EXPECT_FALSE(SyntheticInput::TryGetMousePosition(position))
+        << "the absolute override outlived the plan that set it";
+    // A drag emits no relative displacement at all, so the one piece of state that is
+    // ALLOWED to outlive a plan must not have moved either.
+    EXPECT_FLOAT_EQ(SyntheticInput::GetMouseOffset().x, 0.0f);
+    EXPECT_FLOAT_EQ(SyntheticInput::GetMouseOffset().y, 0.0f);
+}
+
+TEST_F(SyntheticInputTest, AnAbandonedDragDoesNotLeaveAButtonHeld)
+{
+    // The teardown path, which is the one that actually needed a guard. A plan that is
+    // cut short between its press and its release leaves the button logically down,
+    // and a mouse button nothing will ever release is not a cosmetic leak: ImGui pins
+    // its ActiveId while a button is held, which makes IsWindowHovered() false for
+    // every panel and swallows every subsequent click. Reset() is what the editor
+    // calls to guarantee that cannot outlive the plan.
+    SyntheticInput::SetMousePosition({ 640.0f, 360.0f });
+    SyntheticInput::SetMouseButton(Mouse::ButtonLeft, true);
+    ASSERT_TRUE(SyntheticInput::IsMouseButtonDown(Mouse::ButtonLeft));
+
+    SyntheticInput::Reset(); // the plan is abandoned mid-flight
+
+    EXPECT_FALSE(SyntheticInput::IsMouseButtonDown(Mouse::ButtonLeft));
+    glm::vec2 position{ 0.0f };
+    EXPECT_FALSE(SyntheticInput::TryGetMousePosition(position));
+    EXPECT_FLOAT_EQ(Input::GetMousePosition().x, 0.0f);
+}

--- a/docs/agent-rules/notes-mcp-tool-authoring.md
+++ b/docs/agent-rules/notes-mcp-tool-authoring.md
@@ -245,6 +245,45 @@ Established building `olo_render_why_not_visible`:
   reserve reload for edits you expect to compile, and use `olo_shader_errors`/`olo_shader_get` to
   inspect a known-broken shader.
 
+## 10b. A synthetic input event is a REQUEST, not a guarantee — measure it (issue #854)
+
+`olo_input_inject` reported `ok: true` for clicks and drags that did nothing, and kept doing
+so for the rest of the session. It looked like a state latch left behind by `drag`; it was
+not. `ImGui_ImplGlfw_UpdateMouseData()` — called from `ImGui_ImplGlfw_NewFrame()` — polls
+`glfwGetCursorPos` and queues the **hardware** cursor position whenever the window is focused
+and `bd->MouseWindow` is null, i.e. whenever the **physical mouse is not over the window**.
+That is the normal state for an agent-driven session. The plan is drained *before* `NewFrame`,
+so the synthetic position went into ImGui's queue first and the hardware one last, and ImGui
+applies its queue in order. The hardware position won every frame.
+
+Three transferable lessons:
+
+- **The failure was not where the symptom pointed.** The issue (and the tool's own comments)
+  suspected `SyntheticInput`'s absolute override latching. It does not — the drain clears it on
+  every plan, and the poll-based `Input::` path worked correctly throughout (an Alt+middle-drag
+  still panned the editor camera while every ImGui click was inert). Only the ImGui-facing half
+  was broken, which is exactly why the reported symptoms were all widgets: node pins, menus,
+  hierarchy rows. If half your consumers work, you have a *seam* bug, not a state bug.
+- **The "latch" was an environment condition, not stored state.** It correlated with a `drag`
+  only because the physical mouse happened to be off the window from then on. Anything that
+  looks like "one call poisoned the session" deserves a controlled A/B on the *environment*
+  before you go hunting for the state that got stuck: here, the same call, twice, moving
+  nothing but the physical mouse, separated cause from coincidence in one step.
+- **Feeding an event into someone else's input queue does not mean it was accepted.** The
+  durable half of the fix is not making the injection win — that can be undone by a backend
+  upgrade, a second platform viewport, or a human touching the mouse mid-plan. It is that the
+  editor now *measures* where the cursor actually landed and the tool refuses to report `ok`
+  when the measurement disagrees, reporting `after.cursorLanding` so the agent can read it. A
+  write tool that cannot verify its own effect will eventually report success for nothing, and
+  that is worse than being unavailable: it silently invalidates every verification performed
+  after it, including verifications of something unrelated.
+
+Corollary for the docs: this bug had **already been observed and written down** as a permanent
+limitation ("`olo_input_inject` cannot reliably land a Scene Hierarchy row click — the OS cursor
+reasserts over the synthetic position"), and was worked around by adding
+`olo_editor_select_entity` instead of being diagnosed. A limitation you can state that precisely
+is a bug you are one experiment away from fixing.
+
 ## 11. Why `olo_render_toggle_pass` is still deferred
 
 It must be an **ephemeral session override** — not persisted, reset on play-stop. The naive

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -195,7 +195,7 @@ and for what to do when adding a tool.
 | `olo_scene_summary` | active scene name, play state, entity count |
 | `olo_scene_open` | **(consented write)** open / switch the active scene by `path` (a `.olo`/`.scene` file, relative paths resolve against the project asset directory) — the scriptable scene switch. Loads directly, bypassing the auto-save recovery modal a remote agent can't click; stops Play mode first; **cancels any pending auto-save recovery** (an armed recovery modal used to be able to swap the freshly opened scene back out when its button was clicked later, issue #607). Reports the loaded scene name + entity count and settles rendered frames before returning. Gated behind **Agent writes** |
 | `olo_scene_play` / `olo_scene_stop` | **(consented write)** enter / leave Play mode — the same as the editor's Play/Stop buttons, so an agent can verify anything that only runs in Play (physics, cloth, scripts). Transient + fully reversible (stop restores the authored scene); idempotent (`changed:false` when already in that state); **settles rendered frames after a real transition** so an immediately following `olo_screenshot` shows the new state, not the last pre-transition frame (the uniform-grey trap, issue #607); `olo_scene_summary` reports `isPlaying` to confirm. Gated behind **Agent writes** |
-| `olo_editor_select_entity` | **(consented write)** select (or `clear`) the entity in the editor's Scene Hierarchy / Properties panels — the only way to drive the Properties inspector onto a given entity over MCP, unblocking screenshot verification of its rendered component UI. `olo_input_inject` cannot reliably land a Scene Hierarchy row click (the OS cursor reasserts over the synthetic position between injected frames). An unknown `entity` UUID leaves the current selection untouched (`ok:false`), never silently clearing it. Not undoable (selection isn't project data). Gated behind **Agent writes** |
+| `olo_editor_select_entity` | **(consented write)** select (or `clear`) the entity in the editor's Scene Hierarchy / Properties panels — the only way to drive the Properties inspector onto a given entity over MCP, unblocking screenshot verification of its rendered component UI. (Until issue #854, `olo_input_inject` could not reliably land a Scene Hierarchy row click — the hardware cursor reasserted over the synthetic position; that is fixed, so this tool is now a convenience rather than the only way.) An unknown `entity` UUID leaves the current selection untouched (`ok:false`), never silently clearing it. Not undoable (selection isn't project data). Gated behind **Agent writes** |
 | `olo_scene_list_entities` | paginated entity list (id, name, parent, child count) + name filter |
 | `olo_scene_get_entity` | one entity's full component data (YAML) by UUID |
 | `olo_entity_list_fields` | the writable (component, field) pairs of one entity with each field's type, current value, and — for a range-validated field — its `min`/`max`. The read-only discovery half of `olo_entity_set_field`; optional `component` filter. See [Component field writes](#component-field-writes-olo_entity_set_field) |
@@ -749,6 +749,41 @@ path, exactly as a real click does. (The engine's poll-based `Input::IsKeyPresse
 `IsMouseButtonPressed` / `GetMousePosition` read *hardware* state, which no synthetic
 event can move; `OloEngine::SyntheticInput` is the overlay that makes them agree, so an
 injected Ctrl+click really is a Ctrl+click.)
+
+**Why the injected position can be overruled — and how you know (issue #854)**
+
+An injected cursor position is a *request* to the ImGui GLFW backend, not a guarantee.
+`ImGui_ImplGlfw_UpdateMouseData()`, which runs inside `ImGui_ImplGlfw_NewFrame()`, has a
+fallback: whenever the window is **focused** and the **physical mouse is not over it**
+— the normal state for an agent-driven session — it polls `glfwGetCursorPos` and queues
+the *hardware* position. The editor drains the injection plan *before* `NewFrame`, so
+the synthetic position was queued first and the hardware one last, and ImGui applies its
+queue in order. The hardware position therefore won, on every frame, and every injected
+click landed wherever the physical mouse happened to be sitting.
+
+That single fact produced both halves of #854. A `drag` between two node pins did
+nothing, and — because the condition is a property of where the physical mouse is, not
+of the drag — **every later injection in the session was equally inert**, which read as
+the drag having latched something. All of them reported `ok: true`.
+
+Two things now prevent it:
+
+- The editor **holds the backend's cursor-enter latch for the duration of a plan**, so
+  the fallback does not fire and the injected position is the last word. It hands the
+  latch back a few quiet frames after the plan ends, so an injected plan leaves the
+  backend as it found it. (This is not a fiction: a point outside the window is already
+  a hard error, so the synthetic cursor really is inside it.)
+- The editor **measures where the cursor actually landed** and the tool refuses to
+  report `ok` when it disagrees with what was asked. `after.cursorLanding`
+  (`askedX/askedY`, `landedX/landedY`, `landed`) carries the measurement on every
+  `click` / `move` / `drag`. This is the part that matters long-term: the first bullet
+  is a fix that could be undone by a backend upgrade or a second platform viewport, and
+  the difference between a tool that breaks and a tool that *lies* is this check.
+
+So `ok: false` with a "did not go where the injection asked" message means the events
+were delivered somewhere other than where you aimed — retry, and do not trust the
+`after` block as the result of your request. A human moving the physical mouse during
+the call trips it too, which is correct: the injection really was overridden.
 
 **Actions**
 


### PR DESCRIPTION
## What was wrong

`olo_input_inject` returned `ok: true` for drags and clicks that had no effect, and kept
doing so for the rest of the editor session. That is the failure class this repo treats as
the most expensive: not a crash, but a confident wrong answer that silently invalidates
every verification performed after it — including verifications of something unrelated.

## Root cause — not the one the issue suspected

The issue proposed that a `drag` leaves `SyntheticInput`'s absolute cursor override latched.
**It does not.** `EditorLayer::DrainMcpInputQueue` clears the override the moment the queue
empties, on every plan, drag included; a `drag` never touches the persistent relative offset.
The overlay is exonerated, and the poll-based `Input::` path worked correctly throughout —
during the repro an Alt+middle drag still panned the editor camera while every ImGui click
was inert. Only the **ImGui-facing half** was broken, which is exactly why every reported
symptom was a widget: node pins, menus, hierarchy rows.

The real cause is one layer up, in the ImGui GLFW backend:

> `ImGui_ImplGlfw_UpdateMouseData()`, called from `ImGui_ImplGlfw_NewFrame()`, polls
> `glfwGetCursorPos` and queues the **hardware** cursor position whenever the window is
> **focused** and `bd->MouseWindow` is null — i.e. whenever the **physical mouse is not over
> the editor window**, which is the normal state for an agent-driven session.

`DrainMcpInputQueue` runs *before* `ImGuiLayer::Begin` → `NewFrame`, so the synthetic
position went into ImGui's event queue **first** and the hardware one **last**. ImGui applies
its queue in order, so the hardware position won on every frame, and every injected click
landed wherever the physical mouse happened to be sitting.

That single fact produces **both** reported halves. The drag never reached the pins, and
every *later* injection was equally inert — because the condition is a property of where the
physical mouse sits, not of the drag that appeared to start it. Hence "the drag latched the
input state", and hence "a restart cleared it".

### Measured live, before the fix

Same call twice, moving nothing but the physical mouse:

| physical cursor | ImGui cursor after injection | effect |
|---|---|---|
| **inside** the window | `(60, 155)` — as asked | selected the hierarchy row |
| **outside** the window | `(927, 1313)` — the hardware cursor | nothing; selection stale |

Both replied `ok: true`. Six consecutive clicks asking for six different points all reported
`ok: true` while ImGui's cursor stayed frozen at one point that was none of them.

This bug had also **already been written down** as a permanent limitation in
`docs/guides/mcp-diagnostics-server.md` ("`olo_input_inject` cannot reliably land a Scene
Hierarchy row click — the OS cursor reasserts over the synthetic position") and was worked
around by adding `olo_editor_select_entity` rather than diagnosed. That line is corrected here.

## The fix, in two independent parts

**1 — the injected position wins.** `EditorLayer` holds the backend's cursor-enter latch for
the duration of a plan (re-asserted every drained frame, so a real cursor-leave arriving
mid-plan cannot drop it), which stops the fallback firing. This is not a fiction:
`ResolvePoint` already rejects any point outside the window, so the synthetic cursor really
is inside it.

**2 — and the tool refuses to lie about it.** The editor *measures* where the injected cursor
actually landed — sampled one frame after the event is fed in, once ImGui's `NewFrame` has
applied its queue, and re-sampled after the button events so a cursor stolen between the move
and the press is caught too — and `ToJson` refuses to report `ok` when the measurement
disagrees with what was asked. `after.cursorLanding` carries `askedX/askedY`,
`landedX/landedY`, `landed` on every `click` / `move` / `drag`.

Part 2 is the half that matters long-term. Part 1 can be undone by a backend upgrade, a
second platform viewport, or a human grabbing the mouse mid-plan; the difference between a
tool that *breaks* and a tool that *lies* is the check.

**Teardown** (acceptance criterion 2, which is separable and non-negotiable): the latch is
handed back when the plan ends, deferring to `GLFW_HOVERED` as ground truth, and any mouse
button a plan left down is released in **both** sinks — a button ImGui believes is held pins
its `ActiveId`, which makes `IsWindowHovered()` false for every panel and swallows every
later click. `OnDetach` does the same without waiting.

One subtlety worth recording: the hand-back is armed on a short frame countdown rather than
performed on the frame the plan ends. Restoring immediately blanks ImGui's cursor (the
physical mouse is elsewhere) *before* the caller reads the state the injection produced, so
every reply's `after.viewportHovered` / `hoveredEntity` would come back empty — trading one
wrong answer for another.

## Acceptance criteria

- [x] **A `drag` either performs the drag, or fails loudly — never `ok: true` with no effect.**
      Met as *performs the drag*: the mechanism was sound all along, the position was being
      stolen. The loud-failure path exists too, as the landing check.
- [x] **Injection state cannot latch: after any `drag`, a subsequent `click` behaves exactly
      as it would have before it.** Verified live below, in the condition that reproduced it.
- [x] **A regression test pins whichever of the two the fix establishes.**

## Live verification against the fix

Re-run against the shipping binary with the physical cursor parked **off** the editor window
(verified against the window rect, not assumed) — the exact condition that reproduced the bug:

```
windowRect=(342,342)-(2284,1478)  client=1920x1080
physicalCursor=(60,60)  insideWindow=False

### 1. Click a Scene Hierarchy row (the click that was inert before the fix)
  ok=True  (60,117)
  cursorLanding: asked=(60,117) landed=(60,117) landed?=True
  after: selected=None

### 2. A different Scene Hierarchy row - selection must FOLLOW the click
  ok=True  (60,155)
  cursorLanding: asked=(60,155) landed=(60,155) landed?=True
  after: selected=Boat circling (orange)

### 3. Camera focal point before the drag
  camera focalPoint=['-1.416', '0.000', '0.000']
### 4. Alt+middle DRAG across the viewport
  ok=True  from(739,376)->(1022,376)
  cursorLanding: asked=(1022,376) landed=(1021,376) landed?=True
### 5. Camera focal point after the drag - must have moved
  camera focalPoint=['-2.832', '0.000', '0.000']

### 6. The previously-inert click, AFTER the drag (acceptance criterion 2)
  ok=True  (60,117)
  cursorLanding: asked=(60,117) landed=(60,117) landed?=True
  after: selected=None
### 7. ...and the other row again, to prove selection still tracks the click
  ok=True  (60,155)
  cursorLanding: asked=(60,155) landed=(60,155) landed?=True
  after: selected=Boat circling (orange)
```

The drag **did the drag** (`focalPoint` moved by exactly the same `-1.416` as the pre-fix
control run), and the clicks around it land where they aim and change the selection
accordingly — before *and* after the drag.

### ...and the check firing for real

An earlier run of the same script had a bug in the *harness*, not the product: the window-rect
helper was not DPI-aware, so "park the cursor off the window" silently left it **inside** the
window, where my own `SetCursorPos` calls competed with the injection. The tool caught it:

```
### 4. Alt+middle DRAG across the viewport
  ok=False from(739,376)->(1022,376)
  cursorLanding: asked=(1022,376) landed=(1286,662) landed?=False
  message: Injected, but the editor's cursor did not go where the injection asked:
           requested (1022, 376) in window-client pixels, ImGui ended up at (1286, 662). ...
```

That is the whole point of the second half of the fix, demonstrated by accident on a real
competing writer: the drag's camera pan still succeeded, so a naive "did anything change?"
check would have called it a pass — but the cursor genuinely was not where the injection put
it, the release landed somewhere else, and the tool said so instead of reporting `ok`.

## Tests

`OloEngine/tests/MCP/McpInputInjectTest.cpp` — six new cases. The fixture now models a live
editor reporting a landing, so every pre-existing `ok == true` expectation exercises the
verification rather than skipping it.

- `CursorThatDidNotLandWhereAskedIsNotReportedOk` — the events were injected and the frames
  rendered, and it must still not claim success.
- `DragIsVerifiedAgainstItsEndPointNotItsStart` — a drag that lands back on its start has not
  dragged; verifying against the start would call that a success, which is the reported symptom.
- `SubPixelLandingErrorIsStillASuccess` — float round-tripping costs a fraction of a pixel
  (measured: asked 880.5, landed 880.0); a check that cries wolf is worse than no check.
- `ActionsThatInjectNoPositionAreNotLandingChecked` — `key` / `text` / `mouseDelta`.
- `AHostThatCannotMeasureTheLandingStillReportsOk` — no window, no measurement, no false failure.
- `ToleranceCatchesTheRealFailureAndForgivesFloatNoise` — both edges pinned.

`OloEngine/tests/SyntheticInputTest.cpp` — two new cases pinning that a drag leaves the
overlay bit-for-bit as it found it, and that an abandoned drag leaves no button held. These
say **explicitly** that the overlay was not the culprit: the suspicion is a natural one and
will be raised again.

**Proved red before the fix**, per the #847 "test that structurally cannot fail" trap: with
`ok` restored to its pre-#854 expression and everything else unchanged, exactly the two tests
that pin *never `ok: true` with no effect* fail —

```
[  FAILED  ] McpInputInjectTest.CursorThatDidNotLandWhereAskedIsNotReportedOk
[  FAILED  ] McpInputInjectTest.DragIsVerifiedAgainstItsEndPointNotItsStart
[  PASSED  ] 6 tests.
```

The other six pass in both states by design — they pin invariants that must hold either way.
With the fix restored: **53/53 green** across `McpInputInject*` and `SyntheticInput*`, and
**683 passed / 0 failed / 1 skipped** across the whole `Mcp*` suite (684 tests, the skip
pre-existing: `McpHeadlessAttachTest.HostUntilDetached`).

## Docs

- `docs/guides/mcp-diagnostics-server.md` — documents the mechanism and `after.cursorLanding`,
  and corrects the stale line that recorded this bug as a permanent limitation.
- `docs/agent-rules/notes-mcp-tool-authoring.md` — new §10b. The transferable lesson is not
  about this tool: *feeding an event into someone else's input queue does not mean it was
  accepted*, and a write tool that cannot verify its own effect will eventually report success
  for nothing. Also records that the failure was not where the symptom pointed, and that a
  limitation you can state that precisely is a bug you are one experiment away from fixing.

Closes #854
