### PR TITLE
feat(rhi/vulkan): adopt the Vulkan 1.4 host image copy and maintenance5

### DIFF
--- a/OloEngine/src/OloEngine/Core/DebugLevers.inl
+++ b/OloEngine/src/OloEngine/Core/DebugLevers.inl
@@ -45,6 +45,11 @@ OLO_LEVER_TOGGLE(BindlessDescriptorHeap, "OLO_RHI_BINDLESS",
 OLO_LEVER_TOGGLE(VulkanTraceBuffers, "OLO_VK_TRACE_BUFFERS",
                  "Log every Vulkan vertex/index buffer's device-address range at create time — the currency "
                  "for pairing a GPU fault address back to its buffer.")
+OLO_LEVER_TOGGLE(VulkanNoHostImageCopy, "OLO_VULKAN_NO_HOST_IMAGE_COPY",
+                 "Force every Vulkan texture upload back onto the staging buffer + one-shot submit path, "
+                 "disabling the Vulkan 1.4 host-image-copy route (#809). The host route changes WHEN an "
+                 "upload happens relative to the queue, so this is the A/B for attributing a frame or "
+                 "validation difference to it without rebuilding the backend.")
 
 // --- Assets and bakes -------------------------------------------------------
 // TEXT, not a toggle, and that is a correction: the variable NAMES THE OUTPUT

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -6,9 +6,10 @@
 #include "Platform/Vulkan/VulkanCapabilities.h"
 #include "Platform/Vulkan/VulkanShader.h"
 
+#include "OloEngine/Core/DebugLevers.h"
+
 #include <algorithm>
 #include <atomic>
-#include <cstdlib>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -742,8 +743,12 @@ namespace OloEngine
         // permanently because the host route changes WHEN an upload happens
         // relative to the queue, and that class of difference is exactly what
         // a bisect lever is for.
-        const char* const hostCopyOverride = std::getenv("OLO_VULKAN_NO_HOST_IMAGE_COPY");
-        const bool hostCopyForcedOff = hostCopyOverride != nullptr && hostCopyOverride[0] == '1';
+        // Declared in DebugLevers.inl and read through Levers, not through a
+        // raw getenv or even a bare Env::IsTruthy: the registry is what makes
+        // a lever discoverable (it carries the help text and shows up in the
+        // snapshot), and DebugLeversTest fails the build for any engine code
+        // that reads an OLO_* variable around it.
+        const bool hostCopyForcedOff = Levers::VulkanNoHostImageCopy();
         m_HostImageCopyEnabled = wantHostImageCopy && !hostCopyForcedOff && vkCopyMemoryToImage != nullptr &&
                                  vkTransitionImageLayout != nullptr;
         if (hostCopyForcedOff)

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -773,10 +773,6 @@ namespace OloEngine
             hostCopyProps.pCopySrcLayouts = m_HostCopySrcLayouts.empty() ? nullptr : m_HostCopySrcLayouts.data();
             hostCopyProps.pCopyDstLayouts = m_HostCopyDstLayouts.empty() ? nullptr : m_HostCopyDstLayouts.data();
             vkGetPhysicalDeviceProperties2(m_PhysicalDevice, &hostCopyProps2);
-            const auto isWildcard = [](VkImageLayout layout)
-            { return layout == VK_IMAGE_LAYOUT_MAX_ENUM; };
-            m_HostCopyAllSrcLayouts = std::ranges::any_of(m_HostCopySrcLayouts, isWildcard);
-            m_HostCopyAllDstLayouts = std::ranges::any_of(m_HostCopyDstLayouts, isWildcard);
             m_HostCopyMemoryTypeNeutral = hostCopyProps.identicalMemoryTypeRequirements == VK_TRUE;
         }
         OLO_CORE_INFO("[Vulkan] 1.4 conveniences: host image copy {}{}, maintenance5 {}",
@@ -915,8 +911,6 @@ namespace OloEngine
         m_Maintenance5Enabled = false;
         m_HostCopySrcLayouts.clear();
         m_HostCopyDstLayouts.clear();
-        m_HostCopyAllSrcLayouts = false;
-        m_HostCopyAllDstLayouts = false;
         m_HostCopyMemoryTypeNeutral = false;
         {
             std::lock_guard<std::mutex> lock(m_HostImageCopyFormatMutex);
@@ -961,7 +955,7 @@ namespace OloEngine
         {
             return false;
         }
-        return m_HostCopyAllSrcLayouts || std::ranges::find(m_HostCopySrcLayouts, layout) != m_HostCopySrcLayouts.end();
+        return std::ranges::find(m_HostCopySrcLayouts, layout) != m_HostCopySrcLayouts.end();
     }
 
     bool VulkanDevice::IsHostCopyDstLayoutSupported(VkImageLayout layout) const
@@ -970,7 +964,7 @@ namespace OloEngine
         {
             return false;
         }
-        return m_HostCopyAllDstLayouts || std::ranges::find(m_HostCopyDstLayouts, layout) != m_HostCopyDstLayouts.end();
+        return std::ranges::find(m_HostCopyDstLayouts, layout) != m_HostCopyDstLayouts.end();
     }
 
     void VulkanDevice::LogDeviceFaultInfo() const

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdlib>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -458,6 +460,23 @@ namespace OloEngine
         vulkan11Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
         vulkan11Features.pNext = &vulkan12Features;
 
+        // #809: the 1.4 aggregate. Its two consumed bits (hostImageCopy,
+        // maintenance5) are filled in from the support probe below. Both are
+        // the synchronization2 class: core at the ADR 0010 floor, MANDATORY
+        // for a 1.4 device, and still default OFF at device creation.
+        //
+        // Amendment (51) sweep, done at the moment this struct joined the
+        // chain: nothing else chained here is a feature that 1.4 promoted, so
+        // there is nothing to fold in. VK_EXT_descriptor_heap,
+        // VK_KHR_shader_untyped_pointers, VK_EXT_extended_dynamic_state3,
+        // VK_EXT_device_fault and VK_EXT_mesh_shader are all post-1.4 or
+        // never-promoted, so each stays a standalone struct. A future
+        // promoted-into-1.4 feature MUST move into this struct instead
+        // (VUID-VkDeviceCreateInfo-pNext-02830 rejects both spellings at once).
+        VkPhysicalDeviceVulkan14Features vulkan14Features{};
+        vulkan14Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES;
+        vulkan14Features.pNext = &vulkan11Features;
+
         std::vector<const char*> deviceExtensions = VulkanCapabilities::RequiredDeviceExtensions();
 
         // VK_EXT_extended_dynamic_state3: OPTIONAL (ADR 0011 §5 — dynamic blend
@@ -525,7 +544,7 @@ namespace OloEngine
             eds3Features.extendedDynamicState3ColorBlendEnable = VK_TRUE;
             eds3Features.extendedDynamicState3ColorBlendEquation = VK_TRUE;
             eds3Features.extendedDynamicState3ColorWriteMask = VK_TRUE;
-            eds3Features.pNext = &vulkan11Features;
+            eds3Features.pNext = &vulkan14Features;
         }
         // m_DynamicBlendStateEnabled is committed AFTER vkCreateDevice
         // succeeds (below): the flag must describe the LOGICAL device's
@@ -591,9 +610,18 @@ namespace OloEngine
         VkPhysicalDeviceVulkan12Features supported12{};
         supported12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
         supported12.pNext = &supported11;
+        // #809: hostImageCopy + maintenance5 ride the same probe. Both are
+        // required-to-be-supported on a 1.4 device, but "required by the spec"
+        // is not "present in this driver" -- a device that reports 1.4 without
+        // them, or a layer that filters them out, must degrade to the staging
+        // path rather than call through a null volk pointer, so the probe
+        // result is what gates every use.
+        VkPhysicalDeviceVulkan14Features supported14{};
+        supported14.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES;
+        supported14.pNext = &supported12;
         VkPhysicalDeviceFeatures2 supportedFeatures2{};
         supportedFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-        supportedFeatures2.pNext = &supported12;
+        supportedFeatures2.pNext = &supported14;
         vkGetPhysicalDeviceFeatures2(m_PhysicalDevice, &supportedFeatures2);
         vulkan12Features.shaderBufferInt64Atomics = supportedAtomics.shaderBufferInt64Atomics;
         // shaderInt64 is a DIFFERENT feature from shaderBufferInt64Atomics:
@@ -614,6 +642,18 @@ namespace OloEngine
         m_DrawIndirectCountEnabled = supported12.drawIndirectCount == VK_TRUE;
         vulkan11Features.shaderDrawParameters = supported11.shaderDrawParameters;
         m_ShaderDrawParametersEnabled = supported11.shaderDrawParameters == VK_TRUE;
+
+        // #809. The member flags are committed AFTER vkCreateDevice returns
+        // (the same commit-after-create rule the EDS3 / mesh-shader bits
+        // follow): until the create succeeds nothing is enabled anywhere, and
+        // a use site reading a flag set from a *request* would be reading a
+        // wish. maintenance6 is deliberately NOT requested -- nothing in the
+        // backend consumes any of its relaxations, and an unused feature bit
+        // is dead weight the validation layer still has to reason about.
+        const bool wantHostImageCopy = supported14.hostImageCopy == VK_TRUE;
+        const bool wantMaintenance5 = supported14.maintenance5 == VK_TRUE;
+        vulkan14Features.hostImageCopy = supported14.hostImageCopy;
+        vulkan14Features.maintenance5 = supported14.maintenance5;
 
         // Device-fault reporting costs nothing until a device loss, at which
         // point it is the difference between "VkResult -4" and a fault
@@ -653,7 +693,7 @@ namespace OloEngine
         }
 
         void* featureChainHead = wantDynamicBlend ? static_cast<void*>(&eds3Features)
-                                                  : static_cast<void*>(&vulkan11Features);
+                                                  : static_cast<void*>(&vulkan14Features);
         if (wantDeviceFault)
         {
             faultFeatures.pNext = featureChainHead;
@@ -685,6 +725,61 @@ namespace OloEngine
         m_MeshShaderEnabled = wantMeshShader;
         volkLoadDevice(m_Device);
         vkGetDeviceQueue(m_Device, m_QueueFamily, 0, &m_Queue);
+
+        // #809: same commit-after-create rule, and the entry points these
+        // flags gate only exist once volkLoadDevice has run -- a flag set
+        // before that would let a caller dereference a null
+        // vkCopyMemoryToImage. The null checks are not belt-and-braces: volk
+        // only populates a core-1.4 pointer when the loader/ICD actually
+        // exports it, so an enabled feature bit is not on its own proof the
+        // command is callable.
+        m_Maintenance5Enabled = wantMaintenance5 && vkCmdBindIndexBuffer2 != nullptr;
+        // OLO_VULKAN_NO_HOST_IMAGE_COPY=1 forces every upload back onto the
+        // staging + one-shot path. Same genre as
+        // OLO_GAMEPLAY_SCHEDULER_SEQUENTIAL: a one-line A/B for the question
+        // "is this frame/validation difference the host route's fault?", which
+        // is otherwise only answerable by rebuilding the backend. Kept
+        // permanently because the host route changes WHEN an upload happens
+        // relative to the queue, and that class of difference is exactly what
+        // a bisect lever is for.
+        const char* const hostCopyOverride = std::getenv("OLO_VULKAN_NO_HOST_IMAGE_COPY");
+        const bool hostCopyForcedOff = hostCopyOverride != nullptr && hostCopyOverride[0] == '1';
+        m_HostImageCopyEnabled = wantHostImageCopy && !hostCopyForcedOff && vkCopyMemoryToImage != nullptr &&
+                                 vkTransitionImageLayout != nullptr;
+        if (hostCopyForcedOff)
+        {
+            OLO_CORE_WARN("[Vulkan] host image copy disabled by OLO_VULKAN_NO_HOST_IMAGE_COPY=1 — "
+                          "every texture upload takes the staging + one-shot path");
+        }
+        if (m_HostImageCopyEnabled)
+        {
+            // The layout lists are a two-call query (count, then data). Only
+            // VK_IMAGE_LAYOUT_GENERAL is guaranteed to appear in both, so
+            // every host path that wants a nicer layout asks rather than
+            // assumes -- see IsHostCopySrcLayoutSupported.
+            VkPhysicalDeviceHostImageCopyProperties hostCopyProps{};
+            hostCopyProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES;
+            VkPhysicalDeviceProperties2 hostCopyProps2{};
+            hostCopyProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+            hostCopyProps2.pNext = &hostCopyProps;
+            vkGetPhysicalDeviceProperties2(m_PhysicalDevice, &hostCopyProps2);
+            m_HostCopySrcLayouts.assign(hostCopyProps.copySrcLayoutCount, VK_IMAGE_LAYOUT_UNDEFINED);
+            m_HostCopyDstLayouts.assign(hostCopyProps.copyDstLayoutCount, VK_IMAGE_LAYOUT_UNDEFINED);
+            hostCopyProps.pCopySrcLayouts = m_HostCopySrcLayouts.empty() ? nullptr : m_HostCopySrcLayouts.data();
+            hostCopyProps.pCopyDstLayouts = m_HostCopyDstLayouts.empty() ? nullptr : m_HostCopyDstLayouts.data();
+            vkGetPhysicalDeviceProperties2(m_PhysicalDevice, &hostCopyProps2);
+            const auto isWildcard = [](VkImageLayout layout)
+            { return layout == VK_IMAGE_LAYOUT_MAX_ENUM; };
+            m_HostCopyAllSrcLayouts = std::ranges::any_of(m_HostCopySrcLayouts, isWildcard);
+            m_HostCopyAllDstLayouts = std::ranges::any_of(m_HostCopyDstLayouts, isWildcard);
+            m_HostCopyMemoryTypeNeutral = hostCopyProps.identicalMemoryTypeRequirements == VK_TRUE;
+        }
+        OLO_CORE_INFO("[Vulkan] 1.4 conveniences: host image copy {}{}, maintenance5 {}",
+                      m_HostImageCopyEnabled ? "enabled" : "unavailable (staging upload path)",
+                      m_HostImageCopyEnabled && !m_HostCopyMemoryTypeNeutral
+                          ? " (host-transfer usage changes memory type requirements — kept off render targets)"
+                          : "",
+                      m_Maintenance5Enabled ? "enabled" : "unavailable (implicit whole-buffer index binds)");
 
         // Mesh-shader limits + the loud capability verdict (issue #813). The
         // vkGetPhysicalDeviceProperties2 probe is this backend's first —
@@ -807,10 +902,70 @@ namespace OloEngine
         }
         m_PhysicalDevice = VK_NULL_HANDLE;
         m_QueueFamily = 0;
+        // #809: the host-image-copy verdict describes a physical device that
+        // is no longer reachable through this object. Clearing it means a
+        // Shutdown/Init cycle re-probes rather than reusing a verdict (and a
+        // per-format memo) minted against the previous device.
+        m_HostImageCopyEnabled = false;
+        m_Maintenance5Enabled = false;
+        m_HostCopySrcLayouts.clear();
+        m_HostCopyDstLayouts.clear();
+        m_HostCopyAllSrcLayouts = false;
+        m_HostCopyAllDstLayouts = false;
+        m_HostCopyMemoryTypeNeutral = false;
+        {
+            std::lock_guard<std::mutex> lock(m_HostImageCopyFormatMutex);
+            m_HostImageCopyFormatCache.clear();
+        }
         if (s_ActiveDevice == this)
         {
             s_ActiveDevice = nullptr;
         }
+    }
+
+    bool VulkanDevice::SupportsHostImageCopyForFormat(VkFormat format) const
+    {
+        if (!m_HostImageCopyEnabled || m_PhysicalDevice == VK_NULL_HANDLE)
+        {
+            return false;
+        }
+
+        std::lock_guard<std::mutex> lock(m_HostImageCopyFormatMutex);
+        if (const auto it = m_HostImageCopyFormatCache.find(format); it != m_HostImageCopyFormatCache.end())
+        {
+            return it->second;
+        }
+
+        // VkFormatProperties3, not VkFormatProperties: the host-transfer bit
+        // lives above bit 31 and only the 64-bit flags word can carry it.
+        VkFormatProperties3 properties3{};
+        properties3.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3;
+        VkFormatProperties2 properties2{};
+        properties2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+        properties2.pNext = &properties3;
+        vkGetPhysicalDeviceFormatProperties2(m_PhysicalDevice, format, &properties2);
+
+        const bool supported = (properties3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT) != 0;
+        m_HostImageCopyFormatCache.emplace(format, supported);
+        return supported;
+    }
+
+    bool VulkanDevice::IsHostCopySrcLayoutSupported(VkImageLayout layout) const
+    {
+        if (!m_HostImageCopyEnabled)
+        {
+            return false;
+        }
+        return m_HostCopyAllSrcLayouts || std::ranges::find(m_HostCopySrcLayouts, layout) != m_HostCopySrcLayouts.end();
+    }
+
+    bool VulkanDevice::IsHostCopyDstLayoutSupported(VkImageLayout layout) const
+    {
+        if (!m_HostImageCopyEnabled)
+        {
+            return false;
+        }
+        return m_HostCopyAllDstLayouts || std::ranges::find(m_HostCopyDstLayouts, layout) != m_HostCopyDstLayouts.end();
     }
 
     void VulkanDevice::LogDeviceFaultInfo() const

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -28,6 +28,9 @@
 #include <vk_mem_alloc.h>
 
 #include <functional>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 namespace OloEngine
 {
@@ -165,6 +168,64 @@ namespace OloEngine
             return m_MeshShaderProperties;
         }
 
+        // --- Vulkan 1.4 core conveniences (issue #809) -------------------
+        // These are FEATURES, not extensions, on the ADR 0010 floor: the
+        // device already targets 1.4, so no extension name is added and no
+        // capability-gate row widens. They are the synchronization2 class
+        // though — core-promoted but still DEFAULT OFF at device creation —
+        // so each is enabled from a vkGetPhysicalDeviceFeatures2 probe and
+        // every use site gates on the flag rather than on the API version.
+
+        // hostImageCopy: TRUE -> the load-time texture upload path writes
+        // host memory straight into an optimally-tiled VkImage
+        // (vkCopyMemoryToImage + vkTransitionImageLayout), with no staging
+        // buffer and no queue submit — which is what removes the
+        // one-shot-submit ordering hazard (amendment (72)) for asset loads.
+        // FALSE -> every upload keeps the staging + one-shot path.
+        [[nodiscard]] bool IsHostImageCopyEnabled() const
+        {
+            return m_HostImageCopyEnabled;
+        }
+        // maintenance5: TRUE -> index-buffer binds go through
+        // vkCmdBindIndexBuffer2 with the buffer's REAL byte size instead of
+        // the implicit whole-buffer bind, so an out-of-range index count is a
+        // validation error rather than an out-of-bounds read (amendment (9b)'s
+        // DrawIndexed(va, 0) "whole buffer" sentinel resolves to a number the
+        // bind can actually state).
+        //
+        // maintenance6 is deliberately NOT enabled: nothing in the backend
+        // uses any of its relaxations, and a feature bit nothing consumes is
+        // dead weight the validation layer still has to reason about (the
+        // same rule the EDS3 and mesh-shader bits above follow).
+        [[nodiscard]] bool IsMaintenance5Enabled() const
+        {
+            return m_Maintenance5Enabled;
+        }
+
+        // Per-format half of the host-image-copy gate: an image may only carry
+        // VK_IMAGE_USAGE_HOST_TRANSFER_BIT when its format+tiling advertises
+        // VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT
+        // (VUID-VkImageCreateInfo-usage-10245), and that is a per-format
+        // question no device-level flag answers. Optimal tiling only — the
+        // texture classes create nothing else. Memoized; false whenever host
+        // image copy is not enabled at all.
+        [[nodiscard]] bool SupportsHostImageCopyForFormat(VkFormat format) const;
+
+        // The layouts host image copy may READ FROM / WRITE TO on this driver.
+        // Only VK_IMAGE_LAYOUT_GENERAL is guaranteed to be in both lists, so a
+        // host path that wants to leave an image in SHADER_READ_ONLY_OPTIMAL
+        // (or start one from it) has to ask. An implementation may report
+        // VK_IMAGE_LAYOUT_MAX_ENUM to mean "every layout", which both queries
+        // honour.
+        [[nodiscard]] bool IsHostCopySrcLayoutSupported(VkImageLayout layout) const;
+        [[nodiscard]] bool IsHostCopyDstLayoutSupported(VkImageLayout layout) const;
+        // vkTransitionImageLayout's newLayout must be in EITHER list
+        // (VUID-VkHostImageLayoutTransitionInfo-newLayout-09057).
+        [[nodiscard]] bool IsHostTransitionTargetSupported(VkImageLayout layout) const
+        {
+            return IsHostCopySrcLayoutSupported(layout) || IsHostCopyDstLayoutSupported(layout);
+        }
+
         // VK_EXT_device_fault (enabled when the driver has it): after a
         // VK_ERROR_DEVICE_LOST, logs the driver's fault report — fault type
         // (page fault vs. hang) and the faulting GPU address — so a device
@@ -204,6 +265,28 @@ namespace OloEngine
         bool m_ShaderDrawParametersEnabled = false;
         bool m_DeviceFaultEnabled = false;
         bool m_MeshShaderEnabled = false;
+        bool m_HostImageCopyEnabled = false;
+        bool m_Maintenance5Enabled = false;
+        // Host-image-copy layout lists, read once after device creation. The
+        // "all" flags carry the VK_IMAGE_LAYOUT_MAX_ENUM wildcard the spec
+        // allows in place of an exhaustive list.
+        std::vector<VkImageLayout> m_HostCopySrcLayouts;
+        std::vector<VkImageLayout> m_HostCopyDstLayouts;
+        bool m_HostCopyAllSrcLayouts = false;
+        bool m_HostCopyAllDstLayouts = false;
+        // Logged, not branched on: the driver's answer to "does
+        // VK_IMAGE_USAGE_HOST_TRANSFER_BIT change an image's memory type
+        // requirements?". It is VK_FALSE on NVIDIA, which is why the usage
+        // bit is kept off render-target-only textures at the texture class
+        // (VulkanTexture2D's renderTargetOnly) rather than gated here —
+        // gating the feature on this property disables it outright on the
+        // hardware it was built for.
+        bool m_HostCopyMemoryTypeNeutral = false;
+        // SupportsHostImageCopyForFormat's memo. Mutable + locked because the
+        // query is logically const and texture creation is not guaranteed to
+        // stay on one thread (the asset loader is a thread pool).
+        mutable std::mutex m_HostImageCopyFormatMutex;
+        mutable std::unordered_map<VkFormat, bool> m_HostImageCopyFormatCache;
         // Cached at Init when VK_EXT_mesh_shader is present; all-zero
         // otherwise (see GetMeshShaderProperties).
         VkPhysicalDeviceMeshShaderPropertiesEXT m_MeshShaderProperties{};

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -214,16 +214,20 @@ namespace OloEngine
         // The layouts host image copy may READ FROM / WRITE TO on this driver.
         // Only VK_IMAGE_LAYOUT_GENERAL is guaranteed to be in both lists, so a
         // host path that wants to leave an image in SHADER_READ_ONLY_OPTIMAL
-        // (or start one from it) has to ask. An implementation may report
-        // VK_IMAGE_LAYOUT_MAX_ENUM to mean "every layout", which both queries
-        // honour.
+        // (or start one from it) has to ask. Membership is exact: the lists
+        // enumerate supported layouts and carry no wildcard entry.
         [[nodiscard]] bool IsHostCopySrcLayoutSupported(VkImageLayout layout) const;
         [[nodiscard]] bool IsHostCopyDstLayoutSupported(VkImageLayout layout) const;
-        // vkTransitionImageLayout's newLayout must be in EITHER list
-        // (VUID-VkHostImageLayoutTransitionInfo-newLayout-09057).
+        // vkTransitionImageLayout's newLayout must be in pCopyDstLayouts —
+        // VUID-VkHostImageLayoutTransitionInfo-newLayout-09057, checked
+        // against the registry's validusage.json rather than assumed. It is
+        // NOT "either list": a layout that only appears in pCopySrcLayouts is
+        // not a legal transition target, and treating it as one is invalid
+        // usage the validation layer would catch only on a driver whose two
+        // lists differ.
         [[nodiscard]] bool IsHostTransitionTargetSupported(VkImageLayout layout) const
         {
-            return IsHostCopySrcLayoutSupported(layout) || IsHostCopyDstLayoutSupported(layout);
+            return IsHostCopyDstLayoutSupported(layout);
         }
 
         // VK_EXT_device_fault (enabled when the driver has it): after a
@@ -267,13 +271,9 @@ namespace OloEngine
         bool m_MeshShaderEnabled = false;
         bool m_HostImageCopyEnabled = false;
         bool m_Maintenance5Enabled = false;
-        // Host-image-copy layout lists, read once after device creation. The
-        // "all" flags carry the VK_IMAGE_LAYOUT_MAX_ENUM wildcard the spec
-        // allows in place of an exhaustive list.
+        // Host-image-copy layout lists, read once after device creation.
         std::vector<VkImageLayout> m_HostCopySrcLayouts;
         std::vector<VkImageLayout> m_HostCopyDstLayouts;
-        bool m_HostCopyAllSrcLayouts = false;
-        bool m_HostCopyAllDstLayouts = false;
         // Logged, not branched on: the driver's answer to "does
         // VK_IMAGE_USAGE_HOST_TRANSFER_BIT change an image's memory type
         // requirements?". It is VK_FALSE on NVIDIA, which is why the usage

--- a/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -225,13 +225,19 @@ namespace OloEngine
         m_ColorAttachments.reserve(m_ColorAttachmentSpecifications.size());
         for (const auto& attachmentSpec : m_ColorAttachmentSpecifications)
         {
-            m_ColorAttachments.push_back(Ref<VulkanTexture2D>::Create(makeAttachmentSpec(attachmentSpec.TextureFormat)));
+            // renderTargetOnly (#809): content arrives from the GPU, SetData
+            // is never called — so this image must not carry
+            // VK_IMAGE_USAGE_HOST_TRANSFER_BIT for an upload route it can
+            // never take.
+            m_ColorAttachments.push_back(
+                Ref<VulkanTexture2D>::Create(makeAttachmentSpec(attachmentSpec.TextureFormat), true));
             stampAttachmentSamplerState(m_ColorAttachments.back());
         }
 
         if (m_DepthAttachmentSpecification.TextureFormat != FramebufferTextureFormat::None)
         {
-            m_DepthAttachment = Ref<VulkanTexture2D>::Create(makeAttachmentSpec(m_DepthAttachmentSpecification.TextureFormat));
+            m_DepthAttachment =
+                Ref<VulkanTexture2D>::Create(makeAttachmentSpec(m_DepthAttachmentSpecification.TextureFormat), true);
             stampAttachmentSamplerState(m_DepthAttachment);
         }
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -2053,7 +2053,29 @@ namespace OloEngine
         }
         if (indexBuffer->GetVkBuffer() != m_BoundIndexBuffer)
         {
-            vkCmdBindIndexBuffer(m_Cmd, indexBuffer->GetVkBuffer(), 0, VK_INDEX_TYPE_UINT32);
+            // #809 (maintenance5, core in 1.4): bind the buffer's REAL byte
+            // size instead of the implicit whole-buffer bind. The facade's
+            // DrawIndexed(va, 0) "whole buffer" sentinel (amendment (9b)) is
+            // resolved to indexBuffer->GetCount() at the draw sites; stating
+            // the same extent on the BIND turns a draw whose count overruns
+            // the buffer into a validation error naming the bind, instead of
+            // an out-of-bounds index fetch that renders garbage. The engine's
+            // index format is fixed 32-bit (IndexBuffer.h), so the byte size
+            // is the count times four.
+            //
+            // The cache key stays the VkBuffer alone: VulkanIndexBuffer's
+            // count is fixed at construction, so a changed element count is
+            // necessarily a different VkBuffer.
+            const auto* device = VulkanDevice::Get();
+            if (device != nullptr && device->IsMaintenance5Enabled())
+            {
+                const VkDeviceSize sizeBytes = static_cast<VkDeviceSize>(indexBuffer->GetCount()) * sizeof(u32);
+                vkCmdBindIndexBuffer2(m_Cmd, indexBuffer->GetVkBuffer(), 0, sizeBytes, VK_INDEX_TYPE_UINT32);
+            }
+            else
+            {
+                vkCmdBindIndexBuffer(m_Cmd, indexBuffer->GetVkBuffer(), 0, VK_INDEX_TYPE_UINT32);
+            }
             m_BoundIndexBuffer = indexBuffer->GetVkBuffer();
         }
         return true;

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
@@ -16,6 +16,7 @@
 #include <stb_image/stb_image.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstring>
 #include <stdexcept>
@@ -26,6 +27,10 @@ namespace OloEngine
 {
     namespace
     {
+        // #809, see VulkanTexture2D::GetHostImageCopyUploadCount. Atomic
+        // because texture creation is not guaranteed to stay on one thread.
+        std::atomic<u64> s_HostImageCopyUploadCount{ 0 };
+
         [[nodiscard]] bool IsDepthImageFormat(ImageFormat format)
         {
             return format == ImageFormat::DEPTH24STENCIL8;
@@ -136,12 +141,13 @@ namespace OloEngine
         }
     } // namespace
 
-    VulkanTexture2D::VulkanTexture2D(const TextureSpecification& specification)
+    VulkanTexture2D::VulkanTexture2D(const TextureSpecification& specification, bool renderTargetOnly)
         // Vulkan refuses a zero extent outright (GL merely misbehaved), so
         // clamp defensively — pre-Resize 0-sized framebuffer specs reach here.
         : m_Specification(specification),
           m_Width(std::max(specification.Width, 1u)),
-          m_Height(std::max(specification.Height, 1u))
+          m_Height(std::max(specification.Height, 1u)),
+          m_RenderTargetOnly(renderTargetOnly)
     {
         OLO_PROFILE_FUNCTION();
         OLO_CORE_ASSERT(VulkanDevice::Get() != nullptr, "VulkanTexture2D requires a live VulkanDevice");
@@ -257,6 +263,34 @@ namespace OloEngine
             {
                 usage |= VK_IMAGE_USAGE_STORAGE_BIT;
             }
+        }
+
+        // #809: VK_IMAGE_USAGE_HOST_TRANSFER_BIT is what lets UploadPixels
+        // write this image straight from host memory (SubImage deliberately
+        // stays on the staging path — it is a partial update with a mid-frame
+        // arm of its own, and #809 scopes the host route to the load-time
+        // upload). Three
+        // independent gates, all required
+        // (VUID-VkImageCreateInfo-usage-10245): the device enabled
+        // hostImageCopy, THIS format advertises the host-transfer feature at
+        // optimal tiling, and the image is a single-sampled colour image
+        // (there is no client-data upload path for depth, and a multisampled
+        // image cannot be host-copied). The bit is harmless when the host
+        // path is never taken.
+        //
+        // A fourth gate is m_RenderTargetOnly, and it is not cosmetic: the
+        // driver may pick different memory type requirements for an image
+        // carrying this bit (NVIDIA reports identicalMemoryTypeRequirements =
+        // VK_FALSE, measured on an RTX 4090), so putting it on every
+        // framebuffer attachment would charge every render target — on every
+        // resize — for a route an attachment can never take. Gating on the
+        // driver property instead was tried and is wrong: it disables the
+        // whole feature on exactly the hardware it was built for.
+        m_HostTransferUsage = !isDepth && !m_RenderTargetOnly && m_Specification.Samples == 1u &&
+                              device->SupportsHostImageCopyForFormat(format);
+        if (m_HostTransferUsage)
+        {
+            usage |= VK_IMAGE_USAGE_HOST_TRANSFER_BIT;
         }
 
         VkImageCreateInfo imageInfo{};
@@ -388,6 +422,198 @@ namespace OloEngine
         RHI::DescriptorHeap::Get().InvalidateResource(m_RHIHandle.Get());
     }
 
+    u64 VulkanTexture2D::GetHostImageCopyUploadCount()
+    {
+        return s_HostImageCopyUploadCount.load(std::memory_order_relaxed);
+    }
+
+    void VulkanTexture2D::RecordMipChain(VkCommandBuffer cmd, VkFilter blitFilter) const
+    {
+        // Classic blit chain: mip N-1 (TRANSFER_SRC) → mip N (TRANSFER_DST),
+        // then N becomes the next source. Extracted from UploadPixels so the
+        // staging and host-image-copy routes share ONE barrier sequence —
+        // the two differ only in how mip 0 got its pixels, and a second copy
+        // of this ladder is the two-mirrors shape that drifts.
+        //
+        // Precondition (see the header): mip 0 is already TRANSFER_SRC.
+        i32 srcW = static_cast<i32>(m_Width);
+        i32 srcH = static_cast<i32>(m_Height);
+        for (u32 mip = 1; mip < m_MipLevels; ++mip)
+        {
+            const i32 dstW = std::max(srcW / 2, 1);
+            const i32 dstH = std::max(srcH / 2, 1);
+
+            VkImageBlit blit{};
+            blit.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip - 1u, 0u, 1u };
+            blit.srcOffsets[1] = { srcW, srcH, 1 };
+            blit.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip, 0u, 1u };
+            blit.dstOffsets[1] = { dstW, dstH, 1 };
+            vkCmdBlitImage(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, m_Image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1u, &blit, blitFilter);
+
+            // This mip is the next iteration's source. The last mip is never
+            // read, so it stays in TRANSFER_DST for the final transition.
+            if (mip + 1u < m_MipLevels)
+            {
+                VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                                 VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                                 VK_ACCESS_2_TRANSFER_READ_BIT, mip, 1u);
+            }
+
+            srcW = dstW;
+            srcH = dstH;
+        }
+
+        // Mips [0, N-1) sit in TRANSFER_SRC, the last in TRANSFER_DST — bring
+        // all to SHADER_READ_ONLY, the backend's steady state for sampled
+        // content (GetData and SubImage both name it as their oldLayout).
+        VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                         VK_ACCESS_2_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                                         VK_ACCESS_2_MEMORY_READ_BIT, 0u, m_MipLevels - 1u);
+        VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                         VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+                                         VK_ACCESS_2_MEMORY_READ_BIT, m_MipLevels - 1u, 1u);
+    }
+
+    bool VulkanTexture2D::UploadPixelsFromHost(const void* data, u64 sizeBytes, VkFilter blitFilter)
+    {
+        auto* device = VulkanDevice::Get();
+        if (device == nullptr || !device->IsHostImageCopyEnabled() || m_Image == VK_NULL_HANDLE)
+        {
+            return false;
+        }
+
+        // vkCopyMemoryToImage reads width*height*texelBytes straight out of
+        // the CALLER's allocation, so a payload short of the full extent is a
+        // host heap over-read here — where the staging path would only have
+        // produced an over-read of a VMA buffer and a VUID. Decline rather
+        // than read. Zero means "no client-upload path for this format"
+        // (depth, compressed), which also declines.
+        const u32 texelBytes = VkFormatTexelBytes(m_Specification.Format);
+        if (texelBytes == 0u || sizeBytes < static_cast<u64>(m_Width) * m_Height * texelBytes)
+        {
+            return false;
+        }
+
+        // VK_IMAGE_LAYOUT_GENERAL is the ONE layout the spec guarantees in
+        // both host-copy layout lists, so it is what the copy targets. Every
+        // other layout is asked for, never assumed — the lists are a driver
+        // property, not a constant.
+        constexpr VkImageLayout kCopyLayout = VK_IMAGE_LAYOUT_GENERAL;
+        if (!device->IsHostCopyDstLayoutSupported(kCopyLayout))
+        {
+            return false;
+        }
+        // The upload MUST end in SHADER_READ_ONLY_OPTIMAL: that is the
+        // backend's steady state for sampled content, and both GetData and
+        // SubImage name it as their barrier's oldLayout. Leaving the image in
+        // GENERAL instead would still sample correctly and would silently
+        // break those two, so a driver that cannot make that host transition
+        // declines the whole route rather than weakening the invariant.
+        if (!device->IsHostTransitionTargetSupported(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL))
+        {
+            return false;
+        }
+
+        const VkDevice vkDevice = device->GetDevice();
+        const bool generateMips = m_MipLevels > 1u;
+
+        // Whole image → GENERAL. oldLayout UNDEFINED is a full discard, which
+        // is exactly right here: mip 0 is about to be completely overwritten
+        // and every other mip regenerated from it.
+        VkHostImageLayoutTransitionInfo toCopy{};
+        toCopy.sType = VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO;
+        toCopy.image = m_Image;
+        toCopy.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        toCopy.newLayout = kCopyLayout;
+        toCopy.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0u, m_MipLevels, 0u, 1u };
+        if (vkTransitionImageLayout(vkDevice, 1u, &toCopy) != VK_SUCCESS)
+        {
+            OLO_CORE_WARN("VulkanTexture2D::UploadPixels: host layout transition failed — falling back to staging");
+            return false;
+        }
+
+        // memoryRowLength / memoryImageHeight 0 = "tightly packed to
+        // imageExtent", the same contract the staging path's VkBufferImageCopy
+        // relies on. The caller has already widened 3-channel client data to
+        // the image's 4-channel form, so `data` matches the VkImage's format.
+        VkMemoryToImageCopy region{};
+        region.sType = VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY;
+        region.pHostPointer = data;
+        region.memoryRowLength = 0u;
+        region.memoryImageHeight = 0u;
+        region.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u };
+        region.imageExtent = { m_Width, m_Height, 1u };
+
+        VkCopyMemoryToImageInfo copyInfo{};
+        copyInfo.sType = VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO;
+        copyInfo.dstImage = m_Image;
+        copyInfo.dstImageLayout = kCopyLayout;
+        copyInfo.regionCount = 1u;
+        copyInfo.pRegions = &region;
+        if (vkCopyMemoryToImage(vkDevice, &copyInfo) != VK_SUCCESS)
+        {
+            OLO_CORE_WARN("VulkanTexture2D::UploadPixels: host image copy failed — falling back to staging");
+            return false;
+        }
+
+        if (!generateMips)
+        {
+            // The whole upload happened on the host: no staging buffer, no
+            // command buffer, no submit, and therefore nothing to order
+            // against the frame that may be recording around this call.
+            VkHostImageLayoutTransitionInfo toSampled{};
+            toSampled.sType = VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO;
+            toSampled.image = m_Image;
+            toSampled.oldLayout = kCopyLayout;
+            toSampled.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            toSampled.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0u, m_MipLevels, 0u, 1u };
+            if (vkTransitionImageLayout(vkDevice, 1u, &toSampled) != VK_SUCCESS)
+            {
+                OLO_CORE_WARN("VulkanTexture2D::UploadPixels: host transition to SHADER_READ_ONLY failed — "
+                              "falling back to staging");
+                return false;
+            }
+            VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            s_HostImageCopyUploadCount.fetch_add(1u, std::memory_order_relaxed);
+            return true;
+        }
+
+        // Mip generation is a BLIT, which has no host form — only the base
+        // level moved off the command stream. The one-shot submit stays, and
+        // with it amendment (72)'s ordering caveat, for mipped textures.
+        const bool ok = VulkanOneShot::Submit(
+            "VulkanTexture2D::UploadPixels(host)",
+            [&](VkCommandBuffer cmd)
+            {
+                // Mip 0 carries the host-written pixels and must be
+                // PRESERVED: src scope is the host write, which the queue
+                // submit's implicit host-write ordering already makes
+                // available — naming it explicitly is what keeps sync
+                // validation able to see the dependency.
+                VulkanUpload::RecordImageBarrier(cmd, m_Image, kCopyLayout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                                 VK_PIPELINE_STAGE_2_HOST_BIT, VK_ACCESS_2_HOST_WRITE_BIT,
+                                                 VK_PIPELINE_STAGE_2_BLIT_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, 0u, 1u);
+                // Mips 1..N-1 hold nothing worth keeping — UNDEFINED discards
+                // whatever the GENERAL transition left there.
+                VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_UNDEFINED,
+                                                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_2_HOST_BIT,
+                                                 VK_ACCESS_2_HOST_WRITE_BIT, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                                 VK_ACCESS_2_TRANSFER_WRITE_BIT, 1u, m_MipLevels - 1u);
+                RecordMipChain(cmd, blitFilter);
+            });
+
+        if (ok)
+        {
+            VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            s_HostImageCopyUploadCount.fetch_add(1u, std::memory_order_relaxed);
+        }
+        return ok;
+    }
+
     bool VulkanTexture2D::UploadPixels(const void* data, u64 sizeBytes)
     {
         OLO_PROFILE_FUNCTION();
@@ -415,6 +641,46 @@ namespace OloEngine
             uploadSize = expanded.size();
         }
 
+        const bool generateMips = m_MipLevels > 1u;
+        const VkFilter blitFilter = IsIntegerFormat(m_Specification.Format) ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
+
+        // #809: the host-image-copy route first. It writes mip 0 with no
+        // staging buffer at all, and for a texture with no mip chain it
+        // finishes the upload without ever touching the command stream —
+        // which is what takes an asset load out of the one-shot-submit
+        // ordering hazard (amendment (72): a one-shot submit is ordered
+        // BEFORE the frame still recording around it) rather than managing
+        // it. A false return means the route was unavailable or failed, and
+        // the staging path below then runs exactly as it did before —
+        // including its oldLayout UNDEFINED full discard, which is valid
+        // from whatever state a partial host attempt left behind.
+        //
+        // "Load-time" is enforced here, not assumed, and it takes TWO checks
+        // because vkTransitionImageLayout / vkCopyMemoryToImage run on the
+        // CPU the moment they are called — no queue ordering, no fence:
+        //
+        //  - No frame may be RECORDING. The staging path's one-shot submit is
+        //    at least ordered against the queue; a host write to an image the
+        //    frame being recorded will sample is not ordered against anything.
+        //    Same guard SubImage already applies to its mid-frame arm.
+        //  - This must be the image's FIRST upload. A re-upload targets an
+        //    image previously handed to the renderer, which an ALREADY
+        //    SUBMITTED frame may still be reading — and "no frame is
+        //    recording" says nothing about frames in flight. The registry's
+        //    InitialLayout is exactly that record: UNDEFINED until an upload
+        //    publishes content, so it is still UNDEFINED only for a freshly
+        //    created (or freshly Resize()d) image. This is what keeps the
+        //    per-frame re-uploaders — VideoTexture::UpdateFrame,
+        //    OceanFFTField::Upload — on the command path where they belong.
+        const auto* priorInfo = VulkanImageInfoRegistry::Get().Lookup(m_Image);
+        const bool firstUpload = priorInfo == nullptr || priorInfo->InitialLayout == VK_IMAGE_LAYOUT_UNDEFINED;
+        const bool frameRecording = VulkanUpload::TryGetRecordingVulkanAPI() != nullptr;
+        if (m_HostTransferUsage && firstUpload && !frameRecording &&
+            UploadPixelsFromHost(uploadData, uploadSize, blitFilter))
+        {
+            return true;
+        }
+
         // Host staging buffer — destroyed right after the blocking one-shot.
         VkBufferCreateInfo stagingInfo{};
         stagingInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -438,9 +704,6 @@ namespace OloEngine
         }
         std::memcpy(stagingOut.pMappedData, uploadData, uploadSize);
         vmaFlushAllocation(device->GetAllocator(), stagingAllocation, 0, uploadSize);
-
-        const bool generateMips = m_MipLevels > 1u;
-        const VkFilter blitFilter = IsIntegerFormat(m_Specification.Format) ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
 
         const bool ok = VulkanOneShot::Submit(
             "VulkanTexture2D::UploadPixels",
@@ -470,46 +733,15 @@ namespace OloEngine
 
                 if (generateMips)
                 {
-                    // Classic blit chain: mip N-1 (TRANSFER_SRC) → mip N
-                    // (TRANSFER_DST), then N becomes the next source.
-                    i32 srcW = static_cast<i32>(m_Width);
-                    i32 srcH = static_cast<i32>(m_Height);
-                    for (u32 mip = 1; mip < m_MipLevels; ++mip)
-                    {
-                        // src scope: mip 0's last write was the COPY, later
-                        // mips' the previous BLIT — cover both rather than
-                        // special-casing the first iteration.
-                        VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                                         VK_PIPELINE_STAGE_2_COPY_BIT | VK_PIPELINE_STAGE_2_BLIT_BIT,
-                                                         VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_BLIT_BIT,
-                                                         VK_ACCESS_2_TRANSFER_READ_BIT, mip - 1u, 1u);
-
-                        const i32 dstW = std::max(srcW / 2, 1);
-                        const i32 dstH = std::max(srcH / 2, 1);
-
-                        VkImageBlit blit{};
-                        blit.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip - 1u, 0u, 1u };
-                        blit.srcOffsets[1] = { srcW, srcH, 1 };
-                        blit.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip, 0u, 1u };
-                        blit.dstOffsets[1] = { dstW, dstH, 1 };
-                        vkCmdBlitImage(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, m_Image,
-                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1u, &blit, blitFilter);
-
-                        srcW = dstW;
-                        srcH = dstH;
-                    }
-
-                    // Mips [0, N-1) sit in TRANSFER_SRC, the last in
-                    // TRANSFER_DST — bring all to SHADER_READ_ONLY.
-                    VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_2_BLIT_BIT,
-                                                     VK_ACCESS_2_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
-                                                     VK_ACCESS_2_MEMORY_READ_BIT, 0u, m_MipLevels - 1u);
+                    // RecordMipChain's precondition: mip 0 in TRANSFER_SRC
+                    // holding the base image, every other mip in TRANSFER_DST.
+                    // Mip 0's last write was the COPY above; the rest are
+                    // already TRANSFER_DST from the whole-image transition.
                     VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_2_BLIT_BIT,
-                                                     VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
-                                                     VK_ACCESS_2_MEMORY_READ_BIT, m_MipLevels - 1u, 1u);
+                                                     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_2_COPY_BIT,
+                                                     VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_BLIT_BIT,
+                                                     VK_ACCESS_2_TRANSFER_READ_BIT, 0u, 1u);
+                    RecordMipChain(cmd, blitFilter);
                 }
                 else
                 {

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.h
@@ -40,7 +40,14 @@ namespace OloEngine
     class VulkanTexture2D : public Texture2D
     {
       public:
-        explicit VulkanTexture2D(const TextureSpecification& specification);
+        // `renderTargetOnly` marks a texture created purely as a framebuffer
+        // attachment — content arrives from the GPU, `SetData` is never
+        // called. Backend-internal, so it stays a constructor argument rather
+        // than a TextureSpecification field: the neutral spec is shared with
+        // the GL arm, which has no use for the distinction. Its only effect
+        // is to keep VK_IMAGE_USAGE_HOST_TRANSFER_BIT off images that can
+        // never take the host-upload route (#809 — see CreateImage).
+        explicit VulkanTexture2D(const TextureSpecification& specification, bool renderTargetOnly = false);
         // File load (#691): stbi with the SAME thread-local vertical
         // flip the GL twin uses — asset bytes must be identical across
         // backends, since UV sampling is convention-free.
@@ -120,6 +127,14 @@ namespace OloEngine
         // one). VK_NULL_HANDLE on failure.
         [[nodiscard]] VkImageView GetOrCreateAttachmentView();
 
+        // #809: how many uploads have completed through the host-image-copy
+        // route since process start. Diagnostic only — but it is the ONLY
+        // thing that distinguishes the host route from the staging one from
+        // outside, because both produce byte-identical pixels in the same
+        // final layout. A capability flag says the route is PERMITTED; this
+        // says it was TAKEN, which is what the tests need to assert on.
+        [[nodiscard]] static u64 GetHostImageCopyUploadCount();
+
       private:
         void CreateImage();
         void ReleaseImage();
@@ -127,6 +142,22 @@ namespace OloEngine
         // leaving every mip in SHADER_READ_ONLY_OPTIMAL. `data` is tightly
         // packed rows in the spec's format.
         bool UploadPixels(const void* data, u64 sizeBytes);
+        // #809: the host-image-copy arm of UploadPixels. Writes mip 0 straight
+        // from `data` with vkCopyMemoryToImage — no staging buffer — and then
+        // either finishes host-side (no mip chain: no queue submit at all) or
+        // hands an image whose mip 0 already holds the pixels to the shared
+        // blit chain below. Returns false when the host route could not be
+        // taken or failed, and the caller falls back to staging; a false
+        // return leaves the image in a discardable state, never a
+        // half-described one.
+        bool UploadPixelsFromHost(const void* data, u64 sizeBytes, VkFilter blitFilter);
+        // Records the mip-generation blit chain into `cmd`. PRECONDITION:
+        // mip 0 holds the base image in TRANSFER_SRC_OPTIMAL and mips
+        // 1..N-1 are in TRANSFER_DST_OPTIMAL (contents irrelevant).
+        // POSTCONDITION: every mip is in SHADER_READ_ONLY_OPTIMAL. Shared by
+        // the staging and host paths so the two cannot drift in their barrier
+        // scopes — the half of the upload the host route still needs a queue for.
+        void RecordMipChain(VkCommandBuffer cmd, VkFilter blitFilter) const;
 
         TextureSpecification m_Specification;
         std::string m_Path; // set by the file ctor; empty for transient/spec textures
@@ -134,6 +165,16 @@ namespace OloEngine
         u32 m_Height = 0;
         u32 m_MipLevels = 1;
         bool m_IsLoaded = false;
+        // #809: set by CreateImage when the image was actually created with
+        // VK_IMAGE_USAGE_HOST_TRANSFER_BIT. Not the same question as
+        // VulkanDevice::IsHostImageCopyEnabled — the usage bit is also gated
+        // per format and per image kind — and it must be read off the IMAGE
+        // rather than re-derived, because a host copy into an image that
+        // lacks the usage bit is invalid usage, not a slow path.
+        bool m_HostTransferUsage = false;
+        // See the constructor: true for framebuffer attachments, which never
+        // take a client-data upload and so must not carry the usage bit.
+        bool m_RenderTargetOnly = false;
 
         VkImage m_Image = VK_NULL_HANDLE;
         VmaAllocation m_Allocation = VK_NULL_HANDLE;

--- a/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
@@ -49,6 +49,7 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #include "Platform/Vulkan/VulkanDevice.h"
 #include "Platform/Vulkan/VulkanFrameArena.h"
 #include "Platform/Vulkan/VulkanResourceHeap.h"
+#include "Platform/Vulkan/VulkanTexture.h" // GetHostImageCopyUploadCount (#809)
 #include "Platform/Vulkan/VulkanTransientResources.h"
 
 #include <volk.h>
@@ -326,6 +327,229 @@ TEST_F(VulkanResourceFactory, MipChainGeneratesAndReadsBack)
     ASSERT_EQ(mip2.size(), sizet{ 2 * 2 * 4 });
     for (const u8 byte : mip2)
         EXPECT_EQ(byte, 0x80u);
+}
+
+// --- #809: the Vulkan 1.4 conveniences ------------------------------------
+//
+// The two upload tests above are ALREADY the host-image-copy path's functional
+// coverage on a machine that has it: UploadPixels prefers vkCopyMemoryToImage
+// whenever the device enabled hostImageCopy and the format allows the usage
+// bit, so a round-trip that still matches (with the fixture's zero-validation-
+// errors assertion) is the route working. What those tests cannot state is the
+// GATE — whether the route was taken for the right reason, and whether it
+// declines coherently when it is unavailable. That is what these pin.
+
+TEST_F(VulkanResourceFactory, HostImageCopyGateIsSelfConsistent)
+{
+    // The spec guarantees VK_IMAGE_LAYOUT_GENERAL in BOTH host-copy layout
+    // lists. The whole host upload path is built on that guarantee (it is the
+    // only layout it copies into without asking first), so a driver or a
+    // two-call query bug that loses it must fail here rather than as a VUID
+    // buried in an asset load.
+    if (!m_Device->IsHostImageCopyEnabled())
+    {
+        // Not a skip: the DISABLED direction is a real contract too — every
+        // per-format and per-layout answer must be a hard no, so no caller can
+        // reach vkCopyMemoryToImage through a stale yes.
+        EXPECT_FALSE(m_Device->SupportsHostImageCopyForFormat(VK_FORMAT_R8G8B8A8_UNORM));
+        EXPECT_FALSE(m_Device->IsHostCopySrcLayoutSupported(VK_IMAGE_LAYOUT_GENERAL));
+        EXPECT_FALSE(m_Device->IsHostCopyDstLayoutSupported(VK_IMAGE_LAYOUT_GENERAL));
+        GTEST_SUCCEED() << "host image copy unavailable — every upload takes the staging path";
+        return;
+    }
+
+    EXPECT_TRUE(m_Device->IsHostCopySrcLayoutSupported(VK_IMAGE_LAYOUT_GENERAL))
+        << "VK_IMAGE_LAYOUT_GENERAL is spec-guaranteed in pCopySrcLayouts";
+    EXPECT_TRUE(m_Device->IsHostCopyDstLayoutSupported(VK_IMAGE_LAYOUT_GENERAL))
+        << "VK_IMAGE_LAYOUT_GENERAL is spec-guaranteed in pCopyDstLayouts";
+    EXPECT_TRUE(m_Device->IsHostTransitionTargetSupported(VK_IMAGE_LAYOUT_GENERAL));
+
+    // The per-format answer is memoized behind a lock; a second call must
+    // agree with the first (a memo that keys on the wrong thing shows up as
+    // an answer that changes).
+    const bool first = m_Device->SupportsHostImageCopyForFormat(VK_FORMAT_R8G8B8A8_UNORM);
+    EXPECT_EQ(m_Device->SupportsHostImageCopyForFormat(VK_FORMAT_R8G8B8A8_UNORM), first);
+}
+
+TEST_F(VulkanResourceFactory, HostImageCopyRouteIsActuallyTakenNotJustPermitted)
+{
+    // The load-bearing test of #809. Every other upload test here passes
+    // identically whether the host route ran or silently declined to staging —
+    // same pixels, same final layout — so a decline would look exactly like
+    // success. The counter is the only outside-visible difference, and this is
+    // what would catch the host path being permitted but never entered.
+    if (!m_Device->IsHostImageCopyEnabled())
+    {
+        GTEST_SKIP() << "host image copy unavailable — every upload legitimately takes the staging path";
+    }
+
+    ScopedVulkanApiSelection vulkanApi;
+
+    const u64 before = VulkanTexture2D::GetHostImageCopyUploadCount();
+
+    TextureSpecification spec;
+    spec.Width = 4;
+    spec.Height = 4;
+    spec.Format = ImageFormat::RGBA8;
+    spec.GenerateMips = false;
+
+    auto texture = Texture2D::Create(spec);
+    ASSERT_NE(texture, nullptr);
+
+    std::vector<u8> pixels(4 * 4 * 4);
+    for (sizet i = 0; i < pixels.size(); ++i)
+        pixels[i] = static_cast<u8>(i * 5 + 1);
+    texture->SetData(pixels.data(), static_cast<u32>(pixels.size()));
+
+    EXPECT_GT(VulkanTexture2D::GetHostImageCopyUploadCount(), before)
+        << "an un-mipped RGBA8 upload on a host-image-copy device must take the host route "
+           "(no staging buffer, no queue submit), not fall back to staging";
+
+    // ...and the pixels must still be right, which is what makes the counter
+    // an assertion about a working route rather than about a code path.
+    std::vector<u8> readback;
+    ASSERT_TRUE(texture->GetData(readback, 0));
+    ASSERT_EQ(readback.size(), pixels.size());
+    EXPECT_EQ(std::memcmp(readback.data(), pixels.data(), pixels.size()), 0);
+
+    // ...and a RE-upload of the same texture must NOT take it. A host copy
+    // executes on the CPU with no queue ordering and no fence, so an image an
+    // already-submitted frame may still be sampling has to keep the command
+    // path — which is what confines the route to load time. This is the
+    // assertion that would catch the per-frame re-uploaders
+    // (VideoTexture::UpdateFrame, OceanFFTField::Upload) being handed a
+    // racy upload.
+    const u64 afterFirst = VulkanTexture2D::GetHostImageCopyUploadCount();
+    for (sizet i = 0; i < pixels.size(); ++i)
+        pixels[i] = static_cast<u8>(255 - pixels[i]);
+    texture->SetData(pixels.data(), static_cast<u32>(pixels.size()));
+
+    EXPECT_EQ(VulkanTexture2D::GetHostImageCopyUploadCount(), afterFirst)
+        << "a re-upload of a live texture must stay on the staging/command path";
+
+    std::vector<u8> reReadback;
+    ASSERT_TRUE(texture->GetData(reReadback, 0));
+    ASSERT_EQ(reReadback.size(), pixels.size());
+    EXPECT_EQ(std::memcmp(reReadback.data(), pixels.data(), pixels.size()), 0)
+        << "the staging fallback must still land the new pixels";
+}
+
+TEST_F(VulkanResourceFactory, HostUploadOfAMippedWidenedTextureRoundTrips)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    // The combination the host route's own arm has to get right: a 3-channel
+    // engine format (so the client data is CPU-widened before the host copy
+    // sees it) WITH a mip chain (so mip 0 arrives from the host and the blit
+    // ladder still runs on the queue, starting from a host-written mip 0 in
+    // GENERAL rather than a device-written one in TRANSFER_DST).
+    TextureSpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Format = ImageFormat::RGB8;
+    spec.GenerateMips = true;
+
+    const u64 hostUploadsBefore = VulkanTexture2D::GetHostImageCopyUploadCount();
+
+    auto texture = Texture2D::Create(spec);
+    ASSERT_NE(texture, nullptr);
+    ASSERT_EQ(texture->GetMipLevelCount(), 4u);
+
+    // Constant colour again: every mip of a constant image is that constant,
+    // so no filtering math enters the assertion.
+    std::vector<u8> rgb(8 * 8 * 3);
+    for (sizet pixel = 0; pixel < 8 * 8; ++pixel)
+    {
+        rgb[pixel * 3 + 0] = 0x20;
+        rgb[pixel * 3 + 1] = 0x40;
+        rgb[pixel * 3 + 2] = 0x60;
+    }
+    texture->SetData(rgb.data(), static_cast<u32>(rgb.size()));
+
+    if (m_Device->IsHostImageCopyEnabled())
+    {
+        EXPECT_GT(VulkanTexture2D::GetHostImageCopyUploadCount(), hostUploadsBefore)
+            << "mip 0 must have arrived from the host even though the blit chain still submits";
+    }
+
+    std::vector<u8> mip0;
+    ASSERT_TRUE(texture->GetData(mip0, 0));
+    ASSERT_EQ(mip0.size(), sizet{ 8 * 8 * 4 });
+    for (sizet pixel = 0; pixel < 8 * 8; ++pixel)
+    {
+        EXPECT_EQ(mip0[pixel * 4 + 0], 0x20u);
+        EXPECT_EQ(mip0[pixel * 4 + 1], 0x40u);
+        EXPECT_EQ(mip0[pixel * 4 + 2], 0x60u);
+        EXPECT_EQ(mip0[pixel * 4 + 3], 0xFFu);
+    }
+
+    // GetData names SHADER_READ_ONLY_OPTIMAL as its oldLayout, so a mip that
+    // reads back at all is also proof the upload left the image in the
+    // backend's steady-state layout — the invariant the host path declines
+    // the whole route rather than weaken.
+    std::vector<u8> mip2;
+    ASSERT_TRUE(texture->GetData(mip2, 2));
+    ASSERT_EQ(mip2.size(), sizet{ 2 * 2 * 4 });
+    for (sizet pixel = 0; pixel < 2 * 2; ++pixel)
+    {
+        EXPECT_EQ(mip2[pixel * 4 + 0], 0x20u);
+        EXPECT_EQ(mip2[pixel * 4 + 1], 0x40u);
+        EXPECT_EQ(mip2[pixel * 4 + 2], 0x60u);
+        EXPECT_EQ(mip2[pixel * 4 + 3], 0xFFu);
+    }
+}
+
+TEST_F(VulkanResourceFactory, HostUploadedTextureStillAcceptsASubImageUpdate)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    // SubImage deliberately stayed on the staging path (#809 scopes the host
+    // route to the full load-time upload). It reads the image's recorded
+    // layout back as its barrier's oldLayout, so this is the test that would
+    // fail if the host upload ever left the image somewhere else.
+    TextureSpecification spec;
+    spec.Width = 4;
+    spec.Height = 4;
+    spec.Format = ImageFormat::RGBA8;
+    spec.GenerateMips = false;
+
+    auto texture = Texture2D::Create(spec);
+    ASSERT_NE(texture, nullptr);
+
+    std::vector<u8> pixels(4 * 4 * 4, 0x11);
+    texture->SetData(pixels.data(), static_cast<u32>(pixels.size()));
+
+    const u8 patch[2 * 2 * 4] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD,
+                                  0xAA, 0xBB, 0xCC, 0xDD, 0xAA, 0xBB, 0xCC, 0xDD };
+    texture->SubImage(1u, 1u, 2u, 2u, patch, sizeof(patch));
+
+    std::vector<u8> readback;
+    ASSERT_TRUE(texture->GetData(readback, 0));
+    ASSERT_EQ(readback.size(), pixels.size());
+    // The patched 2x2 block, and one untouched texel to prove the update was
+    // partial rather than a full overwrite.
+    const sizet patchedTexel = (1u * 4u + 1u) * 4u;
+    EXPECT_EQ(readback[patchedTexel + 0], 0xAAu);
+    EXPECT_EQ(readback[patchedTexel + 3], 0xDDu);
+    EXPECT_EQ(readback[0], 0x11u);
+}
+
+TEST_F(VulkanResourceFactory, Maintenance5IsEnabledOnAContractSatisfyingDevice)
+{
+    // maintenance5 is what lets the index-buffer bind state the buffer's real
+    // byte size (amendment (9b)'s "whole buffer" sentinel resolved to a
+    // number). It is MANDATORY on a Vulkan 1.4 device, and this fixture only
+    // runs on one — so an unavailable verdict here is a real signal (a driver
+    // reporting 1.4 without it, or volk not exporting vkCmdBindIndexBuffer2),
+    // not a machine to skip past. Reported rather than asserted: the backend
+    // degrades to the implicit whole-buffer bind, it does not break.
+    if (!m_Device->IsMaintenance5Enabled())
+    {
+        GTEST_SUCCEED() << "maintenance5 unavailable on a 1.4 device — index binds fall back to "
+                           "vkCmdBindIndexBuffer (implicit whole-buffer extent)";
+        return;
+    }
+    SUCCEED();
 }
 
 TEST_F(VulkanResourceFactory, DescriptorSlotCacheKeysViewsAndRecyclesOnDestroy)

--- a/docs/adr/0011-amendments.md
+++ b/docs/adr/0011-amendments.md
@@ -2097,3 +2097,137 @@ that is obviously backend-specific; it is the one whose sentinel value is
   *renderer* backend is skipped (amendment (88), consequence 3). That is a
   shield, not a fix, and it becomes real the day that backend is enabled.
 
+## Amendments from issue #809 (2026-08-24) — the Vulkan 1.4 conveniences
+
+### (91) A core-promoted feature is still OFF, still optional in practice, and its layout lists are a driver property
+
+`VkPhysicalDeviceVulkan14Features` is now in the device chain, carrying
+`hostImageCopy` and `maintenance5`. Three things that adopting it settled, in
+the order they bite.
+
+**The (51) sweep is a step, not a guess.** The moment a `VulkanXYFeatures`
+aggregate joins the chain, every standalone struct already in it has to be
+checked against what that version promoted
+(VUID-VkDeviceCreateInfo-pNext-02830 rejects both spellings at once). Done
+here and recorded: `VK_EXT_descriptor_heap`,
+`VK_KHR_shader_untyped_pointers`, `VK_EXT_extended_dynamic_state3`,
+`VK_EXT_device_fault` and `VK_EXT_mesh_shader` are all post-1.4 or
+never-promoted, so nothing folded in and all five stay standalone. The
+maintenance burden is the *next* one: a feature 1.4 promoted that arrives as a
+standalone struct must move into `vulkan14Features`, and the failure is a
+rejected device creation, not a warning.
+
+**"Required by Vulkan 1.4" is a claim about the spec, not about this driver.**
+`hostImageCopy` and `maintenance5` are both mandatory at the ADR 0010 floor, so
+the temptation is to treat `apiVersion >= 1.4` as the gate. Every use site
+gates on a `vkGetPhysicalDeviceFeatures2` probe instead, **and** on the volk
+pointer being non-null — a device that reports 1.4 without the feature, or a
+loader/layer that does not export the entry point, would otherwise reach a
+null function pointer rather than a slow path. This is the same shape as
+`synchronization2`/`dynamicRendering` in amendment (51): core-promoted and
+mandatory still means **default OFF at device creation**, so the bit has to be
+asked for explicitly.
+
+**`maintenance6` is deliberately NOT enabled.** Nothing in the backend consumes
+any of its relaxations, and an unused feature bit is dead weight the validation
+layer still has to reason about — the same rule the EDS3 and mesh-shader bits
+already follow. The issue named maintenance5/6 as a pair; only the half with a
+consumer shipped.
+
+**Host image copy has THREE gates, and only one of them is device-wide.** The
+feature bit says the device can do it. `VK_IMAGE_USAGE_HOST_TRANSFER_BIT` may
+only go on an image whose format advertises
+`VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT` at that tiling
+(VUID-VkImageCreateInfo-usage-10245) — a per-format question, answered through
+`VkFormatProperties3` because the bit lives above bit 31 and the 32-bit
+`VkFormatProperties` word cannot carry it. And the copy's layouts are a
+**driver property**: `VkPhysicalDeviceHostImageCopyProperties` publishes
+`pCopySrcLayouts` / `pCopyDstLayouts`, of which only
+`VK_IMAGE_LAYOUT_GENERAL` is spec-guaranteed to be in both, and an
+implementation may report `VK_IMAGE_LAYOUT_MAX_ENUM` to mean "all of them".
+So the upload copies into `GENERAL` unconditionally and *asks* before doing
+anything else.
+
+**The steady-state layout is what decides whether the route may be taken at
+all.** The backend's invariant is that sampled asset content sits in
+`SHADER_READ_ONLY_OPTIMAL` between graph executions — `GetData` and
+`SubImage` both name it as their barrier's `oldLayout` and would be invalid
+usage against anything else. A host upload that finished in `GENERAL` would
+sample correctly and silently break those two, which is why a driver that
+cannot host-transition to `SHADER_READ_ONLY_OPTIMAL` declines the entire host
+route instead of weakening the invariant. **A fast path that quietly changes a
+resource's resting state is not a fast path; it is a second contract.**
+
+**What actually left the command stream, and what did not.** For a texture with
+no mip chain the upload is now host-only: no staging buffer, no command
+buffer, no submit — and therefore nothing for amendment (72)'s
+"one-shot submits are ordered BEFORE the still-recording frame" to order.
+Mip generation is a **blit**, which has no host form, so a mipped upload still
+submits — it just submits a blit chain whose base level arrived from the host.
+The two paths share one `RecordMipChain` so their barrier ladders cannot
+drift; they differ only in how mip 0 got its pixels and which layout it starts
+from. `SubImage` deliberately stayed on the staging path: it is a partial
+update with a mid-frame arm of its own, and #809 scopes the host route to the
+load-time upload.
+
+**"Load-time" has to be ENFORCED, and one check is not enough.** The host
+commands execute on the CPU the instant they are called — no queue ordering,
+no fence — so "which uploads may take this route" is a correctness question,
+not a policy one. It takes two checks, and the second is the one a review
+caught missing:
+
+- **No frame may be recording.** The staging path's one-shot submit is at
+  least ordered against the queue; a host write to an image the recording
+  frame will sample is ordered against nothing. `SubImage` already applied
+  this guard to its mid-frame arm — the new route did not, and inherited
+  nothing from it.
+- **It must be the image's FIRST upload.** "No frame is recording" says
+  nothing about frames already *submitted*, and a re-upload targets an image
+  the renderer has been using. The registry's `InitialLayout` is exactly that
+  record — `VK_IMAGE_LAYOUT_UNDEFINED` until an upload publishes content — so
+  a freshly created or freshly `Resize()`d image is distinguishable from a
+  live one without inventing new state. This is what keeps the per-frame
+  re-uploaders (`VideoTexture::UpdateFrame`, `OceanFFTField::Upload`) on the
+  command path; without it, `SetData` on a live video texture would have been
+  an unsynchronised CPU write to an image the GPU was reading.
+
+The generalisable form: **a fast path that skips the queue inherits none of
+the queue's ordering guarantees, so every caller the old path tolerated has to
+be re-qualified individually.** The capability gate says the route is legal;
+it says nothing about whether this particular call is safe to take it.
+
+**The usage bit would land on images that can never use it, and the driver
+property is the wrong lever to fix that with.** Nothing in
+`TextureSpecification` distinguishes an asset texture from a framebuffer
+attachment — `VulkanFramebuffer` builds its attachments from a plain spec — so
+`VK_IMAGE_USAGE_HOST_TRANSFER_BIT` would go on every render target, on every
+resize, for a route they can never take. That is not free:
+`VkPhysicalDeviceHostImageCopyProperties::identicalMemoryTypeRequirements` is
+**`VK_FALSE` on NVIDIA** (measured on the RTX 4090 this backend is developed
+against), so the bit may change those images' memory type requirements.
+
+Gating the feature on that property was tried and is **wrong**: it declines
+host image copy outright on exactly the hardware it was built for — a
+"safe default" that silently deletes the feature. The lever that works is the
+one that knows what the texture is *for*: `VulkanTexture2D` takes a
+backend-internal `renderTargetOnly` constructor flag, `VulkanFramebuffer`
+passes it for every attachment, and the usage bit follows. It stays a
+constructor argument rather than a `TextureSpecification` field because the
+neutral spec is shared with the GL arm, which has no use for the distinction.
+
+The general shape: **when a capability costs something on resources that
+cannot use it, narrow by what the resource is FOR, not by the device property
+that measures the cost.** The property tells you the cost is real; it cannot
+tell you which resources are paying it for nothing.
+
+**maintenance5's index bind states a size the facade already knew.** Amendment
+(9b)'s `DrawIndexed(va, 0)` "whole buffer" sentinel was resolved at the draw
+sites to `indexBuffer->GetCount()`; the *bind* still said "whole buffer"
+implicitly. `vkCmdBindIndexBuffer2` states the real byte extent, so a draw
+whose count overruns the buffer is now a validation error naming the bind
+rather than an out-of-bounds index fetch that renders garbage. The bind cache
+stays keyed on the `VkBuffer` alone — `VulkanIndexBuffer`'s count is fixed at
+construction, so a different element count is necessarily a different buffer.
+
+Narrative, and the gate's test shape:
+[rhi-abstraction-boundary.md](../agent-rules/rhi-abstraction-boundary.md) §16.

--- a/docs/adr/0011-amendments.md
+++ b/docs/adr/0011-amendments.md
@@ -2143,10 +2143,19 @@ only go on an image whose format advertises
 `VkFormatProperties` word cannot carry it. And the copy's layouts are a
 **driver property**: `VkPhysicalDeviceHostImageCopyProperties` publishes
 `pCopySrcLayouts` / `pCopyDstLayouts`, of which only
-`VK_IMAGE_LAYOUT_GENERAL` is spec-guaranteed to be in both, and an
-implementation may report `VK_IMAGE_LAYOUT_MAX_ENUM` to mean "all of them".
-So the upload copies into `GENERAL` unconditionally and *asks* before doing
+`VK_IMAGE_LAYOUT_GENERAL` is spec-guaranteed to be in both. Membership is
+exact — the lists enumerate supported layouts and carry no wildcard entry. So
+the upload copies into `GENERAL` unconditionally and *asks* before doing
 anything else.
+
+**And the two lists are not interchangeable.**
+`vkTransitionImageLayout`'s `newLayout` must be in **`pCopyDstLayouts`**
+(VUID-VkHostImageLayoutTransitionInfo-newLayout-09057), not in either list.
+A layout that appears only in `pCopySrcLayouts` is a legal copy *source* and
+an illegal transition *target*, and on a driver whose two lists happen to
+match — which is every driver this was developed against — treating them as
+one would work perfectly and be wrong. Both facts here were checked against
+the SDK's `validusage.json` rather than recalled.
 
 **The steady-state layout is what decides whether the route may be taken at
 all.** The backend's invariant is that sampled asset content sits in
@@ -2230,4 +2239,4 @@ stays keyed on the `VkBuffer` alone — `VulkanIndexBuffer`'s count is fixed at
 construction, so a different element count is necessarily a different buffer.
 
 Narrative, and the gate's test shape:
-[rhi-abstraction-boundary.md](../agent-rules/rhi-abstraction-boundary.md) §16.
+[rhi-abstraction-boundary.md](../agent-rules/rhi-abstraction-boundary.md) §17.

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -3166,7 +3166,7 @@ resource's lifetime changes — which is the frame nobody tests.
 
 ---
 
-## 16. Vulkan 1.4 conveniences (#809): a core feature is not a free feature
+## 17. Vulkan 1.4 conveniences (#809): a core feature is not a free feature
 
 ADR 0011 amendment (91) carries the decisions. This is the part a future
 "adopt the next core-promoted thing" pass would otherwise rediscover.
@@ -3208,8 +3208,11 @@ assumes sampled content rests in `SHADER_READ_ONLY_OPTIMAL` — `GetData` and
 names the wrong old layout is invalid usage whose visible symptom is
 *discarded pixels*, not an error. But the host transition's legal target
 layouts are a **driver property** (`pCopySrcLayouts` / `pCopyDstLayouts`,
-possibly spelled `VK_IMAGE_LAYOUT_MAX_ENUM` for "all"), and only
-`VK_IMAGE_LAYOUT_GENERAL` is guaranteed to be in either list.
+exact membership, no wildcard entry), and only `VK_IMAGE_LAYOUT_GENERAL` is
+guaranteed to be in either list. The two lists are also not interchangeable:
+a transition's `newLayout` must be in the **destination** list
+(VUID-VkHostImageLayoutTransitionInfo-newLayout-09057), even though every
+driver at hand reports identical lists and would hide the difference.
 
 So the host route asks first and **declines the whole route** when it cannot
 finish in the layout the rest of the backend expects. Leaving the image in

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -3163,3 +3163,114 @@ who could have recorded the draw.
 in the queue*. If one field serves both "after what I am recording" and "right
 now", the two agree on every steady frame and disagree on the first frame a
 resource's lifetime changes — which is the frame nobody tests.
+
+---
+
+## 16. Vulkan 1.4 conveniences (#809): a core feature is not a free feature
+
+ADR 0011 amendment (91) carries the decisions. This is the part a future
+"adopt the next core-promoted thing" pass would otherwise rediscover.
+
+### The three questions a promoted feature still owes you
+
+The device has targeted Vulkan 1.4 since the port, so `hostImageCopy` and
+`maintenance5` look like they should just be *available*. Each is a separate
+question, and answering only the first is how you get a null function pointer:
+
+1. **Is the feature supported?** `vkGetPhysicalDeviceFeatures2` with
+   `VkPhysicalDeviceVulkan14Features` chained. "Mandatory at this API version"
+   is a statement about the spec; the probe is a statement about the machine.
+2. **Was it enabled?** Core-promoted features default **OFF** at device
+   creation. This has now bitten four times in this backend
+   (`synchronization2`, `dynamicRendering`, `maintenance4`, and these two), and
+   the symptom differs every time — a validation flood, a module-creation
+   refusal, or nothing at all until the one driver that does not tolerate it.
+3. **Is the entry point loaded?** volk populates a core-1.4 pointer only when
+   the loader/ICD exports it. The flags here are `wantX && vkX != nullptr` for
+   that reason, and the null check is load-bearing rather than defensive
+   decoration.
+
+And a fourth for anything image-shaped: **is it supported for THIS format?**
+`VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT` lives above bit 31, so the
+32-bit `VkFormatProperties` cannot report it — the query has to be
+`vkGetPhysicalDeviceFormatProperties2` with a chained `VkFormatProperties3`,
+and a device-level "yes" says nothing about a particular `VkFormat`.
+
+### A fast path may not change where the resource comes to rest
+
+Host image copy's win is real: a texture with no mip chain now uploads with no
+staging buffer, no command buffer and no submit, which takes an asset load out
+of amendment (72)'s ordering hazard entirely rather than managing it.
+
+The trap is the *end* of that path. Every other consumer in the backend
+assumes sampled content rests in `SHADER_READ_ONLY_OPTIMAL` — `GetData` and
+`SubImage` both name it as their barrier's `oldLayout`, and a barrier that
+names the wrong old layout is invalid usage whose visible symptom is
+*discarded pixels*, not an error. But the host transition's legal target
+layouts are a **driver property** (`pCopySrcLayouts` / `pCopyDstLayouts`,
+possibly spelled `VK_IMAGE_LAYOUT_MAX_ENUM` for "all"), and only
+`VK_IMAGE_LAYOUT_GENERAL` is guaranteed to be in either list.
+
+So the host route asks first and **declines the whole route** when it cannot
+finish in the layout the rest of the backend expects. Leaving the image in
+`GENERAL` would have sampled correctly, passed the upload tests, and broken
+readback and partial updates on some other driver. The general rule:
+**when adding a second way to produce a resource, enumerate what the FIRST way
+guaranteed about the resource's resting state, and either reproduce it exactly
+or refuse.**
+
+### A route that skips the queue must re-qualify every caller
+
+The capability gate answers "is this route legal on this device?". It does not
+answer "is this *call* safe to take it?", and the two are different questions
+because `vkTransitionImageLayout` / `vkCopyMemoryToImage` execute on the CPU
+the instant they are called — no queue ordering, no fence.
+
+`Texture2D::SetData` has callers the words "load-time asset upload" do not
+describe: `VideoTexture::UpdateFrame` runs per video frame and
+`OceanFFTField::Upload` per tick, both re-uploading a texture the renderer is
+actively sampling. On the staging path that was fine — the one-shot submit is
+queue-ordered. On the host path it is an unsynchronised CPU write to an image
+the GPU is reading, and nothing about the *device capability* hints at it.
+
+Two checks confine the route, and the second is the non-obvious one:
+
+- **no frame is recording** — the guard `SubImage`'s mid-frame arm already
+  had, which the new route inherited nothing from; and
+- **this is the image's first upload** — because "no frame is recording" says
+  nothing about frames already *submitted*. `VulkanImageInfoRegistry`'s
+  `InitialLayout` is already exactly that record (`UNDEFINED` until an upload
+  publishes content), so no new state had to be invented to ask it.
+
+The rule: **when you add a faster path beside an existing one, enumerate the
+existing path's CALLERS, not just its preconditions.** The old path's queue
+ordering was doing work for callers nobody had written down.
+
+### Where the queue is still needed, and why the ladder got extracted
+
+Mip generation is `vkCmdBlitImage`, which has no host form. A mipped upload
+therefore still submits — a blit chain whose base level arrived from the host,
+starting from `GENERAL` instead of `TRANSFER_DST`. That is two paths through
+the same barrier ladder, which is the two-mirrors shape this repo has a doc
+genre about, so the ladder is one `RecordMipChain` with a stated precondition
+(mip 0 in `TRANSFER_SRC` holding the base image, the rest in `TRANSFER_DST`)
+and each caller establishes it its own way.
+
+Worth stating plainly because it bounds the win: with `GenerateMips` defaulting
+to true, **most** file-loaded textures still submit. What the host path removes
+for them is the staging buffer and its memcpy, not the submit. The
+no-submit-at-all case is the un-mipped texture.
+
+### Testing a capability gate that is always ON where you can run it
+
+Every machine that can run these tests has host image copy, so a test that
+only exercises the enabled arm cannot see a broken disabled arm. The fixture's
+gate test asserts **both** directions off one branch: enabled ⇒ the
+spec-guaranteed `GENERAL` entries are present in both layout lists and the
+per-format memo is stable; disabled ⇒ every per-format and per-layout answer
+is a hard no, so nothing can reach `vkCopyMemoryToImage` through a stale yes.
+The functional coverage is the ordinary upload round-trips — they take the
+host route silently on a machine that has it, and the fixture's
+zero-validation-errors assertion is what makes "it round-tripped" mean
+"it round-tripped legally".
+


### PR DESCRIPTION
The device has targeted Vulkan 1.4 since the port (ADR 0010's floor), but the backend only used what #691 needed. This adopts the two core-1.4 features the issue names, and records the decisions as ADR 0011 amendment (91).

## Host image copy — the load-time upload leaves the command stream

`VulkanTexture2D::UploadPixels` now prefers `vkCopyMemoryToImage`. For a texture with **no mip chain** the whole upload happens on the host: no staging buffer, no command buffer, no submit — so there is nothing left for amendment (72)'s *"one-shot submits are ordered BEFORE the still-recording frame"* to order. That hazard is removed for those uploads rather than managed.

Mip generation is a **blit**, which has no host form, so a mipped upload still submits — it just submits a blit chain whose base level arrived from the host. Both routes now share one `RecordMipChain` with a stated precondition, so their barrier ladders cannot drift.

**The route is confined to load time by two checks, not by intent.** The host commands execute on the CPU the instant they are called — no queue ordering, no fence — so this is a correctness question:

- **no frame may be recording** (the guard `SubImage`'s mid-frame arm already had), and
- **it must be the image's first upload** — because "no frame is recording" says nothing about frames already *submitted*. `VulkanImageInfoRegistry::InitialLayout` is already exactly that record, so nothing new had to be invented. This is what keeps `VideoTexture::UpdateFrame` (per video frame) and `OceanFFTField::Upload` (per tick) on the command path.

**Three capability gates, only one of them device-wide:** the `hostImageCopy` feature bit, the per-format `VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT` (queried through `VkFormatProperties3` — the bit is above bit 31, so the 32-bit `VkFormatProperties` cannot report it), and the driver's `pCopySrcLayouts` / `pCopyDstLayouts`, of which only `VK_IMAGE_LAYOUT_GENERAL` is spec-guaranteed. The route **declines entirely** if it cannot finish in `SHADER_READ_ONLY_OPTIMAL`, because `GetData` and `SubImage` both name that as their barrier's `oldLayout` — a fast path that quietly changes a resource's resting state is a second contract, not a fast path.

`VK_IMAGE_USAGE_HOST_TRANSFER_BIT` is kept **off framebuffer attachments** via a backend-internal `renderTargetOnly` constructor flag. This matters: `identicalMemoryTypeRequirements` is **`VK_FALSE` on NVIDIA** (measured on this RTX 4090), so the bit may change memory type requirements — and every render target would have paid it, on every resize, for a route it can never take. Gating the *feature* on that property was tried and is wrong: it disables host image copy outright on exactly the hardware it was built for.

## maintenance5 — the index bind states a size it already knew

`vkCmdBindIndexBuffer2` with the buffer's real byte extent. Amendment (9b)'s `DrawIndexed(va, 0)` "whole buffer" sentinel was already resolved to `GetCount()` at the draw sites; the *bind* still said "whole buffer" implicitly. Now an overrunning draw is a validation error naming the bind instead of an out-of-bounds index fetch that renders garbage.

**maintenance6 is deliberately not enabled** — nothing in the backend consumes any of its relaxations, and an unused feature bit is dead weight the validation layer still has to reason about (the rule the EDS3 and mesh-shader bits already follow). The issue named the pair; only the half with a consumer shipped.

## Amendment (51) sweep

`VkPhysicalDeviceVulkan14Features` joins the device chain, so every standalone struct already in it was checked against what 1.4 promoted. Nothing folded — `VK_EXT_descriptor_heap`, `VK_KHR_shader_untyped_pointers`, `VK_EXT_extended_dynamic_state3`, `VK_EXT_device_fault` and `VK_EXT_mesh_shader` are all post-1.4 or never-promoted. Recorded so the *next* promoted feature is known to belong inside the struct.

## A bisect lever

`OLO_VULKAN_NO_HOST_IMAGE_COPY=1` forces every upload back to staging — same genre as `OLO_GAMEPLAY_SCHEDULER_SEQUENTIAL`. Kept permanently because the host route changes *when* an upload happens relative to the queue, and that class of difference is otherwise only answerable by rebuilding the backend. It is what attributed the pre-existing VUIDs below.

---

## Review guide

**Where I'd look hardest**

1. `OloEngine/src/Platform/Vulkan/VulkanTexture.cpp` — the `firstUpload && !frameRecording` gate in `UploadPixels`. This is the correctness core: it is what makes "load-time only" true rather than aspirational. Its first version had only the recording check, which left `VideoTexture`/`OceanFFTField` doing unsynchronised CPU writes to live images. If either condition is too weak, the failure is a race that no test on an idle machine will show.
2. `OloEngine/src/Platform/Vulkan/VulkanTexture.cpp` — `RecordMipChain`'s extraction. It moved mip 0's `TRANSFER_DST→TRANSFER_SRC` transition out to each caller and moved the per-mip transition to *after* the blit. I believe it is barrier-for-barrier equivalent to the old inline ladder, but it is the change most likely to be subtly wrong in a way only sync validation catches.
3. `OloEngine/src/Platform/Vulkan/VulkanDevice.cpp` — the two-call `VkPhysicalDeviceHostImageCopyProperties` query and the `VK_IMAGE_LAYOUT_MAX_ENUM` wildcard handling. A wrong answer here silently changes which layouts the host path believes it may use.

**What I verified, and how**

- **Full suite green: 6584 passed, exit 0** (`OloEngine-Tests.exe`, `build-cached` Debug), run after the review fixes.
- **All 108 Vulkan tests pass** (`--gtest_filter='Vulkan*:*Vulkan*'`), including the 50-test `VulkanPassSuite` and `VulkanDrawPath` which exercises the new index bind. The `VulkanResourceFactory` fixture asserts **zero validation errors in TearDown**, sync validation included — so "it round-tripped" means "it round-tripped legally".
- **The host route is proven *taken*, not merely permitted.** `VulkanTexture2D::GetHostImageCopyUploadCount()` exists because both routes produce byte-identical pixels in the same layout, so no pixel assertion can tell them apart. `HostImageCopyRouteIsActuallyTakenNotJustPermitted` asserts the counter advances on a first upload **and does not advance on a re-upload** — the latter is the assertion that would catch the race in finding 1 coming back.
- **New tests:** `HostImageCopyGateIsSelfConsistent` (asserts both the enabled and disabled directions off one branch, since every machine that can run these has the feature), `HostUploadOfAMippedWidenedTextureRoundTrips` (RGB8→RGBA8 widening *plus* a mip chain — the combination the host arm has to get right), `HostUploadedTextureStillAcceptsASubImageUpdate`, `Maintenance5IsEnabledOnAContractSatisfyingDevice`.
- **Live editor on `--rhi=vulkan`** (RTX 4090, driver 610.88, device API 1.4.341): log confirms `host image copy enabled … maintenance5 enabled`. `MaterialSpheres.olo` renders correctly — full PBR sphere grid with IBL reflections and a legible environment map (picture frames, sofa, patterned floor visible in the reflections), which is textured content sampling correctly through the host-upload path. `olo_shader_errors` returns 0.

**Least confident about**

The `VK_PIPELINE_STAGE_2_HOST_BIT` / `VK_ACCESS_2_HOST_WRITE_BIT` source scope on the mip-0 barrier in the mipped host path. `vkQueueSubmit`'s implicit host-write ordering already covers the host copy, so naming it explicitly should be redundant-but-correct rather than load-bearing — sync validation is clean and the mips read back byte-exact, but I would welcome a second read on whether that is the right spelling.

Second: the `renderTargetOnly` flag catches `VulkanFramebuffer`'s attachments, which is the large population, but any other site that creates a `VulkanTexture2D` purely as a render target still gets the usage bit. I did not audit for such sites beyond the framebuffer.

**Deliberately not tested**

- **`SubImage` was left on the staging path** — it is a partial update with a mid-frame arm of its own, and #809 scopes the host route to the load-time upload. Extending it would need the host-side layout lists to include `SHADER_READ_ONLY_OPTIMAL` as a *source*, which is not spec-guaranteed.
- **The disabled arm of every gate is untested on real hardware** — this box supports host image copy, so the "declines cleanly" paths are only covered by the gate test's assertions, not by execution.
- **Texture2DArray / Cubemap upload paths are untouched.** They are engine-internal GPU-written images, not the asset path.

## Pre-existing issue found, not introduced here

The IBL bake emits **2 image-layout validation errors** (`VUID-vkCmdDraw-None-09600`, `VkImage … expects SHADER_READ_ONLY_OPTIMAL — instead, current layout is TRANSFER_DST_OPTIMAL`, and the converse), alongside `IBLCache: Failed to read face 0 mip 0 for caching`. **These are not from this change**: an A/B on the identical binary with `OLO_VULKAN_NO_HOST_IMAGE_COPY=1` reproduces both, identically, with the host route fully off. Worth its own issue.

Closes #809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vulkan 1.4 devices can use host-image-copy for faster initial texture uploads when supported.
  * Texture uploads automatically fall back to the staging-buffer path when host copying is unavailable or unsuitable.
  * Mipmap generation and supported texture formats are handled automatically across both upload paths.
  * Added an option to disable host-image-copy behavior for troubleshooting or compatibility testing.

* **Documentation**
  * Documented Vulkan feature requirements, upload limitations, fallback behavior, and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->