### PR TITLE
fix(renderer): stop DecalRenderPass's GLStateGuard error spam (#895)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
@@ -136,22 +136,30 @@ namespace OloEngine
         if (m_SelectedSceneDepthTexture.IsValid())
             depthTextureID = context.ResolveTextureHandle(m_SelectedSceneDepthTexture);
 
-        // Detector-only guard: captures GL state at entry and on destruction
-        // diffs against exit state, logging any field this pass failed to
-        // restore. The explicit restore calls further down are what actually
-        // restore -- the default Policy::Log does not roll anything back.
+        // ISSUE #895 (fixed): the manual restore below only ever covered
+        // DepthMask/BlendState(enable)/DepthFunc/Cull, so DepthTest, the
+        // blend func factors, ActiveProgram and VAO escaped every frame that
+        // drained a decal -- 2723 GLStateGuard ERROR lines in a couple of
+        // minutes under Policy::Log, which rolls nothing back.
         //
-        // ISSUE #895: it does not restore enough. This reports 8-9 escaped
-        // fields at ERROR level on EVERY frame that drains a decal, on both
-        // rendering paths (DepthTest, the four blend factors, ActiveProgram,
-        // VAO and the two bound texture slots). Note GLStateGuard::Policy
-        // ::Restore exists and DOES roll back via GLStateSnapshot::ApplyCore()
-        // -- an earlier version of this comment said rollback was impossible,
-        // which is probably why this call site never asked for it. Fixing the
-        // leak is #895; check render-pass-published-state.md before switching
-        // policy, since a pass whose outputs are engine-global bindings must
-        // not be wrapped in a restoring guard at all.
-        GLStateGuard guard("DecalRenderPass");
+        // Policy::Restore is safe here, unlike the DDGI/fog pattern
+        // render-pass-published-state.md warns about: GLStateSnapshot::
+        // ApplyCore() restores only the *core* GL subset (depth/blend/
+        // stencil/cull/polygon-mode/viewport/scissor/FBO/program/VAO) and
+        // deliberately never touches per-slot texture bindings. So it fixes
+        // exactly the fields above without undoing this pass's texture
+        // publishes at TEX_POSTPROCESS_DEPTH / TEX_USER_0 -- both of which
+        // are re-published fresh by whichever pass needs them next (every
+        // other TEX_POSTPROCESS_DEPTH consumer -- SSAO, Fog, DOF, MotionBlur,
+        // TAA, ToneMap -- rebinds it before sampling; TEX_USER_0-2 are
+        // documented pass-local-reuse slots), so nothing downstream depends
+        // on this pass's texture bindings surviving. Residual texture diffs
+        // still surface, just at TRACE instead of ERROR, keeping the log
+        // quiet in steady state while staying discoverable for a leak hunt.
+        // Same shape as PlanarReflectionRenderPass / OverdrawRenderPass /
+        // ShaderDebugDrawPass, which replay geometry with their own
+        // programs/VAOs under Policy::Restore.
+        GLStateGuard guard("DecalRenderPass", GLStateGuard::Policy::Restore);
 
         // Helper: decide whether a packet should be drained by *this*
         // (the graph-scheduled) Execute. In the Deferred path the opaque
@@ -304,6 +312,7 @@ namespace OloEngine
         context.SetBlendState(false);
         RenderCommand::SetDepthFunc(RHI::CompareOp::Less);
         RenderCommand::BackCull();
+        CommandDispatch::InvalidateRenderStateCache();
 
         m_SceneFramebuffer->Unbind();
 


### PR DESCRIPTION
Fixes #895 — `DecalRenderPass` construted its `GLStateGuard` with the default `Policy::Log`, which reports every escaped GL state field at **ERROR** level and rolls nothing back. The pass's manual restore only covered `DepthMask`/`BlendState(enable)`/`DepthFunc`/`Cull`, so `DepthTest`, the four blend func factors, `ActiveProgram` and `VAO` escaped on every frame that drained a decal — 2723 ERROR lines in a couple of minutes on `DecalModeMatrixTest.olo`, on both rendering paths.

`Closes #895`

## The fix

Switch to `Policy::Restore`. This is safe here — unlike the DDGI/fog pattern `docs/agent-rules/render-pass-published-state.md` warns about — because `GLStateSnapshot::ApplyCore()` restores only the **core** GL subset (depth/blend/stencil/cull/polygon-mode/viewport/scissor/FBO/program/VAO) and *deliberately never touches per-slot texture bindings*. So it fixes exactly the fields that were escaping without undoing this pass's texture publishes at `TEX_POSTPROCESS_DEPTH` / `TEX_USER_0`:

- `TEX_POSTPROCESS_DEPTH` is re-published fresh by every downstream consumer (SSAO, Fog, DOF, MotionBlur, TAA, ToneMap all rebind it themselves before sampling) — nothing depends on `DecalRenderPass` leaving it bound.
- `TEX_USER_0-2` are documented pass-local-reuse slots (`ShaderBindingLayout.h`) — same contract.

Residual texture diffs still surface, just at TRACE instead of ERROR — quiet in steady state, discoverable for a future leak hunt. Same shape as `PlanarReflectionRenderPass` / `OverdrawRenderPass` / `ShaderDebugDrawPass`, which also replay geometry with their own programs/VAOs under `Policy::Restore`.

Also added the `CommandDispatch::InvalidateRenderStateCache()` call the non-OIT restore path was missing (the OIT branch already had it) — without it the render-state cache would go stale after the guard's raw restore GL calls bypass the tracked `RenderCommand` layer, risking a downstream pass eliding a call it actually needs to reissue.

**Audit of other `GLStateGuard(` construction sites** (in scope per the issue): every other site already explicitly chooses `Policy::Ignore` or `Policy::Restore` — `DecalRenderPass` was the only one left on the noisy default. No broader sweep needed.

## Verification

- `GLStateGuardTest.*` (37 tests) pass, including `RestorePolicy_RestoresCoreStateOnDtor` and `RestorePolicy_DoesNotUnbindTexturesOrUbosButLogsLeak`, which pin exactly the ApplyCore behaviour this fix relies on.
- Live editor verification on `DecalModeMatrixTest.olo` (per `CLAUDE.md` — headless tests are not sufficient for a rendering change): played the scene on both **Forward** and **Deferred** paths.
  - **Zero** `GLStateGuard[DecalRenderPass]` ERROR lines across ~8000 logged frames on either path (down from 2723 in a couple of minutes).
  - Decals still render their authored colours correctly on both paths — screenshots attached below, consistent with PR #886's recorded baseline (Albedo decal `1.0, 0.251, 0.149`; the checkerboard arm is the known missing-texture placeholder, unrelated to this change).
  - The three remaining `[error]` lines in the session log are a pre-existing missing `Checkerboard.png` asset, unrelated to this fix.

## Out of scope

- **#887** (`DecalComponent` texture references lost on scene round-trip) — same area, deliberately unclaimed this round per the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decal rendering state management to ensure graphics settings are restored correctly after decal passes.
  - Updated non-order-independent transparency rendering to keep subsequent rendering operations synchronized with the restored state.
  - Helps prevent visual inconsistencies and rendering artifacts that could occur after decals are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->