### PR TITLE
test(renderer): cover RGBA16F lightmap arrays across backends

### DIFF
--- a/OloEditor/assets/shaders/tests/LightmapPagedSampling.glsl
+++ b/OloEditor/assets/shaders/tests/LightmapPagedSampling.glsl
@@ -1,0 +1,53 @@
+#type vertex
+#version 460 core
+
+#ifdef OLO_VULKAN
+layout(std430, binding = 57) readonly buffer OloVertexPull
+{
+    float v[];
+} b_Vertices;
+
+layout(location = 0) out vec2 v_TexCoord;
+
+void main()
+{
+    int base = gl_VertexIndex * 5;
+    vec3 position = vec3(b_Vertices.v[base + 0], b_Vertices.v[base + 1], b_Vertices.v[base + 2]);
+    v_TexCoord = vec2(b_Vertices.v[base + 3], b_Vertices.v[base + 4]);
+    gl_Position = vec4(position, 1.0);
+}
+#else
+layout(location = 0) in vec3 a_Position;
+layout(location = 1) in vec2 a_TexCoord;
+
+layout(location = 0) out vec2 v_TexCoord;
+
+void main()
+{
+    v_TexCoord = a_TexCoord;
+    gl_Position = vec4(a_Position, 1.0);
+}
+#endif
+
+#type fragment
+#version 460 core
+
+layout(location = 0) out vec4 o_Color;
+layout(location = 0) in vec2 v_TexCoord;
+
+#include "include/LightmapSampling.glsl"
+
+layout(std140, binding = 2) uniform TestLightmapRegions
+{
+    vec4 u_FirstRegion;
+    vec4 u_SecondRegion;
+    vec4 u_ThirdRegion;
+};
+
+void main()
+{
+    vec4 region = v_TexCoord.x < (1.0 / 3.0)
+        ? u_FirstRegion
+        : (v_TexCoord.x < (2.0 / 3.0) ? u_SecondRegion : u_ThirdRegion);
+    o_Color = sampleLightmapIrradiance(vec2(0.5), region);
+}

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -445,6 +445,7 @@ add_executable(OloEngine-Tests
 		Rendering/PropertyTests/ModelLoadDeterminismTest.cpp
 		Rendering/PropertyTests/DrawIndexedRawOffsetTest.cpp
 		Rendering/PropertyTests/TextureSaveRoundTripTest.cpp
+		Rendering/PropertyTests/Texture2DArrayRoundTripTest.cpp
 		Rendering/PropertyTests/RHIHandleNativeIdentityTest.cpp
 		Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
 		Streaming/SceneStreamingTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/Texture2DArrayRoundTripTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/Texture2DArrayRoundTripTest.cpp
@@ -1,0 +1,122 @@
+#include "OloEnginePCH.h"
+
+#include "PropertyTests/RenderPropertyTest.h"
+#include "Rendering/Texture2DArrayRoundTrip.h"
+
+#include "OloEngine/Renderer/RendererAPI.h"
+#include "OloEngine/Renderer/Texture.h"
+
+#include <gtest/gtest.h>
+#include <glad/gl.h>
+#include <glm/gtc/packing.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <string>
+#include <vector>
+
+// OLO_TEST_LAYER: L3
+
+namespace OloEngine::Tests
+{
+    TEST(Texture2DArrayRoundTrip, KnownHalfEncodedLayersSurviveOnOpenGL)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+        ASSERT_EQ(RendererAPI::GetAPI(), RendererAPI::API::OpenGL);
+        EXPECT_TRUE(KnownHalfEncodedTextureArrayLayersRoundTrip());
+    }
+
+    TEST(Texture2DArrayRoundTrip, CpuHalfPackingMatchesTheLegacyOpenGLConversionWithinOneUlp)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+        ASSERT_EQ(RendererAPI::GetAPI(), RendererAPI::API::OpenGL);
+
+        const f32 halfStepAtOne = std::ldexp(1.0f, -10);
+        const f32 midpoint0 = 1.0f + halfStepAtOne * 0.5f;
+        const f32 midpoint1 = 1.0f + halfStepAtOne * 1.5f;
+        const std::array<f32, 26> values{
+            0.0f,
+            -0.0f,
+            std::ldexp(1.0f, -24),    // minimum half subnormal
+            std::ldexp(1023.0f, -24), // maximum half subnormal
+            std::ldexp(1.0f, -14),    // minimum half normal
+            -std::ldexp(1.0f, -24),
+            -std::ldexp(1023.0f, -24),
+            -std::ldexp(1.0f, -14),
+            0.5f,
+            1.0f,
+            2.0f,
+            65504.0f,  // maximum finite half
+            midpoint0, // exact half-way cases
+            std::nextafter(midpoint0, 0.0f),
+            std::nextafter(midpoint0, 2.0f),
+            midpoint1,
+            std::nextafter(midpoint1, 0.0f),
+            std::nextafter(midpoint1, 2.0f),
+            -midpoint0,
+            -midpoint1,
+            0.0031f, // representative lightmap values
+            0.137f,
+            0.33333334f,
+            0.73f,
+            1.7f,
+            150.125f,
+        };
+
+        std::vector<f32> upload(values.size() * 4);
+        for (sizet texel = 0; texel < values.size(); ++texel)
+        {
+            std::fill_n(upload.begin() + static_cast<std::ptrdiff_t>(texel * 4), 4, values[texel]);
+        }
+
+        TextureSpecification specification;
+        specification.Width = static_cast<u32>(values.size());
+        specification.Height = 1;
+        specification.Format = ImageFormat::RGBA16F;
+        specification.GenerateMips = false;
+        auto texture = Texture2D::Create(specification);
+        ASSERT_TRUE(texture);
+        texture->SetData(upload.data(), static_cast<u32>(upload.size() * sizeof(f32)));
+
+        std::vector<u16> driverWords(upload.size());
+        ASSERT_TRUE(RenderCommand::ReadTextureSubImage(texture->GetRHIHandle(), 0, 0, 0, 0,
+                                                       specification.Width, 1, 1, RHI::Format::RGBA16Float,
+                                                       driverWords.size() * sizeof(u16), driverWords.data()));
+
+        const auto orderedHalf = [](u16 bits) -> i32
+        {
+            const auto magnitude = static_cast<i32>(bits & 0x7FFFu);
+            return (bits & 0x8000u) != 0 ? 0x8000 - magnitude : 0x8000 + magnitude;
+        };
+
+        u32 differingWords = 0;
+        i32 maximumUlp = 0;
+        for (sizet word = 0; word < upload.size(); ++word)
+        {
+            const u16 cpuWord = glm::packHalf1x16(upload[word]);
+            const u16 driverWord = driverWords[word];
+            if (cpuWord != driverWord)
+            {
+                ++differingWords;
+            }
+            const i32 ulp = std::abs(orderedHalf(cpuWord) - orderedHalf(driverWord));
+            maximumUlp = std::max(maximumUlp, ulp);
+            EXPECT_LE(ulp, 1) << "value " << upload[word] << ": CPU half 0x" << std::hex << cpuWord
+                              << ", OpenGL half 0x" << driverWord << std::dec;
+        }
+
+        ::testing::Test::RecordProperty("compared_half_words", static_cast<int>(upload.size()));
+        ::testing::Test::RecordProperty("differing_half_words", static_cast<int>(differingWords));
+        ::testing::Test::RecordProperty("maximum_half_ulp", maximumUlp);
+        if (const auto* vendor = reinterpret_cast<const char*>(::glGetString(GL_VENDOR)))
+            ::testing::Test::RecordProperty("opengl_vendor", vendor);
+        if (const auto* renderer = reinterpret_cast<const char*>(::glGetString(GL_RENDERER)))
+            ::testing::Test::RecordProperty("opengl_renderer", renderer);
+        if (const auto* version = reinterpret_cast<const char*>(::glGetString(GL_VERSION)))
+            ::testing::Test::RecordProperty("opengl_version", version);
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/Texture2DArrayRoundTrip.h
+++ b/OloEngine/tests/Rendering/Texture2DArrayRoundTrip.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "OloEngine/Renderer/RHI/RHITypes.h"
+#include "OloEngine/Renderer/RenderCommand.h"
+#include "OloEngine/Renderer/Texture2DArray.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <format>
+#include <vector>
+
+namespace OloEngine::Tests
+{
+    // Backend-neutral RGBA16F Texture2DArray contract (#951). The caller owns
+    // backend/device setup; everything below stays on the public renderer
+    // facade so the OpenGL and Vulkan invocations exercise the same behavior.
+    [[nodiscard]] inline ::testing::AssertionResult KnownHalfEncodedTextureArrayLayersRoundTrip()
+    {
+        constexpr u32 kWidth = 2;
+        constexpr u32 kHeight = 2;
+        constexpr u32 kLayers = 3;
+        constexpr u32 kChannels = 4;
+        constexpr auto kWordsPerLayer = static_cast<sizet>(kWidth) * kHeight * kChannels;
+
+        // Literal IEEE-754 binary16 words, not floats packed by the code under
+        // test. Every layer and channel differs so a wrong byte stride, channel
+        // order, or array-layer selection produces an attributable mismatch.
+        constexpr std::array<std::array<u16, kWordsPerLayer>, kLayers> kLayerWords{ {
+            { 0x0000u, 0x3C00u, 0xC000u, 0x3800u,
+              0x4000u, 0x4200u, 0x4400u, 0x4500u,
+              0xBC00u, 0x3400u, 0x0400u, 0x0001u,
+              0x7BFFu, 0x03FFu, 0x3555u, 0x3BFFu },
+            { 0x3000u, 0xB000u, 0x3C01u, 0xBC01u,
+              0x4800u, 0xC800u, 0x5000u, 0xD000u,
+              0x2400u, 0xA400u, 0x2C00u, 0xAC00u,
+              0x5400u, 0xD400u, 0x5800u, 0xD800u },
+            { 0x3A00u, 0xBA00u, 0x3E00u, 0xBE00u,
+              0x4100u, 0xC100u, 0x4300u, 0xC300u,
+              0x4600u, 0xC600u, 0x4A00u, 0xCA00u,
+              0x5C00u, 0xDC00u, 0x6000u, 0xE000u },
+        } };
+
+        Texture2DArraySpecification specification;
+        specification.Width = kWidth;
+        specification.Height = kHeight;
+        specification.Layers = kLayers;
+        specification.Format = Texture2DArrayFormat::RGBA16F;
+        specification.GenerateMipmaps = false;
+
+        auto texture = Texture2DArray::Create(specification);
+        if (!texture)
+        {
+            return ::testing::AssertionFailure() << "Texture2DArray::Create returned null";
+        }
+        for (u32 layer = 0; layer < kLayers; ++layer)
+        {
+            texture->SetLayerData(layer, kLayerWords[layer].data(), kWidth, kHeight);
+        }
+
+        std::vector<u16> readback(kWordsPerLayer * kLayers, 0xDEADu);
+        if (!RenderCommand::ReadTextureSubImage(texture->GetRHIHandle(), 0, 0, 0, 0,
+                                                kWidth, kHeight, kLayers, RHI::Format::RGBA16Float,
+                                                readback.size() * sizeof(u16), readback.data()))
+        {
+            return ::testing::AssertionFailure()
+                   << "RGBA16F Texture2DArray readback was refused";
+        }
+
+        for (u32 layer = 0; layer < kLayers; ++layer)
+        {
+            for (sizet word = 0; word < kWordsPerLayer; ++word)
+            {
+                const auto expected = kLayerWords[layer][word];
+                const auto actual = readback[static_cast<sizet>(layer) * kWordsPerLayer + word];
+                if (actual != expected)
+                {
+                    const auto texel = static_cast<u32>(word / kChannels);
+                    const auto channel = static_cast<u32>(word % kChannels);
+                    return ::testing::AssertionFailure()
+                           << std::format("layer {}, texel ({}, {}), channel {}: expected half bits 0x{:04X}, got 0x{:04X}",
+                                          layer, texel % kWidth, texel / kWidth, channel, expected, actual);
+                }
+            }
+        }
+
+        return ::testing::AssertionSuccess();
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
@@ -62,6 +62,8 @@ TEST(VulkanPassSuite, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/GBuffer.h"
 #include "OloEngine/Renderer/Buffer.h"
 #include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/HeapBindingSeam.h"
+#include "OloEngine/Renderer/LightmapPageEncoding.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/Commands/CommandDispatch.h"
 #include "OloEngine/Renderer/Commands/CommandPacket.h"
@@ -113,6 +115,7 @@ TEST(VulkanPassSuite, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/Texture2DArray.h"
 #include "OloEngine/Renderer/UniformBuffer.h"
 #include "Platform/Vulkan/VulkanCapabilities.h"
+#include "Platform/Vulkan/VulkanDescriptorHeapBackend.h"
 #include "Platform/Vulkan/VulkanOneShot.h"
 #include "Platform/Vulkan/VulkanDevice.h"
 #include "Platform/Vulkan/VulkanFrameArena.h"
@@ -544,6 +547,10 @@ class VulkanPassSuite : public ::testing::Test
         // the PROCESS-GLOBAL backend must be the Vulkan one for the duration.
         // Selection stays active for the whole test (factories switch on it
         // at call time); TearDown restores both.
+        m_PreviousDescriptorHeapEnabled = RHI::DescriptorHeap::Get().IsEnabled();
+        m_HadOpenGlContext = glfwGetCurrentContext() != nullptr;
+        if (m_HadOpenGlContext)
+            RenderCommand::ShutdownGpuResources();
         m_Selection.emplace();
         RenderCommand::RecreateForSelectedBackend();
 
@@ -590,6 +597,12 @@ class VulkanPassSuite : public ::testing::Test
         VulkanPipelineBuilder::Get().ReleaseAll();
         VulkanPipelineCache::Get().SaveAndDestroy();
         VulkanFrameArena::Get().ReleaseBuffers();
+        // A tenant that installed the Vulkan descriptor backend must retire it
+        // while its device and resource heap are still alive. SetUp retired the
+        // displaced GL heap before replacing its owning RenderCommand instance;
+        // the ordinary fixture restore below creates a fresh GL backend.
+        if (m_ShutdownDescriptorHeapOnTearDown)
+            RHI::DescriptorHeap::Get().Shutdown();
         VulkanResourceHeap::Get().Release();
         // #691: raw facade resources (CreateTexture2DHandle /
         // CreateFramebufferHandle) are OWNED by process-wide side registries.
@@ -628,9 +641,10 @@ class VulkanPassSuite : public ::testing::Test
         // the restore). Guarded on a live GL context: with none current the
         // caps queries would touch GL functions illegally, and no GL test can
         // run in that environment anyway.
-        if (glfwGetCurrentContext() != nullptr)
+        if (m_HadOpenGlContext)
         {
             RenderCommand::Init();
+            RHI::DescriptorHeap::Get().SetEnabled(m_PreviousDescriptorHeapEnabled);
             // Tenants that re-home process-wide renderer
             // statics onto the Vulkan device (the ShaderDebugDraw channels,
             // the particle batch renderer) tear the GL-currency versions down
@@ -648,6 +662,8 @@ class VulkanPassSuite : public ::testing::Test
         }
         m_ReinitShaderDebugDrawOnTearDown = false;
         m_ReinitParticleBatchRendererOnTearDown = false;
+        m_ShutdownDescriptorHeapOnTearDown = false;
+        m_HadOpenGlContext = false;
     }
 
     // The tenant harness: producer(input) -> passNode -> caller-backed
@@ -786,6 +802,92 @@ class VulkanPassSuite : public ::testing::Test
         VulkanDeferredReclaim::Get().NotifyFrameCompleted();
     }
 
+    struct alignas(16) TestLightmapRegions
+    {
+        glm::vec4 First;
+        glm::vec4 Second;
+        glm::vec4 Third;
+    };
+    static_assert(sizeof(TestLightmapRegions) == 48);
+
+    struct LightmapSampleHarness
+    {
+        Ref<UniformBuffer> LightmapUbo;
+        Ref<UniformBuffer> RegionUbo;
+        Ref<Shader> ShaderProgram;
+        Ref<Framebuffer> Output;
+    };
+
+    LightmapSampleHarness CreateLightmapSampleHarness(u32 size, const TestLightmapRegions& regions)
+    {
+        ShaderBindingLayout::LightmapUBO lightmapData{};
+        lightmapData.Enabled = 1;
+        lightmapData.Intensity = 1.0f;
+        lightmapData.TexelSize = 1.0f;
+
+        LightmapSampleHarness harness;
+        harness.LightmapUbo = UniformBuffer::Create(
+            ShaderBindingLayout::LightmapUBO::GetSize(), ShaderBindingLayout::UBO_LIGHTMAP);
+        if (harness.LightmapUbo)
+            harness.LightmapUbo->SetData(&lightmapData, ShaderBindingLayout::LightmapUBO::GetSize());
+
+        harness.RegionUbo = UniformBuffer::Create(sizeof(TestLightmapRegions), 2);
+        if (harness.RegionUbo)
+            harness.RegionUbo->SetData(&regions, sizeof(regions));
+
+        harness.ShaderProgram = Shader::Create("assets/shaders/tests/LightmapPagedSampling.glsl");
+
+        FramebufferSpecification outputSpec;
+        outputSpec.Width = size;
+        outputSpec.Height = size;
+        outputSpec.Attachments = { FramebufferTextureFormat::RGBA8 };
+        harness.Output = Framebuffer::Create(outputSpec);
+        return harness;
+    }
+
+    std::vector<u8> DrawLightmapSample(u32 size, Ref<Shader>& shader,
+                                       Ref<Framebuffer>& output,
+                                       const std::function<void()>& publishInput)
+    {
+        SubmitFrame(
+            [&]()
+            {
+                output->Bind();
+                RenderCommand::SetViewport(0, 0, size, size);
+                RenderCommand::SetDepthTest(false);
+                RenderCommand::SetDepthMask(false);
+                RenderCommand::SetBlendState(false);
+                RenderCommand::DisableCulling();
+                shader->Bind();
+                publishInput();
+                HeapBinding::FlushOffsets();
+
+                const auto triangle = MeshPrimitives::GetFullscreenTriangle();
+                triangle->Bind();
+                RenderCommand::DrawIndexed(triangle);
+
+                auto& api = static_cast<VulkanRendererAPI&>(RenderCommand::GetRendererAPI());
+                RHI::Barrier toRead{};
+                toRead.Resource = output->GetColorAttachmentHandle(0);
+                toRead.Before = RHI::Access::ColorAttachmentWrite;
+                toRead.After = RHI::Access::ShaderSampleRead;
+                api.IssueBarrierBatch(MemoryBarrierFlags::None, std::span{ &toRead, 1 });
+            });
+
+        auto& api = static_cast<VulkanRendererAPI&>(RenderCommand::GetRendererAPI());
+        EXPECT_EQ(api.GetPreparedDrawsThisRecording(), 1u);
+        EXPECT_EQ(api.GetDroppedDrawsThisRecording(), 0u);
+
+        std::vector<u8> rendered;
+        auto* vkOutput = static_cast<VulkanFramebuffer*>(output.Raw());
+        if (vkOutput->GetColorAttachmentImage(0) == nullptr ||
+            !vkOutput->GetColorAttachmentImage(0)->GetData(rendered, 0))
+        {
+            ADD_FAILURE() << "lightmap output readback failed";
+        }
+        return rendered;
+    }
+
     std::unique_ptr<VulkanDevice> m_Device;
     std::optional<ScopedVulkanApiSelection> m_Selection;
     VkCommandBuffer m_Cmd = VK_NULL_HANDLE;
@@ -805,7 +907,107 @@ class VulkanPassSuite : public ::testing::Test
     // when the tenant fails mid-way.
     bool m_ReinitShaderDebugDrawOnTearDown = false;
     bool m_ReinitParticleBatchRendererOnTearDown = false;
+    bool m_ShutdownDescriptorHeapOnTearDown = false;
+    bool m_PreviousDescriptorHeapEnabled = false;
+    bool m_HadOpenGlContext = false;
 };
+
+TEST_F(VulkanPassSuite, PagedRgba16fLightmapSamplesEveryLayerThroughSlot16)
+{
+    constexpr u32 kSize = 32;
+    constexpr std::array<u16, 4> kRed{ 0x3C00u, 0x0000u, 0x0000u, 0x3C00u };
+    constexpr std::array<u16, 4> kGreen{ 0x0000u, 0x3C00u, 0x0000u, 0x3C00u };
+    constexpr std::array<u16, 4> kBlue{ 0x0000u, 0x0000u, 0x3C00u, 0x3C00u };
+
+    m_ShutdownDescriptorHeapOnTearDown = true;
+    ASSERT_TRUE(VulkanDescriptorHeapBackend::InstallOntoEngineHeap());
+    RHI::DescriptorHeap::Get().SetEnabled(true);
+    ASSERT_TRUE(RHI::DescriptorHeap::Get().IsEnabled());
+
+    Texture2DArraySpecification arraySpec;
+    arraySpec.Width = 1;
+    arraySpec.Height = 1;
+    arraySpec.Layers = 3;
+    arraySpec.Format = Texture2DArrayFormat::RGBA16F;
+    arraySpec.GenerateMipmaps = false;
+    auto atlas = Texture2DArray::Create(arraySpec);
+    ASSERT_TRUE(atlas);
+
+    // Exercise both upload routes: layers 0/1 take the one-shot path before a
+    // recording exists, while page 2 is staged into the live command buffer.
+    atlas->SetLayerData(0, kRed.data(), 1, 1);
+    atlas->SetLayerData(1, kGreen.data(), 1, 1);
+
+    const glm::vec4 fullPage{ 1.0f, 1.0f, 0.0f, 0.0f };
+    const TestLightmapRegions regions{
+        .First = EncodeLightmapRegion(fullPage, 0),
+        .Second = EncodeLightmapRegion(fullPage, 1),
+        .Third = EncodeLightmapRegion(fullPage, 2),
+    };
+    auto harness = CreateLightmapSampleHarness(kSize, regions);
+    ASSERT_TRUE(harness.LightmapUbo);
+    ASSERT_TRUE(harness.RegionUbo);
+    ASSERT_TRUE(harness.ShaderProgram);
+    ASSERT_EQ(harness.ShaderProgram->GetCompilationStatus(), ShaderCompilationStatus::Ready);
+    ASSERT_TRUE(harness.Output);
+
+    VulkanFrameArena::Get().BeginFrame(0);
+    const auto rendered = DrawLightmapSample(
+        kSize, harness.ShaderProgram, harness.Output,
+        [&]()
+        {
+            atlas->SetLayerData(2, kBlue.data(), 1, 1);
+            const RHI::HeapOffset offset = HeapBinding::PublishTextureOffsetAndBind(
+                ShaderBindingLayout::TEX_LIGHTMAP, atlas->GetRHIHandle(),
+                RHI::HeapSlotLifetime::Persistent, {}, RHI::NullSamplerKind::Texture2DArray);
+            EXPECT_TRUE(offset.IsValid());
+        });
+    ASSERT_EQ(rendered.size(), static_cast<sizet>(kSize) * kSize * 4);
+    const auto pixel = [&](u32 x, u32 y)
+    {
+        const auto i = (static_cast<sizet>(y) * kSize + x) * 4;
+        return std::array<int, 4>{ rendered[i], rendered[i + 1], rendered[i + 2], rendered[i + 3] };
+    };
+    EXPECT_EQ(pixel(5, 16), (std::array<int, 4>{ 255, 0, 0, 255 })) << "first region must decode page 0";
+    EXPECT_EQ(pixel(16, 16), (std::array<int, 4>{ 0, 255, 0, 255 })) << "second region must decode page 1";
+    EXPECT_EQ(pixel(27, 16), (std::array<int, 4>{ 0, 0, 255, 255 }))
+        << "third region must decode page 2, including the mid-frame upload";
+}
+
+TEST_F(VulkanPassSuite, Rgba16fLightmapTypedArrayNullFallbackIsTransparentBlack)
+{
+    constexpr u32 kSize = 32;
+
+    m_ShutdownDescriptorHeapOnTearDown = true;
+    ASSERT_TRUE(VulkanDescriptorHeapBackend::InstallOntoEngineHeap());
+    RHI::DescriptorHeap::Get().SetEnabled(true);
+    ASSERT_TRUE(RHI::DescriptorHeap::Get().IsEnabled());
+
+    const glm::vec4 fullPage{ 1.0f, 1.0f, 0.0f, 0.0f };
+    const TestLightmapRegions regions{ fullPage, fullPage, fullPage };
+    auto harness = CreateLightmapSampleHarness(kSize, regions);
+    ASSERT_TRUE(harness.LightmapUbo);
+    ASSERT_TRUE(harness.RegionUbo);
+    ASSERT_TRUE(harness.ShaderProgram);
+    ASSERT_EQ(harness.ShaderProgram->GetCompilationStatus(), ShaderCompilationStatus::Ready);
+    ASSERT_TRUE(harness.Output);
+
+    VulkanFrameArena::Get().BeginFrame(0);
+    const auto rendered = DrawLightmapSample(
+        kSize, harness.ShaderProgram, harness.Output,
+        [&]()
+        {
+            HeapBinding::PublishTextureOffsetAndBind(
+                ShaderBindingLayout::TEX_LIGHTMAP, RHI::NullResource,
+                RHI::HeapSlotLifetime::Persistent, {}, RHI::NullSamplerKind::Texture2DArray);
+            EXPECT_EQ(HeapBinding::StagedOffsetAt(ShaderBindingLayout::TEX_LIGHTMAP).Value,
+                      RHI::NullOffsetForSamplerKind(RHI::NullSamplerKind::Texture2DArray));
+        });
+    ASSERT_EQ(rendered.size(), static_cast<sizet>(kSize) * kSize * 4);
+    const auto i = (static_cast<sizet>(16) * kSize + 16) * 4;
+    EXPECT_EQ((std::array<u8, 4>{ rendered[i], rendered[i + 1], rendered[i + 2], rendered[i + 3] }),
+              (std::array<u8, 4>{ 0, 0, 0, 0 }));
+}
 
 TEST_F(VulkanPassSuite, FxaaPassMatchesTheGoldenThroughTheRenderGraph)
 {

--- a/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanResourceFactoryTest.cpp
@@ -37,6 +37,8 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #else
 
 #include "OloEngine/Renderer/IndexBuffer.h"
+#include "OloEngine/Renderer/RHI/RHIDescriptorHeap.h"
+#include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "OloEngine/Renderer/StorageBuffer.h"
 #include "OloEngine/Renderer/Texture.h"
@@ -45,6 +47,7 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/UniformBuffer.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/VertexBuffer.h"
+#include "Rendering/Texture2DArrayRoundTrip.h"
 #include "Platform/Vulkan/VulkanBufferResources.h"
 #include "Platform/Vulkan/VulkanCapabilities.h"
 #include "Platform/Vulkan/VulkanDescriptorSlotCache.h"
@@ -58,7 +61,9 @@ TEST(VulkanResourceFactory, SkipsWhenNotCompiledIn)
 #include "Platform/Vulkan/VulkanTextureCubemap.h"
 #include "Platform/Vulkan/VulkanTransientResources.h"
 
+#include <glad/gl.h>
 #include <volk.h>
+#include <GLFW/glfw3.h>
 
 #include <algorithm>
 #include <cstring>
@@ -82,6 +87,37 @@ namespace
         {
             RendererAPI::SetAPI(RendererAPI::API::OpenGL);
         }
+    };
+
+    // The shared RGBA16F contract uses the public RenderCommand readback
+    // facade, so this one resource-factory tenant must temporarily recreate
+    // that process-global facade for Vulkan as well as selecting Vulkan for
+    // resource factories. Put the initialized GL facade back for later tests.
+    struct ScopedVulkanRenderCommand
+    {
+        ScopedVulkanRenderCommand()
+            : PreviousDescriptorHeapEnabled(RHI::DescriptorHeap::Get().IsEnabled()),
+              HadOpenGlContext(glfwGetCurrentContext() != nullptr)
+        {
+            if (HadOpenGlContext)
+                RenderCommand::ShutdownGpuResources();
+            RendererAPI::SetAPI(RendererAPI::API::Vulkan);
+            RenderCommand::RecreateForSelectedBackend();
+        }
+
+        ~ScopedVulkanRenderCommand()
+        {
+            RendererAPI::SetAPI(RendererAPI::API::OpenGL);
+            RenderCommand::RecreateForSelectedBackend();
+            if (HadOpenGlContext)
+            {
+                RenderCommand::Init();
+                RHI::DescriptorHeap::Get().SetEnabled(PreviousDescriptorHeapEnabled);
+            }
+        }
+
+        bool PreviousDescriptorHeapEnabled;
+        bool HadOpenGlContext;
     };
 } // namespace
 
@@ -287,6 +323,12 @@ TEST_F(VulkanResourceFactory, TextureUploadRoundTripsThroughGetData)
     ASSERT_TRUE(texture->GetData(readback, 0));
     ASSERT_EQ(readback.size(), pixels.size());
     EXPECT_EQ(std::memcmp(readback.data(), pixels.data(), pixels.size()), 0);
+}
+
+TEST_F(VulkanResourceFactory, Rgba16fTextureArrayLayersRoundTripBitExactlyThroughThePublicFacade)
+{
+    ScopedVulkanRenderCommand vulkanCommand;
+    EXPECT_TRUE(OloEngine::Tests::KnownHalfEncodedTextureArrayLayersRoundTrip());
 }
 
 TEST_F(VulkanResourceFactory, RgbUploadWidensToRgbaWithOpaqueAlpha)


### PR DESCRIPTION
## What and why

- Adds one backend-neutral RGBA16F `Texture2DArray` upload/readback contract and invokes it on OpenGL and Vulkan through the public renderer facade.
- Adds a real Vulkan paged baked-lightmap shader sample through `TEX_LIGHTMAP` (slot 16), covering pages 0/1/2, one-shot uploads, a live-recording layer upload, and the typed `Texture2DArray` null fallback.
- Measures CPU `glm::packHalf1x16` output against the legacy OpenGL driver float-to-RGBA16F conversion across edge, midpoint, signed, and representative lightmap values.
- No production fix was required: the new coverage demonstrated that the current transport, sampling, live upload, and typed-null paths satisfy the contract.

Closes #951

## Validation

Local workstation: NVIDIA GeForce RTX 4090, driver 610.88.

- Locked Debug build of `OloEngine-Tests`: passed.
- Focused feature tests: 5/5 passed, 0 skipped.
- Exact Vulkan-to-OpenGL order regression after lifecycle hardening: 28/28 passed.
- Affected contract batch: 98/98 passed.
- Full suite: 6,693 passed, 26 unrelated/environmental skips, 0 failed (6,719 total).
- `pre-commit run --all-files`: all hooks passed.
- Final independent Standards review: clean.
- Final independent Spec review: clean.

Conversion measurement on NVIDIA OpenGL 4.6.0 / driver 610.88:

- compared half words: 104
- differing half words: 0
- maximum difference: 0 ULP

Decision: retain CPU half conversion. It is bit-identical on the measured driver; the test permits at most 1 ULP, which is immaterial to the region-mean lightmap contract.

Vulkan was exercised locally on the same RTX 4090 (API 1.4.341, driver 610.88) with no skips. Ordinary GitHub-hosted PR runners do not guarantee usable Vulkan hardware. The scheduled/manual AMD GPU workflow includes the full suite on RX 5600 XT hardware, but currently does not explicitly fail on Vulkan-specific skips, so cross-vendor Vulkan execution remains a CI visibility limitation.

## Review guide

Please focus on:

1. Whole-array RGBA16F readback extent and exact layer/texel/channel attribution in the shared contract.
2. Vulkan `SetLayerData` coverage split between the one-shot path and the live command-buffer path.
3. Descriptor-heap ownership during GL/Vulkan facade swaps, slot-16 typed-array publication, and transparent-black null sampling.

Least certain area: CI enforcement of real Vulkan execution on AMD, not the locally exercised NVIDIA behavior.

Deliberately not tested locally: a live Vulkan editor/MCP session and non-NVIDIA hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cross-backend validation for RGBA16F texture-array uploads and readbacks.
  * Added coverage for layer-specific data, edge cases, midpoint values, and representative inputs.
  * Added lightmap sampling tests, including mid-frame uploads and transparent-black fallback behavior.
  * Improved diagnostics with detailed mismatch reporting and graphics hardware metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->