### PR TITLE
fix(audio): a graph sound was unplayable after it ran to its end, and Play() un-froze too early

### DIFF
--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -420,11 +420,25 @@ namespace OloEngine::Audio::SoundGraph
         m_PlayState = SoundPlayState::Playing;
         m_IsFinished = false;
 
+        if (m_Source && m_Source->IsSuspended())
+        {
+            // Lift the OTHER suspension axis — the graph-swap one. SoundGraphSource::Update
+            // parks a source there when the graph reports finished, and nothing but a graph
+            // swap ever cleared it, so a sound that ran to its end could never be played
+            // again. Play is the one place where SuspendProcessing(false)'s counter reset is
+            // CORRECT, because SendPlayEvent below restarts the stream anyway; doing it on
+            // any resume path instead (e.g. in OnVoiceStart) would zero m_CurrentFrame on
+            // every devirtualization and turn a resume back into a restart.
+            m_Source->SuspendProcessing(false);
+        }
+
         // Register with the shared concurrent-voice budget BEFORE raising the graph's Play
-        // event: Acquire drives OnVoiceStart synchronously when this voice wins a slot, and
-        // that is where the gain is un-muted. Starting a re-triggered sound also drops any
-        // previous registration so the budget never holds two records for one graph.
-        ReleaseVoice(/*resumePlayback=*/true);
+        // event, and stay VIRTUALIZED across the whole admission decision: the graph must
+        // not produce a single audible block before the budget has ruled. Acquire drives
+        // OnVoiceStart synchronously if this voice wins a slot, and that is what thaws and
+        // un-mutes it. Releasing first also drops any previous registration so the budget
+        // never holds two records for one graph.
+        ReleaseVoice(/*resumePlayback=*/false);
         const auto handle = OloEngine::Audio::VoiceManager::Get().Acquire(this, BuildVoiceParams());
         m_VoiceHandle.store(handle, std::memory_order_release);
         if (handle == OloEngine::Audio::kInvalidVoiceHandle)
@@ -433,19 +447,12 @@ namespace OloEngine::Audio::SoundGraph
             // fall back to unmanaged playback rather than silence.
             SetVirtualized(false);
         }
-        else if (OloEngine::Audio::VoiceManager::Get().IsVirtual(handle))
-        {
-            // Acquire only emits transitions for state CHANGES, and every voice ENTERS
-            // virtual — so a voice that starts over budget and stays virtual is never
-            // handed to OnVoiceStop and nothing else would put it in the virtualized state.
-            // Without this the SendPlayEvent below starts it at full gain, over the cap.
-            SetVirtualized(true);
-        }
-        else
-        {
-            // Audible: Acquire drove OnVoiceStart synchronously, which already thawed and
-            // un-muted this voice. Nothing left to do.
-        }
+        // Otherwise the budget owns the state: a voice that won a slot was thawed and
+        // un-muted by the OnVoiceStart that Acquire drove, and one that lost stays exactly
+        // as ReleaseVoice left it — muted and frozen, with the Play request latched on the
+        // source until something thaws it. Acquire only emits transitions for state CHANGES
+        // and every voice ENTERS virtual, so an over-budget voice is never handed to
+        // OnVoiceStop; not thawing in the first place is what keeps it silent.
 
         // Forward the Play trigger into the runtime graph. Without this the play state
         // flips to Playing on the sound wrapper but the graph's "Play" event input is

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.cpp
@@ -432,13 +432,32 @@ namespace OloEngine::Audio::SoundGraph
             m_Source->SuspendProcessing(false);
         }
 
-        // Register with the shared concurrent-voice budget BEFORE raising the graph's Play
-        // event, and stay VIRTUALIZED across the whole admission decision: the graph must
-        // not produce a single audible block before the budget has ruled. Acquire drives
-        // OnVoiceStart synchronously if this voice wins a slot, and that is what thaws and
-        // un-mutes it. Releasing first also drops any previous registration so the budget
-        // never holds two records for one graph.
+        // Freeze first, then latch the Play request, then let the budget rule — and stay
+        // VIRTUALIZED across the whole admission decision: the graph must not produce a
+        // single audible block before the budget has ruled. Acquire drives OnVoiceStart
+        // synchronously if this voice wins a slot, and that is what thaws and un-mutes it.
+        // Releasing first also drops any previous registration so the budget never holds
+        // two records for one graph.
         ReleaseVoice(/*resumePlayback=*/false);
+
+        // Forward the Play trigger into the runtime graph. Without this the play state
+        // flips to Playing on the sound wrapper but the graph's "Play" event input is
+        // never raised, so any node listening for that event (WavePlayer, envelopes,
+        // trigger nodes) never fires — the audio callback runs but every node stays at
+        // its idle/silent default.
+        //
+        // Latched HERE, after the freeze and before Acquire, not after the admission
+        // decision: SendPlayEvent only sets a dirty flag that Process consumes on its
+        // first non-suspended block, and the suspended early-out leaves that flag alone
+        // (unlike the input-event ring, which it drains). Raising it after Acquire would
+        // leave a winner thawed and un-muted for the window between OnVoiceStart and this
+        // call, and the audio thread can enter a block inside that window — running the
+        // graph from the PREVIOUS stream's m_CurrentFrame at full gain before the
+        // retrigger lands. Setting the latch while the source is still frozen means the
+        // first audible block is already the restarted one.
+        if (m_Source)
+            m_Source->SendPlayEvent();
+
         const auto handle = OloEngine::Audio::VoiceManager::Get().Acquire(this, BuildVoiceParams());
         m_VoiceHandle.store(handle, std::memory_order_release);
         if (handle == OloEngine::Audio::kInvalidVoiceHandle)
@@ -453,17 +472,6 @@ namespace OloEngine::Audio::SoundGraph
         // source until something thaws it. Acquire only emits transitions for state CHANGES
         // and every voice ENTERS virtual, so an over-budget voice is never handed to
         // OnVoiceStop; not thawing in the first place is what keeps it silent.
-
-        // Forward the Play trigger into the runtime graph. Without this the play state
-        // flips to Playing on the sound wrapper but the graph's "Play" event input is
-        // never raised, so any node listening for that event (WavePlayer, envelopes,
-        // trigger nodes) never fires — the audio callback runs but every node stays at
-        // its idle/silent default. Raised unconditionally, including when this voice lost
-        // the budget above: the request is a latched flag on the source, so a virtualized
-        // voice simply fires it on the first block after it is thawed, starting the graph
-        // when the player can actually hear it rather than burning DSP to run it silently.
-        if (m_Source)
-            m_Source->SendPlayEvent();
 
         return true;
     }

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
@@ -259,11 +259,12 @@ namespace OloEngine
                 ///
                 /// `resumePlayback` decides which state the live source is left in, because
                 /// the budget is no longer tracking this voice and nothing else would ever
-                /// lift its virtualization. Pass TRUE when the voice is about to play again
-                /// (Play) or the object is going away (teardown). Pass FALSE when retiring a
-                /// voice that is meant to fall silent (Stop, natural completion): the source
-                /// stays muted and frozen, which is both silent and free — before #745 the
-                /// graph had no transport, so this could only leave it muted-but-running.
+                /// lift its virtualization. Pass TRUE only when the source must be left
+                /// running with nobody to un-mute it (teardown). Pass FALSE whenever it must
+                /// be left muted and frozen — both when retiring a voice that is meant to
+                /// fall silent (Stop, natural completion), and in Play, where the source has
+                /// to stay silent until Acquire has ruled on the new admission. Before #745
+                /// the graph had no transport, so FALSE could only leave it muted-but-running.
                 void ReleaseVoice(bool resumePlayback) const;
 
                 /// Enter or leave the virtualized state on the live source: the budget's

--- a/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
+++ b/OloEngine/tests/SoundGraphVoiceSuspendTest.cpp
@@ -109,7 +109,16 @@ namespace
     /// depending on a wall-clock measurement that would flake under CI load.
     struct CountingNode final : public sg::NodeProcessor
     {
-        explicit CountingNode(UUID id) : NodeProcessor("CountingNode", id) {}
+        explicit CountingNode(UUID id) : NodeProcessor("CountingNode", id)
+        {
+            // A bindable in-event, so a graph-input route can target this node. Without a
+            // bound handler SoundGraph::SendInputEvent returns false and the source never
+            // flips m_IsPlaying - see MakePlayRoutedCountingGraph.
+            AddInEvent(Identifier("In"), [this](f32 value, i32 sampleOffset)
+                       { (void)value; (void)sampleOffset; ++m_EventsReceived; });
+        }
+
+        u32 m_EventsReceived = 0;
 
         u32 m_ProcessCalls = 0;
         u64 m_FramesProcessed = 0;
@@ -378,4 +387,61 @@ TEST_F(SoundGraphVoiceSuspendTest, AVoiceSuspendedByTheBudgetProducesNoSamples)
     const std::vector<f32> afterThaw = PumpBlocks(*stolen->GetSource(), 2);
     EXPECT_GT(PeakAbs(afterThaw), 0.5f) << "a thawed voice must produce audio again";
     EXPECT_EQ(stolen->GetSource()->GetCurrentFrame(), static_cast<u64>(kBlock) * 2u);
+}
+
+namespace
+{
+    /// A graph whose `Play` input event is actually ROUTED. This matters: `SoundGraph`'s
+    /// constructor adds the `Play` endpoint but binds no handler (`InitializeEndpoints()`
+    /// has no call sites anywhere in the engine), so on an unrouted graph
+    /// `SendInputEvent(IDs::Play)` returns false and `SoundGraphSource::m_IsPlaying` never
+    /// becomes true - which makes the natural-completion path unreachable. A real authored
+    /// one-shot routes Play to its WavePlayer, so it does reach it.
+    Ref<sg::SoundGraph> MakePlayRoutedCountingGraph(CountingNode** outNode)
+    {
+        auto counting = CreateScope<CountingNode>(UUID());
+        *outNode = counting.get();
+        const UUID countingID = counting->m_ID;
+
+        auto graph = Ref<sg::SoundGraph>::Create("PlayRoutedCounting", UUID());
+        graph->AddNode(std::move(counting));
+        EXPECT_TRUE(graph->AddInputEventsRoute(sg::SoundGraph::IDs::Play, countingID, Identifier("In")));
+        graph->SetSampleRate(48000.0f);
+        graph->Init();
+        return graph;
+    }
+} // namespace
+
+TEST_F(SoundGraphVoiceSuspendTest, AGraphSoundCanBeReplayedAfterItRunsToItsEnd)
+{
+    // Natural completion parks the source on the OTHER suspension axis:
+    // SoundGraphSource::Update calls SuspendProcessing(true) once the graph reports
+    // finished. Nothing but a graph swap ever cleared that, so a sound that ran to its end
+    // could never be played again - it stayed in the graph-swap silence path forever while
+    // the wrapper cheerfully reported it playing. Play is the one point where resetting the
+    // source's playback counters is correct, because SendPlayEvent restarts the stream.
+    CountingNode* counting = nullptr;
+    auto sound = CreateScope<sg::SoundGraphSound>();
+    ASSERT_TRUE(sound->InitializeDetachedSource());
+    ASSERT_TRUE(sound->InitializeFromGraph(MakePlayRoutedCountingGraph(&counting)));
+    auto* source = sound->GetSource();
+    ASSERT_NE(source, nullptr);
+
+    ASSERT_TRUE(sound->Play());
+    PumpBlocks(*source, 1); // fires the latched Play request; this graph has no wave
+                            // sources, so AreAllDataSourcesAtEnd() reports finished at once
+    ASSERT_EQ(counting->m_EventsReceived, 1u) << "the Play route must actually be bound";
+
+    sound->Update(0.016f);  // source Update -> SuspendProcessing(true)
+    PumpBlocks(*source, 1); // audio thread acks the suspend
+    sound->Update(0.016f);  // wrapper picks up the finish and retires the voice
+    ASSERT_TRUE(sound->IsFinished()) << "the probe must actually reach natural completion";
+
+    const u32 callsAtCompletion = counting->m_ProcessCalls;
+    ASSERT_TRUE(sound->Play());
+    PumpBlocks(*source, 2);
+    EXPECT_GT(counting->m_ProcessCalls, callsAtCompletion)
+        << "a graph sound must be steppable again after it ended";
+    EXPECT_EQ(counting->m_EventsReceived, 2u)
+        << "the replay's Play trigger must reach the graph";
 }

--- a/docs/agent-rules/audio-voice-budget.md
+++ b/docs/agent-rules/audio-voice-budget.md
@@ -209,17 +209,30 @@ graph voice's logical position — `DurationSeconds == 0` means no auto-retire a
 wrap (§7) — so `OnVoiceStart`'s `positionSeconds` is honoured exactly where it is reachable
 (a fresh start at 0) and self-corrects everywhere else.
 
-**Two consequences worth not re-deriving:**
+**Three consequences worth not re-deriving:**
 
-- **A voice that enters the budget over cap is never handed to `OnVoiceStop`.** `Acquire`
-  emits transitions only for state *changes*, and every voice *enters* virtual — so nothing
-  drives the host into the virtualized state on that path. `SoundGraphSound::Play` therefore
-  checks `IsVirtual(handle)` itself and applies it. Before that check a graph voice which
-  lost the budget at `Play()` time ran at full gain, over the cap; the clip path never had
-  the bug because it starts the backend *only* from `OnVoiceStart`.
+- **`Play()` must stay virtualized across the whole admission decision.** `Acquire` emits
+  transitions only for state *changes*, and every voice *enters* virtual — so a voice that
+  starts over budget is **never** handed to `OnVoiceStop`, and nothing else would put the
+  host into the virtualized state. So the rule is not "virtualize it afterwards", it is
+  **do not un-virtualize it beforehand**: `Play` releases the old handle with
+  `resumePlayback=false` and lets `OnVoiceStart` — which `Acquire` drives synchronously for
+  a winner — be the only thing that thaws. Un-muting first and re-muting after leaves a
+  window in which the audio thread can emit blocks of the *previous* stream at full gain,
+  and leaves an over-budget voice audible if the re-mute is ever forgotten. The clip path
+  never had either problem because `AudioSource` starts `ma_sound` *only* from
+  `OnVoiceStart`.
 - **A stopped or completed graph voice stays frozen.** `ReleaseVoice(resumePlayback=false)`
   leaves it muted *and* suspended, so a one-shot graph that simply ended costs nothing until
   something plays it again. Before #745 that path could only leave it muted-but-running.
+- **…which is why `Play()` also has to lift the OTHER suspension axis.**
+  `SoundGraphSource::Update` parks a finished source with `SuspendProcessing(true)`, and
+  nothing but a graph swap ever cleared it — so a sound that ran to its end could never be
+  played again (it sat in the graph-swap silence path while the wrapper reported it
+  playing). `Play` is the one place where that call's counter reset is *correct*, because
+  `SendPlayEvent` restarts the stream anyway. Do **not** move it onto a resume path such as
+  `OnVoiceStart`: that would zero `m_CurrentFrame` on every devirtualization and turn every
+  resume back into a restart — the exact bug this section exists to prevent.
 
 Watch the polarity trap while you are in there: `SoundGraphSound::m_Priority` is
 miniaudio-flavoured (**0 = highest**) while `VoiceParams::Priority` is the other way round


### PR DESCRIPTION
Follow-up to #885 (#745). Two review findings that were committed on the `#745` branch **after** that PR merged and so never landed — recovered here rather than lost with the worktree.

### 1. A finished graph sound could never be played again

`SoundGraphSource::Update` parks a source on the graph-swap suspension axis (`SuspendProcessing(true)`) once the graph reports finished, and nothing but a graph swap ever cleared it — so every subsequent `Play()` landed in the graph-swap silence path while the wrapper reported the sound playing. Pre-existing, not introduced by the suspend work, but adjacent enough to fix alongside it.

Reproducing it needs a graph whose `Play` input event is actually **routed**: `SoundGraph`'s constructor adds the `Play` endpoint but binds no handler, and `InitializeEndpoints()` — the only thing that would bind one — has zero call sites anywhere in the engine. On an unrouted graph `SendInputEvent(IDs::Play)` returns false, `m_IsPlaying` never becomes true, and the finish path is unreachable. A real authored one-shot routes `Play` to its `WavePlayer`, so it does reach it. The first version of the test used an unrouted probe and **passed against the bug**; `MakePlayRoutedCountingGraph` is what makes it fail.

The fix goes in `Play()`, deliberately **not** in `OnVoiceStart`: `SuspendProcessing(false)` resets `m_CurrentFrame` / `m_IsFinished` / `m_IsPlaying`, which is correct for a replay (`SendPlayEvent` restarts the stream anyway) but would be a serious regression on a resume path — it would zero the frozen position on every devirtualization and turn every resume back into a restart, the exact bug #745 exists to prevent.

### 2. `Play()` thawed the source before the budget had ruled

It released the old voice with `resumePlayback=true` (thaw + un-mute), then called `Acquire`, then re-virtualized if the voice had lost. The end state was right, but the window between them let the audio thread emit blocks of the *previous* stream at full gain — audible for a sound the caller had stopped. Now `Play()` releases with `resumePlayback=false` and stays muted-and-frozen across the whole admission decision; `OnVoiceStart` (which `Acquire` drives synchronously for a winner) is the only thing that thaws. This also deletes the explicit `IsVirtual(handle)` re-virtualize branch #885 added — not un-virtualizing in the first place subsumes it.

This half is structural: single-threaded, `Acquire` is synchronous, so the window is not separately observable from a test. `AGraphVoiceThatNeverWinsASlotStartsSuspended` and `AVoiceSuspendedByTheBudgetProducesNoSamples` continue to pin the end state.

### Verification

`*SoundGraph*:*Voice*:*Audio*` — **201/201 pass** (re-run on this rebase onto current master, not just as originally authored). The new `AGraphSoundCanBeReplayedAfterItRunsToItsEnd` fails without the `Play()` change: `m_ProcessCalls` 1 vs 1, `m_EventsReceived` 1 vs 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replay of naturally completed sound graphs so playback resumes correctly and play events are processed again.
  * Improved voice admission behavior, ensuring sounds remain muted and paused until they are granted playback capacity.
  * Prevented unintended playback-position resets during voice resume operations.

* **Documentation**
  * Clarified sound-voice suspension, replay, and admission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->