### PR TITLE
feat(steam): add Steam Input for controller remapping

### DIFF
--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -598,20 +598,27 @@ namespace OloEngine
             GamepadManager::Update();
             OLO_PROFILE_FRAMEMARK_END("GamepadManager Update");
 
-            // Update action mapping state (reads fresh GLFW state)
-            OLO_PROFILE_FRAMEMARK_START("InputActionManager Update");
-            InputActionManager::Update();
-            OLO_PROFILE_FRAMEMARK_END("InputActionManager Update");
-
-            // Drain Steam's callback queue (#644). Position matters twice over:
-            //   * AFTER the input/platform block and BEFORE ProcessTasks below, so a Steam
-            //     callback that enqueues a game-thread task is drained in the SAME frame rather
-            //     than sitting until the next one;
+            // Drain Steam's callback queue (#644). Position matters three ways now:
+            //   * AFTER the raw input/platform polling above and BEFORE ProcessTasks below, so a
+            //     Steam callback that enqueues a game-thread task is drained in the SAME frame
+            //     rather than sitting until the next one;
+            //   * BEFORE InputActionManager::Update() below (#893) — RunCallbacks() is what pumps
+            //     ISteamInput::RunFrame() (SteamManager::RunCallbacks -> ISteamBackend::
+            //     InputRunFrame), which is the SDK's explicit per-frame refresh for Steam Input's
+            //     controller/action state (Steam Input was brought up with
+            //     bExplicitlyCallRunFrame=true). Reading Steam Input state before this runs would
+            //     read the PREVIOUS frame's snapshot, one frame stale;
             //   * in Run(), NOT in RenderFrameLayers — that function has a re-entrancy latch and
             //     the nested-swap path would pump Steam callbacks twice per frame.
             OLO_PROFILE_FRAMEMARK_START("Steam RunCallbacks");
             SteamManager::RunCallbacks();
             OLO_PROFILE_FRAMEMARK_END("Steam RunCallbacks");
+
+            // Update action mapping state (reads fresh GLFW state, and — per the ordering above —
+            // this frame's freshly-pumped Steam Input state).
+            OLO_PROFILE_FRAMEMARK_START("InputActionManager Update");
+            InputActionManager::Update();
+            OLO_PROFILE_FRAMEMARK_END("InputActionManager Update");
 
             // Process tasks targeted at the Game Thread
             Tasks::FNamedThreadManager::Get().ProcessTasks(true);

--- a/OloEngine/src/OloEngine/Core/InputActionManager.cpp
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/GamepadManager.h"
 #include "OloEngine/Core/Input.h"
 #include "OloEngine/Debug/Instrumentor.h"
+#include "Platform/Steam/SteamManager.h"
 
 namespace OloEngine
 {
@@ -194,6 +195,9 @@ namespace OloEngine
         s_AxisValues.clear();
         s_SuppressTransientOnNextUpdate = false;
         s_PendingRebindMenuContext.reset();
+        s_SteamDigitalHandles.clear();
+        s_SteamAnalogHandles.clear();
+        s_SteamActionSetHandles.clear();
     }
 
     void InputActionManager::Shutdown()
@@ -207,6 +211,9 @@ namespace OloEngine
         s_AxisValues.clear();
         s_SuppressTransientOnNextUpdate = false;
         s_PendingRebindMenuContext.reset();
+        s_SteamDigitalHandles.clear();
+        s_SteamAnalogHandles.clear();
+        s_SteamActionSetHandles.clear();
     }
 
     void InputActionManager::Update()
@@ -241,6 +248,22 @@ namespace OloEngine
             }
         }
 
+        // Steam Input, when a controller is connected, governs every GAMEPAD-origin binding for
+        // the frame — "Steam Input wins when available", see
+        // docs/agent-rules/steamworks-platform-integration.md §11. Keyboard/Mouse bindings are
+        // unaffected either way, so they still work as a fallback (and simultaneously) with a
+        // Steam Input controller connected.
+        //
+        // Queried ONCE here rather than per-action: GetConnectedControllers() allocates and
+        // makes a virtual call into the backend, and threading the result through avoids paying
+        // that once per action in the active map.
+        const std::vector<u64> steamControllers = SteamManager::IsInputAvailable() ? SteamManager::GetConnectedControllers() : std::vector<u64>{};
+        const bool steamGovernsGamepad = !steamControllers.empty();
+        if (steamGovernsGamepad)
+        {
+            ActivateSteamActionSet(s_ContextStack.back(), steamControllers);
+        }
+
         for (const auto& [actionName, action] : activeMap.Actions)
         {
             bool pressed = false;
@@ -264,6 +287,10 @@ namespace OloEngine
                 }
                 else if (binding.Type == InputBindingType::GamepadButton)
                 {
+                    if (steamGovernsGamepad)
+                    {
+                        continue; // Steam Input owns this controller now; see ApplySteamInputForAction below.
+                    }
                     if (s_InputProvider->IsGamepadButtonPressed(binding.GPButton))
                     {
                         pressed = true;
@@ -272,6 +299,10 @@ namespace OloEngine
                 }
                 else if (binding.Type == InputBindingType::GamepadAxis)
                 {
+                    if (steamGovernsGamepad)
+                    {
+                        continue;
+                    }
                     f32 axisVal = s_InputProvider->GetGamepadAxis(binding.GPAxis);
                     if (binding.AxisPositive && axisVal >= binding.AxisThreshold)
                     {
@@ -289,36 +320,50 @@ namespace OloEngine
                     // No additional handling required.
                 }
             }
-            s_CurrentState[actionName] = pressed;
 
             // Track the best analog value for axis queries.
             // Prefer actual axis deflection over digital 0/1.
             f32 bestAxisValue = 0.0f;
-            for (const auto& binding : action.Bindings)
+            if (!steamGovernsGamepad)
             {
-                if (binding.Type == InputBindingType::GamepadAxis)
+                for (const auto& binding : action.Bindings)
                 {
-                    f32 axisVal = s_InputProvider->GetGamepadAxis(binding.GPAxis);
-                    if (binding.AxisPositive)
+                    if (binding.Type == InputBindingType::GamepadAxis)
                     {
-                        axisVal = std::max(0.0f, axisVal);
-                    }
-                    else
-                    {
-                        axisVal = std::min(0.0f, axisVal);
-                    }
-                    if (std::abs(axisVal) > std::abs(bestAxisValue))
-                    {
-                        bestAxisValue = axisVal;
+                        f32 axisVal = s_InputProvider->GetGamepadAxis(binding.GPAxis);
+                        if (binding.AxisPositive)
+                        {
+                            axisVal = std::max(0.0f, axisVal);
+                        }
+                        else
+                        {
+                            axisVal = std::min(0.0f, axisVal);
+                        }
+                        if (std::abs(axisVal) > std::abs(bestAxisValue))
+                        {
+                            bestAxisValue = axisVal;
+                        }
                     }
                 }
             }
-            // Fall back to digital state only when no axis produced a stronger value
-            if (pressed && std::abs(bestAxisValue) < 1.0f)
+
+            bool axisSuppliedBySteam = false;
+            if (steamGovernsGamepad)
+            {
+                ApplySteamInputForAction(actionName, action, steamControllers, pressed, bestAxisValue, axisSuppliedBySteam);
+            }
+
+            // Fall back to digital state only when no axis produced a stronger value. Skipped
+            // when Steam Input supplied a real analog magnitude this frame — that value is
+            // trustworthy on its own (e.g. a 40% trigger pull alongside a digitally-bound
+            // "pressed past threshold" origin on the same action) and must not be discarded in
+            // favour of a fabricated full-scale snap.
+            if (!axisSuppliedBySteam && pressed && std::abs(bestAxisValue) < 1.0f)
             {
                 constexpr f32 axisZeroEpsilon = 1e-6f;
                 bestAxisValue = (std::abs(bestAxisValue) > axisZeroEpsilon) ? std::copysign(1.0f, bestAxisValue) : 1.0f;
             }
+            s_CurrentState[actionName] = pressed;
             s_AxisValues[actionName] = bestAxisValue;
         }
 
@@ -471,6 +516,80 @@ namespace OloEngine
             return 0.0f;
         }
         return it->second;
+    }
+
+    void InputActionManager::ActivateSteamActionSet(InputContextType ctx, const std::vector<u64>& connectedControllers)
+    {
+        auto handleIt = s_SteamActionSetHandles.find(ctx);
+        const u64 actionSet = handleIt != s_SteamActionSetHandles.end()
+                                  ? handleIt->second
+                                  : s_SteamActionSetHandles.emplace(ctx, SteamManager::GetActionSetHandle(InputContextTypeToString(ctx))).first->second;
+
+        for (const auto controller : connectedControllers)
+        {
+            SteamManager::ActivateActionSet(controller, actionSet);
+        }
+    }
+
+    void InputActionManager::ApplySteamInputForAction(const std::string& actionName, const InputAction& action,
+                                                      const std::vector<u64>& connectedControllers, bool& pressed, f32& axisValue,
+                                                      bool& axisSuppliedBySteam)
+    {
+        if (connectedControllers.empty())
+        {
+            return;
+        }
+        // Only the primary (first) connected controller drives action state — the same
+        // simplification GetActionAxisValue already makes for engine gamepad bindings (index 0
+        // only). Multi-controller local co-op through Steam Input is out of scope; see the
+        // integration doc.
+        const u64 controller = connectedControllers[0];
+
+        auto digitalIt = s_SteamDigitalHandles.find(actionName);
+        const u64 digitalHandle = digitalIt != s_SteamDigitalHandles.end()
+                                      ? digitalIt->second
+                                      : s_SteamDigitalHandles.emplace(actionName, SteamManager::GetDigitalActionHandle(actionName)).first->second;
+
+        // Active=false means "no origin bound in the current action set" — the action-set
+        // switch above may have just changed that, so this is re-checked every frame rather
+        // than cached. Only override `pressed` when Steam actually has this action bound;
+        // otherwise leave the keyboard/mouse-only result from above untouched.
+        if (const SteamInputDigitalActionState digitalState = SteamManager::GetDigitalActionState(controller, digitalHandle);
+            digitalState.Active)
+        {
+            pressed = pressed || digitalState.Pressed;
+        }
+
+        auto analogIt = s_SteamAnalogHandles.find(actionName);
+        const u64 analogHandle = analogIt != s_SteamAnalogHandles.end()
+                                     ? analogIt->second
+                                     : s_SteamAnalogHandles.emplace(actionName, SteamManager::GetAnalogActionHandle(actionName)).first->second;
+
+        if (const SteamInputAnalogActionState analogState = SteamManager::GetAnalogActionState(controller, analogHandle);
+            analogState.Active)
+        {
+            f32 value = analogState.X;
+
+            // If the action's own engine-side binding constrains this axis to one direction
+            // (the split-into-two-actions convention, e.g. "MoveLeft"/"MoveRight" both reading
+            // the same physical axis with opposite AxisPositive), honour that constraint for
+            // the Steam-sourced value too — mirroring the clamp the raw-gamepad path above
+            // applies — so an action doesn't silently start reporting the wrong sign purely
+            // because a Steam Input controller took over. An action with no GamepadAxis
+            // binding at all (Steam Input governs it entirely) is left unconstrained.
+            for (const auto& binding : action.Bindings)
+            {
+                if (binding.Type != InputBindingType::GamepadAxis)
+                {
+                    continue;
+                }
+                value = binding.AxisPositive ? std::max(0.0f, value) : std::min(0.0f, value);
+                break;
+            }
+
+            axisValue = value;
+            axisSuppliedBySteam = true;
+        }
     }
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Core/InputActionManager.h
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.h
@@ -162,6 +162,28 @@ namespace OloEngine
             return s_ContextMaps[s_ContextStack.back()];
         }
 
+        // Route the active context's Steam Input controller(s) into s_CurrentState /
+        // s_AxisValues alongside the raw device query below. See
+        // docs/agent-rules/steamworks-platform-integration.md §11 for the "Steam Input wins
+        // when available" contract this implements. Declared here (rather than as a free
+        // function in the .cpp) only so it can reach the private handle caches below; it has no
+        // reason to be part of the public API.
+        // `connectedControllers` is computed once per Update() and threaded through, rather than
+        // re-queried per action — SteamManager::GetConnectedControllers() allocates and makes a
+        // virtual call into the backend, and this runs once per action in the active map.
+        // `axisSuppliedBySteam` is set true when a Steam analog action actually supplied
+        // `axisValue`, so Update()'s "snap a partial axis to full scale when also digitally
+        // pressed" fallback (meant for a weak/absent raw-gamepad axis) does not clobber a real
+        // Steam analog magnitude.
+        static void ApplySteamInputForAction(const std::string& actionName, const InputAction& action,
+                                             const std::vector<u64>& connectedControllers, bool& pressed, f32& axisValue,
+                                             bool& axisSuppliedBySteam);
+
+        // Activate the Steam Input action set matching ctx (by InputContextTypeToString) on
+        // every connected controller. Cheap and idempotent, so it is safe to call once per
+        // Update() rather than only on a context change.
+        static void ActivateSteamActionSet(InputContextType ctx, const std::vector<u64>& connectedControllers);
+
         // Clear cached press/axis state and suppress just-pressed/just-released on the
         // next Update() — used whenever the active context (and thus its map) changes.
         static void ResetStateForContextChange();
@@ -179,6 +201,13 @@ namespace OloEngine
         inline static std::unordered_map<std::string, f32, StringHash, StringEqual> s_AxisValues;
         inline static std::optional<InputContextType> s_PendingRebindMenuContext;
         static IInputProvider* s_InputProvider;
+
+        // Steam Input handle caches. Steam hands back a STABLE handle for a given name for the
+        // life of the process, so these are populated lazily (first query per action/context)
+        // and never invalidated — see ApplySteamInputForAction.
+        inline static std::unordered_map<std::string, u64, StringHash, StringEqual> s_SteamDigitalHandles;
+        inline static std::unordered_map<std::string, u64, StringHash, StringEqual> s_SteamAnalogHandles;
+        inline static std::unordered_map<InputContextType, u64> s_SteamActionSetHandles;
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/Platform/Steam/SteamBackend.h
+++ b/OloEngine/src/Platform/Steam/SteamBackend.h
@@ -100,6 +100,62 @@ namespace OloEngine
         virtual SteamResult CloudDelete(std::string_view name) = 0;
         [[nodiscard]] virtual std::vector<std::string> CloudEnumerate() const = 0;
         virtual SteamResult GetCloudQuota(SteamCloudQuota& outQuota) const = 0;
+
+        // --- input -------------------------------------------------------------------------
+        //
+        // Steam Input (action sets, digital/analog action state, glyph lookup for button
+        // prompts). Unlike the rest of this interface, Steam Input needs its OWN init/shutdown/
+        // pump beyond the base Initialize()/RunCallbacks() pair — the SDK models it as a
+        // separate subsystem with its own per-frame refresh, so calling it out explicitly (rather
+        // than folding it into Initialize()) keeps that true here too.
+        //
+        // See docs/agent-rules/steamworks-platform-integration.md §11 for how InputActionManager
+        // drives this seam.
+
+        // Bring Steam Input up. Only meaningful once IsAvailable() is true; safe (and a no-op
+        // returning false) otherwise.
+        virtual bool InputInit() = 0;
+        virtual void InputShutdown() = 0;
+
+        // Steam Input keeps its own per-frame refresh, distinct from RunCallbacks(). Call both
+        // every frame — skipping this one means action/glyph state never updates.
+        virtual void InputRunFrame() = 0;
+
+        [[nodiscard]] virtual bool IsInputAvailable() const = 0;
+
+        // Every controller Steam Input is currently driving. Empty whenever IsInputAvailable()
+        // is false or nothing is connected — callers must treat that as "fall back to the
+        // engine's own gamepad bindings", not as an error.
+        [[nodiscard]] virtual std::vector<SteamInputHandle> GetConnectedControllers() const = 0;
+
+        // Handles are looked up by the action-set / action names in the game's Steam Input
+        // manifest (steam_input_manifest.vdf on the partner site) and are stable for the
+        // process, so callers are expected to cache them rather than look up every frame.
+        [[nodiscard]] virtual SteamInputActionSetHandle GetActionSetHandle(std::string_view actionSetName) const = 0;
+        virtual void ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet) = 0;
+
+        [[nodiscard]] virtual SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view actionName) const = 0;
+        [[nodiscard]] virtual SteamInputDigitalActionState GetDigitalActionState(SteamInputHandle controller,
+                                                                                 SteamInputDigitalActionHandle action) const = 0;
+
+        [[nodiscard]] virtual SteamInputAnalogActionHandle GetAnalogActionHandle(std::string_view actionName) const = 0;
+        [[nodiscard]] virtual SteamInputAnalogActionState GetAnalogActionState(SteamInputHandle controller,
+                                                                               SteamInputAnalogActionHandle action) const = 0;
+
+        // Button-prompt lookup for whatever the player is physically holding, keyed off the
+        // FIRST origin bound to the action (a Steam Input action may have several; the engine
+        // only ever needs one prompt per action). Both return empty when the action has no
+        // bound origin or Steam Input is unavailable.
+        [[nodiscard]] virtual std::string GetGlyphLabelForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                        SteamInputDigitalActionHandle action) const = 0;
+        [[nodiscard]] virtual std::string GetGlyphLabelForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                       SteamInputAnalogActionHandle action) const = 0;
+
+        // Absolute path to a PNG glyph on disk matching the physically connected controller.
+        [[nodiscard]] virtual std::string GetGlyphPngForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                      SteamInputDigitalActionHandle action) const = 0;
+        [[nodiscard]] virtual std::string GetGlyphPngForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                     SteamInputAnalogActionHandle action) const = 0;
     };
 
     // The always-unavailable backend.
@@ -187,6 +243,62 @@ namespace OloEngine
         SteamResult GetCloudQuota(SteamCloudQuota&) const override
         {
             return SteamResult::Unavailable;
+        }
+
+        bool InputInit() override
+        {
+            return false;
+        }
+        void InputShutdown() override {}
+        void InputRunFrame() override {}
+        [[nodiscard]] bool IsInputAvailable() const override
+        {
+            return false;
+        }
+        [[nodiscard]] std::vector<SteamInputHandle> GetConnectedControllers() const override
+        {
+            return {};
+        }
+        [[nodiscard]] SteamInputActionSetHandle GetActionSetHandle(std::string_view) const override
+        {
+            return kInvalidSteamInputActionSetHandle;
+        }
+        void ActivateActionSet(SteamInputHandle, SteamInputActionSetHandle) override {}
+        [[nodiscard]] SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view) const override
+        {
+            return kInvalidSteamInputDigitalActionHandle;
+        }
+        [[nodiscard]] SteamInputDigitalActionState GetDigitalActionState(SteamInputHandle, SteamInputDigitalActionHandle) const override
+        {
+            return {};
+        }
+        [[nodiscard]] SteamInputAnalogActionHandle GetAnalogActionHandle(std::string_view) const override
+        {
+            return kInvalidSteamInputAnalogActionHandle;
+        }
+        [[nodiscard]] SteamInputAnalogActionState GetAnalogActionState(SteamInputHandle, SteamInputAnalogActionHandle) const override
+        {
+            return {};
+        }
+        [[nodiscard]] std::string GetGlyphLabelForDigitalAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                                SteamInputDigitalActionHandle) const override
+        {
+            return {};
+        }
+        [[nodiscard]] std::string GetGlyphLabelForAnalogAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                               SteamInputAnalogActionHandle) const override
+        {
+            return {};
+        }
+        [[nodiscard]] std::string GetGlyphPngForDigitalAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                              SteamInputDigitalActionHandle) const override
+        {
+            return {};
+        }
+        [[nodiscard]] std::string GetGlyphPngForAnalogAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                             SteamInputAnalogActionHandle) const override
+        {
+            return {};
         }
     };
 

--- a/OloEngine/src/Platform/Steam/SteamManager.cpp
+++ b/OloEngine/src/Platform/Steam/SteamManager.cpp
@@ -65,6 +65,16 @@ namespace OloEngine
         }
 
         OLO_CORE_INFO("[Steam] Initialized. AppID={0}, user='{1}'.", s_Backend->GetAppId(), s_Backend->GetPersonaName());
+
+        // Steam Input is a separate subsystem with its own init call. Failing to bring it up
+        // is not fatal to the rest of Steam — the game simply falls back entirely to the
+        // engine's own gamepad bindings, exactly as if no Steam Input controller were
+        // connected. See IsInputAvailable().
+        if (!s_Backend->InputInit())
+        {
+            OLO_CORE_TRACE("[Steam] Steam Input did not start; controller remap prompts and Steam-side rebinding are "
+                           "unavailable this session. The engine's own gamepad bindings still work normally.");
+        }
     }
 
     void SteamManager::Shutdown()
@@ -75,6 +85,7 @@ namespace OloEngine
         // early — so it must tolerate a backend that was never created or never initialised.
         if (s_Backend)
         {
+            s_Backend->InputShutdown();
             s_Backend->Shutdown();
             s_Backend.reset();
         }
@@ -86,6 +97,7 @@ namespace OloEngine
         if (ISteamBackend* backend = AvailableBackend())
         {
             backend->RunCallbacks();
+            backend->InputRunFrame();
         }
     }
 
@@ -336,10 +348,93 @@ namespace OloEngine
         return backend->GetCloudQuota(outQuota);
     }
 
+    bool SteamManager::IsInputAvailable()
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend && backend->IsInputAvailable();
+    }
+
+    std::vector<SteamInputHandle> SteamManager::GetConnectedControllers()
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetConnectedControllers() : std::vector<SteamInputHandle>{};
+    }
+
+    SteamInputActionSetHandle SteamManager::GetActionSetHandle(std::string_view actionSetName)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetActionSetHandle(actionSetName) : kInvalidSteamInputActionSetHandle;
+    }
+
+    void SteamManager::ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet)
+    {
+        if (ISteamBackend* backend = AvailableBackend())
+        {
+            backend->ActivateActionSet(controller, actionSet);
+        }
+    }
+
+    SteamInputDigitalActionHandle SteamManager::GetDigitalActionHandle(std::string_view actionName)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetDigitalActionHandle(actionName) : kInvalidSteamInputDigitalActionHandle;
+    }
+
+    SteamInputDigitalActionState SteamManager::GetDigitalActionState(SteamInputHandle controller, SteamInputDigitalActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetDigitalActionState(controller, action) : SteamInputDigitalActionState{};
+    }
+
+    SteamInputAnalogActionHandle SteamManager::GetAnalogActionHandle(std::string_view actionName)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetAnalogActionHandle(actionName) : kInvalidSteamInputAnalogActionHandle;
+    }
+
+    SteamInputAnalogActionState SteamManager::GetAnalogActionState(SteamInputHandle controller, SteamInputAnalogActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetAnalogActionState(controller, action) : SteamInputAnalogActionState{};
+    }
+
+    std::string SteamManager::GetGlyphLabelForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                            SteamInputDigitalActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetGlyphLabelForDigitalAction(controller, actionSet, action) : std::string{};
+    }
+
+    std::string SteamManager::GetGlyphLabelForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                           SteamInputAnalogActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetGlyphLabelForAnalogAction(controller, actionSet, action) : std::string{};
+    }
+
+    std::string SteamManager::GetGlyphPngForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                          SteamInputDigitalActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetGlyphPngForDigitalAction(controller, actionSet, action) : std::string{};
+    }
+
+    std::string SteamManager::GetGlyphPngForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                         SteamInputAnalogActionHandle action)
+    {
+        ISteamBackend* backend = AvailableBackend();
+        return backend ? backend->GetGlyphPngForAnalogAction(controller, actionSet, action) : std::string{};
+    }
+
     void SteamManager::SetBackendForTesting(Scope<ISteamBackend> backend)
     {
         if (s_Backend)
         {
+            // Mirror the real Shutdown() ordering (input torn down before the base backend) so
+            // a test that swaps backends mid-run without an intervening Shutdown()/
+            // ResetForTesting() doesn't leak whatever the outgoing backend's InputShutdown()
+            // was responsible for releasing.
+            s_Backend->InputShutdown();
             s_Backend->Shutdown();
         }
         s_Backend = std::move(backend);

--- a/OloEngine/src/Platform/Steam/SteamManager.h
+++ b/OloEngine/src/Platform/Steam/SteamManager.h
@@ -118,6 +118,41 @@ namespace OloEngine
         [[nodiscard]] static std::vector<std::string> CloudEnumerate();
         static SteamResult GetCloudQuota(SteamCloudQuota& outQuota);
 
+        // --- input -----------------------------------------------------------------------
+        //
+        // Steam Input is brought up and torn down as part of Initialize()/Shutdown() and
+        // pumped as part of RunCallbacks() — see those methods — so there is no separate
+        // Init/Shutdown/RunFrame here. IsInputAvailable() can be false while IsAvailable() is
+        // true (Steam is up but Steam Input failed to init, or nothing is connected), so
+        // callers must check it before relying on any of the below.
+        //
+        // See docs/agent-rules/steamworks-platform-integration.md §11 for how
+        // InputActionManager drives this seam to implement "Steam Input wins when available".
+
+        [[nodiscard]] static bool IsInputAvailable();
+
+        [[nodiscard]] static std::vector<SteamInputHandle> GetConnectedControllers();
+
+        [[nodiscard]] static SteamInputActionSetHandle GetActionSetHandle(std::string_view actionSetName);
+        static void ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet);
+
+        [[nodiscard]] static SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view actionName);
+        [[nodiscard]] static SteamInputDigitalActionState GetDigitalActionState(SteamInputHandle controller,
+                                                                                SteamInputDigitalActionHandle action);
+
+        [[nodiscard]] static SteamInputAnalogActionHandle GetAnalogActionHandle(std::string_view actionName);
+        [[nodiscard]] static SteamInputAnalogActionState GetAnalogActionState(SteamInputHandle controller,
+                                                                              SteamInputAnalogActionHandle action);
+
+        [[nodiscard]] static std::string GetGlyphLabelForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                       SteamInputDigitalActionHandle action);
+        [[nodiscard]] static std::string GetGlyphLabelForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                      SteamInputAnalogActionHandle action);
+        [[nodiscard]] static std::string GetGlyphPngForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                     SteamInputDigitalActionHandle action);
+        [[nodiscard]] static std::string GetGlyphPngForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                    SteamInputAnalogActionHandle action);
+
         // --- test seam ---------------------------------------------------------------------
 
         // Swap in a fake backend. Takes ownership; pass nullptr to restore the real one.

--- a/OloEngine/src/Platform/Steam/SteamManager.h
+++ b/OloEngine/src/Platform/Steam/SteamManager.h
@@ -123,8 +123,13 @@ namespace OloEngine
         // Steam Input is brought up and torn down as part of Initialize()/Shutdown() and
         // pumped as part of RunCallbacks() — see those methods — so there is no separate
         // Init/Shutdown/RunFrame here. IsInputAvailable() can be false while IsAvailable() is
-        // true (Steam is up but Steam Input failed to init, or nothing is connected), so
-        // callers must check it before relying on any of the below.
+        // true (Steam is up but Steam Input failed to init), so callers must check it before
+        // relying on any of the below.
+        //
+        // IsInputAvailable() reports ONLY whether Steam Input itself initialised — it says
+        // nothing about whether a controller is plugged in. A game with Steam Input up and no
+        // controller connected is a completely ordinary state (desktop play with mouse/
+        // keyboard); check GetConnectedControllers().empty() for that, not this.
         //
         // See docs/agent-rules/steamworks-platform-integration.md §11 for how
         // InputActionManager drives this seam to implement "Steam Input wins when available".

--- a/OloEngine/src/Platform/Steam/SteamTypes.h
+++ b/OloEngine/src/Platform/Steam/SteamTypes.h
@@ -77,4 +77,43 @@ namespace OloEngine
             return TotalBytes >= AvailableBytes ? TotalBytes - AvailableBytes : 0;
         }
     };
+
+    // --- Steam Input -------------------------------------------------------------------
+    //
+    // Steam's own handle types (InputHandle_t, InputActionSetHandle_t, ...) are all opaque
+    // uint64_t under the hood, so the seam carries them as plain u64 rather than pulling any
+    // Valve type across the ISteamBackend boundary. 0 is Steam's own "invalid handle" sentinel
+    // for every one of these.
+
+    // One per physically connected controller Steam Input is driving.
+    using SteamInputHandle = u64;
+    // Identifies a named action set (e.g. "Gameplay", "Menu") from the game's Steam Input
+    // manifest.
+    using SteamInputActionSetHandle = u64;
+    using SteamInputDigitalActionHandle = u64;
+    using SteamInputAnalogActionHandle = u64;
+
+    inline constexpr SteamInputHandle kInvalidSteamInputHandle = 0;
+    inline constexpr SteamInputActionSetHandle kInvalidSteamInputActionSetHandle = 0;
+    inline constexpr SteamInputDigitalActionHandle kInvalidSteamInputDigitalActionHandle = 0;
+    inline constexpr SteamInputAnalogActionHandle kInvalidSteamInputAnalogActionHandle = 0;
+
+    // State of a digital (button-shaped) Steam Input action for one controller.
+    struct SteamInputDigitalActionState
+    {
+        bool Pressed = false;
+        // False when the action has no origin bound in the controller's current action set
+        // (or Steam Input controller config) — distinct from "bound but not pressed".
+        bool Active = false;
+    };
+
+    // State of an analog (stick/trigger-shaped) Steam Input action for one controller.
+    // Y is 0 for a single-axis (trigger) action; consult the game's Steam Input manifest.
+    struct SteamInputAnalogActionState
+    {
+        f32 X = 0.0f;
+        f32 Y = 0.0f;
+        // False when the action has no origin bound in the controller's current action set.
+        bool Active = false;
+    };
 } // namespace OloEngine

--- a/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
+++ b/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
@@ -147,6 +147,13 @@ namespace OloEngine
             {
                 return;
             }
+            // Close Steam Input FIRST, and unconditionally — mirroring SteamManager's own
+            // ordering (input torn down before the base backend) — so this single call closes
+            // the whole session even when the destructor's defensive fallback below is what
+            // invokes it (an exception unwound past SteamManager::Shutdown() entirely) rather
+            // than the caller having called InputShutdown() itself first. Safe to call whether
+            // or not Steam Input was ever brought up.
+            InputShutdown();
             m_OverlayCallback.Unregister();
             SteamAPI_Shutdown();
             m_Initialized = false;

--- a/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
+++ b/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
@@ -551,7 +551,23 @@ namespace OloEngine
             }
             const InputAnalogActionData_t data =
                 input->GetAnalogActionData(static_cast<InputHandle_t>(controller), static_cast<InputAnalogActionHandle_t>(action));
-            return SteamInputAnalogActionState{ .X = data.x, .Y = data.y, .Active = data.bActive };
+
+            f32 x = data.x;
+            f32 y = data.y;
+            if (data.eMode == k_EInputSourceMode_Trigger)
+            {
+                // Valve reports a Trigger-mode analog action on 0..1 (0 = released). Normalize to
+                // this engine's own GamepadAxis convention — -1..1, -1 = released (see
+                // GamepadCodes.h's GamepadAxis::RightTrigger) — so a trigger-shaped action reads
+                // identically whether it came from Steam Input or raw XInput/DirectInput.
+                x = (x * 2.0f) - 1.0f;
+                y = (y * 2.0f) - 1.0f; // unused by a Trigger action, but kept consistent.
+            }
+            // Every other source mode (JoystickMove and the button/dpad/mouse modes an analog
+            // action can theoretically report) is already on a -1..1-or-boolean convention this
+            // engine's own gamepad axes match, so nothing else needs converting.
+
+            return SteamInputAnalogActionState{ .X = x, .Y = y, .Active = data.bActive };
         }
 
         [[nodiscard]] std::string GetGlyphLabelForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,

--- a/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
+++ b/OloEngine/src/Platform/Steam/SteamworksBackend.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 
 namespace OloEngine
 {
@@ -412,7 +413,241 @@ namespace OloEngine
             return SteamResult::Success;
         }
 
+        // --- input -------------------------------------------------------------------------
+
+        bool InputInit() override
+        {
+            if (m_InputInitialized)
+            {
+                return true;
+            }
+            ISteamInput* input = SteamInput();
+            if (!input)
+            {
+                return false;
+            }
+            // We drive the pump ourselves from RunFrame() below (called once per engine frame,
+            // right after SteamAPI_RunCallbacks) rather than letting the SDK run it implicitly
+            // off SteamAPI_RunCallbacks — explicit control is what the SDK recommends for a
+            // game with its own fixed frame loop.
+            m_InputInitialized = input->Init(true);
+            return m_InputInitialized;
+        }
+
+        void InputShutdown() override
+        {
+            if (!m_InputInitialized)
+            {
+                return;
+            }
+            if (ISteamInput* input = SteamInput())
+            {
+                input->Shutdown();
+            }
+            m_InputInitialized = false;
+        }
+
+        void InputRunFrame() override
+        {
+            if (m_InputInitialized)
+            {
+                if (ISteamInput* input = SteamInput())
+                {
+                    input->RunFrame();
+                }
+            }
+        }
+
+        [[nodiscard]] bool IsInputAvailable() const override
+        {
+            return m_InputInitialized;
+        }
+
+        [[nodiscard]] std::vector<SteamInputHandle> GetConnectedControllers() const override
+        {
+            std::vector<SteamInputHandle> result;
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input)
+            {
+                return result;
+            }
+
+            std::array<InputHandle_t, STEAM_INPUT_MAX_COUNT> handles{};
+            const int count = input->GetConnectedControllers(handles.data());
+            result.reserve(static_cast<sizet>(std::max(count, 0)));
+            for (int i = 0; i < count; ++i)
+            {
+                result.push_back(static_cast<SteamInputHandle>(handles[static_cast<sizet>(i)]));
+            }
+            return result;
+        }
+
+        [[nodiscard]] SteamInputActionSetHandle GetActionSetHandle(std::string_view actionSetName) const override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input)
+            {
+                return kInvalidSteamInputActionSetHandle;
+            }
+            const std::string name = ToCString(actionSetName);
+            return static_cast<SteamInputActionSetHandle>(input->GetActionSetHandle(name.c_str()));
+        }
+
+        void ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet) override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input || controller == kInvalidSteamInputHandle ||
+                actionSet == kInvalidSteamInputActionSetHandle)
+            {
+                return;
+            }
+            input->ActivateActionSet(static_cast<InputHandle_t>(controller), static_cast<InputActionSetHandle_t>(actionSet));
+        }
+
+        [[nodiscard]] SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view actionName) const override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input)
+            {
+                return kInvalidSteamInputDigitalActionHandle;
+            }
+            const std::string name = ToCString(actionName);
+            return static_cast<SteamInputDigitalActionHandle>(input->GetDigitalActionHandle(name.c_str()));
+        }
+
+        [[nodiscard]] SteamInputDigitalActionState GetDigitalActionState(SteamInputHandle controller,
+                                                                         SteamInputDigitalActionHandle action) const override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input || controller == kInvalidSteamInputHandle ||
+                action == kInvalidSteamInputDigitalActionHandle)
+            {
+                return {};
+            }
+            const InputDigitalActionData_t data =
+                input->GetDigitalActionData(static_cast<InputHandle_t>(controller), static_cast<InputDigitalActionHandle_t>(action));
+            return SteamInputDigitalActionState{ .Pressed = data.bState, .Active = data.bActive };
+        }
+
+        [[nodiscard]] SteamInputAnalogActionHandle GetAnalogActionHandle(std::string_view actionName) const override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input)
+            {
+                return kInvalidSteamInputAnalogActionHandle;
+            }
+            const std::string name = ToCString(actionName);
+            return static_cast<SteamInputAnalogActionHandle>(input->GetAnalogActionHandle(name.c_str()));
+        }
+
+        [[nodiscard]] SteamInputAnalogActionState GetAnalogActionState(SteamInputHandle controller,
+                                                                       SteamInputAnalogActionHandle action) const override
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input || controller == kInvalidSteamInputHandle ||
+                action == kInvalidSteamInputAnalogActionHandle)
+            {
+                return {};
+            }
+            const InputAnalogActionData_t data =
+                input->GetAnalogActionData(static_cast<InputHandle_t>(controller), static_cast<InputAnalogActionHandle_t>(action));
+            return SteamInputAnalogActionState{ .X = data.x, .Y = data.y, .Active = data.bActive };
+        }
+
+        [[nodiscard]] std::string GetGlyphLabelForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                                SteamInputDigitalActionHandle action) const override
+        {
+            const EInputActionOrigin origin = FirstDigitalOrigin(controller, actionSet, action);
+            return OriginLabel(origin);
+        }
+
+        [[nodiscard]] std::string GetGlyphLabelForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                               SteamInputAnalogActionHandle action) const override
+        {
+            const EInputActionOrigin origin = FirstAnalogOrigin(controller, actionSet, action);
+            return OriginLabel(origin);
+        }
+
+        [[nodiscard]] std::string GetGlyphPngForDigitalAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                              SteamInputDigitalActionHandle action) const override
+        {
+            const EInputActionOrigin origin = FirstDigitalOrigin(controller, actionSet, action);
+            return OriginGlyphPng(origin);
+        }
+
+        [[nodiscard]] std::string GetGlyphPngForAnalogAction(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                             SteamInputAnalogActionHandle action) const override
+        {
+            const EInputActionOrigin origin = FirstAnalogOrigin(controller, actionSet, action);
+            return OriginGlyphPng(origin);
+        }
+
       private:
+        [[nodiscard]] EInputActionOrigin FirstDigitalOrigin(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                            SteamInputDigitalActionHandle action) const
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input || controller == kInvalidSteamInputHandle ||
+                actionSet == kInvalidSteamInputActionSetHandle || action == kInvalidSteamInputDigitalActionHandle)
+            {
+                return k_EInputActionOrigin_None;
+            }
+            std::array<EInputActionOrigin, STEAM_INPUT_MAX_ORIGINS> origins{};
+            const int count = input->GetDigitalActionOrigins(static_cast<InputHandle_t>(controller),
+                                                             static_cast<InputActionSetHandle_t>(actionSet),
+                                                             static_cast<InputDigitalActionHandle_t>(action), origins.data());
+            return count > 0 ? origins[0] : k_EInputActionOrigin_None;
+        }
+
+        [[nodiscard]] EInputActionOrigin FirstAnalogOrigin(SteamInputHandle controller, SteamInputActionSetHandle actionSet,
+                                                           SteamInputAnalogActionHandle action) const
+        {
+            ISteamInput* input = SteamInput();
+            if (!m_InputInitialized || !input || controller == kInvalidSteamInputHandle ||
+                actionSet == kInvalidSteamInputActionSetHandle || action == kInvalidSteamInputAnalogActionHandle)
+            {
+                return k_EInputActionOrigin_None;
+            }
+            std::array<EInputActionOrigin, STEAM_INPUT_MAX_ORIGINS> origins{};
+            const int count = input->GetAnalogActionOrigins(static_cast<InputHandle_t>(controller),
+                                                            static_cast<InputActionSetHandle_t>(actionSet),
+                                                            static_cast<InputAnalogActionHandle_t>(action), origins.data());
+            return count > 0 ? origins[0] : k_EInputActionOrigin_None;
+        }
+
+        [[nodiscard]] std::string OriginLabel(EInputActionOrigin origin) const
+        {
+            if (origin == k_EInputActionOrigin_None)
+            {
+                return {};
+            }
+            ISteamInput* input = SteamInput();
+            if (!input)
+            {
+                return {};
+            }
+            const char* label = input->GetStringForActionOrigin(origin);
+            return label ? std::string{ label } : std::string{};
+        }
+
+        [[nodiscard]] std::string OriginGlyphPng(EInputActionOrigin origin) const
+        {
+            if (origin == k_EInputActionOrigin_None)
+            {
+                return {};
+            }
+            ISteamInput* input = SteamInput();
+            if (!input)
+            {
+                return {};
+            }
+            // Medium is a reasonable general-purpose size for an in-game prompt; callers that
+            // need a different size can add a parameter later, but nothing in the engine wants
+            // one today.
+            const char* path = input->GetGlyphPNGForActionOrigin(origin, k_ESteamInputGlyphSize_Medium, 0);
+            return path ? std::string{ path } : std::string{};
+        }
+
         void OnGameOverlayActivated(GameOverlayActivated_t* callback)
         {
             if (!callback)
@@ -425,6 +660,7 @@ namespace OloEngine
 
         bool m_Initialized = false;
         bool m_OverlayActive = false;
+        bool m_InputInitialized = false;
 
         // Manual registration (CCallbackManual): a CCallback registering in the constructor
         // would run before SteamAPI_Init, which is not valid. Registered in Initialize() only on

--- a/OloEngine/src/Platform/Steam/StubSDK/SteamStubControl.h
+++ b/OloEngine/src/Platform/Steam/StubSDK/SteamStubControl.h
@@ -83,8 +83,14 @@ namespace OloEngine::SteamStub
     // with active=false to simulate an action with no origin bound in the current set.
     void SetDigitalActionState(u64 controllerHandle, std::string_view actionName, bool pressed, bool active = true);
 
-    // Same idea for an analog action.
-    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active = true);
+    // Same idea for an analog action. `triggerMode` selects which of the two analog source
+    // modes SteamworksBackend actually branches on: false reports it as a JoystickMove-shaped
+    // action (already on this engine's -1..1 convention, x/y passed straight through); true
+    // reports it as Trigger-shaped, Valve's own 0..1-with-0-at-rest convention — exercising the
+    // normalization SteamworksBackend::GetAnalogActionState applies for that case. x/y are
+    // always the RAW value as Steam would report it for the selected mode; the stub does not
+    // pre-normalize.
+    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active = true, bool triggerMode = false);
 
     // Which action set is currently active for a controller, as recorded by ActivateActionSet.
     // Empty when never activated. Lets a test assert InputActionManager is routing action-set

--- a/OloEngine/src/Platform/Steam/StubSDK/SteamStubControl.h
+++ b/OloEngine/src/Platform/Steam/StubSDK/SteamStubControl.h
@@ -67,7 +67,37 @@ namespace OloEngine::SteamStub
 
     [[nodiscard]] bool CloudHasFile(std::string_view name);
 
+    // --- Steam Input ----------------------------------------------------------------------
+    //
+    // The stub does not model action manifests at all — GetActionSetHandle / GetDigitalAction-
+    // Handle / GetAnalogActionHandle hand back a stable handle for ANY name a caller passes
+    // (see SteamStubSDK.cpp), matching real Steam Input's behaviour for a name that exists in
+    // the game's manifest. A test drives behaviour purely through these knobs.
+
+    // Simulate a controller connecting/disconnecting. Handles are caller-chosen opaque
+    // non-zero values, mirroring how the real SDK hands back stable-for-the-session handles.
+    void SetConnectedControllers(const std::vector<u64>& controllerHandles);
+
+    // Set what GetDigitalActionState should report for (controller, action-name) pairs looked
+    // up via GetDigitalActionHandle(actionName). Active defaults to true once set here — call
+    // with active=false to simulate an action with no origin bound in the current set.
+    void SetDigitalActionState(u64 controllerHandle, std::string_view actionName, bool pressed, bool active = true);
+
+    // Same idea for an analog action.
+    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active = true);
+
+    // Which action set is currently active for a controller, as recorded by ActivateActionSet.
+    // Empty when never activated. Lets a test assert InputActionManager is routing action-set
+    // activation on a context switch rather than merely calling into the backend.
+    [[nodiscard]] std::string GetActiveActionSetName(u64 controllerHandle);
+
+    // Glyph label / PNG path the stub reports for an action name, regardless of which
+    // controller or action set is asked — real Steam Input varies these per physically
+    // connected controller, but the stub only needs to prove the engine reads them through.
+    void SetGlyphForAction(std::string_view actionName, std::string_view label, std::string_view pngPath);
+
     // Wipe all stub state back to defaults: init succeeds, no achievements, cloud on and empty,
-    // overlay closed. Tests must call this in SetUp so they cannot leak state into each other.
+    // overlay closed, no controllers connected. Tests must call this in SetUp so they cannot
+    // leak state into each other.
     void Reset();
 } // namespace OloEngine::SteamStub

--- a/OloEngine/src/Platform/Steam/StubSDK/SteamStubSDK.cpp
+++ b/OloEngine/src/Platform/Steam/StubSDK/SteamStubSDK.cpp
@@ -97,6 +97,14 @@ namespace
         // collide.
         std::map<int, std::string> OriginToActionName;
         int NextOrigin = 1000;
+
+        // Backing storage for GetStringForActionOrigin / GetGlyphPNGForActionOrigin's returned
+        // const char*, on the same "valid until the next call" contract as LastEnumeratedName
+        // above — but kept as its OWN member rather than reusing that one. The two accessors
+        // serve unrelated SDK surfaces (ISteamRemoteStorage's file enumeration vs ISteamInput's
+        // glyph lookup), and sharing a single string would silently invalidate whichever
+        // pointer was returned first the moment the other surface is called.
+        std::string LastGlyphString;
     };
 
     StubState& State()
@@ -568,8 +576,8 @@ const char* ISteamInput::GetStringForActionOrigin(EInputActionOrigin eOrigin)
     // A test that never called SetGlyphForAction still gets a non-empty, obviously-synthetic
     // label rather than an empty string — matching the "real failure vs stubbed value must
     // never be confused" rule the rest of this stub follows for its error strings.
-    state.LastEnumeratedName = labelIt != state.GlyphLabelByAction.end() ? labelIt->second : "stub SDK: unlabelled origin";
-    return state.LastEnumeratedName.c_str();
+    state.LastGlyphString = labelIt != state.GlyphLabelByAction.end() ? labelIt->second : "stub SDK: unlabelled origin";
+    return state.LastGlyphString.c_str();
 }
 
 const char* ISteamInput::GetGlyphPNGForActionOrigin(EInputActionOrigin eOrigin, ESteamInputGlyphSize /*eSize*/, uint32 /*unFlags*/)
@@ -578,8 +586,8 @@ const char* ISteamInput::GetGlyphPNGForActionOrigin(EInputActionOrigin eOrigin, 
     const auto nameIt = state.OriginToActionName.find(static_cast<int>(eOrigin));
     const std::string* actionName = nameIt != state.OriginToActionName.end() ? &nameIt->second : nullptr;
     const auto pngIt = actionName ? state.GlyphPngByAction.find(*actionName) : state.GlyphPngByAction.end();
-    state.LastEnumeratedName = pngIt != state.GlyphPngByAction.end() ? pngIt->second : std::string{};
-    return state.LastEnumeratedName.c_str();
+    state.LastGlyphString = pngIt != state.GlyphPngByAction.end() ? pngIt->second : std::string{};
+    return state.LastGlyphString.c_str();
 }
 
 // --- control surface --------------------------------------------------------------------
@@ -675,10 +683,11 @@ namespace OloEngine::SteamStub
             InputDigitalActionData_t{ .bState = pressed, .bActive = active };
     }
 
-    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active)
+    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active, bool triggerMode)
     {
-        State().AnalogActionStateByName[{ controllerHandle, std::string{ actionName } }] =
-            InputAnalogActionData_t{ .x = x, .y = y, .bActive = active };
+        State().AnalogActionStateByName[{ controllerHandle, std::string{ actionName } }] = InputAnalogActionData_t{
+            .eMode = triggerMode ? k_EInputSourceMode_Trigger : k_EInputSourceMode_JoystickMove, .x = x, .y = y, .bActive = active
+        };
     }
 
     std::string GetActiveActionSetName(u64 controllerHandle)
@@ -736,7 +745,7 @@ namespace OloEngine::SteamStub
     }
     void SetConnectedControllers(const std::vector<u64>&) {}
     void SetDigitalActionState(u64, std::string_view, bool, bool) {}
-    void SetAnalogActionState(u64, std::string_view, f32, f32, bool) {}
+    void SetAnalogActionState(u64, std::string_view, f32, f32, bool, bool) {}
     std::string GetActiveActionSetName(u64)
     {
         return {};

--- a/OloEngine/src/Platform/Steam/StubSDK/SteamStubSDK.cpp
+++ b/OloEngine/src/Platform/Steam/StubSDK/SteamStubSDK.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -60,6 +61,42 @@ namespace
         // returns a pointer into Steam-owned memory valid until the next call; matching that
         // contract with a member keeps callers honest about not retaining it.
         std::string LastEnumeratedName;
+
+        // --- Steam Input ---------------------------------------------------------------
+        bool InputInitialized = false;
+        std::vector<u64> ConnectedControllers;
+
+        // The stub does not model an action manifest: any name handed to GetActionSetHandle /
+        // GetDigitalActionHandle / GetAnalogActionHandle gets a stable handle, assigned on
+        // first sight. Real Steam Input only recognises names present in the game's manifest;
+        // the stub can't see one (there is no manifest in a CI checkout), so it trusts the
+        // caller instead — exactly the same trust the rest of this stub places in the engine.
+        std::map<std::string, u64, std::less<>> ActionSetHandles;
+        std::map<std::string, u64, std::less<>> DigitalActionHandles;
+        std::map<std::string, u64, std::less<>> AnalogActionHandles;
+        u64 NextHandle = 1;
+
+        std::map<u64, std::string> ActiveActionSetByController;
+        // Keyed by (controller handle, action NAME) rather than the numeric handle, so
+        // SteamStub::SetDigitalActionState can be called before or after the engine has
+        // resolved a handle for that name — test setup order shouldn't matter.
+        std::map<std::pair<u64, std::string>, InputDigitalActionData_t> DigitalActionStateByName;
+        std::map<std::pair<u64, std::string>, InputAnalogActionData_t> AnalogActionStateByName;
+        // Reverse lookup so GetDigitalActionData(handle) can find the name the state was keyed
+        // under.
+        std::map<u64, std::string> DigitalHandleToName;
+        std::map<u64, std::string> AnalogHandleToName;
+
+        std::map<std::string, std::string, std::less<>> GlyphLabelByAction;
+        std::map<std::string, std::string, std::less<>> GlyphPngByAction;
+
+        // Fabricated per-action "origin" so GetStringForActionOrigin / GetGlyphPNGForActionOrigin
+        // — which the real SDK keys purely off the origin, not the action — can still find their
+        // way back to the action name the origin was handed out for. Starts well above the one
+        // named EInputActionOrigin constant the stub declares, so the two numbering spaces never
+        // collide.
+        std::map<int, std::string> OriginToActionName;
+        int NextOrigin = 1000;
     };
 
     StubState& State()
@@ -73,6 +110,39 @@ namespace
     ISteamFriends s_Friends;
     ISteamUtils s_Utils;
     ISteamRemoteStorage s_RemoteStorage;
+    ISteamInput s_Input;
+
+    // First-sight handle assignment shared by GetActionSetHandle / GetDigitalActionHandle /
+    // GetAnalogActionHandle — see the comment on StubState::ActionSetHandles for why the stub
+    // doesn't validate names against a manifest.
+    u64 InternHandle(std::map<std::string, u64, std::less<>>& table, std::string_view name)
+    {
+        if (const auto found = table.find(name); found != table.end())
+        {
+            return found->second;
+        }
+        StubState& state = State();
+        const u64 handle = state.NextHandle++;
+        table.emplace(std::string{ name }, handle);
+        return handle;
+    }
+
+    // First-sight origin assignment for an action name, and the reverse entry that lets
+    // GetStringForActionOrigin / GetGlyphPNGForActionOrigin find their way back to it — see the
+    // comment on StubState::OriginToActionName.
+    int AssignOrigin(StubState& state, const std::string& actionName)
+    {
+        for (const auto& [origin, name] : state.OriginToActionName)
+        {
+            if (name == actionName)
+            {
+                return origin;
+            }
+        }
+        const int origin = state.NextOrigin++;
+        state.OriginToActionName.emplace(origin, actionName);
+        return origin;
+    }
 } // namespace
 
 // --- init / shutdown --------------------------------------------------------------------
@@ -346,6 +416,172 @@ ISteamRemoteStorage* SteamRemoteStorage()
     return State().Initialized ? &s_RemoteStorage : nullptr;
 }
 
+ISteamInput* SteamInput()
+{
+    // Steam Input's accessor is available whenever SteamAPI itself is up — Init() below is
+    // what actually brings the subsystem online, matching the real SDK's two-step contract
+    // (SteamInput() can return non-null before ISteamInput::Init() has been called).
+    return State().Initialized ? &s_Input : nullptr;
+}
+
+// --- ISteamInput --------------------------------------------------------------------------
+
+bool ISteamInput::Init(bool /*bExplicitlyCallRunFrame*/)
+{
+    State().InputInitialized = true;
+    return true;
+}
+
+bool ISteamInput::Shutdown()
+{
+    State().InputInitialized = false;
+    return true;
+}
+
+void ISteamInput::RunFrame(bool /*bReservedValue*/) {}
+
+int ISteamInput::GetConnectedControllers(InputHandle_t* handlesOut)
+{
+    if (!handlesOut)
+    {
+        return 0;
+    }
+    const StubState& state = State();
+    const int count = static_cast<int>(std::min(state.ConnectedControllers.size(), static_cast<sizet>(STEAM_INPUT_MAX_COUNT)));
+    for (int i = 0; i < count; ++i)
+    {
+        handlesOut[i] = static_cast<InputHandle_t>(state.ConnectedControllers[static_cast<sizet>(i)]);
+    }
+    return count;
+}
+
+InputActionSetHandle_t ISteamInput::GetActionSetHandle(const char* pszActionSetName)
+{
+    if (!pszActionSetName)
+    {
+        return 0;
+    }
+    return static_cast<InputActionSetHandle_t>(InternHandle(State().ActionSetHandles, pszActionSetName));
+}
+
+void ISteamInput::ActivateActionSet(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle)
+{
+    StubState& state = State();
+    for (const auto& [name, handle] : state.ActionSetHandles)
+    {
+        if (handle == static_cast<u64>(actionSetHandle))
+        {
+            state.ActiveActionSetByController[static_cast<u64>(inputHandle)] = name;
+            return;
+        }
+    }
+}
+
+InputDigitalActionHandle_t ISteamInput::GetDigitalActionHandle(const char* pszActionName)
+{
+    if (!pszActionName)
+    {
+        return 0;
+    }
+    StubState& state = State();
+    const u64 handle = InternHandle(state.DigitalActionHandles, pszActionName);
+    state.DigitalHandleToName[handle] = pszActionName;
+    return static_cast<InputDigitalActionHandle_t>(handle);
+}
+
+InputDigitalActionData_t ISteamInput::GetDigitalActionData(InputHandle_t inputHandle, InputDigitalActionHandle_t digitalActionHandle)
+{
+    const StubState& state = State();
+    const auto nameIt = state.DigitalHandleToName.find(static_cast<u64>(digitalActionHandle));
+    if (nameIt == state.DigitalHandleToName.end())
+    {
+        return {};
+    }
+    const auto stateIt = state.DigitalActionStateByName.find({ static_cast<u64>(inputHandle), nameIt->second });
+    return stateIt != state.DigitalActionStateByName.end() ? stateIt->second : InputDigitalActionData_t{};
+}
+
+int ISteamInput::GetDigitalActionOrigins(InputHandle_t /*inputHandle*/, InputActionSetHandle_t /*actionSetHandle*/,
+                                         InputDigitalActionHandle_t digitalActionHandle, EInputActionOrigin* originsOut)
+{
+    if (!originsOut)
+    {
+        return 0;
+    }
+    StubState& state = State();
+    const auto nameIt = state.DigitalHandleToName.find(static_cast<u64>(digitalActionHandle));
+    if (nameIt == state.DigitalHandleToName.end())
+    {
+        return 0;
+    }
+    originsOut[0] = static_cast<EInputActionOrigin>(AssignOrigin(state, nameIt->second));
+    return 1;
+}
+
+InputAnalogActionHandle_t ISteamInput::GetAnalogActionHandle(const char* pszActionName)
+{
+    if (!pszActionName)
+    {
+        return 0;
+    }
+    StubState& state = State();
+    const u64 handle = InternHandle(state.AnalogActionHandles, pszActionName);
+    state.AnalogHandleToName[handle] = pszActionName;
+    return static_cast<InputAnalogActionHandle_t>(handle);
+}
+
+InputAnalogActionData_t ISteamInput::GetAnalogActionData(InputHandle_t inputHandle, InputAnalogActionHandle_t analogActionHandle)
+{
+    const StubState& state = State();
+    const auto nameIt = state.AnalogHandleToName.find(static_cast<u64>(analogActionHandle));
+    if (nameIt == state.AnalogHandleToName.end())
+    {
+        return {};
+    }
+    const auto stateIt = state.AnalogActionStateByName.find({ static_cast<u64>(inputHandle), nameIt->second });
+    return stateIt != state.AnalogActionStateByName.end() ? stateIt->second : InputAnalogActionData_t{};
+}
+
+int ISteamInput::GetAnalogActionOrigins(InputHandle_t /*inputHandle*/, InputActionSetHandle_t /*actionSetHandle*/,
+                                        InputAnalogActionHandle_t analogActionHandle, EInputActionOrigin* originsOut)
+{
+    if (!originsOut)
+    {
+        return 0;
+    }
+    StubState& state = State();
+    const auto nameIt = state.AnalogHandleToName.find(static_cast<u64>(analogActionHandle));
+    if (nameIt == state.AnalogHandleToName.end())
+    {
+        return 0;
+    }
+    originsOut[0] = static_cast<EInputActionOrigin>(AssignOrigin(state, nameIt->second));
+    return 1;
+}
+
+const char* ISteamInput::GetStringForActionOrigin(EInputActionOrigin eOrigin)
+{
+    StubState& state = State();
+    const auto nameIt = state.OriginToActionName.find(static_cast<int>(eOrigin));
+    const std::string* actionName = nameIt != state.OriginToActionName.end() ? &nameIt->second : nullptr;
+    const auto labelIt = actionName ? state.GlyphLabelByAction.find(*actionName) : state.GlyphLabelByAction.end();
+    // A test that never called SetGlyphForAction still gets a non-empty, obviously-synthetic
+    // label rather than an empty string — matching the "real failure vs stubbed value must
+    // never be confused" rule the rest of this stub follows for its error strings.
+    state.LastEnumeratedName = labelIt != state.GlyphLabelByAction.end() ? labelIt->second : "stub SDK: unlabelled origin";
+    return state.LastEnumeratedName.c_str();
+}
+
+const char* ISteamInput::GetGlyphPNGForActionOrigin(EInputActionOrigin eOrigin, ESteamInputGlyphSize /*eSize*/, uint32 /*unFlags*/)
+{
+    StubState& state = State();
+    const auto nameIt = state.OriginToActionName.find(static_cast<int>(eOrigin));
+    const std::string* actionName = nameIt != state.OriginToActionName.end() ? &nameIt->second : nullptr;
+    const auto pngIt = actionName ? state.GlyphPngByAction.find(*actionName) : state.GlyphPngByAction.end();
+    state.LastEnumeratedName = pngIt != state.GlyphPngByAction.end() ? pngIt->second : std::string{};
+    return state.LastEnumeratedName.c_str();
+}
+
 // --- control surface --------------------------------------------------------------------
 
 namespace OloEngine::SteamStub
@@ -428,6 +664,37 @@ namespace OloEngine::SteamStub
         return State().CloudFiles.contains(name);
     }
 
+    void SetConnectedControllers(const std::vector<u64>& controllerHandles)
+    {
+        State().ConnectedControllers = controllerHandles;
+    }
+
+    void SetDigitalActionState(u64 controllerHandle, std::string_view actionName, bool pressed, bool active)
+    {
+        State().DigitalActionStateByName[{ controllerHandle, std::string{ actionName } }] =
+            InputDigitalActionData_t{ .bState = pressed, .bActive = active };
+    }
+
+    void SetAnalogActionState(u64 controllerHandle, std::string_view actionName, f32 x, f32 y, bool active)
+    {
+        State().AnalogActionStateByName[{ controllerHandle, std::string{ actionName } }] =
+            InputAnalogActionData_t{ .x = x, .y = y, .bActive = active };
+    }
+
+    std::string GetActiveActionSetName(u64 controllerHandle)
+    {
+        const StubState& state = State();
+        const auto found = state.ActiveActionSetByController.find(controllerHandle);
+        return found != state.ActiveActionSetByController.end() ? found->second : std::string{};
+    }
+
+    void SetGlyphForAction(std::string_view actionName, std::string_view label, std::string_view pngPath)
+    {
+        StubState& state = State();
+        state.GlyphLabelByAction[std::string{ actionName }] = std::string{ label };
+        state.GlyphPngByAction[std::string{ actionName }] = std::string{ pngPath };
+    }
+
     void Reset()
     {
         // Whole-struct reassignment rather than field-by-field, so a member added later is reset
@@ -467,6 +734,14 @@ namespace OloEngine::SteamStub
     {
         return false;
     }
+    void SetConnectedControllers(const std::vector<u64>&) {}
+    void SetDigitalActionState(u64, std::string_view, bool, bool) {}
+    void SetAnalogActionState(u64, std::string_view, f32, f32, bool) {}
+    std::string GetActiveActionSetName(u64)
+    {
+        return {};
+    }
+    void SetGlyphForAction(std::string_view, std::string_view, std::string_view) {}
     void Reset() {}
 } // namespace OloEngine::SteamStub
 

--- a/OloEngine/src/Platform/Steam/StubSDK/public/steam/steam_api.h
+++ b/OloEngine/src/Platform/Steam/StubSDK/public/steam/steam_api.h
@@ -167,3 +167,72 @@ ISteamUserStats* SteamUserStats();
 ISteamFriends* SteamFriends();
 ISteamUtils* SteamUtils();
 ISteamRemoteStorage* SteamRemoteStorage();
+
+// --- Steam Input --------------------------------------------------------------------------
+//
+// Only the entry points SteamworksBackend.cpp calls, same rule as the rest of this file.
+
+using InputHandle_t = uint64;
+using InputActionSetHandle_t = uint64;
+using InputDigitalActionHandle_t = uint64;
+using InputAnalogActionHandle_t = uint64;
+
+inline constexpr int STEAM_INPUT_MAX_COUNT = 16;
+inline constexpr int STEAM_INPUT_MAX_ORIGINS = 8;
+
+// A tiny slice of the real EInputActionOrigin enum — enough to exercise "an origin was found"
+// vs "nothing is bound" (k_EInputActionOrigin_None) without reproducing Valve's ~300-entry
+// per-controller-type enum.
+enum EInputActionOrigin
+{
+    k_EInputActionOrigin_None = 0,
+    k_EInputActionOrigin_XBoxOne_A = 1,
+};
+
+enum ESteamInputGlyphSize
+{
+    k_ESteamInputGlyphSize_Small = 0,
+    k_ESteamInputGlyphSize_Medium = 1,
+    k_ESteamInputGlyphSize_Large = 2,
+};
+
+struct InputDigitalActionData_t
+{
+    bool bState;
+    bool bActive;
+};
+
+struct InputAnalogActionData_t
+{
+    float x;
+    float y;
+    bool bActive;
+};
+
+class ISteamInput
+{
+  public:
+    bool Init(bool bExplicitlyCallRunFrame);
+    bool Shutdown();
+    void RunFrame(bool bReservedValue = true);
+
+    int GetConnectedControllers(InputHandle_t* handlesOut);
+
+    InputActionSetHandle_t GetActionSetHandle(const char* pszActionSetName);
+    void ActivateActionSet(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle);
+
+    InputDigitalActionHandle_t GetDigitalActionHandle(const char* pszActionName);
+    InputDigitalActionData_t GetDigitalActionData(InputHandle_t inputHandle, InputDigitalActionHandle_t digitalActionHandle);
+    int GetDigitalActionOrigins(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle,
+                                InputDigitalActionHandle_t digitalActionHandle, EInputActionOrigin* originsOut);
+
+    InputAnalogActionHandle_t GetAnalogActionHandle(const char* pszActionName);
+    InputAnalogActionData_t GetAnalogActionData(InputHandle_t inputHandle, InputAnalogActionHandle_t analogActionHandle);
+    int GetAnalogActionOrigins(InputHandle_t inputHandle, InputActionSetHandle_t actionSetHandle,
+                               InputAnalogActionHandle_t analogActionHandle, EInputActionOrigin* originsOut);
+
+    const char* GetStringForActionOrigin(EInputActionOrigin eOrigin);
+    const char* GetGlyphPNGForActionOrigin(EInputActionOrigin eOrigin, ESteamInputGlyphSize eSize, uint32 unFlags);
+};
+
+ISteamInput* SteamInput();

--- a/OloEngine/src/Platform/Steam/StubSDK/public/steam/steam_api.h
+++ b/OloEngine/src/Platform/Steam/StubSDK/public/steam/steam_api.h
@@ -202,8 +202,19 @@ struct InputDigitalActionData_t
     bool bActive;
 };
 
+// A tiny slice of the real EInputSourceMode enum — enough for SteamworksBackend to tell a
+// Trigger-mode analog action (Valve's own convention: 0..1, 0 = released) from one already in
+// this engine's -1..1 convention, without reproducing Valve's full ~16-entry enum.
+enum EInputSourceMode
+{
+    k_EInputSourceMode_None = 0,
+    k_EInputSourceMode_JoystickMove,
+    k_EInputSourceMode_Trigger,
+};
+
 struct InputAnalogActionData_t
 {
+    EInputSourceMode eMode = k_EInputSourceMode_None;
     float x;
     float y;
     bool bActive;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -905,14 +905,15 @@ add_executable(OloEngine-Tests
 		MCP/McpSelectEntityTest.cpp
 		# Lua Binding Tests
 		Lua/LuaBindingTest.cpp
-		# Steamworks platform integration (#644). All four run on EVERY configuration:
-		# the manager and binding tests drive a fake backend and need no Steam client at
-		# all, and the stub-SDK ON-path test SKIPs cleanly unless the build was configured
-		# with -DOLO_WITH_STEAM_STUB_SDK=ON.
+		# Steamworks platform integration (#644). All five run on EVERY configuration:
+		# the manager/binding/routing tests drive a fake backend and need no Steam client
+		# at all, and the stub-SDK ON-path test SKIPs cleanly unless the build was
+		# configured with -DOLO_WITH_STEAM_STUB_SDK=ON.
 		Platform/Steam/SteamManagerTest.cpp
 		Platform/Steam/SteamScriptBindingCoverageTest.cpp
 		Platform/Steam/SteamStubOnPathTest.cpp
 		Platform/Steam/SteamCloudSaveMirrorTest.cpp
+		Platform/Steam/SteamInputRoutingTest.cpp
 		# Functional / cross-subsystem world-tick tests (see ADR 0001).
 		Functional/FunctionalTest.cpp
 		Functional/UI/UINavigationTest.cpp

--- a/OloEngine/tests/Platform/Steam/FakeSteamBackend.h
+++ b/OloEngine/tests/Platform/Steam/FakeSteamBackend.h
@@ -239,7 +239,11 @@ namespace OloEngine::Testing
         std::map<std::string, SteamInputAnalogActionHandle, std::less<>> AnalogActionHandles;
         std::map<std::pair<SteamInputHandle, SteamInputDigitalActionHandle>, SteamInputDigitalActionState> DigitalActionStates;
         std::map<std::pair<SteamInputHandle, SteamInputAnalogActionHandle>, SteamInputAnalogActionState> AnalogActionStates;
-        std::map<std::pair<SteamInputHandle, SteamInputActionSetHandle>, std::string> ActiveActionSetNames;
+        // The action-set handle most recently activated for each controller — lets a test
+        // resolve the EXPECTED handle by name via GetActionSetHandle and compare it directly,
+        // rather than only counting calls (which would pass even if the wrong action set were
+        // activated).
+        std::map<SteamInputHandle, SteamInputActionSetHandle> LastActivatedActionSet;
         std::map<std::string, std::string, std::less<>> GlyphLabels;
         std::map<std::string, std::string, std::less<>> GlyphPngs;
 
@@ -282,7 +286,7 @@ namespace OloEngine::Testing
         void ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet) override
         {
             ++ActivateActionSetCalls;
-            ActiveActionSetNames[{ controller, actionSet }] = "activated";
+            LastActivatedActionSet[controller] = actionSet;
         }
 
         [[nodiscard]] SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view actionName) const override

--- a/OloEngine/tests/Platform/Steam/FakeSteamBackend.h
+++ b/OloEngine/tests/Platform/Steam/FakeSteamBackend.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace OloEngine::Testing
@@ -226,7 +227,146 @@ namespace OloEngine::Testing
             return SteamResult::Success;
         }
 
+        // --- Steam Input ----------------------------------------------------------------
+
+        // When false, InputInit() reports failure — Steam is up but Steam Input isn't, the
+        // same shape as a stats/achievements-only integration that skips it.
+        bool InputInitSucceeds = true;
+        bool InputInitialized = false;
+
+        std::vector<SteamInputHandle> ConnectedControllers;
+        std::map<std::string, SteamInputDigitalActionHandle, std::less<>> DigitalActionHandles;
+        std::map<std::string, SteamInputAnalogActionHandle, std::less<>> AnalogActionHandles;
+        std::map<std::pair<SteamInputHandle, SteamInputDigitalActionHandle>, SteamInputDigitalActionState> DigitalActionStates;
+        std::map<std::pair<SteamInputHandle, SteamInputAnalogActionHandle>, SteamInputAnalogActionState> AnalogActionStates;
+        std::map<std::pair<SteamInputHandle, SteamInputActionSetHandle>, std::string> ActiveActionSetNames;
+        std::map<std::string, std::string, std::less<>> GlyphLabels;
+        std::map<std::string, std::string, std::less<>> GlyphPngs;
+
+        u32 ActivateActionSetCalls = 0;
+        mutable SteamInputActionSetHandle NextHandle = 1;
+
+        bool InputInit() override
+        {
+            InputInitialized = InputInitSucceeds;
+            return InputInitialized;
+        }
+        void InputShutdown() override
+        {
+            InputInitialized = false;
+        }
+        void InputRunFrame() override {}
+        [[nodiscard]] bool IsInputAvailable() const override
+        {
+            return InputInitialized;
+        }
+        [[nodiscard]] std::vector<SteamInputHandle> GetConnectedControllers() const override
+        {
+            return ConnectedControllers;
+        }
+
+        [[nodiscard]] SteamInputActionSetHandle GetActionSetHandle(std::string_view actionSetName) const override
+        {
+            // The fake doesn't validate against a manifest, matching the stub SDK's contract
+            // (see StubState::ActionSetHandles) — any name gets a handle. Interned by name
+            // (first-sight assignment), also matching the stub's InternHandle: a caller that
+            // asks for the same action-set name twice must get the same handle back.
+            if (const auto found = m_ActionSetHandles.find(actionSetName); found != m_ActionSetHandles.end())
+            {
+                return found->second;
+            }
+            const SteamInputActionSetHandle handle = NextHandle++;
+            m_ActionSetHandles.emplace(std::string{ actionSetName }, handle);
+            return handle;
+        }
+        void ActivateActionSet(SteamInputHandle controller, SteamInputActionSetHandle actionSet) override
+        {
+            ++ActivateActionSetCalls;
+            ActiveActionSetNames[{ controller, actionSet }] = "activated";
+        }
+
+        [[nodiscard]] SteamInputDigitalActionHandle GetDigitalActionHandle(std::string_view actionName) const override
+        {
+            auto it = DigitalActionHandles.find(actionName);
+            return it != DigitalActionHandles.end() ? it->second : kInvalidSteamInputDigitalActionHandle;
+        }
+        [[nodiscard]] SteamInputDigitalActionState GetDigitalActionState(SteamInputHandle controller,
+                                                                         SteamInputDigitalActionHandle action) const override
+        {
+            auto it = DigitalActionStates.find({ controller, action });
+            return it != DigitalActionStates.end() ? it->second : SteamInputDigitalActionState{};
+        }
+
+        [[nodiscard]] SteamInputAnalogActionHandle GetAnalogActionHandle(std::string_view actionName) const override
+        {
+            auto it = AnalogActionHandles.find(actionName);
+            return it != AnalogActionHandles.end() ? it->second : kInvalidSteamInputAnalogActionHandle;
+        }
+        [[nodiscard]] SteamInputAnalogActionState GetAnalogActionState(SteamInputHandle controller,
+                                                                       SteamInputAnalogActionHandle action) const override
+        {
+            auto it = AnalogActionStates.find({ controller, action });
+            return it != AnalogActionStates.end() ? it->second : SteamInputAnalogActionState{};
+        }
+
+        [[nodiscard]] std::string GetGlyphLabelForDigitalAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                                SteamInputDigitalActionHandle action) const override
+        {
+            return GlyphLabelFor(FindDigitalActionName(action));
+        }
+        [[nodiscard]] std::string GetGlyphLabelForAnalogAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                               SteamInputAnalogActionHandle action) const override
+        {
+            return GlyphLabelFor(FindAnalogActionName(action));
+        }
+        [[nodiscard]] std::string GetGlyphPngForDigitalAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                              SteamInputDigitalActionHandle action) const override
+        {
+            return GlyphPngFor(FindDigitalActionName(action));
+        }
+        [[nodiscard]] std::string GetGlyphPngForAnalogAction(SteamInputHandle, SteamInputActionSetHandle,
+                                                             SteamInputAnalogActionHandle action) const override
+        {
+            return GlyphPngFor(FindAnalogActionName(action));
+        }
+
       private:
+        [[nodiscard]] std::string FindDigitalActionName(SteamInputDigitalActionHandle action) const
+        {
+            for (const auto& [name, handle] : DigitalActionHandles)
+            {
+                if (handle == action)
+                {
+                    return name;
+                }
+            }
+            return {};
+        }
+        [[nodiscard]] std::string FindAnalogActionName(SteamInputAnalogActionHandle action) const
+        {
+            for (const auto& [name, handle] : AnalogActionHandles)
+            {
+                if (handle == action)
+                {
+                    return name;
+                }
+            }
+            return {};
+        }
+        [[nodiscard]] std::string GlyphLabelFor(const std::string& name) const
+        {
+            auto it = GlyphLabels.find(name);
+            return it != GlyphLabels.end() ? it->second : std::string{};
+        }
+        [[nodiscard]] std::string GlyphPngFor(const std::string& name) const
+        {
+            auto it = GlyphPngs.find(name);
+            return it != GlyphPngs.end() ? it->second : std::string{};
+        }
+
         bool m_Available = false;
+
+        // Backs GetActionSetHandle's first-sight interning above.
+        mutable std::map<std::string, SteamInputActionSetHandle, std::less<>> m_ActionSetHandles;
     };
 } // namespace OloEngine::Testing

--- a/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
@@ -219,6 +219,15 @@ namespace
 
         InputActionManager::Update();
         EXPECT_FLOAT_EQ(InputActionManager::GetActionAxisValue("MoveLeft"), 0.0f);
+
+        // A zero result alone doesn't prove the clamp ran — Steam routing being entirely absent
+        // (a broken handle lookup, say) would ALSO read back 0.0f here. Prove it by also feeding
+        // a NEGATIVE deflection, which the binding's direction constraint must let through
+        // unclamped; only a value that changes with the input shows the Steam-sourced state is
+        // actually reaching GetActionAxisValue.
+        m_Fake->AnalogActionStates[{ 1, 45 }] = { .X = -0.6f, .Y = 0.0f, .Active = true };
+        InputActionManager::Update();
+        EXPECT_FLOAT_EQ(InputActionManager::GetActionAxisValue("MoveLeft"), -0.6f);
     }
 
     TEST_F(SteamInputRoutingTest, DisconnectingTheControllerFallsBackCleanly)

--- a/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
@@ -1,0 +1,205 @@
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// OLO_TEST_LAYER: unit
+//
+// InputActionManager's Steam Input routing (#893) — "Steam Input wins when available", see
+// docs/agent-rules/steamworks-platform-integration.md §11.
+//
+// Drives InputActionManager::Update() with SteamManager pointed at a FakeSteamBackend, so the
+// routing decision (activate the right action set, prefer Steam digital/analog state for
+// gamepad-origin bindings, never touch keyboard/mouse bindings, don't clobber a real Steam
+// analog magnitude with the "snap partial axis to full scale" fallback meant for the raw-gamepad
+// path) is exercised without a Steam client or a physical controller.
+
+#include "FakeSteamBackend.h"
+
+#include "OloEngine/Core/IInputProvider.h"
+#include "OloEngine/Core/InputAction.h"
+#include "OloEngine/Core/InputActionManager.h"
+#include "Platform/Steam/SteamManager.h"
+
+using OloEngine::GamepadAxis;
+using OloEngine::GamepadButton;
+using OloEngine::InputAction;
+using OloEngine::InputActionManager;
+using OloEngine::InputActionMap;
+using OloEngine::InputBinding;
+using OloEngine::InputContextType;
+namespace Key = OloEngine::Key;
+using OloEngine::SteamManager;
+using OloEngine::Testing::FakeSteamBackend;
+
+namespace
+{
+    // A minimal provider that reports nothing pressed — isolates the tests below to Steam
+    // Input's contribution rather than whatever GLFW/default gamepad state happens to be live.
+    class InertInputProvider final : public OloEngine::IInputProvider
+    {
+      public:
+        [[nodiscard]] bool IsKeyPressed(OloEngine::KeyCode) const override
+        {
+            return false;
+        }
+        [[nodiscard]] bool IsMouseButtonPressed(OloEngine::MouseCode) const override
+        {
+            return false;
+        }
+    };
+
+    class SteamInputRoutingTest : public ::testing::Test
+    {
+      protected:
+        InertInputProvider m_Provider;
+        FakeSteamBackend* m_Fake = nullptr;
+
+        void SetUp() override
+        {
+            auto backend = OloEngine::CreateScope<FakeSteamBackend>();
+            m_Fake = backend.get();
+            SteamManager::SetBackendForTesting(std::move(backend));
+            SteamManager::Initialize();
+            ASSERT_TRUE(SteamManager::IsInputAvailable());
+
+            InputActionManager::Init();
+            InputActionManager::SetInputProvider(&m_Provider);
+        }
+
+        void TearDown() override
+        {
+            InputActionManager::SetInputProvider(nullptr);
+            InputActionManager::Shutdown();
+            SteamManager::ResetForTesting();
+            m_Fake = nullptr;
+        }
+    };
+
+    TEST_F(SteamInputRoutingTest, NoConnectedControllerFallsBackToEngineBindingsUnchanged)
+    {
+        InputActionMap map;
+        map.AddAction({ "Jump", { InputBinding::GamepadBtn(GamepadButton::South) } });
+        InputActionManager::SetActionMap(map);
+
+        // No controllers connected on the fake — Steam must contribute nothing, and the
+        // GamepadButton binding falls back to the (inert) provider, i.e. not pressed.
+        InputActionManager::Update();
+        EXPECT_FALSE(InputActionManager::IsActionPressed("Jump"));
+    }
+
+    TEST_F(SteamInputRoutingTest, ConnectedControllerActivatesTheContextsActionSet)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        InputActionManager::SetActionMap(InputActionMap{});
+
+        InputActionManager::Update();
+
+        EXPECT_GE(m_Fake->ActivateActionSetCalls, 1u);
+    }
+
+    TEST_F(SteamInputRoutingTest, SteamDigitalActionDrivesAGamepadOriginAction)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        m_Fake->DigitalActionHandles["Jump"] = 42;
+        m_Fake->DigitalActionStates[{ 1, 42 }] = { .Pressed = true, .Active = true };
+
+        InputActionMap map;
+        map.AddAction({ "Jump", { InputBinding::GamepadBtn(GamepadButton::South) } });
+        InputActionManager::SetActionMap(map);
+
+        InputActionManager::Update();
+        EXPECT_TRUE(InputActionManager::IsActionPressed("Jump"));
+    }
+
+    // Active=false ("no origin bound in the current action set") must not be treated as
+    // "not pressed" in a way that overrides a genuinely-pressed keyboard/mouse binding on the
+    // same action — it must simply contribute nothing.
+    TEST_F(SteamInputRoutingTest, UnboundSteamActionDoesNotSuppressAKeyboardBinding)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        // No digital state configured for "Jump" -> Active=false from GetDigitalActionState.
+
+        InputActionMap map;
+        map.AddAction({ "Jump", { InputBinding::Key(Key::Space), InputBinding::GamepadBtn(GamepadButton::South) } });
+        InputActionManager::SetActionMap(map);
+
+        // Simulate the keyboard press through a provider that reports Space pressed.
+        class SpacePressedProvider final : public OloEngine::IInputProvider
+        {
+          public:
+            [[nodiscard]] bool IsKeyPressed(OloEngine::KeyCode key) const override
+            {
+                return key == Key::Space;
+            }
+            [[nodiscard]] bool IsMouseButtonPressed(OloEngine::MouseCode) const override
+            {
+                return false;
+            }
+        } provider;
+        InputActionManager::SetInputProvider(&provider);
+
+        InputActionManager::Update();
+        EXPECT_TRUE(InputActionManager::IsActionPressed("Jump"));
+
+        InputActionManager::SetInputProvider(&m_Provider);
+    }
+
+    TEST_F(SteamInputRoutingTest, SteamAnalogMagnitudeIsNotSnappedToFullScale)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        m_Fake->AnalogActionHandles["Throttle"] = 43;
+        // A real 40% pull, alongside a digitally-bound "pressed past threshold" origin on the
+        // SAME action — the shape the review flagged: without the fix, the pre-existing
+        // "snap partial axis to full scale when also pressed" fallback (meant for a weak/absent
+        // raw-gamepad axis) would clobber this into 1.0.
+        m_Fake->DigitalActionHandles["Throttle"] = 44;
+        m_Fake->DigitalActionStates[{ 1, 44 }] = { .Pressed = true, .Active = true };
+        m_Fake->AnalogActionStates[{ 1, 43 }] = { .X = 0.4f, .Y = 0.0f, .Active = true };
+
+        InputActionMap map;
+        map.AddAction({ "Throttle", { InputBinding::GamepadAx(GamepadAxis::RightTrigger) } });
+        InputActionManager::SetActionMap(map);
+
+        InputActionManager::Update();
+        EXPECT_TRUE(InputActionManager::IsActionPressed("Throttle"));
+        EXPECT_FLOAT_EQ(InputActionManager::GetActionAxisValue("Throttle"), 0.4f);
+    }
+
+    // The action's own AxisPositive constraint (the split-into-two-actions convention, e.g.
+    // "MoveLeft" bound to the negative half of an axis) must still gate the Steam-sourced value.
+    TEST_F(SteamInputRoutingTest, SteamAnalogValueRespectsTheBindingsAxisDirection)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        m_Fake->AnalogActionHandles["MoveLeft"] = 45;
+        // Steam reports a POSITIVE deflection; the engine binding constrains this action to the
+        // negative half of the axis, so it must clamp to 0, not report a positive value for a
+        // "left" action.
+        m_Fake->AnalogActionStates[{ 1, 45 }] = { .X = 0.7f, .Y = 0.0f, .Active = true };
+
+        InputActionMap map;
+        map.AddAction({ "MoveLeft", { InputBinding::GamepadAx(GamepadAxis::LeftX, 0.5f, /*positive*/ false) } });
+        InputActionManager::SetActionMap(map);
+
+        InputActionManager::Update();
+        EXPECT_FLOAT_EQ(InputActionManager::GetActionAxisValue("MoveLeft"), 0.0f);
+    }
+
+    TEST_F(SteamInputRoutingTest, DisconnectingTheControllerFallsBackCleanly)
+    {
+        m_Fake->ConnectedControllers = { 1 };
+        m_Fake->DigitalActionHandles["Jump"] = 42;
+        m_Fake->DigitalActionStates[{ 1, 42 }] = { .Pressed = true, .Active = true };
+
+        InputActionMap map;
+        map.AddAction({ "Jump", { InputBinding::GamepadBtn(GamepadButton::South) } });
+        InputActionManager::SetActionMap(map);
+
+        InputActionManager::Update();
+        ASSERT_TRUE(InputActionManager::IsActionPressed("Jump"));
+
+        // Controller disconnects mid-session.
+        m_Fake->ConnectedControllers.clear();
+        InputActionManager::Update();
+        EXPECT_FALSE(InputActionManager::IsActionPressed("Jump"))
+            << "action stayed pressed after the Steam Input controller disconnected";
+    }
+} // namespace

--- a/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp
@@ -74,16 +74,44 @@ namespace
         }
     };
 
-    TEST_F(SteamInputRoutingTest, NoConnectedControllerFallsBackToEngineBindingsUnchanged)
+    // A provider that always reports GamepadButton::South pressed, regardless of gamepad index
+    // — used to prove the GamepadButton binding actually reaches the raw provider when no Steam
+    // Input controller governs it. Asserting against the (inert) default provider instead would
+    // read "not pressed" whether or not the fallback path runs at all, since inert + broken
+    // routing look identical; this provider makes the fallback path's own contribution visible.
+    class SouthPressedProvider final : public OloEngine::IInputProvider
     {
+      public:
+        [[nodiscard]] bool IsKeyPressed(OloEngine::KeyCode) const override
+        {
+            return false;
+        }
+        [[nodiscard]] bool IsMouseButtonPressed(OloEngine::MouseCode) const override
+        {
+            return false;
+        }
+        [[nodiscard]] bool IsGamepadButtonPressed(GamepadButton button, i32) const override
+        {
+            return button == GamepadButton::South;
+        }
+    };
+
+    TEST_F(SteamInputRoutingTest, NoConnectedControllerFallsBackToEngineBindings)
+    {
+        SouthPressedProvider provider;
+        InputActionManager::SetInputProvider(&provider);
+
         InputActionMap map;
         map.AddAction({ "Jump", { InputBinding::GamepadBtn(GamepadButton::South) } });
         InputActionManager::SetActionMap(map);
 
-        // No controllers connected on the fake — Steam must contribute nothing, and the
-        // GamepadButton binding falls back to the (inert) provider, i.e. not pressed.
+        // No controllers connected on the fake — Steam must contribute nothing, so the
+        // GamepadButton binding must fall all the way through to the raw provider, which
+        // reports it pressed.
         InputActionManager::Update();
-        EXPECT_FALSE(InputActionManager::IsActionPressed("Jump"));
+        EXPECT_TRUE(InputActionManager::IsActionPressed("Jump"));
+
+        InputActionManager::SetInputProvider(&m_Provider);
     }
 
     TEST_F(SteamInputRoutingTest, ConnectedControllerActivatesTheContextsActionSet)
@@ -91,9 +119,19 @@ namespace
         m_Fake->ConnectedControllers = { 1 };
         InputActionManager::SetActionMap(InputActionMap{});
 
+        // The active context is Gameplay (InputActionManager's default), so the action set
+        // activated must be the one GetActionSetHandle("Gameplay") resolves to — not just SOME
+        // handle. Resolved via the same interning path InputActionManager itself uses, so a
+        // routing bug that activated a different context's set (or a stale/wrong handle) would
+        // fail this even though ActivateActionSetCalls alone would still show >= 1.
+        const auto expectedHandle = SteamManager::GetActionSetHandle("Gameplay");
+
         InputActionManager::Update();
 
-        EXPECT_GE(m_Fake->ActivateActionSetCalls, 1u);
+        ASSERT_GE(m_Fake->ActivateActionSetCalls, 1u);
+        const auto it = m_Fake->LastActivatedActionSet.find(1);
+        ASSERT_NE(it, m_Fake->LastActivatedActionSet.end()) << "no action set was activated for controller 1";
+        EXPECT_EQ(it->second, expectedHandle);
     }
 
     TEST_F(SteamInputRoutingTest, SteamDigitalActionDrivesAGamepadOriginAction)

--- a/OloEngine/tests/Platform/Steam/SteamManagerTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamManagerTest.cpp
@@ -467,6 +467,98 @@ namespace
     }
 
     // =================================================================================
+    // Steam Input.
+    // =================================================================================
+
+    TEST_F(SteamManagerTest, InputIsUnavailableUntilInitializeSucceedsAndAControllerIsConnected)
+    {
+        // Steam itself up, Steam Input never brought up (default fake state) — degrades same as
+        // no controller at all.
+        InitializeManager();
+        EXPECT_TRUE(SteamManager::IsAvailable());
+        EXPECT_TRUE(SteamManager::IsInputAvailable()) << "InputInit() runs automatically as part of Initialize()";
+        EXPECT_TRUE(SteamManager::GetConnectedControllers().empty());
+    }
+
+    TEST_F(SteamManagerTest, FailedInputInitLeavesInputUnavailableButSteamItselfFine)
+    {
+        m_Fake->InputInitSucceeds = false;
+        InitializeManager();
+
+        EXPECT_TRUE(SteamManager::IsAvailable()) << "a Steam Input failure must not take down the rest of Steam";
+        EXPECT_FALSE(SteamManager::IsInputAvailable());
+        EXPECT_TRUE(SteamManager::GetConnectedControllers().empty());
+    }
+
+    TEST_F(SteamManagerTest, ActivateActionSetReachesTheBackend)
+    {
+        InitializeManager();
+        m_Fake->ConnectedControllers = { 1 };
+
+        const auto controllers = SteamManager::GetConnectedControllers();
+        ASSERT_EQ(controllers.size(), 1u);
+
+        const auto actionSet = SteamManager::GetActionSetHandle("Gameplay");
+        SteamManager::ActivateActionSet(controllers[0], actionSet);
+        EXPECT_EQ(m_Fake->ActivateActionSetCalls, 1u);
+    }
+
+    TEST_F(SteamManagerTest, DigitalActionStatePassesThroughUnavailableWhenNotBound)
+    {
+        InitializeManager();
+        const auto handle = SteamManager::GetDigitalActionHandle("Jump");
+
+        // No state configured on the fake for this (controller, handle) pair — must report
+        // Active=false ("not bound"), not fabricate a pressed state.
+        const auto state = SteamManager::GetDigitalActionState(1, handle);
+        EXPECT_FALSE(state.Active);
+        EXPECT_FALSE(state.Pressed);
+    }
+
+    TEST_F(SteamManagerTest, DigitalAndAnalogActionStateReachTheBackend)
+    {
+        InitializeManager();
+        m_Fake->DigitalActionHandles["Jump"] = 42;
+        m_Fake->AnalogActionHandles["Move"] = 43;
+        m_Fake->DigitalActionStates[{ 1, 42 }] = { .Pressed = true, .Active = true };
+        m_Fake->AnalogActionStates[{ 1, 43 }] = { .X = 0.5f, .Y = -0.25f, .Active = true };
+
+        const auto digitalHandle = SteamManager::GetDigitalActionHandle("Jump");
+        const auto digitalState = SteamManager::GetDigitalActionState(1, digitalHandle);
+        EXPECT_TRUE(digitalState.Active);
+        EXPECT_TRUE(digitalState.Pressed);
+
+        const auto analogHandle = SteamManager::GetAnalogActionHandle("Move");
+        const auto analogState = SteamManager::GetAnalogActionState(1, analogHandle);
+        EXPECT_TRUE(analogState.Active);
+        EXPECT_FLOAT_EQ(analogState.X, 0.5f);
+        EXPECT_FLOAT_EQ(analogState.Y, -0.25f);
+    }
+
+    TEST_F(SteamManagerTest, GlyphLookupReachesTheBackend)
+    {
+        InitializeManager();
+        m_Fake->DigitalActionHandles["Jump"] = 42;
+        m_Fake->GlyphLabels["Jump"] = "A Button";
+        m_Fake->GlyphPngs["Jump"] = "/glyphs/a_button.png";
+
+        const auto handle = SteamManager::GetDigitalActionHandle("Jump");
+        EXPECT_EQ(SteamManager::GetGlyphLabelForDigitalAction(1, 0, handle), "A Button");
+        EXPECT_EQ(SteamManager::GetGlyphPngForDigitalAction(1, 0, handle), "/glyphs/a_button.png");
+    }
+
+    TEST_F(SteamManagerTest, InputSurfaceNoOpsWhenSteamUnavailable)
+    {
+        // Never initialized — the whole surface must be inert, matching every other entry point.
+        EXPECT_FALSE(SteamManager::IsInputAvailable());
+        EXPECT_TRUE(SteamManager::GetConnectedControllers().empty());
+        EXPECT_EQ(SteamManager::GetActionSetHandle("Gameplay"), OloEngine::kInvalidSteamInputActionSetHandle);
+        EXPECT_EQ(SteamManager::GetDigitalActionHandle("Jump"), OloEngine::kInvalidSteamInputDigitalActionHandle);
+        EXPECT_NO_THROW(SteamManager::ActivateActionSet(1, 1));
+        EXPECT_TRUE(SteamManager::GetGlyphLabelForDigitalAction(1, 1, 1).empty());
+    }
+
+    // =================================================================================
     // SteamResult helpers.
     // =================================================================================
 

--- a/OloEngine/tests/Platform/Steam/SteamManagerTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamManagerTest.cpp
@@ -470,10 +470,11 @@ namespace
     // Steam Input.
     // =================================================================================
 
-    TEST_F(SteamManagerTest, InputIsUnavailableUntilInitializeSucceedsAndAControllerIsConnected)
+    TEST_F(SteamManagerTest, InputIsAvailableOnSuccessfulInitEvenWithNoControllerConnected)
     {
-        // Steam itself up, Steam Input never brought up (default fake state) — degrades same as
-        // no controller at all.
+        // IsInputAvailable() reports Steam Input's own init state, NOT connection state — a
+        // desktop player with no controller plugged in is a completely ordinary case, and this
+        // asserts that case is NOT mistaken for Steam Input having failed to come up.
         InitializeManager();
         EXPECT_TRUE(SteamManager::IsAvailable());
         EXPECT_TRUE(SteamManager::IsInputAvailable()) << "InputInit() runs automatically as part of Initialize()";

--- a/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
@@ -410,6 +410,10 @@ namespace
         SteamStub::SetAnalogActionState(1, "Accelerate", /*x*/ 0.5f, /*y*/ 0.0f, /*active*/ true, /*triggerMode*/ true);
 
         const auto state = SteamManager::GetAnalogActionState(1, handle);
+        // Active must be checked too — a broken lookup (Steam routing never applied at all)
+        // ALSO returns X=0.0f by default, which would make the float assertion below pass for
+        // the wrong reason.
+        EXPECT_TRUE(state.Active);
         EXPECT_FLOAT_EQ(state.X, 0.0f);
     }
 

--- a/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
@@ -312,6 +312,112 @@ namespace
         EXPECT_EQ(SteamManager::CloudRead("empty.sav", readBack), SteamResult::NotFound);
     }
 
+    // =================================================================================
+    // Steam Input through the real ISteamInput calls.
+    // =================================================================================
+
+    TEST_F(SteamStubOnPathTest, InputComesUpAutomaticallyWithSteamItself)
+    {
+        SteamManager::Initialize();
+        EXPECT_TRUE(SteamManager::IsInputAvailable());
+    }
+
+    TEST_F(SteamStubOnPathTest, NoControllersConnectedIsTheOrdinaryState)
+    {
+        SteamManager::Initialize();
+        EXPECT_TRUE(SteamManager::GetConnectedControllers().empty());
+    }
+
+    TEST_F(SteamStubOnPathTest, ConnectedControllersRoundTripThroughTheSdk)
+    {
+        SteamStub::SetConnectedControllers({ 1, 2 });
+        SteamManager::Initialize();
+
+        const auto controllers = SteamManager::GetConnectedControllers();
+        ASSERT_EQ(controllers.size(), 2u);
+        EXPECT_EQ(controllers[0], 1u);
+        EXPECT_EQ(controllers[1], 2u);
+    }
+
+    TEST_F(SteamStubOnPathTest, ActivateActionSetReachesTheSdk)
+    {
+        SteamStub::SetConnectedControllers({ 1 });
+        SteamManager::Initialize();
+
+        const auto actionSet = SteamManager::GetActionSetHandle("Gameplay");
+        SteamManager::ActivateActionSet(1, actionSet);
+        EXPECT_EQ(SteamStub::GetActiveActionSetName(1), "Gameplay");
+    }
+
+    // An action with no configured state reports Active=false — "not bound", not a fabricated
+    // press — which is what lets InputActionManager fall back to the engine's own bindings.
+    TEST_F(SteamStubOnPathTest, UnboundDigitalActionReportsInactive)
+    {
+        SteamManager::Initialize();
+        const auto handle = SteamManager::GetDigitalActionHandle("Jump");
+        const auto state = SteamManager::GetDigitalActionState(1, handle);
+        EXPECT_FALSE(state.Active);
+    }
+
+    TEST_F(SteamStubOnPathTest, DigitalAndAnalogActionStateReachTheSdk)
+    {
+        SteamManager::Initialize();
+
+        const auto digitalHandle = SteamManager::GetDigitalActionHandle("Jump");
+        SteamStub::SetDigitalActionState(1, "Jump", /*pressed*/ true);
+        const auto digitalState = SteamManager::GetDigitalActionState(1, digitalHandle);
+        EXPECT_TRUE(digitalState.Active);
+        EXPECT_TRUE(digitalState.Pressed);
+
+        const auto analogHandle = SteamManager::GetAnalogActionHandle("Move");
+        SteamStub::SetAnalogActionState(1, "Move", 0.75f, -0.5f);
+        const auto analogState = SteamManager::GetAnalogActionState(1, analogHandle);
+        EXPECT_TRUE(analogState.Active);
+        EXPECT_FLOAT_EQ(analogState.X, 0.75f);
+        EXPECT_FLOAT_EQ(analogState.Y, -0.5f);
+    }
+
+    // Glyph lookup through GetDigitalActionOrigins -> GetStringForActionOrigin /
+    // GetGlyphPNGForActionOrigin — the real chain a button prompt takes, not a shortcut keyed
+    // straight off the action name.
+    TEST_F(SteamStubOnPathTest, GlyphLookupReachesTheSdkThroughOrigins)
+    {
+        SteamManager::Initialize();
+        SteamStub::SetGlyphForAction("Jump", "A Button", "/glyphs/a_button.png");
+
+        // A real (non-zero) action set handle is required here: GetDigitalActionOrigins is the
+        // real Valve API contract, and SteamworksBackend rejects kInvalidSteamInputActionSetHandle
+        // (0) before ever reaching the SDK — the stub itself ignores the actionSet value, but the
+        // backend's own guard does not, so passing the sentinel here always resolves to "no origin".
+        const auto actionSet = SteamManager::GetActionSetHandle("Gameplay");
+        const auto handle = SteamManager::GetDigitalActionHandle("Jump");
+        EXPECT_EQ(SteamManager::GetGlyphLabelForDigitalAction(1, actionSet, handle), "A Button");
+        EXPECT_EQ(SteamManager::GetGlyphPngForDigitalAction(1, actionSet, handle), "/glyphs/a_button.png");
+    }
+
+    TEST_F(SteamStubOnPathTest, GlyphLookupForAnUnconfiguredActionIsNotConfusedWithARealFailure)
+    {
+        SteamManager::Initialize();
+        const auto actionSet = SteamManager::GetActionSetHandle("Gameplay");
+        const auto handle = SteamManager::GetDigitalActionHandle("NeverConfigured");
+
+        // The stub's fallback label is deliberately obviously-synthetic (matching the rule
+        // applied to SteamAPI_InitEx's error message) rather than empty, so a test reading the
+        // log can't mistake it for a real Steam response.
+        EXPECT_EQ(SteamManager::GetGlyphLabelForDigitalAction(1, actionSet, handle), "stub SDK: unlabelled origin");
+        EXPECT_TRUE(SteamManager::GetGlyphPngForDigitalAction(1, actionSet, handle).empty());
+    }
+
+    TEST_F(SteamStubOnPathTest, InputShutdownIsSafeAndRepeatable)
+    {
+        SteamManager::Initialize();
+        ASSERT_TRUE(SteamManager::IsInputAvailable());
+
+        EXPECT_NO_THROW(SteamManager::Shutdown());
+        EXPECT_FALSE(SteamManager::IsInputAvailable());
+        EXPECT_NO_THROW(SteamManager::Shutdown());
+    }
+
     // Per-frame pump against the real SteamAPI_RunCallbacks symbol.
     TEST_F(SteamStubOnPathTest, RunCallbacksIsSafeBeforeAndAfterInit)
     {

--- a/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
+++ b/OloEngine/tests/Platform/Steam/SteamStubOnPathTest.cpp
@@ -377,6 +377,55 @@ namespace
         EXPECT_FLOAT_EQ(analogState.Y, -0.5f);
     }
 
+    // Valve reports a Trigger-mode analog action on 0..1 (0 = released); SteamworksBackend must
+    // normalize that to this engine's own GamepadAxis convention (-1..1, -1 = released — see
+    // GamepadCodes.h's GamepadAxis::RightTrigger) so a trigger-shaped action reads identically
+    // whether it came from Steam Input or raw XInput/DirectInput.
+    TEST_F(SteamStubOnPathTest, TriggerModeAnalogActionAtRestNormalizesToMinusOne)
+    {
+        SteamManager::Initialize();
+        const auto handle = SteamManager::GetAnalogActionHandle("Accelerate");
+        SteamStub::SetAnalogActionState(1, "Accelerate", /*x*/ 0.0f, /*y*/ 0.0f, /*active*/ true, /*triggerMode*/ true);
+
+        const auto state = SteamManager::GetAnalogActionState(1, handle);
+        EXPECT_TRUE(state.Active);
+        EXPECT_FLOAT_EQ(state.X, -1.0f);
+    }
+
+    TEST_F(SteamStubOnPathTest, TriggerModeAnalogActionAtFullPressNormalizesToPlusOne)
+    {
+        SteamManager::Initialize();
+        const auto handle = SteamManager::GetAnalogActionHandle("Accelerate");
+        SteamStub::SetAnalogActionState(1, "Accelerate", /*x*/ 1.0f, /*y*/ 0.0f, /*active*/ true, /*triggerMode*/ true);
+
+        const auto state = SteamManager::GetAnalogActionState(1, handle);
+        EXPECT_TRUE(state.Active);
+        EXPECT_FLOAT_EQ(state.X, 1.0f);
+    }
+
+    TEST_F(SteamStubOnPathTest, TriggerModeAnalogActionAtHalfPressNormalizesToZero)
+    {
+        SteamManager::Initialize();
+        const auto handle = SteamManager::GetAnalogActionHandle("Accelerate");
+        SteamStub::SetAnalogActionState(1, "Accelerate", /*x*/ 0.5f, /*y*/ 0.0f, /*active*/ true, /*triggerMode*/ true);
+
+        const auto state = SteamManager::GetAnalogActionState(1, handle);
+        EXPECT_FLOAT_EQ(state.X, 0.0f);
+    }
+
+    // A JoystickMove-mode action (the default, and what DigitalAndAnalogActionStateReachTheSdk
+    // above already exercises) is already on this engine's -1..1 convention and must NOT be
+    // renormalized — the mode check must be selective, not a blanket transform.
+    TEST_F(SteamStubOnPathTest, JoystickModeAnalogActionIsNotRenormalized)
+    {
+        SteamManager::Initialize();
+        const auto handle = SteamManager::GetAnalogActionHandle("Move");
+        SteamStub::SetAnalogActionState(1, "Move", /*x*/ -0.3f, /*y*/ 0.0f, /*active*/ true, /*triggerMode*/ false);
+
+        const auto state = SteamManager::GetAnalogActionState(1, handle);
+        EXPECT_FLOAT_EQ(state.X, -0.3f);
+    }
+
     // Glyph lookup through GetDigitalActionOrigins -> GetStringForActionOrigin /
     // GetGlyphPNGForActionOrigin — the real chain a button prompt takes, not a shortcut keyed
     // straight off the action name.

--- a/docs/agent-rules/steamworks-platform-integration.md
+++ b/docs/agent-rules/steamworks-platform-integration.md
@@ -474,16 +474,18 @@ would still trigger it here through the untouched GLFW polling).
   isn't a bug to fix here so much as a real limit of the current one-axis-per-action design; a
   future 2D "move" action would need a second engine-side action name (or a new binding shape)
   to carry `Y`, not a change to this routing code.
-- No normalisation between Valve's analog-action range conventions (a Trigger-mode Steam Input
-  action reports `0..1`; a joystick-move action reports `-1..1`) and this engine's own gamepad
-  convention (`GamepadAxis` triggers read `-1..1`, `-1` = released — see `GamepadCodes.h`).
-  `InputAnalogActionData_t::eMode` (`EInputSourceMode`) tells the real SDK which convention
-  applies to a given read, but `ISteamBackend`'s `SteamInputAnalogActionState` does not surface
-  it, so `ApplySteamInputForAction` cannot reconcile the two conventions per-action today. A
-  manifest-defined Trigger-mode action bound to an engine trigger action will therefore read `0`
-  (not `-1`) at rest once Steam Input takes it over — worth knowing before wiring a specific
-  trigger-shaped action through Steam Input, and a candidate for a follow-up that threads `eMode`
-  through the seam if a real Drift binding needs it.
+- **Trigger-mode range normalization is handled, but ONLY for that one mode.** Valve's own
+  analog-action range conventions differ by `InputAnalogActionData_t::eMode`
+  (`EInputSourceMode`): a Trigger-mode action reports `0..1` (`0` = released), a JoystickMove
+  action already reports `-1..1`. `SteamworksBackend::GetAnalogActionState` checks `eMode` and
+  remaps Trigger-mode `x`/`y` to this engine's own `-1..1` / `-1` = released convention
+  (`GamepadAxis::RightTrigger` etc. — see `GamepadCodes.h`) before it ever reaches
+  `ISteamBackend`; every other mode passes through unchanged. `SteamInputAnalogActionState`
+  itself does NOT carry `eMode` — the normalization happens once, at the SDK boundary, so
+  `InputActionManager` and every other caller of `GetAnalogActionState` never need to know Steam
+  Input's source-mode taxonomy exists. Covered by `SteamStubOnPathTest`'s
+  `TriggerModeAnalogActionAt{Rest,FullPress,HalfPress}Normalizes...` and
+  `JoystickModeAnalogActionIsNotRenormalized`.
 
 ### Non-goals (deliberate, not forgotten)
 

--- a/docs/agent-rules/steamworks-platform-integration.md
+++ b/docs/agent-rules/steamworks-platform-integration.md
@@ -506,21 +506,28 @@ the Steamworks partner site for App ID 480, or configured locally through Steam'
 "Manage Steam Input" screen for a connected controller if partner-site access isn't available
 (the origins Steam reports differ, but the plumbing check is the same).
 
-| # | Step | Expected | Result recorded 2026-08-30 |
+| # | Step | Expected | Result recorded 2026-08-31 |
 |---|---|---|---|
-| 1 | Launch with a Steam Input-capable controller connected (Xbox/DualSense/Deck), Steam client running | `SteamManager::IsInputAvailable()` true, `GetConnectedControllers()` non-empty | Not run — no physical controller attached to this machine this session |
-| 2 | Switch `InputContextType` (e.g. open a menu) | The corresponding named action set activates in Steam's overlay controller HUD | Not run |
-| 3 | Press a button bound to an engine action via Steam's configurator to a DIFFERENT physical button than the engine default | The action fires from the remapped button, not the engine default | Not run |
-| 4 | Open Steam's own "Manage controller layout" from the overlay | Reflects the game's action-set names from the manifest | Not run |
-| 5 | Disconnect the controller mid-session | Engine falls back to keyboard/mouse cleanly, no crash, no stuck-pressed action | Not run |
-| 6 | `GetGlyphPngForDigitalAction`/`GetGlyphLabelForDigitalAction` for a bound action | Returns a real PNG path / human string matching the connected controller type | Not run |
-| 7 | Launch with the Steam client NOT running | `IsAvailable()` and `IsInputAvailable()` both false, engine starts normally, gamepad bindings work via GLFW as before | Not run — see §5's Variant A/B contract, exercised automatically by `SteamStubOnPathTest` and `SteamManagerTest` instead |
+| 1 | Launch with a Steam Input-capable controller connected (Xbox/DualSense/Deck), Steam client running | `SteamManager::IsInputAvailable()` true, `GetConnectedControllers()` non-empty | **PASS.** Against the real client, App ID 480, a Steam Controller (new model): `IsInputAvailable=true ConnectedControllers=1`, live-traced from a running editor. |
+| 2 | Switch `InputContextType` (e.g. open a menu) | The corresponding named action set activates in Steam's overlay controller HUD | **PARTIAL.** `ActivateActionSet` reaches the real `ISteamInput::ActivateActionSet` with the correct context-derived name (`ctx=Gameplay`), confirmed live. The returned handle was `0` (invalid) — Spacewar (App 480, a shared app this project does not own) has no Steam Input action manifest defining a `"Gameplay"` action set, so Steam legitimately has nothing to activate. The overlay HUD step itself was not reachable without a bound action set. |
+| 3 | Press a button bound to an engine action via Steam's configurator to a DIFFERENT physical button than the engine default | The action fires from the remapped button, not the engine default | **BLOCKED**, same root cause as row 2 — no manifest means no action exists to bind or remap. Authoring a manifest for App 480 needs partner-site access to a game this project doesn't own; this needs a real owned App ID (i.e. once #878/Drift ships with its own App ID) to test for real. |
+| 4 | Open Steam's own "Manage controller layout" from the overlay | Reflects the game's action-set names from the manifest | **BLOCKED**, same root cause. |
+| 5 | Disconnect the controller mid-session | Engine falls back to keyboard/mouse cleanly, no crash, no stuck-pressed action | **PASS.** Live-traced `ConnectedControllers` dropping `1 → 0` on physical disconnect; editor stayed fully responsive afterward (368 FPS, scene still rendering, no stuck state) — screenshotted. |
+| 6 | `GetGlyphPngForDigitalAction`/`GetGlyphLabelForDigitalAction` for a bound action | Returns a real PNG path / human string matching the connected controller type | **BLOCKED**, same root cause as rows 2–4 — nothing is bound to look up a glyph for. |
+| 7 | Launch with the Steam client NOT running | `IsAvailable()` and `IsInputAvailable()` both false, engine starts normally, gamepad bindings work via GLFW as before | Not run this session — see §5's Variant A/B contract, exercised automatically by `SteamStubOnPathTest` and `SteamManagerTest` instead. |
 
-**Honest status as of this PR: rows 1–6 were not executed.** No Steam Input-capable physical
-controller was available in this session's environment (see
-`docs/agent-rules/oloengine-perf-tests-are-dev-workstation-only.md`-style "dev workstation only"
-caveat — this one is "developer *with a controller in hand*"). Row 7's degradation contract is
-covered by CI (`SteamStubOnPathTest::InputComesUpAutomaticallyWithSteamItself` and friends) and
-by the pre-existing Variant A/B tests. **Rows 1–6 remain the open manual-verification debt for
-whoever next holds a controller and this SDK** — re-run and update this table rather than adding a
-new checklist.
+**Session notes (2026-08-31):** verification used a temporary trace (`OLO_CORE_WARN` calls in
+`InputActionManager::Update`/`ActivateSteamActionSet`, reverted before commit — not shipped) to
+observe `SteamManager` state live, since the MCP diagnostics tool registration needs a session
+reconnect this run never got. Two real findings came out of it, both structural rather than bugs:
+first, the engine's own raw-gamepad diagnostics panel (`GamepadManager`, GLFW-based) correctly
+shows 0 connected devices for a Steam Controller under active Steam Input management — that
+panel is not, and never will be, the right place to check Steam Input connectivity, since Valve's
+controller deliberately does not expose itself as a standard XInput/DirectInput device while
+Steam Input owns it. Second, and more load-bearing: **rows 2, 3, 4 and 6 cannot be meaningfully
+exercised against App 480**, because Steam Input requires a per-app action manifest (action-set
+and action names) that only the app's Steamworks partner can author, and this project does not
+own Spacewar. The plumbing that *reaches* the real SDK is proven (rows 1 and 5, both live,
+both real); the plumbing that depends on manifest content is structurally blocked until Drift
+(#878) has its own App ID to author a manifest against. That is a content/publishing
+prerequisite, not an engine-code gap — record it as such rather than reporting a false pass.

--- a/docs/agent-rules/steamworks-platform-integration.md
+++ b/docs/agent-rules/steamworks-platform-integration.md
@@ -392,3 +392,133 @@ proves the code compiles, links and its branches behave; it proves nothing about
 This repo's own rule — *"whenever the dev box happens to match the value CI varies, local green
 proves nothing"* — bites unusually hard here, because with the real SDK the dev box is the **only**
 box that can be green. The stub job exists so that is not the whole story.
+
+---
+
+## 11. Steam Input on `ISteamBackend`, and the decision on `InputActionManager`
+
+Added for #893 (Deck Verified needs controller remapping through Steam's own configurator, and
+Steam Input is the layer through which most Deck and many desktop players will actually bind
+their controls).
+
+### The surface
+
+`ISteamBackend` gained action sets, digital/analog action state and glyph/origin lookup —
+`SteamTypes.h` (`SteamInputHandle`, `SteamInputActionSetHandle`, `SteamInputDigitalActionHandle`,
+`SteamInputAnalogActionHandle`, `SteamInputDigitalActionState`, `SteamInputAnalogActionState`),
+implemented for real against `ISteamInput` in `SteamworksBackend.cpp`, mirrored in the stub SDK
+(`StubSDK/public/steam/steam_api.h` + `SteamStubSDK.cpp`), and wrapped on `SteamManager`. Unlike
+the rest of the interface, Steam Input needs its own init/shutdown/pump — `SteamManager::
+Initialize()` calls `InputInit()` right after the base `Initialize()` succeeds (logging and
+continuing, never failing, if it doesn't), `RunCallbacks()` calls `InputRunFrame()` alongside
+`SteamAPI_RunCallbacks()`, and `Shutdown()` tears input down before the base backend. So callers
+never call an `Input*` lifecycle method directly — only `SteamManager::IsInputAvailable()` and the
+query methods.
+
+The stub SDK does not model an action manifest (there is no manifest in a CI checkout — a game's
+manifest is authored content, uploaded to the Steamworks partner site, not engine code). Any
+action-set or action **name** the caller passes gets a stable handle assigned on first sight,
+matching how the real SDK behaves for a name that genuinely exists in the manifest. This means the
+stub tests prove the *plumbing* (handles round-trip, action-set activation reaches the SDK,
+digital/analog state and glyph lookup pass through), not that a specific action name is correctly
+declared in a manifest — that part is only checkable against the real SDK with a real manifest
+file, which is tier 2 in §10.
+
+### The decision: Steam Input wins when available, per gamepad-origin binding
+
+**`InputActionManager` decides per-frame, not per-action-map.** When `SteamManager::
+IsInputAvailable()` is true and at least one controller is connected (`GetConnectedControllers()`
+non-empty), `InputActionManager::Update()`:
+
+1. Activates the Steam Input action set whose **name equals `InputContextTypeToString` of the
+   active context** (`"Gameplay"`, `"Menu"`, `"Vehicle"`, `"Custom"`) on every connected
+   controller. This is the load-bearing naming convention: a game's Steam Input manifest must
+   define an action set per `InputContextType` the game uses, named exactly that, or Steam Input
+   silently has nothing bound for that context (see the non-goal risk below).
+2. For every action in the active map, **skips `GamepadButton`/`GamepadAxis` bindings entirely**
+   and instead queries the Steam digital/analog action **whose name equals the `InputAction::Name`**
+   (`GetDigitalActionState`/`GetAnalogActionState`, handles cached for the process after first
+   lookup — see `ApplySteamInputForAction` in `InputActionManager.cpp`). `Active` on the returned
+   state means "Steam has an origin bound to this action in the current set"; when false, the
+   Steam contribution is skipped entirely for that action this frame, not treated as "not
+   pressed" — so an action Steam doesn't recognise falls all the way back to whatever the engine
+   bindings would have said, which is nothing, since gamepad bindings are already skipped. In
+   practice that means: an action absent from the manifest is simply unreachable via a connected
+   Steam Input controller, by design — add it to the manifest, don't add a special case here.
+3. `Keyboard`/`Mouse` bindings are **never affected** — they run exactly as before, both with and
+   without a Steam Input controller connected, so keyboard-and-mouse play is identical either way
+   and a menu/UI flow that expects Enter/Escape to always work keeps working.
+
+The result: **Steam Input governs the physical controller whenever it's present; the engine's own
+gamepad bindings are the fallback for a controller Steam Input isn't driving** (no Steam client,
+Steam Input failed to init, or nothing connected through it). Keyboard and mouse are orthogonal to
+both and always live. This was chosen over the alternative (OR-ing engine gamepad polling
+together with Steam Input state) because the same physical pad can appear to both APIs
+simultaneously under Steam's controller emulation — ORing them risks double-firing an action from
+what is, to the player, a single button press, and it defeats the entire point of Steam Input
+remapping (a player who rebound "Jump" away from the physical A button in Steam's configurator
+would still trigger it here through the untouched GLFW polling).
+
+**Known limitations, deliberate for #893's scope:**
+
+- Only the *first* connected controller (`GetConnectedControllers()[0]`) drives action state —
+  the same simplification the pre-existing `GetActionAxisValue`/`IsGamepadButtonPressed` default
+  (`gamepadIndex = 0`) already made for raw engine bindings. Local multiplayer through Steam
+  Input (per-player controller → per-player action state) is out of scope here; revisit together
+  with any local co-op feature, not before.
+- `ApplySteamInputForAction` only ever reads `SteamInputAnalogActionState::X`. A Steam Input
+  manifest analog action can be 2-axis (a joystick-move action, where `Y` also carries signal);
+  an `InputAction` that wants Steam Input to drive a *vertical* engine axis would currently read
+  0 from Steam while `Active` is true. There's no ambiguity to resolve on the engine's side of
+  `InputAction`/`InputActionMap` — an action is a single named f32, not an X/Y pair — so this
+  isn't a bug to fix here so much as a real limit of the current one-axis-per-action design; a
+  future 2D "move" action would need a second engine-side action name (or a new binding shape)
+  to carry `Y`, not a change to this routing code.
+- No normalisation between Valve's analog-action range conventions (a Trigger-mode Steam Input
+  action reports `0..1`; a joystick-move action reports `-1..1`) and this engine's own gamepad
+  convention (`GamepadAxis` triggers read `-1..1`, `-1` = released — see `GamepadCodes.h`).
+  `InputAnalogActionData_t::eMode` (`EInputSourceMode`) tells the real SDK which convention
+  applies to a given read, but `ISteamBackend`'s `SteamInputAnalogActionState` does not surface
+  it, so `ApplySteamInputForAction` cannot reconcile the two conventions per-action today. A
+  manifest-defined Trigger-mode action bound to an engine trigger action will therefore read `0`
+  (not `-1`) at rest once Steam Input takes it over — worth knowing before wiring a specific
+  trigger-shaped action through Steam Input, and a candidate for a follow-up that threads `eMode`
+  through the seam if a real Drift binding needs it.
+
+### Non-goals (deliberate, not forgotten)
+
+- **Leaderboards, DLC entitlements, UGC/Workshop** — `ISteamBackend` still exposes none of these.
+  Verified absent by the same `grep -r "ISteamLeaderboard\|ISteamDLC\|ISteamUGC" OloEngine/src/`
+  that #893 itself opened with. Revisit only if a specific Drift (#878) feature needs one of
+  them — a Steam Deck-relevant example would be a leaderboard for a time-trial mode, which does
+  not exist today.
+
+### Manual real-SDK verification checklist (tier 2 from §10)
+
+There is no automated way to prove Steam Input against the real client — the stub proves the
+plumbing, nothing about Valve's servers or a real controller. Run this by hand, once per Steam
+Input change, on a machine with `STEAMWORKS_SDK_ROOT` set and `480` in
+`OloEditor/steam_appid.txt` (§10). It needs a Steam Input action manifest for the test app — a
+minimal one action-set-per-`InputContextType`, one digital action per test binding — uploaded via
+the Steamworks partner site for App ID 480, or configured locally through Steam's own
+"Manage Steam Input" screen for a connected controller if partner-site access isn't available
+(the origins Steam reports differ, but the plumbing check is the same).
+
+| # | Step | Expected | Result recorded 2026-08-30 |
+|---|---|---|---|
+| 1 | Launch with a Steam Input-capable controller connected (Xbox/DualSense/Deck), Steam client running | `SteamManager::IsInputAvailable()` true, `GetConnectedControllers()` non-empty | Not run — no physical controller attached to this machine this session |
+| 2 | Switch `InputContextType` (e.g. open a menu) | The corresponding named action set activates in Steam's overlay controller HUD | Not run |
+| 3 | Press a button bound to an engine action via Steam's configurator to a DIFFERENT physical button than the engine default | The action fires from the remapped button, not the engine default | Not run |
+| 4 | Open Steam's own "Manage controller layout" from the overlay | Reflects the game's action-set names from the manifest | Not run |
+| 5 | Disconnect the controller mid-session | Engine falls back to keyboard/mouse cleanly, no crash, no stuck-pressed action | Not run |
+| 6 | `GetGlyphPngForDigitalAction`/`GetGlyphLabelForDigitalAction` for a bound action | Returns a real PNG path / human string matching the connected controller type | Not run |
+| 7 | Launch with the Steam client NOT running | `IsAvailable()` and `IsInputAvailable()` both false, engine starts normally, gamepad bindings work via GLFW as before | Not run — see §5's Variant A/B contract, exercised automatically by `SteamStubOnPathTest` and `SteamManagerTest` instead |
+
+**Honest status as of this PR: rows 1–6 were not executed.** No Steam Input-capable physical
+controller was available in this session's environment (see
+`docs/agent-rules/oloengine-perf-tests-are-dev-workstation-only.md`-style "dev workstation only"
+caveat — this one is "developer *with a controller in hand*"). Row 7's degradation contract is
+covered by CI (`SteamStubOnPathTest::InputComesUpAutomaticallyWithSteamItself` and friends) and
+by the pre-existing Variant A/B tests. **Rows 1–6 remain the open manual-verification debt for
+whoever next holds a controller and this SDK** — re-run and update this table rather than adding a
+new checklist.


### PR DESCRIPTION
Third of four shipping gates for Drift (#878) — see #893.

## What this adds

`ISteamBackend` gains a full Steam Input surface: action sets, digital/analog action handles and
state, and glyph label/PNG lookup for button prompts — implemented for real against `ISteamInput`
in `SteamworksBackend.cpp`, and mirrored in the hand-written stub SDK so the ON path stays
compiled, linked and tested in CI with no Valve SDK present (the existing `steam-stub` CI job).
`SteamManager` wraps it and folds Steam Input's own init/shutdown/pump into its existing
lifecycle — no new public lifecycle calls for game code to remember.

`InputActionManager` now activates the Steam Input action set matching the active
`InputContextType` and, when a controller is connected, routes gamepad-origin bindings
(`GamepadButton`/`GamepadAxis`) through Steam Input instead of raw GLFW polling — **Steam Input
wins when available, engine bindings are the fallback**. Keyboard/Mouse bindings are never
touched either way. The full decision, rationale, and known limitations (single-controller only,
no Y-axis on 2-axis analog actions, no `eMode` range normalization) are written up in
[`docs/agent-rules/steamworks-platform-integration.md` §11](docs/agent-rules/steamworks-platform-integration.md#11-steam-input-on-isteambackend-and-the-decision-on-inputactionmanager).

Leaderboards, DLC entitlements, and UGC/Workshop remain deliberate non-goals — recorded in the
same doc section, with the condition (a specific Drift feature needing one) that would revisit
them.

## Verification

Three tiers, per the doc's existing verification framework:

- **CI, every push:** the OFF path and the ON path via the stub SDK. All confirmed locally before
  pushing: OFF-path build (`STEAMWORKS_SDK_ROOT` unset, fresh tree) succeeded; stub-SDK build
  (`-DOLO_WITH_STEAM_STUB_SDK=ON`) succeeded; full `OloEngine-Tests` suite on the stub build:
  **6789 passed, 0 failed, 8 skipped** (the 8 are pre-existing, unrelated to this change — app-launch
  smokes, a video-decoder fixture, an asset cook, an MCP headless-attach test, and two
  environment-gated tests). Steam-specific filter (`--gtest_filter=*Steam*`): **88/88 passed** —
  the pre-existing 81 plus 7 new `SteamInputRoutingTest` cases covering `InputActionManager`'s
  routing decision end-to-end against a fake backend (action-set activation, digital/analog
  passthrough, keyboard fallback when unbound, an axis-magnitude-clobbering bug I found and fixed
  in self-review, `AxisPositive` direction clamping, and clean fallback on controller disconnect).
- **One machine only:** the real SDK ON build (`STEAMWORKS_SDK_ROOT` pointed at the locally
  installed SDK v1.65) compiled and linked successfully against the real `ISteamInput`.
- **Not verified at all — open:** the manual real-controller checklist (rows 1–6 in the doc's
  §11 table: controller connects, action-set switches with context, a Steam-side remap actually
  overrides the engine default, glyph lookup resolves, clean fallback on disconnect). No
  Steam Input-capable controller was available in the environment this PR was built in. The repo
  owner has two physical Steam Controllers and offered to help run this checklist once the PR
  exists — I'll update the table and comment here with results.

## Review guide

**Where I'd look hardest**
1. `InputActionManager.cpp` — the frame-ordering fix in `Application.cpp` (Steam Input's
   `RunFrame()` must pump before `InputActionManager::Update()` reads it, or every read is one
   frame stale) and the `axisSuppliedBySteam` gate that keeps the pre-existing "snap partial axis
   to full scale when also pressed" fallback from clobbering a real Steam analog magnitude — both
   found by a high-effort self-review after the mechanical build/test pass, not by the original
   implementation.
2. `SteamworksBackend.cpp`'s glyph-origin lookup (`FirstDigitalOrigin`/`FirstAnalogOrigin` →
   `GetStringForActionOrigin`/`GetGlyphPNGForActionOrigin`) — this is the one part of the real SDK
   surface the stub can't meaningfully validate (it fabricates origins rather than reading a real
   manifest), so it's the part most likely to have a real-SDK-only surprise.
3. `StubSDK/SteamStubSDK.cpp`'s origin↔action-name bookkeeping (`AssignOrigin`/
   `OriginToActionName`) — a hand-rolled reverse lookup needed because the real SDK's
   `GetStringForActionOrigin` is keyed purely off the origin, not the action, and the stub has no
   manifest to consult.

**What I verified, and how** — named above; test names are in
`OloEngine/tests/Platform/Steam/SteamInputRoutingTest.cpp` and the extended
`SteamManagerTest.cpp`/`SteamStubOnPathTest.cpp`.

**Least confident about** — the real-SDK glyph/origin behaviour against an actual manifest and
physical controller (see the open checklist above), and the analog range-convention gap
documented in §11 (Trigger-mode `0..1` vs the engine's `-1..1` convention) — flagged as a known
limitation rather than silently guessed at.

**Deliberately not tested** — Lua scripting exposure for Steam Input (the existing `Steam.*` Lua
table is untouched; adding Steam Input bindings there is not required by #893's acceptance
criteria and would expand scope), and local multi-controller/co-op routing (documented as
out-of-scope in §11, matching the pre-existing single-gamepad-index convention).

Closes #893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Steam Input support for connected controllers, action sets, digital and analog actions, and controller glyphs.
  * Gamepad bindings now use Steam Input states when available while preserving keyboard and mouse input.
  * Added fallback behavior when Steam Input is unavailable.

* **Bug Fixes**
  * Input actions now read freshly updated Steam Input state each frame.

* **Tests**
  * Added coverage for routing, controller connections, action states, glyphs, and fallback scenarios.

* **Documentation**
  * Added Steam Input integration guidance and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->