### PR TITLE
feat(terrain): 3D ring-buffer chunk window for volumetric streaming

### DIFF
--- a/OloEngine/src/OloEngine/Math/Math.h
+++ b/OloEngine/src/OloEngine/Math/Math.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "OloEngine/Core/Base.h"
+
 #include <glm/glm.hpp>
 
 #include <cmath>
@@ -69,5 +71,21 @@ namespace OloEngine::Math
                 if (!std::isfinite(m[c][r]))
                     return false;
         return true;
+    }
+
+    // Euclidean modulo — `%` in C++ (and GLSL) truncates toward zero, which
+    // maps a negative value to a NEGATIVE result. Toroidal/wraparound
+    // indexing (a fixed-size ring window, a cascade lattice) needs the
+    // mathematical convention instead: the result is always in [0, modulus)
+    // for any signed input. Shared by DDGI's cascade addressing
+    // (Renderer/DDGI/DDGICommon.h — see DDGI::WrapIndex) and the terrain 3D
+    // ring-buffer chunk window (Terrain/ChunkRingBuffer3D.h): both are the
+    // same footgun (a negative storage index) on the same underlying scheme
+    // — see docs/agent-rules/ddgi-probe-cascades-and-sparsity.md §2.
+    [[nodiscard("the wrapped index is the only effect")]] inline i32 WrapIndex(i32 value, i32 modulus) noexcept
+    {
+        const i32 m = glm::max(modulus, 1);
+        const i32 r = value % m;
+        return (r < 0) ? (r + m) : r;
     }
 } // namespace OloEngine::Math

--- a/OloEngine/src/OloEngine/Renderer/DDGI/DDGICommon.h
+++ b/OloEngine/src/OloEngine/Renderer/DDGI/DDGICommon.h
@@ -20,6 +20,7 @@
 // =============================================================================
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Math/Math.h"
 
 #include <glm/glm.hpp>
 
@@ -435,12 +436,13 @@ namespace OloEngine::DDGI
     // Euclidean modulo — GLSL's `%` and C++'s both truncate toward zero, which
     // maps a negative lattice coordinate to a NEGATIVE storage index. Cascades
     // routinely go negative (the camera moves toward -x), so this is the single
-    // most load-bearing line in the toroidal scheme.
+    // most load-bearing line in the toroidal scheme. Forwards to the shared
+    // implementation in Math::WrapIndex (also used by the terrain ring-buffer
+    // chunk window) — kept as a same-named alias here so call sites in this
+    // file and DDGIMathTest.cpp don't need to change.
     [[nodiscard("the wrapped index is the only effect")]] inline i32 WrapIndex(i32 value, i32 modulus) noexcept
     {
-        const i32 m = glm::max(modulus, 1);
-        const i32 r = value % m;
-        return (r < 0) ? (r + m) : r;
+        return Math::WrapIndex(value, modulus);
     }
 
     [[nodiscard("the storage coordinate is the only effect")]] inline glm::ivec3 StorageCoordForLattice(const glm::ivec3& lattice, const glm::ivec3& dims) noexcept

--- a/OloEngine/src/OloEngine/Terrain/ChunkRingBuffer3D.h
+++ b/OloEngine/src/OloEngine/Terrain/ChunkRingBuffer3D.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Math/Math.h"
 
 #include <glm/glm.hpp>
 #include <vector>
@@ -45,24 +46,17 @@ namespace OloEngine
         }
 
       private:
-        // Euclidean modulo (never negative), so a negative chunk coordinate
-        // wraps into the same slot cycle as its positive congruents instead of
-        // producing a negative array index. `%` in C++ truncates toward zero,
-        // which is the classic footgun here — see docs/agent-rules/
-        // ddgi-probe-cascades-and-sparsity.md §2 for the same trap in a
-        // different subsystem.
-        [[nodiscard]] static i32 WrapAxis(i32 value, i32 length)
-        {
-            const i32 wrapped = value % length;
-            return wrapped < 0 ? wrapped + length : wrapped;
-        }
-
         [[nodiscard]] sizet Index(const glm::ivec3& chunkCoord) const
         {
+            // Euclidean modulo (never negative), so a negative chunk
+            // coordinate wraps into the same slot cycle as its positive
+            // congruents instead of producing a negative array index — the
+            // same footgun and the same fix as DDGI's cascade addressing
+            // (see Math::WrapIndex's doc comment).
             const i32 length = static_cast<i32>(m_SideLength);
-            const i32 x = WrapAxis(chunkCoord.x, length);
-            const i32 y = WrapAxis(chunkCoord.y, length);
-            const i32 z = WrapAxis(chunkCoord.z, length);
+            const i32 x = Math::WrapIndex(chunkCoord.x, length);
+            const i32 y = Math::WrapIndex(chunkCoord.y, length);
+            const i32 z = Math::WrapIndex(chunkCoord.z, length);
             return static_cast<sizet>(x) + static_cast<sizet>(z) * length +
                    static_cast<sizet>(y) * length * length;
         }

--- a/OloEngine/src/OloEngine/Terrain/ChunkRingBuffer3D.h
+++ b/OloEngine/src/OloEngine/Terrain/ChunkRingBuffer3D.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+
+#include <glm/glm.hpp>
+#include <vector>
+
+namespace OloEngine
+{
+    // Fixed-size cubic toroidal ring buffer, addressed by a signed 3D chunk
+    // coordinate that may be arbitrarily large or negative. Storage coordinate
+    // `s` on an axis holds whichever chunk coordinate is currently congruent to
+    // `s` modulo the side length — so moving the logical window by one chunk
+    // does not move any of the other chunks' storage slots, it just relabels
+    // which coordinate the wrapped-around slot now represents.
+    //
+    // O(1) lookup, no hashing, no per-lookup allocation: `At()` is one modulo
+    // per axis. The caller (VolumetricChunkWindow) is responsible for keeping
+    // track of which coordinates are currently valid within the window — this
+    // container is a flat array with wraparound indexing and nothing more.
+    template<typename T>
+    class ChunkRingBuffer3D
+    {
+      public:
+        explicit ChunkRingBuffer3D(u32 sideLength)
+            : m_SideLength(sideLength), m_Storage(static_cast<sizet>(sideLength) * sideLength * sideLength)
+        {
+            OLO_CORE_ASSERT(sideLength % 2 == 1,
+                            "ChunkRingBuffer3D side length must be odd to centre a window on (0,0,0)");
+            OLO_CORE_ASSERT(sideLength > 0, "ChunkRingBuffer3D side length must be positive");
+        }
+
+        [[nodiscard]] T& At(const glm::ivec3& chunkCoord)
+        {
+            return m_Storage[Index(chunkCoord)];
+        }
+        [[nodiscard]] const T& At(const glm::ivec3& chunkCoord) const
+        {
+            return m_Storage[Index(chunkCoord)];
+        }
+
+        [[nodiscard]] u32 GetSideLength() const
+        {
+            return m_SideLength;
+        }
+
+      private:
+        // Euclidean modulo (never negative), so a negative chunk coordinate
+        // wraps into the same slot cycle as its positive congruents instead of
+        // producing a negative array index. `%` in C++ truncates toward zero,
+        // which is the classic footgun here — see docs/agent-rules/
+        // ddgi-probe-cascades-and-sparsity.md §2 for the same trap in a
+        // different subsystem.
+        [[nodiscard]] static i32 WrapAxis(i32 value, i32 length)
+        {
+            const i32 wrapped = value % length;
+            return wrapped < 0 ? wrapped + length : wrapped;
+        }
+
+        [[nodiscard]] sizet Index(const glm::ivec3& chunkCoord) const
+        {
+            const i32 length = static_cast<i32>(m_SideLength);
+            const i32 x = WrapAxis(chunkCoord.x, length);
+            const i32 y = WrapAxis(chunkCoord.y, length);
+            const i32 z = WrapAxis(chunkCoord.z, length);
+            return static_cast<sizet>(x) + static_cast<sizet>(z) * length +
+                   static_cast<sizet>(y) * length * length;
+        }
+
+        u32 m_SideLength;
+        std::vector<T> m_Storage;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
+++ b/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
@@ -1,0 +1,247 @@
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Terrain/ChunkRingBuffer3D.h"
+
+#include <glm/glm.hpp>
+
+#include <functional>
+#include <utility>
+
+namespace OloEngine
+{
+    // A fixed cubic window of chunks streamed around a tracked position (#729).
+    //
+    // Built for a volumetric/voxel world, where the loaded set is a 3D
+    // neighbourhood rather than the 2D quadtree window TerrainStreamer uses for
+    // heightmap terrain (see docs/agent-rules/terrain-gpu-lod-quadtree.md — that
+    // is a different subsystem and this does not replace it). Backed by
+    // ChunkRingBuffer3D for O(1), non-hashing lookup.
+    //
+    // Rebase invariance: feed Update() a position in the SAME frame the window
+    // was built against — an anchor-relative position (trackedPosition minus
+    // some entity/anchor translation that itself shifts under
+    // Scene::RebaseOrigin) rather than the raw absolute world position. Both
+    // terms then shift by the same delta and cancel, so the window never even
+    // observes a rebase — the same fix documented for terrain streaming in
+    // docs/agent-rules/floating-origin-rebase-subsystems.md §4. Feeding an
+    // absolute or render-relative position that itself jumps across a rebase
+    // will make the window treat the rebase as a teleport (see Update()).
+    template<typename T>
+    class VolumetricChunkWindow
+    {
+      public:
+        // Returns the chunk's data, constructed at the given chunk coordinate.
+        using LoadFn = std::function<T(const glm::ivec3&)>;
+        // Called for a chunk leaving the window, before its slot is reused.
+        using UnloadFn = std::function<void(const glm::ivec3&, T&)>;
+
+        struct Config
+        {
+            f32 ChunkWorldSize = 32.0f;
+            // Window covers chunk coordinates within LoadRadius of the centre
+            // on every axis — side length 2*LoadRadius+1.
+            u32 LoadRadius = 3;
+            // Chunks within RenderRadius of the centre are surfaced by
+            // ForEachRenderableChunk; RenderRadius <= LoadRadius lets the
+            // loaded set stay ahead of what's actually drawn (loaded and
+            // rendered radii configurable independently, per the issue).
+            u32 RenderRadius = 3;
+        };
+
+        VolumetricChunkWindow(const Config& config, LoadFn loadFn, UnloadFn unloadFn = nullptr)
+            : m_Config(config), m_Load(std::move(loadFn)), m_Unload(std::move(unloadFn)),
+              m_Buffer(2 * config.LoadRadius + 1)
+        {
+            OLO_CORE_ASSERT(m_Load, "VolumetricChunkWindow requires a load callback");
+            OLO_CORE_ASSERT(config.RenderRadius <= config.LoadRadius,
+                            "RenderRadius must not exceed LoadRadius");
+        }
+
+        // Convert a world-space position to the chunk coordinate containing it.
+        // Floor division (not truncation) so negative coordinates land in the
+        // chunk on the correct side of the origin.
+        [[nodiscard]] static glm::ivec3 WorldToChunk(const glm::vec3& worldPos, f32 chunkWorldSize)
+        {
+            return glm::ivec3(static_cast<i32>(glm::floor(worldPos.x / chunkWorldSize)),
+                              static_cast<i32>(glm::floor(worldPos.y / chunkWorldSize)),
+                              static_cast<i32>(glm::floor(worldPos.z / chunkWorldSize)));
+        }
+
+        // Call once per frame/tick with the tracked position (camera, player,
+        // …) in the window's reference frame — see the rebase note above.
+        //
+        // Returns true if the window's centre chunk changed. A move of N
+        // chunks on an axis loads exactly the N newly-covered planes on that
+        // axis and drops the N vacated ones — never a full-volume rescan —
+        // UNLESS the move exceeds the window's own diameter (a teleport, where
+        // nothing in the old window overlaps the new one), in which case the
+        // whole window is rebuilt because there is no incoming plane to speak
+        // of: every slot is incoming.
+        bool Update(const glm::vec3& trackedPosition)
+        {
+            const glm::ivec3 newCentre = WorldToChunk(trackedPosition, m_Config.ChunkWorldSize);
+
+            if (!m_Initialized)
+            {
+                m_CentreChunk = newCentre;
+                m_Initialized = true;
+                Rebuild();
+                return true;
+            }
+
+            if (newCentre == m_CentreChunk)
+            {
+                return false;
+            }
+
+            const glm::ivec3 diff = newCentre - m_CentreChunk;
+            const i32 diameter = static_cast<i32>(m_Buffer.GetSideLength());
+
+            if (glm::abs(diff.x) >= diameter || glm::abs(diff.y) >= diameter || glm::abs(diff.z) >= diameter)
+            {
+                m_CentreChunk = newCentre;
+                Rebuild();
+                return true;
+            }
+
+            // Walk the move one chunk at a time per axis so each step loads
+            // exactly the plane it uncovers, whether the caller moved one
+            // chunk or several in a single tick.
+            for (i32 axis = 0; axis < 3; ++axis)
+            {
+                const i32 step = diff[axis] > 0 ? 1 : -1;
+                for (i32 moved = 0; moved != diff[axis]; moved += step)
+                {
+                    m_CentreChunk[axis] += step;
+                    LoadIncomingPlane(axis, step);
+                }
+            }
+
+            return true;
+        }
+
+        // O(1), no hashing. Only valid for coordinates within LoadRadius of the
+        // current centre on every axis; returns nullptr outside that window.
+        [[nodiscard]] const T* TryGetChunk(const glm::ivec3& chunkCoord) const
+        {
+            const Slot& slot = m_Buffer.At(chunkCoord);
+            return (slot.Loaded && slot.Coord == chunkCoord) ? &slot.Data : nullptr;
+        }
+        [[nodiscard]] T* TryGetChunk(const glm::ivec3& chunkCoord)
+        {
+            Slot& slot = m_Buffer.At(chunkCoord);
+            return (slot.Loaded && slot.Coord == chunkCoord) ? &slot.Data : nullptr;
+        }
+
+        // Visits every loaded chunk within RenderRadius of the current centre.
+        // Fn: void(const glm::ivec3& coord, const T& data)
+        template<typename Fn>
+        void ForEachRenderableChunk(Fn&& fn) const
+        {
+            const i32 r = static_cast<i32>(m_Config.RenderRadius);
+            for (i32 y = -r; y <= r; ++y)
+            {
+                for (i32 z = -r; z <= r; ++z)
+                {
+                    for (i32 x = -r; x <= r; ++x)
+                    {
+                        const glm::ivec3 coord = m_CentreChunk + glm::ivec3(x, y, z);
+                        const Slot& slot = m_Buffer.At(coord);
+                        if (slot.Loaded && slot.Coord == coord)
+                        {
+                            fn(coord, slot.Data);
+                        }
+                    }
+                }
+            }
+        }
+
+        [[nodiscard]] const glm::ivec3& GetCentreChunk() const
+        {
+            return m_CentreChunk;
+        }
+        [[nodiscard]] u32 GetLoadRadius() const
+        {
+            return m_Config.LoadRadius;
+        }
+        [[nodiscard]] u32 GetRenderRadius() const
+        {
+            return m_Config.RenderRadius;
+        }
+
+        // Reloads every chunk in the window at the current centre. Used
+        // internally for the first Update() and for a teleport; exposed so a
+        // caller can force a reload (e.g. the load callback's data source
+        // changed underneath it).
+        void Rebuild()
+        {
+            const i32 r = static_cast<i32>(m_Config.LoadRadius);
+            for (i32 y = -r; y <= r; ++y)
+            {
+                for (i32 z = -r; z <= r; ++z)
+                {
+                    for (i32 x = -r; x <= r; ++x)
+                    {
+                        const glm::ivec3 coord = m_CentreChunk + glm::ivec3(x, y, z);
+                        LoadSlot(coord);
+                    }
+                }
+            }
+        }
+
+      private:
+        struct Slot
+        {
+            bool Loaded = false;
+            glm::ivec3 Coord{ 0 };
+            T Data{};
+        };
+
+        void LoadSlot(const glm::ivec3& coord)
+        {
+            Slot& slot = m_Buffer.At(coord);
+            if (slot.Loaded && m_Unload)
+            {
+                m_Unload(slot.Coord, slot.Data);
+            }
+            slot.Data = m_Load(coord);
+            slot.Coord = coord;
+            slot.Loaded = true;
+        }
+
+        // Loads the single plane of chunks newly covered after the centre has
+        // just moved by one chunk along `axis` in direction `step` (+1/-1).
+        // The vacated plane on the opposite face is exactly what LoadSlot's
+        // wraparound overwrite evicts — the ring buffer's toroidal storage
+        // means that plane's old slots ARE the new plane's slots.
+        void LoadIncomingPlane(i32 axis, i32 step)
+        {
+            const i32 r = static_cast<i32>(m_Config.LoadRadius);
+            const i32 planeOffset = step > 0 ? r : -r;
+
+            i32 axisA = (axis + 1) % 3;
+            i32 axisB = (axis + 2) % 3;
+
+            for (i32 a = -r; a <= r; ++a)
+            {
+                for (i32 b = -r; b <= r; ++b)
+                {
+                    glm::ivec3 local(0);
+                    local[axis] = planeOffset;
+                    local[axisA] = a;
+                    local[axisB] = b;
+
+                    LoadSlot(m_CentreChunk + local);
+                }
+            }
+        }
+
+        Config m_Config;
+        LoadFn m_Load;
+        UnloadFn m_Unload;
+        ChunkRingBuffer3D<Slot> m_Buffer;
+        glm::ivec3 m_CentreChunk{ 0 };
+        bool m_Initialized = false;
+    };
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
+++ b/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "OloEngine/Core/Base.h"
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Terrain/ChunkRingBuffer3D.h"
 
 #include <glm/glm.hpp>
 
-#include <cmath>
 #include <functional>
 #include <utility>
 
@@ -71,10 +71,9 @@ namespace OloEngine
         // chunk on the correct side of the origin.
         [[nodiscard]] static glm::ivec3 WorldToChunk(const glm::vec3& worldPos, f32 chunkWorldSize)
         {
-            OLO_CORE_ASSERT(chunkWorldSize > 0.0f && std::isfinite(chunkWorldSize),
+            OLO_CORE_ASSERT(chunkWorldSize > 0.0f && Math::IsFinite(chunkWorldSize),
                             "WorldToChunk requires a positive, finite chunkWorldSize");
-            OLO_CORE_ASSERT(std::isfinite(worldPos.x) && std::isfinite(worldPos.y) && std::isfinite(worldPos.z),
-                            "WorldToChunk requires a finite worldPos");
+            OLO_CORE_ASSERT(Math::IsFinite(worldPos), "WorldToChunk requires a finite worldPos");
 
             return glm::ivec3(static_cast<i32>(glm::floor(worldPos.x / chunkWorldSize)),
                               static_cast<i32>(glm::floor(worldPos.y / chunkWorldSize)),

--- a/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
+++ b/OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h
@@ -5,6 +5,7 @@
 
 #include <glm/glm.hpp>
 
+#include <cmath>
 #include <functional>
 #include <utility>
 
@@ -49,9 +50,16 @@ namespace OloEngine
             u32 RenderRadius = 3;
         };
 
+        // (INT32_MAX - 1) / 2: the largest LoadRadius for which 2*LoadRadius+1
+        // (the ring buffer's side length) still fits in an i32 — Update()'s
+        // teleport check casts the side length to i32. A LoadRadius above this
+        // would also ask ChunkRingBuffer3D to allocate side^3 elements, which
+        // fails long before the cast does.
+        static constexpr u32 kMaxLoadRadius = 1073741823u;
+
         VolumetricChunkWindow(const Config& config, LoadFn loadFn, UnloadFn unloadFn = nullptr)
             : m_Config(config), m_Load(std::move(loadFn)), m_Unload(std::move(unloadFn)),
-              m_Buffer(2 * config.LoadRadius + 1)
+              m_Buffer(ValidatedSideLength(config.LoadRadius))
         {
             OLO_CORE_ASSERT(m_Load, "VolumetricChunkWindow requires a load callback");
             OLO_CORE_ASSERT(config.RenderRadius <= config.LoadRadius,
@@ -63,6 +71,11 @@ namespace OloEngine
         // chunk on the correct side of the origin.
         [[nodiscard]] static glm::ivec3 WorldToChunk(const glm::vec3& worldPos, f32 chunkWorldSize)
         {
+            OLO_CORE_ASSERT(chunkWorldSize > 0.0f && std::isfinite(chunkWorldSize),
+                            "WorldToChunk requires a positive, finite chunkWorldSize");
+            OLO_CORE_ASSERT(std::isfinite(worldPos.x) && std::isfinite(worldPos.y) && std::isfinite(worldPos.z),
+                            "WorldToChunk requires a finite worldPos");
+
             return glm::ivec3(static_cast<i32>(glm::floor(worldPos.x / chunkWorldSize)),
                               static_cast<i32>(glm::floor(worldPos.y / chunkWorldSize)),
                               static_cast<i32>(glm::floor(worldPos.z / chunkWorldSize)));
@@ -197,6 +210,17 @@ namespace OloEngine
             glm::ivec3 Coord{ 0 };
             T Data{};
         };
+
+        // Validates LoadRadius BEFORE the ring buffer's side length is computed
+        // or handed to ChunkRingBuffer3D — that constructor allocates side^3
+        // elements, so an unvalidated overflow here would either wrap into a
+        // tiny, wrong-sized buffer or attempt a catastrophic allocation.
+        [[nodiscard]] static u32 ValidatedSideLength(u32 loadRadius)
+        {
+            OLO_CORE_ASSERT(loadRadius <= kMaxLoadRadius,
+                            "LoadRadius exceeds the maximum safe value (2*LoadRadius+1 must fit in i32)");
+            return 2 * loadRadius + 1;
+        }
 
         void LoadSlot(const glm::ivec3& coord)
         {

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -539,6 +539,7 @@ add_executable(OloEngine-Tests
 		Terrain/TerrainGeneratorTest.cpp
 		Terrain/TerrainVirtualTextureTest.cpp
 		Terrain/VoxelGreedyMesherTest.cpp
+		Terrain/VolumetricChunkWindowTest.cpp
 		# Morph Target Tests
 		MorphTargetTest.cpp
 		# AI Behavior Tree & FSM Tests

--- a/OloEngine/tests/Terrain/VolumetricChunkWindowTest.cpp
+++ b/OloEngine/tests/Terrain/VolumetricChunkWindowTest.cpp
@@ -1,0 +1,412 @@
+// OLO_TEST_LAYER: unit
+//
+// Contract tests for the 3D ring-buffer chunk window (issue #729): O(1),
+// non-hashing lookup via ChunkRingBuffer3D, boundary crossings that load only
+// the incoming plane rather than rescanning the whole volume, and correctness
+// across a floating-origin rebase (docs/agent-rules/
+// floating-origin-rebase-subsystems.md). Pure CPU — no GL context, no scene.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "OloEngine/Terrain/ChunkRingBuffer3D.h"
+#include "OloEngine/Terrain/VolumetricChunkWindow.h"
+
+#include <set>
+#include <unordered_set>
+
+using namespace OloEngine;
+
+namespace
+{
+    struct ChunkCoordHash
+    {
+        sizet operator()(const glm::ivec3& c) const
+        {
+            sizet h = std::hash<i32>{}(c.x);
+            h = h * 31 + std::hash<i32>{}(c.y);
+            h = h * 31 + std::hash<i32>{}(c.z);
+            return h;
+        }
+    };
+
+    // Test payload: remembers which coordinate it was loaded for, so a test
+    // can assert a slot's content actually matches its coordinate rather than
+    // trusting the window's own bookkeeping.
+    struct TestChunk
+    {
+        glm::ivec3 Coord{ 0 };
+        u32 LoadOrdinal = 0;
+    };
+
+    // Counts load/unload calls and records every coordinate loaded, so tests
+    // can assert exactly which chunks a boundary crossing touched.
+    struct LoadTracker
+    {
+        u32 LoadCount = 0;
+        u32 UnloadCount = 0;
+        std::vector<glm::ivec3> LoadedCoords;
+        std::unordered_set<glm::ivec3, ChunkCoordHash> ResidentCoords;
+
+        VolumetricChunkWindow<TestChunk>::LoadFn MakeLoadFn()
+        {
+            return [this](const glm::ivec3& coord)
+            {
+                ++LoadCount;
+                LoadedCoords.push_back(coord);
+                ResidentCoords.insert(coord);
+                TestChunk chunk;
+                chunk.Coord = coord;
+                chunk.LoadOrdinal = LoadCount;
+                return chunk;
+            };
+        }
+
+        VolumetricChunkWindow<TestChunk>::UnloadFn MakeUnloadFn()
+        {
+            return [this](const glm::ivec3& coord, TestChunk& /*chunk*/)
+            {
+                ++UnloadCount;
+                ResidentCoords.erase(coord);
+            };
+        }
+    };
+
+    // Enumerate every coordinate within `radius` of `centre` on all three axes.
+    std::vector<glm::ivec3> CubeAround(const glm::ivec3& centre, i32 radius)
+    {
+        std::vector<glm::ivec3> out;
+        out.reserve(static_cast<sizet>(2 * radius + 1) * (2 * radius + 1) * (2 * radius + 1));
+        for (i32 y = -radius; y <= radius; ++y)
+            for (i32 z = -radius; z <= radius; ++z)
+                for (i32 x = -radius; x <= radius; ++x)
+                    out.push_back(centre + glm::ivec3(x, y, z));
+        return out;
+    }
+} // namespace
+
+// ============================================================================
+// ChunkRingBuffer3D — the raw toroidal container
+// ============================================================================
+
+TEST(ChunkRingBuffer3D, AtIsAConstantTimeModuloNoHashing)
+{
+    // Correctness proxy for "O(1), no hashing": distinct coordinates that are
+    // congruent modulo the side length must resolve to the SAME storage slot,
+    // and the container never does anything but arithmetic to find it.
+    ChunkRingBuffer3D<i32> buffer(5); // side length 5 -> period 5 per axis
+
+    buffer.At(glm::ivec3(0, 0, 0)) = 111;
+    EXPECT_EQ(buffer.At(glm::ivec3(5, 0, 0)), 111);
+    EXPECT_EQ(buffer.At(glm::ivec3(-5, 0, 0)), 111);
+    EXPECT_EQ(buffer.At(glm::ivec3(10, -5, 0)), 111);
+}
+
+TEST(ChunkRingBuffer3D, NegativeCoordinatesWrapCorrectlyRatherThanTruncating)
+{
+    // `%` truncates toward zero in C++; a naive `x % L` on a negative x would
+    // produce a negative index. Assert the Euclidean-wrap fixture directly, in
+    // the same spirit as DDGIMath.NegativeLatticeCoordinatesWrapIntoTheStorageWindow.
+    ChunkRingBuffer3D<i32> buffer(3);
+
+    for (i32 i = -9; i <= 9; ++i)
+    {
+        buffer.At(glm::ivec3(i, 0, 0)) = i;
+    }
+    // The last write for each residue class wins; -9..9 covers exactly 3 full
+    // periods for a side length of 3, so the final value at every coordinate
+    // congruent to `c` is whatever was written last, which is `c + 9` (the
+    // highest value in range with that residue).
+    EXPECT_EQ(buffer.At(glm::ivec3(0, 0, 0)), 9);
+    EXPECT_EQ(buffer.At(glm::ivec3(-3, 0, 0)), 9);
+    EXPECT_EQ(buffer.At(glm::ivec3(1, 0, 0)), 7);
+    EXPECT_EQ(buffer.At(glm::ivec3(-2, 0, 0)), 7);
+}
+
+// ============================================================================
+// VolumetricChunkWindow — boundary-plane loading
+// ============================================================================
+
+TEST(VolumetricChunkWindow, FirstUpdateLoadsExactlyTheInitialWindow)
+{
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 2;
+    config.RenderRadius = 2;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    EXPECT_TRUE(window.Update(glm::vec3(0.0f)));
+
+    const auto expected = CubeAround(glm::ivec3(0, 0, 0), 2);
+    EXPECT_EQ(tracker.LoadCount, expected.size());
+    for (const auto& coord : expected)
+    {
+        EXPECT_NE(window.TryGetChunk(coord), nullptr) << "missing (" << coord.x << "," << coord.y << "," << coord.z
+                                                      << ")";
+    }
+}
+
+TEST(VolumetricChunkWindow, StayingInTheSameChunkDoesNothing)
+{
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 2;
+    config.RenderRadius = 2;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f, 0.0f, 0.0f));
+    const u32 loadsAfterFirst = tracker.LoadCount;
+
+    // Still inside chunk (0,0,0) (chunk size 10, covering [0,10) on every
+    // axis) — no boundary crossed.
+    EXPECT_FALSE(window.Update(glm::vec3(3.0f, 2.0f, 4.0f)));
+    EXPECT_EQ(tracker.LoadCount, loadsAfterFirst);
+}
+
+TEST(VolumetricChunkWindow, CrossingOneAxisLoadsExactlyOnePlaneAndDropsTheOpposite)
+{
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 2;
+    config.RenderRadius = 2;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+    ASSERT_EQ(tracker.ResidentCoords.size(), 5u * 5u * 5u);
+    const u32 loadsBeforeCross = tracker.LoadCount;
+
+    // Cross +X into chunk (1,0,0): world x = 10 (chunk size 10).
+    window.Update(glm::vec3(10.5f, 0.0f, 0.0f));
+
+    const u32 loadsThisStep = tracker.LoadCount - loadsBeforeCross;
+    // Exactly one 5x5 plane (LoadRadius=2 -> side 5) is the incoming face.
+    EXPECT_EQ(loadsThisStep, 5u * 5u);
+
+    // The window is now centred on (1,0,0): every coordinate in that cube is
+    // resident, and the vacated x=-2 plane relative to the OLD centre is gone.
+    const auto newWindow = CubeAround(glm::ivec3(1, 0, 0), 2);
+    for (const auto& coord : newWindow)
+    {
+        EXPECT_NE(window.TryGetChunk(coord), nullptr);
+    }
+    for (i32 y = -2; y <= 2; ++y)
+    {
+        for (i32 z = -2; z <= 2; ++z)
+        {
+            EXPECT_EQ(window.TryGetChunk(glm::ivec3(-2, y, z)), nullptr);
+        }
+    }
+    EXPECT_EQ(tracker.ResidentCoords.size(), 5u * 5u * 5u);
+}
+
+TEST(VolumetricChunkWindow, CrossingNegativeAxisLoadsThePlaneOnTheCorrectSide)
+{
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 1;
+    config.RenderRadius = 1;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+    window.Update(glm::vec3(-11.0f, 0.0f, 0.0f)); // chunk (-2, 0, 0)
+
+    EXPECT_EQ(window.GetCentreChunk(), glm::ivec3(-2, 0, 0));
+    for (i32 y = -1; y <= 1; ++y)
+        for (i32 z = -1; z <= 1; ++z)
+            EXPECT_NE(window.TryGetChunk(glm::ivec3(-3, y, z)), nullptr);
+    for (i32 y = -1; y <= 1; ++y)
+        for (i32 z = -1; z <= 1; ++z)
+            EXPECT_EQ(window.TryGetChunk(glm::ivec3(1, y, z)), nullptr);
+}
+
+TEST(VolumetricChunkWindow, MultiAxisCrossingInOneUpdateLeavesEveryFinalSlotCorrect)
+{
+    // Camera jumps diagonally by one chunk on X and Z in a single Update()
+    // call (e.g. a low framerate tick) — every coordinate in the final window
+    // must resolve to itself, not to stale data from the old window.
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 1;
+    config.RenderRadius = 1;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+    window.Update(glm::vec3(10.5f, 0.0f, 10.5f)); // (1,0,0) and (0,0,1) crossed together
+
+    EXPECT_EQ(window.GetCentreChunk(), glm::ivec3(1, 0, 1));
+    const auto expected = CubeAround(glm::ivec3(1, 0, 1), 1);
+    for (const auto& coord : expected)
+    {
+        const TestChunk* chunk = window.TryGetChunk(coord);
+        ASSERT_NE(chunk, nullptr) << "missing (" << coord.x << "," << coord.y << "," << coord.z << ")";
+        EXPECT_EQ(chunk->Coord, coord) << "slot holds stale data for (" << coord.x << "," << coord.y << ","
+                                       << coord.z << ")";
+    }
+}
+
+TEST(VolumetricChunkWindow, MultiChunkJumpWithinTheWindowLoadsOnlyTheCrossedPlanes)
+{
+    // Reference implementation assumes at most one chunk of motion per frame;
+    // this window must not silently corrupt state on a larger jump that still
+    // overlaps the old window (e.g. a stutter, or a teleport within range).
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 3;
+    config.RenderRadius = 3;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+    const u32 loadsBefore = tracker.LoadCount;
+
+    window.Update(glm::vec3(20.5f, 0.0f, 0.0f)); // moves 2 chunks on X
+
+    EXPECT_EQ(window.GetCentreChunk(), glm::ivec3(2, 0, 0));
+    // Two planes crossed on X (from x=-3.. to x=... ), never a full 7^3 rescan.
+    const u32 loadsThisStep = tracker.LoadCount - loadsBefore;
+    EXPECT_LT(loadsThisStep, 7u * 7u * 7u);
+    EXPECT_EQ(loadsThisStep, 2u * 7u * 7u);
+
+    const auto expected = CubeAround(glm::ivec3(2, 0, 0), 3);
+    for (const auto& coord : expected)
+    {
+        const TestChunk* chunk = window.TryGetChunk(coord);
+        ASSERT_NE(chunk, nullptr);
+        EXPECT_EQ(chunk->Coord, coord);
+    }
+}
+
+TEST(VolumetricChunkWindow, JumpBeyondTheWindowDiameterFallsBackToARebuild)
+{
+    // A teleport with no overlap between old and new windows has no "incoming
+    // plane" — every slot is incoming, so a full rebuild is correct, not a bug.
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 1;
+    config.RenderRadius = 1;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+    const u32 loadsBefore = tracker.LoadCount;
+
+    window.Update(glm::vec3(1000.0f, 0.0f, 0.0f)); // chunk (100,0,0) — far beyond the 3-wide window
+
+    EXPECT_EQ(window.GetCentreChunk(), glm::ivec3(100, 0, 0));
+    EXPECT_EQ(tracker.LoadCount - loadsBefore, 3u * 3u * 3u);
+    for (const auto& coord : CubeAround(glm::ivec3(100, 0, 0), 1))
+    {
+        EXPECT_NE(window.TryGetChunk(coord), nullptr);
+    }
+}
+
+TEST(VolumetricChunkWindow, RenderRadiusIsAStrictSubsetOfLoadRadius)
+{
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 3;
+    config.RenderRadius = 1;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(0.0f));
+
+    std::set<std::tuple<i32, i32, i32>> rendered;
+    window.ForEachRenderableChunk(
+        [&](const glm::ivec3& coord, const TestChunk&)
+        { rendered.insert({ coord.x, coord.y, coord.z }); });
+
+    EXPECT_EQ(rendered.size(), 3u * 3u * 3u); // (2*RenderRadius+1)^3
+
+    // Chunks between RenderRadius and LoadRadius are loaded (lookup succeeds)
+    // but not surfaced for rendering.
+    EXPECT_NE(window.TryGetChunk(glm::ivec3(3, 0, 0)), nullptr);
+    EXPECT_FALSE(rendered.contains({ 3, 0, 0 }));
+}
+
+// ============================================================================
+// Floating-origin rebase (#613) — anchor-relative feeding is invariant
+// ============================================================================
+
+TEST(VolumetricChunkWindow, AnchorRelativePositionIsInvariantAcrossARebase)
+{
+    // Mirrors the terrain-streaming fix in docs/agent-rules/
+    // floating-origin-rebase-subsystems.md §4: feed the window a position
+    // relative to an anchor that itself shifts under RebaseOrigin, and the
+    // window never has to know a rebase happened at all.
+    LoadTracker trackerA;
+    LoadTracker trackerB;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 2;
+    config.RenderRadius = 2;
+
+    VolumetricChunkWindow<TestChunk> windowA(config, trackerA.MakeLoadFn(), trackerA.MakeUnloadFn());
+    VolumetricChunkWindow<TestChunk> windowB(config, trackerB.MakeLoadFn(), trackerB.MakeUnloadFn());
+
+    glm::vec3 cameraWorld(123.4f, 5.0f, -67.8f);
+    glm::vec3 anchorWorld(100.0f, 0.0f, -60.0f);
+
+    // Window A: never rebased. Window B: fed anchor-relative coordinates,
+    // then both camera and anchor are shifted by the SAME delta (a rebase),
+    // and updated again from the still-anchor-relative position.
+    windowA.Update(cameraWorld - anchorWorld);
+    windowB.Update(cameraWorld - anchorWorld);
+    ASSERT_EQ(windowA.GetCentreChunk(), windowB.GetCentreChunk());
+    const u32 loadsAfterFirstUpdate = trackerB.LoadCount;
+
+    const glm::vec3 rebaseShift(500.0f, 0.0f, -250.0f);
+    cameraWorld += rebaseShift;
+    anchorWorld += rebaseShift; // the anchor is a root TransformComponent too
+
+    // Camera moved a little further within the same chunk after the rebase.
+    cameraWorld += glm::vec3(0.1f, 0.0f, 0.2f);
+
+    windowB.Update(cameraWorld - anchorWorld);
+
+    // Anchor-relative position is unchanged (within-chunk motion only), so the
+    // rebase must not have triggered any load/unload activity or a teleport.
+    EXPECT_EQ(trackerB.LoadCount, loadsAfterFirstUpdate);
+    EXPECT_EQ(windowA.GetCentreChunk(), windowB.GetCentreChunk());
+}
+
+TEST(VolumetricChunkWindow, RawWorldRelativeFeedingWouldTeleportAcrossARebaseAsAWarning)
+{
+    // Negative control: proves the invariance above is doing real work. If the
+    // window is (incorrectly) fed a position that resets near the origin on a
+    // rebase — the render-relative convention floating origin exists for —
+    // it must observe that as a teleport (full rebuild), not silently corrupt
+    // state. Documents the failure mode the anchor-relative test avoids.
+    LoadTracker tracker;
+    VolumetricChunkWindow<TestChunk>::Config config;
+    config.ChunkWorldSize = 10.0f;
+    config.LoadRadius = 1;
+    config.RenderRadius = 1;
+    VolumetricChunkWindow<TestChunk> window(config, tracker.MakeLoadFn(), tracker.MakeUnloadFn());
+
+    window.Update(glm::vec3(505.0f, 0.0f, 0.0f)); // far from the origin, pre-rebase
+    const u32 loadsBefore = tracker.LoadCount;
+
+    // A rebase resets the render-relative camera position close to the
+    // origin — fed naively (without the anchor-relative correction), that's
+    // indistinguishable from a teleport to this window.
+    window.Update(glm::vec3(5.0f, 0.0f, 0.0f));
+
+    EXPECT_GT(tracker.LoadCount - loadsBefore, 0u);
+    EXPECT_EQ(window.GetCentreChunk(), glm::ivec3(0, 0, 0));
+}
+
+TEST(VolumetricChunkWindow, WorldToChunkFloorsRatherThanTruncatesAtNegativeCoordinates)
+{
+    EXPECT_EQ(VolumetricChunkWindow<TestChunk>::WorldToChunk(glm::vec3(-0.1f, 0.0f, 0.0f), 10.0f),
+              glm::ivec3(-1, 0, 0));
+    EXPECT_EQ(VolumetricChunkWindow<TestChunk>::WorldToChunk(glm::vec3(-10.0f, 0.0f, 0.0f), 10.0f),
+              glm::ivec3(-1, 0, 0));
+    EXPECT_EQ(VolumetricChunkWindow<TestChunk>::WorldToChunk(glm::vec3(9.9f, 0.0f, 0.0f), 10.0f),
+              glm::ivec3(0, 0, 0));
+}


### PR DESCRIPTION
## Summary

Adds a 3D ring-buffer chunk window for volumetric/voxel terrain streaming, per #729's acceptance criteria:

- **`ChunkRingBuffer3D<T>`** (`OloEngine/src/OloEngine/Terrain/ChunkRingBuffer3D.h`) — a fixed cubic toroidal container. Lookup is O(1): one Euclidean modulo per axis, no hashing, no per-lookup allocation.
- **`VolumetricChunkWindow<T>`** (`OloEngine/src/OloEngine/Terrain/VolumetricChunkWindow.h`) — streams a window around a tracked position. `Update()` loads only the plane(s) newly covered by a chunk-boundary crossing and never rescans the volume, with load and render radii configurable independently (chunks between `RenderRadius` and `LoadRadius` stay resident but aren't surfaced for drawing). A move beyond the window's own diameter (a teleport, with no overlap between old and new windows) falls back to a full rebuild, since there is no "incoming plane" in that case — every slot is incoming.
- Ported from the issue's reference implementation (`D:\repos\VoxelEngine\VoxelEngine\3d_ring_buffer.h` + `chunk_manager.h`, MIT), generalized beyond its "at most one chunk of motion per frame" assumption to handle multi-axis and multi-chunk-per-tick moves correctly (single-step-per-axis walk, verified correct by hand-simulation and pinned by tests).
- Rebase correctness (per `docs/agent-rules/floating-origin-rebase-subsystems.md` §4, terrain streaming's `WorldOrigin` fix): the window is designed to be **rebase-free by construction** rather than rebase-aware — fed an anchor-relative position (tracked position minus an anchor translation that itself shifts under `Scene::RebaseOrigin`), both terms cancel and the window never observes a rebase at all. A negative-control test documents what happens if fed a raw render-relative position instead (it's indistinguishable from a teleport).

No existing volumetric/voxel terrain consumer exists yet to wire this into — `TerrainStreamer`'s 2D quadtree window is a different subsystem for heightmap terrain and is untouched by this PR (see `docs/agent-rules/terrain-gpu-lod-quadtree.md`).

## Test plan

- [x] `OloEngine/tests/Terrain/VolumetricChunkWindowTest.cpp` (13 new tests, classified `unit`, pure CPU/no GL context), covering:
  - O(1) modulo indexing and Euclidean (not truncating) wraparound at negative coordinates
  - Single-axis boundary crossing loads exactly one plane and drops the vacated one
  - Negative-axis crossing
  - Multi-axis crossing in one `Update()` call leaves every final slot correct (no stale data)
  - Multi-chunk jump within the window loads only the crossed planes (not a full rescan)
  - A jump beyond the window diameter (teleport) falls back to a full rebuild
  - `RenderRadius` is a strict, independently-configurable subset of `LoadRadius`
  - Anchor-relative feeding is invariant across a simulated origin rebase (positive test) + a negative control showing raw world-relative feeding would look like a teleport
  - `WorldToChunk` floors rather than truncates at negative coordinates
- [x] `cmake --build build-cached --target OloEngine-Tests --config Debug --parallel 6` — exit 0
- [x] `OloEngine-Tests.exe --gtest_filter=ChunkRingBuffer3D.*:VolumetricChunkWindow.*` — 13/13 passed
- [x] `/code-review medium` self-review — no findings

## Review guide

**Where I'd look hardest**
1. `VolumetricChunkWindow.h`'s `Update()`/`LoadIncomingPlane` — the per-axis, per-unit-step walk is the least "obviously correct" part of the diff; I verified it by hand-simulating single-axis, 2-axis-diagonal, and multi-chunk cases against the ring buffer's slot-reuse semantics, and backed that with the multi-axis/multi-chunk tests, but it's worth a second look.
2. `ChunkRingBuffer3D.h`'s `WrapAxis` — the Euclidean-modulo trap this exists to avoid is exactly the DDGI clipmap bug documented in `docs/agent-rules/ddgi-probe-cascades-and-sparsity.md` §2; `NegativeCoordinatesWrapCorrectlyRatherThanTruncating` is built with that fixture shape (asserts a negative-coordinate case can't degenerate into testing only the positive one).

**What I verified, and how** — the full test suite above, plus a manual walkthrough of the multi-axis/diagonal-move algebra before writing the tests (documented in the test names themselves).

**Least confident about** — there is no real volumetric/voxel terrain system in the engine yet to consume this against, so the API shape (load/unload callbacks, `ForEachRenderableChunk`, anchor-relative rebase contract) is my best guess at what a future consumer will want, informed by the reference implementation and the existing `TerrainStreamer`'s shape. It may need adjusting once a real consumer shows up.

**Deliberately not tested** — no live-editor verification: this is pure data-structure/streaming infrastructure with no scene, no rendering, and no GL context involved (per `HANDOVER.md`'s task-specific note), so there's nothing to screenshot.

Closes #729


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added efficient 3D chunk storage with support for signed and negative coordinates.
  - Added volumetric chunk streaming around a tracked position, including loading, unloading, rendering-radius filtering, and teleport-aware rebuilding.
  - Added configurable chunk size and load/render distances.
  - Added world-position-to-chunk conversion with correct handling of negative positions.

- **Tests**
  - Added comprehensive coverage for chunk lookup, streaming updates, rebasing, teleports, and render-radius behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->