### PR TITLE
fix(vulkan,gl): work #801's deferred review findings (#803)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -655,11 +655,29 @@ jobs:
     name: TSan (Linux/Clang)
     needs: detect-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.native == 'true' }}
-    # 120, not 90: a cold sccache restore (concurrent runs evict each other under
-    # the 10 GB repo cache cap) makes the instrumented TSan build alone take ~78
-    # minutes, and a cancelled job skips the cache save — so 90 produced a chronic
-    # cold → timeout → no-save → cold loop across unrelated branches.
-    timeout-minutes: 120
+    # 180, not 120, not 90: the same cold-cache loop, measured twice.
+    #
+    # A cold sccache restore (concurrent runs evict each other under the 10 GB
+    # repo cache cap) makes the instrumented TSan build alone take ~78 minutes,
+    # and a cancelled job skips the cache save — so 90 produced a chronic
+    # cold → timeout → no-save → cold loop across unrelated branches. 120 did
+    # not end it: PR #945 restored a stale key, reported a **2.70% hit rate**
+    # (1371 of 1409 TUs compiled from scratch), spent 92 of its 120 minutes in
+    # the build, and was cancelled at 6224/6651 tests with every one of them
+    # passing and zero ThreadSanitizer reports. Its own `if: always()` save then
+    # failed — "Unable to reserve cache with key … another job may be creating
+    # this cache" — so the next attempt would have started just as cold.
+    #
+    # For scale: the same job on master the day before finished in 86 minutes.
+    # The warm path has always fit; it is only the cold path that does not, and
+    # a timeout on the cold path is what keeps it cold.
+    #
+    # 180 is also what the sibling jobs effectively get. TSan is the ONLY
+    # sanitizer job here with a `timeout-minutes` at all — asan-lsan-linux,
+    # ubsan-linux and asan-windows run under the 360-minute default, and UBSan
+    # has been observed finishing at 126 minutes, i.e. over this cap. The
+    # asymmetry, not the duration, was the bug.
+    timeout-minutes: 180
     # See asan-lsan-linux above for why this pins the distro codename.
     runs-on: ubuntu-24.04
     permissions:

--- a/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Debug/GPUResourceInspector.cpp
@@ -2042,7 +2042,11 @@ namespace OloEngine
         {
             if (i < info.m_ColorAttachmentFormats.size())
             {
-                ImGui::Text("  Attachment %u: Format 0x%X", i, info.m_ColorAttachmentFormats[i]);
+                // Decoded, not raw hex: these carry sized internal formats
+                // now that the GL backend queries the attached object rather
+                // than GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE (#803).
+                ImGui::Text("  Attachment %u: %s", i,
+                            FormatTextureFormat(info.m_ColorAttachmentFormats[i]).c_str());
             }
             else
             {
@@ -2053,7 +2057,7 @@ namespace OloEngine
         // Depth attachment
         if (info.m_HasDepthAttachment)
         {
-            ImGui::Text("Depth Attachment: Format 0x%X", info.m_DepthAttachmentFormat);
+            ImGui::Text("Depth Attachment: %s", FormatTextureFormat(info.m_DepthAttachmentFormat).c_str());
         }
         else
         {
@@ -2063,7 +2067,7 @@ namespace OloEngine
         // Stencil attachment
         if (info.m_HasStencilAttachment)
         {
-            ImGui::Text("Stencil Attachment: Format 0x%X", info.m_StencilAttachmentFormat);
+            ImGui::Text("Stencil Attachment: %s", FormatTextureFormat(info.m_StencilAttachmentFormat).c_str());
         }
         else
         {

--- a/OloEngine/src/OloEngine/Renderer/Debug/ResourceInspectorBackend.h
+++ b/OloEngine/src/OloEngine/Renderer/Debug/ResourceInspectorBackend.h
@@ -98,11 +98,16 @@ namespace OloEngine
             u32 Height = 0;
             u32 Status = 0; // native (backend) framebuffer-status enum value
             u32 ColorAttachmentCount = 0;
-            std::vector<u32> ColorAttachmentFormats; // native enum values
+            // The attachments' SIZED INTERNAL formats, as native enum values
+            // decodable by FormatTextureFormatName — GL_RGBA16F, not the
+            // GL_FLOAT component TYPE the GL arm used to answer with (#803).
+            // 0 means "no queryable object": an attachment of the default
+            // framebuffer, or none at all (0 is GL_NONE).
+            std::vector<u32> ColorAttachmentFormats;
             bool HasDepthAttachment = false;
-            u32 DepthAttachmentFormat = 0; // native enum value
+            u32 DepthAttachmentFormat = 0;
             bool HasStencilAttachment = false;
-            u32 StencilAttachmentFormat = 0; // native enum value
+            u32 StencilAttachmentFormat = 0;
             sizet MemoryUsage = 0;
         };
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLResourceInspectorBackend.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLResourceInspectorBackend.cpp
@@ -36,6 +36,160 @@ namespace OloEngine
                     return 0;
             }
         }
+
+        // One table for the 2D and cubemap arms of QueryTexture (#803).
+        // They were two verbatim copies apart from the depth and
+        // depth-stencil cases, which the cubemap arm simply lacked — cube
+        // maps carry no depth format in this engine, so `allowDepth` keeps
+        // that exact behaviour (a depth token on a cubemap still falls to the
+        // RGBA8 default) instead of silently widening it.
+        //
+        // NOT shared with QueryCaptureSource: that one maps 16F to GL_FLOAT
+        // rather than GL_HALF_FLOAT, reads packed depth-stencil as depth-only
+        // float, adds R11F_G11F_B10F, and REFUSES an unrecognised format
+        // instead of defaulting. It is a different mapping on purpose.
+        void PixelTransferForInternalFormat(GLint internalFormat, bool allowDepth, GLenum& outPixelFormat,
+                                            GLenum& outDataType)
+        {
+            outPixelFormat = GL_RGBA;
+            outDataType = GL_UNSIGNED_BYTE;
+            switch (internalFormat)
+            {
+                case GL_RGBA8:
+                case GL_SRGB8_ALPHA8:
+                    outPixelFormat = GL_RGBA;
+                    outDataType = GL_UNSIGNED_BYTE;
+                    return;
+                case GL_RGB8:
+                case GL_SRGB8:
+                    outPixelFormat = GL_RGB;
+                    outDataType = GL_UNSIGNED_BYTE;
+                    return;
+                case GL_RG8:
+                    outPixelFormat = GL_RG;
+                    outDataType = GL_UNSIGNED_BYTE;
+                    return;
+                case GL_R8:
+                    outPixelFormat = GL_RED;
+                    outDataType = GL_UNSIGNED_BYTE;
+                    return;
+                case GL_RGBA16F:
+                    outPixelFormat = GL_RGBA;
+                    outDataType = GL_HALF_FLOAT;
+                    return;
+                case GL_RGB16F:
+                    outPixelFormat = GL_RGB;
+                    outDataType = GL_HALF_FLOAT;
+                    return;
+                case GL_RG16F:
+                    outPixelFormat = GL_RG;
+                    outDataType = GL_HALF_FLOAT;
+                    return;
+                case GL_R16F:
+                    outPixelFormat = GL_RED;
+                    outDataType = GL_HALF_FLOAT;
+                    return;
+                case GL_RGBA32F:
+                    outPixelFormat = GL_RGBA;
+                    outDataType = GL_FLOAT;
+                    return;
+                case GL_RGB32F:
+                    outPixelFormat = GL_RGB;
+                    outDataType = GL_FLOAT;
+                    return;
+                case GL_RG32F:
+                    outPixelFormat = GL_RG;
+                    outDataType = GL_FLOAT;
+                    return;
+                case GL_R32F:
+                    outPixelFormat = GL_RED;
+                    outDataType = GL_FLOAT;
+                    return;
+                default:
+                    break;
+            }
+
+            if (!allowDepth)
+            {
+                return; // RGBA8/UNSIGNED_BYTE, the pre-existing cubemap default
+            }
+
+            switch (internalFormat)
+            {
+                case GL_DEPTH_COMPONENT16:
+                case GL_DEPTH_COMPONENT24:
+                case GL_DEPTH_COMPONENT32:
+                    outPixelFormat = GL_DEPTH_COMPONENT;
+                    outDataType = GL_UNSIGNED_INT;
+                    return;
+                case GL_DEPTH_COMPONENT32F:
+                    outPixelFormat = GL_DEPTH_COMPONENT;
+                    outDataType = GL_FLOAT;
+                    return;
+                case GL_DEPTH24_STENCIL8:
+                    outPixelFormat = GL_DEPTH_STENCIL;
+                    outDataType = GL_UNSIGNED_INT_24_8;
+                    return;
+                case GL_DEPTH32F_STENCIL8:
+                    outPixelFormat = GL_DEPTH_STENCIL;
+                    outDataType = GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
+                    return;
+                default:
+                    return;
+            }
+        }
+
+        // The SIZED INTERNAL FORMAT of a framebuffer attachment (#803).
+        //
+        // Every one of these queries used to ask for
+        // GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE, which answers
+        // GL_FLOAT / GL_UNSIGNED_NORMALIZED / GL_INT — not a format at all,
+        // while FramebufferQuery documents these fields as native format
+        // enums. The attachment's own object knows the real answer, so ask it:
+        // a texture through glGetTextureLevelParameteriv at the attached
+        // level, a renderbuffer through glGetNamedRenderbufferParameteriv.
+        //
+        // 0 for anything else — the default framebuffer's attachments
+        // (GL_FRAMEBUFFER_DEFAULT) name no object to query, and 0 is
+        // GL_NONE, which is already this field's "no attachment" value.
+        GLint QueryAttachmentInternalFormat(GLenum attachment)
+        {
+            GLint objectType = GL_NONE;
+            glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, attachment,
+                                                  GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &objectType);
+            // OBJECT_NAME is only a legal query once the type says there IS an
+            // object — asking it for GL_NONE or GL_FRAMEBUFFER_DEFAULT is
+            // GL_INVALID_ENUM, and this inspector must not manufacture GL
+            // errors for the code it is inspecting.
+            if (objectType != GL_TEXTURE && objectType != GL_RENDERBUFFER)
+            {
+                return 0;
+            }
+
+            GLint objectName = 0;
+            glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, attachment,
+                                                  GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &objectName);
+            if (objectName == 0)
+            {
+                return 0;
+            }
+
+            GLint internalFormat = 0;
+            if (objectType == GL_TEXTURE)
+            {
+                GLint level = 0;
+                glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, attachment,
+                                                      GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL, &level);
+                glGetTextureLevelParameteriv(static_cast<GLuint>(objectName), level, GL_TEXTURE_INTERNAL_FORMAT,
+                                             &internalFormat);
+            }
+            else
+            {
+                glGetNamedRenderbufferParameteriv(static_cast<GLuint>(objectName), GL_RENDERBUFFER_INTERNAL_FORMAT,
+                                                  &internalFormat);
+            }
+            return internalFormat;
+        }
     } // namespace
 
     // ---- Introspection -----------------------------------------------------
@@ -62,148 +216,12 @@ namespace OloEngine
         outInfo.Height = static_cast<u32>(height);
         outInfo.InternalFormat = static_cast<u32>(internalFormat);
 
+        // Cube maps take the same table minus the depth cases (see the
+        // helper): they cannot carry a depth format here, so an unexpected
+        // depth token keeps falling to the RGBA8 default it always did.
         GLenum pixelFormat = GL_RGBA;
         GLenum dataType = GL_UNSIGNED_BYTE;
-        if (!isCubemap)
-        {
-            // Determine format and type based on internal format
-            switch (internalFormat)
-            {
-                case GL_RGBA8:
-                case GL_SRGB8_ALPHA8:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RGB8:
-                case GL_SRGB8:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RG8:
-                    pixelFormat = GL_RG;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_R8:
-                    pixelFormat = GL_RED;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RGBA16F:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RGB16F:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RG16F:
-                    pixelFormat = GL_RG;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_R16F:
-                    pixelFormat = GL_RED;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RGBA32F:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_RGB32F:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_RG32F:
-                    pixelFormat = GL_RG;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_R32F:
-                    pixelFormat = GL_RED;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_DEPTH_COMPONENT16:
-                case GL_DEPTH_COMPONENT24:
-                case GL_DEPTH_COMPONENT32:
-                    pixelFormat = GL_DEPTH_COMPONENT;
-                    dataType = GL_UNSIGNED_INT;
-                    break;
-                case GL_DEPTH_COMPONENT32F:
-                    pixelFormat = GL_DEPTH_COMPONENT;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_DEPTH24_STENCIL8:
-                    pixelFormat = GL_DEPTH_STENCIL;
-                    dataType = GL_UNSIGNED_INT_24_8;
-                    break;
-                case GL_DEPTH32F_STENCIL8:
-                    pixelFormat = GL_DEPTH_STENCIL;
-                    dataType = GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
-                    break;
-                default:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-            }
-        }
-        else
-        {
-            // Determine format and type based on internal format (same as texture 2D)
-            switch (internalFormat)
-            {
-                case GL_RGBA8:
-                case GL_SRGB8_ALPHA8:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RGB8:
-                case GL_SRGB8:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RG8:
-                    pixelFormat = GL_RG;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_R8:
-                    pixelFormat = GL_RED;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-                case GL_RGBA16F:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RGB16F:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RG16F:
-                    pixelFormat = GL_RG;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_R16F:
-                    pixelFormat = GL_RED;
-                    dataType = GL_HALF_FLOAT;
-                    break;
-                case GL_RGBA32F:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_RGB32F:
-                    pixelFormat = GL_RGB;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_RG32F:
-                    pixelFormat = GL_RG;
-                    dataType = GL_FLOAT;
-                    break;
-                case GL_R32F:
-                    pixelFormat = GL_RED;
-                    dataType = GL_FLOAT;
-                    break;
-                default:
-                    pixelFormat = GL_RGBA;
-                    dataType = GL_UNSIGNED_BYTE;
-                    break;
-            }
-        }
+        PixelTransferForInternalFormat(internalFormat, !isCubemap, pixelFormat, dataType);
         outInfo.PixelFormat = static_cast<u32>(pixelFormat);
         outInfo.DataType = static_cast<u32>(dataType);
 
@@ -317,10 +335,8 @@ namespace OloEngine
             {
                 ++outInfo.ColorAttachmentCount;
 
-                GLint internalFormat;
-                glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i,
-                                                      GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE, &internalFormat);
-                outInfo.ColorAttachmentFormats.push_back(static_cast<u32>(internalFormat));
+                outInfo.ColorAttachmentFormats.push_back(
+                    static_cast<u32>(QueryAttachmentInternalFormat(GL_COLOR_ATTACHMENT0 + i)));
             }
         }
 
@@ -332,10 +348,7 @@ namespace OloEngine
 
         if (outInfo.HasDepthAttachment)
         {
-            GLint depthFormat;
-            glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                                  GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE, &depthFormat);
-            outInfo.DepthAttachmentFormat = static_cast<u32>(depthFormat);
+            outInfo.DepthAttachmentFormat = static_cast<u32>(QueryAttachmentInternalFormat(GL_DEPTH_ATTACHMENT));
         }
 
         // Check stencil attachment
@@ -346,10 +359,7 @@ namespace OloEngine
 
         if (outInfo.HasStencilAttachment)
         {
-            GLint stencilFormat;
-            glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
-                                                  GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE, &stencilFormat);
-            outInfo.StencilAttachmentFormat = static_cast<u32>(stencilFormat);
+            outInfo.StencilAttachmentFormat = static_cast<u32>(QueryAttachmentInternalFormat(GL_STENCIL_ATTACHMENT));
         }
 
         // Estimate memory usage (simplified)
@@ -998,8 +1008,26 @@ namespace OloEngine
         // Modern OpenGL 4.5+ approach: Use immutable buffer storage + DSA
         glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
 
+        // Drain any error the CALLER left pending first, or the check below
+        // would attribute somebody else's failure to this allocation.
+        while (glGetError() != GL_NO_ERROR)
+        {
+        }
+
         // Use modern immutable buffer storage (OpenGL 4.4+)
         glBufferStorage(GL_PIXEL_PACK_BUFFER, static_cast<GLsizeiptr>(dataSize), nullptr, GL_MAP_READ_BIT | GL_DYNAMIC_STORAGE_BIT);
+
+        // A large `dataSize` can fail here with GL_OUT_OF_MEMORY. Unchecked,
+        // the code went on to issue the read into a PBO with no storage, fence
+        // it, and report success — the caller then mapped nothing.
+        if (const GLenum storageError = glGetError(); storageError != GL_NO_ERROR)
+        {
+            OLO_CORE_WARN("[GPUResourceInspector] PBO storage allocation of {} bytes failed (GL error 0x{:X})",
+                          dataSize, static_cast<u32>(storageError));
+            glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+            glDeleteBuffers(1, &pbo);
+            return false;
+        }
 
         // Modern OpenGL 4.5+ DSA: Direct texture access without state changes.
         // For cubemaps the z-offset selects the face (0..5 = +X,-X,+Y,-Y,+Z,-Z);
@@ -1009,7 +1037,12 @@ namespace OloEngine
                              static_cast<GLsizei>(width), static_cast<GLsizei>(height), 1,
                              GL_RGBA, GL_UNSIGNED_BYTE, static_cast<GLsizei>(dataSize), nullptr);
 
-        // Unbind PBO
+        // The ONE unbind, and it must stay here: the read above needs the PBO
+        // bound to route into it, and the binding must be clear before the
+        // fence so the caller's next pack read does not land in this buffer.
+        // Two further unbinds used to follow (one on the fence-failure path,
+        // one labelled "restore"); both were dead, since this call already
+        // left the binding at 0 (#803).
         glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
         // Create modern sync object for better async completion detection (OpenGL 3.2+)
@@ -1018,12 +1051,8 @@ namespace OloEngine
         {
             OLO_CORE_WARN("Failed to create sync fence for texture download");
             glDeleteBuffers(1, &pbo);
-            glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
             return false;
         }
-
-        // Restore PBO binding
-        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
         outTicket.NativeBuffer = static_cast<u32>(pbo);
         outTicket.Fence = fence;

--- a/OloEngine/src/Platform/OpenGL/OpenGLStateGuard.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLStateGuard.cpp
@@ -46,17 +46,6 @@ namespace OloEngine::Detail
             return static_cast<u32>(v);
         }
 
-        u32 GlGetTextureBindingAtUnit(u32 unit, GLenum target)
-        {
-            GLint prevActive = 0;
-            ::glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActive);
-            ::glActiveTexture(GL_TEXTURE0 + unit);
-            GLint bound = 0;
-            ::glGetIntegerv(target, &bound);
-            ::glActiveTexture(static_cast<GLenum>(prevActive));
-            return static_cast<u32>(bound);
-        }
-
         // A snapshotted container-object name is validated before the rebind:
         // the guarded scope may legitimately delete an object that was bound at
         // entry (a render-graph resize destroys framebuffers/VAOs), and
@@ -154,11 +143,24 @@ namespace OloEngine::Detail
         s.m_CapturedTextureSlotLimit = textureSlotLimit;
         s.m_CapturedUboSlotLimit = uboSlotLimit;
 
-        for (u32 i = 0; i < textureSlotLimit; ++i)
+        // Select each unit ONCE and read all three targets while it is active
+        // (#803). This used to run through a per-target helper that saved and
+        // restored GL_ACTIVE_TEXTURE itself, so a 32-unit driver paid 96
+        // redundant glGetIntegerv + glActiveTexture pairs per snapshot. The
+        // active unit is captured above and restored by ApplyGLStateCore, but
+        // this loop restores it too, so a capture on its own is still
+        // side-effect free.
         {
-            s.m_Textures2D[i] = GlGetTextureBindingAtUnit(i, GL_TEXTURE_BINDING_2D);
-            s.m_Textures2DArray[i] = GlGetTextureBindingAtUnit(i, GL_TEXTURE_BINDING_2D_ARRAY);
-            s.m_TexturesCubeMap[i] = GlGetTextureBindingAtUnit(i, GL_TEXTURE_BINDING_CUBE_MAP);
+            GLint prevActive = 0;
+            ::glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActive);
+            for (u32 i = 0; i < textureSlotLimit; ++i)
+            {
+                ::glActiveTexture(GL_TEXTURE0 + i);
+                s.m_Textures2D[i] = GlGetUInt(GL_TEXTURE_BINDING_2D);
+                s.m_Textures2DArray[i] = GlGetUInt(GL_TEXTURE_BINDING_2D_ARRAY);
+                s.m_TexturesCubeMap[i] = GlGetUInt(GL_TEXTURE_BINDING_CUBE_MAP);
+            }
+            ::glActiveTexture(static_cast<GLenum>(prevActive));
         }
 
         for (u32 i = 0; i < uboSlotLimit; ++i)

--- a/OloEngine/src/Platform/Vulkan/VulkanDeferredReclaim.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDeferredReclaim.cpp
@@ -9,6 +9,7 @@
 #include "Platform/Vulkan/VulkanImageInfoRegistry.h"
 #include "Platform/Vulkan/VulkanImageLayoutTracker.h"
 
+#include <exception>
 #include <vector>
 
 namespace OloEngine
@@ -19,58 +20,75 @@ namespace OloEngine
         return *s_Instance;
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkImage image, VmaAllocation allocation)
+    void VulkanDeferredReclaim::Push(const Entry& entry) noexcept
+    {
+        try
+        {
+            m_Entries.push_back(entry);
+        }
+        catch (const std::exception& e)
+        {
+            OLO_CORE_ERROR("VulkanDeferredReclaim: enqueue failed ({}) — the object leaks until process exit", e.what());
+        }
+        catch (...)
+        {
+            OLO_CORE_ERROR("VulkanDeferredReclaim: enqueue failed (unknown exception) — the object leaks until "
+                           "process exit");
+        }
+    }
+
+    void VulkanDeferredReclaim::Enqueue(VkImage image, VmaAllocation allocation) noexcept
     {
         if (image == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .Image = image, .Allocation = allocation, .EnqueuedAtGeneration = m_Generation });
+        Push({ .Image = image, .Allocation = allocation, .EnqueuedAtGeneration = m_Generation });
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkBuffer buffer, VmaAllocation allocation)
+    void VulkanDeferredReclaim::Enqueue(VkBuffer buffer, VmaAllocation allocation) noexcept
     {
         if (buffer == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .Buffer = buffer, .Allocation = allocation, .EnqueuedAtGeneration = m_Generation });
+        Push({ .Buffer = buffer, .Allocation = allocation, .EnqueuedAtGeneration = m_Generation });
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkSemaphore semaphore)
+    void VulkanDeferredReclaim::Enqueue(VkSemaphore semaphore) noexcept
     {
         if (semaphore == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .Semaphore = semaphore, .EnqueuedAtGeneration = m_Generation });
+        Push({ .Semaphore = semaphore, .EnqueuedAtGeneration = m_Generation });
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkPipeline pipeline)
+    void VulkanDeferredReclaim::Enqueue(VkPipeline pipeline) noexcept
     {
         if (pipeline == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .Pipeline = pipeline, .EnqueuedAtGeneration = m_Generation });
+        Push({ .Pipeline = pipeline, .EnqueuedAtGeneration = m_Generation });
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkImageView view)
+    void VulkanDeferredReclaim::Enqueue(VkImageView view) noexcept
     {
         if (view == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .View = view, .EnqueuedAtGeneration = m_Generation });
+        Push({ .View = view, .EnqueuedAtGeneration = m_Generation });
     }
 
-    void VulkanDeferredReclaim::Enqueue(VkQueryPool queryPool)
+    void VulkanDeferredReclaim::Enqueue(VkQueryPool queryPool) noexcept
     {
         if (queryPool == VK_NULL_HANDLE)
         {
             return;
         }
-        m_Entries.push_back({ .QueryPool = queryPool, .EnqueuedAtGeneration = m_Generation });
+        Push({ .QueryPool = queryPool, .EnqueuedAtGeneration = m_Generation });
     }
 
     void VulkanDeferredReclaim::DestroyEntry(const Entry& entry)
@@ -134,7 +152,26 @@ namespace OloEngine
         }
     }
 
-    void VulkanDeferredReclaim::NotifyFrameCompleted()
+    void VulkanDeferredReclaim::DestroyEntryGuarded(const Entry& entry) noexcept
+    {
+        try
+        {
+            DestroyEntry(entry);
+        }
+        catch (const std::exception& e)
+        {
+            OLO_CORE_ERROR("VulkanDeferredReclaim: destroying a reclaim entry threw ({}) — dropping it and "
+                           "continuing the drain",
+                           e.what());
+        }
+        catch (...)
+        {
+            OLO_CORE_ERROR("VulkanDeferredReclaim: destroying a reclaim entry threw (unknown exception) — dropping "
+                           "it and continuing the drain");
+        }
+    }
+
+    void VulkanDeferredReclaim::NotifyFrameCompleted() noexcept
     {
         ++m_Generation;
 
@@ -144,16 +181,16 @@ namespace OloEngine
             {
                 return false;
             }
-            DestroyEntry(entry);
+            DestroyEntryGuarded(entry);
             return true; });
     }
 
-    void VulkanDeferredReclaim::FlushAll()
+    void VulkanDeferredReclaim::FlushAll() noexcept
     {
         // Caller guarantees vkDeviceWaitIdle has already been done.
         for (const auto& entry : m_Entries)
         {
-            DestroyEntry(entry);
+            DestroyEntryGuarded(entry);
         }
         m_Entries.clear();
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanDeferredReclaim.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDeferredReclaim.h
@@ -55,31 +55,44 @@ namespace OloEngine
         // VulkanImageInfoRegistry::Get for the rationale).
         [[nodiscard]] static VulkanDeferredReclaim& Get();
 
-        void Enqueue(VkImage image, VmaAllocation allocation);
-        void Enqueue(VkBuffer buffer, VmaAllocation allocation);
+        // ALL of these are noexcept, and that is load-bearing: every caller is
+        // a resource destructor, the queue is a std::vector, and a push_back
+        // that throws out of a destructor terminates the process. A failed
+        // enqueue drops the entry with an error log — leaking one object until
+        // process exit beats std::terminate, and it stays loud rather than
+        // silent. Callers therefore need no try/catch around Enqueue itself;
+        // the destructors keep theirs for the OTHER teardown work they do.
+        void Enqueue(VkImage image, VmaAllocation allocation) noexcept;
+        void Enqueue(VkBuffer buffer, VmaAllocation allocation) noexcept;
         // Non-VMA device objects share the same generation discipline.
         // A semaphore may be referenced by an in-flight submit's wait/signal
         // list; a pipeline by an in-flight command buffer (ADR 0011 §3(d) —
         // hot-reload destruction is deferred, never inline).
-        void Enqueue(VkSemaphore semaphore);
-        void Enqueue(VkPipeline pipeline);
+        void Enqueue(VkSemaphore semaphore) noexcept;
+        void Enqueue(VkPipeline pipeline) noexcept;
         // Attachment views (vkCmdBeginRendering references them from
         // in-flight command buffers exactly like pipelines).
-        void Enqueue(VkImageView view);
+        void Enqueue(VkImageView view) noexcept;
         // Phase 7 Wave C: occlusion query pools. vkCmdResetQueryPool /
         // vkCmdBeginQuery reference the pool from in-flight command buffers,
         // and DeleteQueries is called from a frame that may still have the
         // previous one submitted — same generation discipline as pipelines.
-        void Enqueue(VkQueryPool queryPool);
+        void Enqueue(VkQueryPool queryPool) noexcept;
 
         // Called by the frame loop once per completed frame. Destroys every
         // entry enqueued >= 2 notifications ago; also unregisters images from
         // VulkanImageInfoRegistry at actual-destroy time.
-        void NotifyFrameCompleted();
+        //
+        // noexcept for the same reason as Enqueue, plus one of its own: both
+        // drain paths run during teardown, and an entry that throws must not
+        // strand the entries BEHIND it — an entry that never reaches
+        // vmaDestroyAllocator is the "allocations not freed" abort. So each
+        // entry's destroy is isolated and a failure is logged, not propagated.
+        void NotifyFrameCompleted() noexcept;
 
         // Destroy everything immediately. Caller guarantees device idle
         // (vkDeviceWaitIdle already done — shutdown, swapchain teardown).
-        void FlushAll();
+        void FlushAll() noexcept;
 
         // Diagnostic/test affordance.
         [[nodiscard]] sizet GetPendingCount() const
@@ -107,6 +120,14 @@ namespace OloEngine
         // dropped with a warn log — leaking at process exit beats calling
         // into a destroyed allocator.
         static void DestroyEntry(const Entry& entry);
+
+        // The one push_back every Enqueue overload funnels through, with the
+        // allocation failure contained (see the Enqueue block above).
+        void Push(const Entry& entry) noexcept;
+
+        // DestroyEntry with any escape contained, so one bad entry cannot
+        // strand the rest of a drain.
+        static void DestroyEntryGuarded(const Entry& entry) noexcept;
 
         // Matches VulkanContextData::kFramesInFlight.
         static constexpr u64 kFramesInFlight = 2;

--- a/OloEngine/src/Platform/Vulkan/VulkanDescriptorHeapBackend.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDescriptorHeapBackend.cpp
@@ -180,6 +180,18 @@ namespace OloEngine
     void VulkanDescriptorHeapBackend::UploadSlots(const u32 firstSlot, const u64* descriptors, const u32 count)
     {
         auto& heap = VulkanResourceHeap::Get();
+        // Probed ONCE, not per slot (#803). TryGetRecordingVulkanAPI does a
+        // dynamic_cast on RenderCommand::GetRendererAPI(), and neither the
+        // installed API object nor its recording state can change inside this
+        // loop — a bindless upload of N descriptors was paying N runtime type
+        // checks against the same object.
+        //
+        // Hoisted to the CALL SITE rather than cached in the helper: a cached
+        // VulkanRendererAPI* would have to be invalidated on
+        // RecreateForSelectedBackend, which is amendment (39)'s
+        // construction-order hazard. A loop-local answer has no lifetime at
+        // all, so it cannot go stale.
+        auto* recordingApi = VulkanUpload::TryGetRecordingVulkanAPI();
         for (u32 i = 0; i < count; ++i)
         {
             const u32 slot = firstSlot + i;
@@ -208,10 +220,10 @@ namespace OloEngine
             // survives this seam, so its failing sample comes from another
             // path — most likely the ImGui viewport binding. Closing this gap
             // is worth doing on its own terms; do not read it as that fix.
-            if (auto* vk = VulkanUpload::TryGetRecordingVulkanAPI(); vk != nullptr)
+            if (recordingApi != nullptr)
             {
-                vk->EnsureImageLayoutForDescriptor(staged.Image, staged.Layout,
-                                                   staged.ViewInfo.subresourceRange);
+                recordingApi->EnsureImageLayoutForDescriptor(staged.Image, staged.Layout,
+                                                             staged.ViewInfo.subresourceRange);
             }
             const bool ok = staged.Type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
                                 ? heap.WriteStorageImage(slot, staged.ViewInfo, staged.Layout)

--- a/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.cpp
@@ -13,6 +13,7 @@
 #include "Platform/Vulkan/VulkanTransientUpload.h"
 
 #include <algorithm>
+#include <exception>
 #include <unordered_set>
 
 namespace OloEngine
@@ -155,30 +156,55 @@ namespace OloEngine
 
     VulkanFramebuffer::~VulkanFramebuffer()
     {
-        // API-side state must not outlive the object: end a scope targeting
-        // this framebuffer and drop any pending lazy clear naming it (a later
-        // materialization would dereference the freed object). Live-object
-        // probe, the ClearData rule.
-        if (auto* vk = VulkanUpload::TryGetVulkanAPI(); vk != nullptr)
+        // No exception may escape a destructor — it terminates the process.
+        // Steps below touch node-based containers and the API facade, so the
+        // whole body is guarded, with the same two arms as every other Vulkan
+        // resource destructor (#803): losing one framebuffer's cleanup beats
+        // std::terminate, and the log keeps it loud.
+        try
         {
-            vk->NotifyFramebufferDestroyed(this, m_RHIHandle.Get());
+            // ORDER MATTERS under the guard: everything that publishes `this`
+            // to something outliving it is dropped FIRST. Each of these is an
+            // erase-by-key on an already-sized container and cannot realistically
+            // throw, so a failure further down can no longer strand a dangling
+            // pointer that ReleaseCachedDepthViewsForImage would later walk into.
+            LiveFramebuffers().erase(this);
+            VulkanBindingState::Get().ClearIfCurrentFramebuffer(this);
+            VulkanRootObjectRegistry::Get().Unregister(m_RHIHandle.Get());
+            // API-side state must not outlive the object: end a scope targeting
+            // this framebuffer and drop any pending lazy clear naming it (a later
+            // materialization would dereference the freed object). Live-object
+            // probe, the ClearData rule.
+            if (auto* vk = VulkanUpload::TryGetVulkanAPI(); vk != nullptr)
+            {
+                vk->NotifyFramebufferDestroyed(this, m_RHIHandle.Get());
+            }
+            // The per-cascade depth views (AttachDepthTextureArrayLayer) are owned
+            // here, not by the array texture — they outlive no frame of their own,
+            // so they retire on the deferred queue like every other view.
+            // (Enqueue is noexcept and contains its own failure.)
+            for (const auto& [key, cachedView] : m_DepthArrayViews)
+            {
+                if (cachedView != VK_NULL_HANDLE)
+                    VulkanDeferredReclaim::Get().Enqueue(cachedView);
+            }
+            m_DepthArrayViews.clear();
+            m_DepthArrayAttachment = DepthArrayLayerAttachment{};
+            // Retire the framebuffer identity; the attachment Refs release next
+            // and each texture enqueues its image on VulkanDeferredReclaim.
+            m_RHIHandle.Reset();
         }
-        VulkanBindingState::Get().ClearIfCurrentFramebuffer(this);
-        VulkanRootObjectRegistry::Get().Unregister(m_RHIHandle.Get());
-        // The per-cascade depth views (AttachDepthTextureArrayLayer) are owned
-        // here, not by the array texture — they outlive no frame of their own,
-        // so they retire on the deferred queue like every other view.
-        for (const auto& [key, cachedView] : m_DepthArrayViews)
+        catch (const std::exception& e)
         {
-            if (cachedView != VK_NULL_HANDLE)
-                VulkanDeferredReclaim::Get().Enqueue(cachedView);
+            OLO_CORE_ERROR("~VulkanFramebuffer: teardown failed ({}) — leaking this framebuffer's views until "
+                           "process exit",
+                           e.what());
         }
-        m_DepthArrayViews.clear();
-        LiveFramebuffers().erase(this);
-        m_DepthArrayAttachment = DepthArrayLayerAttachment{};
-        // Retire the framebuffer identity; the attachment Refs release next
-        // and each texture enqueues its image on VulkanDeferredReclaim.
-        m_RHIHandle.Reset();
+        catch (...)
+        {
+            OLO_CORE_ERROR("~VulkanFramebuffer: teardown failed (unknown exception) — leaking this framebuffer's "
+                           "views until process exit");
+        }
     }
 
     void VulkanFramebuffer::CreateAttachments()

--- a/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanFramebuffer.h
@@ -56,8 +56,9 @@ namespace OloEngine
         // see m_DepthArrayViews for what goes wrong without it.)
         static void ReleaseCachedDepthViewsForImage(VkImage image);
 
-        // Will become meaningful when the orchestrator's VulkanRendererAPI
-        // current-render-target state lands — warn-once no-ops until then.
+        // Publish / clear this framebuffer as the current render target
+        // through VulkanBindingState; the dynamic-rendering scope consumes the
+        // selection lazily at the next draw or clear.
         void Bind() override;
         void Unbind() override;
 
@@ -73,7 +74,9 @@ namespace OloEngine
             return m_RenderViewportHeight;
         }
 
-        // Readback / clear-shaped — pipeline concerns, warn-once no-ops.
+        // Readback rides the ReadTextureSubImage spine (top-down coordinates,
+        // amendment (85)); the three clears ride the facade's transfer clears
+        // — integer for RED_INTEGER slots, float otherwise.
         int ReadPixel(u32 attachmentIndex, int x, int y) override;
         void ClearAttachment(u32 attachmentIndex, int value) override;
         void ClearAttachment(u32 attachmentIndex, const glm::vec4& value) override;

--- a/OloEngine/src/Platform/Vulkan/VulkanOneShot.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanOneShot.cpp
@@ -18,6 +18,7 @@ namespace OloEngine
             // See the header: test-only fault injection for the layout-desync
             // tenants. Render thread only, like the rest of the backend.
             u32 s_FailNextSubmits = 0;
+            u32 s_FailNextFenceWaits = 0;
         } // namespace
 
         void SetFailNextSubmitsForTesting(u32 count)
@@ -29,11 +30,30 @@ namespace OloEngine
         {
             return s_FailNextSubmits;
         }
+
+        void SetFailNextFenceWaitsForTesting(u32 count)
+        {
+            s_FailNextFenceWaits = count;
+        }
+
+        u32 GetPendingFailNextFenceWaitsForTesting()
+        {
+            return s_FailNextFenceWaits;
+        }
 #endif
 
-        bool Submit(const char* what, const std::function<void(VkCommandBuffer)>& record)
+        bool Submit(const char* what, const std::function<void(VkCommandBuffer)>& record, Outcome* outOutcome)
         {
             OLO_PROFILE_FUNCTION();
+
+            // Every early return below leaves this at NotSubmitted, which is
+            // the truth for all of them: none reached vkQueueSubmit2.
+            const auto setOutcome = [outOutcome](Outcome outcome)
+            {
+                if (outOutcome != nullptr)
+                    *outOutcome = outcome;
+            };
+            setOutcome(Outcome::NotSubmitted);
 
 #ifndef OLO_DIST
             if (s_FailNextSubmits > 0)
@@ -123,11 +143,30 @@ namespace OloEngine
             }
             else
             {
+                // ACCEPTED BY THE QUEUE. That, not the fence wait, is what
+                // makes this buffer's transitions real: queue submissions
+                // execute in submit order, so every later submission already
+                // sees the layouts recorded here whether or not the host
+                // managed to observe the fence. Promoting only after a
+                // successful wait left the tracker claiming the OLD layout for
+                // work that was certain to run — the same wrong-oldLayout
+                // desync the rest of #803 is about, just reached by a timeout.
+                immediate.MarkSubmitted();
+                setOutcome(Outcome::Submitted);
+
                 // Blocking wait is the point (see the header): load-time GL
                 // uploads were synchronous, and callers destroy staging
                 // buffers immediately after this returns.
                 constexpr u64 kTimeoutNs = 10'000'000'000ull; // 10 s — an upload that slow is a hang
-                const VkResult waited = vkWaitForFences(device->GetDevice(), 1u, &fence, VK_TRUE, kTimeoutNs);
+                VkResult waited = vkWaitForFences(device->GetDevice(), 1u, &fence, VK_TRUE, kTimeoutNs);
+#ifndef OLO_DIST
+                if (s_FailNextFenceWaits > 0)
+                {
+                    --s_FailNextFenceWaits;
+                    OLO_CORE_WARN("VulkanOneShot::Submit({}): forcing a fence-wait timeout by test injection", what);
+                    waited = VK_TIMEOUT;
+                }
+#endif
                 if (waited != VK_SUCCESS)
                 {
                     OLO_CORE_ERROR("VulkanOneShot::Submit({}): fence wait failed (VkResult {})", what,
@@ -136,9 +175,7 @@ namespace OloEngine
                 }
                 else
                 {
-                    // On the queue and retired: the layouts this buffer
-                    // transitioned are now the images' executed layouts.
-                    immediate.MarkSubmitted();
+                    setOutcome(Outcome::Completed);
                 }
             }
 

--- a/OloEngine/src/Platform/Vulkan/VulkanOneShot.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanOneShot.cpp
@@ -12,9 +12,37 @@ namespace OloEngine
 {
     namespace VulkanOneShot
     {
+#ifndef OLO_DIST
+        namespace
+        {
+            // See the header: test-only fault injection for the layout-desync
+            // tenants. Render thread only, like the rest of the backend.
+            u32 s_FailNextSubmits = 0;
+        } // namespace
+
+        void SetFailNextSubmitsForTesting(u32 count)
+        {
+            s_FailNextSubmits = count;
+        }
+
+        u32 GetPendingFailNextSubmitsForTesting()
+        {
+            return s_FailNextSubmits;
+        }
+#endif
+
         bool Submit(const char* what, const std::function<void(VkCommandBuffer)>& record)
         {
             OLO_PROFILE_FUNCTION();
+
+#ifndef OLO_DIST
+            if (s_FailNextSubmits > 0)
+            {
+                --s_FailNextSubmits;
+                OLO_CORE_WARN("VulkanOneShot::Submit({}): failing by test injection", what);
+                return false;
+            }
+#endif
 
             auto* device = VulkanDevice::Get();
             if (device == nullptr)

--- a/OloEngine/src/Platform/Vulkan/VulkanOneShot.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanOneShot.h
@@ -39,10 +39,34 @@ namespace OloEngine
 {
     namespace VulkanOneShot
     {
+        // Why a failure needs two answers, not one.
+        //
+        // `Submit` returns false for two situations a caller must NOT treat
+        // alike. If it failed before vkQueueSubmit2 — no device, allocation,
+        // begin/end, fence creation, or the submit call itself — nothing was
+        // queued, so nothing the callback recorded will ever execute. But if
+        // the submit was ACCEPTED and only the fence wait timed out, the
+        // command buffer is on the queue and its transitions WILL execute; a
+        // caller that then keeps the old layout has a stale record, which is
+        // the same wrong-oldLayout desync as recording the new one too early
+        // (#803, and see rhi-abstraction-boundary.md §16a).
+        //
+        // So: state a resource reaches through queued work is gated on
+        // `Submitted`, not on the bool. The bool stays "fully completed and
+        // waited", which is what every existing caller means by it.
+        enum class Outcome
+        {
+            NotSubmitted, // never reached the queue — nothing recorded will run
+            Submitted,    // accepted by the queue, but the fence wait did not succeed
+            Completed,    // accepted and retired; the work is done
+        };
+
         // Returns false (with an error log naming `what`) when no live device
         // exists or any Vulkan call fails; the callback is then never invoked
-        // or its recording is discarded. Never throws.
-        bool Submit(const char* what, const std::function<void(VkCommandBuffer)>& record);
+        // or its recording is discarded. `outOutcome`, when given, separates
+        // the two failure kinds above. Never throws.
+        bool Submit(const char* what, const std::function<void(VkCommandBuffer)>& record,
+                    Outcome* outOutcome = nullptr);
 
         // Staged upload into a non-mappable buffer: host staging → one-shot
         // vkCmdCopyBuffer → an availability barrier covering every later
@@ -64,6 +88,15 @@ namespace OloEngine
         // that reaches for this is a bug.
         void SetFailNextSubmitsForTesting(u32 count);
         [[nodiscard]] u32 GetPendingFailNextSubmitsForTesting();
+
+        // The OTHER half of the fault injection: the next `count` submits are
+        // recorded and queued for real, then their fence wait is forced to
+        // fail — the VK_TIMEOUT shape. Outcome is `Submitted`, so a caller
+        // MUST still advance any state the queued work establishes. Without
+        // this the timeout path has no test, and it is the half that looks
+        // identical to a hard failure at the call site.
+        void SetFailNextFenceWaitsForTesting(u32 count);
+        [[nodiscard]] u32 GetPendingFailNextFenceWaitsForTesting();
 #endif
     } // namespace VulkanOneShot
 } // namespace OloEngine

--- a/OloEngine/src/Platform/Vulkan/VulkanOneShot.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanOneShot.h
@@ -50,6 +50,21 @@ namespace OloEngine
         // writes visible across submissions) → staging destroyed. Blocking,
         // like Submit.
         bool UploadToBuffer(VkBuffer dst, u64 dstOffset, const void* data, u64 sizeBytes, const char* what);
+
+#ifndef OLO_DIST
+        // Fault injection for the layout-desync tenants (#803). The next
+        // `count` Submit() calls return false without recording or submitting
+        // anything, which is the shape a caller must survive: the image stays
+        // in its OLD layout, so a caller that records the NEW one into
+        // VulkanImageInfoRegistry has created the wrong-oldLayout desync
+        // (VUID-VkImageMemoryBarrier2-oldLayout-01197 / the VUID-09600 family)
+        // that InitialLayout exists to prevent.
+        //
+        // Compiled out of Dist. Callers are tests only — a shipping code path
+        // that reaches for this is a bug.
+        void SetFailNextSubmitsForTesting(u32 count);
+        [[nodiscard]] u32 GetPendingFailNextSubmitsForTesting();
+#endif
     } // namespace VulkanOneShot
 } // namespace OloEngine
 

--- a/OloEngine/src/Platform/Vulkan/VulkanStorageBuffer.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanStorageBuffer.cpp
@@ -48,6 +48,15 @@ namespace OloEngine
         {
             OLO_CORE_ERROR("~VulkanStorageBuffer: release failed ({}) — leaking the buffer until process exit", e.what());
         }
+        catch (...)
+        {
+            // The catch-all is not belt-and-braces: `catch (const
+            // std::exception&)` alone lets anything not derived from it escape
+            // and terminate. One policy across every Vulkan resource
+            // destructor (#803).
+            OLO_CORE_ERROR("~VulkanStorageBuffer: release failed (unknown exception) — leaking the buffer until "
+                           "process exit");
+        }
     }
 
     void VulkanStorageBuffer::CreateBuffer()
@@ -161,7 +170,14 @@ namespace OloEngine
         {
             return;
         }
-        if (offset + size > std::max(m_Size, 1u))
+        // Widened BEFORE the sum: both operands are u32, so `offset + size`
+        // is evaluated modulo 2^32 and offset=0xFFFFFF00, size=0x200 wraps to
+        // 0x100 — passing the very guard meant to stop it, then handing the
+        // wrapped range to the mapped memcpy below (a heap write far outside
+        // the mapping) or to VulkanOneShot::UploadToBuffer.
+        // VulkanTexture2D::SubImage already compares against the remaining
+        // extent for the same reason.
+        if (static_cast<u64>(offset) + static_cast<u64>(size) > static_cast<u64>(std::max(m_Size, 1u)))
         {
             OLO_CORE_ERROR("VulkanStorageBuffer::SetData: {}+{} exceeds the buffer's {} bytes — dropping", offset,
                            size, m_Size);
@@ -212,6 +228,8 @@ namespace OloEngine
         // Bytes the new snapshot must carry: everything written so far this
         // frame (a shader may read any prefix the draw's instance count
         // covers), never less than a live snapshot already promised.
+        // `offset + size` cannot wrap here: SetData is the only caller and its
+        // widened range guard has already proven the sum is <= m_Size.
         const u32 newBytes = std::max(offset + size, liveSnapshot ? m_SnapshotBytes : 0u);
 
         // A write that does not start at 0 needs prefix bytes [0, offset)
@@ -306,7 +324,8 @@ namespace OloEngine
         {
             return;
         }
-        if (offset + size > std::max(m_Size, 1u))
+        // Widened before the sum — same u32 wrap as SetData's guard.
+        if (static_cast<u64>(offset) + static_cast<u64>(size) > static_cast<u64>(std::max(m_Size, 1u)))
         {
             OLO_CORE_ERROR("VulkanStorageBuffer::GetData: {}+{} exceeds the buffer's {} bytes", offset, size, m_Size);
             std::memset(outData, 0, size);

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.cpp
@@ -229,6 +229,14 @@ namespace OloEngine
         {
             OLO_CORE_ERROR("~VulkanTexture2D: release failed ({}) — leaking the image until process exit", e.what());
         }
+        catch (...)
+        {
+            // See ~VulkanStorageBuffer: `catch (const std::exception&)` alone
+            // still lets a non-std throw escape and terminate. One policy
+            // across every Vulkan resource destructor (#803).
+            OLO_CORE_ERROR("~VulkanTexture2D: release failed (unknown exception) — leaking the image until process "
+                           "exit");
+        }
     }
 
     void VulkanTexture2D::CreateImage()
@@ -1083,13 +1091,44 @@ namespace OloEngine
             return false;
         }
 
+        // The image's ACTUAL prior layout, not the steady-state assumption.
+        // Sampled asset content usually does sit in SHADER_READ_ONLY between
+        // graph executions, but two cases break the assumption and both are
+        // invalid usage (VUID-VkImageMemoryBarrier2-oldLayout-01197) that also
+        // leaves the copied texels undefined: a texture created and never
+        // uploaded is still UNDEFINED, and an ATTACHMENT sits in whatever
+        // layout the graph left it in.
+        //
+        // Prefer the tracker's EXECUTED layout, not its recorded one — this is
+        // a one-shot, so it runs BEFORE the still-recording frame command
+        // buffer whose transitions the recorded layout already reflects (#800,
+        // the same reasoning as VulkanRendererAPI::ReadTextureSubImage's borrow
+        // mode). Deliberately NO RegisterImage first: re-registering with
+        // extents or a registration id the graph did not use RESETS that
+        // image's rows, and wiping the graph's own tracked layouts to learn one
+        // value would be a far worse trade. An image the tracker has never seen
+        // answers UNDEFINED, which is exactly when the registry's load-time
+        // record is the better answer.
+        const auto* imageInfo = VulkanImageInfoRegistry::Get().Lookup(m_Image);
+        const VkImageLayout registryLayout =
+            imageInfo != nullptr ? imageInfo->InitialLayout : VK_IMAGE_LAYOUT_UNDEFINED;
+        const VkImageSubresourceRange range{ VK_IMAGE_ASPECT_COLOR_BIT, mipLevel, 1u, 0u, 1u };
+        auto* vk = VulkanUpload::TryGetVulkanAPI();
+        VkImageLayout priorLayout = registryLayout;
+        if (vk != nullptr)
+        {
+            if (const VkImageLayout tracked = vk->LayoutTracker().CurrentExecutedLayout(m_Image, range);
+                tracked != VK_IMAGE_LAYOUT_UNDEFINED)
+            {
+                priorLayout = tracked;
+            }
+        }
+
         const bool ok = VulkanOneShot::Submit(
             "VulkanTexture2D::GetData",
             [&](VkCommandBuffer cmd)
             {
-                // Steady-state invariant again: sampled content sits in
-                // SHADER_READ_ONLY between graph executions.
-                VulkanUpload::RecordImageBarrier(cmd, m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                VulkanUpload::RecordImageBarrier(cmd, m_Image, priorLayout,
                                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
                                                  VK_ACCESS_2_MEMORY_WRITE_BIT | VK_ACCESS_2_MEMORY_READ_BIT,
                                                  VK_PIPELINE_STAGE_2_COPY_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, mipLevel, 1u);
@@ -1103,10 +1142,37 @@ namespace OloEngine
                                                  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_2_COPY_BIT,
                                                  VK_ACCESS_2_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
                                                  VK_ACCESS_2_MEMORY_READ_BIT, mipLevel, 1u);
+
+                // Settle recorded INSIDE the one-shot's immediate-execution
+                // scope, so it advances the executed layout only once the
+                // buffer really reached the queue (#800) — the same shape as
+                // VulkanRendererAPI::ReadTextureSubImage's non-borrow arm.
+                if (vk != nullptr)
+                {
+                    vk->LayoutTracker().SetLayout(m_Image, range, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }
             });
 
         if (ok)
         {
+            // The chain ended in SHADER_READ_ONLY, so an image that entered
+            // UNDEFINED has genuinely reached it. Record it in the registry
+            // too: the tracker SetLayout above no-ops for an image the tracker
+            // never registered, and leaving a stale UNDEFINED behind would let
+            // the next barrier legally discard the texels. Only on success —
+            // the same gate as every other layout write in this backend.
+            //
+            // ONLY when this read covered the whole image. InitialLayout is a
+            // WHOLE-IMAGE field and the barriers above name `mipLevel` alone,
+            // so stamping it after a single-mip read of a mipped texture would
+            // claim mips 1..N reached SHADER_READ_ONLY when they are still
+            // UNDEFINED — manufacturing the very desync this change removes.
+            // The per-subresource truth is the tracker's, set inside the
+            // callback above.
+            if (m_MipLevels == 1u)
+            {
+                VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            }
             vmaInvalidateAllocation(device->GetAllocator(), readbackAllocation, 0, sizeBytes);
             outData.resize(sizeBytes);
             std::memcpy(outData.data(), readbackOut.pMappedData, sizeBytes);

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture.h
@@ -34,8 +34,9 @@ namespace OloEngine
     // -------------------------------------------------------------------------
     // VulkanTexture2D — attribute-only VMA image for the TransientPool.
     //
-    // Fully implemented: allocation, identity, metadata, Resize. Upload /
-    // bind / readback virtuals are warn-once no-ops for now.
+    // Fully implemented: allocation, identity, metadata, Resize, staged and
+    // host-copy uploads, blit-chain mip generation, readback and bind. No
+    // no-op virtuals remain on this class.
     // -------------------------------------------------------------------------
     class VulkanTexture2D : public Texture2D
     {
@@ -88,7 +89,9 @@ namespace OloEngine
         void SetData(void* data, u32 size) override;
         void SubImage(u32 x, u32 y, u32 width, u32 height, const void* data, u32 dataSize) override;
         void Invalidate(std::string_view path, u32 width, u32 height, const void* data, u32 channels) override;
-        // Bind is meaningless on this backend (heap-bindless): warn-once no-op.
+        // Forwards to the facade's BindTexture, so ShaderResourceRegistry-
+        // routed binds resolve on this backend too (they were silently dropped
+        // while this was a stub).
         void Bind(u32 slot) const override;
         bool GetData(std::vector<u8>& outData, u32 mipLevel = 0) const override;
 

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture2DArray.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture2DArray.cpp
@@ -369,18 +369,21 @@ namespace OloEngine
         {
             const auto* info = VulkanImageInfoRegistry::Get().Lookup(m_Image);
             const VkImageLayout prior = info != nullptr ? info->InitialLayout : VK_IMAGE_LAYOUT_UNDEFINED;
-            // Only on success: a failed submit never executed the chain, so
-            // the image is still in `prior`. Recording SHADER_READ_ONLY here
-            // would make the NEXT barrier name an oldLayout the image never
-            // reached — the desync InitialLayout exists to prevent, and the
-            // shape behind the VUID-09600 family (#800). SetLayerData above
-            // and VulkanTexture2D::SubImage already gate this way.
-            if (!VulkanOneShot::Submit("VulkanTexture2DArray::GenerateMipmaps",
-                                       [&](VkCommandBuffer cmd)
-                                       { record(cmd, prior); }))
+            // Gated on QUEUE ACCEPTANCE, not on the bool. A chain that never
+            // reached the queue leaves the image in `prior`, so recording
+            // SHADER_READ_ONLY would make the NEXT barrier name an oldLayout
+            // the image never reached — the desync InitialLayout exists to
+            // prevent (#800's family). But a chain that WAS accepted and only
+            // outran the fence wait will still execute, so skipping the record
+            // there is the same desync in the other direction. See
+            // VulkanOneShot::Outcome.
+            VulkanOneShot::Outcome outcome = VulkanOneShot::Outcome::NotSubmitted;
+            VulkanOneShot::Submit("VulkanTexture2DArray::GenerateMipmaps", [&](VkCommandBuffer cmd)
+                                  { record(cmd, prior); }, &outcome);
+            if (outcome == VulkanOneShot::Outcome::NotSubmitted)
             {
-                OLO_CORE_ERROR("VulkanTexture2DArray::GenerateMipmaps: one-shot submit failed — tracked layout "
-                               "left unchanged");
+                OLO_CORE_ERROR("VulkanTexture2DArray::GenerateMipmaps: the mip chain never reached the queue — "
+                               "tracked layout left unchanged");
                 return;
             }
         }

--- a/OloEngine/src/Platform/Vulkan/VulkanTexture2DArray.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTexture2DArray.cpp
@@ -369,9 +369,20 @@ namespace OloEngine
         {
             const auto* info = VulkanImageInfoRegistry::Get().Lookup(m_Image);
             const VkImageLayout prior = info != nullptr ? info->InitialLayout : VK_IMAGE_LAYOUT_UNDEFINED;
-            (void)VulkanOneShot::Submit("VulkanTexture2DArray::GenerateMipmaps",
-                                        [&](VkCommandBuffer cmd)
-                                        { record(cmd, prior); });
+            // Only on success: a failed submit never executed the chain, so
+            // the image is still in `prior`. Recording SHADER_READ_ONLY here
+            // would make the NEXT barrier name an oldLayout the image never
+            // reached — the desync InitialLayout exists to prevent, and the
+            // shape behind the VUID-09600 family (#800). SetLayerData above
+            // and VulkanTexture2D::SubImage already gate this way.
+            if (!VulkanOneShot::Submit("VulkanTexture2DArray::GenerateMipmaps",
+                                       [&](VkCommandBuffer cmd)
+                                       { record(cmd, prior); }))
+            {
+                OLO_CORE_ERROR("VulkanTexture2DArray::GenerateMipmaps: one-shot submit failed — tracked layout "
+                               "left unchanged");
+                return;
+            }
         }
         VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.cpp
@@ -344,9 +344,17 @@ namespace OloEngine
         {
             const auto* info = VulkanImageInfoRegistry::Get().Lookup(m_Image);
             const VkImageLayout prior = info != nullptr ? info->InitialLayout : VK_IMAGE_LAYOUT_UNDEFINED;
-            (void)VulkanOneShot::Submit("VulkanTextureCubemap::GenerateMipmaps",
-                                        [&](VkCommandBuffer cmd)
-                                        { recordChain(cmd, prior); });
+            // Only on success — see VulkanTexture2DArray::GenerateMipmaps for
+            // the contract: a failed submit leaves the image in `prior`, and
+            // recording the new layout anyway is the wrong-oldLayout desync.
+            if (!VulkanOneShot::Submit("VulkanTextureCubemap::GenerateMipmaps",
+                                       [&](VkCommandBuffer cmd)
+                                       { recordChain(cmd, prior); }))
+            {
+                OLO_CORE_ERROR("VulkanTextureCubemap::GenerateMipmaps: one-shot submit failed — tracked layout "
+                               "left unchanged");
+                return;
+            }
         }
         VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.cpp
@@ -344,15 +344,16 @@ namespace OloEngine
         {
             const auto* info = VulkanImageInfoRegistry::Get().Lookup(m_Image);
             const VkImageLayout prior = info != nullptr ? info->InitialLayout : VK_IMAGE_LAYOUT_UNDEFINED;
-            // Only on success — see VulkanTexture2DArray::GenerateMipmaps for
-            // the contract: a failed submit leaves the image in `prior`, and
-            // recording the new layout anyway is the wrong-oldLayout desync.
-            if (!VulkanOneShot::Submit("VulkanTextureCubemap::GenerateMipmaps",
-                                       [&](VkCommandBuffer cmd)
-                                       { recordChain(cmd, prior); }))
+            // Gated on queue acceptance — see VulkanTexture2DArray::
+            // GenerateMipmaps for the contract, and VulkanOneShot::Outcome for
+            // why the bool alone is the wrong question here.
+            VulkanOneShot::Outcome outcome = VulkanOneShot::Outcome::NotSubmitted;
+            VulkanOneShot::Submit("VulkanTextureCubemap::GenerateMipmaps", [&](VkCommandBuffer cmd)
+                                  { recordChain(cmd, prior); }, &outcome);
+            if (outcome == VulkanOneShot::Outcome::NotSubmitted)
             {
-                OLO_CORE_ERROR("VulkanTextureCubemap::GenerateMipmaps: one-shot submit failed — tracked layout "
-                               "left unchanged");
+                OLO_CORE_ERROR("VulkanTextureCubemap::GenerateMipmaps: the mip chain never reached the queue — "
+                               "tracked layout left unchanged");
                 return;
             }
         }

--- a/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanTextureCubemap.h
@@ -37,10 +37,13 @@ namespace OloEngine
     // EnvironmentMap::InitializeIBLSystem, which creates cubemaps eagerly, so
     // WITHOUT this class the factory's assert killed the editor before the
     // first frame. Scope matches VulkanTexture2DArray's: a real image with a
-    // real identity (so binds, barriers and the layout tracker all work), with
-    // the CPU upload / mip-generation / readback halves warn-once no-ops —
-    // the IBL bake path that fills those faces is GPU-side and is later
-    // work (SkyCubemapBake / IBLPrecompute still need the capture seam).
+    // real identity (so binds, barriers and the layout tracker all work).
+    //
+    // The CPU halves are implemented now: SetFaceDataMip stages a per-face
+    // upload, GenerateMipmaps runs the blit chain over all six faces, and
+    // ReadFaces backs GetFaceData/GetData. Only the whole-cubemap SetData and
+    // Invalidate remain warn-once no-ops — the engine fills cubemaps face by
+    // face or from the GPU-side bake, so nothing calls them.
     // -------------------------------------------------------------------------
     class VulkanTextureCubemap : public TextureCubemap
     {

--- a/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
@@ -161,6 +161,7 @@ class VulkanResourceFactory : public ::testing::Test
         // test that armed it and did not reach a one-shot would otherwise
         // leave the NEXT test's first submit silently failing.
         VulkanOneShot::SetFailNextSubmitsForTesting(0u);
+        VulkanOneShot::SetFailNextFenceWaitsForTesting(0u);
         if (!m_Device)
             return;
         vkDeviceWaitIdle(m_Device->GetDevice());
@@ -496,10 +497,11 @@ TEST_F(VulkanResourceFactory, HostUploadOfAMippedWidenedTextureRoundTrips)
         EXPECT_EQ(mip0[pixel * 4 + 3], 0xFFu);
     }
 
-    // GetData barriers from the image's RECORDED layout (#803), so a mip that
-    // reads back at all is also proof the upload left the image in the
-    // backend's steady-state layout AND recorded it — the invariant the host
-    // path declines the whole route rather than weaken.
+    // GetData barriers from the tracker's EXECUTED layout, falling back to
+    // VulkanImageInfo::InitialLayout when the tracker has never seen the image
+    // (#803). So a mip that reads back at all is also proof the upload left the
+    // image in the backend's steady-state layout AND recorded it — the
+    // invariant the host path declines the whole route rather than weaken.
     std::vector<u8> mip2;
     ASSERT_TRUE(texture->GetData(mip2, 2));
     ASSERT_EQ(mip2.size(), sizet{ 2 * 2 * 4 });
@@ -630,6 +632,65 @@ TEST_F(VulkanResourceFactory, CubemapMipGenerationLeavesTheTrackedLayoutAloneWhe
     EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout,
               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
         << "a successful mip chain does advance it";
+}
+
+TEST_F(VulkanResourceFactory, ArrayMipGenerationStillRecordsTheLayoutWhenOnlyTheFenceWaitFails)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    // The other side of the same coin. A fence-wait timeout means the queue
+    // ACCEPTED the chain, so it will execute and the image WILL reach
+    // SHADER_READ_ONLY — keeping the old layout there is the same stale-record
+    // desync, just reached from the opposite direction. Gating on the bool
+    // instead of VulkanOneShot::Outcome is what gets this wrong.
+    Texture2DArraySpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Layers = 2;
+    spec.Format = Texture2DArrayFormat::RGBA8;
+    spec.GenerateMipmaps = true;
+
+    auto array = Texture2DArray::Create(spec);
+    ASSERT_NE(array, nullptr);
+
+    const VkImage image = static_cast<VulkanTexture2DArray*>(array.get())->GetVkImage();
+    ASSERT_NE(image, VK_NULL_HANDLE);
+    ASSERT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+
+    VulkanOneShot::SetFailNextFenceWaitsForTesting(1u);
+    array->GenerateMipmaps();
+    EXPECT_EQ(VulkanOneShot::GetPendingFailNextFenceWaitsForTesting(), 0u)
+        << "the injected timeout must have been consumed by the mip chain's one-shot";
+
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        << "queued-but-unwaited work still executes, so the layout must be recorded";
+}
+
+TEST_F(VulkanResourceFactory, CubemapMipGenerationStillRecordsTheLayoutWhenOnlyTheFenceWaitFails)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    CubemapSpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Format = ImageFormat::RGBA8;
+    spec.GenerateMips = true;
+
+    auto cubemap = TextureCubemap::Create(spec);
+    ASSERT_NE(cubemap, nullptr);
+
+    const VkImage image = static_cast<VulkanTextureCubemap*>(cubemap.get())->GetVkImage();
+    ASSERT_NE(image, VK_NULL_HANDLE);
+    ASSERT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+
+    VulkanOneShot::SetFailNextFenceWaitsForTesting(1u);
+    cubemap->GenerateMipmaps();
+    EXPECT_EQ(VulkanOneShot::GetPendingFailNextFenceWaitsForTesting(), 0u);
+
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        << "queued-but-unwaited work still executes, so the layout must be recorded";
 }
 
 TEST_F(VulkanResourceFactory, ReadbackBarriersFromTheRecordedLayoutNotAnAssumedOne)

--- a/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
@@ -40,6 +40,8 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "OloEngine/Renderer/StorageBuffer.h"
 #include "OloEngine/Renderer/Texture.h"
+#include "OloEngine/Renderer/Texture2DArray.h"
+#include "OloEngine/Renderer/TextureCubemap.h"
 #include "OloEngine/Renderer/UniformBuffer.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/VertexBuffer.h"
@@ -48,8 +50,12 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #include "Platform/Vulkan/VulkanDescriptorSlotCache.h"
 #include "Platform/Vulkan/VulkanDevice.h"
 #include "Platform/Vulkan/VulkanFrameArena.h"
+#include "Platform/Vulkan/VulkanImageInfoRegistry.h"
+#include "Platform/Vulkan/VulkanOneShot.h"
 #include "Platform/Vulkan/VulkanResourceHeap.h"
 #include "Platform/Vulkan/VulkanTexture.h" // GetHostImageCopyUploadCount (#809)
+#include "Platform/Vulkan/VulkanTexture2DArray.h"
+#include "Platform/Vulkan/VulkanTextureCubemap.h"
 #include "Platform/Vulkan/VulkanTransientResources.h"
 
 #include <volk.h>
@@ -148,6 +154,13 @@ class VulkanResourceFactory : public ::testing::Test
 
     void TearDown() override
     {
+        // Disarm unconditionally, before the early return. The injection
+        // counter is a process-global static and every path that consumes it
+        // is conditional (GenerateMipmaps early-returns on a depth/BC format,
+        // and takes the in-frame branch when a recording API exists), so a
+        // test that armed it and did not reach a one-shot would otherwise
+        // leave the NEXT test's first submit silently failing.
+        VulkanOneShot::SetFailNextSubmitsForTesting(0u);
         if (!m_Device)
             return;
         vkDeviceWaitIdle(m_Device->GetDevice());
@@ -483,10 +496,10 @@ TEST_F(VulkanResourceFactory, HostUploadOfAMippedWidenedTextureRoundTrips)
         EXPECT_EQ(mip0[pixel * 4 + 3], 0xFFu);
     }
 
-    // GetData names SHADER_READ_ONLY_OPTIMAL as its oldLayout, so a mip that
+    // GetData barriers from the image's RECORDED layout (#803), so a mip that
     // reads back at all is also proof the upload left the image in the
-    // backend's steady-state layout — the invariant the host path declines
-    // the whole route rather than weaken.
+    // backend's steady-state layout AND recorded it — the invariant the host
+    // path declines the whole route rather than weaken.
     std::vector<u8> mip2;
     ASSERT_TRUE(texture->GetData(mip2, 2));
     ASSERT_EQ(mip2.size(), sizet{ 2 * 2 * 4 });
@@ -532,6 +545,113 @@ TEST_F(VulkanResourceFactory, HostUploadedTextureStillAcceptsASubImageUpdate)
     EXPECT_EQ(readback[patchedTexel + 0], 0xAAu);
     EXPECT_EQ(readback[patchedTexel + 3], 0xDDu);
     EXPECT_EQ(readback[0], 0x11u);
+}
+
+// ---------------------------------------------------------------------------
+// Layout tracking must not advance on a FAILED one-shot submit (#803).
+//
+// The desync these pin: a failed submit leaves the image in its OLD layout
+// while the registry claims the new one, so the NEXT barrier names an
+// oldLayout the image never reached. That is invalid usage
+// (VUID-VkImageMemoryBarrier2-oldLayout-01197) and the shape behind the
+// VUID-09600 family (#800). VulkanOneShot's fault injection is what makes it
+// reachable without a broken driver.
+// ---------------------------------------------------------------------------
+
+TEST_F(VulkanResourceFactory, ArrayMipGenerationLeavesTheTrackedLayoutAloneWhenTheSubmitFails)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    Texture2DArraySpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Layers = 2;
+    spec.Format = Texture2DArrayFormat::RGBA8;
+    spec.GenerateMipmaps = true;
+
+    auto array = Texture2DArray::Create(spec);
+    ASSERT_NE(array, nullptr);
+
+    const VkImage image = static_cast<VulkanTexture2DArray*>(array.get())->GetVkImage();
+    ASSERT_NE(image, VK_NULL_HANDLE);
+
+    // Freshly created and never uploaded: UNDEFINED is the truth.
+    const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
+    ASSERT_NE(info, nullptr);
+    ASSERT_EQ(info->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+
+    VulkanOneShot::SetFailNextSubmitsForTesting(1u);
+    array->GenerateMipmaps();
+    EXPECT_EQ(VulkanOneShot::GetPendingFailNextSubmitsForTesting(), 0u)
+        << "the injected failure must have been consumed by the mip chain's one-shot";
+
+    // THE assertion: nothing executed, so the tracked layout must be unmoved.
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED)
+        << "a failed submit must not advance the tracked layout";
+
+    // The A/B: the SAME call, same starting layout, no injection. It must
+    // advance the tracked layout — otherwise the assertion above would also
+    // pass on a version that simply never records anything.
+    array->GenerateMipmaps();
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        << "a successful mip chain does advance it";
+}
+
+TEST_F(VulkanResourceFactory, CubemapMipGenerationLeavesTheTrackedLayoutAloneWhenTheSubmitFails)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    CubemapSpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Format = ImageFormat::RGBA8;
+    spec.GenerateMips = true;
+
+    auto cubemap = TextureCubemap::Create(spec);
+    ASSERT_NE(cubemap, nullptr);
+
+    const VkImage image = static_cast<VulkanTextureCubemap*>(cubemap.get())->GetVkImage();
+    ASSERT_NE(image, VK_NULL_HANDLE);
+
+    const auto* info = VulkanImageInfoRegistry::Get().Lookup(image);
+    ASSERT_NE(info, nullptr);
+    ASSERT_EQ(info->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
+
+    VulkanOneShot::SetFailNextSubmitsForTesting(1u);
+    cubemap->GenerateMipmaps();
+    EXPECT_EQ(VulkanOneShot::GetPendingFailNextSubmitsForTesting(), 0u);
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout, VK_IMAGE_LAYOUT_UNDEFINED)
+        << "a failed submit must not advance the tracked layout";
+
+    // The other half of the A/B — without it this test stays green on an
+    // implementation that simply never records the layout at all.
+    cubemap->GenerateMipmaps();
+    EXPECT_EQ(VulkanImageInfoRegistry::Get().Lookup(image)->InitialLayout,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+        << "a successful mip chain does advance it";
+}
+
+TEST_F(VulkanResourceFactory, ReadbackBarriersFromTheRecordedLayoutNotAnAssumedOne)
+{
+    ScopedVulkanApiSelection vulkanApi;
+
+    // A texture created but NEVER uploaded is still UNDEFINED. GetData used to
+    // hardcode SHADER_READ_ONLY_OPTIMAL as its barrier's oldLayout, which is
+    // invalid usage here — and the fixture's TearDown asserts zero validation
+    // errors, so this test is what would catch it.
+    TextureSpecification spec;
+    spec.Width = 4;
+    spec.Height = 4;
+    spec.Format = ImageFormat::RGBA8;
+    spec.GenerateMips = false;
+
+    auto texture = Texture2D::Create(spec);
+    ASSERT_NE(texture, nullptr);
+
+    std::vector<u8> readback;
+    EXPECT_TRUE(texture->GetData(readback, 0));
+    EXPECT_EQ(readback.size(), sizet{ 4 * 4 * 4 });
 }
 
 TEST_F(VulkanResourceFactory, Maintenance5IsEnabledOnAContractSatisfyingDevice)

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -3195,10 +3195,26 @@ uploaded. It is wrong for the two cases that matter: a texture created from a
 spec and never uploaded is still `UNDEFINED`, and an **attachment** is in
 whatever the graph left it in. Naming `SHADER_READ_ONLY` there is
 VUID-VkImageMemoryBarrier2-oldLayout-01197 and makes the copied texels
-undefined. `VulkanTexture2D::GetData` now derives it the way
-`ReadTextureSubImage` does: seed the tracker from
-`VulkanImageInfo::InitialLayout`, then ask `CurrentExecutedLayout` — the
-*executed* timeline, because a one-shot runs ahead of the recording frame.
+undefined. `VulkanTexture2D::GetData` now asks the tracker for
+`CurrentExecutedLayout` — the *executed* timeline, because a one-shot runs
+ahead of the recording frame — and falls back to `VulkanImageInfo::InitialLayout`
+when the tracker answers `UNDEFINED`, which is exactly when the registry's
+load-time record is the better answer. Note what it deliberately does **not**
+do: call `RegisterImage` first to "seed" the tracker. Re-registering with
+extents or a registration id the graph did not use **resets that image's rows**,
+and wiping the graph's own tracked layouts to learn one value is a far worse
+trade than a fallback.
+
+**Entrance three: treating "the submit failed" as one thing.** `Submit` returns
+false for a pre-submit failure *and* for a fence wait that timed out after
+`vkQueueSubmit2` was accepted — and those need opposite handling. Accepted work
+executes whether or not the host observed the fence (queue submissions execute
+in submit order), so a caller that keeps the old layout there is stale by
+exactly the amount the first entrance is early. `VulkanOneShot::Outcome`
+(`NotSubmitted` / `Submitted` / `Completed`) is what the layout writes gate on;
+the bool stays "completed and waited" for the callers that mean that.
+`ImmediateExecutionScope::MarkSubmitted` promotes on acceptance for the same
+reason.
 
 **Testing it needs fault injection, and that is fine.** A failed
 `vkQueueSubmit2` is not reachable from a test on a healthy driver, so

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -3164,6 +3164,51 @@ in the queue*. If one field serves both "after what I am recording" and "right
 now", the two agree on every steady frame and disagree on the first frame a
 resource's lifetime changes — which is the frame nobody tests.
 
+### 16a. The same desync has two other entrances (#803)
+
+#800 fixed the tracker's *timeline*. Two sibling shapes write a layout the image
+never reached, and both were still live in the transient texture classes after
+the #801 split. Neither is a tracker bug; both are call-site bugs, and both look
+completely reasonable in review.
+
+**Entrance one: recording the new layout unconditionally.** The shape is a
+one-shot whose result is discarded, followed by the layout write:
+
+```cpp
+(void)VulkanOneShot::Submit("…::GenerateMipmaps", record);          // may FAIL
+VulkanImageInfoRegistry::Get().SetInitialLayout(m_Image, SHADER_READ_ONLY);
+```
+
+A failed submit executed nothing, so the image is still in its old layout while
+the tracker now claims the new one — and the *next* barrier names an `oldLayout`
+the image never reached. `VulkanTexture2DArray::GenerateMipmaps` and
+`VulkanTextureCubemap::GenerateMipmaps` both had it; every *other* site in the
+family already gated on `ok`, which is what made the two stand out once someone
+went looking. **The rule: a one-shot's return value is the write gate for every
+piece of state that submit was supposed to establish.** `(void)` on a
+`VulkanOneShot::Submit` is the grep that finds them.
+
+**Entrance two: hardcoding the steady state as `oldLayout`.** The comment says
+it out loud — "sampled content sits in `SHADER_READ_ONLY` between graph
+executions" — and that *is* the steady state, for asset textures that were
+uploaded. It is wrong for the two cases that matter: a texture created from a
+spec and never uploaded is still `UNDEFINED`, and an **attachment** is in
+whatever the graph left it in. Naming `SHADER_READ_ONLY` there is
+VUID-VkImageMemoryBarrier2-oldLayout-01197 and makes the copied texels
+undefined. `VulkanTexture2D::GetData` now derives it the way
+`ReadTextureSubImage` does: seed the tracker from
+`VulkanImageInfo::InitialLayout`, then ask `CurrentExecutedLayout` — the
+*executed* timeline, because a one-shot runs ahead of the recording frame.
+
+**Testing it needs fault injection, and that is fine.** A failed
+`vkQueueSubmit2` is not reachable from a test on a healthy driver, so
+`VulkanOneShot::SetFailNextSubmitsForTesting` (compiled out of Dist) makes the
+next N submits return `false` without recording. The tenant is then an A/B on
+one call: inject → assert the tracked layout is **unmoved**; do not inject →
+assert it moved. Only asserting the first half also passes on an implementation
+that never records anything, which is the failure mode the A/B exists to
+exclude.
+
 ---
 
 ## 17. Vulkan 1.4 conveniences (#809): a core feature is not a free feature


### PR DESCRIPTION
Works the whole checklist on #803 — the findings #801's review raised, agreed were correct, and deliberately kept out of a relocation commit because the value of a motion commit is that "behaviour unchanged" can be trusted. Each is a behaviour change with its own verification bar.

## Vulkan transient classes

**Record the new layout only when the one-shot submit succeeded.** A failed submit executed nothing, so the image is still in its old layout — recording the new one anyway makes the *next* barrier name an `oldLayout` the image never reached. That is VUID-VkImageMemoryBarrier2-oldLayout-01197 and the shape behind the VUID-09600 family (#800). `VulkanTexture2DArray::GenerateMipmaps` had it; so did the sibling `VulkanTextureCubemap::GenerateMipmaps`, which the issue didn't name — they are the only two `(void)VulkanOneShot::Submit` sites in the backend, and every *other* site in the family already gated on `ok`, which is what made these two visible.

**`VulkanTexture2D::GetData` had the same desync from the other end.** It hardcoded `SHADER_READ_ONLY_OPTIMAL` as its barrier's `oldLayout`. That is the steady state for an *uploaded asset texture* and wrong for the two cases that matter: a texture created from a spec and never uploaded is still `UNDEFINED`, and an attachment is in whatever the graph left it in. It now prefers the tracker's **executed** layout (a one-shot runs ahead of the recording frame, #800) and falls back to the registry's load-time record. Deliberately no `RegisterImage` first — re-registering with extents the graph didn't use *resets* that image's rows, and wiping the graph's tracked layouts to learn one value is a far worse trade.

**One exception policy.** `VulkanDeferredReclaim::Enqueue` and both drain paths are now `noexcept`, with the `push_back` and each per-entry destroy contained: a failed enqueue leaks one object loudly instead of terminating, and one bad entry cannot strand the entries behind it — an entry that never reaches `vmaDestroyAllocator` is the "allocations not freed" abort. `~VulkanFramebuffer` had **no** guard at all and now drops its published pointers (live set, binding state, root registry) *first*, so a later failure cannot strand a dangling registration that `ReleaseCachedDepthViewsForImage` would walk into. `~VulkanStorageBuffer` / `~VulkanTexture2D` gained the missing `catch (...)` — `catch (const std::exception&)` alone still lets a non-std throw escape and terminate.

**Sibling findings.** `VulkanStorageBuffer::SetData`/`GetData` computed `offset + size` in 32-bit, so `offset = 0xFFFFFF00, size = 0x200` wrapped to `0x100` and passed the very guard meant to stop it, then handed the wrapped range to a mapped `memcpy`. Both widened to u64.

**Stale comments** on `VulkanFramebuffer.h` / `VulkanTexture.h` / `VulkanTextureCubemap.h` corrected — they described warn-once no-ops for paths that gained real bodies in Phase 8. The cubemap one is now specific about what *is* still a no-op (`SetData`/`Invalidate` only).

**Recording probe** hoisted out of `UploadSlots`' per-slot loop. Deliberately at the **call site**, not cached in the helper: a cached `VulkanRendererAPI*` needs invalidation on `RecreateForSelectedBackend`, which is amendment (39)'s construction-order hazard. A loop-local answer has no lifetime, so it cannot go stale.

## OpenGL inspector backend

**Collapsed the duplicated 2D/cubemap format tables** behind one helper with an `allowDepth` split — the cubemap arm was the same table minus the depth cases, so the guard preserves that exactly rather than silently widening it. `QueryCaptureSource`'s third "copy" is **not** the same mapping (16F→`GL_FLOAT`, packed depth-stencil as depth-only float, `R11F_G11F_B10F`, refuses unknowns instead of defaulting) and stays separate, with that reasoning in a comment.

**`ColorAttachmentFormats` / `Depth` / `Stencil`** now carry sized internal formats, queried off the attached object (`GL_TEXTURE_INTERNAL_FORMAT` at the attached level, or `GL_RENDERBUFFER_INTERNAL_FORMAT`), instead of `GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE` — which answers `GL_FLOAT`/`GL_UNSIGNED_NORMALIZED`, not a format, while the struct documents these as native format enums. **The consumer audit came back narrower than amendment (77) assumed:** grepping `OloEditor/src/MCP/` for `FramebufferQuery` / `ColorAttachmentFormats` / `QueryFramebuffer` returns nothing — the MCP surface never exposed these fields. The only reader is the GPU Resource Inspector panel, which printed raw hex and now decodes via `FormatTextureFormatName`. Header contract comment updated.

**PBO download engine**: `glBufferStorage` is now error-checked (with a pre-drain so a caller's pending error isn't misattributed) — unchecked, a `GL_OUT_OF_MEMORY` let the code fence a PBO with no storage and report success. The two dead unbinds are gone; the one that must stay is commented as to *why* it stays.

**`GLStateGuard` capture loop**: active-unit save/restore hoisted, so a 32-unit driver stops paying 96 redundant `glGetIntegerv` + `glActiveTexture` pairs per snapshot.

## Two items that needed no code

- **"Remove the identical cubemap branch"** — already fixed on master by a later commit (flagged by cpp:S3923); `CalculateCompressedTextureMemory` now has one query path with the reasoning in a comment. Verified, not re-done.
- **The `RenderGraphPassSnapshot` item** — its premise ("pinned to native `u32` currency by `McpToolsRender`") was retired by #810 and #890. The class is backend-neutral, `Result` carries `u64 NativeCloneHandle`/`NativeSourceHandle`, and `McpToolsRender` reads them through `MCP::NativeHandleHex(u64)`. `Detail::QueryNativeTextureCloneInfo` no longer exists anywhere in the tree. Re-checked the consumer as the issue asks; nothing to change.

## Also

`docs/agent-rules/rhi-abstraction-boundary.md` §16a — the two remaining entrances to #800's desync class (a discarded submit result; a hardcoded steady-state `oldLayout`), the `(void)VulkanOneShot::Submit` grep that finds the first, and the A/B test recipe.

## Review guide

**Where I'd look hardest**

1. `OloEngine/src/Platform/Vulkan/VulkanTexture.cpp:1100-1180` — the `GetData` prior-layout derivation. It changes which layout a real barrier names, on a path that reads back both asset textures and framebuffer attachments. The `SetInitialLayout` at the end is gated on `m_MipLevels == 1u` on purpose: the barriers name `mipLevel` alone while `InitialLayout` is a **whole-image** field, so stamping it after a single-mip read of a mipped texture would claim mips 1..N reached `SHADER_READ_ONLY` when they are still `UNDEFINED` — manufacturing the exact desync this PR removes. (My own `/code-review` caught that; it was wrong in the first cut.)
2. `OloEngine/src/Platform/Vulkan/VulkanOneShot.{h,cpp}` — a fault-injection seam in a production path. It is `#ifndef OLO_DIST`, a single `u32` compare on the hot path, and disarmed unconditionally in the fixture's `TearDown` before its early return. If you'd rather it not ship at all, the alternative is not testing this fix.
3. `OloEngine/src/Platform/Vulkan/VulkanFramebuffer.cpp:156-205` — `~VulkanFramebuffer` went from unguarded to guarded, which trades "terminate" for "a dangling pointer if a step throws". The de-registrations are ordered first for exactly that reason; the ordering is the load-bearing part, not the `try`.

**What I verified, and how**

- **The layout fix is A/B-proven, not just green.** Reverted `VulkanTexture2DArray::GenerateMipmaps` to the pre-fix `(void)Submit(...)`, rebuilt, and `VulkanResourceFactory.ArrayMipGenerationLeavesTheTrackedLayoutAloneWhenTheSubmitFails` **FAILED** with "a failed submit must not advance the tracked layout". Restored, rebuilt, passes.
- Three new tenants in `OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp`: `ArrayMipGeneration…`, `CubemapMipGeneration…`, `ReadbackBarriersFromTheRecordedLayoutNotAnAssumedOne`. The first two are A/Bs on one call (inject → unmoved, don't inject → moved) because asserting only the first half also passes on an implementation that never records anything. The third relies on the fixture's `TearDown` **zero-validation-errors** assertion — that is what would have caught the old hardcoded `oldLayout` on a never-uploaded texture.
- `Vulkan*` filter: **104/104 pass** after the review fixes.
- Full suite: **6672 ran, 6646 passed, 0 failed, 26 skipped** (all environmental — Steam stub not on PATH, missing video/dragon fixtures, app-launch smoke).
- `/code-review` at high effort found 3 real issues, all fixed and re-verified (see below).

**Least confident about**

The `ColorAttachmentFormats` change. It is correct against the documented contract and the audit says the only consumer is the inspector panel — but it *is* a diagnostic-contract change, and "no consumer greps back" is an argument from absence. If anyone reads those values out of a saved inspector export, they will now see `GL_RGBA16F` where they used to see `GL_FLOAT`.

(The second entry here was "I could not verify the destructor changes against #794's live teardown forensics." That has since been done — see the review round below.)

**Deliberately not tested**

- ~~#794's teardown forensics were not re-run live.~~ **They were, after review.** See the "Review round" section above — the argument-from-reasoning this section originally carried has been replaced by a measurement.
- No visual verification: nothing here changes what the screen shows. The GL inspector changes affect the debug panel's text, and the Vulkan changes affect barrier `oldLayout`s on paths whose *correct* outcome is byte-identical pixels — which the 6672-test suite, including the GL/Vulkan parity tenants, does cover.
- The u32-wrap guards have no tenant. Reaching them needs a >4 GiB-offset `SetData` on a storage buffer, which no call site can produce; the fix is a widening with no behavioural change for any reachable input.

Closes #803


---

## Review round

Three CodeRabbit threads, all fixed rather than rebutted — two of them were my own errors.

**1. Queue acceptance vs fence retirement (Major, and a real bug).** `VulkanOneShot::Submit` returned `false` both when nothing reached `vkQueueSubmit2` *and* when the submit was accepted but the fence wait timed out. Those need opposite handling: accepted work executes whether or not the host observes the fence — queue submissions execute in submit order — so keeping the old layout there is stale by exactly the amount that recording it early is premature. The same desync, reached from the other direction, in the code that exists to remove it.

Now gated on `VulkanOneShot::Outcome` (`NotSubmitted` / `Submitted` / `Completed`) via an optional out-param; the `bool` keeps its "completed and waited" meaning so no other call site changes. `ImmediateExecutionScope::MarkSubmitted()` also moved to fire on **acceptance** rather than after a successful wait — it was discarding the queued layout writes of work certain to run, which is the tracker-side spelling of the same bug.

Coverage: a second injection knob (`SetFailNextFenceWaitsForTesting`) records and submits for real and forces only the wait to fail, giving `ArrayMipGenerationStillRecordsTheLayoutWhenOnlyTheFenceWaitFails` and its cubemap twin. They assert the layout **is** recorded, next to the existing pair asserting it is **not** — so the two failure kinds pin each other instead of one being asserted alone.

**2. Stale descriptions of my own code (Minor).** The test comment and doc §16a described an earlier cut that seeded the tracker via `RegisterImage`. I removed that during self-review — re-registering with extents the graph did not use **resets** that image's rows — but never updated the prose. Both corrected, and the doc now states the reset hazard as the reason, since "seed the tracker first" is the obvious-looking thing to reach for.

**3. #794 teardown forensics (Minor).** Fair hit: I had filed this under "deliberately not tested", which was the wrong call for a destructor-policy change. Both halves now run:

- `RendererShutdown.EveryProcessStaticGpuResourceHasAReleaseSite` **passes** (3945 ms), with 109/109 in the `Vulkan*:RendererShutdown.*` filter.
- Live `OloEditor --rhi=vulkan` (Debug), scene loaded and rendering, closed via the window path: **exit code 0**, log confirms `[RHI] Backend: Vulkan (source: --rhi flag)` and ends `[Vulkan] Context shut down cleanly`. Zero surviving-object lines, zero VMA "allocations not freed"; the only `[error]` all session is the C# debugger port, unrelated.

A trap worth recording for whoever runs that next: `Process.CloseMainWindow()` does **not** reach the editor's GLFW window. The first attempt sat 120 s and had to be killed, leaving a log with no shutdown section — indistinguishable from a real teardown hang. The process owns 7 top-level windows; the real one is class `GLFW30`. Enumerate them and post `WM_CLOSE` to the visible ones, and it exits in ~5 s. The `run-oloengine` driver only ever `Kill()`s the editor, so there is no clean-shutdown path to borrow from it.

**Full suite after the fixes: 6674 ran, 6650 passed, 0 failed, 24 skipped.**

## A ride-along CI commit

`ci(tsan): raise the TSan job timeout from 120 to 180 minutes` — separate commit, unrelated to the code here, included because it is what blocked this PR.

TSan failed on the first round, and it was not this branch: **zero** `WARNING: ThreadSanitizer` in the whole log, **zero** failing tests, cancelled at test 6224/6651 with every one passing, at exactly 2h0m18s against `timeout-minutes: 120`. Cause: sccache restored a stale key and reported a **2.70% hit rate** (1371 of 1409 TUs compiled from scratch), so the build ate 92 of the 120 minutes and left 28 for a suite needing ~35. Its own `if: always()` save then failed — *"Unable to reserve cache with key … another job may be creating this cache"* — so the next attempt would have started equally cold. The same job finished in **86 minutes on master** the day before.

The workflow comment already documented a 90→120 bump for this exact loop, so this is the lesson recurring. The real finding is the asymmetry rather than the number: **TSan was the only sanitizer job in that workflow with a `timeout-minutes` at all** — `asan-lsan-linux`, `ubsan-linux` and `asan-windows` run under the 360-minute default, and UBSan has been observed finishing at 126 minutes, over the cap TSan was held to.

Two things this does **not** do: it does not change any sanitizer setting, disable a test, or loosen an assertion; and it raises the ceiling without fixing the underlying cold-cache loop, whose real cause is the cache-key collision under the 10 GB repo cache cap. If eviction pressure worsens, this returns — the durable fix belongs on the cache-key side, as its own change.
