### PR TITLE
fix(vulkan): align Drift foliage pipeline contracts

### DIFF
--- a/OloEditor/assets/shaders/Impostor_Bake.glsl
+++ b/OloEditor/assets/shaders/Impostor_Bake.glsl
@@ -10,9 +10,23 @@
 #type vertex
 #version 460 core
 
+#ifdef OLO_VULKAN
+// The Vulkan backend deliberately declares no fixed-function vertex input.
+// ImpostorBaker draws an ordinary engine MeshSource vertex stream, so consume
+// the canonical 32-byte Vertex layout through the engine-wide pull binding:
+// vec3 position @ 0, vec3 normal @ 12, vec2 UV @ 24. This is the same V1
+// contract as PBR_MultiLight/PBR_GBuffer and preserves the mesh data used by
+// the OpenGL attribute route below.
+layout(std430, binding = 57) readonly buffer OloVertexPull
+{
+    float v[];
+} b_Vertices;
+#define OLO_PULLED_VERTEX 1
+#else
 layout(location = 0) in vec3 a_Position;
 layout(location = 1) in vec3 a_Normal;
 layout(location = 2) in vec2 a_TexCoord;
+#endif
 
 layout(std140, binding = 55) uniform ImpostorBakeParams
 {
@@ -28,6 +42,12 @@ layout(location = 2) out vec2 v_TexCoord;
 
 void main()
 {
+#ifdef OLO_PULLED_VERTEX
+    int vertBase = gl_VertexIndex * 8;
+    vec3 a_Position = vec3(b_Vertices.v[vertBase + 0], b_Vertices.v[vertBase + 1], b_Vertices.v[vertBase + 2]);
+    vec3 a_Normal = vec3(b_Vertices.v[vertBase + 3], b_Vertices.v[vertBase + 4], b_Vertices.v[vertBase + 5]);
+    vec2 a_TexCoord = vec2(b_Vertices.v[vertBase + 6], b_Vertices.v[vertBase + 7]);
+#endif
     v_ObjPos = a_Position;
     v_Normal = a_Normal; // object space
     v_TexCoord = a_TexCoord;

--- a/OloEngine/src/OloEngine/Renderer/GBuffer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/GBuffer.cpp
@@ -17,25 +17,21 @@ namespace OloEngine
             spec.Width = width;
             spec.Height = height;
             spec.Samples = sampleCount;
-            spec.Attachments = FramebufferAttachmentSpecification{
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RGBA8 },       // RT0 Albedo + Metallic
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RGBA16F },     // RT1 Normal + Roughness + AO
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RGBA16F },     // RT2 Emissive + Flags
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RG16F },       // RT3 Velocity
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RED_INTEGER }, // RT4 EntityID (picking)
-                FramebufferTextureSpecification{ FramebufferTextureFormat::RGBA16F },     // RT5 Baked lightmap irradiance + coverage (issue #865)
-                // Depth must match the scene framebuffer's depth format
-                // (`FramebufferTextureFormat::Depth` = DEPTH24STENCIL8) so that
-                // `RenderCommand::BlitFramebuffer(RHI::BlitAspect::Depth, …)` — the path used
-                // by `DeferredLightingPass` to hand G-Buffer depth to downstream
-                // passes and by `SceneRenderPass::ResolveToScene` in forward+ —
-                // succeeds. A format mismatch here surfaces as a per-frame flood
-                // of `GL_INVALID_OPERATION: Depth formats do not match` and
-                // leaves the scene-FB depth uninitialised, breaking every
-                // downstream depth-read (overlays, foliage, decals, water,
-                // SSAO/GTAO, fog, DoF, motion blur).
-                FramebufferTextureSpecification{ FramebufferTextureFormat::Depth }
-            };
+            spec.Attachments.Attachments.reserve(GBuffer::s_ColorAttachmentFormats.size() + 1);
+            for (const auto format : GBuffer::s_ColorAttachmentFormats)
+                spec.Attachments.Attachments.emplace_back(format);
+
+            // Depth must match the scene framebuffer's depth format
+            // (`FramebufferTextureFormat::Depth` = DEPTH24STENCIL8) so that
+            // `RenderCommand::BlitFramebuffer(RHI::BlitAspect::Depth, …)` — the path used
+            // by `DeferredLightingPass` to hand G-Buffer depth to downstream
+            // passes and by `SceneRenderPass::ResolveToScene` in forward+ —
+            // succeeds. A format mismatch here surfaces as a per-frame flood
+            // of `GL_INVALID_OPERATION: Depth formats do not match` and
+            // leaves the scene-FB depth uninitialised, breaking every
+            // downstream depth-read (overlays, foliage, decals, water,
+            // SSAO/GTAO, fog, DoF, motion blur).
+            spec.Attachments.Attachments.emplace_back(FramebufferTextureFormat::Depth);
             return spec;
         }
 

--- a/OloEngine/src/OloEngine/Renderer/GBuffer.h
+++ b/OloEngine/src/OloEngine/Renderer/GBuffer.h
@@ -5,6 +5,8 @@
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Renderer/Framebuffer.h"
 
+#include <array>
+
 namespace OloEngine
 {
     // @brief 6-RT G-Buffer for the deferred renderer.
@@ -55,6 +57,20 @@ namespace OloEngine
             EntityID = 4, // RED_INTEGER — per-pixel picking entity ID (cleared to -1)
             BakedGI = 5,  // RGBA16F     — baked lightmap irradiance + coverage (issue #865)
             Count = 6
+        };
+
+        // The production-owned colour-attachment contract in AttachmentIndex
+        // order. GBuffer.cpp builds both the draw and resolve framebuffers from
+        // this table, and reflection tests compare every full G-Buffer writer
+        // against it, so shader numeric types and attachment formats cannot
+        // drift as independent mirrors.
+        inline static constexpr std::array<FramebufferTextureFormat, Count> s_ColorAttachmentFormats = {
+            FramebufferTextureFormat::RGBA8,
+            FramebufferTextureFormat::RGBA16F,
+            FramebufferTextureFormat::RGBA16F,
+            FramebufferTextureFormat::RG16F,
+            FramebufferTextureFormat::RED_INTEGER,
+            FramebufferTextureFormat::RGBA16F,
         };
 
         // Create a G-Buffer sized to (width, height). sampleCount = 1 means

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -1496,11 +1496,6 @@ namespace OloEngine
             return CreateRenderStreamDrawCall<T>(RenderStreamType::Foliage);
         }
 
-        static void SubmitFoliagePacket(CommandPacket* packet)
-        {
-            SubmitRenderStreamPacket(RenderStreamType::Foliage, packet);
-        }
-
         template<typename T>
         static CommandPacket* CreateForwardOverlayDrawCall()
         {

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -1350,8 +1350,9 @@ namespace OloEngine
             f32 ParallaxScale = 0.5f;
         };
 
-        // Foliage rendering (submits DrawFoliageLayerCommand to FoliageRenderPass bucket)
-        static CommandPacket* DrawFoliageLayer(
+        // Foliage rendering. This function owns submission as well as packet
+        // allocation so the two operations cannot select different streams.
+        static void DrawFoliageLayer(
             RHI::ResourceHandle vertexArrayID, u32 indexCount, u32 instanceCount,
             RHI::ResourceHandle albedoTextureID,
             const glm::mat4& modelTransform,

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DSpecializedDraws.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DSpecializedDraws.cpp
@@ -15,6 +15,28 @@
 
 namespace OloEngine
 {
+    namespace
+    {
+        // Select the stream whose framebuffer matches the active foliage
+        // shader's fragment interface. The G-Buffer variant must execute in
+        // Geometry/SceneRenderPass; forward and impostor variants execute in
+        // FoliageRenderPass against the Scene MRT.
+        [[nodiscard]] constexpr Renderer3D::RenderStreamType SelectFoliageRenderStream(
+            bool useImpostor, RenderingPath path, bool gBufferRouteReady) noexcept
+        {
+            return !useImpostor && path == RenderingPath::Deferred && gBufferRouteReady
+                       ? Renderer3D::RenderStreamType::Geometry
+                       : Renderer3D::RenderStreamType::Foliage;
+        }
+
+        using FoliageStream = Renderer3D::RenderStreamType;
+        static_assert(SelectFoliageRenderStream(false, RenderingPath::Deferred, true) == FoliageStream::Geometry);
+        static_assert(SelectFoliageRenderStream(true, RenderingPath::Deferred, true) == FoliageStream::Foliage);
+        static_assert(SelectFoliageRenderStream(false, RenderingPath::Deferred, false) == FoliageStream::Foliage);
+        static_assert(SelectFoliageRenderStream(false, RenderingPath::Forward, true) == FoliageStream::Foliage);
+        static_assert(SelectFoliageRenderStream(false, RenderingPath::ForwardPlus, true) == FoliageStream::Foliage);
+    } // namespace
+
     CommandPacket* Renderer3D::DrawDecal(
         const glm::mat4& decalTransform,
         const glm::mat4& inverseDecalTransform,
@@ -164,7 +186,7 @@ namespace OloEngine
         return packet;
     }
 
-    CommandPacket* Renderer3D::DrawFoliageLayer(
+    void Renderer3D::DrawFoliageLayer(
         RHI::ResourceHandle vertexArrayID, u32 indexCount, u32 instanceCount,
         RHI::ResourceHandle albedoTextureID,
         const glm::mat4& modelTransform,
@@ -182,12 +204,12 @@ namespace OloEngine
         if (!s_Data.Pipeline->RenderStreamPasses.Foliage)
         {
             OLO_CORE_ERROR("Renderer3D::DrawFoliageLayer: FoliagePass is null!");
-            return nullptr;
+            return;
         }
 
         if (!s_Data.FoliageShader)
         {
-            return nullptr;
+            return;
         }
 
         // Octahedral impostor path (issue #433): always routes through the
@@ -199,8 +221,9 @@ namespace OloEngine
         // G-Buffer variant shader so foliage participates in the deferred
         // lighting composite. Falls back to the forward FoliagePass route
         // when the variant is missing.
-        const bool deferredActive = (s_Data.Settings.Path == RenderingPath::Deferred);
-        const bool useGBufferVariant = !useImpostor && deferredActive && s_Data.FoliageGBufferShader && s_Data.Pipeline->FrameCorePasses.Scene;
+        const bool gBufferRouteReady = s_Data.FoliageGBufferShader && s_Data.Pipeline->FrameCorePasses.Scene;
+        const RenderStreamType targetStream = SelectFoliageRenderStream(useImpostor, s_Data.Settings.Path, gBufferRouteReady);
+        const bool useGBufferVariant = targetStream == RenderStreamType::Geometry;
         Ref<Shader> activeShader = useImpostor         ? s_Data.FoliageImpostorShader
                                    : useGBufferVariant ? s_Data.FoliageGBufferShader
                                                        : s_Data.FoliageShader;
@@ -211,17 +234,15 @@ namespace OloEngine
             const BoundingBox worldBounds = layerBounds.Transform(modelTransform);
             if (!s_Data.ViewFrustum.IsBoundingBoxVisible(worldBounds))
             {
-                return nullptr;
+                return;
             }
         }
 
-        CommandPacket* packet = useGBufferVariant
-                                    ? CreateDrawCall<DrawFoliageLayerCommand>()
-                                    : CreateFoliageDrawCall<DrawFoliageLayerCommand>();
+        CommandPacket* packet = CreateRenderStreamDrawCall<DrawFoliageLayerCommand>(targetStream);
         if (!packet)
         {
             OLO_CORE_ERROR("Renderer3D::DrawFoliageLayer: Failed to allocate foliage command packet!");
-            return nullptr;
+            return;
         }
         auto* cmd = packet->GetCommandData<DrawFoliageLayerCommand>();
         cmd->header.type = CommandType::DrawFoliageLayer;
@@ -282,7 +303,12 @@ namespace OloEngine
         metadata.m_IsStatic = false;
         packet->SetMetadata(metadata);
 
-        return packet;
+        // Allocation and submission use the SAME selected stream. Previously
+        // the G-Buffer packet was allocated from Geometry but returned to a
+        // caller that unconditionally submitted it to FoliageRenderPass. That
+        // executed Foliage_Instance_GBuffer against the forward Scene MRT,
+        // mapping its float location 1 onto Scene's R32_SINT entity-ID target.
+        SubmitRenderStreamPacket(targetStream, packet);
     }
 
     CommandPacket* Renderer3D::DrawWaterSurface(

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -8752,7 +8752,7 @@ namespace OloEngine
                             impostor.Radius = layer.ImpostorRadius;
                         }
 
-                        auto* packet = Renderer3D::DrawFoliageLayer(
+                        Renderer3D::DrawFoliageLayer(
                             layer.VertexArrayID, layer.IndexCount, layer.InstanceCount,
                             layer.AlbedoTextureID,
                             modelMat,
@@ -8764,10 +8764,6 @@ namespace OloEngine
                             layer.Bounds,
                             entityID,
                             impostor);
-                        if (packet)
-                        {
-                            Renderer3D::SubmitFoliagePacket(packet);
-                        }
                     }
                 }
             }

--- a/OloEngine/tests/Rendering/ShaderHarness.h
+++ b/OloEngine/tests/Rendering/ShaderHarness.h
@@ -294,18 +294,18 @@ namespace OloEngine::Tests::ShaderHarness
         shaderc::Compiler& compiler)
     {
         constexpr auto kShadercEnvVulkan14 = static_cast<shaderc_env_version>((1u << 22) | (4u << 12));
-        constexpr auto kShadercEnvVulkan13 = static_cast<shaderc_env_version>((1u << 22) | (3u << 12));
         constexpr auto kShadercSpirv16 = static_cast<shaderc_spirv_version>((1u << 16) | (6u << 8));
+        constexpr auto kShadercSpirv15 = static_cast<shaderc_spirv_version>((1u << 16) | (5u << 8));
         static_assert(static_cast<u32>(kShadercEnvVulkan14) == 0x00404000u);
-        static_assert(static_cast<u32>(kShadercEnvVulkan13) == 0x00403000u);
         static_assert(static_cast<u32>(kShadercSpirv16) == 0x00010600u);
+        static_assert(static_cast<u32>(kShadercSpirv15) == 0x00010500u);
 
         const std::string name = shaderPath.generic_string();
-        const auto compileForEnvironment = [&](shaderc_env_version environment)
+        const auto compileForEnvironment = [&](shaderc_env_version environment, shaderc_spirv_version spirvVersion)
         {
             shaderc::CompileOptions options;
             options.SetTargetEnvironment(shaderc_target_env_vulkan, environment);
-            options.SetTargetSpirv(kShadercSpirv16);
+            options.SetTargetSpirv(spirvVersion);
             options.SetPreserveBindings(true);
             options.SetAutoBindUniforms(false);
             options.SetGenerateDebugInfo();
@@ -316,19 +316,20 @@ namespace OloEngine::Tests::ShaderHarness
             return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
         };
 
-        auto result = compileForEnvironment(kShadercEnvVulkan14);
+        auto result = compileForEnvironment(kShadercEnvVulkan14, kShadercSpirv16);
         // Ubuntu's shaderc 2023.8 accepts the hand-encoded Vulkan 1.4 value but
         // silently treats it as Vulkan 1.0. Its optimiser then rejects the
         // explicitly requested SPIR-V 1.6 module. Production cannot run Vulkan
         // on that pre-1.4 toolchain, but sanitizer CI still needs to reflect the
-        // same OLO_VULKAN/SPIR-V 1.6 interface. Vulkan 1.3 is the nearest target
-        // that old shaderc understands and has the same SPIR-V 1.6 ceiling.
+        // same OLO_VULKAN interface. Retry only that toolchain diagnostic with
+        // the Vulkan 1.2/SPIR-V 1.5 pair already used by CompileStageToSpv; the
+        // reflected stage inputs, outputs and descriptor bindings are unchanged.
         constexpr std::string_view kUnsupportedVulkan14Diagnostic =
             "Invalid SPIR-V binary version 1.6 for target environment SPIR-V 1.0";
         if (result.GetCompilationStatus() == shaderc_compilation_status_internal_error &&
             std::string_view(result.GetErrorMessage()).contains(kUnsupportedVulkan14Diagnostic))
         {
-            return compileForEnvironment(kShadercEnvVulkan13);
+            return compileForEnvironment(shaderc_env_version_vulkan_1_2, kShadercSpirv15);
         }
         return result;
     }

--- a/OloEngine/tests/Rendering/ShaderHarness.h
+++ b/OloEngine/tests/Rendering/ShaderHarness.h
@@ -279,4 +279,36 @@ namespace OloEngine::Tests::ShaderHarness
         const std::string name = shaderPath.generic_string();
         return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
     }
+
+    /// Compile one raster stage through the exact production VulkanShader tier:
+    /// Vulkan 1.4, SPIR-V 1.6, OLO_VULKAN=1, debug names and performance
+    /// optimisation. Contract tests use this route when the authoring-side
+    /// backend fork itself is what must be reflected (not the OpenGL-via-SPIR-V
+    /// tier used by CompileStageToSpv above).
+    inline shaderc::SpvCompilationResult CompileVulkanBackendStageToSpv(
+        const fs::path& shaderPath,
+        const std::string& stageSource,
+        shaderc_shader_kind kind,
+        const fs::path& root,
+        shaderc::Compiler& compiler)
+    {
+        shaderc::CompileOptions options;
+        constexpr auto kShadercEnvVulkan14 = static_cast<shaderc_env_version>((1u << 22) | (4u << 12));
+        constexpr auto kShadercSpirv16 = static_cast<shaderc_spirv_version>((1u << 16) | (6u << 8));
+        static_assert(static_cast<u32>(kShadercEnvVulkan14) == 0x00404000u);
+        static_assert(static_cast<u32>(kShadercSpirv16) == 0x00010600u);
+
+        options.SetTargetEnvironment(shaderc_target_env_vulkan, kShadercEnvVulkan14);
+        options.SetTargetSpirv(kShadercSpirv16);
+        options.SetPreserveBindings(true);
+        options.SetAutoBindUniforms(false);
+        options.SetGenerateDebugInfo();
+        options.SetOptimizationLevel(shaderc_optimization_level_performance);
+        options.SetSuppressWarnings();
+        options.AddMacroDefinition("OLO_VULKAN", "1");
+        options.SetIncluder(std::make_unique<Includer>(root));
+
+        const std::string name = shaderPath.generic_string();
+        return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
+    }
 } // namespace OloEngine::Tests::ShaderHarness

--- a/OloEngine/tests/Rendering/ShaderHarness.h
+++ b/OloEngine/tests/Rendering/ShaderHarness.h
@@ -326,8 +326,7 @@ namespace OloEngine::Tests::ShaderHarness
         // reflected stage inputs, outputs and descriptor bindings are unchanged.
         constexpr std::string_view kUnsupportedVulkan14Diagnostic =
             "Invalid SPIR-V binary version 1.6 for target environment SPIR-V 1.0";
-        if (result.GetCompilationStatus() == shaderc_compilation_status_internal_error &&
-            std::string_view(result.GetErrorMessage()).contains(kUnsupportedVulkan14Diagnostic))
+        if (std::string_view(result.GetErrorMessage()).contains(kUnsupportedVulkan14Diagnostic))
         {
             return compileForEnvironment(shaderc_env_version_vulkan_1_2, kShadercSpirv15);
         }

--- a/OloEngine/tests/Rendering/ShaderHarness.h
+++ b/OloEngine/tests/Rendering/ShaderHarness.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -280,7 +281,7 @@ namespace OloEngine::Tests::ShaderHarness
         return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
     }
 
-    /// Compile one raster stage through the exact production VulkanShader tier:
+    /// Compile one raster stage through the production VulkanShader tier:
     /// Vulkan 1.4, SPIR-V 1.6, OLO_VULKAN=1, debug names and performance
     /// optimisation. Contract tests use this route when the authoring-side
     /// backend fork itself is what must be reflected (not the OpenGL-via-SPIR-V
@@ -292,23 +293,43 @@ namespace OloEngine::Tests::ShaderHarness
         const fs::path& root,
         shaderc::Compiler& compiler)
     {
-        shaderc::CompileOptions options;
         constexpr auto kShadercEnvVulkan14 = static_cast<shaderc_env_version>((1u << 22) | (4u << 12));
+        constexpr auto kShadercEnvVulkan13 = static_cast<shaderc_env_version>((1u << 22) | (3u << 12));
         constexpr auto kShadercSpirv16 = static_cast<shaderc_spirv_version>((1u << 16) | (6u << 8));
         static_assert(static_cast<u32>(kShadercEnvVulkan14) == 0x00404000u);
+        static_assert(static_cast<u32>(kShadercEnvVulkan13) == 0x00403000u);
         static_assert(static_cast<u32>(kShadercSpirv16) == 0x00010600u);
 
-        options.SetTargetEnvironment(shaderc_target_env_vulkan, kShadercEnvVulkan14);
-        options.SetTargetSpirv(kShadercSpirv16);
-        options.SetPreserveBindings(true);
-        options.SetAutoBindUniforms(false);
-        options.SetGenerateDebugInfo();
-        options.SetOptimizationLevel(shaderc_optimization_level_performance);
-        options.SetSuppressWarnings();
-        options.AddMacroDefinition("OLO_VULKAN", "1");
-        options.SetIncluder(std::make_unique<Includer>(root));
-
         const std::string name = shaderPath.generic_string();
-        return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
+        const auto compileForEnvironment = [&](shaderc_env_version environment)
+        {
+            shaderc::CompileOptions options;
+            options.SetTargetEnvironment(shaderc_target_env_vulkan, environment);
+            options.SetTargetSpirv(kShadercSpirv16);
+            options.SetPreserveBindings(true);
+            options.SetAutoBindUniforms(false);
+            options.SetGenerateDebugInfo();
+            options.SetOptimizationLevel(shaderc_optimization_level_performance);
+            options.SetSuppressWarnings();
+            options.AddMacroDefinition("OLO_VULKAN", "1");
+            options.SetIncluder(std::make_unique<Includer>(root));
+            return compiler.CompileGlslToSpv(stageSource, kind, name.c_str(), options);
+        };
+
+        auto result = compileForEnvironment(kShadercEnvVulkan14);
+        // Ubuntu's shaderc 2023.8 accepts the hand-encoded Vulkan 1.4 value but
+        // silently treats it as Vulkan 1.0. Its optimiser then rejects the
+        // explicitly requested SPIR-V 1.6 module. Production cannot run Vulkan
+        // on that pre-1.4 toolchain, but sanitizer CI still needs to reflect the
+        // same OLO_VULKAN/SPIR-V 1.6 interface. Vulkan 1.3 is the nearest target
+        // that old shaderc understands and has the same SPIR-V 1.6 ceiling.
+        constexpr std::string_view kUnsupportedVulkan14Diagnostic =
+            "Invalid SPIR-V binary version 1.6 for target environment SPIR-V 1.0";
+        if (result.GetCompilationStatus() == shaderc_compilation_status_internal_error &&
+            std::string_view(result.GetErrorMessage()).contains(kUnsupportedVulkan14Diagnostic))
+        {
+            return compileForEnvironment(kShadercEnvVulkan13);
+        }
+        return result;
     }
 } // namespace OloEngine::Tests::ShaderHarness

--- a/OloEngine/tests/Rendering/ShaderStageContractTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderStageContractTest.cpp
@@ -34,9 +34,12 @@
 #include <gtest/gtest.h>
 #include <spirv_cross/spirv_cross.hpp>
 
+#include "OloEngine/Renderer/GBuffer.h"
+#include "OloEngine/Renderer/ShaderBindingLayout.h"
 #include "ShaderHarness.h"
 
 #include <algorithm>
+#include <array>
 #include <set>
 #include <sstream>
 #include <string>
@@ -322,6 +325,152 @@ namespace OloEngine::Tests
             EXPECT_EQ(locations, mode.ExpectedLocations)
                 << mode.Why << " — every fragment output location must equal the G-Buffer RT index the "
                 << "mode's draw-attachment map assigns it, or the write lands on no attachment (#770).";
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // VulkanVertexPullShadersExposeNoFixedFunctionInputs (issue #955)
+    //
+    // Vulkan pipelines deliberately publish an empty fixed-function vertex-input
+    // state. Mesh shaders therefore read VAO stream 0 through the engine-wide
+    // vertex-pull SSBO at binding 57. A fixed layout(location=N) input compiles
+    // successfully, but vkCreateGraphicsPipelines then reports VUID-07904 for
+    // every declared attribute and the bake consumes undefined vertex data.
+    //
+    // Compile the exact production Vulkan branch and reflect both sides of the
+    // contract: no stage inputs, plus every pull stream the draw shape requires.
+    // The positive binding assertions prevent an empty-input shader that never
+    // reads its vertex/instance data from satisfying the test accidentally.
+    // -------------------------------------------------------------------------
+    TEST(ShaderStageContract, VulkanVertexPullShadersExposeNoFixedFunctionInputs)
+    {
+        struct PullContract
+        {
+            const char* m_Shader;
+            std::set<u32> m_RequiredBindings;
+        };
+        const PullContract contracts[] = {
+            { "Impostor_Bake.glsl", { ShaderBindingLayout::SSBO_VERTEX_PULL } },
+            { "Foliage_Instance.glsl", { ShaderBindingLayout::SSBO_VERTEX_PULL, ShaderBindingLayout::SSBO_BONE_PULL } },
+            { "Foliage_Depth.glsl", { ShaderBindingLayout::SSBO_VERTEX_PULL, ShaderBindingLayout::SSBO_BONE_PULL } },
+            { "Foliage_Instance_GBuffer.glsl", { ShaderBindingLayout::SSBO_VERTEX_PULL, ShaderBindingLayout::SSBO_BONE_PULL } },
+            { "Foliage_Impostor.glsl", { ShaderBindingLayout::SSBO_VERTEX_PULL, ShaderBindingLayout::SSBO_BONE_PULL } },
+        };
+
+        const fs::path root = SH::ResolveShaderRoot();
+        ASSERT_FALSE(root.empty());
+
+        shaderc::Compiler compiler;
+        ASSERT_TRUE(compiler.IsValid());
+
+        for (const auto& contract : contracts)
+        {
+            SCOPED_TRACE(contract.m_Shader);
+            const fs::path path = root / contract.m_Shader;
+            ASSERT_TRUE(fs::exists(path)) << path.generic_string();
+
+            bool sawVertexStage = false;
+            for (const auto& [kind, stageSource] : SH::SplitByType(SH::ReadWholeFile(path)))
+            {
+                if (kind != shaderc_glsl_vertex_shader)
+                    continue;
+                sawVertexStage = true;
+
+                const auto result = SH::CompileVulkanBackendStageToSpv(path, stageSource, kind, root, compiler);
+                ASSERT_EQ(result.GetCompilationStatus(), shaderc_compilation_status_success)
+                    << result.GetErrorMessage();
+
+                spirv_cross::Compiler reflection(std::vector<u32>(result.cbegin(), result.cend()));
+                const auto resources = reflection.get_shader_resources();
+                EXPECT_TRUE(resources.stage_inputs.empty())
+                    << "VulkanPipelineBuilder publishes no fixed-function vertex attributes; "
+                       "the Vulkan stage must pull every required stream.";
+
+                std::set<u32> storageBindings;
+                for (const auto& buffer : resources.storage_buffers)
+                    storageBindings.insert(reflection.get_decoration(buffer.id, spv::DecorationBinding));
+                for (const u32 binding : contract.m_RequiredBindings)
+                    EXPECT_TRUE(storageBindings.contains(binding))
+                        << "missing required vertex-pull SSBO binding " << binding;
+            }
+            EXPECT_TRUE(sawVertexStage);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // FullGBufferWritersMatchTheProductionAttachmentNumericTypes (issue #955)
+    //
+    // The table is not a test-side copy: GBuffer.cpp creates its real draw and
+    // resolve framebuffers from GBuffer::s_ColorAttachmentFormats. Reflect every
+    // full writer against that same production-owned ordering so moving an int
+    // output onto a float attachment (or vice versa) fails before Vulkan reports
+    // undefined values at draw time.
+    // -------------------------------------------------------------------------
+    TEST(ShaderStageContract, FullGBufferWritersMatchTheProductionAttachmentNumericTypes)
+    {
+        static constexpr std::array s_Writers = {
+            "PBR_GBuffer.glsl",
+            "PBR_GBuffer_Skinned.glsl",
+            "Skybox_GBuffer.glsl",
+            "LightCube_GBuffer.glsl",
+            "InfiniteGrid_GBuffer.glsl",
+            "Terrain_GBuffer.glsl",
+            "Terrain_Voxel_GBuffer.glsl",
+            "Terrain_VoxelGreedy_GBuffer.glsl",
+            "Foliage_Instance_GBuffer.glsl",
+            "VirtualMeshGBuffer.glsl",
+            "VirtualMeshletGBuffer.glsl",
+        };
+
+        const fs::path root = SH::ResolveShaderRoot();
+        ASSERT_FALSE(root.empty());
+        shaderc::Compiler compiler;
+        ASSERT_TRUE(compiler.IsValid());
+
+        for (const char* shader : s_Writers)
+        {
+            SCOPED_TRACE(shader);
+            const fs::path path = root / shader;
+            ASSERT_TRUE(fs::exists(path)) << path.generic_string();
+
+            bool sawFragmentStage = false;
+            for (const auto& [kind, stageSource] : SH::SplitByType(SH::ReadWholeFile(path)))
+            {
+                if (kind != shaderc_glsl_fragment_shader)
+                    continue;
+                sawFragmentStage = true;
+
+                const auto result = SH::CompileVulkanBackendStageToSpv(path, stageSource, kind, root, compiler);
+                ASSERT_EQ(result.GetCompilationStatus(), shaderc_compilation_status_success)
+                    << result.GetErrorMessage();
+
+                spirv_cross::Compiler reflection(std::vector<u32>(result.cbegin(), result.cend()));
+                const auto& outputs = reflection.get_shader_resources().stage_outputs;
+                ASSERT_EQ(outputs.size(), GBuffer::s_ColorAttachmentFormats.size())
+                    << "a full G-Buffer writer must define every attachment, including BakedGI";
+
+                std::set<u32> locations;
+                for (const auto& output : outputs)
+                {
+                    const u32 location = reflection.get_decoration(output.id, spv::DecorationLocation);
+                    ASSERT_LT(location, GBuffer::s_ColorAttachmentFormats.size());
+                    locations.insert(location);
+
+                    const auto baseType = reflection.get_type(output.type_id).basetype;
+                    const auto format = GBuffer::s_ColorAttachmentFormats[location];
+                    const auto expectedType = format == FramebufferTextureFormat::RED_INTEGER
+                                                  ? spirv_cross::SPIRType::Int
+                                                  : spirv_cross::SPIRType::Float;
+                    EXPECT_EQ(baseType, expectedType)
+                        << "fragment output location " << location
+                        << " has a numeric class incompatible with its production G-Buffer attachment";
+                }
+
+                EXPECT_EQ(locations.size(), GBuffer::s_ColorAttachmentFormats.size());
+                for (u32 location = 0; location < GBuffer::s_ColorAttachmentFormats.size(); ++location)
+                    EXPECT_TRUE(locations.contains(location)) << "missing G-Buffer output location " << location;
+            }
+            EXPECT_TRUE(sawFragmentStage);
         }
     }
 } // namespace OloEngine::Tests


### PR DESCRIPTION
## What

Fix both deterministic Vulkan pipeline-contract violations exposed by Drift:

- `Impostor_Bake.glsl` now uses the engine's binding-57 vertex-pull contract on Vulkan, consuming the canonical 32-byte static-mesh layout instead of declaring fixed-function locations 0/1/2 against Vulkan's intentionally empty vertex-input state. The OpenGL attribute path remains unchanged.
- Deferred non-impostor foliage now allocates **and submits** its packet through the Geometry stream. Previously it allocated from Geometry but returned the packet to `Scene`, which unconditionally submitted it to the Foliage stream; `Foliage_Instance_GBuffer` consequently ran against the forward Scene MRT and mapped float location 1 onto an `R32_SINT` target.

`DrawFoliageLayer` now owns both operations so their stream selections cannot drift. Its constexpr selector is pinned for Forward, Forward+, Deferred, impostor, and unavailable-G-buffer fallback cases.

## Contract coverage

- The production G-buffer attachment formats now have one ordered table used to build the framebuffer and to validate reflected full-writer output numeric types.
- Vulkan shader-contract tests compile through the exact production Vulkan tier and assert that all foliage/bake vertex stages expose no fixed-function inputs while retaining their required pull bindings.
- Every full G-buffer writer is reflected against the production attachment table: six locations, float outputs everywhere except the integer entity-ID target.

## Verification

- Locked Debug build: `OloEditor` + `OloEngine-Tests` passed.
- Focused contracts passed:
  - `ShaderStageContract.VulkanVertexPullShadersExposeNoFixedFunctionInputs`
  - `ShaderStageContract.FullGBufferWritersMatchTheProductionAttachmentNumericTypes`
  - `VulkanPassSuite.FoliageInstancePullDrawsThreeTintedCards`
  - `GBufferLayout.*`
  - `GBufferBakedGIContract.EveryGBufferWriterDeclaresAndWritesTheBakedGITarget`
- Final full suite: **6,716 tests / 1,068 suites**, **6,692 passed**, 12 disabled, zero failures (821.5 s).
- OpenGL cross-check: Drift opened and completed Forward → Deferred → Forward; `olo_shader_errors` count 0.

## Vulkan acceptance evidence

Fresh `--rhi=vulkan` launch of the final rebuilt binary, then `Scenes/Drift.olo` and the acknowledged sequence:

`forward → forwardplus → deferred → forward`

Final log counts across scene load, five successful impostor-atlas bakes, and all transitions:

| Contract message | Count |
|---|---:|
| `VUID-VkGraphicsPipelineCreateInfo-Input-07904` | 0 |
| `R32_SINT` output-format mismatch | 0 |
| `Foliage_Instance_GBuffer` misroute | 0 |
| `olo_shader_errors` | 0 |

The final frame and deferred foliage from multiple angles were visually inspected. The run also exposed an independent Renderer2D unused-MRT-output warning, now tracked separately as #957 rather than expanding this issue.

## Review guide

Start with `Renderer3DSpecializedDraws.cpp`: the important invariant is that the selected shader, packet allocator, and submit target all describe the same framebuffer contract. Then inspect the Vulkan branch in `Impostor_Bake.glsl` and the production-owned table in `GBuffer.h` together with the two reflection tests.

The parts most deserving scrutiny are the static mesh stride/offsets in the bake shader and the classification of deferred non-impostor foliage as Geometry while impostors and all forward paths remain Foliage.

Least confident area: live Vulkan validation used one NVIDIA device; the contract tests provide the cross-driver protection. I did not run sanitizer configurations locally; CI owns those configurations. The remaining #957 warning is explicitly out of scope and does not overlap either target message.

Closes #955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved foliage rendering reliability across deferred and impostor workflows.
  - Prevented invalid foliage draw submissions when required rendering resources are unavailable.
  - Improved consistency between G-buffer color attachments and depth output.
  - Increased stability of foliage layer rendering across supported paths.

- **Tests**
  - Added Vulkan shader validation for vertex input bindings and G-buffer attachment coverage.
  - Added checks confirming shader output types match configured rendering formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->