### PR TITLE
feat(audio): suspend SoundGraph voices instead of muting them (#745)

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -261,7 +261,7 @@ namespace OloEngine::Audio::SoundGraph
         // Hand the voice slot back before the graph goes away — the budget holds a raw
         // pointer to this host and must never drive a torn-down one. Also reached from the
         // destructor, which is the only teardown path some owners take.
-        ReleaseVoice(/*restoreGain=*/true);
+        ReleaseVoice(/*resumePlayback=*/true);
 
         if (m_Source)
         {
@@ -304,7 +304,7 @@ namespace OloEngine::Audio::SoundGraph
         return params;
     }
 
-    void SoundGraphSound::ReleaseVoice(bool restoreGain) const
+    void SoundGraphSound::ReleaseVoice(bool resumePlayback) const
     {
         const auto handle = m_VoiceHandle.exchange(OloEngine::Audio::kInvalidVoiceHandle, std::memory_order_acq_rel);
         if (handle != OloEngine::Audio::kInvalidVoiceHandle)
@@ -312,16 +312,34 @@ namespace OloEngine::Audio::SoundGraph
             OloEngine::Audio::VoiceManager::Get().Release(handle);
         }
 
-        if (restoreGain)
+        // The budget is no longer tracking this voice, so nothing else will ever change its
+        // virtualization state again — whichever state we leave it in is permanent.
+        SetVirtualized(!resumePlayback);
+    }
+
+    void SoundGraphSound::SetVirtualized(bool virtualized) const
+    {
+        if (virtualized)
         {
-            // The budget is no longer tracking this voice, so nothing else would ever lift
-            // its mute — do it here, before it plays again.
+            // Mute BEFORE freezing. The audio thread may still be inside a block, or start
+            // one, between these two writes; a gain-0 block is silent, whereas freezing
+            // first and muting second would let a full-gain block through and then cut it
+            // dead mid-waveform.
+            m_VoiceGainScale.store(0.0f, std::memory_order_relaxed);
+            ApplyEffectiveGain();
+            if (m_Source)
+                m_Source->SetVoiceSuspended(true);
+        }
+        else
+        {
+            // Thaw BEFORE un-muting, the mirror image: the first block the graph produces
+            // after the thaw must already be at the right gain, and un-muting first would
+            // publish full gain onto a source that is still emitting silence.
+            if (m_Source)
+                m_Source->SetVoiceSuspended(false);
             m_VoiceGainScale.store(1.0f, std::memory_order_relaxed);
             ApplyEffectiveGain();
         }
-        // Otherwise leave the mute in place: this voice is being retired, and the graph
-        // runtime has no way to actually stop, so restoring gain would make a sound that
-        // is supposed to be over audible again.
     }
 
     void SoundGraphSound::SyncVoiceParams() const
@@ -350,23 +368,34 @@ namespace OloEngine::Audio::SoundGraph
         SyncVoiceParams();
     }
 
-    bool SoundGraphSound::OnVoiceStart(f64 /*positionSeconds*/) const
+    bool SoundGraphSound::OnVoiceStart(f64 positionSeconds) const
     {
-        // positionSeconds is ignored: the graph runtime has no seek, and it never stopped
-        // advancing while muted, so it is already at the right phase. See the class
-        // comment for why muting (rather than suspending) is the virtualization here.
-        m_VoiceGainScale.store(1.0f, std::memory_order_relaxed);
-        ApplyEffectiveGain();
+        // Thawing resumes the graph at the exact frame it was frozen on, which satisfies
+        // positionSeconds whenever positionSeconds is that frame — a fresh start (0.0), and
+        // any resume the budget's own clock has not yet run past. It cannot satisfy a LATER
+        // position: for a procedural graph, getting to frame N means computing frames
+        // 0..N, so honouring the extra would spend exactly the CPU the suspension saved,
+        // in one audio callback. (The graph runtime is roughly real-time in a Debug build —
+        // docs/design/soundgraph-metasounds.md — so even a bounded catch-up burst is an
+        // underrun, not an optimisation. That is why there is no seek here rather than
+        // that nobody wrote one.)
+        //
+        // The engine self-corrects rather than carrying the lie: OnVoiceQueryPosition is
+        // authoritative while a voice is audible, so VoiceManager::Update pulls its record
+        // back to the graph's real frame on the very next tick.
+        (void)positionSeconds;
+        SetVirtualized(false);
         return true;
     }
 
     f64 SoundGraphSound::OnVoiceStop() const
     {
-        m_VoiceGainScale.store(0.0f, std::memory_order_relaxed);
-        ApplyEffectiveGain();
-        // Negative: no transport to report a position from, so the budget keeps advancing
-        // its own logical clock for this voice.
-        return -1.0;
+        SetVirtualized(true);
+        // The graph is frozen now, so its frame counter IS where playback stopped — report
+        // it so the budget anchors the record on the truth instead of integrating onward
+        // from a stale value. Negative (no source, or no sample rate yet) falls back to the
+        // manager's own logical clock, which is the contract's documented escape hatch.
+        return OnVoiceQueryPosition();
     }
 
     f64 SoundGraphSound::OnVoiceQueryPosition() const
@@ -395,24 +424,24 @@ namespace OloEngine::Audio::SoundGraph
         // event: Acquire drives OnVoiceStart synchronously when this voice wins a slot, and
         // that is where the gain is un-muted. Starting a re-triggered sound also drops any
         // previous registration so the budget never holds two records for one graph.
-        ReleaseVoice(/*restoreGain=*/true);
+        ReleaseVoice(/*resumePlayback=*/true);
         const auto handle = OloEngine::Audio::VoiceManager::Get().Acquire(this, BuildVoiceParams());
         m_VoiceHandle.store(handle, std::memory_order_release);
         if (handle == OloEngine::Audio::kInvalidVoiceHandle)
         {
             // Only reachable if Acquire was handed a null host, which cannot happen here;
             // fall back to unmanaged playback rather than silence.
-            m_VoiceGainScale.store(1.0f, std::memory_order_relaxed);
-            ApplyEffectiveGain();
+            SetVirtualized(false);
         }
 
         // Forward the Play trigger into the runtime graph. Without this the play state
         // flips to Playing on the sound wrapper but the graph's "Play" event input is
         // never raised, so any node listening for that event (WavePlayer, envelopes,
         // trigger nodes) never fires — the audio callback runs but every node stays at
-        // its idle/silent default. Raised even when virtualized: the graph must keep
-        // advancing while muted, which is what makes a devirtualized loop come back in
-        // phase instead of restarting.
+        // its idle/silent default. Raised unconditionally, including when this voice lost
+        // the budget above: the request is a latched flag on the source, so a virtualized
+        // voice simply fires it on the first block after it is thawed, starting the graph
+        // when the player can actually hear it rather than burning DSP to run it silently.
         if (m_Source)
             m_Source->SendPlayEvent();
 
@@ -421,7 +450,7 @@ namespace OloEngine::Audio::SoundGraph
 
     bool SoundGraphSound::Stop()
     {
-        ReleaseVoice(/*restoreGain=*/false);
+        ReleaseVoice(/*resumePlayback=*/false);
 
         // Cancel any active fades
         m_IsFading = false;
@@ -783,7 +812,7 @@ namespace OloEngine::Audio::SoundGraph
                     // never do so. Scene::InitializeAudioSoundGraph hands the Sound to the
                     // scene and nothing calls Stop() on a graph that simply ended, so
                     // without this every finished one-shot graph holds a slot forever.
-                    ReleaseVoice(/*restoreGain=*/false);
+                    ReleaseVoice(/*resumePlayback=*/false);
                     if (m_OnPlaybackComplete)
                         m_OnPlaybackComplete();
                 }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -433,6 +433,14 @@ namespace OloEngine::Audio::SoundGraph
             // fall back to unmanaged playback rather than silence.
             SetVirtualized(false);
         }
+        else if (OloEngine::Audio::VoiceManager::Get().IsVirtual(handle))
+        {
+            // Acquire only emits transitions for state CHANGES, and every voice ENTERS
+            // virtual — so a voice that starts over budget and stays virtual is never
+            // handed to OnVoiceStop and nothing else would put it in the virtualized state.
+            // Without this the SendPlayEvent below starts it at full gain, over the cap.
+            SetVirtualized(true);
+        }
 
         // Forward the Play trigger into the runtime graph. Without this the play state
         // flips to Playing on the sound wrapper but the graph's "Play" event input is

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -441,6 +441,11 @@ namespace OloEngine::Audio::SoundGraph
             // Without this the SendPlayEvent below starts it at full gain, over the cap.
             SetVirtualized(true);
         }
+        else
+        {
+            // Audible: Acquire drove OnVoiceStart synchronously, which already thawed and
+            // un-muted this voice. Nothing left to do.
+        }
 
         // Forward the Play trigger into the runtime graph. Without this the play state
         // flips to Playing on the sound wrapper but the graph's "Play" event input is

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
@@ -87,14 +87,21 @@ namespace OloEngine
             /// clip path. Both paths MUST route through VoiceManager or the cap is
             /// enforced on only half the engine's sounds.
             ///
-            /// Limitation, deliberate: the SoundGraph runtime has no transport control
-            /// (SoundGraphSource exposes SendPlayEvent and nothing to seek or suspend
-            /// with), so virtualizing a graph voice mutes it rather than stopping it. That
-            /// still frees the audible slot and keeps the mix within budget — and it makes
-            /// resume-in-phase trivially correct, because the graph never stopped
-            /// advancing — but unlike the clip path it does NOT reclaim the DSP cost.
-            /// Reclaiming that needs a stop/seek API on SoundGraphSource first (issue
-            /// #745).
+            /// Virtualizing a graph voice mutes it AND freezes the graph runtime
+            /// (SoundGraphSource::SetVoiceSuspended, issue #745): while it is virtual the
+            /// graph is not stepped at all, so the DSP cost is genuinely reclaimed the way
+            /// ma_sound_stop reclaims it on the clip path. Thawing continues the same
+            /// sample stream — node state is not saved and restored, it is simply not
+            /// advanced — so it is a resume rather than #730's restart-instead-of-resume
+            /// bug.
+            ///
+            /// The one thing it cannot do, and this is inherent rather than missing API:
+            /// come back at the position the voice WOULD have reached had it kept running.
+            /// For a procedural graph, advancing to frame N is exactly the DSP work of
+            /// frames 0..N, so reclaiming the CPU and preserving that phase are the same
+            /// computation and you get one or the other. OnVoiceStart's positionSeconds is
+            /// therefore honoured only where it is reachable (a fresh start at 0); see the
+            /// comment there and docs/agent-rules/audio-voice-budget.md section 8.
             class SoundGraphSound : public IPlayableAudio, public OloEngine::Audio::IVoiceHost
             {
               public:
@@ -250,13 +257,19 @@ namespace OloEngine
                 OloEngine::Audio::VoiceParams BuildVoiceParams() const;
                 /// Hand the slot back and forget the handle. Idempotent.
                 ///
-                /// `restoreGain` decides whether the budget's mute is lifted on the way
-                /// out. Pass true when the voice is about to play again (Play) or the
-                /// object is going away (teardown); pass FALSE when retiring a voice that
-                /// is meant to fall silent (Stop, natural completion) — the graph runtime
-                /// has no transport, so un-muting a still-running virtualized graph would
-                /// make a stopped sound audible again.
-                void ReleaseVoice(bool restoreGain) const;
+                /// `resumePlayback` decides which state the live source is left in, because
+                /// the budget is no longer tracking this voice and nothing else would ever
+                /// lift its virtualization. Pass TRUE when the voice is about to play again
+                /// (Play) or the object is going away (teardown). Pass FALSE when retiring a
+                /// voice that is meant to fall silent (Stop, natural completion): the source
+                /// stays muted and frozen, which is both silent and free — before #745 the
+                /// graph had no transport, so this could only leave it muted-but-running.
+                void ReleaseVoice(bool resumePlayback) const;
+
+                /// Enter or leave the virtualized state on the live source: the budget's
+                /// gain mute plus the graph-runtime freeze that actually reclaims the DSP
+                /// cost. Order matters in both directions — see the definition.
+                void SetVirtualized(bool virtualized) const;
                 /// Push refreshed scoring inputs at the budget.
                 void SyncVoiceParams() const;
                 /// Apply m_Volume scaled by the budget's mute state to the live graph.

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -434,6 +434,15 @@ namespace OloEngine::Audio::SoundGraph
         }
     }
 
+    void SoundGraphSource::SetVoiceSuspended(bool suspended)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Plain store, no ack handshake — see the header. The audio thread reads this at
+        // the top of ProcessSamples and skips the whole graph step while it is set.
+        m_VoiceSuspended.store(suspended, std::memory_order_release);
+    }
+
     bool SoundGraphSource::IsFinished() const noexcept
     {
         return m_IsFinished.load(std::memory_order_relaxed) && !m_IsPlaying.load(std::memory_order_relaxed);
@@ -918,6 +927,36 @@ namespace OloEngine::Audio::SoundGraph
 
         if (!m_Graph || IsSuspended())
         {
+            SilenceOutputBuffers(ppFramesOut, frameCount);
+            return;
+        }
+
+        // Voice-budget freeze (issue #745). Everything below this point — the preset apply,
+        // the wave-player refills, SoundGraph::Process, the outgoing-event pump and the
+        // frame-counter advance — is the DSP cost that virtualizing a voice is supposed to
+        // reclaim, so the whole of it is skipped rather than being run into a muted output.
+        // The graph object itself is left completely untouched, which is what makes the
+        // thaw a continuation of the same sample stream instead of a restart.
+        if (m_VoiceSuspended.load(std::memory_order_acquire))
+        {
+            // Keep applying queued parameter writes: they are O(1) endpoint-cell writes,
+            // not DSP, and dropping them would silently lose a preset applied while the
+            // voice was virtual. Gated on the preset having been applied at least once so
+            // a queued write can't be clobbered by a first-block preset apply after thaw.
+            if (m_PresetIsInitialized)
+                UpdateChangedParameters();
+
+            // External triggers are scheduled at a sample offset within a SPECIFIC block,
+            // and this block is not happening. Firing them into a graph that will not be
+            // stepped would leave nodes latched mid-attack for the whole suspension, so
+            // discard them instead — and discarding also stops a long suspension from
+            // filling the ring and back-pressuring the main thread's SendInputEvent.
+            // Popped one by one rather than Clear()ed: this is the consumer side of an
+            // SPSC ring with a live producer, and Clear() rewinds the WRITE index too.
+            InputEventEntry discarded;
+            while (m_InputEventQueue.Pop(discarded))
+                ;
+
             SilenceOutputBuffers(ppFramesOut, frameCount);
             return;
         }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.cpp
@@ -436,11 +436,11 @@ namespace OloEngine::Audio::SoundGraph
 
     void SoundGraphSource::SetVoiceSuspended(bool suspended)
     {
-        OLO_PROFILE_FUNCTION();
-
-        // Plain store, no ack handshake — see the header. The audio thread reads this at
-        // the top of ProcessSamples and skips the whole graph step while it is set.
-        m_VoiceSuspended.store(suspended, std::memory_order_release);
+        // No profile zone: this is a single atomic store, so the zone would cost more than
+        // the work. Plain store, no ack handshake and default ordering — see the header.
+        // The audio thread reads this at the top of ProcessSamples and skips the whole
+        // graph step while it is set.
+        m_VoiceSuspended.store(suspended);
     }
 
     bool SoundGraphSource::IsFinished() const noexcept
@@ -937,7 +937,7 @@ namespace OloEngine::Audio::SoundGraph
         // reclaim, so the whole of it is skipped rather than being run into a muted output.
         // The graph object itself is left completely untouched, which is what makes the
         // thaw a continuation of the same sample stream instead of a restart.
-        if (m_VoiceSuspended.load(std::memory_order_acquire))
+        if (m_VoiceSuspended.load())
         {
             // Keep applying queued parameter writes: they are O(1) endpoint-cell writes,
             // not DSP, and dropping them would silently lose a preset applied while the
@@ -955,7 +955,8 @@ namespace OloEngine::Audio::SoundGraph
             // SPSC ring with a live producer, and Clear() rewinds the WRITE index too.
             InputEventEntry discarded;
             while (m_InputEventQueue.Pop(discarded))
-                ;
+            {
+            }
 
             SilenceOutputBuffers(ppFramesOut, frameCount);
             return;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
@@ -122,11 +122,19 @@ namespace OloEngine::Audio::SoundGraph
             Unlike SuspendProcessing there is no suspend/ack handshake: nothing is being
             torn down here, so a one-block overlap in either direction is inaudible (the
             owner mutes before freezing and thaws before un-muting, which covers the click).
-            Callable from any thread. */
+            Callable from any thread.
+
+            Default (sequentially consistent) ordering, unlike the acquire/release on
+            m_Suspended next to it, and the difference is deliberate: m_Suspended publishes
+            the m_Graph swap, so it needs a release/acquire pair to make that write visible.
+            This flag publishes nothing - it is a lone boolean gate with no data hanging off
+            it - so there is nothing for a weaker order to buy. On x86-64 a seq_cst load is
+            the same plain mov as an acquire load, and the store happens on a virtualize /
+            devirtualize transition rather than per block. */
         void SetVoiceSuspended(bool suspended);
         bool IsVoiceSuspended() const
         {
-            return m_VoiceSuspended.load(std::memory_order_relaxed);
+            return m_VoiceSuspended.load();
         }
 
         bool IsFinished() const noexcept;

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSource.h
@@ -91,6 +91,44 @@ namespace OloEngine::Audio::SoundGraph
         {
             return m_Suspended.load(std::memory_order_relaxed);
         }
+
+        /** Voice-budget suspension (issue #745) - freeze the graph runtime.
+
+            A SECOND, INDEPENDENT suspension axis from SuspendProcessing above, and the two
+            must not be conflated. That one is the graph-swap handshake: the main thread
+            raises a flag, waits for the audio thread to acknowledge it, swaps m_Graph, and
+            resumes - and its resume deliberately RESETS the playback counters, because a
+            freshly installed graph starts from zero. This one is the concurrent-voice
+            budget virtualizing a voice, and it resets nothing.
+
+            While it is set, ProcessSamples emits silence and does not step the graph at
+            all: no BeginProcessBlock, no SoundGraph::Process, no outgoing-event pump, no
+            frame-counter advance. That whole skipped block IS the DSP cost virtualization
+            is supposed to reclaim, and which muting the graph's Volume input did not.
+
+            Resuming is exact rather than approximate. Node state - envelope phases, filter
+            histories, WavePlayer read cursors - is neither saved nor restored; it is simply
+            not advanced, so the sample stream continues from the frame it stopped on
+            instead of restarting from the graph's initial state (issue #730's acceptance
+            criterion 2). No per-node save/restore is needed, because nothing is torn down.
+
+            What a resume canNOT do is jump forward to the position the voice would have
+            reached had it never been suspended. For a procedural graph, advancing to frame
+            N *is* the DSP work of frames 0..N - "reclaim the CPU" and "come back in the
+            phase it would have been in" are the same computation, so you get one or the
+            other and never both. The clip path escapes that only because a decoded PCM
+            stream has an O(1) seek. See docs/agent-rules/audio-voice-budget.md section 8.
+
+            Unlike SuspendProcessing there is no suspend/ack handshake: nothing is being
+            torn down here, so a one-block overlap in either direction is inaudible (the
+            owner mutes before freezing and thaws before un-muting, which covers the click).
+            Callable from any thread. */
+        void SetVoiceSuspended(bool suspended);
+        bool IsVoiceSuspended() const
+        {
+            return m_VoiceSuspended.load(std::memory_order_relaxed);
+        }
+
         bool IsFinished() const noexcept;
         bool IsPlaying() const;
 
@@ -328,6 +366,10 @@ namespace OloEngine::Audio::SoundGraph
 
         std::atomic<bool> m_Suspended{ false };
         AtomicFlag m_SuspendFlag;
+        // Voice-budget freeze (issue #745). Deliberately separate from m_Suspended: that
+        // one is the graph-swap handshake whose resume resets the playback counters, which
+        // is exactly what a virtualized voice must NOT do. See SetVoiceSuspended.
+        std::atomic<bool> m_VoiceSuspended{ false };
         u32 m_SampleRate = 0;
         u32 m_BlockSize = 0;
         u32 m_ChannelCount = 2;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(OloEngine-Tests
 		SoundGraphInstantiationTest.cpp
 		SoundGraphTypedConnectionTest.cpp
 		SoundGraphSampleAccurateTriggerTest.cpp
+		SoundGraphVoiceSuspendTest.cpp
 		SoundGraphParameterWiringTest.cpp
 		SoundGraphControlRoutingTest.cpp
 		SoundGraphCacheTest.cpp

--- a/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
+++ b/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
@@ -1,0 +1,326 @@
+// OLO_TEST_LAYER: unit
+//
+// =============================================================================
+// SoundGraphVoiceSuspendTest — voice-budget suspension of a SoundGraph voice
+// (issue #745, follow-up to the concurrent-voice budget in #730)
+//
+// Before #745 a virtualized graph voice was only MUTED: the graph kept being
+// stepped every block, so the budget bounded what you heard but not what the CPU
+// did. `SoundGraphSource::SetVoiceSuspended` freezes the runtime instead — while
+// it is set, ProcessSamples emits silence and does not step the graph at all.
+//
+// Every assertion below is written against the suspend behaviour and FAILS on
+// the old muting behaviour, which is the point issue #745 makes explicitly: a
+// phase test alone passes trivially on a graph that never stopped running, so it
+// proves nothing on its own. The two halves are asserted together:
+//
+//   * CPU IS RECLAIMED — a counting node's Process() call count does not advance
+//     across a suspension, and the graph's own frame counter is frozen with it.
+//     (On the muting behaviour the count keeps climbing.)
+//   * RESUME IS A CONTINUATION, NOT A RESTART — a suspended-and-resumed source
+//     emits exactly the sample stream a continuously-running twin emits at the
+//     same *processed-block* ordinal, and specifically NOT the graph's opening
+//     block. That is #730 acceptance criterion 2, which the tempting
+//     "stop the graph and re-raise SendPlayEvent" fix would break.
+//
+// What is deliberately NOT asserted, because it is unreachable rather than
+// unimplemented: that a resumed voice lands at the position it would have
+// reached had it kept running. For a procedural graph, advancing to frame N is
+// exactly the DSP work of frames 0..N, so reclaiming the CPU and preserving that
+// phase are the same computation. See docs/agent-rules/audio-voice-budget.md §8.
+//
+// All of it runs headless: no ma_engine, no audio device, no mounted asset.
+// SoundGraphSource::ProcessSamples is driven directly (the pattern
+// SoundGraphSampleAccurateTriggerTest established), and SoundGraphSound is built
+// through InitializeDetachedSource, which allocates a source without attaching it
+// to miniaudio.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Asset/SoundGraphAsset.h"
+#include "OloEngine/Audio/SoundGraph/GraphGeneration.h"
+#include "OloEngine/Audio/SoundGraph/NodeProcessor.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraph.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphFactory.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphPrototype.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSound.h"
+#include "OloEngine/Audio/SoundGraph/SoundGraphSource.h"
+#include "OloEngine/Audio/VoiceManager.h"
+#include "OloEngine/Core/Log.h"
+#include "OloEngine/Core/Ref.h"
+#include "OloEngine/Core/UUID.h"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+using namespace OloEngine; // NOLINT(google-build-using-namespace)
+namespace sg = OloEngine::Audio::SoundGraph;
+
+namespace
+{
+    constexpr u32 kBlock = 480;  // 10 ms at 48 kHz, a typical miniaudio block
+    constexpr u32 kChannels = 2; // SoundGraphSource's default output channel count
+
+    void AddConn(SoundGraphAsset& asset, UUID srcID, const std::string& srcEndpoint,
+                 UUID dstID, const std::string& dstEndpoint, bool isEvent)
+    {
+        SoundGraphConnection c;
+        c.m_SourceNodeID = srcID;
+        c.m_SourceEndpoint = srcEndpoint;
+        c.m_TargetNodeID = dstID;
+        c.m_TargetEndpoint = dstEndpoint;
+        c.m_IsEvent = isEvent;
+        asset.AddConnection(c);
+    }
+
+    /// A 440 Hz sine wired straight to the graph's stereo output. An oscillator is
+    /// the right probe here because its output is phase-bearing: a restart is
+    /// visible as a return to the opening block, which a constant or a noise
+    /// source could not distinguish.
+    Ref<sg::SoundGraph> MakeSineGraph()
+    {
+        SoundGraphAsset asset;
+        asset.SetName("SuspendProbeSine");
+
+        SoundGraphNodeData sine;
+        sine.m_ID = UUID();
+        sine.m_Type = "SineOscillator";
+        sine.m_Name = "Sine";
+        sine.m_Properties["Frequency"] = "440";
+        sine.m_Properties["Amplitude"] = "1.0";
+        asset.AddNode(sine);
+
+        AddConn(asset, sine.m_ID, "OutValue", UUID(0), "OutLeft", /*isEvent=*/false);
+        AddConn(asset, sine.m_ID, "OutValue", UUID(0), "OutRight", /*isEvent=*/false);
+
+        Ref<sg::Prototype> prototype = sg::CompileAssetToPrototype(asset);
+        EXPECT_NE(prototype, nullptr) << "MakeSineGraph: asset failed to compile";
+        Ref<sg::SoundGraph> instance = sg::CreateInstance(prototype);
+        EXPECT_NE(instance, nullptr) << "MakeSineGraph: prototype failed to instantiate";
+        return instance;
+    }
+
+    /// Counts Process() calls. This is the DSP-cost probe: "did the graph run?"
+    /// is exactly the question #745 is about, and a call count answers it without
+    /// depending on a wall-clock measurement that would flake under CI load.
+    struct CountingNode final : public sg::NodeProcessor
+    {
+        explicit CountingNode(UUID id) : NodeProcessor("CountingNode", id) {}
+
+        u32 m_ProcessCalls = 0;
+        u64 m_FramesProcessed = 0;
+
+        void Process(u32 numFrames) final
+        {
+            ++m_ProcessCalls;
+            m_FramesProcessed += numFrames;
+        }
+    };
+
+    /// Pull `blockCount` blocks through the source and return the interleaved
+    /// samples of every block concatenated, so callers can compare streams.
+    std::vector<f32> PumpBlocks(sg::SoundGraphSource& source, u32 blockCount)
+    {
+        std::vector<f32> captured;
+        captured.reserve(static_cast<sizet>(blockCount) * kBlock * kChannels);
+
+        std::vector<f32> bus(static_cast<sizet>(kBlock) * kChannels, 0.0f);
+        for (u32 block = 0; block < blockCount; ++block)
+        {
+            std::ranges::fill(bus, 0.0f);
+            f32* busPtr = bus.data();
+            source.ProcessSamples(&busPtr, kBlock);
+            captured.insert(captured.end(), bus.begin(), bus.end());
+        }
+        return captured;
+    }
+
+    f32 PeakAbs(const std::vector<f32>& samples)
+    {
+        f32 peak = 0.0f;
+        for (const f32 sample : samples)
+            peak = std::max(peak, std::abs(sample));
+        return peak;
+    }
+} // namespace
+
+class SoundGraphVoiceSuspendTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        Log::Initialize();
+        // VoiceManager::Get() is process-wide, so leave it exactly as found — a leaked
+        // voice or an altered cap would surface as an unrelated failure much later in
+        // the run, in whichever audio test happens to go next.
+        m_SavedMaxVoices = OloEngine::Audio::VoiceManager::Get().GetMaxVoices();
+        OloEngine::Audio::VoiceManager::Get().Reset();
+    }
+
+    void TearDown() override
+    {
+        OloEngine::Audio::VoiceManager::Get().Reset();
+        OloEngine::Audio::VoiceManager::Get().SetMaxVoices(m_SavedMaxVoices);
+    }
+
+  private:
+    u32 m_SavedMaxVoices = 0;
+};
+
+// ===========================================================================
+// SoundGraphSource — the transport itself
+// ===========================================================================
+
+TEST_F(SoundGraphVoiceSuspendTest, SuspendedSourceDoesNotStepTheGraph)
+{
+    auto counting = CreateScope<CountingNode>(UUID());
+    auto* countingPtr = counting.get();
+
+    auto graph = Ref<sg::SoundGraph>::Create("CountingGraph", UUID());
+    graph->AddNode(std::move(counting));
+    graph->SetSampleRate(48000.0f);
+    graph->Init();
+
+    sg::SoundGraphSource source;
+    ASSERT_TRUE(source.ReplaceGraph(graph));
+    EXPECT_FALSE(source.IsVoiceSuspended()) << "a fresh source must start running";
+
+    PumpBlocks(source, 3);
+    const u32 callsBeforeSuspend = countingPtr->m_ProcessCalls;
+    ASSERT_EQ(callsBeforeSuspend, 3u) << "the graph must be stepped once per block while running";
+
+    // The whole of issue #745 in one assertion: blocks pulled through a suspended
+    // source cost nothing. On the pre-#745 muting behaviour this count would be 6.
+    source.SetVoiceSuspended(true);
+    EXPECT_TRUE(source.IsVoiceSuspended());
+    PumpBlocks(source, 3);
+    EXPECT_EQ(countingPtr->m_ProcessCalls, callsBeforeSuspend)
+        << "a suspended voice must not step the graph — that is the DSP cost being reclaimed";
+
+    source.SetVoiceSuspended(false);
+    PumpBlocks(source, 2);
+    EXPECT_EQ(countingPtr->m_ProcessCalls, callsBeforeSuspend + 2u)
+        << "a thawed voice must be stepped again";
+}
+
+TEST_F(SoundGraphVoiceSuspendTest, SuspendedSourceEmitsSilenceAndHoldsItsFrameCounter)
+{
+    sg::SoundGraphSource source;
+    ASSERT_TRUE(source.ReplaceGraph(MakeSineGraph()));
+
+    const std::vector<f32> audible = PumpBlocks(source, 2);
+    ASSERT_GT(PeakAbs(audible), 0.5f) << "the probe graph must produce signal while running";
+    const u64 frameAtSuspend = source.GetCurrentFrame();
+    ASSERT_EQ(frameAtSuspend, static_cast<u64>(kBlock) * 2u);
+
+    source.SetVoiceSuspended(true);
+    const std::vector<f32> suspended = PumpBlocks(source, 4);
+    EXPECT_FLOAT_EQ(PeakAbs(suspended), 0.0f) << "a suspended voice must emit silence, not a stale block";
+
+    // The frame counter is what OnVoiceQueryPosition reports, so freezing it is what
+    // keeps the budget's record anchored to where the graph really is rather than to
+    // a position it never computed.
+    EXPECT_EQ(source.GetCurrentFrame(), frameAtSuspend)
+        << "a frozen graph advanced no frames, and must not claim to have";
+}
+
+TEST_F(SoundGraphVoiceSuspendTest, ResumedSourceContinuesTheSampleStreamInsteadOfRestarting)
+{
+    // Two identical graphs. `continuous` runs six blocks straight through;
+    // `suspended` runs three, sleeps through four, then runs three more. If the
+    // suspension is a freeze, the second source's blocks 4-6 are bit-identical to
+    // the first source's blocks 4-6 — same node state, same sample stream, merely
+    // delayed in wall time.
+    sg::SoundGraphSource continuous;
+    ASSERT_TRUE(continuous.ReplaceGraph(MakeSineGraph()));
+    sg::SoundGraphSource suspended;
+    ASSERT_TRUE(suspended.ReplaceGraph(MakeSineGraph()));
+
+    const std::vector<f32> continuousHead = PumpBlocks(continuous, 3);
+    const std::vector<f32> continuousTail = PumpBlocks(continuous, 3);
+
+    const std::vector<f32> suspendedHead = PumpBlocks(suspended, 3);
+    ASSERT_EQ(suspendedHead, continuousHead) << "the two probe graphs must start identically";
+
+    suspended.SetVoiceSuspended(true);
+    PumpBlocks(suspended, 4);
+    suspended.SetVoiceSuspended(false);
+    const std::vector<f32> suspendedTail = PumpBlocks(suspended, 3);
+
+    ASSERT_EQ(suspendedTail.size(), continuousTail.size());
+    for (sizet i = 0; i < suspendedTail.size(); ++i)
+    {
+        ASSERT_FLOAT_EQ(suspendedTail[i], continuousTail[i])
+            << "sample " << i << ": a resumed voice must continue the stream it was frozen on";
+    }
+
+    // ...and specifically it must NOT be the graph's opening block, which is what
+    // "stop the graph and re-raise SendPlayEvent" would have produced — the
+    // restart-instead-of-resume bug virtualization exists to prevent (#730 AC2).
+    // 440 Hz at 48 kHz does not complete a whole number of cycles in 480 frames, so
+    // block 4 and block 1 are genuinely different signal.
+    const std::vector<f32> openingBlock(continuousHead.begin(),
+                                        continuousHead.begin() + static_cast<sizet>(kBlock) * kChannels);
+    const std::vector<f32> resumedBlock(suspendedTail.begin(),
+                                        suspendedTail.begin() + static_cast<sizet>(kBlock) * kChannels);
+    EXPECT_NE(resumedBlock, openingBlock) << "a resume must not replay the graph's initial state";
+}
+
+// ===========================================================================
+// SoundGraphSound — the IVoiceHost seam the budget actually drives
+// ===========================================================================
+
+namespace
+{
+    /// A device-free SoundGraphSound wrapping the sine probe. InitializeDetachedSource
+    /// allocates the source without attaching it to ma_engine, so the graph can be
+    /// stepped by hand from the test thread.
+    Scope<sg::SoundGraphSound> MakeDetachedSound()
+    {
+        auto sound = CreateScope<sg::SoundGraphSound>();
+        EXPECT_TRUE(sound->InitializeDetachedSource());
+        EXPECT_TRUE(sound->InitializeFromGraph(MakeSineGraph()));
+        return sound;
+    }
+} // namespace
+
+TEST_F(SoundGraphVoiceSuspendTest, VirtualizingAGraphVoiceSuspendsItsSourceAndDevirtualizingResumesIt)
+{
+    auto& manager = OloEngine::Audio::VoiceManager::Get();
+    manager.SetMaxVoices(1);
+
+    auto loud = MakeDetachedSound();
+    auto quiet = MakeDetachedSound();
+    // Priority is miniaudio-flavoured here (0 = highest), and BuildVoiceParams inverts it.
+    // 200 rather than 255 deliberately: 255 normalises to a score of exactly 0, and a
+    // zero-scoring voice is a separate policy case from "loses on merit".
+    loud->SetPriority(0);
+    quiet->SetPriority(200);
+
+    ASSERT_TRUE(quiet->Play());
+    ASSERT_TRUE(quiet->GetSource() != nullptr);
+    EXPECT_FALSE(quiet->GetSource()->IsVoiceSuspended())
+        << "the only voice in a one-slot budget must be running";
+
+    // The higher-priority voice takes the slot; the loser is virtualized, and after
+    // #745 that means its graph is actually frozen rather than merely muted.
+    ASSERT_TRUE(loud->Play());
+    ASSERT_TRUE(quiet->IsVirtualized());
+    EXPECT_TRUE(quiet->GetSource()->IsVoiceSuspended())
+        << "a virtualized graph voice must be suspended, not just muted (issue #745)";
+    EXPECT_FALSE(loud->GetSource()->IsVoiceSuspended()) << "the winning voice must be running";
+
+    // Give the slot back and the loser must thaw.
+    ASSERT_TRUE(loud->Stop());
+    manager.Update(0.016f);
+    ASSERT_FALSE(quiet->IsVirtualized());
+    EXPECT_FALSE(quiet->GetSource()->IsVoiceSuspended())
+        << "a devirtualized graph voice must be thawed again";
+    // A stopped voice stays frozen: it is silent, and now it is free as well.
+    EXPECT_TRUE(loud->GetSource()->IsVoiceSuspended())
+        << "a stopped graph voice must not keep paying DSP cost";
+}

--- a/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
+++ b/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
@@ -324,3 +324,58 @@ TEST_F(SoundGraphVoiceSuspendTest, VirtualizingAGraphVoiceSuspendsItsSourceAndDe
     EXPECT_TRUE(loud->GetSource()->IsVoiceSuspended())
         << "a stopped graph voice must not keep paying DSP cost";
 }
+
+TEST_F(SoundGraphVoiceSuspendTest, AGraphVoiceThatNeverWinsASlotStartsSuspended)
+{
+    // Acquire only emits transitions for state CHANGES and every voice ENTERS virtual,
+    // so a voice that starts over budget is never handed to OnVoiceStop. Before #745
+    // nothing else applied the virtualized state on that path and the voice played at
+    // full gain, over the cap.
+    auto& manager = OloEngine::Audio::VoiceManager::Get();
+    manager.SetMaxVoices(1);
+
+    auto incumbent = MakeDetachedSound();
+    incumbent->SetPriority(0);
+    ASSERT_TRUE(incumbent->Play());
+
+    auto latecomer = MakeDetachedSound();
+    latecomer->SetPriority(200);
+    ASSERT_TRUE(latecomer->Play());
+
+    ASSERT_TRUE(latecomer->IsVirtualized());
+    EXPECT_TRUE(latecomer->GetSource()->IsVoiceSuspended())
+        << "a voice that loses the budget at Play() time must not run at all";
+}
+
+TEST_F(SoundGraphVoiceSuspendTest, AVoiceSuspendedByTheBudgetProducesNoSamples)
+{
+    // The seam test above checks the flag; this one checks the flag is load-bearing,
+    // by pumping real blocks through the virtualized voice's source and asserting the
+    // graph never ran. That is the assertion the pre-#745 mute could not pass.
+    auto& manager = OloEngine::Audio::VoiceManager::Get();
+    manager.SetMaxVoices(1);
+
+    auto incumbent = MakeDetachedSound();
+    incumbent->SetPriority(0);
+    ASSERT_TRUE(incumbent->Play());
+
+    auto stolen = MakeDetachedSound();
+    stolen->SetPriority(200);
+    ASSERT_TRUE(stolen->Play());
+    ASSERT_TRUE(stolen->IsVirtualized());
+
+    const std::vector<f32> whileVirtual = PumpBlocks(*stolen->GetSource(), 4);
+    EXPECT_FLOAT_EQ(PeakAbs(whileVirtual), 0.0f);
+    EXPECT_EQ(stolen->GetSource()->GetCurrentFrame(), 0u)
+        << "a virtualized graph voice must not have advanced a single frame";
+
+    // And once it wins the slot back it produces signal from frame 0 — its latched
+    // Play request fires on the first block after the thaw.
+    ASSERT_TRUE(incumbent->Stop());
+    manager.Update(0.016f);
+    ASSERT_FALSE(stolen->IsVirtualized());
+
+    const std::vector<f32> afterThaw = PumpBlocks(*stolen->GetSource(), 2);
+    EXPECT_GT(PeakAbs(afterThaw), 0.5f) << "a thawed voice must produce audio again";
+    EXPECT_EQ(stolen->GetSource()->GetCurrentFrame(), static_cast<u64>(kBlock) * 2u);
+}

--- a/docs/agent-rules/audio-voice-budget.md
+++ b/docs/agent-rules/audio-voice-budget.md
@@ -209,8 +209,14 @@ graph voice's logical position — `DurationSeconds == 0` means no auto-retire a
 wrap (§7) — so `OnVoiceStart`'s `positionSeconds` is honoured exactly where it is reachable
 (a fresh start at 0) and self-corrects everywhere else.
 
-**One consequence worth not re-deriving:**
+**Two consequences worth not re-deriving:**
 
+- **A voice that enters the budget over cap is never handed to `OnVoiceStop`.** `Acquire`
+  emits transitions only for state *changes*, and every voice *enters* virtual — so nothing
+  drives the host into the virtualized state on that path. `SoundGraphSound::Play` therefore
+  checks `IsVirtual(handle)` itself and applies it. Before that check a graph voice which
+  lost the budget at `Play()` time ran at full gain, over the cap; the clip path never had
+  the bug because it starts the backend *only* from `OnVoiceStart`.
 - **A stopped or completed graph voice stays frozen.** `ReleaseVoice(resumePlayback=false)`
   leaves it muted *and* suspended, so a one-shot graph that simply ended costs nothing until
   something plays it again. Before #745 that path could only leave it muted-but-running.

--- a/docs/agent-rules/audio-voice-budget.md
+++ b/docs/agent-rules/audio-voice-budget.md
@@ -156,22 +156,64 @@ voice): such a voice is **never** auto-retired and its owner must `Release` it �
 `AudioSource` / `SoundGraphSound` happens in `Stop()` *and* in the destructor, because the
 manager holds a raw `IVoiceHost*` and must never drive a torn-down host.
 
-## 8. The two backends virtualize differently, and one of them can't do it properly
+## 8. The two backends virtualize differently, and the difference is not a gap in the API
 
 | | clip path (`AudioSource`) | graph path (`SoundGraphSound`) |
 |---|---|---|
-| virtualize | `ma_sound_stop` — frees mixer *and* DSP cost | mute the graph's `Volume` input |
-| devirtualize | `ma_sound_seek_to_pcm_frame(position)` + start | un-mute |
-| resume phase | exact (sample cursor) | exact for free (the graph never stopped) |
-| reclaims CPU | yes | **no** |
+| virtualize | `ma_sound_stop` — frees mixer *and* DSP cost | mute `Volume` **and** `SetVoiceSuspended(true)` — freezes the runtime |
+| devirtualize | `ma_sound_seek_to_pcm_frame(position)` + start | thaw, then un-mute |
+| resume phase | the position it *would* have reached | the frame it was frozen on |
+| reclaims CPU | yes | **yes** (since #745) |
 
-`SoundGraphSource` exposes `SendPlayEvent()` and nothing to seek or suspend with, so a
-virtualized graph voice is silenced rather than suspended. That still holds the audible cap
-— which is the acceptance criterion — but it does not reclaim the DSP cost. Fixing that
-needs a stop/seek API on `SoundGraphSource` first (tracked as **#745**, which also raises
-the harder question of whether the graph's stateful nodes can be resumed deterministically
-at all); don't "fix" it by stopping the graph, which would restart it from its initial
-state on devirtualization and reintroduce §3's bug.
+**Suspending is a freeze, not a stop.** `SoundGraphSource::SetVoiceSuspended(true)` makes
+`ProcessSamples` emit silence and skip the whole graph step — no `BeginProcessBlock`, no
+`SoundGraph::Process`, no outgoing-event pump, no frame-counter advance. That skipped block
+*is* the DSP cost, so it is genuinely reclaimed rather than merely inaudible.
+
+**It needs no per-node save/restore, and #745's feared blocker does not apply.** The worry
+that stateful nodes (envelope phases, IIR filter histories, `WavePlayer` read cursors) would
+need their own snapshot machinery is a worry about *stopping and restarting*. A freeze saves
+and restores nothing because it destroys nothing: the graph object is untouched for the
+whole suspension and the next block continues the identical sample stream. The audit that
+backs this: every node's state is advanced only by its own `Process(numFrames)`, and nothing
+in the graph runtime is driven by wall-clock time — the only two `std::chrono` reads under
+`Nodes/` are noise-seed initialisation (`ArrayNodes.h`, `GeneratorNodes.h`), read once at
+`Init()` and never during playback. So "not stepped" and "stopped for a while" are
+indistinguishable from inside the graph.
+
+**Do NOT "fix" it by stopping the graph and re-raising `SendPlayEvent()`.** That restarts
+every node from its initial state on devirtualization, which is §3's
+restart-instead-of-resume bug and #730's acceptance criterion 2. It is also the reason the
+freeze is a *separate* flag from `SoundGraphSource::SuspendProcessing`: that one is the
+graph-swap handshake, and **its resume deliberately zeroes the playback counters**. Reusing
+it for the voice budget would silently turn a resume into a restart.
+
+**What a graph voice still cannot do — and this is inherent, not missing API.** It cannot
+come back at the position it *would* have reached had it never been suspended (§3's rule 3;
+the clip path's `ma_sound_seek_to_pcm_frame`). For a procedural graph, advancing to frame N
+*is* the DSP work of frames 0..N — "reclaim the CPU" and "preserve that phase" are the same
+computation, so you get one or the other and never both. The clip path escapes it only
+because a decoded PCM stream has an O(1) seek: its position is an index, not a result.
+
+A bounded catch-up burst on resume is not a way out either. The graph runtime is roughly
+real-time in a Debug build (`docs/design/soundgraph-metasounds.md` gates on
+`effectiveRateHz` staying within 10% of the sample rate), so fast-forwarding even 85 ms of
+silence inside one audio callback costs ~85 ms of CPU in a callback with a ~10 ms budget.
+An underrun, not an optimisation. Amortising it over later blocks re-pays the entire saving
+and leaves the voice audible-but-out-of-phase while it catches up.
+
+The engine does not carry the resulting inconsistency: `OnVoiceQueryPosition` is
+authoritative while a voice is audible (§3), so `VoiceManager::Update` pulls the record back
+to the graph's real frame on the first tick after devirtualization. Nothing else reads a
+graph voice's logical position — `DurationSeconds == 0` means no auto-retire and no loop
+wrap (§7) — so `OnVoiceStart`'s `positionSeconds` is honoured exactly where it is reachable
+(a fresh start at 0) and self-corrects everywhere else.
+
+**One consequence worth not re-deriving:**
+
+- **A stopped or completed graph voice stays frozen.** `ReleaseVoice(resumePlayback=false)`
+  leaves it muted *and* suspended, so a one-shot graph that simply ended costs nothing until
+  something plays it again. Before #745 that path could only leave it muted-but-running.
 
 Watch the polarity trap while you are in there: `SoundGraphSound::m_Priority` is
 miniaudio-flavoured (**0 = highest**) while `VoiceParams::Priority` is the other way round


### PR DESCRIPTION
Closes #745.

**Outcome: implemented, not won't-fix.** The issue offered two legitimate exits and asked
for the resumability audit first. The audit says the graph *can* be suspended and resumed
deterministically — and needs no per-node save/restore at all, because the blocker the issue
feared is a blocker for *stopping and restarting* the graph, not for *freezing* it.

---

## Part 1 — the resumability audit

Every `NodeProcessor` subclass under `Audio/SoundGraph/Nodes/` (27 types across
`ArrayNodes.h`, `EnvelopeNodes.h`, `GeneratorNodes.h`, `MathNodes.h`, `MusicNodes.h`,
`TriggerNodes.h`, `WavePlayer.h`), plus `SoundGraph` and `SoundGraphSource`'s own playback
state, was checked for anything whose value depends on *when* it is processed rather than on
*how many frames* it has processed.

| state | where | advanced by |
|---|---|---|
| envelope stage + level | `ADEnvelope`, `ADSREnvelope` | own `Process(numFrames)` |
| oscillator phase (`m_PhaseAccumulator`) | Sine / Saw / Square / Triangle | own `Process(numFrames)` |
| delay/repeat counters (`m_FrameTime = 1/sampleRate`) | `DelayedTrigger`, `RepeatTrigger` | own `Process(numFrames)` |
| trigger counters | `TriggerCounter` | incoming events |
| wave read cursor + ring buffer | `WavePlayer` / `WaveSource` | `BeginProcessBlock` refill + `Process` |
| RNG stream | `Random`, `GetRandom`, `Noise` | own `Process` / trigger |
| graph frame index | `SoundGraph::ProcessChunk` | `+= numFrames` |
| source frame counter | `SoundGraphSource::ProcessSamples` | `fetch_add(frameCount)` |

**Nothing in the runtime path reads a clock.** The only two `std::chrono` reads anywhere
under `Nodes/` are noise-seed initialisation (`ArrayNodes.h:32`, `GeneratorNodes.h:315`),
consulted once when a seed is 0 and never during playback.

So a graph that is not stepped is a graph that has not moved. There is nothing to save and
nothing to restore: freezing needs zero state machinery, and the resume is a bit-exact
continuation of the same sample stream. "Not stepped for 4 blocks" and "stepped 4 blocks
later" are indistinguishable from inside the graph.

The issue's worry — that stateful nodes would need their own save/restore — is real, but
about the *other* implementation: stop the graph and re-raise `SendPlayEvent()`. That
destroys state and restarts from the initial state, which is exactly #730 acceptance
criterion 2's bug. That is the design this PR avoids, not the one it implements.

### The one thing that genuinely cannot be done

Resuming at the position the voice *would* have reached (§3 rule 3, what
`ma_sound_seek_to_pcm_frame` gives the clip path) is **unreachable for a procedural graph,
and not for want of API**: advancing to frame N *is* the DSP work of frames 0..N. Reclaiming
the CPU and preserving that phase are the same computation, so you get one or the other.
The clip path escapes it only because a decoded PCM stream has an O(1) seek — its position
is an index, not a result.

A bounded catch-up burst on resume is not a way out either. The graph runtime is roughly
real-time in a Debug build (`docs/design/soundgraph-metasounds.md` gates on `effectiveRateHz`
staying within 10% of the sample rate), so fast-forwarding 85 ms of silence inside one audio
callback costs ~85 ms of CPU in a callback with a ~10 ms budget — an underrun, not an
optimisation. Amortising it over later blocks re-pays the entire saving *and* leaves the
voice audible-but-out-of-phase while it catches up.

So the shipped trade is explicit: **exact continuation + full CPU reclaim**, instead of
**exact would-have-been phase + no CPU reclaim**. Nothing in the engine carries the resulting
inconsistency — `OnVoiceQueryPosition` is authoritative while a voice is audible, so
`VoiceManager::Update` pulls the record back to the graph's real frame on the first tick
after devirtualization, and nothing else reads a graph voice's logical position
(`DurationSeconds == 0` means no auto-retire and no loop wrap).

---

## Part 2 — the transport API

`SoundGraphSource::SetVoiceSuspended(bool)` / `IsVoiceSuspended()`. While set,
`ProcessSamples` emits silence and skips the whole graph step: no `BeginProcessBlock`, no
`SoundGraph::Process`, no outgoing-event pump, no frame-counter advance.

It is a **second, independent** suspension axis from the existing `SuspendProcessing`, and
deliberately so: that one is the graph-swap handshake and **its resume zeroes the playback
counters**, so reusing it for the voice budget would have silently turned every resume into
a restart. No ack handshake here — nothing is torn down, so a one-block overlap either way
is inaudible, and the owner mutes before freezing / thaws before un-muting to cover the click.

While frozen, queued parameter writes are still applied (O(1) endpoint-cell writes, not DSP,
so a preset applied to a virtual voice is not lost); queued external input events are drained
and discarded, because they are scheduled at a sample offset inside a block that is not
happening.

## Part 3 — the voice host

`SoundGraphSound::OnVoiceStart` / `OnVoiceStop` use the transport instead of gain alone, and
`ReleaseVoice(resumePlayback=false)` now leaves a stopped or naturally-completed voice frozen
as well as silent — so a finished one-shot graph costs nothing until something plays it
again. `OnVoiceStop` also reports the frozen frame counter rather than `-1.0`, so the budget
anchors its record on the truth. The class comment at `SoundGraphSound.h` that stated the
limitation is replaced by the real trade-off.

## Part 4 — the tests

`OloEngine/tests/SoundGraphVoiceSuspendTest.cpp` — headless, no `ma_engine`, no audio
device, no mounted asset. Six tests, both halves the issue asks for:

* **CPU is reclaimed** — a counting node's `Process()` call count does not move across a
  suspension, the frame counter is frozen with it, and the output bus is silent.
* **Resume is a continuation, not a restart** — a suspended-and-resumed source emits
  bit-identical samples to a continuously-running twin at the same processed-block ordinal,
  and specifically **not** the graph's opening block.

**Every one of the six was verified to FAIL on the old behaviour**, by neutering
`SetVoiceSuspended` to a no-op (i.e. mute-only) and re-running: 6 failed, 0 passed. That is
the trap the issue calls out — a phase test alone passes trivially on a graph that never
stopped running.

## Measurement

Not a forecast. Debug build, this box, 32 graph voices × 200 blocks of 480 frames each
(a one-node sine graph, so this is a floor on the saving for a real graph):

```
running 92.5 ms, suspended 0.4 ms (99.6% reclaimed)
```

Measured with a temporary test that is **not** committed (a timing assertion here would be a
flake in CI).

## Ride-along fix (separate commit)

`fix(audio): a graph voice that loses the budget at Play() time played over the cap` —
`VoiceManager::Acquire` emits transitions only for state *changes* and every voice *enters*
`Virtual`, so a voice that starts over budget is never handed to `OnVoiceStop`, and nothing
put `SoundGraphSound` into its virtualized state on that path. `Play()` then started the
graph at full gain while the budget's records said it was virtual. The clip path never had
this because `AudioSource` starts `ma_sound` only from `OnVoiceStart`. Found while wiring the
transport; unrelated to it in cause, so it is its own commit with its own two tests.

## Verification

* `OloEngine-Tests` Debug (clang-cl, `build-cached`): `*SoundGraph*:*Voice*:*Audio*` —
  **200/200 pass**.
* Both commits build and pass independently (checked before each commit).
* No GPU / live-editor verification: this change touches no rendering and no editor surface.

## Docs

`docs/agent-rules/audio-voice-budget.md` §8 rewritten — the comparison table now has "yes"
in the graph column, plus the freeze-vs-stop distinction, the audit summary, why the
would-have-been phase is unreachable, and the two consequences (the `Play()` guard, and
stopped voices staying frozen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice virtualization for sound graphs, reducing DSP usage by muting and pausing voices that temporarily lose playback priority.
  * Virtualized voices now resume from their preserved sample stream without restarting or resetting graph state.
  * Voices that begin playback over the available voice budget are handled correctly and can resume when capacity returns.

* **Bug Fixes**
  * Prevented suspended voices from processing audio or advancing playback while virtualized.

* **Documentation**
  * Clarified voice virtualization, resumption behavior, and position handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->