### PR TITLE
docs(adr): decide native Linux runtime over Proton, editor stays Windows-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,8 +350,9 @@ C++23 baseline, OpenGL 4.6 with DSA. Layout:
 - `OloEditor/` — ImGui editor. Panels under `src/`; runtime assets under `assets/`; sample game under `SandboxProject/`.
 - `OloRuntime/` — standalone game runtime that loads what the editor builds.
 - `OloServer/` — headless dedicated server. Linux is a first-class CI target, not just a WSL2
-  convenience: `OloEngine-Tests`, `OloRuntime` and `OloServer` build on `ubuntu-24.04` in every
-  `vulkan-off.yml`/`video-ffmpeg.yml`/`steam-stub.yml` run, and `gpu-conformance-amd.yml` runs the
+  convenience: `vulkan-off.yml` builds `OloEngine-Tests`, `OloRuntime` **and** `OloServer` on
+  `ubuntu-24.04`; `video-ffmpeg.yml` and `steam-stub.yml` build and run `OloEngine-Tests` there
+  too (engine core only, not the runtime/server targets); and `gpu-conformance-amd.yml` runs the
   full suite (goldens included) on real Linux/AMD hardware. `OloEditor` is the one target that is
   **not** CI-built on Linux — see [ADR 0015](docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md).
 - `OloEngine-ScriptCore/` (C# / Mono, Windows only) and `OloEngine-LuaScriptCore/` (Lua / Sol2, all platforms).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,11 @@ C++23 baseline, OpenGL 4.6 with DSA. Layout:
 - `OloEngine/src/Platform/` — platform-specific implementations (sibling of `OloEngine/`, not under it). Per-OS / per-API glue lives here.
 - `OloEditor/` — ImGui editor. Panels under `src/`; runtime assets under `assets/`; sample game under `SandboxProject/`.
 - `OloRuntime/` — standalone game runtime that loads what the editor builds.
-- `OloServer/` — headless dedicated server (the only target that runs on WSL2).
+- `OloServer/` — headless dedicated server. Linux is a first-class CI target, not just a WSL2
+  convenience: `OloEngine-Tests`, `OloRuntime` and `OloServer` build on `ubuntu-24.04` in every
+  `vulkan-off.yml`/`video-ffmpeg.yml`/`steam-stub.yml` run, and `gpu-conformance-amd.yml` runs the
+  full suite (goldens included) on real Linux/AMD hardware. `OloEditor` is the one target that is
+  **not** CI-built on Linux — see [ADR 0015](docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md).
 - `OloEngine-ScriptCore/` (C# / Mono, Windows only) and `OloEngine-LuaScriptCore/` (Lua / Sol2, all platforms).
 - `OloEngine/vendor/` — `FetchContent` / CPM downloads. **Never edit; CMake reconfigure wipes changes.**
 

--- a/docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md
+++ b/docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md
@@ -1,0 +1,145 @@
+# Linux ships as a native runtime, not under Proton — and the editor stays Windows-only
+
+Issue [#892](https://github.com/drsnuggles8/OloEngineBase/issues/892), the second of *Drift*'s
+(#878) four shipping gates, asks two questions in a deliberate order: **native Linux vs Proton**
+first, because the answer resizes everything else, and then whether the *editor* needs to exist on
+Linux at all. This ADR answers both, backed by what CI already proves and by an actual Linux build
+attempt of `OloEditor` (see "Build attempt" below).
+
+## Question 1 — native Linux, or Windows-under-Proton for the shipped game?
+
+**Native.** This is not a green-field choice: `OloRuntime` and `OloServer` are already
+continuously built and tested on Linux, and have been for a while.
+
+- `.github/workflows/vulkan-off.yml`, `video-ffmpeg.yml`, and `steam-stub.yml` all build
+  `OloEngine-Tests`, `OloRuntime` and `OloServer` on `ubuntu-24.04` — on every PR that touches the
+  relevant paths, on every push to `master`, and on a weekly schedule.
+- `.github/workflows/gpu-conformance-amd.yml` runs the **full test suite, goldens and visual
+  evidence included**, against a real AMD Navi 10 (RX 5600 XT) via Mesa radeonsi on a self-hosted
+  Linux runner — genuine cross-vendor hardware validation, not a software rasterizer stand-in.
+
+That is a stronger position than "we could probably get Proton to work." Proton adds a
+translation layer (DXVK/VKD3D, FEX where relevant, Wine's Win32 surface) between the game and the
+Linux kernel/driver for a payoff that only matters if we *didn't* already have a native Linux
+runtime — we do, and it is hardware-validated on every relevant CI run. Shipping under Proton would
+mean deliberately routing around a path we already exercise natively, to reach a compatibility
+layer we have never tested against. There is no scenario here where Proton is the better bet.
+
+Concretely: Drift ships a native Linux `OloRuntime`/`OloServer` build. Steam Deck compatibility
+follows from that (native Linux + Proton *not required* is the best-case Deck compatibility
+rating), and the sibling packaging issue (#894, steamcmd/depot automation) targets the native Linux
+depot, not a Proton-tagged Windows one.
+
+## Question 2 — does the editor need to ship, or even build, on Linux?
+
+**No.** Drift is authored on Windows; only the runtime ships to and runs on Linux. This is the
+"most likely" outcome the issue itself predicted, and the build attempt below confirms there is no
+forcing reason to change it.
+
+### Build attempt
+
+Before ruling the editor out, we tried to actually build it, per the issue's explicit instruction
+not to guess. Environment: WSL2 Ubuntu 24.04, clang-19 (the compiler every Linux CI job in this
+repo already pins for the C++23 standard library), the `x64-linux` vcpkg triplet, Ninja, on
+`origin/master` @ `bb68d50b8` — the same commit this worktree branched from.
+
+**Result: it does not build clean, but it gets close, and both blockers found are real,
+specific, and understood — not a wall of unknown breakage.**
+
+1. **Configure succeeds outright.** CMake resolves the full dependency graph — OpenVDB, Vulkan
+   (`glslc`/`glslangValidator` found), OpenGL, Boost — with zero platform-specific configure
+   errors. `OloEditor`, like every other target, is not gated behind a Windows-only
+   `if(WIN32)` in the root `CMakeLists.txt`.
+2. **736 of 798 build steps succeed**, including the entire `OloEngine` static-library chain
+   (core, renderer, content) and every vendored dependency (imgui, imguizmo, glad, lua,
+   xatlas, bc7enc). The Windows-guarded `#ifdef OLO_PLATFORM_WINDOWS` blocks around
+   `<Windows.h>` in `ContentBrowserItem.cpp`/`ContentBrowserPanel.cpp` — the two editor files
+   that looked riskiest on an unguarded grep — compile out cleanly, as intended.
+3. **First real blocker: `OloRuntime` (not `OloEditor` specifically) fails to *link*** with
+   `ld.lld: error: undefined symbol: std::__stacktrace_impl::_S_current(...)` from
+   `Platform/OpenGL/OpenGLDebug.cpp`'s `std::stacktrace::current()` call. `OloEngine/CMakeLists.txt`
+   already has machinery for exactly this (`OLO_HAVE_LIBSTDCXXEXP`, a `check_linker_flag(CXX
+   "-lstdc++exp" ...)` with a GCC-only glob fallback) — but in this exact environment (WSL2
+   Ubuntu 24.04, clang-19 selecting its GCC-14 install) the `check_linker_flag` call itself
+   evaluates false, even though `clang++-19 -lstdc++exp` links a trivial program with no error
+   when tried directly. The existing fallback is gated `elseif(CMAKE_CXX_COMPILER_ID STREQUAL
+   "GNU")`, so it never engages for Clang. This did not reproduce as a documentation error: the
+   repo's Linux CI jobs (`vulkan-off.yml` et al.) build `OloRuntime` with the identical
+   clang-19/`ubuntu-24.04` pairing and are green, so the check evidently passes there — this
+   looks like an environment-specific `try_compile` quirk rather than a universal break, and
+   root-causing it further is out of this issue's scope. Passing `-lstdc++exp` explicitly via
+   `CMAKE_EXE_LINKER_FLAGS` unblocks the link.
+4. **With that workaround, the build proceeds all the way into `OloEditor`'s own sources** and
+   hits two genuine, editor-specific compile errors in
+   `OloEditor/src/Panels/SceneHierarchyPanel.cpp` (lines 4261 and 4590):
+
+   ```
+   error: use 'template' keyword to treat 'GetComponent' as a dependent template name
+       connectedLabel = opt->GetComponent<TagComponent>().Tag;
+   ```
+
+   This is a standard two-phase-name-lookup strictness difference: MSVC accepts
+   `opt->GetComponent<TagComponent>()` on a dependent type without disambiguation, Clang (and
+   GCC) require `opt->template GetComponent<TagComponent>()`. A real, narrow, two-line
+   portability bug — not evidence of a deep architectural problem, and not touched here per the
+   "prove, not necessarily fix" scope of this issue.
+5. **`OloEngine-ScriptCore` never entered the picture** — its `CMakeLists.txt` inclusion is
+   itself gated `if(CMAKE_GENERATOR MATCHES "Visual Studio")`, so under Ninja (the only
+   generator this attempt could use on Linux) C# scripting is not merely broken, it is absent
+   from the build graph entirely. Per `CLAUDE.md`'s existing note, a Linux editor build would
+   ship with no working C# scripting even past the two errors above.
+
+Net: with two known, fixable snags — one link-flag detection gap and one two-line dependent-name
+fix — `OloEditor` is plausibly reachable on Linux. It is not there today, and per the decision
+below, nobody is going to finish that walk, because there is no one who needs to.
+
+### Why "no" even setting the build result aside
+
+1. **A game can be authored on one platform and shipped on another.** Nothing about Drift's asset
+   pipeline, scene format, or build tooling requires the machine that ships the binary to be the
+   machine that edited the scene — `OloRuntime` already loads exactly what `OloEditor` produces,
+   cross-platform, because scenes/assets are data, not compiled editor state.
+2. **The team's actual editing machines are Windows.** There is no workflow today, or asked for by
+   any issue, that has a developer opening `OloEditor` on Linux. Building it there would be
+   maintaining a capability nobody uses.
+3. **`OloEngine-ScriptCore` (C#/Mono) only builds under the Visual Studio generator** — a Linux
+   editor would ship without working C# scripting, or would need a second scripting-build path
+   built and maintained for a platform with no actual editing users. That is real, ongoing cost for
+   a capability with no consumer.
+4. **The cost of being wrong is low and reversible.** If a Linux editor is ever genuinely needed —
+   a contributor who only has Linux, say — the runtime's Linux CI coverage means the hard part
+   (engine core, RHI, asset loading) is already proven there; only the editor-specific surface
+   (ImGui platform backend, native file dialogs — already implemented per PR #365's
+   zenity/kdialog work, panels) would be new ground.
+
+## Decision
+
+- **Ship Drift as a native Linux runtime build.** Not Proton.
+- **`OloEditor` is Windows-only**, by decision, not by oversight. It is not built, tested, or
+  supported on Linux, and no CI job builds it there.
+- The sibling packaging issue (#894) targets a native Linux depot for `OloRuntime`/`OloServer`; it
+  does not need a Proton-compatibility layer or a Linux editor artifact.
+
+## What this ADR does NOT do
+
+- It does not add a CI job that builds `OloEditor` on Linux. Per the decision above, there is
+  nothing for such a job to protect — it would be spending CI minutes keeping a capability green
+  that nobody uses, exactly the failure mode `docs/agent-rules/build-trees-and-windows-asan.md` and
+  the vulkan-off.yml header warn against ("a reassuring no-op"). If the editor is ever put in
+  scope, add the job at that point, modeled on `vulkan-off.yml`'s Linux job shape.
+- It does not touch `OloEditor/src` to fix or work around anything the build attempt found. The
+  brief was "prove or drop," not "make it work" — see the acceptance criteria in #892.
+
+## Consequences
+
+- `CLAUDE.md`'s `OloServer/` line, which understated Linux coverage as "the only target that runs
+  on WSL2," is corrected to describe what CI actually builds and to point here.
+- A future contributor asking "why doesn't the editor build on Linux" has a recorded answer instead
+  of an unexamined gap — the exact outcome #892 was filed to force.
+- If this decision is ever revisited, it is a genuine reconsideration (new information: a Linux
+  contributor, a marketing reason to demo the editor cross-platform), not a rediscovery of facts
+  already known today.
+
+## Status
+
+Accepted.

--- a/docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md
+++ b/docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md
@@ -11,9 +11,11 @@ attempt of `OloEditor` (see "Build attempt" below).
 **Native.** This is not a green-field choice: `OloRuntime` and `OloServer` are already
 continuously built and tested on Linux, and have been for a while.
 
-- `.github/workflows/vulkan-off.yml`, `video-ffmpeg.yml`, and `steam-stub.yml` all build
-  `OloEngine-Tests`, `OloRuntime` and `OloServer` on `ubuntu-24.04` — on every PR that touches the
-  relevant paths, on every push to `master`, and on a weekly schedule.
+- `.github/workflows/vulkan-off.yml` builds `OloEngine-Tests`, `OloRuntime` **and** `OloServer`
+  on `ubuntu-24.04` — on every PR that touches the relevant paths, on every push to `master`, and
+  on a weekly schedule. `video-ffmpeg.yml` and `steam-stub.yml` also build and run on
+  `ubuntu-24.04`, but only `OloEngine-Tests` — they exercise the engine core on Linux, not
+  `OloRuntime`/`OloServer` specifically.
 - `.github/workflows/gpu-conformance-amd.yml` runs the **full test suite, goldens and visual
   evidence included**, against a real AMD Navi 10 (RX 5600 XT) via Mesa radeonsi on a self-hosted
   Linux runner — genuine cross-vendor hardware validation, not a software rasterizer stand-in.


### PR DESCRIPTION
Closes #892

## What changed

- **ADR 0015** (`docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md`) records the two decisions #892 asked for, in order:
  1. **Native Linux, not Proton**, for Drift's shipped runtime — `OloRuntime`/`OloServer` are already continuously built and hardware-tested on Linux (`vulkan-off.yml` builds both on `ubuntu-24.04`; `gpu-conformance-amd.yml` runs the full suite, goldens included, on real AMD hardware).
  2. **`OloEditor` stays Windows-only**, by decision, backed by an actual build attempt — not a guess.
- **`CLAUDE.md`** — the stale "`OloServer` is the only target that runs on WSL2" line is corrected to reflect what CI actually builds on Linux, and points at the ADR.

## The build attempt

Per the issue's explicit instruction not to guess, I built `OloEditor` on Linux (WSL2 Ubuntu 24.04, clang-19, `x64-linux` vcpkg triplet, Ninja) on `origin/master` @ `bb68d50b8`. Findings, in the ADR's "Build attempt" section:

- Configure succeeds cleanly — no `if(WIN32)` gate anywhere blocks it.
- 736/798 build steps succeed, including the entire `OloEngine` static-lib chain.
- `OloRuntime` fails to *link* on `std::stacktrace` symbols — an existing `OLO_HAVE_LIBSTDCXXEXP` CMake check evaluates false in this specific toolchain pairing even though `-lstdc++exp` links fine standalone. Working around it manually unblocks the link.
- Past that, `OloEditor`'s own sources hit two genuine Clang two-phase-lookup errors in `SceneHierarchyPanel.cpp` (`use 'template' keyword to treat 'GetComponent' as a dependent template name`).
- `OloEngine-ScriptCore` (C#) is gated `if(CMAKE_GENERATOR MATCHES "Visual Studio")`, so under Ninja it's absent from the build graph entirely — confirming the issue's suspicion.

None of this is fixed here — the issue's scope is "prove or drop," and the ADR's own decision (editor stays Windows-only, authored on Windows, ships Linux runtime-only) means there's no Linux editing workflow to justify carrying the fix forward.

## Review guide

**Where I'd look hardest**
1. `docs/adr/0015-...md` — "Question 1" section: the native-vs-Proton reasoning is the load-bearing decision for the sibling packaging issue (#894); worth checking it isn't overstating CI coverage.
2. The "Build attempt" section's factual claims about which CI job builds which target — self-review already caught and fixed one overclaim (video-ffmpeg.yml/steam-stub.yml only build `OloEngine-Tests`, not `OloRuntime`/`OloServer`; only `vulkan-off.yml` builds all three).

**What I verified, and how** — every CI-coverage claim in the ADR and the `CLAUDE.md` line is checked against the actual workflow YAML (`grep -n "target"` against `vulkan-off.yml`, `video-ffmpeg.yml`, `steam-stub.yml`, `gpu-conformance-amd.yml`), not from memory or the issue body alone. The build-attempt findings are from an actual run's log, not inference — including reproducing the `OLO_HAVE_LIBSTDCXXEXP` check failure in isolation to confirm it's a real `try_compile` result and not a fluke.

**Least confident about** — *why* `OLO_HAVE_LIBSTDCXXEXP` evaluates false in this WSL2 environment specifically when the repo's own Linux CI (same clang-19/ubuntu-24.04 pairing) is green. I isolated that it reproduces with a minimal `check_linker_flag` test once `CMAKE_CXX_STANDARD`/extensions are involved, but didn't fully root-cause it — documented as an open, environment-specific quirk rather than chased further, since it's out of this issue's scope.

**Deliberately not tested** — did not attempt to fix the `SceneHierarchyPanel.cpp` two-phase-lookup errors or add a Linux CI job for `OloEditor`, per the ADR's decision that the editor is out of scope.