### PR TITLE
fix(renderer): foliage impostor cards render at terrain-local coordinates (#953)

### DIFF
--- a/OloEditor/assets/shaders/Foliage_Impostor.glsl
+++ b/OloEditor/assets/shaders/Foliage_Impostor.glsl
@@ -105,7 +105,24 @@ void main()
 
     float scale = a_PositionScale.w;
     float rotation = a_RotationHeight.x;
-    float radius = u_ImpostorParams1.y * scale;  // world-space card radius
+    float height = a_RotationHeight.y;
+
+    // World-space card radius. u_ImpostorParams1.y is the OBJECT-space radius the
+    // bake framed the mesh with, and the meshes are authored unit-height
+    // (pine.obj spans y in [0,1], radius 0.560) — so the per-instance world
+    // height has to come back in here, exactly as the near path applies it
+    // (`localPos.y *= height * scale` in Foliage_Instance.glsl). This used to
+    // read only `scale`, drawing a 9-16 m pine as a ~1.5 m card: an ~8x shrink
+    // the moment an instance crossed ImpostorStartDistance (issue #953).
+    //
+    // UNIFORM, not anisotropic. Matching the near quad's aspect exactly would
+    // mean stretching the card 1:16, which renders the baked pine as a needle —
+    // and the near quad is a deliberately different thing anyway (a tufted
+    // billboard; the impostor is what "gives the tree line a 3D silhouette from
+    // any azimuth at range", issue #433). Scaling uniformly puts the drawn tree
+    // at exactly `height * scale` tall, so nothing pops vertically across the
+    // transition, and leaves it its own proportions.
+    float radius = u_ImpostorParams1.y * height * scale;
 
     // Instance pivot. Foliage's per-instance positions are TERRAIN-LOCAL (x/z in
     // [0, WorldSize], y the raw sampled height), so they only become world

--- a/OloEditor/assets/shaders/Foliage_Impostor.glsl
+++ b/OloEditor/assets/shaders/Foliage_Impostor.glsl
@@ -141,13 +141,22 @@ void main()
     // which is the out-of-bounds hazard the old comment was really about (issue
     // #433). The two got conflated, and the transform was dropped with them.
     vec3 instWorld = (u_Model * vec4(a_PositionScale.xyz, 1.0)).xyz;
-    // Anchor the impostor so its bounding sphere RESTS ON the ground: centre one
-    // world radius above the instance ground point. This is independent of how
-    // the source mesh is authored (centred-on-origin vs base-at-origin) — using
-    // the baked centre.y directly would half-bury a centred mesh, and a
-    // camera-looking-down view then flattens that half-buried card into the
-    // terrain and depth-culls it (issue #433).
-    vec3 cardCenter = instWorld + vec3(0.0, radius, 0.0);
+    // Anchor the card on the MESH CENTRE, because that is what the bake framed:
+    // ImpostorBaker centres each tile on the source mesh's bounding-box centre
+    // and spans +-u_ImpostorParams1.y around it, so the card's centre has to
+    // land on that same point in world space or the tree floats inside its own
+    // card. The meshes are authored base-at-origin (pine.obj spans y in [0,1])
+    // and the near path already relies on that (`localPos.y *= height * scale`
+    // in Foliage_Instance.glsl), so the centre is half the drawn height up.
+    //
+    // This offset by `radius` instead, which was indistinguishable while radius
+    // was the UNIT-mesh radius (~0.5 m). The moment radius became
+    // R0 * height * scale (6-12 m for Drift's pines) the same line lifted the
+    // card centre — and the tree drawn around it — metres into the air: trees in
+    // the sky. The card's BOTTOM stayed on the terrain, so the card extent
+    // looked right and only its contents floated, which is what made this read
+    // as a placement bug rather than an anchoring one.
+    vec3 cardCenter = instWorld + vec3(0.0, 0.5 * height * scale, 0.0);
 
     // Subtle whole-card wind sway (legacy sine model, matching the near
     // billboard's fallback branch) so a distant tree still moves with the wind.

--- a/OloEditor/assets/shaders/Foliage_Impostor.glsl
+++ b/OloEditor/assets/shaders/Foliage_Impostor.glsl
@@ -107,13 +107,23 @@ void main()
     float rotation = a_RotationHeight.x;
     float radius = u_ImpostorParams1.y * scale;  // world-space card radius
 
-    // Instance pivot. Foliage's per-instance positions are absolute world in
-    // a_PositionScale; the foliage command uploads only a SINGLE model-matrix
-    // entry to the InstanceData SSBO, so indexing it by gl_InstanceIndex for
-    // instance > 0 reads out of bounds (zero matrix on this driver) and would
-    // collapse every card to the origin. Shift to render-relative space directly
-    // (subtract the render origin) instead of going through u_Model (issue #433).
-    vec3 instWorld = a_PositionScale.xyz - u_RenderOrigin;
+    // Instance pivot. Foliage's per-instance positions are TERRAIN-LOCAL (x/z in
+    // [0, WorldSize], y the raw sampled height), so they only become world
+    // positions after the owning terrain's transform — which DrawFoliageLayer
+    // uploads as the single u_Model entry, already made render-relative by
+    // UploadModelInstance. Foliage_Instance.glsl has always multiplied through
+    // it; this stage did not, and subtracted the render origin directly instead
+    // on the belief that a_PositionScale was absolute world (issue #953). It is
+    // not: no island sits at the origin, so every impostor card rendered at its
+    // island's LOCAL coordinates — all six islands' pines piled into one heap
+    // over open water near (0,0,0), hanging above anything the terrain can
+    // reach, which from the boat reads as a swarm of dark specks in the sky.
+    //
+    // The OLO_INSTANCE_SINGLE define above is what makes u_Model safe here: it
+    // pins the read to instances[0] rather than indexing by gl_InstanceIndex,
+    // which is the out-of-bounds hazard the old comment was really about (issue
+    // #433). The two got conflated, and the transform was dropped with them.
+    vec3 instWorld = (u_Model * vec4(a_PositionScale.xyz, 1.0)).xyz;
     // Anchor the impostor so its bounding sphere RESTS ON the ground: centre one
     // world radius above the instance ground point. This is independent of how
     // the source mesh is authored (centred-on-origin vs base-at-origin) — using

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -8322,6 +8322,18 @@ namespace OloEngine
                         foliage.m_NeedsRebuild = true;
                     }
 
+                    // Instance positions are terrain-LOCAL, so the renderer needs
+                    // the owning terrain's transform to place them. The main draw
+                    // gets it via DrawFoliageLayer's modelTransform, but the SHADOW
+                    // path (FoliageRenderer::RenderShadows, driven straight off the
+                    // renderer by ShadowRenderPass) has no command packet to carry
+                    // it and was uploading identity — casting every island's foliage
+                    // shadow from a heap of plants at the world origin (issue #953).
+                    // Set every frame, not just on rebuild, so a terrain that moves
+                    // takes its foliage with it.
+                    foliage.m_Renderer->SetTerrainTransform(
+                        foliageView.get<TransformComponent>(entity).GetTransform());
+
                     if (foliage.m_NeedsRebuild && terrain.m_TerrainData)
                     {
                         foliage.m_Renderer->GenerateInstances(

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.cpp
@@ -329,20 +329,27 @@ namespace OloEngine
         m_VisibleInstances = 0;
 
         // Foliage's per-blade transforms come from its own instance VBO
-        // (a_PositionScale, a_RotationHeight) in absolute world space. The
-        // shaders read `u_Model` from the engine's ModelInstanceBuffer
-        // (binding 15). Upload the render-relative model matrix once so it (a)
-        // overrides whatever the previous DrawMesh wrote into the SSBO and (b)
-        // shifts the absolute blade positions into render-relative space —
-        // camera-relative rendering (issue #429). The matrix is a pure
-        // translation by -renderOrigin, so the default identity Normal matrix
-        // is correct; the foliage shaders add u_RenderOrigin back for the
-        // world-anchored wind field. No-op near origin (renderOrigin == 0).
+        // (a_PositionScale, a_RotationHeight) in TERRAIN-LOCAL space — the same
+        // space the terrain mesh is authored in, because GenerateInstances
+        // derives them straight from the heightfield (x/z in [0, WorldSize], y
+        // the raw sampled height, no base offset). The shaders read `u_Model`
+        // from the engine's ModelInstanceBuffer (binding 15). Upload the owning
+        // terrain's render-relative model matrix once so it (a) overrides
+        // whatever the previous DrawMesh wrote into the SSBO, (b) places the
+        // plants on their island, and (c) shifts them into render-relative
+        // space — camera-relative rendering (issue #429). The foliage shaders
+        // add u_RenderOrigin back for the world-anchored wind field.
+        //
+        // This used to upload plain identity, on the stated belief that the
+        // instance positions were already absolute world (issue #953). They are
+        // not, and no island in Drift sits at the origin, so all six islands'
+        // foliage was drawn in one heap over open water near (0,0,0) — read
+        // from the boat as a swarm of dark specks hanging in the sky.
         if (auto instanceBuffer = Renderer3D::GetModelInstanceBuffer())
         {
             InstanceData bladeModel{};
             bladeModel.EntityID = -1;
-            bladeModel.Transform = MakeModelRelative(glm::mat4(1.0f), Renderer3D::GetRenderOrigin());
+            bladeModel.Transform = MakeModelRelative(m_TerrainTransform, Renderer3D::GetRenderOrigin());
             bladeModel.PrevTransform = bladeModel.Transform;
             const std::span<const InstanceData> one(&bladeModel, 1);
             instanceBuffer->Upload(one);
@@ -398,14 +405,15 @@ namespace OloEngine
 
         // Same render-relative model pattern as Render() (issue #429): the depth
         // shader reads u_Model from the ModelInstanceBuffer and foliage's per-blade
-        // data is absolute world, so translate by -renderOrigin to render the
-        // shadow caster in the same render-relative space as the shifted lightVP.
-        // No-op near origin.
+        // data is TERRAIN-LOCAL (see Render), so go through the owning terrain's
+        // transform and then -renderOrigin, to render the shadow caster in the
+        // same render-relative space as the shifted lightVP. Must stay identical
+        // to the main pass or the shadow detaches from the plant (issue #953).
         if (auto instanceBuffer = Renderer3D::GetModelInstanceBuffer())
         {
             InstanceData bladeModel{};
             bladeModel.EntityID = -1;
-            bladeModel.Transform = MakeModelRelative(glm::mat4(1.0f), Renderer3D::GetRenderOrigin());
+            bladeModel.Transform = MakeModelRelative(m_TerrainTransform, Renderer3D::GetRenderOrigin());
             bladeModel.PrevTransform = bladeModel.Transform;
             const std::span<const InstanceData> one(&bladeModel, 1);
             instanceBuffer->Upload(one);

--- a/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
+++ b/OloEngine/src/OloEngine/Terrain/Foliage/FoliageRenderer.h
@@ -93,6 +93,28 @@ namespace OloEngine
         // Render shadow depth pass for all layers
         void RenderShadows(const Ref<Shader>& depthShader);
 
+        // The owning terrain entity's world transform. GenerateInstances emits
+        // instance positions in TERRAIN-LOCAL space (x/z in [0, WorldSize], y
+        // the raw sampled height in [0, HeightScale] — no base offset), exactly
+        // like the terrain mesh itself, so something has to place them.
+        //
+        // The MAIN draw gets that transform from its command packet
+        // (Scene passes it to Renderer3D::DrawFoliageLayer, and
+        // CommandDispatch::DrawFoliageLayer uploads it as the shaders' single
+        // `u_Model` entry). RenderShadows has no command packet — ShadowRenderPass
+        // drives it straight off this object — so it needs the transform stored
+        // here, and it was uploading plain identity instead, casting every
+        // island's foliage shadow from a heap of plants at the world origin
+        // (issue #953). Render() below uploads it too, for when it regains a
+        // caller; it currently has none.
+        //
+        // Kept as a MATRIX rather than baked into the instance positions so a
+        // terrain that moves takes its foliage with it, with no rebuild.
+        void SetTerrainTransform(const glm::mat4& transform)
+        {
+            m_TerrainTransform = transform;
+        }
+
         [[nodiscard]] u32 GetTotalInstanceCount() const;
         [[nodiscard]] u32 GetVisibleInstanceCount() const
         {
@@ -153,6 +175,7 @@ namespace OloEngine
         void UpdateImpostorAtlas(LayerRenderData& data, const FoliageLayer& layer);
 
         std::vector<LayerRenderData> m_Layers;
+        glm::mat4 m_TerrainTransform{ 1.0f };
         u32 m_VisibleInstances = 0;
         f32 m_Time = 0.0f;
         f32 m_PrevTime = 0.0f;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ add_executable(OloEngine-Tests
 		Rendering/Baking/LightmapAtlasPagingTest.cpp
 		Rendering/Baking/LightProbePathTracedBakeTest.cpp
 		Asset/LightmapAssetSerializationTest.cpp
+		Rendering/FoliageImpostorPlacementTest.cpp
 		Rendering/PODCommandTest.cpp
 		Rendering/ShaderBindingLayoutTest.cpp
 		Rendering/ShaderReflectionBindingTest.cpp

--- a/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
+++ b/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
@@ -42,7 +42,9 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <cctype>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -96,6 +98,44 @@ namespace
         }
         return out;
     }
+    /// The comma-separated arguments of the first `vec3(...)` in `expr`, with all
+    /// whitespace removed. Returns empty if there is no balanced vec3 call.
+    [[nodiscard]] std::vector<std::string> Vec3Args(const std::string& expr)
+    {
+        const auto open = expr.find("vec3(");
+        if (open == std::string::npos)
+            return {};
+        std::vector<std::string> args;
+        std::string current;
+        int depth = 0;
+        for (std::size_t i = open + 4; i < expr.size(); ++i)
+        {
+            const char c = expr[i];
+            if (c == '(')
+            {
+                if (++depth == 1)
+                    continue; // the vec3's own opening paren
+            }
+            else if (c == ')')
+            {
+                if (--depth == 0)
+                {
+                    args.push_back(current);
+                    return args;
+                }
+            }
+            else if (c == ',' && depth == 1)
+            {
+                args.push_back(current);
+                current.clear();
+                continue;
+            }
+            if (!std::isspace(static_cast<unsigned char>(c)))
+                current.push_back(c);
+        }
+        return {}; // unbalanced
+    }
+
 } // namespace
 
 // Both stages must place the instance stream the same way. This is the
@@ -149,13 +189,33 @@ TEST(FoliageImpostorPlacementTest, ImpostorCardIsAnchoredOnTheMeshCentreNotItsRa
     ASSERT_NE(at, std::string::npos) << "no card anchor expression found";
     const std::string expr = vertex.substr(at, vertex.find(';', at) - at);
 
-    EXPECT_NE(expr.find("height"), std::string::npos)
-        << "the card anchor does not scale with the plant height: " << expr
-        << " -- the bake centres the tile on the mesh's bounding-box centre, so the anchor must "
-           "be half the DRAWN height. Anchoring by the card radius instead floats the tree inside "
-           "its own card once the radius carries the height (issue #953).";
-    EXPECT_EQ(expr.find(", radius,"), std::string::npos)
-        << "the card anchor is back to offsetting by the card radius: " << expr;
+    // Assert what the offset IS, not merely that the word "height" appears in it:
+    // `vec3(0.0, height, 0.0)` and `vec3(0.0, height * 2.0, 0.0)` both mention the
+    // height and both float the tree. Term ORDER is free — `0.5 * height * scale`,
+    // `height * scale * 0.5` and `scale * height * 0.5` are the same offset — so
+    // the Y term is checked by the factors it carries, not by its spelling.
+    const std::vector<std::string> args = Vec3Args(expr);
+    ASSERT_EQ(args.size(), 3u) << "card anchor is not a vec3(x, y, z) offset: " << expr;
+
+    EXPECT_TRUE(args[0] == "0.0" || args[0] == "0") << "card anchor shifts X: " << expr;
+    EXPECT_TRUE(args[2] == "0.0" || args[2] == "0") << "card anchor shifts Z: " << expr;
+
+    const std::string& y = args[1];
+    const bool carriesHeight = y.find("height") != std::string::npos;
+    const bool carriesScale = y.find("scale") != std::string::npos;
+    const bool carriesHalf = y.find("0.5") != std::string::npos || y.find("/2.0") != std::string::npos ||
+                             y.find("/2") != std::string::npos;
+
+    EXPECT_TRUE(carriesHeight && carriesScale && carriesHalf)
+        << "the card anchor must be HALF the DRAWN height (height * scale), because the bake "
+           "centres each tile on the source mesh's bounding-box centre. Got: "
+        << y
+        << " -- missing" << (carriesHalf ? "" : " the 1/2 factor") << (carriesHeight ? "" : " the height")
+        << (carriesScale ? "" : " the instance scale") << " (issue #953).";
+
+    EXPECT_EQ(y.find("radius"), std::string::npos)
+        << "the card anchor is back to offsetting by the card radius: " << y
+        << " -- that floats the tree inside its own card once the radius carries the height.";
 }
 
 // The card has to carry the per-instance height, or it is short by the whole

--- a/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
+++ b/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
@@ -134,3 +134,24 @@ TEST(FoliageImpostorPlacementTest, ImpostorDoesNotTreatInstancePositionsAsAbsolu
            "indexing by gl_InstanceIndex, which is the out-of-bounds hazard from issue #433 that "
            "the original comment conflated this with.";
 }
+
+// The card has to carry the per-instance height, or it is short by the whole
+// unit-height-mesh factor.
+TEST(FoliageImpostorPlacementTest, ImpostorCardRadiusUsesThePerInstanceHeight)
+{
+    const std::string vertex = StripComments(VertexStageOf(ReadShader("Foliage_Impostor.glsl")));
+    ASSERT_FALSE(vertex.empty());
+
+    EXPECT_NE(vertex.find("a_RotationHeight.y"), std::string::npos)
+        << "Foliage_Impostor.glsl never reads the per-instance height. The foliage meshes are "
+           "authored unit-height (pine.obj spans y in [0,1]) and the near path applies the world "
+           "height itself (`localPos.y *= height * scale`), so a card sized from the bake radius "
+           "and `scale` alone is short by that factor — issue #953 measured a 9-16 m pine drawn "
+           "as a ~1.5 m card.";
+
+    const auto radiusAt = vertex.find("float radius =");
+    ASSERT_NE(radiusAt, std::string::npos) << "no card radius expression found";
+    const std::string radiusExpr = vertex.substr(radiusAt, vertex.find(';', radiusAt) - radiusAt);
+    EXPECT_NE(radiusExpr.find("height"), std::string::npos)
+        << "the card radius expression does not include the per-instance height: " << radiusExpr;
+}

--- a/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
+++ b/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
@@ -1,0 +1,136 @@
+// =============================================================================
+// FoliageImpostorPlacementTest.cpp
+//
+// Pins the placement/sizing contract shared by the two foliage vertex stages
+// (issue #953). Both draw the SAME instance stream — FoliageRenderer emits one
+// `{PositionScale, RotationHeight, ColorAlpha}` per plant — so they must agree
+// on what that stream means. They did not:
+//
+//   * positions are TERRAIN-LOCAL (FoliageRenderer::GenerateInstances derives
+//     x/z from tile coordinates starting at 0, and y from
+//     `GetHeightAt() * heightScale` with no base offset), and become world
+//     positions only through the owning terrain's transform, which
+//     CommandDispatch::DrawFoliageLayer uploads as the single `u_Model` entry.
+//     Foliage_Instance.glsl multiplied through it; Foliage_Impostor.glsl
+//     subtracted the render origin directly instead, on the belief that the
+//     positions were already absolute world. No island in Drift sits at the
+//     origin, so every impostor card rendered at its island's LOCAL
+//     coordinates — all six islands' pines in one heap over open water near
+//     (0,0,0), above anything the terrain can reach. From the boat that reads
+//     as a swarm of dark specks hanging in the sky, which is how it was
+//     reported, and it is why the search started at "sky/atmosphere bug".
+//
+//   * the per-instance world height lives in `a_RotationHeight.y`. The meshes
+//     are authored unit-height (pine.obj spans y in [0,1]), so a card sized
+//     without it is short by that whole factor — a 9-16 m pine drew as a
+//     ~1.5 m card the moment it crossed ImpostorStartDistance.
+//
+// Source-text assertions rather than a render, because the failure mode is a
+// shader silently diverging from its sibling: a GPU test would only catch it in
+// a scene whose terrain is NOT at the origin, and the visual result (foliage
+// slightly misplaced, or absent at range) is easy to read as art. Text is also
+// what makes this cheap enough to run in headless CI, where the #953 repro
+// (a large viewport, an island off the origin) does not exist.
+//
+// OLO_TEST_LAYER: unit
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace
+{
+    namespace fs = std::filesystem;
+
+    [[nodiscard]] std::string ReadShader(const char* name)
+    {
+        const fs::path path = fs::path{ OLO_TEST_EDITOR_ROOT } / "assets" / "shaders" / name;
+        std::ifstream in(path);
+        if (!in)
+            return {};
+        std::ostringstream oss;
+        oss << in.rdbuf();
+        return oss.str();
+    }
+
+    /// The vertex stage only — `#type fragment` onward is a different program
+    /// and has its own `u_Model`-free coordinate conventions.
+    [[nodiscard]] std::string VertexStageOf(const std::string& source)
+    {
+        const auto vs = source.find("#type vertex");
+        if (vs == std::string::npos)
+            return {};
+        const auto fsStart = source.find("#type fragment", vs);
+        return source.substr(vs, (fsStart == std::string::npos) ? std::string::npos : fsStart - vs);
+    }
+
+    /// Strip // and /* */ comments so a doc comment quoting an expression can
+    /// never satisfy (or break) an assertion about the CODE.
+    [[nodiscard]] std::string StripComments(const std::string& src)
+    {
+        std::string out;
+        out.reserve(src.size());
+        for (std::size_t i = 0; i < src.size();)
+        {
+            if (src.compare(i, 2, "//") == 0)
+            {
+                while (i < src.size() && src[i] != '\n')
+                    ++i;
+            }
+            else if (src.compare(i, 2, "/*") == 0)
+            {
+                const auto end = src.find("*/", i + 2);
+                i = (end == std::string::npos) ? src.size() : end + 2;
+            }
+            else
+            {
+                out.push_back(src[i]);
+                ++i;
+            }
+        }
+        return out;
+    }
+} // namespace
+
+// Both stages must place the instance stream the same way. This is the
+// two-mirrors-drift guard: whichever stage is edited, the other has to keep up.
+TEST(FoliageImpostorPlacementTest, BothFoliageStagesPlaceInstancesThroughTheTerrainTransform)
+{
+    for (const char* shader : { "Foliage_Instance.glsl", "Foliage_Impostor.glsl" })
+    {
+        const std::string source = ReadShader(shader);
+        ASSERT_FALSE(source.empty()) << "could not read " << shader;
+
+        const std::string vertex = StripComments(VertexStageOf(source));
+        ASSERT_FALSE(vertex.empty()) << shader << " has no #type vertex stage";
+
+        EXPECT_NE(vertex.find("u_Model * vec4(a_PositionScale.xyz"), std::string::npos)
+            << shader
+            << ": the vertex stage must turn the TERRAIN-LOCAL instance position into a world "
+               "position through u_Model (the owning terrain's transform, uploaded by "
+               "CommandDispatch::DrawFoliageLayer and already made render-relative by "
+               "UploadModelInstance). Without it the plants render at their island's local "
+               "coordinates — see issue #953.";
+    }
+}
+
+// The specific regression: the impostor stage must not go back to treating the
+// instance position as absolute world.
+TEST(FoliageImpostorPlacementTest, ImpostorDoesNotTreatInstancePositionsAsAbsoluteWorld)
+{
+    const std::string vertex = StripComments(VertexStageOf(ReadShader("Foliage_Impostor.glsl")));
+    ASSERT_FALSE(vertex.empty());
+
+    EXPECT_EQ(vertex.find("a_PositionScale.xyz - u_RenderOrigin"), std::string::npos)
+        << "Foliage_Impostor.glsl is subtracting the render origin from the instance position "
+           "again. That treats a TERRAIN-LOCAL position as absolute world (issue #953). Reading "
+           "u_Model here is safe: OLO_INSTANCE_SINGLE pins it to instances[0] rather than "
+           "indexing by gl_InstanceIndex, which is the out-of-bounds hazard from issue #433 that "
+           "the original comment conflated this with.";
+}

--- a/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
+++ b/OloEngine/tests/Rendering/FoliageImpostorPlacementTest.cpp
@@ -135,6 +135,29 @@ TEST(FoliageImpostorPlacementTest, ImpostorDoesNotTreatInstancePositionsAsAbsolu
            "the original comment conflated this with.";
 }
 
+// The card's ANCHOR has to scale with the card too. Sizing the card by the plant
+// height without moving the anchor lifted the card centre — and the tree drawn
+// around it — metres into the air, which put trees in the sky. The bake centres
+// each tile on the mesh's bounding-box centre, so the anchor is half the drawn
+// height, never the card radius.
+TEST(FoliageImpostorPlacementTest, ImpostorCardIsAnchoredOnTheMeshCentreNotItsRadius)
+{
+    const std::string vertex = StripComments(VertexStageOf(ReadShader("Foliage_Impostor.glsl")));
+    ASSERT_FALSE(vertex.empty());
+
+    const auto at = vertex.find("cardCenter = instWorld");
+    ASSERT_NE(at, std::string::npos) << "no card anchor expression found";
+    const std::string expr = vertex.substr(at, vertex.find(';', at) - at);
+
+    EXPECT_NE(expr.find("height"), std::string::npos)
+        << "the card anchor does not scale with the plant height: " << expr
+        << " -- the bake centres the tile on the mesh's bounding-box centre, so the anchor must "
+           "be half the DRAWN height. Anchoring by the card radius instead floats the tree inside "
+           "its own card once the radius carries the height (issue #953).";
+    EXPECT_EQ(expr.find(", radius,"), std::string::npos)
+        << "the card anchor is back to offsetting by the card radius: " << expr;
+}
+
 // The card has to carry the per-instance height, or it is short by the whole
 // unit-height-mesh factor.
 TEST(FoliageImpostorPlacementTest, ImpostorCardRadiusUsesThePerInstanceHeight)


### PR DESCRIPTION
Fixes #953.

## What it actually was

The "black speckles in the sky" are **pine impostor cards rendered at terrain-local coordinates**.

`FoliageRenderer::GenerateInstances` derives instance positions straight from the heightfield — x/z from tile coordinates starting at 0, y from `GetHeightAt() * heightScale` with no base offset — so they live in the same space the terrain mesh is authored in, and become world positions only through the owning terrain's transform. `CommandDispatch::DrawFoliageLayer` uploads that transform as the shaders' single `u_Model` entry, and `Foliage_Instance.glsl` has always multiplied through it.

`Foliage_Impostor.glsl` did not:

```glsl
vec3 instWorld = a_PositionScale.xyz - u_RenderOrigin;
```

No island in Drift sits at the origin, so all six islands' pines rendered in one heap over open water near (0,0,0), hanging above anything the terrain can reach. From the boat that is a swarm of dark dots in the sky — which is why this was reported as a sky artefact and chased through the atmosphere, cloud and water paths first.

The shader's comment justified skipping `u_Model` by the out-of-bounds hazard from #433. That hazard is about *indexing* `instances[gl_InstanceIndex]` when foliage uploads only one entry; `OLO_INSTANCE_SINGLE` — already defined in this shader — pins the read to `instances[0]` and makes `u_Model` safe. The two got conflated, and the transform was dropped with them.

**Second site, same cause:** `FoliageRenderer::RenderShadows` uploaded plain identity. It is live (`ShadowRenderPass` drives it straight off the renderer) and has no command packet to carry the transform, so foliage shadows were cast from that same origin heap.

## Evidence

Measured over MCP on `Scenes/Drift.olo` at render 5248x2517, counting isolated dark pixels in the sky band. Same cameras, same resolution, only the pivot expression toggled between runs:

| camera | before | after |
|---|---|---|
| horizon-island | 34 | **0** |
| origin-look | 18 | **0** |
| boat-chase | 62 | **1** |
| high-wide | 0 | 0 |

The remaining one is foliage (0 with every `FoliageComponent` disabled, 1 restored) sitting 1–9 px above the island's ridge line — a tree on the skyline, which is scenery rather than a defect.

## Hypotheses falsified first

The issue had already ruled geometry out because depth reads the far plane and `SceneEntityID` reads -1 — sound for opaque geometry, but foliage writes neither, so that inference pointed away from the real owner. Working at native resolution with controls (`olo_screenshot` downscales to 1024 wide and smears a one-pixel speck into its neighbours, so `olo_render_probe_pixel` was the only usable instrument), these were each tested and **falsified**:

- **bad mip / undefined derivatives** from the `texture()` calls inside the non-quad-uniform `continue` — `textureQueryLod` = 0.00, all three taps run
- **UV clamped to a tile border** — mid-tile at (0.45, 0.72)
- **corrupt impostor atlas** — contents match `grass.png` x the authored `BaseColor` exactly
- **viewport parity / resolution** — resolution only decides whether the sub-pixel card clears the alpha cutoff at all, which is why a small window shows zero specks and "cannot reproduce" there means "the window was too small"

The pass and shader were then identified positively rather than by elimination: `SceneColor` after `ScenePass` = [1.31, 0.83, 0.09] (sky) vs after `FoliagePass` = [0.006, 0.014, 0.001], and marking the two foliage shaders in distinct colours made the speck read pure impostor with terrain and sky controls untouched.

## Second commit: the card was also ~8x too small

Independent defect found on the way. The card never read the per-instance height:

```glsl
float radius = u_ImpostorParams1.y * scale;
```

`u_ImpostorParams1.y` is the object-space radius `ImpostorBaker` framed the mesh with, and the foliage meshes are authored unit-height (`pine.obj` spans y in [0,1], radius 0.560). The near path supplies the world size itself (`localPos.y *= height * scale`, height 9–16 m for the Pines layer); the impostor left that factor out. The arithmetic closes on the live frame — a probed card reported radius 0.745 m, and 0.745 / 0.560 = 1.33, inside the layer's MinScale 0.9 / MaxScale 1.4.

**Uniform rather than anisotropic, decided by looking at the frame.** Matching the near quad's footprint exactly reproduces its own 1:16 stretch and renders the baked pine as a needle — the skyline grew in 83 of 1024 columns, as isolated one-column spikes. The near quad is deliberately a different thing (a tufted billboard; the impostor is what "gives the tree line a 3D silhouette from any azimuth at range", #433), so the card scales uniformly by `height * scale`: the drawn tree is exactly that tall, nothing pops vertically across the transition, and it keeps its proportions. The same skyline that had no trees on it before now shows recognisable conifer silhouettes.

## Tests

New `FoliageImpostorPlacementTest` (3 tests, `unit`) asserts both foliage vertex stages place the shared instance stream the same way — the two-mirrors-drift shape, since they consume one stream and must agree on what it means. Source-text rather than a render: a GPU test only catches this in a scene whose terrain is off the origin, and the visual result is easy to read as art. **All three fail on the pre-fix shader and pass on this one.**

Targeted run (`*Foliage*:*Impostor*:*Terrain*:*Shadow*`): 365 passed, 1 pre-existing skip, 0 failures.

## Not verified

- The shadow-path change rests on it using the same matrix as the main pass — `olo_render_capture_target` returns "no GPU backing this frame" for the shadow map, so I could not capture one.
- `TransformComponent.Rotation` is not MCP-editable, so the dusk scene could not be relit for a daylight check; logged against #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected foliage placement across terrain islands.
  * Fixed foliage shadows appearing at the world origin instead of beneath their plants.
  * Improved render-relative positioning and impostor sizing for more accurate visuals.

* **Tests**
  * Added coverage to verify foliage impostor placement, transforms, and height-based sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->