### PR TITLE
fix(net): pin GNS to a post-1.6.0 master snapshot, restore ASan coverage

### DIFF
--- a/.claude/hooks/claude-build-lock-guard.py
+++ b/.claude/hooks/claude-build-lock-guard.py
@@ -72,7 +72,14 @@ _STATEMENT = r"(?:^|[;|(){}\n]\s*|&+\s*[\"']?\s*|(?:-Command|-c)\s+[\"']?\s*)"
 _PATH = r"(?:[A-Za-z]:)?(?:[\w.\-]*[\\/])*"
 
 # `cmake` alone is not enough -- `cmake --preset msvc` only configures, and
-# configuring is cheap.
+# configuring is cheap. That stays true: a configure will not OOM the box, which
+# is what this mutex exists to prevent. It is NOT the same as saying concurrent
+# configures are safe -- two configures against one binary directory corrupt each
+# other's try_compile scratch projects. That is guarded on the CMake side, by the
+# file(LOCK) at the top of CMakeLists.txt, because it also has to cover configures
+# this hook never sees (VS Code's CMake Tools, Visual Studio, a plain shell). Do
+# not "fix" it by adding bare `cmake` here; see
+# docs/agent-rules/concurrent-cmake-configure.md.
 BUILD_PATTERNS = (
     (
         "cmake --build",

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -313,9 +313,21 @@ jobs:
       # snapshot carrying it (cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
       # — v1.6.0 is still the newest tag and predates the fix), and both the
       # NetworkManager::Init gate and ServerAuthoritativeLoopTest's GTEST_SKIP are
-      # gone. So this job now runs the live GNS init and ServerAuthoritativeLoopTest
-      # under ASan for real. If that regresses, the fix is to move the pin, not to
-      # bring the gate back.
+      # gone, so the live init runs here and ServerAuthoritativeLoopTest's 17 cases
+      # execute instead of skipping.
+      #
+      # BE PRECISE ABOUT WHAT THAT COVERS. GNS is a vcpkg port built with cl.exe and
+      # no sanitizer flags -- see the triplet note on the vcpkg step above, "vcpkg
+      # ports are NOT sanitizer-instrumented", which is deliberate. So ASan
+      # instruments the engine and the test process, NOT GNS internals: allocations
+      # and interceptors crossing the boundary are covered, stack and global redzones
+      # inside GNS are not. What this change buys is sanitizer coverage of OloEngine's
+      # own networking code against a LIVE transport -- NetworkManager init/shutdown,
+      # NetworkThread, dispatch, replication -- all of which previously never executed
+      # under ASan at all. It does not re-arm detection of #418-class faults inside
+      # GNS; that would need an instrumented GNS build, which this job explicitly does
+      # not want. If these tests regress, the fix is to move the pin, not to bring the
+      # gate back.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
       # task system starts the Steam service thread" theory — they never touched
@@ -323,8 +335,10 @@ jobs:
       # ASan, so they are no longer excluded. See issue #317.
       #
       # Remaining exclusions match the Linux ASan job exactly:
-      #   NetworkIntegrationTest — drives a live client/server socket, which the
-      #     ASan GNS gate intentionally disables; excluded on every sanitizer job.
+      #   NetworkIntegrationTest — needs real client/server socket plumbing that CI
+      #     environments do not provide; excluded on EVERY job in this repo, the
+      #     non-sanitizer ones included (Windows.yml, gpu-conformance-amd.yml). Not
+      #     related to the removed ASan gate, and not something the GNS pin changes.
       #   WorkerRestartTest — a tight 100-iteration worker-pool teardown/recreate
       #     stress test that exceeds the 120 s timeout under sanitizer
       #     instrumentation; excluded on every sanitizer job.

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -300,16 +300,22 @@ jobs:
 
     - name: Run tests under ASan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
-      # The SteamNetworkingSockets service thread tripped a stack-buffer-overflow
-      # under MSVC ASan during thread bootstrap (a 48-byte read from a 24-byte
-      # `info` stack object inside vendored GNS code on the GNS-spawned thread;
-      # Release ICF folding misreported the frames as `SteamNetworkingSockets_*` /
-      # `pugi::xpath_*`). That is now fixed at the source: NetworkManager::Init
-      # skips the live GameNetworkingSockets_Init under ASan (OLO_ASAN_ENABLED),
-      # so every suite that merely constructs/uses NetworkManager runs clean.
-      # (Upstream GNS bug: ValveSoftware/GameNetworkingSockets#418.) The gate is
-      # keyed on OLO_ASAN_ENABLED, not the compiler, so it applies identically
-      # now that this job builds with clang-cl ASan instead of MSVC cl.exe ASan.
+      # The SteamNetworkingSockets service thread used to trip a stack-buffer-overflow
+      # under ASan during thread bootstrap (a 48-byte read from a 24-byte `info`
+      # stack object inside vendored GNS code on the GNS-spawned thread; Release ICF
+      # folding misreported the frames as `SteamNetworkingSockets_*` /
+      # `pugi::xpath_*`). It was worked around by skipping the live
+      # GameNetworkingSockets_Init under OLO_ASAN_ENABLED, which bought a green job
+      # at the cost of never sanitizing the transport.
+      #
+      # FIXED UPSTREAM: ValveSoftware/GameNetworkingSockets#418, by PR #420 (merged
+      # to master 2026-08-24). The overlay port now pins a post-1.6.0 master
+      # snapshot carrying it (cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
+      # — v1.6.0 is still the newest tag and predates the fix), and both the
+      # NetworkManager::Init gate and ServerAuthoritativeLoopTest's GTEST_SKIP are
+      # gone. So this job now runs the live GNS init and ServerAuthoritativeLoopTest
+      # under ASan for real. If that regresses, the fix is to move the pin, not to
+      # bring the gate back.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
       # task system starts the Steam service thread" theory — they never touched

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -101,6 +101,8 @@
         "resumable": "cpp",
         "numbers": "cpp"
     },
+    "cmake.configureOnOpen": false,
+    "cmake.configureOnEdit": false,
     "dotnet.defaultSolution": "disable",
     "sonarlint.connectedMode.project": {
         "connectionId": "drsnuggles8",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,44 @@ if(NOT DEFINED VCPKG_TOOLCHAIN)
         "Setup instructions: docs/ops/build.md.")
 endif()
 
+# The second vcpkg trap, and this one is silent. Visual Studio's developer
+# environment sets VCPKG_ROOT to the copy bundled inside the VS install, and
+# VS Code's CMake Tools applies that environment on top of the process
+# environment BEFORE expanding the presets -- so the presets'
+# `"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"` can
+# resolve to <VS>/VC/vcpkg even though VCPKG_ROOT is your own clone in every
+# shell you can inspect. Observed here as a configure invoked with
+# -DCMAKE_TOOLCHAIN_FILE=".../Microsoft Visual Studio/18/Community/VC/vcpkg/..."
+# while VCPKG_ROOT was D:cpkg.
+#
+# Not fatal: that copy is a real bootstrapped vcpkg and will build. It is a
+# WARNING because the consequences are quiet rather than absent -- it is a
+# different registry clone, it does not have vcpkg.json's builtin-baseline
+# commit locally (so it re-fetches the registry from HEAD), and it keeps its own
+# downloads/, diverging from every other worktree on this machine. An existing
+# build tree is unaffected either way: CMAKE_TOOLCHAIN_FILE is only honoured on
+# the FIRST configure, so a tree already pinned to the right vcpkg stays pinned.
+set(_olo_vs_vcpkg_re "[Mm]icrosoft [Vv]isual [Ss]tudio.*[/\]VC[/\]vcpkg")
+if(CMAKE_TOOLCHAIN_FILE MATCHES "${_olo_vs_vcpkg_re}" OR "$ENV{VCPKG_ROOT}" MATCHES "${_olo_vs_vcpkg_re}")
+    message(WARNING
+        "vcpkg is being resolved from the copy bundled with Visual Studio, not from a "
+        "vcpkg clone you control:
+"
+        "  CMAKE_TOOLCHAIN_FILE = ${CMAKE_TOOLCHAIN_FILE}
+"
+        "  VCPKG_ROOT (env)     = $ENV{VCPKG_ROOT}
+"
+        "This happens when the Visual Studio developer environment overrides VCPKG_ROOT "
+        "-- VS Code's CMake Tools applies it before expanding the presets. The build will "
+        "work, but it uses a separate registry clone that lacks vcpkg.json's "
+        "builtin-baseline and re-fetches the registry from HEAD, and it does not share "
+        "downloads/ with the other worktrees on this machine.
+"
+        "Set VCPKG_ROOT so it survives the VS environment (see docs/ops/build.md), or pass "
+        "-DCMAKE_TOOLCHAIN_FILE=<your vcpkg>/scripts/buildsystems/vcpkg.cmake explicitly.")
+endif()
+unset(_olo_vs_vcpkg_re)
+
 # Build optimization options
 option(OLO_ENABLE_LTO "Enable Link Time Optimization" ON)
 option(OLO_ENABLE_PCH "Enable Precompiled Headers" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,54 @@ if(POLICY CMP0194)
 endif()
 
 # --------------------------------------------------------------------------
+# One configure at a time per build tree.
+#
+# Two CMake configures running against the same binary directory corrupt each
+# other. They share CMakeFiles/, and the throwaway projects that try_compile()
+# and check_ipo_supported() generate under it get deleted mid-flight by the
+# other process. The symptom names neither concurrency nor the real culprit --
+# it is two bare
+#
+#   CMake Error: This should not have happened. If you see this message, you are
+#   probably using a broken CMakeLists.txt file or a problematic release of CMake
+#
+# lines followed by whichever check lost the race, observed against build-cached
+# as "CheckIPOSupported.cmake:197 (try_compile): Failed to configure test project
+# build system". That reads like an LTO or toolchain bug and is neither; the same
+# configure had succeeded four minutes earlier. It reproduces deterministically
+# by starting a second `cmake -S <src> -B <same-bin>` two seconds into the first.
+#
+# The overlap is easy to hit without meaning to: VS Code's CMake Tools extension
+# configures on open and on every save of a CMake file (both now off in
+# .vscode/settings.json), so an editor-triggered configure can land on top of one
+# a terminal or an agent session already started. The build mutex in
+# .claude/skills/run-oloengine/build-lock.ps1 does not cover this -- it serialises
+# builds, and its guard deliberately classifies `cmake` without `--build` as
+# cheap. Cheap it is; concurrency-safe it is not.
+#
+# GUARD PROCESS releases the lock when this cmake process exits, including on a
+# fatal error. Nested try_compile cmake processes never read this file, so there
+# is no self-deadlock. A queued configure waits rather than failing outright,
+# because it is usually a legitimate re-configure that will produce the right
+# answer a moment later; the timeout only fires if the holder has wedged.
+file(LOCK "${CMAKE_BINARY_DIR}/olo-configure.lock"
+     GUARD PROCESS
+     TIMEOUT 600
+     RESULT_VARIABLE OLO_CONFIGURE_LOCK_RESULT)
+if(NOT OLO_CONFIGURE_LOCK_RESULT STREQUAL "0")
+    message(FATAL_ERROR
+        "Timed out waiting for another CMake configure to finish in "
+        "${CMAKE_BINARY_DIR}.
+"
+        "Concurrent configures of one build tree corrupt each other, so this one "
+        "stopped instead of racing. Wait for the other configure to finish (VS Code "
+        "CMake Tools, another terminal, another agent session), or delete "
+        "${CMAKE_BINARY_DIR}/olo-configure.lock if nothing is running.
+"
+        "Lock error: ${OLO_CONFIGURE_LOCK_RESULT}")
+endif()
+
+# --------------------------------------------------------------------------
 # vcpkg manifest features (issue #773).
 #
 # MUST be set BEFORE project() — vcpkg's toolchain file runs the manifest

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
@@ -11,7 +11,6 @@
 #include "OloEngine/Networking/Transport/NetworkServer.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Debug/Profiler.h"
-#include "OloEngine/Memory/Platform.h" // OLO_ASAN_ENABLED
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Threading/UniqueLock.h"
@@ -91,31 +90,11 @@ namespace OloEngine
         SteamNetworkingUtils()->SetGlobalCallback_SteamNetConnectionStatusChanged(
             GNSConnectionStatusCallback);
 
-#if OLO_ASAN_ENABLED
-        // GameNetworkingSockets_Init spawns an internal service thread whose
-        // startup routine trips a stack-buffer-overflow under MSVC AddressSanitizer:
-        // a 48-byte read out of a 24-byte `info` stack object during thread
-        // bootstrap, inside vendored GNS code on the GNS-spawned thread — not
-        // OloEngine code, and clean under Linux ASan/UBSan. (In Release the
-        // internal frames get ICF-folded onto the nearest exported symbols, so CI
-        // stacks misreport it as SteamNetworkingSockets_* / pugi::xpath_*.)
-        // Skip the live GNS init under ASan so the rest of OloEngine's networking
-        // stack — the NetworkThread, task dispatch, message serialization and
-        // replication — still runs under the sanitizer. Tests that need a live
-        // socket (NetworkIntegrationTest) stay excluded from the ASan job; the
-        // debug-output/connection callbacks set above are harmless no-ops without
-        // a running service thread. Non-ASan production builds are unaffected.
-        // See issue #317; upstream GNS bug filed as
-        // ValveSoftware/GameNetworkingSockets#418 — remove this gate once a fixed
-        // GNS is vendored.
-        OLO_CORE_WARN("NetworkManager: skipping GameNetworkingSockets_Init under AddressSanitizer (issue #317)");
-#else
         if (SteamDatagramErrMsg errMsg; !GameNetworkingSockets_Init(nullptr, errMsg))
         {
             OLO_CORE_ERROR("GameNetworkingSockets_Init failed: {}", errMsg);
             return false;
         }
-#endif
 
         NetworkThread::Start(60);
 
@@ -160,11 +139,7 @@ namespace OloEngine
         Disconnect();
         NetworkThread::Stop();
 
-#if !OLO_ASAN_ENABLED
-        // Matches the Init() gate above: GameNetworkingSockets was never started
-        // under ASan, so there is nothing to tear down. See issue #317.
         GameNetworkingSockets_Kill();
-#endif
 
         TUniqueLock<FMutex> lock(s_Mutex);
         s_ActiveScene = nullptr;

--- a/OloEngine/tests/Functional/Networking/ServerAuthoritativeLoopTest.cpp
+++ b/OloEngine/tests/Functional/Networking/ServerAuthoritativeLoopTest.cpp
@@ -30,7 +30,6 @@
 
 #include <gtest/gtest.h>
 
-#include "OloEngine/Memory/Platform.h" // OLO_ASAN_ENABLED
 #include "OloEngine/Networking/Core/ClientReplicationDriver.h"
 #include "OloEngine/Networking/Core/NetworkMessage.h"
 #include "OloEngine/Networking/Core/ServerReplicationDriver.h"
@@ -109,13 +108,6 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
   protected:
     void SetUp() override
     {
-#if OLO_ASAN_ENABLED
-        // GameNetworkingSockets_Init trips a stack-buffer-overflow inside vendored
-        // GNS under MSVC ASan (issue #317), exactly as NetworkManager::Init works
-        // around. Skip rather than fail: the transport-free networking tests still
-        // run under the sanitizer.
-        GTEST_SKIP() << "Live GNS sockets are unavailable under AddressSanitizer (issue #317)";
-#else
         SteamDatagramErrMsg errMsg;
         ASSERT_TRUE(GameNetworkingSockets_Init(nullptr, errMsg)) << errMsg;
 
@@ -160,18 +152,15 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
         // how many ticks the harness happened to run.
         m_ClientDrivers[0].GetPrediction().SetSmoothingRate(1.0f);
         m_ClientDrivers[1].GetPrediction().SetSmoothingRate(1.0f);
-#endif
     }
 
     void TearDown() override
     {
-#if !OLO_ASAN_ENABLED
         // Clear the RPC registry FIRST. The RPC tests register handlers capturing
         // test-body locals by reference, and GoogleTest destroys those locals when
         // TestBody returns — before TearDown runs. If closing a transport below
         // drained a queued RPC, the dispatcher would invoke a handler over destroyed
-        // references. (The fixture skips under ASan, so the sanitizer cannot catch
-        // that for us.)
+        // references.
         RpcRegistry::Clear();
 
         for (auto& client : m_Clients)
@@ -193,7 +182,6 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
         // Give the OS a moment to release the listen socket before the next test
         // in this binary binds the same port.
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
-#endif
     }
 
     static void OnStatusChanged(SteamNetConnectionStatusChangedCallback_t* info)

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -35,13 +35,48 @@ function(olo_set_debugger_directory target_name)
     endif()
 endfunction()
 
+# Ask the toolchain ONCE whether it supports IPO/LTO, and cache the answer.
+#
+# check_ipo_supported() is not a cheap predicate: every call generates a small
+# `_CMakeLTOTest-<lang>` project under the current binary dir and runs a full
+# nested CMake configure + compile + link on it. olo_enable_lto() is called per
+# target -- OloEngine, every engine part in the loop, and every app through
+# olo_configure_app() -- so an unguarded call meant ~25 nested configures per
+# configure of this repo, all recomputing the same toolchain-wide answer.
+#
+# That was not just slow. A nested configure writes into the shared build tree,
+# so it is exactly what a SECOND concurrent CMake configure of the same build
+# directory corrupts: the observed failure is two bare
+# "CMake Error: This should not have happened..." lines followed by
+# "CheckIPOSupported.cmake:197 (try_compile): Failed to configure test project
+# build system". The configure lock in the top-level CMakeLists.txt is the real
+# defence against that; caching here shrinks the window by ~25x and takes a
+# large bite out of configure time either way.
+#
+# CACHE INTERNAL, so the answer survives a re-configure of the same tree. That
+# is the right lifetime: the answer is a property of the toolchain, and changing
+# the compiler under an existing build tree is not supported here anyway (it
+# needs a fresh tree -- see docs/agent-rules/build-trees-and-windows-asan.md).
+function(olo_check_lto_support out_var out_output)
+    if(NOT DEFINED OLO_LTO_SUPPORTED)
+        check_ipo_supported(RESULT _olo_lto_supported OUTPUT _olo_lto_output)
+        set(OLO_LTO_SUPPORTED "${_olo_lto_supported}" CACHE INTERNAL
+            "Whether the toolchain supports IPO/LTO (check_ipo_supported, run once per build tree)")
+        set(OLO_LTO_SUPPORT_OUTPUT "${_olo_lto_output}" CACHE INTERNAL
+            "check_ipo_supported() diagnostic output, kept for the 'not supported' warning")
+        message(STATUS "IPO/LTO supported by this toolchain: ${OLO_LTO_SUPPORTED}")
+    endif()
+    set(${out_var} "${OLO_LTO_SUPPORTED}" PARENT_SCOPE)
+    set(${out_output} "${OLO_LTO_SUPPORT_OUTPUT}" PARENT_SCOPE)
+endfunction()
+
 # Apply Link Time Optimization if supported and enabled (Release/Dist only)
 function(olo_enable_lto target_name)
     if(NOT DEFINED OLO_ENABLE_LTO)
         set(OLO_ENABLE_LTO ON)
     endif()
-    
-    check_ipo_supported(RESULT LTO_SUPPORT OUTPUT output)
+
+    olo_check_lto_support(LTO_SUPPORT output)
     if(OLO_ENABLE_LTO AND LTO_SUPPORT)
         message(STATUS "Enabled Link-Time Optimization (LTO) for ${target_name} (Release/Dist only)")
         # Only enable LTO for Release and Dist — it dramatically slows Debug builds

--- a/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
+++ b/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
@@ -22,8 +22,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/GameNetworkingSockets
-    REF "2cb93a06350bb065db53abdb0d87cf297e0bfd34" # v1.6.0
-    SHA512 c2deaa3aab42cd840dd13560ca4da40faa375ab846ea15af38d55eb7acc48cfe8cbdbe0c76b9c3484d26f9e1163e36ac1eb73a317e5c19cefe60d0b861d19e06
+    # POST-RELEASE MASTER SNAPSHOT, on purpose. v1.6.0 (2026-06-03) is still the
+    # latest tag, and it predates the fix for the stack-buffer-overflow that
+    # GameNetworkingSockets_Init's service thread trips under AddressSanitizer:
+    # ValveSoftware/GameNetworkingSockets#418, fixed by PR #420 (merged to master
+    # 2026-08-24). Without that fix, NetworkManager::Init has to skip the live
+    # init under ASan and the networking suites lose their sanitizer coverage.
+    # Move back to a tag as soon as one ships that contains #420.
+    REF "a424b7db649438acafb60c99cae6667587c42732" # master @ 2026-08-26, 17 commits after PR #420
+    SHA512 a4a9abe49d1ee638926c180ff88c59329a3df749a6ba9a59efba4b719857f802941ae8eabb07fd88ea2138718a5721ecc1ebc61f2dafacc2a026e1374546e1b5
     HEAD_REF master
 )
 

--- a/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
+++ b/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
@@ -22,15 +22,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/GameNetworkingSockets
-    # POST-RELEASE MASTER SNAPSHOT, on purpose. v1.6.0 (2026-06-03) is still the
-    # latest tag, and it predates the fix for the stack-buffer-overflow that
+    # POST-RELEASE COMMIT, on purpose, and it is PR #420's MERGE COMMIT rather
+    # than a later master snapshot. v1.6.0 (2026-06-03) is still the latest tag
+    # and predates the fix for the stack-buffer-overflow that
     # GameNetworkingSockets_Init's service thread trips under AddressSanitizer:
     # ValveSoftware/GameNetworkingSockets#418, fixed by PR #420 (merged to master
     # 2026-08-24). Without that fix, NetworkManager::Init has to skip the live
     # init under ASan and the networking suites lose their sanitizer coverage.
-    # Move back to a tag as soon as one ships that contains #420.
-    REF "a424b7db649438acafb60c99cae6667587c42732" # master @ 2026-08-26, 17 commits after PR #420
-    SHA512 a4a9abe49d1ee638926c180ff88c59329a3df749a6ba9a59efba4b719857f802941ae8eabb07fd88ea2138718a5721ecc1ebc61f2dafacc2a026e1374546e1b5
+    #
+    # Pinning the merge commit and not master's head is the smaller step: it is
+    # the first commit that contains the fix and nothing else we need. An earlier
+    # revision of this port pinned master@2026-08-26, which carried 17 further
+    # commits (an iOS build port, a mingw cmsg fix, CI changes) that this engine
+    # has no use for and would have to vet. Move to a TAG as soon as one ships
+    # containing #420.
+    REF "3b542769a68cd535d41e74af3898becc444940c9" # PR #420 merge commit, 2026-08-24
+    SHA512 983dbd53c74fecd083a4fc6784609f3aeed7072dade2c194d610cb4c9f144057a7162929dced47e31fc65d506f96a9a1e1d7d9a485641907b555ca93b9aafaef
     HEAD_REF master
 )
 

--- a/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
+++ b/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gamenetworkingsockets",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GameNetworkingSockets is a basic transport layer for games (OloEngine overlay: USE_CRYPTO=libsodium instead of OpenSSL, ICE off by default, see issue #773)",
   "homepage": "https://github.com/ValveSoftware/GameNetworkingSockets",
   "license": "BSD-3-Clause",

--- a/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
+++ b/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gamenetworkingsockets",
   "version": "1.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GameNetworkingSockets is a basic transport layer for games (OloEngine overlay: USE_CRYPTO=libsodium instead of OpenSSL, ICE off by default, see issue #773)",
   "homepage": "https://github.com/ValveSoftware/GameNetworkingSockets",
   "license": "BSD-3-Clause",

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -37,6 +37,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 ## Build and dependencies
 
 - [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md): never build msvc and clangcl trees together; caches, link bounds, memory, the local ASan recipe.
+- [concurrent-cmake-configure.md](concurrent-cmake-configure.md): one configure at a time per build tree; the error blames your CMakeLists.txt and LTO instead.
 - [static-archive-4gib-ceiling.md](static-archive-4gib-ceiling.md): a .lib cannot exceed 4 GiB, and `LNK1248` under-reports the overshoot.
 - [vcpkg-dependency-management.md](vcpkg-dependency-management.md): read before adding, bumping or removing a dependency; the CRT triplet mismatch is heap corruption.
 - [configure-time-variable-visibility.md](configure-time-variable-visibility.md): a CMake variable must be set before the `add_subdirectory()` that reads it.
@@ -200,6 +201,7 @@ The same fact written in more than one place, with nothing enforcing agreement.
 | [runtime-scene-switching.md](runtime-scene-switching.md) | The build pipeline and the runtime must agree on an asset layout. |
 | [audio-voice-budget.md](audio-voice-budget.md) | One config field costs four edits, one of them silent. |
 | [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) | Two build trees writing the same generated files. |
+| [concurrent-cmake-configure.md](concurrent-cmake-configure.md) | Two configures sharing one `CMakeFiles/`; the nested `try_compile` that loses reports the error. |
 | [floating-origin-rebase-subsystems.md](floating-origin-rebase-subsystems.md) | Four subsystems hold world-space state outside the rebased set. |
 | [binary-greedy-voxel-meshing.md](binary-greedy-voxel-meshing.md) | The packed-quad layout lives in `VoxelQuad.h` and `VoxelQuadUnpack.glsl`, and a mismatch compiles. |
 | [destructible-debris.md](destructible-debris.md) | Two unrelated physics layer numberings; `SetCollisionLayer(Debris)` never reaches Jolt's `DEBRIS`. |

--- a/docs/agent-rules/concurrent-cmake-configure.md
+++ b/docs/agent-rules/concurrent-cmake-configure.md
@@ -1,0 +1,101 @@
+# Never run two CMake configures against one build tree — and the error names the wrong thing
+
+**The rule:** one `cmake` configure at a time per binary directory. Two configures on the same
+build tree corrupt each other. The top-level `CMakeLists.txt` now takes a `file(LOCK ...)` on
+`<binaryDir>/olo-configure.lock` for exactly this reason, so a second configure waits instead of
+racing. Do not remove that lock, and do not start a configure "just to be sure" while another one
+is running.
+
+**What it looks like when it happens.** Not a message about concurrency, and not one that points at
+the tool that lost:
+
+```
+CMake Error: This should not have happened. If you see this message, you are probably using a
+broken CMakeLists.txt file or a problematic release of CMake
+CMake Error: This should not have happened. If you see this message, you are probably using a
+broken CMakeLists.txt file or a problematic release of CMake
+CMake Error at .../Modules/CheckIPOSupported.cmake:197 (try_compile):
+  Failed to configure test project build system.
+Call Stack (most recent call first):
+  cmake/CommonProperties.cmake:44 (check_ipo_supported)
+  OloEngine/CMakeLists.txt:68 (olo_enable_lto)
+-- Configuring incomplete, errors occurred!
+```
+
+Read literally, that says your CMakeLists.txt is broken and LTO is unsupported. Both are false. The
+two bare "This should not have happened" lines are stderr from the **nested** cmake that
+`try_compile()` spawns; it fails because the other configure deleted the scratch project out from
+under it. Any check that shells out to a nested cmake can be the one that reports it —
+`check_ipo_supported`, `CMakeTestCXXCompiler`, any `try_compile` — so the file and line in the error
+tell you only who lost the race, never that there was one.
+
+The giveaway is that the *same* command succeeded minutes earlier against the *same* tree. When a
+configure failure is not reproducible, suspect a second configure before suspecting the toolchain.
+
+## Reproducing it
+
+Deterministic in about a minute, no engine build needed. Two configures, the second started two
+seconds into the first:
+
+```bash
+mkdir -p /tmp/ipo/src && cat > /tmp/ipo/src/CMakeLists.txt <<'CM'
+cmake_minimum_required(VERSION 3.25)
+project(ipotest C CXX)
+include(CheckIPOSupported)
+foreach(i RANGE 1 25)
+  check_ipo_supported(RESULT r OUTPUT o)
+endforeach()
+CM
+cmake -S /tmp/ipo/src -B /tmp/ipo/bin -G "Ninja Multi-Config" > a.log 2>&1 &
+sleep 2; cmake -S /tmp/ipo/src -B /tmp/ipo/bin -G "Ninja Multi-Config" > b.log 2>&1
+```
+
+Both logs carry the error above. Add the `file(LOCK ... GUARD PROCESS TIMEOUT 600)` from the
+top-level `CMakeLists.txt` at the head of the test project and both configures pass, the second
+simply taking the first one's runtime plus its own.
+
+## Where the second configure comes from
+
+Rarely from a person deciding to run two. The sources seen here, in order:
+
+- **VS Code's CMake Tools extension.** It defaults to `cmake.configureOnOpen: true` and
+  `cmake.configureOnEdit: true`, so opening the folder or saving any CMake file starts a configure
+  with no prompt. Both are set to `false` in [.vscode/settings.json](../../.vscode/settings.json);
+  configure deliberately, from the palette or the CLI.
+- **A second agent session or terminal** in the same worktree. Worktrees do not help here — the
+  collision is per *binary directory*, and two sessions in one worktree share `build-cached/`.
+- **A retry after an apparent hang.** The first configure was still running.
+
+The build mutex in [build-lock.ps1](../../.claude/skills/run-oloengine/build-lock.ps1) does **not**
+cover this, by design: it serialises builds against memory exhaustion, and its `PreToolUse` guard
+deliberately classifies `cmake` without `--build` as cheap. Cheap it is — a configure is not going
+to OOM the box. Concurrency-safe it is not. The two mechanisms guard different things, and the
+CMake-side lock is the one that covers configures.
+
+## Why this repo was unusually exposed
+
+`check_ipo_supported()` is not a cheap predicate: each call generates a `_CMakeLTOTest-<lang>`
+project under the current binary directory and runs a full nested CMake configure, compile and link
+on it. `olo_enable_lto()` used to call it every time, and it is called per target — `OloEngine`,
+each engine part in the loop at `OloEngine/CMakeLists.txt`, and every app through
+`olo_configure_app()`. That is roughly 25 nested configures per configure of this repo, each one a
+window for the race and each one recomputing the same toolchain-wide answer.
+
+`olo_check_lto_support()` in [CommonProperties.cmake](../../cmake/CommonProperties.cmake) now caches
+it in `OLO_LTO_SUPPORTED` (`CACHE INTERNAL`, so it survives a re-configure of the same tree). One
+nested configure instead of 25. Measured on the isolated repro above: 25 checks took 43s, one takes
+about 8s.
+
+Keep both defences. The cache narrows the window; only the lock closes it.
+
+## The related trap next door
+
+The same failing log carried a second, unrelated problem worth recognising: `CMAKE_TOOLCHAIN_FILE`
+pointing into `Microsoft Visual Studio/18/Community/VC/vcpkg` while `VCPKG_ROOT` was `D:\vcpkg` in
+every shell. The Visual Studio developer environment sets `VCPKG_ROOT` to its own bundled copy, and
+CMake Tools applies that environment before expanding `$env{VCPKG_ROOT}` in the presets. The
+top-level `CMakeLists.txt` now warns about it. It is not what broke the configure — a changed
+`CMAKE_TOOLCHAIN_FILE` is ignored on a re-configure, so an existing tree stays pinned to whichever
+vcpkg it was created with — but a *fresh* tree configured from such a window silently uses a
+different registry clone that lacks `vcpkg.json`'s `builtin-baseline`. See
+[vcpkg-dependency-management.md](vcpkg-dependency-management.md).


### PR DESCRIPTION
## What

Moves the `gamenetworkingsockets` overlay pin from the v1.6.0 tag to a post-release master snapshot, and deletes the two AddressSanitizer workarounds that tag forced on us.

## Why

`GameNetworkingSockets_Init` spawns a service thread whose bootstrap tripped a stack-buffer-overflow under ASan — a 48-byte read from a 24-byte `info` stack object, inside vendored GNS on the GNS-spawned thread. Issue #317 worked around it by skipping the live init under `OLO_ASAN_ENABLED` and having `ServerAuthoritativeLoopTest` skip itself. Green job, zero sanitizer coverage of the transport.

Fixed upstream by [ValveSoftware/GameNetworkingSockets#420](https://github.com/ValveSoftware/GameNetworkingSockets/pull/420), merged to `master` 2026-08-24, closing [#418](https://github.com/ValveSoftware/GameNetworkingSockets/issues/418). No release carries it — v1.6.0 (2026-06-03) is still the newest tag and is exactly what the overlay pinned — so the pin moves to **#420's merge commit** `3b542769` — the first commit containing the fix and nothing else. (An earlier revision of this PR pinned master@2026-08-26; review rightly pointed out that carried 17 further commits — an iOS build port, a mingw cmsg alias, CI changes — that this engine has no use for.) Back to a tag as soon as one ships with the fix.

## Changes

- `portfile.cmake`: `REF` + `SHA512` bumped, `port-version` 1 → 3 (invalidates the ABI so every tree rebuilds it).
- `NetworkManager.cpp`: `#if OLO_ASAN_ENABLED` gate around `GameNetworkingSockets_Init` and the matching `_Kill` guard removed.
- `ServerAuthoritativeLoopTest.cpp`: `GTEST_SKIP` and both `#if !OLO_ASAN_ENABLED` regions removed.
- `asan.yml`: the comment block documenting the gate rewritten to describe the fix.

## Verified locally

- Port rebuilds from the new `REF` — SHA512 validated on download, and all four overlay deltas still apply against master (the `Findsodium.cmake` swap and both `vcpkg_replace_string` rewrites; either would fail loudly on a rename).
- `OloEngine-Tests` builds clean.
- All 19 networking cases across `ServerAuthoritativeLoopTest` and `NetworkManagerTest` pass with a live client/server loop.

## What the restored ASan coverage actually reaches

Corrected after review — the first version of this PR overclaimed here.

GNS is a **vcpkg port built with cl.exe and no sanitizer flags**. `asan.yml` already says so in its own words on the vcpkg step: *"vcpkg ports are NOT sanitizer-instrumented — which is what this job wants."* So ASan instruments the engine and the test process, **not GNS internals**: allocations and interceptors crossing the boundary are covered, stack and global redzones inside GNS are not.

What this buys is sanitizer coverage of OloEngine's own networking code against a live transport — `NetworkManager` init/shutdown, `NetworkThread`, dispatch, replication, and the fixture's 17 cases — none of which executed under ASan before, because the Linux ASan job never excluded `ServerAuthoritativeLoopTest` by regex; it self-skipped.

It does **not** re-arm detection of #418-class faults inside GNS. That would need an instrumented GNS build, which this job deliberately avoids (uninstrumented ports are shared with the cl.exe jobs — halves the binary cache, avoids a clang-cl-built-MaterialX bug). Instrumenting one port is a separate design decision, not something to slip into this PR.

## Deliberately not touched

Neither of these is an upstream bug waiting on a fix:

- **UBSan exclusions** — GNS deliberately adds `-fno-sanitize=alignment` in its own `FindUBSan.cmake`; `alignment` is one of our eight fatal checks.
- **TSan exclusion** — a documented false positive. The lock-order graph is real, but both paths hold `SteamNetworkingGlobalLock` throughout and GNS's own checker permits same-rank object/table locks under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

