### PR TITLE
perf(splat): replace the bitonic GPU splat sort with a stable four-pass radix

### DIFF
--- a/OloEditor/assets/shaders/tests/SplatSpike_BitonicSort.comp
+++ b/OloEditor/assets/shaders/tests/SplatSpike_BitonicSort.comp
@@ -6,19 +6,26 @@
 // lexicographically, which for the caller's complemented depth keys means
 // far-to-near with ties broken on the unique cloud index.
 //
-// WHY BITONIC AND NOT A RADIX SORT. #1038 proposed a four-pass LSD radix over
-// GPUPrefixSum, which is the faster algorithm and is what a production path
-// should end up with. It is not what shipped here, for one reason: a radix sort
-// is only a drop-in replacement for the CPU reference if it is STABLE, and a
-// stable GPU radix needs per-tile rank computation (ballot-based, or a
-// 256x256 shared histogram it cannot afford) that is easy to get subtly wrong
-// and hard to prove right. Bitonic sorting on the PAIR is a total order, so
-// stability is not a property it needs to have -- exactly one permutation
-// satisfies the comparison, and GaussianSplatGpuOrderingParityTest can assert
-// index-for-index equality with the CPU rather than "same set, roughly ordered".
-// For a spike whose whole point is a trustworthy measurement, a slower
-// algorithm that is provably identical beat a faster one that is probably
-// right. ADR 0018 section 3.3 has the reasoning and 5.2 the numbers.
+// THIS IS NO LONGER THE SPLAT SORT. Issue #1043 replaced it with the four-pass
+// LSD radix in SplatSpike_RadixHistogram.comp + SplatSpike_RadixScatter.comp,
+// and this network is retained only as the A/B CONTROL that
+// GaussianSplatGpuOrderingParityTest interleaves against -- the same role
+// SplatSpike_OpaqueBaseline.glsl plays for the raster pass (ADR 0018 section
+// 5.3). GpuViewOrdering compiles it lazily, so nothing but the measurement
+// pays for it. Do not reach for it as a fallback: the reason it went is that
+// it is only defined on a power-of-two array, which made the ordering cost a
+// step function of the padding rather than a curve in the cloud.
+//
+// WHY IT SHIPPED FIRST, WHICH IS STILL WORTH KNOWING. #1038 proposed the radix
+// and did not build it, because a radix is only a drop-in replacement for the
+// CPU reference if it is STABLE, and a stable GPU radix needs per-tile rank
+// computation that is easy to get subtly wrong and hard to prove right.
+// Bitonic sorting on the PAIR is a total order, so stability is not a property
+// it needs to have -- exactly one permutation satisfies the comparison. For a
+// spike whose whole point was a trustworthy measurement, a slower algorithm
+// that was provably identical beat a faster one that was probably right.
+// #1043 is where the rank computation got done properly; the reasoning lives
+// in SplatSpike_RadixScatter.comp and ADR 0018 sections 3.2 and 3.3.
 //
 // THE TWO ENTRY POINTS. A naive bitonic network is O(log^2 N) dispatches, each
 // re-reading the whole array from global memory: 231 of them at 2^21 elements.

--- a/OloEditor/assets/shaders/tests/SplatSpike_Cull.comp
+++ b/OloEditor/assets/shaders/tests/SplatSpike_Cull.comp
@@ -12,18 +12,34 @@
 // cpu-gpu-surface-parity.md.
 //
 // MARK IN PLACE, DO NOT COMPACT. A culled splat writes the maximum key rather
-// than being removed, so the sort array stays a fixed power of two and its
-// length never depends on a count the CPU would have to read back. The
+// than being removed, so the sort array's length is a fixed function of the
+// cloud and never depends on a count the CPU would have to read back. The
 // alternative -- an atomic append -- makes the array smaller when culling is
 // aggressive and costs a readback (or an indirect dispatch) to know how much to
 // sort. For a cloud whose splats are mostly on screen, which is the case this
 // exists to make fast, the two do the same amount of work.
 //
 // The key is the COMPLEMENT of the view depth's bit pattern, so an ascending
-// sort yields far-to-near. Ties break on the payload, which is the unique cloud
-// index, so the ordering is a TOTAL order: exactly one output permutation
-// satisfies it and the result is bit-identical to the CPU's stable sort without
-// the GPU sort itself having to be stable.
+// sort yields far-to-near.
+//
+// TIES ARE BROKEN BY POSITION, WHICH IS WHY THE SORT MUST BE STABLE. #1038's
+// bitonic network compared the (key, payload) PAIR, so it needed no stability;
+// the radix in SplatSpike_RadixScatter.comp that replaced it (issue #1043)
+// sorts on the key alone, and reproduces the CPU reference's (key, index) total
+// order only because it is stable and this shader writes b_Order[slot] = slot.
+// Change either half and equal-depth splats start swapping between frames,
+// which is a shimmer a viewer notices.
+//
+// TWO PROPERTIES THE REJECT KEY DEPENDS ON, both true and neither obvious.
+// A rejected or padding slot carries kInvalid, and it has to sort STRICTLY
+// behind every survivor rather than merely tie with one, because a tie would be
+// broken by slot order and a reject at a low slot would land in front of a
+// survivor at a high one. It does: a survivor's key is ~floatBitsToUint(depth)
+// with depth > u_CullParams.y, so a POSITIVE near clip makes every survivor key
+// strictly less than 0xFFFFFFFF. A near clip of zero or below is already
+// meaningless -- the Gaussian's projection diverges at the eye plane -- and it
+// is also where the CPU reference and this shader stop agreeing about a
+// non-positive depth at all, so it is out of contract on both sides.
 // =============================================================================
 
 #version 460 core
@@ -80,7 +96,7 @@ layout(std140, binding = 7) uniform SplatCullUniforms
     vec4 u_ViewportFocal; // xy = viewport pixels, zw = focal length in pixels
     vec4 u_Planes[6];     // world-space frustum planes, xyz = normal, w = distance
     vec4 u_CullParams;    // y = near clip, z = min screen extent px, w = min alpha
-    uvec4 u_Counts;       // x = splat count, y = padded power-of-two capacity
+    uvec4 u_Counts;       // x = splat count, y = padded sort capacity
 };
 
 const uint kInvalid = 0xFFFFFFFFu;

--- a/OloEditor/assets/shaders/tests/SplatSpike_RadixHistogram.comp
+++ b/OloEditor/assets/shaders/tests/SplatSpike_RadixHistogram.comp
@@ -1,0 +1,87 @@
+// =============================================================================
+// SplatSpike_RadixHistogram.comp
+//
+// Pass 1 of 3 in one digit of the Gaussian-splat LSD radix sort (issue #1043).
+// Counts how many of this tile's keys land in each of the 256 bins of the
+// current 8-bit digit and writes that count TRANSPOSED:
+//
+//     b_Hist[bin * numTiles + tile]
+//
+// WHY TRANSPOSED, WHICH IS THE WHOLE TRICK. A single exclusive scan over that
+// flat array is simultaneously (a) the global bin offsets, because the array is
+// bin-major, and (b) each tile's offset WITHIN its bin, because the tiles of a
+// bin are contiguous and in tile order. So the scatter pass needs one load,
+// b_Hist[bin * numTiles + tile], to know exactly where its run of `bin` starts
+// in the output -- and because tiles are laid out in increasing order inside
+// each bin, the result is STABLE across tiles for free. The stability that has
+// to be worked for is the one WITHIN a tile, and that is
+// SplatSpike_RadixScatter.comp's job.
+//
+// THE ARRAY IS PADDED TO A WHOLE NUMBER OF TILES, so there is no bounds test in
+// the loop below. GpuViewOrdering::PaddedCapacityFor rounds the cloud up to a
+// multiple of kTile and SplatSpike_Cull.comp fills the slack with the maximum
+// key, which sorts behind every real splat. That padding is at most kTile-1
+// elements, which is what replaced the bitonic network's power-of-two padding
+// and its step function (ADR 0018 section 5.2).
+// =============================================================================
+
+#version 460 core
+
+layout(local_size_x = 256) in;
+
+// Must equal kRadixThreads / kRadixElementsPerThread / kSortTile in
+// GaussianSplatGpuOrdering.cpp, and match SplatSpike_RadixScatter.comp.
+const uint kThreads = 256u;
+const uint kElementsPerThread = 8u;
+const uint kTile = kThreads * kElementsPerThread;
+const uint kRadixBins = 256u;
+
+layout(std430, binding = 2) readonly buffer SplatKeyBuffer
+{
+    uint b_Keys[];
+};
+
+// u32[kRadixBins * numTiles], bin-major. GPUPrefixSum scans this in place
+// between this dispatch and the scatter.
+layout(std430, binding = 9) writeonly buffer SplatRadixHistogram
+{
+    uint b_Hist[];
+};
+
+layout(std140, binding = 8) uniform SplatSortUniforms
+{
+    // x = element count (a multiple of kTile)
+    // y = shift: the low bit of this pass's 8-bit digit -- 0, 8, 16 or 24
+    // z = numTiles = count / kTile
+    // w = unused
+    uvec4 u_SortParams;
+};
+
+shared uint s_Hist[kRadixBins];
+
+void main()
+{
+    uint local = gl_LocalInvocationID.x;
+    uint tile = gl_WorkGroupID.x;
+    uint shift = u_SortParams.y;
+    uint numTiles = u_SortParams.z;
+
+    // One thread per bin, which is why the workgroup size and the bin count are
+    // the same number.
+    s_Hist[local] = 0u;
+    barrier();
+
+    // BLOCKED, NOT STRIDED: thread t owns the contiguous run
+    // [t*kElementsPerThread, (t+1)*kElementsPerThread). The scatter has to use
+    // the same decomposition for its ranks to mean anything, and a blocked run
+    // is what makes "elements before mine in this tile" a per-thread prefix sum
+    // rather than an interleave. The loads look uncoalesced and are not, in
+    // effect: the warp sweeps the whole cache line set on its first iteration
+    // and the remaining seven hit L1.
+    uint base = tile * kTile + local * kElementsPerThread;
+    for (uint e = 0u; e < kElementsPerThread; ++e)
+        atomicAdd(s_Hist[(b_Keys[base + e] >> shift) & 0xFFu], 1u);
+    barrier();
+
+    b_Hist[local * numTiles + tile] = s_Hist[local];
+}

--- a/OloEditor/assets/shaders/tests/SplatSpike_RadixScatter.comp
+++ b/OloEditor/assets/shaders/tests/SplatSpike_RadixScatter.comp
@@ -1,0 +1,230 @@
+// =============================================================================
+// SplatSpike_RadixScatter.comp
+//
+// Pass 3 of 3 in one digit of the Gaussian-splat LSD radix sort (issue #1043).
+// Reads the scanned transposed histogram, works out where each of this tile's
+// (key, payload) pairs belongs in the output, and writes them there.
+//
+// THIS SHADER IS THE WHOLE REASON #1038 SHIPPED A BITONIC NETWORK INSTEAD.
+// A radix sort only reproduces the CPU reference index for index if it is
+// STABLE, and the stable part is exactly the line below marked "local rank":
+// how many earlier elements OF THIS TILE carry the same digit.
+//
+// GET IT WRONG AND THE SORT IS NOT MERELY UNSTABLE, IT IS WRONG. An LSD radix
+// carries the previous pass's order forward through the current one, so a rank
+// that is not the element's position breaks the ordering of DISTINCT keys as
+// well -- which is the loud half of the failure, and the half every parity case
+// catches. The quiet half only shows up when keys TIE: any permutation of equal
+// keys is correctly sorted, so the array looks right and only the payload order
+// is wrong, which on screen is two splats at the same depth swapping between
+// frames. GaussianSplatGpuOrderingParityTest's all-identical-depths case is the
+// oracle for that half. ADR 0018 sections 3.2 and 3.3 have the argument.
+//
+// HOW THE RANK IS COMPUTED, AND WHY IT IS NOT A 256-WIDE SCAN. The obvious
+// formulation -- a kRadixBins x kThreads matrix of per-thread counts, scanned
+// down each bin -- is 256 KiB of shared memory and does not fit. Instead the
+// tile is LOCALLY SORTED by the digit, stably, using kRadixBits successive
+// one-bit splits. A one-bit split is a single workgroup prefix sum and is
+// stable by construction, so eight of them leave the tile ordered by digit with
+// equal digits still in their original relative order. Once that holds, an
+// element's rank inside its digit is just its position minus where its digit's
+// run starts -- one subtraction, no per-bin scan.
+//
+// The cost is kRadixBits workgroup scans per tile per digit, all in shared
+// memory, against four passes over global memory for the whole sort. The
+// bitonic network it replaces made 91 global passes at 2^22.
+// =============================================================================
+
+#version 460 core
+
+layout(local_size_x = 256) in;
+
+// Must equal kRadixThreads / kRadixElementsPerThread / kSortTile in
+// GaussianSplatGpuOrdering.cpp, and match SplatSpike_RadixHistogram.comp.
+const uint kThreads = 256u;
+const uint kElementsPerThread = 8u;
+const uint kTile = kThreads * kElementsPerThread;
+const uint kRadixBits = 8u;
+const uint kRadixBins = 256u;
+
+layout(std430, binding = 2) readonly buffer SplatKeyBuffer
+{
+    uint b_Keys[];
+};
+
+layout(std430, binding = 1) readonly buffer SplatOrderBuffer
+{
+    uint b_Order[];
+};
+
+layout(std430, binding = 6) writeonly buffer SplatKeyOutBuffer
+{
+    uint b_KeysOut[];
+};
+
+layout(std430, binding = 5) writeonly buffer SplatOrderOutBuffer
+{
+    uint b_OrderOut[];
+};
+
+// Scanned in place by GPUPrefixSum since SplatSpike_RadixHistogram.comp wrote
+// it, so element [bin * numTiles + tile] is now the output offset at which this
+// tile's run of `bin` begins.
+layout(std430, binding = 9) readonly buffer SplatRadixHistogram
+{
+    uint b_Hist[];
+};
+
+layout(std140, binding = 8) uniform SplatSortUniforms
+{
+    // x = element count (a multiple of kTile)
+    // y = shift: the low bit of this pass's 8-bit digit -- 0, 8, 16 or 24
+    // z = numTiles = count / kTile
+    // w = unused
+    uvec4 u_SortParams;
+};
+
+shared uint s_Keys[kTile];
+shared uint s_Order[kTile];
+shared uint s_Scan[2][kThreads];
+shared uint s_ScanTotal;
+shared uint s_BinStart[kRadixBins];
+shared uint s_GlobalBase[kRadixBins];
+
+// Inclusive prefix sum of `value` over the workgroup's kThreads lanes; the
+// group total is left in s_ScanTotal.
+//
+// PING-PONGED RATHER THAN IN PLACE so each Hillis-Steele step needs ONE barrier
+// instead of two (read-all, barrier, write-all). Eight steps run per one-bit
+// split and eight splits per digit, so halving the barriers here halves the
+// synchronisation cost of the whole sort.
+//
+// A lane only ever reads and writes its OWN slot outside the loop, which is why
+// two consecutive calls need no barrier between them: the cross-lane read
+// inside the loop is always preceded by this function's own first barrier.
+uint WorkgroupInclusiveScan(uint value)
+{
+    uint local = gl_LocalInvocationID.x;
+    uint cur = 0u;
+    s_Scan[0][local] = value;
+    barrier();
+
+    for (uint offset = 1u; offset < kThreads; offset <<= 1u)
+    {
+        uint prev = cur;
+        cur = 1u - cur;
+        s_Scan[cur][local] = s_Scan[prev][local] + ((local >= offset) ? s_Scan[prev][local - offset] : 0u);
+        barrier();
+    }
+
+    if (local == kThreads - 1u)
+        s_ScanTotal = s_Scan[cur][local];
+    barrier();
+    return s_Scan[cur][local];
+}
+
+void main()
+{
+    uint local = gl_LocalInvocationID.x;
+    uint tile = gl_WorkGroupID.x;
+    uint shift = u_SortParams.y;
+    uint numTiles = u_SortParams.z;
+    uint lane = local * kElementsPerThread; // this thread's first slot in the tile
+
+    // One thread per bin -- which is why the workgroup size and the bin count
+    // are the same number -- reading where this tile's run of that bin starts
+    // in the output. This is the only thing the scan pass exists to produce.
+    s_GlobalBase[local] = b_Hist[local * numTiles + tile];
+
+    // Blocked, exactly as the histogram read it: see the note there.
+    uint base = tile * kTile + lane;
+    uint keys[kElementsPerThread];
+    uint payload[kElementsPerThread];
+    for (uint e = 0u; e < kElementsPerThread; ++e)
+    {
+        keys[e] = b_Keys[base + e];
+        payload[e] = b_Order[base + e];
+    }
+    barrier();
+
+    // ---------------------------------------------------------------------
+    // Stable local sort of the tile by this pass's 8-bit digit, LSB first.
+    // ---------------------------------------------------------------------
+    for (uint bit = 0u; bit < kRadixBits; ++bit)
+    {
+        uint mask = 1u << (shift + bit);
+
+        uint myZeros = 0u;
+        for (uint e = 0u; e < kElementsPerThread; ++e)
+            myZeros += ((keys[e] & mask) == 0u) ? 1u : 0u;
+
+        uint inclusive = WorkgroupInclusiveScan(myZeros);
+        uint zerosBefore = inclusive - myZeros;
+        uint totalZeros = s_ScanTotal;
+
+        // Zeros take the front of the tile in their original relative order and
+        // ones follow in theirs. That is what makes ONE split stable, and eight
+        // stable splits a stable sort by the 8-bit digit.
+        uint zeroSlot = zerosBefore;
+        uint oneSlot = totalZeros + (lane - zerosBefore);
+        uint destination[kElementsPerThread];
+        for (uint e = 0u; e < kElementsPerThread; ++e)
+        {
+            if ((keys[e] & mask) == 0u)
+            {
+                destination[e] = zeroSlot;
+                zeroSlot += 1u;
+            }
+            else
+            {
+                destination[e] = oneSlot;
+                oneSlot += 1u;
+            }
+        }
+
+        // Every lane holds its values in registers, so the tile is permuted
+        // through a SINGLE shared array rather than a ping-pong. This barrier
+        // is what guarantees the previous iteration's read-back finished before
+        // anything overwrites the slot it came from.
+        barrier();
+        for (uint e = 0u; e < kElementsPerThread; ++e)
+        {
+            s_Keys[destination[e]] = keys[e];
+            s_Order[destination[e]] = payload[e];
+        }
+        barrier();
+        for (uint e = 0u; e < kElementsPerThread; ++e)
+        {
+            keys[e] = s_Keys[lane + e];
+            payload[e] = s_Order[lane + e];
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Where each digit's run begins inside the now-sorted tile.
+    // ---------------------------------------------------------------------
+    // Exactly one position per present digit satisfies this, because the tile
+    // is sorted -- so no initialisation and no atomics are needed, and a digit
+    // absent from the tile is never read below.
+    for (uint e = 0u; e < kElementsPerThread; ++e)
+    {
+        uint i = lane + e;
+        uint digit = (s_Keys[i] >> shift) & 0xFFu;
+        uint previous = (i == 0u) ? 0u : (i - 1u);
+        uint previousDigit = (s_Keys[previous] >> shift) & 0xFFu;
+        if (i == 0u || previousDigit != digit)
+            s_BinStart[digit] = i;
+    }
+    barrier();
+
+    for (uint e = 0u; e < kElementsPerThread; ++e)
+    {
+        uint i = lane + e;
+        uint digit = (s_Keys[i] >> shift) & 0xFFu;
+        // The local rank -- how many earlier elements of this tile share this
+        // digit. Stability lives on this line.
+        uint destination = s_GlobalBase[digit] + (i - s_BinStart[digit]);
+        b_KeysOut[destination] = s_Keys[i];
+        b_OrderOut[destination] = s_Order[i];
+    }
+}

--- a/OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.cpp
@@ -3,6 +3,7 @@
 
 #include "OloEngine/Debug/Instrumentor.h"
 #include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/GPUPrefixSum.h"
 #include "OloEngine/Renderer/MemoryBarrierFlags.h"
 #include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/StorageBuffer.h"
@@ -14,6 +15,7 @@
 #include <bit>
 #include <cmath>
 #include <limits>
+#include <utility>
 
 namespace OloEngine::GaussianSplat
 {
@@ -28,12 +30,35 @@ namespace OloEngine::GaussianSplat
         constexpr u32 kBindingKeys = 2;
         constexpr u32 kBindingStats = 3;
         constexpr u32 kBindingIndirect = 4;
+        constexpr u32 kBindingOrderOut = 5;
+        constexpr u32 kBindingKeysOut = 6;
+        constexpr u32 kBindingHistogram = 9;
         constexpr u32 kBindingCullUbo = 7;
         constexpr u32 kBindingSortUbo = 8;
 
-        // Must equal `kTile` in SplatSpike_BitonicSort.comp and
-        // `local_size_x` in both compute shaders.
-        constexpr u32 kSortTile = 512;
+        // The radix tile. Must equal kThreads * kElementsPerThread in
+        // SplatSpike_RadixHistogram.comp and SplatSpike_RadixScatter.comp.
+        //
+        // 2048 RATHER THAN A SMALLER TILE FOR TWO SEPARATE REASONS, both worth
+        // stating because a future reader will want to shrink it for occupancy.
+        // First, the scatter's shared-memory cost is the tile (16 KiB of keys
+        // and payloads plus 4 KiB of scan and bin state) while its barrier cost
+        // is per tile and NOT per element, so a bigger tile amortises the eight
+        // one-bit splits over more work. Second, the transposed histogram is
+        // 256 * (count / kSortTile) elements and has to fit
+        // GPUPrefixSum::kMaxElements; the static_assert below pins that this
+        // tile size makes kMaxSplats fit, and halving the tile would break it.
+        constexpr u32 kSortTile = 2048;
+        constexpr u32 kRadixBins = 256;
+        // Four 8-bit digits over the 32-bit key. EVEN BY REQUIREMENT, not by
+        // coincidence: the scatter ping-pongs between the key/order buffers and
+        // their scratch twins, so an even number of passes is what leaves the
+        // result in the buffers the draw and the readback read.
+        constexpr u32 kRadixPasses = 4;
+        static_assert(kRadixPasses % 2 == 0, "the radix ping-pong lands in the scratch buffers on an odd pass count");
+
+        // The bitonic control's tile: `kTile` in SplatSpike_BitonicSort.comp.
+        constexpr u32 kBitonicTile = 512;
         constexpr u32 kWorkGroupSize = 256;
 
         constexpr u32 kStatSlots = 5; // Drawn, BehindNearPlane, FrustumCulled, TooSmall, TooFaint
@@ -54,6 +79,9 @@ namespace OloEngine::GaussianSplat
         };
         static_assert(sizeof(CullUniforms) == 272);
 
+        // One buffer serves both sorts, because they need the same number of
+        // words and never run in the same dispatch. Radix: (count, shift,
+        // numTiles, unused). Bitonic: (count, k, j, localMode).
         struct SortUniforms
         {
             glm::uvec4 SortParams{ 0u };
@@ -84,10 +112,27 @@ namespace OloEngine::GaussianSplat
         }
     } // namespace
 
+    // The radix's own ceiling, checked here rather than trusted. The scan has to
+    // cover one entry per (bin, tile), and GPUPrefixSum caps a single scan at
+    // kMaxElements; at kSortTile = 2048 the largest cloud this pass accepts
+    // needs 8,388,608 of them against a limit of 16,776,960. Shrink kSortTile
+    // and this stops holding before anything else does.
+    static_assert(static_cast<u64>(kRadixBins) * ((GpuViewOrdering::kMaxSplats + kSortTile - 1) / kSortTile) <=
+                      static_cast<u64>(GPUPrefixSum::kMaxElements),
+                  "the transposed radix histogram at kMaxSplats does not fit one GPUPrefixSum scan");
+
     auto GpuViewOrdering::PaddedCapacityFor(u32 count) -> u32
     {
         OLO_CORE_ASSERT(count <= kMaxSplats, "GpuViewOrdering::PaddedCapacityFor above kMaxSplats");
-        const u32 atLeastATile = std::max(std::min(count, kMaxSplats), kSortTile);
+        const u32 clamped = std::min(count, kMaxSplats);
+        const u32 tiles = std::max(1u, (clamped + kSortTile - 1) / kSortTile);
+        return tiles * kSortTile;
+    }
+
+    auto GpuViewOrdering::BitonicPaddedCapacityFor(u32 count) -> u32
+    {
+        OLO_CORE_ASSERT(count <= kMaxSplats, "GpuViewOrdering::BitonicPaddedCapacityFor above kMaxSplats");
+        const u32 atLeastATile = std::max(std::min(count, kMaxSplats), kBitonicTile);
         return std::bit_ceil(atLeastATile);
     }
 
@@ -100,8 +145,8 @@ namespace OloEngine::GaussianSplat
     {
         // Leave no buffer of ours on a shared binding point for whatever runs
         // next in this process (testing-architecture.md 6.4).
-        for (const Ref<StorageBuffer>& buffer :
-             { m_SplatBuffer, m_OrderBuffer, m_KeyBuffer, m_StatsBuffer, m_IndirectBuffer })
+        for (const Ref<StorageBuffer>& buffer : { m_SplatBuffer, m_OrderBuffer, m_KeyBuffer, m_OrderScratch,
+                                                  m_KeyScratch, m_HistogramBuffer, m_StatsBuffer, m_IndirectBuffer })
         {
             if (buffer)
                 buffer->Unbind();
@@ -122,8 +167,22 @@ namespace OloEngine::GaussianSplat
         OLO_PROFILE_FUNCTION();
 
         m_CullShader = ComputeShader::Create("assets/shaders/tests/SplatSpike_Cull.comp");
-        m_SortShader = ComputeShader::Create("assets/shaders/tests/SplatSpike_BitonicSort.comp");
-        m_Ready = m_CullShader && m_CullShader->IsValid() && m_SortShader && m_SortShader->IsValid();
+        m_HistogramShader = ComputeShader::Create("assets/shaders/tests/SplatSpike_RadixHistogram.comp");
+        m_ScatterShader = ComputeShader::Create("assets/shaders/tests/SplatSpike_RadixScatter.comp");
+        m_Ready = m_CullShader && m_CullShader->IsValid() && m_HistogramShader && m_HistogramShader->IsValid() &&
+                  m_ScatterShader && m_ScatterShader->IsValid();
+
+        if (m_Ready)
+        {
+            // The scan is consumed, not owned: #713 already tests it, and a
+            // second device-level scan in the engine would be a second thing to
+            // keep correct for no benefit.
+            m_PrefixSum = Ref<GPUPrefixSum>::Create();
+            m_PrefixSum->EnsureInitialised();
+            m_Ready = m_PrefixSum->IsAvailable();
+            if (!m_Ready)
+                OLO_CORE_ERROR("GpuViewOrdering::Initialize: GPUPrefixSum is unavailable, so the radix sort has no scan");
+        }
 
         if (m_Ready)
         {
@@ -132,6 +191,94 @@ namespace OloEngine::GaussianSplat
             m_Ready = m_CullUniforms && m_SortUniforms;
         }
         return m_Ready;
+    }
+
+    auto GpuViewOrdering::SetSortAlgorithm(SortAlgorithm algorithm) -> bool
+    {
+        OLO_CORE_ASSERT(m_Ready, "GpuViewOrdering::SetSortAlgorithm before a successful Initialize");
+
+        if (algorithm == SortAlgorithm::Bitonic && !m_BitonicShader)
+        {
+            m_BitonicShader = ComputeShader::Create("assets/shaders/tests/SplatSpike_BitonicSort.comp");
+            if (!m_BitonicShader || !m_BitonicShader->IsValid())
+            {
+                OLO_CORE_ERROR("GpuViewOrdering: SplatSpike_BitonicSort.comp failed to compile; the A/B control is unavailable");
+                m_BitonicShader = nullptr;
+                return false;
+            }
+        }
+
+        if (algorithm != m_Algorithm)
+        {
+            m_Algorithm = algorithm;
+            // The two sorts pad differently, so every buffer sized from the
+            // padding has to follow. The splat records do not, which is the
+            // whole reason this is not just `SetCloud` again: an A/B that
+            // re-uploaded 96 MB of records between samples would be measuring
+            // the upload.
+            if (m_SplatBuffer)
+                ResizeSortBuffers();
+        }
+        return true;
+    }
+
+    void GpuViewOrdering::ResetIndirectCommand()
+    {
+        // { count = 6 vertices, instanceCount = 0, first = 0, baseInstance = 0 }.
+        // instanceCount is the only field the GPU writes.
+        //
+        // SIX VERTICES, NOT A FOUR-VERTEX STRIP. The quad is two triangles
+        // because RendererAPI::DrawArraysIndirect draws GL_TRIANGLES, and
+        // adapting the shader to the facade is the right way round: reaching
+        // for a raw glDrawArraysIndirect to keep a strip is what the RHI
+        // boundary ratchet exists to stop (issue #691, ADR 0011).
+        //
+        // CALLED WHENEVER THE ORDER BUFFER IS INVALIDATED, not only per frame.
+        // A fresh StorageBuffer is uninitialised, so `SetCloud` followed
+        // straight by `DrawIndirect` used to read an instance count that was
+        // whatever the driver handed back, and `SetSortAlgorithm` reallocates
+        // the order buffer under a command that still holds the LAST frame's
+        // count. Zeroing it here makes the failure mode "draws nothing", which
+        // is visible, instead of "draws the right number of garbage indices",
+        // which renders a plausible frame.
+        if (!m_IndirectBuffer)
+            return;
+        const std::array<u32, 4> indirect{ 6u, 0u, 0u, 0u };
+        m_IndirectBuffer->SetData(indirect.data(), static_cast<u32>(indirect.size() * sizeof(u32)));
+    }
+
+    void GpuViewOrdering::ResizeSortBuffers()
+    {
+        m_PaddedCapacity = (m_Algorithm == SortAlgorithm::Radix) ? PaddedCapacityFor(m_SplatCount)
+                                                                 : BitonicPaddedCapacityFor(m_SplatCount);
+
+        const u32 slotBytes = m_PaddedCapacity * static_cast<u32>(sizeof(u32));
+        m_OrderBuffer = StorageBuffer::Create(slotBytes, kBindingOrder, StorageBufferUsage::DynamicCopy);
+        m_KeyBuffer = StorageBuffer::Create(slotBytes, kBindingKeys, StorageBufferUsage::DynamicCopy);
+
+        if (m_Algorithm == SortAlgorithm::Radix)
+        {
+            m_OrderScratch = StorageBuffer::Create(slotBytes, kBindingOrderOut, StorageBufferUsage::DynamicCopy);
+            m_KeyScratch = StorageBuffer::Create(slotBytes, kBindingKeysOut, StorageBufferUsage::DynamicCopy);
+            const u32 histogramBytes =
+                kRadixBins * (m_PaddedCapacity / kSortTile) * static_cast<u32>(sizeof(u32));
+            m_HistogramBuffer =
+                StorageBuffer::Create(histogramBytes, kBindingHistogram, StorageBufferUsage::DynamicCopy);
+        }
+        else
+        {
+            // Released rather than kept: the bitonic control is only ever the
+            // second half of an A/B, and 3 x 16 MiB of idle scratch during it
+            // would sit on the very budget the measurement is about.
+            m_OrderScratch = nullptr;
+            m_KeyScratch = nullptr;
+            m_HistogramBuffer = nullptr;
+        }
+
+        // The order buffer just became a fresh, uninitialised allocation, so
+        // whatever instance count the indirect command still carries now points
+        // into it. See ResetIndirectCommand.
+        ResetIndirectCommand();
     }
 
     void GpuViewOrdering::SetCloud(const SplatCloud& cloud)
@@ -152,26 +299,28 @@ namespace OloEngine::GaussianSplat
             m_SplatBuffer = nullptr;
             m_OrderBuffer = nullptr;
             m_KeyBuffer = nullptr;
+            m_OrderScratch = nullptr;
+            m_KeyScratch = nullptr;
+            m_HistogramBuffer = nullptr;
             m_StatsBuffer = nullptr;
             m_IndirectBuffer = nullptr;
             return;
         }
 
         m_SplatCount = cloud.Count();
-        m_PaddedCapacity = PaddedCapacityFor(m_SplatCount);
 
         const u32 splatBytes = std::max<u32>(static_cast<u32>(cloud.GpuBytes()), sizeof(GpuSplat));
         m_SplatBuffer = StorageBuffer::Create(splatBytes, kBindingSplats, StorageBufferUsage::DynamicDraw);
         if (m_SplatCount > 0)
             m_SplatBuffer->SetData(cloud.Splats().data(), static_cast<u32>(cloud.GpuBytes()));
 
-        const u32 slotBytes = m_PaddedCapacity * static_cast<u32>(sizeof(u32));
-        m_OrderBuffer = StorageBuffer::Create(slotBytes, kBindingOrder, StorageBufferUsage::DynamicCopy);
-        m_KeyBuffer = StorageBuffer::Create(slotBytes, kBindingKeys, StorageBufferUsage::DynamicCopy);
+        ResizeSortBuffers();
+
         m_StatsBuffer =
             StorageBuffer::Create(kStatSlots * static_cast<u32>(sizeof(u32)), kBindingStats, StorageBufferUsage::DynamicCopy);
         m_IndirectBuffer =
             StorageBuffer::Create(4 * static_cast<u32>(sizeof(u32)), kBindingIndirect, StorageBufferUsage::DynamicCopy);
+        ResetIndirectCommand();
     }
 
     void GpuViewOrdering::BuildOrdering(const glm::mat4& view,
@@ -220,16 +369,7 @@ namespace OloEngine::GaussianSplat
 
         m_StatsBuffer->ClearData();
 
-        // { count = 6 vertices, instanceCount = 0, first = 0, baseInstance = 0 }.
-        // instanceCount is the only field the GPU writes.
-        //
-        // SIX VERTICES, NOT A FOUR-VERTEX STRIP. The quad is two triangles
-        // because RendererAPI::DrawArraysIndirect draws GL_TRIANGLES, and
-        // adapting the shader to the facade is the right way round: reaching
-        // for a raw glDrawArraysIndirect to keep a strip is what the RHI
-        // boundary ratchet exists to stop (issue #691, ADR 0011).
-        const std::array<u32, 4> indirect{ 6u, 0u, 0u, 0u };
-        m_IndirectBuffer->SetData(indirect.data(), static_cast<u32>(indirect.size() * sizeof(u32)));
+        ResetIndirectCommand();
 
         m_SplatBuffer->Bind();
         m_OrderBuffer->Bind();
@@ -243,16 +383,120 @@ namespace OloEngine::GaussianSplat
         m_Dispatches.Cull = 1;
         RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
 
-        // The bitonic network. Every step whose stride is at least the tile
-        // width has to go through global memory; the rest of that k's steps are
-        // finished inside one workgroup, which is what keeps the dispatch count
-        // at 2 log N instead of log^2 N.
-        m_SortShader->Bind();
-        const u32 localTiles = m_PaddedCapacity / kSortTile;
+        if (m_Algorithm == SortAlgorithm::Radix)
+            SortRadix();
+        else
+            SortBitonic();
+
+        // The order buffer is about to be read by a vertex shader and the
+        // indirect buffer by the command processor, neither of which the
+        // storage barrier above covers.
+        RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage | MemoryBarrierFlags::Command);
+    }
+
+    void GpuViewOrdering::SortRadix()
+    {
+        OLO_PROFILE_FUNCTION();
+
+        // Four 8-bit LSD passes over the complemented depth key, ping-ponging
+        // between the live buffers and their scratch twins. Each pass is a tile
+        // histogram, one GPUPrefixSum exclusive scan of it, and a scatter.
+        //
+        // NO PASS IS SKIPPED AS UNIFORM, which the CPU reference does do. It
+        // can: it has already read the histogram. Here the histogram only ever
+        // exists on the device, so "is this digit constant?" costs the readback
+        // this whole class is built to avoid -- and a fixed four passes is a
+        // fixed cost, which is the property the issue is about.
+        const u32 numTiles = m_PaddedCapacity / kSortTile;
+        OLO_CORE_ASSERT(numTiles * kSortTile == m_PaddedCapacity,
+                        "the radix sort needs a whole number of tiles; PaddedCapacityFor guarantees it");
+
+        Ref<StorageBuffer> sourceKeys = m_KeyBuffer;
+        Ref<StorageBuffer> sourceOrder = m_OrderBuffer;
+        Ref<StorageBuffer> destinationKeys = m_KeyScratch;
+        Ref<StorageBuffer> destinationOrder = m_OrderScratch;
+        bool scanned = true;
+
+        for (u32 pass = 0; pass < kRadixPasses && scanned; ++pass)
+        {
+            SortUniforms sortUniforms;
+            sortUniforms.SortParams = glm::uvec4(m_PaddedCapacity, pass * 8u, numTiles, 0u);
+            m_SortUniforms->SetData(&sortUniforms, static_cast<u32>(sizeof(sortUniforms)));
+            m_SortUniforms->Bind();
+
+            // Bound by handle rather than by `Bind()`, because which OBJECT
+            // plays "source" swaps every pass while the shaders' binding points
+            // do not.
+            RenderCommand::BindStorageBuffer(kBindingKeys, sourceKeys->GetRHIHandle());
+            RenderCommand::BindStorageBuffer(kBindingOrder, sourceOrder->GetRHIHandle());
+            RenderCommand::BindStorageBuffer(kBindingKeysOut, destinationKeys->GetRHIHandle());
+            RenderCommand::BindStorageBuffer(kBindingOrderOut, destinationOrder->GetRHIHandle());
+            RenderCommand::BindStorageBuffer(kBindingHistogram, m_HistogramBuffer->GetRHIHandle());
+
+            m_HistogramShader->Bind();
+            RenderCommand::DispatchCompute(numTiles, 1, 1);
+            ++m_Dispatches.RadixHistogram;
+            RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
+
+            // Scans in place and emits its own barriers. It binds and releases
+            // SSBOs 54-56 and UBO 79, none of which this pass uses, so the five
+            // bindings above survive it -- but it leaves ITS shader bound, so
+            // the scatter has to rebind.
+            //
+            // A REFUSED SCAN IS NOT SURVIVABLE, so it stops the sort rather
+            // than letting three more passes run on an unscanned histogram.
+            // That would leave every tile's offsets equal to its raw bin count,
+            // and the scatter would pile the whole cloud on top of itself -- a
+            // frame that draws and is wrong, which is the failure mode this
+            // pass is hardest to debug from.
+            scanned = m_PrefixSum->ExclusiveScanInPlace(m_HistogramBuffer, kRadixBins * numTiles);
+            if (!scanned)
+            {
+                OLO_CORE_ERROR("GpuViewOrdering: the radix histogram scan was refused at pass {} of {}; "
+                               "the draw order is undefined for this frame",
+                               pass, kRadixPasses);
+                continue; // fall out of the loop, but through the rebinding below
+            }
+            ++m_Dispatches.RadixScanCalls;
+
+            m_ScatterShader->Bind();
+            RenderCommand::DispatchCompute(numTiles, 1, 1);
+            ++m_Dispatches.RadixScatter;
+            RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
+
+            std::swap(sourceKeys, destinationKeys);
+            std::swap(sourceOrder, destinationOrder);
+        }
+
+        OLO_CORE_ASSERT(!scanned || sourceOrder == m_OrderBuffer,
+                        "the radix ping-pong did not land back in the order buffer");
+
+        // Put the live buffers back on their own binding points and take the
+        // scratch off theirs. Without this the draw would read binding 1 and
+        // find the scratch order buffer sitting on it, which is the previous
+        // pass's data and renders a plausible, wrong frame.
+        m_OrderBuffer->Bind();
+        m_KeyBuffer->Bind();
+        RenderCommand::BindStorageBuffer(kBindingKeysOut, {});
+        RenderCommand::BindStorageBuffer(kBindingOrderOut, {});
+        RenderCommand::BindStorageBuffer(kBindingHistogram, {});
+    }
+
+    void GpuViewOrdering::SortBitonic()
+    {
+        OLO_PROFILE_FUNCTION();
+        OLO_CORE_ASSERT(m_BitonicShader, "GpuViewOrdering::SortBitonic without the control shader");
+
+        // The A/B control, kept from #1038. Every step whose stride is at least
+        // the tile width has to go through global memory; the rest of that k's
+        // steps are finished inside one workgroup, which is what keeps the
+        // dispatch count at 2 log N instead of log^2 N.
+        m_BitonicShader->Bind();
+        const u32 localTiles = m_PaddedCapacity / kBitonicTile;
         for (u32 k = 2; k <= m_PaddedCapacity; k <<= 1)
         {
             u32 j = k >> 1;
-            for (; j > (kSortTile >> 1); j >>= 1)
+            for (; j > (kBitonicTile >> 1); j >>= 1)
             {
                 SortUniforms sortUniforms;
                 sortUniforms.SortParams = glm::uvec4(m_PaddedCapacity, k, j, 0u);
@@ -273,11 +517,6 @@ namespace OloEngine::GaussianSplat
             ++m_Dispatches.SortLocal;
             RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
         }
-
-        // The order buffer is about to be read by a vertex shader and the
-        // indirect buffer by the command processor, neither of which the
-        // storage barrier above covers.
-        RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage | MemoryBarrierFlags::Command);
     }
 
     void GpuViewOrdering::DrawIndirect()

--- a/OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.h
+++ b/OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.h
@@ -6,6 +6,7 @@
 // to reach RefCounted, so a forward declaration compiles the header and fails
 // at every destructor.
 #include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/GPUPrefixSum.h"
 #include "OloEngine/Renderer/Splat/GaussianSplatCloud.h"
 #include "OloEngine/Renderer/Splat/GaussianSplatView.h"
 #include "OloEngine/Renderer/StorageBuffer.h"
@@ -19,9 +20,25 @@
 
 namespace OloEngine::GaussianSplat
 {
-    // The per-view ordering pass on the GPU (issue #1038): the cull, the LOD
-    // test and the back-to-front sort that `BuildViewOrdering` does on the CPU,
-    // as three compute dispatch groups feeding an indirect draw.
+    // Which GPU sort orders the splats. The radix is the pass; the bitonic
+    // network is kept only as the A/B control the measurement interleaves
+    // against, exactly as SplatSpike_OpaqueBaseline.glsl is kept as the
+    // raster pass's control (ADR 0018 section 5.3).
+    //
+    // KEEPING THE CONTROL IS NOT INDECISION ABOUT WHICH SORT SHIPS. GPU timings
+    // on a workstation move by up to 4x run to run with clock state and with
+    // whatever else is on the box, so "the radix is faster" is only a claim if
+    // both paths can be timed in one process, alternating. A before-then-after
+    // measurement charges all of that drift to whichever ran second.
+    enum class SortAlgorithm : u8
+    {
+        Radix,   // four-pass LSD radix over GPUPrefixSum (issue #1043)
+        Bitonic, // the #1038 network, retained as the measurement control
+    };
+
+    // The per-view ordering pass on the GPU (issues #1038, #1043): the cull, the
+    // LOD test and the back-to-front sort that `BuildViewOrdering` does on the
+    // CPU, as compute dispatches feeding an indirect draw.
     //
     // WHY THIS EXISTS. The CPU pass is the one measurement that decided
     // ADR 0018 against making splats a runtime asset type: 16.6 ms at 500 k
@@ -49,9 +66,12 @@ namespace OloEngine::GaussianSplat
         GpuViewOrdering(const GpuViewOrdering&) = delete;
         GpuViewOrdering& operator=(const GpuViewOrdering&) = delete;
 
-        // Compiles the two compute shaders. Returns false (and leaves the
-        // object unusable) if either fails, so a caller without a GL 4.6
-        // context skips rather than asserting.
+        // Compiles the cull and radix compute shaders and brings up the shared
+        // `GPUPrefixSum`. Returns false (and leaves the object unusable) if any
+        // of them fails, so a caller without a GL 4.6 context skips rather than
+        // asserting. The bitonic control's shader is NOT compiled here -- it is
+        // loaded lazily by `SetSortAlgorithm`, so the pass that ships pays
+        // nothing for a shader only the measurement uses.
         [[nodiscard]] auto Initialize() -> bool;
 
         [[nodiscard]] auto IsReady() const -> bool
@@ -59,10 +79,26 @@ namespace OloEngine::GaussianSplat
             return m_Ready;
         }
 
-        // Uploads `cloud` and sizes the per-view buffers. The sort array is
-        // padded to a power of two of at least 512, because the bitonic network
-        // is only defined on a power-of-two array and its shared-memory pass
-        // owns a 512-element tile.
+        // Picks the sort. Safe at any time: the two algorithms pad the sort
+        // array differently, so this re-sizes the key, payload and histogram
+        // buffers, but it does NOT touch the splat records -- which is the
+        // point, because an A/B that re-uploaded a 96 MB cloud between samples
+        // would be measuring the upload. Returns false only if the bitonic
+        // control's shader could not be loaded.
+        //
+        // IT DOES INVALIDATE THE LAST ORDERING, because the order buffer it
+        // reallocates is the one the draw reads. The indirect command's
+        // instance count is zeroed to match, so a `DrawIndirect` issued before
+        // the next `BuildOrdering` draws nothing rather than garbage.
+        [[nodiscard]] auto SetSortAlgorithm(SortAlgorithm algorithm) -> bool;
+
+        [[nodiscard]] auto GetSortAlgorithm() const -> SortAlgorithm
+        {
+            return m_Algorithm;
+        }
+
+        // Uploads `cloud` and sizes the per-view buffers for the current
+        // algorithm's padding.
         void SetCloud(const SplatCloud& cloud);
 
         // One frame's ordering: cull + LOD + sort. Leaves the draw order in the
@@ -90,13 +126,21 @@ namespace OloEngine::GaussianSplat
             return m_SplatCount;
         }
 
-        // Number of compute dispatches the last BuildOrdering issued, split
-        // into the cull and the two sort modes. Reported by the measurement so
-        // the dispatch count is observed rather than recomputed from a formula
-        // that might not match the loop.
+        // Number of compute dispatches the last BuildOrdering issued. Reported
+        // by the measurement so the dispatch count is observed rather than
+        // recomputed from a formula that might not match the loop.
         struct DispatchCounts
         {
             u32 Cull = 0;
+            // Radix: one of each per digit, four digits, so four and four.
+            u32 RadixHistogram = 0;
+            u32 RadixScatter = 0;
+            // Calls to `GPUPrefixSum::ExclusiveScanInPlace`, NOT dispatches:
+            // each call expands to between two and five of its own, and this
+            // class does not get to see how many. Counted separately rather
+            // than folded in so the number stays something that was observed.
+            u32 RadixScanCalls = 0;
+            // Non-zero only under the bitonic control.
             u32 SortGlobal = 0;
             u32 SortLocal = 0;
         };
@@ -105,23 +149,29 @@ namespace OloEngine::GaussianSplat
             return m_Dispatches;
         }
 
-        // Smallest power of two that is >= `count` and >= 512. Only defined
-        // for counts up to kMaxSplats; above that there is no representable
-        // answer and the caller must have rejected the cloud already.
+        // `count` rounded up to a whole number of radix tiles, and at least one
+        // tile. The slack is filled with the maximum sort key, which sorts
+        // behind every real splat, so the sort's length never depends on a
+        // survivor count the CPU would have to read back.
         //
-        // THIS FUNCTION IS THE COST MODEL, WHICH IS NOT OBVIOUS FROM ITS NAME.
-        // The bitonic network sorts the padded array, so ordering cost is a
-        // STEP FUNCTION of this result rather than a curve in `count`. Measured
-        // on an RTX 4090: 2,000,000 splats pad to 2^21 and order in 1.28 ms;
-        // 2,100,000 pad to 2^22 and take 7.84 ms. Five per cent more splats,
-        // 6.1x the time, no visible change to the scene.
-        //
-        // Two consequences for a caller. Keeping a cloud just under a power of
-        // two is worth real frame time, and ADR 0018's supported envelope of
-        // 2 M splats per view is exactly the 2^21 boundary rather than a round
-        // number. Issue #1043 removes the padding entirely by replacing the
-        // sort; until it lands, this is the number to design against.
+        // THIS IS WHAT ISSUE #1043 CHANGED, AND THE POINT IS THE BOUND ON IT.
+        // The bitonic network this replaced padded to a power of two, so the
+        // ordering cost was a STEP FUNCTION of the padding rather than a curve
+        // in `count`: measured on an RTX 4090 with both sorts interleaved in one
+        // process, 2,000,000 splats padded to 2^21 and ordered in 1.24 ms while
+        // 2,100,000 padded to 2^22 and took 2.16 ms -- five per cent more
+        // splats, 1.7x the time (2.7x on the worst of four runs), and no visible
+        // change to the scene. A radix needs no power of two, so the overhead
+        // here is at most kSortTile-1 elements however large the cloud is, and
+        // the same pair costs 0.69 and 0.72 ms. ADR 0018 section 5.2 has the
+        // sweep, and the reason its earlier figure for that step was 6.1x.
         [[nodiscard]] static auto PaddedCapacityFor(u32 count) -> u32;
+
+        // The bitonic control's padding: the smallest power of two that is at
+        // least `count` and at least its 512-element shared-memory tile. Kept
+        // so the A/B can size its buffers, and so the step function the issue
+        // removed stays expressible in a test.
+        [[nodiscard]] static auto BitonicPaddedCapacityFor(u32 count) -> u32;
 
         // Hard ceiling on a cloud this pass will accept, and the reason it is
         // this number rather than a round one: every size in the pass is a u32,
@@ -131,30 +181,52 @@ namespace OloEngine::GaussianSplat
         //     134,217,728 splats -- the narrowing cast in SetCloud would wrap
         //     and allocate a 32-byte buffer for the whole cloud;
         //   * the padded slot size (4 bytes each) wraps at 536,870,913;
-        //   * at 1,073,741,825 the padded capacity is 1<<31 and the sort's
-        //     `for (u32 k = 2; k <= capacity; k <<= 1)` wraps k to zero and
-        //     never terminates;
+        //   * at 1,073,741,825 the bitonic control's padded capacity is 1<<31
+        //     and its `for (u32 k = 2; k <= capacity; k <<= 1)` wraps k to zero
+        //     and never terminates;
         //   * above 1<<31, std::bit_ceil is asked for an unrepresentable 1<<32,
         //     which is undefined.
         //
         // 1<<26 is 67 million splats -- 2 GB of records, an order of magnitude
         // past the largest published capture -- and leaves every one of those
-        // computations with a factor of two or more in hand.
+        // computations with a factor of two or more in hand. The radix adds one
+        // more constraint, that its transposed histogram fit `GPUPrefixSum`;
+        // a static_assert in the .cpp pins that this ceiling satisfies it.
         static constexpr u32 kMaxSplats = 1u << 26;
 
       private:
         void ReleaseBindings() const;
+        // Zeroes the indirect draw's instance count. Called on every path that
+        // invalidates the order buffer, not just per frame.
+        // NOT const: Ref<T> propagates const, so a const method cannot reach
+        // StorageBuffer::SetData through the member (gpu-scan-compaction.md 7).
+        void ResetIndirectCommand();
+        // Sizes the key/payload/scratch/histogram buffers from m_SplatCount and
+        // the current algorithm. Separate from SetCloud so switching algorithms
+        // during an A/B does not re-upload the whole cloud.
+        void ResizeSortBuffers();
+        void SortRadix();
+        void SortBitonic();
 
         bool m_Ready = false;
         u32 m_SplatCount = 0;
         u32 m_PaddedCapacity = 0;
+        SortAlgorithm m_Algorithm = SortAlgorithm::Radix;
         DispatchCounts m_Dispatches;
 
         Ref<ComputeShader> m_CullShader;
-        Ref<ComputeShader> m_SortShader;
+        Ref<ComputeShader> m_HistogramShader;
+        Ref<ComputeShader> m_ScatterShader;
+        Ref<ComputeShader> m_BitonicShader; // lazy; control only
+        Ref<GPUPrefixSum> m_PrefixSum;
         Ref<StorageBuffer> m_SplatBuffer;
         Ref<StorageBuffer> m_OrderBuffer;
         Ref<StorageBuffer> m_KeyBuffer;
+        // The radix scatter cannot write in place, so each pass ping-pongs into
+        // these and the four passes land the result back in the pair above.
+        Ref<StorageBuffer> m_OrderScratch;
+        Ref<StorageBuffer> m_KeyScratch;
+        Ref<StorageBuffer> m_HistogramBuffer;
         Ref<StorageBuffer> m_StatsBuffer;
         Ref<StorageBuffer> m_IndirectBuffer;
         Ref<UniformBuffer> m_CullUniforms;

--- a/OloEngine/tests/Rendering/Splat/GaussianSplatGpuOrderingParityTest.cpp
+++ b/OloEngine/tests/Rendering/Splat/GaussianSplatGpuOrderingParityTest.cpp
@@ -1,7 +1,7 @@
 // OLO_TEST_LAYER: shaderpipe
 // =============================================================================
 // GaussianSplatGpuOrderingParityTest.cpp — the GPU per-view ordering pass
-// against its CPU reference (issue #1038).
+// against its CPU reference (issues #1038, #1043).
 //
 // WHAT MAKES THIS A PARITY TEST AND NOT A SMOKE TEST. The GPU pass is asserted
 // INDEX FOR INDEX against `BuildViewOrdering`, not merely "same set, roughly
@@ -10,6 +10,23 @@
 // permutation satisfies it, so a correct GPU sort has no freedom to differ.
 // A test that only checked the depth ordering would pass with the payload
 // permuted among equal depths, which is the shimmer a viewer actually notices.
+//
+// AND THAT IS WHY THE ASSERTIONS DID NOT MOVE WHEN #1043 REPLACED THE SORT.
+// The bitonic network compared the whole pair, so it needed no stability; the
+// radix sorts on the key alone and must be STABLE for the same equality to
+// hold.
+//
+// WHAT EACH KIND OF CASE ACTUALLY CATCHES, since it is not what it looks like.
+// An LSD radix needs stability to be CORRECT, not merely to be reproducible --
+// every pass has to preserve the previous pass's order among equal digits -- so
+// a broken per-tile rank fails the distinct-key cases loudly, on the keys
+// themselves. `MatchesTheCpuReferenceWhenEveryDepthIsIdentical` is the case
+// that catches what the others cannot: with every key bit-identical, ANY
+// permutation is correctly sorted by key, so the array still looks right and
+// only the payload order can betray a wrong rank. It is the one test whose
+// subject is purely the (key, index) tiebreak the frame depends on. Both claims
+// were checked by replaying the shader's tile decomposition on the CPU against
+// two wrong ranks -- a strided lane assignment and an atomic-style random one.
 //
 // The cull stats are compared field by field for the same reason: a cull that
 // dropped the right NUMBER of splats for the wrong REASON would otherwise look
@@ -132,8 +149,8 @@ namespace OloEngine::Tests
             OLO_ENSURE_GPU_OR_SKIP();
 
             m_Gpu = std::make_unique<GpuViewOrdering>();
-            ASSERT_TRUE(m_Gpu->Initialize())
-                << "SplatSpike_Cull.comp / SplatSpike_BitonicSort.comp failed to compile";
+            ASSERT_TRUE(m_Gpu->Initialize()) << "SplatSpike_Cull.comp / SplatSpike_RadixHistogram.comp / "
+                                                "SplatSpike_RadixScatter.comp failed to compile";
         }
 
         void TearDown() override
@@ -175,28 +192,31 @@ namespace OloEngine::Tests
         std::unique_ptr<GpuViewOrdering> m_Gpu;
     };
 
-    // A PLAIN TEST, NOT A TEST_F, ON PURPOSE. `PaddedCapacityFor` is a pure
-    // function and it decides how the sort buffers are sized and how many
-    // dispatches the bitonic loop issues -- so it is exactly the contract that
-    // should still be checked on a headless runner, where the fixture below
-    // skips for want of a GL context and would take these assertions with it.
-    TEST(GaussianSplatGpuOrderingPadding, IsAPowerOfTwoAndAtLeastOneTile)
+    // PLAIN TESTS, NOT TEST_Fs, ON PURPOSE. The padding functions are pure and
+    // they decide how the sort buffers are sized and how much work the sort
+    // does -- so they are exactly the contract that should still be checked on
+    // a headless runner, where the fixture below skips for want of a GL context
+    // and would take these assertions with it.
+    //
+    // AND THIS IS WHERE ISSUE #1043's FIX IS ACTUALLY PINNED. The measurement
+    // further down cannot be asserted -- a GPU time on a dev workstation moves
+    // 4x run to run -- but the padding it is a consequence of is arithmetic,
+    // deterministic, and reproducible on any machine including CI.
+    TEST(GaussianSplatGpuOrderingPadding, RoundsUpToAWholeRadixTile)
     {
-        // The bitonic network is only defined on a power-of-two array, and its
-        // shared-memory pass owns a 512-element tile, so a cloud smaller than a
-        // tile still has to be padded up to one.
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(0), 512u);
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(1), 512u);
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(512), 512u);
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(513), 1024u);
+        // The radix sorts `count` elements; the only padding is up to a whole
+        // 2048-element tile, so the shader needs no bounds test in its inner
+        // loop and the cull can keep marking rejects in place.
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(0), 2048u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(1), 2048u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(2048), 2048u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(2049), 4096u);
         EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(4096), 4096u);
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(4097), 8192u);
-        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(100000), 131072u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(4097), 6144u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(100000), 100352u);
 
-        // At the ceiling the answer is still representable, which is the whole
-        // reason the ceiling is where it is: one past a power of two is the
-        // worst case, and kMaxSplats is itself a power of two so it maps to
-        // itself rather than doubling.
+        // At the ceiling the answer is still representable, and kMaxSplats is a
+        // multiple of the tile so it maps to itself.
         EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(GpuViewOrdering::kMaxSplats),
                   GpuViewOrdering::kMaxSplats);
         EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(GpuViewOrdering::kMaxSplats - 1),
@@ -204,11 +224,52 @@ namespace OloEngine::Tests
 
         // Every u32 size derived from the ceiling still fits, which is what the
         // constant is chosen for -- 32 bytes of record and 4 bytes of sort slot
-        // per splat, twice over for the key and the payload.
+        // per splat, four times over for the key, the payload and their scratch.
         constexpr u64 kRecordBytes = static_cast<u64>(GpuViewOrdering::kMaxSplats) * 32u;
         constexpr u64 kSlotBytes = static_cast<u64>(GpuViewOrdering::kMaxSplats) * 4u;
         EXPECT_LE(kRecordBytes, static_cast<u64>(std::numeric_limits<u32>::max()));
         EXPECT_LE(kSlotBytes, static_cast<u64>(std::numeric_limits<u32>::max()));
+    }
+
+    TEST(GaussianSplatGpuOrderingPadding, TheStepFunctionIsGone)
+    {
+        // THE ACCEPTANCE CRITERION OF ISSUE #1043, in the one form that can be
+        // asserted rather than printed.
+        //
+        // ADR 0018 section 5.2 measured 2,000,000 splats at 1.24 ms and
+        // 2,100,000 at 2.16 ms under the bitonic network -- 5 % more splats for
+        // 1.7x the time, and nothing about the cloud explained it. What
+        // explained it is right here: the network padded to a power of two, so
+        // those two counts sorted arrays that differed by 2x. The radix pads to
+        // a tile, and the same pair costs 0.69 and 0.72 ms.
+        constexpr u32 kJustUnder = 2000000;
+        constexpr u32 kJustOver = 2100000;
+
+        EXPECT_EQ(GpuViewOrdering::BitonicPaddedCapacityFor(kJustUnder), 1u << 21);
+        EXPECT_EQ(GpuViewOrdering::BitonicPaddedCapacityFor(kJustOver), 1u << 22);
+
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(kJustUnder), 2000896u);
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(kJustOver), 2101248u);
+
+        // 5 % more splats now buys at most 5 % more sorted array, against the
+        // 2x the network charged. Stated as a bound rather than as the two
+        // numbers above so that a future change to the tile size still has to
+        // keep the property this issue existed to establish.
+        const f64 countRatio = static_cast<f64>(kJustOver) / static_cast<f64>(kJustUnder);
+        const f64 paddedRatio = static_cast<f64>(GpuViewOrdering::PaddedCapacityFor(kJustOver)) /
+                                static_cast<f64>(GpuViewOrdering::PaddedCapacityFor(kJustUnder));
+        EXPECT_LT(paddedRatio, countRatio * 1.01)
+            << "the sorted array grew faster than the cloud did: the step function is back";
+
+        // The general form: padding overhead is bounded by one tile, so it is a
+        // vanishing fraction of any cloud worth sorting rather than a factor.
+        for (const u32 count : { 1000u, 4096u, 100000u, 1500000u, 2000000u, 2100000u, 3000000u, 4000000u,
+                                 6000000u, 8000000u, GpuViewOrdering::kMaxSplats })
+        {
+            const u32 padded = GpuViewOrdering::PaddedCapacityFor(count);
+            EXPECT_GE(padded, count) << count;
+            EXPECT_LT(padded - count, 2048u) << count;
+        }
     }
 
     TEST_F(GaussianSplatGpuOrderingTest, MatchesTheCpuReferenceOnTheFixtureFromEveryPose)
@@ -234,6 +295,12 @@ namespace OloEngine::Tests
         // Counts that straddle the padding boundary and the sort tile: one
         // below, exactly on, one above. A network that mishandles its pad
         // silently drops or duplicates the elements at the seam.
+        //
+        // THESE EIGHT COUNTS ARE UNCHANGED FROM #1038 BY REQUIREMENT. They are
+        // the bitonic network's boundaries, and #1043 kept them exactly so the
+        // radix has to clear the bar the sort it replaced cleared, on the same
+        // inputs. `MatchesTheCpuReferenceAcrossTheRadixTileSeam` adds the new
+        // sort's own seam rather than moving these.
         ViewSettings settings;
         settings.MaxSplats = 0;
         settings.MinScreenExtentPixels = 0.5f;
@@ -241,6 +308,23 @@ namespace OloEngine::Tests
         for (const u32 count : { 1u, 511u, 512u, 513u, 1024u, 4095u, 4096u, 4097u })
         {
             const SplatCloud cloud = MakeParityCloud(count, 1038u + count);
+            ExpectParity(cloud, kParityPoses[0], settings);
+        }
+    }
+
+    TEST_F(GaussianSplatGpuOrderingTest, MatchesTheCpuReferenceAcrossTheRadixTileSeam)
+    {
+        // The same idea as the test above, for the boundary the radix
+        // introduced: the sort is dispatched one workgroup per 2048-element
+        // tile, so a count either side of a tile is where a scatter that
+        // mis-ranks its last partial tile shows up.
+        ViewSettings settings;
+        settings.MaxSplats = 0;
+        settings.MinScreenExtentPixels = 0.5f;
+
+        for (const u32 count : { 2047u, 2048u, 2049u, 6143u, 6144u, 6145u })
+        {
+            const SplatCloud cloud = MakeParityCloud(count, 1043u + count);
             ExpectParity(cloud, kParityPoses[0], settings);
         }
     }
@@ -270,6 +354,58 @@ namespace OloEngine::Tests
         ExpectParity(cloud, kParityPoses[0], settings);
     }
 
+    TEST_F(GaussianSplatGpuOrderingTest, MatchesTheCpuReferenceWhenTiesSpanManyRadixTiles)
+    {
+        // THE TIE CASE ABOVE IS 2000 SPLATS, WHICH IS ONE RADIX TILE. That is
+        // not a criticism of it -- it is #1038's test and #1043 kept it exactly
+        // -- but a single tile can only exercise a rank that is wrong WITHIN a
+        // tile. The radix has a second stability obligation the bitonic network
+        // never had: equal keys in tile 5 must land behind equal keys in tile 4.
+        // That comes from writing the histogram transposed,
+        // `hist[bin * numTiles + tile]`, so one scan orders the bins globally
+        // and the tiles within each bin.
+        //
+        // To be straight about what this test adds: a grossly wrong histogram
+        // layout already fails the fixture test loudly, because the fixture is
+        // two tiles of mostly distinct depths. What is NOT otherwise covered is
+        // a large tie GROUP spanning a tile seam, which is the shape a real
+        // scan of a flat wall produces and the shape in which a cross-tile rank
+        // error stays quiet. Two clouds: one where every depth is identical
+        // across three tiles, and one where seventeen depth groups straddle the
+        // seams.
+        ViewSettings settings;
+        settings.MaxSplats = 0;
+
+        const auto makePlanarCloud = [](u32 count, u32 distinctDepths) -> SplatCloud
+        {
+            std::vector<glm::vec3> positions(count);
+            std::vector<glm::vec3> shDc(count, glm::vec3(0.0f));
+            std::vector<f32> logit(count, 1.0f);
+            std::vector<glm::vec3> logScale(count, glm::vec3(std::log(0.02f)));
+            std::vector<glm::vec4> rotation(count, glm::vec4(1.0f, 0.0f, 0.0f, 0.0f));
+            std::mt19937 rng(4243);
+            std::uniform_real_distribution<f32> spread(-1.0f, 1.0f);
+            for (u32 i = 0; i < count; ++i)
+            {
+                // Depths drawn from a small discrete set, and the whole cloud
+                // kept well inside the frustum at every one of them. Both
+                // matter: the groups have to be exact bitwise ties rather than
+                // near-ties the two processors could round apart, and no splat
+                // may sit within a ULP of a cull threshold or the exact-parity
+                // assertions flake for a reason that is not the sort's.
+                const f32 z = 0.05f * static_cast<f32>(i % distinctDepths);
+                positions[i] = glm::vec3(spread(rng), spread(rng), z);
+            }
+            SplatCloud cloud;
+            cloud.Build(positions, shDc, logit, logScale, rotation);
+            return cloud;
+        };
+
+        // 6000 splats is two whole tiles plus a partial third.
+        ExpectParity(makePlanarCloud(6000, 1), kParityPoses[0], settings);
+        ExpectParity(makePlanarCloud(6000, 17), kParityPoses[0], settings);
+    }
+
     TEST_F(GaussianSplatGpuOrderingTest, TheIndirectDrawCountIsWrittenByTheGpu)
     {
         // The acceptance criterion that keeps a readback off the frame path:
@@ -292,15 +428,52 @@ namespace OloEngine::Tests
         m_Gpu->ReadbackOrdering(gpu);
         EXPECT_GT(gpu.Stats.Drawn, 0u);
 
-        // The dispatch count is 1 cull + 2 log N sort passes, not log^2 N; if
-        // the shared-memory mode regressed to one dispatch per step this jumps
-        // by an order of magnitude and the measurement in ADR 0018 stops
-        // meaning what it says.
+        // The sort's shape, pinned. A four-pass LSD radix is FOUR histograms,
+        // four scans and four scatters WHATEVER the cloud is -- that constant
+        // is the whole difference from the bitonic network, whose 2 log N grew
+        // with the padded array and reached 91 global passes at 2^22. A
+        // regression to a per-digit loop that ran more than four times, or to
+        // the bitonic path by default, fails here rather than only in a
+        // measurement nobody reads.
         const GpuViewOrdering::DispatchCounts dispatches = m_Gpu->LastDispatchCounts();
-        std::printf("[splat-gpu] padded=%u dispatches: cull=%u sortGlobal=%u sortLocal=%u\n",
-                    m_Gpu->PaddedCapacity(), dispatches.Cull, dispatches.SortGlobal, dispatches.SortLocal);
+        std::printf("[splat-gpu] padded=%u dispatches: cull=%u histogram=%u scatter=%u scanCalls=%u\n",
+                    m_Gpu->PaddedCapacity(), dispatches.Cull, dispatches.RadixHistogram, dispatches.RadixScatter,
+                    dispatches.RadixScanCalls);
         EXPECT_EQ(dispatches.Cull, 1u);
-        EXPECT_LT(dispatches.SortGlobal + dispatches.SortLocal, 64u);
+        EXPECT_EQ(dispatches.RadixHistogram, 4u);
+        EXPECT_EQ(dispatches.RadixScatter, 4u);
+        EXPECT_EQ(dispatches.RadixScanCalls, 4u);
+        EXPECT_EQ(dispatches.SortGlobal, 0u) << "the bitonic control ran instead of the radix";
+        EXPECT_EQ(dispatches.SortLocal, 0u) << "the bitonic control ran instead of the radix";
+    }
+
+    TEST_F(GaussianSplatGpuOrderingTest, TheBitonicControlStillAgreesWithTheCpuReference)
+    {
+        // The A/B control is only worth measuring against if it is still
+        // correct, and it is only still correct if something exercises it: a
+        // control that has quietly rotted makes the comparison in
+        // MeasureRadixAgainstTheBitonicControl meaningless in the direction
+        // that flatters the change.
+        ASSERT_TRUE(m_Gpu->SetSortAlgorithm(SortAlgorithm::Bitonic))
+            << "SplatSpike_BitonicSort.comp failed to compile";
+        ASSERT_EQ(m_Gpu->GetSortAlgorithm(), SortAlgorithm::Bitonic);
+
+        ViewSettings settings;
+        settings.MaxSplats = 0;
+        settings.MinScreenExtentPixels = 0.5f;
+
+        // 5000 SPLATS, NOT A ROUND NUMBER: the radix pads it to 6144 (three
+        // tiles) and the bitonic network to 8192 (a power of two), so the
+        // padding assertion below actually proves which sort ran. At 3000 both
+        // answer 4096 and it would prove nothing.
+        const SplatCloud cloud = MakeParityCloud(5000u, 1043u);
+        ExpectParity(cloud, kParityPoses[0], settings);
+
+        const GpuViewOrdering::DispatchCounts dispatches = m_Gpu->LastDispatchCounts();
+        EXPECT_EQ(m_Gpu->PaddedCapacity(), 8192u) << "the control must still pad to a power of two";
+        EXPECT_EQ(GpuViewOrdering::PaddedCapacityFor(5000u), 6144u) << "and the radix must not";
+        EXPECT_EQ(dispatches.RadixHistogram, 0u);
+        EXPECT_GT(dispatches.SortGlobal + dispatches.SortLocal, 0u);
     }
 
     // -------------------------------------------------------------------------
@@ -308,57 +481,190 @@ namespace OloEngine::Tests
     // workstation is a flake (oloengine-perf-tests-are-dev-workstation-only).
     // -------------------------------------------------------------------------
 
+    namespace
+    {
+        // One GL_TIME_ELAPSED bracket around one BuildOrdering, drained.
+        [[nodiscard]] f64 TimeOneOrdering(GpuViewOrdering& gpu, const glm::mat4& view, const glm::mat4& projection,
+                                          const glm::vec2& viewport, const ViewSettings& settings)
+        {
+            u32 query = 0;
+            ::glCreateQueries(GL_TIME_ELAPSED, 1, &query);
+            ::glBeginQuery(GL_TIME_ELAPSED, query);
+            gpu.BuildOrdering(view, projection, viewport, settings);
+            ::glEndQuery(GL_TIME_ELAPSED);
+            ::glFinish();
+
+            u64 nanoseconds = 0;
+            ::glGetQueryObjectui64v(query, GL_QUERY_RESULT, &nanoseconds);
+            ::glDeleteQueries(1, &query);
+            return static_cast<f64>(nanoseconds) / 1.0e6;
+        }
+
+        [[nodiscard]] glm::mat4 MeasurementView()
+        {
+            return glm::lookAt(glm::vec3(0.0f, 0.0f, 6.0f), glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+        }
+
+        // Run the pass until the GPU has been busy for a quarter second, then
+        // throw those runs away.
+        //
+        // ONE WARM-UP DISPATCH IS NOT A WARM-UP ON THIS BOX, and getting that
+        // wrong produced a table that read like a real finding. Building a
+        // 2 M-splat cloud in a Debug host takes SECONDS, the GPU idles through
+        // all of it and drops its clocks, and four adjacent millisecond samples
+        // never bring them back -- so 2,000,000 measured at 2.7 ms while
+        // 1,500,000 measured at 0.58 ms and 3,000,000 at 0.98 ms, which is an
+        // impossible shape for a sort that is linear in the count. The rows
+        // that looked slow were the rows whose cloud took longest to build.
+        // ADR 0018 section 5.3 recorded the same effect for the raster pass
+        // (10.3 ms against 4.3 ms for an identical draw); this is that lesson
+        // applied to a sweep whose per-row CPU setup cost varies by 2000x.
+        void WarmUp(GpuViewOrdering& gpu, const glm::mat4& view, const glm::mat4& projection,
+                    const glm::vec2& viewport, const ViewSettings& settings)
+        {
+            constexpr auto kWarmDuration = std::chrono::milliseconds(250);
+            constexpr int kMaxIterations = 500;
+            const auto start = std::chrono::steady_clock::now();
+            for (int i = 0; i < kMaxIterations; ++i)
+            {
+                gpu.BuildOrdering(view, projection, viewport, settings);
+                ::glFinish();
+                if (std::chrono::steady_clock::now() - start >= kWarmDuration)
+                    break;
+            }
+        }
+
+        // Minimum and median of a run of adjacent timings. The minimum is the
+        // least noisy estimator of the steady state; the median is reported
+        // beside it because when the two disagree the box was not idle, and
+        // that is the only in-band signal a reader gets.
+        struct Timing
+        {
+            f64 MinMs = 0.0;
+            f64 MedianMs = 0.0;
+        };
+        [[nodiscard]] Timing TimeOrdering(GpuViewOrdering& gpu, const glm::mat4& view, const glm::mat4& projection,
+                                          const glm::vec2& viewport, const ViewSettings& settings)
+        {
+            constexpr int kSamples = 9;
+            std::vector<f64> samples;
+            samples.reserve(kSamples);
+            for (int i = 0; i < kSamples; ++i)
+                samples.push_back(TimeOneOrdering(gpu, view, projection, viewport, settings));
+            std::sort(samples.begin(), samples.end());
+            return { samples.front(), samples[samples.size() / 2] };
+        }
+    } // namespace
+
     TEST_F(GaussianSplatGpuOrderingTest, MeasureGpuOrderingCost)
     {
-        const glm::mat4 view =
-            glm::lookAt(glm::vec3(0.0f, 0.0f, 6.0f), glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+        const glm::mat4 view = MeasurementView();
         const glm::mat4 projection = ParityProjection();
         const glm::vec2 viewport(kWidth, kHeight);
         ViewSettings settings;
         settings.MaxSplats = 0;
 
-        std::printf("\n[splat-gpu] ---- per-view ordering, GPU (this machine, not a CI gate) ----\n");
-        std::printf("[splat-gpu] %10s %10s %10s %12s\n", "splats", "padded", "drawn", "gpu-ms");
+        std::printf("\n[splat-gpu] ---- per-view ordering, radix (this machine, not a CI gate) ----\n");
+        std::printf("[splat-gpu] %10s %10s %10s %10s %10s %10s\n", "splats", "padded", "drawn", "min-ms",
+                    "median-ms", "ns/splat");
 
-        // 2,000,000 and 2,100,000 straddle a power of two: they pad to
-        // 2^21 and 2^22 respectively. Both are in the list on purpose, because
-        // the pair separates "large clouds are expensive" from "crossing a
-        // padding boundary is expensive", and those imply completely different
-        // advice.
-        for (const u32 count : { 4096u, 100000u, 500000u, 2000000u, 2100000u, 4000000u })
+        // THE SHAPE OF THIS LIST IS THE MEASUREMENT. 2,000,000 and 2,100,000
+        // straddle a power of two, which is what the bitonic network charged
+        // 1.7-2.7x for; 1,500,000 and 3,000,000 sit nowhere near one, so
+        // together the set separates "large clouds are expensive" (a curve)
+        // from "crossing a padding boundary is expensive" (a step), and those
+        // imply completely different advice to whoever authors a capture.
+        //
+        // The ns/splat column is the one to read across rows: a sort that
+        // scales with the cloud holds it roughly flat, and a sort that scales
+        // with a padded array does not. The median beside the minimum is the
+        // honesty column -- when the two disagree by more than a few per cent
+        // the box was not idle and the row should not be quoted.
+        for (const u32 count : { 4096u, 100000u, 500000u, 1500000u, 2000000u, 2100000u, 3000000u, 4000000u,
+                                 6000000u, 8000000u })
         {
             const SplatCloud cloud = MakeParityCloud(count, 77u + count);
             m_Gpu->SetCloud(cloud);
 
-            // Warm up: the first dispatch of a freshly sized buffer pays for
-            // allocation and shader residency, not for the work.
-            m_Gpu->BuildOrdering(view, projection, viewport, settings);
-            ::glFinish();
-
-            // Minimum of four, for the reason ADR 0018 section 5.3 records: the
-            // absolute time moves by up to 2x with GPU clock state, and the
-            // minimum is the least noisy estimator of the steady state.
-            f64 bestMs = 1.0e30;
-            for (int i = 0; i < 4; ++i)
-            {
-                u32 query = 0;
-                ::glCreateQueries(GL_TIME_ELAPSED, 1, &query);
-                ::glBeginQuery(GL_TIME_ELAPSED, query);
-                m_Gpu->BuildOrdering(view, projection, viewport, settings);
-                ::glEndQuery(GL_TIME_ELAPSED);
-                ::glFinish();
-
-                u64 nanoseconds = 0;
-                ::glGetQueryObjectui64v(query, GL_QUERY_RESULT, &nanoseconds);
-                ::glDeleteQueries(1, &query);
-                bestMs = std::min(bestMs, static_cast<f64>(nanoseconds) / 1.0e6);
-            }
+            WarmUp(*m_Gpu, view, projection, viewport, settings);
+            const Timing timing = TimeOrdering(*m_Gpu, view, projection, viewport, settings);
 
             ViewOrdering gpu;
             m_Gpu->ReadbackOrdering(gpu);
-            std::printf("[splat-gpu] %10u %10u %10u %12.3f\n", count, m_Gpu->PaddedCapacity(), gpu.Stats.Drawn,
-                        bestMs);
+            std::printf("[splat-gpu] %10u %10u %10u %10.3f %10.3f %10.3f\n", count, m_Gpu->PaddedCapacity(),
+                        gpu.Stats.Drawn, timing.MinMs, timing.MedianMs,
+                        timing.MinMs * 1.0e6 / static_cast<f64>(count));
         }
         std::printf("[splat-gpu] ----------------------------------------------------------------\n\n");
+    }
+
+    TEST_F(GaussianSplatGpuOrderingTest, MeasureRadixAgainstTheBitonicControl)
+    {
+        // INTERLEAVED, NOT A-THEN-B, and that is not fastidiousness. The
+        // identical dispatch sequence on this box has been measured at 0.506,
+        // 1.127 and 2.150 ms across three runs -- a 4x spread from GPU clock
+        // state and from whatever else is on the machine. Measuring the whole
+        // of A and then the whole of B charges all of that drift to whichever
+        // ran second, which is enough to invert a comparison. Alternating
+        // A,B,A,B splits it between them; the minimum of each side is then the
+        // least noisy estimator of the steady state
+        // (gpu-timing-measurement, ADR 0018 section 5.3).
+        const glm::mat4 view = MeasurementView();
+        const glm::mat4 projection = ParityProjection();
+        const glm::vec2 viewport(kWidth, kHeight);
+        ViewSettings settings;
+        settings.MaxSplats = 0;
+
+        if (!m_Gpu->SetSortAlgorithm(SortAlgorithm::Bitonic))
+            GTEST_SKIP() << "the bitonic control shader did not compile on this driver";
+        ASSERT_TRUE(m_Gpu->SetSortAlgorithm(SortAlgorithm::Radix));
+
+        std::printf("\n[splat-gpu] ---- radix against the bitonic control, interleaved ----\n");
+        std::printf("[splat-gpu] %10s %10s %10s %10s %10s %8s\n", "splats", "radixPad", "bitonicPad", "radix-ms",
+                    "bitonic-ms", "speedup");
+
+        // Four counts, each earning its place. 4,096 is the fixture, and it is
+        // the one place the radix could legitimately LOSE -- its fixed cost is
+        // nine dispatches plus four scans whatever the cloud, against a network
+        // that at this size is only six global steps and twelve local ones, so
+        // the honest table has to include the size that flatters the old sort.
+        // 500 k is the control that straddles nothing, so a run in which every
+        // row moved together would read as a machine effect rather than a win.
+        // And the 2.0 M / 2.1 M pair either side of 2^21 is the whole reason
+        // issue #1043 exists.
+        for (const u32 count : { 4096u, 500000u, 2000000u, 2100000u })
+        {
+            const SplatCloud cloud = MakeParityCloud(count, 77u + count);
+
+            f64 bestRadixMs = 1.0e30;
+            f64 bestBitonicMs = 1.0e30;
+            u32 radixPadded = 0;
+            u32 bitonicPadded = 0;
+
+            for (int block = 0; block < 3; ++block)
+            {
+                ASSERT_TRUE(m_Gpu->SetSortAlgorithm(SortAlgorithm::Radix));
+                if (block == 0)
+                    m_Gpu->SetCloud(cloud); // uploads once; SetSortAlgorithm only resizes the sort buffers
+                WarmUp(*m_Gpu, view, projection, viewport, settings);
+                radixPadded = m_Gpu->PaddedCapacity();
+                bestRadixMs =
+                    std::min(bestRadixMs, TimeOrdering(*m_Gpu, view, projection, viewport, settings).MinMs);
+
+                ASSERT_TRUE(m_Gpu->SetSortAlgorithm(SortAlgorithm::Bitonic));
+                WarmUp(*m_Gpu, view, projection, viewport, settings);
+                bitonicPadded = m_Gpu->PaddedCapacity();
+                bestBitonicMs =
+                    std::min(bestBitonicMs, TimeOrdering(*m_Gpu, view, projection, viewport, settings).MinMs);
+            }
+
+            std::printf("[splat-gpu] %10u %10u %10u %10.3f %10.3f %7.2fx\n", count, radixPadded, bitonicPadded,
+                        bestRadixMs, bestBitonicMs, bestBitonicMs / bestRadixMs);
+        }
+        std::printf("[splat-gpu] ----------------------------------------------------------------\n\n");
+
+        // Leave the object on the algorithm that ships, so a later test in this
+        // process inherits the pass rather than the control.
+        ASSERT_TRUE(m_Gpu->SetSortAlgorithm(SortAlgorithm::Radix));
     }
 } // namespace OloEngine::Tests

--- a/docs/adr/0018-gaussian-splats-gpu-ordering-and-merge-lod.md
+++ b/docs/adr/0018-gaussian-splats-gpu-ordering-and-merge-lod.md
@@ -5,17 +5,23 @@ viability spike. This is its decision record: what was built, what it measured, 
 does and does not interact with in this engine, and the two numbers that decide whether the feature
 is affordable.
 
-**The decision, up front.** Gaussian splats are viable in OloEngine **up to about 2 M splats per
-view**. Two things had to be true and now are, both measured in this PR: the per-view ordering runs
-on the GPU (**0.50 ms for 500 k splats, 1.28 ms for 2 M**, against 16.55 ms for 500 k on one CPU
-thread), and LOD comes from **merging** splats offline rather than selecting among them at draw
-time. What is *not* done, deliberately, is the integration: no component, no scene serialization, no
-asset-registry entry, no Vulkan port. §4 states every interaction a splat cloud has and does not
-have, and §6 says what remains.
+**The decision, up front.** Gaussian splats are viable in OloEngine. Two things had to be true and
+now are: the per-view ordering runs on the GPU (**0.24 ms for 500 k splats, 0.69 ms for 2 M, 2.21 ms
+for 8 M**, against 16.55 ms for 500 k on one CPU thread), and LOD comes from **merging** splats
+offline rather than selecting among them at draw time. What is *not* done, deliberately, is the
+integration: no component, no scene serialization, no asset-registry entry, no Vulkan port. §4
+states every interaction a splat cloud has and does not have, and §6 says what remains.
 
-**The 2 M ceiling is a real edge, not a round number.** The bitonic sort pads to a power of two, and
-crossing one is a cliff: 2,000,000 splats order in 1.28 ms and 2,100,000 — five per cent more — take
-7.84 ms. §5.2 has the measurement and §6 turns it into a condition.
+**The ordering pass no longer sets a ceiling, and the story of how it stopped is the useful part.**
+The first version of this ADR capped the feature at 2 M splats per view, because the bitonic sort it
+shipped with is only defined on a power-of-two array: 2,000,000 splats ordered in 1.28 ms and
+2,100,000 — five per cent more — took several times that, purely because the array doubled.
+[#1043](https://github.com/drsnuggles8/OloEngineBase/issues/1043) replaced it with a four-pass LSD
+radix, which pads to a 2048-element tile instead. The step is gone, the pass is 1.7–2.9× faster
+above 500 k (and 1.5× *slower* on the 4,096-splat fixture, which §5.2 tabulates rather than hides),
+and it costs 0.28–0.47 ns per splat from 500 k to 8 M. §5.2 has all of it — including a **correction
+to this ADR's own earlier measurement**: that 6.1× step was really 1.75–2.7×, and the remainder it
+called "unexplained" was a downclocked GPU rather than a cache effect.
 
 **This ADR reversed its own conclusion inside one PR, and the honest version is worth keeping.** The
 first draft said "do not proceed": the CPU ordering pass cost 16.6 ms at 500 k splats, a whole 60 Hz
@@ -24,7 +30,10 @@ frame, against published captures of 1–6 M splats. That was the right call on 
 [#1039](https://github.com/drsnuggles8/OloEngineBase/issues/1039) — the two preconditions it named —
 were implemented, and the blocking number moved by more than an order of magnitude. The measurement
 was the argument in both directions — and then a third measurement, the padding cliff in §5.2, put a
-ceiling on the new answer that no amount of reasoning would have found.
+ceiling on the new answer that no amount of reasoning would have found. #1043 then removed that
+ceiling and, in the course of it, showed that the cliff had been *over*-measured. Four turns, all of
+them driven by a number rather than by an argument, and one of them by finding a fault in a number
+this document had already published.
 
 ---
 
@@ -34,7 +43,8 @@ ceiling on the new answer that no amount of reasoning would have found.
 |---|---|
 | PLY importer + 32-byte GPU record | `OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatCloud.{h,cpp}` |
 | CPU reference: cull, LOD, budget, back-to-front sort | `OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatView.{h,cpp}` |
-| GPU per-view ordering + indirect draw (#1038) | `OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.{h,cpp}`, `SplatSpike_Cull.comp`, `SplatSpike_BitonicSort.comp` |
+| GPU per-view ordering + indirect draw (#1038, #1043) | `OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatGpuOrdering.{h,cpp}`, `SplatSpike_Cull.comp`, `SplatSpike_RadixHistogram.comp`, `SplatSpike_RadixScatter.comp` |
+| Bitonic sort, retained as the A/B control (#1038) | `SplatSpike_BitonicSort.comp` |
 | Hierarchical LOD by merging (#1039) | `OloEngine/src/OloEngine/Renderer/Splat/GaussianSplatLod.{h,cpp}` |
 | EWA splat rasteriser | `OloEditor/assets/shaders/tests/SplatSpike_Gaussian.glsl` |
 | Opaque control, same set, no sort or blend | `OloEditor/assets/shaders/tests/SplatSpike_OpaqueBaseline.glsl` |
@@ -97,14 +107,15 @@ cost of the whole technique.
 
 ### 3.1 The pass, on both processors
 
-`BuildViewOrdering` (CPU) and `SplatSpike_Cull.comp` + `SplatSpike_BitonicSort.comp` (GPU) do the
+`BuildViewOrdering` (CPU) and `SplatSpike_Cull.comp` + the radix sort (GPU) do the
 same four things: alpha reject → near-plane reject (the projection diverges at the eye plane, so
 there is no correct thing to draw there) → conservative frustum cull against the splat's 3σ radius →
 **LOD**, dropping any splat whose 3σ footprint projects below a pixel threshold → sort far-to-near.
 
 The CPU version stays as the **reference**, not as a fallback. `GaussianSplatGpuOrderingParityTest`
 asserts the two agree *index for index and stat for stat* across four poses, eight splat counts
-straddling the sort's padding boundary, and a cloud where every depth is bit-identical.
+straddling the bitonic network's padding boundary, six more straddling the radix tile, a cloud where
+every depth is bit-identical, and two more where tie groups span three tiles.
 
 ### 3.2 The sort key is a total order, which is what makes exact parity possible
 
@@ -117,8 +128,10 @@ satisfies it.
 That single property buys three things at once, and it is the reason the GPU work is provable rather
 than plausible:
 
-* the CPU's stable radix sort and the GPU's unstable bitonic network produce the **same array**, so
-  the parity test can assert equality instead of "same set, roughly ordered";
+* there is a single right answer, so the parity test can assert **equality** instead of "same set,
+  roughly ordered". #1038's bitonic network got that for free by comparing the *pair*; #1043's radix
+  sorts on the key alone and earns it by being **stable** over an array the cull writes in index
+  order. Both reproduce the CPU array exactly, by different arguments -- see 3.3;
 * the cull can write its results in any order — it marks rejects in place with the maximum key rather
   than compacting, so the sort array is a fixed power of two whose length never depends on a count
   the CPU would have to read back;
@@ -129,24 +142,58 @@ radix pass's buckets: that pass is usually skipped as uniform (the top byte of a
 plus most of the exponent), and a reversal implemented there silently returns ascending order in
 exactly that case.
 
-### 3.3 Why the GPU sort is bitonic and not the radix #1038 proposed
+### 3.3 The GPU sort is a four-pass LSD radix, and its stability is the load-bearing part
 
-#1038 proposed a four-pass LSD radix over `GPUPrefixSum` (#713). That is the faster algorithm and it
-is what a production path should end up with. It is not what shipped, for one reason: a radix sort
-only replaces the CPU reference if it is **stable**, and a stable GPU radix needs per-tile rank
-computation — ballot-based, or a 256×256 shared histogram it cannot afford — which is easy to get
-subtly wrong and hard to prove right. Bitonic sorting on the *pair* needs no stability at all
-(§3.2), so the parity test can be exact. For a spike whose entire value is a trustworthy
-measurement, a slower algorithm that is provably identical beat a faster one that is probably right.
+The sort is four 8-bit LSD radix passes over the 32-bit key
+([#1043](https://github.com/drsnuggles8/OloEngineBase/issues/1043)). Each pass is three dispatches:
+a tile histogram writing `hist[bin * numTiles + tile]`, one `GPUPrefixSum` exclusive scan of that
+transposed array (#713 -- consumed, not reimplemented), and a scatter. Twelve dispatches plus four
+scans, **whatever the cloud is**, and no power-of-two padding: the array is rounded up to a whole
+2048-element tile and no further, so the ordering cost is a curve in the cloud rather than a step
+function of the padding. 5.2 is the before and after.
 
-The naive bitonic network is O(log²N) dispatches — 231 for 2²¹ elements, each re-reading the whole
-array. A 512-element workgroup tile absorbs the last nine steps of every k in shared memory, which
-takes 2²¹ to 78 global plus 21 local and the 4096-element fixture from 78 to 6 global plus 12 local.
-That is a constant-factor win, not a change of order: the global half is still O(log²N), and it is
-the reason a radix sort — O(N) per pass, four passes — remains the right endpoint. The measured
-dispatch count for the fixture is 1 cull + 6 global + 12 local = **19**, and
-`TheIndirectDrawCountIsWrittenByTheGpu` pins it so a regression to one-dispatch-per-step cannot pass
-unnoticed.
+**A radix only replaces the CPU reference if it is stable**, and that is what #1038 declined to
+attempt inside a spike. The comparison in 3.2 is a total order over (key, index); a radix sees only
+the key, so equal keys come out in input order — which is index order, because the cull writes
+`b_Order[slot] = slot`. Stability is therefore the whole of the parity guarantee.
+
+It is worth being exact about how a wrong rank fails, because the intuition is wrong in a way that
+would misdirect a future debugger. An LSD radix carries each pass's order forward into the next, so a
+rank that is not the element's position breaks **distinct** keys too — the array comes out genuinely
+unsorted, and every parity case fails on the keys. The subtle half appears only on **ties**: any
+permutation of equal keys is correctly sorted, so the array looks right and only the payload order is
+wrong, which on screen is two splats at the same depth swapping between frames. That is the half
+`MatchesTheCpuReferenceWhenEveryDepthIsIdentical` exists for, and it is the only case whose subject
+is purely the tiebreak. Both halves were confirmed by replaying the shader's tile decomposition on
+the CPU against two deliberately wrong ranks.
+
+The rank that has to be exact is **how many earlier elements of the same tile carry the same digit**.
+The direct formulation — a 256 × 256 matrix of per-thread counts, scanned down each bin — is 256 KiB
+of shared memory and does not fit, which is the "256×256 shared histogram it cannot afford" the first
+version of this section named. `SplatSpike_RadixScatter.comp` avoids it: it **locally sorts each tile
+by the digit**, stably, with eight successive one-bit splits, each of which is a single workgroup
+prefix sum and stable by construction. Once the tile is sorted, an element's rank inside its digit is
+its position minus where that digit's run starts — one subtraction, no per-bin scan. Cross-tile
+stability is free from the transposed histogram layout, because the scan visits a bin's tiles in tile
+order.
+
+**The sanctioned fallback was not needed.** #1043 offered a 64-bit (key, index) composite as the
+escape hatch if stability proved impractical — eight passes instead of four, restoring the total
+order by brute force. The four-pass stable version works and is what shipped.
+
+**The bitonic network is kept, and only as the A/B control.** `SplatSpike_BitonicSort.comp` is still
+in the tree, compiled lazily, selected by `SortAlgorithm::Bitonic`, and exercised by
+`TheBitonicControlStillAgreesWithTheCpuReference` so it cannot rot into a flattering comparison. Its
+role is exactly `SplatSpike_OpaqueBaseline.glsl`'s in 5.3: GPU timings on this workstation move up to
+4× run to run, so "the radix is faster" is only a claim if both paths can be timed in one process,
+alternating. It is not a fallback — it is the thing that was replaced, retained so the replacement
+stays measurable.
+
+For the record, since it is the number the radix is measured against: the naive bitonic network is
+O(log²N) dispatches — 231 for 2²¹ elements, each re-reading the whole array. A 512-element workgroup
+tile absorbed the last nine steps of every k in shared memory, taking 2²¹ to 78 global plus 21 local.
+That was a constant-factor win, not a change of order, and it is why a radix — O(N) per pass, four
+passes — was always the right endpoint.
 
 ### 3.4 LOD is merging, not selection
 
@@ -212,62 +259,118 @@ Memory is still where a splat cloud is *worst* against a mesh asset, and the rat
 shares one texture across thousands of triangles and streams by mip, while splat memory is linear in
 captured detail with nothing to share.
 
-### 5.2 The per-view ordering pass: CPU reference against the GPU pass
+### 5.2 The per-view ordering pass
 
-The CPU column is Release, single-threaded, mean of 20 iterations, median of three runs on an idle
-machine, measured with a standalone `-O2` probe over the same translation units — the Debug suite's
-own numbers are 5–10× higher because `/MDd` checked iterators serialise every `std::vector` access.
-The GPU column is `GL_TIME_ELAPSED` around the whole pass (cull + LOD + sort), minimum of four
-samples, on an idle machine; host build configuration does not change GPU work.
+Three tables: what the CPU costs, what the radix sort that ships costs, and the two sorts against
+each other. **Read the method note first, because the first version of this section got it wrong.**
 
-| splats | padded to | GPU drawn | CPU whole pass | GPU whole pass |
-|---:|---:|---:|---:|---:|
-| 4,096 | 4,096 | 3,043 | 0.14 ms | **0.089 ms** |
-| 100,000 | 131,072 | 74,431 | 2.60 ms | **0.259 ms** |
-| 500,000 | 524,288 | 372,165 | 16.55 ms | **0.503 ms** |
-| 2,000,000 | 2,097,152 | 1,488,977 | 155.3 ms† | **1.277 ms** |
-| 2,100,000 | 4,194,304 | 1,563,181 | — | **7.844 ms** |
-| 4,000,000 | 4,194,304 | 2,977,678 | — | **19.539 ms** |
+**Method.** The CPU column is Release, single-threaded, mean of 20 iterations, median of three runs
+on an idle machine, measured with a standalone `-O2` probe over the same translation units — the
+Debug suite's own numbers are 5–10× higher because `/MDd` checked iterators serialise every
+`std::vector` access. The GPU columns are `GL_TIME_ELAPSED` around the whole pass (cull + LOD +
+sort), **after a 250 ms warm-up loop**, minimum of nine adjacent samples, minimum again across three
+runs on an idle box; host build configuration does not change GPU work. The rows below are one
+such run rather than a per-row minimum across four, because that run's minimum and median agree to
+within 1 % on every row -- which is the in-band evidence that the box was idle for all of it, and
+which stitching best-of rows together would throw away. The spread across the four runs is 5-15 % on
+every row above 500 k, except where a sibling worktree started compiling mid-run.
+
+**That warm-up is not boilerplate, and leaving it out invented a finding.** Building a 2 M-splat
+cloud in a Debug host takes seconds, the GPU idles through all of it and drops its clocks, and four
+adjacent millisecond samples never bring them back — so the *slow* rows in a sweep are the rows
+whose CPU-side setup took longest, not the rows that do more work. Measured that way, 2,000,000
+splats reported 2.7 ms while 1,500,000 reported 0.58 ms and 3,000,000 reported 0.98 ms, which is an
+impossible shape for a sort that is linear in the count. With the warm-up, every row falls into
+line. §5.3 had already recorded the same effect for the raster pass (10.3 ms against 4.3 ms for an
+identical draw); this section did not apply it, and 5.2 as first written is the cost of that.
+
+#### The radix sort, which is what ships
+
+| splats | padded to | GPU drawn | CPU whole pass | GPU whole pass | ns per splat |
+|---:|---:|---:|---:|---:|---:|
+| 4,096 | 4,096 | 3,043 | 0.14 ms | **0.165 ms** | 40.3 |
+| 100,000 | 100,352 | 74,431 | 2.60 ms | **0.138 ms** | 1.38 |
+| 500,000 | 501,760 | 372,165 | 16.55 ms | **0.237 ms** | 0.47 |
+| 1,500,000 | 1,501,184 | 1,116,534 | — | **0.561 ms** | 0.37 |
+| 2,000,000 | 2,000,896 | 1,488,977 | 155.3 ms† | **0.688 ms** | 0.34 |
+| 2,100,000 | 2,101,248 | 1,563,181 | — | **0.724 ms** | 0.34 |
+| 3,000,000 | 3,000,320 | 2,233,155 | — | **0.957 ms** | 0.32 |
+| 4,000,000 | 4,001,792 | 2,977,678 | — | **1.311 ms** | 0.33 |
+| 6,000,000 | 6,000,640 | 4,466,033 | — | **1.709 ms** | 0.28 |
+| 8,000,000 | 8,001,536 | 5,954,725 | — | **2.206 ms** | 0.28 |
 
 The draw count is the GPU pass's, which runs with the budget lifted (`MaxSplats = 0`). The CPU pass
 applies its default 1,048,576 budget, which binds only on the 2 M row — † marks it, and there the
 CPU number is the cost of doing *less* work than the GPU column beside it. On every other row the
 budget never engages and the two passes cull the same set.
 
-**This is the number that reversed the decision.** A 16.7 ms frame at 60 Hz has everything else in
-the engine in it too. On the CPU, giving the ordering a fifth of the frame bought 120–150 k visible
-splats; on the GPU the same 3.3 ms buys **2 M**, and 2 M is inside the 1–6 M range published 3DGS
-room captures occupy.
+**The last column is the result.** From 500 k to 8 M the pass costs 0.28–0.47 ns per splat, drifting
+*down* as the fixed cost amortises — the ordering is linear in the cloud, which is what a four-pass
+radix promises and what the bitonic network could not do at any size. **2,000,000 and 2,100,000, the
+pair this whole issue was filed over, now differ by 5.2 % for 5.0 % more splats.** Below about 100 k the pass is dominated by
+its own fixed cost — one cull, four histograms, four scatters and four `GPUPrefixSum` calls, whatever
+the count — which is why the 4,096 row is 30 ns per splat. The A/B below measures that end too,
+because "is the new sort ever slower?" is the obvious question and the fixture is where the answer
+could be yes.
 
-**Then look at the last three rows, because they are the more useful finding.** 2,000,000 and
-2,100,000 differ by 5 % in splat count and by **6.1× in cost**. Nothing about the cloud explains
-that; what changed is the padding. The bitonic network is only defined on a power-of-two array, so
-2,000,000 pads to 2²¹ and 2,100,000 pads to 2²² — twice the array, and one more k level, meaning 13
-extra global passes over it.
+#### The radix against the bitonic network it replaced
 
-**A doubling that costs 6.1× is more than a doubling explains, and the remainder is not accounted
-for here.** What *is* derivable: the array doubles (2×), and 2²² has one more k level than 2²¹, which
-is 13 more global passes rather than 78 (1.17×). Together that predicts about **2.3×**, against 6.1×
-measured — so roughly 2.6× is unexplained.
+Interleaved A,B,A,B in one process (`MeasureRadixAgainstTheBitonicControl`), because the same
+dispatch sequence on this box has been measured at 0.506, 1.127 and 2.150 ms across three runs and
+an A-then-B comparison charges all of that drift to whichever ran second.
 
-Cache is the obvious suspect and the arithmetic does **not** support the simple version of it: at
-8 bytes per slot the key and payload arrays are 16 MiB at 2²¹ and 32 MiB at 2²², both of which fit
-inside this GPU's 72 MB last-level cache, so "the working set falls out of cache" is not it. Whether
-the bitonic access pattern actually realises that reuse is a different question, and one
-`GL_TIME_ELAPSED` cannot answer — it establishes the timing and the padding, not the mechanism, and
-no profiler counter was collected. Anyone who needs the mechanism should collect one.
+| splats | radix pad | bitonic pad | radix | bitonic | speed-up |
+|---:|---:|---:|---:|---:|---:|
+| 4,096 | 4,096 | 4,096 | 0.124 ms | **0.081 ms** | **0.65×** |
+| 500,000 | 501,760 | 524,288 | **0.246 ms** | 0.484 ms | 1.97× |
+| 2,000,000 | 2,000,896 | 2,097,152 | **0.712 ms** | 1.239 ms | 1.74× |
+| 2,100,000 | 2,101,248 | 4,194,304 | **0.751 ms** | 2.164 ms | 2.88× |
 
-None of that changes the decision, because the decision rests on the shape rather than the cause:
+Three things to read off it, and the first is the one a table like this usually omits.
 
-* **cost is a step function of `PaddedCapacityFor(count)`, not of `count`.** One splat over a power
-  of two doubles the array and can cost several times more;
-* past that step it keeps climbing — 2.1 M and 4 M pad identically and still differ by 2.5× — so the
-  step is not the whole story, but it is the discontinuity that would bite an artist who added a few
-  splats to a scan and watched the frame time triple.
+**The radix loses on the fixture, by 1.5×.** At 4,096 splats both sorts pad to the same 4,096 and the
+network needs only six global steps and twelve local ones, against a radix whose cost is nine
+dispatches and four scans no matter how small the cloud is. That is a real regression at that size
+and it is the right trade anyway: 0.124 ms against 0.081 ms is 43 microseconds on a cloud nobody
+ships, and the crossover is somewhere below 100 k where both are already under 0.15 ms.
 
-**So the demonstrated envelope is 2 M splats per view, not 6 M.** Between the padding boundaries at
-2²¹ and 2²² the ordering pass alone costs 8–20 ms, which is a whole 60 Hz frame before anything else
-in the engine runs. §6 makes the consequence a condition rather than a footnote.
+**The radix is 1.7–2.0× faster where the padding does not bite**, which is the algorithmic win — four
+passes over memory against 78 global ones.
+
+**And it is 2.9× faster one splat past a power of two**, which is the padding win. That one does not
+shrink with tuning; it disappears, because there is no count at which the radix pays a step.
+
+**These four ratios are the most trustworthy numbers in this section**, and that is a property of the
+method rather than luck: two runs on different box states produced 0.65× / 1.97× / 1.74× / 2.88× and
+0.66× / 1.98× / 1.72× / 2.88×. Interleaving cancels the drift that moves both columns together, which
+is why §5.3 already said the ratio is what to trust and the absolutes are not. Re-derive the
+absolutes before quoting them anywhere else; the ratios should reproduce.
+
+#### The step was real, and it was 1.75–2.7×, not 6.1×
+
+The bitonic column above crosses 2²¹ between its last two rows, so it measures the step this issue
+was filed over — and it comes out at **1.75×** in the run tabulated, and at 2.3×, 2.6× and 2.7× on
+three repeat runs, against the **6.1×** recorded when this ADR was first written.
+
+The difference is the warm-up, and it resolves a loose end that section left open. The first version
+reasoned that a doubled array plus one more k level predicts about **2.3×**, measured 6.1×, and
+recorded that "roughly 2.6× is unexplained" — then went looking for a cache mechanism and correctly
+reported that the arithmetic did not support one, because 16 MiB and 32 MiB both fit this GPU's
+72 MB last-level cache. **The unexplained remainder was not a cache effect. It was a cold GPU.**
+2,100,000 was the row whose cloud took longest to build in the runs available at the time, so it
+absorbed the largest downclock. The predicted 2.3× was right all along.
+
+That correction makes the step **less than half** what #1043's problem statement claims, and it is
+worth saying plainly rather than leaving the old number standing: anyone re-deriving the motivation
+from that issue will not reproduce 6.1×. It does not change the decision, because the decision never
+rested on the size of the step:
+
+* **the bitonic cost was a step function of `PaddedCapacityFor(count)` and the radix's is not.**
+  A 1.75–2.7× discontinuity for 5 % more splats is still a discontinuity an artist would hit by
+  adding splats to a scan, and still one nothing on screen explains;
+* the radix is faster **everywhere above about 100 k**, step or no step, so removing the
+  discontinuity cost nothing to buy — 43 microseconds on a 4,096-splat fixture, and nothing anywhere
+  a real capture lives.
 
 Two details about the CPU side are worth keeping. **The sort was never the expensive half of the CPU
 pass** — at 500 k it was 5 ms of 16.5; the other 11 ms was one covariance unpack, one dot product and
@@ -310,9 +413,11 @@ them. `Splat_Corner_ReversedOrder.png` is the same pose drawn front-to-back — 
 inverts, and the frame moves 3.9/255 mean absolute difference, which is what makes the sort's
 necessity visible rather than asserted.
 
-`Splat_Corner_GpuOrdered.png` is the same pose ordered by the GPU pass and drawn indirectly. It
-matches the CPU-ordered frame to under 0.5/255, which is the end-to-end check that the index parity
-in §3.1 actually reaches the screen.
+`Splat_Corner_GpuOrdered.png` is the same pose ordered by the GPU pass and drawn indirectly. Since
+#1043 it matches the CPU-ordered frame at **0.0000/255** — the two PNGs are byte-identical, where
+the bitonic version agreed to under 0.5/255. That is the end-to-end check that the index parity in
+§3.1 actually reaches the screen, and it is exact now because a stable radix over a total order has
+no freedom left: same order buffer, same draw, same pixels.
 
 ### 5.5 Selection against merging, at matched splat counts
 
@@ -354,21 +459,33 @@ these terms:
    and as documentation of the algorithm; it is not a supported runtime path at scan scale.
 2. **LOD is built offline by merging.** The selection budget in `ViewSettings::MaxSplats` remains
    only as the negative control the tests pin; new work must not reach for it as a LOD knob.
-3. **The supported envelope is 2 M splats per view**, which is `PaddedCapacityFor` = 2²¹. That is
-   not a soft guideline: §5.2 measures the next step at 6.1× the cost for 5 % more splats. A capture
-   that needs more is a request for the radix sort in §6's list, not for a bigger budget.
-4. **The contract in §4 does not change quietly.** A PR that gives a splat cloud shadows, collision
+3. **The ordering pass no longer sets an envelope, and #1043 is why the number moved rather than
+   the reasoning.** The first version of this ADR said 2 M splats per view, and that ceiling was the
+   bitonic network's power-of-two padding: past 2²¹ the ordering alone cost a whole 60 Hz frame.
+   With the radix, §5.2 measures **0.69 ms at 2 M, 1.71 ms at 6 M and 2.21 ms at 8 M** and
+   0.28–0.47 ns per splat throughout, so the ordering is under an eighth of a 60 Hz frame across the
+   entire 1–6 M range that published 3DGS room captures occupy, and there is no discontinuity
+   anywhere in it. **Nothing in this ADR now measures an ordering limit below 8 M**, which is where
+   the sweep stops, not where the pass stops scaling.
+4. **What binds instead is the raster pass, and this ADR does not have that number at scan scale.**
+   §5.3 measured the splat raster at 6.0 ms for 496 k splats drawn and at 1.8× an equivalent opaque
+   pass, and splat cost is *overdraw* cost, which grows as the camera approaches. Extrapolating that
+   row linearly puts a 1.5 M-splat draw at a whole frame on its own. So the honest statement is that
+   the constraint moved from the ordering, which is now measured and cheap, to the raster, which is
+   scene-dependent and was only ever measured on a 4,096-splat fixture. **Anyone who needs an
+   envelope for a real capture has to measure the raster on that capture**; quoting 2 M, or 8 M, as
+   a supported number would be inventing one.
+5. **The contract in §4 does not change quietly.** A PR that gives a splat cloud shadows, collision
    or probe capture amends this ADR first.
 
-Still unbuilt. The first is a performance requirement the envelope above depends on; the rest are
-integration work rather than open questions:
+Done since the first version of this ADR:
 
-- **Replace the bitonic sort with a four-pass LSD radix** ([#1043](https://github.com/drsnuggles8/OloEngineBase/issues/1043)).
-  This is what lifts the 2 M ceiling, and §5.2 is why: bitonic pads to a power of two, so the cost
-  is a step function of the padding rather than of the cloud, and its 91 global passes over memory
-  at 2²² are what fall off the cache. A radix needs no padding at all and makes four passes over
-  memory instead of ninety-one. `GPUPrefixSum` (#713) supplies the scan; the stability problem
-  §3.3 describes is the work.
+- **The four-pass LSD radix sort** ([#1043](https://github.com/drsnuggles8/OloEngineBase/issues/1043)),
+  which is what lifted the ordering ceiling. §3.3 is the algorithm and the stability argument, §5.2
+  the measurement. `GPUPrefixSum` (#713) supplies the scan, consumed unchanged.
+
+Still unbuilt, all of it integration work rather than open questions:
+
 - **`SplatCloudComponent` and its cross-binding touch-points** — the `CLAUDE.md` table in full, plus
   a scene-YAML block written by hand because the component holds a `Ref<T>`.
 - **Content-sniffing PLY import dispatch** — `.ply` already means `MeshSource`, so the importer has
@@ -380,8 +497,13 @@ integration work rather than open questions:
 
 The three integration items are deliberately not filed as issues: they are one coherent piece of work
 that should be scoped together once someone commits to shipping the feature, and three separate
-issues in front of the picker would invite starting in the middle. The radix sort is filed, because
-it is a self-contained performance problem with a measured motivation and it gates the envelope.
+issues in front of the picker would invite starting in the middle. The radix sort *was* filed
+separately, because it was a self-contained performance problem with a measured motivation and it
+gated the envelope; that is the shape to copy if anything else here needs splitting out.
+
+**The next measurement anyone should take is the raster pass at 1–6 M splats**, per point 4 above.
+It is not filed either, because it belongs with the integration work that would give it a real
+scene to measure -- a 4,096-splat fixture cannot answer it.
 
 ---
 

--- a/docs/agent-rules/gpu-scan-compaction.md
+++ b/docs/agent-rules/gpu-scan-compaction.md
@@ -247,3 +247,20 @@ and skip the whole path when the answer is no. `GPUPrefixSumTest` does exactly t
   buffer method. The empty-scan case originally called `ClearData()` through one; routing `count == 0`
   through the normal single-work-group dispatch (every lane out of range, total 0) removed both the
   const problem and the special case.
+- **`kMaxElements` bounds your TILE SIZE, not just your element count.** A histogram-and-scatter pass
+  built on this scan (the splat radix sort, #1043) scans `bins x ceil(maxCount / tile)` entries, so
+  shrinking the tile for occupancy silently walks the largest supported input past the scan's 16.7 M
+  ceiling — at the ceiling, where nothing routinely runs. Pin the relation with a `static_assert`
+  next to the tile constant rather than a comment; the splat pass has one.
+- **A radix sort needs a tie test, and it needs a MULTI-TILE one.** An LSD radix needs stability to
+  be *correct* — each pass carries the last one's order forward — so a wrong per-tile rank scrambles
+  distinct keys and fails loudly. The quiet case is the tie: with equal keys any permutation is
+  correctly sorted, so only the payload order is wrong. And a *single-tile* tie cloud cannot see a
+  cross-tile rank error at all, which is what the transposed `hist[bin * numTiles + tile]` layout
+  exists to prevent. Test both (`MatchesTheCpuReference{WhenEveryDepthIsIdentical,
+  WhenTiesSpanManyRadixTiles}`).
+- **Prove the algorithm on the CPU before spending a build on it.** Transcribing the tile
+  decomposition, the splits and the scatter into ~150 lines of Python and diffing against `sorted()`
+  costs minutes against a build that costs an hour of lock queue. It is also how the bullet above was
+  checked rather than guessed: replaying the shader against a strided lane assignment and against an
+  atomic-style random rank showed which cases each actually fails.


### PR DESCRIPTION
Replaces the bitonic GPU splat sort with a four-pass LSD radix, so the per-view ordering cost is a
curve in the cloud rather than a step function of the padding.

## What changed

Per digit: a tile histogram written **transposed** as `hist[bin * numTiles + tile]`, one
`GPUPrefixSum` exclusive scan of it, then a scatter. Four digits, so eight sort dispatches plus a
cull plus four scan calls, **whatever the cloud is**. `GPUPrefixSum` is consumed unchanged — no edit
to it, additive or otherwise.

The array is padded to a whole 2048-element tile and no further, so the overhead is bounded by 2047
elements however large the cloud is. The cull, the key and the payload are untouched: the issue lists
both as non-goals and the key is already exact and monotonic.

**Stability was the work, and the stable route was taken — no 64-bit composite fallback.** The parity
test asserts the GPU order is index-for-index identical to the CPU reference, which holds only
because the comparison is a total order over (key, index). A radix sees the key alone, so it
reproduces that order only if it is stable over an array the cull writes in index order. The rank
that has to be exact — how many earlier elements of the same tile carry the same digit — is computed
by **locally sorting each tile with eight one-bit splits**, each of which is a workgroup prefix sum
and stable by construction. That sidesteps the 256×256 shared histogram #1038 correctly judged
unaffordable (it is 256 KiB). Cross-tile stability is free from the transposed layout.

**No parity assertion was weakened.** Four poses, eight awkward counts and the all-identical-depths
tie case are byte-identical to #1038's. Three cases were *added*.

**The bitonic network stays as the A/B control**, compiled lazily so the shipping path pays nothing
for it, and exercised by `TheBitonicControlStillAgreesWithTheCpuReference` so it cannot rot into a
flattering comparison. Same role `SplatSpike_OpaqueBaseline.glsl` plays for the raster pass
(ADR 0018 §5.3). Timings here move up to 4× run to run, so "the radix is faster" is only a claim if
both paths can be timed in one process, alternating.

## Measurements

RTX 4090, idle box, `GL_TIME_ELAPSED`, **250 ms warm-up**, min of nine adjacent samples. Not CI
gates.

| splats | padded | ordering | ns/splat |
|---:|---:|---:|---:|
| 500,000 | 501,760 | 0.237 ms | 0.47 |
| 1,500,000 | 1,501,184 | 0.561 ms | 0.37 |
| **2,000,000** | 2,000,896 | **0.688 ms** | 0.34 |
| **2,100,000** | 2,101,248 | **0.724 ms** | 0.34 |
| 3,000,000 | 3,000,320 | 0.957 ms | 0.32 |
| 6,000,000 | 6,000,640 | 1.709 ms | 0.28 |
| 8,000,000 | 8,001,536 | 2.206 ms | 0.28 |

**The 2.0 M / 2.1 M pair — the whole motivation — is 5.2 % apart for 5.0 % more splats**, against
the step it used to pay. ns/splat is flat-to-falling from 500 k to 8 M.

Interleaved A/B, and these ratios reproduced across two runs to within 0.02×:

| splats | radix | bitonic | speed-up |
|---:|---:|---:|---:|
| 4,096 | 0.124 ms | **0.081 ms** | **0.65×** |
| 500,000 | 0.246 ms | 0.484 ms | 1.97× |
| 2,000,000 | 0.712 ms | 1.239 ms | 1.74× |
| 2,100,000 | 0.751 ms | 2.164 ms | 2.88× |

**The radix loses on the 4,096-splat fixture by 1.5×** and that row is in the table rather than
omitted: its fixed cost is nine dispatches plus four scans whatever the cloud, against a network that
at that size is six global steps. It is 43 microseconds on a cloud nobody ships.

### A correction to ADR 0018's own earlier measurement

The step this issue was filed over was recorded as **6.1×**. Measured with a proper warm-up it is
**1.75–2.7×**. §5.2's original arithmetic predicted ~2.3× and called the remainder "unexplained",
then looked for a cache mechanism and correctly reported the numbers did not support one — because
the remainder was a **downclocked GPU**, not cache. Building a 2 M cloud in a Debug host takes
seconds, the GPU idles through it, and one warm-up dispatch does not recover the clocks; the slow
rows were the rows whose CPU-side setup took longest. The ADR now says so.

That makes the motivation smaller than #1043 claims, and the ADR says that plainly rather than
leaving the old number standing. It does not change the conclusion: a 1.75–2.7× discontinuity for
5 % more splats is still a discontinuity nothing on screen explains, and the radix is faster
everywhere above ~100 k anyway.

## ADR 0018

Updated in this PR, as required. §5.2 rewritten with the method note and all three tables; §3.3
rewritten from "why bitonic, not radix" to the radix and its stability argument; §6's envelope
restated — **the ordering pass no longer sets one**, and the honest statement is that the constraint
moved to the raster pass, which §5.3 only ever measured on a 4,096-splat fixture. I did not invent a
new supported number to replace 2 M.

## Ride-along fix

The indirect draw command is now zeroed on every path that invalidates the order buffer, not just per
frame. `SetCloud` left it uninitialised (a `DrawIndirect` before the first `BuildOrdering` read
whatever the driver returned — pre-existing since #1038), and the new `SetSortAlgorithm` reallocates
the order buffer under a command still holding the last frame's count. Both now draw nothing rather
than a plausible frame of garbage indices. It is **not** in its own commit because it lives inside a
function this change rewrote; isolating it would have produced a commit that neither builds nor reads
alone.

## Review guide

**Where I'd look hardest**

1. `OloEditor/assets/shaders/tests/SplatSpike_RadixScatter.comp` — the eight one-bit splits and the
   `s_BinStart` run detection. This is the only place stability can be wrong, and a wrong rank
   produces a plausible frame. The `barrier()` immediately before the permute write is the
   load-bearing one: it is what stops the previous iteration's read-back racing the overwrite.
2. `GaussianSplatGpuOrdering.cpp::SortRadix` — the ping-pong. Four passes must land the result back
   in `m_KeyBuffer`/`m_OrderBuffer`; an odd pass count leaves it in scratch and the draw reads stale
   data. Pinned by a `static_assert` and a runtime assert, but it is the kind of thing that survives
   both if someone adds a fifth pass.
3. `GaussianSplatGpuOrderingParityTest.cpp::WarmUp` — the measurement method. Every number in the ADR
   depends on it, and the previous method produced a table that read like a finding and was not.

**What I verified, and how**

- `GaussianSplatGpuOrderingParityTest` — 9/9, including the four unchanged poses, the eight unchanged
  awkward counts, the unchanged tie case, and the new tile-seam and multi-tile-tie cases. Full splat
  suite **47/47**, run twice.
- **Before the first build**, I transcribed the scatter's exact tile decomposition, splits and
  scatter into Python and diffed against `sorted()` across eleven key distributions — all stable.
  Then replayed it against two *deliberately wrong* ranks (a strided lane assignment and an
  atomic-style random one) to find out which tests actually catch which failure. That is how the test
  and ADR comments about the failure modes came to be right: my first draft of them said an unstable
  radix "passes every other test", which is false — an LSD radix needs stability to be *correct*, so
  distinct-key cases fail loudly and only ties fail quietly. The simulation caught it.
- The same method showed the 2000-splat tie case is a **single tile** and cannot see a cross-tile
  rank error at all — which is why `MatchesTheCpuReferenceWhenTiesSpanManyRadixTiles` exists.
- **Rendering evidence**: `GpuOrderedFrameMatchesTheCpuOrderedFrame` reports **0.0000/255** — the
  GPU-ordered and CPU-ordered PNGs are now **byte-identical** (`cmp` confirms), where the bitonic
  version agreed to under 0.5/255. I looked at `Splat_Corner_GpuOrdered.png` and `Splat_Front.png`:
  discs cut each other along the right half-spaces, edge-on discs are thin lines, the shell
  composites over all of them. No golden churn — `git status` on `assets/tests/visual/` is clean
  after two full runs.
- All four `.comp` files validated with `glslc` against **both** `vulkan1.2` and `opengl4.5`.

**Least confident about**

**The 8 M row, and the absolutes generally.** The A/B ratios reproduced to within 0.02× across runs;
the sweep's absolutes moved 5–15 % between runs and much more when a sibling worktree was compiling.
8 M is the largest count measured and it is where I have the fewest clean samples. The *shape* —
linear, no step — is what I would defend; a specific millisecond figure is not.

Second: I have not run this on any GPU but this RTX 4090. The scatter uses 20 KiB of shared memory
(within the 32 KiB GL 4.3 minimum) and no subgroup ops, so it should be portable, but
`assets/shaders/tests/` is excluded from `ShaderCompilationTest`, so **CI will not compile these two
shaders at all** and the parity tests skip headless. This lands untested by CI by construction — the
`glslc` runs above are the substitute.

**Deliberately not tested**

The `ResetIndirectCommand` hardening. Observing it needs a readback of the indirect buffer, which is
new API surface for a three-line safety net on a path no caller uses; the failure it prevents is
"draws nothing" instead of "draws garbage", which is the safe direction either way.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - GPU ordering now uses a radix-sort pipeline by default, improving scalability for large Gaussian-splat scenes.
  - Sorting capacity is aligned to 2,048-element tiles instead of power-of-two array limits, removing the previous 2-million-splat ordering ceiling.
  - GPU ordering now matches CPU ordering byte-for-byte, including stable handling of equal-depth splats.

- **Reliability**
  - Indirect rendering commands and GPU buffers are reset and synchronized more consistently during ordering updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->