### PR TITLE
ci(linux): clang-23 on hosted runners, drop the dead clang-19 pin on the box

### DIFF
--- a/.claude/hooks/claude-build-lock-guard.py
+++ b/.claude/hooks/claude-build-lock-guard.py
@@ -72,7 +72,14 @@ _STATEMENT = r"(?:^|[;|(){}\n]\s*|&+\s*[\"']?\s*|(?:-Command|-c)\s+[\"']?\s*)"
 _PATH = r"(?:[A-Za-z]:)?(?:[\w.\-]*[\\/])*"
 
 # `cmake` alone is not enough -- `cmake --preset msvc` only configures, and
-# configuring is cheap.
+# configuring is cheap. That stays true: a configure will not OOM the box, which
+# is what this mutex exists to prevent. It is NOT the same as saying concurrent
+# configures are safe -- two configures against one binary directory corrupt each
+# other's try_compile scratch projects. That is guarded on the CMake side, by the
+# file(LOCK) at the top of CMakeLists.txt, because it also has to cover configures
+# this hook never sees (VS Code's CMake Tools, Visual Studio, a plain shell). Do
+# not "fix" it by adding bare `cmake` here; see
+# docs/agent-rules/concurrent-cmake-configure.md.
 BUILD_PATTERNS = (
     (
         "cmake --build",

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -139,7 +139,7 @@ runs:
         # list is worth far more than those seconds, because a per-job list is how
         # one job quietly acquires a dependency the others do not have.
         sudo apt-get install -y \
-          clang-19 lld-19 \
+          clang-23 lld-23 \
           libvulkan-dev vulkan-validationlayers \
           libgl-dev libglu1-mesa-dev \
           libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev \
@@ -272,62 +272,55 @@ runs:
       run: |
         set -euo pipefail
         if [ "$OLO_RUNNER_ENVIRONMENT" = "github-hosted" ]; then
-          # clang-19 from apt.llvm.org. The engine needs a C++23 STANDARD LIBRARY,
+          # clang-23 from apt.llvm.org. The engine needs a C++23 STANDARD LIBRARY,
           # not merely a C++23 compiler: Core/Reflection uses std::forward_like,
           # which ubuntu-24.04's default libstdc++ does not provide.
-          cc=clang-19; cxx=clang++-19
+          cc=clang-23; cxx=clang++-23
           python_exe="$OLO_HOSTED_PYTHON"
           extra=""
         else
-          # THE PINNED TOOLCHAIN, on the box too (#1015 item A). Rocky 10's
-          # system clang is 21 and clang-19 is not in the base repos, but EPEL
-          # (enabled on the box) ships `clang19` / `compiler-rt19` / `lld19` at
-          # the same 19.1.7 the hosted arm gets from apt.llvm.org. It installs
-          # under /usr/lib64/llvm19/bin and stays off PATH, so it is selected by
-          # absolute path here -- and `-fuse-ld=lld` resolves the ld.lld beside
-          # the compiler before it searches PATH, so the linker follows.
+          # NO VERSION PIN ON THE BOX -- it uses Rocky 10's system clang, and that
+          # is now a deliberate choice rather than a fallback.
           #
-          # VERIFY, never install (the convention at the top of this file): when
-          # the pin is not provisioned the job WARNS and builds with the system
-          # clang rather than failing. Two reasons that is the right shape:
+          # This used to pin clang-19 by absolute path at /usr/lib64/llvm19/bin,
+          # matching the version the hosted arm got from apt.llvm.org. Two things
+          # ended that:
           #
-          #   * The version skew was never the cause of anything. #1010 blamed
-          #     "clang 21 against gcc-toolset-15's libstdc++" for two UBSan
-          #     reports inside the standard library; a 200-line probe of
-          #     unordered_map / vector under the exact Sanitizers.cmake flags is
-          #     clean at every optimisation level under BOTH libstdc++ pairings
-          #     (gcc 14 and gcc-toolset-15), and the two reports are a real
-          #     use-after-free in ShaderRegistry teardown that any compiler
-          #     reproduces given a GL context. So the fallback is not a degraded
-          #     gate, it is a second compiler version -- coverage, not a defect.
-          #   * A missing pin must not take the box out: the routing in asan.yml
-          #     sends every same-repo PR's sanitizer jobs here, and a hard
-          #     failure would block every PR on one maintainer running `dnf`.
+          #   * The pin was never actually provisioned. /usr/lib64/llvm19 does not
+          #     exist on the box (only llvm21), so every self-hosted sanitizer run
+          #     was already taking the warn-and-fall-back path below. The pin was a
+          #     comment describing a machine state that was not true.
+          #   * The hosted arm has moved to clang-23, and Rocky 10 cannot follow.
+          #     EPEL tops out at clang20 (20.1.8); there is no clang22 or clang23
+          #     package. Pinning a version the distro does not ship just recreates
+          #     the same unprovisioned pin one number higher.
           #
-          # The warning is a run-summary annotation, so the state is visible
-          # without opening the log. When a self-hosted job fails and its hosted
-          # twin does not, read the "toolchain:" line below before assuming the
-          # box is broken. Provisioning: docs/ops/self-hosted-linux-toolchain.md.
-          # All three packages or none: a clang19 without compiler-rt19 would
-          # configure fine and fail every sanitizer LINK on "cannot find
-          # libclang_rt.asan.a", where the system clang would have worked. The
-          # runtime dir is asked of the compiler itself, so the check follows
-          # whatever layout the package uses.
-          pinned_bin=/usr/lib64/llvm19/bin
-          pinned_ok=0
-          if [ -x "$pinned_bin/clang++" ] && [ -x "$pinned_bin/clang" ] && [ -x "$pinned_bin/ld.lld" ]; then
-            rt_dir=$("$pinned_bin/clang++" -print-runtime-dir 2>/dev/null || true)
-            if [ -n "$rt_dir" ] && ls "$rt_dir"/libclang_rt.asan*.a >/dev/null 2>&1 \
-               && ls "$rt_dir"/libclang_rt.tsan*.a >/dev/null 2>&1 \
-               && ls "$rt_dir"/libclang_rt.ubsan*.a >/dev/null 2>&1; then
-              pinned_ok=1
-            fi
-          fi
-          if [ "$pinned_ok" -eq 1 ]; then
-            cc="$pinned_bin/clang"; cxx="$pinned_bin/clang++"
-          else
-            cc=clang; cxx=clang++
-            echo "::warning title=pinned clang-19 not provisioned::building with $(command -v clang++) ($(clang++ --version | head -1)). Provision the pin (compiler, linker AND sanitizer runtimes) with: sudo dnf install -y clang19 compiler-rt19 lld19 -- see docs/ops/self-hosted-linux-toolchain.md"
+          # So the box uses what it has: clang 21.1.8 from the base repos, with
+          # compiler-rt-21 and lld-21 installed, which carry the asan / tsan / ubsan
+          # runtimes this job needs (verified on the box, not assumed).
+          #
+          # The version skew against the hosted arm is coverage, not a defect --
+          # that argument predates this change and still holds. #1010 blamed
+          # "clang 21 against gcc-toolset-15's libstdc++" for two UBSan reports
+          # inside the standard library; a 200-line probe of unordered_map / vector
+          # under the exact Sanitizers.cmake flags is clean at every optimisation
+          # level under BOTH libstdc++ pairings (gcc 14 and gcc-toolset-15), and the
+          # two reports are a real use-after-free in ShaderRegistry teardown that any
+          # compiler reproduces given a GL context.
+          #
+          # VERIFY, never install (the convention at the top of this file). What is
+          # checked is the SANITIZER RUNTIMES, not the version: a clang without
+          # compiler-rt configures fine and fails every sanitizer LINK on "cannot
+          # find libclang_rt.asan.a". The runtime dir is asked of the compiler
+          # itself, so the check follows whatever layout the distro uses.
+          #
+          # A missing runtime warns rather than fails: asan.yml routes every
+          # same-repo PR's sanitizer jobs here, and a hard failure would block every
+          # PR on one maintainer running `dnf`.
+          cc=clang; cxx=clang++
+          rt_dir=$("$cxx" -print-runtime-dir 2>/dev/null || true)
+          if [ -z "$rt_dir" ]              || ! ls "$rt_dir"/libclang_rt.asan*.a >/dev/null 2>&1              || ! ls "$rt_dir"/libclang_rt.tsan*.a >/dev/null 2>&1              || ! ls "$rt_dir"/libclang_rt.ubsan*.a >/dev/null 2>&1; then
+            echo "::warning title=sanitizer runtimes missing::$(command -v clang++) ($(clang++ --version | head -1)) has no complete compiler-rt at '${rt_dir:-<unknown>}'. Every sanitizer link will fail. Install with: sudo dnf install -y compiler-rt lld -- see docs/ops/self-hosted-linux-toolchain.md"
           fi
           python_exe="$(command -v python3)"
           # OLO_ENABLE_COMPILER_CACHE is added HERE rather than at each call site

--- a/.github/actions/setup-llvm-apt/action.yml
+++ b/.github/actions/setup-llvm-apt/action.yml
@@ -19,7 +19,11 @@ inputs:
   version:
     description: 'LLVM major version to register (the apt component and the sources.list filename).'
     required: false
-    default: '19'
+    # 23 since the LLVM 23.1.0 move. apt.llvm.org publishes an llvm-toolchain-noble-23
+    # suite carrying clang-23 / lld-23 / libc++-23-dev; verified against its
+    # binary-amd64 Packages index before the bump, because a version with no suite
+    # here fails as an apt 404 several steps later rather than at this one.
+    default: '23'
   distro:
     description: 'Ubuntu codename of the apt.llvm.org tree to use. Must match the runner image.'
     required: false

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -313,9 +313,21 @@ jobs:
       # snapshot carrying it (cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
       # — v1.6.0 is still the newest tag and predates the fix), and both the
       # NetworkManager::Init gate and ServerAuthoritativeLoopTest's GTEST_SKIP are
-      # gone. So this job now runs the live GNS init and ServerAuthoritativeLoopTest
-      # under ASan for real. If that regresses, the fix is to move the pin, not to
-      # bring the gate back.
+      # gone, so the live init runs here and ServerAuthoritativeLoopTest's 17 cases
+      # execute instead of skipping.
+      #
+      # BE PRECISE ABOUT WHAT THAT COVERS. GNS is a vcpkg port built with cl.exe and
+      # no sanitizer flags -- see the triplet note on the vcpkg step above, "vcpkg
+      # ports are NOT sanitizer-instrumented", which is deliberate. So ASan
+      # instruments the engine and the test process, NOT GNS internals: allocations
+      # and interceptors crossing the boundary are covered, stack and global redzones
+      # inside GNS are not. What this change buys is sanitizer coverage of OloEngine's
+      # own networking code against a LIVE transport -- NetworkManager init/shutdown,
+      # NetworkThread, dispatch, replication -- all of which previously never executed
+      # under ASan at all. It does not re-arm detection of #418-class faults inside
+      # GNS; that would need an instrumented GNS build, which this job explicitly does
+      # not want. If these tests regress, the fix is to move the pin, not to bring the
+      # gate back.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
       # task system starts the Steam service thread" theory — they never touched
@@ -323,8 +335,10 @@ jobs:
       # ASan, so they are no longer excluded. See issue #317.
       #
       # Remaining exclusions match the Linux ASan job exactly:
-      #   NetworkIntegrationTest — drives a live client/server socket, which the
-      #     ASan GNS gate intentionally disables; excluded on every sanitizer job.
+      #   NetworkIntegrationTest — needs real client/server socket plumbing that CI
+      #     environments do not provide; excluded on EVERY job in this repo, the
+      #     non-sanitizer ones included (Windows.yml, gpu-conformance-amd.yml). Not
+      #     related to the removed ASan gate, and not something the GNS pin changes.
       #   WorkerRestartTest — a tight 100-iteration worker-pool teardown/recreate
       #     stress test that exceeds the 120 s timeout under sanitizer
       #     instrumentation; excluded on every sanitizer job.

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -413,14 +413,16 @@ jobs:
     #      hardware the runner happens to have. GPU coverage under a sanitizer is
     #      a separate scheduled job with its own baseline (gpu-sanitizers-amd.yml).
     #   2. The box's compiler was clang 21 against gcc-toolset-15's libstdc++,
-    #      not the hosted arm's pinned clang, and UBSan reported inside the standard
-    #      library. setup-linux-build now resolves the pinned toolchain on the
-    #      self-hosted arm as well; when it is not provisioned it WARNS (a
-    #      run-summary annotation naming the dnf command) and builds with the
-    #      system clang 21 rather than failing -- see its "Resolve toolchain"
-    #      step for why a missing pin must not take the box out. Read the
-    #      "toolchain:" line of a self-hosted job before comparing it with a
-    #      hosted one.
+    #      not the hosted arm's clang, and UBSan reported inside the standard
+    #      library. That difference is now permanent and deliberate:
+    #      setup-linux-build uses the system clang and clang++ unconditionally on
+    #      the self-hosted arm -- there is no version pin to resolve, because
+    #      hosted is on clang-23 and Rocky 10's EPEL tops out at clang20. What it
+    #      verifies instead is compiler-rt: an incomplete set of asan/tsan/ubsan
+    #      runtimes WARNS (a run-summary annotation naming the dnf command)
+    #      rather than failing, since a hard failure would block every same-repo
+    #      PR. Read the "toolchain:" line of a self-hosted job before comparing
+    #      it with a hosted one -- the two arms run different compilers.
     #
     # The acceptance test for this routing is a same-commit A/B: dispatch the
     # workflow once normally and once with `force_hosted: true`, then compare

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -300,16 +300,22 @@ jobs:
 
     - name: Run tests under ASan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
-      # The SteamNetworkingSockets service thread tripped a stack-buffer-overflow
-      # under MSVC ASan during thread bootstrap (a 48-byte read from a 24-byte
-      # `info` stack object inside vendored GNS code on the GNS-spawned thread;
-      # Release ICF folding misreported the frames as `SteamNetworkingSockets_*` /
-      # `pugi::xpath_*`). That is now fixed at the source: NetworkManager::Init
-      # skips the live GameNetworkingSockets_Init under ASan (OLO_ASAN_ENABLED),
-      # so every suite that merely constructs/uses NetworkManager runs clean.
-      # (Upstream GNS bug: ValveSoftware/GameNetworkingSockets#418.) The gate is
-      # keyed on OLO_ASAN_ENABLED, not the compiler, so it applies identically
-      # now that this job builds with clang-cl ASan instead of MSVC cl.exe ASan.
+      # The SteamNetworkingSockets service thread used to trip a stack-buffer-overflow
+      # under ASan during thread bootstrap (a 48-byte read from a 24-byte `info`
+      # stack object inside vendored GNS code on the GNS-spawned thread; Release ICF
+      # folding misreported the frames as `SteamNetworkingSockets_*` /
+      # `pugi::xpath_*`). It was worked around by skipping the live
+      # GameNetworkingSockets_Init under OLO_ASAN_ENABLED, which bought a green job
+      # at the cost of never sanitizing the transport.
+      #
+      # FIXED UPSTREAM: ValveSoftware/GameNetworkingSockets#418, by PR #420 (merged
+      # to master 2026-08-24). The overlay port now pins a post-1.6.0 master
+      # snapshot carrying it (cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
+      # — v1.6.0 is still the newest tag and predates the fix), and both the
+      # NetworkManager::Init gate and ServerAuthoritativeLoopTest's GTEST_SKIP are
+      # gone. So this job now runs the live GNS init and ServerAuthoritativeLoopTest
+      # under ASan for real. If that regresses, the fix is to move the pin, not to
+      # bring the gate back.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
       # task system starts the Steam service thread" theory — they never touched

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -413,7 +413,7 @@ jobs:
     #      hardware the runner happens to have. GPU coverage under a sanitizer is
     #      a separate scheduled job with its own baseline (gpu-sanitizers-amd.yml).
     #   2. The box's compiler was clang 21 against gcc-toolset-15's libstdc++,
-    #      not the pinned clang-19, and UBSan reported inside the standard
+    #      not the hosted arm's pinned clang, and UBSan reported inside the standard
     #      library. setup-linux-build now resolves the pinned toolchain on the
     #      self-hosted arm as well; when it is not provisioned it WARNS (a
     #      run-summary annotation naming the dnf command) and builds with the

--- a/.github/workflows/steam-stub.yml
+++ b/.github/workflows/steam-stub.yml
@@ -236,7 +236,7 @@ jobs:
       # path still compile, link and behave", not "does the whole engine still work", which the
       # main Windows/Linux workflows already answer.
       # The compiler comes from the setup step above rather than being named here: it is
-      # clang-19 from apt.llvm.org on a hosted runner (ubuntu-24.04's default libstdc++
+      # clang-23 from apt.llvm.org on a hosted runner (ubuntu-24.04's default libstdc++
       # lacks C++23 library pieces this engine uses) and the system clang on the
       # self-hosted box. lld either way — the default linker can OOM a hosted runner
       # while linking the full static engine.

--- a/.github/workflows/video-ffmpeg.yml
+++ b/.github/workflows/video-ffmpeg.yml
@@ -71,7 +71,7 @@ jobs:
       # The engine needs a C++23 STANDARD LIBRARY, not just a C++23 compiler:
       # Core/Reflection/MemberList.h uses std::forward_like, which ubuntu-24.04's default
       # GCC/libstdc++ does not provide ("error: 'forward_like' is not a member of 'std'").
-      # Every other Linux job in this repo pins clang-19 from apt.llvm.org for the same
+      # Every other Linux job in this repo pins clang-23 from apt.llvm.org for the same
       # reason — see asan.yml and steam-stub.yml. Without this, fixing the OOM below only
       # moves the failure (issue #796, root cause 2).
       - name: Add LLVM apt repository (Linux)
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             nasm \
-            clang-19 lld-19 \
+            clang-23 lld-23 \
             libgl-dev libglu1-mesa-dev \
             libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev \
@@ -127,7 +127,7 @@ jobs:
           # multi-config (build type comes from --config at build time) and MSVC is
           # already the right compiler there.
           #
-          # -DCMAKE_{C,CXX}_COMPILER=clang-19/clang++-19: see the LLVM apt step above —
+          # -DCMAKE_{C,CXX}_COMPILER=clang-23/clang++-23: see the LLVM apt step above —
           #   the default GCC/libstdc++ lacks std::forward_like.
           # -DCMAKE_BUILD_TYPE=Release: Unix Makefiles is SINGLE-config, so the build
           #   type must be set here. The build step's `--config Release` was silently
@@ -145,8 +145,8 @@ jobs:
           TOOLCHAIN_ARGS=()
           if [ "${{ matrix.os }}" = "Linux" ]; then
             TOOLCHAIN_ARGS=(
-              -DCMAKE_C_COMPILER=clang-19
-              -DCMAKE_CXX_COMPILER=clang++-19
+              -DCMAKE_C_COMPILER=clang-23
+              -DCMAKE_CXX_COMPILER=clang++-23
               -DCMAKE_BUILD_TYPE=Release
               -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
               -DOLO_ENABLE_LTO=OFF

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -101,6 +101,8 @@
         "resumable": "cpp",
         "numbers": "cpp"
     },
+    "cmake.configureOnOpen": false,
+    "cmake.configureOnEdit": false,
     "dotnet.defaultSolution": "disable",
     "sonarlint.connectedMode.project": {
         "connectionId": "drsnuggles8",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,44 @@ if(NOT DEFINED VCPKG_TOOLCHAIN)
         "Setup instructions: docs/ops/build.md.")
 endif()
 
+# The second vcpkg trap, and this one is silent. Visual Studio's developer
+# environment sets VCPKG_ROOT to the copy bundled inside the VS install, and
+# VS Code's CMake Tools applies that environment on top of the process
+# environment BEFORE expanding the presets -- so the presets'
+# `"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"` can
+# resolve to <VS>/VC/vcpkg even though VCPKG_ROOT is your own clone in every
+# shell you can inspect. Observed here as a configure invoked with
+# -DCMAKE_TOOLCHAIN_FILE=".../Microsoft Visual Studio/18/Community/VC/vcpkg/..."
+# while VCPKG_ROOT was D:cpkg.
+#
+# Not fatal: that copy is a real bootstrapped vcpkg and will build. It is a
+# WARNING because the consequences are quiet rather than absent -- it is a
+# different registry clone, it does not have vcpkg.json's builtin-baseline
+# commit locally (so it re-fetches the registry from HEAD), and it keeps its own
+# downloads/, diverging from every other worktree on this machine. An existing
+# build tree is unaffected either way: CMAKE_TOOLCHAIN_FILE is only honoured on
+# the FIRST configure, so a tree already pinned to the right vcpkg stays pinned.
+set(_olo_vs_vcpkg_re "[Mm]icrosoft [Vv]isual [Ss]tudio.*[/\]VC[/\]vcpkg")
+if(CMAKE_TOOLCHAIN_FILE MATCHES "${_olo_vs_vcpkg_re}" OR "$ENV{VCPKG_ROOT}" MATCHES "${_olo_vs_vcpkg_re}")
+    message(WARNING
+        "vcpkg is being resolved from the copy bundled with Visual Studio, not from a "
+        "vcpkg clone you control:
+"
+        "  CMAKE_TOOLCHAIN_FILE = ${CMAKE_TOOLCHAIN_FILE}
+"
+        "  VCPKG_ROOT (env)     = $ENV{VCPKG_ROOT}
+"
+        "This happens when the Visual Studio developer environment overrides VCPKG_ROOT "
+        "-- VS Code's CMake Tools applies it before expanding the presets. The build will "
+        "work, but it uses a separate registry clone that lacks vcpkg.json's "
+        "builtin-baseline and re-fetches the registry from HEAD, and it does not share "
+        "downloads/ with the other worktrees on this machine.
+"
+        "Set VCPKG_ROOT so it survives the VS environment (see docs/ops/build.md), or pass "
+        "-DCMAKE_TOOLCHAIN_FILE=<your vcpkg>/scripts/buildsystems/vcpkg.cmake explicitly.")
+endif()
+unset(_olo_vs_vcpkg_re)
+
 # Build optimization options
 option(OLO_ENABLE_LTO "Enable Link Time Optimization" ON)
 option(OLO_ENABLE_PCH "Enable Precompiled Headers" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,54 @@ if(POLICY CMP0194)
 endif()
 
 # --------------------------------------------------------------------------
+# One configure at a time per build tree.
+#
+# Two CMake configures running against the same binary directory corrupt each
+# other. They share CMakeFiles/, and the throwaway projects that try_compile()
+# and check_ipo_supported() generate under it get deleted mid-flight by the
+# other process. The symptom names neither concurrency nor the real culprit --
+# it is two bare
+#
+#   CMake Error: This should not have happened. If you see this message, you are
+#   probably using a broken CMakeLists.txt file or a problematic release of CMake
+#
+# lines followed by whichever check lost the race, observed against build-cached
+# as "CheckIPOSupported.cmake:197 (try_compile): Failed to configure test project
+# build system". That reads like an LTO or toolchain bug and is neither; the same
+# configure had succeeded four minutes earlier. It reproduces deterministically
+# by starting a second `cmake -S <src> -B <same-bin>` two seconds into the first.
+#
+# The overlap is easy to hit without meaning to: VS Code's CMake Tools extension
+# configures on open and on every save of a CMake file (both now off in
+# .vscode/settings.json), so an editor-triggered configure can land on top of one
+# a terminal or an agent session already started. The build mutex in
+# .claude/skills/run-oloengine/build-lock.ps1 does not cover this -- it serialises
+# builds, and its guard deliberately classifies `cmake` without `--build` as
+# cheap. Cheap it is; concurrency-safe it is not.
+#
+# GUARD PROCESS releases the lock when this cmake process exits, including on a
+# fatal error. Nested try_compile cmake processes never read this file, so there
+# is no self-deadlock. A queued configure waits rather than failing outright,
+# because it is usually a legitimate re-configure that will produce the right
+# answer a moment later; the timeout only fires if the holder has wedged.
+file(LOCK "${CMAKE_BINARY_DIR}/olo-configure.lock"
+     GUARD PROCESS
+     TIMEOUT 600
+     RESULT_VARIABLE OLO_CONFIGURE_LOCK_RESULT)
+if(NOT OLO_CONFIGURE_LOCK_RESULT STREQUAL "0")
+    message(FATAL_ERROR
+        "Timed out waiting for another CMake configure to finish in "
+        "${CMAKE_BINARY_DIR}.
+"
+        "Concurrent configures of one build tree corrupt each other, so this one "
+        "stopped instead of racing. Wait for the other configure to finish (VS Code "
+        "CMake Tools, another terminal, another agent session), or delete "
+        "${CMAKE_BINARY_DIR}/olo-configure.lock if nothing is running.
+"
+        "Lock error: ${OLO_CONFIGURE_LOCK_RESULT}")
+endif()
+
+# --------------------------------------------------------------------------
 # vcpkg manifest features (issue #773).
 #
 # MUST be set BEFORE project() — vcpkg's toolchain file runs the manifest

--- a/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
+++ b/OloEngine/src/OloEngine/Networking/Core/NetworkManager.cpp
@@ -11,7 +11,6 @@
 #include "OloEngine/Networking/Transport/NetworkServer.h"
 #include "OloEngine/Core/Log.h"
 #include "OloEngine/Debug/Profiler.h"
-#include "OloEngine/Memory/Platform.h" // OLO_ASAN_ENABLED
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Threading/UniqueLock.h"
@@ -91,31 +90,11 @@ namespace OloEngine
         SteamNetworkingUtils()->SetGlobalCallback_SteamNetConnectionStatusChanged(
             GNSConnectionStatusCallback);
 
-#if OLO_ASAN_ENABLED
-        // GameNetworkingSockets_Init spawns an internal service thread whose
-        // startup routine trips a stack-buffer-overflow under MSVC AddressSanitizer:
-        // a 48-byte read out of a 24-byte `info` stack object during thread
-        // bootstrap, inside vendored GNS code on the GNS-spawned thread — not
-        // OloEngine code, and clean under Linux ASan/UBSan. (In Release the
-        // internal frames get ICF-folded onto the nearest exported symbols, so CI
-        // stacks misreport it as SteamNetworkingSockets_* / pugi::xpath_*.)
-        // Skip the live GNS init under ASan so the rest of OloEngine's networking
-        // stack — the NetworkThread, task dispatch, message serialization and
-        // replication — still runs under the sanitizer. Tests that need a live
-        // socket (NetworkIntegrationTest) stay excluded from the ASan job; the
-        // debug-output/connection callbacks set above are harmless no-ops without
-        // a running service thread. Non-ASan production builds are unaffected.
-        // See issue #317; upstream GNS bug filed as
-        // ValveSoftware/GameNetworkingSockets#418 — remove this gate once a fixed
-        // GNS is vendored.
-        OLO_CORE_WARN("NetworkManager: skipping GameNetworkingSockets_Init under AddressSanitizer (issue #317)");
-#else
         if (SteamDatagramErrMsg errMsg; !GameNetworkingSockets_Init(nullptr, errMsg))
         {
             OLO_CORE_ERROR("GameNetworkingSockets_Init failed: {}", errMsg);
             return false;
         }
-#endif
 
         NetworkThread::Start(60);
 
@@ -160,11 +139,7 @@ namespace OloEngine
         Disconnect();
         NetworkThread::Stop();
 
-#if !OLO_ASAN_ENABLED
-        // Matches the Init() gate above: GameNetworkingSockets was never started
-        // under ASan, so there is nothing to tear down. See issue #317.
         GameNetworkingSockets_Kill();
-#endif
 
         TUniqueLock<FMutex> lock(s_Mutex);
         s_ActiveScene = nullptr;

--- a/OloEngine/tests/Functional/Networking/ServerAuthoritativeLoopTest.cpp
+++ b/OloEngine/tests/Functional/Networking/ServerAuthoritativeLoopTest.cpp
@@ -30,7 +30,6 @@
 
 #include <gtest/gtest.h>
 
-#include "OloEngine/Memory/Platform.h" // OLO_ASAN_ENABLED
 #include "OloEngine/Networking/Core/ClientReplicationDriver.h"
 #include "OloEngine/Networking/Core/NetworkMessage.h"
 #include "OloEngine/Networking/Core/ServerReplicationDriver.h"
@@ -109,13 +108,6 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
   protected:
     void SetUp() override
     {
-#if OLO_ASAN_ENABLED
-        // GameNetworkingSockets_Init trips a stack-buffer-overflow inside vendored
-        // GNS under MSVC ASan (issue #317), exactly as NetworkManager::Init works
-        // around. Skip rather than fail: the transport-free networking tests still
-        // run under the sanitizer.
-        GTEST_SKIP() << "Live GNS sockets are unavailable under AddressSanitizer (issue #317)";
-#else
         SteamDatagramErrMsg errMsg;
         ASSERT_TRUE(GameNetworkingSockets_Init(nullptr, errMsg)) << errMsg;
 
@@ -160,18 +152,15 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
         // how many ticks the harness happened to run.
         m_ClientDrivers[0].GetPrediction().SetSmoothingRate(1.0f);
         m_ClientDrivers[1].GetPrediction().SetSmoothingRate(1.0f);
-#endif
     }
 
     void TearDown() override
     {
-#if !OLO_ASAN_ENABLED
         // Clear the RPC registry FIRST. The RPC tests register handlers capturing
         // test-body locals by reference, and GoogleTest destroys those locals when
         // TestBody returns — before TearDown runs. If closing a transport below
         // drained a queued RPC, the dispatcher would invoke a handler over destroyed
-        // references. (The fixture skips under ASan, so the sanitizer cannot catch
-        // that for us.)
+        // references.
         RpcRegistry::Clear();
 
         for (auto& client : m_Clients)
@@ -193,7 +182,6 @@ class ServerAuthoritativeLoopTest : public ::testing::Test
         // Give the OS a moment to release the listen socket before the next test
         // in this binary binds the same port.
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
-#endif
     }
 
     static void OnStatusChanged(SteamNetConnectionStatusChangedCallback_t* info)

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -35,13 +35,48 @@ function(olo_set_debugger_directory target_name)
     endif()
 endfunction()
 
+# Ask the toolchain ONCE whether it supports IPO/LTO, and cache the answer.
+#
+# check_ipo_supported() is not a cheap predicate: every call generates a small
+# `_CMakeLTOTest-<lang>` project under the current binary dir and runs a full
+# nested CMake configure + compile + link on it. olo_enable_lto() is called per
+# target -- OloEngine, every engine part in the loop, and every app through
+# olo_configure_app() -- so an unguarded call meant ~25 nested configures per
+# configure of this repo, all recomputing the same toolchain-wide answer.
+#
+# That was not just slow. A nested configure writes into the shared build tree,
+# so it is exactly what a SECOND concurrent CMake configure of the same build
+# directory corrupts: the observed failure is two bare
+# "CMake Error: This should not have happened..." lines followed by
+# "CheckIPOSupported.cmake:197 (try_compile): Failed to configure test project
+# build system". The configure lock in the top-level CMakeLists.txt is the real
+# defence against that; caching here shrinks the window by ~25x and takes a
+# large bite out of configure time either way.
+#
+# CACHE INTERNAL, so the answer survives a re-configure of the same tree. That
+# is the right lifetime: the answer is a property of the toolchain, and changing
+# the compiler under an existing build tree is not supported here anyway (it
+# needs a fresh tree -- see docs/agent-rules/build-trees-and-windows-asan.md).
+function(olo_check_lto_support out_var out_output)
+    if(NOT DEFINED OLO_LTO_SUPPORTED)
+        check_ipo_supported(RESULT _olo_lto_supported OUTPUT _olo_lto_output)
+        set(OLO_LTO_SUPPORTED "${_olo_lto_supported}" CACHE INTERNAL
+            "Whether the toolchain supports IPO/LTO (check_ipo_supported, run once per build tree)")
+        set(OLO_LTO_SUPPORT_OUTPUT "${_olo_lto_output}" CACHE INTERNAL
+            "check_ipo_supported() diagnostic output, kept for the 'not supported' warning")
+        message(STATUS "IPO/LTO supported by this toolchain: ${OLO_LTO_SUPPORTED}")
+    endif()
+    set(${out_var} "${OLO_LTO_SUPPORTED}" PARENT_SCOPE)
+    set(${out_output} "${OLO_LTO_SUPPORT_OUTPUT}" PARENT_SCOPE)
+endfunction()
+
 # Apply Link Time Optimization if supported and enabled (Release/Dist only)
 function(olo_enable_lto target_name)
     if(NOT DEFINED OLO_ENABLE_LTO)
         set(OLO_ENABLE_LTO ON)
     endif()
-    
-    check_ipo_supported(RESULT LTO_SUPPORT OUTPUT output)
+
+    olo_check_lto_support(LTO_SUPPORT output)
     if(OLO_ENABLE_LTO AND LTO_SUPPORT)
         message(STATUS "Enabled Link-Time Optimization (LTO) for ${target_name} (Release/Dist only)")
         # Only enable LTO for Release and Dist — it dramatically slows Debug builds

--- a/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
+++ b/cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
@@ -22,8 +22,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/GameNetworkingSockets
-    REF "2cb93a06350bb065db53abdb0d87cf297e0bfd34" # v1.6.0
-    SHA512 c2deaa3aab42cd840dd13560ca4da40faa375ab846ea15af38d55eb7acc48cfe8cbdbe0c76b9c3484d26f9e1163e36ac1eb73a317e5c19cefe60d0b861d19e06
+    # POST-RELEASE MASTER SNAPSHOT, on purpose. v1.6.0 (2026-06-03) is still the
+    # latest tag, and it predates the fix for the stack-buffer-overflow that
+    # GameNetworkingSockets_Init's service thread trips under AddressSanitizer:
+    # ValveSoftware/GameNetworkingSockets#418, fixed by PR #420 (merged to master
+    # 2026-08-24). Without that fix, NetworkManager::Init has to skip the live
+    # init under ASan and the networking suites lose their sanitizer coverage.
+    # Move back to a tag as soon as one ships that contains #420.
+    REF "a424b7db649438acafb60c99cae6667587c42732" # master @ 2026-08-26, 17 commits after PR #420
+    SHA512 a4a9abe49d1ee638926c180ff88c59329a3df749a6ba9a59efba4b719857f802941ae8eabb07fd88ea2138718a5721ecc1ebc61f2dafacc2a026e1374546e1b5
     HEAD_REF master
 )
 

--- a/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
+++ b/cmake/overlay-ports/gamenetworkingsockets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gamenetworkingsockets",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GameNetworkingSockets is a basic transport layer for games (OloEngine overlay: USE_CRYPTO=libsodium instead of OpenSSL, ICE off by default, see issue #773)",
   "homepage": "https://github.com/ValveSoftware/GameNetworkingSockets",
   "license": "BSD-3-Clause",

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ The three workflow slash commands live in [`.claude/commands/`](../.claude/comma
 - [ops/deployment.md](ops/deployment.md) — OloServer deployment / packaging.
 - [ops/self-hosted-gpu-runner.md](ops/self-hosted-gpu-runner.md) — the self-hosted AMD GPU CI runner.
 - [ops/self-hosted-host-hygiene.md](ops/self-hosted-host-hygiene.md) — the box behind the runners: the update timer must not reboot under a job, the GPU resets during the suite, one host is shared.
-- [ops/self-hosted-linux-toolchain.md](ops/self-hosted-linux-toolchain.md) — the pinned clang-19 is provisioned by hand and selected by absolute path; a missing pin warns, never installs.
+- [ops/self-hosted-linux-toolchain.md](ops/self-hosted-linux-toolchain.md) — hosted Linux pins clang-23 from apt.llvm.org; the self-hosted box uses its system clang, and a missing sanitizer runtime warns, never installs.
 
 ## adr/ — architecture decision records
 

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -37,6 +37,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 ## Build and dependencies
 
 - [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md): never build msvc and clangcl trees together; caches, link bounds, memory, the local ASan recipe.
+- [concurrent-cmake-configure.md](concurrent-cmake-configure.md): one configure at a time per build tree; the error blames your CMakeLists.txt and LTO instead.
 - [static-archive-4gib-ceiling.md](static-archive-4gib-ceiling.md): a .lib cannot exceed 4 GiB, and `LNK1248` under-reports the overshoot.
 - [vcpkg-dependency-management.md](vcpkg-dependency-management.md): read before adding, bumping or removing a dependency; the CRT triplet mismatch is heap corruption.
 - [configure-time-variable-visibility.md](configure-time-variable-visibility.md): a CMake variable must be set before the `add_subdirectory()` that reads it.
@@ -200,6 +201,7 @@ The same fact written in more than one place, with nothing enforcing agreement.
 | [runtime-scene-switching.md](runtime-scene-switching.md) | The build pipeline and the runtime must agree on an asset layout. |
 | [audio-voice-budget.md](audio-voice-budget.md) | One config field costs four edits, one of them silent. |
 | [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) | Two build trees writing the same generated files. |
+| [concurrent-cmake-configure.md](concurrent-cmake-configure.md) | Two configures sharing one `CMakeFiles/`; the nested `try_compile` that loses reports the error. |
 | [floating-origin-rebase-subsystems.md](floating-origin-rebase-subsystems.md) | Four subsystems hold world-space state outside the rebased set. |
 | [binary-greedy-voxel-meshing.md](binary-greedy-voxel-meshing.md) | The packed-quad layout lives in `VoxelQuad.h` and `VoxelQuadUnpack.glsl`, and a mismatch compiles. |
 | [destructible-debris.md](destructible-debris.md) | Two unrelated physics layer numberings; `SetCollisionLayer(Debris)` never reaches Jolt's `DEBRIS`. |

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -679,7 +679,7 @@ Two things follow, and the first one cost this repo ten weeks of red CI.
 carries the whole set in one place: `uses: ./.github/actions/setup-llvm-apt` plus
 `clang-23 lld-23` in the apt list (the default libstdc++ lacks
 `std::forward_like`, which `Core/Reflection/MemberList.h` uses),
-`-DCMAKE_{C,CXX}_COMPILER=clang(++)-19`, `-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld`
+`-DCMAKE_{C,CXX}_COMPILER=clang(++)-23`, `-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld`
 (BFD `ld` can exceed a 16 GB runner on this link), `CMAKE_BUILD_TYPE` at configure
 time (`--config` is *silently ignored* by the single-config generator — it will
 happily lie to you about building Release), and an explicit `--parallel N`.

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -672,12 +672,12 @@ Two things follow, and the first one cost this repo ten weeks of red CI.
    throttling `LuaScriptGlue.cpp` / `McpFieldRegistry.cpp`. Pick the number
    against evidence rather than against the pools you think are protecting you.
    The proven-green reference points on `ubuntu-24.04` are `steam-stub.yml`
-   (`--parallel 4`, `OloEngine-Tests`, Debug, clang-19 + lld) and `asan.yml`'s
+   (`--parallel 4`, `OloEngine-Tests`, Debug, clang-23 + lld) and `asan.yml`'s
    sanitizer jobs (`--parallel 2`, where each TU costs ~3 GB).
 
 **When you add a Linux CI job, copy `steam-stub.yml`, not a Windows job.** It
 carries the whole set in one place: `uses: ./.github/actions/setup-llvm-apt` plus
-`clang-19 lld-19` in the apt list (the default libstdc++ lacks
+`clang-23 lld-23` in the apt list (the default libstdc++ lacks
 `std::forward_like`, which `Core/Reflection/MemberList.h` uses),
 `-DCMAKE_{C,CXX}_COMPILER=clang(++)-19`, `-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld`
 (BFD `ld` can exceed a 16 GB runner on this link), `CMAKE_BUILD_TYPE` at configure

--- a/docs/agent-rules/concurrent-cmake-configure.md
+++ b/docs/agent-rules/concurrent-cmake-configure.md
@@ -1,0 +1,101 @@
+# Never run two CMake configures against one build tree — and the error names the wrong thing
+
+**The rule:** one `cmake` configure at a time per binary directory. Two configures on the same
+build tree corrupt each other. The top-level `CMakeLists.txt` now takes a `file(LOCK ...)` on
+`<binaryDir>/olo-configure.lock` for exactly this reason, so a second configure waits instead of
+racing. Do not remove that lock, and do not start a configure "just to be sure" while another one
+is running.
+
+**What it looks like when it happens.** Not a message about concurrency, and not one that points at
+the tool that lost:
+
+```
+CMake Error: This should not have happened. If you see this message, you are probably using a
+broken CMakeLists.txt file or a problematic release of CMake
+CMake Error: This should not have happened. If you see this message, you are probably using a
+broken CMakeLists.txt file or a problematic release of CMake
+CMake Error at .../Modules/CheckIPOSupported.cmake:197 (try_compile):
+  Failed to configure test project build system.
+Call Stack (most recent call first):
+  cmake/CommonProperties.cmake:44 (check_ipo_supported)
+  OloEngine/CMakeLists.txt:68 (olo_enable_lto)
+-- Configuring incomplete, errors occurred!
+```
+
+Read literally, that says your CMakeLists.txt is broken and LTO is unsupported. Both are false. The
+two bare "This should not have happened" lines are stderr from the **nested** cmake that
+`try_compile()` spawns; it fails because the other configure deleted the scratch project out from
+under it. Any check that shells out to a nested cmake can be the one that reports it —
+`check_ipo_supported`, `CMakeTestCXXCompiler`, any `try_compile` — so the file and line in the error
+tell you only who lost the race, never that there was one.
+
+The giveaway is that the *same* command succeeded minutes earlier against the *same* tree. When a
+configure failure is not reproducible, suspect a second configure before suspecting the toolchain.
+
+## Reproducing it
+
+Deterministic in about a minute, no engine build needed. Two configures, the second started two
+seconds into the first:
+
+```bash
+mkdir -p /tmp/ipo/src && cat > /tmp/ipo/src/CMakeLists.txt <<'CM'
+cmake_minimum_required(VERSION 3.25)
+project(ipotest C CXX)
+include(CheckIPOSupported)
+foreach(i RANGE 1 25)
+  check_ipo_supported(RESULT r OUTPUT o)
+endforeach()
+CM
+cmake -S /tmp/ipo/src -B /tmp/ipo/bin -G "Ninja Multi-Config" > a.log 2>&1 &
+sleep 2; cmake -S /tmp/ipo/src -B /tmp/ipo/bin -G "Ninja Multi-Config" > b.log 2>&1
+```
+
+Both logs carry the error above. Add the `file(LOCK ... GUARD PROCESS TIMEOUT 600)` from the
+top-level `CMakeLists.txt` at the head of the test project and both configures pass, the second
+simply taking the first one's runtime plus its own.
+
+## Where the second configure comes from
+
+Rarely from a person deciding to run two. The sources seen here, in order:
+
+- **VS Code's CMake Tools extension.** It defaults to `cmake.configureOnOpen: true` and
+  `cmake.configureOnEdit: true`, so opening the folder or saving any CMake file starts a configure
+  with no prompt. Both are set to `false` in [.vscode/settings.json](../../.vscode/settings.json);
+  configure deliberately, from the palette or the CLI.
+- **A second agent session or terminal** in the same worktree. Worktrees do not help here — the
+  collision is per *binary directory*, and two sessions in one worktree share `build-cached/`.
+- **A retry after an apparent hang.** The first configure was still running.
+
+The build mutex in [build-lock.ps1](../../.claude/skills/run-oloengine/build-lock.ps1) does **not**
+cover this, by design: it serialises builds against memory exhaustion, and its `PreToolUse` guard
+deliberately classifies `cmake` without `--build` as cheap. Cheap it is — a configure is not going
+to OOM the box. Concurrency-safe it is not. The two mechanisms guard different things, and the
+CMake-side lock is the one that covers configures.
+
+## Why this repo was unusually exposed
+
+`check_ipo_supported()` is not a cheap predicate: each call generates a `_CMakeLTOTest-<lang>`
+project under the current binary directory and runs a full nested CMake configure, compile and link
+on it. `olo_enable_lto()` used to call it every time, and it is called per target — `OloEngine`,
+each engine part in the loop at `OloEngine/CMakeLists.txt`, and every app through
+`olo_configure_app()`. That is roughly 25 nested configures per configure of this repo, each one a
+window for the race and each one recomputing the same toolchain-wide answer.
+
+`olo_check_lto_support()` in [CommonProperties.cmake](../../cmake/CommonProperties.cmake) now caches
+it in `OLO_LTO_SUPPORTED` (`CACHE INTERNAL`, so it survives a re-configure of the same tree). One
+nested configure instead of 25. Measured on the isolated repro above: 25 checks took 43s, one takes
+about 8s.
+
+Keep both defences. The cache narrows the window; only the lock closes it.
+
+## The related trap next door
+
+The same failing log carried a second, unrelated problem worth recognising: `CMAKE_TOOLCHAIN_FILE`
+pointing into `Microsoft Visual Studio/18/Community/VC/vcpkg` while `VCPKG_ROOT` was `D:\vcpkg` in
+every shell. The Visual Studio developer environment sets `VCPKG_ROOT` to its own bundled copy, and
+CMake Tools applies that environment before expanding `$env{VCPKG_ROOT}` in the presets. The
+top-level `CMakeLists.txt` now warns about it. It is not what broke the configure — a changed
+`CMAKE_TOOLCHAIN_FILE` is ignored on a re-configure, so an existing tree stays pinned to whichever
+vcpkg it was created with — but a *fresh* tree configured from such a window silently uses a
+different registry clone that lacks `vcpkg.json`'s `builtin-baseline`. See
+[vcpkg-dependency-management.md](vcpkg-dependency-management.md).

--- a/docs/agent-rules/vcpkg-dependency-management.md
+++ b/docs/agent-rules/vcpkg-dependency-management.md
@@ -335,7 +335,7 @@ It does not have to be. Ubuntu 24.04 under WSL2 matches the runner image, and th
 `tsan-linux` job reproduces locally in one pass:
 
 ```bash
-sudo apt-get install -y clang-19 lld-19 ninja-build autoconf-archive gdb   # + the job's dep list
+sudo apt-get install -y clang-23 lld-23 ninja-build autoconf-archive gdb   # + the job's dep list
 git clone https://github.com/microsoft/vcpkg ~/vcpkg        # NOT --depth 1: the manifest
 ~/vcpkg/bootstrap-vcpkg.sh -disableMetrics                  # baseline commit must be present
 cmake -S . -B build -G Ninja \

--- a/docs/agent-rules/vcpkg-dependency-management.md
+++ b/docs/agent-rules/vcpkg-dependency-management.md
@@ -341,7 +341,7 @@ git clone https://github.com/microsoft/vcpkg ~/vcpkg        # NOT --depth 1: the
 cmake -S . -B build -G Ninja \
   -DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake \
   -DVCPKG_TARGET_TRIPLET=x64-linux \
-  -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_C_COMPILER=clang-19 \
+  -DCMAKE_CXX_COMPILER=clang++-23 -DCMAKE_C_COMPILER=clang-23 \
   -DCMAKE_BUILD_TYPE=Debug -DOLO_ENABLE_TSAN=ON -DBUILD_TESTS=ON \
   -DOLO_VIDEO_FFMPEG=OFF -DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF -DOLO_WITH_MATERIALX=OFF \
   "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -lstdc++exp"

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -16,7 +16,8 @@ and the Linux CI jobs in
 
 **The Linux sanitizer jobs run here with hosted parity** (#1015): every ctest-launched test
 process gets `--olo-gl-backend=none`, so the GL-gated tests skip exactly as they do on a
-hosted runner, and the compiler is the pinned clang-19 when provisioned. #1010's measurement
+hosted runner. The compiler is NOT the same as hosted -- the box builds with its system
+clang 21, hosted builds with clang-23 -- which is deliberate. #1010's measurement
 (215 failures of 6,909 here against 1 of 6,940 hosted) was two engine bugs the GPU exposed,
 not the toolchain — see [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md).
 The GPU-under-sanitizer coverage is its own scheduled job,
@@ -486,18 +487,23 @@ X/Wayland `-devel` set; creates the `~/.cache/olo/*` directories from §1c; and
 registers `olo-ci-1` and `olo-ci-2` with labels `self-hosted,linux,x64,olo-ci`
 under user systemd, exactly like the GPU runner.
 
-**The compiler is the pinned clang-19 when the box is provisioned, and clang 21
-when it is not.** Every hosted Linux job pins clang-19 from apt.llvm.org because
-ubuntu-24.04's default libstdc++ lacks `std::forward_like`. Rocky 10's base repos
-have no clang-19, but EPEL ships the same 19.1.7 as `clang19` / `compiler-rt19` /
-`lld19` under `/usr/lib64/llvm19/bin`, and `scripts/setup-olo-ci-host.sh` installs
-it (#1015). `setup-linux-build` selects it by absolute path when the compiler, its
-linker AND its sanitizer runtimes are all present, and otherwise emits a
-`::warning` and builds with the system clang 21 — a missing pin must not take the
-box out, since every same-repo PR's sanitizer jobs land here.
+**The box builds with Rocky 10's system clang (21.1.8); the hosted arm builds with
+clang-23 from apt.llvm.org.** That skew is deliberate, not a missing pin. Hosted
+needs a clang from apt.llvm.org at all because ubuntu-24.04's default libstdc++
+lacks `std::forward_like`; the box cannot follow it, because EPEL on Rocky 10 tops
+out at `clang20` and ships no `clang22` or `clang23`.
 
-So the box may be running either compiler. **Read the job's `toolchain:` line
-rather than assuming**, and read it before concluding the box is broken when a
+There used to be a `clang-19` pin here, selected by absolute path from
+`/usr/lib64/llvm19/bin`. It was never provisioned — that directory does not exist
+on the box — so every self-hosted sanitizer run had silently been taking the
+fallback path for as long as the pin stood. `setup-linux-build` now verifies the
+**sanitizer runtimes** instead of a version, and `scripts/setup-olo-ci-host.sh`
+provisions `compiler-rt` and `lld` for the system clang. A missing runtime emits a
+`::warning` rather than failing — it must not take the box out, since every
+same-repo PR's sanitizer jobs land here.
+
+**Read the job's `toolchain:` line rather than assuming**, and read it before
+concluding the box is broken when a
 self-hosted job fails and its hosted fallback passes. The full rule and the
 evidence that the version skew was never the cause of #1010's 215 failures are in
 [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md).
@@ -593,7 +599,7 @@ stable enough to be worth trending — unlike hosted-runner perf data.
 |---|---|
 | A Linux CI job queues forever | no `olo-ci` runner is online — `gh api repos/drsnuggles8/OloEngineBase/actions/runners`. There is no automatic hosted fallback for a same-repo PR: the `runs-on` expression chose this box before scheduling |
 | `clang: command not found` on an `olo-ci` job | the CI provisioning was never run — `sudo bash scripts/setup-olo-ci-runners.sh` (§6) |
-| A job fails here and its hosted rerun passes | check the compiler first, and read the job's `toolchain:` line rather than assuming. A provisioned box builds with the pinned clang-19, the same version the hosted arm gets; without the pin the job prints a `::warning` and falls back to the system clang 21. See [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md) |
+| A job fails here and its hosted rerun passes | check the compiler first, and read the job's `toolchain:` line rather than assuming. The box builds with its system clang 21 and hosted builds with clang-23, by design; a `::warning` about sanitizer runtimes means compiler-rt is missing, not that the version is wrong. See [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md) |
 | `undefined symbol: std::__stacktrace_impl::_S_current` at link | `libstdc++exp.a` is missing from the GCC install clang selected. Rocky's clang picks **gcc-toolset-15**, which omits it, while the base GCC 14 beside it has it. `OloEngine/CMakeLists.txt` globs the base dirs and links it explicitly — that fallback used to be GNU-only on the (backwards) premise that clang resolves it itself |
 | A job is CANCELLED mid-build with no error, or "the self-hosted runner lost communication with the server" | the host rebooted. Two known causes, told apart by `journalctl -b -1` (the previous boot's last lines): a kernel update applied by `dnf-automatic-install.timer` in its 06:00–07:00 local slot (`shutdown -r +5` in the log; 2026-08-11, 08-14, 08-22), or a failed GPU runtime-PM wake (`amdgpu asic init failed` after a run of `SMU is resuming`; 2026-09-02 00:39, under the ASan test step, which killed both in-flight sanitizer jobs). `scripts/setup-olo-ci-host.sh` makes the timer skip a slot while a job runs and pins the GPU active so it never takes the wake path. The timer guard is BEST EFFORT: its `ExecCondition` runs once, before `dnf-automatic-install.service` starts, so a job picked up while dnf is already working is not seen and a kernel update's `shutdown -r +5` still lands on it. Before a planned update, drain the pool by hand — stop the `Runner.Listener` processes or mark the runners offline through the GitHub API, then restore afterward ([self-hosted-host-hygiene.md](self-hosted-host-hygiene.md) §1) Details: [self-hosted-host-hygiene.md](self-hosted-host-hygiene.md) |
 | Cold builds despite the persistent caches | `~/.cache/olo` is owned by the wrong user, or the job took the hosted arm. The setup step logs the resolved cache dir |

--- a/docs/ops/self-hosted-host-hygiene.md
+++ b/docs/ops/self-hosted-host-hygiene.md
@@ -76,11 +76,11 @@ Memory is the other shared budget: an instrumented compile is ~3 GB per translat
 an instrumented `OloEngine-Tests` link several more, so every self-hosted build caps its
 parallelism and sets `OLO_LINK_JOBS=1`; two sanitizer jobs at once already use most of the box.
 
-## 4. The compiler is pinned by provisioning, verified by the workflow
+## 4. The sanitizer runtimes are provisioned, verified by the workflow
 
 See [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md). The short version: the
-job warns and builds with the system clang 21 until `clang19` from EPEL is installed, and the
-warning is the only thing the install changes.
+box builds with its system clang 21 (hosted is on clang-23, deliberately), and the job warns
+until `compiler-rt` and `lld` are installed beside it. There is no version pin to provision.
 
 ## Root steps, once
 

--- a/docs/ops/self-hosted-host-hygiene.md
+++ b/docs/ops/self-hosted-host-hygiene.md
@@ -79,8 +79,18 @@ parallelism and sets `OLO_LINK_JOBS=1`; two sanitizer jobs at once already use m
 ## 4. The sanitizer runtimes are provisioned, verified by the workflow
 
 See [self-hosted-linux-toolchain.md](self-hosted-linux-toolchain.md). The short version: the
-box builds with its system clang 21 (hosted is on clang-23, deliberately), and the job warns
-until `compiler-rt` and `lld` are installed beside it. There is no version pin to provision.
+box builds with its system clang 21 (hosted is on clang-23, deliberately), and there is no
+version pin to provision.
+
+The two missing-piece outcomes are NOT the same, which matters when you read a red job:
+
+- **`lld` missing — the job FAILS.** `lld` is in the "Preflight — toolchain" step's required
+  binary list, alongside `cmake`, `ninja`, `ccache`, `clang`, `clang++`, `python3` and `nasm`.
+  A missing one is an `::error` and `exit 1` before anything is configured.
+- **`compiler-rt` missing — the job WARNS and carries on.** The runtime check in "Resolve
+  toolchain" emits a `::warning` naming the `dnf` command. The build then fails later at the
+  first sanitizer link (`cannot find libclang_rt.asan.a`), so nothing is silently skipped —
+  the warning just tells you why, several minutes earlier than the linker would.
 
 ## Root steps, once
 
@@ -88,6 +98,7 @@ until `compiler-rt` and `lld` are installed beside it. There is no version pin t
 sudo bash scripts/setup-olo-ci-host.sh
 ```
 
-Idempotent. Installs the pinned compiler, the update-timer drop-in and the GPU runtime-PM
-rule, then prints the resulting state. Nothing in any workflow installs or changes host state; a self-hosted step
+Idempotent. Installs the sanitizer runtimes and `lld` for the system clang, the update-timer
+drop-in and the GPU runtime-PM rule, then prints the resulting state. It installs no pinned
+compiler -- there is no version pin any more. Nothing in any workflow installs or changes host state; a self-hosted step
 verifies and names this script when it finds something missing.

--- a/docs/ops/self-hosted-linux-toolchain.md
+++ b/docs/ops/self-hosted-linux-toolchain.md
@@ -1,4 +1,4 @@
-# Self-hosted Linux runners: the compiler is provisioned, selected by absolute path, and never installed by a job
+# Self-hosted Linux runners: the box builds with its system clang, and a job verifies but never installs
 
 Issue [#1015](https://github.com/drsnuggles8/OloEngineBase/issues/1015), item A. Applies to
 every job that calls [`setup-linux-build`](../../.github/actions/setup-linux-build/action.yml)
@@ -7,24 +7,32 @@ GPU-under-sanitizer nightly.
 
 ## The rule
 
-1. The hosted arm builds with clang-19 from apt.llvm.org (19.1.7). The self-hosted arm builds
-   with the same major version when the box has it: EPEL's `clang19` / `compiler-rt19` /
-   `lld19` install under `/usr/lib64/llvm19/bin`, off `PATH`, and the action selects them by
-   absolute path. `-fuse-ld=lld` resolves the `ld.lld` beside the compiler before it searches
-   `PATH`, so the linker follows without a second setting.
-2. When the pin is missing, the action prints a `::warning` annotation naming the install
-   command and builds with the system clang (21 on Rocky 10). It does not fail. A self-hosted
-   step verifies and never installs (the convention at the top of the action), and a hard
-   failure here would block every same-repo PR's sanitizer jobs on one maintainer running
-   `dnf`.
-3. Every configure log starts with one line, `toolchain: <compiler> (<version>) / <python>`.
+1. The hosted arm builds with **clang-23** from apt.llvm.org. The self-hosted arm builds with
+   **Rocky 10's system clang** (21.1.8, with `compiler-rt-21` and `lld-21`). The two arms are
+   deliberately different versions -- see the next section -- and there is no version pin on
+   the box any more.
+2. The box cannot follow the hosted arm. EPEL on Rocky 10 tops out at `clang20` (20.1.8);
+   there is no `clang22` or `clang23` package. Pinning a version the distro does not ship only
+   recreates the unprovisioned pin this rule replaced: the previous `clang-19` pin named
+   `/usr/lib64/llvm19/bin`, which **did not exist on the box** -- every self-hosted sanitizer
+   run had already been taking the fallback path, silently, for as long as the pin stood.
+3. What the action verifies is the **sanitizer runtimes, not the version**. A clang without
+   `compiler-rt` configures fine and fails every sanitizer LINK on `cannot find
+   libclang_rt.asan.a`. The runtime directory is asked of the compiler itself
+   (`clang++ -print-runtime-dir`), so the check follows whatever layout the distro uses.
+4. A missing runtime prints a `::warning` annotation naming the install command and carries
+   on. It does not fail. A self-hosted step verifies and never installs (the convention at the
+   top of the action), and a hard failure here would block every same-repo PR's sanitizer jobs
+   on one maintainer running `dnf`.
+5. Every configure log starts with one line, `toolchain: <compiler> (<version>) / <python>`.
    When a self-hosted job fails and its hosted twin does not, read that line before reading
-   anything else.
+   anything else -- the two arms run different compilers by design.
 
-Install the pin with `sudo bash scripts/setup-olo-ci-host.sh` (see
+Provision the runtimes with `sudo dnf install -y compiler-rt lld`, or run
+`sudo bash scripts/setup-olo-ci-host.sh` (see
 [self-hosted-host-hygiene.md](self-hosted-host-hygiene.md)).
 
-## Why the pin is optional: the version skew was never the cause
+## Why the version skew is fine: it was never the cause
 
 #1010 measured the sanitizer jobs on the box, saw 215 failures against 1 hosted, and blamed
 half of them on "clang 21 against gcc-toolset-15's libstdc++": two UBSan reports inside the

--- a/scripts/setup-olo-ci-host.sh
+++ b/scripts/setup-olo-ci-host.sh
@@ -3,13 +3,15 @@
 # never perform (issue #1015). Companion to setup-olo-ci-runners.sh, which
 # provisions the runner pool; this one owns the two things that pool did not:
 #
-#   1. The pinned compiler. The hosted Linux jobs build with clang-19 from
-#      apt.llvm.org; Rocky 10's base repos stop at clang 21, but EPEL ships
-#      clang19 / compiler-rt19 / lld19 at the same 19.1.7. setup-linux-build
-#      selects /usr/lib64/llvm19/bin when it exists and WARNS (then builds with
-#      the system clang) when it does not -- so this step flips a warning, not a
-#      failure. docs/ops/self-hosted-linux-toolchain.md says why the pin is
-#      optional rather than required.
+#   1. The sanitizer runtimes for the system compiler. The box builds with
+#      Rocky 10's own clang (21.1.8) -- there is no version pin any more, because
+#      the hosted arm is on clang-23 and EPEL tops out at clang20, so no pin can
+#      match. What the box DOES need is compiler-rt and lld beside that clang:
+#      without compiler-rt every sanitizer link fails on "cannot find
+#      libclang_rt.asan.a". setup-linux-build VERIFIES the runtimes and WARNS
+#      (then builds anyway) when they are absent, so this step flips a warning,
+#      not a failure. docs/ops/self-hosted-linux-toolchain.md says why the
+#      version skew against the hosted arm is fine.
 #
 #   2. Unattended updates that reboot under a running job.
 #      dnf-automatic-install.timer (06:00 local + up to 60 min) applies updates
@@ -55,16 +57,23 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# ---------------------------------------------------------------- 1. clang-19
-# All three or none: setup-linux-build selects the compiler by path and relies
-# on ld.lld and the sanitizer runtimes sitting beside it.
-if [ -x /usr/lib64/llvm19/bin/clang++ ] && [ -x /usr/lib64/llvm19/bin/ld.lld ]    && ls /usr/lib64/llvm19/lib/clang/19/lib/*/libclang_rt.asan*.a >/dev/null 2>&1; then
-  echo "clang-19 already provisioned: $(/usr/lib64/llvm19/bin/clang++ --version | head -1)"
+# ------------------------------------------------- 1. sanitizer runtimes + lld
+# Asked of the compiler itself rather than hardcoded: the runtime directory
+# layout is the distro's business, and it moves between clang majors.
+rt_dir=$(clang++ -print-runtime-dir 2>/dev/null || true)
+if [ -n "$rt_dir" ]    && ls "$rt_dir"/libclang_rt.asan*.a >/dev/null 2>&1    && ls "$rt_dir"/libclang_rt.tsan*.a >/dev/null 2>&1    && ls "$rt_dir"/libclang_rt.ubsan*.a >/dev/null 2>&1    && command -v ld.lld >/dev/null 2>&1; then
+  echo "sanitizer toolchain already provisioned: $(clang++ --version | head -1)"
 else
-  dnf install -y clang19 compiler-rt19 lld19
-  echo "clang-19 provisioned: $(/usr/lib64/llvm19/bin/clang++ --version | head -1)"
+  dnf install -y clang compiler-rt lld
+  rt_dir=$(clang++ -print-runtime-dir 2>/dev/null || true)
+  echo "sanitizer toolchain provisioned: $(clang++ --version | head -1)"
 fi
-test -x /usr/lib64/llvm19/bin/ld.lld || { echo "lld19 did not install ld.lld beside clang-19" >&2; exit 1; }
+# All three runtimes or none: a compiler-rt missing tsan configures fine and
+# fails only the TSan job's link, hours later and in a job nobody was watching.
+for san in asan tsan ubsan; do
+  ls "$rt_dir"/libclang_rt.$san*.a >/dev/null 2>&1     || { echo "compiler-rt did not install libclang_rt.$san beside clang++ (looked in '${rt_dir:-<unknown>}')" >&2; exit 1; }
+done
+command -v ld.lld >/dev/null 2>&1 || { echo "lld did not install ld.lld" >&2; exit 1; }
 
 # ------------------------------------------- 2. no reboot under a running job
 # Idempotent for real: write to a temp file and only install + reload when the
@@ -113,7 +122,8 @@ done
 # ------------------------------------------------------------------- report
 echo
 echo "state:"
-echo "  clang-19:  /usr/lib64/llvm19/bin/clang++ -> $(/usr/lib64/llvm19/bin/clang++ --version | head -1)"
+echo "  clang:     $(command -v clang++) -> $(clang++ --version | head -1)"
+echo "  runtimes:  $(clang++ -print-runtime-dir 2>/dev/null || echo '<unknown>')"
 echo "  timer:     $(systemctl list-timers dnf-automatic-install.timer --no-pager | sed -n 2p)"
 echo "  condition: $(grep ExecCondition "$dropin")"
 echo "  gpu:       $(for dev in /sys/bus/pci/drivers/amdgpu/0000:*; do printf '%s control=%s status=%s ' "$(basename "$dev")" "$(cat "$dev/power/control")" "$(cat "$dev/power/runtime_status")"; done)"

--- a/scripts/setup-olo-ci-runners.sh
+++ b/scripts/setup-olo-ci-runners.sh
@@ -46,13 +46,13 @@ fi
 #   clang / lld / compiler-rt   the sanitizer jobs are clang-only, and
 #                               -fsanitize=address|undefined|thread needs the
 #                               compiler-rt runtimes. Rocky 10 ships clang 21.
-#   clang19 / lld19 /           the PIN (#1015): the same 19.1.7 the hosted
-#   compiler-rt19               jobs get from apt.llvm.org, from EPEL, under
-#                               /usr/lib64/llvm19/bin. setup-linux-build selects
-#                               it by absolute path when present and warns
-#                               (then builds with clang 21) when not, so the
-#                               system clang stays as the fallback and as a
-#                               second compiler version for local builds.
+#                               There is no VERSION pin any more (#1015 had one:
+#                               EPEL's clang19 under /usr/lib64/llvm19/bin, which
+#                               was never actually installed on the box, so every
+#                               run silently took the fallback). Hosted is on
+#                               clang-23 and EPEL tops out at clang20, so no pin
+#                               can match; the box uses its system clang and
+#                               setup-linux-build verifies the RUNTIMES instead.
 #                               docs/ops/self-hosted-linux-toolchain.md.
 #                               setup-olo-ci-host.sh installs the same three
 #                               packages on their own for a box that is
@@ -70,7 +70,6 @@ fi
 echo "== packages =="
 dnf install -y \
     clang clang-tools-extra lld compiler-rt libomp libomp-devel \
-    clang19 compiler-rt19 lld19 \
     mesa-libEGL-devel libglvnd-devel \
     libXrandr-devel libXinerama-devel libXcursor-devel libXi-devel libXext-devel \
     wayland-devel wayland-protocols-devel libxkbcommon-devel \


### PR DESCRIPTION
Option 2 of the three we discussed: hosted Linux to clang-23, and the self-hosted arm fixed to describe reality instead of a pin that was never there.

Follows #1024 (Windows LLVM 23.1.0). Kept separate on purpose — a four-major compiler jump can red the sanitizer jobs on its own findings, and that must not be able to sink the Windows fix.

## Hosted: clang-19 → clang-23

`setup-llvm-apt`'s default and the apt lists that name the compiler directly (`setup-linux-build`, `video-ffmpeg`).

Verified the suite exists **before** bumping — `llvm-toolchain-noble-23` publishes `clang-23`, `lld-23` and `libc++-23-dev` in its `binary-amd64` index. A version with no suite fails as an apt 404 several steps after the step that chose it, so this is worth checking rather than assuming.

The reason hosted needs apt.llvm.org at all is unchanged: ubuntu-24.04's default libstdc++ has no `std::forward_like`, and `Core/Reflection` uses it.

## Self-hosted: the clang-19 pin was never provisioned

Two findings, either one sufficient:

1. **The pin didn't exist on the box.** `setup-linux-build` selected `/usr/lib64/llvm19/bin` when present — on the box only `llvm21` exists. So every self-hosted sanitizer run had already been taking the documented warn-and-fall-back path, silently, for as long as the pin stood. The comment described a machine state that was not true.
2. **The box cannot follow 23.** EPEL on Rocky 10.2 tops out at `clang20` (20.1.8); no `clang22`, no `clang23`. Pinning a version the distro doesn't ship just recreates the same unprovisioned pin one number higher.

So the box uses what it has — system clang 21.1.8 with `compiler-rt-21` and `lld-21` — and the action now verifies the **sanitizer runtimes** rather than a version. That's the check that protects something real: a clang without compiler-rt configures fine and fails every sanitizer *link* on `cannot find libclang_rt.asan.a`. The runtime dir is asked of the compiler itself, so it follows whatever layout the distro uses. Still a warning, never a failure — `asan.yml` routes every same-repo PR's sanitizer jobs here.

Confirmed on the box over ssh before writing any of it:

```
clang version 21.1.8 (RESF 21.1.8-1.el10)     LLD 21.1.8
asan: present   tsan: present   ubsan: present
compiler-rt-21.1.8-1.el10.x86_64   lld-21.1.8-1.el10.x86_64
```

The resulting skew between the arms is coverage, not a defect — the #1010 argument for that is unchanged and quoted where it was.

## Provisioning + docs

- `setup-olo-ci-host.sh` installs `compiler-rt` + `lld` for the system clang instead of EPEL's clang19 trio, and checks **all three** runtimes rather than asan alone (a compiler-rt missing tsan fails only the TSan job's link, hours later, in a job nobody was watching).
- `setup-olo-ci-runners.sh` drops the three `clang19` packages.
- Docs updated in six places, including the two that stated the pin as current fact (`docs/README.md`, `self-hosted-gpu-runner.md`).

## Checks

Every touched YAML parses; every shell step in `setup-linux-build` passes `bash -n`; both provisioning scripts pass `bash -n`.

**What CI has to prove:** that the engine and its sanitizer flags are clean under clang-23. That's the part I can't verify locally, and the reason this is its own PR.

## Not touched

`setup-linux-build`'s line about "the HOSTED SDK build (1.4.321.0 + clang-19)" — that records what a past measurement was made against, not what the job runs now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Tooling**
  - Updated hosted Linux build and video workflows to Clang/LLD 23.
  - Self-hosted runners now use system Clang and verify sanitizer runtimes.
  - Added protection against concurrent CMake configuration conflicts and improved toolchain mismatch warnings.
  - CMake now avoids repeating expensive LTO capability checks.

- **Bug Fixes**
  - GameNetworkingSockets initialization and networking tests now run consistently under sanitizers.
  - Updated the bundled networking dependency to include an upstream stack-overflow fix.

- **Documentation**
  - Added guidance for concurrent CMake configuration and refreshed toolchain setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->