### PR TITLE
fix(vulkan): bind raw buffers to SSBO points instead of losing the device

### DIFF
--- a/OloEngine/src/Platform/Vulkan/VulkanBindingState.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBindingState.cpp
@@ -73,6 +73,21 @@ namespace OloEngine
         m_StorageBuffers[binding] = buffer;
     }
 
+    void VulkanBindingState::SetStorageBufferAddress(u32 binding, u64 address)
+    {
+        if (binding >= kMaxBufferBindings)
+        {
+            OLO_CORE_WARN("VulkanBindingState: SSBO binding {} out of range", binding);
+            return;
+        }
+        m_StorageBufferAddresses[binding] = address;
+    }
+
+    u64 VulkanBindingState::GetStorageBufferAddress(u32 binding) const
+    {
+        return binding < kMaxBufferBindings ? m_StorageBufferAddresses[binding] : 0;
+    }
+
     VulkanUniformBuffer* VulkanBindingState::GetUniformBuffer(u32 binding) const
     {
         return binding < kMaxBufferBindings ? m_UniformBuffers[binding] : nullptr;
@@ -81,6 +96,21 @@ namespace OloEngine
     VulkanStorageBuffer* VulkanBindingState::GetStorageBuffer(u32 binding) const
     {
         return binding < kMaxBufferBindings ? m_StorageBuffers[binding] : nullptr;
+    }
+
+    void VulkanBindingState::ClearStorageBufferAddress(u64 address)
+    {
+        if (address == 0)
+        {
+            return;
+        }
+        for (auto& entry : m_StorageBufferAddresses)
+        {
+            if (entry == address)
+            {
+                entry = 0;
+            }
+        }
     }
 
     void VulkanBindingState::ClearBuffer(const void* buffer)

--- a/OloEngine/src/Platform/Vulkan/VulkanBindingState.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBindingState.cpp
@@ -98,6 +98,24 @@ namespace OloEngine
         return binding < kMaxBufferBindings ? m_StorageBuffers[binding] : nullptr;
     }
 
+    // GLOBAL-ONLY BY CONSTRUCTION, and that is sufficient — the reasoning is
+    // not local, so it is written down here (issue #1052).
+    //
+    // Get() answers a WORKER's mirror while a RecordParallel item runs on that
+    // thread, so clearing through Get() clears one mirror. Both callers —
+    // VulkanRawBufferRegistry::Allocate's orphan path and ::Destroy — are
+    // RefuseOnWorker entry points, so they always run on the render thread and
+    // Get() is Global() there. A worker mirror cannot be holding a stale
+    // address at that moment either: RecordParallel forks through a BLOCKING
+    // ParallelFor under an m_InParallelRegion guard, so while worker mirrors
+    // exist the render thread is inside that call and cannot be retiring a
+    // buffer; and a worker seeds its copy FROM Global at the fork, so a clear
+    // that happened before the fork is inherited.
+    //
+    // This is the same discipline the object-pointer twin ClearBuffer relies on
+    // (see the header's dangling-pointer note). If RecordParallel ever becomes
+    // non-blocking, or a resource entry point loses its RefuseOnWorker guard,
+    // BOTH paths need active-mirror tracking, not just this one.
     void VulkanBindingState::ClearStorageBufferAddress(u64 address)
     {
         if (address == 0)

--- a/OloEngine/src/Platform/Vulkan/VulkanBindingState.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanBindingState.h
@@ -82,6 +82,21 @@ namespace OloEngine
         void SetStorageBuffer(u32 binding, VulkanStorageBuffer* buffer);
         [[nodiscard]] VulkanUniformBuffer* GetUniformBuffer(u32 binding) const;
         [[nodiscard]] VulkanStorageBuffer* GetStorageBuffer(u32 binding) const;
+        // A raw buffer (CreateBufferHandle) bound to an SSBO binding point:
+        // there is no engine object to point at, so the bind stages the ADDRESS
+        // (issue #1052). Set to 0 to clear. Only consulted when the same binding
+        // has no VulkanStorageBuffer occupant, so the object path is unchanged.
+        // `u64` rather than VkDeviceAddress: this header is deliberately free of
+        // the Vulkan headers (Core/Base + ShaderBindingLayout only), and the
+        // publication site already carries the address as u64.
+        void SetStorageBufferAddress(u32 binding, u64 address);
+        [[nodiscard]] u64 GetStorageBufferAddress(u32 binding) const;
+        // The raw-buffer twin of ClearBuffer: called when a raw buffer's
+        // storage is retired, so a destroyed allocation's address can never be
+        // published to a shader. A staged address outlives its buffer
+        // otherwise, which is the dangling-pointer version of the very fault
+        // this path exists to prevent (issue #1052).
+        void ClearStorageBufferAddress(u64 address);
         // Called from destructors: drop every entry pointing at `buffer`.
         void ClearBuffer(const void* buffer);
 
@@ -127,6 +142,7 @@ namespace OloEngine
       private:
         std::array<VulkanUniformBuffer*, kMaxBufferBindings> m_UniformBuffers{};
         std::array<VulkanStorageBuffer*, kMaxBufferBindings> m_StorageBuffers{};
+        std::array<u64, kMaxBufferBindings> m_StorageBufferAddresses{};
         std::array<u32, kMaxTextureSlots> m_TextureHeapSlots{};
         std::array<u32, kMaxTextureSlots> m_TextureSamplerSlots{}; ///< Zero-init IS DefaultSlot.
         std::array<u32, kMaxTextureSlots> m_ImageHeapSlots{};

--- a/OloEngine/src/Platform/Vulkan/VulkanBufferResources.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanBufferResources.cpp
@@ -294,6 +294,9 @@ namespace OloEngine
         // under the SAME identity.
         if (entry->Buffer != VK_NULL_HANDLE || entry->Allocation != VK_NULL_HANDLE)
         {
+            // Unstage before retiring: a bind point still holding the old
+            // address would publish a freed allocation (issue #1052).
+            VulkanBindingState::Get().ClearStorageBufferAddress(entry->DeviceAddress);
             VulkanDeferredReclaim::Get().Enqueue(entry->Buffer, entry->Allocation);
             *entry = Entry{};
         }
@@ -304,8 +307,16 @@ namespace OloEngine
         // The GL twin's raw buffers serve as SSBO scratch, copy endpoints and
         // indirect-args storage interchangeably; one conservative usage set
         // keeps the facade's "a buffer is a buffer" contract.
+        //
+        // SHADER_DEVICE_ADDRESS (issue #1052): a raw buffer bound to an SSBO
+        // binding point reaches the shader as a root-data POINTER like every
+        // other buffer, and the address cannot be taken without this CREATE-time
+        // bit. Its absence is what made SSBO_VIRTUAL_INDICES unbindable and lost
+        // the device on every virtual-geometry scene. VulkanVertexBuffer and
+        // VulkanIndexBuffer already set it; the raw family was the outlier.
         bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-                           VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+                           VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
+                           VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
         VmaAllocationCreateInfo allocInfo{};
@@ -351,6 +362,11 @@ namespace OloEngine
             entry->Coherent = (memProps & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0;
         }
 
+        VkBufferDeviceAddressInfo addressInfo{};
+        addressInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+        addressInfo.buffer = buffer;
+        entry->DeviceAddress = vkGetBufferDeviceAddress(device->GetDevice(), &addressInfo);
+
         // Keep generic native resolution working (CopyBufferSubData's operands
         // and barrier lowering resolve through the identity registry).
         RHI::ResourceRegistry::Get().UpdateNative(handle, VkHandleToU64(buffer));
@@ -371,6 +387,9 @@ namespace OloEngine
         }
         if (it->second.Buffer != VK_NULL_HANDLE || it->second.Allocation != VK_NULL_HANDLE)
         {
+            // Unstage before retiring — see the matching call in Allocate's
+            // orphan path (issue #1052).
+            VulkanBindingState::Get().ClearStorageBufferAddress(it->second.DeviceAddress);
             VulkanDeferredReclaim::Get().Enqueue(it->second.Buffer, it->second.Allocation);
         }
         m_Entries.erase(it);

--- a/OloEngine/src/Platform/Vulkan/VulkanBufferResources.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanBufferResources.h
@@ -158,6 +158,10 @@ namespace OloEngine
             bool Coherent = true;
             u64 Size = 0;
             RHI::MemoryResidency Residency = RHI::MemoryResidency::DeviceLocal;
+            /// Root-data address, for a raw buffer bound to an SSBO binding
+            /// point (issue #1052). Object-backed buffers keep theirs on the
+            /// object; a raw buffer has no object, so it lives here.
+            VkDeviceAddress DeviceAddress = 0;
         };
 
         [[nodiscard]] static VulkanRawBufferRegistry& Get();

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -2275,8 +2275,32 @@ namespace OloEngine
                     static VulkanWarnOnceSet s_WarnedBindings; // items may fail concurrently (#806)
                     if (s_WarnedBindings.Insert(std::string(shaderName) + ":" + std::to_string(binding.Binding)))
                     {
-                        OLO_CORE_WARN("[RHI/Vulkan] '{}' buffer binding {} has no published occupant — null block",
-                                      shaderName, binding.Binding);
+                        // An unfed UBO reads defined zeros — wrong, survivable.
+                        // An unfed SSBO is a small block a shader INDEXES, and
+                        // the index usually comes from a DIFFERENT buffer that
+                        // was fed correctly, so the read lands outside it and
+                        // loses the device. That asymmetry is the whole of
+                        // #1052, so the two cases do not get the same voice.
+                        if (isStorage)
+                        {
+                            OLO_CORE_ERROR("[RHI/Vulkan] '{}' STORAGE binding {} has no published occupant — "
+                                           "substituting the null block, which a shader that indexes this buffer "
+                                           "will read past (issue #1052). Bind it, or stop declaring it.",
+                                           shaderName, binding.Binding);
+                        }
+                        else
+                        {
+                            OLO_CORE_WARN("[RHI/Vulkan] '{}' buffer binding {} has no published occupant — null block",
+                                          shaderName, binding.Binding);
+                        }
+                    }
+                    // Counted separately from the stub tally so existing
+                    // "must not fall through to a stub" assertions keep meaning
+                    // exactly what they meant, and a tenant can assert on THIS
+                    // deliberately.
+                    if (isStorage)
+                    {
+                        m_UnfedStorageBindings.fetch_add(1, std::memory_order_relaxed);
                     }
                     address = VulkanFrameArena::Get().GetNullBlockAddress();
                 }
@@ -3818,6 +3842,14 @@ namespace OloEngine
         if (entry == nullptr || entry->Kind != VulkanRootObjectKind::UniformBuffer)
         {
             VulkanBindingState::Get().SetUniformBuffer(bindingPoint, nullptr);
+            // An UNBIND is routine; a handle that resolves nowhere is not. Same
+            // rule as BindStorageBuffer below (issue #1052): a bind that cannot
+            // do what it was asked says so, rather than leaving the point empty
+            // and letting the publication site substitute a block.
+            if (buffer.IsValid())
+            {
+                UnimplementedStub("BindUniformBuffer(unresolvable buffer)", StubKind::PreconditionFailure);
+            }
             return;
         }
         VulkanBindingState::Get().SetUniformBuffer(bindingPoint, static_cast<VulkanUniformBuffer*>(entry->Object));

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -2252,6 +2252,16 @@ namespace OloEngine
                     // dispatch fresh buffers.
                     address = commandOrderedBufferReads ? ssbo->GetRootDataAddress() : ssbo->GetDeviceAddress();
                 }
+                else if (isStorage)
+                {
+                    // A raw buffer staged by BindStorageBuffer (issue #1052).
+                    // No snapshot seam applies: a raw buffer has no per-frame
+                    // arena copy, so draws and dispatches both read the one
+                    // persistent allocation — the pre-snapshot GL behaviour,
+                    // and what its GPU-writing tenants (indirect args, the
+                    // virtual-geometry index arena) require anyway.
+                    address = bindingState.GetStorageBufferAddress(binding.Binding);
+                }
                 if (address == 0)
                 {
                     // Warn once per shader+binding, then substitute the
@@ -3815,13 +3825,47 @@ namespace OloEngine
 
     void VulkanRendererAPI::BindStorageBuffer(u32 bindingPoint, RHI::ResourceHandle buffer)
     {
+        auto& bindingState = VulkanBindingState::Get();
         const auto* entry = VulkanRootObjectRegistry::Get().Lookup(buffer);
-        if (entry == nullptr || entry->Kind != VulkanRootObjectKind::StorageBuffer)
+        if (entry != nullptr && entry->Kind == VulkanRootObjectKind::StorageBuffer)
         {
-            VulkanBindingState::Get().SetStorageBuffer(bindingPoint, nullptr);
+            bindingState.SetStorageBuffer(bindingPoint, static_cast<VulkanStorageBuffer*>(entry->Object));
+            bindingState.SetStorageBufferAddress(bindingPoint, 0);
             return;
         }
-        VulkanBindingState::Get().SetStorageBuffer(bindingPoint, static_cast<VulkanStorageBuffer*>(entry->Object));
+
+        // A RAW buffer (CreateBufferHandle) is a legitimate SSBO occupant, not
+        // an error — GL's "a buffer is a buffer" reaches here whenever one
+        // object serves two roles. Virtual geometry's index arena is exactly
+        // that: an element buffer AND SSBO_VIRTUAL_INDICES, so it lives in
+        // VulkanRawBufferRegistry and never in the root-object registry.
+        //
+        // This arm used to fall through to SetStorageBuffer(nullptr) SILENTLY.
+        // The binding then took the frame arena's null block, and because that
+        // block is small while the shaders index it with real cluster offsets
+        // (localIndices[cluster.IndexBase + ...]), every virtual-geometry scene
+        // read far past it and lost the device — VK_ERROR_DEVICE_LOST out of
+        // vkQueueSubmit2, reported as a READ of an invalid address. The null
+        // block defends against dereferencing address 0; it cannot defend
+        // against an out-of-range read from a legitimately mapped substitute.
+        // Issue #1052.
+        bindingState.SetStorageBuffer(bindingPoint, nullptr);
+        if (auto* raw = VulkanRawBufferRegistry::Get().Lookup(buffer);
+            raw != nullptr && raw->DeviceAddress != 0)
+        {
+            bindingState.SetStorageBufferAddress(bindingPoint, raw->DeviceAddress);
+            return;
+        }
+        bindingState.SetStorageBufferAddress(bindingPoint, 0);
+
+        // An UNBIND (the null handle) is routine — passes clear their bind
+        // points. A handle that resolves nowhere is not: it is the silent
+        // no-occupant path above, and it must say so rather than let the
+        // publication site substitute a block the shader will read past.
+        if (buffer.IsValid())
+        {
+            UnimplementedStub("BindStorageBuffer(unresolvable buffer)", StubKind::PreconditionFailure);
+        }
     }
 
     void VulkanRendererAPI::BindShaderProgram(RHI::ResourceHandle program)

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.h
@@ -35,6 +35,7 @@
 #include <volk.h>
 
 #include <array>
+#include <atomic>
 #include <mutex>
 #include <span>
 #include <string>
@@ -253,6 +254,16 @@ namespace OloEngine
             OutsideRecording,
             Count
         };
+        /// Times a STORAGE binding was published as the arena's null block
+        /// because nothing fed it (issue #1052). Non-zero means a shader is
+        /// reading a zero-filled stand-in it may index out of; it is the
+        /// device-loss precursor, so a tenant that renders real geometry should
+        /// assert this is 0 the way it asserts the stub count is.
+        [[nodiscard]] u64 GetUnfedStorageBindingCount() const
+        {
+            return m_UnfedStorageBindings.load(std::memory_order_relaxed);
+        }
+
         [[nodiscard]] u64 GetUnimplementedStubHitCount() const
         {
             return m_UnimplementedStubHits;
@@ -674,6 +685,10 @@ namespace OloEngine
         // Stub bookkeeping may be touched from RecordParallel workers (a
         // refused entry point counts as a stub hit), hence the mutex.
         mutable std::mutex m_StubMutex;
+        // Unfed STORAGE bindings that took the null-block substitution
+        // (issue #1052). Atomic, not mutex-guarded like the stub tally: the
+        // publication site runs per draw and may fork across recording workers.
+        mutable std::atomic<u64> m_UnfedStorageBindings{ 0 };
         mutable u64 m_UnimplementedStubHits = 0;
         mutable std::array<u64, static_cast<sizet>(StubKind::Count)> m_StubHitsByKind{};
         mutable std::unordered_set<std::string> m_WarnedStubs;

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -293,6 +293,7 @@ add_executable(OloEngine-Tests
 		# root-data assembly, the thin-PSO fetch and the lazy dynamic-
 		# rendering scope. Same SKIP ladder + zero-validation bar.
 		Rendering/VulkanDrawPathTest.cpp
+		Rendering/VulkanRawBufferStorageBindingTest.cpp
 		# #691 Phase 7 Stage 1.6b: REAL passes through the REAL render graph on
 		# a device — transients, planner barriers, pass bodies recording via
 		# the process-global backend; first tenant is the golden-gated FXAA

--- a/OloEngine/tests/Rendering/VulkanRawBufferStorageBindingTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanRawBufferStorageBindingTest.cpp
@@ -1,0 +1,199 @@
+// OLO_TEST_LAYER: plumbing
+// =============================================================================
+// VulkanRawBufferStorageBindingTest — issue #1052.
+//
+// A RAW buffer (RenderCommand::CreateBufferHandle + AllocateBufferStorage) bound
+// to an SSBO binding point must reach the shader as a real device address.
+//
+// It did not. `VulkanRendererAPI::BindStorageBuffer` resolved only
+// `VulkanRootObjectRegistry` — the object-backed family — so a raw handle took
+// the `entry == nullptr` arm, which SILENTLY called
+// `SetStorageBuffer(binding, nullptr)` and returned. The publication site then
+// found no occupant and substituted the frame arena's null block.
+//
+// That substitution is deliberate and its comment is right about what it
+// prevents: handing a shader address 0 is a GPU page fault that escalates to
+// VK_ERROR_DEVICE_LOST. What it cannot prevent is a read that walks OFF a
+// legitimately mapped but tiny block — and that is exactly what virtual
+// geometry does, because SSBO_VIRTUAL_INDICES (binding 42) is a raw handle
+// (`VirtualMeshRegistry::m_IndexBuffer`, "element-buffer + SSBO arena") and its
+// shaders index it as `localIndices[cluster.IndexBase + ...]` with offsets in
+// the millions. Every virtual-geometry scene on Vulkan died this way:
+//
+//     [RHI/Vulkan] 'VirtualClusterRaster_Int64' buffer binding 42 has no
+//                  published occupant — null block
+//     [Vulkan] DEVICE FAULT REPORT: fault address 0x457fd8000 — READ of invalid address
+//     === CRASH: vkQueueSubmit2 failed (VkResult -4) ===
+//
+// So the contract pinned here is the one that was missing: a raw buffer is a
+// legitimate SSBO occupant, it publishes a NON-ZERO address, and retiring its
+// storage unstages that address rather than leaving a freed allocation bound.
+//
+// Device-gated; SKIPs cleanly headless, like the rest of the Vulkan ladder.
+// =============================================================================
+
+#include "OloEnginePCH.h"
+
+#include "OloEngine/Core/Base.h"
+
+#include <gtest/gtest.h>
+
+#if !OLO_WITH_VULKAN
+
+TEST(VulkanRawBufferStorageBinding, SkipsWhenNotCompiledIn)
+{
+    GTEST_SKIP() << "Built with OLO_WITH_VULKAN=OFF — the Vulkan backend is not compiled in.";
+}
+
+#else
+
+#include "OloEngine/Renderer/RHI/RHITypes.h"
+#include "OloEngine/Renderer/RenderCommand.h"
+#include "OloEngine/Renderer/RendererAPI.h"
+#include "OloEngine/Renderer/ShaderBindingLayout.h"
+
+#include "Platform/Vulkan/VulkanBindingState.h"
+#include "Platform/Vulkan/VulkanBufferResources.h"
+#include "Platform/Vulkan/VulkanDeferredReclaim.h"
+#include "Platform/Vulkan/VulkanDevice.h"
+#include "Platform/Vulkan/VulkanFrameArena.h"
+
+#include "VulkanTestSupport.h"
+
+#include <memory>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        using OloEngine::Tests::ProbeVulkanDeviceTestGate;
+        using OloEngine::Tests::ScopedVulkanRenderCommandSelection;
+
+        // The binding the bug was found on. Any SSBO point would do; using the
+        // real one keeps the test pointing at the failure it describes.
+        constexpr u32 kBinding = ShaderBindingLayout::SSBO_VIRTUAL_INDICES;
+        constexpr u64 kBytes = 64u * 1024u;
+    } // namespace
+
+    class VulkanRawBufferStorageBinding : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            const auto gate = ProbeVulkanDeviceTestGate();
+            if (!gate.Available)
+                GTEST_SKIP() << gate.Reason;
+
+            m_Device = std::make_unique<VulkanDevice>();
+            try
+            {
+                m_Device->Init([](VkInstance)
+                               { return VK_NULL_HANDLE; });
+            }
+            catch (const std::exception& e)
+            {
+                m_Device.reset();
+                GTEST_SKIP() << "Vulkan bring-up refused on a contract-satisfying machine: " << e.what();
+            }
+            VulkanDevice::ResetValidationErrorCount();
+        }
+
+        void TearDown() override
+        {
+            if (m_Device == nullptr)
+                return;
+            VulkanBindingState::Get().SetStorageBufferAddress(kBinding, 0);
+            VulkanBindingState::Get().SetStorageBuffer(kBinding, nullptr);
+            VulkanFrameArena::Get().ReleaseBuffers();
+            VulkanDeferredReclaim::Get().FlushAll();
+            EXPECT_EQ(VulkanDevice::GetValidationErrorCount(), 0u)
+                << "a raw-buffer SSBO bind must raise no validation error "
+                   "(SHADER_DEVICE_ADDRESS is a create-time usage bit)";
+            m_Device->Shutdown();
+            m_Device.reset();
+        }
+
+        std::unique_ptr<VulkanDevice> m_Device;
+    };
+
+    // The regression. Before #1052 the staged address was 0 and the shader was
+    // handed the null block instead.
+    TEST_F(VulkanRawBufferStorageBinding, ARawBufferBoundToAnSsboPointPublishesItsAddress)
+    {
+        ScopedVulkanRenderCommandSelection vulkan;
+
+        const RHI::ResourceHandle handle = RenderCommand::CreateBufferHandle();
+        ASSERT_TRUE(handle.IsValid()) << "CreateBufferHandle minted nothing";
+        RenderCommand::AllocateBufferStorage(handle, kBytes, RHI::MemoryResidency::DeviceLocal);
+
+        // The registry must have taken an address at all — that needs
+        // VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT at CREATE time, which the
+        // raw family did not set.
+        auto* entry = VulkanRawBufferRegistry::Get().Lookup(handle);
+        ASSERT_NE(entry, nullptr) << "AllocateBufferStorage did not register the raw buffer";
+        EXPECT_NE(entry->Buffer, VK_NULL_HANDLE);
+        ASSERT_NE(entry->DeviceAddress, 0u)
+            << "no device address for a raw buffer — the usage bit is missing again";
+
+        RenderCommand::BindStorageBuffer(kBinding, handle);
+
+        // The whole point: the binding resolves to THIS buffer, not to nothing.
+        EXPECT_EQ(VulkanBindingState::Get().GetStorageBufferAddress(kBinding), entry->DeviceAddress)
+            << "a raw buffer bound to an SSBO point did not publish its address — the shader would "
+               "read the frame arena's null block and walk off it (issue #1052)";
+
+        // ... and it is NOT masquerading as an object-backed occupant.
+        EXPECT_EQ(VulkanBindingState::Get().GetStorageBuffer(kBinding), nullptr);
+
+        RenderCommand::DeleteBuffer(handle);
+    }
+
+    // Retiring the storage must unstage the address. A bind point still holding
+    // a freed allocation's address is the dangling-pointer version of the same
+    // fault.
+    TEST_F(VulkanRawBufferStorageBinding, DeletingTheBufferUnstagesItsAddress)
+    {
+        ScopedVulkanRenderCommandSelection vulkan;
+
+        const RHI::ResourceHandle handle = RenderCommand::CreateBufferHandle();
+        ASSERT_TRUE(handle.IsValid());
+        RenderCommand::AllocateBufferStorage(handle, kBytes, RHI::MemoryResidency::DeviceLocal);
+        RenderCommand::BindStorageBuffer(kBinding, handle);
+        ASSERT_NE(VulkanBindingState::Get().GetStorageBufferAddress(kBinding), 0u)
+            << "precondition: the address must be staged before this test means anything";
+
+        RenderCommand::DeleteBuffer(handle);
+
+        EXPECT_EQ(VulkanBindingState::Get().GetStorageBufferAddress(kBinding), 0u)
+            << "a deleted raw buffer left its address staged — the next publication would hand a "
+               "shader a freed allocation";
+    }
+
+    // A re-allocate under the same identity (GL's glNamedBufferData orphaning)
+    // retires the old storage too, so the stale address must not survive it.
+    TEST_F(VulkanRawBufferStorageBinding, ReallocatingUnstagesTheOldAddress)
+    {
+        ScopedVulkanRenderCommandSelection vulkan;
+
+        const RHI::ResourceHandle handle = RenderCommand::CreateBufferHandle();
+        ASSERT_TRUE(handle.IsValid());
+        RenderCommand::AllocateBufferStorage(handle, kBytes, RHI::MemoryResidency::DeviceLocal);
+        RenderCommand::BindStorageBuffer(kBinding, handle);
+        const VkDeviceAddress first = VulkanBindingState::Get().GetStorageBufferAddress(kBinding);
+        ASSERT_NE(first, 0u);
+
+        RenderCommand::AllocateBufferStorage(handle, kBytes * 2u, RHI::MemoryResidency::DeviceLocal);
+
+        // Either unstaged, or already re-staged to the NEW storage — never left
+        // pointing at the retired allocation.
+        const VkDeviceAddress after = VulkanBindingState::Get().GetStorageBufferAddress(kBinding);
+        auto* entry = VulkanRawBufferRegistry::Get().Lookup(handle);
+        ASSERT_NE(entry, nullptr);
+        EXPECT_TRUE(after == 0u || after == entry->DeviceAddress)
+            << "the bind point still points at the orphaned allocation";
+
+        RenderCommand::DeleteBuffer(handle);
+    }
+} // namespace OloEngine::Tests
+
+#endif // OLO_WITH_VULKAN

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -26,6 +26,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [testing-architecture.md](testing-architecture.md): which renderer layer or Functional axis a new test belongs to, and the registration contract.
 - [../testing.md](../testing.md): why we test what we test; value heuristic, anti-patterns, retirement criteria.
 - [substituted-seams-compound.md](substituted-seams-compound.md): every substitution a test makes is a seam it stops testing, and they compound — including building the same object a different way.
+- [no-silent-fallbacks.md](no-silent-fallbacks.md): a path that cannot do what it was asked says so loudly and countably; rank a fallback by whether the substituted value can be INDEXED.
 - [reference-path-tracer.md](reference-path-tracer.md): the ground-truth oracle for "is it correct", where a golden can only say "did it change".
 - [vendor-golden-baseline-crosscheck.md](vendor-golden-baseline-crosscheck.md): measure the noise floor and audit a recording before baking a per-vendor baseline.
 - [single-mesh-visual-test-lighting.md](single-mesh-visual-test-lighting.md): give a visual-test scene a ground plane, then look at the PNG.
@@ -172,6 +173,7 @@ The dominant archetype here. If your change is in one of these areas, a passing 
 | [vulkan-command-ordered-buffer-writes.md](vulkan-command-ordered-buffer-writes.md) | Two scenes rendered skybox-only with zero errors because no test interleaved two SSBO uploads with draws. |
 | [gl-global-setter-resets-indexed-state.md](gl-global-setter-resets-indexed-state.md) | Every Vulkan draw wrote colour attachment 0 alone, and the forward path only displays attachment 0. |
 | [substituted-seams-compound.md](substituted-seams-compound.md) | A decal tenant made three substitutions, each hiding a different live bug; no decal had ever produced a pixel. |
+| [no-silent-fallbacks.md](no-silent-fallbacks.md) | Two defensible fallbacks composed into VK_ERROR_DEVICE_LOST on every virtual-geometry scene, three layers from the cause, with both Vulkan VG tests passing. |
 | [compute-written-texture-mip-chain.md](compute-written-texture-mip-chain.md) | A compute kernel wrote mip 0 and left coarser mips stale; the visual test was green because every mip was uniformly stale. |
 | [gpu-scan-compaction.md](gpu-scan-compaction.md) | A compaction test that sorts both sides passes identically on `atomicAdd` and on the scan replacing it. |
 | [variable-rate-compute-shading.md](variable-rate-compute-shading.md) | A classifier that coarsens nothing passes every "did coarsening damage the image" assertion. |

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -25,7 +25,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 
 - [testing-architecture.md](testing-architecture.md): which renderer layer or Functional axis a new test belongs to, and the registration contract.
 - [../testing.md](../testing.md): why we test what we test; value heuristic, anti-patterns, retirement criteria.
-- [substituted-seams-compound.md](substituted-seams-compound.md): every substitution a test makes is a seam it stops testing, and they compound.
+- [substituted-seams-compound.md](substituted-seams-compound.md): every substitution a test makes is a seam it stops testing, and they compound — including building the same object a different way.
 - [reference-path-tracer.md](reference-path-tracer.md): the ground-truth oracle for "is it correct", where a golden can only say "did it change".
 - [vendor-golden-baseline-crosscheck.md](vendor-golden-baseline-crosscheck.md): measure the noise floor and audit a recording before baking a per-vendor baseline.
 - [single-mesh-visual-test-lighting.md](single-mesh-visual-test-lighting.md): give a visual-test scene a ground plane, then look at the PNG.

--- a/docs/agent-rules/no-silent-fallbacks.md
+++ b/docs/agent-rules/no-silent-fallbacks.md
@@ -1,0 +1,95 @@
+# No silent fallbacks
+
+Applies to: the whole engine, and to review of any diff.
+
+**A path that cannot do what it was asked must say so — loudly, and into something a test can
+assert on. It must not substitute a plausible default and continue.** A fallback that is genuinely
+needed for safety is kept *and* made loud; those are not alternatives.
+
+The shape to reject, wherever it appears:
+
+```cpp
+if (!resolved)
+{
+    SetSomething(binding, nullptr);   // plausible default
+    return;                           // no warn, no counter, no assert
+}
+```
+
+## Why: two reasonable fallbacks composed into a device loss
+
+Issue #1052. `VulkanRendererAPI::BindStorageBuffer` could not resolve a raw-buffer handle, so it
+bound null and returned — silently. The publication site then found the binding unoccupied and
+substituted the frame arena's zero-filled **null block**, which is itself a *deliberate* fallback
+with a good reason: handing a shader address 0 is a page fault that escalates to
+`VK_ERROR_DEVICE_LOST`, and that had already happened once.
+
+Each decision is defensible alone. Composed, they turned "this entry point is not lowered yet" into
+`vkQueueSubmit2` failing with `VK_ERROR_DEVICE_LOST` on **every** virtual-geometry scene on Vulkan —
+and the failure surfaced three layers from its cause, as a `READ of invalid address` at a hardware
+fault address. Two Vulkan virtual-geometry tests passed throughout.
+
+## Rank a fallback by whether the substituted value can be INDEXED
+
+This is the part that decides severity, and it is not obvious:
+
+- An unfed **UBO** reads deterministic zeros. Defined, usually wrong-looking, survivable.
+- An unfed **SSBO** is a *small* block that a shader **indexes** — and the index normally comes from
+  a **different buffer that was fed correctly**. The read lands outside the stand-in and loses the
+  device.
+
+That asymmetry is the whole of #1052: the cluster records (binding 33) were fed and supplied a real
+`cluster.IndexBase` in the millions, while the index arena (binding 42) was the null block.
+
+**So: an unfed SSBO is safe only while everything that indexes it is also unfed.** Measured on this
+engine — a Vulkan sweep of six scenes plus the virtual-geometry scenes found 21 distinct unfed
+bindings, of which 7 are SSBOs (the Forward+ light lists, a lightmap vertex-pull buffer, the terrain
+VT feedback buffer). All 7 are currently harmless *by accident*: they are unfed as a **group**, so
+the count that drives the loop reads 0 out of the same null block and the indexing never happens:
+
+```glsl
+uvec2 tileData = fplusGetTileData(viewDepth);  // fplusGrid[...] -> null block -> (0, 0)
+uint count = tileData.y;                       // 0
+for (uint i = 0u; i < count; ++i)              // never runs
+    fplusLightIndices[offset + i];             // never reached
+```
+
+Feed one member of such a group without feeding its siblings and it detonates. Do not read "no
+crash today" as "safe".
+
+## The counter-moves
+
+- **Warn once, and count.** The engine already has the shape:
+  `UnimplementedStub(entry, StubKind::PreconditionFailure)` warns once per entry point and
+  increments a tally, and `VulkanDrawPathTest` asserts `GetUnimplementedStubHitCount() == 0` — "the
+  draw path must not fall through to a stub". A silent `return;` after a failed lookup is the bug,
+  not the house style.
+- **Give the dangerous case its own voice and its own counter.** An unfed *storage* binding now logs
+  at ERROR and increments `GetUnfedStorageBindingCount()`, separate from the stub tally so existing
+  assertions keep meaning what they meant. A tenant that renders real geometry should assert it is
+  zero.
+- **Assert the counter in tenants, not just in the one test that already does.** That check is
+  *backend-shaped* rather than feature-shaped: it catches the next unlowered path in whatever pass
+  reaches it first, which is exactly what did not happen here.
+- **In review, treat `if (!x) { setDefault(); return; }` with no diagnostic as a finding**, the same
+  way a swallowed exception would be. Ask what the caller does next with the default.
+
+## What stayed green
+
+Two Vulkan virtual-geometry tests, both passing, for as long as the bug existed — they hand-author
+the cluster set and build the failing buffer a different way (see
+[substituted-seams-compound.md](substituted-seams-compound.md), second instance). The stub counter
+that would have caught it exists and is asserted — but only on the draw path, never on a
+virtual-geometry tenant. And `RendererAttachedTest`, which every virtual-geometry evidence test
+rides, creates a GL context only, so the real pass had never executed on Vulkan in any test.
+
+Found on #1052 / PR #1054.
+
+## Related
+
+- [substituted-seams-compound.md](substituted-seams-compound.md) — every substitution a test makes
+  is a seam it stops testing, including building the same object a different way.
+- [gl-global-setter-resets-indexed-state.md](gl-global-setter-resets-indexed-state.md) — the other
+  family of silent state loss.
+- [live-verification-noise-floor.md](live-verification-noise-floor.md) — a green result that proves
+  nothing is worse than a red one.

--- a/docs/agent-rules/substituted-seams-compound.md
+++ b/docs/agent-rules/substituted-seams-compound.md
@@ -138,10 +138,14 @@ m_IndexBuffer = RenderCommand::CreateBufferHandle();   // RAW handle
 and then binds it a second way the test never does — as `SSBO_VIRTUAL_INDICES`.
 An object-backed `VulkanIndexBuffer` already carries
 `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` and registers in
-`VulkanRootObjectRegistry`; a raw handle had neither, so `BindStorageBuffer`
-resolved nothing, silently bound null, and every VG scene on Vulkan lost the
-device. The test could not fail: the buffer it exercises is not the buffer that
-breaks.
+`VulkanRootObjectRegistry`. A raw handle is registered too — `CreateHandle`
+enters it in `RHI::ResourceRegistry` and in `VulkanRawBufferRegistry` — just not
+in `VulkanRootObjectRegistry`, which is the only one `BindStorageBuffer`
+consulted, and it lacked the usage bit besides. **That is what made this hard to
+see: the handle was valid everywhere anyone thought to look.** It resolved
+nothing at the one registry that mattered, silently bound null, and every VG
+scene on Vulkan lost the device. The test could not fail: the buffer it
+exercises is not the buffer that breaks.
 
 **The rule this adds.** A substitution is not only "called a different function"
 — it is also "built the same object a different way". When a tenant constructs an

--- a/docs/agent-rules/substituted-seams-compound.md
+++ b/docs/agent-rules/substituted-seams-compound.md
@@ -113,6 +113,64 @@ mechanism runs.
 - A feature with no scene has no coverage, whatever the suite says. Add the
   scene, then look at the pixels.
 
+## Second instance: a substituted BUFFER CONSTRUCTION, #1052
+
+The archetype repeats with the object under test swapped for a differently-*built*
+one, which is harder to see than a substituted call.
+
+`VulkanPassSuite.VirtualGeometryMdiCountDrawsHandAuthoredClusters` pins the
+virtual-geometry indirect-draw entry on Vulkan with the real
+`VirtualMeshGBuffer.glsl`, and says plainly in its header that the full pass is
+"disproportionate headlessly" so it hand-authors the cluster set. Reasonable, and
+documented. But it builds the index data as
+
+```cpp
+auto indexBuffer = IndexBuffer::Create(indices, 12);   // object-backed
+vao->SetIndexBuffer(indexBuffer);
+```
+
+while `VirtualMeshRegistry` builds the real one as
+
+```cpp
+m_IndexBuffer = RenderCommand::CreateBufferHandle();   // RAW handle
+```
+
+and then binds it a second way the test never does — as `SSBO_VIRTUAL_INDICES`.
+An object-backed `VulkanIndexBuffer` already carries
+`VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` and registers in
+`VulkanRootObjectRegistry`; a raw handle had neither, so `BindStorageBuffer`
+resolved nothing, silently bound null, and every VG scene on Vulkan lost the
+device. The test could not fail: the buffer it exercises is not the buffer that
+breaks.
+
+**The rule this adds.** A substitution is not only "called a different function"
+— it is also "built the same object a different way". When a tenant constructs an
+input itself, check it against the production *constructor*, not against the
+production *type*: same factory, same usage flags, same registry, bound at every
+binding point the real path binds it at. `IndexBuffer::Create` and
+`CreateBufferHandle` both produce "an index buffer" and share nothing that
+mattered here.
+
+**The cheap detector that would have caught it.** `VulkanRendererAPI` already
+counts unimplemented-stub hits, and `VulkanDrawPathTest` asserts
+`GetUnimplementedStubHitCount() == 0` — "the draw path must not fall through to a
+stub". No virtual-geometry tenant makes that assertion, so its fall-throughs were
+counted by nobody. Asserting that counter across a tenant's frame is one line and
+it is backend-shaped rather than feature-shaped: it catches the *next* unlowered
+path too, in whatever pass finds it first.
+
+Two aggravating conditions, both worth checking before trusting a Vulkan result:
+
+- **`RendererAttachedTest` creates a GL 4.6 context only.** Every virtual-geometry
+  evidence test rides it, so the real pass has never executed on Vulkan in any
+  test — the "a feature with no scene has no coverage" rule, one level up: a
+  feature with no scene *on that backend* has no coverage there.
+- **`driver.ps1` has no `--rhi` passthrough**, so the standard tooling launches
+  OpenGL and a "Vulkan session" that used `attach` is running GL. Reaching this
+  needed a hand-rolled launch with `--rhi=vulkan`.
+
+Found on #1052 / PR #1054.
+
 ## Related
 
 - [gl-global-setter-resets-indexed-state.md](gl-global-setter-resets-indexed-state.md)


### PR DESCRIPTION
## What changed

Every virtual-geometry scene lost the GPU device on Vulkan — `vkQueueSubmit2` returning
`VK_ERROR_DEVICE_LOST` after a `DEVICE FAULT REPORT: READ of invalid address`, within a couple of
seconds of the first VG frame. Reproduced on `origin/master` @ `eb5a0e60c` on a 324-cluster scene
and a 118,102-cluster one, so it was never a size or frame-arena problem (I chased the arena
overflow first; the small scene faults with no overflow at all, which killed that theory).

`SSBO_VIRTUAL_INDICES` is minted by `VirtualMeshRegistry` through `CreateBufferHandle`, because it
is dual-purpose — a GL element buffer *and* the cluster index arena. On Vulkan that lands in
`VulkanRawBufferRegistry`, while `BindStorageBuffer` resolved only `VulkanRootObjectRegistry`. A raw
handle therefore took the `entry == nullptr` arm, which **silently** called
`SetStorageBuffer(binding, nullptr)` and returned.

The publication site then found no occupant and substituted the frame arena's null block. That
substitution is deliberate and its comment is right about what it prevents: handing a shader address
0 is a page fault that escalates to `DEVICE_LOST`. What it cannot prevent is a read that walks *off*
a legitimately mapped but small block — and that is exactly what the VG shaders do,
`localIndices[cluster.IndexBase + ...]` with offsets in the millions.

So a raw buffer is now a first-class SSBO occupant:

- `VulkanRawBufferRegistry::Allocate` takes `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` at create
  time and keeps the address on its `Entry`. `VulkanVertexBuffer` and `VulkanIndexBuffer` already
  set that bit; the raw family was the outlier.
- `VulkanBindingState` stages the address (`u64`, not `VkDeviceAddress` — that header is
  deliberately free of the Vulkan headers), and the publication site reads it only when no
  `VulkanStorageBuffer` occupant holds the point, so the object path is untouched.
- Retiring the storage — `Destroy`, or a `glNamedBufferData`-shaped re-allocate — **unstages** it,
  so a bind point can never publish a freed allocation. That is the dangling-pointer version of the
  same fault and it gets its own test.
- The silent arm is now **loud**: a handle that resolves nowhere goes through
  `UnimplementedStub(PreconditionFailure)`, the way `BindShaderProgram` already treats the same
  condition two functions below. Silence is what turned an unlowered path into a device loss.

## What this does NOT do — read this before merging

**It stops the crash. It does not make virtual geometry render on Vulkan.** Three RHI entry points
on the same path are still `#691` no-ops:

```
[RHI/Vulkan] SetVertexArrayIndexBuffer      — no Vulkan lowering yet (#691); no-op
[RHI/Vulkan] AllocatePersistentUploadStorage — no Vulkan lowering yet (#691); no-op
[RHI/Vulkan] UploadBufferSubData             — no Vulkan lowering yet (#691); no-op
```

so the hardware arm still logs `indexed draw without an index buffer — dropped` and no VG pixels
land. A wide capture of `VirtualGeometryTest.olo` on Vulkan after this change shows the ground plane
and skybox and **no helmets**. #1052 stays open for that remainder, with these three named.

I am deliberately not bundling those: each is its own lowering with its own hazards (the Vulkan draw
path pulls vertices and has no vertex-input state at all, so the index-buffer bind is a design
question, not a transcription), and the device loss is the part that takes the editor and the GPU
down with it.

## Verification

**The fault is gone.** Same build, same scene, Vulkan (`[RHI] Backend: Vulkan (source: --rhi flag)`,
RTX 4090, driver 104.256.0, API 1.4.351):

| | before | after |
|---|---|---|
| `binding 42 has no published occupant` | 3 shaders | **0** |
| `DEVICE FAULT REPORT` / `vkQueueSubmit2 failed` | yes, ~2 s in | **none** |
| editor after 5 min untouched | dead | **alive** |
| `olo_scene_open` | main-thread timeout (it was faulting) | returns normally |
| `olo_virtual_geometry_stats` | — | 4143 clusters drawn, `silentlyDrewNothing: false` |
| `olo_shader_errors` | — | 0 |

One honest note on that soak: an earlier run *did* fault at ~84 s, and I chased it before concluding
anything. It follows a **window resize** (`Swapchain recreated` → `ReadTextureSubImage: fence wait
failed`), which my screenshot driver triggered on a zero-size window — a different signature from
the VG one, and adjacent to the known pre-existing #800 resize validation error. Left untouched, the
session runs indefinitely.

**Three regression tests**, `VulkanRawBufferStorageBindingTest` (`plumbing`, device-gated, SKIPs
headless):

- a raw buffer bound to an SSBO point publishes **its own** address (and is not masquerading as an
  object occupant);
- deleting the buffer unstages the address;
- re-allocating under the same identity does not leave the bind point on the orphaned allocation.

The first asserts `entry->DeviceAddress != 0`, which cannot hold without the create-time usage bit —
so it fails if that bit is ever dropped again.

**Suites:** `Vulkan*:VirtualGeometry*:VirtualCluster*:VirtualMesh*` — 207 passed, 1 skipped
(`VirtualMeshRealAssetCook.StanfordDragon`, a fetch-on-demand asset absent in this worktree), 0
failed. Zero Vulkan validation errors (the fixture asserts it).

**Not affected:** OpenGL. Every edit is under `Platform/Vulkan/`.

## Review guide

**Where I'd look hardest**

1. `VulkanRendererAPI::BindStorageBuffer` — the arm order. An object occupant still wins; the raw
   path only runs on a miss, and it clears the sibling (`SetStorageBufferAddress(0)` on the object
   path, `SetStorageBuffer(nullptr)` on the raw path) so the two can never both be live on one
   binding.
2. The publication site's new `else if (isStorage)`. It is KIND-guarded like the arms above it, so a
   UBO binding whose number aliases an SSBO still resolves to the null block rather than to the raw
   address.
3. `VulkanBufferResources.cpp` unstaging in **both** retire paths (`Allocate`'s orphan branch and
   `Destroy`). Missing either leaves a freed address bound.

**Least confident about** — thread-safety posture. `BindStorageBuffer` has no `RefuseOnWorker` guard
and can run during parallel recording (#806); it now does a second registry lookup
(`VulkanRawBufferRegistry`, whose header says "render-thread only") alongside the
`VulkanRootObjectRegistry` lookup that was already there. Concurrent *reads* of the map are fine and
`CopyBufferSubData` already resolves raw handles during recording, so this is the same posture as
today rather than a new exposure — but it is the thing I would want a second opinion on, and if the
answer is "raw lookups must not happen off the render thread" then the pre-existing ones need the
same treatment.

**Deliberately not done** — the three lowerings above, and the `#800` resize fault.

Refs #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Vulkan storage-buffer handling for raw buffers, preventing valid buffer data from being replaced by a null allocation.
  - Prevented stale buffer addresses from being used after buffers are deleted or reallocated.
  - Improved diagnostics for unresolved storage-buffer bindings and tracked these occurrences for easier troubleshooting.

- **Tests**
  - Added Vulkan regression coverage for raw-buffer binding, deletion, and reallocation scenarios.

- **Documentation**
  - Added guidance on avoiding silent fallbacks and ensuring tests reflect production rendering paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->