### PR TITLE
fix: four tooling/engine fixes from a memory-workaround audit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
           {
             "type": "command",
             "shell": "bash",
-            "command": "if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/claude-stop-hook.ps1; else sh .claude/hooks/claude-stop-hook.sh; fi"
+            "command": "hooks=\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks\"; if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -ExecutionPolicy Bypass -File \"$hooks/claude-stop-hook.ps1\"; else sh \"$hooks/claude-stop-hook.sh\"; fi"
           }
         ]
       }

--- a/.claude/skills/run-oloengine/driver.ps1
+++ b/.claude/skills/run-oloengine/driver.ps1
@@ -50,7 +50,15 @@ param(
     # only works if OloEditor is genuinely the top-most visible window (it usually is
     # NOT, because a background process cannot steal foreground on Windows).
     [ValidateSet('print', 'screen')]
-    [string]$Method = 'print'
+    [string]$Method = 'print',
+
+    # Backend selection, forwarded to the app as `--rhi=<value>`. Without this
+    # the driver could only ever launch the default (OpenGL), so any Vulkan
+    # session had to be started by hand outside the driver -- losing the log
+    # snapshot, the window wait and the capture path with it. Empty = let the
+    # app pick (config file, then OpenGL).
+    [ValidateSet('', 'opengl', 'vulkan')]
+    [string]$Rhi = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -238,6 +246,11 @@ function Start-Editor {
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $exePath
     $psi.WorkingDirectory = $workDir
+    if ($Rhi) {
+        # EditorLayer parses argv for `--rhi=`; anything it does not recognise
+        # is treated as a project path, so pass the flag verbatim.
+        $psi.Arguments = "--rhi=$Rhi"
+    }
     # detached (launch): ShellExecute starts it in its own console so it
     # survives this script exiting. inline (capture): inherit the console so
     # the editor's log streams here, and we kill it ourselves before exiting.

--- a/OloEngine/src/OloEngine/Core/Log.cpp
+++ b/OloEngine/src/OloEngine/Core/Log.cpp
@@ -46,6 +46,40 @@ namespace OloEngine
     }
 #endif
 
+    // Precedence: an explicit SetLogFile() call, then OLO_LOG_FILE from the
+    // environment, then the historical default. Every process used to share
+    // that default and open it truncating, so whichever started last erased the
+    // others' diagnostics.
+    std::string Log::ResolveLogFileName()
+    {
+        if (!s_LogFileName.empty())
+        {
+            return s_LogFileName;
+        }
+
+        // No std::getenv on the MSVC CRT without the deprecation opt-out;
+        // _dupenv_s is the sanctioned form and hands back an owned buffer.
+#ifdef OLO_PLATFORM_WINDOWS
+        char* value = nullptr;
+        sizet length = 0;
+        if (_dupenv_s(&value, &length, "OLO_LOG_FILE") == 0 && value != nullptr)
+        {
+            std::string result(value);
+            std::free(value);
+            if (!result.empty())
+            {
+                return result;
+            }
+        }
+#else
+        if (const char* value = std::getenv("OLO_LOG_FILE"); value != nullptr && *value != '\0')
+        {
+            return std::string(value);
+        }
+#endif
+        return std::string("OloEngine.log");
+    }
+
     Log& Log::Get()
     {
         // Intentionally leaked to survive static teardown — other statics
@@ -62,7 +96,7 @@ namespace OloEngine
 
         std::vector<spdlog::sink_ptr> logSinks;
         logSinks.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-        logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>("OloEngine.log", true));
+        logSinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(ResolveLogFileName(), true));
         logSinks.emplace_back(m_RingbufferSink);
 
         logSinks[0]->set_pattern("%^[%T] %n: %v%$");

--- a/OloEngine/src/OloEngine/Core/Log.h
+++ b/OloEngine/src/OloEngine/Core/Log.h
@@ -95,6 +95,20 @@ namespace OloEngine
             (void)Get();
         }
 
+        // Overrides the file sink's path. Every process defaulted to
+        // "OloEngine.log" in the cwd and opened it truncating, so a test run
+        // from OloEditor/ erased a live editor's log mid-session. Call this
+        // before Initialize()/Get(); afterwards the sink already exists and the
+        // call does nothing. OLO_LOG_FILE overrides the default too, for
+        // tooling that cannot rebuild.
+        static void SetLogFile(std::string_view path)
+        {
+            if (!s_Initialized.load(std::memory_order_acquire))
+            {
+                s_LogFileName = std::string(path);
+            }
+        }
+
         // Returns a pointer to the singleton if it has already been constructed,
         // or nullptr if Get() has never been called.  Safe to call from crash
         // handlers and other contexts where heavy initialization is undesirable.
@@ -187,7 +201,14 @@ namespace OloEngine
         Log();
         ~Log();
 
+        // Precedence: SetLogFile(), then OLO_LOG_FILE, then "OloEngine.log".
+        static std::string ResolveLogFileName();
+
         static inline std::atomic<bool> s_Initialized{ false };
+
+        // Read once by the constructor. Not atomic: SetLogFile() is documented
+        // as pre-Initialize(), which is single-threaded startup.
+        static inline std::string s_LogFileName{};
 
         // lock-free tag map: readers take a snapshot shared_ptr, writers copy-and-swap
         using TagMap = std::unordered_map<std::string, TagDetails>;

--- a/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
+++ b/OloEngine/src/OloEngine/Scripting/Lua/LuaScriptGlue.cpp
@@ -838,19 +838,29 @@ namespace OloEngine
             });
 
         // --- GLM vector types (needed before components that use them) ---
+        // sol::constructors alone binds only `vec3.new(x, y, z)`; the bare
+        // `vec3(x, y, z)` every Lua author reaches for first raised "attempt to
+        // call a table value". sol::call_constructor installs __call on the
+        // type table so both spellings work.
+        using Vec2Ctors = sol::constructors<glm::vec2(), glm::vec2(float), glm::vec2(float, float)>;
         lua.new_usertype<glm::vec2>("vec2",
-                                    sol::constructors<glm::vec2(), glm::vec2(float), glm::vec2(float, float)>(),
+                                    Vec2Ctors(),
+                                    sol::call_constructor, Vec2Ctors(),
                                     "x", &glm::vec2::x,
                                     "y", &glm::vec2::y);
 
+        using Vec3Ctors = sol::constructors<glm::vec3(), glm::vec3(float), glm::vec3(float, float, float)>;
         lua.new_usertype<glm::vec3>("vec3",
-                                    sol::constructors<glm::vec3(), glm::vec3(float), glm::vec3(float, float, float)>(),
+                                    Vec3Ctors(),
+                                    sol::call_constructor, Vec3Ctors(),
                                     "x", &glm::vec3::x,
                                     "y", &glm::vec3::y,
                                     "z", &glm::vec3::z);
 
+        using Vec4Ctors = sol::constructors<glm::vec4(), glm::vec4(float), glm::vec4(float, float, float, float)>;
         lua.new_usertype<glm::vec4>("vec4",
-                                    sol::constructors<glm::vec4(), glm::vec4(float), glm::vec4(float, float, float, float)>(),
+                                    Vec4Ctors(),
+                                    sol::call_constructor, Vec4Ctors(),
                                     "x", &glm::vec4::x,
                                     "y", &glm::vec4::y,
                                     "z", &glm::vec4::z,

--- a/OloEngine/tests/Lua/LuaBindingTest.cpp
+++ b/OloEngine/tests/Lua/LuaBindingTest.cpp
@@ -143,11 +143,28 @@ TEST_F(LuaBindingTest, Vectors_ConstructViaBareCall)
     EXPECT_FLOAT_EQ(v4.get<f32>(2), 3.0f);
     EXPECT_FLOAT_EQ(v4.get<f32>(3), 4.0f);
 
-    // The single-argument and default constructors reach through the same
-    // metamethod, and `.new(...)` must keep working beside it.
-    auto mixed = lua.script("local a = vec3(7.0); local b = vec3.new(1.0, 2.0, 3.0); return a.z, b.x");
-    EXPECT_FLOAT_EQ(mixed.get<f32>(0), 7.0f);
-    EXPECT_FLOAT_EQ(mixed.get<f32>(1), 1.0f);
+    // The single-argument form broadcasts, so check all three components --
+    // checking only z would still pass if the scalar reached one lane.
+    auto broadcast = lua.script("local v = vec3(7.0); return v.x, v.y, v.z");
+    EXPECT_FLOAT_EQ(broadcast.get<f32>(0), 7.0f);
+    EXPECT_FLOAT_EQ(broadcast.get<f32>(1), 7.0f);
+    EXPECT_FLOAT_EQ(broadcast.get<f32>(2), 7.0f);
+
+    // The zero-argument constructor reaches through the same metamethod, so it
+    // is worth proving it is callable -- but NOT worth asserting its contents.
+    // This project does not define GLM_FORCE_CTOR_INIT, so glm::vec3() leaves
+    // its members uninitialized; asserting zeros here would read indeterminate
+    // values and pass or fail by luck. Assign, then read back instead.
+    auto defaulted = lua.script("local v = vec3(); v.x = 2.0; v.y = 3.0; v.z = 4.0; return v.x, v.y, v.z");
+    EXPECT_FLOAT_EQ(defaulted.get<f32>(0), 2.0f);
+    EXPECT_FLOAT_EQ(defaulted.get<f32>(1), 3.0f);
+    EXPECT_FLOAT_EQ(defaulted.get<f32>(2), 4.0f);
+
+    // `.new(...)` must keep working beside the bare call.
+    auto viaNew = lua.script("local v = vec3.new(1.0, 2.0, 3.0); return v.x, v.y, v.z");
+    EXPECT_FLOAT_EQ(viaNew.get<f32>(0), 1.0f);
+    EXPECT_FLOAT_EQ(viaNew.get<f32>(1), 2.0f);
+    EXPECT_FLOAT_EQ(viaNew.get<f32>(2), 3.0f);
 }
 
 // =============================================================================

--- a/OloEngine/tests/Lua/LuaBindingTest.cpp
+++ b/OloEngine/tests/Lua/LuaBindingTest.cpp
@@ -121,6 +121,35 @@ TEST_F(LuaBindingTest, Vec4_ConstructAndAccess)
     EXPECT_FLOAT_EQ(result.get<f32>(3), 4.0f);
 }
 
+// The bare-call spelling every Lua author reaches for first. Before
+// sol::call_constructor was registered alongside the constructor list, only
+// `.new(...)` existed and `vec3(1, 2, 3)` raised "attempt to call a table
+// value" — a dead end that reads like the type is missing rather than the
+// call form being unbound.
+TEST_F(LuaBindingTest, Vectors_ConstructViaBareCall)
+{
+    auto v2 = lua.script("local v = vec2(4.0, 5.0); return v.x, v.y");
+    EXPECT_FLOAT_EQ(v2.get<f32>(0), 4.0f);
+    EXPECT_FLOAT_EQ(v2.get<f32>(1), 5.0f);
+
+    auto v3 = lua.script("local v = vec3(1.0, 2.0, 3.0); return v.x, v.y, v.z");
+    EXPECT_FLOAT_EQ(v3.get<f32>(0), 1.0f);
+    EXPECT_FLOAT_EQ(v3.get<f32>(1), 2.0f);
+    EXPECT_FLOAT_EQ(v3.get<f32>(2), 3.0f);
+
+    auto v4 = lua.script("local v = vec4(1.0, 2.0, 3.0, 4.0); return v.x, v.y, v.z, v.w");
+    EXPECT_FLOAT_EQ(v4.get<f32>(0), 1.0f);
+    EXPECT_FLOAT_EQ(v4.get<f32>(1), 2.0f);
+    EXPECT_FLOAT_EQ(v4.get<f32>(2), 3.0f);
+    EXPECT_FLOAT_EQ(v4.get<f32>(3), 4.0f);
+
+    // The single-argument and default constructors reach through the same
+    // metamethod, and `.new(...)` must keep working beside it.
+    auto mixed = lua.script("local a = vec3(7.0); local b = vec3.new(1.0, 2.0, 3.0); return a.z, b.x");
+    EXPECT_FLOAT_EQ(mixed.get<f32>(0), 7.0f);
+    EXPECT_FLOAT_EQ(mixed.get<f32>(1), 1.0f);
+}
+
 // =============================================================================
 // TransformComponent
 // =============================================================================

--- a/OloEngine/tests/OloEngineTest.cpp
+++ b/OloEngine/tests/OloEngineTest.cpp
@@ -22,7 +22,12 @@ int main(int argc, char** argv)
     // read it yet.
     OloEngine::Levers::SetRenderGraphDiagnostics(true);
 
-    // Initialize logging explicitly
+    // Initialize logging explicitly. The suite gets its own file: run from
+    // OloEditor/ (which the visual tests require) it shared OloEngine.log with
+    // a live editor and, opening truncating, erased that editor's diagnostics
+    // mid-session — so a shader error under investigation became the suite's
+    // shutdown noise.
+    OloEngine::Log::SetLogFile("OloEngine-Tests.log");
     OloEngine::Log::Initialize();
 
     // Most headless tests never construct an Application, so the startup line


### PR DESCRIPTION
Four unrelated tooling/engine fixes, each in its own commit. All came out of an audit of the workarounds recorded in this project's agent memory — checking which ones were still real.

## Fixes

**`fix(core)`: give each process its own log file.** Every process opened `OloEngine.log` in the cwd with `truncate=true`. Running the test suite from `OloEditor/` — which the visual tests require — wiped a live editor's log mid-session, so a shader error under investigation became the suite's shutdown noise. `Log::SetLogFile()` (pre-`Initialize`) and `OLO_LOG_FILE` now override the path; the suite claims `OloEngine-Tests.log`. The editor's default is unchanged, so `driver.ps1` and the docs that read `OloEngine.log` still work.

**`fix(lua)`: vec2/3/4 construction by bare call.** `sol::constructors` alone binds only `vec3.new(x, y, z)`; the bare `vec3(x, y, z)` raised *"attempt to call a table value"*, which reads like the type is missing rather than the call form being unbound. `sol::call_constructor` installs `__call`; `.new(...)` is unaffected.

**`feat(tooling)`: `-Rhi` passthrough in `driver.ps1`.** `Start-Editor` passed no arguments, so the driver could only launch the default backend. Any Vulkan session had to be started by hand outside the driver, losing the window wait, log snapshot and capture path.

**`fix(hooks)`: absolute Stop hook path.** The PreToolUse build-lock hook already resolved via `${CLAUDE_PROJECT_DIR:-.}`; the Stop hook beside it did not, so a stray `cd subdir` broke it — the same wedge the build-lock guard was hardened against.

## Verification

- Full suite (excluding visual/golden/perf) **passes** — exit code comes straight from `RUN_ALL_TESTS()`. This matters because `Log.h` is included in nearly every TU.
- Log fix: wrote a sentinel into `OloEditor/OloEngine.log`, ran the suite from `OloEditor/`; sentinel intact, `OloEngine-Tests.log` written beside it.
- Lua: new `LuaBindingTest.Vectors_ConstructViaBareCall`; the three existing `.new()` tests still pass.
- `driver.ps1` parses clean.

## Not changed, but worth recording

A live MCP editor session (raw HTTP, MaterialLab.olo, deferred) disproved two long-standing entries in the agent memory:

- **`olo_postprocess_settings_set` does render.** `Exposure` 1→6 moved 8/8 probed pixels, `Gamma` 2.2→1.0 moved 8/8, against a measured noise floor of exactly 0. The earlier "writes are inert" reading was SSGI contributing nothing in that scene — toggling the whole feature moves 0/8 pixels, so its intensity trivially does too. Two gotchas that produce a false negative here: probing `albedo` (a GBuffer channel that cannot change with lighting), and using Courtyard, whose run-to-run noise equals a weak effect.
- **Docked-panel input injection works.** Four clicks at `space:"window"` selected four different Scene Hierarchy rows, each confirmed via `after.selectedEntity`.

Separately confirmed already-fixed upstream and needing no work: the shared fixture temp-dir race (#789, raw `temp_directory_path()` sites down 154 → 7), MCP gizmo suppression (`olo_editor_debug_draw_set`), and the `OloEditor → OloEngine-ScriptCore` dependency edge.

## Follow-ups filed elsewhere

- `olo_screenshot` still has no `path` argument — added to #607.
- Test runs leave `OloEditor/SupportedTargetTestGame/` untracked and un-gitignored (pre-existing).
- Evidence-PNG churn and the shader-binding validator's test-taxonomy problem are open design calls, deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added graphics backend selection for launched applications, supporting OpenGL or Vulkan.
  - Added configurable log file paths through startup settings or the `OLO_LOG_FILE` environment variable.
  - Lua scripts can now construct vectors using `vec2(...)`, `vec3(...)`, and `vec4(...)` syntax.

- **Bug Fixes**
  - Hook scripts now resolve correctly from the project directory, regardless of the current working directory.

- **Tests**
  - Added coverage for Lua vector construction and assigned the test suite a dedicated log file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->