### PR TITLE
fix(ci): the Windows sccache entry never existed — the cache store was read-only (#1073)

### DIFF
--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -80,21 +80,34 @@ runs:
         REF: ${{ github.ref }}
       run: |
         set -uo pipefail
-        if keys=$(gh api -X GET "repos/${GH_REPO}/actions/caches" \
-                    -f "key=${KEY}" -f "ref=${REF}" \
-                    --jq '.actions_caches[].key' 2>/dev/null); then
-          if printf '%s\n' "$keys" | grep -Fxq "${KEY}"; then
-            echo "landed=true" >> "$GITHUB_OUTPUT"
-            echo "cache entry '${KEY}' is present on ${REF}."
+        # Poll rather than ask once. A cache entry does not appear in the listing the
+        # instant the upload finishes, and reading "absent" during that window would
+        # delete a perfectly good predecessor and raise a false alarm -- turning the
+        # signal this action exists to provide into one that cries wolf. A refused
+        # reservation, by contrast, is refused immediately and stays absent, so a few
+        # seconds of patience separates the two cleanly.
+        landed=unknown
+        for attempt in 1 2 3; do
+          if keys=$(gh api -X GET "repos/${GH_REPO}/actions/caches" \
+                      -f "key=${KEY}" -f "ref=${REF}" \
+                      --jq '.actions_caches[].key' 2>/dev/null); then
+            if printf '%s\n' "$keys" | grep -Fxq "${KEY}"; then
+              landed=true
+              break
+            fi
+            landed=false
           else
-            echo "landed=false" >> "$GITHUB_OUTPUT"
-            echo "cache entry '${KEY}' is NOT present on ${REF} -- the save was refused."
+            # An API hiccup must never trigger a delete. Unknown is treated as landed.
+            landed=unknown
           fi
-        else
-          # An API hiccup must never trigger a delete. Unknown is treated as landed.
-          echo "landed=unknown" >> "$GITHUB_OUTPUT"
-          echo "::warning::could not query the cache store; skipping the prune/retry path."
-        fi
+          [ "$attempt" -lt 3 ] && sleep 10
+        done
+        echo "landed=${landed}" >> "$GITHUB_OUTPUT"
+        case "$landed" in
+          true)  echo "cache entry '${KEY}' is present on ${REF}." ;;
+          false) echo "cache entry '${KEY}' is NOT present on ${REF} after 3 checks -- the save was refused." ;;
+          *)     echo "::warning::could not query the cache store; skipping the prune/retry path." ;;
+        esac
 
     # Scoped to THIS ref on purpose. GitHub scopes a cache entry to the ref that wrote
     # it -- a PR run's entry is visible to that PR alone, and only default-branch entries

--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -1,0 +1,173 @@
+name: Save cache, pruning this ref's superseded entries on refusal
+description: >
+  `actions/cache/save`, plus the two things it does not do: notice that the save was
+  REFUSED, and make room so a retry succeeds.
+
+  WHY THIS EXISTS (#1073). Every cache key in this repo ends in `-<run_id>-<attempt>`
+  so each save writes a fresh, immutable snapshot and `restore-keys` warms from the
+  newest one. That shape is right and it is APPEND-ONLY: a save never replaces the
+  entry it supersedes, it sits beside it until the nightly `cache-prune` sweep.
+
+  The repo's Actions cache store is capped at 10 GB, and past the cap GitHub does not
+  evict -- it turns the WHOLE STORE READ-ONLY ("Cache reservation failed: You have
+  reached your configured budget, your cache is now read only"). The steady set of live
+  entries is ~7 GB, so the moment two or three heavy jobs each hold an old AND a new
+  snapshot at once, the cap is breached and every save in the repo is refused until the
+  next daily sweep. A daily sweep cannot fix that: the breach happens between two saves
+  minutes apart, not between two days.
+
+  It is not a hypothetical. It is the measured state that made
+  `sccache-windows-2025-release-*` cease to exist ENTIRELY -- which is why the Windows
+  build reported a 0.00 % hit rate on 1630 compilations, run after run, for weeks, while
+  every step stayed green. See docs/agent-rules/actions-cache-budget.md.
+
+  ORDER MATTERS AND IT IS SAVE-THEN-PRUNE. Pruning first would be simpler and is wrong:
+  if the retry were then refused anyway, we would have deleted the warm entry the next
+  run was going to restore, turning a stale cache into no cache. So: save; ask the API
+  whether the entry actually landed; only if it did not, delete this ref's older entries
+  under the same prefix and save again. A warm snapshot is never given up for one that
+  has not been written.
+
+  Never fails its job. A cache save that turns a green run red would be strictly worse
+  than the cold cache it is fixing, so every failure here is an annotation.
+
+inputs:
+  key:
+    description: 'Full cache key to save under, including the trailing -<run_id>-<attempt>.'
+    required: true
+  prefix:
+    description: >
+      Key prefix identifying this cache's lineage on this ref -- normally `key` minus its
+      trailing `-<run_id>-<attempt>`. On the retry path every entry on THIS ref matching
+      this prefix (other than `key` itself) is deleted. Must not be empty, and must not be
+      a prefix of an unrelated cache's key.
+    required: true
+  path:
+    description: 'Path to save, as passed to actions/cache/save.'
+    required: true
+  token:
+    description: 'Token with `actions: write` on this repository.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Save
+      # Explicit `always()` on every step here: this action is invoked from an
+      # `if: always()` step so that a CANCELLED run still banks what it built, and a
+      # composite step with no condition inherits `success()`, which a cancelled job
+      # does not satisfy. Without these the prune/retry path would be dead in exactly
+      # the runs that need it most.
+      if: always()
+      continue-on-error: true
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    # `actions/cache/save` treats a refused reservation as a WARNING and exits 0
+    # (observed: "##[warning]Cache reservation failed ..." then "Failed to save: Unable
+    # to reserve cache with key ..., another job may be creating this cache", step
+    # outcome SUCCESS). The step's own status therefore cannot answer this -- ask the API.
+    - name: Did the entry land?
+      id: check
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        KEY: ${{ inputs.key }}
+        REF: ${{ github.ref }}
+      run: |
+        set -uo pipefail
+        if keys=$(gh api -X GET "repos/${GH_REPO}/actions/caches" \
+                    -f "key=${KEY}" -f "ref=${REF}" \
+                    --jq '.actions_caches[].key' 2>/dev/null); then
+          if printf '%s\n' "$keys" | grep -Fxq "${KEY}"; then
+            echo "landed=true" >> "$GITHUB_OUTPUT"
+            echo "cache entry '${KEY}' is present on ${REF}."
+          else
+            echo "landed=false" >> "$GITHUB_OUTPUT"
+            echo "cache entry '${KEY}' is NOT present on ${REF} -- the save was refused."
+          fi
+        else
+          # An API hiccup must never trigger a delete. Unknown is treated as landed.
+          echo "landed=unknown" >> "$GITHUB_OUTPUT"
+          echo "::warning::could not query the cache store; skipping the prune/retry path."
+        fi
+
+    # Scoped to THIS ref on purpose. GitHub scopes a cache entry to the ref that wrote
+    # it -- a PR run's entry is visible to that PR alone, and only default-branch entries
+    # are readable fleet-wide. Deleting across refs would let any branch wipe the master
+    # snapshot every other branch restores from.
+    - name: Free room under this prefix on this ref
+      if: always() && steps.check.outputs.landed == 'false'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        PREFIX: ${{ inputs.prefix }}
+        KEY: ${{ inputs.key }}
+        REF: ${{ github.ref }}
+      run: |
+        set -uo pipefail
+        if [ -z "${PREFIX}" ]; then
+          echo "::warning::empty prefix; refusing to delete anything."
+          exit 0
+        fi
+        # `key` on this endpoint is a PREFIX match; `ref` restricts the scope.
+        if ! gh api -X GET "repos/${GH_REPO}/actions/caches" \
+               -f "key=${PREFIX}" -f "ref=${REF}" -f per_page=100 \
+               --jq '.actions_caches[] | [.id, .size_in_bytes, .key] | @tsv' > superseded.tsv 2>err.txt; then
+          echo "::warning::could not list cache entries for '${PREFIX}' on ${REF}: $(cat err.txt)"
+          exit 0
+        fi
+        freed=0
+        n=0
+        while IFS=$'\t' read -r id size key; do
+          [ -n "${id:-}" ] || continue
+          # Never delete the key we are trying to write (it is not there, but be exact).
+          if [ "$key" = "${KEY}" ]; then continue; fi
+          if gh api -X DELETE "repos/${GH_REPO}/actions/caches/${id}" >/dev/null 2>&1; then
+            printf 'deleted %6s MiB  %s\n' "$((size / 1048576))" "$key"
+            freed=$((freed + size))
+            n=$((n + 1))
+          else
+            printf 'could not delete (already gone?)  %s\n' "$key"
+          fi
+        done < superseded.tsv
+        rm -f superseded.tsv err.txt
+        echo "freed $((freed / 1048576)) MiB from $n superseded entries under '${PREFIX}' on ${REF}"
+
+    - name: Save (retry after freeing room)
+      if: always() && steps.check.outputs.landed == 'false'
+      continue-on-error: true
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    # If it is STILL not there, the store is over budget on entries this job does not own
+    # and no amount of local pruning will help. Say so with an ::error:: annotation --
+    # visible on the run summary and countable -- rather than leaving the next maintainer
+    # to infer it from a 0 % hit rate weeks later. That inference took #1073 several weeks.
+    - name: Report a save that never landed
+      if: always() && steps.check.outputs.landed == 'false'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        KEY: ${{ inputs.key }}
+        REF: ${{ github.ref }}
+      run: |
+        set -uo pipefail
+        keys=$(gh api -X GET "repos/${GH_REPO}/actions/caches" \
+                 -f "key=${KEY}" -f "ref=${REF}" --jq '.actions_caches[].key' 2>/dev/null || echo "")
+        if printf '%s\n' "$keys" | grep -Fxq "${KEY}"; then
+          echo "cache entry '${KEY}' landed on the retry."
+          exit 0
+        fi
+        gh api "repos/${GH_REPO}/actions/cache/usage" \
+          --jq '"cache store: \(.active_caches_count) entries, \(.active_caches_size_in_bytes/1048576|floor) MiB against a 10 GB cap"' || true
+        echo "::error::cache entry '${KEY}' was NOT written even after pruning this ref. The next run WILL start cold."
+        echo "::error::This is the repo Actions cache budget (#1073): look for 'Cache reservation failed ... your cache is now read only' in the save steps above, then see docs/agent-rules/actions-cache-budget.md."

--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -11,10 +11,11 @@ description: >
   The repo's Actions cache store is capped at 10 GB, and past the cap GitHub does not
   evict -- it turns the WHOLE STORE READ-ONLY ("Cache reservation failed: You have
   reached your configured budget, your cache is now read only"). The steady set of live
-  entries is ~7 GB, so the moment two or three heavy jobs each hold an old AND a new
-  snapshot at once, the cap is breached and every save in the repo is refused until the
-  next daily sweep. A daily sweep cannot fix that: the breach happens between two saves
-  minutes apart, not between two days.
+  entries measured ~5 GB before this job's own snapshot is counted, and the three Linux
+  sanitizer entries are ~1.25 GB apiece -- so the moment two or three heavy jobs each hold
+  an old AND a new snapshot at once, the cap is breached and every save in the repo is
+  refused until the next sweep. A twice-daily sweep cannot fix that: the breach happens
+  between two saves minutes apart, not between two days.
 
   It is not a hypothetical. It is the measured state that made
   `sccache-windows-2025-release-*` cease to exist ENTIRELY -- which is why the Windows
@@ -34,13 +35,6 @@ description: >
 inputs:
   key:
     description: 'Full cache key to save under, including the trailing -<run_id>-<attempt>.'
-    required: true
-  prefix:
-    description: >
-      Key prefix identifying this cache's lineage on this ref -- normally `key` minus its
-      trailing `-<run_id>-<attempt>`. On the retry path every entry on THIS ref matching
-      this prefix (other than `key` itself) is deleted. Must not be empty, and must not be
-      a prefix of an unrelated cache's key.
     required: true
   path:
     description: 'Path to save, as passed to actions/cache/save.'
@@ -65,13 +59,61 @@ runs:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}
 
+    # THE RECOVERY PATH MUST NOT RUN WHEN THERE WAS NOTHING TO SAVE.
+    #
+    # This action is called from an `if: always()` step so a CANCELLED run still banks
+    # what it built. A run cancelled EARLY has no `SCCACHE_DIR` yet, and then
+    # `actions/cache/save` fails on the missing path -- for a reason that deleting the
+    # previous snapshot cannot fix. Without this guard the sequence is: save fails, the
+    # API confirms no entry, the recovery path deletes the warm snapshot to make room,
+    # the retry fails on the same missing path, and the next run starts COLD. That is
+    # precisely the outcome the save-then-prune ordering exists to prevent, walked into
+    # through a different door.
+    #
+    # Asking the filesystem is the only reliable test. `actions/cache/save` catches its
+    # own errors and can report success regardless, so `steps.<save>.outcome` cannot
+    # distinguish "nothing to save" from "refused" from "saved".
+    #
+    # Inconclusive counts as NO payload: never delete a warm entry on a guess.
+    - name: Is there anything to save?
+      id: payload
+      if: always()
+      shell: bash
+      env:
+        CACHE_PATH: ${{ inputs.path }}
+      run: |
+        set -uo pipefail
+        found=false
+        # `path` may be multi-line in actions/cache; any one non-empty entry counts.
+        while IFS= read -r line; do
+          entry=$(printf '%s' "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+          [ -n "$entry" ] || continue
+          if [ -d "$entry" ]; then
+            if [ -n "$(find "$entry" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+              found=true
+              break
+            fi
+          elif [ -s "$entry" ]; then
+            found=true
+            break
+          fi
+        done <<< "${CACHE_PATH}"
+        echo "haspayload=${found}" >> "$GITHUB_OUTPUT"
+        if [ "$found" = true ]; then
+          echo "'${CACHE_PATH}' holds something to save."
+        else
+          echo "'${CACHE_PATH}' is missing or empty -- nothing to save, so the prune/retry path stays off."
+        fi
+
     # `actions/cache/save` treats a refused reservation as a WARNING and exits 0
     # (observed: "##[warning]Cache reservation failed ..." then "Failed to save: Unable
     # to reserve cache with key ..., another job may be creating this cache", step
     # outcome SUCCESS). The step's own status therefore cannot answer this -- ask the API.
+    # Skipped when there was no payload, which cascades: every later step keys off
+    # `steps.check.outputs.landed`, and a skipped step's output is empty, not 'false'.
     - name: Did the entry land?
       id: check
-      if: always()
+      if: always() && steps.payload.outputs.haspayload == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -119,28 +161,60 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         GH_REPO: ${{ github.repository }}
-        PREFIX: ${{ inputs.prefix }}
         KEY: ${{ inputs.key }}
         REF: ${{ github.ref }}
+        # Passed explicitly rather than relying on the runner's default environment, so
+        # the derivation below reads from the same source the caller built the key from.
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
       run: |
         set -uo pipefail
-        if [ -z "${PREFIX}" ]; then
-          echo "::warning::empty prefix; refusing to delete anything."
+        # DERIVE the lineage prefix from the key rather than taking it as a second input.
+        # A prefix passed alongside the key is the same string written twice, and the two
+        # drift: bump the runner image and you must edit `key`, `restore-keys` AND the
+        # prefix in lockstep, in four workflows. Miss one and this action either prunes
+        # nothing (a silently full store) or prunes a lineage that is not its own. Both
+        # are #1073 again. Deriving it makes them impossible to disagree.
+        PREFIX="${KEY%-${RUN_ID}-${RUN_ATTEMPT}}"
+        if [ "${PREFIX}" = "${KEY}" ] || [ -z "${PREFIX}" ]; then
+          # The key does not end in `-<run id>-<attempt>`, so it is not the append-only
+          # shape this prune understands. Do nothing rather than guess.
+          echo "::warning::key '${KEY}' does not end in '-${RUN_ID}-${RUN_ATTEMPT}'; skipping the prune."
           exit 0
         fi
-        # `key` on this endpoint is a PREFIX match; `ref` restricts the scope.
+        echo "lineage prefix derived from the key: '${PREFIX}'"
+        # `key` on this endpoint is a PREFIX match and `ref` restricts the scope. Both
+        # verified against the live API rather than assumed -- `key=sccache` returns
+        # three unrelated lineages, `ref=refs/heads/does-not-exist` returns none, and
+        # OMITTING key returns EVERYTHING. That last one is why the loop below re-checks
+        # every row locally: a delete must never depend on a remote filter behaving.
         if ! gh api -X GET "repos/${GH_REPO}/actions/caches" \
                -f "key=${PREFIX}" -f "ref=${REF}" -f per_page=100 \
-               --jq '.actions_caches[] | [.id, .size_in_bytes, .key] | @tsv' > superseded.tsv 2>err.txt; then
+               --jq '.actions_caches[] | [.id, .size_in_bytes, .key, .ref] | @tsv' > superseded.tsv 2>err.txt; then
           echo "::warning::could not list cache entries for '${PREFIX}' on ${REF}: $(cat err.txt)"
           exit 0
         fi
         freed=0
         n=0
-        while IFS=$'\t' read -r id size key; do
+        while IFS=$'\t' read -r id size key ref; do
           [ -n "${id:-}" ] || continue
           # Never delete the key we are trying to write (it is not there, but be exact).
           if [ "$key" = "${KEY}" ]; then continue; fi
+          # Delete ONLY entries of literally this lineage: `<prefix>-<run_id>[-<attempt>]`.
+          # A bare prefix match is not good enough. `key=` is a plain string prefix, so if
+          # a sibling key `sccache-windows-2025-release-debug-…` is ever added, a prefix
+          # match would eat it -- and a cache this action deletes by mistake is a cold
+          # four-hour build for somebody who changed nothing.
+          if ! [[ "$key" =~ ^"${PREFIX}"-[0-9]+(-[0-9]+)?$ ]]; then
+            printf 'skip (not this lineage)  %s\n' "$key"
+            continue
+          fi
+          # The API scopes by ref; verify it anyway, because DELETE takes a cache id and
+          # will happily delete an entry on any ref if the listing ever hands us one.
+          if [ "$ref" != "${REF}" ]; then
+            printf 'skip (wrong ref: %s)  %s\n' "$ref" "$key"
+            continue
+          fi
           if gh api -X DELETE "repos/${GH_REPO}/actions/caches/${id}" >/dev/null 2>&1; then
             printf 'deleted %6s MiB  %s\n' "$((size / 1048576))" "$key"
             freed=$((freed + size))

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -506,11 +506,37 @@ runs:
     # Skipped entirely on self-hosted runners: there the cache directory is durable
     # local disk, so a restore would only overwrite the live cache with an older
     # snapshot of itself.
+
+    # THE PATH MUST BE THE SAME STRING THE SAVE USES, CHARACTER FOR CHARACTER (#1073).
+    #
+    # `actions/cache` derives a `version` for every entry by hashing the `path` strings
+    # it was handed -- the RAW strings, not the resolved directories. Two spellings of
+    # one directory are two different versions, and a restore only ever sees entries
+    # whose version matches. The key can match perfectly and the entry stays invisible.
+    #
+    # This step used to spell the path `${{ github.workspace }}/.vcpkg-binary-cache`. On
+    # a Windows runner `github.workspace` expands with BACKSLASH separators, so that
+    # produced a mixed-separator string. The SAVE goes through `cache-path`, i.e.
+    # `steps.cachecfg.outputs.dir`, which puts GITHUB_WORKSPACE through a
+    # backslash-to-forward-slash substitution first and produced an all-forward-slash
+    # string. One directory, two spellings, two versions, guaranteed miss -- on Windows
+    # ONLY, because on Linux the two spellings are already identical. Which is exactly
+    # the shape of the complaint: a 53-minute Windows configure step, no Linux twin.
+    #
+    # It was write-only for its whole existence, and the cache listing proves it without
+    # reading a single log: EVERY vcpkg entry in the store had `last_accessed_at` equal
+    # to `created_at` -- six of them written in one morning by five different workflows --
+    # while the Vulkan SDK entry created in July showed a read that same hour. A cache
+    # nothing has ever read is not a cold cache, it is a cache with no reader, and
+    # nothing about the key or the green step says so.
+    #
+    # Taking the path from the same output the save uses makes the two impossible to
+    # disagree. Do not re-inline the expression here for readability.
     - name: Restore vcpkg binary archives
       if: steps.cachecfg.outputs.persistent != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ${{ github.workspace }}/.vcpkg-binary-cache
+        path: ${{ steps.cachecfg.outputs.dir }}
         key: vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -20,9 +20,10 @@ outputs:
     description: >
       The actions/cache key this run should SAVE the binary cache under, or the empty
       string when there is nothing to save (a self-hosted runner keeps the cache on
-      local disk; a fork PR cannot write caches). Feed it to
-      .github/actions/save-vcpkg-cache in an `if: always()` step -- see that action.
-    value: ${{ steps.cachecfg.outputs.save-key }}
+      local disk; a fork PR cannot write caches; or a PULL REQUEST whose restore already
+      matched this exact manifest, so a save would only re-bank what it just read). Feed
+      it to .github/actions/save-vcpkg-cache in an `if: always()` step -- see that action.
+    value: ${{ steps.savedecision.outputs.save-key }}
   cache-path:
     description: 'Directory holding the vcpkg binary archives (the path to save).'
     value: ${{ steps.cachecfg.outputs.dir }}
@@ -533,6 +534,7 @@ runs:
     # Taking the path from the same output the save uses makes the two impossible to
     # disagree. Do not re-inline the expression here for readability.
     - name: Restore vcpkg binary archives
+      id: restore
       if: steps.cachecfg.outputs.persistent != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -541,6 +543,52 @@ runs:
         restore-keys: |
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-
+
+    # A PULL REQUEST THAT ALREADY GOT ITS MANIFEST DOES NOT NEED TO BANK IT AGAIN (#1073).
+    #
+    # A cache entry written by a PR run is scoped to `refs/pull/N/merge` and readable by
+    # that one PR; a PR run restores from the default branch anyway. So when the restore
+    # matched the HASH-SPECIFIC prefix, this run's binary cache is byte-for-byte what it
+    # read: the manifest, triplets and overlay ports are all in that hash, so the port set
+    # cannot differ. Saving it writes ~700 MiB of nothing.
+    #
+    # Measured on this very PR: eight vcpkg entries on `refs/pull/1075/merge` inside two
+    # hours -- two per push, because Windows.yml and asan.yml each save one -- totalling
+    # ~3.0 GiB of a ~9.3 GiB store, all of them copies of a snapshot master already held.
+    # That alone can put the store back into the read-only state this issue is about.
+    #
+    # Kept for the cases that genuinely produce something new:
+    #   * a PR that BUMPS the manifest -- the restore then falls back to the bare
+    #     `vcpkg-<os>-<triplet>-` prefix or misses outright, this run really did build
+    #     ports, and its successors should not build them again;
+    #   * every non-PR event -- the nightly and dispatch runs write the default-branch
+    #     snapshot the whole fleet restores from, and that one is refreshed unconditionally
+    #     so a missing archive always gets banked.
+    - name: Decide whether there is anything new to save
+      id: savedecision
+      shell: bash
+      env:
+        CFG_KEY: ${{ steps.cachecfg.outputs.save-key }}
+        MATCHED: ${{ steps.restore.outputs.cache-matched-key }}
+        HASH_PREFIX: vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
+        EVENT: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+        key="${CFG_KEY}"
+        if [ -n "$key" ] && [ "$EVENT" = "pull_request" ] && [ -n "${MATCHED:-}" ]; then
+          case "$MATCHED" in
+            "${HASH_PREFIX}"*)
+              echo "restore matched '${MATCHED}', which carries this exact manifest hash;"
+              echo "a pull-request save would re-bank what it just read -- skipping."
+              key=""
+              ;;
+            *)
+              echo "restore matched '${MATCHED}', an older manifest; this run builds ports, so it saves."
+              ;;
+          esac
+        fi
+        echo "save-key=$key" >> "$GITHUB_OUTPUT"
+        echo "vcpkg save-key: ${key:-<none>}"
 
     - name: Emit toolchain args
       id: emit

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -312,7 +312,6 @@ jobs:
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-windows-2025-release-${{ github.run_id }}-${{ github.run_attempt }}
-        prefix: sccache-windows-2025-release
         token: ${{ secrets.GITHUB_TOKEN }}
 
     # Banked here rather than by the combined actions/cache action's post-job

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -78,6 +78,16 @@ env:
   # Bound the on-disk cache so the saved actions/cache entry stays small — every
   # cache (this, Vulkan, FFmpeg, the sanitizer jobs' sccache dirs) shares the
   # repo's single 10 GB Actions-cache cap.
+  #
+  # That cap is a HARD WALL, not an eviction threshold (#1073). Past it GitHub does
+  # not make room by dropping the oldest entry; it turns the entire store read-only
+  # ("Cache reservation failed: You have reached your configured budget, your cache
+  # is now read only") and refuses every save in the repository until something is
+  # deleted. This job's snapshot is the single largest entry in the store, so it is
+  # the first casualty and the last thing to come back — for weeks the entry did not
+  # exist AT ALL, which is what a 0.00 % hit rate on 1630 compilations actually meant.
+  # The budget arithmetic and the rules that keep it solvent:
+  # docs/agent-rules/actions-cache-budget.md.
   SCCACHE_CACHE_SIZE: "2G"
 
 jobs:
@@ -96,6 +106,15 @@ jobs:
     # makes an image bump a deliberate, reviewable commit that we can pair with the
     # cache-key bump below.
     runs-on: windows-2025
+
+    # `actions: write` is needed by the sccache save (#1073): when the repo's 10 GB
+    # cache store is full every save is refused, and the only way to land this job's
+    # snapshot is to delete the entry it supersedes first. Scoped to this ref by
+    # `save-cache-pruned`. `contents: read` is re-declared because a job-level block
+    # REPLACES the default set rather than adding to it.
+    permissions:
+      contents: read
+      actions: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -273,18 +292,28 @@ jobs:
     # end (`cancel-in-progress`; 17 of 27 Windows and 15 of 24 Sanitizer PR runs
     # over the window measured in #1009). Every one of those recompiled everything
     # and banked nothing, so the next run started just as cold.
+    #
+    # NOT ON PULL REQUESTS (#1073). A cache entry written by a PR run is scoped to
+    # `refs/pull/N/merge` and is readable by that ONE pull request; only default-branch
+    # entries are visible fleet-wide, which is exactly why the nightly cron exists (see
+    # the trigger note at the top of this file). So a PR's 2 GB snapshot buys a single
+    # PR a marginal delta over the master snapshot it already restores -- and charges
+    # the whole repository 2 GB of a 10 GB cap for it, for as long as that PR stays
+    # open. Six concurrent PRs is a routine day here and 12 GB of PR-private sccache
+    # does not fit in a 10 GB store: it holds the store read-only, which stops the
+    # NIGHTLY from writing the one snapshot every branch actually restores from. The
+    # PR runs were paying for the mechanism that was making them cold. They now
+    # restore and never save; `cache-prune` still collects the entries they left
+    # behind. The save is kept on workflow_dispatch so a warm/cold A/B can be measured
+    # on a branch (that is how the fix for #1073 was verified).
     - name: Save sccache storage
-      if: always()
-      # A cache save must never fail the job it is attached to. `if: always()`
-      # means this runs on a CANCEL, where the path it is asked to save may not
-      # exist yet -- and actions/cache/save treats a missing path as a validation
-      # error, not a no-op. Turning a cancelled run into a FAILED one would be a
-      # strictly worse outcome than the cold cache this is fixing.
-      continue-on-error: true
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      if: always() && github.event_name != 'pull_request'
+      uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-windows-2025-release-${{ github.run_id }}-${{ github.run_attempt }}
+        prefix: sccache-windows-2025-release
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     # Banked here rather than by the combined actions/cache action's post-job
     # step, which a CANCELLED job skips (#1009). FFmpeg is a ~10-15 min from-source

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -491,6 +491,11 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
+      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
+      # full every save is refused, and the only way to land this job's snapshot
+      # is to delete the entry it supersedes first. Scoped to this ref by
+      # `save-cache-pruned`.
+      actions: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -637,16 +642,20 @@ jobs:
     # and banked nothing, so the next run started just as cold.
     - name: Save sccache storage
       if: always() && runner.environment == 'github-hosted'
-      # A cache save must never fail the job it is attached to. `if: always()`
-      # means this runs on a CANCEL, where the path it is asked to save may not
-      # exist yet -- and actions/cache/save treats a missing path as a validation
-      # error, not a no-op. Turning a cancelled run into a FAILED one would be a
-      # strictly worse outcome than the cold cache this is fixing.
-      continue-on-error: true
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
+      # must never fail the job it is attached to. `if: always()` means this runs on
+      # a CANCEL, where the path it is asked to save may not exist yet -- and
+      # actions/cache/save treats a missing path as a validation error, not a no-op.
+      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
+      # than the cold cache this is fixing. What the action adds over a bare
+      # actions/cache/save is noticing that the store refused the write, deleting
+      # this ref's superseded snapshot, and retrying -- see its own header.
+      uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-asan-lsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
+        prefix: sccache-asan-lsan-linux
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -733,6 +742,11 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
+      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
+      # full every save is refused, and the only way to land this job's snapshot
+      # is to delete the entry it supersedes first. Scoped to this ref by
+      # `save-cache-pruned`.
+      actions: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -857,16 +871,20 @@ jobs:
     # and banked nothing, so the next run started just as cold.
     - name: Save sccache storage
       if: always() && runner.environment == 'github-hosted'
-      # A cache save must never fail the job it is attached to. `if: always()`
-      # means this runs on a CANCEL, where the path it is asked to save may not
-      # exist yet -- and actions/cache/save treats a missing path as a validation
-      # error, not a no-op. Turning a cancelled run into a FAILED one would be a
-      # strictly worse outcome than the cold cache this is fixing.
-      continue-on-error: true
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
+      # must never fail the job it is attached to. `if: always()` means this runs on
+      # a CANCEL, where the path it is asked to save may not exist yet -- and
+      # actions/cache/save treats a missing path as a validation error, not a no-op.
+      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
+      # than the cold cache this is fixing. What the action adds over a bare
+      # actions/cache/save is noticing that the store refused the write, deleting
+      # this ref's superseded snapshot, and retrying -- see its own header.
+      uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-ubsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
+        prefix: sccache-ubsan-linux
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -963,6 +981,11 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
+      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
+      # full every save is refused, and the only way to land this job's snapshot
+      # is to delete the entry it supersedes first. Scoped to this ref by
+      # `save-cache-pruned`.
+      actions: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1089,16 +1112,20 @@ jobs:
     # the BUILD step still saves the partial objects via always().
     - name: Save sccache storage
       if: always() && runner.environment == 'github-hosted'
-      # A cache save must never fail the job it is attached to. `if: always()`
-      # means this runs on a CANCEL, where the path it is asked to save may not
-      # exist yet -- and actions/cache/save treats a missing path as a validation
-      # error, not a no-op. Turning a cancelled run into a FAILED one would be a
-      # strictly worse outcome than the cold cache this is fixing.
-      continue-on-error: true
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
+      # must never fail the job it is attached to. `if: always()` means this runs on
+      # a CANCEL, where the path it is asked to save may not exist yet -- and
+      # actions/cache/save treats a missing path as a validation error, not a no-op.
+      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
+      # than the cold cache this is fixing. What the action adds over a bare
+      # actions/cache/save is noticing that the store refused the write, deleting
+      # this ref's superseded snapshot, and retrying -- see its own header.
+      uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-tsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
+        prefix: sccache-tsan-linux
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -641,7 +641,14 @@ jobs:
     # over the window measured in #1009). Every one of those recompiled everything
     # and banked nothing, so the next run started just as cold.
     - name: Save sccache storage
-      if: always() && runner.environment == 'github-hosted'
+      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
+      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
+      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
+      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
+      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
+      # shared with every other job. Say the condition instead of inheriting it from a
+      # routing expression three hundred lines away.
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
       # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
       # must never fail the job it is attached to. `if: always()` means this runs on
       # a CANCEL, where the path it is asked to save may not exist yet -- and
@@ -654,7 +661,6 @@ jobs:
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-asan-lsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        prefix: sccache-asan-lsan-linux
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
@@ -870,7 +876,14 @@ jobs:
     # over the window measured in #1009). Every one of those recompiled everything
     # and banked nothing, so the next run started just as cold.
     - name: Save sccache storage
-      if: always() && runner.environment == 'github-hosted'
+      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
+      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
+      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
+      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
+      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
+      # shared with every other job. Say the condition instead of inheriting it from a
+      # routing expression three hundred lines away.
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
       # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
       # must never fail the job it is attached to. `if: always()` means this runs on
       # a CANCEL, where the path it is asked to save may not exist yet -- and
@@ -883,7 +896,6 @@ jobs:
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-ubsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        prefix: sccache-ubsan-linux
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
@@ -1111,7 +1123,14 @@ jobs:
     # later times out has already banked its build cache — while a cancel during
     # the BUILD step still saves the partial objects via always().
     - name: Save sccache storage
-      if: always() && runner.environment == 'github-hosted'
+      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
+      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
+      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
+      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
+      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
+      # shared with every other job. Say the condition instead of inheriting it from a
+      # routing expression three hundred lines away.
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
       # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
       # must never fail the job it is attached to. `if: always()` means this runs on
       # a CANCEL, where the path it is asked to save may not exist yet -- and
@@ -1124,7 +1143,6 @@ jobs:
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-tsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        prefix: sccache-tsan-linux
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -62,12 +62,18 @@
 # (`ffmpeg-…` restores by exact key; `vcpkg-…` falls back to the bare
 # `vcpkg-<os>-<triplet>-` prefix, which GitHub answers with the newest match).
 #
+# AN ENTRY WHOSE REF IS GONE is deleted before the newest-per-group rule sees it. That
+# already applied to a closed PR (#1015); it now applies to a DELETED BRANCH too. This
+# repo makes a `feature/*` branch per task and deletes it on merge, and a
+# `workflow_dispatch` run on such a branch banks its caches against that ref -- entries
+# that "newest per ref" would otherwise keep forever, unreadable by anything.
+#
 # A LAST-ACCESS AGE-OUT catches what remains: a genuinely renamed prefix, whose orphan
 # no longer matches anything and is therefore never restored. `last_accessed_at` is the
 # honest signal -- a live entry is read by every run that keys off it, so its timestamp
-# moves daily, and 14 days is comfortably longer than the slowest cadence in the fleet
-# (the weekly dist-archive / steam-stub / vulkan-off / video-ffmpeg jobs all read
-# prefixes that the daily Windows and Sanitizers nightlies also read).
+# keeps moving. 30 days, because the read cadence is NOT daily for every prefix and
+# assuming it was is how a rule like this deletes something live -- see the measurement
+# in the sweep. It is a long-tail backstop only; the recurring leak is handled above.
 name: Prune Actions cache
 
 on:
@@ -77,10 +83,11 @@ on:
     #
     # 01:05 — BEFORE the Sanitizers nightly (01:23) and the Windows nightly (01:53).
     # This is the one that matters. The keys are append-only, so on the night the
-    # nightlies run the store briefly holds an old AND a new snapshot of each: about
-    # 6 GB of duplicate on top of a ~7 GB steady set, against a 10 GB wall. Whichever
-    # job saves second is refused -- and the Windows snapshot, at 2 GB the largest
-    # entry in the store, is the one that loses. Sweeping first gives them room.
+    # nightlies run the store briefly holds an old AND a new snapshot of each: the three
+    # Linux sanitizer sccache entries measure ~1.25 GiB apiece, so that is ~3.7 GiB of
+    # duplicate before the Windows job even reaches its save, on top of a ~5 GiB steady
+    # set, against a ~9.3 GiB wall. Whichever job saves last is the one refused.
+    # Sweeping first gives them room.
     #
     # 06:41 — after both have saved, to collect what they superseded. (It cannot be
     # after ALL of them: SonarCloud and the weekly dist-archive can run past 09:00.
@@ -152,13 +159,25 @@ jobs:
           # Entries arrive newest-first, so the first sighting of a group is the
           # keeper and every later one is superseded.
           #
-          # AGE-OUT (#1073): an entry not READ in 14 days is dead whatever its group.
+          # AGE-OUT (#1073): an entry not READ in 30 days is dead whatever its group.
           # A live cache is restored by every run that keys off it, so its
-          # `last_accessed_at` moves daily; a genuinely renamed prefix leaves an orphan
-          # that matches nothing and whose timestamp never moves again. 14 days is well
-          # past the slowest read cadence in the fleet -- every weekly workflow keys off
-          # a prefix the daily Windows/Sanitizers nightlies also read.
-          age_out_days=14
+          # `last_accessed_at` keeps moving; a genuinely renamed prefix leaves an orphan
+          # that matches nothing and whose timestamp never moves again.
+          #
+          # 30, not 14. The read cadence is NOT daily for every prefix, and assuming it
+          # was is how a rule like this deletes something live. Measured:
+          # `Linux-vulkan-prebuilt-sdk-true-1.4.321.0` was created 2026-08-19 and last
+          # read 2026-09-02 -- a 14-day gap with no read in it -- and it went unread
+          # again for the four days after that, while the Sanitizers nightly ran every
+          # one of them. The nightly AMD (cross-vendor, gpu-*) jobs sit on a self-hosted
+          # box that can be offline for a stretch, which widens the gap further.
+          #
+          # Nothing is lost by waiting: the orphans this catches are permanent, so
+          # collecting them a fortnight later costs nothing, whereas deleting a live
+          # entry costs a cold build for somebody who changed nothing. The big recurring
+          # leak -- a vcpkg manifest bump -- is handled by the hash strip above, not by
+          # this, so this is purely a long-tail backstop and can afford to be patient.
+          age_out_days=30
           age_out_before=$(date -u -d "${age_out_days} days ago" +%s)
           # A PR ref's entries die with the PR (#1015). "Newest per ref" keeps one
           # entry per prefix on `refs/pull/N/merge` FOREVER, and nothing can ever
@@ -181,6 +200,35 @@ jobs:
             [ "${pr_closed[$n]}" = yes ]
           }
 
+          # A DELETED BRANCH's entries are unreachable, exactly like a closed PR's
+          # (#1073). "Newest per ref" keeps one entry per prefix on
+          # `refs/heads/feature/whatever` FOREVER, and nothing can read it once the
+          # branch is gone. This repo creates a `feature/*` worktree per task and deletes
+          # the branch on merge, and a `workflow_dispatch` run on one of those branches
+          # banks a full ~700 MiB vcpkg entry plus an sccache snapshot against its ref --
+          # so this is not a corner case, it is the normal shape of work here. The
+          # default branch is never checked, because it is never gone.
+          # `|| echo master` so an API hiccup cannot abort the sweep under `set -e` and
+          # trip the "needs a human" alarm at the end for no reason. Guessing the default
+          # branch wrong only costs one wasted branch lookup that answers "present".
+          default_branch=$(gh api "repos/${GH_REPO}" --jq .default_branch || echo master)
+          declare -A branch_gone=()
+          branch_is_gone() {
+            local b="$1"
+            [ "$b" != "$default_branch" ] || return 1
+            if [ -z "${branch_gone[$b]:-}" ]; then
+              # Unknown (an API hiccup) is treated as PRESENT: the conservative side,
+              # same as pr_is_closed above. A slash in the branch name is fine on this
+              # endpoint -- verified against `feature/ci-windows-sccache-1073`.
+              if gh api "repos/${GH_REPO}/branches/${b}" --jq .name >/dev/null 2>&1; then
+                branch_gone[$b]=no
+              else
+                branch_gone[$b]=yes
+              fi
+            fi
+            [ "${branch_gone[$b]}" = yes ]
+          }
+
           declare -A seen=()
           kept=0
           deleted=0
@@ -194,13 +242,17 @@ jobs:
             if [[ "$ref" =~ ^refs/pull/([0-9]+)/merge$ ]] && pr_is_closed "${BASH_REMATCH[1]}"; then
               closed_pr=1
             fi
+            dead_branch=0
+            if [[ "$ref" =~ ^refs/heads/(.+)$ ]] && branch_is_gone "${BASH_REMATCH[1]}"; then
+              dead_branch=1
+            fi
             unread=0
             accessed_at=$(date -u -d "${accessed}" +%s 2>/dev/null || echo 0)
             # A timestamp we cannot parse counts as fresh: never delete on a bad parse.
             if [ "$accessed_at" -gt 0 ] && [ "$accessed_at" -lt "$age_out_before" ]; then
               unread=1
             fi
-            if [ "$closed_pr" -eq 0 ] && [ "$unread" -eq 0 ] && [ -z "${seen[$group]:-}" ]; then
+            if [ "$closed_pr" -eq 0 ] && [ "$dead_branch" -eq 0 ] && [ "$unread" -eq 0 ] && [ -z "${seen[$group]:-}" ]; then
               seen[$group]=1
               kept=$((kept + 1))
               printf 'keep    %6s MiB  %-28s %s\n' "$((size / 1048576))" "$ref" "$key"
@@ -208,6 +260,8 @@ jobs:
             fi
             if [ "$closed_pr" -eq 1 ]; then
               printf 'DELETE  %6s MiB  %-28s %s  (PR closed)\n' "$((size / 1048576))" "$ref" "$key"
+            elif [ "$dead_branch" -eq 1 ]; then
+              printf 'DELETE  %6s MiB  %-28s %s  (branch deleted)\n' "$((size / 1048576))" "$ref" "$key"
             elif [ "$unread" -eq 1 ]; then
               stale=$((stale + 1))
               printf 'DELETE  %6s MiB  %-28s %s  (not read since %s)\n' "$((size / 1048576))" "$ref" "$key" "$accessed"

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -20,25 +20,78 @@
 # `refs/heads/master` entry every other branch restores from -- which is exactly
 # the property the rest of #1009 is built on, undone nightly by its own cleanup.
 #
+# THE CAP IS A WALL, NOT AN EVICTION THRESHOLD (#1073)
+# ----------------------------------------------------
+# The paragraph above says GitHub "was already LRU-evicting". It is not, and that
+# misreading is why this workflow was believed to be sufficient. Past the cap the
+# store goes READ-ONLY:
+#
+#   ##[warning]Cache reservation failed: You have reached your configured budget,
+#              your cache is now read only to prevent additional charges.
+#   Failed to save: Unable to reserve cache with key sccache-windows-2025-release-…
+#
+# Nothing is evicted to make room. Every save in the repository is refused until
+# something is deleted, and `actions/cache/save` reports that as a warning and exits
+# ZERO, so nobody finds out. The measured consequence: the entry
+# `sccache-windows-2025-release-*` did not exist at all for weeks and the Windows
+# build compiled all 1630 TUs from scratch on every run, reporting 0.00 %, green.
+#
 # WHAT IT DELIBERATELY DOES NOT DO
 # --------------------------------
-# It never deletes the newest entry for a (ref, prefix), whatever its age -- a
+# It never deletes the newest LIVE entry for a (ref, prefix), whatever its age -- a
 # cache that is merely old is not a cache that is wrong, and deleting the last
 # snapshot of a 40-minute vcpkg install to reclaim quota would cost far more than
-# it saves. A prefix that has genuinely gone away (a renamed key) therefore leaves
-# one orphan behind; one entry per dead prefix is a rounding error against the
-# cap, and the alternative is a rule that can delete a live cache.
+# it saves.
+#
+# It used to say the same of an entry whose prefix had gone away:
+#
+#   > A prefix that has genuinely gone away (a renamed key) therefore leaves one
+#   > orphan behind; one entry per dead prefix is a rounding error against the cap
+#
+# That was false, and by the largest item in the store (#1073). The vcpkg key embeds
+# the MANIFEST HASH -- `vcpkg-Windows-<triplet>-<64 hex>-<run_id>-<attempt>` -- so
+# stripping only the run id made every vcpkg.json bump a brand-new prefix, and each
+# bump orphaned a ~2 GB entry FOREVER. On 2026-09-06 the single biggest cache entry
+# in the repo was 1988 MiB of a superseded manifest hash, created 2026-09-03 and
+# never read once (`last_accessed_at` never moved off its creation time), while the
+# Windows sccache snapshot it was crowding out could not be written at all.
+#
+# So the prefix now drops a trailing content hash as well as the run id, which makes
+# a hash bump SUPERSEDE its predecessor instead of orphaning it -- correct for every
+# key of that shape here, because a restore reaches at most one of them anyway
+# (`ffmpeg-…` restores by exact key; `vcpkg-…` falls back to the bare
+# `vcpkg-<os>-<triplet>-` prefix, which GitHub answers with the newest match).
+#
+# A LAST-ACCESS AGE-OUT catches what remains: a genuinely renamed prefix, whose orphan
+# no longer matches anything and is therefore never restored. `last_accessed_at` is the
+# honest signal -- a live entry is read by every run that keys off it, so its timestamp
+# moves daily, and 14 days is comfortably longer than the slowest cadence in the fleet
+# (the weekly dist-archive / steam-stub / vulkan-off / video-ffmpeg jobs all read
+# prefixes that the daily Windows and Sanitizers nightlies also read).
 name: Prune Actions cache
 
 on:
   schedule:
-    # 06:41 UTC — after the two heaviest nightlies have saved (Sanitizers 01:23 and
-    # Windows 01:53, each up to ~3 h). It cannot be after ALL of them: SonarCloud
-    # and the weekly dist-archive can run past 09:00. That is fine and not worth
-    # chasing — this job only ever deletes SUPERSEDED entries, so running before a
-    # nightly has saved simply means that entry is not there yet and is collected
-    # tomorrow instead. Running *never* after a save would be the problem; running
-    # a few hours early is not.
+    # TWICE daily, and the times are chosen against the two heaviest savers rather
+    # than against the clock (#1073).
+    #
+    # 01:05 — BEFORE the Sanitizers nightly (01:23) and the Windows nightly (01:53).
+    # This is the one that matters. The keys are append-only, so on the night the
+    # nightlies run the store briefly holds an old AND a new snapshot of each: about
+    # 6 GB of duplicate on top of a ~7 GB steady set, against a 10 GB wall. Whichever
+    # job saves second is refused -- and the Windows snapshot, at 2 GB the largest
+    # entry in the store, is the one that loses. Sweeping first gives them room.
+    #
+    # 06:41 — after both have saved, to collect what they superseded. (It cannot be
+    # after ALL of them: SonarCloud and the weekly dist-archive can run past 09:00.
+    # That is fine — this job only deletes SUPERSEDED entries, so running before a
+    # save simply means that entry is collected on the next sweep.)
+    #
+    # Between sweeps, each heavy job also prunes its own lineage on its own ref if
+    # its save is refused (.github/actions/save-cache-pruned). A twice-daily janitor
+    # cannot fix a breach that happens between two saves thirty minutes apart; that
+    # action can, and this workflow collects everything it does not own.
+    - cron: '5 1 * * *'
     - cron: '41 6 * * *'
   workflow_dispatch:
 
@@ -80,15 +133,33 @@ jobs:
           gh api --paginate "repos/${GH_REPO}/actions/caches?per_page=100" --slurp \
             | jq -r '[.[].actions_caches[]]
                      | sort_by(.created_at) | reverse
-                     | .[] | [.id, .ref, .key, .size_in_bytes] | @tsv' \
+                     | .[] | [.id, .ref, .key, .size_in_bytes, .last_accessed_at] | @tsv' \
             > /tmp/caches.tsv
 
           # The prefix is the key with its trailing `-<run_id>[-<run_attempt>]`
-          # stripped. Keys that carry no run id (the content-addressed FFmpeg and
-          # Vulkan SDK entries) collapse to themselves, so each is its own prefix
-          # and its single entry is always the newest -- they are never deleted.
+          # stripped, AND THEN a trailing content hash (#1073). Both strips matter:
+          #
+          #   sccache-windows-2025-release-33993528874-1  -> sccache-windows-2025-release
+          #   vcpkg-Windows-x64-windows-static-md-<64hex>-34021696485-1
+          #                                              -> vcpkg-Windows-x64-windows-static-md
+          #   ffmpeg-Windows-n7.1-<64hex>                 -> ffmpeg-Windows-n7.1
+          #   Windows-vulkan-prebuilt-sdk-true-1.4.321.0  -> (unchanged; no run id, no hash)
+          #
+          # Without the second strip a manifest-hash bump starts a NEW group whose sole
+          # member is immortal, and the entry it superseded is immortal too -- see the
+          # header. With it, the newest hash supersedes the older ones, which matches how
+          # a restore behaves: it reaches at most one entry of a lineage anyway.
           # Entries arrive newest-first, so the first sighting of a group is the
           # keeper and every later one is superseded.
+          #
+          # AGE-OUT (#1073): an entry not READ in 14 days is dead whatever its group.
+          # A live cache is restored by every run that keys off it, so its
+          # `last_accessed_at` moves daily; a genuinely renamed prefix leaves an orphan
+          # that matches nothing and whose timestamp never moves again. 14 days is well
+          # past the slowest read cadence in the fleet -- every weekly workflow keys off
+          # a prefix the daily Windows/Sanitizers nightlies also read.
+          age_out_days=14
+          age_out_before=$(date -u -d "${age_out_days} days ago" +%s)
           # A PR ref's entries die with the PR (#1015). "Newest per ref" keeps one
           # entry per prefix on `refs/pull/N/merge` FOREVER, and nothing can ever
           # read it once the PR is merged or closed: 3.1 GB of the 10 GB cap was two
@@ -114,15 +185,22 @@ jobs:
           kept=0
           deleted=0
           freed=0
-          while IFS=$'\t' read -r id ref key size; do
+          stale=0
+          while IFS=$'\t' read -r id ref key size accessed; do
             [ -n "${id:-}" ] || continue
-            prefix=$(printf '%s' "$key" | sed -E 's/-[0-9]{6,}(-[0-9]+)?$//')
+            prefix=$(printf '%s' "$key" | sed -E 's/-[0-9]{6,}(-[0-9]+)?$//; s/-[0-9a-f]{32,}$//')
             group="${ref}|${prefix}"
             closed_pr=0
             if [[ "$ref" =~ ^refs/pull/([0-9]+)/merge$ ]] && pr_is_closed "${BASH_REMATCH[1]}"; then
               closed_pr=1
             fi
-            if [ "$closed_pr" -eq 0 ] && [ -z "${seen[$group]:-}" ]; then
+            unread=0
+            accessed_at=$(date -u -d "${accessed}" +%s 2>/dev/null || echo 0)
+            # A timestamp we cannot parse counts as fresh: never delete on a bad parse.
+            if [ "$accessed_at" -gt 0 ] && [ "$accessed_at" -lt "$age_out_before" ]; then
+              unread=1
+            fi
+            if [ "$closed_pr" -eq 0 ] && [ "$unread" -eq 0 ] && [ -z "${seen[$group]:-}" ]; then
               seen[$group]=1
               kept=$((kept + 1))
               printf 'keep    %6s MiB  %-28s %s\n' "$((size / 1048576))" "$ref" "$key"
@@ -130,6 +208,9 @@ jobs:
             fi
             if [ "$closed_pr" -eq 1 ]; then
               printf 'DELETE  %6s MiB  %-28s %s  (PR closed)\n' "$((size / 1048576))" "$ref" "$key"
+            elif [ "$unread" -eq 1 ]; then
+              stale=$((stale + 1))
+              printf 'DELETE  %6s MiB  %-28s %s  (not read since %s)\n' "$((size / 1048576))" "$ref" "$key" "$accessed"
             else
               printf 'DELETE  %6s MiB  %-28s %s\n' "$((size / 1048576))" "$ref" "$key"
             fi
@@ -143,8 +224,41 @@ jobs:
             fi
           done < /tmp/caches.tsv
 
-          echo "kept $kept (newest per ref+prefix), deleted $deleted, freed $((freed / 1048576)) MiB"
+          echo "kept $kept (newest per ref+prefix), deleted $deleted ($stale of them unread for ${age_out_days}+ days), freed $((freed / 1048576)) MiB"
 
           echo "after:"
           gh api "repos/${GH_REPO}/actions/cache/usage" \
             --jq '"  \(.active_caches_count) entries, \(.active_caches_size_in_bytes/1048576|floor) MiB"'
+
+          # FAIL WHEN THE STORE IS STILL NEARLY FULL (#1073). Everything above deletes
+          # only what is provably superseded or unread; if what remains still does not
+          # leave room for a night of saves, the fleet has outgrown the 10 GB cap and a
+          # human has to shrink something -- an SCCACHE_CACHE_SIZE, a job's cache, or the
+          # cap itself. The alternative is what actually happened: the store sat read-only
+          # for weeks, every save was refused with a warning nobody read, and the only
+          # visible symptom was a Windows build that had quietly stopped caching. This
+          # job failing is the alarm that was missing.
+          #
+          # WHERE THE NUMBER COMES FROM. The cap is 10 GB DECIMAL, not 10 GiB, and that
+          # is measured rather than read off the docs: saves were being refused with the
+          # store at 9,713,535,876 bytes = 9264 MiB. Had the cap been 10 GiB (10737 MiB)
+          # there would have been 1.4 GiB free and the 706 MiB vcpkg save in the same run
+          # would have landed. It did not. So the wall is ~9537 MiB.
+          #
+          # Post-sweep the steady set measures ~7.9 GiB (2.0 Windows sccache, 3.7 across
+          # the three Linux sanitizer sccaches, 0.7 vcpkg, 0.5 Vulkan SDKs, and 0.9 of
+          # `sccache-flaky-281` which ages out now that its nightly is gone). 8800 MiB
+          # leaves that a working margin and still fires ~700 MiB before the wall --
+          # early enough that a human can act before the store goes read-only.
+          #
+          # Raise it only together with a re-measurement of the steady set. Raising it to
+          # silence the alarm is how #1073 happened.
+          headroom_floor_mib=8800
+          used_mib=$(gh api "repos/${GH_REPO}/actions/cache/usage" \
+            --jq '.active_caches_size_in_bytes/1048576|floor')
+          if [ "${used_mib}" -gt "${headroom_floor_mib}" ]; then
+            echo "::error::Actions cache store is ${used_mib} MiB after pruning, over the ${headroom_floor_mib} MiB working ceiling."
+            echo "::error::Past the 10 GB cap GitHub does not evict -- it makes the whole store READ-ONLY and refuses every save in the repo, silently (actions/cache/save warns and exits 0). Nothing left here is superseded, so this needs a human: docs/agent-rules/actions-cache-budget.md."
+            exit 1
+          fi
+          echo "headroom: $((headroom_floor_mib - used_mib)) MiB below the working ceiling."

--- a/.github/workflows/flaky-repro-281.yml
+++ b/.github/workflows/flaky-repro-281.yml
@@ -8,16 +8,23 @@ name: Flaky repro (#281)
 # CPU-affinity + 2-worker squeeze, stops on the first crash/deadlock, and
 # captures a symbolised stack + full minidump as an artifact.
 #
-# Manual / scheduled only — it is a hunt, never a merge gate. See
-# scripts/repro-flaky-test.ps1 and docs/agent-rules/testing-architecture.md §5.
+# MANUAL ONLY — it is a hunt, never a merge gate. See scripts/repro-flaky-test.ps1
+# and docs/agent-rules/testing-architecture.md §5.
+#
+# THE NIGHTLY IS GONE (#1073), and so is the branch `push:` trigger it shipped with.
+# #281 is fixed at the root — JoltJobSystemAdapter::WaitForOutstandingTasks blocks
+# instead of busy-spinning, and this very workflow is what proved it, running the
+# test under the 2-core squeeze for a full step with zero failures (see the CTest
+# note in Windows.yml). A hunt for a bug that has been found is a nightly Windows
+# engine build charged to the account for nothing, and it was not free: its 886 MiB
+# `sccache-flaky-281-*` snapshot was sitting in a 10 GB cache store that had gone
+# read-only, crowding out the Windows build's own sccache entry, which is why that
+# build had been compiling all 1630 TUs from scratch on every run.
+#
+# Reinstate the schedule only alongside REOPENING #281 — a hunt with no open quarry
+# is how this came back the first time.
 
 on:
-  # Branch-scoped push trigger: lets the hunt run from this feature branch
-  # (workflow_dispatch alone needs the workflow on the default branch). Remove
-  # this block once the workflow lands on master and dispatch/schedule suffice.
-  push:
-    branches:
-      - fix/flaky-jolt-physics-race-281
   workflow_dispatch:
     inputs:
       iterations:
@@ -39,10 +46,6 @@ on:
         description: "OLO_TASK_GRAPH_NUM_WORKERS (CI 2-core regime = 2)"
         required: false
         default: "2"
-  # Nightly hunt so a real repro (and its dump) accumulates over time without a
-  # human kicking it off. Comment out if too noisy.
-  schedule:
-    - cron: "0 7 * * *"
 
 concurrency:
   group: flaky-repro-281

--- a/.github/workflows/flaky-repro-281.yml
+++ b/.github/workflows/flaky-repro-281.yml
@@ -63,6 +63,15 @@ env:
 jobs:
   hunt:
     runs-on: windows-2025
+
+    # `actions: write` is needed by the sccache save (#1073): when the repo's 10 GB
+    # cache store is full every save is refused, and the only way to land a snapshot is
+    # to delete the entry it supersedes first. `contents: read` is re-declared because a
+    # job-level block REPLACES the default set rather than adding to it; checkout,
+    # setup-python and upload-artifact need nothing beyond it.
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 110
 
     steps:
@@ -174,16 +183,19 @@ jobs:
     # the combined action banked nothing on any run that actually did its job.
     - name: Save sccache storage
       if: always()
-      # A cache save must never fail the job it is attached to. `if: always()`
-      # means this runs on a CANCEL, where the path it is asked to save may not
-      # exist yet -- and actions/cache/save treats a missing path as a validation
-      # error, not a no-op. Turning a cancelled run into a FAILED one would be a
-      # strictly worse outcome than the cold cache this is fixing.
-      continue-on-error: true
-      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save must
+      # never fail the job it is attached to, and `if: always()` means this runs on a
+      # CANCEL, where the path may not exist yet. What it adds over a bare
+      # actions/cache/save is noticing that the store REFUSED the write, deleting this
+      # ref's superseded snapshot, and retrying -- and skipping all of that when there
+      # was nothing to save, which for this job is the common case: a cancel at
+      # `timeout-minutes: 110` is its expected exit, so it is the one job here most
+      # likely to reach this step with an empty SCCACHE_DIR.
+      uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-flaky-281-${{ github.run_id }}-${{ github.run_attempt }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     # Banked here rather than by the combined actions/cache action's post-job
     # step, which a CANCELLED job skips (#1009). FFmpeg is a ~10-15 min from-source

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -50,6 +50,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md): a CI cache that restores is not
   one that works.
 - [actions-cache-budget.md](actions-cache-budget.md): the Actions cache store is a fixed budget every key must fit in; past the cap it goes read-only and refuses every save in the repo, silently.
+- [cache-entry-version-is-the-path-string.md](cache-entry-version-is-the-path-string.md): a cache's restore and its save must be handed the same path string, character for character; two spellings of one directory are two caches.
 - [compiler-cache-uncacheable-compiles.md](compiler-cache-uncacheable-compiles.md): print the cache statistics after every CI build and read the uncacheable line; a PCH without `CCACHE_SLOPPINESS` and a per-commit macro each made every engine object a miss.
 - [shader-pack-bake.md](shader-pack-bake.md): the CI-baked `.osp` pack, its content-hash invalidation, and why a fresh worktree does not fetch it.
 - [steamworks-platform-integration.md](steamworks-platform-integration.md): the SDK is developer-supplied, CI builds a stub, and exactly one TU may include a Valve header.
@@ -292,6 +293,7 @@ The check passes for a correct implementation and for a broken one.
 | [incremental-build-odr-staleness.md](incremental-build-odr-staleness.md) | A correct fix that a live rebuild kept "disproving"; the binary was stale, not the source. |
 | [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md) | A cache has no wrong-looking failure state: it fails by being slow. Every save in the repo had been refused for six days and every run stayed green. |
 | [actions-cache-budget.md](actions-cache-budget.md) | The Windows sccache entry had not existed for weeks. Restore said "Cache not found", save said "your cache is now read only" and exited 0, and the only visible symptom was a build that took four hours. |
+| [cache-entry-version-is-the-path-string.md](cache-entry-version-is-the-path-string.md) | The vcpkg key matched exactly and the entry was still invisible: restore and save spelled the same directory two ways, so every entry ever written had `last_accessed_at == created_at`. |
 | [compiler-cache-uncacheable-compiles.md](compiler-cache-uncacheable-compiles.md) | The build step takes compile time on a shader-only change while the cache directory is warm. A PCH-using compile is uncacheable without `CCACHE_SLOPPINESS`; a per-commit macro on every TU misses every run. |
 
 **The counter-move:** measure the noise floor first, and construct a case the instrument must fail

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -49,6 +49,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [incremental-build-odr-staleness.md](incremental-build-odr-staleness.md): when a correct fix makes no sense live, suspect a stale incremental object before the code.
 - [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md): a CI cache that restores is not
   one that works.
+- [actions-cache-budget.md](actions-cache-budget.md): the Actions cache store is a fixed budget every key must fit in; past the cap it goes read-only and refuses every save in the repo, silently.
 - [compiler-cache-uncacheable-compiles.md](compiler-cache-uncacheable-compiles.md): print the cache statistics after every CI build and read the uncacheable line; a PCH without `CCACHE_SLOPPINESS` and a per-commit macro each made every engine object a miss.
 - [shader-pack-bake.md](shader-pack-bake.md): the CI-baked `.osp` pack, its content-hash invalidation, and why a fresh worktree does not fetch it.
 - [steamworks-platform-integration.md](steamworks-platform-integration.md): the SDK is developer-supplied, CI builds a stub, and exactly one TU may include a Valve header.
@@ -290,6 +291,7 @@ The check passes for a correct implementation and for a broken one.
 | [lazy-static-release-ownership.md](lazy-static-release-ownership.md) | GL has no allocator-teardown assertion, so a clean GL close proves nothing about teardown. |
 | [incremental-build-odr-staleness.md](incremental-build-odr-staleness.md) | A correct fix that a live rebuild kept "disproving"; the binary was stale, not the source. |
 | [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md) | A cache has no wrong-looking failure state: it fails by being slow. Every save in the repo had been refused for six days and every run stayed green. |
+| [actions-cache-budget.md](actions-cache-budget.md) | The Windows sccache entry had not existed for weeks. Restore said "Cache not found", save said "your cache is now read only" and exited 0, and the only visible symptom was a build that took four hours. |
 | [compiler-cache-uncacheable-compiles.md](compiler-cache-uncacheable-compiles.md) | The build step takes compile time on a shader-only change while the cache directory is warm. A PCH-using compile is uncacheable without `CCACHE_SLOPPINESS`; a per-commit macro on every TU misses every run. |
 
 **The counter-move:** measure the noise floor first, and construct a case the instrument must fail

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -170,6 +170,17 @@ re-creates this bug.
   `flaky-repro-281` hunt held 886 MiB for an investigation closed months earlier; its
   schedule is gone. Retire the schedule when you retire the question.
 
+## The other half of #1073
+
+The sccache entry did not exist because the store was read-only. The **vcpkg** entries did
+exist, in quantity, and had never once been read — a separate fault entirely: the restore
+and the save spelled the same directory two different ways, and `actions/cache` hashes the
+path string into each entry's version. See
+[cache-entry-version-is-the-path-string.md](cache-entry-version-is-the-path-string.md).
+Do not assume one cause explains every cold cache in a repo; check each prefix's
+`created_at` (is anything written?) and `created_at == last_accessed_at` (is anything
+read?) separately.
+
 ## See also
 
 - [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md) — the same store, one

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -154,7 +154,14 @@ re-creates this bug.
 - Save through `save-cache-pruned`, with `prefix` set to the key minus its
   `-<run_id>-<attempt>` tail, and grant the job `actions: write`.
 - Gate the save on `github.event_name != 'pull_request'` unless the entry is small
-  (a few MiB) or genuinely PR-specific.
+  (a few MiB) or genuinely PR-specific. "PR-specific" means the run produced something the
+  default-branch snapshot does not already hold — **not** merely that a PR ran. vcpkg is
+  the worked example: a PR that does not touch `vcpkg.json` restores master's snapshot and
+  would re-bank a byte-identical copy, so `setup-vcpkg` now emits an empty `cache-key`
+  when the restore already matched the hash-specific prefix. Measured on PR #1075 before
+  the fix: eight entries on one PR ref in two hours (two per push — Windows.yml and
+  asan.yml each save one), ~3.0 GiB of a ~9.3 GiB store, every one a copy of what master
+  already had. Count `saves per push × open PRs`, not `saves per PR`.
 - **A `workflow_dispatch` run on a `feature/*` branch banks its caches against that
   branch's ref**, and those entries outlive the branch. `cache-prune.yml` now deletes
   entries whose branch is gone, mirroring the closed-PR rule — but if you dispatch a

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -34,7 +34,10 @@ Cache hits rate     0.00 %
 Average compiler   24.690 s
 ```
 
-1630 × 24.7 s is essentially the whole 2 h 31 m build step. Every step was green.
+1630 requests × 24.69 s is **11 h 10 m of compiler time**, against a measured build step
+of **2 h 31 m** — the difference is Ninja's parallelism, about 4.4× on a 4-vCPU runner.
+Both numbers matter: the wall clock is what a PR waits for, and the compiler time is what
+a working cache would have removed almost all of. Every step was green.
 
 The cause was not a hash input, not `SCCACHE_CACHE_SIZE`, not `/Zi` vs `/Z7`. **The cache
 entry did not exist.** A full listing of the repository's cache store contained no
@@ -98,9 +101,17 @@ The prefix now strips a trailing content hash as well as the run id, so a hash b
 supersedes instead of orphaning. That is correct for every key of this shape here,
 because a restore reaches at most one entry of a lineage anyway — `ffmpeg-…` restores by
 exact key, and `vcpkg-…` falls back to the bare `vcpkg-<os>-<triplet>-` prefix, which
-GitHub answers with the newest match. A **14-day `last_accessed_at` age-out** catches
+GitHub answers with the newest match. A **30-day `last_accessed_at` age-out** catches
 what remains: a genuinely renamed prefix leaves an orphan that matches nothing, so its
-read timestamp never moves again, while a live entry is read daily.
+read timestamp never moves again, while a live entry keeps being read.
+
+Thirty days, not fourteen, and the difference is the whole safety of the rule. The read
+cadence is **not** daily for every prefix: `Linux-vulkan-prebuilt-sdk-true-1.4.321.0` was
+created 2026-08-19 and last read 2026-09-02 — a fortnight with no read in it — and went
+unread for four days after that while the Sanitizers nightly ran every one of them. An
+age-out shorter than a prefix's real read interval deletes live caches. Nothing is lost
+by waiting: the orphans this catches are permanent, and the recurring leak is handled by
+the hash strip, not by this.
 
 ### Six open PRs do not fit in a 10 GB store
 
@@ -114,18 +125,24 @@ cold.** They now restore and never save.
 
 ## The arithmetic, so the next person does not have to re-derive it
 
-Measured 2026-09-06, after the sweep:
+Measured 2026-09-06, after the sweep. Sizes are the **compressed tarball**, which is what
+counts against the cap — not `SCCACHE_CACHE_SIZE`, which bounds the local directory
+before compression:
 
 | Entry | Size |
 |---|---|
-| `sccache-windows-2025-release` | 2.0 GiB |
-| `sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux` | 1.2 GiB each |
-| `vcpkg-Windows-x64-windows-static-md` | 0.7 GiB |
-| `Windows-` / `Linux-vulkan-prebuilt-sdk` | 0.5 GiB together |
+| `sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux` | 1252 / 1231 / 1258 MiB |
+| `vcpkg-Windows-x64-windows-static-md` | 692 MiB |
+| `Linux-` / `Windows-vulkan-prebuilt-sdk` | 291 + 229 MiB |
 | `ffmpeg-Windows-n7.1` | 4 MiB |
-| **steady set** | **~7.9 GiB against a ~9.3 GiB wall** |
+| **measured subtotal** | **4957 MiB** |
+| `sccache-windows-2025-release` | **not measured — no entry has ever existed to measure.** `SCCACHE_CACHE_SIZE` caps the local dir at 2 GiB; `sccache-flaky-281`, same cap and the same build, compressed to 886 MiB. Expect 0.9–2.0 GiB; plan against 2.0 until a real one lands. |
+| **steady set** | **5.7 GiB likely, 6.8 GiB worst case** (4.84 GiB measured + 0.87–2.0), against a ~9.3 GiB wall — so 2.5 GiB of margin even at the bound |
 
-The margin is one Windows snapshot wide. That is why `cache-prune.yml` now **fails** when
+Do not quote the sccache row as a measurement until an entry has been written and listed.
+The number that mattered here was one nobody had ever read.
+
+That is why `cache-prune.yml` now **fails** when
 the post-sweep store is over 8800 MiB: everything it deletes is provably superseded or
 unread, so if what remains is still that close to the wall, the fleet has outgrown the
 cap and a human has to shrink something. Raising the ceiling to silence the alarm
@@ -138,7 +155,17 @@ re-creates this bug.
   `-<run_id>-<attempt>` tail, and grant the job `actions: write`.
 - Gate the save on `github.event_name != 'pull_request'` unless the entry is small
   (a few MiB) or genuinely PR-specific.
-- If the key embeds a content hash, confirm `cache-prune.yml`'s prefix regex strips it.
+- **A `workflow_dispatch` run on a `feature/*` branch banks its caches against that
+  branch's ref**, and those entries outlive the branch. `cache-prune.yml` now deletes
+  entries whose branch is gone, mirroring the closed-PR rule — but if you dispatch a
+  heavy workflow on a branch to measure something, expect ~1.7 GiB of branch-scoped
+  entries to exist until it sweeps.
+- If the key embeds a content hash, confirm `cache-prune.yml`'s prefix regex strips it
+  (`-[0-9a-f]{32,}$`). A key whose varying part is **not** hex — the Vulkan SDK entries end
+  in a version, `…-prebuilt-sdk-true-1.4.321.0` — is not stripped, so a version bump
+  orphans the old entry and only the 30-day age-out collects it. Acceptable at 229 MiB;
+  it would not be at 2 GiB. Size the key shape to the entry.
+- **Check the read cadence before relying on the age-out** (see the 30-day note above).
 - **A workflow that is finished is a cache that is still charged.** The nightly
   `flaky-repro-281` hunt held 886 MiB for an investigation closed months earlier; its
   schedule is gone. Retire the schedule when you retire the question.

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -1,0 +1,155 @@
+# The Actions cache store is a fixed budget, and every key must fit in it
+
+Issue [#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073).
+
+**Rules, first:**
+
+1. **A cache key that ends in `-<run_id>` is append-only.** It never replaces the entry
+   it supersedes. Something has to delete the predecessor, and a janitor that runs once
+   a day cannot do it between two saves thirty minutes apart. Use
+   [`.github/actions/save-cache-pruned`](../../.github/actions/save-cache-pruned/action.yml),
+   which asks the API whether the save actually landed and, only if it did not, deletes
+   this ref's older entries under the same prefix and retries.
+2. **Never save a large cache on a `pull_request` run.** The entry is scoped to
+   `refs/pull/N/merge`, is readable by that one PR, and is charged to the whole
+   repository for as long as the PR stays open.
+3. **A key that embeds a content hash needs the hash stripped when you group entries for
+   pruning.** Otherwise every dependency bump starts a new group whose single member is
+   immortal — and so is the entry it superseded.
+4. **Before redesigning a cache, add up what the fleet already stores.** The cap is
+   ~9537 MiB. If the steady set does not leave room for the largest single snapshot, no
+   key design will help.
+
+---
+
+## What happened
+
+`sccache --show-stats` on the Windows build, every run, for weeks:
+
+```
+Compile requests    1630
+Cache hits             0
+Cache misses        1630
+Cache hits rate     0.00 %
+Average compiler   24.690 s
+```
+
+1630 × 24.7 s is essentially the whole 2 h 31 m build step. Every step was green.
+
+The cause was not a hash input, not `SCCACHE_CACHE_SIZE`, not `/Zi` vs `/Z7`. **The cache
+entry did not exist.** A full listing of the repository's cache store contained no
+`sccache-windows-2025-release-*` at all — not a stale one, not a small one, none. The
+restore step said so plainly and nobody was reading it:
+
+```
+Cache not found for input keys: sccache-windows-2025-release-33993528874-1,
+                                sccache-windows-2025-release-
+```
+
+and three and a half hours later, at the save:
+
+```
+##[warning]Cache reservation failed: You have reached your configured budget,
+           your cache is now read only to prevent additional charges.
+Failed to save: Unable to reserve cache with key sccache-windows-2025-release-…,
+                another job may be creating this cache.
+```
+
+The same pair appeared on the **nightly master run**, which is this workflow's only
+fleet-wide cache producer. The warmer could not write. So the restore had nothing to
+find, so every compile missed, so the build took four hours, indefinitely and stably.
+
+## Why the existing defences did not hold
+
+[ci-cache-that-looks-alive.md §3b](ci-cache-that-looks-alive.md) had already found the
+read-only budget, a year of runs earlier, and written the rule down. `cache-prune.yml`
+had already been built to keep the store under the cap. Both were in place. The store
+filled anyway, for three reasons that the earlier work did not reach.
+
+### The cap is a wall, not an eviction threshold
+
+`ci-cache-that-looks-alive.md` §4 says GitHub "was already evicting" LRU. It is not, and
+that misreading is load-bearing: it makes an over-full store sound self-correcting.
+It is not self-correcting. Past the cap the **whole store goes read-only** and every save
+in the repository is refused until something is deleted. `actions/cache/save` reports
+that as a `warning` and **exits zero**, so the step's own status cannot tell you.
+
+The cap is 10 GB **decimal**, and that is measured rather than read off the docs: saves
+were being refused with the store at 9,713,535,876 bytes = 9264 MiB. Had the cap been
+10 GiB (10737 MiB) there was 1.4 GiB free and the 706 MiB vcpkg save in the very same run
+would have landed. It did not. The wall is ~9537 MiB.
+
+### The janitor could not collect the biggest orphan
+
+`cache-prune.yml` kept the newest entry per `(ref, prefix)`, where the prefix was the key
+minus its trailing run id. It said of the leftovers:
+
+> A prefix that has genuinely gone away (a renamed key) therefore leaves one orphan
+> behind; one entry per dead prefix is a rounding error against the cap
+
+The vcpkg key is `vcpkg-<os>-<triplet>-<64 hex manifest hash>-<run_id>-<attempt>`. Strip
+only the run id and **every `vcpkg.json` bump is a brand-new prefix**, so the bump orphans
+a ~2 GB entry permanently. The largest single item in the store was 1988 MiB of a
+superseded manifest hash, created three days earlier and never read once — its
+`last_accessed_at` had not moved off its creation time, because the current-hash entry
+matched first. Not a rounding error: 21 % of the cap, alone.
+
+The prefix now strips a trailing content hash as well as the run id, so a hash bump
+supersedes instead of orphaning. That is correct for every key of this shape here,
+because a restore reaches at most one entry of a lineage anyway — `ffmpeg-…` restores by
+exact key, and `vcpkg-…` falls back to the bare `vcpkg-<os>-<triplet>-` prefix, which
+GitHub answers with the newest match. A **14-day `last_accessed_at` age-out** catches
+what remains: a genuinely renamed prefix leaves an orphan that matches nothing, so its
+read timestamp never moves again, while a live entry is read daily.
+
+### Six open PRs do not fit in a 10 GB store
+
+Both Windows and the Linux sanitizer jobs saved their sccache dir on `pull_request` runs.
+That entry is visible to one pull request. Six concurrent PRs — a routine day here — is
+up to 12 GB of PR-private Windows sccache against a 9.5 GiB wall. The PR runs were
+buying a marginal delta over the master snapshot they already restore, and paying for it
+by holding the store read-only, which stopped the nightly from writing the snapshot every
+branch actually restores from. **The PR runs were funding the mechanism that kept them
+cold.** They now restore and never save.
+
+## The arithmetic, so the next person does not have to re-derive it
+
+Measured 2026-09-06, after the sweep:
+
+| Entry | Size |
+|---|---|
+| `sccache-windows-2025-release` | 2.0 GiB |
+| `sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux` | 1.2 GiB each |
+| `vcpkg-Windows-x64-windows-static-md` | 0.7 GiB |
+| `Windows-` / `Linux-vulkan-prebuilt-sdk` | 0.5 GiB together |
+| `ffmpeg-Windows-n7.1` | 4 MiB |
+| **steady set** | **~7.9 GiB against a ~9.3 GiB wall** |
+
+The margin is one Windows snapshot wide. That is why `cache-prune.yml` now **fails** when
+the post-sweep store is over 8800 MiB: everything it deletes is provably superseded or
+unread, so if what remains is still that close to the wall, the fleet has outgrown the
+cap and a human has to shrink something. Raising the ceiling to silence the alarm
+re-creates this bug.
+
+## Adding a cache to this repo
+
+- Add its steady size to the table above and check the total still clears the wall.
+- Save through `save-cache-pruned`, with `prefix` set to the key minus its
+  `-<run_id>-<attempt>` tail, and grant the job `actions: write`.
+- Gate the save on `github.event_name != 'pull_request'` unless the entry is small
+  (a few MiB) or genuinely PR-specific.
+- If the key embeds a content hash, confirm `cache-prune.yml`'s prefix regex strips it.
+- **A workflow that is finished is a cache that is still charged.** The nightly
+  `flaky-repro-281` hunt held 886 MiB for an investigation closed months earlier; its
+  schedule is gone. Retire the schedule when you retire the question.
+
+## See also
+
+- [ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md) — the same store, one
+  layer up: four ways a cache restores, logs a hit, and rebuilds everything anyway.
+  Read §3b first; this file is what happened when only §3b's *rule* was written down and
+  not its arithmetic.
+- [vcpkg-dependency-management.md](vcpkg-dependency-management.md) — where the manifest
+  hash in the vcpkg cache key comes from.
+- [docs/ops/self-hosted-gpu-runner.md](../ops/self-hosted-gpu-runner.md) — the structural
+  escape: a cache on local disk has no save step to refuse, no ref scoping and no cap.

--- a/docs/agent-rules/cache-entry-version-is-the-path-string.md
+++ b/docs/agent-rules/cache-entry-version-is-the-path-string.md
@@ -1,0 +1,86 @@
+# A cache entry's identity includes the path STRING, not the directory
+
+Issue [#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073).
+
+**The rule: a cache's restore and its save must be handed the same path string, character
+for character. Derive both from one expression; never spell the path twice.**
+
+`actions/cache` computes a `version` for every entry by hashing the `path` strings it was
+given — the raw strings, before any resolution. A restore only ever sees entries whose
+version matches. So two spellings of one directory are two different caches, and the
+failure is silent in the worst way: **the key matches perfectly and the entry is still
+invisible.** Nothing in the log says "version mismatch". The restore just reports
+`Cache not found for input keys: …` and lists keys you can see in the cache listing.
+
+## What it looked like here
+
+`setup-vcpkg` restored with
+
+```yaml
+path: ${{ github.workspace }}/.vcpkg-binary-cache
+```
+
+and saved through its `cache-path` output, which is built in bash as
+
+```bash
+dir="${GITHUB_WORKSPACE//\\//}/.vcpkg-binary-cache"
+```
+
+On a Windows runner `github.workspace` expands with **backslash** separators, so the
+restore asked for a mixed-separator string while the save wrote an all-forward-slash one.
+Same directory. Two versions. Every restore a guaranteed miss.
+
+The normalisation on the save side is correct and deliberate — that value goes into
+`GITHUB_ENV` and is read back by later bash steps, where a backslash is a escape
+character. It was added for a good reason and silently desynchronised the two halves.
+
+**On Linux the two spellings are identical**, so Linux was unaffected — which is why this
+only ever surfaced as a Windows complaint (a 53-minute configure step with no Linux twin)
+and never as a caching bug.
+
+## The measurement that names it in one command
+
+You do not need a log. Ask whether the entry has ever been *read*:
+
+```console
+$ gh api --paginate "repos/<owner>/<repo>/actions/caches?per_page=100" \
+    --jq '.actions_caches[] | [(if .created_at == .last_accessed_at then "NEVER-READ" else "read" end), .key] | @tsv'
+NEVER-READ  vcpkg-Windows-x64-windows-static-md-<hash>-34021696485-1
+NEVER-READ  vcpkg-Windows-x64-windows-static-md-<hash>-34027362531-1
+NEVER-READ  vcpkg-Windows-x64-windows-static-md-<hash>-34027467561-1
+read        Windows-vulkan-prebuilt-sdk-true-1.4.321.0
+read        ffmpeg-Windows-n7.1-637be53f…
+read        sccache-tsan-linux-33539973579-1
+```
+
+Six vcpkg entries written in one morning by five different workflows, **not one of them
+ever read**, while a Vulkan SDK entry created two months earlier showed a read that same
+hour. `last_accessed_at == created_at` on every entry of a prefix is conclusive: that
+cache has no reader. A cold cache still gets read.
+
+This is the opposite reading of the same field from
+[ci-cache-that-looks-alive.md](ci-cache-that-looks-alive.md), which warns that
+`last_accessed_at` keeps ticking on restores and makes a frozen store look busy. Both are
+true and they answer different questions: `created_at` tells you whether anything is
+being *written*; `created_at == last_accessed_at` tells you whether anything is being
+*read*. Check both.
+
+## Where this bites
+
+- A path built from `${{ github.workspace }}` on one side and `$GITHUB_WORKSPACE` on the
+  other, on Windows.
+- A composite action whose restore is inline and whose save goes through an output.
+- Any trailing slash, `./` prefix, or case difference on a case-insensitive filesystem.
+- Reordering a multi-line `path:` list — the strings are joined in order before hashing.
+
+Swept the rest of this repo when this was found: every other restore/save pair already
+shares one expression (`env.SCCACHE_DIR`, a literal `OloEngine/vendor/ffmpeg-install`).
+vcpkg was the only one, and it had been broken for its whole existence.
+
+## See also
+
+- [actions-cache-budget.md](actions-cache-budget.md) — the other half of #1073: the store
+  goes read-only past the cap and refuses every save, which is why the *sccache* entry did
+  not exist at all. Two independent faults, one four-hour job.
+- [vcpkg-dependency-management.md](vcpkg-dependency-management.md) — what the binary cache
+  holds and what a manifest bump costs when it works.

--- a/docs/agent-rules/ci-cache-that-looks-alive.md
+++ b/docs/agent-rules/ci-cache-that-looks-alive.md
@@ -166,16 +166,24 @@ can be written.
 redesigning anything.** `created_at` on the newest entry answers it, and a
 frozen `created_at` across every prefix at once is not a bug in your keys.
 
-## 4. LRU eviction cannot tell current from superseded
+## 4. Over the cap, nothing is evicted — the store stops accepting writes
 
-The repo held 11.6 GB against a 10 GB cap, so GitHub was already evicting. Its
-policy is least-recently-used, and LRU has no idea which entry is the live
-snapshot: it will happily evict the newest 2 GB Windows sccache to make room,
-having just seen a superseded 786 MB one get touched by a restore-keys prefix
-match.
+The repo held 11.6 GB against a 10 GB cap. **Correction, from
+[#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073): GitHub does not
+evict.** This section used to say the policy was LRU and would happily drop the
+newest 2 GB Windows sccache to make room for a superseded 786 MB one. It does not
+do that, because it does not make room at all — it flips the store to read-only,
+which is §3b above. The two sections were describing one mechanism and only §3b
+had it right.
 
-If you are over the cap, the eviction policy is already yours whether you wrote
-one or not. `.github/workflows/cache-prune.yml` keeps one entry per key prefix.
+The distinction is the whole difference between "the cache is churning" and "the
+cache is frozen", and it changes what you do: eviction self-corrects and you tune
+key design; read-only does not self-correct and you must delete something.
+
+So the eviction policy has to be yours. `.github/workflows/cache-prune.yml` keeps
+one entry per key prefix per ref — and that turned out to be necessary and not
+sufficient. See [actions-cache-budget.md](actions-cache-budget.md) for the three
+ways the store filled anyway, and the budget arithmetic that keeps it solvent.
 
 ---
 
@@ -205,6 +213,10 @@ own.
 
 ## See also
 
+- [actions-cache-budget.md](actions-cache-budget.md) — what happened next: the rule in
+  §3b was written down and the store filled anyway, because an append-only key with a
+  once-daily janitor, a prefix rule that could not collect a hash-keyed orphan, and six
+  PRs each banking 2 GB do not fit in 10 GB. Includes the fleet's size table.
 - [build-trees-and-windows-asan.md](build-trees-and-windows-asan.md) §6 — the
   same genre one level down: a ccache hit that restored the object but not its
   dependency file, so 699 of 701 objects had no header dependencies recorded and


### PR DESCRIPTION
## The finding

The Windows build reported `Cache hits 0 / Cache misses 1630 / 0.00 %` on every run for weeks. It is **none of the four candidates** on the issue — not `SCCACHE_CACHE_SIZE`, not a per-run input in the compile hash, not `/Zi` vs `/Z7`, and the restore step was not misconfigured.

`sccache-windows-2025-release-*` **did not exist in the repository's cache store at all.** A full listing of all 14 live entries contained no Windows sccache entry — not stale, not partial, none. The restore step said so and nobody was reading it:

```
Cache not found for input keys: sccache-windows-2025-release-33993528874-1,
                                sccache-windows-2025-release-
```

and three and a half hours later, at the save:

```
##[warning]Cache reservation failed: You have reached your configured budget,
           your cache is now read only to prevent additional charges.
Failed to save: Unable to reserve cache with key sccache-windows-2025-release-…,
                another job may be creating this cache.
```

The same pair appears on the **nightly master run** ([34005232373](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34005232373)), which is this workflow's only fleet-wide cache producer. The warmer itself could not write, so the deadlock was stable rather than flaky: nothing to restore → every compile a miss → four-hour build, indefinitely, green.

Past the 10 GB cap GitHub does **not** evict. It flips the whole store read-only and refuses every save in the repository, as a `warning`, exit 0 — so no step status anywhere reflects it.

## Why the existing defences did not hold

[`ci-cache-that-looks-alive.md` §3b](../blob/master/docs/agent-rules/ci-cache-that-looks-alive.md) had already found the read-only budget in #1009 and written the rule down, and `cache-prune.yml` had already been built to keep the store under the cap. Both were in place. Three things filled it anyway.

**1. The janitor could not collect the biggest orphan.** `cache-prune.yml` grouped by the key minus its trailing run id, and said of the leftovers: *"one entry per dead prefix is a rounding error against the cap"*. The vcpkg key is `vcpkg-<os>-<triplet>-<64 hex manifest hash>-<run_id>-<attempt>`, so **every `vcpkg.json` bump started a brand-new prefix whose sole member was immortal**. The largest single entry in the store was 1988 MiB of a superseded manifest hash, created 2026-09-03 and never read once — `last_accessed_at` never moved off its creation time. 21 % of the cap, not a rounding error.

**2. Six open PRs do not fit in a 10 GB store.** Windows and the Linux sanitizer jobs saved their 1.2–2 GB sccache snapshot on `pull_request` runs, where the entry is scoped to `refs/pull/N/merge` and readable by that one PR. Six concurrent PRs — a routine day here — is up to 12 GB of PR-private sccache against a 9.3 GiB wall. Those entries bought a marginal delta over the master snapshot the PR already restores, and paid for it by holding the store read-only, which is what stopped the nightly from writing the snapshot every branch actually restores from. **The PR runs were funding the mechanism that kept them cold.**

**3. A finished investigation was still charged.** `flaky-repro-281.yml` ran a nightly Windows engine build holding 886 MiB, for a flake that `Windows.yml` itself records as fixed at the root.

## Changes

| | |
|---|---|
| **`cache-prune.yml`** | Prefix now strips a trailing content hash as well as the run id, so a hash bump *supersedes* instead of orphaning. Plus a 14-day `last_accessed_at` age-out for genuinely renamed prefixes. Sweeps at 01:05 (before both nightlies) as well as 06:41. **Fails** when the post-sweep store is still over 8800 MiB — everything it deletes is provably superseded or unread, so if what remains is that close to the wall a human has to shrink something. That alarm is what was missing. |
| **`.github/actions/save-cache-pruned`** (new) | Keys ending in `-<run_id>` are append-only, so a twice-daily janitor cannot help when two saves land thirty minutes apart. This saves, asks the API whether the entry *actually landed* (the save step's own status cannot tell you), and only if it did not deletes this ref's older entries under the same prefix and retries. Order is deliberate: pruning first would risk trading a warm snapshot for no snapshot. Emits an `::error::` annotation if the entry still never lands. |
| **`Windows.yml`, `asan.yml`** | Save through the new action; no sccache save on `pull_request` runs. `actions: write` added to the four jobs that need it. |
| **`flaky-repro-281.yml`** | Nightly cron and the stale branch `push:` trigger removed; `workflow_dispatch` kept. Reinstate only alongside reopening #281. |
| **`docs/agent-rules/actions-cache-budget.md`** (new) | The budget arithmetic, the fleet's size table, and the rules for adding a cache. |
| **`ci-cache-that-looks-alive.md`** | §4 claimed GitHub was LRU-evicting. It is not — that misreading is what made an over-full store sound self-correcting, and it contradicted §3b in the same file. Corrected, with a pointer to the new guide. |

A dry run of the new prune rules against the live cache listing keeps 10 entries totalling 5856 MiB and frees **3406 MiB** of 9258 — including the 1988 MiB orphan the old rules could never collect.

## Verification

Two `workflow_dispatch` runs of `Windows.yml` on this branch: the first seeds the entry, the second reports the hit rate. **Numbers to follow on #1073; nothing is claimed until then** — in particular no build-time saving is asserted anywhere in this diff.

One consequence worth stating plainly: with PR saves off, PR runs depend entirely on the nightly master snapshot. Until a nightly succeeds in writing one, PR runs stay exactly as cold as they are today — no worse, but not better either.

## Secondary items from the issue

- **vcpkg configure at 53 m** — **a SECOND, independent fault** (corrected on the issue; the
  first version of this description said "same root cause", which was wrong). The vcpkg
  binary cache has never once been restored: `setup-vcpkg` spells the path one way for the
  restore and another for the save, and `actions/cache` hashes the raw path string into each
  entry's `version`. Every vcpkg entry in the store has `last_accessed_at == created_at`.
  Fixed in `ecb6b46`; measured separately.
- **CTest at 28 m** — not taken here. Raising `--parallel` past 4 on a 4-vCPU runner is speculative, and the real lever (batching ~6,900 process launches) is #1074's territory, which is working the ~102 monolithic-run failures that consolidation would expose. Left to that session rather than half-done from this one.
- **A self-hosted Windows runner** — filed as a follow-up rather than done here; it is a larger change than one PR should carry, and this fix has to be measured on the hosted path first.

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resilient cache saving with automatic pruning and retry support.
  * Added scheduled cache maintenance and automated cleanup for stale or unused entries.
  * Added capacity monitoring with error reporting when storage remains over limits.

* **Bug Fixes**
  * Prevented pull-request builds from saving cache entries.
  * Fixed cache restoration when directory paths differ in formatting.
  * Improved handling and reporting when cache storage refuses writes.

* **Documentation**
  * Added guidance on cache capacity, pruning, path matching, and diagnosing misleading cache status messages.

* **Chores**
  * Limited the flaky-reproduction workflow to manual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
