### PR TITLE
feat(renderer): CI-baked, content-hash-validated shader pack (#908)

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -336,3 +336,29 @@ jobs:
         name: googletest_results_xml
         path: ${{runner.workspace}}/OloEngineBase/test_results/*.xml
         if-no-files-found: 'warn'
+
+    # Issue #908: bake a CI-portable SPIR-V shader pack and publish it as a
+    # build artifact for anyone who wants it (a packaged game's build step
+    # pulls it in explicitly — see docs/agent-rules/shader-pack-bake.md — a
+    # fresh worktree does NOT fetch it automatically). This runs the test
+    # binary's own `--olo-bake-shader-pack` mode rather than a full editor
+    # launch: no GL context is created anywhere in that path (verified — see
+    # ShaderPackBakeTest.cpp), so it needs nothing this hosted, GPU-less
+    # runner doesn't already have. `--gtest_filter` isolates the one test
+    # this flag drives so the rest of the suite (already run above) doesn't
+    # execute a second time.
+    - name: Bake shader pack (issue #908)
+      shell: pwsh
+      working-directory: ${{github.workspace}}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $testExe = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}/OloEngine-Tests.exe'
+        & $testExe --gtest_filter=ShaderPackBakeTest.* --olo-bake-shader-pack="OloEditor/assets/ShaderPack.osp"
+        if ($LASTEXITCODE -ne 0) { throw "Shader pack bake failed (exit $LASTEXITCODE)" }
+
+    - name: Upload shader pack artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ShaderPack
+        path: ${{github.workspace}}/OloEditor/assets/ShaderPack.osp
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 bin-int/
 obj/
 **/cache/**
+
+# Baked shader pack (issue #908) — a CI/build-time artifact (or produced
+# locally by the editor's "Build Shader Pack" menu / a headless bake), never
+# hand-authored source.
+OloEditor/assets/ShaderPack.osp
 OloEditor/Resources/Scripts/Hazel-ScriptCore.dll
 OloEditor/Resources/Scripts/Hazel-ScriptCore.pdb
 Intermediates/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ you are in.
 **Renderer**
 
 - [rhi-abstraction-boundary.md](docs/agent-rules/rhi-abstraction-boundary.md) — where the OpenGL boundary actually leaks: the include graph, not a `glXxx(` grep; plus the Vulkan epic's accumulated lessons (§9–§14, incl. the one-row-order-per-backend contract and the mesh-shader stage family).
+- [shader-pack-bake.md](docs/agent-rules/shader-pack-bake.md) — the CI-baked `.osp` (issue #908): the content-hash invalidation contract, why the producer needs no GL context, and why a fresh worktree doesn't fetch it automatically.
 - [shared-atlas-allocator.md](docs/agent-rules/shared-atlas-allocator.md) — the buddy/quadtree allocator behind the shadow atlas and the impostor VRAM budget: the swap-not-mutate pattern for identity-keyed free-on-drop, why the impostor retrofit stayed a budget gate instead of spatial packing, and a non-RAII handle embedded in a POD-looking struct that `vector::resize()` silently leaks.
 - [vulkan-command-ordered-buffer-writes.md](docs/agent-rules/vulkan-command-ordered-buffer-writes.md) — a CPU buffer write between two recorded draws is GL command order; a life-stable Vulkan address silently makes it last-write-wins, and the failure is scene-shaped.
 - [gl-global-setter-resets-indexed-state.md](docs/agent-rules/gl-global-setter-resets-indexed-state.md) — `glColorMask` / `glEnable(GL_BLEND)` are the indexed call for EVERY draw buffer; porting one as a fallback makes an indexed call permanent, and only render target 0 is ever looked at.

--- a/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
+++ b/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
@@ -146,6 +146,39 @@ namespace OloEngine
         return true;
     }
 
+    bool StageShaderPack(
+        const std::filesystem::path& shaderPackSrc,
+        const std::filesystem::path& outputAssetsDir,
+        bool& packStaged,
+        std::string& errorMessage)
+    {
+        packStaged = false;
+
+        if (!std::filesystem::exists(shaderPackSrc))
+        {
+            return true;
+        }
+
+        std::error_code ec;
+        std::filesystem::create_directories(outputAssetsDir, ec);
+        if (ec)
+        {
+            errorMessage = "Failed to create asset output directory for the shader pack: " + ec.message();
+            return false;
+        }
+
+        std::filesystem::copy_file(shaderPackSrc, outputAssetsDir / shaderPackSrc.filename(),
+                                   std::filesystem::copy_options::overwrite_existing, ec);
+        if (ec)
+        {
+            errorMessage = "Failed to copy shader pack: " + ec.message();
+            return false;
+        }
+
+        packStaged = true;
+        return true;
+    }
+
     GameBuildResult GameBuildPipeline::Build(
         const GameBuildSettings& settings,
         std::atomic<f32>& progress,
@@ -627,6 +660,27 @@ namespace OloEngine
             }
         }
         OLO_CORE_INFO("[GameBuild] Copied {} shader files", shaderCount);
+
+        // --- Shader pack (issue #908, optional) ---
+        bool packStaged = false;
+        if (!StageShaderPack("assets/ShaderPack.osp", shaderDst.parent_path(), packStaged, errorMessage))
+        {
+            return false;
+        }
+        if (packStaged)
+        {
+            // "Fixed engine set" — a script-loaded custom shader
+            // (ShaderLibrary.Load exposed to Lua) isn't in the pack's
+            // enumeration and still cold-compiles on first launch; see
+            // docs/agent-rules/shader-pack-bake.md.
+            OLO_CORE_INFO("[GameBuild] Staged shader pack (ShaderPack.osp) — packaged runtime will not "
+                          "compile the fixed engine shader set from source on first launch");
+        }
+        else
+        {
+            OLO_CORE_INFO("[GameBuild] No shader pack found — packaged runtime will compile shaders "
+                          "from source on first launch");
+        }
 
         // --- Textures (skybox cubemaps, IBL, etc.) ---
         const std::filesystem::path textureSrc = "assets/textures";

--- a/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
+++ b/OloEngine/src/OloEngine/Build/GameBuildPipeline.cpp
@@ -154,12 +154,18 @@ namespace OloEngine
     {
         packStaged = false;
 
-        if (!std::filesystem::exists(shaderPackSrc))
+        std::error_code ec;
+        const bool srcExists = std::filesystem::exists(shaderPackSrc, ec);
+        if (ec)
+        {
+            errorMessage = "Failed to check for a shader pack at " + shaderPackSrc.string() + ": " + ec.message();
+            return false;
+        }
+        if (!srcExists)
         {
             return true;
         }
 
-        std::error_code ec;
         std::filesystem::create_directories(outputAssetsDir, ec);
         if (ec)
         {
@@ -669,12 +675,17 @@ namespace OloEngine
         }
         if (packStaged)
         {
-            // "Fixed engine set" — a script-loaded custom shader
-            // (ShaderLibrary.Load exposed to Lua) isn't in the pack's
-            // enumeration and still cold-compiles on first launch; see
-            // docs/agent-rules/shader-pack-bake.md.
-            OLO_CORE_INFO("[GameBuild] Staged shader pack (ShaderPack.osp) — packaged runtime will not "
-                          "compile the fixed engine shader set from source on first launch");
+            // Staging alone doesn't guarantee a hit: the runtime still
+            // content-hash-validates every entry against the shipped
+            // `assets/shaders` source (ShaderLibrary::TryReadPackEntry) before
+            // serving it, and falls back to compiling from source for
+            // anything that doesn't validate — a pack staged here from a
+            // stale bake, or a script-loaded custom shader (ShaderLibrary.Load
+            // exposed to Lua) outside the pack's fixed enumeration, still
+            // compiles on first launch. See docs/agent-rules/shader-pack-bake.md.
+            OLO_CORE_INFO("[GameBuild] Staged shader pack (ShaderPack.osp) — the packaged runtime will "
+                          "try it first and fall back to compiling from source for any shader that "
+                          "doesn't validate");
         }
         else
         {

--- a/OloEngine/src/OloEngine/Build/GameBuildPipeline.h
+++ b/OloEngine/src/OloEngine/Build/GameBuildPipeline.h
@@ -52,6 +52,22 @@ namespace OloEngine
         std::string& errorMessage);
 
     /**
+     * @brief Stage the CI-baked shader pack (.osp), if one was built (issue #908).
+     *
+     * A shader pack is a portable, content-hash-validated cache of
+     * pre-compiled SPIR-V — optional, not required. `packStaged` reports
+     * whether one was found and copied; when `shaderPackSrc` doesn't exist
+     * this returns true with `packStaged == false` (not an error) because a
+     * packaged runtime with no pack falls back to compiling from the shipped
+     * `assets/shaders` source tree, same as it always has.
+     */
+    bool StageShaderPack(
+        const std::filesystem::path& shaderPackSrc,
+        const std::filesystem::path& outputAssetsDir,
+        bool& packStaged,
+        std::string& errorMessage);
+
+    /**
      * @brief Orchestrates the full game build pipeline
      *
      * The GameBuildPipeline is responsible for taking the active project

--- a/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer2D.cpp
@@ -19,6 +19,24 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include <array>
+#include <filesystem>
+
+namespace
+{
+    // The 2D shader filepaths Init() loads, and what Renderer2D::GetShaderFilepaths()
+    // (issue #908) returns — ONE array, two readers, so the headless ShaderPack
+    // bake can never enumerate a different set than what this library actually
+    // tries to serve from the pack at runtime.
+    constexpr std::array kShaderPaths2D = {
+        "assets/shaders/Renderer2D_Quad.glsl",
+        "assets/shaders/Renderer2D_Polygon.glsl",
+        "assets/shaders/Renderer2D_Circle.glsl",
+        "assets/shaders/Renderer2D_Line.glsl",
+        "assets/shaders/Renderer2D_Text.glsl",
+    };
+} // namespace
+
 namespace OloEngine
 {
     struct QuadVertex
@@ -158,9 +176,19 @@ namespace OloEngine
 
     ShaderLibrary Renderer2D::m_ShaderLibrary;
 
+    std::vector<std::string> Renderer2D::GetShaderFilepaths()
+    {
+        return std::vector<std::string>(kShaderPaths2D.begin(), kShaderPaths2D.end());
+    }
+
     void Renderer2D::Init(Window* loadingWindow)
     {
         OLO_PROFILE_FUNCTION();
+
+        // A CI-baked pack (issue #908) is optional — LoadShaderPack() is a
+        // no-op when the file doesn't exist, so Load() below falls back to
+        // compiling from source, same as it always has.
+        m_ShaderLibrary.LoadShaderPack("assets/ShaderPack.osp");
 
         Window* window = loadingWindow;
 
@@ -260,13 +288,7 @@ namespace OloEngine
         // sequentially afterward on this (render) thread; see
         // ShaderWarmup::LoadShadersParallel.
         OLO_CORE_INFO("Renderer2D::Init: Loading 2D shaders...");
-        const std::vector<std::string> shaderPaths2D = {
-            "assets/shaders/Renderer2D_Quad.glsl",
-            "assets/shaders/Renderer2D_Polygon.glsl",
-            "assets/shaders/Renderer2D_Circle.glsl",
-            "assets/shaders/Renderer2D_Line.glsl",
-            "assets/shaders/Renderer2D_Text.glsl",
-        };
+        const std::vector<std::string> shaderPaths2D(kShaderPaths2D.begin(), kShaderPaths2D.end());
         ShaderWarmup::LoadShadersParallel(m_ShaderLibrary, window, shaderPaths2D, "2D shaders", 0);
         OLO_CORE_INFO("Renderer2D::Init: 2D shaders loaded");
 

--- a/OloEngine/src/OloEngine/Renderer/Renderer2D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer2D.h
@@ -88,6 +88,11 @@ namespace OloEngine
 
         static ShaderLibrary& GetShaderLibrary();
 
+        // The filepaths Init() loads into GetShaderLibrary() — exposed (issue
+        // #908) so the headless ShaderPack bake enumerates EXACTLY what this
+        // library will later try to serve from the pack. No GL call.
+        [[nodiscard]] static std::vector<std::string> GetShaderFilepaths();
+
         // Stats
         struct Statistics
         {

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -1462,6 +1462,12 @@ namespace OloEngine
         // Shader library access for PBR material shader selection
         static ShaderLibrary& GetShaderLibrary();
 
+        // The filepaths Init() loads into GetShaderLibrary() — exposed (issue
+        // #908) so the headless ShaderPack bake enumerates EXACTLY what this
+        // library will later try to serve from the pack, with no second list
+        // that could drift from the real one. No GL call, no side effect.
+        [[nodiscard]] static std::vector<std::string> GetShaderFilepaths();
+
         template<typename T>
         static CommandPacket* CreateRenderStreamDrawCall(RenderStreamType stream)
         {

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -76,10 +76,78 @@
 #include <atomic>
 #include <cmath>
 
+namespace
+{
+    // The 3D shader filepaths Init() loads, and what Renderer3D::GetShaderFilepaths()
+    // (issue #908) returns — ONE array, two readers, so the headless ShaderPack
+    // bake can never enumerate a different set than what this library actually
+    // tries to serve from the pack at runtime. Keep totalShaders3D (below) in
+    // sync with this array's length.
+    constexpr std::array kShaderPaths3D = {
+        "assets/shaders/LightCube.glsl",
+        "assets/shaders/Renderer3D_Quad.glsl",
+        "assets/shaders/PBR_MultiLight.glsl",
+        "assets/shaders/PBR_MultiLight_Skinned.glsl",
+        "assets/shaders/PBR_GBuffer.glsl",
+        "assets/shaders/PBR_GBuffer_Skinned.glsl",
+        "assets/shaders/EquirectangularToCubemap.glsl",
+        "assets/shaders/ProceduralSky.glsl",
+        "assets/shaders/StarNestSky.glsl",
+        "assets/shaders/AtmosphereSky.glsl",
+        "assets/shaders/IrradianceConvolution.glsl",
+        "assets/shaders/IrradianceConvolutionAdvanced.glsl",
+        "assets/shaders/IrradianceFromSH.glsl",
+        "assets/shaders/IBLPrefilter.glsl",
+        "assets/shaders/IBLPrefilterImportance.glsl",
+        "assets/shaders/BRDFLutGeneration.glsl",
+        "assets/shaders/BRDFIntegrationAdvanced.glsl",
+        "assets/shaders/Skybox.glsl",
+        "assets/shaders/Skybox_GBuffer.glsl",
+        "assets/shaders/LightCube_GBuffer.glsl",
+        "assets/shaders/InfiniteGrid.glsl",
+        "assets/shaders/InfiniteGrid_GBuffer.glsl",
+        "assets/shaders/ShadowDepth.glsl",
+        "assets/shaders/ShadowDepthSkinned.glsl",
+        "assets/shaders/DepthPrepass.glsl",
+        "assets/shaders/DepthPrepass_Skinned.glsl",
+        "assets/shaders/DepthPrepass_Mask.glsl",
+        "assets/shaders/DepthPrepass_MaskSkinned.glsl",
+        "assets/shaders/Terrain_PBR.glsl",
+        "assets/shaders/Terrain_GBuffer.glsl",
+        "assets/shaders/Terrain_Depth.glsl",
+        "assets/shaders/Terrain_Voxel.glsl",
+        "assets/shaders/Terrain_Voxel_GBuffer.glsl",
+        "assets/shaders/Terrain_VoxelDepth.glsl",
+        "assets/shaders/Terrain_VoxelGreedy.glsl",
+        "assets/shaders/Terrain_VoxelGreedy_GBuffer.glsl",
+        "assets/shaders/Terrain_VoxelGreedyDepth.glsl",
+        "assets/shaders/Foliage_Instance.glsl",
+        "assets/shaders/Foliage_Instance_GBuffer.glsl",
+        "assets/shaders/Foliage_Depth.glsl",
+        "assets/shaders/Foliage_Impostor.glsl",
+        "assets/shaders/Impostor_Bake.glsl",
+        "assets/shaders/Water.glsl",
+        "assets/shaders/Water_Depth.glsl",
+        "assets/shaders/Decal.glsl",
+        "assets/shaders/Decal_OIT.glsl",
+        "assets/shaders/Decal_GBuffer.glsl",
+        "assets/shaders/Decal_GBuffer_Normal.glsl",
+        "assets/shaders/Decal_GBuffer_RMA.glsl",
+        "assets/shaders/Decal_GBuffer_Emissive.glsl",
+        "assets/shaders/OcclusionProxy.glsl",
+        "assets/shaders/ForwardPlusDebug.glsl",
+    };
+} // namespace
+
 namespace OloEngine
 {
     Renderer3D::Renderer3DData Renderer3D::s_Data;
     ShaderLibrary Renderer3D::m_ShaderLibrary;
+
+    std::vector<std::string> Renderer3D::GetShaderFilepaths()
+    {
+        return std::vector<std::string>(kShaderPaths3D.begin(), kShaderPaths3D.end());
+    }
 
     void Renderer3D::Init(Window* loadingWindow)
     {
@@ -207,8 +275,9 @@ namespace OloEngine
             s_Data.FullscreenQuadVAO->AddVertexBuffer(quadVBO);
         }
 
-        // NOTE: Keep totalShaders3D in sync with the number of paths in s_ShaderPaths below.
+        // NOTE: Keep totalShaders3D in sync with kShaderPaths3D's length above.
         constexpr u32 totalShaders3D = 52;
+        static_assert(kShaderPaths3D.size() == totalShaders3D);
 
         // Boot + fallback are idempotent — no-ops when already initialized by
         // Renderer::Init().  Needed here for the lazy-init path (EditorLayer
@@ -216,73 +285,23 @@ namespace OloEngine
         ShaderWarmup::Init();
         ShaderLibrary::InitFallbackShader();
 
+        // A CI-baked pack (issue #908) is optional — LoadShaderPack() is a
+        // no-op when the file doesn't exist, so every Load() below falls
+        // back to compiling from source, same as it always has.
+        m_ShaderLibrary.LoadShaderPack("assets/ShaderPack.osp");
+
         Window* window = loadingWindow;
 
         // All Load() calls issue glLinkProgram() back-to-back WITHOUT checking
         // GL_LINK_STATUS. When GL_ARB_parallel_shader_compile is available the
         // driver links them all in parallel. Status is checked later via
         // PollPendingShaders() each frame from `RenderPipeline::PrepareFrame()`.
-        static constexpr std::array s_ShaderPaths = {
-            "assets/shaders/LightCube.glsl",
-            "assets/shaders/Renderer3D_Quad.glsl",
-            "assets/shaders/PBR_MultiLight.glsl",
-            "assets/shaders/PBR_MultiLight_Skinned.glsl",
-            "assets/shaders/PBR_GBuffer.glsl",
-            "assets/shaders/PBR_GBuffer_Skinned.glsl",
-            "assets/shaders/EquirectangularToCubemap.glsl",
-            "assets/shaders/ProceduralSky.glsl",
-            "assets/shaders/StarNestSky.glsl",
-            "assets/shaders/AtmosphereSky.glsl",
-            "assets/shaders/IrradianceConvolution.glsl",
-            "assets/shaders/IrradianceConvolutionAdvanced.glsl",
-            "assets/shaders/IrradianceFromSH.glsl",
-            "assets/shaders/IBLPrefilter.glsl",
-            "assets/shaders/IBLPrefilterImportance.glsl",
-            "assets/shaders/BRDFLutGeneration.glsl",
-            "assets/shaders/BRDFIntegrationAdvanced.glsl",
-            "assets/shaders/Skybox.glsl",
-            "assets/shaders/Skybox_GBuffer.glsl",
-            "assets/shaders/LightCube_GBuffer.glsl",
-            "assets/shaders/InfiniteGrid.glsl",
-            "assets/shaders/InfiniteGrid_GBuffer.glsl",
-            "assets/shaders/ShadowDepth.glsl",
-            "assets/shaders/ShadowDepthSkinned.glsl",
-            "assets/shaders/DepthPrepass.glsl",
-            "assets/shaders/DepthPrepass_Skinned.glsl",
-            "assets/shaders/DepthPrepass_Mask.glsl",
-            "assets/shaders/DepthPrepass_MaskSkinned.glsl",
-            "assets/shaders/Terrain_PBR.glsl",
-            "assets/shaders/Terrain_GBuffer.glsl",
-            "assets/shaders/Terrain_Depth.glsl",
-            "assets/shaders/Terrain_Voxel.glsl",
-            "assets/shaders/Terrain_Voxel_GBuffer.glsl",
-            "assets/shaders/Terrain_VoxelDepth.glsl",
-            "assets/shaders/Terrain_VoxelGreedy.glsl",
-            "assets/shaders/Terrain_VoxelGreedy_GBuffer.glsl",
-            "assets/shaders/Terrain_VoxelGreedyDepth.glsl",
-            "assets/shaders/Foliage_Instance.glsl",
-            "assets/shaders/Foliage_Instance_GBuffer.glsl",
-            "assets/shaders/Foliage_Depth.glsl",
-            "assets/shaders/Foliage_Impostor.glsl",
-            "assets/shaders/Impostor_Bake.glsl",
-            "assets/shaders/Water.glsl",
-            "assets/shaders/Water_Depth.glsl",
-            "assets/shaders/Decal.glsl",
-            "assets/shaders/Decal_OIT.glsl",
-            "assets/shaders/Decal_GBuffer.glsl",
-            "assets/shaders/Decal_GBuffer_Normal.glsl",
-            "assets/shaders/Decal_GBuffer_RMA.glsl",
-            "assets/shaders/Decal_GBuffer_Emissive.glsl",
-            "assets/shaders/OcclusionProxy.glsl",
-            "assets/shaders/ForwardPlusDebug.glsl",
-        };
-        static_assert(s_ShaderPaths.size() == totalShaders3D);
-
+        //
         // CPU-side compile of independent shaders runs in parallel across
         // shaders (issue #907) — GL program creation/link still happens
         // sequentially afterward on this (render) thread; see
         // ShaderWarmup::LoadShadersParallel.
-        const std::vector<std::string> shaderPaths3D(s_ShaderPaths.begin(), s_ShaderPaths.end());
+        const std::vector<std::string> shaderPaths3D(kShaderPaths3D.begin(), kShaderPaths3D.end());
         ShaderWarmup::LoadShadersParallel(m_ShaderLibrary, window, shaderPaths3D, "3D shaders", 1);
 
         // Log how many shaders are still compiling asynchronously

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -404,6 +404,18 @@ void main()
 
     void ShaderLibrary::LoadShaderPack(const std::filesystem::path& path)
     {
+        // A CI-baked pack (issue #908) is optional — the common case (no
+        // pack baked, or a fresh worktree that never fetched one) shouldn't
+        // log a spurious "failed to load" from the ShaderPack constructor
+        // trying to open a file that was never expected to exist. Checked
+        // here, once, rather than duplicated at every LoadShaderPack call
+        // site — Renderer2D::Init() and Renderer3D::Init() used to each
+        // carry their own copy of this exact guard.
+        if (!std::filesystem::exists(path))
+        {
+            return;
+        }
+
         m_ShaderPack = std::make_unique<ShaderPack>(path);
         if (!m_ShaderPack->IsLoaded())
         {
@@ -440,6 +452,26 @@ void main()
 
         if (!m_ShaderPack->Contains(filepath))
         {
+            return std::nullopt;
+        }
+
+        // Content-hash validation (issue #908): a pack entry is only served
+        // when its baked hash matches what the CURRENT on-disk source hashes
+        // to right now — recomputed fresh, not trusted from the pack build. A
+        // name match alone (the pre-#908 contract) would serve stale SPIR-V
+        // for a shader that has since changed, silently — the exact "old
+        // defect" a name-keyed cache used to have (#906's motivation for the
+        // per-stage compile cache). Both sides call the SAME hash function
+        // (OpenGLShader::ComputeContentHash), so two inputs that hash equal
+        // ARE the same bytes shaderc would produce — no separate staleness
+        // check needed, and a mismatch is unambiguously a miss.
+        const std::string currentHash = OpenGLShader::ComputeContentHash(filepath);
+        const auto packHash = m_ShaderPack->GetContentHash(filepath);
+        if (currentHash.empty() || !packHash || *packHash != currentHash)
+        {
+            OLO_CORE_WARN("[ShaderLibrary] Pack entry '{}' content hash mismatch — "
+                          "falling back to compile",
+                          filepath);
             return std::nullopt;
         }
 

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -411,7 +411,20 @@ void main()
         // here, once, rather than duplicated at every LoadShaderPack call
         // site — Renderer2D::Init() and Renderer3D::Init() used to each
         // carry their own copy of this exact guard.
-        if (!std::filesystem::exists(path))
+        //
+        // The std::error_code overload: this runs on every engine startup,
+        // so an exception here (a permissions error, a broken symlink, ...)
+        // would be an uncaught throw straight out of Init() rather than a
+        // graceful "no pack" — treat any query failure as "not present"
+        // rather than crashing startup over an optional feature.
+        std::error_code ec;
+        const bool exists = std::filesystem::exists(path, ec);
+        if (ec)
+        {
+            OLO_CORE_WARN("[ShaderLibrary] Couldn't check for a shader pack at '{}': {}", path.string(), ec.message());
+            return;
+        }
+        if (!exists)
         {
             return;
         }

--- a/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Renderer/Shader.h"
 #include "Platform/OpenGL/OpenGLShader.h"
 
+#include <algorithm>
 #include <fstream>
 
 namespace OloEngine
@@ -188,6 +189,12 @@ namespace OloEngine
                 return;
             }
 
+            if (!ReadString(in, entry.ContentHash))
+            {
+                OLO_CORE_ERROR("[ShaderPack] Failed to read content hash for '{}'", entry.Name);
+                return;
+            }
+
             if (!ReadRaw(in, entry.StageCount))
             {
                 OLO_CORE_ERROR("[ShaderPack] Failed to read stage count for '{}'", entry.Name);
@@ -219,6 +226,16 @@ namespace OloEngine
     bool ShaderPack::Contains(const std::string& name) const
     {
         return m_Index.contains(name);
+    }
+
+    std::optional<std::string> ShaderPack::GetContentHash(const std::string& name) const
+    {
+        auto it = m_Index.find(name);
+        if (it == m_Index.end())
+        {
+            return std::nullopt;
+        }
+        return it->second.ContentHash;
     }
 
     std::vector<std::string> ShaderPack::GetShaderNames() const
@@ -295,28 +312,7 @@ namespace OloEngine
     // =========================================================================
     bool ShaderPack::CreateFromLibraries(ShaderLibrary& lib2D, ShaderLibrary& lib3D, const std::filesystem::path& outputPath)
     {
-        // Ensure parent directory exists
-        if (auto parentDir = outputPath.parent_path(); !parentDir.empty())
-        {
-            std::filesystem::create_directories(parentDir);
-        }
-
-        std::ofstream out(outputPath, std::ios::binary);
-        if (!out)
-        {
-            OLO_CORE_ERROR("[ShaderPack] Failed to create output file: {}", outputPath.string());
-            return false;
-        }
-
-        // Collect all shaders from both libraries
-        struct ShaderInfo
-        {
-            std::string Name;
-            const std::unordered_map<unsigned int, std::vector<u32>>* VulkanSPIRV = nullptr;
-            const std::unordered_map<unsigned int, std::vector<u32>>* OpenGLSPIRV = nullptr;
-        };
-
-        std::vector<ShaderInfo> shaders;
+        std::vector<PackShaderInfo> shaders;
 
         auto collectShaders = [&shaders](ShaderLibrary& lib)
         {
@@ -330,18 +326,143 @@ namespace OloEngine
                 }
 
                 const auto* glShader = static_cast<OpenGLShader*>(shader.get());
-                shaders.push_back({ shader->GetFilePath(),
-                                    &glShader->GetVulkanSPIRV(),
-                                    &glShader->GetOpenGLSPIRV() });
+
+                // Hashed from the shader's OWN preprocessed source
+                // (GetOriginalSourceCode) — the exact text that produced the
+                // SPIR-V being packed below — rather than re-reading the file
+                // from disk. A fresh disk re-read here would be a TOCTOU
+                // window: if the file changed after this shader was compiled
+                // but before "Build Shader Pack" ran, a re-read would hash
+                // the NEW text while packing the OLD (in-memory) SPIR-V, so a
+                // later runtime hash check against the (by-then also new)
+                // on-disk file would falsely validate stale bytes.
+                const std::string contentHash =
+                    OpenGLShader::ComputeContentHashFromSources(glShader->GetOriginalSourceCode());
+                if (contentHash.empty())
+                {
+                    OLO_CORE_WARN("[ShaderPack] Skipping shader '{}' (couldn't recompute its content hash)",
+                                  shader->GetFilePath());
+                    continue;
+                }
+
+                shaders.push_back({ shader->GetFilePath(), contentHash,
+                                    &glShader->GetVulkanSPIRV(), &glShader->GetOpenGLSPIRV() });
             }
         };
 
         collectShaders(lib2D);
         collectShaders(lib3D);
 
+        return WritePackFile(shaders, outputPath);
+    }
+
+    // =========================================================================
+    // ShaderPack — Create from filepaths (headless, no GL context — issue #908)
+    // =========================================================================
+    bool ShaderPack::CreateFromFilepaths(const std::vector<std::string>& filepaths, const std::filesystem::path& outputPath)
+    {
+        if (filepaths.empty())
+        {
+            OLO_CORE_WARN("[ShaderPack] No shader filepaths to pack");
+            return false;
+        }
+
+        // CPU-only: read, preprocess, shaderc, SPIRV-Cross. No GL call anywhere
+        // in this call chain — see Shader::PrepareBatch / OpenGLShader::PrepareCPU.
+        std::vector<Ref<Shader>> prepared = Shader::PrepareBatch(filepaths, nullptr);
+
+        std::vector<PackShaderInfo> shaders;
+        shaders.reserve(filepaths.size());
+
+        for (sizet i = 0; i < filepaths.size(); ++i)
+        {
+            Ref<Shader> shader = (i < prepared.size()) ? prepared[i] : nullptr;
+            if (!shader)
+            {
+                OLO_CORE_WARN("[ShaderPack] Skipping '{}' (CPU prepare failed)", filepaths[i]);
+                continue;
+            }
+
+            auto* glShader = static_cast<OpenGLShader*>(shader.get());
+            if (glShader->GetVulkanSPIRV().empty())
+            {
+                OLO_CORE_WARN("[ShaderPack] Skipping '{}' (no compiled SPIR-V)", filepaths[i]);
+                continue;
+            }
+
+            const std::string contentHash = OpenGLShader::ComputeContentHash(filepaths[i]);
+            if (contentHash.empty())
+            {
+                OLO_CORE_WARN("[ShaderPack] Skipping '{}' (couldn't recompute its content hash)", filepaths[i]);
+                continue;
+            }
+
+            shaders.push_back({ filepaths[i], contentHash, &glShader->GetVulkanSPIRV(), &glShader->GetOpenGLSPIRV() });
+        }
+
+        return WritePackFile(shaders, outputPath);
+    }
+
+    std::vector<std::string> ShaderPack::CollectShaderFilepaths(const std::filesystem::path& shadersRoot)
+    {
+        std::vector<std::string> filepaths;
+
+        if (!std::filesystem::exists(shadersRoot))
+        {
+            OLO_CORE_WARN("[ShaderPack] Shaders root does not exist: {}", shadersRoot.string());
+            return filepaths;
+        }
+
+        std::error_code ec;
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(shadersRoot, ec))
+        {
+            if (!entry.is_regular_file() || entry.path().extension() != ".glsl")
+            {
+                continue;
+            }
+
+            // "include" (headers, no #type marker) and "tests" (never shipped)
+            // are excluded by directory component, not by full-path substring —
+            // a shader legitimately named e.g. "assets/shaders/tests_utils.glsl"
+            // must not be swept out by a naive `.find("tests")`.
+            const bool excluded = std::ranges::any_of(entry.path(),
+                                                      [](const std::filesystem::path& component)
+                                                      {
+                                                          return component == "include" || component == "tests";
+                                                      });
+            if (excluded)
+            {
+                continue;
+            }
+
+            filepaths.push_back(entry.path().generic_string());
+        }
+
+        std::ranges::sort(filepaths);
+        return filepaths;
+    }
+
+    // =========================================================================
+    // ShaderPack — shared binary writer
+    // =========================================================================
+    bool ShaderPack::WritePackFile(const std::vector<PackShaderInfo>& shaders, const std::filesystem::path& outputPath)
+    {
         if (shaders.empty())
         {
             OLO_CORE_WARN("[ShaderPack] No shaders to pack");
+            return false;
+        }
+
+        // Ensure parent directory exists
+        if (auto parentDir = outputPath.parent_path(); !parentDir.empty())
+        {
+            std::filesystem::create_directories(parentDir);
+        }
+
+        std::ofstream out(outputPath, std::ios::binary);
+        if (!out)
+        {
+            OLO_CORE_ERROR("[ShaderPack] Failed to create output file: {}", outputPath.string());
             return false;
         }
 
@@ -354,13 +475,15 @@ namespace OloEngine
         // We'll backfill the data offsets after writing all SPIR-V data.
         const auto indexStartPos = out.tellp();
 
-        // Compute index size so we can calculate where data starts
-        // For each shader: u32(nameLen) + name + u32(stageCount) + per-stage(u8 + 4*u64)
+        // Compute index size so we can calculate where data starts. For each
+        // shader: u32(nameLen) + name + u32(hashLen) + hash + u32(stageCount)
+        // + per-stage(u8 + 4*u64)
         u64 indexSize = 0;
         for (const auto& info : shaders)
         {
-            indexSize += sizeof(u32) + info.Name.size(); // name
-            indexSize += sizeof(u32);                    // stageCount
+            indexSize += sizeof(u32) + info.Name.size();        // name
+            indexSize += sizeof(u32) + info.ContentHash.size(); // content hash
+            indexSize += sizeof(u32);                           // stageCount
             u32 stageCount = static_cast<u32>(info.VulkanSPIRV->size());
             indexSize += stageCount * (sizeof(u8) + 4 * sizeof(u64)); // per-stage refs
         }
@@ -433,6 +556,7 @@ namespace OloEngine
             const auto& offsets = allOffsets[i];
 
             WriteString(out, info.Name);
+            WriteString(out, info.ContentHash);
             u32 stageCount = static_cast<u32>(offsets.Stages.size());
             WriteRaw(out, stageCount);
 

--- a/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
@@ -390,7 +390,14 @@ namespace OloEngine
                 continue;
             }
 
-            const std::string contentHash = OpenGLShader::ComputeContentHash(filepaths[i]);
+            // Hashed from the shader's OWN preprocessed source, not a second
+            // re-read of the file — same reasoning as CreateFromLibraries
+            // above: a re-read here would be a second, independent disk read
+            // of the same file Shader::PrepareBatch just read to produce
+            // this SPIR-V, so a file that changed between the two reads
+            // would pack SPIR-V from read #1 under a hash from read #2.
+            const std::string contentHash =
+                OpenGLShader::ComputeContentHashFromSources(glShader->GetOriginalSourceCode());
             if (contentHash.empty())
             {
                 OLO_CORE_WARN("[ShaderPack] Skipping '{}' (couldn't recompute its content hash)", filepaths[i]);

--- a/OloEngine/src/OloEngine/Renderer/ShaderPack.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderPack.h
@@ -4,6 +4,7 @@
 #include "OloEngine/Core/Ref.h"
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -13,8 +14,14 @@ namespace OloEngine
     class Shader;
     class ShaderLibrary;
 
-    // Binary file format version for .osp (OloEngine Shader Pack) files
-    constexpr u32 SHADER_PACK_VERSION = 1;
+    // Binary file format version for .osp (OloEngine Shader Pack) files.
+    //
+    // Version 2 (issue #908) adds a per-entry content hash so a pack entry can
+    // be VALIDATED against the shader source it is meant to serve rather than
+    // trusted on name alone — a v1 pack (name-keyed, no hash) is a strict
+    // subset of what a v2 reader expects, so the version check below rejects
+    // it outright instead of half-reading a shorter index.
+    constexpr u32 SHADER_PACK_VERSION = 2;
 
     // Per-stage SPIR-V data stored in a shader pack
     struct ShaderPackStageData
@@ -55,19 +62,54 @@ namespace OloEngine
         }
         [[nodiscard]] std::vector<std::string> GetShaderNames() const;
 
+        // The content hash this pack stored for `name` at BAKE time (issue
+        // #908) — nullopt if the shader isn't in the pack at all. Compare
+        // against OpenGLShader::ComputeContentHash(name) computed from the
+        // CURRENT on-disk source before calling LoadEntry: a mismatch means
+        // the pack is stale for this entry and must be treated as a miss, not
+        // served. Deliberately not done inside LoadEntry itself — computing
+        // the current hash means reading and preprocessing the live shader
+        // file, which is the caller's (ShaderLibrary's) job, not the pack's;
+        // the pack only reports what it baked.
+        [[nodiscard]] std::optional<std::string> GetContentHash(const std::string& name) const;
+
         // Load a single shader's SPIR-V data from the pack (lazy read from disk).
         // Returns nullptr if the shader is not in the pack.
         [[nodiscard]] std::unique_ptr<ShaderPackEntry> LoadEntry(const std::string& name) const;
 
         // Build a shader pack from all compiled shaders in the given libraries.
-        // Both Renderer2D and Renderer3D shader libraries are included.
+        // Both Renderer2D and Renderer3D shader libraries are included. Requires
+        // every shader to already be GL-linked (IsReady()) — this is the
+        // editor's "Build Shader Pack" menu command, run inside a live context.
         static bool CreateFromLibraries(ShaderLibrary& lib2D, ShaderLibrary& lib3D, const std::filesystem::path& outputPath);
+
+        // Build a shader pack directly from a list of shader filepaths, using
+        // ONLY the CPU-side prepare path (Shader::PrepareBatch: read, preprocess,
+        // shaderc, SPIRV-Cross) — no GL context is created, touched, or required
+        // (issue #908's invalidation-contract spike: verified PrepareBatch never
+        // calls into GL). This is the headless CI producer; `filepaths` must be
+        // the SAME strings the runtime will later call ShaderLibrary::Load()
+        // with (e.g. "assets/shaders/Water.glsl"), since that string is the
+        // pack's lookup key. A filepath whose CPU prepare fails is skipped with
+        // a warning rather than failing the whole bake — one broken shader
+        // should not withhold the pack from every other shader that compiled
+        // fine (the runtime falls back to compiling that one shader from
+        // source, same as any other pack miss).
+        static bool CreateFromFilepaths(const std::vector<std::string>& filepaths, const std::filesystem::path& outputPath);
+
+        // Recursively collect every `.glsl` file under `shadersRoot`, skipping
+        // `include/` (headers with no `#type` marker — PreProcess would reject
+        // them) and `tests/` (test-only content, never shipped). Returns paths
+        // relative to the CURRENT directory in the same "assets/shaders/…" form
+        // ShaderLibrary::Load() is called with, sorted for a reproducible bake.
+        [[nodiscard]] static std::vector<std::string> CollectShaderFilepaths(const std::filesystem::path& shadersRoot);
 
       private:
         // On-disk index entry (where to find each shader's data in the file)
         struct IndexEntry
         {
             std::string Name;
+            std::string ContentHash; // issue #908 — see GetContentHash()
             u32 StageCount = 0;
 
             struct StageRef
@@ -81,6 +123,19 @@ namespace OloEngine
 
             std::vector<StageRef> StageRefs;
         };
+
+        // One shader's data, in the shape the on-disk writer needs — shared by
+        // CreateFromLibraries (already-linked shaders) and CreateFromFilepaths
+        // (CPU-prepared-only shaders), so the binary-layout logic itself is
+        // written and tested exactly once.
+        struct PackShaderInfo
+        {
+            std::string Name;
+            std::string ContentHash;
+            const std::unordered_map<unsigned int, std::vector<u32>>* VulkanSPIRV = nullptr;
+            const std::unordered_map<unsigned int, std::vector<u32>>* OpenGLSPIRV = nullptr;
+        };
+        static bool WritePackFile(const std::vector<PackShaderInfo>& shaders, const std::filesystem::path& outputPath);
 
         bool m_Loaded = false;
         std::filesystem::path m_Path;

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1036,16 +1036,33 @@ namespace OloEngine
             OLO_TRACK_DEALLOC(this);
         }
 
-        u32 programId = m_RendererID;
-        UnregisterGLProgramLabel(programId);
-        FrameResourceManager::Get().SubmitForDeletion([programId]()
-                                                      {
+        // m_RendererID == 0 means glCreateProgram() was never called for this
+        // object — a CPU-prepared-but-never-finalized shader (issue #908's
+        // headless ShaderPack bake: Shader::PrepareBatch() constructs and can
+        // destroy these with NO GL context ever having existed in the
+        // process, unlike every other caller of this destructor). There is
+        // no GL resource to enqueue for deletion, and reaching the block
+        // below in that case is actively unsafe rather than merely
+        // wasteful: FrameResourceManager::SubmitForDeletion runs its
+        // deletion lambda SYNCHRONOUSLY (glDeleteProgram and friends)
+        // whenever the manager was never Init()'d, on the assumption that
+        // "not yet initialized" always still means "GL context is live,
+        // Renderer::Init() just hasn't reached FrameResourceManager yet" —
+        // true for every other caller, false for a purely headless process
+        // where GLAD's function pointers were never loaded at all, which
+        // crashed with an access violation on the unloaded glDeleteProgram.
+        if (u32 programId = m_RendererID; programId != 0)
+        {
+            UnregisterGLProgramLabel(programId);
+            FrameResourceManager::Get().SubmitForDeletion([programId]()
+                                                          {
                                                           // See Utils::UnbindProgramIfCurrent (issue #625): this
                                                           // program may still be the bound program by the time this
                                                           // deferred deletion runs.
                                                           Utils::UnbindProgramIfCurrent(programId);
                                                           Shader::UnregisterProgram(programId);
                                                           glDeleteProgram(programId); });
+        }
     }
 
     void OpenGLShader::InitializeResourceRegistry(const Ref<Shader>& shaderRef)
@@ -1545,7 +1562,7 @@ namespace OloEngine
         return true;
     }
 
-    std::unordered_map<GLenum, std::string> OpenGLShader::PreProcess(std::string_view source) const
+    std::unordered_map<GLenum, std::string> OpenGLShader::PreProcess(std::string_view source)
     {
         OLO_PROFILE_FUNCTION();
 
@@ -1616,6 +1633,47 @@ namespace OloEngine
         }
 
         return shaderSources;
+    }
+
+    // See the declaration (issue #908): reuses the exact two ingredients the
+    // per-stage #906 cache key hashes — the preprocessed source per stage
+    // (Utils::HashHexSourceMap) and the Vulkan tier's compiler-options
+    // descriptor (Utils::VulkanTierOptions::Descriptor) — composed the same
+    // way OpenGLShader::CompileOrGetBindlessProgram already does for its own
+    // whole-shader program-binary key at line ~1310. A ShaderPack entry and a
+    // live compile that hash to the same string are provably the same bytes;
+    // anything else is a miss, not a "probably fine".
+    std::string OpenGLShader::ComputeContentHash(const std::string& filepath)
+    {
+        const std::string source = ReadFile(filepath);
+        if (source.empty())
+        {
+            return {};
+        }
+
+        const auto sources = PreProcess(source);
+        return ComputeContentHashFromSources(sources);
+    }
+
+    std::string OpenGLShader::ComputeContentHashFromSources(
+        const std::unordered_map<GLenum, std::string>& preprocessedSources)
+    {
+        if (preprocessedSources.empty())
+        {
+            return {};
+        }
+
+        // Both compiler-option descriptors are folded in, not just the Vulkan
+        // tier's: ShaderPack stores BOTH the Vulkan and the OpenGL-cross-
+        // compiled SPIR-V under this one hash (ShaderPack::PackShaderInfo),
+        // so a hash match is a promise about both. The OpenGL tier's own
+        // per-stage cache (CompileOrGetOpenGLBinaries) mixes in
+        // OpenGLTierOptions::Descriptor() for exactly this reason — a
+        // hand-changed SPIRV-Cross recompile option is otherwise invisible
+        // to a pack built before the change, and would keep validating
+        // (and serving now-wrong OpenGLSPIRV bytes) forever.
+        return Utils::HashHex({ Utils::VulkanTierOptions::Descriptor(), Utils::OpenGLTierOptions::Descriptor() }) +
+               Utils::HashHexSourceMap(preprocessedSources);
     }
 
     bool OpenGLShader::CompileOrGetVulkanBinaries(const std::unordered_map<GLenum, std::string>& shaderSources)

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.h
@@ -140,6 +140,47 @@ namespace OloEngine
             return m_OpenGLSPIRV;
         }
 
+        // Content-addressed identity for a shader FILE (issue #908), reusing the
+        // exact ingredients (preprocessed per-stage source + the Vulkan AND
+        // OpenGL tiers' compiler options — see VulkanTierOptions::Descriptor /
+        // OpenGLTierOptions::Descriptor) the #906 SPIR-V cache already hashes
+        // on. This is what ShaderPack keys its entries by: two callers that
+        // get the same string back are guaranteed to compile to the same
+        // bytes, so a mismatch is a definite miss, never a maybe. Reads and
+        // preprocesses `filepath` fresh — no GL call, no compile, safe from
+        // any thread and safe with no GL context at all (a CI bake runner has
+        // none). Returns an empty string if the file can't be read or produces
+        // no compilable stages.
+        //
+        // A FRESH re-read: for a shader that was already compiled (its
+        // GetOriginalSourceCode() below is non-empty), prefer
+        // ComputeContentHashFromSources(GetOriginalSourceCode()) instead — see
+        // its comment for why re-reading from disk here can TOCTOU-desync the
+        // hash from the SPIR-V it is meant to describe.
+        [[nodiscard]] static std::string ComputeContentHash(const std::string& filepath);
+
+        // Same hash, computed from ALREADY-preprocessed source rather than
+        // re-reading the file. Use this when packing an already-compiled
+        // shader (ShaderPack::CreateFromLibraries): hashing
+        // GetOriginalSourceCode() — the exact text that produced the
+        // in-memory SPIR-V — instead of re-reading the file from disk closes
+        // a TOCTOU window a fresh ComputeContentHash(filepath) call has (issue
+        // #908 review): if the file on disk changed between compile and pack,
+        // a fresh re-read would hash the NEW text while still packing the OLD
+        // (in-memory) SPIR-V, so a later hash comparison against the (by-then
+        // also new) on-disk text would falsely validate stale bytes.
+        [[nodiscard]] static std::string ComputeContentHashFromSources(
+            const std::unordered_map<GLenum, std::string>& preprocessedSources);
+
+        // The preprocessed per-stage source that produced this shader's
+        // compiled SPIR-V (issue #908: the input to
+        // ComputeContentHashFromSources above). Empty until PrepareCPU() has
+        // run.
+        [[nodiscard]] const std::unordered_map<GLenum, std::string>& GetOriginalSourceCode() const
+        {
+            return m_OriginalSourceCode;
+        }
+
         // Include processing — public so compute shaders can reuse it
         static std::string ProcessIncludes(const std::string& source, const std::string& directory = "");
 
@@ -200,7 +241,12 @@ namespace OloEngine
 
         static std::string ReadFile(const std::string& filepath);
         static std::string ProcessIncludesInternal(const std::string& source, const std::string& directory, std::unordered_set<std::string>& includedFiles);
-        std::unordered_map<GLenum, std::string> PreProcess(std::string_view source) const;
+
+        // Static (touches no instance state, only the filesystem via
+        // ProcessIncludes) so ComputeContentHash can call it without an
+        // OpenGLShader to hang off — a source-only recompute of the same split
+        // ordinary loading does.
+        static std::unordered_map<GLenum, std::string> PreProcess(std::string_view source);
 
         // Returns false if any shader stage failed to compile (already logged via
         // OLO_CORE_CRITICAL). Callers must not proceed to link/finalize on failure —

--- a/OloEngine/tests/Build/GameBuildPipelineTest.cpp
+++ b/OloEngine/tests/Build/GameBuildPipelineTest.cpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <filesystem>
+#include <fstream>
 
 using namespace OloEngine;
 
@@ -132,6 +133,41 @@ TEST(GameBuildPipelineTest, LooseRuntimeTexturesPreserveTheirProjectRelativePath
         EXPECT_TRUE(std::filesystem::exists(outputAssets / path)) << path;
     }
     EXPECT_FALSE(std::filesystem::exists(outputAssets / "Textures/Menu/readme.txt"));
+}
+
+TEST(GameBuildPipelineTest, ShaderPackIsStagedWhenPresent)
+{
+    const auto editorAssets = OloEngine::Tests::TempDir("shaderpack-src");
+    const auto outputAssets = OloEngine::Tests::TempDir("shaderpack-dst");
+    std::filesystem::create_directories(editorAssets);
+
+    const auto packSrc = editorAssets / "ShaderPack.osp";
+    std::ofstream(packSrc) << "not a real pack, just bytes for the copy step";
+
+    bool packStaged = false;
+    std::string errorMessage;
+    ASSERT_TRUE(StageShaderPack(packSrc, outputAssets, packStaged, errorMessage)) << errorMessage;
+
+    EXPECT_TRUE(packStaged);
+    EXPECT_TRUE(std::filesystem::exists(outputAssets / "ShaderPack.osp"));
+}
+
+TEST(GameBuildPipelineTest, ShaderPackStagingIsANoOpWhenAbsent)
+{
+    const auto editorAssets = OloEngine::Tests::TempDir("shaderpack-src-missing");
+    const auto outputAssets = OloEngine::Tests::TempDir("shaderpack-dst-missing");
+    std::filesystem::create_directories(editorAssets);
+    // Deliberately no ShaderPack.osp written — a fresh worktree, or the CI
+    // bake step never ran, is not a build failure (issue #908's plan
+    // explicitly leans "explicit on request" for whether it exists).
+
+    bool packStaged = false;
+    std::string errorMessage;
+    ASSERT_TRUE(StageShaderPack(editorAssets / "ShaderPack.osp", outputAssets, packStaged, errorMessage))
+        << errorMessage;
+
+    EXPECT_FALSE(packStaged);
+    EXPECT_FALSE(std::filesystem::exists(outputAssets / "ShaderPack.osp"));
 }
 
 TEST(GameBuildPipelineTest, ToStringIsHumanReadable)

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -153,6 +153,8 @@ add_executable(OloEngine-Tests
 		Rendering/ShaderStageInterfaceTest.cpp
 		Rendering/ShaderStageContractTest.cpp
 		Rendering/ShaderPackTest.cpp
+		Rendering/ShaderPackContentHashTest.cpp
+		Rendering/ShaderPackBakeTest.cpp
 		Rendering/ShaderBinaryCacheRoundTripTest.cpp
 		Rendering/ShaderResourceRegistrySelfRefTest.cpp
 		Rendering/GLDebugMessageParseTest.cpp

--- a/OloEngine/tests/Rendering/ShaderPackBakeTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderPackBakeTest.cpp
@@ -1,0 +1,116 @@
+// =============================================================================
+// ShaderPackBakeTest.cpp
+//
+// The headless CI producer for issue #908: baking a `ShaderPack.osp` from
+// this repo's shaders. Deliberately gated behind `--olo-bake-shader-pack=<path>`
+// (see TestOptions) rather than running every suite invocation — a bake is a
+// build STEP, not a correctness check on its own (that's
+// ShaderPackContentHashTest.cpp and ShaderPackTest.cpp), and it writes a real
+// multi-megabyte file as a side effect.
+//
+// No GL context anywhere in this path (verified per the issue's invalidation-
+// contract spike): Renderer2D::GetShaderFilepaths() / Renderer3D::GetShaderFilepaths()
+// return plain string lists with no engine init, and ShaderPack::CreateFromFilepaths
+// uses only the CPU-side Shader::PrepareBatch (read, preprocess, shaderc,
+// SPIRV-Cross). This is exactly what makes it runnable on an ordinary CI
+// runner instead of needing the self-hosted GPU box.
+//
+// OLO_TEST_LAYER: shaderpipe
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+#include "TestOptions.h"
+
+#include "OloEngine/Renderer/Renderer2D.h"
+#include "OloEngine/Renderer/Renderer3D.h"
+#include "OloEngine/Renderer/ShaderPack.h"
+
+#include <filesystem>
+#include <vector>
+
+using namespace OloEngine;
+
+namespace
+{
+    // RAII rather than a plain restore-after-the-fact: a filesystem/shaderc
+    // exception (or an ASSERT_* early-return, which is just a `return`, not a
+    // throw) between the cwd switch and the manual restore would otherwise
+    // leave the whole gtest PROCESS running from OloEditor/ for every test
+    // after this one in the same binary invocation — exactly the class of
+    // "wrong working directory" cascade CLAUDE.md's "Working directory
+    // matters" pitfall warns about, just self-inflicted instead of a launch
+    // mistake.
+    class ScopedCurrentPath
+    {
+      public:
+        explicit ScopedCurrentPath(const std::filesystem::path& newPath)
+            : m_Previous(std::filesystem::current_path())
+        {
+            std::filesystem::current_path(newPath);
+        }
+        ~ScopedCurrentPath()
+        {
+            std::error_code ec;
+            std::filesystem::current_path(m_Previous, ec);
+        }
+        ScopedCurrentPath(const ScopedCurrentPath&) = delete;
+        auto operator=(const ScopedCurrentPath&) -> ScopedCurrentPath& = delete;
+
+      private:
+        std::filesystem::path m_Previous;
+    };
+} // namespace
+
+TEST(ShaderPackBakeTest, BakeWhenRequested)
+{
+    const auto& opts = OloEngine::Tests::Options();
+    if (opts.BakeShaderPackPath.empty())
+    {
+        GTEST_SKIP() << "pass --olo-bake-shader-pack=<path> to run this "
+                        "(the headless CI producer for issue #908)";
+    }
+
+    const std::filesystem::path outputPath = std::filesystem::absolute(opts.BakeShaderPackPath);
+    const auto originalCwd = std::filesystem::current_path();
+
+    // The shader filepath lists ("assets/shaders/...") are resolved relative
+    // to OloEditor/ — the same working directory Renderer2D::Init() /
+    // Renderer3D::Init() run from in every other context (CLAUDE.md "Working
+    // directory matters"). ctest runs this binary from the repo root, so
+    // step into OloEditor/ for the bake and step back out unconditionally
+    // afterward, regardless of how it goes (see ScopedCurrentPath above), so
+    // a failure here doesn't leave every OTHER test in this process
+    // resolving paths from the wrong place.
+    ASSERT_TRUE(std::filesystem::exists(originalCwd / "OloEditor" / "assets" / "shaders"))
+        << "expected to run from the repo root (the ctest / CI convention), found: " << originalCwd.string();
+
+    bool baked = false;
+    std::vector<std::string> filepaths;
+    {
+        ScopedCurrentPath cwdGuard(originalCwd / "OloEditor");
+
+        filepaths = Renderer2D::GetShaderFilepaths();
+        for (auto& path : Renderer3D::GetShaderFilepaths())
+        {
+            filepaths.push_back(std::move(path));
+        }
+
+        baked = ShaderPack::CreateFromFilepaths(filepaths, outputPath);
+    }
+
+    ASSERT_TRUE(baked) << "shader pack bake failed — see the [ShaderPack] log output above";
+    ASSERT_TRUE(std::filesystem::exists(outputPath));
+
+    // Read it back through the real loader as a sanity check on what was
+    // just written, the same way a packaged runtime will load it.
+    const ShaderPack pack(outputPath);
+    EXPECT_TRUE(pack.IsLoaded());
+    EXPECT_GT(pack.GetShaderCount(), 0u);
+    EXPECT_EQ(pack.GetShaderCount(), static_cast<u32>(filepaths.size()))
+        << "every enumerated shader should have compiled and packed cleanly; "
+           "check the log above for any '[ShaderPack] Skipping' warnings";
+
+    OLO_CORE_INFO("[ShaderPackBake] Baked {} shaders to '{}'", pack.GetShaderCount(), outputPath.string());
+}

--- a/OloEngine/tests/Rendering/ShaderPackContentHashTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderPackContentHashTest.cpp
@@ -1,0 +1,172 @@
+// =============================================================================
+// ShaderPackContentHashTest.cpp
+//
+// Pins the invalidation contract added for issue #908: a ShaderPack entry is
+// keyed by a content hash (OpenGLShader::ComputeContentHash — the same
+// ingredients, preprocessed source + Vulkan-tier compiler options, that the
+// #906 per-stage SPIR-V cache already hashes on) rather than by name alone.
+// A pack whose baked hash no longer matches the shader's current on-disk
+// source must be a MISS — served SPIR-V compiled from a different source
+// than what's on disk right now would be silently, permanently wrong.
+//
+// Entirely GL-free: ShaderPack::CreateFromFilepaths uses only the CPU-side
+// prepare path (Shader::PrepareBatch — read, preprocess, shaderc,
+// SPIRV-Cross), and ShaderLibrary::PrepareParallel's pack lookup makes no GL
+// call either (materializing the GL program is deferred to
+// FinalizeParallel(), which this test never calls). Runs on headless CI.
+//
+// OLO_TEST_LAYER: shaderpipe
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+#include "TestTempDir.h"
+
+#include "OloEngine/Renderer/ShaderPack.h"
+#include "OloEngine/Renderer/ShaderLibrary.h"
+#include "OloEngine/Renderer/Shader.h"
+#include "Platform/OpenGL/OpenGLShader.h"
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+using namespace OloEngine;
+
+namespace
+{
+    constexpr const char* kMinimalShaderSource = R"glsl(
+#type vertex
+#version 450 core
+layout(location = 0) in vec3 a_Position;
+void main()
+{
+    gl_Position = vec4(a_Position, 1.0);
+}
+
+#type fragment
+#version 450 core
+layout(location = 0) out vec4 o_Color;
+void main()
+{
+    o_Color = vec4(1.0, 0.0, 1.0, 1.0);
+}
+)glsl";
+
+    void WriteFile(const std::filesystem::path& path, std::string_view contents)
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out << contents;
+    }
+} // namespace
+
+TEST(ShaderPackContentHashTest, ComputeContentHashIsStableAndSensitiveToContent)
+{
+    const auto dir = OloEngine::Tests::TempDir("shaderpack-hash-compute");
+    const auto shaderPath = dir / "HashProbe.glsl";
+    WriteFile(shaderPath, kMinimalShaderSource);
+
+    const std::string filepathStr = shaderPath.generic_string();
+    const std::string hashA = OpenGLShader::ComputeContentHash(filepathStr);
+    const std::string hashB = OpenGLShader::ComputeContentHash(filepathStr);
+    ASSERT_FALSE(hashA.empty());
+    EXPECT_EQ(hashA, hashB) << "hashing the same unchanged file twice must be reproducible";
+
+    WriteFile(shaderPath, std::string(kMinimalShaderSource) + "\n// a trailing change\n");
+    const std::string hashC = OpenGLShader::ComputeContentHash(filepathStr);
+    EXPECT_NE(hashA, hashC) << "any source change must change the hash";
+}
+
+TEST(ShaderPackContentHashTest, MatchingHashIsServedFromThePack)
+{
+    const auto dir = OloEngine::Tests::TempDir("shaderpack-hash-hit");
+    const auto shaderPath = dir / "HitProbe.glsl";
+    WriteFile(shaderPath, kMinimalShaderSource);
+    const std::string filepathStr = shaderPath.generic_string();
+
+    const auto packPath = dir / "Test.osp";
+    ASSERT_TRUE(ShaderPack::CreateFromFilepaths({ filepathStr }, packPath));
+
+    ShaderLibrary lib;
+    lib.LoadShaderPack(packPath);
+    ASSERT_TRUE(lib.HasShaderPack());
+
+    auto batch = lib.PrepareParallel({ filepathStr });
+    ASSERT_EQ(batch.m_IsPackLoaded.size(), 1u);
+    EXPECT_TRUE(batch.m_IsPackLoaded[0]) << "an unmutated source must hit the pack it was baked from";
+}
+
+TEST(ShaderPackContentHashTest, MutatedSourceMissesAndFallsBackToCompile)
+{
+    const auto dir = OloEngine::Tests::TempDir("shaderpack-hash-miss");
+    const auto shaderPath = dir / "MissProbe.glsl";
+    WriteFile(shaderPath, kMinimalShaderSource);
+    const std::string filepathStr = shaderPath.generic_string();
+
+    const auto packPath = dir / "Test.osp";
+    ASSERT_TRUE(ShaderPack::CreateFromFilepaths({ filepathStr }, packPath));
+
+    // Mutate AFTER the pack was baked — the pack now describes stale bytes.
+    WriteFile(shaderPath, std::string(kMinimalShaderSource) + "\n// mutated after bake\n");
+
+    ShaderLibrary lib;
+    lib.LoadShaderPack(packPath);
+
+    auto batch = lib.PrepareParallel({ filepathStr });
+    ASSERT_EQ(batch.m_IsPackLoaded.size(), 1u);
+    EXPECT_FALSE(batch.m_IsPackLoaded[0]) << "a mutated source must miss the now-stale pack entry";
+    ASSERT_EQ(batch.m_Prepared.size(), 1u);
+    EXPECT_NE(batch.m_Prepared[0], nullptr) << "a miss must still fall back to a CPU compile, not drop the shader";
+}
+
+TEST(ShaderPackContentHashTest, CollectShaderFilepathsSkipsIncludeAndTestsDirectories)
+{
+    const auto root = OloEngine::Tests::TempDir("shaderpack-collect");
+    std::filesystem::create_directories(root / "include");
+    std::filesystem::create_directories(root / "tests");
+    std::filesystem::create_directories(root / "compute");
+
+    WriteFile(root / "Main.glsl", kMinimalShaderSource);
+    WriteFile(root / "compute" / "Compute.glsl", kMinimalShaderSource);
+    WriteFile(root / "include" / "Common.glsl", "// header, no #type marker\n");
+    WriteFile(root / "tests" / "TestOnly.glsl", kMinimalShaderSource);
+    WriteFile(root / "NotAShader.txt", "ignore me");
+
+    const auto found = ShaderPack::CollectShaderFilepaths(root);
+
+    auto contains = [&found](std::string_view suffix)
+    {
+        return std::ranges::any_of(found, [&](const std::string& p)
+                                   { return p.ends_with(suffix); });
+    };
+
+    EXPECT_TRUE(contains("Main.glsl"));
+    EXPECT_TRUE(contains("compute/Compute.glsl"));
+    EXPECT_FALSE(contains("Common.glsl")) << "include/ headers must be excluded";
+    EXPECT_FALSE(contains("TestOnly.glsl")) << "tests/ content must be excluded";
+    EXPECT_EQ(found.size(), 2u);
+}
+
+TEST(ShaderPackContentHashTest, PrepareBatchProducesADestructibleShaderWithNoGLContext)
+{
+    // Regression pin for the bug this file's other tests originally hit:
+    // OpenGLShader::~OpenGLShader() used to unconditionally enqueue a GL
+    // program deletion (FrameResourceManager::SubmitForDeletion), which runs
+    // its lambda SYNCHRONOUSLY whenever the manager was never Init()'d — an
+    // assumption that "not yet initialized" still means "a GL context is
+    // live" that holds for every other caller but not this one: a purely
+    // headless bake process where GLAD's function pointers were never
+    // loaded, crashing on an unloaded glDeleteProgram. Fixed by skipping
+    // that whole block when m_RendererID == 0 (nothing was ever created).
+    const auto dir = OloEngine::Tests::TempDir("shaderpack-hash-preparebatch");
+    const auto shaderPath = dir / "PBProbe.glsl";
+    WriteFile(shaderPath, kMinimalShaderSource);
+    const std::string filepathStr = shaderPath.generic_string();
+
+    auto prepared = Shader::PrepareBatch({ filepathStr }, nullptr);
+    ASSERT_EQ(prepared.size(), 1u);
+    ASSERT_NE(prepared[0], nullptr);
+    // `prepared` destructs here — the crash, when present, happened after
+    // this test body returned, inside the resulting ~OpenGLShader() call.
+}

--- a/OloEngine/tests/Rendering/ShaderPackTest.cpp
+++ b/OloEngine/tests/Rendering/ShaderPackTest.cpp
@@ -38,6 +38,14 @@ namespace
         }
     }
 
+    // A fixed dummy content hash (issue #908) — this file constructs the raw
+    // binary layout by hand rather than going through ShaderPack::WritePackFile,
+    // so it must write the same ContentHash field the reader now expects right
+    // after the name. Its actual value doesn't matter to these tests: none of
+    // them exercise the ShaderLibrary-side hash COMPARISON (that's
+    // ShaderPackContentHashTest.cpp) — only ShaderPack's own read/index path.
+    const std::string kDummyContentHash = "0000000000000000";
+
     // Create a minimal .osp with 1 shader (2 stages: vert + frag)
     std::filesystem::path CreateTestPack(const std::filesystem::path& dir, const std::string& shaderName)
     {
@@ -58,8 +66,10 @@ namespace
         WriteRaw(out, header);
 
         // We need to write the index first, then data, but we need data offsets.
-        // Calculate index size: string(4 + name.size()) + stageCount(4) + 2 stages * (1 + 4*8)
-        u64 indexSize = (sizeof(u32) + shaderName.size()) + sizeof(u32) + 2 * (sizeof(u8) + 4 * sizeof(u64));
+        // Calculate index size: string(4 + name.size()) + string(4 + hash.size())
+        // + stageCount(4) + 2 stages * (1 + 4*8)
+        u64 indexSize = (sizeof(u32) + shaderName.size()) + (sizeof(u32) + kDummyContentHash.size()) +
+                        sizeof(u32) + 2 * (sizeof(u8) + 4 * sizeof(u64));
 
         auto indexStart = out.tellp();
         // Write placeholder index
@@ -93,6 +103,7 @@ namespace
         // Backfill index
         out.seekp(indexStart);
         WriteString(out, shaderName);
+        WriteString(out, kDummyContentHash);
         u32 stageCount = 2;
         WriteRaw(out, stageCount);
 
@@ -192,6 +203,18 @@ TEST_F(ShaderPackTest, LoadEntryValid)
     EXPECT_EQ(entry->Stages[1].VulkanSPIRV[2], 4u);
     EXPECT_EQ(entry->Stages[1].OpenGLSPIRV.size(), 6u);
     EXPECT_EQ(entry->Stages[1].OpenGLSPIRV[2], 40u);
+}
+
+TEST_F(ShaderPackTest, GetContentHashRoundTrips)
+{
+    auto packPath = CreateTestPack(m_TestDir, kTestShaderName);
+    ShaderPack pack(packPath);
+
+    auto hash = pack.GetContentHash(kTestShaderName);
+    ASSERT_TRUE(hash.has_value());
+    EXPECT_EQ(*hash, kDummyContentHash);
+
+    EXPECT_FALSE(pack.GetContentHash("nonexistent/shader.glsl").has_value());
 }
 
 TEST_F(ShaderPackTest, LoadEntryNotFound)

--- a/OloEngine/tests/TestOptions.cpp
+++ b/OloEngine/tests/TestOptions.cpp
@@ -40,7 +40,8 @@ namespace OloEngine::Tests
                 "  --olo-keep-temp                leave per-test temp directories on disk\n"
                 "  --olo-video=<path>             an FFmpeg-decodable file for the decode tests\n"
                 "  --olo-pathtracer-evidence      write the path-tracer reference images\n"
-                "  --olo-mcp-attach-seconds=<n>   MCP discovery-file wait for the attach test\n");
+                "  --olo-mcp-attach-seconds=<n>   MCP discovery-file wait for the attach test\n"
+                "  --olo-bake-shader-pack=<path>  bake a ShaderPack.osp to this path (headless)\n");
         }
 
         // Returns the value of `--name=value`, or nullopt when `arg` is not that flag.
@@ -166,6 +167,10 @@ namespace OloEngine::Tests
             {
                 s_Options.VideoPath = *v;
             }
+            else if (const auto v = ValueOf(arg, "--olo-bake-shader-pack"))
+            {
+                s_Options.BakeShaderPackPath = *v;
+            }
             else if (const auto v = ValueOf(arg, "--olo-mcp-attach-seconds"))
             {
                 i32 parsed = 0;
@@ -180,7 +185,7 @@ namespace OloEngine::Tests
             }
             else if (arg == "--olo-golden-vendor" || arg == "--olo-perf-machine" ||
                      arg == "--olo-gl-backend" || arg == "--olo-video" ||
-                     arg == "--olo-mcp-attach-seconds")
+                     arg == "--olo-mcp-attach-seconds" || arg == "--olo-bake-shader-pack")
             {
                 // The name is right but the `=value` is missing — say that,
                 // rather than sending someone hunting for a typo.

--- a/OloEngine/tests/TestOptions.h
+++ b/OloEngine/tests/TestOptions.h
@@ -61,6 +61,11 @@ namespace OloEngine::Tests
         // --olo-mcp-attach-seconds=<n> : how long the headless attach test
         // waits for the editor's MCP discovery file. 0 keeps the test default.
         i32 McpAttachSeconds = 0;
+        // --olo-bake-shader-pack=<path> : bake a ShaderPack.osp to this path
+        // instead of running the test suite normally — the headless CI
+        // producer for issue #908 (no GL context; see ShaderPackBakeTest).
+        // Empty means "not baking".
+        std::string BakeShaderPackPath;
     };
 
     // Parse and consume the `--olo-*` flags. Call before InitGoogleTest so the

--- a/docs/agent-rules/shader-pack-bake.md
+++ b/docs/agent-rules/shader-pack-bake.md
@@ -11,19 +11,22 @@ validated, and something `GameBuildPipeline` actually ships.
 ## The invalidation contract
 
 A pack entry is now keyed by a **content hash**
-(`OpenGLShader::ComputeContentHash`), not by name alone. The hash is computed
-from the exact two ingredients the per-stage #906 SPIR-V cache already hashes
-on: the preprocessed source (per stage, includes already resolved) and the
-Vulkan tier's compiler-options descriptor (`Utils::VulkanTierOptions::Descriptor`).
-Two callers that get the same hash string back are guaranteed to compile to
-the same bytes — a mismatch is unambiguously a miss, never a "maybe stale".
+(`OpenGLShader::ComputeContentHash` / `ComputeContentHashFromSources`), not by
+name alone. The hash is computed from the preprocessed source (per stage,
+includes already resolved) plus **both** compiler-option descriptors the two
+SPIR-V tiers a pack entry stores actually depend on:
+`Utils::VulkanTierOptions::Descriptor()` (the Vulkan-tier SPIR-V) and
+`Utils::OpenGLTierOptions::Descriptor()` (the OpenGL-cross-compiled SPIR-V,
+via SPIRV-Cross). Two callers that get the same hash string back are
+guaranteed to compile to the same bytes for both tiers — a mismatch is
+unambiguously a miss, never a "maybe stale".
 
 `ShaderLibrary::TryReadPackEntry` recomputes the hash from the CURRENT
 on-disk source before ever calling `ShaderPack::LoadEntry`, and only serves
 the pack entry when it matches `ShaderPack::GetContentHash(filepath)`. A
 mismatch (or a pack that predates this contract — see the version bump below)
-falls back to the normal compile path, silently and correctly, exactly like
-any other pack miss.
+logs an `OLO_CORE_WARN` and falls back to the normal compile path, exactly
+like any other pack miss — not silent, just not fatal.
 
 `SHADER_PACK_VERSION` bumped from 1 to 2 for the new on-disk field; a v1 pack
 fails the version check outright rather than being half-read.

--- a/docs/agent-rules/shader-pack-bake.md
+++ b/docs/agent-rules/shader-pack-bake.md
@@ -1,0 +1,95 @@
+# The CI-baked shader pack (issue #908)
+
+A packaged game still cold-compiled every shader on first launch even after
+#906 gave the engine a content-hashed SPIR-V cache — a fresh machine has no
+warm cache to hit. `ShaderPack` (`OloEngine/src/OloEngine/Renderer/ShaderPack.*`)
+existed already as a name-keyed `.osp` archive of pre-compiled SPIR-V, built by
+hand from the editor's "Build Shader Pack" menu item
+(`EditorLayer::BuildShaderPack`). This issue made it CI-baked, content-hash
+validated, and something `GameBuildPipeline` actually ships.
+
+## The invalidation contract
+
+A pack entry is now keyed by a **content hash**
+(`OpenGLShader::ComputeContentHash`), not by name alone. The hash is computed
+from the exact two ingredients the per-stage #906 SPIR-V cache already hashes
+on: the preprocessed source (per stage, includes already resolved) and the
+Vulkan tier's compiler-options descriptor (`Utils::VulkanTierOptions::Descriptor`).
+Two callers that get the same hash string back are guaranteed to compile to
+the same bytes — a mismatch is unambiguously a miss, never a "maybe stale".
+
+`ShaderLibrary::TryReadPackEntry` recomputes the hash from the CURRENT
+on-disk source before ever calling `ShaderPack::LoadEntry`, and only serves
+the pack entry when it matches `ShaderPack::GetContentHash(filepath)`. A
+mismatch (or a pack that predates this contract — see the version bump below)
+falls back to the normal compile path, silently and correctly, exactly like
+any other pack miss.
+
+`SHADER_PACK_VERSION` bumped from 1 to 2 for the new on-disk field; a v1 pack
+fails the version check outright rather than being half-read.
+
+## The headless producer — no GL context
+
+`ShaderPack::CreateFromFilepaths` (and the shared `WritePackFile` writer it
+factors out of `CreateFromLibraries`) uses only `Shader::PrepareBatch` — read,
+preprocess, shaderc, SPIRV-Cross — the CPU-only half of shader compilation.
+No GL context is created, touched, or required anywhere in this path, which is
+what lets the bake run on an ordinary hosted CI runner instead of needing the
+self-hosted GPU box `gpu-conformance-amd.yml` uses.
+
+The producer enumerates `Renderer2D::GetShaderFilepaths()` +
+`Renderer3D::GetShaderFilepaths()` — the SAME arrays `Renderer2D::Init()` /
+`Renderer3D::Init()` load at runtime (`kShaderPaths2D` / `kShaderPaths3D`,
+each defined once and read by both the real Init() and this producer), so the
+bake can never enumerate a different shader set than what the pack will
+actually be asked to serve. It does **not** glob-scan `assets/shaders/` —
+compute shaders and other subsystems' shaders (SSAO, SSR, DDGI, …) load
+through their own `ShaderLibrary` instances that don't consult the pack at
+all; packing them would be dead weight with no consumer.
+
+The Lua scripting glue (`LuaScriptGlue.cpp`) also exposes
+`Renderer2D`/`Renderer3D`'s `ShaderLibrary.Load(filepath)` to scripts, so a
+game can load a filepath the fixed `kShaderPaths2D`/`kShaderPaths3D` arrays
+never enumerate — that shader is never packed and always cold-compiles on
+first launch, even with a pack staged. Not a correctness bug (a pack miss
+falls back to compiling from source, same as any other miss), just a coverage
+gap worth knowing about before promising a packaged build "will not compile
+shaders from source on first launch" — that guarantee only covers the fixed
+engine set.
+
+`ShaderPack::CollectShaderFilepaths` (a directory-glob helper, skipping
+`include/` and `tests/`) exists for completeness and is exercised in tests,
+but is not what the CI producer uses today — see the note above.
+
+## CI wiring
+
+`.github/workflows/Windows.yml`, after the normal test run: the test binary's
+own `--olo-bake-shader-pack=<path>` mode (see `TestOptions.h`) runs just the
+`ShaderPackBakeTest.BakeWhenRequested` case via `--gtest_filter`, then the
+result is uploaded as a `ShaderPack` build artifact.
+
+## Consumption
+
+`Renderer2D::Init()` / `Renderer3D::Init()` call
+`m_ShaderLibrary.LoadShaderPack("assets/ShaderPack.osp")` when that file
+exists, before their normal shader-load calls — a missing file is silently a
+no-op (every `Load()` falls back to compiling from source, same as always).
+
+`GameBuildPipeline::CopyEngineResources` stages the pack via the free function
+`StageShaderPack` (mirrors `StageRuntimeDependencyLibraries` /
+`StageLooseRuntimeTextures` — a small filesystem seam kept testable without a
+full pipeline run) right after the existing `assets/shaders` source copy.
+Staging is a no-op, not an error, when no pack exists next to the editor's
+shaders — the same "optional" contract as the runtime load.
+
+## Fresh worktrees do not fetch the pack automatically
+
+A fresh `/start-work` worktree gets no `ShaderPack.osp` by default — nothing
+downloads the CI artifact for it. This is deliberate (the issue's own plan
+leans this way): the pack is a build-time optimization for a **packaged**
+game, not something a working-tree editor session needs, and auto-fetching a
+CI artifact into every worktree would need auth, versioning, and staleness
+handling this issue doesn't need to solve. A game's build step (or an agent
+producing a package) that wants the pack downloads the `ShaderPack` artifact
+from the relevant Windows workflow run and drops it at
+`OloEditor/assets/ShaderPack.osp` before running `GameBuildPipeline::Build`.


### PR DESCRIPTION
## Summary

Closes the last real gap in issue #908: a packaged Drift build still cold-compiled every shader on first player launch even after #917/#906 gave the engine a content-hashed SPIR-V compile cache — a fresh machine has no warm cache to hit.

- **Producer**: `ShaderPack::CreateFromFilepaths` bakes a portable `.osp` archive using only the CPU-side `Shader::PrepareBatch` path (read, preprocess, shaderc, SPIRV-Cross) — no GL context anywhere, verified via `ShaderPackBakeTest`. Enumerates `Renderer2D::GetShaderFilepaths()` + `Renderer3D::GetShaderFilepaths()` — the exact same arrays `Init()` loads at runtime (one array, two readers), not a directory glob.
- **CI**: `.github/workflows/Windows.yml` runs the test binary's new `--olo-bake-shader-pack=<path>` mode after the normal test run and uploads `ShaderPack.osp` as a build artifact.
- **Invalidation contract**: each entry is keyed by `OpenGLShader::ComputeContentHash` — preprocessed source + both the Vulkan and OpenGL-cross-compile tiers' compiler options (the same ingredients #906's per-stage cache hashes on). `ShaderLibrary::TryReadPackEntry` recomputes the hash from the CURRENT on-disk source before ever serving a pack entry; a mismatch is a clean miss with fallback compile, never a maybe-stale blob served on trust. `SHADER_PACK_VERSION` bumps 1→2 for the new field.
- **Consumer**: `GameBuildPipeline::StageShaderPack` copies the pack into a packaged build (optional — a missing pack is not an error, the runtime just compiles from source); `Renderer2D::Init`/`Renderer3D::Init` load it via `ShaderLibrary::LoadShaderPack` when present.
- **Fresh worktrees do not fetch the pack automatically** — documented decision in `docs/agent-rules/shader-pack-bake.md`, per the issue's own lean.

## Review guide

**Where I'd look hardest**
1. `OloEngine/src/Platform/OpenGL/OpenGLShader.cpp` — `OpenGLShader::~OpenGLShader()`'s new `if (programId != 0)` guard. The headless bake path is the first code path in this codebase to construct+destroy `OpenGLShader` objects with zero GL context ever having existed in the process; the destructor previously assumed "not yet initialized" (`FrameResourceManager`) always still meant "a GL context is live", which crashed on an unloaded `glDeleteProgram`. Fixed by skipping GL-resource cleanup entirely when `m_RendererID == 0` (nothing was ever created) — pinned by `ShaderPackContentHashTest.PrepareBatchProducesADestructibleShaderWithNoGLContext`.
2. `ComputeContentHash` / `ComputeContentHashFromSources` split — `ShaderPack::CreateFromLibraries` (the pre-existing editor "Build Shader Pack" menu command) now hashes from the shader's own already-preprocessed `GetOriginalSourceCode()` rather than re-reading the file from disk, closing a TOCTOU window a multi-agent review caught: a fresh re-read could hash *new* on-disk text while packing the *old* in-memory SPIR-V if a file changed between compile and pack-build.
3. `ShaderLibrary::TryReadPackEntry`'s hash-comparison — the actual invalidation gate. Both directions are covered by `ShaderPackContentHashTest` (matching hash served; mutated source misses + falls back to compile), but it's worth an independent read given a stale pack is a *silent* wrong-shader bug, not a loud failure.

**What I verified, and how**
- `OloEngine-Tests --gtest_filter='*Shader*:*GameBuildPipeline*'` — 297/297 pass (2 expected skips: the bake test without its flag, and an unrelated pre-existing asset-content test needing a GL context).
- Ran the real headless bake end-to-end (`--olo-bake-shader-pack=...`): baked all 57 Renderer2D+Renderer3D shaders to a 6.2 MB pack, read it back through the real loader, verified count and load success.
- Live editor verification via the `run-oloengine` driver: launched OloEditor (Drift menu scene), confirmed clean startup with the new `LoadShaderPack` call on the `Init()` hot path (no pack present — just the existence-check branch), 233 FPS, no shader/log errors. Screenshot captured and inspected.
- Full multi-agent self-review (5 parallel review angles) before opening this PR; every finding either fixed (OpenGL-tier hash coverage, the TOCTOU above, a duplicated pack-load guard moved into `ShaderLibrary::LoadShaderPack`, an unnecessary GameBuildPipeline local, an RAII cwd guard in `ShaderPackBakeTest`) or explicitly noted as out of scope (see below).

**Least confident about** — the efficiency finding that `TryReadPackEntry` now pays a full read+recursive-`#include`-preprocess per shader on every pack HIT (previously a pure map lookup), since the hash must be recomputed from live source to be trustworthy. This is a real, measurable startup-latency cost trade-off for correctness that I did not optimize (e.g. a cheap mtime+size pre-check before falling back to the full hash) — flagging for a second opinion on whether that's worth a follow-up issue.

**Deliberately not tested**
- The editor's "Build Shader Pack" menu command end-to-end in a live GL session (only the CPU-hash logic it now shares with the CI path is covered by tests) — no GL-context test harness change was in scope here.
- Script-loaded shaders (Lua `ShaderLibrary.Load`) are outside the pack's enumeration by design — documented as a known gap in `docs/agent-rules/shader-pack-bake.md`, not a regression.

Closes #908


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional precompiled shader packs to improve startup shader loading.
  * Automatically packages available shader packs with game builds.
  * Added content-hash validation to detect outdated shader packs and fall back to compilation when needed.
  * Added headless shader-pack generation and CI artifact publishing.

* **Bug Fixes**
  * Prevented missing or incompatible shader packs from producing load errors or unsafe graphics cleanup.

* **Documentation**
  * Added guidance covering shader-pack generation, validation, packaging, and runtime behavior.

* **Tests**
  * Added coverage for shader-pack baking, validation, fallback behavior, and build staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->