### PR TITLE
fix(renderer): resolve project-relative texture paths before re-reading them (#1067)

### DIFF
--- a/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetSerializer.cpp
@@ -350,16 +350,21 @@ namespace OloEngine
         // so the build never fails just because one texture couldn't be compressed.
         CompressedTextureImage cooked;
         bool haveCooked = false;
-        // Non-throwing existence check: a filesystem error (permissions, bad path) must
-        // fall through to the uncompressed raw record, never propagate an exception up to
+        // `path` is GetPath() — the PROJECT-RELATIVE spelling for every texture that came
+        // through the asset system, which does not resolve against the process cwd (#1067).
+        // Resolving it here is what makes the cook reachable at all: the bare relative path
+        // failed the existence check below for every such texture, so the BC7 cook was
+        // silently skipped and the pack shipped them uncompressed. The helper's existence
+        // check is non-throwing, which this path requires — a filesystem error (permissions,
+        // bad path) must fall through to the uncompressed raw record, never propagate up to
         // BuildImpl and abort the whole pack build over one texture.
-        std::error_code existsEc;
+        const std::filesystem::path cookSource = Texture2D::ResolveStoredSourcePath(path);
         if (IsAssetPackCompressionEnabled() && !IsCompressedFormat(spec.Format) &&
-            !path.empty() && !IsOloTexPath(path) && std::filesystem::exists(path, existsEc))
+            !path.empty() && !IsOloTexPath(path) && !cookSource.empty())
         {
             TextureCompression::CompressOptions opts;
             opts.GenerateMips = spec.GenerateMips;
-            if (TextureCompression::CompressImageFile(path, opts, cooked) && cooked.IsValid())
+            if (TextureCompression::CompressImageFile(cookSource.string(), opts, cooked) && cooked.IsValid())
                 haveCooked = true;
             else
                 OLO_CORE_WARN("TextureSerializer::SerializeToAssetPack - cook failed for '{}'; shipping it uncompressed", path);
@@ -549,7 +554,14 @@ namespace OloEngine
         Ref<Texture2D> texture;
         if (!path.empty())
         {
-            texture = Texture2D::Create(path, srgb);
+            // Same project-relative spelling as the cook side (#1067): an uncompressed
+            // record embeds no pixels, so this re-reads the loose file and must resolve
+            // the path the same way. Keep `path` as the identity so GetPath() still
+            // reports the portable spelling. When it cannot be resolved the helper has
+            // already logged why; fall through with the original so the existing
+            // failure handling below reports the load error as before.
+            const std::filesystem::path resolved = Texture2D::ResolveStoredSourcePath(path);
+            texture = Texture2D::Create(resolved.empty() ? path : resolved.string(), srgb, path);
         }
         else
         {

--- a/OloEngine/src/OloEngine/Renderer/Texture.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Texture.cpp
@@ -1,6 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Renderer/Texture.h"
 
+#include "OloEngine/Project/Project.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
 
@@ -12,6 +13,43 @@
 
 namespace OloEngine
 {
+    std::filesystem::path Texture2D::ResolveStoredSourcePath(std::string_view sourcePath)
+    {
+        if (sourcePath.empty())
+            return {};
+
+        std::filesystem::path path(sourcePath);
+        if (!path.is_relative())
+            return path;
+
+        // A relative path is only openable by luck: it resolves against the process
+        // working directory, which is not the project root. Prefer the project-rooted
+        // spelling the asset system stores, and only when that file is really there —
+        // a texture created from a genuinely CWD-relative path still reloads.
+        std::error_code ec;
+        const bool haveProject = Project::GetActive() != nullptr;
+        if (haveProject)
+        {
+            if (std::filesystem::path projectRooted = Project::GetProjectDirectory() / path;
+                std::filesystem::exists(projectRooted, ec))
+            {
+                return projectRooted;
+            }
+        }
+
+        if (std::filesystem::exists(path, ec))
+            return path;
+
+        // Neither base has the file. Say so and refuse — handing the relative path to
+        // the loader anyway would read against the CWD, which is the silent failure
+        // this helper exists to remove (#1067).
+        OLO_CORE_ERROR("Texture2D::ResolveStoredSourcePath: cannot resolve relative source path '{}' ({}); "
+                       "refusing to re-read it against the process working directory",
+                       sourcePath,
+                       haveProject ? "not found under the active project directory either" : "no active project");
+        return {};
+    }
+
     Ref<Texture2D> Texture2D::Create(const TextureSpecification& specification)
     {
         switch (Renderer::GetAPI())

--- a/OloEngine/src/OloEngine/Renderer/Texture.h
+++ b/OloEngine/src/OloEngine/Renderer/Texture.h
@@ -5,6 +5,7 @@
 #include "OloEngine/Core/Ref.h"
 #include "OloEngine/Renderer/RendererResource.h"
 
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -210,6 +211,27 @@ namespace OloEngine
         {
             return false;
         }
+
+        // Resolve a stored source path (what GetPath() reports) to a path the
+        // process can actually open. Used by Reload()'s re-read and by the
+        // asset-pack serializer, which stores the same spelling and re-reads the
+        // loose file at cook and load time.
+        //
+        // The two spellings that reach here are NOT interchangeable (#1067).
+        // Texture2D::Create(path) stores whatever the caller passed — usually
+        // absolute. The asset system instead stores the PROJECT-RELATIVE spelling
+        // ("Assets/Textures/Foo.png"), deliberately, so saved scenes stay portable
+        // across machines; but the editor's working directory is OloEditor/, one
+        // level above the project, so re-reading that spelling verbatim resolves
+        // against the wrong base and can never find the file. Relative paths are
+        // therefore resolved against Project::GetProjectDirectory(), exactly as
+        // every AssetSerializer does.
+        //
+        // Returns an empty path when the source cannot be resolved — no source
+        // path, or a relative one that exists neither under the active project nor
+        // relative to the working directory — having logged why. Callers refuse the
+        // reload rather than reading from a base that happens to be the CWD.
+        [[nodiscard("Store this!")]] static std::filesystem::path ResolveStoredSourcePath(std::string_view sourcePath);
 
         static Ref<Texture2D> Create(const TextureSpecification& specification);
         // Create a GPU texture from an offline block-compressed (BC7/BC5) mip chain,

--- a/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -404,6 +404,15 @@ namespace OloEngine
         if (m_Path.empty())
             return false;
 
+        // m_Path is the texture's *identity*, not necessarily something this process
+        // can open — the asset system stores a project-relative spelling. The shared
+        // helper resolves it (and logs if it can't); see its comment for #1067.
+        const std::filesystem::path readPath = ResolveStoredSourcePath(m_Path);
+        if (readPath.empty())
+            return false;
+
+        const std::string readPathString = readPath.string();
+
         int width = 0;
         int height = 0;
         int channels = 0;
@@ -413,13 +422,13 @@ namespace OloEngine
         stbi_uc* data = nullptr;
         {
             OLO_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::Reload");
-            data = ::stbi_load(m_Path.c_str(), &width, &height, &channels, 0);
+            data = ::stbi_load(readPathString.c_str(), &width, &height, &channels, 0);
         }
         ::stbi_set_flip_vertically_on_load_thread(0);
 
         if (!data)
         {
-            OLO_CORE_ERROR("OpenGLTexture2D::Reload: failed to re-read texture '{}'", m_Path);
+            OLO_CORE_ERROR("OpenGLTexture2D::Reload: failed to re-read texture '{}' (from '{}')", m_Path, readPathString);
             return false;
         }
 

--- a/OloEngine/tests/Asset/TextureSourcePathResolutionTest.cpp
+++ b/OloEngine/tests/Asset/TextureSourcePathResolutionTest.cpp
@@ -1,0 +1,197 @@
+#include "OloEnginePCH.h"
+
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// TextureSourcePathResolutionTest — issue #1067.
+//
+// Texture2D::ResolveStoredSourcePath is the whole of that bug's fix: every
+// backend's Reload() re-reads the path this returns. The defect was that
+// Reload() used the stored source path verbatim, and the asset system stores
+// the PROJECT-RELATIVE spelling ("Assets/Textures/Foo.png") on purpose — so the
+// re-read resolved against the process working directory (OloEditor/, one level
+// above the project) and could never find the file. Hot-reload was dead for
+// every texture that came through TextureSerializer.
+//
+// Why this file is CPU-only, and why that matters: the test that exercises the
+// real thing (TextureInPlaceReloadTest) needs a GL 4.6 context, so CI SKIPs it
+// and the regression could come back green. The resolution rule is pure path
+// logic with no GPU in it, so it can be pinned here and actually run on every
+// push. See docs/agent-rules/substituted-seams-compound.md — the point is to
+// cover the seam that broke, not a friendlier neighbour of it.
+//
+// No GPU, no textures: the helper is a static that takes a string.
+// =============================================================================
+
+#include "OloEngine/Project/Project.h"
+#include "OloEngine/Renderer/Texture.h"
+
+#include <gtest/gtest.h>
+
+#include "TestTempDir.h"
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+namespace OloEngine::Tests
+{
+    namespace
+    {
+        void WriteFile(const std::filesystem::path& path)
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(path.parent_path(), ec);
+            std::ofstream out(path, std::ios::binary | std::ios::trunc);
+            ASSERT_TRUE(out.is_open()) << "could not create " << path.string();
+            out << "not really a png";
+        }
+
+        // A project rooted in this case's temp directory, which is never the
+        // process working directory — that difference is the bug.
+        std::filesystem::path MakeProject(const char* label)
+        {
+            const std::filesystem::path dir = TempDir(label);
+            std::error_code ec;
+            std::filesystem::create_directories(dir / "Assets", ec);
+
+            {
+                std::ofstream proj(dir / "PathResolution.oloproj");
+                EXPECT_TRUE(proj.is_open()) << "could not write the temp .oloproj";
+                proj << "Project:\n"
+                        "  Name: PathResolution\n"
+                        "  StartScene: \"\"\n"
+                        "  AssetDirectory: \"Assets\"\n"
+                        "  ScriptModulePath: \"\"\n";
+            }
+
+            EXPECT_TRUE(Project::Load(dir / "PathResolution.oloproj"))
+                << "Project::Load failed for the temp project at " << dir.string();
+            return dir;
+        }
+
+        struct ProjectScope
+        {
+            ~ProjectScope()
+            {
+                // Leave the no-project state behind: these cases install a project
+                // into a process-wide static, and the next test must not inherit a
+                // project rooted in a temp directory that is about to disappear.
+                Project::Unload();
+            }
+        };
+
+        // Runs a case with the working directory moved somewhere this test owns,
+        // restoring it on every exit path. Needed because one case has to exercise
+        // "relative to the CWD" — and writing a probe file into the real working
+        // directory would drop a fixed-name directory in the repo root, which is the
+        // shared-mutable-path pattern TestTempDir.h (and its pre-commit hook) forbid.
+        struct ScopedWorkingDirectory
+        {
+            explicit ScopedWorkingDirectory(const std::filesystem::path& to)
+                : Previous(std::filesystem::current_path())
+            {
+                std::filesystem::current_path(to);
+            }
+
+            ~ScopedWorkingDirectory()
+            {
+                std::error_code ec;
+                std::filesystem::current_path(Previous, ec);
+            }
+
+            std::filesystem::path Previous;
+        };
+    } // namespace
+
+    // The #1067 case itself: the asset system's project-relative spelling resolves
+    // against the project directory, not the CWD.
+    TEST(TextureSourcePathResolution, ResolvesAProjectRelativePathAgainstTheProjectDirectory)
+    {
+        ProjectScope scope;
+        const std::filesystem::path projectDir = MakeProject("relative_resolves");
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        const std::filesystem::path relative = std::filesystem::path("Assets") / "Textures" / "Foo.png";
+        WriteFile(projectDir / relative);
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        ASSERT_NE(projectDir, std::filesystem::current_path())
+            << "the temp project is the working directory, so this case could pass "
+               "with the bug present.";
+
+        const std::filesystem::path resolved = Texture2D::ResolveStoredSourcePath(relative.string());
+        EXPECT_EQ(resolved, projectDir / relative);
+    }
+
+    // An absolute path is what Texture2D::Create(path) stores; it must survive
+    // untouched — this is the spelling that always worked, and the fix must not
+    // start prefixing it.
+    TEST(TextureSourcePathResolution, LeavesAnAbsolutePathAlone)
+    {
+        ProjectScope scope;
+        const std::filesystem::path projectDir = MakeProject("absolute_untouched");
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        const std::filesystem::path absolute = projectDir / "Assets" / "Textures" / "Bar.png";
+        WriteFile(absolute);
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        EXPECT_EQ(Texture2D::ResolveStoredSourcePath(absolute.string()), absolute);
+    }
+
+    // A path that exists relative to the working directory but not under the
+    // project keeps working — engine-owned textures (editor icons) are loaded that
+    // way, and the fix must not break their reload.
+    TEST(TextureSourcePathResolution, FallsBackToAWorkingDirectoryRelativePathThatExists)
+    {
+        ProjectScope scope;
+        const std::filesystem::path projectDir = MakeProject("cwd_relative");
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        // A working directory this case owns, so the probe below is not written into
+        // the repo root. It is deliberately NOT the project directory.
+        const std::filesystem::path workingDir = TempDir("cwd_relative_cwd");
+        const ScopedWorkingDirectory movedCwd(workingDir);
+        ASSERT_NE(std::filesystem::current_path(), projectDir);
+
+        // Authored under the CWD, deliberately absent from the project tree.
+        const std::filesystem::path relative = std::filesystem::path("Icons") / "Icon.png";
+        WriteFile(std::filesystem::current_path() / relative);
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+        ASSERT_FALSE(std::filesystem::exists(projectDir / relative))
+            << "the probe leaked into the project tree, so this case proves nothing.";
+
+        EXPECT_EQ(Texture2D::ResolveStoredSourcePath(relative.string()), relative);
+    }
+
+    // Unresolvable input refuses loudly rather than handing the loader a path that
+    // silently reads against the CWD — the failure mode #1067 was.
+    TEST(TextureSourcePathResolution, RefusesARelativePathThatExistsNowhere)
+    {
+        ProjectScope scope;
+        MakeProject("missing_refuses");
+        ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+        const std::filesystem::path missing =
+            std::filesystem::path("Assets") / "Textures" / "NotHere_1067.png";
+        EXPECT_TRUE(Texture2D::ResolveStoredSourcePath(missing.string()).empty());
+    }
+
+    // With no project open there is no base to resolve against; a relative path
+    // must not fall through to the CWD.
+    TEST(TextureSourcePathResolution, RefusesARelativePathWhenNoProjectIsOpen)
+    {
+        ProjectScope scope;
+        Project::Unload();
+
+        const std::filesystem::path relative = std::filesystem::path("Assets") / "Textures" / "Foo.png";
+        EXPECT_TRUE(Texture2D::ResolveStoredSourcePath(relative.string()).empty());
+    }
+
+    // An empty source path is the "spec-created texture" case: nothing to re-read,
+    // and no error worth logging.
+    TEST(TextureSourcePathResolution, ReturnsEmptyForAnEmptySourcePath)
+    {
+        EXPECT_TRUE(Texture2D::ResolveStoredSourcePath("").empty());
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -163,6 +163,7 @@ add_executable(OloEngine-Tests
 		Rendering/Baking/LightmapAtlasPagingTest.cpp
 		Rendering/Baking/LightProbePathTracedBakeTest.cpp
 		Asset/LightmapAssetSerializationTest.cpp
+		Asset/TextureSourcePathResolutionTest.cpp
 		Rendering/FoliageImpostorPlacementTest.cpp
 		Rendering/PODCommandTest.cpp
 		Rendering/ShaderBindingLayoutTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/TextureInPlaceReloadTest.cpp
@@ -22,6 +22,18 @@
 // than caching it; the reload's inspector/binding-cache teardown accounts for the
 // swap either way. The test deliberately does not assert on the raw name value.)
 //
+// Issue #1067 added the third case below. The first case passes with the
+// asset-system hot-reload path completely broken, because it builds its texture
+// with an ABSOLUTE path via Texture2D::Create — the one spelling of m_Path that
+// stbi_load could always resolve. Every texture that arrives through
+// TextureSerializer carries the PROJECT-RELATIVE spelling instead (deliberately,
+// so saved scenes stay portable), and the editor runs with cwd = OloEditor/, one
+// level above the project — so Reload()'s re-read could never find the file and
+// hot-reload was dead for every real asset. That is the substituted seam
+// described in docs/agent-rules/substituted-seams-compound.md: the friendlier
+// construction is what made the case green. The third test drives the real
+// seam — EditorAssetManager::ReloadData over a texture imported from a project.
+//
 // GL-gated: SKIPs cleanly when no GL 4.6 context is available (headless CI).
 // =============================================================================
 
@@ -29,6 +41,8 @@
 
 #include "RenderPropertyTest.h"
 
+#include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
+#include "OloEngine/Project/Project.h"
 #include "OloEngine/Renderer/Texture.h"
 
 #define GLFW_INCLUDE_NONE
@@ -40,6 +54,7 @@
 #include "TestTempDir.h"
 
 #include <filesystem>
+#include <fstream>
 #include <system_error>
 #include <vector>
 
@@ -70,6 +85,19 @@ namespace OloEngine::Tests
         {
             return OloEngine::Tests::TempFile("olo_texture_inplace_reload_544.png");
         }
+
+        // Drops the process-wide Project + EditorAssetManager statics on EVERY exit
+        // path. A bare call on the last line is not enough: any earlier ASSERT_*
+        // returns first — including the ReloadData assert, the one that fires on a
+        // real regression — and the manager would then outlive TempRoot's atexit
+        // remove_all and serialize its registry into a deleted directory.
+        struct ProjectScope
+        {
+            ~ProjectScope()
+            {
+                Project::Unload();
+            }
+        };
     } // namespace
 
     TEST(TextureInPlaceReload, PreservesIdentityAndRefreshesContents)
@@ -143,5 +171,124 @@ namespace OloEngine::Tests
         EXPECT_TRUE(texture->GetPath().empty());
 
         EXPECT_FALSE(texture->Reload());
+    }
+    // -------------------------------------------------------------------------
+    // Issue #1067: the same in-place reload, reached the way the editor reaches
+    // it — through EditorAssetManager::ReloadData for a texture that was imported
+    // from a project and therefore carries a project-relative source path.
+    //
+    // The temp project directory is deliberately NOT the process working
+    // directory, which is what makes the relative path unresolvable against the
+    // CWD; before the fix, Reload() logged "failed to re-read texture" and
+    // ReloadData silently fell back to replacing the object, so a Material's
+    // cached Ref<Texture2D> kept showing the pre-edit pixels forever.
+    //
+    // ProjectScope drops both statics on every exit path. Without that the asset
+    // manager — and the texture it caches — outlive the case: the renderer's
+    // teardown reports a surviving GPU allocation, and the registry serializes at
+    // static-destruction time, after TempRoot has already been removed ("Failed to
+    // open file: ...AssetRegistry.oar"). Unloading leaves the clean no-project
+    // state every other asset-backed test sets up for itself.
+    // -------------------------------------------------------------------------
+    TEST(TextureInPlaceReload, ReloadsATextureImportedThroughTheAssetSystem)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        const ProjectScope projectScope;
+        const std::filesystem::path projectDir = OloEngine::Tests::TempDir("project_1067");
+        const std::filesystem::path relativePath = std::filesystem::path("Assets") / "Textures" / "HotReload1067.png";
+        const std::filesystem::path absolutePath = projectDir / relativePath;
+
+        std::error_code ec;
+        std::filesystem::create_directories(absolutePath.parent_path(), ec);
+        ASSERT_FALSE(ec) << "could not create the temp project asset directory: " << ec.message();
+
+        // "HotReload1067" carries none of the colour-texture name suffixes
+        // (diffuse/albedo/basecolor/emissive), so TextureSerializer's naming
+        // heuristic loads it linear and the readback below is byte-exact.
+        ASSERT_TRUE(WriteSolidPng(absolutePath, 2, 2, 255, 0, 0, 255)) << "failed to write the initial PNG";
+
+        {
+            std::ofstream proj(projectDir / "TextureReload1067.oloproj");
+            ASSERT_TRUE(proj.is_open()) << "could not write the temp .oloproj";
+            proj << "Project:\n"
+                    "  Name: TextureReload1067\n"
+                    "  StartScene: \"\"\n"
+                    "  AssetDirectory: \"Assets\"\n"
+                    "  ScriptModulePath: \"\"\n";
+        }
+
+        ASSERT_TRUE(Project::Load(projectDir / "TextureReload1067.oloproj"))
+            << "Project::Load failed for the temp project at " << projectDir.string();
+        ASSERT_NE(Project::GetProjectDirectory(), std::filesystem::current_path())
+            << "the temp project is the process working directory, so a CWD-relative "
+               "re-read would resolve by accident and this test would prove nothing.";
+
+        auto manager = Ref<EditorAssetManager>::Create();
+        // No file watcher: this test triggers the reload itself, and a background
+        // watcher outlives the case and races the next one.
+        manager->Initialize(false);
+        Project::SetAssetManager(manager);
+
+        const AssetHandle handle = manager->ImportAsset(absolutePath);
+        ASSERT_NE(static_cast<u64>(handle), 0ULL) << "ImportAsset returned a zero handle for the probe texture";
+
+        auto texture = manager->GetAsset(handle).As<Texture2D>();
+        ASSERT_TRUE(texture) << "GetAsset returned null or a non-Texture2D for the probe";
+        ASSERT_TRUE(texture->IsLoaded());
+        ASSERT_EQ(2u, texture->GetWidth());
+        ASSERT_EQ(2u, texture->GetHeight());
+
+        // The asymmetry that IS the bug: this path stores the relative spelling,
+        // Texture2D::Create(absolute) stores an absolute one. If this ever becomes
+        // absolute the case still passes but stops covering #1067 — hence the
+        // assertion rather than a comment.
+        ASSERT_TRUE(std::filesystem::path(texture->GetPath()).is_relative())
+            << "the asset system no longer stores a project-relative source path ('"
+            << texture->GetPath()
+            << "'), so this case no longer exercises the #1067 resolution failure.";
+
+        Texture2D* const objectBefore = texture.get();
+        {
+            std::vector<u8> before;
+            ReadbackRgba8(texture->GetRendererID(), 2, 2, before);
+            ASSERT_GE(before.size(), 4u);
+            ASSERT_EQ(255u, before[0]) << "the probe did not load as solid red";
+            ASSERT_EQ(0u, before[1]);
+        }
+
+        // What the editor sees when someone saves the .png: new contents, and a
+        // different size so a stale upload cannot masquerade as a fresh one.
+        ASSERT_TRUE(WriteSolidPng(absolutePath, 4, 4, 0, 255, 0, 255)) << "failed to overwrite the PNG";
+
+        ASSERT_TRUE(manager->ReloadData(handle)) << "EditorAssetManager::ReloadData failed for a tracked, loaded texture";
+
+        auto refreshed = manager->GetAsset(handle).As<Texture2D>();
+        ASSERT_TRUE(refreshed) << "the texture is missing from the cache after the reload";
+
+        // In place: the same object, so every Ref<Texture2D> a material captured
+        // still points at the refreshed texture (issue #544's guarantee, now over
+        // the asset-system path).
+        EXPECT_EQ(objectBefore, refreshed.get())
+            << "ReloadData replaced the object instead of refreshing it in place — the "
+               "in-place branch declined, which is what a failed re-read looks like from here.";
+        EXPECT_TRUE(refreshed->IsLoaded());
+        EXPECT_EQ(4u, refreshed->GetWidth());
+        EXPECT_EQ(4u, refreshed->GetHeight());
+
+        // And the pixels actually moved.
+        {
+            std::vector<u8> after;
+            ReadbackRgba8(refreshed->GetRendererID(), 4, 4, after);
+            ASSERT_GE(after.size(), 4u);
+            EXPECT_EQ(0u, after[0]) << "the texture still carries the pre-edit red pixels";
+            EXPECT_EQ(255u, after[1]);
+            EXPECT_EQ(0u, after[2]);
+        }
+
+        // Release the texture so the registry serializes while the temp directory
+        // still exists (see the note above); ~ProjectScope drops the statics.
+        texture.Reset();
+        refreshed.Reset();
     }
 } // namespace OloEngine::Tests


### PR DESCRIPTION
Texture hot-reload never worked for any texture that came from the asset system. Editing a
`.png` under the project and saving it logged an error and left the old pixels on screen
until the editor was restarted.

`TextureSerializer` deliberately stores the **project-relative** spelling
(`Assets/Textures/Foo.png`) as a texture's identity, so saved scenes stay portable across
machines. But OloEditor runs with `cwd = OloEditor/`, one level above the project, so
`OpenGLTexture2D::Reload()` handed `stbi_load` a path that could never resolve. The existing
`TextureInPlaceReloadTest` passed the whole time because it builds its texture with an
**absolute** `TempFile` path via `Texture2D::Create` — the one spelling that always worked.

## What changed

**`Texture2D::ResolveStoredSourcePath`** (`Renderer/Texture.{h,cpp}`) — resolves a stored
source path to something the process can actually open: relative → project-rooted when that
file exists, else CWD-relative when *that* exists, else empty **plus a log line naming why**.
Absolute paths pass through untouched. It lives in `Texture2D` rather than in the GL backend
so it is shared, independently testable without a GPU, and inherited by any backend that
implements `Reload()` later.

I agree with the issue's rejection of the alternative (store absolute, derive the
pack-relative spelling at use sites): the relative spelling is load-bearing for scene
portability and for the pack re-read, and that approach would push the conversion into every
consumer of `GetPath()`.

**Second commit — the same defect in the asset-pack path**, found during self-review.
`SerializeToAssetPack` checked `exists(<project-relative>)` against the CWD, so the automatic
BC7 cook was **silently skipped for every asset-system texture** and the pack shipped them
uncompressed; `DeserializeFromAssetPack` then re-read the same unresolvable path at runtime,
and since an uncompressed record embeds no pixels, the texture loaded blank. Separate commit,
per CLAUDE.md.

## Deliberately not included: the Vulkan half

`VulkanTexture2D` has no `Reload()`, so Vulkan takes the object-replacing fallback and a
cached `Ref<Texture2D>` keeps showing pre-edit pixels — #544's bug, still open on that
backend. I implemented the in-place version (it looked mechanical: `Invalidate()` already
does release → recreate → upload → `InvalidateResource`) **and reverted it**, because in the
live editor it renders the surface **flat red**.

Attribution is not a guess: same build, `Reload()` returning false renders the texture
intact; the in-place `Reload()` renders red. Filed with full evidence, four
non-reproducing test configurations and a working probe harness as
**#1078**.

## Review guide

**Where I'd look hardest**

1. `Renderer/Texture.cpp` — `ResolveStoredSourcePath`'s **fallback ordering**. Project-rooted
   wins only when the file is actually there, then a CWD-relative path that exists is
   honoured (editor icons load that way), then refusal. That ordering is the whole behaviour
   and the part most likely to be wrong in a way tests don't show.
2. `Asset/AssetSerializer.cpp:361` — the cook site now refuses via the helper instead of a
   bare `exists()`. A genuinely missing loose file now produces an error log where it used to
   fall through silently. I think loud is right here; say so if you disagree.
3. `Asset/AssetSerializer.cpp:563` — the runtime load falls through with the *original*
   spelling when resolution fails, so existing failure handling is unchanged rather than
   newly returning null.

**What I verified, and how**

- `TextureSourcePathResolution.*` — 6 CPU cases, **no GPU gate, so CI actually runs them**.
  The hardware-gated cases below are skipped in CI, which is how this regression could return
  green.
- `TextureInPlaceReload.ReloadsATextureImportedThroughTheAssetSystem` — drives
  `EditorAssetManager::ReloadData` with a temp project; asserts identity, dimensions and
  pixels. Asserts the stored path *is relative*, so the case cannot silently stop covering
  #1067.
- **Negative control** — with the pre-fix behaviour restored, 4 of these go red and
  `TextureInPlaceReload.PreservesIdentityAndRefreshesContents` (the pre-existing case) stays
  **green**, demonstrating the substituted seam rather than asserting it.
- **Live editor, OpenGL** — overwrote `DriftMenuBackground-v2.png` with the editor running:
  the background visibly changed with no restart and the log carried **zero** error lines.
  Before/after captures via `olo_screenshot`.
- 37 tests green including every `AssetPack*` / `RuntimeAssetPack*` case and
  `AssetHotReloadDoesNotDeadlockTest`.

**Least confident about**

The CWD-relative fallback in `ResolveStoredSourcePath`. I added it so engine-owned textures
loaded by a genuinely CWD-relative path keep reloading, but I did not find a live example of
one — it is defensive. If reviewers would rather this refused outright and forced every
caller to hand over an absolute or project-relative path, that is a smaller, sharper contract
and I would take it.

**Deliberately not tested**

The asset-pack cook/load fix has **no new test**. Both sites need a built pack plus a project
on disk, and the existing `AssetPack*` suites construct records directly rather than cooking
from loose files. I verified no regression (37 green) but did not pin the fix itself; that is
a real gap and I would rather name it than imply coverage. The Vulkan path is untested here
because it was reverted — #1078 carries the harness.

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
