### PR TITLE
fix(build): stop cpp-httplib resolving DNS on a libc-internal thread (#787)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -824,75 +824,22 @@ jobs:
       # graph over mutex ADDRESSES — it models neither the dominating global lock nor
       # object reachability, so it cannot see either guarantee. See #636.
       #
-      # McpProgressHttpTest — spins up a live cpp-httplib server (its own listener
-      # thread + per-connection worker pool) and drives real httplib::Client
-      # requests against it, then destroys the server in TearDown. Under TSan all
-      # three cases raw-SEGFAULT (no ThreadSanitizer race report is printed — the
-      # process dies in a signal, not a reported race). Investigated rather than
-      # blindly quarantined:
-      #   * It is NOT the SSE/progress path — PostWithoutTokenStaysPlainJson, which
-      #     returns plain JSON and never opens an event stream, crashes too. The
-      #     common factor is only the httplib server+client socket/thread lifecycle.
-      #   * ASan+LSan is GREEN on the same commit, which rules out a heap
-      #     use-after-free in the engine's own objects (ASan would catch it).
-      #   * McpServer::Stop() is carefully ordered — m_Http->stop() → join the
-      #     listen thread → m_Http.reset() (which joins the worker pool) → only then
-      #     clear m_Sessions/m_Token — so a worker outlives no McpServer member; and
-      #     the cancel path shares its flag as shared_ptr<atomic<bool>>, outliving
-      #     both threads. No engine-side teardown UAF is visible by inspection.
-      # So the crash lives in vendored cpp-httplib's socket/thread teardown under
-      # TSan's pthread interception — the same "live networking library misbehaves
-      # only under TSan" category as the GNS excludes above (green under the normal
-      # build and ASan+LSan). First seen once the setup-vcpkg retry let the TSan
-      # suite reach the test phase again post-#773. Tracked for a real fix (httplib
-      # bump / test-harness teardown barrier) rather than left silent.
-      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.|^McpProgressHttpTest\.'
+      # McpProgressHttpTest used to be excluded here and is not any more (#787).
+      # It was never an httplib teardown bug: the vcpkg port propagates
+      # CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO (upstream's CMake default, and a
+      # silent behaviour change from #773 — the pre-vcpkg header drop set no
+      # definitions), which on glibc resolves through getaddrinfo_a() on a thread
+      # glibc creates inside libc. TSan never sees that thread, so it has no
+      # ThreadState and its first intercepted malloc faults inside TSan's own
+      # allocator — a bare SIGSEGV with no report. OloEngine/vendor/CMakeLists.txt
+      # now filters that definition off the imported target; see the comment there.
+      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.'
       env:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build
         # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
         TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
-
-    # TEMPORARY (issue #787) — capture a real stack for the McpProgressHttpTest
-    # SEGFAULTs that the run step above excludes. The exclusion means CI never
-    # sees more than "***Exception: SegFault" with no sanitizer report, and TSan
-    # only runs here (docs/agent-rules/tsan-only-runs-in-ci-not-windows.md), so
-    # this step is how the stack gets captured at all. Strictly non-gating:
-    # continue-on-error plus `|| true` on every command. Removed once the root
-    # cause is pinned.
-    - name: Diagnose McpProgressHttpTest SEGFAULT (#787)
-      if: always()
-      continue-on-error: true
-      working-directory: ${{github.workspace}}/OloEditor
-      env:
-        BIN: ${{github.workspace}}/build/OloEngine/tests/OloEngine-Tests
-        BASE_TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=0:abort_on_error=0:second_deadlock_stack=1
-      run: |
-        sudo apt-get install -y -qq gdb || { sudo apt-get update && sudo apt-get install -y -qq gdb; }
-        echo "binary: $BIN"
-        ls -la "$BIN" || true
-        for CASE in \
-          McpProgressHttpTest.PostWithoutTokenStaysPlainJson \
-          McpProgressHttpTest.PostWithProgressTokenStreamsSseThenFinalResponse \
-          McpProgressHttpTest.CancelOverHttpSuppressesTheSseResponseFrame ; do
-          echo "::group::$CASE - bare run, TSan verbosity=1"
-          TSAN_OPTIONS="${BASE_TSAN_OPTIONS}:verbosity=1" "$BIN" --gtest_filter="$CASE" 2>&1 | tail -120 || true
-          echo "::endgroup::"
-          echo "::group::$CASE - gdb backtrace (TSan handle_segv=0)"
-          TSAN_OPTIONS="${BASE_TSAN_OPTIONS}:handle_segv=0:handle_abort=0" \
-            gdb -batch -nx \
-              -ex 'set confirm off' \
-              -ex 'set pagination off' \
-              -ex 'handle SIGSEGV stop print nopass' \
-              -ex run \
-              -ex 'info program' \
-              -ex 'info registers rip rsp' \
-              -ex 'bt' \
-              -ex 'thread apply all bt' \
-              --args "$BIN" --gtest_filter="$CASE" 2>&1 | tail -250 || true
-          echo "::endgroup::"
-        done
 
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -854,6 +854,46 @@ jobs:
         TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
+    # TEMPORARY (issue #787) — capture a real stack for the McpProgressHttpTest
+    # SEGFAULTs that the run step above excludes. The exclusion means CI never
+    # sees more than "***Exception: SegFault" with no sanitizer report, and TSan
+    # only runs here (docs/agent-rules/tsan-only-runs-in-ci-not-windows.md), so
+    # this step is how the stack gets captured at all. Strictly non-gating:
+    # continue-on-error plus `|| true` on every command. Removed once the root
+    # cause is pinned.
+    - name: Diagnose McpProgressHttpTest SEGFAULT (#787)
+      if: always()
+      continue-on-error: true
+      working-directory: ${{github.workspace}}/OloEditor
+      env:
+        BIN: ${{github.workspace}}/build/OloEngine/tests/OloEngine-Tests
+        BASE_TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=0:abort_on_error=0:second_deadlock_stack=1
+      run: |
+        sudo apt-get install -y -qq gdb || { sudo apt-get update && sudo apt-get install -y -qq gdb; }
+        echo "binary: $BIN"
+        ls -la "$BIN" || true
+        for CASE in \
+          McpProgressHttpTest.PostWithoutTokenStaysPlainJson \
+          McpProgressHttpTest.PostWithProgressTokenStreamsSseThenFinalResponse \
+          McpProgressHttpTest.CancelOverHttpSuppressesTheSseResponseFrame ; do
+          echo "::group::$CASE - bare run, TSan verbosity=1"
+          TSAN_OPTIONS="${BASE_TSAN_OPTIONS}:verbosity=1" "$BIN" --gtest_filter="$CASE" 2>&1 | tail -120 || true
+          echo "::endgroup::"
+          echo "::group::$CASE - gdb backtrace (TSan handle_segv=0)"
+          TSAN_OPTIONS="${BASE_TSAN_OPTIONS}:handle_segv=0:handle_abort=0" \
+            gdb -batch -nx \
+              -ex 'set confirm off' \
+              -ex 'set pagination off' \
+              -ex 'handle SIGSEGV stop print nopass' \
+              -ex run \
+              -ex 'info program' \
+              -ex 'info registers rip rsp' \
+              -ex 'bt' \
+              -ex 'thread apply all bt' \
+              --args "$BIN" --gtest_filter="$CASE" 2>&1 | tail -250 || true
+          echo "::endgroup::"
+        done
+
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded
       # to read for forks). Skip the reporter there; same-repo PRs and

--- a/OloEngine/vendor/CMakeLists.txt
+++ b/OloEngine/vendor/CMakeLists.txt
@@ -135,6 +135,41 @@ endif()
 # <winsock2.h> stays off the whole engine's include path.
 find_package(httplib CONFIG REQUIRED)
 
+# Drop CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO from the port's interface
+# definitions (issue #787). It is upstream's CMake default, so the vcpkg port
+# propagates it — but before #773 we consumed cpp-httplib as a DOWNLOAD_ONLY
+# header drop with NO compile definitions at all, so the move to the port
+# switched this on silently. It is not a knob anyone here asked for: it makes
+# getaddrinfo_with_timeout() bound DNS resolution by the client's connection
+# timeout, and nothing in this repo sets a connection timeout (grep
+# set_connection_timeout — there are no call sites).
+#
+# On glibc it routes every resolve through getaddrinfo_a(), which runs the
+# lookup on a thread glibc creates INSIDE libc (resolv/gai_misc.c
+# handle_requests). That thread never goes through the PLT, so TSan's
+# pthread_create interceptor never sees it and it has no __tsan::ThreadState —
+# its first intercepted malloc() then faults inside TSan's own allocator
+# (__tsan::user_alloc_internal), killing the process with a bare SIGSEGV and no
+# report, because TSan cannot report from a thread it does not know about. That
+# is the McpProgressHttpTest crash, and it would equally kill ANY future TSan
+# run that resolves a hostname. ASan is unaffected, which is why the ASan job
+# stayed green and made this look like an httplib teardown bug.
+#
+# Upstream's own comment on this path (their #2431) notes the glibc cancel path
+# can hold the caller for the system resolver timeout anyway, so the option
+# largely does not deliver its advertised benefit here. Turning it off restores
+# the pre-#773 behaviour — a plain synchronous getaddrinfo() — on every
+# platform, which keeps DNS semantics uniform rather than per-OS.
+#
+# Filtered rather than overwritten so the port's other definitions (the
+# NO_EXCEPTIONS / *_SUPPORT / Darwin entries) survive a port update untouched.
+get_target_property(OLO_HTTPLIB_DEFS httplib::httplib INTERFACE_COMPILE_DEFINITIONS)
+if(OLO_HTTPLIB_DEFS)
+    list(FILTER OLO_HTTPLIB_DEFS EXCLUDE REGEX "CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")
+    set_target_properties(httplib::httplib PROPERTIES
+                          INTERFACE_COMPILE_DEFINITIONS "${OLO_HTTPLIB_DEFS}")
+endif()
+
 if(OLO_WITH_ALEMBIC)
     # Alembic::Alembic propagates Imath::Imath and its include dirs, so both the
     # IMATH_INSTALL export-validation hack and the $<BUILD_INTERFACE:> wrapper

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -102,7 +102,9 @@ position, gradually) · [runtime-scene-switching.md](runtime-scene-switching.md)
 shipped games only) · [crowd-manager-follower-parity.md](crowd-manager-follower-parity.md) (a
 component's teardown, when `m_Registry.destroy()` skips `OnComponentRemoved`) ·
 [vcpkg-dependency-management.md](vcpkg-dependency-management.md) (three of five traps silent —
-including a forced port option that never applied) ·
+including a forced port option that never applied; and trap 9, where moving a dependency to a port
+switched ON an upstream-default option the old header drop never set, which killed ThreadSanitizer
+outright on any hostname resolution) ·
 [asset-import-usd-alembic.md](asset-import-usd-alembic.md) (winding, up-axis, unit scale, UV origin) ·
 [mcp-protocol-eras.md](mcp-protocol-eras.md) (swapping the event stream's notification carrier drops
 pushes that nothing reports missing — which is why the new carrier runs *beside* the deprecated one,

--- a/docs/agent-rules/vcpkg-dependency-management.md
+++ b/docs/agent-rules/vcpkg-dependency-management.md
@@ -268,6 +268,109 @@ happens to match the value CI varies, local green proves nothing.** When a fix t
 a version/path/platform difference, verify the *mechanism* (here: read the compile
 line), not the outcome.
 
+## Trap 9 — a port's usage requirements can switch on behaviour the old wiring never had
+
+Moving a dependency to vcpkg does not only change *where the headers come from*. A port
+installs a CMake package config, and that config carries the upstream project's
+`target_compile_definitions` — including options whose **upstream CMake default is ON**.
+If the pre-move wiring was a `DOWNLOAD_ONLY` header drop behind a bare `INTERFACE`
+target, it set **no definitions at all**, so the move silently enables every
+default-ON option at once. Nobody reviews a flag that appears in a generated
+`<port>Targets.cmake`.
+
+This is what issue #787 was. `cpp-httplib` moved to the port in #773; the port
+propagates `CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO`, which the old CPM block never
+defined:
+
+```cmake
+# build/vcpkg_installed/x64-linux/share/httplib/httplibTargets.cmake
+INTERFACE_COMPILE_DEFINITIONS "...;$<$<BOOL:ON>:CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO>"
+```
+
+On glibc that macro routes every name resolution through `getaddrinfo_a()`, which runs
+the lookup on a thread **glibc creates inside libc** (`resolv/gai_misc.c`,
+`handle_requests`). That call never goes through the PLT, so **ThreadSanitizer's
+`pthread_create` interceptor never sees the thread**: it has no `__tsan::ThreadState`,
+and its first intercepted `malloc()` faults inside TSan's own allocator
+(`__tsan::user_alloc_internal`). The process dies with a **bare SIGSEGV and no
+ThreadSanitizer report at all** — TSan cannot report from a thread it does not know
+about. ASan is unaffected, so the ASan job stays green, which is exactly what made this
+look like a library teardown bug for two weeks.
+
+**The tell in a backtrace:** every TSan-known thread has a `__tsan_thread_start_func`
+frame between `start_thread` and the thread body. The faulting thread did not:
+
+```
+#3  __interceptor_malloc ()
+#4  generate_addrinfo () at ./nss/getaddrinfo.c:1081
+#7  handle_requests () at ./resolv/gai_misc.c:329
+#8  start_thread ()          <-- no __tsan_thread_start_func: TSan does not know this thread
+```
+
+Two general rules fall out of it:
+
+- **After moving a dependency to a port, diff the definitions.** `grep
+  INTERFACE_COMPILE_DEFINITIONS <vcpkg_installed>/<triplet>/share/<pkg>/*.cmake` and
+  compare against what the old wiring set. Anything newly ON is an un-reviewed
+  behaviour change, not a build detail. This is the same "verify, don't assume" rule as
+  the option-names section above, applied to the *consuming* side.
+- **Filter, don't overwrite,** when you need to drop one. Rewriting the whole property
+  would silently discard the port's other definitions on the next port update:
+
+  ```cmake
+  get_target_property(OLO_HTTPLIB_DEFS httplib::httplib INTERFACE_COMPILE_DEFINITIONS)
+  list(FILTER OLO_HTTPLIB_DEFS EXCLUDE REGEX "CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")
+  set_target_properties(httplib::httplib PROPERTIES
+                        INTERFACE_COMPILE_DEFINITIONS "${OLO_HTTPLIB_DEFS}")
+  ```
+
+A bump is not always the answer, either: `getaddrinfo_a()` is still on cpp-httplib's
+master (0.53.1) with no opt-out macro, so upgrading the port would not have fixed this.
+Checking that before spending a round is cheap — `curl` the upstream header and grep it.
+
+### Reproducing a Linux-only sanitizer crash without CI
+
+TSan runs only in CI here, which frames a bug like this as "one hour per iteration".
+It does not have to be. Ubuntu 24.04 under WSL2 matches the runner image, and the whole
+`tsan-linux` job reproduces locally in one pass:
+
+```bash
+sudo apt-get install -y clang-19 lld-19 ninja-build autoconf-archive gdb   # + the job's dep list
+git clone https://github.com/microsoft/vcpkg ~/vcpkg        # NOT --depth 1: the manifest
+~/vcpkg/bootstrap-vcpkg.sh -disableMetrics                  # baseline commit must be present
+cmake -S . -B build -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_TARGET_TRIPLET=x64-linux \
+  -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_C_COMPILER=clang-19 \
+  -DCMAKE_BUILD_TYPE=Debug -DOLO_ENABLE_TSAN=ON -DBUILD_TESTS=ON \
+  -DOLO_VIDEO_FFMPEG=OFF -DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF -DOLO_WITH_MATERIALX=OFF \
+  "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -lstdc++exp"
+cmake --build build --target OloEngine-Tests --parallel 6
+```
+
+Two things that are not obvious:
+
+- **`-lstdc++exp` is required locally but not on the runner.** WSL had gcc-14 installed
+  alongside gcc-13, clang picks gcc-14's libstdc++ headers, and `<stacktrace>` there
+  needs the separate library. Without it the *final link* fails after a ~40-minute
+  build.
+- **Run it through `build-lock.ps1` like any other build.** A WSL build spends host RAM;
+  the cross-worktree mutex does not care which kernel is compiling.
+
+Then, to turn a bare SIGSEGV into a stack, take TSan's signal handler out of the way so
+the debugger gets the fault:
+
+```bash
+cd OloEditor   # gtest_discover_tests' WORKING_DIRECTORY
+TSAN_OPTIONS='halt_on_error=0:abort_on_error=0:handle_segv=0' \
+  gdb -batch -nx -ex 'handle SIGSEGV stop print nopass' -ex run \
+      -ex bt -ex 'thread apply all bt' \
+      --args ../build/OloEngine/tests/OloEngine-Tests --gtest_filter=Suite.Case
+```
+
+`handle_segv=0` is the load-bearing part: without it TSan swallows the signal and prints
+nothing, which is the state the CI log was stuck in.
+
 ## Per-port exceptions live in the triplet, not in a forked portfile
 
 A triplet is loaded once *per port*, with `PORT` set, so it can carry a targeted exception


### PR DESCRIPTION
Fixes #787 — the three `McpProgressHttpTest` cases raw-SEGFAULT under the TSan job and were excluded from it.

The recorded conclusion on the issue ("vendored cpp-httplib socket/thread teardown") was wrong on both counts: it is not cpp-httplib's fault, and it is not teardown.

## Root cause

The vcpkg port propagates `CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO` through its package config, because that is upstream's CMake default:

```cmake
# build/vcpkg_installed/x64-linux/share/httplib/httplibTargets.cmake
INTERFACE_COMPILE_DEFINITIONS "...;$<$<BOOL:ON>:CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO>"
```

Before #773 we consumed cpp-httplib as a `DOWNLOAD_ONLY` header drop behind a bare `INTERFACE` target that set **no compile definitions at all** — so the move to the port switched this on silently. That is also why the crash appeared exactly when it did.

On glibc the macro routes every name resolution through `getaddrinfo_a()`, which runs the lookup on a thread **glibc creates inside libc** (`resolv/gai_misc.c`, `handle_requests`). That call never goes through the PLT, so **TSan's `pthread_create` interceptor never sees the thread**: it has no `__tsan::ThreadState`, and its first intercepted `malloc()` faults inside TSan's own allocator. Hence a bare `SIGSEGV` with **no ThreadSanitizer report** — TSan cannot report from a thread it does not know about. ASan is unaffected, which is why the ASan job stayed green and this looked like a library teardown bug.

The captured stack, with the tell — every TSan-known thread in the process has a `__tsan_thread_start_func` frame; the faulting one does not:

```
#0  __sanitizer::CombinedAllocator<...__tsan::AP64...>::Allocate ()
#1  __tsan::user_alloc_internal ()
#3  __interceptor_malloc ()
#4  generate_addrinfo () at ./nss/getaddrinfo.c:1081
#7  handle_requests () at ./resolv/gai_misc.c:329
#8  start_thread ()          <-- no __tsan_thread_start_func
```

Two supporting facts that redirect the diagnosis: the fault is at **connect** time inside `httplib::Client`'s resolve (main thread sits in `getaddrinfo_with_timeout` → `gai_suspend`), not in `Stop()`; and all three cases die at 0.24 s, which is process-startup time — before the tool body could run.

## Fix

Filter the definition off the imported target in `OloEngine/vendor/CMakeLists.txt`, restoring the pre-#773 behaviour — a plain synchronous `getaddrinfo()` — on every platform, so DNS semantics stay uniform rather than per-OS.

- Nothing in this repo sets a connection timeout (`grep set_connection_timeout` → no call sites), so the option's only observable effect here was the crash.
- Upstream's own comment on that path (their #2431) notes the glibc cancel path can hold the caller for the system resolver timeout past the caller's connection timeout, so the option largely does not deliver its advertised benefit on glibc anyway.
- **Filtered, not overwritten**, so the port's other definitions survive a port update untouched.
- **A bump would not have fixed it**: `getaddrinfo_a()` is still on cpp-httplib master (0.53.1) with no opt-out macro. I checked before spending a round.

## Verification

Built a local Linux TSan build of `OloEngine-Tests` mirroring the `tsan-linux` job (Ubuntu 24.04 under WSL2 + clang-19 + vcpkg `x64-linux` + `-DOLO_ENABLE_TSAN=ON`), which reproduced the crash exactly — `exit=139`, same log cut-off point as CI.

| | before | after |
|---|---|---|
| the 3 `McpProgressHttpTest` cases | SIGSEGV (139) | pass, no TSan reports |
| `--gtest_repeat=8` | — | 24/24 pass |
| whole `Mcp*` set | — | 696 passed, 3 skipped (GPU-gated), 0 reports |
| `getaddrinfo_a` in the binary | referenced | absent |

CI on this PR is the confirmation with the exclusion actually removed.

## Also in this PR

- `.github/workflows/asan.yml` — drops `^McpProgressHttpTest\.` from the TSan `--exclude-regex` and replaces the (now wrong) rationale comment with the real cause. The temporary gdb diagnostic step from the first commit is removed again.
- `docs/agent-rules/vcpkg-dependency-management.md` — trap 9: a port's usage requirements can switch on behaviour the old wiring never had; diff the definitions after a dependency move, and filter rather than overwrite. Plus a section on reproducing a Linux-only sanitizer crash locally under WSL instead of one CI round per iteration, including the `handle_segv=0` trick that turns a bare SIGSEGV into a stack, and the `-lstdc++exp` gotcha.

### The stack was captured on the runner too, not only locally

The first commit on this branch added a temporary non-gating `gdb -batch` step to the `tsan-linux` job (removed again in the fix commit). It ran on the real runner against the pre-fix build and produced the **identical** frames for all three cases — same `rip`, same `__tsan::user_alloc_internal` → `__interceptor_malloc` → `generate_addrinfo` → `handle_requests` chain:

```
Thread 5 "OloEngine-Tests" received signal SIGSEGV, Segmentation fault.
#0  __sanitizer::CombinedAllocator<...__tsan::AP64...>::Allocate ()
#1  __tsan::user_alloc_internal (...)
#3  __interceptor_malloc ()
#4  generate_addrinfo (...) at ./nss/getaddrinfo.c:1081
```

So the WSL reproduction is the same failure as CI's, not a look-alike — which is what makes the local before/after table above load-bearing rather than suggestive.
