### PR TITLE
fix(terrain): filter distant heightmap displacement

### DIFF
--- a/OloEditor/assets/shaders/Terrain_Depth.glsl
+++ b/OloEditor/assets/shaders/Terrain_Depth.glsl
@@ -143,6 +143,8 @@ layout(binding = 23) uniform sampler2D u_TerrainHeightmap;
 layout(binding = 30) uniform sampler2D u_SnowDepthMap;
 #endif
 
+#include "include/TerrainHeightSampling.glsl"
+
 // Snow Accumulation UBO (binding 16)
 layout(std140, binding = 16) uniform SnowAccumulationParams {
     mat4 u_ClipmapViewProj[3];
@@ -162,7 +164,8 @@ void main()
 
     // Displace Y from heightmap
     float heightScale = u_WorldSizeAndHeightScale.z;
-    pos.y = texture(u_TerrainHeightmap, uv).r * heightScale;
+    float heightMip = oloTerrainHeightMip(tc_TexCoord[0], tc_TexCoord[1], tc_TexCoord[2]);
+    pos.y = oloTerrainFilteredHeight(uv, heightMip) * heightScale;
 
     // Snow accumulation displacement (must match Terrain_PBR.glsl)
     if (u_DisplacementParams.z > 0.5)

--- a/OloEditor/assets/shaders/Terrain_GBuffer.glsl
+++ b/OloEditor/assets/shaders/Terrain_GBuffer.glsl
@@ -176,6 +176,8 @@ layout(binding = 23) uniform sampler2D u_TerrainHeightmap;
 layout(binding = 30) uniform sampler2D u_SnowDepthMap;
 #endif
 
+#include "include/TerrainHeightSampling.glsl"
+
 layout(std140, binding = 16) uniform SnowAccumulationParams {
     mat4 u_ClipmapViewProj[3];
     vec4 u_ClipmapCenterAndExtent[3];
@@ -204,7 +206,8 @@ void main()
     vec3 nrm = normalize(interpolate3(tc_Normal[0], tc_Normal[1], tc_Normal[2]));
 
     float heightScale = u_WorldSizeAndHeightScale.z;
-    float sampledHeight = texture(u_TerrainHeightmap, uv).r * heightScale;
+    float heightMip = oloTerrainHeightMip(tc_TexCoord[0], tc_TexCoord[1], tc_TexCoord[2]);
+    float sampledHeight = oloTerrainFilteredHeight(uv, heightMip) * heightScale;
     pos.y = sampledHeight;
 
     if (u_DisplacementParams.z > 0.5)
@@ -220,14 +223,14 @@ void main()
         }
     }
 
-    float texelSize = u_TerrainParams.x;
+    float texelSize = u_TerrainParams.x * exp2(heightMip);
     float worldSizeX = u_WorldSizeAndHeightScale.x;
     float worldSizeZ = u_WorldSizeAndHeightScale.y;
 
-    float hL = texture(u_TerrainHeightmap, uv + vec2(-texelSize, 0.0)).r * heightScale;
-    float hR = texture(u_TerrainHeightmap, uv + vec2( texelSize, 0.0)).r * heightScale;
-    float hD = texture(u_TerrainHeightmap, uv + vec2(0.0, -texelSize)).r * heightScale;
-    float hU = texture(u_TerrainHeightmap, uv + vec2(0.0,  texelSize)).r * heightScale;
+    float hL = oloTerrainFilteredHeight(uv + vec2(-texelSize, 0.0), heightMip) * heightScale;
+    float hR = oloTerrainFilteredHeight(uv + vec2( texelSize, 0.0), heightMip) * heightScale;
+    float hD = oloTerrainFilteredHeight(uv + vec2(0.0, -texelSize), heightMip) * heightScale;
+    float hU = oloTerrainFilteredHeight(uv + vec2(0.0,  texelSize), heightMip) * heightScale;
 
     float dX = (hR - hL) / (2.0 * texelSize * worldSizeX);
     float dZ = (hU - hD) / (2.0 * texelSize * worldSizeZ);

--- a/OloEditor/assets/shaders/Terrain_PBR.glsl
+++ b/OloEditor/assets/shaders/Terrain_PBR.glsl
@@ -178,6 +178,8 @@ layout(binding = 23) uniform sampler2D u_TerrainHeightmap;
 layout(binding = 30) uniform sampler2D u_SnowDepthMap;
 #endif
 
+#include "include/TerrainHeightSampling.glsl"
+
 // Snow Accumulation UBO (binding 16)
 layout(std140, binding = 16) uniform SnowAccumulationParams {
     mat4 u_ClipmapViewProj[3];
@@ -207,7 +209,8 @@ void main()
     vec3 nrm = normalize(interpolate3(tc_Normal[0], tc_Normal[1], tc_Normal[2]));
 
     float heightScale = u_WorldSizeAndHeightScale.z;
-    float sampledHeight = texture(u_TerrainHeightmap, uv).r * heightScale;
+    float heightMip = oloTerrainHeightMip(tc_TexCoord[0], tc_TexCoord[1], tc_TexCoord[2]);
+    float sampledHeight = oloTerrainFilteredHeight(uv, heightMip) * heightScale;
 
     // Displace Y from heightmap
     pos.y = sampledHeight;
@@ -233,14 +236,14 @@ void main()
     }
 
     // Recompute normal from heightmap derivatives
-    float texelSize = u_TerrainParams.x;
+    float texelSize = u_TerrainParams.x * exp2(heightMip);
     float worldSizeX = u_WorldSizeAndHeightScale.x;
     float worldSizeZ = u_WorldSizeAndHeightScale.y;
 
-    float hL = texture(u_TerrainHeightmap, uv + vec2(-texelSize, 0.0)).r * heightScale;
-    float hR = texture(u_TerrainHeightmap, uv + vec2( texelSize, 0.0)).r * heightScale;
-    float hD = texture(u_TerrainHeightmap, uv + vec2(0.0, -texelSize)).r * heightScale;
-    float hU = texture(u_TerrainHeightmap, uv + vec2(0.0,  texelSize)).r * heightScale;
+    float hL = oloTerrainFilteredHeight(uv + vec2(-texelSize, 0.0), heightMip) * heightScale;
+    float hR = oloTerrainFilteredHeight(uv + vec2( texelSize, 0.0), heightMip) * heightScale;
+    float hD = oloTerrainFilteredHeight(uv + vec2(0.0, -texelSize), heightMip) * heightScale;
+    float hU = oloTerrainFilteredHeight(uv + vec2(0.0,  texelSize), heightMip) * heightScale;
 
     float dX = (hR - hL) / (2.0 * texelSize * worldSizeX);
     float dZ = (hU - hD) / (2.0 * texelSize * worldSizeZ);

--- a/OloEditor/assets/shaders/include/TerrainHeightSampling.glsl
+++ b/OloEditor/assets/shaders/include/TerrainHeightSampling.glsl
@@ -1,0 +1,29 @@
+#ifndef TERRAIN_HEIGHT_SAMPLING_GLSL
+#define TERRAIN_HEIGHT_SAMPLING_GLSL
+
+// A tessellation-evaluation shader has no implicit texture derivatives. Using
+// texture() therefore selects mip zero even when a coarse terrain node places
+// its vertices many heightmap texels apart. That undersamples the heightfield
+// and turns sub-vertex detail into detached distant summits (issue #953).
+//
+// gl_TessLevelOuter[i] is the subdivision count for the edge opposite control
+// point i. Divide each UV edge by its actual subdivision count, then convert
+// the largest resulting footprint to source texels. This works for both the
+// GPU-driven unit patches and the CPU chunk fallback; it describes the
+// geometry that will really be emitted rather than guessing from distance.
+float oloTerrainHeightMip(vec2 uv0, vec2 uv1, vec2 uv2)
+{
+    float edge0 = length(uv1 - uv2) / max(gl_TessLevelOuter[0], 1.0);
+    float edge1 = length(uv2 - uv0) / max(gl_TessLevelOuter[1], 1.0);
+    float edge2 = length(uv0 - uv1) / max(gl_TessLevelOuter[2], 1.0);
+    float footprintTexels = max(max(edge0, edge1), edge2) * float(max(u_HeightmapResolution, 1));
+    float maxMip = floor(log2(float(max(u_HeightmapResolution, 1))));
+    return clamp(log2(max(footprintTexels, 1.0)), 0.0, maxMip);
+}
+
+float oloTerrainFilteredHeight(vec2 uv, float mip)
+{
+    return textureLod(u_TerrainHeightmap, uv, mip).r;
+}
+
+#endif // TERRAIN_HEIGHT_SAMPLING_GLSL

--- a/OloEngine/src/OloEngine/Terrain/TerrainData.cpp
+++ b/OloEngine/src/OloEngine/Terrain/TerrainData.cpp
@@ -245,7 +245,7 @@ namespace OloEngine
         spec.Width = m_Resolution;
         spec.Height = m_Resolution;
         spec.Format = ImageFormat::R32F;
-        spec.GenerateMips = false;
+        spec.GenerateMips = true;
 
         m_GPUHeightmap = Texture2D::Create(spec);
         m_GPUHeightmap->SetData(m_Heights.data(), static_cast<u32>(m_Heights.size() * sizeof(f32)));
@@ -272,7 +272,17 @@ namespace OloEngine
         if (width == 0 || height == 0)
             return;
 
-        // Extract the sub-region into a contiguous buffer
+        if (m_GPUHeightmap->GetMipLevelCount() > 1)
+        {
+            // Every coarser level depends on the edited base region. Texture2D has
+            // no backend-neutral partial-mip regeneration command, so refresh the
+            // complete base image and let SetData rebuild the chain on both APIs.
+            // Terrain sculpt uploads happen before the frame is recorded.
+            m_GPUHeightmap->SetData(m_Heights.data(), static_cast<u32>(m_Heights.size() * sizeof(f32)));
+            return;
+        }
+
+        // Extract the sub-region into a contiguous buffer.
         std::vector<f32> regionData(static_cast<sizet>(width) * height);
         for (u32 row = 0; row < height; ++row)
         {
@@ -281,7 +291,7 @@ namespace OloEngine
             std::memcpy(&regionData[dstOffset], &m_Heights[srcOffset], width * sizeof(f32));
         }
 
-        // Partial upload via SubImage
+        // Single-level textures can retain the cheap partial upload.
         u32 dataSize = width * height * static_cast<u32>(sizeof(f32));
         m_GPUHeightmap->SubImage(x, y, width, height, regionData.data(), dataSize);
     }

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -888,16 +888,17 @@ namespace OloEngine
                                                   GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_UNSYNCHRONIZED_BIT))
             {
                 std::memcpy(ptr, data, size);
-                glUnmapNamedBuffer(pbo);
-
-                // glTextureSubImage2D sources from the bound GL_PIXEL_UNPACK_BUFFER when
-                // the data pointer is a (null) buffer offset. Restore the binding to 0 after.
-                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
-                glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<int>(m_Width), static_cast<int>(m_Height), m_DataFormat, dataType, nullptr);
-                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-                uploadedViaPbo = true;
+                if (glUnmapNamedBuffer(pbo) == GL_TRUE)
+                {
+                    // glTextureSubImage2D sources from the bound GL_PIXEL_UNPACK_BUFFER when
+                    // the data pointer is a (null) buffer offset. Restore the binding to 0 after.
+                    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+                    glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<int>(m_Width), static_cast<int>(m_Height), m_DataFormat, dataType, nullptr);
+                    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+                    uploadedViaPbo = true;
+                }
             }
-            // Map failed — fall through to the direct (client-memory) upload below.
+            // Map or unmap failed — fall through to the direct (client-memory) upload below.
         }
 
         if (!uploadedViaPbo)

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -866,6 +866,7 @@ namespace OloEngine
 
         // Streaming path: route the upload through a double-buffered PBO ring so the
         // CPU copy and the GPU DMA overlap instead of stalling the render thread.
+        bool uploadedViaPbo = false;
         if (m_Specification.Streaming && m_Specification.Samples <= 1u && data)
         {
             if (m_PBO[0] == 0u || m_PBOCapacity != size)
@@ -894,12 +895,23 @@ namespace OloEngine
                 glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
                 glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<int>(m_Width), static_cast<int>(m_Height), m_DataFormat, dataType, nullptr);
                 glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-                return;
+                uploadedViaPbo = true;
             }
             // Map failed — fall through to the direct (client-memory) upload below.
         }
 
-        glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<int>(m_Width), static_cast<int>(m_Height), m_DataFormat, dataType, data);
+        if (!uploadedViaPbo)
+        {
+            glTextureSubImage2D(m_RendererID, 0, 0, 0, static_cast<int>(m_Width), static_cast<int>(m_Height), m_DataFormat, dataType, data);
+        }
+
+        if (m_MipLevels > 1u)
+        {
+            glGenerateTextureMipmap(m_RendererID);
+            m_MipsPopulated = true;
+            glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER,
+                                SelectMinFilter(IsIntegerFormat(m_Specification.Format), true));
+        }
     }
 
     void OpenGLTexture2D::SubImage(u32 x, u32 y, u32 width, u32 height, const void* data, [[maybe_unused]] u32 dataSize)

--- a/OloEngine/tests/Rendering/RenderPathDriftTest.cpp
+++ b/OloEngine/tests/Rendering/RenderPathDriftTest.cpp
@@ -344,4 +344,45 @@ namespace OloEngine::Tests
                "draw that is handed its material — say so in the TU:\n"
                "    // OLO_MATERIAL_RESOLVE_EXEMPT: <reason>";
     }
+
+    // -------------------------------------------------------------------------------------
+    // (c) ONE terrain-height sampling rule. Coarse terrain nodes must not sample mip zero.
+    //
+    // The GPU-driven terrain path deliberately reduces vertex density with distance. Sampling
+    // the full-resolution heightmap at those sparse vertices aliases sub-vertex terrain detail
+    // into detached one-pixel summits above a distant silhouette (issue #953). Forward,
+    // deferred and depth must derive the same footprint and sample the same filtered height;
+    // otherwise a path switch changes the geometry, or the depth prepass disagrees with color.
+    // -------------------------------------------------------------------------------------
+    TEST(RenderPathDrift, EveryTerrainDisplacementStageUsesTheSharedFootprintFilter)
+    {
+        const std::filesystem::path root = RepoRoot();
+        const std::filesystem::path shaderDir = root / "OloEditor/assets/shaders";
+        const std::filesystem::path helperPath = shaderDir / "include/TerrainHeightSampling.glsl";
+        const std::string helper = StripComments(ReadFile(helperPath));
+
+        ASSERT_FALSE(helper.empty()) << "missing shared terrain-height sampler: " << helperPath.string();
+        EXPECT_NE(helper.find("gl_TessLevelOuter"), std::string::npos)
+            << "terrain height filtering must follow the tessellated UV footprint, not camera distance alone";
+        EXPECT_NE(helper.find("u_HeightmapResolution"), std::string::npos)
+            << "the UV footprint must be converted to source-heightmap texels";
+        EXPECT_NE(helper.find("textureLod"), std::string::npos)
+            << "a non-fragment stage has no implicit derivatives; terrain height sampling needs an explicit mip";
+
+        for (const char* shaderName : { "Terrain_PBR.glsl", "Terrain_GBuffer.glsl", "Terrain_Depth.glsl" })
+        {
+            const std::filesystem::path shaderPath = shaderDir / shaderName;
+            const std::string source = StripComments(ReadFile(shaderPath));
+            ASSERT_FALSE(source.empty()) << "could not read " << shaderPath.string();
+            EXPECT_NE(source.find("include/TerrainHeightSampling.glsl"), std::string::npos)
+                << shaderName << " bypasses the shared terrain-height sampling rule";
+            EXPECT_NE(source.find("oloTerrainFilteredHeight("), std::string::npos)
+                << shaderName << " still displaces terrain from an unfiltered height sample";
+        }
+
+        const std::string terrainData = StripComments(ReadFile(root / "OloEngine/src/OloEngine/Terrain/TerrainData.cpp"));
+        ASSERT_FALSE(terrainData.empty());
+        EXPECT_NE(terrainData.find("spec.GenerateMips = true"), std::string::npos)
+            << "the explicit terrain LOD is useless unless TerrainData uploads a height mip chain";
+    }
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/ResourceInspectorTextureQueryTest.cpp
+++ b/OloEngine/tests/Rendering/ResourceInspectorTextureQueryTest.cpp
@@ -27,6 +27,7 @@
 #include "PropertyTests/RenderPropertyTest.h"
 
 #include "Platform/OpenGL/OpenGLResourceInspectorBackend.h"
+#include "Platform/OpenGL/OpenGLTexture.h"
 
 #include <glad/gl.h>
 
@@ -155,4 +156,32 @@ TEST(ResourceInspectorTextureQuery, MutableSingleLevelTextureIsNotReportedAsAFul
     EXPECT_EQ(query.MemoryUsage, ExpectedRgba8Bytes(1));
 
     ::glDeleteTextures(1, &texture);
+}
+
+TEST(OpenGLTextureMipUpload, SetDataPopulatesTheRequestedMipChain)
+{
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    OloEngine::TextureSpecification spec;
+    spec.Width = 8;
+    spec.Height = 8;
+    spec.Format = OloEngine::ImageFormat::RGBA8;
+    spec.GenerateMips = true;
+
+    auto texture = OloEngine::Ref<OloEngine::OpenGLTexture2D>::Create(spec);
+    ASSERT_NE(texture, nullptr);
+    ASSERT_EQ(texture->GetMipLevelCount(), 4u);
+
+    // A constant image has the same value in every generated mip. Before #953,
+    // SetData wrote level zero only; the allocated lower levels remained undefined.
+    std::vector<u8> pixels(8u * 8u * 4u, 0x80u);
+    texture->SetData(pixels.data(), static_cast<u32>(pixels.size()));
+
+    std::vector<u8> mip2;
+    ASSERT_TRUE(texture->GetData(mip2, 2));
+    ASSERT_EQ(mip2.size(), sizet{ 2u * 2u * 4u });
+    for (const u8 byte : mip2)
+    {
+        EXPECT_EQ(byte, 0x80u);
+    }
 }


### PR DESCRIPTION
## Summary

- Filter terrain height displacement by the tessellated UV footprint, preventing sparse distant terrain nodes from aliasing heightmap detail into horizon specks.
- Use the same explicit mip selection in Forward, G-buffer, and depth terrain passes, including matching normal derivatives.
- Generate and refresh terrain heightmap mip chains after full uploads; sculpt edits re-upload the complete heightmap so dependent mips stay valid.
- Fix OpenGL `Texture2D::SetData` to populate requested mip chains, with focused coverage.

## Verification

- Locked cached Debug build: `OloEngine-Tests` and `OloEditor`.
- Focused tests: `RenderPathDrift.*:OpenGLTextureMipUpload.*` — 4/4 passed.
- OpenGL editor smoke test on NVIDIA RTX 4090: rendered the terrain scene successfully; `Terrain_PBR`, `Terrain_GBuffer`, and `Terrain_Depth` compiled successfully through both Vulkan SPIR-V and OpenGL shader paths.

## Notes

Follow-up to #953. Terrain sculpt changes deliberately perform a full heightmap upload because the texture facade has no backend-neutral partial mip regeneration operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terrain heightmap updates when textures use mipmaps, ensuring terrain rendering stays accurate after regional uploads.
  * Improved texture streaming uploads and mipmap generation reliability.
  * Applied consistent, footprint-aware terrain height sampling across forward, deferred, and depth rendering paths.

* **Tests**
  * Added coverage for generated texture mip levels and terrain displacement sampling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->