### PR TITLE
fix(asset): scene texture paths resolve against project root, not cwd (#887)

### DIFF
--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -746,8 +746,38 @@ namespace OloEngine
     {
         OLO_PROFILER_SCOPE("EditorAssetManager::ImportAsset");
 
-        // Normalize to absolute project path before checking existence
-        std::filesystem::path absolutePath = std::filesystem::absolute(filepath);
+        // Normalize to an absolute path. A relative input is ambiguous between two
+        // conventions that both exist in checked-in scene content today (issue #887):
+        //   - project-relative ("Assets/Textures/Foo.png") — the current, documented
+        //     contract (SceneSerializer::LoadSceneTexture resolves scene texture paths
+        //     against the project asset root), used by newly-authored references.
+        //   - working-directory-relative ("SandboxProject/Assets/Textures/Foo.png") — an
+        //     older spelling several existing scenes still carry (PinkCubeWithTextures,
+        //     the Sponza scenes, VehiclesTest, Drift), which happens to resolve correctly
+        //     because OloEditor's actual cwd is OloEditor/, one level above the project
+        //     directory (OloEditor/SandboxProject/).
+        // Try the documented project-relative form first; only a path that doesn't exist
+        // there falls back to plain std::filesystem::absolute() (cwd-relative), so those
+        // older scenes keep resolving exactly as before until they're resaved. Resolving
+        // unconditionally against cwd (the previous behaviour) silently walked a
+        // project-relative input into the engine's own OloEditor/assets/ tree instead
+        // whenever a same-named file happened to exist there too — found, but keyed under
+        // a bogus "../assets/..." relative path that never matched a subsequent
+        // correctly-spelled lookup, and whose own load then failed because *that* path
+        // isn't valid from cwd either.
+        std::filesystem::path absolutePath;
+        if (filepath.is_absolute())
+        {
+            absolutePath = filepath;
+        }
+        else
+        {
+            std::filesystem::path projectRelative = m_ProjectPath / filepath;
+            std::error_code existsEc;
+            absolutePath = (std::filesystem::exists(projectRelative, existsEc) && !existsEc)
+                               ? projectRelative
+                               : std::filesystem::absolute(filepath);
+        }
 
         // Use error_code overload to handle filesystem errors gracefully
         std::error_code ec;
@@ -772,7 +802,7 @@ namespace OloEngine
         }
 
         // Convert to project-relative path
-        std::filesystem::path relativePath = GetRelativePath(filepath);
+        std::filesystem::path relativePath = GetRelativePath(absolutePath);
 
         // Check if already imported
         if (AssetHandle existingHandle = m_AssetRegistry.GetHandleFromPath(relativePath); existingHandle != 0)

--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -109,21 +109,31 @@ namespace OloEngine
 
     bool TextureSerializer::TryLoadData(const AssetMetadata& metadata, Ref<Asset>& asset) const
     {
+        // metadata.FilePath is project-root-relative (e.g. "Assets/Textures/Foo.png"),
+        // not relative to the process's current working directory — OloEditor runs with
+        // cwd = OloEditor/, one level above the project (OloEditor/SandboxProject/), so
+        // reading metadata.FilePath verbatim resolves against the wrong base. Every other
+        // AssetSerializer::TryLoadData in this file prefixes Project::GetProjectDirectory();
+        // this one has to do the same for the actual file read, while keeping the
+        // project-relative spelling as the texture's reported identity (GetPath(), and what
+        // scene YAML round-trips) so saved scenes stay portable across machines/checkouts.
+        const std::filesystem::path fullPath = Project::GetProjectDirectory() / metadata.FilePath;
+
         // Offline block-compressed container (#440): read the BCn mip chain and upload
         // it straight into a GPU-compressed texture.
         if (IsOloTexPath(metadata.FilePath))
         {
             CompressedTextureImage image;
-            if (!TextureCompression::ReadFile(metadata.FilePath.string(), image))
+            if (!TextureCompression::ReadFile(fullPath.string(), image))
             {
-                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to read .olotex: {}", metadata.FilePath.string());
+                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to read .olotex: {}", fullPath.string());
                 return false;
             }
             image.SourcePath = metadata.FilePath.string(); // so GetPath() -> pack re-read works
             Ref<Texture2D> texture = Texture2D::Create(image);
             if (!texture || !texture->IsLoaded())
             {
-                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to create compressed texture: {}", metadata.FilePath.string());
+                OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to create compressed texture: {}", fullPath.string());
                 return false;
             }
             texture->m_Handle = metadata.Handle;
@@ -133,10 +143,10 @@ namespace OloEngine
 
         const std::string filename = metadata.FilePath.filename().string();
         const bool srgb = IsLikelyColorTextureByName(filename);
-        Ref<Texture2D> texture = Texture2D::Create(metadata.FilePath.string(), srgb);
+        Ref<Texture2D> texture = Texture2D::Create(fullPath.string(), srgb, metadata.FilePath.string());
         if (!texture)
         {
-            OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to create texture: {}", metadata.FilePath.string());
+            OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to create texture: {}", fullPath.string());
             return false;
         }
 
@@ -145,7 +155,7 @@ namespace OloEngine
         if (!result)
         {
             texture->SetFlag(AssetFlag::Invalid, true);
-            OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to load texture: {}", metadata.FilePath.string());
+            OLO_CORE_ERROR("TextureSerializer::TryLoadData - Failed to load texture: {}", fullPath.string());
         }
 
         asset = texture; // Direct assignment - Ref<Texture2D> should convert to Ref<Asset>
@@ -158,14 +168,19 @@ namespace OloEngine
 
         // This method is safe to call from any thread - no GPU/GL calls here
 
+        // metadata.FilePath is project-root-relative — see the matching comment in
+        // TryLoadData. Read from the project-rooted absolute path; keep the identity
+        // (image.SourcePath / rawData.DebugName) as the relative spelling.
+        const std::filesystem::path fullPath = Project::GetProjectDirectory() / metadata.FilePath;
+
         // Offline block-compressed container (#440): reading the .olotex blob is pure
         // CPU work, so it belongs on the worker thread; GPU upload happens in Finalize.
         if (IsOloTexPath(metadata.FilePath))
         {
             CompressedTextureImage image;
-            if (!TextureCompression::ReadFile(metadata.FilePath.string(), image))
+            if (!TextureCompression::ReadFile(fullPath.string(), image))
             {
-                OLO_CORE_ERROR("TextureSerializer::TryLoadRawData - Failed to read .olotex: {}", metadata.FilePath.string());
+                OLO_CORE_ERROR("TextureSerializer::TryLoadRawData - Failed to read .olotex: {}", fullPath.string());
                 return false;
             }
             image.SourcePath = metadata.FilePath.string(); // so GetPath() -> pack re-read works
@@ -173,7 +188,7 @@ namespace OloEngine
             return true;
         }
 
-        std::string path = metadata.FilePath.string();
+        std::string path = fullPath.string();
 
         int width = 0;
         int height = 0;

--- a/OloEngine/src/OloEngine/Renderer/Texture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Texture.cpp
@@ -80,7 +80,7 @@ namespace OloEngine
         return nullptr;
     }
 
-    Ref<Texture2D> Texture2D::Create(const std::string& path, bool srgb)
+    Ref<Texture2D> Texture2D::Create(const std::string& path, bool srgb, const std::string& identityPath)
     {
         switch (Renderer::GetAPI())
         {
@@ -95,7 +95,7 @@ namespace OloEngine
                 // #691: file-load arm (stbi + one-shot upload).
                 if (VulkanDevice::Get() != nullptr)
                 {
-                    return Ref<VulkanTexture2D>::Create(path, srgb);
+                    return Ref<VulkanTexture2D>::Create(path, srgb, identityPath);
                 }
 #endif
                 OLO_CORE_ASSERT(false, "RendererAPI::Vulkan: no VulkanDevice is up (or OLO_WITH_VULKAN is compiled out)!");
@@ -103,7 +103,7 @@ namespace OloEngine
             }
             case RendererAPI::API::OpenGL:
             {
-                return Ref<OpenGLTexture2D>::Create(path, srgb);
+                return Ref<OpenGLTexture2D>::Create(path, srgb, identityPath);
             }
         }
 

--- a/OloEngine/src/OloEngine/Renderer/Texture.h
+++ b/OloEngine/src/OloEngine/Renderer/Texture.h
@@ -186,7 +186,13 @@ namespace OloEngine
         // emissive, UI) so the GPU converts samples from sRGB to linear on
         // read. Leave srgb=false (default) for data textures (normal map,
         // metallic-roughness, AO, heightmap) where bytes are already linear.
-        static Ref<Texture2D> Create(const std::string& path, bool srgb = false);
+        // `path` is read from directly (stbi_load gets it verbatim) and becomes
+        // GetPath()'s value UNLESS `identityPath` is non-empty, in which case
+        // `identityPath` is stored instead — used by the asset pipeline, which
+        // must read from an absolute, project-rooted path (the process's cwd is
+        // not the project directory) while still reporting the project-relative
+        // path scene YAML expects back from GetPath().
+        static Ref<Texture2D> Create(const std::string& path, bool srgb = false, const std::string& identityPath = "");
 
         // Asset interface
         static constexpr AssetType GetStaticType() noexcept

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -330,7 +330,7 @@ namespace OloEngine
         m_IsLoaded = true;
     }
 
-    OpenGLTexture2D::OpenGLTexture2D(const std::string& path, bool srgb)
+    OpenGLTexture2D::OpenGLTexture2D(const std::string& path, bool srgb, const std::string& identityPath)
     {
         OLO_PROFILE_FUNCTION();
 
@@ -364,7 +364,7 @@ namespace OloEngine
             return;
         }
 
-        InvalidateImpl(path, static_cast<u32>(width), static_cast<u32>(height), data, static_cast<u32>(channels));
+        InvalidateImpl(identityPath.empty() ? path : identityPath, static_cast<u32>(width), static_cast<u32>(height), data, static_cast<u32>(channels));
 
         ::stbi_image_free(data);
     }

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.h
@@ -11,7 +11,7 @@ namespace OloEngine
     {
       public:
         explicit OpenGLTexture2D(const TextureSpecification& specification);
-        explicit OpenGLTexture2D(const std::string& path, bool srgb = false);
+        explicit OpenGLTexture2D(const std::string& path, bool srgb = false, const std::string& identityPath = "");
         // Upload an offline block-compressed (BC7/BC5) mip chain (#440). Falls back to
         // CPU-decompressed RGBA8 when the driver lacks BPTC/RGTC support.
         explicit OpenGLTexture2D(const CompressedTextureImage& compressedImage);

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
@@ -166,7 +166,7 @@ namespace OloEngine
         VulkanUpload::TrackLive(this, "VulkanTexture2D(spec)");
     }
 
-    VulkanTexture2D::VulkanTexture2D(const std::string& path, bool srgb)
+    VulkanTexture2D::VulkanTexture2D(const std::string& path, bool srgb, const std::string& identityPath)
     {
         VulkanUpload::TrackLive(this, "VulkanTexture2D(path)");
         OLO_PROFILE_FUNCTION();
@@ -196,7 +196,7 @@ namespace OloEngine
         }
 
         m_Specification.SRGB = srgb;
-        Invalidate(path, static_cast<u32>(width), static_cast<u32>(height), data, static_cast<u32>(channels));
+        Invalidate(identityPath.empty() ? path : identityPath, static_cast<u32>(width), static_cast<u32>(height), data, static_cast<u32>(channels));
         ::stbi_image_free(data);
     }
 

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.h
@@ -44,7 +44,7 @@ namespace OloEngine
         // File load (#691): stbi with the SAME thread-local vertical
         // flip the GL twin uses — asset bytes must be identical across
         // backends, since UV sampling is convention-free.
-        VulkanTexture2D(const std::string& path, bool srgb);
+        VulkanTexture2D(const std::string& path, bool srgb, const std::string& identityPath = "");
         ~VulkanTexture2D() override;
 
         const TextureSpecification& GetSpecification() const override

--- a/OloEngine/tests/AssetSceneLoadTest.cpp
+++ b/OloEngine/tests/AssetSceneLoadTest.cpp
@@ -469,4 +469,175 @@ namespace OloEngine::Tests
         }
     }
 
+    // -------------------------------------------------------------------------------
+    // Issue #887: DecalComponent texture references were lost on a scene round-trip
+    // (empty path via YAML, dropped via .scenebin) because EditorAssetManager::ImportAsset
+    // resolved a project-relative scene texture path ("Assets/Textures/Foo.png") against
+    // the process's current working directory instead of the project directory — silently
+    // wrong whenever OloEditor's actual cwd (OloEditor/) happens to contain a same-named
+    // file under its own generic assets/ tree too, which it does for every shipped
+    // texture. A texture whose resolution fails this way ends up as a non-null placeholder
+    // Ref<Texture2D> with an empty GetPath(), which SceneSerializer still happily writes —
+    // and a component that round-tripped that empty path once already writes nothing at
+    // all on the NEXT save, since the empty path fails to resolve back into a texture on
+    // reload.
+    //
+    // This pins the fix for both the decal texture arm (the reported symptom, freshly
+    // authored with the current "Assets/..." convention) and the pre-existing sprite
+    // texture control (PinkCubeWithTextures.olo, still spelled the older
+    // "SandboxProject/Assets/..." working-directory-relative way, which ImportAsset must
+    // keep resolving via its cwd-relative fallback) so a regression in either direction is
+    // caught. Two loads of the same scene path are checked because the reported failure is
+    // a "second load" class of bug: the binary sidecar written on the first load must carry
+    // the same correct path forward, not silently drop it.
+    TEST(AssetSceneLoad, DecalAndSpriteTexturePathsSurviveRoundTrip)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        if (!Renderer3D::IsInitialized())
+        {
+            Renderer::Init(RendererType::Renderer3D, /*loadingWindow=*/nullptr);
+        }
+
+        GLStateGuard glGuard("AssetSceneLoad.TexturePathRoundTrip", GLStateGuard::Policy::Restore);
+
+        std::string stageError;
+        const fs::path tempRoot = StageSandboxProjectIntoTemp(stageError);
+        ASSERT_FALSE(tempRoot.empty())
+            << "Failed to stage SandboxProject into temp dir: " << stageError;
+
+        struct Cleanup
+        {
+            fs::path Dir;
+            ~Cleanup()
+            {
+                std::error_code ec;
+                for (int attempt = 0; attempt < 3; ++attempt)
+                {
+                    ec.clear();
+                    fs::remove_all(Dir, ec);
+                    std::error_code existsEc;
+                    if (!fs::exists(Dir, existsEc))
+                        return;
+                }
+                OLO_CORE_WARN("AssetSceneLoad: could not remove staging dir '{}': {}", Dir.string(), ec.message());
+            }
+        } cleanup{ tempRoot };
+
+        const fs::path projectFile = FindProjectFile(tempRoot);
+        ASSERT_FALSE(projectFile.empty())
+            << "No .oloproj found inside staged temp project at " << tempRoot.string();
+
+        ASSERT_TRUE(Project::Load(projectFile))
+            << "Project::Load failed on staged temp project.";
+
+        auto assetManager = Ref<EditorAssetManager>::Create();
+        assetManager->Initialize(/*startFileWatcher=*/false);
+        Project::SetAssetManager(assetManager);
+
+        struct AssetManagerShutdown
+        {
+            Ref<EditorAssetManager> Mgr;
+            ~AssetManagerShutdown()
+            {
+                if (Mgr)
+                    Mgr->Shutdown();
+            }
+        } assetManagerShutdown{ assetManager };
+
+        // Load a scene twice through the SAME path (exercising both the YAML load, which
+        // also writes the .scenebin sidecar, and the second call's binary-sidecar fast
+        // path) and return the requested texture's GetPath() both times.
+        auto loadTwiceAndGetPath = [](const fs::path& scenePath, auto&& findTexture) -> std::pair<std::string, std::string>
+        {
+            std::string first;
+            std::string second;
+            {
+                auto scene = Scene::Create();
+                SceneSerializer serializer(scene);
+                bool ok = serializer.Deserialize(scenePath);
+                EXPECT_TRUE(ok) << "First Deserialize() of " << scenePath.string() << " failed.";
+                if (ok)
+                {
+                    Ref<Texture2D> tex = findTexture(scene);
+                    first = tex ? tex->GetPath() : std::string{ "<null texture ref>" };
+                }
+            }
+            {
+                auto scene = Scene::Create();
+                SceneSerializer serializer(scene);
+                bool ok = serializer.Deserialize(scenePath);
+                EXPECT_TRUE(ok) << "Second Deserialize() of " << scenePath.string() << " failed.";
+                if (ok)
+                {
+                    Ref<Texture2D> tex = findTexture(scene);
+                    second = tex ? tex->GetPath() : std::string{ "<null texture ref>" };
+                }
+            }
+            return { first, second };
+        };
+
+        // -------------------- decal arm (issue #887's reported symptom) --------------------
+        {
+            const fs::path scenePath = tempRoot / "Assets" / "Scenes" / "DecalModeMatrixTest.olo";
+            ASSERT_TRUE(fs::exists(scenePath)) << scenePath.string();
+
+            auto findEmissiveDecalTexture = [](const Ref<Scene>& scene) -> Ref<Texture2D>
+            {
+                Ref<Texture2D> result;
+                auto view = scene->GetAllEntitiesWith<TagComponent, DecalComponent>();
+                for (auto entity : view)
+                {
+                    const auto& [tag, decal] = view.get<TagComponent, DecalComponent>(entity);
+                    if (tag.Tag == "Decal Emissive")
+                    {
+                        result = decal.m_EmissiveTexture;
+                        break;
+                    }
+                }
+                return result;
+            };
+
+            auto [firstPath, secondPath] = loadTwiceAndGetPath(scenePath, findEmissiveDecalTexture);
+            EXPECT_FALSE(firstPath.empty())
+                << "DecalComponent::m_EmissiveTexture had an empty GetPath() on the FIRST load "
+                   "(YAML) — the texture failed to resolve and a placeholder was silently substituted.";
+            EXPECT_FALSE(secondPath.empty())
+                << "DecalComponent::m_EmissiveTexture had an empty GetPath() on the SECOND load "
+                   "(binary sidecar) — the reference was dropped on the fast path.";
+            EXPECT_EQ(firstPath, secondPath)
+                << "The YAML and binary-sidecar loads disagree about the decal's texture path.";
+        }
+
+        // -------------------- sprite control (pre-existing, older path spelling) --------------------
+        {
+            const fs::path scenePath = tempRoot / "Assets" / "Scenes" / "PinkCubeWithTextures.olo";
+            ASSERT_TRUE(fs::exists(scenePath)) << scenePath.string();
+
+            auto findFirstSpriteTexture = [](const Ref<Scene>& scene) -> Ref<Texture2D>
+            {
+                Ref<Texture2D> result;
+                auto view = scene->GetAllEntitiesWith<SpriteRendererComponent>();
+                for (auto entity : view)
+                {
+                    const auto& src = view.get<SpriteRendererComponent>(entity);
+                    if (src.Texture)
+                    {
+                        result = src.Texture;
+                        break;
+                    }
+                }
+                return result;
+            };
+
+            auto [firstPath, secondPath] = loadTwiceAndGetPath(scenePath, findFirstSpriteTexture);
+            EXPECT_FALSE(firstPath.empty())
+                << "SpriteRendererComponent::Texture had an empty GetPath() on the FIRST load — "
+                   "the older 'SandboxProject/Assets/...' path spelling must still resolve.";
+            EXPECT_FALSE(secondPath.empty())
+                << "SpriteRendererComponent::Texture had an empty GetPath() on the SECOND load.";
+            EXPECT_EQ(firstPath, secondPath);
+        }
+    }
+
 } // namespace OloEngine::Tests


### PR DESCRIPTION
## Summary

Root-caused and fixed #887. The decal texture arm was the reported symptom; the
underlying bug affected any scene-authored, project-relative texture path
("Assets/Textures/Foo.png"), not just decals.

**Root cause**, found by driving the live editor over its MCP diagnostics server and
reading `OloEngine.log`:

1. `EditorAssetManager::ImportAsset` resolved a relative input path via
   `std::filesystem::absolute()`, which resolves against the process's **current
   working directory** (`OloEditor/`), not the **project directory**
   (`OloEditor/SandboxProject/`) the path is documented to be relative to. Because
   `OloEditor/` also ships a copy of every generic texture under its own `assets/`
   tree, this wrong resolution frequently "succeeded" anyway — but registered the
   asset under a bogus `../assets/...` relative key.
2. `TextureSerializer::TryLoadData` then read straight from that bogus (still
   cwd-relative) key instead of prefixing `Project::GetProjectDirectory()`, the way
   every other `AssetSerializer::TryLoadData` in the file already does. The actual
   pixel load failed, and `AssetManager::ResolveAssetOrPlaceholder` silently
   substituted a placeholder texture — non-null, but with an empty `GetPath()`.

`SceneSerializer` then wrote that empty path back into the scene YAML, and a
component that had already round-tripped an empty path once dropped the reference
entirely on the *next* save (the `.scenebin` symptom) — an empty path fails to
resolve back into a texture on reload, so nothing is written at all. This matches
the "double-silent, second-load" framing in the issue exactly.

## Fix

- `EditorAssetManager::ImportAsset` now tries the documented project-relative
  resolution first, falling back to the previous cwd-relative behaviour only when
  that fails — several existing scenes (`PinkCubeWithTextures`, the Sponza scenes,
  `VehiclesTest`, `Drift`) still carry the older working-directory-relative
  spelling and must keep resolving unchanged.
- `TextureSerializer::TryLoadData`/`TryLoadRawData` now read from
  `Project::GetProjectDirectory() / metadata.FilePath`, matching every other
  serializer in the file, while keeping the *reported* identity (`GetPath()`)
  project-relative — via a new optional `identityPath` parameter on
  `Texture2D::Create`, threaded through both the OpenGL and Vulkan backends
  (purely additive, default-valued, so no existing call site changes behaviour).

Verified live over the editor's MCP diagnostics server, before and after the fix,
across both the YAML and `.scenebin` load paths (see log excerpts in the linked
issue investigation).

## Test plan

- [x] New `AssetSceneLoad.DecalAndSpriteTexturePathsSurviveRoundTrip` — loads
      `DecalModeMatrixTest.olo` and `PinkCubeWithTextures.olo` twice each (once via
      YAML, once via the resulting `.scenebin` sidecar) through a staged
      `EditorAssetManager`, asserting both texture paths survive non-empty and
      identical across both loads.
- [x] `OloEngine-Tests.exe --gtest_filter="AssetSceneLoad.*"` — 3/3 passed.
- [x] `OloEngine-Tests.exe --gtest_filter="*Texture*:*Sprite*:*Decal*:ComponentRoundTrip.*:SceneBinarySidecar.*:*AssetContentValidity*"` — 355/355 passed.
- [x] Live-verified in the running editor via MCP (`olo_scene_open` +
      `olo://scene/current`): both `DecalModeMatrixTest.olo`'s
      `EmissiveTexturePath` and `PinkCubeWithTextures.olo`'s `TexturePath` resolve
      correctly and round-trip through both load paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
