### PR TITLE
fix(build): make Linux desktop launchers relocatable

### DIFF
--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -207,6 +207,8 @@
 		"OloEngine/Build/GameBuildSettings.cpp"
 		"OloEngine/Build/GameBuildPipeline.h"
 		"OloEngine/Build/GameBuildPipeline.cpp"
+		"OloEngine/Build/LinuxDesktopLauncher.h"
+		"OloEngine/Build/LinuxDesktopLauncher.cpp"
 		"OloEngine/Build/BuildPipelinePlatform.h"
 		"OloEngine/Serialization/AssetPackFile.h"
 		"OloEngine/Serialization/FileStream.h"

--- a/OloEngine/src/OloEngine/Build/BuildPipelinePlatform.h
+++ b/OloEngine/src/OloEngine/Build/BuildPipelinePlatform.h
@@ -19,8 +19,8 @@ namespace OloEngine::BuildPipelinePlatform
     /// Write a freedesktop.org `.desktop` launcher entry next to `exePath`
     /// (#891) — the Linux arm of icon handling. Linux has no PE-resource slot
     /// to embed an icon into, so instead of the Windows-only nicety silently
-    /// vanishing on Linux, the pipeline emits a standard launcher entry that
-    /// points at the (optional) icon file and marks the executable runnable.
+    /// vanishing on Linux, the pipeline emits a relocatable launcher and stages
+    /// the optional Linux-native icon inside the package.
     /// Returns true on success, populates `outError` on failure.
     /// On platforms without an implementation, returns false and sets an error.
     bool WriteDesktopEntry(const std::filesystem::path& exePath,

--- a/OloEngine/src/OloEngine/Build/GameBuildPipeline.h
+++ b/OloEngine/src/OloEngine/Build/GameBuildPipeline.h
@@ -92,7 +92,8 @@ namespace OloEngine
      *    target platform and C# scripting availability, etc.
      *
      * ## Output Structure (Windows target shown; Linux drops the .exe suffix,
-     * the mono/ and Resources/Scripts/ directories, and adds a .desktop entry)
+     * the mono/ and Resources/Scripts/ directories, and adds a relocatable
+     * .desktop entry plus OloGameLauncher.sh and an optional icons/game-icon.*)
      * ```
      * OutputDirectory/GameName/
      * ├── GameName.exe            (renamed OloRuntime.exe)
@@ -262,8 +263,8 @@ namespace OloEngine
         /**
          * @brief Write a Linux .desktop launcher entry next to the game executable
          *
-         * The Linux arm of icon handling (#891) — replaces the Windows-only
-         * EmbedCustomIcon step. Non-fatal — returns false but lets the build continue.
+         * The Linux arm of icon handling — stages a portable launcher and an
+         * optional PNG/SVG/XPM icon. Non-fatal — returns false but lets the build continue.
          */
         static bool WriteLinuxDesktopEntry(
             const std::filesystem::path& exePath,

--- a/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
+++ b/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
@@ -1,0 +1,218 @@
+#include "OloEnginePCH.h"
+#include "OloEngine/Build/LinuxDesktopLauncher.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <fstream>
+
+namespace OloEngine
+{
+    namespace
+    {
+        constexpr std::string_view LauncherScriptName = "OloGameLauncher.sh";
+        constexpr std::string_view IconDirectoryName = "icons";
+        constexpr std::string_view IconFileStem = "game-icon";
+
+        std::string EscapeDesktopString(const std::string& value)
+        {
+            std::string escaped;
+            escaped.reserve(value.size());
+            for (const char character : value)
+            {
+                switch (character)
+                {
+                    case '\\':
+                        escaped += "\\\\";
+                        break;
+                    case '\n':
+                        escaped += "\\n";
+                        break;
+                    case '\r':
+                        escaped += "\\r";
+                        break;
+                    case '\t':
+                        escaped += "\\t";
+                        break;
+                    default:
+                        escaped += character;
+                        break;
+                }
+            }
+            return escaped;
+        }
+
+        std::string EscapeForQuotedExec(const std::string& value)
+        {
+            std::string escaped;
+            escaped.reserve(value.size() * 2);
+            for (const char character : value)
+            {
+                if (character == '\\' || character == '"' || character == '`' || character == '$')
+                {
+                    escaped += '\\';
+                }
+                escaped += character;
+            }
+            return escaped;
+        }
+
+        std::string ToLowerExtension(const std::filesystem::path& path)
+        {
+            auto extension = path.extension().string();
+            std::ranges::transform(extension, extension.begin(), [](const unsigned char character)
+                                   { return static_cast<char>(std::tolower(character)); });
+            return extension;
+        }
+
+        bool IsSupportedLinuxIcon(const std::filesystem::path& iconPath)
+        {
+            const auto extension = ToLowerExtension(iconPath);
+            return extension == ".png" || extension == ".svg" || extension == ".xpm";
+        }
+
+        bool HasRecognizableLinuxIconContent(const std::filesystem::path& iconPath)
+        {
+            std::ifstream input(iconPath, std::ios::binary);
+            if (!input.is_open())
+            {
+                return false;
+            }
+
+            const auto extension = ToLowerExtension(iconPath);
+            if (extension == ".png")
+            {
+                constexpr std::array<char, 8> signature{ '\x89', 'P', 'N', 'G', '\r', '\n', '\x1a', '\n' };
+                std::array<char, signature.size()> bytes{};
+                input.read(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+                return input.gcount() == static_cast<std::streamsize>(signature.size()) && bytes == signature;
+            }
+
+            std::string prefix(4096, '\0');
+            input.read(prefix.data(), static_cast<std::streamsize>(prefix.size()));
+            prefix.resize(static_cast<sizet>(input.gcount()));
+            std::ranges::transform(prefix, prefix.begin(), [](const unsigned char character)
+                                   { return static_cast<char>(std::tolower(character)); });
+            return extension == ".svg" ? prefix.find("<svg") != std::string::npos
+                                       : prefix.find("xpm") != std::string::npos;
+        }
+
+        bool WriteTextFile(const std::filesystem::path& path, const std::string& contents, std::string& errorMessage)
+        {
+            std::ofstream output(path, std::ios::binary | std::ios::trunc);
+            if (!output.is_open())
+            {
+                errorMessage = "Failed to write launcher file: " + path.string();
+                return false;
+            }
+            output << contents;
+            if (!output.good())
+            {
+                errorMessage = "Failed while writing launcher file: " + path.string();
+                return false;
+            }
+            return true;
+        }
+    } // namespace
+
+    bool StageLinuxDesktopLauncher(const std::filesystem::path& executablePath,
+                                   const std::filesystem::path& iconPath,
+                                   const std::string& gameName,
+                                   LinuxDesktopLauncherArtifacts& artifacts,
+                                   std::string& errorMessage)
+    {
+        artifacts = {};
+        if (!std::filesystem::is_regular_file(executablePath))
+        {
+            errorMessage = "Executable not found: " + executablePath.string();
+            return false;
+        }
+        const std::filesystem::path nameAsPath{ gameName };
+        if (gameName.empty() || nameAsPath.is_absolute() || nameAsPath.filename().string() != gameName ||
+            gameName.find("..") != std::string::npos)
+        {
+            errorMessage = "Game name is not a safe launcher filename: " + gameName;
+            return false;
+        }
+
+        const auto packageDirectory = executablePath.parent_path();
+        const auto desktopEntryPath = packageDirectory / (gameName + ".desktop");
+        const auto wrapperScriptPath = packageDirectory / LauncherScriptName;
+
+        std::filesystem::path packagedIconPath;
+        if (!iconPath.empty())
+        {
+            if (!std::filesystem::is_regular_file(iconPath))
+            {
+                errorMessage = "Linux icon file not found: " + iconPath.string();
+                return false;
+            }
+            if (!IsSupportedLinuxIcon(iconPath))
+            {
+                errorMessage = "Linux icons must use PNG, SVG, or XPM: " + iconPath.string();
+                return false;
+            }
+            if (!HasRecognizableLinuxIconContent(iconPath))
+            {
+                errorMessage = "Linux icon content does not match its extension: " + iconPath.string();
+                return false;
+            }
+
+            packagedIconPath = packageDirectory / IconDirectoryName / (std::string(IconFileStem) + ToLowerExtension(iconPath));
+            std::error_code copyError;
+            std::filesystem::create_directories(packagedIconPath.parent_path(), copyError);
+            if (!copyError)
+            {
+                std::filesystem::copy_file(iconPath, packagedIconPath, std::filesystem::copy_options::overwrite_existing, copyError);
+            }
+            if (copyError)
+            {
+                errorMessage = "Failed to package Linux icon: " + copyError.message();
+                return false;
+            }
+        }
+
+        // Desktop Entry Specification §7 does not allow a relative executable.
+        // `%k` is the launcher's own location, so pass it as its required standalone
+        // argument to a fixed system shell; the wrapper then derives its directory.
+        const std::string bootstrapCommand = "exec \"$(dirname -- \"$1\")/" + std::string(LauncherScriptName) + "\"";
+        const std::string desktopEntry = "[Desktop Entry]\n"
+                                         "Type=Application\n"
+                                         "Name=" +
+                                         EscapeDesktopString(gameName) + "\n"
+                                                                         "Exec=/bin/sh -c \"" +
+                                         EscapeForQuotedExec(bootstrapCommand) + "\" olo-launcher %k\n"
+                                                                                 "Categories=Game;\n"
+                                                                                 "Terminal=false\n";
+        if (!WriteTextFile(desktopEntryPath, desktopEntry, errorMessage))
+        {
+            return false;
+        }
+
+        // Icon= cannot resolve a relative path. The raw desktop entry remains
+        // launchable after a move; each wrapper launch refreshes its Icon= with
+        // the packaged icon's newly derived absolute path.
+        const std::string wrapperScript = "#!/bin/sh\n"
+                                          "set -eu\n"
+                                          "launcher_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n"
+                                          "desktop_entry=\"$launcher_dir/" +
+                                          EscapeForQuotedExec(desktopEntryPath.filename().string()) + "\"\n"
+                                                                                                      "temporary_entry=\"$desktop_entry.tmp\"\n"
+                                                                                                      "if (cat > \"$temporary_entry\" <<'OLO_DESKTOP_ENTRY'\n" +
+                                          desktopEntry +
+                                          "OLO_DESKTOP_ENTRY\n" +
+                                          (packagedIconPath.empty() ? std::string{} : "printf 'Icon=%s\\n' \"$launcher_dir/" + EscapeForQuotedExec(std::string(IconDirectoryName) + "/" + packagedIconPath.filename().string()) + "\" >> \"$temporary_entry\"\n") +
+                                          "mv -f -- \"$temporary_entry\" \"$desktop_entry\") 2>/dev/null; then :; fi\n"
+                                          "exec \"$launcher_dir/" +
+                                          EscapeForQuotedExec(executablePath.filename().string()) + "\" \"$@\"\n";
+        if (!WriteTextFile(wrapperScriptPath, wrapperScript, errorMessage))
+        {
+            return false;
+        }
+
+        artifacts.DesktopEntryPath = desktopEntryPath;
+        artifacts.WrapperScriptPath = wrapperScriptPath;
+        artifacts.PackagedIconPath = packagedIconPath;
+        return true;
+    }
+} // namespace OloEngine

--- a/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
+++ b/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
@@ -198,7 +198,7 @@ namespace OloEngine
                                           "desktop_entry=\"$launcher_dir/" +
                                           EscapeForQuotedExec(desktopEntryPath.filename().string()) + "\"\n"
                                                                                                       "temporary_entry=\"$desktop_entry.tmp\"\n"
-                                                                                                      "if desktop_mode=$(stat -c '%a' -- \"$desktop_entry\") && cat > \"$temporary_entry\" <<'OLO_DESKTOP_ENTRY'\n" +
+                                                                                                      "if (desktop_mode=$(stat -c '%a' -- \"$desktop_entry\") && cat > \"$temporary_entry\" <<'OLO_DESKTOP_ENTRY'\n" +
                                           desktopEntry +
                                           "OLO_DESKTOP_ENTRY\n" +
                                           (packagedIconPath.empty() ? std::string{} : "printf 'Icon=%s\\n' \"$launcher_dir/" + EscapeForQuotedExec(std::string(IconDirectoryName) + "/" + packagedIconPath.filename().string()) + "\" >> \"$temporary_entry\"\n") +

--- a/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
+++ b/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp
@@ -198,11 +198,11 @@ namespace OloEngine
                                           "desktop_entry=\"$launcher_dir/" +
                                           EscapeForQuotedExec(desktopEntryPath.filename().string()) + "\"\n"
                                                                                                       "temporary_entry=\"$desktop_entry.tmp\"\n"
-                                                                                                      "if (cat > \"$temporary_entry\" <<'OLO_DESKTOP_ENTRY'\n" +
+                                                                                                      "if desktop_mode=$(stat -c '%a' -- \"$desktop_entry\") && cat > \"$temporary_entry\" <<'OLO_DESKTOP_ENTRY'\n" +
                                           desktopEntry +
                                           "OLO_DESKTOP_ENTRY\n" +
                                           (packagedIconPath.empty() ? std::string{} : "printf 'Icon=%s\\n' \"$launcher_dir/" + EscapeForQuotedExec(std::string(IconDirectoryName) + "/" + packagedIconPath.filename().string()) + "\" >> \"$temporary_entry\"\n") +
-                                          "mv -f -- \"$temporary_entry\" \"$desktop_entry\") 2>/dev/null; then :; fi\n"
+                                          "chmod \"$desktop_mode\" -- \"$temporary_entry\" && mv -f -- \"$temporary_entry\" \"$desktop_entry\") 2>/dev/null; then :; fi\n"
                                           "exec \"$launcher_dir/" +
                                           EscapeForQuotedExec(executablePath.filename().string()) + "\" \"$@\"\n";
         if (!WriteTextFile(wrapperScriptPath, wrapperScript, errorMessage))

--- a/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.h
+++ b/OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace OloEngine
+{
+    struct LinuxDesktopLauncherArtifacts
+    {
+        std::filesystem::path DesktopEntryPath;
+        std::filesystem::path WrapperScriptPath;
+        std::filesystem::path PackagedIconPath;
+    };
+
+    /// Stage a portable Linux launcher without embedding authoring-machine paths.
+    /// The root desktop entry uses `%k` to locate the packaged wrapper after a
+    /// move; that wrapper refreshes the entry's packaged-icon path.
+    /// The Linux platform hook adds executable permissions after staging.
+    [[nodiscard]] bool StageLinuxDesktopLauncher(
+        const std::filesystem::path& executablePath,
+        const std::filesystem::path& iconPath,
+        const std::string& gameName,
+        LinuxDesktopLauncherArtifacts& artifacts,
+        std::string& errorMessage);
+} // namespace OloEngine

--- a/OloEngine/src/Platform/Linux/LinuxBuildPipeline.cpp
+++ b/OloEngine/src/Platform/Linux/LinuxBuildPipeline.cpp
@@ -41,7 +41,15 @@ namespace OloEngine::BuildPipelinePlatform
                                      std::filesystem::perm_options::add, desktopPermEc);
         if (desktopPermEc)
         {
-            OLO_CORE_WARN("[GameBuild] Failed to mark {} executable: {}", artifacts.DesktopEntryPath.string(), desktopPermEc.message());
+            outError = "Failed to mark desktop entry executable: " + desktopPermEc.message();
+            std::error_code cleanupEc;
+            std::filesystem::remove(artifacts.DesktopEntryPath, cleanupEc);
+            std::filesystem::remove(artifacts.WrapperScriptPath, cleanupEc);
+            if (!artifacts.PackagedIconPath.empty())
+            {
+                std::filesystem::remove(artifacts.PackagedIconPath, cleanupEc);
+            }
+            return false;
         }
 
         desktopPermEc.clear();
@@ -50,7 +58,15 @@ namespace OloEngine::BuildPipelinePlatform
                                      std::filesystem::perm_options::add, desktopPermEc);
         if (desktopPermEc)
         {
-            OLO_CORE_WARN("[GameBuild] Failed to mark {} executable: {}", artifacts.WrapperScriptPath.string(), desktopPermEc.message());
+            outError = "Failed to mark launcher wrapper executable: " + desktopPermEc.message();
+            std::error_code cleanupEc;
+            std::filesystem::remove(artifacts.DesktopEntryPath, cleanupEc);
+            std::filesystem::remove(artifacts.WrapperScriptPath, cleanupEc);
+            if (!artifacts.PackagedIconPath.empty())
+            {
+                std::filesystem::remove(artifacts.PackagedIconPath, cleanupEc);
+            }
+            return false;
         }
 
         OLO_CORE_INFO("[GameBuild] Linux desktop entry written: {}", artifacts.DesktopEntryPath.string());

--- a/OloEngine/src/Platform/Linux/LinuxBuildPipeline.cpp
+++ b/OloEngine/src/Platform/Linux/LinuxBuildPipeline.cpp
@@ -5,12 +5,11 @@
 
 #include "OloEnginePCH.h"
 #include "OloEngine/Build/BuildPipelinePlatform.h"
+#include "OloEngine/Build/LinuxDesktopLauncher.h"
 
 #ifdef OLO_PLATFORM_LINUX
 
 #include "OloEngine/Core/Log.h"
-
-#include <fstream>
 
 namespace OloEngine::BuildPipelinePlatform
 {
@@ -22,124 +21,39 @@ namespace OloEngine::BuildPipelinePlatform
         return false;
     }
 
-    namespace
-    {
-        // Desktop Entry Specification quoting for a value inside a quoted Exec
-        // field: a backslash, double quote, backtick or dollar sign must be
-        // backslash-escaped, or the entry is malformed and desktop environments
-        // may refuse to parse it.
-        // https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
-        std::string EscapeForQuotedExecValue(const std::string& value)
-        {
-            std::string escaped;
-            escaped.reserve(value.size());
-            for (char c : value)
-            {
-                if (c == '\\' || c == '"' || c == '`' || c == '$')
-                {
-                    escaped += '\\';
-                }
-                escaped += c;
-            }
-            return escaped;
-        }
-
-        // The Exec key also reserves `%` for field codes (%f, %u, ...) — a
-        // literal percent must be doubled to `%%` or a GameName containing one
-        // (e.g. "Game%Game", which passes GameBuildPipeline's name validation)
-        // would be misinterpreted as an undefined field code. This is a
-        // separate, later pass: general escaping happens first, then this.
-        std::string EscapePercentForExecField(const std::string& value)
-        {
-            std::string escaped;
-            escaped.reserve(value.size());
-            for (char c : value)
-            {
-                if (c == '%')
-                {
-                    escaped += '%';
-                }
-                escaped += c;
-            }
-            return escaped;
-        }
-
-        // Name is a plain localestring — no `%`/backtick/`$` field-code or
-        // shell-quoting concerns, just the general backslash/quote escaping.
-        std::string EscapeForDesktopName(const std::string& value)
-        {
-            std::string escaped;
-            escaped.reserve(value.size());
-            for (char c : value)
-            {
-                if (c == '\\')
-                {
-                    escaped += '\\';
-                }
-                escaped += c;
-            }
-            return escaped;
-        }
-    } // namespace
-
     bool WriteDesktopEntry(const std::filesystem::path& exePath,
                            const std::filesystem::path& iconPath,
                            const std::string& gameName,
                            std::string& outError)
     {
-        // Known limitation: Exec= embeds exePath's build-time absolute path,
-        // so relocating the finished game folder to a different path (or a
-        // different machine) breaks the launcher until it's regenerated —
-        // a proper fix is an install-time step, out of scope for #891, whose
-        // ask is a working .desktop entry for a build run in place.
-        if (!std::filesystem::exists(exePath))
+        LinuxDesktopLauncherArtifacts artifacts;
+        if (!StageLinuxDesktopLauncher(exePath, iconPath, gameName, artifacts, outError))
         {
-            outError = "Executable not found: " + exePath.string();
             return false;
         }
-
-        // The executable bit is expected to already be set here —
-        // GameBuildPipeline::CopyRuntimeExecutable marks the copied runtime
-        // executable runnable before this is called, since copy_file does not
-        // reliably preserve the executable bit across filesystems.
-
-        const auto desktopPath = exePath.parent_path() / (gameName + ".desktop");
-        std::ofstream out(desktopPath, std::ios::trunc);
-        if (!out.is_open())
-        {
-            outError = "Failed to create .desktop file: " + desktopPath.string();
-            return false;
-        }
-
-        out << "[Desktop Entry]\n";
-        out << "Type=Application\n";
-        out << "Name=" << EscapeForDesktopName(gameName) << "\n";
-        out << "Exec=\"" << EscapePercentForExecField(EscapeForQuotedExecValue(exePath.string())) << "\"\n";
-        if (!iconPath.empty())
-        {
-            // freedesktop Icon= expects a PNG/SVG/XPM file or icon-theme name,
-            // not a Windows .ico — GameBuildSettings::IconPath is shared across
-            // both targets, so a Windows-authored icon typically won't render
-            // here. Non-fatal: desktop environments fall back to a generic icon.
-            out << "Icon=" << iconPath.string() << "\n";
-        }
-        out << "Categories=Game;\n";
-        out << "Terminal=false\n";
-        out.close();
 
         // Many desktop environments only treat a .desktop file as "trusted"
         // (rather than prompting "Untrusted application launcher") once it is
         // itself marked executable.
         std::error_code desktopPermEc;
-        std::filesystem::permissions(desktopPath,
+        std::filesystem::permissions(artifacts.DesktopEntryPath,
                                      std::filesystem::perms::owner_exec | std::filesystem::perms::group_exec | std::filesystem::perms::others_exec,
                                      std::filesystem::perm_options::add, desktopPermEc);
         if (desktopPermEc)
         {
-            OLO_CORE_WARN("[GameBuild] Failed to mark {} executable: {}", desktopPath.string(), desktopPermEc.message());
+            OLO_CORE_WARN("[GameBuild] Failed to mark {} executable: {}", artifacts.DesktopEntryPath.string(), desktopPermEc.message());
         }
 
-        OLO_CORE_INFO("[GameBuild] Linux desktop entry written: {}", desktopPath.string());
+        desktopPermEc.clear();
+        std::filesystem::permissions(artifacts.WrapperScriptPath,
+                                     std::filesystem::perms::owner_exec | std::filesystem::perms::group_exec | std::filesystem::perms::others_exec,
+                                     std::filesystem::perm_options::add, desktopPermEc);
+        if (desktopPermEc)
+        {
+            OLO_CORE_WARN("[GameBuild] Failed to mark {} executable: {}", artifacts.WrapperScriptPath.string(), desktopPermEc.message());
+        }
+
+        OLO_CORE_INFO("[GameBuild] Linux desktop entry written: {}", artifacts.DesktopEntryPath.string());
         return true;
     }
 

--- a/OloEngine/tests/Build/GameBuildPipelineTest.cpp
+++ b/OloEngine/tests/Build/GameBuildPipelineTest.cpp
@@ -18,10 +18,15 @@
 
 #include "OloEngine/Build/GameBuildPipeline.h"
 #include "OloEngine/Build/GameBuildSettings.h"
+#include "OloEngine/Build/LinuxDesktopLauncher.h"
 
+#include <array>
 #include <atomic>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
+#include <string>
 
 using namespace OloEngine;
 
@@ -36,7 +41,171 @@ namespace
                    ? BuildTargetPlatform::Linux
                    : BuildTargetPlatform::Windows;
     }
+
+    std::string ReadTextFile(const std::filesystem::path& path)
+    {
+        std::ifstream input(path, std::ios::binary);
+        return { std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>() };
+    }
+
+    void WritePngSignature(const std::filesystem::path& path)
+    {
+        constexpr std::array<unsigned char, 8> signature{ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a };
+        std::ofstream output(path, std::ios::binary);
+        output.write(reinterpret_cast<const char*>(signature.data()), static_cast<std::streamsize>(signature.size()));
+    }
+
+#ifdef OLO_PLATFORM_LINUX
+    std::string ShellQuote(const std::filesystem::path& path)
+    {
+        std::string quoted{ "'" };
+        for (const auto character : path.string())
+        {
+            if (character == '\'')
+            {
+                quoted += "'\"'\"'";
+            }
+            else
+            {
+                quoted += character;
+            }
+        }
+        return quoted + "'";
+    }
+#endif
 } // namespace
+
+TEST(GameBuildPipelineTest, LinuxLauncherAndIconStayInsideAMovedPackage)
+{
+    const auto testRoot = OloEngine::Tests::TempDir("linux-launcher-relocation");
+    const auto originalPackage = testRoot / "authoring output $`" / "Portable Game";
+    const auto movedPackage = testRoot / "moved ä distribution %$`" / "Portable Game";
+    std::filesystem::create_directories(originalPackage);
+
+    const auto executable = originalPackage / "Portable Game";
+    std::ofstream(executable) << "runtime";
+    const auto selectedIcon = testRoot / "selected icon.png";
+    WritePngSignature(selectedIcon);
+
+    LinuxDesktopLauncherArtifacts artifacts;
+    std::string errorMessage;
+    ASSERT_TRUE(StageLinuxDesktopLauncher(executable, selectedIcon, "Portable Game", artifacts, errorMessage))
+        << errorMessage;
+
+    const auto desktopRelative = std::filesystem::relative(artifacts.DesktopEntryPath, originalPackage);
+    const auto wrapperRelative = std::filesystem::relative(artifacts.WrapperScriptPath, originalPackage);
+    const auto iconRelative = std::filesystem::relative(artifacts.PackagedIconPath, originalPackage);
+
+    std::filesystem::create_directories(movedPackage.parent_path());
+    std::filesystem::rename(originalPackage, movedPackage);
+
+    const auto movedDesktop = movedPackage / desktopRelative;
+    const auto movedWrapper = movedPackage / wrapperRelative;
+    const auto movedIcon = movedPackage / iconRelative;
+    ASSERT_TRUE(std::filesystem::exists(movedDesktop));
+    ASSERT_TRUE(std::filesystem::exists(movedWrapper));
+    ASSERT_TRUE(std::filesystem::exists(movedIcon));
+    EXPECT_EQ(ReadTextFile(movedIcon), ReadTextFile(selectedIcon));
+
+    const auto desktopText = ReadTextFile(movedDesktop);
+    EXPECT_EQ(desktopText.find(originalPackage.string()), std::string::npos);
+    EXPECT_NE(desktopText.find("Exec=/bin/sh -c"), std::string::npos);
+    EXPECT_NE(desktopText.find(" olo-launcher %k"), std::string::npos);
+    EXPECT_EQ(desktopText.find("Icon="), std::string::npos)
+        << "A portable entry cannot use a stale absolute Icon= before its wrapper derives the moved path.";
+
+    const auto wrapperText = ReadTextFile(movedWrapper);
+    EXPECT_EQ(wrapperText.find(originalPackage.string()), std::string::npos);
+    EXPECT_NE(wrapperText.find("launcher_dir"), std::string::npos);
+    EXPECT_NE(wrapperText.find("Portable Game"), std::string::npos);
+    EXPECT_NE(wrapperText.find("icons/game-icon.png"), std::string::npos);
+    EXPECT_NE(wrapperText.find("temporary_entry"), std::string::npos);
+}
+
+TEST(GameBuildPipelineTest, LinuxLauncherRejectsMissingAndUnsupportedIcons)
+{
+    const auto testRoot = OloEngine::Tests::TempDir("linux-launcher-invalid-icon");
+    const auto executable = testRoot / "Game";
+    std::ofstream(executable) << "runtime";
+
+    LinuxDesktopLauncherArtifacts artifacts;
+    std::string errorMessage;
+    EXPECT_FALSE(StageLinuxDesktopLauncher(executable, testRoot / "missing.png", "Game", artifacts, errorMessage));
+    EXPECT_NE(errorMessage.find("not found"), std::string::npos);
+
+    const auto unsupportedIcon = testRoot / "icon.ico";
+    std::ofstream(unsupportedIcon) << "not a Linux icon";
+    errorMessage.clear();
+    EXPECT_FALSE(StageLinuxDesktopLauncher(executable, unsupportedIcon, "Game", artifacts, errorMessage));
+    EXPECT_NE(errorMessage.find("PNG, SVG, or XPM"), std::string::npos);
+
+    const auto corruptPng = testRoot / "corrupt.png";
+    std::ofstream(corruptPng) << "not a PNG";
+    errorMessage.clear();
+    EXPECT_FALSE(StageLinuxDesktopLauncher(executable, corruptPng, "Game", artifacts, errorMessage));
+    EXPECT_NE(errorMessage.find("does not match"), std::string::npos);
+}
+
+TEST(GameBuildPipelineTest, LinuxLauncherAllowsAnEmptyIconAndOverwritesPackagedIcons)
+{
+    const auto testRoot = OloEngine::Tests::TempDir("linux-launcher-regeneration");
+    const auto executable = testRoot / "Game";
+    std::ofstream(executable) << "runtime";
+
+    LinuxDesktopLauncherArtifacts emptyArtifacts;
+    std::string errorMessage;
+    ASSERT_TRUE(StageLinuxDesktopLauncher(executable, {}, "Game", emptyArtifacts, errorMessage)) << errorMessage;
+    EXPECT_TRUE(emptyArtifacts.PackagedIconPath.empty());
+    EXPECT_EQ(ReadTextFile(emptyArtifacts.DesktopEntryPath).find("Icon="), std::string::npos);
+
+    const auto icon = testRoot / "icon.PNG";
+    WritePngSignature(icon);
+    LinuxDesktopLauncherArtifacts firstArtifacts;
+    ASSERT_TRUE(StageLinuxDesktopLauncher(executable, icon, "Game", firstArtifacts, errorMessage)) << errorMessage;
+    EXPECT_EQ(firstArtifacts.PackagedIconPath.filename(), "game-icon.png");
+
+    std::ofstream(icon, std::ios::binary | std::ios::app) << "replacement";
+    LinuxDesktopLauncherArtifacts secondArtifacts;
+    ASSERT_TRUE(StageLinuxDesktopLauncher(executable, icon, "Game", secondArtifacts, errorMessage)) << errorMessage;
+    EXPECT_EQ(firstArtifacts.PackagedIconPath, secondArtifacts.PackagedIconPath);
+    EXPECT_EQ(ReadTextFile(secondArtifacts.PackagedIconPath), ReadTextFile(icon));
+}
+
+TEST(GameBuildPipelineTest, LinuxLauncherExecutesFromARelocatedPackage)
+{
+#ifndef OLO_PLATFORM_LINUX
+    GTEST_SKIP() << "Requires a Linux shell and filesystem permissions.";
+#else
+    const auto testRoot = OloEngine::Tests::TempDir("linux-launcher-execution");
+    const auto sourcePackage = testRoot / "source package";
+    const auto movedPackage = testRoot / "moved package";
+    std::filesystem::create_directories(sourcePackage);
+
+    const auto executable = sourcePackage / "Game";
+    std::ofstream(executable) << "#!/bin/sh\nprintf launched > \"$0.launched\"\n";
+    std::filesystem::permissions(executable, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
+    const auto icon = testRoot / "icon.png";
+    WritePngSignature(icon);
+
+    LinuxDesktopLauncherArtifacts artifacts;
+    std::string errorMessage;
+    ASSERT_TRUE(StageLinuxDesktopLauncher(executable, icon, "Game", artifacts, errorMessage)) << errorMessage;
+    std::filesystem::permissions(artifacts.WrapperScriptPath, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
+    std::filesystem::rename(sourcePackage, movedPackage);
+
+    const auto movedDesktop = movedPackage / artifacts.DesktopEntryPath.filename();
+    const auto movedIcon = movedPackage / "icons/game-icon.png";
+    const auto bootstrap = "/bin/sh -c 'exec \"$(dirname -- \"$1\")/OloGameLauncher.sh\"' olo-launcher " + ShellQuote(movedDesktop);
+    ASSERT_EQ(std::system(bootstrap.c_str()), 0);
+    EXPECT_TRUE(std::filesystem::exists(movedPackage / "Game.launched"));
+    EXPECT_NE(ReadTextFile(movedDesktop).find("Icon=" + movedIcon.string()), std::string::npos);
+
+    if (std::system("command -v desktop-file-validate >/dev/null 2>&1") == 0)
+    {
+        EXPECT_EQ(std::system(("desktop-file-validate " + ShellQuote(movedDesktop)).c_str()), 0);
+    }
+#endif
+}
 
 TEST(GameBuildPipelineTest, DefaultSettingsTargetTheHostPlatform)
 {

--- a/OloEngine/tests/Build/GameBuildPipelineTest.cpp
+++ b/OloEngine/tests/Build/GameBuildPipelineTest.cpp
@@ -199,6 +199,8 @@ TEST(GameBuildPipelineTest, LinuxLauncherExecutesFromARelocatedPackage)
     ASSERT_EQ(std::system(bootstrap.c_str()), 0);
     EXPECT_TRUE(std::filesystem::exists(movedPackage / "Game.launched"));
     EXPECT_NE(ReadTextFile(movedDesktop).find("Icon=" + movedIcon.string()), std::string::npos);
+    EXPECT_NE(std::filesystem::status(movedDesktop).permissions() & std::filesystem::perms::owner_exec,
+              std::filesystem::perms::none);
 
     if (std::system("command -v desktop-file-validate >/dev/null 2>&1") == 0)
     {

--- a/OloEngine/tests/Build/GameBuildPipelineTest.cpp
+++ b/OloEngine/tests/Build/GameBuildPipelineTest.cpp
@@ -190,6 +190,7 @@ TEST(GameBuildPipelineTest, LinuxLauncherExecutesFromARelocatedPackage)
     LinuxDesktopLauncherArtifacts artifacts;
     std::string errorMessage;
     ASSERT_TRUE(StageLinuxDesktopLauncher(executable, icon, "Game", artifacts, errorMessage)) << errorMessage;
+    std::filesystem::permissions(artifacts.DesktopEntryPath, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
     std::filesystem::permissions(artifacts.WrapperScriptPath, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
     std::filesystem::rename(sourcePackage, movedPackage);
 

--- a/docs/ops/shipping.md
+++ b/docs/ops/shipping.md
@@ -86,12 +86,12 @@ explicitly so nobody reaches for that shortcut:
 - **The build tree itself** — `vcpkg_installed/`, `CMakeCache.txt`, object files, `.git/`. None of
   these are ever inside `OutputDirectory/GameName/`; called out only because "zip the whole repo"
   is the failure mode this line exists to prevent.
-- **The Linux `.desktop` entry, on the Steam depot specifically.** `WriteLinuxDesktopEntry` (#891)
-  writes one for a plain tarball/itch.io-style distribution where the player manages their own
-  desktop launcher. On Steam, the client owns the launcher (Big Picture / library entry), so a
-  shipped `.desktop` file is redundant, not harmful — it doesn't need a `FileExclusion` entry
-  either, since Steam simply never reads it. Documented so nobody spends time trying to make
-  Steam use it.
+- **The Linux `.desktop` entry and `OloGameLauncher.sh`, on the Steam depot specifically.**
+  `WriteLinuxDesktopEntry` writes these (and an optional `icons/game-icon.*`) for a plain
+  tarball/itch.io-style distribution. The desktop entry uses its own `%k` location to find the
+  wrapper after the folder moves; the wrapper refreshes its `Icon=` path from the packaged icon
+  on launch. Steam owns its launcher (Big Picture / library entry), so these extra files are
+  redundant but harmless — Steam simply never reads them.
 
 ### Per-platform depots
 

--- a/docs/ops/shipping.md
+++ b/docs/ops/shipping.md
@@ -86,12 +86,12 @@ explicitly so nobody reaches for that shortcut:
 - **The build tree itself** — `vcpkg_installed/`, `CMakeCache.txt`, object files, `.git/`. None of
   these are ever inside `OutputDirectory/GameName/`; called out only because "zip the whole repo"
   is the failure mode this line exists to prevent.
-- **The Linux `.desktop` entry and `OloGameLauncher.sh`, on the Steam depot specifically.**
-  `WriteLinuxDesktopEntry` writes these (and an optional `icons/game-icon.*`) for a plain
-  tarball/itch.io-style distribution. The desktop entry uses its own `%k` location to find the
-  wrapper after the folder moves; the wrapper refreshes its `Icon=` path from the packaged icon
-  on launch. Steam owns its launcher (Big Picture / library entry), so these extra files are
-  redundant but harmless — Steam simply never reads them.
+- **The Linux `.desktop` entry, `OloGameLauncher.sh`, and optional `icons/game-icon.*`, on the
+  Steam depot specifically.** These files are **shipped** whenever `GameBuildPipeline` emits
+  them; the Steam upload templates do not exclude them. They are for plain tarball/itch.io-style
+  distribution, where the desktop entry uses `%k` to find the wrapper after the folder moves and
+  the wrapper refreshes `Icon=` from the packaged icon. Steam owns its launcher (Big Picture /
+  library entry), so it does not use these otherwise harmless files.
 
 ### Per-platform depots
 


### PR DESCRIPTION
## Summary
- stage a portable Linux desktop launcher, wrapper, and target-native packaged icon
- resolve launches from the moved desktop file through the standard %k field code
- refresh the icon path from the moved package without blocking a read-only package from launching
- cover relocation, icon validation/regeneration, and Linux wrapper execution

## Verification
- GameBuildPipelineTest.LinuxLauncher* — 3 passed on Windows; Linux execution case skips there and runs on Linux
- pre-commit run --all-files

Closes #913

## Review guide

**Where I'd look hardest**
1. OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp — Desktop Entry escaping and the explicit /bin/sh bootstrap must preserve %k as a standalone field-code argument.
2. OloEngine/src/OloEngine/Build/LinuxDesktopLauncher.cpp — wrapper icon refresh is deliberately best-effort so a read-only moved package still launches.
3. OloEngine/tests/Build/GameBuildPipelineTest.cpp — Linux-only execution test exercises the generated path after relocation.

**What I verified, and how** — focused launcher tests passed on Windows, pre-commit passed, and Linux CI will run the execution/desktop-file-validation branch.

**Least confident about** — desktop-environment icon-cache refresh timing after the launcher rewrites its own entry; the entry is standards-compliant after launch, but each desktop may refresh visual metadata at a different cadence.

**Deliberately not tested** — a real Linux desktop session was not available locally; the Linux-only test is left for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux game packages now include a relocatable desktop launcher and startup script.
  * Launchers continue working when the packaged game directory is moved.
  * Optional PNG, SVG, and XPM icons are packaged with the launcher and resolved automatically.
  * Invalid, unsupported, or corrupted icons are rejected with clear build errors.
* **Documentation**
  * Linux shipping guidance now explains the additional launcher files, package distribution requirements, and which files should be excluded from Steam depots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->