### PR TITLE
fix(asset): EditorAssetManager hot-reload deadlock — unlock the callee, not the caller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ you are in.
 **Concurrency & memory**
 
 - [intrusive-refcount-weakref-races.md](docs/agent-rules/intrusive-refcount-weakref-races.md) — a decrement-then-reread of a refcount is a TOCTOU double-free even when both operations are atomic.
+- [non-recursive-lock-self-locking-helper.md](docs/agent-rules/non-recursive-lock-self-locking-helper.md) — a helper that locks internally, called under the same non-recursive lock, parks the thread silently; fix the callee, and don't wrap a self-synchronised member in a redundant outer lock.
 - [spinlock-payload-cache-line-separation.md](docs/agent-rules/spinlock-payload-cache-line-separation.md) — a lock sharing a cache line with its payload costs the owner an invalidate round-trip on every acquire.
 - [per-frame-scratch-reuse.md](docs/agent-rules/per-frame-scratch-reuse.md) — three things to check before promoting a per-tick scratch vector to persistent state.
 

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -1238,6 +1238,8 @@
 
 		"OloEngine/Threading/ExternalMutex.h"
 		"OloEngine/Threading/IntrusiveMutex.h"
+		"OloEngine/Threading/LockDebug.cpp"
+		"OloEngine/Threading/LockDebug.h"
 		"OloEngine/Threading/LockTags.h"
 		"OloEngine/Threading/Mutex.cpp"
 		"OloEngine/Threading/Mutex.h"

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -409,12 +409,18 @@ namespace OloEngine
                     TUniqueLock<FSharedMutex> lock(m_RegistryMutex);
                     m_AssetRegistry.UpdateMetadata(assetHandle, metadata);
                 }
-                // OUTSIDE the lock scope: SerializeAssetRegistry takes
-                // m_RegistryMutex itself, and FSharedMutex is non-recursive —
-                // calling it while holding the lock self-deadlocked the game
-                // thread on every hot-reload of an existing tracked asset
-                // (found by cracking a wedged editor with cdb during the #439
-                // lightmap re-bake, which modifies its .olmap in place).
+                // OUTSIDE the lock scope. This used to be load-bearing: while
+                // SerializeAssetRegistry still took m_RegistryMutex, holding the
+                // lock across it self-deadlocked the game thread on every
+                // hot-reload of an existing tracked asset — issue #439's lightmap
+                // re-bake (fixed here in aa37548c7) and, from a build predating
+                // that fix, issue #863's filewatch hot-reload during a cold-cache
+                // scene load. SerializeAssetRegistry no longer locks at all, so
+                // this scoping is now belt-and-braces rather than the only thing
+                // standing between a hot-reload and a wedged editor. Keep it: the
+                // registry write does not need to be atomic with the metadata
+                // update, and holding an exclusive lock across a full-file write
+                // is not free.
                 SerializeAssetRegistry(); // Persist the updated timestamp
             }
             else
@@ -871,7 +877,19 @@ namespace OloEngine
         std::vector<EditorAssetLoadResponse> freshAssets;
         if (m_AssetThread->RetrieveReadyAssets(freshAssets))
         {
-            // Integrate ready assets into the main asset manager
+            // Integrate ready assets into the main asset manager.
+            //
+            // The two locks are taken in SEPARATE scopes, never nested — the same
+            // shape the raw-asset branch above already uses. This file now has no
+            // lock nesting at all: m_AssetsMutex, m_RegistryMutex and
+            // m_DependenciesMutex are each acquired and released on their own, so
+            // there is no lock ORDER to get wrong and no ABBA to audit. That was
+            // already true everywhere except right here, where m_RegistryMutex was
+            // taken inside m_AssetsMutex once per ready asset.
+            // Only the handles integrated HERE — loadedEvents may already carry
+            // entries from the raw-asset branch above, whose status this function
+            // has set already.
+            std::vector<AssetHandle> integratedHandles;
             {
                 TUniqueLock<FSharedMutex> lock(m_AssetsMutex);
                 for (const auto& response : freshAssets)
@@ -882,18 +900,23 @@ namespace OloEngine
                         OLO_CORE_TRACE("SyncWithAssetThread: Integrated asset {} from async load",
                                        (u64)response.Metadata.Handle);
 
-                        // Update asset status to Loaded in registry
-                        {
-                            TUniqueLock<FSharedMutex> registryLock(m_RegistryMutex);
-                            auto metadata = m_AssetRegistry.GetMetadata(response.Metadata.Handle);
-                            if (metadata.IsValid())
-                            {
-                                metadata.Status = AssetStatus::Loaded;
-                                m_AssetRegistry.UpdateMetadata(response.Metadata.Handle, metadata);
-                            }
-                        }
-
+                        integratedHandles.push_back(response.Metadata.Handle);
                         loadedEvents.push_back({ response.Metadata.Handle, response.Metadata.Type, response.Metadata.FilePath });
+                    }
+                }
+            }
+
+            // Update asset status to Loaded in the registry, outside m_AssetsMutex.
+            if (!integratedHandles.empty())
+            {
+                TUniqueLock<FSharedMutex> registryLock(m_RegistryMutex);
+                for (const AssetHandle integrated : integratedHandles)
+                {
+                    auto metadata = m_AssetRegistry.GetMetadata(integrated);
+                    if (metadata.IsValid())
+                    {
+                        metadata.Status = AssetStatus::Loaded;
+                        m_AssetRegistry.UpdateMetadata(integrated, metadata);
                     }
                 }
             }
@@ -1433,8 +1456,26 @@ namespace OloEngine
     {
         try
         {
-            TUniqueLock<FSharedMutex> lock(m_RegistryMutex);
-
+            // Deliberately takes NO m_RegistryMutex. AssetRegistry::Serialize
+            // acquires the registry's own FSharedMutex in shared mode around the
+            // whole write, so the snapshot is already consistent; an outer
+            // exclusive m_RegistryMutex added nothing but a way to deadlock.
+            //
+            // It is the *second* acquisition that kills you: m_RegistryMutex is a
+            // non-recursive FSharedMutex, so any caller that already holds it and
+            // then reaches this function parks the calling thread forever with no
+            // assert, no log line and no CPU burn. That happened twice inside one
+            // day — issue #439's lightmap re-bake (fixed in aa37548c7 by moving one
+            // call outside the lock) and issue #863's filewatch hot-reload during a
+            // cold-cache scene load, which is the SAME line reached by a different
+            // trigger. Moving individual call sites out of the lock fixes one
+            // caller; not locking here at all fixes every present and future one.
+            //
+            // What m_RegistryMutex is still for: compound read-modify-write
+            // sequences on m_AssetRegistry (SetAssetStatus, the status updates in
+            // SyncWithAssetThread, ReloadData's LastWriteTime refresh), where two
+            // individually-atomic AssetRegistry calls have to be atomic together.
+            // A single self-synchronised call like Serialize needs none of that.
             const std::filesystem::path registryPath = Project::GetAssetRegistryPath();
             return m_AssetRegistry.Serialize(registryPath);
         }

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -294,6 +294,15 @@ namespace OloEngine
 
         /**
          * @brief Serialize the asset registry to disk
+         *
+         * Takes no EditorAssetManager-level lock — AssetRegistry::Serialize does its
+         * own shared locking, which is all a single self-synchronised call needs. It
+         * is therefore safe to call from anywhere, including from a caller that
+         * already holds m_RegistryMutex. That is deliberate: m_RegistryMutex is a
+         * non-recursive FSharedMutex, so while this function did lock, a caller that
+         * reached it holding the lock parked forever with no assert and no log line
+         * (issues #439 and #863, same line, two different triggers).
+         *
          * @return True if serialization was successful
          */
         bool SerializeAssetRegistry();

--- a/OloEngine/src/OloEngine/Threading/LockDebug.cpp
+++ b/OloEngine/src/OloEngine/Threading/LockDebug.cpp
@@ -1,0 +1,35 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Threading/LockDebug.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/Log.h"
+
+namespace OloEngine::LockDebug
+{
+    void ReportSelfDeadlock(const void* mutex, EMode wanted)
+    {
+        const EMode held = HeldMode(mutex);
+        const auto modeName = [](EMode mode)
+        { return mode == EMode::Exclusive ? "exclusive" : "shared"; };
+
+        // Logged, not asserted, so the diagnosis survives a build with no debugger
+        // attached — which is every CI run and every Release editor. This is the message
+        // that issues #439 and #863 each cost a live cdb session to work out.
+        OLO_CORE_ERROR(
+            "Self-deadlock on a non-recursive lock at {}: this thread already holds it "
+            "({}), and is now asking for it {}. The acquisition below this line will park "
+            "the thread FOREVER — no further log lines, no CPU, no crash record. Something "
+            "further up this call chain took the lock; a helper that locks internally is "
+            "the usual culprit (issues #439 and #863 were both SerializeAssetRegistry "
+            "reached from inside a locked scope). Fix the callee if you can: a public "
+            "method that locks a non-recursive mutex constrains every caller forever. "
+            "See docs/agent-rules/non-recursive-lock-self-locking-helper.md.",
+            mutex, modeName(held), modeName(wanted));
+
+        // Break where the debugger can show the offending stack. Compiles to nothing
+        // outside a Debug engine build, in which case the log line above is the whole
+        // report and execution continues into the park — the pre-existing behaviour,
+        // now explained.
+        OLO_DEBUGBREAK();
+    }
+} // namespace OloEngine::LockDebug

--- a/OloEngine/src/OloEngine/Threading/LockDebug.h
+++ b/OloEngine/src/OloEngine/Threading/LockDebug.h
@@ -1,0 +1,215 @@
+// LockDebug.h - same-thread re-entrancy detection for non-recursive locks
+//
+// Turns a silent, permanent park into an immediate assert naming the offending lock.
+//
+// WHY THIS EXISTS
+// ---------------
+// FSharedMutex does not support recursive locking, and an exclusive lock and a shared
+// lock may not be held simultaneously by the same thread. Break either rule and the
+// thread parks in ParkingLot::Wait forever: no assert, no log line, no CPU, no crash
+// record — a wedged process that looks identical to a slow one. The editor's game
+// thread was lost to exactly this twice in one day (issues #439 and #863, the same
+// line reached by two different triggers), and each cost a live debugging session with
+// cdb to find something the process could have said itself in a microsecond.
+//
+// Documenting the rule was not enough, because the rule is invisible at the call site:
+// `SerializeAssetRegistry()` looks like an ordinary helper, and whether it is safe to
+// call depends on a lock acquired several frames up the stack. This detector makes the
+// composition itself loud. See
+// docs/agent-rules/non-recursive-lock-self-locking-helper.md.
+//
+// HOW IT WORKS
+// ------------
+// A thread-local table of the locks this thread currently holds, keyed by address. The
+// mutex objects themselves are NOT modified and NOT grown — sizeof(FSharedMutex) is
+// four bytes in every configuration, exactly as before, so there is no layout change to
+// go stale in an incremental build and nothing for a concurrent branch to rebase onto.
+//
+// COST
+// ----
+// Compiled out entirely unless OLO_LOCK_DEBUG (defaults to !NDEBUG; see below). When on,
+// each acquire/release scans a small thread-local array. FSharedMutex guards
+// manager-and-registry-granularity state, not per-task hot paths, so this is noise
+// against a Debug build. FMutex is deliberately NOT instrumented: it is used inside the
+// task scheduler's hot path and inside the locking primitives themselves, where the
+// cost and the re-entrancy risk are both different questions.
+//
+// LIMITS (deliberate, and all fail toward silence rather than a false alarm)
+// -------------------------------------------------------------------------
+//  * A lock acquired on one thread and released on another is not tracked correctly.
+//    That is already a bug for these types, and every in-tree acquisition goes through
+//    the scoped TUniqueLock / TSharedLock guards, so acquire and release are the same
+//    thread by construction.
+//  * Beyond kMaxTrackedLocks simultaneously-held locks on one thread, tracking stops
+//    and detection silently degrades to off for that thread rather than guessing.
+
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+// Gated on NDEBUG, deliberately NOT on OLO_DEBUG.
+//
+// OLO_DEBUG is a PRIVATE compile definition of the OloEngine target, so it is absent
+// when this header is compiled into OloEditor or OloEngine-Tests (verified: those TUs
+// receive neither OLO_DEBUG nor NDEBUG). FSharedMutex::Lock is an inline function, so
+// gating its body on a macro that differs between translation units is an ODR
+// violation, and the linker would pick one definition arbitrarily -- meaning the
+// detector could silently vanish from exactly the build relying on it. The same
+// reasoning is why ENTT_USE_ATOMIC is PUBLIC on the OloEngine target (see CLAUDE.md).
+// NDEBUG is supplied per-configuration by CMake to every target uniformly, so all TUs
+// in a build agree on it.
+//
+// For the same reason the check below must NOT expand OLO_CORE_ASSERT, whose definition
+// also turns on OLO_DEBUG. It calls an out-of-line reporting function instead, so the
+// inline body is textually identical everywhere.
+//
+// Override by defining OLO_LOCK_DEBUG yourself -- uniformly, for the whole build.
+#if !defined(OLO_LOCK_DEBUG)
+#if defined(NDEBUG)
+#define OLO_LOCK_DEBUG 0
+#else
+#define OLO_LOCK_DEBUG 1
+#endif
+#endif
+
+namespace OloEngine::LockDebug
+{
+    enum class EMode : u8
+    {
+        Exclusive,
+        Shared
+    };
+
+    // Per-thread capacity. Deep lock nesting is itself a smell; 64 is far above
+    // anything in this engine and keeps the scan trivially short.
+    inline constexpr u32 kMaxTrackedLocks = 64;
+
+    namespace Private
+    {
+        struct FHeldLock
+        {
+            const void* Mutex = nullptr;
+            EMode Mode = EMode::Exclusive;
+        };
+
+        // Trivially destructible on purpose: no thread-exit teardown ordering to get
+        // wrong, which matters because these live as long as any thread that locks.
+        inline thread_local FHeldLock s_Held[kMaxTrackedLocks]{};
+        inline thread_local u32 s_HeldCount = 0;
+        inline thread_local bool s_Overflowed = false;
+
+        [[nodiscard]] inline i32 FindHeld(const void* mutex)
+        {
+            for (u32 i = 0; i < s_HeldCount; ++i)
+            {
+                if (s_Held[i].Mutex == mutex)
+                    return static_cast<i32>(i);
+            }
+            return -1;
+        }
+    } // namespace Private
+
+    // @brief Does the calling thread already hold this lock, in either mode?
+    [[nodiscard]] inline bool IsHeldByCurrentThread(const void* mutex)
+    {
+        return Private::FindHeld(mutex) >= 0;
+    }
+
+    // @brief The mode this thread holds `mutex` in. Only meaningful when
+    //        IsHeldByCurrentThread(mutex) is true.
+    [[nodiscard]] inline EMode HeldMode(const void* mutex)
+    {
+        const i32 index = Private::FindHeld(mutex);
+        return index >= 0 ? Private::s_Held[static_cast<u32>(index)].Mode : EMode::Exclusive;
+    }
+
+    // @brief Would acquiring `mutex` in `wanted` mode park this thread against itself?
+    //
+    // True for EVERY combination, because these locks are non-recursive in both modes:
+    //   exclusive → exclusive   the classic self-deadlock
+    //   exclusive → shared      the mixed-mode case FSharedMutex's header forbids
+    //   shared    → exclusive   ditto, and the shape issues #439 / #863 both hit
+    //   shared    → shared      parks whenever a writer is already queued, because
+    //                           FSharedMutex gives waiting writers priority over new
+    //                           readers — so it deadlocks intermittently, which is worse
+    //                           than deadlocking always.
+    //
+    // This is the predicate behind the check, exposed so it can be unit-tested without
+    // actually taking a lock twice (which would hang the test rather than fail it).
+    [[nodiscard]] inline bool WouldSelfDeadlock(const void* mutex, EMode wanted)
+    {
+        (void)wanted;
+        return IsHeldByCurrentThread(mutex);
+    }
+
+    // @brief Record that the calling thread acquired `mutex`. Silently stops tracking
+    //        past kMaxTrackedLocks rather than evicting an entry (which would create a
+    //        false negative that looks like a pass).
+    inline void OnAcquired(const void* mutex, EMode mode)
+    {
+        if (Private::s_HeldCount >= kMaxTrackedLocks)
+        {
+            Private::s_Overflowed = true;
+            return;
+        }
+        Private::s_Held[Private::s_HeldCount++] = { mutex, mode };
+    }
+
+    // @brief Record that the calling thread released `mutex`. A release of something not
+    //        tracked (overflowed, or acquired on another thread) is ignored.
+    inline void OnReleased(const void* mutex, EMode mode)
+    {
+        (void)mode;
+        const i32 index = Private::FindHeld(mutex);
+        if (index < 0)
+            return;
+        Private::s_Held[static_cast<u32>(index)] = Private::s_Held[--Private::s_HeldCount];
+    }
+
+    // @brief Test/diagnostic helper: how many locks this thread is tracking.
+    [[nodiscard]] inline u32 HeldCountForCurrentThread()
+    {
+        return Private::s_HeldCount;
+    }
+
+    // @brief Log the offending lock and break into the debugger.
+    //
+    // Deliberately OUT OF LINE (defined in LockDebug.cpp): it needs OLO_DEBUGBREAK and
+    // the logger, both gated on the engine-private OLO_DEBUG, and an inline body whose
+    // contents depend on a per-target macro is an ODR violation. One definition, in one
+    // TU, keeps every caller's inline body identical.
+    //
+    // NOT marked [[noreturn]]: with no debugger attached the process continues and then
+    // genuinely deadlocks on the next line, which is the pre-existing behaviour. The
+    // point is that it now says so first, instead of going silent forever.
+    void ReportSelfDeadlock(const void* mutex, EMode wanted);
+
+    // @brief Test helper: drop this thread's tracking state.
+    inline void ResetCurrentThread()
+    {
+        Private::s_HeldCount = 0;
+        Private::s_Overflowed = false;
+    }
+} // namespace OloEngine::LockDebug
+
+#if OLO_LOCK_DEBUG
+
+#define OLO_LOCK_DEBUG_CHECK_ACQUIRE(mutexPtr, mode)                                     \
+    do                                                                                   \
+    {                                                                                    \
+        if (OLO_UNLIKELY(::OloEngine::LockDebug::WouldSelfDeadlock((mutexPtr), (mode)))) \
+        {                                                                                \
+            ::OloEngine::LockDebug::ReportSelfDeadlock((mutexPtr), (mode));              \
+        }                                                                                \
+    } while (0)
+
+#define OLO_LOCK_DEBUG_ON_ACQUIRED(mutexPtr, mode) ::OloEngine::LockDebug::OnAcquired((mutexPtr), (mode))
+#define OLO_LOCK_DEBUG_ON_RELEASED(mutexPtr, mode) ::OloEngine::LockDebug::OnReleased((mutexPtr), (mode))
+
+#else
+
+#define OLO_LOCK_DEBUG_CHECK_ACQUIRE(mutexPtr, mode) ((void)0)
+#define OLO_LOCK_DEBUG_ON_ACQUIRED(mutexPtr, mode) ((void)0)
+#define OLO_LOCK_DEBUG_ON_RELEASED(mutexPtr, mode) ((void)0)
+
+#endif

--- a/OloEngine/src/OloEngine/Threading/SharedMutex.h
+++ b/OloEngine/src/OloEngine/Threading/SharedMutex.h
@@ -14,6 +14,7 @@
 
 #include "OloEngine/Core/Base.h"
 #include "OloEngine/Threading/IntrusiveMutex.h"
+#include "OloEngine/Threading/LockDebug.h"
 #include "OloEngine/Threading/SharedLock.h"
 #include "OloEngine/HAL/ParkingLot.h"
 #include "OloEngine/HAL/PlatformProcess.h"
@@ -58,26 +59,40 @@ namespace OloEngine
         [[nodiscard]] inline bool TryLock()
         {
             u32 Expected = m_State.load(std::memory_order_relaxed);
-            return !(Expected & (IsLockedFlag | SharedLockCountMask)) &&
-                   m_State.compare_exchange_strong(Expected, Expected | IsLockedFlag,
-                                                   std::memory_order_acquire, std::memory_order_relaxed);
+            const bool bAcquired = !(Expected & (IsLockedFlag | SharedLockCountMask)) &&
+                                   m_State.compare_exchange_strong(Expected, Expected | IsLockedFlag,
+                                                                   std::memory_order_acquire, std::memory_order_relaxed);
+            if (bAcquired)
+            {
+                OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Exclusive);
+            }
+            return bAcquired;
         }
 
         // @brief Acquire an exclusive lock, blocking until available
         inline void Lock()
         {
+            // Checked BEFORE the acquisition attempt: past this point a re-entrant call
+            // parks in ParkingLot::Wait and never returns, so an assert after the fact
+            // would never run.
+            OLO_LOCK_DEBUG_CHECK_ACQUIRE(this, LockDebug::EMode::Exclusive);
+
             u32 Expected = 0;
             if (OLO_LIKELY(m_State.compare_exchange_weak(Expected, IsLockedFlag,
                                                          std::memory_order_acquire, std::memory_order_relaxed)))
             {
+                OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Exclusive);
                 return;
             }
             LockSlow();
+            OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Exclusive);
         }
 
         // @brief Release an exclusive lock
         inline void Unlock()
         {
+            OLO_LOCK_DEBUG_ON_RELEASED(this, LockDebug::EMode::Exclusive);
+
             // Unlock immediately to allow other threads to acquire the lock while this thread
             // looks for a thread to wake.
             u32 LastState = m_State.fetch_sub(IsLockedFlag, std::memory_order_release);
@@ -109,6 +124,7 @@ namespace OloEngine
                 if (OLO_LIKELY(m_State.compare_exchange_weak(Expected, Expected + (1 << SharedLockCountShift),
                                                              std::memory_order_acquire, std::memory_order_relaxed)))
                 {
+                    OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Shared);
                     return true;
                 }
             }
@@ -118,19 +134,27 @@ namespace OloEngine
         // @brief Acquire a shared lock, blocking until available
         inline void LockShared()
         {
+            // See Lock(): the check has to precede the acquisition, because the failure
+            // mode is a park that never comes back.
+            OLO_LOCK_DEBUG_CHECK_ACQUIRE(this, LockDebug::EMode::Shared);
+
             u32 Expected = m_State.load(std::memory_order_relaxed);
             if (OLO_LIKELY(!(Expected & (IsLockedFlag | MayHaveWaitingLockFlag)) &&
                            m_State.compare_exchange_weak(Expected, Expected + (1 << SharedLockCountShift),
                                                          std::memory_order_acquire, std::memory_order_relaxed)))
             {
+                OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Shared);
                 return;
             }
             LockSharedSlow();
+            OLO_LOCK_DEBUG_ON_ACQUIRED(this, LockDebug::EMode::Shared);
         }
 
         // @brief Release a shared lock
         inline void UnlockShared()
         {
+            OLO_LOCK_DEBUG_ON_RELEASED(this, LockDebug::EMode::Shared);
+
             // Unlock immediately to allow other threads to acquire the lock while this thread
             // looks for a thread to wake.
             const u32 LastState = m_State.fetch_sub(1 << SharedLockCountShift, std::memory_order_release);

--- a/OloEngine/tests/AssetContentValidityTest.cpp
+++ b/OloEngine/tests/AssetContentValidityTest.cpp
@@ -2068,8 +2068,9 @@ namespace OloEngine::Tests
     // `<project>/Config/InputActions.yaml`. The engine loads it on
     // project open if present; missing is fine (input actions are an
     // optional engine feature). If present, malformed YAML or a missing
-    // top-level `InputActions` key crashes the editor's input subsystem
-    // on startup.
+    // top-level `InputActionContexts` (or legacy `InputActionMap`) key
+    // crashes the editor's input subsystem on startup — see
+    // `InputActionSerializer::Deserialize`.
     // -------------------------------------------------------------------------
     // -------------------------------------------------------------------------
     // Path-based asset references in scenes resolve on disk
@@ -2355,10 +2356,11 @@ namespace OloEngine::Tests
         auto node = ParseYAMLFile(path, reason);
         ASSERT_TRUE(node) << "InputActions.yaml failed to parse: " << reason;
 
-        // Accept either a top-level `InputActions` (canonical) or
-        // `ActionMap` (engine has historically used both — match either).
-        EXPECT_TRUE((*node)["InputActions"] || (*node)["ActionMap"])
-            << "InputActions.yaml missing top-level 'InputActions' (or 'ActionMap') key.";
+        // Accept either the canonical `InputActionContexts` sequence or the
+        // legacy `InputActionMap` root — the two shapes `InputActionSerializer::
+        // Deserialize` actually understands.
+        EXPECT_TRUE((*node)["InputActionContexts"] || (*node)["InputActionMap"])
+            << "InputActions.yaml missing top-level 'InputActionContexts' (or legacy 'InputActionMap') key.";
     }
 
     // -------------------------------------------------------------------------

--- a/OloEngine/tests/Async/LockDebugTest.cpp
+++ b/OloEngine/tests/Async/LockDebugTest.cpp
@@ -1,0 +1,199 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// LockDebugTest — the same-thread re-entrancy detector behind FSharedMutex.
+//
+// What this guards: the detector that turns "the thread parks forever with no
+// assert, no log line and no CPU" into an immediate assert naming the lock. That
+// failure cost a live cdb session twice in one day (issues #439 and #863), and a
+// detector that quietly stops detecting would restore the silence without any
+// visible symptom — nothing else in the suite would notice.
+//
+// The tests drive LockDebug's bookkeeping DIRECTLY rather than through a real
+// FSharedMutex, for one deliberate reason: exercising the real thing means
+// actually taking a lock twice, which in a Debug build trips the assert (and in
+// a Release build genuinely hangs). Asserting on the predicate keeps this a
+// normal, fast, non-death test that runs in every configuration.
+//
+// Each case resets the thread's state first — the table is thread_local and
+// gtest runs cases on one thread, so state leaks between cases otherwise.
+// =============================================================================
+
+#include "OloEngine/Threading/LockDebug.h"
+#include "OloEngine/Threading/SharedMutex.h"
+#include "OloEngine/Threading/SharedLock.h"
+#include "OloEngine/Threading/UniqueLock.h"
+
+#include <thread>
+
+using namespace OloEngine;
+using LockDebug::EMode;
+
+namespace
+{
+    class LockDebugTest : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            LockDebug::ResetCurrentThread();
+        }
+        void TearDown() override
+        {
+            LockDebug::ResetCurrentThread();
+        }
+    };
+} // namespace
+
+TEST_F(LockDebugTest, AnUnheldLockIsNotReportedAsHeld)
+{
+    int fakeMutex = 0;
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&fakeMutex));
+    EXPECT_FALSE(LockDebug::WouldSelfDeadlock(&fakeMutex, EMode::Exclusive));
+    EXPECT_FALSE(LockDebug::WouldSelfDeadlock(&fakeMutex, EMode::Shared));
+}
+
+TEST_F(LockDebugTest, EveryReAcquisitionCombinationIsReportedAsASelfDeadlock)
+{
+    // All four are bugs: FSharedMutex is non-recursive in both modes, and its own
+    // header forbids one thread holding an exclusive and a shared lock at once.
+    // shared -> shared is included because waiting writers get priority over new
+    // readers, so it parks intermittently — the worst of the four to debug.
+    struct Combination
+    {
+        EMode Held;
+        EMode Wanted;
+        const char* What;
+    };
+    constexpr Combination combinations[] = {
+        { EMode::Exclusive, EMode::Exclusive, "exclusive then exclusive" },
+        { EMode::Exclusive, EMode::Shared, "exclusive then shared" },
+        { EMode::Shared, EMode::Exclusive, "shared then exclusive (the #439 / #863 shape)" },
+        { EMode::Shared, EMode::Shared, "shared then shared" },
+    };
+
+    for (const auto& combination : combinations)
+    {
+        LockDebug::ResetCurrentThread();
+        int fakeMutex = 0;
+
+        LockDebug::OnAcquired(&fakeMutex, combination.Held);
+        EXPECT_TRUE(LockDebug::WouldSelfDeadlock(&fakeMutex, combination.Wanted))
+            << "re-acquiring the same non-recursive lock (" << combination.What
+            << ") was not flagged — the detector would let this park the thread silently, "
+               "which is the entire failure it exists to prevent.";
+    }
+}
+
+TEST_F(LockDebugTest, ReleasingClearsTheHoldSoNormalSequentialLockingIsNotFlagged)
+{
+    int fakeMutex = 0;
+
+    LockDebug::OnAcquired(&fakeMutex, EMode::Exclusive);
+    LockDebug::OnReleased(&fakeMutex, EMode::Exclusive);
+
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&fakeMutex));
+    EXPECT_FALSE(LockDebug::WouldSelfDeadlock(&fakeMutex, EMode::Exclusive))
+        << "a lock/unlock/lock sequence was flagged as a self-deadlock — this would fire "
+           "on ordinary correct code and the detector would have to be turned off.";
+    EXPECT_EQ(LockDebug::HeldCountForCurrentThread(), 0u);
+}
+
+TEST_F(LockDebugTest, DistinctLocksDoNotAliasEachOther)
+{
+    int first = 0;
+    int second = 0;
+
+    LockDebug::OnAcquired(&first, EMode::Exclusive);
+
+    EXPECT_TRUE(LockDebug::WouldSelfDeadlock(&first, EMode::Exclusive));
+    EXPECT_FALSE(LockDebug::WouldSelfDeadlock(&second, EMode::Exclusive))
+        << "holding one lock flagged an unrelated one — the table is keyed by address, "
+           "so this would make every nested lock of two different mutexes assert.";
+}
+
+TEST_F(LockDebugTest, ReleasingOutOfOrderKeepsTheRemainingHoldsIntact)
+{
+    // The table swaps the last entry into the freed slot, so a release from the
+    // middle must not lose or duplicate anything.
+    int a = 0, b = 0, c = 0;
+    LockDebug::OnAcquired(&a, EMode::Exclusive);
+    LockDebug::OnAcquired(&b, EMode::Shared);
+    LockDebug::OnAcquired(&c, EMode::Exclusive);
+
+    LockDebug::OnReleased(&b, EMode::Shared);
+
+    EXPECT_EQ(LockDebug::HeldCountForCurrentThread(), 2u);
+    EXPECT_TRUE(LockDebug::IsHeldByCurrentThread(&a));
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&b));
+    EXPECT_TRUE(LockDebug::IsHeldByCurrentThread(&c))
+        << "the swap-with-last removal dropped the last entry — deep nesting would stop "
+           "being tracked, silently.";
+}
+
+TEST_F(LockDebugTest, TrackingIsPerThreadSoTwoThreadsHoldingDifferentLocksDoNotSeeEachOther)
+{
+    // The whole point of shared/exclusive locking is that other threads hold them
+    // concurrently. If the table were global, every real concurrent acquisition
+    // would assert.
+    int mine = 0;
+    LockDebug::OnAcquired(&mine, EMode::Exclusive);
+
+    bool otherThreadSawMyHold = true;
+    std::thread other([&]
+                      { otherThreadSawMyHold = LockDebug::IsHeldByCurrentThread(&mine); });
+    other.join();
+
+    EXPECT_FALSE(otherThreadSawMyHold)
+        << "one thread's holds are visible to another — the detector would fire on "
+           "ordinary concurrent access, which is what these locks are FOR.";
+}
+
+TEST_F(LockDebugTest, OverflowStopsTrackingRatherThanEvictingAnEntry)
+{
+    // Degrading to "not detected" is the safe direction. Evicting an entry to make
+    // room would make a genuinely-held lock report as free — a false negative that
+    // looks exactly like a pass.
+    std::vector<int> mutexes(LockDebug::kMaxTrackedLocks + 8, 0);
+    for (auto& m : mutexes)
+        LockDebug::OnAcquired(&m, EMode::Exclusive);
+
+    EXPECT_EQ(LockDebug::HeldCountForCurrentThread(), LockDebug::kMaxTrackedLocks);
+    EXPECT_TRUE(LockDebug::IsHeldByCurrentThread(&mutexes[0]))
+        << "the first lock was evicted to make room — holds must never be forgotten "
+           "while still held.";
+}
+
+TEST_F(LockDebugTest, RealFSharedMutexAcquisitionsAreTrackedThroughTheScopedGuards)
+{
+    // The bookkeeping above is only useful if the mutex actually calls it. This is
+    // the wiring check — and it is skipped when the detector is compiled out,
+    // rather than asserting something that is deliberately absent.
+#if OLO_LOCK_DEBUG
+    FSharedMutex mutex;
+
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&mutex));
+    {
+        TUniqueLock<FSharedMutex> lock(mutex);
+        EXPECT_TRUE(LockDebug::IsHeldByCurrentThread(&mutex))
+            << "FSharedMutex::Lock did not register the hold — the detector is wired up "
+               "wrong and would never fire on a real self-deadlock.";
+        EXPECT_EQ(LockDebug::HeldMode(&mutex), EMode::Exclusive);
+    }
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&mutex))
+        << "FSharedMutex::Unlock did not clear the hold — the next acquisition of this "
+           "mutex would assert spuriously.";
+
+    {
+        TSharedLock<FSharedMutex> lock(mutex);
+        EXPECT_TRUE(LockDebug::IsHeldByCurrentThread(&mutex));
+        EXPECT_EQ(LockDebug::HeldMode(&mutex), EMode::Shared);
+    }
+    EXPECT_FALSE(LockDebug::IsHeldByCurrentThread(&mutex));
+#else
+    GTEST_SKIP() << "OLO_LOCK_DEBUG is off in this configuration; the mutex does not "
+                    "call into LockDebug, so there is no wiring to verify.";
+#endif
+}

--- a/OloEngine/tests/Async/SharedMutexTest.cpp
+++ b/OloEngine/tests/Async/SharedMutexTest.cpp
@@ -54,19 +54,74 @@ TEST_F(SharedMutexTest, SingleThreadShared)
 
 TEST_F(SharedMutexTest, MultipleReaders)
 {
+    // This used to take three shared locks on ONE thread. That is not "multiple
+    // readers" — it is recursive locking, which FSharedMutex explicitly does not
+    // support ("is not fair and does not support recursive locking"), and it is a
+    // latent deadlock: LockShared blocks once a writer is queued, because waiting
+    // writers get priority over new readers. It passed only because no writer ever
+    // contended in this test. LockDebug (added with issue #863) flags it, which is
+    // how it was found.
+    //
+    // Multiple readers means multiple THREADS holding the shared lock at the same
+    // time, so that is what this now asserts: every reader must be able to acquire
+    // while all the others are still holding.
+    constexpr u32 ReaderCount = 3;
     FSharedMutex Mutex;
+    std::atomic<u32> Acquired{ 0 };
+    std::atomic<bool> Release{ false };
+    std::atomic<u32> Failures{ 0 };
 
-    // Multiple readers should be allowed
-    Mutex.LockShared();
-    Mutex.LockShared();
-    Mutex.LockShared();
+    std::vector<std::thread> Readers;
+    Readers.reserve(ReaderCount);
+    for (u32 i = 0; i < ReaderCount; ++i)
+    {
+        Readers.emplace_back([&]
+                             {
+            Mutex.LockShared();
+            Acquired.fetch_add(1, std::memory_order_acq_rel);
 
-    EXPECT_FALSE(Mutex.IsLocked());
+            // Hold until every reader is in. If shared locks were exclusive of one
+            // another this never completes, which the bounded wait below reports as
+            // a failure rather than hanging the suite.
+            while (!Release.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+
+            if (Mutex.IsLocked())
+                Failures.fetch_add(1, std::memory_order_relaxed);
+
+            Mutex.UnlockShared(); });
+    }
+
+    // Bounded: a genuine regression here is "a reader never acquires", which would
+    // otherwise hang forever. One-sided and generous — this is a liveness bound, not
+    // a timing measurement.
+    const auto Deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (Acquired.load(std::memory_order_acquire) < ReaderCount &&
+           std::chrono::steady_clock::now() < Deadline)
+    {
+        std::this_thread::yield();
+    }
+
+    const u32 AcquiredCount = Acquired.load(std::memory_order_acquire);
+    EXPECT_EQ(AcquiredCount, ReaderCount)
+        << "only " << AcquiredCount << " of " << ReaderCount
+        << " readers acquired the shared lock concurrently — shared locking is behaving "
+           "exclusively, which defeats the entire point of a reader-writer lock.";
     EXPECT_TRUE(Mutex.IsLockedShared());
+    EXPECT_FALSE(Mutex.IsLocked());
 
-    Mutex.UnlockShared();
-    Mutex.UnlockShared();
-    Mutex.UnlockShared();
+    Release.store(true, std::memory_order_release);
+    for (std::thread& Reader : Readers)
+    {
+        Reader.join();
+    }
+
+    EXPECT_EQ(Failures.load(), 0u)
+        << "a reader observed the mutex as exclusively locked while it held a shared lock.";
+    EXPECT_FALSE(Mutex.IsLockedShared())
+        << "the shared count did not return to zero after every reader released.";
 }
 
 TEST_F(SharedMutexTest, TryLockWhenUnlocked)

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(OloEngine-Tests
 		Async/MutexLockRateTest.cpp
 		Async/SemaphoreTest.cpp
 		Async/ManualResetEventTest.cpp
+		Async/LockDebugTest.cpp
 		Async/SharedMutexTest.cpp
 		Async/SharedRecursiveMutexTest.cpp
 		Async/ExternalMutexTest.cpp

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -953,6 +953,7 @@ add_executable(OloEngine-Tests
 		Functional/AnimationPhysics/HumanoidLocomotionWalkTest.cpp
 		Functional/AnimationPhysics/MorphTargetGraphAnimationTest.cpp
 		Functional/Navigation/NavAgentReachesTargetTest.cpp
+		Functional/Asset/AssetHotReloadDoesNotDeadlockTest.cpp
 		Functional/Asset/AssetManagerImportsStagedAssetTest.cpp
 		Functional/Gameplay/TimedQuestFailsAfterDeadlineTest.cpp
 		Functional/Gameplay/AbilityCooldownTicksDownViaSceneTickTest.cpp

--- a/OloEngine/tests/Functional/Asset/AssetHotReloadDoesNotDeadlockTest.cpp
+++ b/OloEngine/tests/Functional/Asset/AssetHotReloadDoesNotDeadlockTest.cpp
@@ -1,0 +1,178 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: Functional
+// =============================================================================
+// AssetHotReloadDoesNotDeadlockTest — Functional Test.
+//
+// Cross-subsystem seam under test:
+//   filewatch hot-reload → EditorAssetManager::ReloadData → AssetRegistry
+//   metadata refresh → SerializeAssetRegistry. That tail is where the editor
+//   wedged twice in one day (issues #439 and #863): ReloadData held the
+//   non-recursive m_RegistryMutex, SerializeAssetRegistry took it again, and
+//   the game thread parked in ParkingLot::Wait forever — no assert, no log
+//   line, no CPU. Both reports were live-editor findings; nothing headless had
+//   ever called ReloadData, which is why the same line could be rediscovered
+//   through a second trigger after the first fix shipped.
+//
+// This is the missing headless coverage, and it asserts two things that a
+// careless fix breaks in opposite directions:
+//
+//   1. ReloadData RETURNS — it does not park the calling thread.
+//   2. Hot-reload still HAPPENS — the new file contents are actually live
+//      afterwards. Silently dropping the reload also makes (1) pass.
+//
+// Reaching the deadlocking tail at all needs an asset that is both tracked (in
+// the registry) and successfully loaded; miss either and ReloadData returns
+// early, before the line under test, and the case asserts nothing while looking
+// green. The probe asset below is authored by the test so both hold by
+// construction, and so the reload is observable rather than merely successful.
+//
+// A ScriptFile is used on purpose: ScriptFileSerializer is CPU-only (YAML text
+// → ScriptFileAsset, no GPU resources), so the whole path runs with no GL
+// context and this is a normal CI citizen rather than one more workstation-only
+// SKIP.
+//
+// On the liveness assertion: the regression this guards is a PERMANENT park,
+// not a slow path, so a generous upper bound separates pass from fail with no
+// sensitivity at either end (a healthy reload of a 3-line file is sub-
+// millisecond). ReloadData runs on a worker only so that a regression fails
+// THIS case instead of hanging the whole suite — the lock discipline under test
+// is a property of ReloadData itself and is thread-independent, so nothing
+// about the assertion depends on which thread makes the call.
+// =============================================================================
+
+#include "Functional/FunctionalTest.h"
+
+#include "OloEngine/Asset/Asset.h"
+#include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
+#include "OloEngine/Asset/AssetTypes.h"
+#include "OloEngine/Project/Project.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+
+using namespace OloEngine;
+using namespace OloEngine::Functional;
+
+namespace
+{
+    // Comfortably above a healthy reload of a 3-line text asset, comfortably
+    // below any CI job timeout. The failure it detects never completes at all.
+    constexpr auto kReloadLivenessBudget = std::chrono::seconds(30);
+
+    // .cs maps to AssetType::ScriptFile; ScriptFileSerializer reads the file as
+    // YAML and wants a `ScriptFile` node, so the probe carries one. Authored by
+    // the test rather than staged from SandboxProject, so the reload's effect is
+    // something this test chose and can therefore assert on.
+    constexpr const char* kProbeRelativePath = "Assets/Scripts/Source/HotReloadProbe.cs";
+
+    std::string ProbeContents(const std::string& className)
+    {
+        return "ScriptFile:\n  ClassNamespace: Sandbox\n  ClassName: " + className + "\n";
+    }
+
+    void WriteProbe(const std::filesystem::path& path, const std::string& className)
+    {
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream out(path, std::ios::trunc);
+        ASSERT_TRUE(out.is_open()) << "could not write the probe asset at " << path.string();
+        out << ProbeContents(className);
+    }
+} // namespace
+
+class AssetHotReloadDoesNotDeadlockTest : public FunctionalTest
+{
+  protected:
+    void BuildScene() override
+    {
+        // No staged SandboxProject assets — the probe is authored below, after
+        // the temp project directory exists.
+        EnableAssetManager({});
+    }
+};
+
+TEST_F(AssetHotReloadDoesNotDeadlockTest, ReloadDataOfALoadedAssetCompletesAndPublishesTheNewContents)
+{
+    ASSERT_TRUE(Project::GetActive())
+        << "Project::Load failed — no active project after EnableAssetManager.";
+
+    auto manager = Project::GetAssetManager().As<EditorAssetManager>();
+    ASSERT_TRUE(manager)
+        << "Project::GetAssetManager returned null or non-EditorAssetManager — "
+           "harness wiring is broken.";
+
+    const auto probePath = StagedAssetAbsolutePath(kProbeRelativePath);
+    WriteProbe(probePath, "BeforeReload");
+    ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+    // Tracked: without a registry entry ReloadData bails on invalid metadata.
+    const AssetHandle handle = manager->ImportAsset(probePath);
+    ASSERT_NE(static_cast<u64>(handle), 0ULL)
+        << "ImportAsset returned a zero handle for " << kProbeRelativePath
+        << " — the .cs extension is no longer mapped to ScriptFile, so ReloadData "
+           "would return early and this case would assert nothing.";
+
+    // Loaded: without a cached entry the reload takes the placeholder branch and
+    // returns before the registry-persist tail under test.
+    auto original = manager->GetAsset(handle).As<ScriptFileAsset>();
+    ASSERT_TRUE(original)
+        << "GetAsset returned null (or a non-ScriptFileAsset) for the probe — "
+           "ScriptFileSerializer failed to load a CPU-only asset.";
+    ASSERT_TRUE(manager->IsAssetLoaded(handle))
+        << "the probe did not land in the loaded-asset cache.";
+    ASSERT_EQ(original->GetClassName(), "BeforeReload")
+        << "the probe did not round-trip its own contents, so the post-reload "
+           "comparison below would prove nothing.";
+
+    // What filewatch sees: the file changed on disk. ReloadData is exactly what
+    // its Reload decision calls, via ReloadDataAsync onto the game thread.
+    WriteProbe(probePath, "AfterReload");
+    ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+    // Everything the worker touches is captured BY VALUE through shared state:
+    // on a regression the thread parks forever and outlives this stack frame, so
+    // a reference capture would dangle on exactly the failure path.
+    auto reloadResult = std::make_shared<std::promise<bool>>();
+    auto reloaded = reloadResult->get_future();
+    // `mutable` because Ref<T> propagates constness: a by-value capture in a
+    // non-mutable lambda is const, and ReloadData is not a const member.
+    std::thread worker([manager, handle, reloadResult]() mutable
+                       { reloadResult->set_value(manager->ReloadData(handle)); });
+    // Detached for the same reason: a thread parked holding the registry lock can
+    // never be joined. The process still exits cleanly.
+    worker.detach();
+
+    ASSERT_EQ(reloaded.wait_for(kReloadLivenessBudget), std::future_status::ready)
+        << "EditorAssetManager::ReloadData did not return within "
+        << kReloadLivenessBudget.count()
+        << "s — the caller is parked, not slow. This is the issue #439 / #863 "
+           "deadlock: something on ReloadData's path acquired the non-recursive "
+           "m_RegistryMutex twice on one thread. Look for a call to "
+           "SerializeAssetRegistry — or any other m_RegistryMutex acquisition — "
+           "made while that lock is already held. See "
+           "docs/agent-rules/non-recursive-lock-self-locking-helper.md.";
+
+    EXPECT_TRUE(reloaded.get())
+        << "ReloadData reported failure for a tracked, loaded, existing asset — "
+           "hot-reload is broken in a different way than the deadlock this test "
+           "guards.";
+
+    // The reload actually took effect. A fix that quietly drops filewatch events
+    // (or reloads into a discarded object) satisfies the liveness assertion above
+    // and fails here, which is the point of asserting both.
+    ASSERT_TRUE(manager->IsAssetLoaded(handle))
+        << "ReloadData returned true but the asset is no longer cached.";
+    auto refreshed = manager->GetAsset(handle).As<ScriptFileAsset>();
+    ASSERT_TRUE(refreshed) << "the reloaded asset is missing or the wrong type.";
+    EXPECT_EQ(refreshed->GetClassName(), "AfterReload")
+        << "the cached asset still carries the pre-edit contents — the reload "
+           "returned success without publishing the new data.";
+
+    EXPECT_TRUE(manager->GetMetadata(handle).IsValid())
+        << "the registry lost the probe's metadata across a reload.";
+}

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -167,7 +167,11 @@ that must outlive the level that created it) ·
 [render-graph-transient-aliasing.md](render-graph-transient-aliasing.md) (a read from a pooled
 resource whose lifetime already ended) ·
 [intrusive-refcount-weakref-races.md](intrusive-refcount-weakref-races.md) (TOCTOU between a
-decrement and a re-read) · [per-frame-scratch-reuse.md](per-frame-scratch-reuse.md) (promoting a
+decrement and a re-read) ·
+[non-recursive-lock-self-locking-helper.md](non-recursive-lock-self-locking-helper.md) (a locked
+scope that calls a sibling method which locks the same non-recursive mutex — deterministic, silent,
+and fixed twice in one day because the first fix moved a *caller* instead of unlocking the
+*callee*) · [per-frame-scratch-reuse.md](per-frame-scratch-reuse.md) (promoting a
 per-tick local to persistent state) ·
 [parallelizable-mover-systems.md](parallelizable-mover-systems.md) (splitting a system at its write
 boundary) · [gl-clear-program-revalidation.md](gl-clear-program-revalidation.md) (what is *bound*
@@ -301,6 +305,7 @@ Everything above, plus the docs that are pure reference rather than postmortem.
 
 **Concurrency & memory** —
 [intrusive-refcount-weakref-races.md](intrusive-refcount-weakref-races.md) ·
+[non-recursive-lock-self-locking-helper.md](non-recursive-lock-self-locking-helper.md) ·
 [spinlock-payload-cache-line-separation.md](spinlock-payload-cache-line-separation.md) ·
 [per-frame-scratch-reuse.md](per-frame-scratch-reuse.md)
 

--- a/docs/agent-rules/non-recursive-lock-self-locking-helper.md
+++ b/docs/agent-rules/non-recursive-lock-self-locking-helper.md
@@ -171,6 +171,48 @@ resolves to `Ignore`, so touching a file proves nothing by itself:
    `submitted` prove the reload republished the asset rather than dropping it. Liveness alone does
    not.
 
+## 6a. The detector — you should not need this document to find it twice
+
+Everything above is discipline, and discipline is what failed here: the same line was
+rediscovered the same day, by a second person, through a different trigger. So the check is now in
+the code. `FSharedMutex` asks, before every blocking acquisition, whether the calling thread
+already holds that lock, and says so:
+
+```
+Self-deadlock on a non-recursive lock at 0x2a6d683e874: this thread already holds it (exclusive),
+and is now asking for it exclusive. The acquisition below this line will park the thread FOREVER
+— no further log lines, no CPU, no crash record. …
+```
+
+Measured against the #863 bug deliberately reintroduced: the regression test used to fail after
+**30,023 ms** with a timeout that named nothing, and now fails in **0.3 s** with the lock, both
+modes and the cause printed. That is the difference between "something is wrong somewhere" and a
+diagnosis.
+
+Four things about it worth knowing before you touch it
+(`OloEngine/src/OloEngine/Threading/LockDebug.h`):
+
+- **It costs the mutex nothing.** The held-lock table is `thread_local`, keyed by mutex address.
+  `sizeof(FSharedMutex)` is still four bytes in every configuration — no layout to go stale in an
+  incremental build (cf. [incremental-build-odr-staleness.md](incremental-build-odr-staleness.md)).
+- **It is gated on `NDEBUG`, not `OLO_DEBUG`, and reports out of line rather than through
+  `OLO_CORE_ASSERT`.** `OLO_DEBUG` is **PRIVATE** to the `OloEngine` target, so it is absent when
+  these headers are compiled into `OloEditor` or `OloEngine-Tests` — those TUs receive neither
+  `OLO_DEBUG` nor `NDEBUG`. Gating an *inline* function's body on a per-target macro is an ODR
+  violation whose arbitrary winner might be the copy with the detector compiled out. This is the
+  same hazard `CLAUDE.md` describes for `ENTT_USE_ATOMIC`, and it is worth remembering generally:
+  **`OLO_CORE_ASSERT` inside header/inline engine code is a no-op wherever that header lands
+  outside the engine library.**
+- **All four re-acquisition combinations are flagged**, including shared→shared: waiting writers
+  get priority over new readers, so a recursive shared lock deadlocks *whenever a writer happens
+  to be queued* — intermittently, which is worse to debug than always.
+- **It found something the first time it ran.** `SharedMutexTest.MultipleReaders` modelled
+  "multiple readers" as three shared locks on one thread. It was the only hit across 6412 tests,
+  and it now uses three real threads.
+
+`FMutex` is deliberately *not* instrumented — it sits in the task scheduler's hot path and inside
+the locking primitives themselves, where both the cost and the re-entrancy question are different.
+
 ## 7. Checklist
 
 - Calling a sibling method from inside a locked scope? Open it and check what it locks. "It's just
@@ -184,7 +226,9 @@ resolves to `Ignore`, so touching a file proves nothing by itself:
   class — or restructure into sequential scopes and buy the stronger invariant instead.
 - `FSharedMutex` is **not** recursive, and an exclusive lock and a shared lock may not be held
   simultaneously by the same thread. If you genuinely need recursion, `FSharedRecursiveMutex`
-  exists — but wanting it is usually a sign the structure is wrong, not the mutex.
+  exists — but wanting it is usually a sign the structure is wrong, not the mutex. §6a will now
+  tell you at runtime if you get this wrong; do not treat that as permission to stop thinking
+  about it, because the detector only sees the acquisitions that actually execute.
 
 ## Related
 

--- a/docs/agent-rules/non-recursive-lock-self-locking-helper.md
+++ b/docs/agent-rules/non-recursive-lock-self-locking-helper.md
@@ -1,0 +1,183 @@
+# A self-locking helper called under its own non-recursive lock
+
+**The failure:** `EditorAssetManager::ReloadData` held `m_RegistryMutex` and called
+`SerializeAssetRegistry()`, which took the same lock. `FSharedMutex` is not recursive, so the
+calling thread parked in `ParkingLot::Wait` and never came back. The editor's game thread was
+gone: no assert, no log line, no CPU, no crash record — just a window that stopped answering.
+
+It was found and fixed once (issue **#439**, `aa37548c7`), and independently rediscovered the same
+day through a completely different trigger (issue **#863**), because the first fix moved *one call
+site* out of the lock and left the loaded gun on the table.
+
+Read this before adding a lock to a manager class, and before calling any sibling method from
+inside a locked scope.
+
+---
+
+## 1. The shape
+
+```cpp
+void Manager::DoWork()
+{
+    TUniqueLock<FSharedMutex> lock(m_Mutex);   // (1) acquire
+    m_Thing.Update(...);
+    Persist();                                 // (3) …which acquires again → park
+}
+
+bool Manager::Persist()
+{
+    TUniqueLock<FSharedMutex> lock(m_Mutex);   // (2) a helper that locks internally
+    return m_Thing.WriteToDisk(path);
+}
+```
+
+Both halves read as correct in isolation. `Persist()` locking is *defensive* — it is a public
+method, other callers do not hold the lock, and locking there is the obviously-safe choice. The
+bug only exists in the composition, and nothing in the type system, the compiler, the linter or
+the test suite looks at the composition.
+
+`FSharedMutex` says so in its own header — *"is not fair and does not support recursive locking"*
+— and the failure is 100% deterministic once the two frames meet. This is not a race. There is
+nothing timing-dependent about it. The *trigger* can be rare; the deadlock, once triggered, is
+certain.
+
+## 2. Why the first fix did not hold
+
+`aa37548c7` fixed #439 by scoping the lock so the `Persist()` call fell outside it:
+
+```cpp
+{
+    TUniqueLock<FSharedMutex> lock(m_RegistryMutex);
+    m_AssetRegistry.UpdateMetadata(assetHandle, metadata);
+}
+SerializeAssetRegistry();   // outside — correct
+```
+
+That is the right change for that call site and it is still in the code. But it fixes a *caller*.
+The dangerous property lives in the *callee*: `SerializeAssetRegistry()` was a public method that
+took a non-recursive lock, so every present and future caller had to know not to be holding it —
+a rule enforced by nothing but a comment. Issue #863 arrived through filewatch hot-reload during a
+cold-cache scene load rather than through a lightmap re-bake, on a build made hours before
+`aa37548c7` landed, and produced the identical stack at the identical line.
+
+**Fixing the caller fixes one path. Fixing the callee fixes the archetype.**
+
+## 3. The fix that holds: notice the outer lock was redundant
+
+`SerializeAssetRegistry()` did exactly one thing under `m_RegistryMutex`:
+
+```cpp
+return m_AssetRegistry.Serialize(registryPath);
+```
+
+and `AssetRegistry::Serialize` **already** takes the registry's own `FSharedMutex` in shared mode
+around the whole write. The outer lock protected nothing the inner lock did not, and bought
+nothing but a way to deadlock. Deleting it makes the re-entrant call harmless from every call
+site, forever, with no discipline to remember and no assert to fire.
+
+This generalises. `EditorAssetManager` wraps `AssetRegistry`, and `AssetRegistry` is
+**self-synchronised** — every public method locks. So a manager-level lock around a *single*
+registry call is always redundant. It is not redundant around a **compound** sequence:
+
+```cpp
+TUniqueLock<FSharedMutex> lock(m_RegistryMutex);
+auto metadata = m_AssetRegistry.GetMetadata(handle);   // two individually-atomic
+metadata.Status = status;                              // calls that must be
+m_AssetRegistry.UpdateMetadata(handle, metadata);      // atomic TOGETHER
+```
+
+That read-modify-write is the actual job of `m_RegistryMutex`, and `SetAssetStatus`, the status
+updates in `SyncWithAssetThread` and `ReloadData`'s `LastWriteTime` refresh all need it.
+
+**The rule:** when you put a mutex around a member that already locks itself, ask what compound
+operation you are making atomic. If the answer is "none, it's one call", the lock is not
+protection — it is a re-entrancy trap with no upside.
+
+## 4. Also remove the lock *order*, not just the recursion
+
+The same change dropped the one place in `EditorAssetManager` that nested two different mutexes:
+`SyncWithAssetThread` held `m_AssetsMutex` exclusively across its integration loop and took
+`m_RegistryMutex` inside it, once per ready asset. There was no `m_RegistryMutex → m_AssetsMutex`
+path anywhere, so it was not an ABBA *yet* — it was one future edit away from being one.
+
+Splitting it into two sequential scopes (which the raw-asset branch immediately above already
+did) makes a stronger statement than "the current order is consistent":
+
+> `EditorAssetManager` acquires `m_AssetsMutex`, `m_RegistryMutex` and `m_DependenciesMutex` one
+> at a time and never nests them. There is no lock order, so there is no lock order to get wrong.
+
+An invariant a reviewer can check by grepping for a nested `TUniqueLock` beats an ordering
+convention nobody has written down. If you add a nesting, you are re-introducing the audit.
+
+## 5. Diagnosis: telling a wedge from a slow cook
+
+Both #439 and #863 were first mistaken for "the mesh cook is taking a while". The signature that
+separates them:
+
+| | slow | deadlocked |
+|---|---|---|
+| process CPU | rising | **flat at 0 ms across every thread** |
+| the log | still producing lines | silent, mid-operation |
+| MCP calls | answer, slowly | *"Timed out waiting for the editor main thread"* |
+
+Zero CPU with over a hundred live threads is the tell. Once you have it, crack the live process
+with the store-package `cdb` (recipe in the `windbg-cdb-location-this-box` memory note) and dump
+**every** thread, not just the main one:
+
+```
+~*k
+```
+
+A stack of `NtWaitForAlertByThreadId` → `ParkingLot::Wait` → `FSharedMutex::LockSlow` →
+`FSharedMutex::Lock` names the *victim*. The victim's own stack is enough only when the other
+acquisition is on the same thread — which is exactly the case here, and is why `~0k` alone
+happened to be sufficient twice. Do not count on that: `~*k` costs nothing and the same-thread
+answer is visible in it too (the culprit frame is further down the *same* stack).
+
+## 6. Why no headless test caught it
+
+Both reports were live-editor findings, and #863's own framing was that the bug is *"invisible to
+every headless test"*. It was — but not because the path is untestable. Nothing headless had ever
+called `EditorAssetManager::ReloadData` at all, because reaching its persist tail needs an asset
+that is both **tracked** (in the registry) and **loaded** (in the cache); miss either and
+`ReloadData` returns early, before the deadlocking line, and a test written without noticing that
+asserts nothing while looking green.
+
+`OloEngine/tests/Functional/Asset/AssetHotReloadDoesNotDeadlockTest.cpp` is that coverage. Two
+things about how it is written are worth copying:
+
+- It stages a **`.cs` script file**, because `ScriptFileSerializer` is CPU-only (text →
+  `ScriptFileAsset`, no GPU resources). The path runs with no GL context, so the test is a normal
+  CI citizen rather than one more `SKIP` that only ever runs on a workstation.
+- It calls `ReloadData` on a worker with a bounded wait and fails on timeout, rather than calling
+  it inline. That is not a timing assertion in the sense
+  [timed-wait-test-assertions.md](timed-wait-test-assertions.md) warns about: the regression is a
+  **permanent** park, so any generous upper bound separates pass from fail with no sensitivity at
+  either end. The worker exists only so that a regression fails *this case* instead of hanging the
+  whole suite.
+
+## 7. Checklist
+
+- Calling a sibling method from inside a locked scope? Open it and check what it locks. "It's just
+  a helper" is how both of these happened.
+- Adding a lock around a member that locks itself? Name the compound operation it makes atomic. If
+  there isn't one, don't add it.
+- Making a public method lock defensively? That is a constraint on every caller forever. Prefer a
+  self-synchronised callee, or split into a locking public wrapper and an unlocked private core
+  (`DoThingUnlocked()`), so the internal caller has something safe to call.
+- Nesting two mutexes? Say why in a comment, and check for the reverse order across the whole
+  class — or restructure into sequential scopes and buy the stronger invariant instead.
+- `FSharedMutex` is **not** recursive, and an exclusive lock and a shared lock may not be held
+  simultaneously by the same thread. If you genuinely need recursion, `FSharedRecursiveMutex`
+  exists — but wanting it is usually a sign the structure is wrong, not the mutex.
+
+## Related
+
+- [intrusive-refcount-weakref-races.md](intrusive-refcount-weakref-races.md) — the other
+  hand-ported UE concurrency primitive whose failure mode is silent.
+- [notes-core-and-threading.md](notes-core-and-threading.md) — the task system, `Ref<T>` constness,
+  lock-free testing.
+- [notes-editor-and-assets.md](notes-editor-and-assets.md) — filewatch import, Content Browser
+  refresh, asset placeholders.
+- [timed-wait-test-assertions.md](timed-wait-test-assertions.md) — when a timed assertion *is* a
+  flake trap, and why a liveness bound on a permanent hang is not one.

--- a/docs/agent-rules/non-recursive-lock-self-locking-helper.md
+++ b/docs/agent-rules/non-recursive-lock-self-locking-helper.md
@@ -156,6 +156,21 @@ things about how it is written are worth copying:
   either end. The worker exists only so that a regression fails *this case* instead of hanging the
   whole suite.
 
+**To exercise the same path in a live editor** (worth doing once for any change to this seam), you
+must first get the asset genuinely *loaded* — a filewatch event on a tracked-but-unloaded asset
+resolves to `Ignore`, so touching a file proves nothing by itself:
+
+1. Open `VirtualGeometryTest.olo` and set `olo_renderer_settings_set renderpath=deferred`. The
+   `VirtualMeshComponent` submission loop runs only on Deferred, and it is the only thing that
+   resolves those mesh-source handles — on Forward nothing loads and every event is ignored. See
+   [notes-editor-and-assets.md](notes-editor-and-assets.md) §2.
+2. Confirm a `Loaded asset: <path>` trace appeared for the file you are about to touch.
+3. Touch it. You should see `🔄 Hot-reload triggered` followed by `Reloaded asset`, about a second
+   apart, with the editor still answering MCP in single-digit milliseconds.
+4. Re-check `olo_virtual_geometry_stats` afterwards: `unresolvedAssets: 0` and a non-zero
+   `submitted` prove the reload republished the asset rather than dropping it. Liveness alone does
+   not.
+
 ## 7. Checklist
 
 - Calling a sibling method from inside a locked scope? Open it and check what it locks. "It's just

--- a/docs/agent-rules/notes-editor-and-assets.md
+++ b/docs/agent-rules/notes-editor-and-assets.md
@@ -44,6 +44,20 @@ To surface a file live without the user pressing F5, call
 - **Hot-reload only assets that are currently loaded** (`IsAssetLoaded`). Otherwise a large new
   file spams partial-content reloads as it streams in. The decision lives in the pure,
   unit-tested `DecideFileWatchAction` (`Asset/AssetFileWatchPolicy.h`).
+- **"Currently loaded" is decided by whether anything actually *resolved* the handle this
+  session, which a renderer setting can gate — so `Reload` can look permanently dead when it is
+  merely idle.** `m_LoadedAssets` is populated by `EditorAssetManager::GetAsset`, i.e. by a
+  consumer asking for the asset. A `VirtualMeshComponent`'s mesh source is resolved *only* by the
+  submission loop in `Scene.cpp`, which runs **only on the Deferred path** — so with the editor on
+  Forward, opening `VirtualGeometryTest.olo` loads no mesh at all, every filewatch event on those
+  files reports `loaded=false`, and every decision is `Ignore`. Nothing is wrong; nothing asked.
+  This cost an hour during #863 and produced a nearly-filed phantom bug ("hot-reload is unreachable
+  for scene assets"). **Before concluding a path is unreachable, check `olo_virtual_geometry_stats`
+  — its `renderingPath` field and its own `note` say this in plain words — and confirm a
+  `Loaded asset: <path>` trace exists for the asset you are about to touch.** An absence in the log
+  is not evidence of a broken code path; it is equally evidence of an idle one. Related:
+  [non-recursive-lock-self-locking-helper.md](non-recursive-lock-self-locking-helper.md) §6, on why
+  this seam had no headless coverage at all.
 - The registry file is `<project>/AssetRegistry.oar`; `.oar` maps to no `AssetType`, so persisting
   it cannot re-enter the handler. It is **git-tracked** — revert it after any live drop-file test.
 


### PR DESCRIPTION
## What #863 actually was

The issue's own diagnosis was explicitly a guess — *"presumably against a lock the in-flight load
path already holds on the same thread's call chain, or an ABBA with the loader"*. It is the first
of those, and it is not timing-dependent at all.

Pre-`aa37548c7`, `EditorAssetManager::ReloadData` looked like this:

```cpp
TUniqueLock<FSharedMutex> lock(m_RegistryMutex);      // acquire
m_AssetRegistry.UpdateMetadata(assetHandle, metadata);
SerializeAssetRegistry();                             // …which acquires it again → park
```

`m_RegistryMutex` is a non-recursive `FSharedMutex`, so the calling thread parks in
`ParkingLot::Wait` and never returns. That is the reported stack, frame for frame, and it fires
**every** time `ReloadData` reaches that block for a tracked, loaded asset — i.e. on any
hot-reload at all. The cold mesh cache is only what made filewatch fire; nothing about the
deadlock itself is probabilistic.

**#863 was therefore already fixed on `master`.** The timeline (all 2026-08-21 UTC):

| | |
|---|---|
| 06:57 | `aa37548c7` authored in the #439 worktree — same line, found via a lightmap re-bake |
| 08:06 | #863 filed from the #813 worktree, on a build that predated it |
| 11:06 | `aa37548c7` reaches `master` in PR #861 |
| 12:05 | PR #859 (#813) merges |

Two sessions hit the same line an hour apart through different triggers; one fixed it, the other
filed it, and nothing connected them. Confirmed empirically rather than by reading: with the
pre-`aa37548c7` shape restored locally, the new regression test below parks for its full 30 s
budget; with `master`'s code it passes in 38 ms. That A/B also settles hypothesis (b) — there is
no ABBA here, it is one thread taking one mutex twice.

## What this PR changes

Verifying "already fixed" is worth little on its own — the bug was *found twice in one day*, and
the reason it could come back is that `aa37548c7` fixed a **caller** while the hazard lived in the
**callee**. `SerializeAssetRegistry()` was a public method taking a non-recursive lock, so every
present and future caller had to know not to be holding it, enforced by a comment.

1. **`SerializeAssetRegistry` no longer locks at all.** It did exactly one thing under
   `m_RegistryMutex` — call `AssetRegistry::Serialize`, which already takes the registry's own
   `FSharedMutex` in shared mode around the whole write. The outer lock protected nothing the
   inner one didn't and bought only a way to deadlock. Removing it makes re-entrant calls harmless
   from every call site, present and future, with no discipline to remember.

   `m_RegistryMutex` is still load-bearing for **compound** read-modify-write sequences on
   `m_AssetRegistry` (`SetAssetStatus`, the status updates in `SyncWithAssetThread`, `ReloadData`'s
   `LastWriteTime` refresh), where two individually-atomic registry calls must be atomic together.
   A single self-synchronised call needs none of it.

2. **`SyncWithAssetThread` no longer nests two mutexes.** It held `m_AssetsMutex` exclusively across
   its integration loop and took `m_RegistryMutex` inside it, once per ready asset. There is no
   `m_RegistryMutex → m_AssetsMutex` path anywhere, so it was not an ABBA — it was one edit away
   from being one. Split into sequential scopes (the shape the raw-asset branch immediately above
   already used), which buys a stronger and greppable invariant: **`EditorAssetManager` acquires
   its three mutexes one at a time and never nests them, so there is no lock order to get wrong.**

3. **The headless coverage that was missing** —
   `OloEngine/tests/Functional/Asset/AssetHotReloadDoesNotDeadlockTest.cpp`. Both reports were
   live-editor findings and #863's framing was that this is "invisible to every headless test". It
   was, but not because the path is untestable: nothing headless had ever called `ReloadData`.
   Reaching the deadlocking tail needs an asset that is both **tracked** and **loaded** — miss
   either and `ReloadData` returns early, before the line under test, and a test written without
   noticing asserts nothing while looking green.

4. **A postmortem** — `docs/agent-rules/non-recursive-lock-self-locking-helper.md`, linked from
   both indexes. The archetype (a helper that locks internally, called under the same non-recursive
   lock), why fixing the caller didn't hold, the "is this outer lock redundant?" test, and the
   0-CPU-vs-slow-cook diagnosis table.

5. **A runtime detector, because documenting the rule demonstrably was not enough.**
   `FSharedMutex` now checks, before every blocking acquisition, whether the calling thread already
   holds that lock, and reports it instead of parking:

   ```
   Self-deadlock on a non-recursive lock at 0x2a6d683e874: this thread already holds it
   (exclusive), and is now asking for it exclusive. The acquisition below this line will park the
   thread FOREVER — no further log lines, no CPU, no crash record. …
   ```

   Measured against the #863 bug deliberately reintroduced: the regression test above used to fail
   after **30,023 ms** with a timeout naming nothing; with the detector it fails in **0.3 s** with
   the lock, both modes and the cause printed.

## Verification

- **The regression guard is a real guard, proven by A/B.** Pre-`aa37548c7` shape restored →
  `AssetHotReloadDoesNotDeadlockTest` fails after exactly 30 023 ms with its own diagnostic;
  restored to this PR's code → passes in 38 ms. Both directions were built and run, not reasoned
  about.
- **The test asserts hot-reload still WORKS, not just that it returns.** The probe asset is
  authored by the test with `ClassName: BeforeReload`, rewritten to `AfterReload`, and the case
  asserts the cached asset carries the new value afterwards. A "fix" that silently drops filewatch
  events — the classic careless fix here — passes the liveness assertion and fails this one.
- **Live editor, current `master` + this PR:** cold `Assets/cache/mesh`, `VirtualGeometryTest.olo`
  opened over `olo_scene_open`; the editor stayed responsive (MCP round-trips in 9–26 ms) with CPU
  climbing normally, and filewatch events were processed and logged throughout the load rather than
  going silent.
- **The detector is not noisy, and it found something on its first run.** Full suite with it live:
  **6412 tests, 6389 passed, zero self-deadlock reports** — except one. `SharedMutexTest.MultipleReaders`
  modelled "multiple readers" as three shared locks on **one thread**. That is recursive locking,
  which `FSharedMutex` explicitly does not support, and it is a latent deadlock rather than a
  quibble: `LockShared` blocks once a writer is queued. It passed only because no writer ever
  contended, and it never tested the property it was named for. Now rewritten to use three real
  threads. It was the only hit across the whole suite.
- **Full `OloEngine-Tests` suite** — see the run summary in the self-review comment.

## Note for the four sibling branches — read this bit

This **does** now touch `Threading/`, which the handover asked me to flag loudly. Two things make
the rebase cost approximately zero:

- **`sizeof(FSharedMutex)` is unchanged — still four bytes, in every configuration.** The
  held-lock table is `thread_local`, keyed by mutex address; the mutex itself gains no member. So
  there is no layout change to go stale in an incremental build.
- **No API change.** `Lock` / `LockShared` / `Unlock` / `UnlockShared` / `TryLock` /
  `TryLockShared` keep their signatures and semantics; the additions are compiled out entirely
  under `NDEBUG`.

The one thing to know: the detector is gated on **`NDEBUG`, not `OLO_DEBUG`**, and reports through
an out-of-line function rather than `OLO_CORE_ASSERT`. `OLO_DEBUG` is PRIVATE to the `OloEngine`
target, so it is absent when these headers compile into `OloEditor` or `OloEngine-Tests` (verified
in the generated ninja files: those TUs get neither `OLO_DEBUG` nor `NDEBUG`). Gating an *inline*
function's body on a per-target macro is an ODR violation whose arbitrary winner could be the copy
with the detector compiled out. The general corollary, which is worth knowing independently of this
PR: **`OLO_CORE_ASSERT` inside header/inline engine code is a no-op wherever that header lands
outside the engine library** — `FSharedMutex::Unlock` already had one.

Closes #863

## Review guide

**Where I'd look hardest**

1. `Threading/LockDebug.h` + the `FSharedMutex` hooks — the widest-blast-radius change here by
   far, and the one I would review first. Specifically: is the `NDEBUG` gate genuinely uniform
   across every target in every configuration (I verified Debug from the generated ninja files and
   reasoned about Release/Dist from CMake's defaults), and is flagging shared→shared too
   aggressive for anything outside the suite?
2. `EditorAssetManager.cpp` — `SerializeAssetRegistry` dropping `m_RegistryMutex`. The claim is
   that the outer lock was redundant because `AssetRegistry` is self-synchronised. The one visible
   behaviour change: `SerializeAssetRegistry` no longer excludes a concurrent `SetAssetStatus`, so
   the `.oar` can now be written between that function's `GetMetadata` and `UpdateMetadata`. The
   snapshot is still complete and consistent (`AssetRegistry::Serialize` holds the registry's own
   shared lock across the whole write) — it may just record the pre-update status of one entry,
   which is equally true of a write one microsecond earlier. I believe that is a non-change; it is
   the part I'd want a second reader on.
3. `EditorAssetManager.cpp` — the `SyncWithAssetThread` split. The status loop now runs over
   `integratedHandles`, deliberately *not* over `loadedEvents`, because `loadedEvents` may already
   carry entries from the raw-asset branch above whose status this function has set already.
4. `AssetHotReloadDoesNotDeadlockTest.cpp` — the detached worker. It is detached because a parked
   thread holding the registry lock can never be joined, and everything it touches is captured by
   value through shared state so it cannot dangle on the failure path.

**What I verified, and how** — the A/B above (built and ran both shapes), the two-directional
assertions in `AssetHotReloadDoesNotDeadlockTest`, a live cold-cache scene open over MCP, and the
full suite.

**Least confident about** — two things. (1) Whether flagging **shared→shared** re-entrancy is the
right call. It is a genuine latent deadlock and the primitive's own header forbids it, and it cost
nothing across 6412 tests, but it is the rule most likely to fire on code that has "always worked".
Narrowing the detector to the exclusive-involving combinations would be a one-line change if that
turns out to be wrong. (2) Whether `SerializeAssetRegistry` losing exclusion against
`SetAssetStatus` matters to anyone. I argued above that it doesn't; the alternative would be to
keep the lock and add a private unlocked core, which is more machinery for a property I don't
think is load-bearing.

**Deliberately not tested** — I did not reproduce the original wedge in the live editor, because
the fix for it is already on `master` and reproducing it would mean shipping a build with the bug
reintroduced. The A/B in the test binary covers the same ground with a deterministic result. I also
could not arrange a live filewatch `Reload` decision on demand: every asset I touched in a running
editor came back `loaded=false`, so the watcher chose `Ignore`. That gap is exactly what the new
headless test now covers, and it is why `ReloadData` had no coverage in the first place.
