### PR TITLE
fix(renderer): stabilize Drift model depth-prepass replays

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/CameraRelative.h
+++ b/OloEngine/src/OloEngine/Renderer/CameraRelative.h
@@ -102,6 +102,18 @@ namespace OloEngine
         return viewRel;
     }
 
+    // Build the main camera's render-relative view-projection from the stored
+    // projection and view matrices. Keep this as a direct P * V_rel product:
+    // recovering P as (VP * inverse(V)) is only algebraically equivalent and
+    // introduces enough f32 error for a later CameraUBO upload to disagree with
+    // an earlier depth prepass at GL_LEQUAL (issues #952 and #954).
+    [[nodiscard]] inline glm::mat4 MakeViewProjectionRelative(const glm::mat4& projection,
+                                                              const glm::mat4& viewWorld,
+                                                              const glm::vec3& origin)
+    {
+        return projection * MakeViewRelative(viewWorld, origin);
+    }
+
     // Build a render-relative view-projection (or any camera-space *) matrix
     // from its world counterpart:  mRel = mWorld * translate(origin), so that
     // mRel * (worldPos - origin) == mWorld * worldPos. Used for the main

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
@@ -1325,11 +1325,6 @@ namespace OloEngine
         if (!s_Data.CameraUBO)
             return;
 
-        // Same packing as the terrain/voxel inline uploads — derive Projection
-        // from VP * inverse(View) so callers only have to set the three matrices
-        // + position via Set*. PrevViewProjection comes from the true previous
-        // frame propagated by Renderer3D (no aliasing of the current VP).
-        //
         // Camera-relative (issue #429): the stored matrices are world-space, so
         // rebuild the view / view-projection about the render origin and supply
         // the camera position relative to it before upload. This one path covers
@@ -1337,9 +1332,11 @@ namespace OloEngine
         // sets world mirror matrices via Set* then calls this).
         const glm::vec3 origin = s_Data.RenderOrigin;
         const glm::mat4 relView = MakeViewRelative(s_Data.ViewMatrix, origin);
-        // Projection is translation-free, so it is identical whether taken from
-        // the world or relative VP — derive it once for the UBO's Projection.
-        const glm::mat4 projection = s_Data.ViewProjectionMatrix * glm::inverse(s_Data.ViewMatrix);
+        // Use the stored projection directly. Reconstructing it as VP * inverse(V)
+        // is algebraically valid but not bit-stable in f32; terrain and voxel
+        // draws re-upload this shared UBO between the depth and colour replays,
+        // so even a small reconstruction error can make GL_LEQUAL reject pixels.
+        const glm::mat4& projection = s_Data.ProjectionMatrix;
 
         // A8 projection seam: the stored matrices stay GL-convention; the
         // GPU-visible copies flip at upload (identity on GL). This one seam
@@ -1348,7 +1345,8 @@ namespace OloEngine
         // consumers difference clip .xy against the current (flipped)
         // rasterized position, and the two flip flavours agree on .xy.
         ShaderBindingLayout::CameraUBO cameraData{};
-        cameraData.ViewProjection = RHI::AdjustProjectionForBackend(projection * relView);
+        cameraData.ViewProjection = RHI::AdjustProjectionForBackend(
+            MakeViewProjectionRelative(projection, s_Data.ViewMatrix, origin));
         cameraData.View = relView;
         cameraData.Projection = RHI::AdjustProjectionForBackend(projection);
         cameraData.Position = MakePositionRelative(s_Data.ViewPos, origin);

--- a/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RenderPipeline.cpp
@@ -495,7 +495,8 @@ namespace OloEngine
         // is a byte-identical no-op — existing near-origin scenes are unaffected.
         const glm::vec3 renderOrigin = data.RenderOrigin;
         const glm::mat4 relativeView = MakeViewRelative(data.ViewMatrix, renderOrigin);
-        const glm::mat4 relativeViewProjection = data.ProjectionMatrix * relativeView;
+        const glm::mat4 relativeViewProjection =
+            MakeViewProjectionRelative(data.ProjectionMatrix, data.ViewMatrix, renderOrigin);
         const glm::mat4 relativePrevViewProjection = MakeViewProjectionRelative(data.PrevViewProjectionMatrix, renderOrigin);
 
         // CommandDispatch keeps the *world* camera matrices — depth sort keys and

--- a/OloEngine/tests/Rendering/CameraRelativeTest.cpp
+++ b/OloEngine/tests/Rendering/CameraRelativeTest.cpp
@@ -12,6 +12,7 @@
 #include "OloEnginePCH.h"
 #include <gtest/gtest.h>
 
+#include "OloEngine/Math/Math.h"
 #include "OloEngine/Renderer/CameraRelative.h"
 
 #include <glm/glm.hpp>
@@ -151,7 +152,7 @@ TEST(CameraRelative, MainCameraPackingDoesNotReconstructProjectionFromViewProjec
         for (int row = 0; row < 4; ++row)
         {
             EXPECT_FLOAT_EQ(packed[column][row], viewProjection[column][row]);
-            differentComponents += packed[column][row] != reconstructed[column][row] ? 1u : 0u;
+            differentComponents += !Math::BitwiseEqual(packed[column][row], reconstructed[column][row]) ? 1u : 0u;
         }
     }
     EXPECT_GT(differentComponents, 0u)

--- a/OloEngine/tests/Rendering/CameraRelativeTest.cpp
+++ b/OloEngine/tests/Rendering/CameraRelativeTest.cpp
@@ -128,6 +128,36 @@ TEST(CameraRelative, RelativeViewProjectionIsInvariantForNearbyGeometry)
         EXPECT_NEAR(ndcRel[i], ndcWorld[i], 1e-3f) << "ndc component " << i;
 }
 
+TEST(CameraRelative, MainCameraPackingDoesNotReconstructProjectionFromViewProjection)
+{
+    // Regression for #952/#954. A terrain draw re-uploads the shared CameraUBO
+    // between the depth and colour replays. The old upload recovered projection
+    // as (P * V) * inverse(V); at this deterministic repro pose that is not
+    // bit-identical to P and changes clip-space depth despite being
+    // algebraically equivalent.
+    const glm::vec3 eye(6.55f, 4.57f, -241.0f);
+    const glm::vec3 target(0.0f, 0.6f, -250.0f);
+    const glm::mat4 projection = glm::perspective(glm::radians(45.0f), 16.0f / 9.0f, 0.1f, 1000.0f);
+    const glm::mat4 view = glm::lookAt(eye, target, { 0.0f, 1.0f, 0.0f });
+    const glm::mat4 viewProjection = projection * view;
+
+    const glm::mat4 packed = MakeViewProjectionRelative(projection, view, glm::vec3(0.0f));
+    const glm::mat4 reconstructedProjection = viewProjection * glm::inverse(view);
+    const glm::mat4 reconstructed = reconstructedProjection * MakeViewRelative(view, glm::vec3(0.0f));
+
+    u32 differentComponents = 0;
+    for (int column = 0; column < 4; ++column)
+    {
+        for (int row = 0; row < 4; ++row)
+        {
+            EXPECT_FLOAT_EQ(packed[column][row], viewProjection[column][row]);
+            differentComponents += packed[column][row] != reconstructed[column][row] ? 1u : 0u;
+        }
+    }
+    EXPECT_GT(differentComponents, 0u)
+        << "The repro depends on inverse-based projection recovery losing exact depth parity";
+}
+
 // -----------------------------------------------------------------------------
 // The payoff: fine local geometric detail is what f32 loses far from origin (a
 // mesh's sub-ULP vertex offsets collapse — the visible jitter/deformation). The


### PR DESCRIPTION
## Summary

- make every main-camera CameraUBO upload compose the relative view-projection from the exact stored projection matrix
- remove inverse-based projection recovery from terrain/voxel-triggered shared CameraUBO refreshes
- add a deterministic camera-packing regression at the reported Drift boat pose

## Root cause

The scene depth prepass and colour replay shared one command bucket, but terrain/voxel commands later in the first replay refreshed the shared CameraUBO. That refresh reconstructed projection as `(P * V) * inverse(V)`. It is algebraically equivalent to `P`, but not bit-stable in f32. The second replay therefore projected the boat at a different depth, and ordinary `LEQUAL` rejected either the whole boat or a hard screen-space portion of it. The material, model, visibility, and draw packets remained valid.

The fix keeps all uploads on the same direct `P * V_relative` construction. It does not weaken the depth function, add bias, or add warm-up frames.

## Verification

- guarded Debug build: `OloEngine-Tests` and `OloEditor`
- 18/18 focused tests passed: CameraRelative, Renderer2DCameraRelative, TerrainCameraRelativeLOD, and BindlessShaderPipeline depth-invariant route
- deterministic +10.4 degree all-grey pose: fully shaded
- deterministic +7.2 degree alternating half-cut pose: stable across repeated consecutive captures
- visual matrix passed with depth prepass forced on:
  - OpenGL: Forward, Forward+, Deferred
  - Vulkan: Forward, Forward+, Deferred
- fresh boot on both RHIs, live path switching, real viewport resize, Edit mode, and OpenGL Play mode passed

## Related issues

- #931 is related in shape (command order mutating shared GPU-visible state), but not the same root: that issue concerns command-ordered Vulkan buffer lifetime/upload behavior, while this fix is exact CameraUBO projection packing across scene replays.
- #901 remains an independent CSM/GTAO thin-geometry speckle investigation. Its later grey-boat observation is explained by this depth-replay mismatch, but the original speckles are not changed here.

Closes #952
Closes #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera-relative rendering accuracy by preserving the original projection data.
  * Reduced floating-point differences that could affect rendered scenes and camera movement.

* **Tests**
  * Added coverage to verify accurate camera matrix data and prevent regressions in rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->