### PR TITLE
docs(renderer): the blue-noise tile costs 8 KiB per pass, not 32 KB

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/BlueNoise.h
+++ b/OloEngine/src/OloEngine/Renderer/BlueNoise.h
@@ -447,8 +447,14 @@ namespace OloEngine::BlueNoise
     // order. A shared lazy static that owns a GL object is the shape
     // docs/agent-rules/lazy-static-release-ownership.md is about; this one
     // cannot leak a resource because it holds none. Each pass uploads its own
-    // texture from these bytes (32 KB of VRAM apiece), which is also what keeps
-    // the tile out of any per-frame global-bind ordering question.
+    // texture from these bytes, which is also what keeps the tile out of any
+    // per-frame global-bind ordering question.
+    //
+    // That duplication costs 8 KiB of VRAM per pass: kTileSize * kTileSize *
+    // kChannels = 64 * 64 * 2 bytes, and CreateBlueNoiseTexture asks for
+    // RG8UNorm through CreateTexture2DHandle, whose storage is immutable and
+    // SINGLE-MIP on both backends — so there is no chain to add. Two passes
+    // hold one today (SSR and SSGI), i.e. 16 KiB total.
     [[nodiscard]] inline const TileBytes& GetTileRG()
     {
         static const TileBytes s_Tile = GenerateTileRG();


### PR DESCRIPTION
CodeRabbit finding on #889, which had already merged by the time it was picked up
— so it lands here rather than as a fixup on that PR.

## The claim

The paragraph above `BlueNoise::GetTileRG()` put each pass's copy of the tile at
**"32 KB of VRAM apiece"**. The real figure is **8 KiB**, 4x smaller:

- `kTileSize * kTileSize * kChannels` = `64 * 64 * 2` = 8192 bytes;
- `CreateBlueNoiseTexture` asks for `RG8UNorm` via `CreateTexture2DHandle`, whose
  storage is immutable and **single-mip** on both backends — so there is no chain
  to round it up either.

Two passes hold one today (`SSRRenderPass`, `SSGIRenderPass`), so the duplication
that paragraph is justifying costs **16 KiB** in total, not 64 KB.

## Why bother with a comment

That paragraph is not decoration — it exists to argue that per-pass duplication is
cheap enough to prefer over a shared GPU-owning static, which is the
`lazy-static-release-ownership.md` shape it explicitly cites. A 4x-inflated cost is
an argument *against* the design the paragraph concludes with, so the next person
weighing "should this be shared?" would be reading evidence pointing the wrong way.

Comment only — ownership, upload behaviour and the POD-static rationale are
untouched.

## Verification

Not built. The change is comment text inside an existing block and cannot alter
compilation; the pre-commit hook (clang-format included) passed.
