### PR TITLE
fix(vulkan): stop back-face culling the deferred lighting fullscreen triangle

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Passes/DeferredLightingPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/DeferredLightingPass.cpp
@@ -208,7 +208,28 @@ namespace OloEngine
         context.SetDepthTest(false);
         context.SetDepthMask(false);
         context.SetBlendState(false);
-        RenderCommand::SetCullFace(RHI::CullMode::Back);
+        // CULLING OFF, like every other fullscreen pass -- and it is not
+        // cosmetic (issue #1002). This pass used to set the cull FACE only,
+        // leaving whatever enable the last geometry pass recorded standing,
+        // and on Vulkan that silently removed the whole draw: the deferred
+        // lighting output reached no render target at all and the viewport
+        // showed the AO buffer over the clear colour.
+        //
+        // The fullscreen triangle writes NDC directly. Every OTHER triangle in
+        // the frame reaches clip space through the Vulkan projection seam,
+        // which NEGATES clip y -- and VulkanPipelineBuilder::FlushDynamicState
+        // maps the recorded GL winding to the SAME VkFrontFace precisely
+        // because that negation and Vulkan's y-down framebuffer compose to
+        // identity for such geometry. An NDC-passthrough triangle gets only
+        // the y-down half of that pair, so its apparent winding is the
+        // OPPOSITE of every projected mesh's: measured 2026-09-01, the shared
+        // fullscreen triangle is front-facing on GL under glFrontFace(GL_CCW)
+        // and back-facing on Vulkan under VK_FRONT_FACE_COUNTER_CLOCKWISE.
+        // Neither backend is wrong; the two conventions simply cannot both be
+        // served by one winding, so a fullscreen draw must not be face-culled
+        // at all. Pinned by the culling-enabled arm of
+        // VulkanPassSuite.DeferredLightingShadesAKnownGBufferAndBlitsEntityIds.
+        RenderCommand::DisableCulling();
 
         const u32 sampleCount = m_GBuffer->GetSampleCount();
         const bool useMSAAShading = m_UseMSAAShading;

--- a/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanPipelineBuilder.cpp
@@ -825,6 +825,22 @@ namespace OloEngine
         // so an inversion here fails loudly in both directions rather than
         // being masked by the reflection's own handedness reversal.
         //
+        // THE COMPOSITION IS CONDITIONAL ON THE SEAM BEING IN THE PIPELINE, and
+        // that is the half this comment used to leave implicit (issue #1002).
+        // Geometry that writes NDC straight out of the vertex stage -- every
+        // fullscreen triangle -- never meets the projection seam, so it gets
+        // only the framebuffer-y half of the pair and its apparent winding is
+        // the OPPOSITE of a projected mesh's: measured live, the shared
+        // fullscreen triangle is front-facing on GL under CCW and back-facing
+        // here under VK_FRONT_FACE_COUNTER_CLOCKWISE. One winding cannot serve
+        // both conventions and neither rule can move (swapping here is the
+        // inside-out regression described above), so the rule is a CALL-SITE
+        // rule: a fullscreen draw must DISABLE culling, never merely set the
+        // cull face. The paragraph above already noted that every fullscreen
+        // tenant drew with culling off -- DeferredLightingPass was the one that
+        // did not, and its entire draw was silently culled on Vulkan.
+        // See docs/agent-rules/rhi-abstraction-boundary.md §19.
+        //
         // Composed HERE, in the backend's one state-translation point, never at
         // call sites: a pass-local override (PlanarReflection's Clockwise for
         // the mirrored replay) then means exactly what it means on GL.

--- a/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
@@ -5716,6 +5716,24 @@ TEST_F(VulkanPassSuite, DeferredLightingShadesAKnownGBufferAndBlitsEntityIds)
     SubmitFrame(
         [&]()
         {
+            // THE PRODUCTION PRECONDITION, and the whole reason this tenant
+            // exists in this shape (issue #1002). A real deferred frame reaches
+            // DeferredLightingPass straight out of the G-buffer geometry pass,
+            // so BACK-FACE CULLING IS ENABLED when the fullscreen lighting
+            // triangle is drawn. This test used to run with the recorded
+            // default (culling off), where the pass's own cull state is inert —
+            // and that one substitution hid the bug completely: the pass set
+            // the cull FACE without disabling culling, and on Vulkan the
+            // NDC-passthrough triangle is BACK-facing (it skips the projection
+            // seam's clip-y negation that FlushDynamicState's no-swap winding
+            // rule is composed against), so the entire lighting draw was culled
+            // and SceneColor kept its clear colour. Recording the enable here
+            // is what makes the lit-band assertions below fail if anything ever
+            // face-culls this draw again.
+            RenderCommand::EnableCulling();
+            RenderCommand::SetCullFace(RHI::CullMode::Back);
+            RenderCommand::SetFrontFace(RHI::FrontFace::CounterClockwise);
+
             // Author the G-buffer content the pass's blits copy: entity RT4
             // -> 42, depth -> 1.0 (float RTs -> 0, unread here).
             gbufferSamplingFB->ClearAllAttachments(glm::vec4(0.0f), 42);
@@ -5728,6 +5746,10 @@ TEST_F(VulkanPassSuite, DeferredLightingShadesAKnownGBufferAndBlitsEntityIds)
                 api.IssueBarrierBatch(MemoryBarrierFlags::None, std::span{ &toSampled, 1 });
             }
             graph.Execute();
+            // Put the recorded default back: this state is PROCESS-global, so a
+            // later tenant that never states an opinion would otherwise inherit
+            // the enable recorded above.
+            RenderCommand::DisableCulling();
 
             RHI::Barrier toSampled{};
             toSampled.Resource = sceneFramebuffer->GetColorAttachmentHandle(0);

--- a/docs/agent-rules/rhi-abstraction-boundary.md
+++ b/docs/agent-rules/rhi-abstraction-boundary.md
@@ -3395,3 +3395,90 @@ corroborate either way; and it is one failure at the end of a long local suite,
 which is exactly where a failure gets attributed to whatever you just changed.
 The A/B is cheap and settles it — `git switch --detach <base>`, build, run that
 one test. Do that before either fixing or excusing it.
+
+---
+
+## 19. The no-swap winding rule holds for PROJECTED geometry only (#1002)
+
+`VulkanPipelineBuilder::FlushDynamicState` maps the recorded GL winding to the
+**same** `VkFrontFace` — no swap — and the comment at that call explains why: the
+projection seam negates clip y, Vulkan's framebuffer y already points down where
+GL's window y points up, and the two inversions compose to identity. That
+reasoning is correct, and it is also **conditional**: it needs the seam's
+negation to be in the pipeline at all.
+
+A fullscreen triangle writes NDC straight out of the vertex stage. It never
+touches the projection seam, so it gets **one** inversion, not two — and its
+apparent winding is therefore the *opposite* of every projected mesh's. Measured
+live on 2026-09-01, on the shared `MeshPrimitives::GetFullscreenTriangle()`, with
+`cullMode = BACK` and `frontFace = COUNTER_CLOCKWISE` recorded on both backends:
+
+| backend | the same fullscreen triangle is… |
+|---|---|
+| OpenGL (`glFrontFace(GL_CCW)`) | **front**-facing — it draws |
+| Vulkan (`VK_FRONT_FACE_COUNTER_CLOCKWISE`) | **back**-facing — it is culled |
+
+Neither backend is wrong and neither rule can be changed: swapping the winding in
+`FlushDynamicState` would turn every solid mesh inside-out on Vulkan (that exact
+regression shipped once and is recorded in the same comment), and reversing the
+primitive's index order would fix NDC-passthrough draws while looking harmless
+today only because nothing else culls them. **One winding cannot serve both
+conventions.** So the rule is a call-site rule:
+
+> **A fullscreen (NDC-passthrough) draw must disable face culling, not merely set
+> the cull face.** Setting the face alone leaves the previous pass's *enable*
+> standing, and in a deferred frame the previous pass is the G-buffer geometry
+> pass, which enables it.
+
+### Why it took a rank-#1 bug to find
+
+`DeferredLightingPass` was the only fullscreen pass whose *only* culling call was
+`SetCullFace(Back)` — the face without the enable. On GL that line is inert (the
+triangle is front-facing either way). On Vulkan it deleted the entire deferred
+lighting draw, and the failure had **no** loud symptom to attach to:
+
+* the viewport was not black — it showed the AO buffer over the clear colour,
+  which reads as a plausible if flat shading bug;
+* `OloEngine.log` was clean: no VUID, no dropped-draw counter, no PSO failure.
+  The draw was fully *recorded* — correct scope, correct attachment, correct root
+  data, non-zero vertex-pull address — it simply rasterised nothing;
+* the Vulkan pass-suite tenant for the pass **passed**, because a synthetic frame
+  starts from the recorded default `Culling = false`, where the pass's own cull
+  state is inert. One substituted precondition, the whole bug hidden — the
+  archetype in [substituted-seams-compound.md](substituted-seams-compound.md).
+
+### The instrument that settled it
+
+Reading state was not enough: every dumped field (colour mask, blend, scissor,
+viewport, attachment format, pull address) was *correct*. What separated "the
+write is masked" from "there are no fragments" was recording a
+`vkCmdClearAttachments` of a distinctive colour into the **same scope**, right
+beside the draw:
+
+* the clear colour appeared in the target ⇒ the scope, the attachment and the
+  write path are all fine;
+* the draw's own colour did not ⇒ zero fragments, so look at rasterisation
+  (cull, scissor, winding, degenerate positions), not at the write.
+
+### The rest of the fullscreen family is safe by ORDERING, not by statement
+
+Worth knowing before adding a pass. Most fullscreen passes touch culling not at
+all; they are safe because of where they sit in the 48-pass deferred order:
+
+```
+ScenePass (geometry, culling ON) -> VirtualGeometry -> PlanarReflection ->
+Overdraw[off] -> DeferredGPUOcclusion -> DeferredOpaqueDecal (geometry) ->
+GTAO -> VirtualShadowMapMark -> DeferredLighting[off] -> Particle ->
+SSS[off] -> AOApply[off] -> ... everything downstream inherits "off"
+```
+
+`[off]` marks a pass that states `DisableCulling()`. `DeferredLightingPass` is the
+first fullscreen *draw* after geometry, so it is the one that meets the enable —
+every later one inherits the "off" that it, `SSSPass` and `AOApplyPass` leave
+behind. **A new fullscreen pass inserted between geometry and `AOApplyPass` would
+hit exactly this bug**, so state the disable rather than relying on the position.
+
+That is a two-line, one-rebuild instrument and it is worth reaching for before any
+further state auditing. Then A/B the candidates with env-gated levers in one build
+(`cullMode = NONE`, `frontFace = CLOCKWISE`, forced enable on **both** backends)
+rather than one rebuild per hypothesis.


### PR DESCRIPTION
## Vulkan Deferred rendered no lit output — the fullscreen lighting triangle was back-face culled

Closes #1002.

`DeferredLightingPass` was the only fullscreen pass whose *only* culling call was
`SetCullFace(Back)` — the face without the enable, so whatever the G-buffer
geometry pass recorded stayed standing. On OpenGL that line is inert; on Vulkan it
deleted the entire deferred lighting draw, so `SceneColor` never received anything
and the viewport showed the AO buffer over the clear colour.

Most other fullscreen passes never mention culling; they are safe only because
they sit *after* `DeferredLightingPass` / `SSSPass` / `AOApplyPass`, which do
disable it. `DeferredLightingPass` is the first fullscreen draw after geometry, so
it is the one that meets the enable — a new fullscreen pass inserted anywhere
between geometry and `AOApplyPass` would hit the same bug. That ordering is now
written down in the doc section below.

### Mechanism

`VulkanPipelineBuilder::FlushDynamicState` maps the recorded GL winding to the
**same** `VkFrontFace` — no swap — because the projection seam negates clip y and
Vulkan's framebuffer y already points down, and the two inversions compose to
identity. **That composition needs the seam to be in the pipeline.**

A fullscreen triangle writes NDC straight out of the vertex stage and never meets
the seam. It gets one inversion instead of two, so its apparent winding is the
*opposite* of every projected mesh's. Measured with the identical recorded state
(cull `Back`, front face `CounterClockwise`) on
`MeshPrimitives::GetFullscreenTriangle()`:

| backend | the same triangle is… |
|---|---|
| OpenGL, `glFrontFace(GL_CCW)` | **front**-facing — it draws |
| Vulkan, `VK_FRONT_FACE_COUNTER_CLOCKWISE` | **back**-facing — it is culled |

Neither rule can move — swapping in the backend is the "every solid mesh
inside-out" regression already recorded there, and one winding cannot serve both
conventions. So it is a call-site rule, and the fix is to state the disable that
the pass was relying on its neighbours for.

### Change

* `DeferredLightingPass::Execute` — `SetCullFace(Back)` → `DisableCulling()`.
  One line; the rest of the hunk is the comment explaining the parity trap.
* `VulkanPipelineBuilder::FlushDynamicState` — comment only: the no-swap winding
  rule's "every fullscreen tenant drew with culling off" premise was load-bearing
  and is now stated as a condition.
* `VulkanPassSuite.DeferredLightingShadesAKnownGBufferAndBlitsEntityIds` — record
  the **production precondition** (culling enabled, `Back`, `CCW`) before
  `graph.Execute()`. The tenant used to run from the recorded default
  `Culling = false`, where the pass's own cull state is inert, and that single
  substitution hid the bug completely.
* `docs/agent-rules/rhi-abstraction-boundary.md` §19 — the parity trap, why it had
  no loud symptom, and the `vkCmdClearAttachments`-beside-the-draw instrument that
  separates "the write is masked" from "there are no fragments".

No GLSL touched, so no conflict with #996 / PR #1004's flags-lane work.

### Verification

Numbers are `SceneColor` per-channel `[min, max]`, scene
`Scenes/PBRClosureV2Test.olo`, NVIDIA RTX 4090.

| configuration | `SceneColor` r/g/b max | verdict |
|---|---|---|
| Vulkan Deferred, **before** | `0.09998 / 0.09998 / 0.09998` — uniform, colour spread **0.0** | the bug |
| Vulkan Deferred, **after** | **`9.211 / 6.031 / 2.906`** | fixed |
| Vulkan Forward (control) | `9.219 / 6.027 / 5.027` — unchanged | unaffected |
| OpenGL Deferred, slot-based | `9.211 / 6.031 / 2.906` | unchanged |
| OpenGL Deferred, `OLO_RHI_BINDLESS=1` | `9.211 / 6.031 / 2.906` | unchanged |
| OpenGL Forward (control) | `9.219 / 6.027 / 5.027` | unchanged |

Vulkan Deferred now matches OpenGL Deferred to every digit reported. The OpenGL
side was A/B'd against a pre-fix build of the same tree: same four camera angles,
same stats, and the four captured PNGs are **byte-identical** pre- and post-fix.


Screenshots from four camera angles were captured and read back on both backends;
`OloEngine.log` carries no new VUIDs on either (the pre-existing
`'DeferredLighting' buffer binding 68/78/81/82 has no published occupant` warnings
are unchanged, and match `PBR_MultiLight`'s set as the issue records).

`VulkanPassSuite.*` + `VulkanDrawPath.*`: 58/58 pass.

The test guard was confirmed to be a guard, not decoration: with the fix reverted
and the test change kept, the lit band reads `(0,0,0)` against an expected
`(69,18,18)` and the tenant fails.

### Follow-up worth considering, not done here

The safe-by-ordering property above is fragile. A `context.DrawFullscreen(va)`
helper that owns the disable would make it structural, but it touches ~30 call
sites and is well outside this issue — filing it as a note rather than smuggling
it into a one-line bug fix.
