### PR TITLE
fix(renderer): make a per-attachment blend disable outrank the global enable

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/DecalRenderPass.cpp
@@ -270,8 +270,10 @@ namespace OloEngine
                     packet->Execute(rendererAPI);
             }
 
-            RenderCommand::SetBlendStateForAttachment(0, false);
-            RenderCommand::SetBlendStateForAttachment(1, false);
+            // Withdraw the per-attachment opinions this path stated — see
+            // issue #896: `false` is a standing DISABLE, not a restore.
+            RenderCommand::ResetBlendStateForAttachment(0);
+            RenderCommand::ResetBlendStateForAttachment(1);
             RenderCommand::SetBlendFunc(RHI::BlendFactor::SrcAlpha, RHI::BlendFactor::OneMinusSrcAlpha);
             context.SetBlendState(false);
 
@@ -506,8 +508,18 @@ namespace OloEngine
 
         // Restore RT2 blend state — emissive additive blending leaks into
         // the next pass otherwise (observed as SSAO / GTAO darkening the
-        // emissive channel during composite).
-        RenderCommand::SetBlendStateForAttachment(2, false);
+        // emissive channel during composite). WITHDRAW the opinion rather than
+        // disabling: a standing disable would leak just as far, in the other
+        // direction (issue #896).
+        RenderCommand::ResetBlendStateForAttachment(2);
+        // ...and the FUNC divert that went with it. SetBlendFuncForAttachment
+        // above pointed RT2 at One/One, and only a GLOBAL SetBlendFunc takes
+        // that back (glBlendFunc overwrites every buffer's func). This path,
+        // unlike the OIT one below, had no global func call of its own — so
+        // RT2 kept One/One and would have blended additively with it the next
+        // time anything enabled blending. Same restore line the OIT path and
+        // ParticleRenderPass already use.
+        RenderCommand::SetBlendFunc(RHI::BlendFactor::SrcAlpha, RHI::BlendFactor::OneMinusSrcAlpha);
 
         // The per-attachment mask / blend / draw-buffer calls above bypass the
         // cached render-state tracking; invalidate so the

--- a/OloEngine/src/OloEngine/Renderer/Passes/OITResolveRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/OITResolveRenderPass.cpp
@@ -141,7 +141,13 @@ namespace OloEngine
         // Restore mutable GL state for subsequent passes.
         RenderCommand::SetColorMaskForAttachment(1, true, true, true, true);
         RenderCommand::SetColorMaskForAttachment(2, true, true, true, true);
-        RenderCommand::SetBlendStateForAttachment(0, false);
+        // WITHDRAW all three opinions, not just attachment 0's. A per-attachment
+        // blend enable outranks the global flag until it is withdrawn, so
+        // passing `false` here would leave RT0/RT1/RT2 pinned OFF for every
+        // later pass in the process rather than restoring them (issue #896).
+        RenderCommand::ResetBlendStateForAttachment(0);
+        RenderCommand::ResetBlendStateForAttachment(1);
+        RenderCommand::ResetBlendStateForAttachment(2);
         context.SetBlendState(false);
         // Clearing the inputs needs the seam AND its own flush. Under the heap
         // there is no bind to undo — the shader reads an offset — so an offset

--- a/OloEngine/src/OloEngine/Renderer/Passes/ParticleRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/ParticleRenderPass.cpp
@@ -137,9 +137,11 @@ namespace OloEngine
             ParticleBatchRenderer::SetOITMode(false);
 
             // Restore global blend state so subsequent passes don't inherit
-            // the per-attachment WB-OIT factors.
-            RenderCommand::SetBlendStateForAttachment(0, false);
-            RenderCommand::SetBlendStateForAttachment(1, false);
+            // the per-attachment WB-OIT factors. WITHDRAW the enables rather
+            // than disabling them — a per-attachment opinion outranks the
+            // global flag until it is withdrawn (issue #896).
+            RenderCommand::ResetBlendStateForAttachment(0);
+            RenderCommand::ResetBlendStateForAttachment(1);
             RenderCommand::SetBlendFunc(RHI::BlendFactor::SrcAlpha, RHI::BlendFactor::OneMinusSrcAlpha);
             context.SetBlendState(false);
 
@@ -168,7 +170,12 @@ namespace OloEngine
 
             RenderCommand::SetDepthFunc(RHI::CompareOp::Less);
             context.SetDepthMask(true);
-            RenderCommand::SetBlendStateForAttachment(0, false);
+            // All three opinions this path stated, withdrawn (issue #896) —
+            // attachments 1 and 2 were disabled above and would otherwise stay
+            // disabled for the rest of the process.
+            RenderCommand::ResetBlendStateForAttachment(0);
+            RenderCommand::ResetBlendStateForAttachment(1);
+            RenderCommand::ResetBlendStateForAttachment(2);
             context.SetBlendState(false);
 
             m_SceneFramebuffer->Unbind();

--- a/OloEngine/src/OloEngine/Renderer/RGCommandContext.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RGCommandContext.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/RGCommandContext.h"
 
+#include "OloEngine/Renderer/Commands/RenderCommand.h" // MAX_MASKED_COLOR_ATTACHMENTS
 #include "OloEngine/Renderer/HeapBindingSeam.h"
 #include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/RenderGraph.h"
@@ -32,6 +33,15 @@ namespace OloEngine
     {
         // Keep in sync with the engine's default render-state contract.
         RenderCommand::SetBlendState(false);
+        // ...INCLUDING the per-attachment blend opinions, which SetBlendState
+        // above does NOT flatten (issue #896 — an opinion outranks the global
+        // flag until it is withdrawn). Before the tri-state this line was
+        // enough on GL, where glDisable(GL_BLEND) wiped every glEnablei, so a
+        // pass that forgot to restore one was silently healed here. It is not
+        // any more, which is precisely why this is the place to say "no pass
+        // has an opinion" out loud.
+        for (u32 attachment = 0; attachment < MAX_MASKED_COLOR_ATTACHMENTS; ++attachment)
+            RenderCommand::ResetBlendStateForAttachment(attachment);
         RenderCommand::SetDepthTest(true);
         RenderCommand::SetDepthMask(true);
         RenderCommand::SetDepthFunc(RHI::CompareOp::Less);

--- a/OloEngine/src/OloEngine/Renderer/RenderCommand.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderCommand.h
@@ -353,10 +353,18 @@ namespace OloEngine
             s_RendererAPI->IssueBarrierBatch(flags, barriers);
         }
 
-        // Per-attachment blend control
+        // Per-attachment blend control. Tri-state: see the declaration in
+        // RendererAPI.h -- an attachment a pass turned on or off keeps that
+        // opinion until ResetBlendStateForAttachment withdraws it, so every
+        // pass that states one has to withdraw it before returning.
         static void SetBlendStateForAttachment(u32 attachment, bool enabled)
         {
             s_RendererAPI->SetBlendStateForAttachment(attachment, enabled);
+        }
+
+        static void ResetBlendStateForAttachment(u32 attachment)
+        {
+            s_RendererAPI->ResetBlendStateForAttachment(attachment);
         }
 
         static void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst)

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.h
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.h
@@ -256,8 +256,21 @@ namespace OloEngine
         virtual void SetColorMask(bool red, bool green, bool blue, bool alpha) = 0;
         virtual void SetColorMaskForAttachment(u32 attachment, bool red, bool green, bool blue, bool alpha) = 0;
 
-        // Per-attachment blend control (needed for mixed integer/float framebuffer attachments)
+        // Per-attachment blend control (needed for mixed integer/float framebuffer attachments).
+        //
+        // This is a THREE-state knob, not a bool: an attachment either carries a
+        // pass's opinion (enabled / disabled) or carries none and follows the
+        // global SetBlendState. SetBlendStateForAttachment states an opinion;
+        // ResetBlendStateForAttachment withdraws it. A pass that turned an
+        // attachment on or off MUST reset it before returning, exactly as it
+        // restores a colour mask -- an opinion left behind outlives the pass
+        // (issue #896, and the #823 archetype it comes from).
         virtual void SetBlendStateForAttachment(u32 attachment, bool enabled) = 0;
+        // Withdraw the per-attachment opinion: attachment `attachment` goes back
+        // to following the global blend enable. On GL that is glEnablei /
+        // glDisablei re-issued from the tracked global flag (GL has no "unset"
+        // for a draw buffer); on Vulkan it clears the recorded override.
+        virtual void ResetBlendStateForAttachment(u32 attachment) = 0;
         // Per-attachment blend function (needed for weighted-blended OIT — accum/revealage differ)
         virtual void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst) = 0;
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -91,7 +91,11 @@ namespace OloEngine
         glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, GL_TRUE);
 #endif
 
-        glEnable(GL_BLEND);
+        // Through the facade, not a raw glEnable: SetBlendState owns the
+        // m_BlendEnabled mirror a per-attachment withdrawal reads, and a raw
+        // call here would leave it claiming "disabled" while GL blends
+        // (issue #896).
+        SetBlendState(true);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
         // Disable dithering — legacy feature for 8-bit displays that triggers
@@ -611,6 +615,8 @@ namespace OloEngine
             s_BlendEnabled = value;
         }
 
+        m_BlendEnabled = value;
+
         if (value)
         {
             glEnable(GL_BLEND);
@@ -619,6 +625,13 @@ namespace OloEngine
         {
             glDisable(GL_BLEND);
         }
+
+        // glEnable(GL_BLEND) is glEnablei for EVERY draw buffer, so the call
+        // above just flattened any per-attachment opinion a pass is holding.
+        // The engine's contract is that an opinion survives until it is
+        // explicitly withdrawn, so put them back -- see the declaration of
+        // m_AttachmentBlend (issue #896).
+        ReassertAttachmentBlendOpinions();
     }
     void OpenGLRendererAPI::SetBlendFunc(RHI::BlendFactor sfactor, RHI::BlendFactor dfactor)
     {
@@ -1047,6 +1060,13 @@ namespace OloEngine
             return;
         }
 
+        if (attachment < kMaxTrackedDrawBuffers)
+        {
+            m_AttachmentBlend[attachment] =
+                enabled ? AttachmentBlendOpinion::Enabled : AttachmentBlendOpinion::Disabled;
+            m_AnyAttachmentBlendOpinion = true;
+        }
+
         if (enabled)
         {
             glEnablei(GL_BLEND, attachment);
@@ -1054,6 +1074,71 @@ namespace OloEngine
         else
         {
             glDisablei(GL_BLEND, attachment);
+        }
+    }
+
+    void OpenGLRendererAPI::ResetBlendStateForAttachment(u32 attachment)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (attachment >= static_cast<u32>(m_MaxDrawBuffers))
+        {
+            OLO_CORE_ERROR("OpenGLRendererAPI::ResetBlendStateForAttachment - attachment index {} exceeds GL_MAX_DRAW_BUFFERS {}",
+                           attachment, m_MaxDrawBuffers);
+            return;
+        }
+
+        if (attachment < kMaxTrackedDrawBuffers)
+        {
+            m_AttachmentBlend[attachment] = AttachmentBlendOpinion::None;
+            m_AnyAttachmentBlendOpinion = false;
+            for (const AttachmentBlendOpinion opinion : m_AttachmentBlend)
+            {
+                if (opinion != AttachmentBlendOpinion::None)
+                {
+                    m_AnyAttachmentBlendOpinion = true;
+                    break;
+                }
+            }
+        }
+
+        // "No opinion" is not a state a GL draw buffer can hold, so withdrawing
+        // one means re-issuing the GLOBAL enable at this index. Read from the
+        // mirror, because GL will not answer the question — see the
+        // m_BlendEnabled declaration for the measurement.
+        if (m_BlendEnabled)
+        {
+            glEnablei(GL_BLEND, attachment);
+        }
+        else
+        {
+            glDisablei(GL_BLEND, attachment);
+        }
+    }
+
+    void OpenGLRendererAPI::ReassertAttachmentBlendOpinions()
+    {
+        // Nothing to put back in the common case: no pass is mid-flight, so no
+        // attachment carries an opinion and the global call stands alone.
+        if (!m_AnyAttachmentBlendOpinion)
+            return;
+
+        const u32 trackedCount =
+            m_MaxDrawBuffers > 0 ? std::min(static_cast<u32>(m_MaxDrawBuffers), kMaxTrackedDrawBuffers)
+                                 : kMaxTrackedDrawBuffers;
+        for (u32 i = 0; i < trackedCount; ++i)
+        {
+            switch (m_AttachmentBlend[i])
+            {
+                case AttachmentBlendOpinion::Enabled:
+                    glEnablei(GL_BLEND, i);
+                    break;
+                case AttachmentBlendOpinion::Disabled:
+                    glDisablei(GL_BLEND, i);
+                    break;
+                case AttachmentBlendOpinion::None:
+                    break;
+            }
         }
     }
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
@@ -116,6 +116,7 @@ namespace OloEngine
                               u32 layer, RHI::Access access, RHI::Format format) override;
 
         void SetBlendStateForAttachment(u32 attachment, bool enabled) override;
+        void ResetBlendStateForAttachment(u32 attachment) override;
         void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst) override;
         void CopyImageSubData(u32 srcID, TextureTargetType srcTarget, u32 dstID, TextureTargetType dstTarget,
                               u32 width, u32 height);
@@ -325,6 +326,58 @@ namespace OloEngine
         // be called once the clear has been issued).
         bool LiftAttachmentColorMasksForClear();
         void RestoreAttachmentColorMasks();
+
+        // THE BLEND ENABLE IS A TRI-STATE PER DRAW BUFFER, and this pair is how
+        // GL holds it. Raw GL cannot: glEnablei/glDisablei is the only way to
+        // speak to a draw buffer, there is no "unset", and glEnable(GL_BLEND)
+        // is defined as glEnablei for every buffer -- so a per-attachment
+        // opinion would evaporate at the next global call, silently and at a
+        // distance.
+        //
+        // The engine's contract is that it does NOT: an attachment a pass
+        // turned on or off keeps that until ResetBlendStateForAttachment
+        // withdraws it (issue #896). So SetBlendState issues the global call
+        // and then re-asserts every standing opinion on top, the same
+        // save/restore shape m_AttachmentColorMasks already uses for clears.
+        // m_AnyAttachmentBlendOpinion keeps that loop off the common path,
+        // where no pass is mid-flight and nothing has an opinion at all.
+        //
+        // This is the opposite composition to m_AttachmentColorMasks, on
+        // purpose: a colour mask has no "unset" in the engine either, and its
+        // global setter genuinely overwrites (issue #823). Do not make them
+        // consistent -- SetColorMask's callers depend on the overwrite, and
+        // these ones depend on it not happening.
+        enum class AttachmentBlendOpinion : u8
+        {
+            None = 0,
+            Disabled,
+            Enabled,
+        };
+        std::array<AttachmentBlendOpinion, kMaxTrackedDrawBuffers> m_AttachmentBlend{};
+        bool m_AnyAttachmentBlendOpinion = false;
+
+        // The global GL_BLEND flag as this class last set it. A withdrawal has
+        // to put the draw buffer back on the global value, and there is no way
+        // to ASK GL for it: `glIsEnabled(GL_BLEND)` is documented as the index-0
+        // value but does not behave as one here — measured on NVIDIA
+        // (RTX 4090, driver 98.352.0), after glDisable(GL_BLEND) +
+        // glEnablei(GL_BLEND, 1) it returns TRUE while glIsEnabledi(GL_BLEND, 0)
+        // returns FALSE. So it reports "some index is on", not the global, and
+        // is useless as the withdrawal's input. Hence the mirror.
+        //
+        // Its one gap, stated rather than papered over: a raw GL_BLEND flip
+        // that bypasses this class stales it. Init() below is handled (it goes
+        // through SetBlendState); GLStateGuard's restore
+        // (OpenGLStateGuard.cpp) is not, and that guard already documents that
+        // it neither captures nor restores per-attachment blend state. The
+        // exposure is bounded because every withdrawal in the engine sits
+        // beside a global SetBlendState that refreshes this — see the pass
+        // restore blocks and RGCommandContext::ResetGraphicsStateToDefault.
+        bool m_BlendEnabled = false;
+
+        // Re-issue every standing per-attachment opinion. Called after the
+        // global glEnable/glDisable(GL_BLEND) has flattened them.
+        void ReassertAttachmentBlendOpinions();
 
         bool m_DepthTestEnabled = false;
         bool m_DepthMaskEnabled = true;

--- a/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
@@ -52,6 +52,29 @@ namespace OloEngine
             }
         }
 
+        // Does attachment `i` blend? ONE function, called by both the baked
+        // (GetOrCreateGraphics) and the dynamic (FlushDynamicState) route, so
+        // the two lowerings cannot drift apart — they were previously two
+        // copies of the same expression, kept in step only by a comment.
+        //
+        // A per-attachment opinion outranks the global `Blend` in BOTH
+        // directions; only Inherit falls through to it. The rule, and why each
+        // arm is load-bearing, is at the AttachmentBlend declaration in
+        // VulkanRendererAPI.h (issues #823 and #896).
+        [[nodiscard]] bool ResolveBlendEnable(const VulkanRecordedPipelineState& state, const u32 attachment)
+        {
+            switch (state.AttachmentBlend[attachment])
+            {
+                case VulkanRecordedPipelineState::AttachmentBlendOpinion::ForceOn:
+                    return true;
+                case VulkanRecordedPipelineState::AttachmentBlendOpinion::ForceOff:
+                    return false;
+                case VulkanRecordedPipelineState::AttachmentBlendOpinion::Inherit:
+                    break;
+            }
+            return state.Blend;
+        }
+
         // --- RHI → Vk state-enum lowering ------------------------------------
         [[nodiscard]] VkCompareOp ToVk(RHI::CompareOp op)
         {
@@ -494,8 +517,8 @@ namespace OloEngine
             }
             for (u32 i = 0; i < safeTargets.ColorCount; ++i)
             {
-                blendHash = HashCombine(blendHash, state.AttachmentBlend[i] ? 1u : 0u);
-                blendHash = HashCombine(blendHash, state.AttachmentBlendFuncSet[i] ? 1u : 0u);
+                blendHash = HashCombine(blendHash, static_cast<u64>(state.AttachmentBlend[i]));
+                blendHash = HashCombine(blendHash, static_cast<u64>(state.AttachmentBlendFunc[i]));
                 blendHash = HashCombine(blendHash, static_cast<u64>(state.AttachmentBlendSrc[i]));
                 blendHash = HashCombine(blendHash, static_cast<u64>(state.AttachmentBlendDst[i]));
                 blendHash = HashCombine(blendHash, state.AttachmentColorMask[i]);
@@ -627,19 +650,18 @@ namespace OloEngine
                 // must produce identical blend behaviour for one recorded
                 // state, and every field read here is in BakedBlendHash.
                 // ENABLE and FUNC divert independently (GL parity, see the
-                // AttachmentBlendFuncSet comment): glEnablei alone keeps the
+                // AttachmentBlendFunc comment): glEnablei alone keeps the
                 // GLOBAL blend func; only glBlendFunci diverts the factors.
-                const bool useAttachmentFunc = state.AttachmentBlendFuncSet[i];
+                const bool useAttachmentFunc =
+                    state.AttachmentBlendFunc[i] == VulkanRecordedPipelineState::AttachmentBlendFuncOpinion::Diverted;
                 // Integer attachments cannot blend — see the identical mask
                 // in FlushDynamicState (the two routes must agree).
-                // The OR is deliberate and is NOT the colour-mask rule below:
-                // a per-attachment enable is an opt-in LAYERED ON TOP of the
-                // global flag, which is what lets DecalRenderPass blend RT2
-                // additively for an Emissive decal whose PODRenderState carries
-                // blendEnabled=false. Pinned by the Emissive arm of
-                // VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets.
+                // A per-attachment OPINION outranks the global flag in both
+                // directions and only Inherit falls through to it — NOT an OR.
+                // See the rule at the AttachmentBlend declaration; both arms
+                // are load-bearing and each was a bug once (#823 / #896).
                 attachment.blendEnable = (!IsIntegerFormat(safeTargets.ColorFormats[i]) &&
-                                          (state.AttachmentBlend[i] || state.Blend))
+                                          ResolveBlendEnable(state, i))
                                              ? VK_TRUE
                                              : VK_FALSE;
                 attachment.srcColorBlendFactor = ToVk(useAttachmentFunc ? state.AttachmentBlendSrc[i] : state.BlendSrcRGB);
@@ -848,11 +870,12 @@ namespace OloEngine
             {
                 // Per-attachment state where the pass set it, the global
                 // recorded state otherwise. ENABLE and FUNC divert
-                // independently (GL parity, see the AttachmentBlendFuncSet
+                // independently (GL parity, see the AttachmentBlendFunc
                 // comment): glEnablei alone keeps the GLOBAL blend func; only
                 // glBlendFunci diverts the factors — AttachmentBlendSrc/Dst
-                // are meaningful only when AttachmentBlendFuncSet[i] is true.
-                const bool useAttachmentFunc = state.AttachmentBlendFuncSet[i];
+                // are meaningful only where AttachmentBlendFunc[i] is Diverted.
+                const bool useAttachmentFunc =
+                    state.AttachmentBlendFunc[i] == VulkanRecordedPipelineState::AttachmentBlendFuncOpinion::Diverted;
                 // An INTEGER attachment can never blend: R32_SINT (the
                 // engine's entity-ID render target) carries no
                 // COLOR_ATTACHMENT_BLEND format feature, and enabling blend
@@ -863,10 +886,11 @@ namespace OloEngine
                 // forward/G-buffer family — tripped this on the first live
                 // frame. Masking it here keeps GL's "just ignore it"
                 // behaviour and costs the caller nothing.
-                // Per-attachment enable ORs on top of the global flag — see the
-                // identical expression on the baked route in GetOrCreateGraphics.
+                // A per-attachment enable OPINION outranks the global flag —
+                // see the identical expression on the baked route in
+                // GetOrCreateGraphics, and the rule at the declaration.
                 const bool blendableFormat = !IsIntegerFormat(targets.ColorFormats[i]);
-                const bool enabled = blendableFormat && (state.AttachmentBlend[i] || state.Blend);
+                const bool enabled = blendableFormat && ResolveBlendEnable(state, i);
                 enables[i] = enabled ? VK_TRUE : VK_FALSE;
                 equations[i] = {
                     .srcColorBlendFactor = ToVk(useAttachmentFunc ? state.AttachmentBlendSrc[i] : state.BlendSrcRGB),

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -950,16 +950,12 @@ namespace OloEngine
     }
     void VulkanRendererAPI::SetBlendState(const bool value)
     {
-        // Deliberately does NOT fill AttachmentBlend, unlike SetColorMask below.
-        // GL's glEnable(GL_BLEND) would clear the per-buffer enables, but the
-        // engine's passes are written against OR semantics instead: DecalRenderPass
-        // turns RT2 on with SetBlendStateForAttachment(2, true) for an Emissive
-        // decal whose PODRenderState carries blendEnabled=false, and relies on the
-        // per-attachment enable surviving the global disable that
-        // ApplyPODRenderState then issues. Matching GL here would delete that
-        // additive accumulation on Vulkan without fixing it on GL, so the
-        // divergence is recorded rather than "corrected" — see the note at the
-        // AttachmentBlend declaration.
+        // Deliberately does NOT touch AttachmentBlend, unlike SetColorMask
+        // below. A per-attachment blend opinion OUTRANKS this flag in both
+        // directions and is withdrawn only by ResetBlendStateForAttachment —
+        // see the rule at the AttachmentBlend declaration. The GL backend
+        // re-asserts its standing opinions after glEnable/glDisable(GL_BLEND)
+        // so that both backends implement that one rule.
         m_State.Blend = value;
     }
     void VulkanRendererAPI::SetBlendFunc(const RHI::BlendFactor sfactor, const RHI::BlendFactor dfactor)
@@ -970,8 +966,8 @@ namespace OloEngine
         m_State.BlendDstAlpha = dfactor;
         // glBlendFunc overwrites EVERY buffer's func in GL — the recorded
         // per-attachment funcs must stop diverting (see the struct comment).
-        for (bool& funcSet : m_State.AttachmentBlendFuncSet)
-            funcSet = false;
+        for (auto& funcOpinion : m_State.AttachmentBlendFunc)
+            funcOpinion = VulkanRecordedPipelineState::AttachmentBlendFuncOpinion::Inherit;
     }
     void VulkanRendererAPI::SetBlendFuncSeparate(const RHI::BlendFactor srcRGB, const RHI::BlendFactor dstRGB,
                                                  const RHI::BlendFactor srcAlpha, const RHI::BlendFactor dstAlpha)
@@ -981,8 +977,8 @@ namespace OloEngine
         m_State.BlendSrcAlpha = srcAlpha;
         m_State.BlendDstAlpha = dstAlpha;
         // Same glBlendFuncSeparate global-overwrite semantics as SetBlendFunc.
-        for (bool& funcSet : m_State.AttachmentBlendFuncSet)
-            funcSet = false;
+        for (auto& funcOpinion : m_State.AttachmentBlendFunc)
+            funcOpinion = VulkanRecordedPipelineState::AttachmentBlendFuncOpinion::Inherit;
     }
     void VulkanRendererAPI::SetBlendEquation(const RHI::BlendOp mode)
     {
@@ -1100,7 +1096,18 @@ namespace OloEngine
     {
         if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
             return;
-        m_State.AttachmentBlend[attachment] = enabled;
+        // States an opinion that outranks the global flag until it is
+        // withdrawn. `false` is ForceOff, NOT "back to normal" — a pass
+        // restoring its state wants ResetBlendStateForAttachment (issue #896).
+        m_State.AttachmentBlend[attachment] = enabled
+                                                  ? VulkanRecordedPipelineState::AttachmentBlendOpinion::ForceOn
+                                                  : VulkanRecordedPipelineState::AttachmentBlendOpinion::ForceOff;
+    }
+    void VulkanRendererAPI::ResetBlendStateForAttachment(const u32 attachment)
+    {
+        if (attachment >= VulkanRecordedPipelineState::kMaxAttachments)
+            return;
+        m_State.AttachmentBlend[attachment] = VulkanRecordedPipelineState::AttachmentBlendOpinion::Inherit;
     }
     void VulkanRendererAPI::SetBlendFuncForAttachment(const u32 attachment, const RHI::BlendFactor src, const RHI::BlendFactor dst)
     {
@@ -1108,7 +1115,8 @@ namespace OloEngine
             return;
         m_State.AttachmentBlendSrc[attachment] = src;
         m_State.AttachmentBlendDst[attachment] = dst;
-        m_State.AttachmentBlendFuncSet[attachment] = true; // glBlendFunci semantics
+        // glBlendFunci semantics — diverted until the global setter withdraws it.
+        m_State.AttachmentBlendFunc[attachment] = VulkanRecordedPipelineState::AttachmentBlendFuncOpinion::Diverted;
     }
     void VulkanRendererAPI::SetPatchVertexCount(const u32 patchVertices)
     {

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
@@ -101,7 +101,7 @@ namespace OloEngine
         u32 PatchVertexCount = 3;
 
         // THE COLOUR MASK AND THE BLEND ENABLE COMPOSE DIFFERENTLY HERE, on
-        // purpose — do not "make them consistent" without re-reading this.
+        // purpose -- do not "make them consistent" without re-reading this.
         //
         // AttachmentColorMask is the lowering's ONLY input: SetColorMask
         // overwrites every entry (glColorMask is defined as glColorMaski for
@@ -110,35 +110,84 @@ namespace OloEngine
         // DISABLES the attachments a command names and relies on the global
         // call to have re-enabled the rest. Before that fill existed, a
         // narrowing indexed call was permanent for the PROCESS, and one
-        // Renderer3D::DrawLine killed every G-Buffer attachment above 0 —
+        // Renderer3D::DrawLine killed every G-Buffer attachment above 0 --
         // issue #823.
         //
-        // AttachmentBlend does NOT work that way: it ORs on top of `Blend`, so
-        // SetBlendState deliberately leaves it alone. GL would clear it, but
-        // the engine's passes are written against the OR — DecalRenderPass
-        // enables RT2 per-attachment for an Emissive decal whose
-        // PODRenderState carries blendEnabled=false, and matching GL would
-        // delete that additive accumulation on Vulkan without fixing it on GL.
-        // The consequence is that a per-attachment blend DISABLE cannot
-        // override a global enable (OITResolveRenderPass asks for one); that
-        // asymmetry is real, is GL-divergent in the other direction, and is
-        // filed as ISSUE #896 rather than changed here. Any fix must keep the
-        // DecalRenderPass Emissive case above working -- the naive symmetric
-        // version was written during #823 and reverted because it deleted that
-        // additive accumulation on Vulkan while fixing nothing on GL.
-        bool AttachmentBlend[kMaxAttachments] = {};
+        // AttachmentBlend does NOT work that way. It is a TRI-STATE per
+        // attachment and it OUTRANKS the global `Blend`, in BOTH directions:
+        //
+        //   Inherit  -- no pass has an opinion; the attachment follows `Blend`.
+        //   ForceOn  -- blend this attachment even if `Blend` is false.
+        //   ForceOff -- do not blend it even if `Blend` is true.
+        //
+        // so SetBlendState writes `Blend` and leaves this array alone, and only
+        // SetBlendStateForAttachment / ResetBlendStateForAttachment move it.
+        // GL's global glEnable(GL_BLEND) would flatten the array instead; the
+        // GL backend re-asserts the standing opinions on top of the global call
+        // so both backends implement THIS rule rather than two different ones
+        // (OpenGLRendererAPI::ReassertAttachmentBlendOpinions).
+        //
+        // Both arms are load-bearing and each was a bug once:
+        //
+        //   ForceOn  -- DecalRenderPass enables RT2 per-attachment for an
+        //               Emissive decal whose PODRenderState carries
+        //               blendEnabled=false, and the additive One/One
+        //               accumulation depends on that enable surviving the
+        //               global disable ApplyPODRenderState then issues. The
+        //               naive "match GL, let the global win" version was
+        //               written during #823 and reverted because it deleted
+        //               exactly this. Pinned by the Emissive arm of
+        //               VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets.
+        //   ForceOff -- OITResolveRenderPass disables RT1 (entity ID, an
+        //               integer target) and RT2 (view normals) per attachment
+        //               while compositing. Under the OR this array used to be,
+        //               those two calls were no-ops the moment anything had
+        //               enabled blending globally, so the pass silently did not
+        //               get the disables it asked for -- issue #896. Pinned by
+        //               VulkanDrawPath.PerAttachmentBlendOpinionOutranksTheGlobalEnable.
+        //
+        // THE PRICE, and it is the #823 archetype pointing the other way: an
+        // opinion left behind outlives the pass that stated it, for the rest of
+        // the process. A pass that turns an attachment on or off MUST call
+        // ResetBlendStateForAttachment before it returns -- restoring by
+        // passing `false` to the setter is NOT a withdrawal, it is a ForceOff
+        // that would kill blending on that attachment permanently.
+        enum class AttachmentBlendOpinion : u8
+        {
+            Inherit = 0,
+            ForceOff,
+            ForceOn,
+        };
+        AttachmentBlendOpinion AttachmentBlend[kMaxAttachments] = {};
         RHI::BlendFactor AttachmentBlendSrc[kMaxAttachments] = {};
         RHI::BlendFactor AttachmentBlendDst[kMaxAttachments] = {};
+        // The same "did a pass state an opinion for attachment i" idea, one arm
+        // narrower -- the FUNC has no on/off, only diverted or inherited, so
+        // Inherit/Diverted is the whole state space.
+        //
         // GL parity (#691, found by the OITResolve tenant):
         // glEnablei(GL_BLEND, i) alone does NOT give buffer i its own blend
-        // func — the GLOBAL glBlendFunc applies until glBlendFunci names the
+        // func -- the GLOBAL glBlendFunc applies until glBlendFunci names the
         // buffer. A pass that per-attachment-ENABLES but sets only the global
         // func (OITResolve) must therefore blend with the global factors, not
-        // the never-written per-attachment defaults (Zero/Zero). This flag
-        // records "SetBlendFuncForAttachment was called for i"; the global
-        // SetBlendFunc/SetBlendFuncSeparate clear it (glBlendFunc overwrites
-        // every buffer's func in GL).
-        bool AttachmentBlendFuncSet[kMaxAttachments] = {};
+        // the never-written per-attachment defaults (Zero/Zero).
+        // SetBlendFuncForAttachment diverts buffer i; the global
+        // SetBlendFunc/SetBlendFuncSeparate withdraw every divert (glBlendFunc
+        // overwrites every buffer's func in GL). AttachmentBlendSrc/Dst are
+        // meaningful only where this says Diverted.
+        //
+        // Note the asymmetry with AttachmentBlend directly above: the global
+        // func setter DOES flatten this array while the global enable does not
+        // flatten that one. That is not an oversight -- no caller wants a
+        // surviving per-attachment FUNC (the passes here always re-state theirs
+        // next to the enable), and the global-flatten is what makes a missed
+        // withdrawal self-healing for the one of the pair where it can be.
+        enum class AttachmentBlendFuncOpinion : u8
+        {
+            Inherit = 0,
+            Diverted,
+        };
+        AttachmentBlendFuncOpinion AttachmentBlendFunc[kMaxAttachments] = {};
         u8 AttachmentColorMask[kMaxAttachments] = { 0xF, 0xF, 0xF, 0xF, 0xF, 0xF, 0xF, 0xF };
     };
 
@@ -435,6 +484,7 @@ namespace OloEngine
         void SetColorMask(bool red, bool green, bool blue, bool alpha) override;
         void SetColorMaskForAttachment(u32 attachment, bool red, bool green, bool blue, bool alpha) override;
         void SetBlendStateForAttachment(u32 attachment, bool enabled) override;
+        void ResetBlendStateForAttachment(u32 attachment) override;
         void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst) override;
         void CopyImageSubData(RHI::ResourceHandle src, TextureTargetType srcTarget, RHI::ResourceHandle dst, TextureTargetType dstTarget, u32 width, u32 height) override;
         void CopyImageSubDataFull(RHI::ResourceHandle src, TextureTargetType srcTarget, i32 srcLevel, i32 srcZ, RHI::ResourceHandle dst, TextureTargetType dstTarget, i32 dstLevel, i32 dstZ, u32 width, u32 height) override;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -416,6 +416,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/McpPerfSettleTest.cpp
 		Rendering/PropertyTests/VideoOverlayVisualEvidenceTest.cpp
 		Rendering/PropertyTests/AutoExposureEvidenceTest.cpp
+		Rendering/PropertyTests/GLAttachmentBlendOpinionTest.cpp
 		Rendering/PropertyTests/GPUReadbackStatsEvidenceTest.cpp
 		Rendering/PropertyTests/TestFailureCapture.cpp
 		Rendering/PropertyTests/TestFailureCaptureTest.cpp

--- a/OloEngine/tests/Rendering/MockRendererAPI.h
+++ b/OloEngine/tests/Rendering/MockRendererAPI.h
@@ -843,6 +843,13 @@ namespace OloEngine::Testing
             m_Calls.push_back(c);
         }
 
+        void ResetBlendStateForAttachment(u32 attachment) override
+        {
+            RecordedCall c{ "ResetBlendStateForAttachment" };
+            c.ParamU32_0 = attachment;
+            m_Calls.push_back(c);
+        }
+
         void SetBlendFuncForAttachment(u32 attachment, RHI::BlendFactor src, RHI::BlendFactor dst) override
         {
             RecordedCall c{ "SetBlendFuncForAttachment" };

--- a/OloEngine/tests/Rendering/PropertyTests/GLAttachmentBlendOpinionTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/GLAttachmentBlendOpinionTest.cpp
@@ -1,0 +1,128 @@
+// OLO_TEST_LAYER: plumbing
+// =============================================================================
+// GLAttachmentBlendOpinionTest — the GL arm of the per-attachment blend
+// tri-state (issue #896).
+//
+// The engine's contract is that a per-attachment blend opinion OUTRANKS the
+// global enable in both directions and is withdrawn only by an explicit
+// ResetBlendStateForAttachment. Raw GL does not work that way: glEnablei /
+// glDisablei is the only way to speak to a draw buffer, there is no "unset",
+// and glEnable(GL_BLEND) is DEFINED as glEnablei for every buffer — so on GL
+// the contract exists only because OpenGLRendererAPI::SetBlendState re-asserts
+// the standing opinions after the global call
+// (ReassertAttachmentBlendOpinions).
+//
+// Vulkan's arm of the same contract is pinned by
+// VulkanDrawPath.PerAttachmentBlendOpinionOutranksTheGlobalEnable, which reads
+// the composed result out of rendered pixels. This one asks the GL state
+// machine directly with glIsEnabledi, because on GL the driver's per-buffer
+// enable IS the state under test — there is no recorded array to lower, and a
+// pixel probe would only re-test blending.
+//
+// A withdrawal has to put the draw buffer back on the GLOBAL enable, and the
+// backend reads that from its own mirror because GL will not answer the
+// question. `glIsEnabled(GL_BLEND)` is documented as the index-0 value and does
+// not behave as one: measured here on NVIDIA (RTX 4090, driver 98.352.0), after
+// glDisable(GL_BLEND) + glEnablei(GL_BLEND, 1) it returns TRUE while
+// glIsEnabledi(GL_BLEND, 0) returns FALSE — i.e. "some index is on", not the
+// global. An earlier revision of this change queried it and this test is what
+// caught that, which is the reason the assertions below read the driver with
+// the INDEXED query throughout.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "RendererAttachedTest.h"
+
+#include "OloEngine/Renderer/Commands/RenderCommand.h" // MAX_MASKED_COLOR_ATTACHMENTS
+#include "OloEngine/Renderer/RenderCommand.h"
+
+#include <gtest/gtest.h>
+
+#include <glad/gl.h>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        [[nodiscard]] bool BlendEnabledFor(const u32 drawBuffer)
+        {
+            return ::glIsEnabledi(GL_BLEND, drawBuffer) == GL_TRUE;
+        }
+    } // namespace
+
+    // The fixture exists only to guarantee Renderer::Init has run, so the GL
+    // backend knows GL_MAX_DRAW_BUFFERS — the per-attachment entry points
+    // reject every index until it does. No scene is needed: this test drives
+    // the facade directly and reads the driver back.
+    class GLAttachmentBlendOpinion : public RendererAttachedTest
+    {
+      protected:
+        void BuildScene() override
+        {
+            // Intentionally empty — see the class comment.
+        }
+    };
+
+    TEST_F(GLAttachmentBlendOpinion, OpinionOutranksTheGlobalEnableAndWithdrawalRestoresIt)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        RendererAPI& api = RenderCommand::GetRendererAPI();
+
+        // Baseline: nothing has an opinion, so every draw buffer follows the
+        // global call. This is the control for everything below — if it fails,
+        // no later assertion means anything.
+        api.SetBlendState(true);
+        EXPECT_TRUE(BlendEnabledFor(0)) << "with no opinion standing, draw buffer 0 must follow SetBlendState(true)";
+        EXPECT_TRUE(BlendEnabledFor(1)) << "with no opinion standing, draw buffer 1 must follow SetBlendState(true)";
+
+        // ForceOff survives a global ENABLE — the #896 arm.
+        // OITResolveRenderPass asks for exactly this on its entity-ID and
+        // view-normal targets.
+        api.SetBlendStateForAttachment(1, false);
+        EXPECT_FALSE(BlendEnabledFor(1)) << "the indexed disable did not reach the driver at all";
+        api.SetBlendState(true); // the flatten that used to erase it
+        EXPECT_TRUE(BlendEnabledFor(0)) << "draw buffer 0 has no opinion and must still follow the global enable";
+        EXPECT_FALSE(BlendEnabledFor(1))
+            << "a per-attachment DISABLE must outrank a later global SetBlendState(true) — glEnable(GL_BLEND) is "
+               "glEnablei for every buffer, so SetBlendState has to re-assert the standing opinions (issue #896)";
+
+        // ForceOn survives a global DISABLE — the #823 arm, which
+        // DecalRenderPass's Emissive additive accumulation rides on.
+        api.SetBlendStateForAttachment(1, true);
+        api.SetBlendState(false);
+        EXPECT_FALSE(BlendEnabledFor(0)) << "draw buffer 0 has no opinion and must follow the global disable";
+        EXPECT_TRUE(BlendEnabledFor(1))
+            << "a per-attachment ENABLE must outrank a later global SetBlendState(false) — this is the enable "
+               "DecalRenderPass installs for an Emissive decal whose PODRenderState carries blendEnabled=false";
+
+        // Withdrawal is the only way out of either state, and puts the buffer
+        // back on the global flag — in both directions.
+        api.ResetBlendStateForAttachment(1);
+        EXPECT_FALSE(BlendEnabledFor(1)) << "after withdrawal, draw buffer 1 must follow the global disable";
+        api.SetBlendState(true);
+        EXPECT_TRUE(BlendEnabledFor(1))
+            << "after withdrawal, draw buffer 1 must follow the global enable too — a withdrawal that only "
+               "half-worked would leave the old opinion standing here";
+
+        // Withdrawing an attachment that never had an opinion is a no-op, and
+        // withdrawing one does not disturb another's. Both are load-bearing:
+        // RGCommandContext::ResetGraphicsStateToDefault withdraws all eight
+        // attachments unconditionally, most of which no pass ever touched, and
+        // the pass restore blocks withdraw their own indices one at a time
+        // while a sibling pass's opinion may still stand.
+        api.SetBlendState(false);
+        api.SetBlendStateForAttachment(1, true);
+        api.ResetBlendStateForAttachment(2); // never given an opinion
+        EXPECT_FALSE(BlendEnabledFor(2)) << "withdrawing an untouched attachment must leave it on the global";
+        EXPECT_TRUE(BlendEnabledFor(1))
+            << "withdrawing attachment 2 disturbed attachment 1's standing opinion — withdrawals are per-index";
+
+        // Leave nothing standing for the next test in this process — the leak
+        // the tri-state makes possible, and the reason every pass withdraws.
+        for (u32 attachment = 0; attachment < MAX_MASKED_COLOR_ATTACHMENTS; ++attachment)
+            api.ResetBlendStateForAttachment(attachment);
+        api.SetBlendState(false);
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PropertyTests/GLAttachmentBlendOpinionTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/GLAttachmentBlendOpinionTest.cpp
@@ -70,6 +70,15 @@ namespace OloEngine::Tests
 
         RendererAPI& api = RenderCommand::GetRendererAPI();
 
+        // Opinions outlive the pass that stated them and this backend is
+        // process-global, so the baseline below cannot assume it starts clean —
+        // an earlier test in this binary leaving a ForceOff on 0 or 1 would
+        // fail the control before the real scenario was ever reached. Clear
+        // first, then establish the baseline. (The cleanup at the end of this
+        // test protects the NEXT test; this protects THIS one.)
+        for (u32 attachment = 0; attachment < MAX_MASKED_COLOR_ATTACHMENTS; ++attachment)
+            api.ResetBlendStateForAttachment(attachment);
+
         // Baseline: nothing has an opinion, so every draw buffer follows the
         // global call. This is the control for everything below — if it fails,
         // no later assertion means anything.

--- a/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
@@ -918,13 +918,18 @@ void main()
                     tintUbo->Bind();
                     api.SetBlendFunc(RHI::BlendFactor::One, RHI::BlendFactor::One);
 
-                    // Phase 1 — the OITResolveRenderPass shape. Blending on
-                    // globally, one attachment disabled per-attachment.
+                    // Phase 1 — the OITResolveRenderPass shape. One attachment
+                    // disabled per-attachment, and the global enable AFTER it:
+                    // the opposite order would still pass on a build where
+                    // SetBlendState flattens the array, because the ForceOff
+                    // would be installed after the flatten. Stating the opinion
+                    // first is what makes this an assertion about SURVIVING a
+                    // global enable rather than merely outranking one.
                     drawGreenOver(forcedOff,
                                   [&]()
                                   {
-                                      api.SetBlendState(true);
                                       api.SetBlendStateForAttachment(1, false);
+                                      api.SetBlendState(true);
                                   });
 
                     // Phase 2 — the DecalRenderPass Emissive shape, with the

--- a/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanDrawPathTest.cpp
@@ -795,4 +795,227 @@ void main()
     api.SetColorMask(true, true, true, true);
 }
 
+// =============================================================================
+// A per-attachment blend opinion outranks the global enable, BOTH WAYS
+// (issue #896, and the half of #823 that was deliberately left open).
+//
+// The recorded per-attachment blend state used to be a bool that could only
+// OR onto the global flag, so `SetBlendStateForAttachment(i, false)` did not
+// mean what its name says: the moment anything enabled blending globally the
+// call was a no-op. OITResolveRenderPass asks for exactly that on RT1 (entity
+// ID, an integer target) and RT2 (view normals) and did not get it on Vulkan,
+// where GL would have disabled them. It was invisible because the same pass
+// also colour-masks those two attachments to zero — a broken contract with no
+// symptom, waiting for the first caller who disables without also masking.
+//
+// It is a TRI-STATE now, so all three states need pinning, and they need
+// pinning from ONE recording: the state is process-scoped, so a fresh frame
+// per case would reset the very thing under test.
+//
+//   ForceOff  — survives a global ENABLE.                  (the #896 fix)
+//   ForceOn   — survives a global DISABLE.                 (the #823 tenant:
+//               DecalRenderPass's Emissive additive accumulation, which the
+//               naive "match GL" fix deleted and which this must not.)
+//   Inherit   — after ResetBlendStateForAttachment, follows the global again.
+//
+// Each phase is the next one's control. Attachments 0 and 2 are never given an
+// opinion in any phase, so they read out the global flag and say whether the
+// blend that phase asserts about was live at all — without them a build where
+// blending never happened would pass the ForceOff assertion trivially.
+//
+// The probe: clear RED, draw GREEN with a One/One blend func. A texel that
+// blended reads YELLOW (green + red); one that did not reads GREEN.
+// =============================================================================
+TEST_F(VulkanDrawPath, PerAttachmentBlendOpinionOutranksTheGlobalEnable)
+{
+    ScopedVulkanApiSelection vulkanApi;
+    VulkanFrameArena::Get().BeginFrame(0);
+
+    constexpr u32 kSize = 32;
+    constexpr u32 kAttachments = 3;
+
+    constexpr const char* kMrtBlendFragmentSrc = R"(
+#version 460 core
+layout(location = 0) in vec2 v_TexCoord;
+layout(location = 0) out vec4 o_Rt0;
+layout(location = 1) out vec4 o_Rt1;
+layout(location = 2) out vec4 o_Rt2;
+
+layout(std140, binding = 3) uniform TintBlock
+{
+    vec4 u_Tint;
+};
+
+void main()
+{
+    o_Rt0 = u_Tint;
+    o_Rt1 = u_Tint;
+    o_Rt2 = u_Tint;
+}
+)";
+
+    FramebufferSpecification fbSpec;
+    fbSpec.Width = kSize;
+    fbSpec.Height = kSize;
+    fbSpec.Attachments = { FramebufferTextureFormat::RGBA8, FramebufferTextureFormat::RGBA8,
+                           FramebufferTextureFormat::RGBA8 };
+    auto forcedOff = Framebuffer::Create(fbSpec);
+    ASSERT_NE(forcedOff, nullptr);
+    auto forcedOn = Framebuffer::Create(fbSpec);
+    ASSERT_NE(forcedOn, nullptr);
+    auto withdrawn = Framebuffer::Create(fbSpec);
+    ASSERT_NE(withdrawn, nullptr);
+
+    const f32 vertices[] = { -1.0f, -1.0f, 3.0f, -1.0f, -1.0f, 3.0f };
+    auto vertexBuffer = VertexBuffer::Create(vertices, sizeof(vertices));
+    u32 indices[] = { 0, 1, 2 };
+    auto indexBuffer = IndexBuffer::Create(indices, 3);
+    auto vertexArray = VertexArray::Create();
+    vertexArray->AddVertexBuffer(vertexBuffer);
+    vertexArray->SetIndexBuffer(indexBuffer);
+
+    auto tintUbo = UniformBuffer::Create(16, 3);
+    auto shader = Ref<VulkanShader>::Create("DrawPathMrtBlend", kVertexSrc, kMrtBlendFragmentSrc);
+    ASSERT_EQ(shader->GetCompilationStatus(), ShaderCompilationStatus::Ready);
+
+    VulkanRendererAPI api;
+
+    constexpr f32 kGreen[4] = { 0.0f, 1.0f, 0.0f, 1.0f };
+
+    const auto transitionAll = [&api](const Ref<Framebuffer>& target, const RHI::Access before,
+                                      const RHI::Access after)
+    {
+        for (u32 i = 0; i < kAttachments; ++i)
+        {
+            RHI::Barrier barrier{};
+            barrier.Resource = target->GetColorAttachmentHandle(i);
+            barrier.Before = before;
+            barrier.After = after;
+            api.IssueBarrierBatch(MemoryBarrierFlags::None, std::span{ &barrier, 1 });
+        }
+    };
+
+    const auto drawGreenOver = [&](Ref<Framebuffer>& target, const std::function<void()>& installBlendState)
+    {
+        target->Bind();
+        api.SetViewport(0, 0, kSize, kSize);
+        api.SetClearColor({ 1.0f, 0.0f, 0.0f, 1.0f });
+        api.Clear();
+        installBlendState();
+        tintUbo->SetData(kGreen, sizeof(kGreen));
+        api.DrawIndexed(vertexArray, 3);
+        target->Unbind();
+    };
+
+    SubmitFrame(api,
+                [&]()
+                {
+                    transitionAll(forcedOff, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+                    transitionAll(forcedOn, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+                    transitionAll(withdrawn, RHI::Access::Undefined, RHI::Access::ColorAttachmentWrite);
+
+                    shader->Bind();
+                    tintUbo->Bind();
+                    api.SetBlendFunc(RHI::BlendFactor::One, RHI::BlendFactor::One);
+
+                    // Phase 1 — the OITResolveRenderPass shape. Blending on
+                    // globally, one attachment disabled per-attachment.
+                    drawGreenOver(forcedOff,
+                                  [&]()
+                                  {
+                                      api.SetBlendState(true);
+                                      api.SetBlendStateForAttachment(1, false);
+                                  });
+
+                    // Phase 2 — the DecalRenderPass Emissive shape, with the
+                    // global call AFTER the indexed one, the order
+                    // ApplyPODRenderState actually produces.
+                    drawGreenOver(forcedOn,
+                                  [&]()
+                                  {
+                                      api.SetBlendStateForAttachment(1, true);
+                                      api.SetBlendState(false);
+                                  });
+
+                    // Phase 3 — the withdrawal. Global is still false from
+                    // phase 2, so attachment 1 must stop blending; if the
+                    // reset did nothing it would still carry phase 2's
+                    // ForceOn and blend.
+                    drawGreenOver(withdrawn, [&]()
+                                  { api.ResetBlendStateForAttachment(1); });
+
+                    transitionAll(forcedOff, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                    transitionAll(forcedOn, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                    transitionAll(withdrawn, RHI::Access::ColorAttachmentWrite, RHI::Access::ShaderSampleRead);
+                });
+
+    EXPECT_EQ(api.GetUnimplementedStubHitCount(), 0u) << "the MRT blend path must not fall through to a stub";
+
+    // `target` is deliberately NOT const — see the same note on the colour-mask
+    // test above (Ref<T>::Raw() const-propagates).
+    const auto centreTexel = [](Ref<Framebuffer>& target, u32 attachmentIndex,
+                                std::array<u8, 4>& out) -> bool
+    {
+        auto* vkFramebuffer = static_cast<VulkanFramebuffer*>(target.Raw());
+        const auto attachment = vkFramebuffer->GetColorAttachmentImage(attachmentIndex);
+        if (attachment == nullptr)
+            return false;
+        std::vector<u8> pixels;
+        if (!attachment->GetData(pixels, 0) || pixels.size() != sizet{ kSize } * kSize * 4)
+            return false;
+        const sizet offset = ((sizet{ kSize } / 2) * kSize + kSize / 2) * 4;
+        out = { pixels[offset + 0], pixels[offset + 1], pixels[offset + 2], pixels[offset + 3] };
+        return true;
+    };
+
+    // green over red, One/One: R and G both saturate, alpha 1+1 clamps to 1.
+    constexpr std::array<u8, 4> kBlendedTexel{ 0xFF, 0xFF, 0x00, 0xFF };
+    constexpr std::array<u8, 4> kGreenTexel{ 0x00, 0xFF, 0x00, 0xFF };
+
+    std::array<u8, 4> texel{};
+
+    // Phase 1. Attachments 0 and 2 are the control: they carry no opinion, so
+    // they show whether the global enable was live at all.
+    ASSERT_TRUE(centreTexel(forcedOff, 0, texel));
+    EXPECT_EQ(texel, kBlendedTexel) << "attachment 0 has no per-attachment opinion and must follow SetBlendState(true)";
+    ASSERT_TRUE(centreTexel(forcedOff, 2, texel));
+    EXPECT_EQ(texel, kBlendedTexel) << "attachment 2 has no per-attachment opinion and must follow SetBlendState(true)";
+    ASSERT_TRUE(centreTexel(forcedOff, 1, texel));
+    EXPECT_EQ(texel, kGreenTexel)
+        << "SetBlendStateForAttachment(1, false) did not survive the global SetBlendState(true) — a "
+           "per-attachment DISABLE has to outrank the global enable, which is what OITResolveRenderPass "
+           "asks for on its entity-ID and view-normal targets (issue #896)";
+
+    // Phase 2. The direction the naive #823 fix broke: this is what
+    // DecalRenderPass's Emissive additive accumulation rides on.
+    ASSERT_TRUE(centreTexel(forcedOn, 0, texel));
+    EXPECT_EQ(texel, kGreenTexel) << "attachment 0 has no opinion and must follow SetBlendState(false)";
+    ASSERT_TRUE(centreTexel(forcedOn, 2, texel));
+    EXPECT_EQ(texel, kGreenTexel) << "attachment 2 has no opinion and must follow SetBlendState(false)";
+    ASSERT_TRUE(centreTexel(forcedOn, 1, texel));
+    EXPECT_EQ(texel, kBlendedTexel)
+        << "SetBlendStateForAttachment(1, true) did not survive the global SetBlendState(false) that followed "
+           "it — DecalRenderPass enables RT2 this way for an Emissive decal whose PODRenderState carries "
+           "blendEnabled=false (issue #823)";
+
+    // Phase 3. Withdrawing the opinion puts the attachment back on the global
+    // flag — the only way out of the two states above, and the reason a pass
+    // restoring its state must not just pass `false`.
+    for (u32 i = 0; i < kAttachments; ++i)
+    {
+        ASSERT_TRUE(centreTexel(withdrawn, i, texel)) << "attachment " << i << " readback failed";
+        EXPECT_EQ(texel, kGreenTexel)
+            << "attachment " << i
+            << " blended after ResetBlendStateForAttachment(1) with the global enable off — the withdrawal "
+               "must put attachment 1 back on SetBlendState (issue #896)";
+    }
+
+    // Leave nothing standing for the next test in this binary — the very leak
+    // the tri-state makes possible.
+    for (u32 i = 0; i < VulkanRecordedPipelineState::kMaxAttachments; ++i)
+        api.ResetBlendStateForAttachment(i);
+    api.SetBlendState(false);
+    api.SetBlendFunc(RHI::BlendFactor::SrcAlpha, RHI::BlendFactor::OneMinusSrcAlpha);
+}
+
 #endif // OLO_WITH_VULKAN

--- a/docs/agent-rules/gl-global-setter-resets-indexed-state.md
+++ b/docs/agent-rules/gl-global-setter-resets-indexed-state.md
@@ -126,11 +126,13 @@ licence.** Two adjacent pieces of state with the same GL rule can have different
 callers depending on different semantics, and the only thing that separates them
 is running the suite that covers the caller.
 
-`RendererAPI` has exactly three indexed entry points —
+`RendererAPI` has three indexed *setters* —
 `SetColorMaskForAttachment`, `SetBlendStateForAttachment`,
 `SetBlendFuncForAttachment`. Two of the three globals overwrite their array
 (`SetColorMask`, and `SetBlendFunc` which already did); `SetBlendState` does
-not, for the reason above.
+not, for the reason above. (#896 added a fourth per-attachment entry point,
+`ResetBlendStateForAttachment`, which is not a setter but a withdrawal — see
+the next section.)
 
 ## What the blend twin turned out to need: a third state (#896)
 
@@ -168,20 +170,27 @@ A withdrawal has to put the draw buffer back on the *global* enable, and the
 obvious way to avoid mirroring a flag is to ask GL for it. That does not work,
 and the failure is quiet.
 
-`glIsEnabled(GL_BLEND)` is specified as the index-0 value of an indexed
-capability. Measured on NVIDIA (RTX 4090, driver 98.352.0), after
-`glDisable(GL_BLEND)` followed by `glEnablei(GL_BLEND, 1)`:
+**The spec rule:** `glIsEnabled(GL_BLEND)` queries the index-0 value — it is
+equivalent to `glIsEnabledi(GL_BLEND, 0)`. So even a conforming implementation
+answers "is blending on for draw buffer 0", never "what did the last global
+call say" — and draw buffer 0 can hold an opinion of its own, which is exactly
+what `DecalRenderPass` and `ParticleRenderPass` install. On that basis alone it
+is the wrong input for a withdrawal.
 
-| query | returns |
-|---|---|
-| `glIsEnabled(GL_BLEND)` | **`GL_TRUE`** |
-| `glIsEnabledi(GL_BLEND, 0)` | `GL_FALSE` |
+**And this driver does not even give the spec answer.** Measured on NVIDIA
+(RTX 4090, driver 98.352.0) — a driver-specific observation, not general GL
+behaviour — after `glDisable(GL_BLEND)` followed by `glEnablei(GL_BLEND, 1)`:
 
-So it answers "some index is on", not "the global is on", and a withdrawal
-reading it restores the wrong state for every draw buffer whenever any *other*
-attachment holds an enable — precisely the situation a withdrawal happens in.
-The backend keeps a mirror instead, and every query in the GL test reads the
-**indexed** form.
+| query | returns | spec-conforming answer |
+|---|---|---|
+| `glIsEnabled(GL_BLEND)` | **`GL_TRUE`** | `GL_FALSE` (index 0 is disabled) |
+| `glIsEnabledi(GL_BLEND, 0)` | `GL_FALSE` | `GL_FALSE` |
+
+Here it reports "some index is on". Either way — spec answer or this driver's —
+a withdrawal reading it restores the wrong state whenever another attachment
+holds an enable, precisely the situation a withdrawal happens in. The backend
+keeps a mirror instead, and every query in the GL test reads the **indexed**
+form.
 
 The mirror's one gap is stated at its declaration rather than papered over: a
 raw `GL_BLEND` flip that bypasses the class stales it. `Init()` is routed

--- a/docs/agent-rules/gl-global-setter-resets-indexed-state.md
+++ b/docs/agent-rules/gl-global-setter-resets-indexed-state.md
@@ -128,9 +128,100 @@ is running the suite that covers the caller.
 
 `RendererAPI` has exactly three indexed entry points —
 `SetColorMaskForAttachment`, `SetBlendStateForAttachment`,
-`SetBlendFuncForAttachment`. Two of the three globals now overwrite their array
-(`SetColorMask`, and `SetBlendFunc` which already did); `SetBlendState`
-deliberately does not, for the reason above.
+`SetBlendFuncForAttachment`. Two of the three globals overwrite their array
+(`SetColorMask`, and `SetBlendFunc` which already did); `SetBlendState` does
+not, for the reason above.
+
+## What the blend twin turned out to need: a third state (#896)
+
+Recording the divergence bought time, and left a second defect underneath it.
+A bool that can only OR cannot say **"off"**: `SetBlendStateForAttachment(i,
+false)` was a no-op the instant anything enabled blending globally, so
+`OITResolveRenderPass`'s disables on RT1 (entity ID, an *integer* target) and
+RT2 (view normals) never reached the pipeline on Vulkan. Nothing showed,
+because that pass colour-masks both attachments to zero as well — a broken
+contract with no symptom, which is the hardest kind to keep fixed.
+
+Both callers are served once the per-attachment state stops being a bool:
+
+| state | means | who needs it |
+|---|---|---|
+| `Inherit` | no pass has an opinion; follow the global | everything else |
+| `ForceOn` | blend even if the global says no | `DecalRenderPass` Emissive |
+| `ForceOff` | do not blend even if the global says yes | `OITResolveRenderPass` |
+
+The global setter then has nothing to guess at, and the two arms stop being in
+tension — the thing that made the naive fix look mandatory was reading a
+two-state variable as if it could express three.
+
+**Both backends implement that rule, not two different ones.** Raw GL cannot
+hold "unset" for a draw buffer, so `OpenGLRendererAPI::SetBlendState` issues
+`glEnable`/`glDisable(GL_BLEND)` and then re-asserts every standing opinion on
+top (`ReassertAttachmentBlendOpinions`), the save/restore shape
+`m_AttachmentColorMasks` already used for clears. A side effect worth knowing:
+that is what finally gives the emissive decal its additive accumulation on GL,
+where it had never worked.
+
+### `glIsEnabled(GL_BLEND)` does not report index 0 — don't withdraw from it
+
+A withdrawal has to put the draw buffer back on the *global* enable, and the
+obvious way to avoid mirroring a flag is to ask GL for it. That does not work,
+and the failure is quiet.
+
+`glIsEnabled(GL_BLEND)` is specified as the index-0 value of an indexed
+capability. Measured on NVIDIA (RTX 4090, driver 98.352.0), after
+`glDisable(GL_BLEND)` followed by `glEnablei(GL_BLEND, 1)`:
+
+| query | returns |
+|---|---|
+| `glIsEnabled(GL_BLEND)` | **`GL_TRUE`** |
+| `glIsEnabledi(GL_BLEND, 0)` | `GL_FALSE` |
+
+So it answers "some index is on", not "the global is on", and a withdrawal
+reading it restores the wrong state for every draw buffer whenever any *other*
+attachment holds an enable — precisely the situation a withdrawal happens in.
+The backend keeps a mirror instead, and every query in the GL test reads the
+**indexed** form.
+
+The mirror's one gap is stated at its declaration rather than papered over: a
+raw `GL_BLEND` flip that bypasses the class stales it. `Init()` is routed
+through `SetBlendState` for exactly this reason; `GLStateGuard`'s restore is
+not, and that guard already documents that it neither captures nor restores
+per-attachment blend state. The exposure is bounded because every withdrawal in
+the engine sits beside a global `SetBlendState` that refreshes the mirror.
+
+The general point: **a facade that mirrors driver state has to own every write
+to it, and "just ask the driver" is only an escape when the driver's query
+answers the question you are actually asking.** This one doesn't, and nothing
+but running it says so — the first version of this fix queried GL, and the GL
+test below is what caught it.
+
+**The price is the #823 archetype pointing the other way**, and it is the part
+to be careful with. An opinion now outlives the pass that stated it, so
+"restore" can no longer be spelled by passing `false` — that is a standing
+disable, and on attachment 0 it would kill blending for the rest of the
+process. `ResetBlendStateForAttachment` is the withdrawal, and every pass that
+states an opinion has to call it: `OITResolveRenderPass`,
+`DecalRenderPass` (both paths) and `ParticleRenderPass` (both paths) were all
+restoring only *some* of the attachments they had touched, because under the OR
+the rest were harmless.
+
+Pinned on both backends, and the two tests ask the question differently
+because the state under test is not the same object:
+
+- `VulkanDrawPath.PerAttachmentBlendOpinionOutranksTheGlobalEnable` drives all
+  three states through **one recording** — the same reason the colour-mask test
+  does: the state is process-scoped, so a fresh frame per case would reset the
+  thing under test. It reads the composed result out of rendered pixels
+  (clear red, draw green with a `One/One` func: blended reads yellow, unblended
+  reads green), because on Vulkan the recorded array has to survive a lowering.
+  Each phase is the next one's control, and the two attachments that never carry
+  an opinion are what prove blending was live at all.
+- `GLAttachmentBlendOpinion.OpinionOutranksTheGlobalEnableAndWithdrawalRestoresIt`
+  asks the GL state machine directly with `glIsEnabledi`, because on GL the
+  driver's per-buffer enable **is** the state under test — there is no recorded
+  array to lower, and a pixel probe would only re-test blending. It is also the
+  test that caught the `glIsEnabled` trap above.
 
 Pinned by `VulkanDrawPath.GlobalColorMaskResetsPerAttachmentDivergence`,
 which drives three render targets through **one recording** — because the leak


### PR DESCRIPTION
## What was wrong

`SetBlendStateForAttachment(i, false)` did not mean what its name says. `VulkanRendererAPI`'s recorded per-attachment blend state was a **bool that could only OR** onto the global `Blend` flag, so a per-attachment *disable* was a no-op the moment anything enabled blending globally. `OITResolveRenderPass` asks for exactly that on RT1 (entity ID — an **integer** target) and RT2 (view normals), and did not get it on Vulkan where GL would have disabled them.

**This was latent, not visible, and the PR should not be read as more.** The same pass also colour-masks those two attachments to zero, so nothing was written regardless — and those masks are not flattened by the #853 mechanism, because `DrawFullscreenTriangle` issues an immediate `context.DrawIndexed` rather than a command packet. It was a **broken API contract with no current symptom**: the next caller who relies on that disable *without* also masking colour would silently get blending, on Vulkan only.

## The shape of the fix

The bool could not express "off" because it was carrying two jobs. Splitting them into a tri-state serves both callers at once, and dissolves the tension that made the naive fix look mandatory:

| state | means | who needs it |
|---|---|---|
| `Inherit` | no pass has an opinion; follow the global | everything else |
| `ForceOn` | blend even if the global says no | `DecalRenderPass` Emissive |
| `ForceOff` | do not blend even if the global says yes | `OITResolveRenderPass` |

`SetBlendState` then has nothing to guess at. The naive symmetric fix — let the global win, as GL does — **was written during #823 and reverted**, because it deleted working additive emissive-decal accumulation on Vulkan while fixing nothing on GL. That direction is now `ForceOn`, and it is pinned rather than merely preserved.

**Both backends implement that one rule, not two different ones.** Raw GL cannot hold "unset" for a draw buffer, so `OpenGLRendererAPI::SetBlendState` issues the global `glEnable`/`glDisable(GL_BLEND)` and then re-asserts every standing opinion on top (`ReassertAttachmentBlendOpinions`) — the same save/restore shape `m_AttachmentColorMasks` already used for clears.

⚠️ **One deliberate behaviour change on the default backend:** that is what finally gives the emissive decal its additive accumulation **on GL**, where it had never worked. No golden covers decals, and no golden file moved in this run.

## The price, and how it is paid

This is the #823 archetype pointing the other way: **an opinion now outlives the pass that stated it.** "Restore" can no longer be spelled by passing `false` — that is a standing disable, and on attachment 0 it would kill blending for the rest of the process.

`ResetBlendStateForAttachment` is the withdrawal. `OITResolveRenderPass`, `DecalRenderPass` (both paths) and `ParticleRenderPass` (both paths) were each restoring only *some* of the attachments they had touched, because under the OR the rest were harmless — all now withdraw every one, and `RGCommandContext::ResetGraphicsStateToDefault` withdraws the lot.

## Folded in

- `AttachmentBlendFuncSet` → `AttachmentBlendFunc` (`Inherit` / `Diverted`) — the same "did a pass state an opinion" idea, one arm narrower. Its deliberate asymmetry with the enable (the global func setter *does* flatten it) is now written down instead of implied.
- The two Vulkan lowering routes (baked `GetOrCreateGraphics`, dynamic `FlushDynamicState`) now share one `ResolveBlendEnable` instead of two copies of an expression kept in step by a comment.

## Two nearby defects fixed on the way

Both pre-existing, neither introduced here:

- `DecalRenderPass::ExecuteOnGBuffer` never withdrew its RT2 blend-**func** divert (`One/One`). Inert under the OR because RT2's enable was false anyway; not inert now. It now issues the same global `SetBlendFunc` restore the other two paths already used.
- `OpenGLRendererAPI::Init()` set `GL_BLEND` with a raw `glEnable`, leaving the facade's mirror claiming "disabled" while the driver blended.

## Review guide

**Where I'd look hardest**

1. **`OpenGLRendererAPI::SetBlendState` → `ReassertAttachmentBlendOpinions`** — this is the only part that changes what the *default* backend puts on screen. It is called on essentially every packet via `ApplyPODRenderState`; the `m_AnyAttachmentBlendOpinion` early-out keeps the loop off the common path, but if that flag were ever wrong the cost lands in the hot path. The behavioural question worth a second opinion: making GL sticky removes a **self-healing** property it had — a pass that forgot to restore a per-attachment enable used to be silently fixed by the next global call, and now is not. I audited every `SetBlendStateForAttachment` call site (there are only three passes) and added the withdrawal to the documented full reset, but "I found all the callers" is exactly the claim worth re-checking.
2. **The pass restore blocks** (`OITResolveRenderPass.cpp`, `ParticleRenderPass.cpp`, `DecalRenderPass.cpp`) — each previously restored a *subset* of what it touched. The failure mode of getting one wrong is a process-scoped blend leak, which is #823's shape and was invisible for a whole phase.
3. **`VulkanRendererAPI.h`, the `AttachmentBlend` declaration** — the composition rule lives there rather than at the setter, deliberately (that convention is the only reason this bug was discoverable). Worth reading as documentation, not just as a diff.

**What I verified, and how**

- `VulkanDrawPath.PerAttachmentBlendOpinionOutranksTheGlobalEnable` (new) — all three states through **one recording** on a real RTX 4090, because the state is process-scoped and a fresh frame per case would reset the thing under test. Probe: clear red, draw green with `One/One`; blended reads yellow, unblended reads green. Each phase is the next one's control, and attachments 0 and 2 never carry an opinion, so they prove blending was *live* while attachment 1 stayed unblended — without them, a build where blending never happened would pass the `ForceOff` assertion trivially.
- `GLAttachmentBlendOpinion.OpinionOutranksTheGlobalEnableAndWithdrawalRestoresIt` (new) — the GL arm, asking the state machine directly with `glIsEnabledi`, because on GL the driver's per-buffer enable *is* the state under test.
- `VulkanPassSuite.DecalGBufferModeMatrixMasksItsTargetRenderTargets` — **the gate**. This is the tenant that rejected the naive fix during #823, and since #886 it runs through the production dispatch. Passes.
- `VulkanDrawPath.GlobalColorMaskResetsPerAttachmentDivergence` — the #823 colour-mask pin, unchanged and still green.
- Full suite: **6553 passed, 26 skipped (environment-gated), 0 failures.** No golden file changed; the 32 dirty PNGs under `assets/tests/visual/` are the known per-run evidence churn and are deliberately not staged.

**Least confident about**

Two things, in order:

1. **`GLStateGuard` can stale the mirror.** `OpenGLStateGuard.cpp` restores `GL_BLEND` with raw `::glEnable`/`::glDisable`, bypassing `SetBlendState`, so it neither refreshes `m_BlendEnabled` nor re-asserts standing opinions. The guard already documents that it does not capture or restore per-attachment blend state, so this is pre-existing rather than new, and the exposure is bounded — every withdrawal in the engine sits beside a global `SetBlendState` that refreshes the mirror. But it is a real hole and I chose to state it at the declaration rather than widen the diff into the guard. **Happy to be told that is the wrong call.**
2. **The GL behaviour change is verified by tests, not by pixels.** I did not capture editor frames of an emissive-decal scene before/after. There is no decal golden, and `DecalModeMatrixTest.olo` exists but I did not drive it live.

**Something the review caught that I got wrong** — worth flagging because the fix is in the diff: my first attempt at the withdrawal asked the driver (`glIsEnabled(GL_BLEND)`) instead of keeping a mirror, on the reasoning that a mirror can go stale. The new GL test failed, and the measurement is in `docs/agent-rules/`: on this NVIDIA driver, after `glDisable(GL_BLEND)` + `glEnablei(GL_BLEND, 1)`, `glIsEnabled(GL_BLEND)` returns `GL_TRUE` while `glIsEnabledi(GL_BLEND, 0)` returns `GL_FALSE`. It reports "some index is on", not the global, so it is useless as a withdrawal's input — and it is wrong exactly when a withdrawal happens.

**Deliberately not tested**

- The `dynamicBlend == false` baked lowering route. This host has EDS3, so `FlushDynamicState` is what actually runs; the baked route is the documented fallback column that is "expected never to trigger on the desktop floor". Both routes now call the same `ResolveBlendEnable`, which is the point of extracting it — but only one of them is exercised here.
- Live editor frames (see "least confident" #2).

Closes #896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering-state restoration across decals, particles, and compositing passes.
  * Prevented blend settings from persisting incorrectly between render operations.
  * Ensured attachment-specific blend overrides correctly inherit global settings when reset.
  * Improved consistency across OpenGL and Vulkan rendering paths.

* **Tests**
  * Added coverage for per-attachment blend behavior, overrides, resets, and inheritance across both graphics backends.

* **Documentation**
  * Documented the updated three-state blend behavior and state-reset rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->