### PR TITLE
fix(cmake): the VS-bundled-vcpkg guard never matched a backslash path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,14 @@ endif()
 # downloads/, diverging from every other worktree on this machine. An existing
 # build tree is unaffected either way: CMAKE_TOOLCHAIN_FILE is only honoured on
 # the FIRST configure, so a tree already pinned to the right vcpkg stays pinned.
-set(_olo_vs_vcpkg_re "[Mm]icrosoft [Vv]isual [Ss]tudio.*[/\]VC[/\]vcpkg")
+set(_olo_vs_vcpkg_re "[Mm]icrosoft [Vv]isual [Ss]tudio.*[/\\]VC[/\\]vcpkg")
+# NOTE the DOUBLED backslash. This is a quoted argument, so CMake unescapes it
+# before the regex engine ever sees it: "[/\]" becomes the regex [/], a class
+# holding only the forward slash, and the backslash alternative is silently gone.
+# That matters because the two operands are spelled differently: CMAKE_TOOLCHAIN_FILE
+# is normalised to forward slashes and matched either way, but $ENV{VCPKG_ROOT} on
+# Windows keeps its backslashes -- so the single-backslash version checked only the
+# half that cannot be acted on, and never fired for the env var that causes this.
 if(CMAKE_TOOLCHAIN_FILE MATCHES "${_olo_vs_vcpkg_re}" OR "$ENV{VCPKG_ROOT}" MATCHES "${_olo_vs_vcpkg_re}")
     message(WARNING
         "vcpkg is being resolved from the copy bundled with Visual Studio, not from a "


### PR DESCRIPTION
Small correctness fix, found in review of #1023 and never landed — `origin/master` still carries the broken pattern.

## The bug

The regex added in `2593d50e5` was written as `"[/\]VC[/\]vcpkg"` in a **quoted argument**, so CMake unescapes it before the regex engine sees it: `"[/\]"` becomes the regex `[/]` — a character class holding only the forward slash. The backslash alternative is silently gone. No error, no warning, just a narrower match than the source reads as.

That removed exactly the half of the check that can act on anything. The two operands are spelled differently:

- `CMAKE_TOOLCHAIN_FILE` arrives normalised to forward slashes → matched fine.
- `$ENV{VCPKG_ROOT}` on Windows keeps its backslashes → **never matched**.

And the env var is the one the warning tells you to fix.

## The fix

Doubling the backslash yields the regex `[/\]`, which matches both.

Verified with `cmake -P` on the exact line from the file:

| Path | before | after |
|---|---|---|
| `C:/Program Files/Microsoft Visual Studio/18/Community/VC/vcpkg/…` | MATCH | MATCH |
| `C:\Program Files\Microsoft Visual Studio\18\Community\VC\vcpkg` | **NO MATCH** | MATCH |
| `D:/vcpkg/scripts/buildsystems/vcpkg.cmake` | no match | no match |

🤖 Generated with [Claude Code](https://claude.com/claude-code)