### PR TITLE
feat(mcp): olo_input_inject exposes ImGui hover/active state (#921)

### DIFF
--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -13,6 +13,7 @@
 #include "OloEngine/Core/SyntheticInput.h"
 
 #include <backends/imgui_impl_glfw.h>
+#include <imgui_internal.h> // GImGui->HoveredWindow/HoveredId/ActiveId for GetMcpInputState (issue #921)
 #include <GLFW/glfw3.h>
 #include <stb_image/stb_image_write.h>
 
@@ -1214,6 +1215,15 @@ namespace OloEngine
         state.CursorAskedY = m_McpCursorAskedY;
         state.CursorLandedX = m_McpCursorLandedX;
         state.CursorLandedY = m_McpCursorLandedY;
+
+        // What ImGui's hit-test resolved on the last frame the plan actually ran
+        // (issue #921) — latched by DrainMcpInputQueue every tick, not read live
+        // here. A live read at THIS point (after the plan drained, and possibly
+        // after the cursor has already been handed back to "nowhere") answers a
+        // different question than the one this field exists to answer.
+        state.HoveredWindowName = m_McpHoveredWindowName;
+        state.HoveredId = m_McpHoveredId;
+        state.ActiveId = m_McpActiveId;
         return state;
     }
 
@@ -2802,6 +2812,25 @@ namespace OloEngine
         if (m_EditorPreferencesPanel.OnImGuiRender(m_Prefs))
         {
             ApplyPreferences();
+        }
+
+        // Latch what ImGui's hit-test resolved THIS frame (issue #921), while an
+        // injected plan is in flight (or just drained — one extra frame past empty
+        // so the plan's LAST tick, where a press/release actually lands, is never
+        // missed). g.HoveredWindow/HoveredId/ActiveId are computed once per frame in
+        // NewFrame and then USED by every widget's ButtonBehavior during THIS same
+        // frame's Begin/End calls above — so reading them here, after every panel
+        // has run, is what makes the value match what ImGui itself actually decided.
+        // Reading them from DrainMcpInputQueue (tried first) reads the PREVIOUS
+        // frame's resolution, since that runs before NewFrame; reading them from the
+        // tool's post-hoc GetInputState() call reads whatever is hovered at report
+        // time, which can be long after the plan (and its cursor) are gone. Neither
+        // answers "what did ImGui do with the click" — this does.
+        if (::GImGui != nullptr && (!m_McpInputQueue.empty() || m_McpCursorRestoreCountdown > 0))
+        {
+            m_McpHoveredWindowName = ::GImGui->HoveredWindow != nullptr ? ::GImGui->HoveredWindow->Name : std::string{};
+            m_McpHoveredId = ::GImGui->HoveredId;
+            m_McpActiveId = ::GImGui->ActiveId;
         }
     }
 

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -510,6 +510,17 @@ namespace OloEngine
         f32 m_McpCursorAskedY = 0.0f;
         f32 m_McpCursorLandedX = 0.0f;
         f32 m_McpCursorLandedY = 0.0f;
+        // What ImGui's hit-test resolved on the LAST frame an injected plan actually
+        // ran (issue #921), captured at the end of OnImGuiRender (after every panel
+        // has run its Begin/widgets for the frame) while a plan is in flight. A live
+        // read taken when the tool reports back — after the plan has drained and the
+        // cursor may already have been handed back to "nowhere" — is stale by
+        // construction: g.HoveredWindow answers "what's under the cursor NOW", and by
+        // then there may BE no cursor. Latching it during the plan is what makes the
+        // diagnostic answer the question it's meant to answer.
+        std::string m_McpHoveredWindowName;
+        u32 m_McpHoveredId = 0;
+        u32 m_McpActiveId = 0;
 
         // Undo/Redo
         CommandHistory m_CommandHistory;

--- a/OloEditor/src/MCP/McpInputInject.h
+++ b/OloEditor/src/MCP/McpInputInject.h
@@ -1113,6 +1113,14 @@ namespace OloEngine::MCP::InputInject
                                            { "landedY", state.CursorLandedY },
                                            { "landed", landedRaw } };
         }
+        // What ImGui's hit-test resolved at the moment of this snapshot (issue #921):
+        // the difference between "reached the widget, widget ignored it" (a hovered
+        // window/id that names the widget you clicked) and "never reached the widget
+        // at all" (empty/unrelated hoveredWindow), which the cursor-landing check
+        // above cannot tell apart on its own.
+        after["hoveredWindow"] = state.HoveredWindowName.empty() ? Json(nullptr) : Json(state.HoveredWindowName);
+        after["hoveredId"] = state.HoveredId;
+        after["activeId"] = state.ActiveId;
         after["selectedEntity"] = state.SelectedEntityId == 0
                                       ? Json(nullptr)
                                       : Json{ { "id", std::to_string(state.SelectedEntityId) },

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -581,6 +581,19 @@ namespace OloEngine::MCP
         f32 CursorAskedY = 0.0f;
         f32 CursorLandedX = 0.0f;
         f32 CursorLandedY = 0.0f;
+
+        // What ImGui itself thinks is under the cursor / holding input RIGHT NOW
+        // (issue #921). `landed` above only proves the cursor POSITION took; it says
+        // nothing about whether ImGui's hit-test then routed that position to a
+        // widget. Without this, "the click landed and the widget ignored it" and
+        // "ImGui never resolved a hover at that point at all" were indistinguishable
+        // from the tool's reply alone — exactly the silent-failure shape this issue
+        // is about. Read directly off ImGui's internal state (g.HoveredWindow /
+        // g.HoveredId / g.ActiveId), which is why this needs no plumbing of its own:
+        // it is always live, not something only a mouse action populates.
+        std::string HoveredWindowName; // empty = ImGui has no hovered window this frame
+        u32 HoveredId = 0;             // ImGui item id under the cursor, 0 = none
+        u32 ActiveId = 0;              // ImGui item id currently holding the mouse, 0 = none
     };
 
     // Editor liveness + window state (issue #607) — the answer to "is the editor

--- a/OloEditor/src/MCP/McpToolsInput.cpp
+++ b/OloEditor/src/MCP/McpToolsInput.cpp
@@ -352,9 +352,14 @@ namespace OloEngine::MCP
                                                                             .Desc("Accumulated relative displacement from mouseDelta calls, in window-client logical pixels. Unlike an absolute injection this PERSISTS after the call — that is what lets a delta-integrating consumer register the movement. Zero it with mouseDelta { resetOffset: true }."))
                                                    .Prop("selectedEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the selected entity, or null when none."))
                                                    .Prop("hoveredEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the entity under the cursor, or null when none."))
-                                                   .Prop("hoveredWindow", Schema::Raw(Json{ { "type", Json::array({ "string", "null" }) } }).Desc("issue #921: the ImGui window name under the cursor on the last frame the injected plan ran (g.HoveredWindow), or null when ImGui resolved no window there at all. Distinguishes 'the click reached a window but missed every widget' (this set, hoveredId 0) from 'the click never reached ImGui' (null)."))
+                                                   .Prop("hoveredWindow", Schema::Raw(Json{ { "type", Json::array({ "string", "null" }) } })
+                                                                              .Desc("issue #921: the ImGui window name under the cursor on the last frame the injected "
+                                                                                    "plan ran (g.HoveredWindow), or null when ImGui resolved no window there at all. "
+                                                                                    "Distinguishes 'the click reached a window but missed every widget' (this set, "
+                                                                                    "hoveredId 0) from 'the click never reached ImGui' (null)."))
                                                    .Prop("hoveredId", Schema::Int().Desc("issue #921: the ImGui item id under the cursor (g.HoveredId), 0 when no widget was hovered even though hoveredWindow may be set."))
-                                                   .Prop("activeId", Schema::Int().Desc("issue #921: the ImGui item id currently holding the mouse (g.ActiveId), 0 when nothing is active — normal for a plain click once ButtonBehavior releases it."))
+                                                   .Prop("activeId", Schema::Int().Desc("issue #921: the ImGui item id currently holding the mouse (g.ActiveId), 0 when "
+                                                                                        "nothing is active — normal for a plain click once ButtonBehavior releases it."))
                                                    .Desc("Post-injection editor state — the state change the injection caused."))
                                 .Required({ "available", "ok", "framesInjected", "message", "after" });
         tool.MainMarshaled = true;

--- a/OloEditor/src/MCP/McpToolsInput.cpp
+++ b/OloEditor/src/MCP/McpToolsInput.cpp
@@ -189,7 +189,13 @@ namespace OloEngine::MCP
                             { "cursorAskedX", state.CursorAskedX },
                             { "cursorAskedY", state.CursorAskedY },
                             { "cursorLandedX", state.CursorLandedX },
-                            { "cursorLandedY", state.CursorLandedY } };
+                            { "cursorLandedY", state.CursorLandedY },
+                            // ImGui's own hit-test resolution (issue #921) — named
+                            // "imgui*" to avoid colliding with the entity-hover keys
+                            // above, which are a completely different concept.
+                            { "imguiHoveredWindow", state.HoveredWindowName },
+                            { "imguiHoveredId", state.HoveredId },
+                            { "imguiActiveId", state.ActiveId } };
                     if (context.GetEditorLiveness)
                     {
                         const McpEditorLiveness liveness = context.GetEditorLiveness();
@@ -223,6 +229,9 @@ namespace OloEngine::MCP
             state.CursorAskedY = stateJson.value("cursorAskedY", 0.0f);
             state.CursorLandedX = stateJson.value("cursorLandedX", 0.0f);
             state.CursorLandedY = stateJson.value("cursorLandedY", 0.0f);
+            state.HoveredWindowName = stateJson.value("imguiHoveredWindow", std::string{});
+            state.HoveredId = stateJson.value("imguiHoveredId", static_cast<u32>(0));
+            state.ActiveId = stateJson.value("imguiActiveId", static_cast<u32>(0));
 
             McpInputViewportInfo info;
             info.Available = true;
@@ -343,6 +352,9 @@ namespace OloEngine::MCP
                                                                             .Desc("Accumulated relative displacement from mouseDelta calls, in window-client logical pixels. Unlike an absolute injection this PERSISTS after the call — that is what lets a delta-integrating consumer register the movement. Zero it with mouseDelta { resetOffset: true }."))
                                                    .Prop("selectedEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the selected entity, or null when none."))
                                                    .Prop("hoveredEntity", Schema::Raw(Json{ { "type", Json::array({ "object", "null" }) } }).Desc("{id, name} of the entity under the cursor, or null when none."))
+                                                   .Prop("hoveredWindow", Schema::Raw(Json{ { "type", Json::array({ "string", "null" }) } }).Desc("issue #921: the ImGui window name under the cursor on the last frame the injected plan ran (g.HoveredWindow), or null when ImGui resolved no window there at all. Distinguishes 'the click reached a window but missed every widget' (this set, hoveredId 0) from 'the click never reached ImGui' (null)."))
+                                                   .Prop("hoveredId", Schema::Int().Desc("issue #921: the ImGui item id under the cursor (g.HoveredId), 0 when no widget was hovered even though hoveredWindow may be set."))
+                                                   .Prop("activeId", Schema::Int().Desc("issue #921: the ImGui item id currently holding the mouse (g.ActiveId), 0 when nothing is active — normal for a plain click once ButtonBehavior releases it."))
                                                    .Desc("Post-injection editor state — the state change the injection caused."))
                                 .Required({ "available", "ok", "framesInjected", "message", "after" });
         tool.MainMarshaled = true;

--- a/OloEngine/tests/MCP/McpInputInjectTest.cpp
+++ b/OloEngine/tests/MCP/McpInputInjectTest.cpp
@@ -171,6 +171,9 @@ namespace
                     state.CursorLandedX = end.WindowX + m_CursorLandingOffsetX;
                     state.CursorLandedY = end.WindowY + m_CursorLandingOffsetY;
                 }
+                state.HoveredWindowName = m_HoveredWindowName;
+                state.HoveredId = m_HoveredId;
+                state.ActiveId = m_ActiveId;
                 return ToolResult::Text(
                     Inject::ToJson(result, state, m_ViewportInfo, request, start, end, /*timedOut*/ false).dump());
             };
@@ -184,6 +187,11 @@ namespace
         f32 m_CursorLandingOffsetX = 0.0f;
         f32 m_CursorLandingOffsetY = 0.0f;
         int m_InjectCount = 0;
+        // What ImGui's hit-test resolved (issue #921) — defaults to "nothing
+        // hovered", the honest answer for a fake with no ImGui context at all.
+        std::string m_HoveredWindowName;
+        u32 m_HoveredId = 0;
+        u32 m_ActiveId = 0;
         McpInputPlan m_LastPlan;
         Inject::ResolvedPoint m_LastStart;
         McpServer m_Server; // declared last => destroyed first (its handler refs members)
@@ -359,6 +367,68 @@ TEST_F(McpInputInjectTest, AHostThatCannotMeasureTheLandingStillReportsOk)
     const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
     EXPECT_TRUE(payload["ok"].get<bool>());
     EXPECT_FALSE(payload["after"].contains("cursorLanding"));
+}
+
+// ---- issue #921: telling "reached the widget, widget ignored it" apart from
+// "never reached the widget" ---------------------------------------------------
+//
+// `cursorLanding` (issue #854) only proves the injected POSITION took. It says
+// nothing about whether ImGui's hit-test then routed that position to a widget —
+// the exact gap #921 reports: a docked-panel click lands (`cursorLanding.landed:
+// true`), reports `ok: true`, and the widget never reacts. `after.hoveredWindow` /
+// `hoveredId` / `activeId` are read straight off ImGui's own hit-test result
+// (EditorLayer's g.HoveredWindow / g.HoveredId / g.ActiveId), so a session can now
+// distinguish the two failure shapes instead of guessing from silence.
+
+TEST_F(McpInputInjectTest, HoveredWindowSetButNoItemMeansReachedTheWidgetAreaNotTheWidget)
+{
+    m_Server.SetAllowWrites(true);
+    // ImGui resolved a window at the click point, but no specific item — the
+    // "landed in the right neighborhood, missed the actual control" shape.
+    m_HoveredWindowName = "Terrain Editor";
+    m_HoveredId = 0;
+    m_ActiveId = 0;
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(76, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_EQ(payload["after"]["hoveredWindow"].get<std::string>(), "Terrain Editor");
+    EXPECT_EQ(payload["after"]["hoveredId"].get<u32>(), 0u);
+    EXPECT_EQ(payload["after"]["activeId"].get<u32>(), 0u);
+}
+
+TEST_F(McpInputInjectTest, NoHoveredWindowMeansTheClickNeverReachedAnyWidgetAtAll)
+{
+    m_Server.SetAllowWrites(true);
+    // ImGui resolved NO window at all — a stronger, different failure than the
+    // above: the click never reached anything ImGui knows about.
+    // m_HoveredWindowName left at its default (empty).
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(77, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_TRUE(payload["after"]["hoveredWindow"].is_null());
+    EXPECT_EQ(payload["after"]["hoveredId"].get<u32>(), 0u);
+}
+
+TEST_F(McpInputInjectTest, HoveredWindowAndItemBothSetMeansTheClickReachedARealWidget)
+{
+    m_Server.SetAllowWrites(true);
+    // The success shape: a window AND an item id, and (once the button transition
+    // is processed) an active id — the click reached an actual control.
+    m_HoveredWindowName = "Renderer Settings";
+    m_HoveredId = 1234;
+    m_ActiveId = 1234;
+
+    const Json response = m_Server.HandleMessage(
+        MakeCallRequest(78, "olo_input_inject", Json{ { "action", "click" }, { "x", 640 }, { "y", 360 } }));
+    const Json payload = Json::parse(response["result"]["content"][0]["text"].get<std::string>());
+    EXPECT_TRUE(payload["ok"].get<bool>());
+    EXPECT_EQ(payload["after"]["hoveredWindow"].get<std::string>(), "Renderer Settings");
+    EXPECT_EQ(payload["after"]["hoveredId"].get<u32>(), 1234u);
+    EXPECT_EQ(payload["after"]["activeId"].get<u32>(), 1234u);
 }
 
 TEST(McpInputInjectLanding, ToleranceCatchesTheRealFailureAndForgivesFloatNoise)

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -845,6 +845,9 @@ The response's `after` block already reports the consequence — no second round
   "after": {
     "pending": false,
     "viewportHovered": true,
+    "hoveredWindow": "Viewport",
+    "hoveredId": 0,
+    "activeId": 0,
     "selectedEntity": { "id": "12652600558176869447", "name": "Cube" },
     "hoveredEntity":  { "id": "12652600558176869447", "name": "Cube" }
   }
@@ -863,6 +866,48 @@ The response's `after` block already reports the consequence — no second round
 For an ImGui widget (a menu, a panel button, a hierarchy row), use `space: "window"` and
 read the pixel off a full-window screenshot from the `run-oloengine` driver
 (`driver.ps1 -Action shot`, which captures the whole window, not just the viewport).
+
+**`after.hoveredWindow` / `hoveredId` / `activeId` — did the click reach a widget at all?
+(issue #921)**
+
+`cursorLanding` above only proves the injected cursor *position* took. It says nothing
+about whether ImGui's hit-test then routed that position to a widget — which is exactly
+the gap issue #921 reported: a click on a docked-panel widget can report `ok: true`,
+`cursorLanding.landed: true`, and still do nothing, because the click reached a DIFFERENT
+window than the one the widget lives in. These three fields are read straight off ImGui's
+own hit-test result (`g.HoveredWindow` / `g.HoveredId` / `g.ActiveId`), latched on the last
+frame the injected plan actually ran (not read after the fact, when the cursor may already
+be gone) — so a reply now distinguishes three shapes:
+
+- `hoveredWindow: null` — ImGui found **no window at all** under the cursor. The click
+  never reached ImGui in any meaningful sense.
+- `hoveredWindow` set, `hoveredId: 0` — ImGui found a window, but **no specific item** in
+  it. The click landed in that window's real estate but missed every widget — often a
+  sign the target widget's actual clickable rect is smaller, or positioned differently,
+  than it visually appears (e.g. a dock node whose hit-test rect doesn't match what it
+  paints — see the note on a known instance of this below).
+- `hoveredWindow` and `hoveredId` both set — the click reached a real widget. `activeId`
+  matching `hoveredId` means that widget is now holding the mouse (e.g. mid-drag on a
+  slider); for a plain click it is normal for `activeId` to already be back to 0 by the
+  time this is read, since `ButtonBehavior` clears it on release.
+
+```jsonc
+// A docked panel where the click silently misses every widget:
+// olo_input_inject { "action": "click", "x": 246, "y": 90, "space": "window" }
+{ "ok": true, "after": { "hoveredWindow": "Terrain Editor", "hoveredId": 0, "activeId": 0 } }
+// -> reached the panel's own window, but not any control inside it. Nudge the
+//    coordinate, or suspect the panel's hit-test rect doesn't match its paint area.
+```
+
+Known instance of the "wrong rect" shape: a panel docked into a **newly created** split
+(dragged there mid-session, as opposed to one restored from a layout already saved in
+`imgui.ini`) can end up with a hit-test rect narrower than the area it visually paints —
+so a click on the *visually* correct spot for a control near the far edge of the panel
+actually lands on whatever sibling panel's rect still (incorrectly) covers that space,
+which silently swallows the click. `hoveredWindow` names that sibling, not the panel you
+aimed at, which is how you tell the two apart without guessing. Tracked as a follow-up
+(root cause is in ImGui's docking layout, not in `olo_input_inject`'s injection path) —
+see issue #921's tracker for the filed follow-up.
 
 **Caveats**
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -882,10 +882,8 @@ be gone) — so a reply now distinguishes three shapes:
 - `hoveredWindow: null` — ImGui found **no window at all** under the cursor. The click
   never reached ImGui in any meaningful sense.
 - `hoveredWindow` set, `hoveredId: 0` — ImGui found a window, but **no specific item** in
-  it. The click landed in that window's real estate but missed every widget — often a
-  sign the target widget's actual clickable rect is smaller, or positioned differently,
-  than it visually appears (e.g. a dock node whose hit-test rect doesn't match what it
-  paints — see the note on a known instance of this below).
+  it. The click landed in that window's real estate but missed every widget — usually a
+  coordinate slightly off the intended control; nudge it and re-check `hoveredId`.
 - `hoveredWindow` and `hoveredId` both set — the click reached a real widget. `activeId`
   matching `hoveredId` means that widget is now holding the mouse (e.g. mid-drag on a
   slider); for a plain click it is normal for `activeId` to already be back to 0 by the
@@ -896,18 +894,8 @@ be gone) — so a reply now distinguishes three shapes:
 // olo_input_inject { "action": "click", "x": 246, "y": 90, "space": "window" }
 { "ok": true, "after": { "hoveredWindow": "Terrain Editor", "hoveredId": 0, "activeId": 0 } }
 // -> reached the panel's own window, but not any control inside it. Nudge the
-//    coordinate, or suspect the panel's hit-test rect doesn't match its paint area.
+//    coordinate and re-check hoveredId.
 ```
-
-Known instance of the "wrong rect" shape: a panel docked into a **newly created** split
-(dragged there mid-session, as opposed to one restored from a layout already saved in
-`imgui.ini`) can end up with a hit-test rect narrower than the area it visually paints —
-so a click on the *visually* correct spot for a control near the far edge of the panel
-actually lands on whatever sibling panel's rect still (incorrectly) covers that space,
-which silently swallows the click. `hoveredWindow` names that sibling, not the panel you
-aimed at, which is how you tell the two apart without guessing. Tracked as a follow-up
-(root cause is in ImGui's docking layout, not in `olo_input_inject`'s injection path) —
-see issue #921's tracker for the filed follow-up.
 
 **Caveats**
 


### PR DESCRIPTION
## Summary

`olo_input_inject`'s `cursorLanding` check (#854) only proves the injected cursor *position* took — it says nothing about whether ImGui's hit-test then routed that position to a widget. That's exactly the gap #921 reports: a docked-panel click reports `ok: true` / `landed: true` and the widget never reacts, with no way to distinguish "reached the widget, widget ignored it" from "never reached anything ImGui knows about".

- `after.hoveredWindow` / `hoveredId` / `activeId` close it, read straight off ImGui's own `g.HoveredWindow` / `g.HoveredId` / `g.ActiveId`.
- Latched at the end of `EditorLayer::OnImGuiRender()` — after every panel has drawn for the frame, the same point `ButtonBehavior` itself resolves against — while an injected plan is active or in its post-plan settle window. A live read taken when the tool reports back (after the plan has drained, possibly after the cursor has already been handed back to "nowhere") answers a different, useless question.
- Getting the capture point right took two iterations, both empirically verified live: capturing inside `DrainMcpInputQueue` (before `NewFrame`) always read the *previous* frame's resolution; capturing after the plan and countdown drain read stale/absent hover. The current point — end of `OnImGuiRender`, guarded on the plan still being active or settling — was confirmed against a known-good control (a menu-bar click correctly reports `hoveredWindow: "##MainMenuBar"`) before trusting it against the actual bug.

## What the live diagnostic actually found

Using the now-working diagnostic to drive the investigation (not just add it), I traced #921's mechanism: a panel docked into a **newly created split** ends up with an ImGui hit-test rect **narrower than the area it visually paints**. Concretely, on the Terrain Editor panel docked into a new top-level split:

```jsonc
// x well inside the panel's visually-full-width strip, y on the "Edit Mode" row
// olo_input_inject { "action": "move", "x": 246, "y": 90, "space": "window" }
{ "after": { "hoveredWindow": "Terrain Editor", "hoveredId": 0 } }   // reaches the panel, misses every control

// x further right, still visually well inside the same panel
// olo_input_inject { "action": "move", "x": 280, "y": 90, "space": "window" }
{ "after": { "hoveredWindow": "Scene Hierarchy", "hoveredId": 1603940588 } }  // a SIBLING panel's rect wins instead
```

The switch boundary (~x=270) matches the sibling panel's own dock-column width almost exactly, and survives a full editor restart (the corrupted layout persists in `imgui.ini`) — so this is a genuine ImGui docking-layout bug, not an artifact of the injection path itself. Filed separately as #944, since it needs a live-GL-context editor test fixture to pin properly (out of scope for the headless `McpInputInjectTest`/`SyntheticInputTest` home this issue named), and it isn't yet confirmed whether a real (non-synthetic) mouse drag reproduces the identical corruption.

## Review guide

**Where I'd look hardest**
1. `OloEditor/src/EditorLayer.cpp` (the `OnImGuiRender()` capture site, ~line 2829) — the guard condition (`!m_McpInputQueue.empty() || m_McpCursorRestoreCountdown > 0`) is the one place this PR's whole value depends on; get the timing wrong and the diagnostic silently goes back to reporting nothing useful, the way two earlier iterations did before I found this one.
2. `OloEditor/src/MCP/McpToolsInput.cpp` — the intermediate `stateJson` round-trip. The first version of this fix set the fields correctly in `EditorLayer::GetMcpInputState()` but never wired them through this JSON hop, so they silently reset to null/0 every time — caught only by adding a temporary `OLO_CORE_WARN` and checking `OloEngine.log` against a live editor. Worth double-checking the key names (`imguiHoveredWindow`/`imguiHoveredId`/`imguiActiveId`) don't collide with the existing entity-hover `hoveredId` key in the same object.

**What I verified, and how**
- Unit tests: `McpInputInjectTest.*Hovered*` (3 new tests) plus the full `McpInputInject*`/`SyntheticInputTest.*` suite (56 tests) — `OloEngine-Tests.exe --gtest_filter=...`, all pass.
- Live, over MCP, against a running editor (`run-oloengine` skill `attach`): confirmed `hoveredWindow: "##MainMenuBar"` on a menu-bar click (known-good control), then used the diagnostic to trace the actual docked-panel failure mechanism described above — screenshots and raw MCP responses captured throughout the investigation.
- Confirmed the fix required BOTH the `EditorLayer.cpp` capture-point relocation AND the `McpToolsInput.cpp` JSON round-trip fix — verified each was broken independently (first attempt: correct capture point, but always-null in the reply; traced to the missing JSON keys) and both together produce the correct live result.

**Least confident about** — whether the "narrower hit-test rect after a new split" root cause (#944) is specific to synthetic/interpolated drag sequences or reproduces identically with a real mouse. I could not test a real drag from this session; #944's acceptance criteria calls that out explicitly.

**Deliberately not tested** — a live-GL-context regression test for the #944 root cause itself; that needs an editor-level fixture (`RendererAttachedTest`-shaped, not the headless `McpInputInjectTest`/`SyntheticInputTest` home this issue named), tracked as part of #944 rather than blocking this PR.

Closes #921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input-injection diagnostics with hovered window, hovered item, and active item details.
  * Responses now distinguish between missed windows, missed widgets, and successfully targeted widgets.

* **Documentation**
  * Added guidance and examples for interpreting input hit-test results, including dock-layout mismatches.

* **Tests**
  * Added coverage for window-level, widget-level, and successful input targeting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->