### PR TITLE
fix(ci): the cache-prune ceiling read a lagging endpoint and failed a healthy store

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -234,6 +234,7 @@ jobs:
           deleted=0
           freed=0
           stale=0
+          kept_bytes=0
           while IFS=$'\t' read -r id ref key size accessed; do
             [ -n "${id:-}" ] || continue
             prefix=$(printf '%s' "$key" | sed -E 's/-[0-9]{6,}(-[0-9]+)?$//; s/-[0-9a-f]{32,}$//')
@@ -255,6 +256,7 @@ jobs:
             if [ "$closed_pr" -eq 0 ] && [ "$dead_branch" -eq 0 ] && [ "$unread" -eq 0 ] && [ -z "${seen[$group]:-}" ]; then
               seen[$group]=1
               kept=$((kept + 1))
+              kept_bytes=$((kept_bytes + size))
               printf 'keep    %6s MiB  %-28s %s\n' "$((size / 1048576))" "$ref" "$key"
               continue
             fi
@@ -280,9 +282,11 @@ jobs:
 
           echo "kept $kept (newest per ref+prefix), deleted $deleted ($stale of them unread for ${age_out_days}+ days), freed $((freed / 1048576)) MiB"
 
+          # From the sweep's own arithmetic, not `cache/usage`, for the reason given at
+          # the ceiling check below. The "before" line above still uses the endpoint --
+          # it is only ever indicative, and a stale reading there misleads nobody.
           echo "after:"
-          gh api "repos/${GH_REPO}/actions/cache/usage" \
-            --jq '"  \(.active_caches_count) entries, \(.active_caches_size_in_bytes/1048576|floor) MiB"'
+          echo "  $kept entries, $((kept_bytes / 1048576)) MiB"
 
           # FAIL WHEN THE STORE IS STILL NEARLY FULL (#1073). Everything above deletes
           # only what is provably superseded or unread; if what remains still does not
@@ -308,8 +312,19 @@ jobs:
           # Raise it only together with a re-measurement of the steady set. Raising it to
           # silence the alarm is how #1073 happened.
           headroom_floor_mib=8800
-          used_mib=$(gh api "repos/${GH_REPO}/actions/cache/usage" \
-            --jq '.active_caches_size_in_bytes/1048576|floor')
+
+          # SUM THE LISTING, NOT `/actions/cache/usage` -- that endpoint LAGS behind
+          # deletions, badly. Measured on run 34039757109: this sweep freed 5567 MiB and
+          # the listing summed to 6491 MiB immediately afterwards, while `cache/usage`
+          # still reported the pre-sweep 10231 MiB -- the identical number it had just
+          # printed as "before". The ceiling check read that stale value and FAILED the
+          # job, on a store that was comfortably healthy.
+          #
+          # A false alarm is worse than no alarm: a job that cries wolf daily is a job
+          # everyone learns to ignore, which is exactly the blindness #1073 was about.
+          # `kept_bytes` is the sum of the entries this sweep decided to keep, so it is
+          # the post-sweep total by construction and costs no extra API call.
+          used_mib=$((kept_bytes / 1048576))
           if [ "${used_mib}" -gt "${headroom_floor_mib}" ]; then
             echo "::error::Actions cache store is ${used_mib} MiB after pruning, over the ${headroom_floor_mib} MiB working ceiling."
             echo "::error::Past the 10 GB cap GitHub does not evict -- it makes the whole store READ-ONLY and refuses every save in the repo, silently (actions/cache/save warns and exits 0). Nothing left here is superseded, so this needs a human: docs/agent-rules/actions-cache-budget.md."


### PR DESCRIPTION
Follow-up defect from #1073, found by the alarm firing on its first real sweep.

## What happened

Run [34039757109](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34039757109) did its job perfectly:

```
before:
  10 entries, 10231 MiB
DELETE  1826 MiB  refs/heads/feature/ci-windows-sccache-1073  sccache-…-34038267811-1  (branch deleted)
DELETE  1825 MiB  refs/heads/feature/ci-windows-sccache-1073  sccache-…-34027467561-1  (branch deleted)
DELETE   706 MiB  refs/heads/feature/ci-windows-sccache-1073  vcpkg-…-34027467561-1    (branch deleted)
DELETE   706 MiB  refs/pull/1075/merge                        vcpkg-…-34030643249-1    (PR closed)
DELETE     4 MiB  refs/pull/1075/merge                        ffmpeg-…                 (PR closed)
DELETE   497 MiB  refs/pull/1079/merge                        vcpkg-…-34034431792-1
kept 11 (newest per ref+prefix), deleted 6, freed 5567 MiB
```

That is the **dead-branch rule working on its first outing** — 4357 MiB stranded on the branch that merging #1075 deleted, exactly the leak it was added for. The listing summed to **6491 MiB** immediately afterwards, comfortably under the 8800 MiB ceiling.

**It failed anyway.**

## Why

The ceiling check reads `/actions/cache/usage`, and that endpoint lags behind deletions. It reported `10231 MiB` after the sweep — the identical number it had printed as `before:`. The check compared a stale pre-sweep figure against the ceiling and raised `::error::` on a healthy store.

The same endpoint had already disagreed with the listing earlier in the day (8 entries / 7834 MiB against a listing of 14 entries / 4957 MiB). That should have been the tell, and I used it anyway.

## Fix

`kept_bytes` accumulates the size of every entry the sweep decides to keep. It is the post-sweep total *by construction*, costs no extra API call, and cannot go stale. The `after:` line reports it too. `before:` still uses the endpoint — it is indicative only, and a stale reading there misleads nobody.

## Why this is worth a same-day PR

A false alarm is worse than no alarm. A job that cries wolf every night is a job everyone learns to ignore, and being ignored is precisely what let the original 0.00 % hit rate survive for weeks. An alarm this new cannot afford to be wrong on its first day.

Verification is the next scheduled sweep (01:05 UTC) reporting an `after:` that matches the listing, and passing. The store is currently at 6491 MiB across 11 entries.

Refs #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)