### PR TITLE
perf(renderer): compile independent shaders concurrently across the CPU tier

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
@@ -255,26 +255,20 @@ namespace OloEngine
             samplers[i] = i;
         }
 
-        OLO_CORE_INFO("Renderer2D::Init: Loading Renderer2D_Quad...");
-        m_ShaderLibrary.Load("assets/shaders/Renderer2D_Quad.glsl");
-        OLO_CORE_INFO("Renderer2D::Init: Renderer2D_Quad loaded, calling RenderProgressFrame(1/5)");
-        ShaderWarmup::RenderProgressFrame(1.0f / 5.0f, window, "2D shaders", 1, 5, 0);
-        OLO_CORE_INFO("Renderer2D::Init: Loading Renderer2D_Polygon...");
-        m_ShaderLibrary.Load("assets/shaders/Renderer2D_Polygon.glsl");
-        OLO_CORE_INFO("Renderer2D::Init: Renderer2D_Polygon loaded, calling RenderProgressFrame(2/5)");
-        ShaderWarmup::RenderProgressFrame(2.0f / 5.0f, window, "2D shaders", 2, 5, 0);
-        OLO_CORE_INFO("Renderer2D::Init: Loading Renderer2D_Circle...");
-        m_ShaderLibrary.Load("assets/shaders/Renderer2D_Circle.glsl");
-        OLO_CORE_INFO("Renderer2D::Init: Renderer2D_Circle loaded, calling RenderProgressFrame(3/5)");
-        ShaderWarmup::RenderProgressFrame(3.0f / 5.0f, window, "2D shaders", 3, 5, 0);
-        OLO_CORE_INFO("Renderer2D::Init: Loading Renderer2D_Line...");
-        m_ShaderLibrary.Load("assets/shaders/Renderer2D_Line.glsl");
-        OLO_CORE_INFO("Renderer2D::Init: Renderer2D_Line loaded, calling RenderProgressFrame(4/5)");
-        ShaderWarmup::RenderProgressFrame(4.0f / 5.0f, window, "2D shaders", 4, 5, 0);
-        OLO_CORE_INFO("Renderer2D::Init: Loading Renderer2D_Text...");
-        m_ShaderLibrary.Load("assets/shaders/Renderer2D_Text.glsl");
-        OLO_CORE_INFO("Renderer2D::Init: Renderer2D_Text loaded, calling RenderProgressFrame(5/5)");
-        ShaderWarmup::RenderProgressFrame(5.0f / 5.0f, window, "2D shaders", 5, 5, 0);
+        // CPU-side compile of independent shaders runs in parallel across
+        // shaders (issue #907) — GL program creation/link still happens
+        // sequentially afterward on this (render) thread; see
+        // ShaderWarmup::LoadShadersParallel.
+        OLO_CORE_INFO("Renderer2D::Init: Loading 2D shaders...");
+        const std::vector<std::string> shaderPaths2D = {
+            "assets/shaders/Renderer2D_Quad.glsl",
+            "assets/shaders/Renderer2D_Polygon.glsl",
+            "assets/shaders/Renderer2D_Circle.glsl",
+            "assets/shaders/Renderer2D_Line.glsl",
+            "assets/shaders/Renderer2D_Text.glsl",
+        };
+        ShaderWarmup::LoadShadersParallel(m_ShaderLibrary, window, shaderPaths2D, "2D shaders", 0);
+        OLO_CORE_INFO("Renderer2D::Init: 2D shaders loaded");
 
         // Wait for any remaining async GPU links before resolving shader refs.
         ShaderWarmup::RunWarmupScreen(m_ShaderLibrary, window);

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -207,8 +207,7 @@ namespace OloEngine
             s_Data.FullscreenQuadVAO->AddVertexBuffer(quadVBO);
         }
 
-        u32 shaderIdx = 0;
-        // NOTE: Keep totalShaders3D in sync with the number of Load() calls below.
+        // NOTE: Keep totalShaders3D in sync with the number of paths in s_ShaderPaths below.
         constexpr u32 totalShaders3D = 52;
 
         // Boot + fallback are idempotent — no-ops when already initialized by
@@ -279,11 +278,12 @@ namespace OloEngine
         };
         static_assert(s_ShaderPaths.size() == totalShaders3D);
 
-        for (const auto* path : s_ShaderPaths)
-        {
-            m_ShaderLibrary.Load(path);
-            ShaderWarmup::RenderProgressFrame(static_cast<f32>(++shaderIdx) / totalShaders3D, window, "3D shaders", static_cast<i32>(shaderIdx), static_cast<i32>(totalShaders3D), 1);
-        }
+        // CPU-side compile of independent shaders runs in parallel across
+        // shaders (issue #907) — GL program creation/link still happens
+        // sequentially afterward on this (render) thread; see
+        // ShaderWarmup::LoadShadersParallel.
+        const std::vector<std::string> shaderPaths3D(s_ShaderPaths.begin(), s_ShaderPaths.end());
+        ShaderWarmup::LoadShadersParallel(m_ShaderLibrary, window, shaderPaths3D, "3D shaders", 1);
 
         // Log how many shaders are still compiling asynchronously
         if (const u32 pending = m_ShaderLibrary.GetPendingCount(); pending > 0)

--- a/OloEngine/src/OloEngine/Renderer/Shader.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shader.cpp
@@ -198,4 +198,69 @@ namespace OloEngine
         OLO_CORE_ASSERT(false, "Unknown RendererAPI!");
         return nullptr;
     }
+
+    namespace
+    {
+        // Shared fallback for a backend with no CPU-only prepare step (issue
+        // #907 covers OpenGL only) — synchronous Create() per shader.
+        // FinalizeBatch()'s matching branch then passes these straight
+        // through, since Create() already fully creates them.
+        std::vector<Ref<Shader>> PrepareBatchSequentialFallback(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
+        {
+            std::vector<Ref<Shader>> result;
+            result.reserve(filepaths.size());
+            for (const auto& path : filepaths)
+            {
+                result.push_back(Shader::Create(path));
+                if (progressCounter != nullptr)
+                {
+                    progressCounter->fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            return result;
+        }
+    } // namespace
+
+    std::vector<Ref<Shader>> Shader::PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
+    {
+        switch (Renderer::GetAPI())
+        {
+            case RendererAPI::API::None:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return {};
+            }
+            case RendererAPI::API::Vulkan:
+                // No CPU-only prepare step on this backend yet — a future
+                // Vulkan-side parallel prepare can slot in here without
+                // touching callers.
+                return PrepareBatchSequentialFallback(filepaths, progressCounter);
+            case RendererAPI::API::OpenGL:
+                return OpenGLShader::PrepareBatch(filepaths, progressCounter);
+        }
+
+        OLO_CORE_ASSERT(false, "Unknown RendererAPI!");
+        return {};
+    }
+
+    std::vector<Ref<Shader>> Shader::FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal)
+    {
+        switch (Renderer::GetAPI())
+        {
+            case RendererAPI::API::None:
+            {
+                OLO_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
+                return prepared;
+            }
+            case RendererAPI::API::Vulkan:
+                // PrepareBatch() already fully created these via the
+                // sequential fallback above — nothing left to do.
+                return prepared;
+            case RendererAPI::API::OpenGL:
+                return OpenGLShader::FinalizeBatch(std::move(prepared), alreadyFinal);
+        }
+
+        OLO_CORE_ASSERT(false, "Unknown RendererAPI!");
+        return prepared;
+    }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Shader.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shader.cpp
@@ -199,28 +199,6 @@ namespace OloEngine
         return nullptr;
     }
 
-    namespace
-    {
-        // Shared fallback for a backend with no CPU-only prepare step (issue
-        // #907 covers OpenGL only) — synchronous Create() per shader.
-        // FinalizeBatch()'s matching branch then passes these straight
-        // through, since Create() already fully creates them.
-        std::vector<Ref<Shader>> PrepareBatchSequentialFallback(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
-        {
-            std::vector<Ref<Shader>> result;
-            result.reserve(filepaths.size());
-            for (const auto& path : filepaths)
-            {
-                result.push_back(Shader::Create(path));
-                if (progressCounter != nullptr)
-                {
-                    progressCounter->fetch_add(1, std::memory_order_relaxed);
-                }
-            }
-            return result;
-        }
-    } // namespace
-
     std::vector<Ref<Shader>> Shader::PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
     {
         switch (Renderer::GetAPI())
@@ -231,10 +209,14 @@ namespace OloEngine
                 return {};
             }
             case RendererAPI::API::Vulkan:
-                // No CPU-only prepare step on this backend yet — a future
-                // Vulkan-side parallel prepare can slot in here without
-                // touching callers.
-                return PrepareBatchSequentialFallback(filepaths, progressCounter);
+                // No CPU-only prepare step on this backend, and Create()
+                // touches the device/driver (vkCreateShaderModule) — must
+                // not run on whatever background thread PrepareBatch() is
+                // called from (issue #907 review). Leave every entry null;
+                // FinalizeBatch() below does the real (sequential, render-
+                // thread) Create() call for each. progressCounter has
+                // nothing honest to report here — see the header comment.
+                return std::vector<Ref<Shader>>(filepaths.size());
             case RendererAPI::API::OpenGL:
                 return OpenGLShader::PrepareBatch(filepaths, progressCounter);
         }
@@ -243,7 +225,7 @@ namespace OloEngine
         return {};
     }
 
-    std::vector<Ref<Shader>> Shader::FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal)
+    std::vector<Ref<Shader>> Shader::FinalizeBatch(const std::vector<std::string>& filepaths, std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal)
     {
         switch (Renderer::GetAPI())
         {
@@ -253,9 +235,23 @@ namespace OloEngine
                 return prepared;
             }
             case RendererAPI::API::Vulkan:
-                // PrepareBatch() already fully created these via the
-                // sequential fallback above — nothing left to do.
-                return prepared;
+            {
+                // PrepareBatch() deliberately left every entry null (see
+                // above) — do the real Create() here instead, sequentially,
+                // now that this is contractually the render thread.
+                const sizet count = filepaths.size();
+                std::vector<Ref<Shader>> result(count);
+                for (sizet i = 0; i < count; ++i)
+                {
+                    if (i < alreadyFinal.size() && alreadyFinal[i])
+                    {
+                        result[i] = prepared[i]; // pack-loaded upstream — not exercised by Vulkan today, kept symmetric with OpenGL
+                        continue;
+                    }
+                    result[i] = Create(filepaths[i]);
+                }
+                return result;
+            }
             case RendererAPI::API::OpenGL:
                 return OpenGLShader::FinalizeBatch(std::move(prepared), alreadyFinal);
         }

--- a/OloEngine/src/OloEngine/Renderer/Shader.h
+++ b/OloEngine/src/OloEngine/Renderer/Shader.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "OloEngine/Renderer/RHI/RHITypes.h"
+#include <atomic>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "OloEngine/Core/Ref.h"
 #include <glm/glm.hpp>
@@ -174,5 +176,34 @@ namespace OloEngine
 
         static Ref<Shader> Create(const std::string& filepath);
         static Ref<Shader> Create(const std::string& name, const std::string& vertexSrc, const std::string& fragmentSrc);
+
+        // --- Batch loading with cross-shader CPU parallelism (issue #907) ---
+        //
+        // The engine's shader-compile pipeline splits into a CPU tier (disk
+        // read, GLSL preprocessing, shaderc, SPIRV-Cross, on-disk cache) and a
+        // GPU tier (glLinkProgram, which the driver itself already links in
+        // the background via GL_ARB/KHR_parallel_shader_compile — see
+        // ShaderLibrary::PollPendingShaders). The CPU tier has no GL
+        // dependency and is embarrassingly parallel ACROSS independent
+        // shaders, but GL calls are not thread-safe off the context thread —
+        // so PrepareBatch() may run on any thread (including a background
+        // task, while the caller pumps its own render loop), and
+        // FinalizeBatch() MUST run on the render thread.
+        //
+        // A backend without a CPU-only prepare step (Vulkan today) falls
+        // back to synchronous Create() per shader inside PrepareBatch(), so
+        // FinalizeBatch() is always safe to call — it is simply a no-op pass-
+        // through on such a backend.
+        //
+        // `progressCounter`, if non-null, is atomically incremented once per
+        // shader as its CPU-side work completes — poll it from another
+        // thread for progress-bar feedback while PrepareBatch() runs.
+        static std::vector<Ref<Shader>> PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter = nullptr);
+
+        // `alreadyFinal[i]` marks an entry that is already a fully created,
+        // linked shader (e.g. loaded from a shader pack upstream of
+        // PrepareBatch()) — FinalizeBatch() passes such entries through
+        // unchanged instead of trying to finalize them a second time.
+        static std::vector<Ref<Shader>> FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal);
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Shader.h
+++ b/OloEngine/src/OloEngine/Renderer/Shader.h
@@ -190,20 +190,29 @@ namespace OloEngine
         // task, while the caller pumps its own render loop), and
         // FinalizeBatch() MUST run on the render thread.
         //
-        // A backend without a CPU-only prepare step (Vulkan today) falls
-        // back to synchronous Create() per shader inside PrepareBatch(), so
-        // FinalizeBatch() is always safe to call — it is simply a no-op pass-
-        // through on such a backend.
+        // A backend without a CPU-only prepare step (Vulkan today) leaves
+        // every entry null in PrepareBatch() and defers the ENTIRE
+        // synchronous Create() call to FinalizeBatch() instead — Create()
+        // touches the device/driver (e.g. VulkanShader's vkCreateShaderModule),
+        // which is exactly the kind of call PrepareBatch()'s "safe on any
+        // thread" contract forbids (issue #907 review).
         //
         // `progressCounter`, if non-null, is atomically incremented once per
         // shader as its CPU-side work completes — poll it from another
-        // thread for progress-bar feedback while PrepareBatch() runs.
+        // thread for progress-bar feedback while PrepareBatch() runs. A
+        // backend with no CPU-only prepare step has nothing to report here;
+        // its progress only moves during FinalizeBatch(), which does not
+        // take a progressCounter because it must already be on the render
+        // thread when it runs.
         static std::vector<Ref<Shader>> PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter = nullptr);
 
         // `alreadyFinal[i]` marks an entry that is already a fully created,
         // linked shader (e.g. loaded from a shader pack upstream of
         // PrepareBatch()) — FinalizeBatch() passes such entries through
         // unchanged instead of trying to finalize them a second time.
-        static std::vector<Ref<Shader>> FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal);
+        // `filepaths` must be the same list (same order) passed to the
+        // PrepareBatch() call that produced `prepared` — needed by a backend
+        // that deferred its entire Create() here (see PrepareBatch() above).
+        static std::vector<Ref<Shader>> FinalizeBatch(const std::vector<std::string>& filepaths, std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal);
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -59,12 +59,13 @@ namespace OloEngine
         return shader;
     }
 
-    ShaderLibrary::PreparedShaderBatch ShaderLibrary::PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
+    ShaderLibrary::PreparedShaderBatch ShaderLibrary::PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter) const
     {
         OLO_PROFILE_FUNCTION();
 
         const sizet count = filepaths.size();
         PreparedShaderBatch batch;
+        batch.m_FilePaths = filepaths;
         batch.m_Prepared.resize(count);
         batch.m_IsPackLoaded.assign(count, false);
         batch.m_PackEntries.resize(count);
@@ -131,12 +132,32 @@ namespace OloEngine
             }
         }
 
-        std::vector<Ref<Shader>> finalized = Shader::FinalizeBatch(std::move(batch.m_Prepared), batch.m_IsPackLoaded);
-        for (const auto& shader : finalized)
+        std::vector<Ref<Shader>> finalized = Shader::FinalizeBatch(batch.m_FilePaths, std::move(batch.m_Prepared), batch.m_IsPackLoaded);
+
+        // A null entry means PrepareBatch() caught an exception for that
+        // shader (OpenGLShader::PrepareBatch) — dropping it silently is not
+        // enough: Renderer3D::Init resolves every shader by name through an
+        // unchecked Get(), which asserts on a missing entry (or, with asserts
+        // compiled out, hands the caller a null Ref that crashes at draw
+        // time). Register the fallback shader under the expected name so one
+        // broken shader stays a visible magenta mesh instead of a startup
+        // assert or a null dereference (issue #568's contract, extended to
+        // this batch path).
+        const sizet finalizedCount = finalized.size();
+        for (sizet i = 0; i < finalizedCount; ++i)
         {
-            if (shader)
+            if (finalized[i])
             {
-                Add(shader);
+                Add(finalized[i]);
+                continue;
+            }
+
+            const std::string name = std::filesystem::path(batch.m_FilePaths[i]).stem().string();
+            OLO_CORE_ERROR("[ShaderLibrary] '{}' failed CPU preparation — registering the fallback shader", name);
+            if (auto fallback = GetFallbackShader(); fallback && !Exists(name))
+            {
+                Add(name, fallback);
+                finalized[i] = fallback;
             }
         }
         return finalized;

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -59,6 +59,94 @@ namespace OloEngine
         return shader;
     }
 
+    ShaderLibrary::PreparedShaderBatch ShaderLibrary::PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        const sizet count = filepaths.size();
+        PreparedShaderBatch batch;
+        batch.m_Prepared.resize(count);
+        batch.m_IsPackLoaded.assign(count, false);
+        batch.m_PackEntries.resize(count);
+
+        // Shader packs are pre-compiled SPIR-V — a lookup + decode, not a
+        // compile — so resolve them sequentially up front; only what's left
+        // needs the parallel CPU-compile path. TryReadPackEntry() (unlike the
+        // old TryLoadFromPack() this replaced here) makes NO GL call, so this
+        // whole loop stays safe on whatever thread PrepareParallel() runs on
+        // — the actual GL program is materialized later, in
+        // FinalizeParallel(), which is contractually the render thread.
+        std::vector<std::string> toCompile;
+        std::vector<sizet> toCompileIndices;
+        toCompile.reserve(count);
+        toCompileIndices.reserve(count);
+
+        for (sizet i = 0; i < count; ++i)
+        {
+            if (auto entry = TryReadPackEntry(filepaths[i]))
+            {
+                batch.m_PackEntries[i] = std::move(entry);
+                batch.m_IsPackLoaded[i] = true;
+                if (progressCounter != nullptr)
+                {
+                    progressCounter->fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            else
+            {
+                toCompile.push_back(filepaths[i]);
+                toCompileIndices.push_back(i);
+            }
+        }
+
+        if (!toCompile.empty())
+        {
+            std::vector<Ref<Shader>> prepared = Shader::PrepareBatch(toCompile, progressCounter);
+            const sizet preparedCount = prepared.size();
+            for (sizet j = 0; j < preparedCount; ++j)
+            {
+                batch.m_Prepared[toCompileIndices[j]] = prepared[j];
+            }
+        }
+
+        return batch;
+    }
+
+    std::vector<Ref<Shader>> ShaderLibrary::FinalizeParallel(PreparedShaderBatch batch)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // GL calls below — the caller contract (ShaderLibrary::FinalizeParallel)
+        // requires this to run on the render thread. Materialize every pack-
+        // loaded entry's GL program NOW (deferred from PrepareParallel() —
+        // see PackEntryCPUData) before handing the batch to
+        // Shader::FinalizeBatch, which skips indices already marked
+        // m_IsPackLoaded and passes them through untouched.
+        const sizet count = batch.m_Prepared.size();
+        for (sizet i = 0; i < count; ++i)
+        {
+            if (batch.m_IsPackLoaded[i])
+            {
+                batch.m_Prepared[i] = CreateShaderFromPackEntry(std::move(*batch.m_PackEntries[i]));
+            }
+        }
+
+        std::vector<Ref<Shader>> finalized = Shader::FinalizeBatch(std::move(batch.m_Prepared), batch.m_IsPackLoaded);
+        for (const auto& shader : finalized)
+        {
+            if (shader)
+            {
+                Add(shader);
+            }
+        }
+        return finalized;
+    }
+
+    std::vector<Ref<Shader>> ShaderLibrary::LoadParallel(const std::vector<std::string>& filepaths)
+    {
+        return FinalizeParallel(PrepareParallel(filepaths));
+    }
+
     Ref<Shader> ShaderLibrary::Get(const std::string& name)
     {
         OLO_CORE_ASSERT(Exists(name), "Shader '{}' not found!", name);
@@ -310,30 +398,45 @@ void main()
 
     Ref<Shader> ShaderLibrary::TryLoadFromPack(const std::string& filepath)
     {
-        if (!m_ShaderPack || !m_ShaderPack->IsLoaded())
+        auto entry = TryReadPackEntry(filepath);
+        if (!entry)
         {
             return nullptr;
+        }
+        return CreateShaderFromPackEntry(std::move(*entry));
+    }
+
+    // CPU-only: pack lookup + SPIR-V decode. See the class-level comment on
+    // PackEntryCPUData — deliberately makes NO GL call (issue #907), unlike
+    // the old TryLoadFromPack() this was split out of, which called straight
+    // through to OpenGLShader::CreateFromPackData (glCreateProgram et al.).
+    std::optional<ShaderLibrary::PackEntryCPUData> ShaderLibrary::TryReadPackEntry(const std::string& filepath) const
+    {
+        if (!m_ShaderPack || !m_ShaderPack->IsLoaded())
+        {
+            return std::nullopt;
         }
 
         if (!m_ShaderPack->Contains(filepath))
         {
-            return nullptr;
+            return std::nullopt;
         }
 
         auto entry = m_ShaderPack->LoadEntry(filepath);
         if (!entry || entry->Stages.empty())
         {
             OLO_CORE_WARN("[ShaderLibrary] Pack entry '{}' loaded but empty", filepath);
-            return nullptr;
+            return std::nullopt;
         }
 
         // Convert pack stage data (u8-encoded stages) back to GLenum-keyed maps
-        std::unordered_map<unsigned int, std::vector<u32>> vulkanSPIRV;
-        std::unordered_map<unsigned int, std::vector<u32>> openGLSPIRV;
+        PackEntryCPUData data;
+        data.m_Name = entry->Name;
+        data.m_FilePath = filepath;
 
         for (auto& stageData : entry->Stages)
         {
-            unsigned int glStage = 0;
+            u32 glStage = 0;
             switch (stageData.Stage)
             {
                 case 1:
@@ -353,16 +456,23 @@ void main()
                     break; // GL_COMPUTE_SHADER
                 default:
                     OLO_CORE_ERROR("[ShaderLibrary] Unknown stage {} in pack entry '{}'", stageData.Stage, filepath);
-                    return nullptr;
+                    return std::nullopt;
             }
 
-            vulkanSPIRV[glStage] = std::move(stageData.VulkanSPIRV);
-            openGLSPIRV[glStage] = std::move(stageData.OpenGLSPIRV);
+            data.m_VulkanSPIRV[glStage] = std::move(stageData.VulkanSPIRV);
+            data.m_OpenGLSPIRV[glStage] = std::move(stageData.OpenGLSPIRV);
         }
 
-        OLO_CORE_TRACE("[ShaderLibrary] Loading '{}' from shader pack", filepath);
-        return OpenGLShader::CreateFromPackData(entry->Name, filepath,
-                                                std::move(vulkanSPIRV),
-                                                std::move(openGLSPIRV));
+        OLO_CORE_TRACE("[ShaderLibrary] Read '{}' from shader pack", filepath);
+        return data;
+    }
+
+    // GL-touching: MUST run on the render thread.
+    Ref<Shader> ShaderLibrary::CreateShaderFromPackEntry(PackEntryCPUData entry)
+    {
+        OLO_CORE_TRACE("[ShaderLibrary] Loading '{}' from shader pack", entry.m_FilePath);
+        return OpenGLShader::CreateFromPackData(entry.m_Name, entry.m_FilePath,
+                                                std::move(entry.m_VulkanSPIRV),
+                                                std::move(entry.m_OpenGLSPIRV));
     }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.h
@@ -60,13 +60,19 @@ namespace OloEngine
         // a render loop (progress bar, window events) while PrepareParallel()
         // runs on a background task — see ShaderWarmup::LoadShadersParallel
         // for the pattern.
+        //
+        // THIS CLASS IS NOT INTERNALLY SYNCHRONIZED. While PrepareParallel()
+        // is in flight on another thread, no other method on the SAME
+        // ShaderLibrary may be called — Add()/Load()/Get()/LoadShaderPack()
+        // all touch m_Shaders/m_ShaderPack without a lock.
         struct PreparedShaderBatch
         {
-            std::vector<Ref<Shader>> m_Prepared;                        // non-pack entries: CPU-prepared, GL not yet created. Pack entries: null until FinalizeParallel() materializes them from m_PackEntries.
+            std::vector<std::string> m_FilePaths;                       // same order/size as passed to PrepareParallel() — every array below is indexed against this
+            std::vector<Ref<Shader>> m_Prepared;                        // non-pack entries: CPU-prepared, GL not yet created (null if PrepareBatch() couldn't even prepare it — see FinalizeParallel()). Pack entries: null until FinalizeParallel() materializes them from m_PackEntries.
             std::vector<bool> m_IsPackLoaded;                           // same size as m_Prepared — true where the entry came from a shader pack
             std::vector<std::optional<PackEntryCPUData>> m_PackEntries; // same size — decoded pack data for m_IsPackLoaded[i]==true entries, nullopt otherwise
         };
-        PreparedShaderBatch PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter = nullptr);
+        [[nodiscard]] PreparedShaderBatch PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter = nullptr) const;
         std::vector<Ref<Shader>> FinalizeParallel(PreparedShaderBatch batch);
 
         // Convenience one-call form: PrepareParallel() + FinalizeParallel()

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -29,6 +31,49 @@ namespace OloEngine
         void Add(const Ref<Shader>& shader);
         Ref<Shader> Load(const std::string& filepath);
         Ref<Shader> Load(const std::string& name, const std::string& filepath);
+
+        // --- Batch loading with cross-shader CPU parallelism (issue #907) ---
+        //
+        // Result returned in the same order as `filepaths`, one entry per
+        // path (regardless of whether it came from a shader pack or a fresh
+        // compile). Every entry is added to this library under the name
+        // derived from its filepath, same as Load(filepath).
+
+        // CPU-decoded shader-pack entry (issue #907): the pack-lookup half of
+        // the old TryLoadFromPack, with the GL-touching half
+        // (CreateShaderFromPackEntry, below) split out — see PreparedShaderBatch.
+        struct PackEntryCPUData
+        {
+            std::string m_Name;
+            std::string m_FilePath;
+            std::unordered_map<u32, std::vector<u32>> m_VulkanSPIRV;
+            std::unordered_map<u32, std::vector<u32>> m_OpenGLSPIRV;
+        };
+
+        // Two-phase form: PrepareParallel() may run on ANY thread — it makes
+        // NO GL call, including for a shader-pack hit: decoding a pack
+        // entry's SPIR-V (TryReadPackEntry, below) is a pure CPU read, and
+        // materializing the actual GL program from it is deferred to
+        // FinalizeParallel(). FinalizeParallel() MUST run on the render
+        // thread (it issues every GL program creation/link, pack-loaded or
+        // freshly compiled alike). Split them yourself when you want to pump
+        // a render loop (progress bar, window events) while PrepareParallel()
+        // runs on a background task — see ShaderWarmup::LoadShadersParallel
+        // for the pattern.
+        struct PreparedShaderBatch
+        {
+            std::vector<Ref<Shader>> m_Prepared;                        // non-pack entries: CPU-prepared, GL not yet created. Pack entries: null until FinalizeParallel() materializes them from m_PackEntries.
+            std::vector<bool> m_IsPackLoaded;                           // same size as m_Prepared — true where the entry came from a shader pack
+            std::vector<std::optional<PackEntryCPUData>> m_PackEntries; // same size — decoded pack data for m_IsPackLoaded[i]==true entries, nullopt otherwise
+        };
+        PreparedShaderBatch PrepareParallel(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter = nullptr);
+        std::vector<Ref<Shader>> FinalizeParallel(PreparedShaderBatch batch);
+
+        // Convenience one-call form: PrepareParallel() + FinalizeParallel()
+        // with no progress polling, called synchronously on this thread
+        // (which must then be the render thread). Use the two-phase form
+        // above instead when a UI needs to stay responsive during the load.
+        std::vector<Ref<Shader>> LoadParallel(const std::vector<std::string>& filepaths);
 
         Ref<Shader> Get(const std::string& name);
 
@@ -83,6 +128,16 @@ namespace OloEngine
         // Try to create a shader from the loaded shader pack.
         // Returns nullptr if no pack or shader not in pack.
         Ref<Shader> TryLoadFromPack(const std::string& filepath);
+
+        // CPU-only half of TryLoadFromPack (issue #907): pack lookup + SPIR-V
+        // decode, no GL call — safe from any thread. Returns nullopt on the
+        // same conditions TryLoadFromPack would have returned nullptr for.
+        [[nodiscard]] std::optional<PackEntryCPUData> TryReadPackEntry(const std::string& filepath) const;
+
+        // GL-touching half of TryLoadFromPack: materializes the actual GL
+        // program from already-decoded pack data. MUST run on the render
+        // thread.
+        [[nodiscard]] static Ref<Shader> CreateShaderFromPackEntry(PackEntryCPUData entry);
 
         std::unordered_map<std::string, Ref<Shader>> m_Shaders;
         std::unique_ptr<ShaderPack> m_ShaderPack;

--- a/OloEngine/src/OloEngine/Renderer/ShaderWarmup.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderWarmup.cpp
@@ -12,6 +12,8 @@
 #include "OloEngine/Async/Async.h"
 
 #include <atomic>
+#include <chrono>
+#include <thread>
 
 namespace OloEngine
 {
@@ -354,16 +356,45 @@ void main()
         // half of the pipeline instead of the GPU-link half.
         TFuture<ShaderLibrary::PreparedShaderBatch> future = Async(
             EAsyncExecution::TaskGraph,
-            [&library, &filepaths, &prepared]() -> ShaderLibrary::PreparedShaderBatch
+            [&library, &filepaths, &prepared]()
             {
                 return library.PrepareParallel(filepaths, &prepared);
             });
 
+        // TFuture has no waiting destructor. The lambda above captures
+        // `library`/`filepaths`/`prepared` by reference from THIS stack
+        // frame — if RenderProgressFrame ever throws before future.Get()
+        // runs below, the background task must still be joined before this
+        // function's locals are destroyed, or the task can go on touching
+        // freed stack memory. This guard's destructor runs on every exit
+        // path (normal or exceptional); Wait() on an already-completed
+        // future (the normal path, after future.Get()) is a no-op.
+        struct FutureJoinGuard
+        {
+            TFuture<ShaderLibrary::PreparedShaderBatch>* m_Future;
+            ~FutureJoinGuard()
+            {
+                if (m_Future->IsValid())
+                {
+                    m_Future->Wait();
+                }
+            }
+        } futureJoinGuard{ &future };
+
+        // Poll at roughly one display frame. Without a throttle here the
+        // loop is bounded only by SwapBuffers, so with vsync OFF it spins at
+        // thousands of iterations per second — burning a CPU core the
+        // TaskGraph compile workers need (eating into the very speedup this
+        // function exists to deliver) and issuing one SetTitle (a
+        // synchronous window-message call on Windows) per iteration for a
+        // bar that changes at most `total` times.
+        constexpr auto kPollInterval = std::chrono::milliseconds(16);
         while (!future.IsReady())
         {
-            const auto current = static_cast<i32>(prepared.load(std::memory_order_relaxed));
+            const auto current = static_cast<i32>(prepared.load());
             const f32 progress = total > 0 ? static_cast<f32>(current) / static_cast<f32>(total) : 1.0f;
             RenderProgressFrame(progress, window, label, current, total, phase);
+            std::this_thread::sleep_for(kPollInterval);
         }
 
         RenderProgressFrame(1.0f, window, label, total, total, phase);

--- a/OloEngine/src/OloEngine/Renderer/ShaderWarmup.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderWarmup.cpp
@@ -9,6 +9,9 @@
 #include "OloEngine/Renderer/UniformBuffer.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Core/Window.h"
+#include "OloEngine/Async/Async.h"
+
+#include <atomic>
 
 namespace OloEngine
 {
@@ -316,6 +319,57 @@ void main()
         OLO_CORE_TRACE("RenderProgressFrame: SwapBuffers...");
         window->SwapBuffers();
         OLO_CORE_TRACE("RenderProgressFrame: Done.");
+    }
+
+    std::vector<Ref<Shader>> ShaderWarmup::LoadShadersParallel(
+        ShaderLibrary& library, Window* window, const std::vector<std::string>& filepaths,
+        const std::string_view label, const i32 phase)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        if (filepaths.empty())
+        {
+            return {};
+        }
+
+        // Headless mode, or the boot shader isn't ready yet: no progress UI
+        // is possible either way — RenderProgressFrame is a total no-op
+        // (no PollEvents, no SwapBuffers) whenever `!s_BootShader ||
+        // !s_BootShader->IsReady()`, same guard RunWarmupScreen makes below.
+        // Without this, the poll loop's RenderProgressFrame calls would do
+        // nothing every iteration and it would busy-spin with no window pump
+        // until the background PrepareParallel() task finishes — exactly the
+        // unresponsive-window failure mode this function exists to avoid.
+        if (!window || !s_BootShader || !s_BootShader->IsReady())
+        {
+            return library.LoadParallel(filepaths);
+        }
+
+        std::atomic<u32> prepared{ 0 };
+        const auto total = static_cast<i32>(filepaths.size());
+
+        // Phase A (CPU compile) runs on a background task so THIS thread
+        // stays free to pump window events and redraw the progress bar —
+        // mirrors RunWarmupScreen's link-wait loop below, just for the CPU
+        // half of the pipeline instead of the GPU-link half.
+        TFuture<ShaderLibrary::PreparedShaderBatch> future = Async(
+            EAsyncExecution::TaskGraph,
+            [&library, &filepaths, &prepared]() -> ShaderLibrary::PreparedShaderBatch
+            {
+                return library.PrepareParallel(filepaths, &prepared);
+            });
+
+        while (!future.IsReady())
+        {
+            const auto current = static_cast<i32>(prepared.load(std::memory_order_relaxed));
+            const f32 progress = total > 0 ? static_cast<f32>(current) / static_cast<f32>(total) : 1.0f;
+            RenderProgressFrame(progress, window, label, current, total, phase);
+        }
+
+        RenderProgressFrame(1.0f, window, label, total, total, phase);
+
+        // Phase B — GL calls, must run on this (render) thread.
+        return library.FinalizeParallel(future.Get());
     }
 
     void ShaderWarmup::RunWarmupScreen(ShaderLibrary& library, Window* window)

--- a/OloEngine/src/OloEngine/Renderer/ShaderWarmup.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderWarmup.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Core/Ref.h"
 
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace OloEngine
 {
     class Window;
+    class Shader;
+    class ShaderLibrary;
 
     // Renders a minimal loading screen while shaders compile asynchronously.
     // Uses a tiny "boot" shader compiled synchronously before any async loads begin.
@@ -32,6 +37,25 @@ namespace OloEngine
         // When `window` is nullptr (e.g. headless tests), falls back to
         // library.FlushPendingShaders() (synchronous, no progress UI).
         static void RunWarmupScreen(class ShaderLibrary& library, Window* window);
+
+        // Load every shader in `filepaths` into `library`, with the CPU-side
+        // compile of independent shaders running in parallel across shaders
+        // (issue #907 — see ShaderLibrary::PrepareParallel/FinalizeParallel).
+        // The calling thread stays free to poll and redraw the progress bar
+        // (and pump window events, via RenderProgressFrame -> PollEvents)
+        // while that parallel CPU work runs on background tasks — same
+        // "keep the window responsive while we wait" contract as
+        // RunWarmupScreen above, just for the CPU tier instead of the GPU-
+        // link tier. GL program creation/link itself still happens
+        // sequentially back on this thread afterward, which MUST be the
+        // render thread.
+        //
+        // When `window` is nullptr (e.g. headless tests), falls back to
+        // library.LoadParallel() (synchronous, no progress UI, no polling).
+        // `label`/`phase` are forwarded to RenderProgressFrame as-is.
+        static std::vector<Ref<Shader>> LoadShadersParallel(
+            ShaderLibrary& library, Window* window, const std::vector<std::string>& filepaths,
+            std::string_view label, i32 phase);
 
         // Release boot shader resources.
         static void Shutdown();

--- a/OloEngine/src/Platform/OpenGL/OpenGLComputeShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLComputeShader.cpp
@@ -17,6 +17,15 @@
 
 namespace OloEngine
 {
+    // NOT covered by the cross-shader parallel-compile path added for
+    // graphics shaders (issue #907, see OpenGLShader::PrepareBatch /
+    // Shader::PrepareBatch): compute shaders hand include-resolved GLSL
+    // straight to glShaderSource/glCompileShader below with no shaderc/
+    // SPIRV-Cross hop and — see the class doc — no on-disk cache at all, so
+    // there is no CPU-only tier to split out and run off the render thread;
+    // the whole compile is one GL call. Load call sites for compute shaders
+    // stay sequential. A cache (and the parallel split that would come with
+    // it) is a separate, larger change tracked outside this issue.
     OpenGLComputeShader::OpenGLComputeShader(const std::string& filepath)
         : m_FilePath(filepath)
     {

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -568,33 +568,82 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
 
+        PrepareCPU();
+        FinalizeGL();
+    }
+
+    OpenGLShader::OpenGLShader(PrepareTag, const std::string& filepath)
+        : m_FilePath(filepath)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // See m_SkipNestedParallelism's declaration: this constructor only
+        // ever runs inside PrepareBatch()'s outer ParallelFor across
+        // shaders, where per-shader inner stage parallelism is redundant
+        // scheduling overhead rather than real speedup.
+        m_SkipNestedParallelism = true;
+        PrepareCPU();
+    }
+
+    // CPU-only compile (issue #907): everything the old single-phase
+    // constructor did up to its first GL call. No glXxx here — this is what
+    // makes it safe to run PrepareBatch() across many shaders in parallel on
+    // worker threads. See FinalizeGL() below for the GL half.
+    void OpenGLShader::PrepareCPU()
+    {
+        OLO_PROFILE_FUNCTION();
+
         m_CompilationStatus = ShaderCompilationStatus::Pending;
 
         Utils::CreateCacheDirectoryIfNeeded();
-        const std::string source = ReadFile(filepath);
+        const std::string source = ReadFile(m_FilePath);
 
         const auto shaderSources = PreProcess(source);
 
-        // Store original source code for debugging (after we have shader ID)
-        // This will be called later after CreateProgram when m_RendererID is available
-
         // Extract shader name from filepath first
-        auto lastSlash = filepath.find_last_of("/\\");
-        const auto lastDot = filepath.rfind('.');
+        auto lastSlash = m_FilePath.find_last_of("/\\");
+        const auto lastDot = m_FilePath.rfind('.');
         lastSlash = lastSlash == std::string::npos ? 0 : (lastSlash + 1);
-        const auto count = lastDot == std::string::npos ? (filepath.size() - lastSlash) : (lastDot - lastSlash);
-        m_Name = filepath.substr(lastSlash, count);
+        const auto count = lastDot == std::string::npos ? (m_FilePath.size() - lastSlash) : (lastDot - lastSlash);
+        m_Name = m_FilePath.substr(lastSlash, count);
 
         // Make this shader reloadable BY NAME regardless of who owns it — a
         // ShaderLibrary or a render pass member (issue #607). Registered before
         // the compile so a shader whose GLSL is broken at boot can still be
         // fixed on disk and reloaded over MCP instead of needing a restart.
+        // ShaderRegistry is mutex-protected, so this is safe from a worker
+        // thread too (issue #907).
         ShaderRegistry::Get().RegisterShader(m_Name, this);
 
-        OLO_SHADER_COMPILATION_START(m_Name, filepath);
-        const Timer timer;
+        OLO_SHADER_COMPILATION_START(m_Name, m_FilePath);
+        m_CompileTimer.Reset();
 
-        OLO_CORE_INFO("Compiling shader '{}' from '{}'", m_Name, filepath);
+        OLO_CORE_INFO("Compiling shader '{}' from '{}'", m_Name, m_FilePath);
+
+        // The bindless DECISION is CPU-only (a text scan of the source plus a
+        // plain bool flag — RHI::DescriptorHeap::IsEnabled() — no GL call),
+        // so it can be made here; only the raw-GLSL glCreateShader/link that
+        // WantsBindlessVariant gates is a GL call, deferred to FinalizeGL().
+        // A shader that wants it skips the SPIR-V tiers entirely, same as the
+        // old single-phase constructor did.
+        m_WantsBindless = WantsBindlessVariant(shaderSources);
+        if (m_WantsBindless)
+        {
+            m_OriginalSourceCode = shaderSources;
+            return;
+        }
+
+        m_VulkanCompileOk = CompileOrGetVulkanBinaries(shaderSources);
+        m_OpenGLCompileOk = m_VulkanCompileOk && CompileOrGetOpenGLBinaries();
+    }
+
+    // GL half of construction (issue #907): must run on the render thread.
+    // Reproduces the exact branch structure the old single-phase constructor
+    // had after its CompileOrGet*Binaries() calls, using PrepareCPU()'s
+    // results instead of computing them inline.
+    void OpenGLShader::FinalizeGL()
+    {
+        OLO_PROFILE_FUNCTION();
 
         // The bindless variant is tried FIRST and is allowed to decline. It
         // cannot share the path below — glslang rejects GL_ARB_bindless_texture
@@ -602,15 +651,26 @@ namespace OloEngine
         // route exists for (issue #691, BindlessShaderPipelineTest).
         // On any failure it falls through to the ordinary path, so a broken
         // bindless branch costs the optimisation and not the shader.
-        if (WantsBindlessVariant(shaderSources) && CreateProgramFromRawGLSL(shaderSources))
+        if (m_WantsBindless && CreateProgramFromRawGLSL(m_OriginalSourceCode))
         {
-            const f64 bindlessTime = timer.ElapsedMillis();
+            const f64 bindlessTime = m_CompileTimer.ElapsedMillis();
             OLO_CORE_INFO("Shader creation took {0} ms (bindless route)", bindlessTime);
             OLO_SHADER_COMPILATION_END(m_RendererID, m_RendererID != 0, "", bindlessTime);
             return;
         }
 
-        if (!CompileOrGetVulkanBinaries(shaderSources))
+        if (m_WantsBindless)
+        {
+            // Bindless was requested but declined — PrepareCPU() skipped the
+            // SPIR-V tiers entirely for this (rare/opt-in) case, so compile
+            // them now. This is the one case FinalizeGL() still does real CPU
+            // work on the render thread; acceptable because it is the
+            // declined case, not the common load-time path this issue speeds up.
+            m_VulkanCompileOk = CompileOrGetVulkanBinaries(m_OriginalSourceCode);
+            m_OpenGLCompileOk = m_VulkanCompileOk && CompileOrGetOpenGLBinaries();
+        }
+
+        if (!m_VulkanCompileOk)
         {
             // A user-authored GLSL syntax/compile error is not an engineering
             // invariant violation — surface it as a Failed shader instead of
@@ -637,7 +697,7 @@ namespace OloEngine
                 {
                     CreateProgramForAmd();
                 }
-                else if (CompileOrGetOpenGLBinaries())
+                else if (m_OpenGLCompileOk)
                 {
                     CreateProgram();
                 }
@@ -652,7 +712,7 @@ namespace OloEngine
                 m_CompilationStatus = ShaderCompilationStatus::Failed;
             }
         }
-        else if (CompileOrGetOpenGLBinaries())
+        else if (m_OpenGLCompileOk)
         {
             CreateProgram();
         }
@@ -660,7 +720,7 @@ namespace OloEngine
         {
             m_CompilationStatus = ShaderCompilationStatus::Failed;
         }
-        const f64 compilationTime = timer.ElapsedMillis();
+        const f64 compilationTime = m_CompileTimer.ElapsedMillis();
 
         // If the shader is still Compiling (async path), report that; otherwise it's Ready/Failed
         if (m_CompilationStatus == ShaderCompilationStatus::Compiling)
@@ -683,6 +743,106 @@ namespace OloEngine
         {
             m_DeferredCompilationTime = compilationTime;
         }
+    }
+
+    std::vector<Ref<Shader>> OpenGLShader::PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        const sizet n = filepaths.size();
+        std::vector<Ref<Shader>> result(n);
+
+        // Called here too (not a substitute for it): PrepareCPU() below still
+        // calls this itself, once per shader, since it must also work for the
+        // ordinary single-shader constructor which never goes through this
+        // function. Calling it once up front just avoids paying for N
+        // existence checks before the first shader that actually needs to
+        // create the directory does — it does NOT eliminate the per-shader
+        // calls, which stay safe only because CreateCacheDirectoryIfNeeded()
+        // uses the non-throwing std::error_code filesystem overloads.
+        Utils::CreateCacheDirectoryIfNeeded();
+
+        // CPU tier only (disk read, preprocessing, shaderc, SPIRV-Cross, disk
+        // cache, reflection) — no GL call is made until FinalizeBatch() runs,
+        // so constructing and preparing each shader on its own worker task is
+        // safe. Independent shaders share no mutable state: content-hashed
+        // cache filenames, a per-object resource registry, and a mutex-
+        // guarded ShaderRegistry/ShaderDebugger for the bookkeeping that IS
+        // shared.
+        ParallelFor(
+            "ShaderPrepareCPU",
+            static_cast<i32>(n),
+            [&filepaths, &result, progressCounter](const i32 index)
+            {
+                const auto idx = static_cast<sizet>(index);
+                // ParallelFor's worker executor is noexcept (see ParallelFor.h)
+                // — an exception escaping here would call std::terminate()
+                // instead of the graceful "surface as Failed" behaviour issue
+                // #568 established for a broken shader (Reload() catches the
+                // equivalent calls for the same reason). shaderc/SPIRV-Cross
+                // and filesystem calls can throw, so this must not let one.
+                // A caught failure leaves result[idx] null; FinalizeBatch()
+                // and ShaderLibrary::FinalizeParallel() already tolerate a
+                // null entry (skipped, never added to the library) exactly
+                // like any other unrecoverable per-shader failure.
+                try
+                {
+                    auto* raw = new OpenGLShader(PrepareTag{}, filepaths[idx]);
+                    result[idx] = Ref<Shader>(raw);
+                }
+                catch (const std::exception& e)
+                {
+                    OLO_CORE_ERROR("[ShaderPrepareCPU] '{}' threw during CPU-side compile: {}", filepaths[idx], e.what());
+                }
+                catch (...)
+                {
+                    OLO_CORE_ERROR("[ShaderPrepareCPU] '{}' threw a non-std::exception during CPU-side compile", filepaths[idx]);
+                }
+
+                if (progressCounter != nullptr)
+                {
+                    progressCounter->fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+
+        return result;
+    }
+
+    std::vector<Ref<Shader>> OpenGLShader::FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal)
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // GL calls below — the caller contract (Shader::FinalizeBatch) requires
+        // this to run on the render thread. Sequential on purpose: each
+        // glLinkProgram is issued back-to-back without blocking on it (the
+        // driver itself links in the background via
+        // GL_ARB/KHR_parallel_shader_compile, polled later by
+        // ShaderLibrary::PollPendingShaders) — this loop is just the
+        // sequential ISSUING, matching the comment on the original per-shader
+        // load loop in Renderer3DLifecycle.cpp.
+        const sizet preparedCount = prepared.size();
+        for (sizet i = 0; i < preparedCount; ++i)
+        {
+            if (i < alreadyFinal.size() && alreadyFinal[i])
+            {
+                continue; // pack-loaded shader — already fully created upstream
+            }
+
+            Ref<Shader>& shaderRef = prepared[i];
+            if (!shaderRef)
+            {
+                continue;
+            }
+
+            auto* glShader = static_cast<OpenGLShader*>(shaderRef.get());
+            glShader->FinalizeGL();
+            if (glShader->IsReady())
+            {
+                glShader->InitializeResourceRegistry(shaderRef);
+            }
+        }
+
+        return prepared;
     }
 
     OpenGLShader::OpenGLShader(std::string name, std::string_view vertexSrc, std::string_view fragmentSrc)
@@ -1522,7 +1682,11 @@ namespace OloEngine
                 result.SpirvData = std::vector<u32>(spirvModule.cbegin(), spirvModule.cend());
                 result.Success = true;
                 result.NeedsCache = !disableCache;
-            });
+            },
+            // See m_SkipNestedParallelism: this shader's own stages don't need
+            // a second, nested layer of parallelism when PrepareBatch()'s
+            // outer ParallelFor across shaders already provides it.
+            m_SkipNestedParallelism ? EParallelForFlags::ForceSingleThread : EParallelForFlags::None);
 
         // Collect results and write cache (sequential to avoid map race conditions).
         // This loop itself is single-threaded (ParallelFor above already joined all
@@ -1716,7 +1880,9 @@ namespace OloEngine
                 result.SpirvData = std::vector<u32>(spirvModule.cbegin(), spirvModule.cend());
                 result.Success = true;
                 result.NeedsCache = !disableCache;
-            });
+            },
+            // See m_SkipNestedParallelism (same rationale as CompileOrGetVulkanBinaries's ParallelFor call above).
+            m_SkipNestedParallelism ? EParallelForFlags::ForceSingleThread : EParallelForFlags::None);
 
         // Collect results and write cache (sequential). Single-threaded here too
         // (ParallelFor above already joined), so this bool accumulation is race-free.

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -441,6 +441,48 @@ namespace OloEngine
             return static_cast<bool>(in);
         }
 
+        // Cross-shader parallel prepare (issue #907) means the content-
+        // addressed cache key (source/SPIR-V bytes + options + stage) can
+        // collide ACROSS shader files, not just across stages of one shader:
+        // two different .glsl files whose preprocessed stage text is byte-
+        // identical (e.g. a shared vertex stage across several *_GBuffer_*
+        // variants) hash to the SAME cache path, and PrepareBatch's outer
+        // ParallelFor can now have two different worker threads writing it
+        // at once — impossible before this PR, when ParallelFor only ever
+        // ran across one shader's own 1-2 stages (which differ in the
+        // hashed stage name, so never collided). A plain std::ofstream
+        // write is then observable half-written by a concurrent reader.
+        // Write to a writer-unique temp file and atomically rename it into
+        // place instead, so a reader only ever sees a complete file or none.
+        static void WriteSpirvCacheFileAtomic(const std::filesystem::path& target, const std::vector<u32>& words)
+        {
+            static std::atomic<u64> s_WriterCounter{ 0 };
+            const std::filesystem::path tmp = target.string() + ".tmp" + std::to_string(s_WriterCounter.fetch_add(1));
+
+            std::error_code ec;
+            {
+                std::ofstream out(tmp, std::ios::out | std::ios::binary);
+                if (!out.is_open())
+                {
+                    return;
+                }
+                out.write(reinterpret_cast<const char*>(words.data()), static_cast<std::streamsize>(words.size() * sizeof(u32)));
+                out.flush();
+                if (!out)
+                {
+                    out.close();
+                    std::filesystem::remove(tmp, ec);
+                    return;
+                }
+            }
+
+            std::filesystem::rename(tmp, target, ec);
+            if (ec)
+            {
+                std::filesystem::remove(tmp, ec);
+            }
+        }
+
         // Applies the SPIR-V tier's shaderc options AND describes them as text
         // in one place — the description is hashed into the cache key, so
         // there is no second place that can fall out of sync with the actual
@@ -583,6 +625,14 @@ namespace OloEngine
         // scheduling overhead rather than real speedup.
         m_SkipNestedParallelism = true;
         PrepareCPU();
+        // The outer ParallelFor's task ends when this constructor returns.
+        // Every later compile on this object — FinalizeGL()'s declined-
+        // bindless recompile, Reload() — runs with no outer parallelism to
+        // avoid oversubscribing, so it must be free to use the inner stage
+        // ParallelFor again. Without this the flag stayed true for the
+        // object's whole lifetime, silently forcing every future reload of
+        // a batch-loaded shader to compile its stages single-threaded.
+        m_SkipNestedParallelism = false;
     }
 
     // CPU-only compile (issue #907): everything the old single-phase
@@ -1708,17 +1758,14 @@ namespace OloEngine
 
             shaderData[result.Stage] = result.SpirvData;
 
-            // Write to cache if needed
+            // Write to cache if needed. Atomic (temp file + rename) — see
+            // Utils::WriteSpirvCacheFileAtomic: two shaders in this same
+            // cross-shader ParallelFor batch can hash to the same cache
+            // path, so a plain std::ofstream here is a torn-file race that
+            // did not exist before this PR.
             if (result.NeedsCache)
             {
-                std::ofstream out(result.CachePath, std::ios::out | std::ios::binary);
-                if (out.is_open())
-                {
-                    out.write(reinterpret_cast<const char*>(result.SpirvData.data()),
-                              result.SpirvData.size() * sizeof(u32));
-                    out.flush();
-                    out.close();
-                }
+                Utils::WriteSpirvCacheFileAtomic(result.CachePath, result.SpirvData);
             }
         }
 
@@ -1903,17 +1950,14 @@ namespace OloEngine
                 m_OpenGLSourceCode[result.Stage] = result.GlslSource;
             }
 
-            // Write to cache if needed
+            // Write to cache if needed. Atomic (temp file + rename) — see
+            // Utils::WriteSpirvCacheFileAtomic: two shaders in this same
+            // cross-shader ParallelFor batch can hash to the same cache
+            // path, so a plain std::ofstream here is a torn-file race that
+            // did not exist before this PR.
             if (result.NeedsCache)
             {
-                std::ofstream out(result.CachePath, std::ios::out | std::ios::binary);
-                if (out.is_open())
-                {
-                    out.write(reinterpret_cast<const char*>(result.SpirvData.data()),
-                              result.SpirvData.size() * sizeof(u32));
-                    out.flush();
-                    out.close();
-                }
+                Utils::WriteSpirvCacheFileAtomic(result.CachePath, result.SpirvData);
             }
         }
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.h
@@ -1,10 +1,13 @@
 #pragma once
+#include "OloEngine/Core/Timer.h"
 #include "OloEngine/Renderer/RHI/RHIResourceRegistry.h"
 #include "OloEngine/Renderer/Shader.h"
 #include "OloEngine/Renderer/ShaderResourceRegistry.h"
 #include <glm/glm.hpp>
+#include <atomic>
 #include <filesystem>
 #include <unordered_set>
+#include <vector>
 
 namespace OloEngine
 {
@@ -148,6 +151,20 @@ namespace OloEngine
             std::unordered_map<GLenum, std::vector<u32>> vulkanSPIRV,
             std::unordered_map<GLenum, std::vector<u32>> openGLSPIRV);
 
+        // --- Batch loading with cross-shader CPU parallelism (issue #907) ---
+        // See Shader::PrepareBatch/FinalizeBatch for the two-phase contract.
+        // PrepareBatch() constructs one OpenGLShader per filepath and runs
+        // its CPU-only compile (ReadFile/PreProcess/shaderc/SPIRV-Cross/disk
+        // cache) in parallel across shaders via ParallelFor — no GL call is
+        // made until FinalizeBatch() below, so this may run on any thread.
+        static std::vector<Ref<Shader>> PrepareBatch(const std::vector<std::string>& filepaths, std::atomic<u32>* progressCounter);
+
+        // Issues the GL program creation/link for every CPU-prepared shader,
+        // sequentially, on the calling thread — MUST be the render thread.
+        // Entries where `alreadyFinal[i]` is true (pack-loaded, upstream of
+        // PrepareBatch) pass through untouched.
+        static std::vector<Ref<Shader>> FinalizeBatch(std::vector<Ref<Shader>> prepared, const std::vector<bool>& alreadyFinal);
+
       private:
         // Tag type for the pack-data constructor (internal only)
         struct PackDataTag
@@ -160,6 +177,26 @@ namespace OloEngine
                      const std::string& filepath,
                      std::unordered_map<GLenum, std::vector<u32>> vulkanSPIRV,
                      std::unordered_map<GLenum, std::vector<u32>> openGLSPIRV);
+
+        // Tag type for the CPU-prepare-only constructor used by PrepareBatch()
+        // (internal only — see the class-level comment above).
+        struct PrepareTag
+        {
+        };
+
+        // Runs ONLY the CPU-side compile (PrepareCPU() below) — no GL calls,
+        // m_CompilationStatus stays Pending until FinalizeGL() runs.
+        OpenGLShader(PrepareTag, const std::string& filepath);
+
+        // CPU-only compile: disk read, preprocessing, shaderc, SPIRV-Cross,
+        // disk cache, reflection. No GL call — safe from any thread. Shared
+        // by the ordinary synchronous constructor and PrepareBatch().
+        void PrepareCPU();
+
+        // GL program creation/link, using whatever PrepareCPU() computed.
+        // MUST run on the render thread. Shared by the ordinary synchronous
+        // constructor and FinalizeBatch().
+        void FinalizeGL();
 
         static std::string ReadFile(const std::string& filepath);
         static std::string ProcessIncludesInternal(const std::string& source, const std::string& directory, std::unordered_set<std::string>& includedFiles);
@@ -291,6 +328,31 @@ namespace OloEngine
 
         // Shader stage IDs kept alive until link completes (then detached/deleted)
         std::vector<u32> m_PendingShaderIDs;
+
+        // --- PrepareCPU() / FinalizeGL() split state (issue #907) ---
+        // Set by PrepareCPU(); read by FinalizeGL() to reproduce the exact
+        // branch the old single-phase constructor took, without redoing GL-
+        // free work FinalizeGL() has no business repeating.
+        bool m_WantsBindless = false;   // WantsBindlessVariant(m_OriginalSourceCode) — decided in PrepareCPU() (no GL call), acted on in FinalizeGL()
+        bool m_VulkanCompileOk = false; // CompileOrGetVulkanBinaries() result (skipped when m_WantsBindless — see PrepareCPU())
+        bool m_OpenGLCompileOk = false; // CompileOrGetOpenGLBinaries() result (same)
+
+        // True only for a PrepareTag-constructed shader (i.e. running inside
+        // PrepareBatch()'s outer ParallelFor across shaders). CompileOrGet*
+        // Binaries() each run their own inner ParallelFor over a shader's 1-2
+        // stages, which is the right call when it is the ONLY parallelism
+        // (the ordinary single-shader constructor) but becomes 52 outer tasks
+        // each launching more nested tasks for 1-2 items when it is NOT — pure
+        // scheduling overhead with no work left to parallelize into, measured
+        // to cost most of the batch's would-be speedup. Read by CompileOrGet*
+        // Binaries() to force their inner ParallelFor single-threaded in that
+        // case, so the only parallelism is the outer one (issue #907).
+        bool m_SkipNestedParallelism = false;
+        // Starts timing at the same point the old constructor's local `const
+        // Timer timer;` did (after registration/logging, before compile) —
+        // see PrepareCPU()/FinalizeGL(). Kept as a member so total elapsed
+        // time still covers both phases, wherever/whenever FinalizeGL() runs.
+        Timer m_CompileTimer;
     };
 
 } // namespace OloEngine


### PR DESCRIPTION
## Summary

Renderer3D/Renderer2D loaded their boot shaders (52 + 5) one at a time. The
CPU tier of each shader compile — disk read, GLSL preprocessing, shaderc,
SPIRV-Cross, on-disk cache read/write — has no GL dependency and is
embarrassingly parallel across independent shaders, but the outer load loops
ran it fully serially, so only the 1-2 stages *within* one shader ever
overlapped. `GL_ARB/KHR_parallel_shader_compile` already handles the GPU
link tier asynchronously; this PR parallelizes the CPU tier to match, while
keeping every GL call on the render thread as it must be.

## What changed

- `OpenGLShader` construction splits into `PrepareCPU()` (no GL call, safe
  on any thread) and `FinalizeGL()` (GL program creation/link — render
  thread only). `OpenGLShader::PrepareBatch()`/`FinalizeBatch()` run the CPU
  phase for N shaders in parallel via `ParallelFor`, then issue GL calls for
  all of them sequentially on the calling thread.
- `Shader::PrepareBatch()`/`FinalizeBatch()` expose this per backend —
  OpenGL gets the parallel path; Vulkan/None fall back to a sequential
  `Create()` loop, so the API is correct everywhere even though only OpenGL
  is sped up (issue scope).
- `ShaderLibrary::PrepareParallel()`/`FinalizeParallel()` add the
  shader-pack lookup path. A pack hit is also split into a CPU-only decode
  (`TryReadPackEntry`) and a GL-touching materialize step
  (`CreateShaderFromPackEntry`), so a pack hit never issues GL calls off the
  render thread either — this matters once shader packs get wired into a
  packaged build's boot path, even though nothing calls `LoadShaderPack` yet.
- `ShaderWarmup::LoadShadersParallel()` runs the CPU phase as a background
  task while polling an atomic progress counter and redrawing the loading
  screen on the render thread — the window keeps pumping events instead of
  freezing for the whole batch. Falls back to synchronous loading headless
  or if the boot shader isn't ready yet (both cases make `RenderProgressFrame`
  a no-op, so polling it would otherwise busy-spin).
- `m_SkipNestedParallelism`: a shader's own inner per-stage `ParallelFor`
  (shaderc/SPIRV-Cross across a shader's 1-2 stages) is disabled when it's
  running inside `PrepareBatch()`'s outer parallel loop across shaders —
  nesting two layers of `ParallelFor` here oversubscribed the scheduler
  and measurably ate most of the outer parallelism's benefit (see numbers
  below: fixing this took the cold-launch time from ~97s to ~77-85s).
- GL **compute** shaders are explicitly out of scope, documented at the
  `OpenGLComputeShader` constructor: they compile raw GLSL directly with no
  shaderc/SPIRV-Cross hop and no on-disk cache at all, so there's no
  CPU-only tier to split out.

## Verification

**Measured, cold launch, empty `OLO_SHADER_CACHE_DIR`, Debug config, this
box, otherwise idle** (process-launch → both 2D and 3D shader libraries
report all shaders ready):

| State | Elapsed |
|---|---|
| Serial baseline (pre-PR) | ~116s |
| Parallel, nested-`ParallelFor` oversubscription bug | ~97s |
| Parallel, fixed (`m_SkipNestedParallelism`) — sample 1 | ~85s |
| Parallel, fixed — sample 2 | ~77s |

~30% faster than the serial baseline on this box. Note: this differs from
the ~220s serial figure cited in the originating issue's own investigation
— different measurement conditions (build/machine state) — but the
before/after comparison above was taken under identical, controlled
conditions on the same box back-to-back.

- Full suite: **6553 passed, 24 skipped** (environment-gated — Steam SDK,
  GPU-context-required tests), **0 failed**.
- Shader-focused slice (`--gtest_filter=*Shader*`): **273 passed, 1 skipped**,
  0 failed — run twice (before and after the code-review fixes below).
- `OloEngine`, `OloEngine-Tests`, and `OloEditor` all build clean (0 errors).

## Review guide

**Where I'd look hardest**
1. `OloEngine/src/Platform/OpenGL/OpenGLShader.cpp` — `PrepareCPU()`/
   `FinalizeGL()` reproduce the old single-phase constructor's exact branch
   structure (bindless / AMD-legacy-driver / ordinary SPIR-V) but split
   across two calls; a subtle divergence there would be a silent correctness
   bug, not a build failure.
2. `ShaderLibrary::PrepareParallel()`/`FinalizeParallel()`'s pack-entry split
   — this path is currently untested end-to-end because `LoadShaderPack()`
   has zero call sites in the tree, so the CPU/GL split for a pack hit is
   verified by code inspection, not a live test.
3. `m_SkipNestedParallelism` — a hand-carried flag rather than a general
   nested-`ParallelFor` fix in the scheduler itself (see "Deliberately not
   done" below).

**What I verified, and how** — full test suite (6553/6577 pass, 0 fail);
shader-focused gtest slice run twice (before and after folding in
code-review findings); `OloEngine`/`OloEngine-Tests`/`OloEditor` all build
clean; measured cold-launch numbers above, each state sampled at least once,
the fixed-parallel state sampled twice to sanity-check the ~10% run-to-run
spread against the ~30% measured improvement.

**Least confident about** — the shader-pack path (point 2 above): correct
by inspection and by symmetry with the ordinary `PrepareCPU`/`FinalizeGL`
split, but not exercised by any test because nothing in the tree currently
loads a pack.

**Deliberately not done** (raised by self-review, judged out of scope for
this issue):
- Reusing `GPUResourceQueue`'s existing off-thread-prepare +
  main-thread-finalize pattern (used by `ComputeShader::CreateFromFileAsync`)
  instead of the new `Async`/`TFuture` + atomic-counter mechanism here. The
  two aren't quite the same shape — `GPUResourceQueue` defers *when* an
  already-synchronous `Create()` runs; this PR splits *what work* runs on
  which thread — and unifying them is a larger refactor than this issue.
- `LoadShadersParallel`'s poll loop and `RunWarmupScreen`'s poll loop are
  structurally identical but not factored into one shared helper.
- `m_SkipNestedParallelism` is local to `OpenGLShader`; every other
  `ParallelFor` call site in the engine that could get nested inside another
  will hit the same oversubscription cost and need its own flag. A general
  nesting-aware `ParallelFor` is a scheduler-level change, not a shader-
  loading one.
- Minor efficiency nits (a couple of `std::string` vector copies feeding the
  batch APIs) — negligible next to a multi-second compile, not worth the
  churn under this issue's scope.

Closes #907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved shader loading by compiling multiple shaders in parallel, reducing startup and warmup time.
  - Kept final graphics setup coordinated to maintain rendering stability.

- **User Experience**
  - Shader warmup screens now remain responsive while loading and continue displaying progress.
  - Headless operation continues to work without requiring a window.

- **Compatibility**
  - Preserved existing shader-pack support and fallback behavior across supported graphics backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->