### PR TITLE
fix(renderer): pair GGX D and the height-correlated Smith G on one alpha

### DIFF
--- a/OloEditor/assets/shaders/include/PBRCommon.glsl
+++ b/OloEditor/assets/shaders/include/PBRCommon.glsl
@@ -133,7 +133,10 @@ vec3 fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
 // DISTRIBUTION FUNCTIONS
 // =============================================================================
 
-// GGX/Trowbridge-Reitz normal distribution function
+// GGX/Trowbridge-Reitz normal distribution function.
+// alpha = roughness^2 (`a`), and `a2` is alpha^2. This is the reference
+// convention THE ALPHA LEDGER below records; every G in this file is stated
+// relative to it.
 float distributionGGX(vec3 N, vec3 H, float roughness)
 {
     float a = roughness * roughness;
@@ -148,7 +151,10 @@ float distributionGGX(vec3 N, vec3 H, float roughness)
     return num / max(denom, EPSILON);
 }
 
-// Anisotropic GGX distribution
+// Anisotropic GGX distribution.
+// Takes ALPHAS, not roughnesses, despite the parameter names: `a2` here is
+// alphaX * alphaY. Callers must square the roughness themselves. Deliberate
+// exception to THE ALPHA LEDGER below; currently unreferenced.
 float distributionGGXAnisotropic(vec3 N, vec3 H, vec3 T, vec3 B, float roughnessX, float roughnessY)
 {
     float TdotH = dot(T, H);
@@ -166,8 +172,47 @@ float distributionGGXAnisotropic(vec3 N, vec3 H, vec3 T, vec3 B, float roughness
 // =============================================================================
 // GEOMETRY FUNCTIONS
 // =============================================================================
+//
+// -----------------------------------------------------------------------------
+// THE ALPHA LEDGER — read before touching any D or G in this file (issue #904)
+// -----------------------------------------------------------------------------
+// GGX is parameterised by `alpha`, the microfacet slope distribution width.
+// This engine's authoring parameter is `roughness`, and the mapping every
+// function here agrees on is Burley's:
+//
+//     alpha = roughness * roughness
+//
+// A `D` and a `G` evaluated at DIFFERENT alphas describe two different
+// surfaces. The result is plausible rather than obviously broken — no NaN, no
+// black pixel, just a highlight subtly shaped for a surface nobody authored —
+// which is exactly how the mismatch this ledger exists to prevent survived
+// unnoticed. So every function below states its convention, and the two
+// deliberate exceptions state WHY they differ instead of quietly differing:
+//
+//   distributionGGX                alpha = roughness^2   (a  = alpha, a2 = alpha^2)
+//   visibilitySmithGGXCorrelated   alpha = roughness^2   (a2 = alpha^2)
+//   ggxSmithLambda / ggxVNDFWeight alpha = roughness^2   (see A NOTE ON ALPHA below)
+//
+//   geometrySchlickGGX / geometrySmith — DELIBERATE EXCEPTION.
+//       Karis 2013's UE4 direct-lighting remap, k = (roughness + 1)^2 / 8.
+//       This is NOT a third alpha convention: it is a closed-form
+//       APPROXIMATION of the Smith G for the same alpha = roughness^2 surface,
+//       with Disney's "reduce the hotness of direct lighting" adjustment folded
+//       into the remap. Left as-is on purpose: `cookTorranceBRDF` — the BRDF
+//       every shipping lit pass actually calls — uses it, it is mirrored in
+//       Renderer/PathTracing/ReferenceBRDF.h so the offline reference tracer
+//       integrates the same thing, and replacing it would move every lit golden
+//       in the suite. That is a separate, deliberate decision, not part of #904.
+//
+//   distributionGGXAnisotropic — DELIBERATE EXCEPTION.
+//       Takes ALPHAS directly despite its parameter names: its
+//       `a2 = roughnessX * roughnessY` is alphaX * alphaY, so callers must pass
+//       roughness^2 themselves. Currently has no callers.
+// -----------------------------------------------------------------------------
 
-// Smith's method for masking-shadowing function (single direction)
+// Smith's method for masking-shadowing function (single direction).
+// Schlick-GGX with the UE4 direct-lighting k remap — a deliberate exception to
+// the alpha ledger above; see it before "fixing" this.
 float geometrySchlickGGX(float NdotV, float roughness)
 {
     float r = (roughness + 1.0);
@@ -179,7 +224,9 @@ float geometrySchlickGGX(float NdotV, float roughness)
     return num / max(denom, EPSILON);
 }
 
-// Smith's method considering both geometry obstruction and geometry shadowing
+// Smith's method considering both geometry obstruction and geometry shadowing.
+// Separable (not height-correlated) form, built on the UE4 k remap above — the
+// same deliberate exception to the alpha ledger.
 float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
 {
     float NdotV = max(dot(N, V), 0.0);
@@ -190,13 +237,52 @@ float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
     return ggx1 * ggx2;
 }
 
-// Height-correlated Smith G function (more accurate)
-float geometrySmithHeightCorrelated(vec3 N, vec3 V, vec3 L, float roughness)
+// Height-correlated Smith VISIBILITY term for GGX (Heitz 2014, "Understanding
+// the Masking-Shadowing Function", in the algebraic form Filament ships as
+// V_SmithGGXCorrelated).
+//
+// Two things this returns that its old name `geometrySmithHeightCorrelated`
+// did not say — both fixed under issue #904:
+//
+//  1. IT IS V, NOT G.  V = G2 / (4 * NdotV * NdotL): the 4*NdotV*NdotL from the
+//     Cook-Torrance denominator is already folded in, and cancels analytically
+//     against the sqrt terms. That cancellation is the entire point of the V
+//     form — it removes the 0/0 at grazing incidence. A caller must therefore
+//     write  D * V * F,  and must NOT divide by 4*NdotV*NdotL again. The old
+//     name read as a G, and its one caller (cookTorranceBRDFEnhanced) duly
+//     divided a second time.
+//
+//  2. alpha = roughness^2, matching distributionGGX. The previous version set
+//     `a2 = roughness * roughness`, squaring roughness ONCE where the formula
+//     wants alpha^2 = roughness^4.
+//
+//     Which direction that errs in is worth stating, because issue #904 states
+//     it BACKWARDS and the wrong version is the intuitive one. `a2 = r^2`
+//     means an effective alpha of r, while the correct alpha is r^2 — and
+//     r > r^2 for every r in (0, 1). So the old G modelled a ROUGHER surface
+//     than D did and masked MORE, not less. Correcting it makes those pixels
+//     BRIGHTER.
+//
+//     The error is also not largest on rough surfaces. It scales with the
+//     ratio r / r^2 = 1/r, so it peaks at LOW-to-mid roughness at grazing
+//     angles: measured over a (roughness x NdotV x NdotL) sweep, the worst G2
+//     discrepancy is 78% relative at roughness ~0.15 with both cosines near
+//     grazing, against ~14% at roughness 0.8 head-on.
+//
+// Pinned two ways, because neither catches the other's failure:
+//   * ReferenceBRDFTest.HeightCorrelatedVisibilityMatchesTheVndfLambda — an
+//     exact algebraic identity against ggxSmithLambda (the Lambda the VNDF path
+//     pairs with D). It holds for alpha = roughness^2 and no other convention,
+//     so reintroducing the single-square fails it at every roughness.
+//   * ReferenceBRDFGpuParity — this compiled GLSL against the C++ mirror in
+//     Renderer/PathTracing/ReferenceBRDF.h, so the two cannot drift.
+float visibilitySmithGGXCorrelated(vec3 N, vec3 V, vec3 L, float roughness)
 {
     float NdotV = max(dot(N, V), 0.0);
     float NdotL = max(dot(N, L), 0.0);
 
-    float a2 = roughness * roughness;
+    float alpha = roughness * roughness;
+    float a2 = alpha * alpha;
     float GGXV = NdotL * sqrt(NdotV * NdotV * (1.0 - a2) + a2);
     float GGXL = NdotV * sqrt(NdotL * NdotL * (1.0 - a2) + a2);
 
@@ -234,7 +320,14 @@ vec3 cookTorranceBRDF(vec3 N, vec3 V, vec3 L, vec3 albedo, float metallic, float
     return kD * albedo * INV_PI + specular;
 }
 
-// Enhanced BRDF with height-correlated Smith G function
+// Enhanced BRDF using the height-correlated Smith visibility term.
+//
+// NOTE: currently has no callers — its only caller,
+// calculateLightContributionEnhanced below, is itself unreferenced. The
+// shipping lit passes all call cookTorranceBRDF above. Kept (and made correct)
+// rather than deleted so that wiring it up is a one-line change that does not
+// also have to re-derive the math; that wiring is deliberately NOT part of
+// issue #904, because it would move every lit golden in the suite.
 vec3 cookTorranceBRDFEnhanced(vec3 N, vec3 V, vec3 L, vec3 albedo, float metallic, float roughness)
 {
     vec3 H = normalize(V + L);
@@ -243,12 +336,13 @@ vec3 cookTorranceBRDFEnhanced(vec3 N, vec3 V, vec3 L, vec3 albedo, float metalli
     F0 = mix(F0, albedo, metallic);
 
     float NDF = distributionGGX(N, H, roughness);
-    float G = geometrySmithHeightCorrelated(N, V, L, roughness);
+    // Vis is the VISIBILITY term: G2 / (4 * NdotV * NdotL), with the
+    // Cook-Torrance denominator already folded in. Multiply, do not divide
+    // again — see visibilitySmithGGXCorrelated.
+    float Vis = visibilitySmithGGXCorrelated(N, V, L, roughness);
     vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
 
-    vec3 numerator = NDF * G * F;
-    float denominator = 4.0 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + EPSILON;
-    vec3 specular = numerator / denominator;
+    vec3 specular = NDF * Vis * F;
 
     vec3 kS = F;
     vec3 kD = vec3(1.0) - kS;
@@ -549,12 +643,18 @@ vec3  importanceSampleGGX(vec2 Xi, vec3 N, float r) { return ImportanceSampleGGX
 // A NOTE ON ALPHA
 // ---------------------------------------------------------------------------
 // These functions use alpha = roughness * roughness, matching distributionGGX
-// above (whose `a` is roughness*roughness and `a2` its square). They therefore
-// do NOT match geometrySmithHeightCorrelated, which squares roughness only
-// once — a pre-existing inconsistency between the engine's D and G terms,
-// noted here rather than changed because moving it would shift every lit
-// golden. The Lambda below is the one that pairs with D, which is what
-// unbiasedness requires.
+// above (whose `a` is roughness*roughness and `a2` its square). The Lambda
+// below is the one that pairs with D, which is what unbiasedness requires.
+//
+// This block used to record a divergence: geometrySmithHeightCorrelated
+// squared roughness only once, so the engine's D and G described different
+// surfaces, and that was noted here rather than fixed because it was believed
+// to move every lit golden. Issue #904 resolved it — the mismatched function
+// turned out to be on an unreferenced path, so nothing rendered had to change.
+// It is now visibilitySmithGGXCorrelated and agrees with the alpha used here;
+// the exact identity between the two is asserted by
+// ReferenceBRDFTest.HeightCorrelatedVisibilityMatchesTheVndfLambda. See THE
+// ALPHA LEDGER in the GEOMETRY FUNCTIONS section for the whole picture.
 // =============================================================================
 
 // Smith's Lambda for GGX, from the cosine with the (macro)surface normal.

--- a/OloEditor/assets/shaders/tests/PbrBrdfParityProbe.glsl
+++ b/OloEditor/assets/shaders/tests/PbrBrdfParityProbe.glsl
@@ -29,7 +29,17 @@
 // A non-grey albedo is deliberate: it makes a channel swap or a luminance
 // collapse in either implementation visible, which a white albedo would hide.
 //
-// Output: .rgb = cookTorranceBRDF(...), .a = 1.
+// Output: .rgb = cookTorranceBRDF(...)
+//         .a   = visibilitySmithGGXCorrelated(...)
+//
+// The alpha channel rides along for issue #904. The height-correlated
+// visibility term is not on the shipping lit path, but it IS a PBRCommon
+// function with a C++ mirror, and an unmirrored-or-unpinned function is one
+// nothing can detect drift in. Reusing this probe's grid rather than adding a
+// second one keeps both sides decoding identical parameters by construction.
+// Note N == V here, so NdotV is pinned at 1 and only the NdotL half of the
+// term's (NdotV, NdotL) symmetry is swept — which is enough to expose an
+// alpha-convention error, since V varies strongly with alpha at low NdotL.
 // =============================================================================
 
 #type vertex
@@ -82,5 +92,6 @@ void main()
 
     vec3 albedo = vec3(0.9, 0.6, 0.3);
 
-    o_Color = vec4(cookTorranceBRDF(N, V, L, albedo, metallic, roughness), 1.0);
+    o_Color = vec4(cookTorranceBRDF(N, V, L, albedo, metallic, roughness),
+                   visibilitySmithGGXCorrelated(N, V, L, roughness));
 }

--- a/OloEngine/src/OloEngine/Renderer/PathTracing/ReferenceBRDF.h
+++ b/OloEngine/src/OloEngine/Renderer/PathTracing/ReferenceBRDF.h
@@ -24,8 +24,11 @@
 //     reference brighter than the renderer at mirror roughness.
 //   * `GeometrySmith` uses the Schlick-GGX k = (r+1)^2/8 remap (the UE4 direct-
 //     lighting form), not the height-correlated Smith. PBRCommon has BOTH
-//     (`geometrySmithHeightCorrelated`); `cookTorranceBRDF` — the function the
-//     lit passes actually call — uses this one.
+//     (`visibilitySmithGGXCorrelated`, mirrored below as
+//     `VisibilitySmithGGXCorrelated`); `cookTorranceBRDF` — the function the
+//     lit passes actually call — uses this one. See THE ALPHA LEDGER in
+//     PBRCommon.glsl's GEOMETRY FUNCTIONS section for why the two differ and
+//     why that difference is deliberate rather than the #904 bug.
 //   * `CookTorranceBRDF` computes kD = 1 - F with F evaluated at the HALF
 //     vector, which is the common (mildly non-reciprocal) formulation. It is
 //     what ships, so it is what the reference integrates.
@@ -199,6 +202,59 @@ namespace OloEngine::PathTracing
         kD *= 1.0f - metallic;
 
         return kD * albedo * kInvPi + specular;
+    }
+
+    // -------------------------------------------------------------------------
+    // Height-correlated Smith, and the Lambda it must agree with (issue #904)
+    //
+    // These two are NOT on the shipping lit path — `CookTorranceBRDF` above is,
+    // and it uses the UE4 k remap. They are mirrored here because they are the
+    // pair whose alpha convention #904 was about, and because ReferenceBRDF.h
+    // is where this repo pins GLSL functions against C++: an unmirrored GLSL
+    // function is one nothing can detect drift in.
+    // -------------------------------------------------------------------------
+
+    // Smith's Lambda for GGX from the cosine with the macrosurface normal
+    // (GLSL: ggxSmithLambda). Takes ALPHA, not roughness — matching the GLSL,
+    // whose callers pass roughness * roughness.
+    //
+    // THERE IS A SECOND C++ MIRROR OF THIS FUNCTION: `Vndf::SmithLambda` in
+    // OloEngine/tests/Rendering/StochasticSamplerTest.cpp. That is deliberate,
+    // not an oversight to be tidied away — it is f64 because it backs a
+    // brute-force reference integrator whose whole value is precision, and
+    // narrowing it to this f32 form would weaken the test it exists for. Each
+    // copy carries its own guard (this one by
+    // HeightCorrelatedVisibilityMatchesTheVndfLambda, that one by
+    // VndfEstimatorMatchesBruteForce), so neither can drift silently. If you
+    // add a THIRD, stop and reuse one of these instead.
+    [[nodiscard]] inline f32 GgxSmithLambda(f32 nDotX, f32 alpha) noexcept
+    {
+        const f32 c = std::clamp(std::abs(nDotX), 1.0e-4f, 1.0f);
+        const f32 c2 = c * c;
+        const f32 tan2 = (1.0f - c2) / c2;
+        return 0.5f * (-1.0f + std::sqrt(1.0f + alpha * alpha * tan2));
+    }
+
+    // Height-correlated Smith VISIBILITY (GLSL: visibilitySmithGGXCorrelated).
+    //
+    // Returns V = G2 / (4 * nDotV * nDotL) — the Cook-Torrance denominator is
+    // folded in and cancels. Callers multiply: D * V * F. Do not divide by
+    // 4*nDotV*nDotL again; that double-divide is precisely the bug #904 fixed
+    // on the GLSL side.
+    //
+    // alpha = roughness^2, so a2 = roughness^4, matching DistributionGGX.
+    [[nodiscard]] inline f32 VisibilitySmithGGXCorrelated(const glm::vec3& n, const glm::vec3& v, const glm::vec3& l,
+                                                          f32 roughness) noexcept
+    {
+        const f32 nDotV = std::max(glm::dot(n, v), 0.0f);
+        const f32 nDotL = std::max(glm::dot(n, l), 0.0f);
+
+        const f32 alpha = roughness * roughness;
+        const f32 a2 = alpha * alpha;
+        const f32 ggxV = nDotL * std::sqrt(nDotV * nDotV * (1.0f - a2) + a2);
+        const f32 ggxL = nDotV * std::sqrt(nDotL * nDotL * (1.0f - a2) + a2);
+
+        return 0.5f / std::max(ggxV + ggxL, kEpsilon);
     }
 
     // -------------------------------------------------------------------------

--- a/OloEngine/src/OloEngine/Renderer/PathTracing/ReferenceBRDF.h
+++ b/OloEngine/src/OloEngine/Renderer/PathTracing/ReferenceBRDF.h
@@ -227,7 +227,8 @@ namespace OloEngine::PathTracing
     // HeightCorrelatedVisibilityMatchesTheVndfLambda, that one by
     // VndfEstimatorMatchesBruteForce), so neither can drift silently. If you
     // add a THIRD, stop and reuse one of these instead.
-    [[nodiscard]] inline f32 GgxSmithLambda(f32 nDotX, f32 alpha) noexcept
+    [[nodiscard("The Lambda is the masking term; discarding it drops the shadowing.")]] inline f32
+    GgxSmithLambda(f32 nDotX, f32 alpha) noexcept
     {
         const f32 c = std::clamp(std::abs(nDotX), 1.0e-4f, 1.0f);
         const f32 c2 = c * c;
@@ -243,11 +244,20 @@ namespace OloEngine::PathTracing
     // on the GLSL side.
     //
     // alpha = roughness^2, so a2 = roughness^4, matching DistributionGGX.
-    [[nodiscard]] inline f32 VisibilitySmithGGXCorrelated(const glm::vec3& n, const glm::vec3& v, const glm::vec3& l,
-                                                          f32 roughness) noexcept
+    //
+    // Takes COSINES where the GLSL takes vectors, which is the one place this
+    // port deliberately does not mirror its counterpart's signature. Three
+    // adjacent `const glm::vec3&` parameters are silently swappable at a call
+    // site — and the GLSL's own body immediately reduces them to two cosines
+    // anyway, so nothing is lost. `DistributionGGXSamplingDensity` above sets
+    // the same precedent. The `max(dot(...), 0)` clamp the GLSL applies is kept
+    // INSIDE this function rather than pushed onto callers, so the quirk still
+    // lives in the mirror where it belongs.
+    [[nodiscard("This is the visibility term; discarding it silently drops masking-shadowing.")]] inline f32
+    VisibilitySmithGGXCorrelated(f32 nDotV, f32 nDotL, f32 roughness) noexcept
     {
-        const f32 nDotV = std::max(glm::dot(n, v), 0.0f);
-        const f32 nDotL = std::max(glm::dot(n, l), 0.0f);
+        nDotV = std::max(nDotV, 0.0f);
+        nDotL = std::max(nDotL, 0.0f);
 
         const f32 alpha = roughness * roughness;
         const f32 a2 = alpha * alpha;

--- a/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFGpuParityTest.cpp
+++ b/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFGpuParityTest.cpp
@@ -263,4 +263,84 @@ namespace OloEngine::Tests
         EXPECT_GT(maximum, 0.5f) << "the probe target is uniformly near zero — the shader almost certainly "
                                     "failed to compile, which would make the parity test above pass vacuously";
     }
+    // The alpha channel of the same probe carries visibilitySmithGGXCorrelated
+    // (issue #904). It is a separate test rather than extra channels in the
+    // test above so that a failure names WHICH function drifted — the two have
+    // completely different causes and completely different fixes.
+    //
+    // This is the guard that makes the #904 fix un-regressable across the
+    // language boundary: restoring the old `a2 = roughness * roughness` on
+    // either side alone fails here at every roughness except the two fixed
+    // points (0 and 1, where roughness^2 == roughness).
+    TEST(ReferenceBRDFGpuParity, HeightCorrelatedVisibilityMatchesCppMirror)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        ParityProbeHarness harness;
+        harness.Draw();
+
+        std::vector<f32> pixels;
+        harness.ReadOutput(pixels);
+        ASSERT_EQ(pixels.size(), static_cast<sizet>(kWidth) * kHeight * 4);
+
+        const glm::vec3 n(0.0f, 0.0f, 1.0f);
+        const glm::vec3 v(0.0f, 0.0f, 1.0f);
+
+        // Same tolerance model as the BRDF comparison above, and for the same
+        // reason: V spans orders of magnitude between a near-mirror surface and
+        // a rough grazing one, so relative-with-an-absolute-floor is the only
+        // shape that is neither vacuous at the top nor impossible at the bottom.
+        constexpr f32 kRelativeTolerance = 0.01f;
+        constexpr f32 kAbsoluteFloor = 1e-4f;
+
+        u32 mismatches = 0;
+        f32 worstRelative = 0.0f;
+        u32 worstX = 0;
+        u32 worstY = 0;
+        f32 maximum = 0.0f;
+
+        for (u32 y = 0; y < kHeight; ++y)
+        {
+            for (u32 x = 0; x < kWidth; ++x)
+            {
+                const GridPoint point = DecodeGridPoint(x, y);
+                const f32 expected = VisibilitySmithGGXCorrelated(n, v, point.L, point.Roughness);
+                const f32 actual = pixels[(static_cast<sizet>(y) * kWidth + x) * 4 + 3];
+
+                ASSERT_TRUE(std::isfinite(actual))
+                    << "GPU produced a non-finite visibility term at (" << x << ", " << y << ")";
+                maximum = std::max(maximum, actual);
+
+                const f32 difference = std::abs(actual - expected);
+                const f32 scale = std::max({ std::abs(expected), std::abs(actual), kAbsoluteFloor });
+                const f32 relative = difference / scale;
+                if (relative > worstRelative)
+                {
+                    worstRelative = relative;
+                    worstX = x;
+                    worstY = y;
+                }
+                if (relative > kRelativeTolerance && difference > kAbsoluteFloor)
+                    ++mismatches;
+            }
+        }
+
+        // Guards against the whole comparison passing vacuously on a cleared
+        // target, exactly as ProbeGridCoversANonTrivialRange does for .rgb.
+        EXPECT_GT(maximum, 0.1f) << "the probe's alpha channel is uniformly near zero — the shader almost "
+                                    "certainly failed to compile";
+
+        const GridPoint worstPoint = DecodeGridPoint(worstX, worstY);
+        EXPECT_EQ(mismatches, 0u)
+            << mismatches << " of " << (kWidth * kHeight) << " samples disagree.\n"
+            << "Worst at roughness = " << worstPoint.Roughness << ", NdotL = " << worstPoint.L.z << " (relative "
+            << worstRelative << ")\n"
+            << "  GLSL visibilitySmithGGXCorrelated = " << pixels[(static_cast<sizet>(worstY) * kWidth + worstX) * 4 + 3]
+            << "\n"
+            << "  C++  VisibilitySmithGGXCorrelated = "
+            << VisibilitySmithGGXCorrelated(n, v, worstPoint.L, worstPoint.Roughness) << "\n"
+            << "The height-correlated Smith term has DRIFTED between PBRCommon.glsl and\n"
+            << "Renderer/PathTracing/ReferenceBRDF.h. Check the alpha convention first: it must be\n"
+            << "alpha = roughness^2 on BOTH sides (see THE ALPHA LEDGER in PBRCommon.glsl).";
+    }
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFGpuParityTest.cpp
+++ b/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFGpuParityTest.cpp
@@ -304,7 +304,8 @@ namespace OloEngine::Tests
             for (u32 x = 0; x < kWidth; ++x)
             {
                 const GridPoint point = DecodeGridPoint(x, y);
-                const f32 expected = VisibilitySmithGGXCorrelated(n, v, point.L, point.Roughness);
+                const f32 expected =
+                    VisibilitySmithGGXCorrelated(glm::dot(n, v), glm::dot(n, point.L), point.Roughness);
                 const f32 actual = pixels[(static_cast<sizet>(y) * kWidth + x) * 4 + 3];
 
                 ASSERT_TRUE(std::isfinite(actual))
@@ -338,7 +339,7 @@ namespace OloEngine::Tests
             << "  GLSL visibilitySmithGGXCorrelated = " << pixels[(static_cast<sizet>(worstY) * kWidth + worstX) * 4 + 3]
             << "\n"
             << "  C++  VisibilitySmithGGXCorrelated = "
-            << VisibilitySmithGGXCorrelated(n, v, worstPoint.L, worstPoint.Roughness) << "\n"
+            << VisibilitySmithGGXCorrelated(glm::dot(n, v), glm::dot(n, worstPoint.L), worstPoint.Roughness) << "\n"
             << "The height-correlated Smith term has DRIFTED between PBRCommon.glsl and\n"
             << "Renderer/PathTracing/ReferenceBRDF.h. Check the alpha convention first: it must be\n"
             << "alpha = roughness^2 on BOTH sides (see THE ALPHA LEDGER in PBRCommon.glsl).";

--- a/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFTest.cpp
+++ b/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFTest.cpp
@@ -34,6 +34,7 @@
 #include <cmath>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OloEngine::Tests
@@ -49,6 +50,46 @@ namespace OloEngine::Tests
         {
             return glm::vec2(static_cast<f32>(i) / static_cast<f32>(n),
                              SamplerDetail::ToUnitFloat(SamplerDetail::ReverseBits(i)));
+        }
+
+        // Strip `//` comments and collapse whitespace runs, so a source-text
+        // assertion is about the CODE rather than about one formatting of it.
+        // Both halves earn their place: without the comment strip, a comment
+        // that merely *describes* the old expression would trip the negative
+        // assertions below; without the whitespace collapse, a clang-format run
+        // could fail the test with a message claiming the math regressed.
+        [[nodiscard]] std::string NormalizeGlsl(std::string_view source)
+        {
+            std::string out;
+            out.reserve(source.size());
+
+            bool pendingSpace = false;
+            for (sizet i = 0; i < source.size(); ++i)
+            {
+                const char c = source[i];
+
+                if (c == '/' && i + 1 < source.size() && source[i + 1] == '/')
+                {
+                    while (i < source.size() && source[i] != '\n')
+                        ++i;
+                    pendingSpace = true;
+                    continue;
+                }
+
+                // Deliberately not std::isspace: the <cctype> overloads are
+                // locale-sensitive, and GLSL whitespace is exactly these four.
+                if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+                {
+                    pendingSpace = true;
+                    continue;
+                }
+
+                if (pendingSpace && !out.empty())
+                    out.push_back(' ');
+                pendingSpace = false;
+                out.push_back(c);
+            }
+            return out;
         }
 
         // Uniform-hemisphere Monte Carlo estimate of the directional albedo
@@ -215,8 +256,10 @@ namespace OloEngine::Tests
     // =========================================================================
     TEST(ReferenceBRDF, HeightCorrelatedVisibilityMatchesTheVndfLambda)
     {
-        const glm::vec3 n(0.0f, 0.0f, 1.0f);
-
+        // Both closed forms depend on the geometry only through the two
+        // cosines, so the sweep is over those directly rather than over
+        // vectors that would immediately be reduced to them.
+        //
         // NdotV and NdotL are floored at 0.02 rather than swept to 0: below
         // that the EPSILON clamp inside VisibilitySmithGGXCorrelated engages
         // and the closed forms legitimately part company. Reproducing that
@@ -233,14 +276,12 @@ namespace OloEngine::Tests
             for (u32 vi = 0; vi < 16; ++vi)
             {
                 const f32 nDotV = std::max((static_cast<f32>(vi) + 0.5f) / 16.0f, kCosineFloor);
-                const glm::vec3 v(std::sqrt(std::max(0.0f, 1.0f - nDotV * nDotV)), 0.0f, nDotV);
 
                 for (u32 li = 0; li < 16; ++li)
                 {
                     const f32 nDotL = std::max((static_cast<f32>(li) + 0.5f) / 16.0f, kCosineFloor);
-                    const glm::vec3 l(std::sqrt(std::max(0.0f, 1.0f - nDotL * nDotL)), 0.0f, nDotL);
 
-                    const f32 filament = VisibilitySmithGGXCorrelated(n, v, l, roughness);
+                    const f32 filament = VisibilitySmithGGXCorrelated(nDotV, nDotL, roughness);
 
                     const f32 lambdaV = GgxSmithLambda(nDotV, alpha);
                     const f32 lambdaL = GgxSmithLambda(nDotL, alpha);
@@ -320,7 +361,7 @@ namespace OloEngine::Tests
                 const glm::vec3 h = glm::normalize(v + l);
                 // F == 1: this is the white furnace, so every microfacet
                 // reflects everything and the integral is pure geometry.
-                const f64 value = static_cast<f64>(DistributionGGX(n, h, roughness)) * static_cast<f64>(VisibilitySmithGGXCorrelated(n, v, l, roughness));
+                const f64 value = static_cast<f64>(DistributionGGX(n, h, roughness)) * static_cast<f64>(VisibilitySmithGGXCorrelated(1.0f, cosTheta, roughness));
                 sum += value * static_cast<f64>(cosTheta) * static_cast<f64>(kTwoPi);
             }
             return sum / static_cast<f64>(kSamples);
@@ -389,27 +430,43 @@ namespace OloEngine::Tests
         ASSERT_NE(bodyEnd, std::string::npos);
         const std::string body = src.substr(visibilityDecl, bodyEnd - visibilityDecl);
 
-        EXPECT_NE(body.find("float alpha = roughness * roughness;"), std::string::npos)
-            << "visibilitySmithGGXCorrelated no longer derives alpha = roughness^2.";
-        EXPECT_NE(body.find("float a2 = alpha * alpha;"), std::string::npos)
+        const std::string bodyFlat = NormalizeGlsl(body);
+        EXPECT_NE(bodyFlat.find("float alpha = roughness * roughness;"), std::string::npos)
+            << "visibilitySmithGGXCorrelated no longer derives alpha = roughness^2. (If the local was "
+               "merely renamed, update this test — but check the math first.)";
+        EXPECT_NE(bodyFlat.find("float a2 = alpha * alpha;"), std::string::npos)
             << "visibilitySmithGGXCorrelated no longer squares ALPHA. If this reverted to\n"
                "`a2 = roughness * roughness` then D and G describe different surfaces again — see\n"
                "THE ALPHA LEDGER in PBRCommon.glsl. That is issue #904, and nothing else in this\n"
                "suite would notice, because the function is on a dead call chain.";
 
-        // The caller must multiply, not divide again.
+        // The caller must multiply by the visibility term, never divide again.
         const sizet enhancedDecl = src.find("vec3 cookTorranceBRDFEnhanced(");
         ASSERT_NE(enhancedDecl, std::string::npos) << "cookTorranceBRDFEnhanced is gone from PBRCommon.glsl";
         const sizet enhancedEnd = src.find("\n}", enhancedDecl);
         ASSERT_NE(enhancedEnd, std::string::npos);
-        const std::string enhanced = src.substr(enhancedDecl, enhancedEnd - enhancedDecl);
+        const std::string enhancedFlat = NormalizeGlsl(src.substr(enhancedDecl, enhancedEnd - enhancedDecl));
 
-        EXPECT_NE(enhanced.find("vec3 specular = NDF * Vis * F;"), std::string::npos)
-            << "cookTorranceBRDFEnhanced no longer forms its specular term as D * V * F.";
-        EXPECT_EQ(enhanced.find("4.0 * max(dot(N, V)"), std::string::npos)
-            << "cookTorranceBRDFEnhanced divides by 4*NdotV*NdotL again. visibilitySmithGGXCorrelated\n"
-               "already folds that denominator in — dividing a second time cost the specular lobe\n"
-               "~3.6x of its energy at roughness 0.3 (directional albedo 0.99 -> 0.27) before #904.";
+        EXPECT_NE(enhancedFlat.find("visibilitySmithGGXCorrelated("), std::string::npos)
+            << "cookTorranceBRDFEnhanced no longer calls visibilitySmithGGXCorrelated.";
+
+        // These two are the load-bearing assertions, and they are deliberately
+        // about CHARACTERS rather than about one spelling of the expression.
+        // With comments stripped, the correct body contains no division and no
+        // digit 4 at all — so every way of rewriting the Cook-Torrance
+        // denominator back in (`4.0 * max(dot(N, V), 0.0) * ...`, `4.0*NdotV*NdotL`,
+        // `/ (4.0 * ...)`, a hoisted `float denom = ...`) trips one of them.
+        // An earlier version of this test matched a single literal spelling,
+        // which the exact regression it names could have walked straight past.
+        EXPECT_EQ(enhancedFlat.find('/'), std::string::npos)
+            << "cookTorranceBRDFEnhanced contains a division. visibilitySmithGGXCorrelated returns V =\n"
+               "G2/(4 NdotV NdotL) — the denominator is already folded in, and dividing a second time\n"
+               "cost the specular lobe ~3.6x of its energy at roughness 0.3 (directional albedo\n"
+               "0.99 -> 0.27) before #904. If a division is legitimately needed here, this assertion\n"
+               "has to be replaced by one that still rules that regression out.";
+        EXPECT_EQ(enhancedFlat.find('4'), std::string::npos)
+            << "cookTorranceBRDFEnhanced mentions a 4 — almost certainly the 4*NdotV*NdotL factor "
+               "coming back. See the assertion above.";
     }
 
     // =========================================================================

--- a/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFTest.cpp
+++ b/OloEngine/tests/Rendering/PathTracing/ReferenceBRDFTest.cpp
@@ -23,6 +23,8 @@
 
 #include "OloEnginePCH.h"
 
+#include "Rendering/ShaderHarness.h"
+
 #include "OloEngine/Renderer/PathTracing/PathSampler.h"
 #include "OloEngine/Renderer/PathTracing/ReferenceBRDF.h"
 
@@ -31,6 +33,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace OloEngine::Tests
@@ -181,6 +184,232 @@ namespace OloEngine::Tests
             EXPECT_GE(integral, kLowerBound) << "roughness = " << roughness;
             EXPECT_LE(integral, kUpperBound) << "roughness = " << roughness << " — the BRDF is creating energy";
         }
+    }
+
+    // =========================================================================
+    // D and G must agree about alpha (issue #904).
+    //
+    // THE PIN, AND WHY IT IS AN IDENTITY RATHER THAN A TOLERANCE.
+    //
+    // The height-correlated Smith visibility has two equivalent closed forms:
+    //
+    //   Filament:  V = 0.5 / (NdotL*sqrt(NdotV^2(1-a2)+a2) + NdotV*sqrt(NdotL^2(1-a2)+a2))
+    //   Heitz:     V = 1 / (4 * NdotV * NdotL * (1 + Lambda(NdotV) + Lambda(NdotL)))
+    //
+    // They are algebraically the SAME function — but only when both are handed
+    // the same alpha. `VisibilitySmithGGXCorrelated` uses the first, and
+    // `GgxSmithLambda` (the Lambda the VNDF path pairs with the D it sampled)
+    // uses the second. So evaluating both and demanding they agree is a direct,
+    // exact test of the proposition "D and G describe the same surface" — with
+    // no Monte Carlo noise and no tolerance to argue about.
+    //
+    // Teeth, measured: the pre-#904 convention (`a2 = roughness * roughness`,
+    // squaring roughness once instead of using alpha^2 = roughness^4) misses
+    // this identity by up to 60% relative. It agrees only at the two fixed
+    // points of x -> x^2, roughness 0 and 1, which is exactly why eyeballing a
+    // mid-roughness render never caught it.
+    //
+    // This is the assertion that catches the ALPHA half of #904. The furnace
+    // test below catches the other half (V vs G, the double divide); neither
+    // sees the other's failure, so both are here.
+    // =========================================================================
+    TEST(ReferenceBRDF, HeightCorrelatedVisibilityMatchesTheVndfLambda)
+    {
+        const glm::vec3 n(0.0f, 0.0f, 1.0f);
+
+        // NdotV and NdotL are floored at 0.02 rather than swept to 0: below
+        // that the EPSILON clamp inside VisibilitySmithGGXCorrelated engages
+        // and the closed forms legitimately part company. Reproducing that
+        // clamp is the point of the port (see ReferenceBRDF.h's fidelity
+        // notes), so the identity is asserted where the clamp is inactive.
+        constexpr f32 kCosineFloor = 0.02f;
+
+        f32 worstRelative = 0.0f;
+        for (u32 ri = 0; ri < 16; ++ri)
+        {
+            const f32 roughness = (static_cast<f32>(ri) + 0.5f) / 16.0f;
+            const f32 alpha = roughness * roughness;
+
+            for (u32 vi = 0; vi < 16; ++vi)
+            {
+                const f32 nDotV = std::max((static_cast<f32>(vi) + 0.5f) / 16.0f, kCosineFloor);
+                const glm::vec3 v(std::sqrt(std::max(0.0f, 1.0f - nDotV * nDotV)), 0.0f, nDotV);
+
+                for (u32 li = 0; li < 16; ++li)
+                {
+                    const f32 nDotL = std::max((static_cast<f32>(li) + 0.5f) / 16.0f, kCosineFloor);
+                    const glm::vec3 l(std::sqrt(std::max(0.0f, 1.0f - nDotL * nDotL)), 0.0f, nDotL);
+
+                    const f32 filament = VisibilitySmithGGXCorrelated(n, v, l, roughness);
+
+                    const f32 lambdaV = GgxSmithLambda(nDotV, alpha);
+                    const f32 lambdaL = GgxSmithLambda(nDotL, alpha);
+                    const f32 heitz = 1.0f / (4.0f * nDotV * nDotL * (1.0f + lambdaV + lambdaL));
+
+                    const f32 relative = std::abs(filament - heitz) / std::max(filament, 1e-8f);
+                    worstRelative = std::max(worstRelative, relative);
+
+                    ASSERT_LT(relative, 1e-4f)
+                        << "D and G disagree about alpha at roughness = " << roughness << ", NdotV = " << nDotV
+                        << ", NdotL = " << nDotL << "\n"
+                        << "  visibilitySmithGGXCorrelated = " << filament << "\n"
+                        << "  1 / (4 NdotV NdotL (1 + Lv + Ll)) = " << heitz << "  (alpha = " << alpha << ")\n"
+                        << "These are the same function evaluated two ways; they can only differ if the two\n"
+                        << "sides were handed different alphas. Check that BOTH use alpha = roughness^2 —\n"
+                        << "see THE ALPHA LEDGER in OloEditor/assets/shaders/include/PBRCommon.glsl.";
+                }
+            }
+        }
+
+        // Non-vacuity: an identity test that never evaluated anything would
+        // also report a worst case of exactly zero.
+        EXPECT_GT(worstRelative, 0.0f) << "the sweep produced bit-identical results everywhere, which means it "
+                                          "almost certainly did not run the two different formulations";
+    }
+
+    // =========================================================================
+    // White furnace on the height-correlated specular lobe (issue #904).
+    //
+    // Integrates D * V * (n.l) with F held at 1 — the directional albedo of the
+    // specular lobe alone. What each bound is for:
+    //
+    //   UPPER — energy conservation. A single-scattering microfacet BRDF may
+    //     lose energy (it models no inter-reflection between microfacets) but
+    //     must never create it.
+    //
+    //   LOWER, over a deliberately narrow roughness window — this is the one
+    //     that catches the V-vs-G confusion IN THE C++ MIRROR. Note the limit:
+    //     it integrates D * V directly, so it does NOT reach the GLSL caller
+    //     `cookTorranceBRDFEnhanced`; that half is pinned by the source-text
+    //     assertion below, because the function is unreachable and cannot be
+    //     evaluated by any probe. `visibilitySmithGGXCorrelated`
+    //     returns V = G2/(4 NdotV NdotL), with the Cook-Torrance denominator
+    //     already folded in; the pre-#904 caller divided by 4*NdotV*NdotL a
+    //     SECOND time. Measured, that costs roughly 3.6x of the lobe's energy
+    //     at roughness 0.3 (0.99 -> 0.27), which sails straight through any
+    //     upper bound and through every "is the image plausible" check.
+    //
+    // The window is [0.3, 0.5] on purpose, and both ends are load-bearing:
+    // below ~0.27 the EPSILON clamp inside D suppresses the peak (0.002 at
+    // roughness 0.05 — shipped behaviour, asserted separately above), and above
+    // ~0.6 single-scattering GGX legitimately sheds energy (0.31 at roughness
+    // 1.0). Only in between is the lobe near-white, and only there does a lower
+    // bound mean anything.
+    //
+    // Note this does NOT catch the alpha mismatch: with the wrong alpha the
+    // integral moves from 0.991 to 0.986 at roughness 0.3, comfortably inside
+    // any honest band. That is what the identity test above is for.
+    // =========================================================================
+    TEST(ReferenceBRDF, HeightCorrelatedSpecularLobeConservesEnergy)
+    {
+        constexpr u32 kSamples = 1u << 16;
+        const glm::vec3 n(0.0f, 0.0f, 1.0f);
+        const glm::vec3 v(0.0f, 0.0f, 1.0f);
+
+        const auto lobeAlbedo = [&](f32 roughness) -> f64
+        {
+            f64 sum = 0.0;
+            for (u32 i = 0; i < kSamples; ++i)
+            {
+                const glm::vec2 xi = Hammersley(i, kSamples);
+                const f32 cosTheta = xi.x;
+                const f32 sinTheta = std::sqrt(std::max(0.0f, 1.0f - cosTheta * cosTheta));
+                const f32 phi = kTwoPi * xi.y;
+                const glm::vec3 l(std::cos(phi) * sinTheta, std::sin(phi) * sinTheta, cosTheta);
+
+                const glm::vec3 h = glm::normalize(v + l);
+                // F == 1: this is the white furnace, so every microfacet
+                // reflects everything and the integral is pure geometry.
+                const f64 value = static_cast<f64>(DistributionGGX(n, h, roughness)) * static_cast<f64>(VisibilitySmithGGXCorrelated(n, v, l, roughness));
+                sum += value * static_cast<f64>(cosTheta) * static_cast<f64>(kTwoPi);
+            }
+            return sum / static_cast<f64>(kSamples);
+        };
+
+        // Energy is never created, anywhere in the domain.
+        for (u32 bin = 0; bin < 32; ++bin)
+        {
+            const f32 roughness = std::max((static_cast<f32>(bin) + 0.5f) / 32.0f, kMinRoughness);
+            EXPECT_LE(lobeAlbedo(roughness), 1.02)
+                << "roughness = " << roughness << " — the specular lobe is creating energy";
+        }
+
+        // The near-white window, where a lower bound has meaning.
+        for (const f32 roughness : { 0.3f, 0.35f, 0.4f, 0.45f, 0.5f })
+        {
+            const f64 albedo = lobeAlbedo(roughness);
+            EXPECT_GE(albedo, 0.85)
+                << "roughness = " << roughness << " — the specular lobe lost energy it should not have.\n"
+                << "The usual cause is treating visibilitySmithGGXCorrelated as a G and dividing by\n"
+                << "4 * NdotV * NdotL again; it is a V, and that denominator is already folded in.";
+            EXPECT_LE(albedo, 1.02) << "roughness = " << roughness;
+        }
+    }
+
+    // =========================================================================
+    // The GLSL side of the #904 fix, pinned by reading the shader source
+    // (issue #904).
+    //
+    // WHY A TEXT ASSERTION AND NOT A NUMERICAL ONE. The two tests above pin the
+    // C++ mirror, and ReferenceBRDFGpuParity pins the compiled
+    // `visibilitySmithGGXCorrelated` against it. None of them reaches the
+    // remaining half of the fix: `cookTorranceBRDFEnhanced` must MULTIPLY by the
+    // visibility term rather than divide by 4*NdotV*NdotL a second time, and
+    // that function is on a dead call chain, so no probe evaluates it and no
+    // golden would move if it regressed. Reverting that one line leaves the
+    // entire suite green — which is precisely the shape of bug #904 was.
+    //
+    // So pin the source text. This is the same tactic
+    // StochasticSampler.ShaderCarriesThePathSamplerConstants uses on
+    // StochasticCommon.glsl, for the same reason: the thing that can drift is
+    // not reachable by evaluation.
+    //
+    // Runs headless (it reads a file, it does not compile anything), so unlike
+    // the GPU parity test it gates CI.
+    // =========================================================================
+    TEST(ReferenceBRDF, PbrCommonKeepsTheAlphaConventionAndTheVisibilityMultiply)
+    {
+        const auto root = Tests::ShaderHarness::ResolveShaderRoot();
+        ASSERT_FALSE(root.empty()) << "could not resolve the shader root";
+        const std::string src = Tests::ShaderHarness::ReadWholeFile(root / "include" / "PBRCommon.glsl");
+        ASSERT_FALSE(src.empty()) << "PBRCommon.glsl is missing or unreadable";
+
+        // The function must still exist under the name that says it returns a
+        // visibility term. A rename back to `geometrySmith*` is the first step
+        // of reintroducing the double divide.
+        const sizet visibilityDecl = src.find("float visibilitySmithGGXCorrelated(");
+        ASSERT_NE(visibilityDecl, std::string::npos)
+            << "visibilitySmithGGXCorrelated is gone from PBRCommon.glsl. If it was renamed, the name "
+               "must still say VISIBILITY — it returns G2/(4 NdotV NdotL), and every caller depends on "
+               "that.";
+
+        // alpha = roughness^2, then a2 = alpha^2. The pre-#904 bug was the
+        // single square: `float a2 = roughness * roughness;`.
+        const sizet bodyEnd = src.find("\n}", visibilityDecl);
+        ASSERT_NE(bodyEnd, std::string::npos);
+        const std::string body = src.substr(visibilityDecl, bodyEnd - visibilityDecl);
+
+        EXPECT_NE(body.find("float alpha = roughness * roughness;"), std::string::npos)
+            << "visibilitySmithGGXCorrelated no longer derives alpha = roughness^2.";
+        EXPECT_NE(body.find("float a2 = alpha * alpha;"), std::string::npos)
+            << "visibilitySmithGGXCorrelated no longer squares ALPHA. If this reverted to\n"
+               "`a2 = roughness * roughness` then D and G describe different surfaces again — see\n"
+               "THE ALPHA LEDGER in PBRCommon.glsl. That is issue #904, and nothing else in this\n"
+               "suite would notice, because the function is on a dead call chain.";
+
+        // The caller must multiply, not divide again.
+        const sizet enhancedDecl = src.find("vec3 cookTorranceBRDFEnhanced(");
+        ASSERT_NE(enhancedDecl, std::string::npos) << "cookTorranceBRDFEnhanced is gone from PBRCommon.glsl";
+        const sizet enhancedEnd = src.find("\n}", enhancedDecl);
+        ASSERT_NE(enhancedEnd, std::string::npos);
+        const std::string enhanced = src.substr(enhancedDecl, enhancedEnd - enhancedDecl);
+
+        EXPECT_NE(enhanced.find("vec3 specular = NDF * Vis * F;"), std::string::npos)
+            << "cookTorranceBRDFEnhanced no longer forms its specular term as D * V * F.";
+        EXPECT_EQ(enhanced.find("4.0 * max(dot(N, V)"), std::string::npos)
+            << "cookTorranceBRDFEnhanced divides by 4*NdotV*NdotL again. visibilitySmithGGXCorrelated\n"
+               "already folds that denominator in — dividing a second time cost the specular lobe\n"
+               "~3.6x of its energy at roughness 0.3 (directional albedo 0.99 -> 0.27) before #904.";
     }
 
     // =========================================================================

--- a/docs/agent-rules/reference-path-tracer.md
+++ b/docs/agent-rules/reference-path-tracer.md
@@ -65,8 +65,11 @@ as a silent brightness change:
   therefore *collapses* as roughness → 0 instead of becoming a mirror. Pinned by
   `ReferenceBRDF.GgxNdfPeakIsEpsilonClampedAtLowRoughness`.
 - `cookTorranceBRDF` uses the Schlick-GGX `k = (r+1)²/8` remap, not the height-correlated Smith —
-  even though `PBRCommon.glsl` also *has* `geometrySmithHeightCorrelated`. The lit passes call the
-  former.
+  even though `PBRCommon.glsl` also *has* `visibilitySmithGGXCorrelated`. The lit passes call the
+  former. (That second function is mirrored here too, as `VisibilitySmithGGXCorrelated`, even
+  though nothing shades with it: a GLSL function with no C++ mirror is one `ReferenceBRDFGpuParity`
+  cannot detect drift in, and #904 was exactly such a drift sitting undisturbed. See THE ALPHA
+  LEDGER in `PBRCommon.glsl` for why the two G terms legitimately differ.)
 - `kD = 1 - F` with `F` evaluated at the **half vector**: the common, mildly non-reciprocal
   formulation. It ships, so it is what the reference integrates.
 

--- a/docs/agent-rules/stochastic-sampling-and-temporal-resolve.md
+++ b/docs/agent-rules/stochastic-sampling-and-temporal-resolve.md
@@ -300,11 +300,25 @@ unweighted form FAILS the same comparison**. Without that second half the test
 passes on the bug it was written for.
 
 **Alpha convention.** These functions use `alpha = roughness²`, matching
-`distributionGGX`. They deliberately do NOT match `geometrySmithHeightCorrelated`,
-which squares roughness only once — a pre-existing D/G inconsistency in this
-engine, left alone because moving it would shift every lit golden. Unbiasedness
-requires the Λ paired with the *D you sampled*, so the VNDF block carries its own
-`ggxSmithLambda`.
+`distributionGGX`. Unbiasedness requires the Λ paired with the *D you sampled*,
+so the VNDF block carries its own `ggxSmithLambda`.
+
+They used to disagree with `geometrySmithHeightCorrelated`, which squared
+roughness only once. That was recorded here as a pre-existing D/G inconsistency
+"left alone because moving it would shift every lit golden" — and the second
+half of that sentence was **wrong**, which is why it survived two more issues.
+#904 checked instead of assuming: the mismatched function's only caller chain
+(`cookTorranceBRDFEnhanced` → `calculateLightContributionEnhanced`) had **zero
+references repo-wide**, so nothing rendered used it and no golden moved. It is
+now `visibilitySmithGGXCorrelated`, on `alpha = roughness²` like everything
+else, and `ReferenceBRDFTest.HeightCorrelatedVisibilityMatchesTheVndfLambda`
+asserts the exact algebraic identity between it and the `ggxSmithLambda` above.
+
+The general lesson is worth more than the fix: **"changing this would move every
+golden" is a claim about the call graph, and it is one grep.** Costed at "a
+whole rebake plus a visual audit", it was never re-checked; the grep took a
+minute and the rebake turned out not to exist. Verify reach before you price a
+correctness fix out of scope.
 
 **Fresnel goes with the microfacet.** A VNDF-sampled ray must evaluate Schlick
 against `dot(V, H)`, not `dot(V, N)`. On a smooth surface H == N and it makes no


### PR DESCRIPTION
GGX's `D` and the height-correlated Smith `G` in `PBRCommon.glsl` disagreed about what
`alpha` means. This pairs them, fixes a second bug found in the same function, and pins both
so they cannot drift apart again.

## The issue's premise is wrong in three ways, and each one matters

I checked the call graph before starting the rebake the issue asks for. It does not exist.

**1. This is not on "every lit surface" — it is on no surface at all.**

```
geometrySmithHeightCorrelated  <- cookTorranceBRDFEnhanced  <- calculateLightContributionEnhanced  <- (nothing)
```

All three had **zero references repo-wide** outside `PBRCommon.glsl` itself. Every shipping lit
pass calls `cookTorranceBRDF`, which uses the separable Schlick-GGX `k = (r+1)²/8` remap. The
repo already said so — `ReferenceBRDF.h`'s own fidelity notes read *"`cookTorranceBRDF` — the
function the lit passes actually call — uses this one."*

**So no golden moved, and there is no rebake in this PR.** `procedural-generator-golden-coupling.md`
required fix-and-rebake to ship together; there was nothing to rebake. `git status` after a full
suite run shows no golden PNG changes attributable to this diff.

**2. The stated direction is backwards.** The issue says the old `G` was *"smoother than the one
`D` is describing"* and predicts rough grazing surfaces get **darker**. `a2 = roughness * roughness`
means an effective `alpha = r`, while the correct `alpha = r²` — and `r > r²` for every `r` in
`(0,1)`. The old `G` therefore modelled a **rougher** surface and masked **more**. Correcting it
makes those pixels **brighter**. (The issue's "roughness `sqrt(alpha)`" is a units slip:
`sqrt(alpha) = r` is the *alpha*, not the roughness.)

**3. The error does not peak on rough surfaces.** It scales with `r / r² = 1/r`, so it peaks at
**low-to-mid** roughness at grazing. Measured over a `(roughness × NdotV × NdotL)` sweep:

| where | worst `G₂` discrepancy |
|---|---|
| roughness ≈ 0.15, both cosines grazing | **78% relative** |
| roughness 0.8, head-on | ~14% relative |

## What changed

The functional diff is nine lines; everything else is documentation and tests.

**The alpha fix.** `a2 = roughness * roughness` → `alpha = roughness * roughness; a2 = alpha * alpha`.

**A second bug in the same function.** It returns Filament's **visibility** term
`V = G₂ / (4·NdotV·NdotL)` — the Cook-Torrance denominator is already folded in and cancels
analytically, which is the whole point of the `V` form. Its one caller then divided by
`4·NdotV·NdotL` **again**. Measured cost: the specular lobe's directional albedo drops from
**0.99 to 0.27** at roughness 0.3, a ~3.6× energy loss. Renamed
`geometrySmithHeightCorrelated` → `visibilitySmithGGXCorrelated` so the name states what it
returns, and dropped the second divide.

**The third parameterisation, decided explicitly.** `geometrySchlickGGX`'s UE4 `k` remap is **not**
a third alpha convention — it is a closed-form *approximation* of the Smith `G` for the same
`alpha = roughness²` surface, with Disney's hotness adjustment folded in. **Left unchanged on
purpose**: it is what every shipping lit pass uses, and replacing it genuinely would move every lit
golden. That is a separate decision, not #904. `distributionGGXAnisotropic` is a fourth case — it
takes alphas directly despite its parameter names. Both are now recorded as deliberate exceptions
in a new **ALPHA LEDGER** comment block, which is the thing that actually prevents recurrence: the
mismatch survived because three conventions sat in one file with nothing saying which was which.

**The VNDF path (issue step 3).** Already correct — #706/#889 gave it its own `ggxSmithLambda` on
the D-consistent alpha. Its "A NOTE ON ALPHA" comment is now stale and is rewritten. I did **not**
collapse it into the shared function: `ggxVNDFWeight` needs Λ *per direction* to form `G2/G1`,
which the Filament closed form cannot supply. The two are now consistent but not redundant.

## Verification

**`ReferenceBRDFTest.HeightCorrelatedVisibilityMatchesTheVndfLambda`** (L1, headless, CI) — the real
pin. The height-correlated Smith has two equivalent closed forms, Filament's and Heitz's
`1 / (4·NdotV·NdotL·(1 + Λv + Λl))`. They are the same function *only when handed the same alpha*,
so asserting they agree is an exact test of "D and G describe the same surface" — no Monte Carlo
noise, no tolerance to argue about. Measured: agreement to **2.8e-16**; the old convention misses
by up to **60%**.

**`ReferenceBRDFTest.HeightCorrelatedSpecularLobeConservesEnergy`** (L1, headless, CI) — white
furnace, `F = 1`. The upper bound is energy conservation; the lower bound over `[0.3, 0.5]` catches
the V-vs-G double divide **in the C++ mirror** (0.99 → 0.27). Both window ends are load-bearing and
documented.

**`ReferenceBRDFTest.PbrCommonKeepsTheAlphaConventionAndTheVisibilityMultiply`** (L1, headless, CI)
— added during self-review, which found a real hole: every numerical test above evaluates `D * V`
directly, so **reverting the GLSL `cookTorranceBRDFEnhanced` to the double divide left the whole
suite green.** That function is unreachable, so no probe evaluates it and no golden moves — exactly
the shape of the original bug. It is now pinned by reading the shader source, the same tactic
`StochasticSampler.ShaderCarriesThePathSamplerConstants` already uses on `StochasticCommon.glsl`
for the same reason: the thing that can drift is not reachable by evaluation.

**`ReferenceBRDFGpuParity.HeightCorrelatedVisibilityMatchesCppMirror`** (shaderpipe, GPU) — the
cross-language guard. `PbrBrdfParityProbe.glsl`'s alpha channel now carries the new function, so
the compiled GLSL is diffed texel-for-texel against the C++ mirror. Restoring the old convention on
*either* side alone fails here.

**Correctness, not just "did it change?"** — per `reference-path-tracer.md`, a golden cannot answer
this and the goldens did not move anyway. The corrected form matches Heitz's ground-truth Λ
definition to **3.3e-16** across a `(roughness × NdotV × NdotL)` grid; the old one deviates by up to
**0.53 absolute** on a 0–1 scale. That is the rough-grazing cross-check the issue asked for.

**No pixels to look at.** Per `CLAUDE.md`, a rendering change needs screenshot evidence — but this
change is provably unreachable from any render path, so there is no frame to capture. That is a
claim you can check in one grep, and it is the load-bearing claim of this PR.

## Docs

`stochastic-sampling-and-temporal-resolve.md` and `reference-path-tracer.md` both asserted the
now-false premise. Both corrected, with the general lesson recorded: **"changing this would move
every golden" is a claim about the call graph, and it is one grep.** Costed at a full rebake plus
visual audit, it was never re-checked across two issues; the grep took a minute and the rebake
turned out not to exist.

## Review guide

**Where I'd look hardest**

1. `OloEditor/assets/shaders/include/PBRCommon.glsl` — `cookTorranceBRDFEnhanced` now computes
   `NDF * Vis * F` with **no** `/(4·NdotV·NdotL)`. If you believe that function returns a `G` and
   not a `V`, this looks like a dropped denominator. It is not — but it is the one line where being
   wrong would be silent — and, because the function is unreachable, the only thing standing
   between it and a silent revert is the source-text assertion.
2. The **deliberate non-change** to `geometrySchlickGGX`. I argue it is an approximation of the
   same alpha rather than a third convention. If that reasoning is wrong, the file still holds two
   parameterisations and the ledger is misleading rather than helpful.
3. `PbrBrdfParityProbe.glsl` — I repurposed its alpha channel from a constant `1.0`. Single
   consumer, verified, and its two existing tests read only `.rgb`; worth a second pair of eyes.

**What I verified, and how** — the three tests named above; a `(roughness × NdotV × NdotL)` sweep
against Heitz's Λ (fixed 3.3e-16, broken up to 0.53); a repo-wide reference count proving the call
chain is dead; and confirmation that the shader cache keys on *preprocessed* source
(`OpenGLShader.cpp:337,1399`), so the GPU parity test compiles the new code rather than a stale
binary.

**Second self-review finding, fixed** — I had introduced a *second* C++ mirror of `ggxSmithLambda`;
`Vndf::SmithLambda` in `StochasticSamplerTest.cpp` already existed. Kept both deliberately (that
one is `f64` because it backs a brute-force integrator whose whole value is precision) and
documented why at the declaration, with a note to stop at two. Each copy carries its own guard.

**Least confident about** — whether `cookTorranceBRDFEnhanced` should have been **deleted** rather
than fixed. It has no callers and now never will unless someone wires it up. I kept it because the
issue's acceptance criteria name the function explicitly, and because a correct dead function is a
one-line wiring job while a wrong one is a trap. Deleting it instead is a defensible call and I'd
take that review.

**Deliberately not tested** — the shipping `cookTorranceBRDF` path, unchanged by this PR and
already covered by `ReferenceBRDFGpuParity.CppMirrorMatchesCompiledPbrCommon`. No lit goldens were
rebaked, because none moved. GLSL `ggxSmithLambda` still has no GPU-side pin (both its C++ mirrors
are guarded, but the compiled shader is not) — pre-existing, untouched by this PR, and out of scope
here.

Closes #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GGX height-correlated visibility calculations for more accurate path-traced reflections.
  * Corrected roughness-to-alpha handling in BRDF visibility evaluation.

* **Tests**
  * Added CPU and GPU parity checks across varied lighting and roughness conditions.
  * Added regression coverage for energy conservation, numerical validity, and shader consistency.

* **Documentation**
  * Updated BRDF and sampling documentation to reflect corrected visibility and alpha conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->