### PR TITLE
fix(renderer): let the renderer re-arm singletons a Vulkan device test tears down (#1074)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.cpp
@@ -1302,6 +1302,13 @@ namespace OloEngine
         s_FrameData.ForwardPlus = nullptr;
     }
 
+    bool CommandDispatch::HasUBOReferences()
+    {
+        // The camera UBO stands for the set: SetUBOReferences publishes them
+        // together and Shutdown resets them together.
+        return Data().CameraUBO != nullptr;
+    }
+
     void CommandDispatch::SetUBOReferences(
         const Ref<UniformBuffer>& cameraUBO,
         const Ref<UniformBuffer>& materialUBO,

--- a/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.h
+++ b/OloEngine/src/OloEngine/Renderer/Commands/CommandDispatch.h
@@ -142,6 +142,12 @@ namespace OloEngine
         static const glm::vec3& GetViewPosition();
 
         // Shared scene/runtime bindings supplied by the renderer frontend at init.
+        /// Whether the shared scene buffers are currently published here.
+        /// False after `Shutdown()`, and the signal `Renderer3D::BeginScene`
+        /// uses to re-home its own buffers when something tore the dispatcher
+        /// down underneath it (issue #1074).
+        [[nodiscard]] static bool HasUBOReferences();
+
         static void SetUBOReferences(
             const Ref<UniformBuffer>& cameraUBO,
             const Ref<UniformBuffer>& materialUBO,

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -248,6 +248,36 @@ namespace OloEngine
         // render" gates only.
         static bool HasInitialized();
 
+        /// Re-publish the process-global `CommandDispatch` bindings that `Init`
+        /// established: the shared camera / material / bone UBOs, the model
+        /// instance buffer and the Forward+ pointer.
+        ///
+        /// `Init` publishes these exactly once, so anything that calls
+        /// `CommandDispatch::Shutdown()` while this renderer is still live
+        /// silently drops them and every later draw runs with no camera or
+        /// material UBO bound — geometry stops appearing, with no GL error and
+        /// no log line to point at. There was previously no way back from that
+        /// short of a full renderer restart.
+        ///
+        /// Today's caller is the Vulkan device test in the single-process suite
+        /// (issue #1074): its buffers are allocated against a device it then
+        /// destroys, so it MUST shut the dispatcher down, and this is how the
+        /// GL renderer that outlives it gets its bindings back. The same
+        /// sequence is what device-lost recovery or a runtime RHI switch would
+        /// need, which is why this lives here rather than in the test.
+        ///
+        /// No-op when `Init` has not run. Safe to call repeatedly.
+        static void RepublishCommandDispatchBindings();
+
+      private:
+        /// Re-take ownership of the process-wide singletons `Init` brought up
+        /// (the command dispatcher's shared buffers, the GPU pass-timer pool)
+        /// when something has shut them down while this renderer stayed live.
+        /// Called at the top of every `BeginScene`; cheap when nothing moved.
+        static void ReclaimSharedRenderState();
+
+      public:
+
         // Diagnostics: which GPU-resource-holding members of s_Data are still alive?
         //
         // Shutdown() must release every one of them. A Ref<> it forgets survives into

--- a/OloEngine/src/OloEngine/Renderer/Renderer3D.h
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3D.h
@@ -277,7 +277,6 @@ namespace OloEngine
         static void ReclaimSharedRenderState();
 
       public:
-
         // Diagnostics: which GPU-resource-holding members of s_Data are still alive?
         //
         // Shutdown() must release every one of them. A Ref<> it forgets survives into

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DFrameSetup.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DFrameSetup.cpp
@@ -1,5 +1,7 @@
 #include "OloEnginePCH.h"
 #include "OloEngine/Math/Math.h"
+#include "OloEngine/Renderer/Commands/CommandDispatch.h"
+#include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Renderer/Renderer3DInternal.h"
 
@@ -43,9 +45,29 @@ namespace OloEngine
         s_Data.CullFarClip = s_Data.CameraFarClip;
     }
 
+    void Renderer3D::ReclaimSharedRenderState()
+    {
+        // Re-take ownership of the process-wide singletons Init brought up, if
+        // anything shut them down while this renderer stayed live. A Vulkan
+        // device test does exactly that, and must: their GPU objects belong to
+        // the device it is about to destroy. Left dead, the dispatcher hands
+        // every later draw no camera or material UBO and the timer pool measures
+        // nothing — with no GL error and no log line to point at (issue #1074).
+        //
+        // Lazy on purpose. Restoring at the point of teardown would republish
+        // GL-currency handles across the Vulkan suites that follow, which is the
+        // hazard VulkanPassSuiteTest documents; doing it as we begin a frame
+        // re-arms them on OUR backend, at the moment we are about to need them.
+        if (!CommandDispatch::HasUBOReferences())
+            RepublishCommandDispatchBindings();
+        if (auto& passTimers = GPUPassTimerPool::GetInstance(); !passTimers.IsInitialized())
+            passTimers.Initialize();
+    }
+
     void Renderer3D::BeginScene(const PerspectiveCamera& camera)
     {
         OLO_PROFILE_FUNCTION();
+        ReclaimSharedRenderState();
         AdvanceDecalVisibilityFrame();
         // Ray-traced shadow candidates are per-frame (issue #1056). Cleared
         // HERE so an empty list can only mean "no light asked this frame" —
@@ -69,6 +91,7 @@ namespace OloEngine
     void Renderer3D::BeginScene(const EditorCamera& camera)
     {
         OLO_PROFILE_FUNCTION();
+        ReclaimSharedRenderState();
         AdvanceDecalVisibilityFrame();
         // Ray-traced shadow candidates are per-frame (issue #1056). Cleared
         // HERE so an empty list can only mean "no light asked this frame" —
@@ -92,6 +115,7 @@ namespace OloEngine
     void Renderer3D::BeginScene(const Camera& camera, const glm::mat4& transform)
     {
         OLO_PROFILE_FUNCTION();
+        ReclaimSharedRenderState();
         AdvanceDecalVisibilityFrame();
         // Ray-traced shadow candidates are per-frame (issue #1056). Cleared
         // HERE so an empty list can only mean "no light asked this frame" —

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -475,13 +475,7 @@ namespace OloEngine
             s_Data.LightProbeSHBuffer->SetData(zeros.data(), dummySSBOSize);
         }
 
-        CommandDispatch::SetUBOReferences(
-            s_Data.SharedSceneUBOs.Camera,
-            s_Data.SharedSceneUBOs.Material,
-            s_Data.BoneMatricesUBO,
-            s_Data.ModelInstanceBuffer,
-            s_Data.PrevBoneMatricesUBO,
-            &s_Data.ForwardPlus);
+        RepublishCommandDispatchBindings();
 
         EnvironmentMap::InitializeIBLSystem(m_ShaderLibrary);
         OLO_CORE_INFO("IBL system initialized.");
@@ -585,6 +579,29 @@ namespace OloEngine
     bool Renderer3D::HasInitialized()
     {
         return s_Data.CoreInitialized;
+    }
+
+    void Renderer3D::RepublishCommandDispatchBindings()
+    {
+        OLO_PROFILE_FUNCTION();
+        // Guard on HasInitialized, not IsInitialized: the latter means "the
+        // render graph is built and we are ready to draw", which is not the
+        // question here — Init calls this before the graph exists.
+        if (!HasInitialized())
+            return;
+
+        // Both halves are idempotent, and together they are what lets a caller
+        // that shut the dispatcher down recover: Initialize re-establishes the
+        // dispatch-function resolver, SetUBOReferences re-publishes the buffers
+        // that Init otherwise binds exactly once.
+        CommandDispatch::Initialize();
+        CommandDispatch::SetUBOReferences(
+            s_Data.SharedSceneUBOs.Camera,
+            s_Data.SharedSceneUBOs.Material,
+            s_Data.BoneMatricesUBO,
+            s_Data.ModelInstanceBuffer,
+            s_Data.PrevBoneMatricesUBO,
+            &s_Data.ForwardPlus);
     }
 
     std::vector<std::string> Renderer3D::DebugLiveGpuOwningStatics()

--- a/OloEngine/tests/AssetSceneLoadTest.cpp
+++ b/OloEngine/tests/AssetSceneLoadTest.cpp
@@ -258,6 +258,32 @@ namespace OloEngine::Tests
             {
                 if (Mgr)
                     Mgr->Shutdown();
+
+                // Shutting the manager down is not the same as uninstalling it.
+                // `Project` holds the active project and the asset manager in
+                // two statics, and without this the process is left with a
+                // SHUT-DOWN manager and a project whose directory `cleanup`
+                // deletes a moment later — both still non-null.
+                //
+                // That corpse poisons every later test in a single-process run
+                // (issue #1074). The renderer fixtures install their own temp
+                // project guarded by `if (!Project::GetActive() ||
+                // !Project::HasAssetManager())`; both are non-null here, so
+                // they skip their own setup and adopt this one instead. Their
+                // `AssetManager::AddMemoryOnlyAsset` calls then register into a
+                // dead manager, `GetAsset<T>` hands back nothing, and the
+                // subject of the test never renders — a visual-evidence test
+                // measuring an empty frame ~2,000 tests later, with nothing
+                // pointing back here. This single test accounted for 21 of the
+                // 102 monolithic-run failures.
+                //
+                // `Unload()` drops both statics, which is the pristine state
+                // every fixture is written to handle. Deliberately not "restore
+                // whatever was there before": the previous value could itself
+                // be a corpse, and `GetAssetManager()` asserts on null, so a
+                // caller that forgets to check now fails loudly instead of
+                // silently reading a dead manager.
+                Project::Unload();
             }
         } assetManagerShutdown{ assetManager };
 
@@ -542,6 +568,32 @@ namespace OloEngine::Tests
             {
                 if (Mgr)
                     Mgr->Shutdown();
+
+                // Shutting the manager down is not the same as uninstalling it.
+                // `Project` holds the active project and the asset manager in
+                // two statics, and without this the process is left with a
+                // SHUT-DOWN manager and a project whose directory `cleanup`
+                // deletes a moment later — both still non-null.
+                //
+                // That corpse poisons every later test in a single-process run
+                // (issue #1074). The renderer fixtures install their own temp
+                // project guarded by `if (!Project::GetActive() ||
+                // !Project::HasAssetManager())`; both are non-null here, so
+                // they skip their own setup and adopt this one instead. Their
+                // `AssetManager::AddMemoryOnlyAsset` calls then register into a
+                // dead manager, `GetAsset<T>` hands back nothing, and the
+                // subject of the test never renders — a visual-evidence test
+                // measuring an empty frame ~2,000 tests later, with nothing
+                // pointing back here. This single test accounted for 21 of the
+                // 102 monolithic-run failures.
+                //
+                // `Unload()` drops both statics, which is the pristine state
+                // every fixture is written to handle. Deliberately not "restore
+                // whatever was there before": the previous value could itself
+                // be a corpse, and `GetAssetManager()` asserts on null, so a
+                // caller that forgets to check now fails loudly instead of
+                // silently reading a dead manager.
+                Project::Unload();
             }
         } assetManagerShutdown{ assetManager };
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -543,7 +543,9 @@ add_executable(OloEngine-Tests
 		# that drains + asserts a clean glGetError() after every test, pinning
 		# GL-context pollution to its source. Registered from OloEngineTest.cpp.
 		Rendering/PropertyTests/GLErrorStateCheck.cpp
+		Rendering/PropertyTests/RendererStateCheck.cpp
 		Rendering/PropertyTests/GLErrorStateCheckTest.cpp
+		Rendering/PropertyTests/RendererStateCheckTest.cpp
 		Rendering/PropertyTests/ModelLoadDeterminismTest.cpp
 		Rendering/PropertyTests/DrawIndexedRawOffsetTest.cpp
 		Rendering/PropertyTests/TextureSaveRoundTripTest.cpp

--- a/OloEngine/tests/OloEngineTest.cpp
+++ b/OloEngine/tests/OloEngineTest.cpp
@@ -5,6 +5,7 @@
 #include "OloEngine/Core/DebugLevers.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "Rendering/PropertyTests/GLErrorStateCheck.h"
+#include "Rendering/PropertyTests/RendererStateCheck.h"
 #include "Rendering/PropertyTests/TestFailureCapture.h"
 #include "TestOptions.h"
 #include "TestTempDir.h"
@@ -69,6 +70,14 @@ int main(int argc, char** argv)
     // pollutes the shared, process-wide GL context is pinned to its source
     // rather than misattributed to a later unrelated GPU test (issue #485).
     OloEngine::Tests::GLErrorState::RegisterListener();
+    // Restore the process-global renderer CONFIGURATION after every test, and
+    // account for every test that left it changed (issue #1074). GL state and
+    // renderer configuration are different hazards: the guard above catches a
+    // dirty `glGetError()` queue, this one catches a rendering path or settings
+    // struct left switched to something the next test never asked for — which
+    // has no GL-level symptom at all and instead makes a later visual-evidence
+    // test quietly measure the wrong pipeline.
+    OloEngine::Tests::RendererState::RegisterListener();
     // Give every test a freshly-emptied scratch directory on its first
     // TempDir()/TempFile() call — the clean slate the per-fixture `SetUp`
     // remove_all blocks used to provide, and which `--gtest_repeat` (same case,

--- a/OloEngine/tests/Rendering/PropertyTests/LightmapVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/LightmapVisualEvidenceTest.cpp
@@ -306,7 +306,7 @@ namespace OloEngine::Tests
             // project, mirroring VirtualGeometryVisualEvidenceTest (incl. its
             // "leave the manager installed at teardown" rationale —
             // SetAssetManager asserts non-null).
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 std::error_code ec;
                 fs::path const projectDir = TempDir("project");

--- a/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
@@ -1458,7 +1458,7 @@ namespace OloEngine::Tests
         void BuildScene() override
         {
             // AssetManager::AddMemoryOnlyAsset needs an active project + asset manager.
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 std::error_code ec;
                 fs::path const projectDir = OloEngine::Tests::TempDir("project");

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
@@ -27,7 +27,7 @@ namespace OloEngine::Tests::RendererState
         // If one of these fires, the settings struct grew a non-trivial member.
         // Give it an `operator==` and compare it explicitly instead of adding
         // it to the memcmp path.
-        template <typename T>
+        template<typename T>
         [[nodiscard]] bool BytesEqual(const T& a, const T& b)
         {
             static_assert(std::is_trivially_copyable_v<T>,
@@ -40,19 +40,19 @@ namespace OloEngine::Tests::RendererState
         // Describe and Restore all walk this list, so an entry added to one is
         // an entry added to all three — the failure mode that produced this
         // whole issue was a save/restore pair that covered different sets.
-#define OLO_RENDERER_STATE_STRUCT_ENTRIES(X)                                                       \
-    X(Renderer, "RendererSettings", Renderer3D::GetRendererSettings())                             \
-    X(PostProcess, "PostProcessSettings", Renderer3D::GetPostProcessSettings())                    \
-    X(Snow, "SnowSettings", Renderer3D::GetSnowSettings())                                         \
-    X(Fog, "FogSettings", Renderer3D::GetFogSettings())                                            \
-    X(Wind, "WindSettings", Renderer3D::GetWindSettings())                                         \
-    X(SnowAccumulation, "SnowAccumulationSettings", Renderer3D::GetSnowAccumulationSettings())     \
-    X(WaterDisturbance, "WaterDisturbanceSettings", Renderer3D::GetWaterDisturbanceSettings())     \
-    X(WaterWakeShape, "WaterWakeSettings", Renderer3D::GetWaterWakeSettings())                     \
-    X(WaterFoamAdvection, "WaterFoamSettings", Renderer3D::GetWaterFoamSettings())                 \
-    X(SnowEjecta, "SnowEjectaSettings", Renderer3D::GetSnowEjectaSettings())                       \
-    X(Precipitation, "PrecipitationSettings", Renderer3D::GetPrecipitationSettings())              \
-    X(Cloudscape, "CloudscapeRenderState", Renderer3D::GetCloudscapeState())                       \
+#define OLO_RENDERER_STATE_STRUCT_ENTRIES(X)                                                   \
+    X(Renderer, "RendererSettings", Renderer3D::GetRendererSettings())                         \
+    X(PostProcess, "PostProcessSettings", Renderer3D::GetPostProcessSettings())                \
+    X(Snow, "SnowSettings", Renderer3D::GetSnowSettings())                                     \
+    X(Fog, "FogSettings", Renderer3D::GetFogSettings())                                        \
+    X(Wind, "WindSettings", Renderer3D::GetWindSettings())                                     \
+    X(SnowAccumulation, "SnowAccumulationSettings", Renderer3D::GetSnowAccumulationSettings()) \
+    X(WaterDisturbance, "WaterDisturbanceSettings", Renderer3D::GetWaterDisturbanceSettings()) \
+    X(WaterWakeShape, "WaterWakeSettings", Renderer3D::GetWaterWakeSettings())                 \
+    X(WaterFoamAdvection, "WaterFoamSettings", Renderer3D::GetWaterFoamSettings())             \
+    X(SnowEjecta, "SnowEjectaSettings", Renderer3D::GetSnowEjectaSettings())                   \
+    X(Precipitation, "PrecipitationSettings", Renderer3D::GetPrecipitationSettings())          \
+    X(Cloudscape, "CloudscapeRenderState", Renderer3D::GetCloudscapeState())                   \
     X(UnderwaterFog, "UnderwaterFogState", Renderer3D::GetUnderwaterFogState())
 
         // The scalar toggles, which have distinct getters and setters rather
@@ -118,15 +118,15 @@ namespace OloEngine::Tests::RendererState
 
         std::vector<std::string> changed;
 
-#define OLO_DIFF_STRUCT(member, label, accessor)                                                   \
-    if (!BytesEqual(before.member, after.member))                                                  \
+#define OLO_DIFF_STRUCT(member, label, accessor)  \
+    if (!BytesEqual(before.member, after.member)) \
         changed.emplace_back(label);
         OLO_RENDERER_STATE_STRUCT_ENTRIES(OLO_DIFF_STRUCT)
 #undef OLO_DIFF_STRUCT
 
-#define OLO_DIFF_SCALAR(member, label, getter, setter)                                             \
-    if (before.member != after.member)                                                             \
-        changed.emplace_back(std::string(label) + " (" + (before.member ? "true" : "false") +      \
+#define OLO_DIFF_SCALAR(member, label, getter, setter)                                        \
+    if (before.member != after.member)                                                        \
+        changed.emplace_back(std::string(label) + " (" + (before.member ? "true" : "false") + \
                              " -> " + (after.member ? "true" : "false") + ")");
         OLO_RENDERER_STATE_SCALAR_ENTRIES(OLO_DIFF_SCALAR)
 #undef OLO_DIFF_SCALAR

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
@@ -16,17 +16,32 @@ namespace OloEngine::Tests::RendererState
 {
     namespace
     {
-        // Every entry in a Snapshot is compared byte-for-byte. That is only
-        // sound for trivially copyable types: for those, the copy that built
-        // the snapshot reproduced the object representation exactly, padding
-        // included, so two snapshots taken the same way differ in their padding
-        // only if something actually wrote it. A type with a std::string or a
-        // Ref<T> in it would compare pointer values and report a spurious leak,
-        // so it is rejected here rather than silently mis-measured.
+        // Every entry in a Snapshot is compared byte-for-byte, and `Capture`
+        // fills each one with `std::memcpy` from the live object rather than by
+        // assignment. That pairing is what makes the comparison sound.
         //
-        // If one of these fires, the settings struct grew a non-trivial member.
-        // Give it an `operator==` and compare it explicitly instead of adding
-        // it to the memcmp path.
+        // Assignment would not be enough: the implicitly-defined copy assignment
+        // operator is specified as MEMBERWISE, so it need not carry a struct's
+        // padding bytes across, and most of these structs are padded — a leading
+        // `bool Enabled` followed by an `f32` leaves three bytes that no member
+        // owns. Every mainstream compiler implements a trivial copy as a byte
+        // copy and it works out, but relying on that is relying on something the
+        // standard does not promise. `memcpy` promises it: both snapshots are
+        // verbatim images of the same object, so they differ in a padding byte
+        // only if something actually wrote one.
+        //
+        // Byte comparison rather than field-by-field is also the deliberate
+        // choice for WHAT this measures. These structs are mostly `f32` and
+        // `glm::vec3`, and CLAUDE.md forbids `==` on both; a semantic comparison
+        // would need epsilons, and an epsilon is exactly how a small real leak
+        // stops being reported. "Not one bit moved" is the contract a test is
+        // being held to here.
+        //
+        // A type with a `std::string` or a `Ref<T>` in it would compare pointer
+        // values and report a spurious leak, so it is rejected outright rather
+        // than silently mis-measured. If this fires, the settings struct grew a
+        // non-trivial member: give it an `operator==` and compare it explicitly
+        // instead of adding it to the memcmp path.
         template<typename T>
         [[nodiscard]] bool BytesEqual(const T& a, const T& b)
         {
@@ -95,7 +110,13 @@ namespace OloEngine::Tests::RendererState
         if (!Renderer3D::IsInitialized())
             return false;
 
-#define OLO_CAPTURE_STRUCT(member, label, accessor) out.member = (accessor);
+        // memcpy, not assignment — see BytesEqual: the comparison is byte-wise,
+        // so the capture has to carry padding bytes too or two snapshots of an
+        // unchanged struct could differ in bytes no member owns.
+#define OLO_CAPTURE_STRUCT(member, label, accessor)                            \
+    static_assert(std::is_trivially_copyable_v<decltype(out.member)>,          \
+                  "RendererState::Snapshot entries are captured with memcpy"); \
+    std::memcpy(&out.member, &(accessor), sizeof(out.member));
         OLO_RENDERER_STATE_STRUCT_ENTRIES(OLO_CAPTURE_STRUCT)
 #undef OLO_CAPTURE_STRUCT
 

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.cpp
@@ -1,0 +1,284 @@
+#include "OloEnginePCH.h"
+#include "RendererStateCheck.h"
+
+#include "OloEngine/Renderer/Renderer3D.h"
+
+#include "TestOptions.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace OloEngine::Tests::RendererState
+{
+    namespace
+    {
+        // Every entry in a Snapshot is compared byte-for-byte. That is only
+        // sound for trivially copyable types: for those, the copy that built
+        // the snapshot reproduced the object representation exactly, padding
+        // included, so two snapshots taken the same way differ in their padding
+        // only if something actually wrote it. A type with a std::string or a
+        // Ref<T> in it would compare pointer values and report a spurious leak,
+        // so it is rejected here rather than silently mis-measured.
+        //
+        // If one of these fires, the settings struct grew a non-trivial member.
+        // Give it an `operator==` and compare it explicitly instead of adding
+        // it to the memcmp path.
+        template <typename T>
+        [[nodiscard]] bool BytesEqual(const T& a, const T& b)
+        {
+            static_assert(std::is_trivially_copyable_v<T>,
+                          "RendererState::Snapshot compares entries with memcmp; a non-trivially "
+                          "copyable settings struct must be compared field-wise instead.");
+            return std::memcmp(&a, &b, sizeof(T)) == 0;
+        }
+
+        // The single place that knows which entries a Snapshot holds. Capture,
+        // Describe and Restore all walk this list, so an entry added to one is
+        // an entry added to all three — the failure mode that produced this
+        // whole issue was a save/restore pair that covered different sets.
+#define OLO_RENDERER_STATE_STRUCT_ENTRIES(X)                                                       \
+    X(Renderer, "RendererSettings", Renderer3D::GetRendererSettings())                             \
+    X(PostProcess, "PostProcessSettings", Renderer3D::GetPostProcessSettings())                    \
+    X(Snow, "SnowSettings", Renderer3D::GetSnowSettings())                                         \
+    X(Fog, "FogSettings", Renderer3D::GetFogSettings())                                            \
+    X(Wind, "WindSettings", Renderer3D::GetWindSettings())                                         \
+    X(SnowAccumulation, "SnowAccumulationSettings", Renderer3D::GetSnowAccumulationSettings())     \
+    X(WaterDisturbance, "WaterDisturbanceSettings", Renderer3D::GetWaterDisturbanceSettings())     \
+    X(WaterWakeShape, "WaterWakeSettings", Renderer3D::GetWaterWakeSettings())                     \
+    X(WaterFoamAdvection, "WaterFoamSettings", Renderer3D::GetWaterFoamSettings())                 \
+    X(SnowEjecta, "SnowEjectaSettings", Renderer3D::GetSnowEjectaSettings())                       \
+    X(Precipitation, "PrecipitationSettings", Renderer3D::GetPrecipitationSettings())              \
+    X(Cloudscape, "CloudscapeRenderState", Renderer3D::GetCloudscapeState())                       \
+    X(UnderwaterFog, "UnderwaterFogState", Renderer3D::GetUnderwaterFogState())
+
+        // The scalar toggles, which have distinct getters and setters rather
+        // than a single by-reference accessor.
+#define OLO_RENDERER_STATE_SCALAR_ENTRIES(X)                                                       \
+    X(FrustumCulling, "FrustumCullingEnabled", Renderer3D::IsFrustumCullingEnabled(),              \
+      Renderer3D::EnableFrustumCulling)                                                            \
+    X(DynamicCulling, "DynamicCullingEnabled", Renderer3D::IsDynamicCullingEnabled(),              \
+      Renderer3D::EnableDynamicCulling)                                                            \
+    X(DepthAwareClusterCulling, "DepthAwareClusterCullingEnabled",                                 \
+      Renderer3D::IsDepthAwareClusterCullingEnabled(), Renderer3D::EnableDepthAwareClusterCulling) \
+    X(OcclusionCulling, "OcclusionCullingEnabled", Renderer3D::IsOcclusionCullingEnabled(),        \
+      Renderer3D::EnableOcclusionCulling)                                                          \
+    X(HZBOcclusionCulling, "HZBOcclusionCullingEnabled",                                           \
+      Renderer3D::IsHZBOcclusionCullingEnabled(), Renderer3D::EnableHZBOcclusionCulling)           \
+    X(CullingCameraFrozen, "CullingCameraFrozen", Renderer3D::IsCullingCameraFrozen(),             \
+      Renderer3D::SetCullingCameraFrozen)                                                          \
+    X(CameraRelative, "CameraRelativeEnabled", Renderer3D::IsCameraRelativeEnabled(),              \
+      Renderer3D::SetCameraRelativeEnabled)                                                        \
+    X(SelectionOutline, "SelectionOutlineEnabled", Renderer3D::IsSelectionOutlineEnabled(),        \
+      Renderer3D::SetSelectionOutlineEnabled)                                                      \
+    X(ForceDisableCulling, "ForceDisableCulling", Renderer3D::IsForceDisableCulling(),             \
+      Renderer3D::SetForceDisableCulling)
+
+        u32 s_LeakCount = 0;
+
+        // test full name -> the state entries it leaked, for the end-of-run
+        // summary. A map keeps the summary stable and deduplicated when a test
+        // runs more than once (--gtest_repeat).
+        std::map<std::string, std::string>& LeakLedger()
+        {
+            static std::map<std::string, std::string> ledger;
+            return ledger;
+        }
+    } // namespace
+
+    bool Capture(Snapshot& out)
+    {
+        out = Snapshot{};
+        if (!Renderer3D::IsInitialized())
+            return false;
+
+#define OLO_CAPTURE_STRUCT(member, label, accessor) out.member = (accessor);
+        OLO_RENDERER_STATE_STRUCT_ENTRIES(OLO_CAPTURE_STRUCT)
+#undef OLO_CAPTURE_STRUCT
+
+#define OLO_CAPTURE_SCALAR(member, label, getter, setter) out.member = (getter);
+        OLO_RENDERER_STATE_SCALAR_ENTRIES(OLO_CAPTURE_SCALAR)
+#undef OLO_CAPTURE_SCALAR
+
+        out.RenderScale = Renderer3D::GetRenderScale();
+        out.Valid = true;
+        return true;
+    }
+
+    u32 Describe(const Snapshot& before, const Snapshot& after, std::string& outDetail)
+    {
+        // A test that initialized or shut down the renderer has no before/after
+        // pair. That is not a leak, and guessing at one would make the first
+        // GPU test in every run permanently guilty.
+        if (!before.Valid || !after.Valid)
+            return 0;
+
+        std::vector<std::string> changed;
+
+#define OLO_DIFF_STRUCT(member, label, accessor)                                                   \
+    if (!BytesEqual(before.member, after.member))                                                  \
+        changed.emplace_back(label);
+        OLO_RENDERER_STATE_STRUCT_ENTRIES(OLO_DIFF_STRUCT)
+#undef OLO_DIFF_STRUCT
+
+#define OLO_DIFF_SCALAR(member, label, getter, setter)                                             \
+    if (before.member != after.member)                                                             \
+        changed.emplace_back(std::string(label) + " (" + (before.member ? "true" : "false") +      \
+                             " -> " + (after.member ? "true" : "false") + ")");
+        OLO_RENDERER_STATE_SCALAR_ENTRIES(OLO_DIFF_SCALAR)
+#undef OLO_DIFF_SCALAR
+
+        // Never `!=` on a float (CLAUDE.md); a render scale that moved by less
+        // than this is not something a test set deliberately.
+        if (std::abs(before.RenderScale - after.RenderScale) > 1e-6f)
+            changed.emplace_back("RenderScale");
+
+        if (changed.empty())
+            return 0;
+
+        for (sizet i = 0; i < changed.size(); ++i)
+        {
+            if (i != 0)
+                outDetail += ", ";
+            outDetail += changed[i];
+        }
+        return static_cast<u32>(changed.size());
+    }
+
+    void Restore(const Snapshot& snapshot)
+    {
+        if (!snapshot.Valid || !Renderer3D::IsInitialized())
+            return;
+
+        // The by-reference settings accessors return an lvalue, so assignment
+        // through them writes the live struct. Cloudscape and underwater fog
+        // are const-getter / setter pairs and are handled after the macro.
+        Renderer3D::GetRendererSettings() = snapshot.Renderer;
+        Renderer3D::GetPostProcessSettings() = snapshot.PostProcess;
+        Renderer3D::GetSnowSettings() = snapshot.Snow;
+        Renderer3D::GetFogSettings() = snapshot.Fog;
+        Renderer3D::GetWindSettings() = snapshot.Wind;
+        Renderer3D::GetSnowAccumulationSettings() = snapshot.SnowAccumulation;
+        Renderer3D::GetWaterDisturbanceSettings() = snapshot.WaterDisturbance;
+        Renderer3D::GetWaterWakeSettings() = snapshot.WaterWakeShape;
+        Renderer3D::GetWaterFoamSettings() = snapshot.WaterFoamAdvection;
+        Renderer3D::GetSnowEjectaSettings() = snapshot.SnowEjecta;
+        Renderer3D::GetPrecipitationSettings() = snapshot.Precipitation;
+        Renderer3D::SetCloudscapeState(snapshot.Cloudscape);
+        Renderer3D::SetUnderwaterFogState(snapshot.UnderwaterFog);
+
+#define OLO_RESTORE_SCALAR(member, label, getter, setter) setter(snapshot.member);
+        OLO_RENDERER_STATE_SCALAR_ENTRIES(OLO_RESTORE_SCALAR)
+#undef OLO_RESTORE_SCALAR
+
+        Renderer3D::SetRenderScale(snapshot.RenderScale);
+
+        // Restoring the settings STRUCT is not the same as restoring the
+        // renderer. `ApplyRendererSettings` is what pushes `Path` and the AO
+        // technique into the render graph's "configured-for" state; without it
+        // the structs read correct while the graph stays built for whatever the
+        // polluting test switched it to — the same bug, one level down, and
+        // invisible to this guard's own comparison. Cheap when nothing moved:
+        // the expensive ConfigureRenderGraph is guarded behind an actual
+        // path/AO mismatch.
+        Renderer3D::ApplyRendererSettings();
+    }
+
+    u32 LeakCount()
+    {
+        return s_LeakCount;
+    }
+
+    // =========================================================================
+    // GoogleTest listener — restores (and accounts for) renderer configuration
+    // around every test.
+    // =========================================================================
+    namespace
+    {
+        class RendererStateListener : public ::testing::EmptyTestEventListener
+        {
+          public:
+            void OnTestStart(const ::testing::TestInfo&) override
+            {
+                Capture(m_Before);
+            }
+
+            void OnTestEnd(const ::testing::TestInfo& info) override
+            {
+                Snapshot after;
+                Capture(after);
+
+                std::string detail;
+                const u32 changed = Describe(m_Before, after, detail);
+
+                // Restore before anything else can run, whether or not this
+                // test is one we would report. A SKIPPED test that got far
+                // enough to write a setting leaks exactly as a failing one
+                // does, and the next test inherits it either way.
+                Restore(m_Before);
+
+                if (changed == 0)
+                    return;
+
+                ++s_LeakCount;
+                LeakLedger()[std::string(info.test_suite_name()) + "." + info.name()] = detail;
+
+                if (!Options().StrictRendererState)
+                    return;
+
+                const ::testing::TestResult* result = info.result();
+                if (result != nullptr && result->Skipped())
+                    return;
+
+                // Attribute the failure to the polluting test's own source
+                // location, not this file, so "jump to failure" lands on the
+                // culprit. OnTestEnd fires in reverse listener order, so this
+                // is recorded before the result printer reads the result and
+                // the test correctly prints [ FAILED ].
+                const char* const file = info.file() != nullptr ? info.file() : __FILE__;
+                const int line = info.file() != nullptr ? info.line() : __LINE__;
+                ADD_FAILURE_AT(file, line)
+                    << "Renderer configuration not restored after test; leaked: " << detail
+                    << ". This test changed process-global renderer state that every later test in "
+                       "this binary shares. The leak was restored here so it cannot corrupt a later "
+                       "test (see issue #1074), but fix the source: save and restore what you "
+                       "change, or move the change behind the fixture that owns it.";
+            }
+
+            void OnTestProgramEnd(const ::testing::UnitTest&) override
+            {
+                const auto& ledger = LeakLedger();
+                if (ledger.empty())
+                    return;
+
+                // Printed unconditionally, including on an otherwise green run.
+                // A leak that has been repaired is still a bug in the test that
+                // caused it, and this is the only place it is visible when
+                // --olo-strict-renderer-state is off.
+                std::printf("\n[ RENDERER STATE ] %zu test(s) leaked process-global renderer "
+                            "configuration; each leak was restored so it could not affect a later "
+                            "test. Re-run with --olo-strict-renderer-state to fail them.\n",
+                            ledger.size());
+                for (const auto& [testName, detail] : ledger)
+                    std::printf("[ RENDERER STATE ]   %s: %s\n", testName.c_str(), detail.c_str());
+                std::fflush(stdout);
+            }
+
+          private:
+            Snapshot m_Before;
+        };
+
+        bool s_Registered = false;
+    } // namespace
+
+    void RegisterListener()
+    {
+        if (s_Registered)
+            return;
+        s_Registered = true;
+        ::testing::UnitTest::GetInstance()->listeners().Append(new RendererStateListener());
+    }
+} // namespace OloEngine::Tests::RendererState

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.h
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheck.h
@@ -1,0 +1,151 @@
+// =============================================================================
+// RendererStateCheck.h
+//
+// Cross-test guard for the process-wide RENDERER CONFIGURATION (issue #1074).
+//
+// The rule this enforces: a test must leave the process-global renderer
+// configuration exactly as it found it. Everything else here is the story of
+// why that needs a guard rather than a convention.
+//
+// `Renderer3D::s_Data` is a single static shared by every test in this binary,
+// and roughly a dozen of its members are *configuration* rather than per-frame
+// scratch: the rendering path, the culling toggles, and eleven settings structs
+// (fog, wind, snow, precipitation, the water fields, post-process). A test that
+// writes one and does not put it back changes what the renderer DOES for every
+// later test in the same process — silently, and with no GL-level symptom for
+// `GLErrorStateCheck` to catch.
+//
+// The failure this produces is uniquely misleading. The victim is a visual
+// evidence test whose feature-on and feature-off captures come out identical,
+// or whose differential reads ~0 where it expected a large one — the effect
+// under test simply is not rendering, because the path or the toggle it needs
+// was left switched off by an unrelated test that ran earlier. The victim
+// passes 10/10 under its own `--gtest_filter` and fails only in the monolithic
+// run, so the evidence points everywhere except the cause. Bisecting one such
+// poisoner to its source took ~5 full-suite runs at 17 minutes each.
+//
+// CI structurally cannot see any of this: `gtest_discover_tests` registers
+// every case as its own ctest entry, so CI runs one process per test and no two
+// of these tests ever share an address space.
+//
+// What the listener does, after EVERY test:
+//
+//   1. **Restores** the configuration to what it was when the test started.
+//      This is the structural fix, and it is why the guard restores rather than
+//      only reporting: a fixture that saves and restores "the two settings I
+//      remembered" leaves the other nine free to leak, and every new settings
+//      struct added to the renderer silently joins the hazard. Restoring
+//      centrally makes a partial restore unexpressible.
+//   2. **Counts** the leak and attributes it to the test that caused it. A
+//      summary at the end of the run names the polluting tests and the state
+//      each one leaked, so a leak is never invisible even when the restore
+//      has already made it harmless.
+//   3. Under `--olo-strict-renderer-state`, additionally **fails** the
+//      polluting test. Off by default because a leak is now repaired rather
+//      than propagated: turning ~100 mystery failures in victim tests into
+//      several hundred failures in polluting tests would trade one unreadable
+//      signal for another. The flag is what a fixture author runs to see their
+//      own leak as a named failure.
+//
+// Why a listener and not a fixture `TearDown()`: most GPU tests are plain
+// `TEST()` bodies gated on `OLO_ENSURE_GPU_OR_SKIP()`, not `TEST_F` subclasses
+// of `RendererAttachedTest`, and a poisoner can be any test in the binary — a
+// fixture teardown would miss exactly the ones nobody thought to look at. This
+// mirrors `GLErrorStateCheck`, which solved the same problem for GL state.
+//
+// Headless-safe: when `Renderer3D` was never initialized (CI without a GPU,
+// where every GL test SKIPs) the check is a clean no-op and never fabricates a
+// failure. It is also a no-op across the boundary where a test initializes or
+// shuts down the renderer, since there is no before/after pair to compare.
+// =============================================================================
+#pragma once
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Renderer/PostProcessSettings.h"
+#include "OloEngine/Renderer/RenderingPath.h"
+#include "OloEngine/Renderer/Water/WaterDisturbanceSystem.h"
+#include "OloEngine/Renderer/Water/WaterFoam.h"
+#include "OloEngine/Renderer/Water/WaterWakeSystem.h"
+
+#include <string>
+
+namespace OloEngine::Tests::RendererState
+{
+    // A copy of every process-global renderer configuration value a test can
+    // reach. Deliberately NOT a copy of `Renderer3D::s_Data`: that struct is
+    // mostly per-frame scratch (matrices, statistics, GPU resource handles)
+    // which every frame overwrites and no test can leak. Only values that
+    // PERSIST across a `BeginScene`/`EndScene` pair belong here — those are the
+    // ones a later test inherits.
+    //
+    // Adding a settings struct to `Renderer3D`? Add it here too. The cost of
+    // forgetting is a new class of cross-test failure that looks like a broken
+    // renderer; `RendererStateCheckTest` pins the count so the omission shows
+    // up as a failing test rather than as folklore.
+    struct Snapshot
+    {
+        bool Valid = false;
+
+        // --- The settings structs, in `Renderer3D` declaration order ---
+        RendererSettings Renderer{};
+        PostProcessSettings PostProcess{};
+        SnowSettings Snow{};
+        FogSettings Fog{};
+        WindSettings Wind{};
+        SnowAccumulationSettings SnowAccumulation{};
+        WaterDisturbanceSettings WaterDisturbance{};
+        WaterWakeSettings WaterWakeShape{};
+        WaterFoam::WaterFoamSettings WaterFoamAdvection{};
+        SnowEjectaSettings SnowEjecta{};
+        PrecipitationSettings Precipitation{};
+
+        // --- Scene-published render state ---
+        CloudscapeRenderState Cloudscape{};
+        UnderwaterFogState UnderwaterFog{};
+
+        // --- Scalar toggles that live outside any settings struct ---
+        // Deliberately ABSENT: `DepthPrepassEnabled`. It is not independent
+        // state — `ApplyRendererSettings` recomputes it from `RendererSettings`
+        // (`ComputeSettingsDerivedDepthPrepass`: Forward+ and Deferred force it
+        // on), and `RendererSettings` is snapshotted above. Snapshotting the
+        // derived value as well reports a leak the first time anything calls
+        // `ApplyRendererSettings` after `Renderer::Init`, because Init leaves
+        // the raw flag at its default without ever running the derivation.
+        bool FrustumCulling = true;
+        bool DynamicCulling = true;
+        bool DepthAwareClusterCulling = true;
+        bool OcclusionCulling = false;
+        bool HZBOcclusionCulling = false;
+        bool CullingCameraFrozen = false;
+        bool CameraRelative = true;
+        bool SelectionOutline = false;
+        bool ForceDisableCulling = false;
+        f32 RenderScale = 1.0f;
+    };
+
+    /// Capture the current process-global renderer configuration. Returns false
+    /// (leaving `out.Valid == false`) when `Renderer3D` is not initialized —
+    /// there is no configuration to read, and no leak is possible.
+    bool Capture(Snapshot& out);
+
+    /// Append a human-readable description of every entry that differs between
+    /// `before` and `after` to `outDetail`, and return how many differed.
+    /// Returns 0 when either snapshot is invalid: a test that brought the
+    /// renderer up or took it down has no before/after pair to compare.
+    u32 Describe(const Snapshot& before, const Snapshot& after, std::string& outDetail);
+
+    /// Write `snapshot` back over the live renderer configuration. Re-applies
+    /// the renderer settings afterwards so the render graph is reconfigured to
+    /// match — a restored `RendererSettings::Path` that the graph was never told
+    /// about leaves the pipeline built for the wrong path, which is the same
+    /// bug with an extra step. No-op when `snapshot.Valid` is false.
+    void Restore(const Snapshot& snapshot);
+
+    /// Installs the renderer-state listener on the global gtest listener list.
+    /// Call once from main() after InitGoogleTest. Idempotent.
+    void RegisterListener();
+
+    /// Number of tests that leaked renderer configuration so far this run.
+    /// Exposed for the end-of-run summary and for self-tests.
+    [[nodiscard]] u32 LeakCount();
+} // namespace OloEngine::Tests::RendererState

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheckTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheckTest.cpp
@@ -36,9 +36,9 @@ namespace OloEngine::Tests
     // permanently guilty of a leak it did not cause.
     TEST(RendererStateCheckTest, InvalidSnapshotPairIsNotALeak)
     {
-        RendererState::Snapshot invalid;   // Valid == false
-        RendererState::Snapshot valid;     //
-        valid.Valid = true;                //
+        RendererState::Snapshot invalid; // Valid == false
+        RendererState::Snapshot valid;   //
+        valid.Valid = true;              //
         valid.Fog.Enabled = !valid.Fog.Enabled;
 
         std::string detail;

--- a/OloEngine/tests/Rendering/PropertyTests/RendererStateCheckTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/RendererStateCheckTest.cpp
@@ -1,0 +1,158 @@
+// OLO_TEST_LAYER: L4
+//
+// Self-test for the cross-test renderer-configuration guard (issue #1074).
+// Proves the three helpers behind the global listener:
+//   - Describe() stays silent across a renderer bring-up/shut-down boundary,
+//     where there is no before/after pair to compare,
+//   - Describe() names the entry that changed, per settings struct and per
+//     scalar toggle,
+//   - Capture() then Restore() round-trips the live renderer configuration,
+//     including the render graph's "configured-for" path.
+//
+// The pure-logic cases build Snapshots by hand and need no GL context, so they
+// run on headless CI where every GPU test skips — which matters, because the
+// guard's whole job is to hold in the monolithic run that only ever happens on
+// a machine with a GPU. The round-trip case is GPU-gated.
+//
+// Each case leaves the renderer configuration as it found it, so the global
+// RendererStateListener does not count it as a leak — the restore half of the
+// contract, verified in place.
+#include "OloEnginePCH.h"
+
+#include "RenderPropertyTest.h"
+#include "RendererStateCheck.h"
+
+#include "OloEngine/Renderer/Renderer.h"
+#include "OloEngine/Renderer/Renderer3D.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace OloEngine::Tests
+{
+    // A test that brought the renderer up (or took it down) has no before/after
+    // pair. Reporting one would make the first GPU test in every run
+    // permanently guilty of a leak it did not cause.
+    TEST(RendererStateCheckTest, InvalidSnapshotPairIsNotALeak)
+    {
+        RendererState::Snapshot invalid;   // Valid == false
+        RendererState::Snapshot valid;     //
+        valid.Valid = true;                //
+        valid.Fog.Enabled = !valid.Fog.Enabled;
+
+        std::string detail;
+        EXPECT_EQ(RendererState::Describe(invalid, valid, detail), 0u);
+        EXPECT_EQ(RendererState::Describe(valid, invalid, detail), 0u);
+        EXPECT_EQ(RendererState::Describe(invalid, invalid, detail), 0u);
+        EXPECT_TRUE(detail.empty());
+    }
+
+    // Two identical valid snapshots are the normal, well-behaved case.
+    TEST(RendererStateCheckTest, IdenticalSnapshotsReportNoLeak)
+    {
+        RendererState::Snapshot before;
+        before.Valid = true;
+        const RendererState::Snapshot after = before;
+
+        std::string detail;
+        EXPECT_EQ(RendererState::Describe(before, after, detail), 0u);
+        EXPECT_TRUE(detail.empty());
+    }
+
+    // A changed settings struct is reported by its type name, so the summary
+    // line says WHAT leaked rather than only that something did.
+    TEST(RendererStateCheckTest, NamesTheChangedSettingsStruct)
+    {
+        RendererState::Snapshot before;
+        before.Valid = true;
+        RendererState::Snapshot after = before;
+        after.Renderer.Path = (before.Renderer.Path == RenderingPath::Deferred)
+                                  ? RenderingPath::Forward
+                                  : RenderingPath::Deferred;
+
+        std::string detail;
+        EXPECT_EQ(RendererState::Describe(before, after, detail), 1u);
+        EXPECT_NE(detail.find("RendererSettings"), std::string::npos) << detail;
+    }
+
+    // A changed scalar toggle is reported with both values, because "culling is
+    // off" is only actionable once you know it was on when the test started.
+    TEST(RendererStateCheckTest, NamesTheChangedScalarToggleWithBothValues)
+    {
+        RendererState::Snapshot before;
+        before.Valid = true;
+        before.FrustumCulling = true;
+        RendererState::Snapshot after = before;
+        after.FrustumCulling = false;
+
+        std::string detail;
+        EXPECT_EQ(RendererState::Describe(before, after, detail), 1u);
+        EXPECT_NE(detail.find("FrustumCullingEnabled"), std::string::npos) << detail;
+        EXPECT_NE(detail.find("true"), std::string::npos) << detail;
+        EXPECT_NE(detail.find("false"), std::string::npos) << detail;
+    }
+
+    // Several leaks in one test are all reported, not just the first. A fixture
+    // that switches the path usually drags a couple of toggles with it, and
+    // fixing one of three is how this bug survived two previous rounds.
+    TEST(RendererStateCheckTest, ReportsEveryChangedEntry)
+    {
+        RendererState::Snapshot before;
+        before.Valid = true;
+        before.FrustumCulling = true;
+        RendererState::Snapshot after = before;
+        after.FrustumCulling = false;
+        after.PostProcess.BloomEnabled = !before.PostProcess.BloomEnabled;
+        after.Fog.Enabled = !before.Fog.Enabled;
+
+        std::string detail;
+        EXPECT_EQ(RendererState::Describe(before, after, detail), 3u);
+        EXPECT_NE(detail.find("PostProcessSettings"), std::string::npos) << detail;
+        EXPECT_NE(detail.find("FogSettings"), std::string::npos) << detail;
+        EXPECT_NE(detail.find("FrustumCullingEnabled"), std::string::npos) << detail;
+    }
+
+    // The round trip against the LIVE renderer: capture, mutate the way a
+    // polluting test does, restore, and confirm the configuration is back —
+    // including the render graph, which `ApplyRendererSettings` reconfigures.
+    // A restore that put the structs back but left the graph built for the
+    // other path would pass a struct comparison and still render every later
+    // test through the wrong pipeline.
+    TEST(RendererStateCheckTest, CaptureRestoreRoundTripsLiveConfiguration)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        if (!Renderer3D::IsInitialized())
+            Renderer::Init(RendererType::Renderer3D, /*loadingWindow=*/nullptr);
+        ASSERT_TRUE(Renderer3D::IsInitialized());
+
+        RendererState::Snapshot before;
+        ASSERT_TRUE(RendererState::Capture(before));
+        EXPECT_TRUE(before.Valid);
+
+        // Mutate exactly as the leak this issue was opened for did: switch the
+        // rendering path and flip a toggle, and apply it so the graph follows.
+        const RenderingPath originalPath = Renderer3D::GetRendererSettings().Path;
+        Renderer3D::GetRendererSettings().Path =
+            (originalPath == RenderingPath::Deferred) ? RenderingPath::Forward
+                                                      : RenderingPath::Deferred;
+        Renderer3D::ApplyRendererSettings();
+        Renderer3D::EnableFrustumCulling(!before.FrustumCulling);
+        Renderer3D::GetFogSettings().Enabled = !before.Fog.Enabled;
+
+        RendererState::Snapshot dirty;
+        ASSERT_TRUE(RendererState::Capture(dirty));
+        std::string leaked;
+        EXPECT_GE(RendererState::Describe(before, dirty, leaked), 2u) << leaked;
+
+        RendererState::Restore(before);
+
+        RendererState::Snapshot restored;
+        ASSERT_TRUE(RendererState::Capture(restored));
+        std::string residue;
+        EXPECT_EQ(RendererState::Describe(before, restored, residue), 0u)
+            << "Restore left renderer configuration changed: " << residue;
+        EXPECT_EQ(Renderer3D::GetRendererSettings().Path, originalPath);
+    }
+} // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/PropertyTests/SubmeshMaterialPathParityTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/SubmeshMaterialPathParityTest.cpp
@@ -648,7 +648,7 @@ namespace OloEngine::Tests
         {
             // AssetManager::AddMemoryOnlyAsset needs an active project + asset manager
             // (same temp-project bootstrap as VirtualGeometryVisualEvidenceTest).
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 namespace fs = std::filesystem;
                 std::error_code ec;

--- a/OloEngine/tests/Rendering/PropertyTests/VirtualGeometryRasterParityTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/VirtualGeometryRasterParityTest.cpp
@@ -275,7 +275,7 @@ namespace OloEngine::Tests
       public:
         void BuildScene() override
         {
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 namespace fs = std::filesystem;
                 std::error_code ec;

--- a/OloEngine/tests/Rendering/PropertyTests/VirtualGeometryVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/VirtualGeometryVisualEvidenceTest.cpp
@@ -252,7 +252,7 @@ namespace OloEngine::Tests
             // + asset manager. Mount a throwaway temp project, mirroring
             // FunctionalTest::EnableAssetManager (incl. its "leave the manager
             // installed at teardown" rationale — SetAssetManager asserts non-null).
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 namespace fs = std::filesystem;
                 std::error_code ec;

--- a/OloEngine/tests/Rendering/PropertyTests/VirtualRasterSubSampleEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/VirtualRasterSubSampleEvidenceTest.cpp
@@ -295,7 +295,7 @@ namespace OloEngine::Tests
         {
             // AssetManager::AddMemoryOnlyAsset needs an active project + asset
             // manager; same throwaway mount as VirtualGeometryVisualEvidence.
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 namespace fs = std::filesystem;
                 std::error_code ec;

--- a/OloEngine/tests/Rendering/PropertyTests/VolumeVDBVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/VolumeVDBVisualEvidenceTest.cpp
@@ -154,7 +154,7 @@ namespace OloEngine::Tests
             // need an active project + asset manager — mount a throwaway temp
             // project, mirroring LightmapVisualEvidenceTest /
             // VirtualGeometryVisualEvidenceTest.
-            if (!Project::GetActive() || !Project::GetAssetManager())
+            if (!Project::GetActive() || !Project::HasAssetManager())
             {
                 std::error_code ec;
                 fs::path const projectDir = TempDir("project");

--- a/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
@@ -53,6 +53,7 @@ TEST(VulkanParallelRecording, SkipsWhenNotCompiledIn)
 #include "OloEngine/Renderer/Debug/GPUPassTimerPool.h"
 #include "OloEngine/Renderer/RenderGraphPlanExecutor.h"
 #include "OloEngine/Renderer/RenderGraphSubmissionPlan.h"
+#include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "OloEngine/Renderer/RHI/RHITypes.h"
 #include "OloEngine/Renderer/Texture.h"
@@ -735,6 +736,20 @@ class VulkanParallelRecordingDevice : public ::testing::Test
 
 TEST_F(VulkanParallelRecordingDevice, GraphRecordsSharedUnboundUniformAndTimesOrderedPasses)
 {
+    // This test asserts on the EXACT set of pass timings it recorded, so it
+    // needs a pool of its own. `Initialize` early-outs when the pool is already
+    // up, so in a single-process run it would otherwise inherit the renderer's
+    // pool and read that frame's ~16 accumulated timings instead of its 2
+    // (issue #1074).
+    //
+    // Released HERE, before the Vulkan backend is selected below, because
+    // `Shutdown` destroys its query objects through `RenderCommand` — the
+    // renderer's queries are GL objects and must be freed on the GL backend that
+    // created them, not through a Vulkan device that never owned them.
+    // `Renderer3D::BeginScene` re-creates the pool on its own backend when it
+    // next draws.
+    GPUPassTimerPool::GetInstance().Shutdown();
+
     ScopedVulkanRenderCommandSelection renderCommandSelection;
     EnsureTaskWorkers();
     auto& api = renderCommandSelection.Get();
@@ -797,6 +812,23 @@ TEST_F(VulkanParallelRecordingDevice, GraphRecordsSharedUnboundUniformAndTimesOr
     ASSERT_EQ(plan.size(), 2u);
     ASSERT_EQ(plan[0].RecordingGroup, plan[1].RecordingGroup);
     ASSERT_NE(plan[0].RecordingGroup, UINT32_MAX);
+    // MeshPrimitives::Shutdown stays UNCONDITIONAL despite being a process-wide
+    // singleton the renderer also owns: the primitives this test builds are
+    // backed by Vulkan buffers, and they must be released before this test's
+    // Vulkan device tears its memory blocks down. Skipping it trades the
+    // cross-test leak for a hard VMA abort — "Some allocations were not freed
+    // before destruction of this memory block". The primitive cache rebuilds
+    // lazily, so the later-test cost is a rebuild rather than a dead singleton.
+    // Initialize unconditionally: this test asserts on the EXACT set of pass
+    // timings it recorded, so it needs a pool of its own. Inheriting the
+    // renderer's carries ~16 accumulated timings and the assertion reads 18
+    // instead of 2.
+    //
+    // Shutdown likewise stays unconditional — the pool's query objects belong to
+    // the Vulkan device selected here. Leaving it dead used to stop every later
+    // GPU-timing test from measuring anything (issue #1074);
+    // `Renderer3D::BeginScene` now re-initializes it when it next draws, on the
+    // renderer's own backend rather than on this device.
     auto& timers = GPUPassTimerPool::GetInstance();
     timers.Initialize(8);
     struct Cleanup
@@ -860,9 +892,19 @@ TEST_F(VulkanParallelRecordingDevice, MeshParticleRangesMatchInlinePixels)
     if (std::filesystem::exists("OloEditor/assets/shaders/Particle_Mesh.glsl"))
         std::filesystem::current_path("OloEditor");
     ASSERT_TRUE(std::filesystem::exists("assets/shaders/Particle_Mesh.glsl"));
+
     ScopedVulkanRenderCommandSelection renderCommandSelection;
     EnsureTaskWorkers();
     auto& api = renderCommandSelection.Get();
+    // Init/Shutdown both stay unconditional: this builds the batch renderer's
+    // buffers against the VULKAN backend selected just above, so reusing the GL
+    // renderer's instance would draw Vulkan work through GL-backed buffers, and
+    // skipping the Shutdown strands Vulkan allocations past device teardown
+    // ("Some allocations were not freed before destruction of this memory
+    // block"). Rebuilding the GL renderer's instance here would not help either:
+    // VulkanPassSuiteTest's own fixture shuts ParticleBatchRenderer down again
+    // a few suites later, so the durable fix for particle rendering after a
+    // Vulkan excursion belongs there, not here.
     ParticleBatchRenderer::Init();
     struct Cleanup
     {
@@ -1012,6 +1054,19 @@ TEST_F(VulkanParallelRecordingDevice, ForkRecordsEachItemIntoItsOwnTargetThrough
 // SSBO, even when the same material index is replayed repeatedly on an item.
 TEST_F(VulkanParallelRecordingDevice, BucketsReplayWithItemOwnedMaterialAndInstanceUploads)
 {
+    // The Shutdown below is NOT optional: this test's dispatcher state is bound
+    // to buffers allocated against the Vulkan device selected here, and they
+    // must be released before that device tears its memory blocks down.
+    // Skipping it aborts the process on a VMA assertion ("Some allocations were
+    // not freed before destruction of this memory block").
+    //
+    // It also drops the shared camera / material / bone UBOs that
+    // `Renderer3D::Init` publishes exactly once, which used to leave every later
+    // rendering test in a single-process run drawing with no camera or material
+    // UBO bound (issue #1074). Nothing is restored here on purpose: republishing
+    // at this point would leave GL-currency handles in the dispatcher across the
+    // Vulkan suites that follow — the hazard VulkanPassSuiteTest documents.
+    // `Renderer3D::BeginScene` re-homes its own buffers when it next draws.
     ScopedVulkanRenderCommandSelection renderCommandSelection;
     EnsureTaskWorkers();
     VulkanFrameArena::Get().BeginFrame(0);

--- a/OloEngine/tests/TestOptions.cpp
+++ b/OloEngine/tests/TestOptions.cpp
@@ -34,6 +34,8 @@ namespace OloEngine::Tests
                 "  --olo-perf-rebase              overwrite this machine's perf baseline\n"
                 "  --olo-perf-strict              fail on a perf regression instead of warning\n"
                 "  --olo-perf-machine=<name>      perf baseline key, overriding the hostname\n"
+                "  --olo-strict-renderer-state    fail a test that leaks process-global renderer\n"
+                "                                 configuration (it is restored either way)\n"
                 "  --olo-bench-assert             make micro-benchmarks assert their budgets\n"
                 "  --olo-soundgraph-perf          run the SoundGraph throughput measurement\n"
                 "  --olo-gl-backend=<egl|glfw|none|auto> force the context-creation path; `none` creates\n"
@@ -139,6 +141,10 @@ namespace OloEngine::Tests
             else if (arg == "--olo-perf-strict")
             {
                 s_Options.PerfStrict = true;
+            }
+            else if (arg == "--olo-strict-renderer-state")
+            {
+                s_Options.StrictRendererState = true;
             }
             else if (arg == "--olo-bench-assert")
             {

--- a/OloEngine/tests/TestOptions.h
+++ b/OloEngine/tests/TestOptions.h
@@ -63,6 +63,15 @@ namespace OloEngine::Tests
         bool PerfStrict = false;
         // --olo-perf-machine=<name> : baseline key, overriding the hostname.
         std::string PerfMachine;
+        // --olo-strict-renderer-state : fail a test that leaves the
+        // process-global renderer configuration different from how it found it
+        // (issue #1074). The leak is restored regardless — see
+        // Rendering/PropertyTests/RendererStateCheck.h; this flag only controls
+        // whether the polluting test is also FAILED. Off by default because a
+        // restored leak is harmless, and reporting every one of them would bury
+        // the run's real failures. Turn it on when you are hunting a leak, or
+        // when a fixture you are writing needs to prove it does not have one.
+        bool StrictRendererState = false;
         // --olo-bench-assert : make the micro-benchmarks assert their budgets
         // rather than only reporting.
         bool BenchAssert = false;

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -36,6 +36,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [timed-wait-test-assertions.md](timed-wait-test-assertions.md): measure timed waits in microseconds and assert one-sided.
 - [thread-local-lifetime-at-exit.md](thread-local-lifetime-at-exit.md): keep the "is it still alive?" signal in a trivially destructible `thread_local`; a destroyed one is not readable.
 - [shared-temp-dir-test-isolation.md](shared-temp-dir-test-isolation.md): use `TestTempDir.h`, never a fixed temp path; every test case is its own process.
+- [cross-test-renderer-state.md](cross-test-renderer-state.md): never shut down a process-wide singleton you did not start, and leave the renderer configuration as you found it; plus the two traps that make single-process bisection lie.
 
 ## Build and dependencies
 
@@ -281,6 +282,7 @@ The check passes for a correct implementation and for a broken one.
 | [volumetric-cloud-debugging.md](volumetric-cloud-debugging.md) | Capture targets show the editor camera; include-only shader edits do not hot-reload; "darker" passes for every uniform veil. |
 | [timed-wait-test-assertions.md](timed-wait-test-assertions.md) | `duration_cast<milliseconds>` truncates toward zero. |
 | [shared-temp-dir-test-isolation.md](shared-temp-dir-test-isolation.md) | A CI comment asserted a safety property nobody had measured. |
+| [cross-test-renderer-state.md](cross-test-renderer-state.md) | A visual test that passes 10/10 in isolation and draws nothing in the full run, with identical engine logs; two poisoners are each necessary and neither sufficient, and a reduced repro reproduces a different bug. |
 | [reference-path-tracer.md](reference-path-tracer.md) | A golden answers "did it change", never "is it correct". |
 | [vendor-golden-baseline-crosscheck.md](vendor-golden-baseline-crosscheck.md) | A per-vendor baseline validates itself; a small cross-vendor RMSE measures portability, not correctness. |
 | [stochastic-sampling-and-temporal-resolve.md](stochastic-sampling-and-temporal-resolve.md) | Every obvious noise metric passes on white noise; only the error spectrum separates blue from white. |

--- a/docs/agent-rules/cross-test-renderer-state.md
+++ b/docs/agent-rules/cross-test-renderer-state.md
@@ -1,0 +1,175 @@
+# Cross-test renderer state
+
+Two rules, in the order they cost us time:
+
+1. **Never shut down a process-wide singleton you did not start.** `Renderer3D::Init` owns
+   `CommandDispatch`, `GPUPassTimerPool`, `ParticleBatchRenderer` and `MeshPrimitives`. A test that
+   tears one down leaves every later rendering test in the process running against a dead one. Guard
+   every `Shutdown()` with whether *you* brought it up.
+2. **Leave the process-global renderer configuration as you found it.** The rendering path, the
+   settings structs and the culling toggles are all one static. A guard now restores these
+   automatically, so a leak is repaired rather than propagated — but it is still a bug in your test,
+   and the run names you in a `[ RENDERER STATE ]` summary.
+
+Rule 1 is what actually caused issue #1074. Rule 2 is what everyone assumed had caused it, including
+the issue itself; the guard built to enforce it found 212 leaking tests and fixed **zero** failures.
+That asymmetry is the most useful thing on this page.
+
+## Why this class exists at all
+
+`OloEngine-Tests.exe` run as ONE process shares a single `Renderer3D::s_Data`, one GL context and one
+set of engine singletons across ~7,600 tests. **CI cannot see any of it**: `tests/CMakeLists.txt`
+uses `gtest_discover_tests`, which registers every case as its own ctest entry, so CI runs one
+process per test and no two of these tests ever share an address space. The monolithic run is the
+only configuration where this class of bug exists, and it is not part of the PR gate.
+
+## The failure signature, and why it points nowhere near the cause
+
+The victim is a visual-evidence test whose feature-on and feature-off captures come out **identical**,
+or whose differential reads ~0 where it expected a large one — `LightmapBleedRoom` wants
+`meanAbsDiff > 3.0` and measures `0.0007`. In the case that was actually diagnosed,
+`VirtualGeometryVisualEvidence` counted **107** red pixels where it needed 800: the sphere simply was
+not drawn.
+
+Three properties make it expensive:
+
+- **The victim passes in isolation**, 10/10 under its own `--gtest_filter`.
+- **The engine logs are identical.** Same passes, same draws, same resource creation — only the
+  pixels differ. There is nothing to grep for.
+- **The poisoner is far away and needs company** (see below).
+
+## The two traps that make bisection lie
+
+### Trap 1 — a reduced configuration reproduces a *different* bug
+
+The obvious method is "prefix + victims, binary-search the prefix". It converges quickly and it can
+converge on the wrong thing. Running `AssetSceneLoad` immediately before the victim suites
+reproduced 21 failures at every bisection step — but as **SEH access violations (0xc0000005)**,
+while the full run has **zero** crashes. Removing suites had created a *new* use-after-free that had
+nothing to do with the 102.
+
+**So a bisection step must check that the victim fails the same WAY, not merely that it fails.**
+Pin a signature first from the full run — here, "10 failures, 0 SEH, red-pixel counts 107–118" — and
+reject any arm that does not match it. The bisection harness must print the mode, every time.
+
+### Trap 2 — one poisoner is not enough
+
+Neither ingredient reproduced anything on its own:
+
+| Configuration | Result |
+|---|---|
+| all 65 victim suites together | passes |
+| all 1150 non-victim suites + victim | passes |
+| `FogVolumeSelfShadowVisualEvidenceTest` + victim | passes |
+| `VulkanParallelRecordingDevice` + victim | crashes (wrong mode — trap 1) |
+| both, plus ~150 suites of other work | **reproduces exactly** |
+
+Both suites are individually *necessary* and neither is *sufficient*. A two-suite repro that does
+not reproduce proves nothing; do not conclude "not reproducible" from a minimal pair.
+
+## The actual defect (issue #1074)
+
+`VulkanParallelRecordingTest.cpp` unconditionally called, in three different tests:
+
+```cpp
+GPUPassTimerPool::GetInstance().Shutdown();
+CommandDispatch::Shutdown();
+MeshPrimitives::Shutdown();
+ParticleBatchRenderer::Shutdown();
+```
+
+Every one of those is owned by the renderer's lifecycle — `Renderer3DLifecycle.cpp` initializes the
+first three at `Renderer3D::Init`, and `Renderer.cpp` owns `MeshPrimitives::Shutdown` in
+`Renderer::Shutdown`. Run standalone (as CI runs it) the renderer is not up, the test owns them, and
+the teardown is correct. Run in one process after the renderer has come up, it is a teardown of
+somebody else's singletons.
+
+### Why "just don't shut them down" is the wrong fix
+
+The obvious fix — guard each `Shutdown()` on whether this test brought the singleton up — is wrong
+here, and it fails loudly in two different ways:
+
+1. **VMA aborts.** These singletons hold buffers allocated against the **Vulkan** device the test
+   selects, and they must be released before it tears its memory blocks down. Skipping the shutdown
+   trades the cross-test leak for a hard abort: *"Some allocations were not freed before destruction
+   of this memory block"*.
+2. **The test starts asserting on someone else's state.** Inheriting the renderer's timer pool
+   instead of building its own left `GraphRecordsSharedUnboundUniformAndTimesOrderedPasses` reading
+   18 accumulated pass timings where it asserts on exactly 2.
+
+Restoring *eagerly* — shut down, then immediately republish — is wrong too, and this one is subtle:
+it leaves GL-currency handles sitting in the dispatcher across the Vulkan suites that run next.
+`VulkanPassSuiteTest.cpp` documents exactly that hazard ("live GL-currency objects with no setter to
+re-home them onto this device"), and doing it moved the VMA abort from one suite to another.
+
+**The fix that works is a lazy self-heal in the engine.** The teardown stays unconditional, and
+`Renderer3D::BeginScene` calls `ReclaimSharedRenderState()`, which re-arms whatever was shut down —
+`RepublishCommandDispatchBindings()` and the timer pool — at the moment the renderer is about to draw
+and on the renderer's own backend:
+
+```cpp
+if (!CommandDispatch::HasUBOReferences())
+    RepublishCommandDispatchBindings();
+if (auto& passTimers = GPUPassTimerPool::GetInstance(); !passTimers.IsInitialized())
+    passTimers.Initialize();
+```
+
+That closes a real engine gap rather than papering over a test: before this there was **no way back**
+from a `CommandDispatch::Shutdown()` short of a full renderer restart. The same sequence is what
+device-lost recovery or a runtime RHI switch would need, which is why it lives in the renderer.
+
+So the rule's second half: **before guarding a `Shutdown()`, ask what backend owns the memory it
+releases.** When the answer is "a device that is about to die", the teardown is not the thing to
+change — give the survivor a way to re-arm itself instead.
+
+The same file already had the right pattern, one line away, for a fourth singleton:
+
+```cpp
+const bool ownsFrameData = !FrameDataBufferManager::IsInitialized();
+if (ownsFrameData) FrameDataBufferManager::Init();
+// ... and only Shutdown() if OwnsFrameData
+```
+
+The fix applies that ownership test to its neighbours. This is the second time this exact defect has
+been found here — a fixture calling `CommandDispatch::Shutdown()` dropped the UBO references
+`Renderer3D` publishes once at `Init()`, so every later rendering test drew with no camera or
+material UBO bound.
+
+## The configuration guard (rule 2)
+
+`RendererStateCheck` installs a GoogleTest listener beside the GL-error one. After every test it
+restores the configuration captured at `OnTestStart`, counts the leak, names it in an end-of-run
+`[ RENDERER STATE ]` summary, and — under `--olo-strict-renderer-state` — fails the polluting test at
+its own source location.
+
+Restoring centrally is deliberate: a fixture that saves "the two settings I remembered" leaves the
+other nine free to leak, and every settings struct added later silently joins the hazard. The restore
+ends with `ApplyRendererSettings()`, because putting the structs back is not the same as putting the
+renderer back — the graph's `ActiveGraphPath` is what selects the pipeline.
+
+**What it measured, and why that is worth knowing:** 212 of ~7,600 tests leak configuration, and all
+of it is scene-published per-frame state — cloudscape, underwater fog, and the three water fields,
+which the scene republishes every frame anyway. Zero tests leaked `RendererSettings`, a rendering
+path, or a culling toggle. Restoring all of it changed the failure count by **0**. The
+"fixture leaks a settings struct" hypothesis was wrong, and the guard is what proved it rather than
+another five 20-minute bisection runs.
+
+Adding a settings struct to `Renderer3D`? Add it to `RendererState::Snapshot` and the
+`OLO_RENDERER_STATE_STRUCT_ENTRIES` X-macro — one entry drives capture, comparison and restore
+together, because the original bug was a save list and a restore list that had drifted apart.
+**Do not snapshot a derived value**: `s_Data.DepthPrepassEnabled` looks independent and is not
+(`ApplyRendererSettings` recomputes it from `RendererSettings`), so snapshotting it reports a leak the
+first time anything calls `ApplyRendererSettings` after `Init`. Snapshot the input, not the output.
+
+## Running the monolithic configuration
+
+```powershell
+# The whole binary in ONE process — the only configuration where this exists.
+.\build-cached\OloEngine\tests\Debug\OloEngine-Tests.exe
+
+# Same, but fail every test that leaks renderer configuration.
+.\build-cached\OloEngine\tests\Debug\OloEngine-Tests.exe --olo-strict-renderer-state
+```
+
+~20 minutes, and it holds the test binary — a concurrent rebuild dies `LNK1104`. It also runs
+`AppLaunchSmoke`, which launches the real editor: expect windows to appear.

--- a/docs/agent-rules/cross-test-renderer-state.md
+++ b/docs/agent-rules/cross-test-renderer-state.md
@@ -2,10 +2,18 @@
 
 Two rules, in the order they cost us time:
 
-1. **Never shut down a process-wide singleton you did not start.** `Renderer3D::Init` owns
+1. **Never leave a process-wide renderer singleton dead.** `Renderer3D::Init` owns
    `CommandDispatch`, `GPUPassTimerPool`, `ParticleBatchRenderer` and `MeshPrimitives`. A test that
-   tears one down leaves every later rendering test in the process running against a dead one. Guard
-   every `Shutdown()` with whether *you* brought it up.
+   tears one down leaves every later rendering test in the process running against a dead one.
+
+   The rule is *not* "guard every `Shutdown()` with whether you brought it up" — that is the obvious
+   fix and it aborts the process. **A test that creates its own Vulkan device MUST still release
+   backend-owned resources before destroying it**, or VMA fires *"Some allocations were not freed
+   before destruction of this memory block"*. Do the teardown, and let the shared state be re-armed
+   lazily afterwards: `Renderer3D::BeginScene` calls `ReclaimSharedRenderState()`, which rebuilds
+   what it finds missing on the renderer's own backend. Release order matters too — free on the
+   backend that created it (the timer pool's queries are GL objects, so its `Shutdown()` belongs
+   *before* the Vulkan selection, not inside it).
 2. **Leave the process-global renderer configuration as you found it.** The rendering path, the
    settings structs and the culling toggles are all one static. A guard now restores these
    automatically, so a leak is repaired rather than propagated — but it is still a bug in your test,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -979,6 +979,44 @@ $f = (python OloEngine/tests/scripts/generate_test_catalogue.py --gtest-filter -
 .\build\OloEngine\tests\Debug\OloEngine-Tests.exe --olo-help
 ```
 
+### 8.1 The single-process run — what CI structurally cannot see
+
+Every workflow above runs the tests through `gtest_discover_tests`, which registers each case as its
+own ctest entry. **CI therefore runs one process per test**, and no two tests ever share an address
+space. That is good isolation and a real blind spot: cross-test state pollution — a test that leaves
+the process-global renderer configured differently from how it found it — cannot exist in that
+configuration, so nothing in the PR gate can catch it.
+
+The monolithic run is the only place it shows up, and it is not automated:
+
+```powershell
+# Every test in ONE process. ~20 minutes; holds the test binary, so a
+# concurrent rebuild dies LNK1104.
+.\build-cached\OloEngine\tests\Debug\OloEngine-Tests.exe
+
+# Same run, but FAIL each test that leaks process-global renderer state
+# rather than only listing it in the end-of-run summary.
+.\build-cached\OloEngine\tests\Debug\OloEngine-Tests.exe --olo-strict-renderer-state
+```
+
+Run it before merging anything that touches a renderer fixture, a `Renderer3D` settings struct, or a
+`Shutdown()` call on an engine singleton. The failure it finds looks nothing like its cause: the
+victim is a visual-evidence test whose feature-on and feature-off captures come out identical, it
+passes 10/10 under its own filter, and its engine logs are identical to a passing run.
+
+Two rules keep tests out of this, both in
+[`agent-rules/cross-test-renderer-state.md`](agent-rules/cross-test-renderer-state.md):
+
+- **Never shut down a process-wide singleton you did not start** (`CommandDispatch`,
+  `GPUPassTimerPool`, `ParticleBatchRenderer`, `MeshPrimitives` are all owned by `Renderer3D::Init`).
+  Standalone, your test owns them and the teardown is right; in one process it is a teardown of
+  someone else's. This caused issue #1074.
+- **Leave the renderer configuration as you found it.** A listener restores it and reports leaks in a
+  `[ RENDERER STATE ]` summary; `--olo-strict-renderer-state` turns each into a failure.
+
+That doc also records the two traps that make bisecting this class produce confident wrong answers —
+worth reading *before* you start bisecting, not after.
+
 The `--olo-*` flags are the suite's own, declared in
 [`OloEngine/tests/TestOptions.h`](../OloEngine/tests/TestOptions.h) and consumed
 in `main` before gtest parses `argv`. They were twelve environment variables

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1007,10 +1007,13 @@ passes 10/10 under its own filter, and its engine logs are identical to a passin
 Two rules keep tests out of this, both in
 [`agent-rules/cross-test-renderer-state.md`](agent-rules/cross-test-renderer-state.md):
 
-- **Never shut down a process-wide singleton you did not start** (`CommandDispatch`,
-  `GPUPassTimerPool`, `ParticleBatchRenderer`, `MeshPrimitives` are all owned by `Renderer3D::Init`).
-  Standalone, your test owns them and the teardown is right; in one process it is a teardown of
-  someone else's. This caused issue #1074.
+- **Never leave a process-wide renderer singleton dead** (`CommandDispatch`, `GPUPassTimerPool`,
+  `ParticleBatchRenderer`, `MeshPrimitives` are all owned by `Renderer3D::Init`). Standalone, your
+  test owns them and the teardown is right; in one process it is a teardown of someone else's. This
+  caused issue #1074. **But if your test made its own Vulkan device, still release backend-owned
+  resources before destroying it** — skipping the teardown trades the leak for a VMA abort, and
+  freeing on the wrong backend is its own bug. Tear down as required, then let
+  `Renderer3D::BeginScene` re-arm the shared state lazily on the renderer's backend.
 - **Leave the renderer configuration as you found it.** A listener restores it and reports leaks in a
   `[ RENDERER STATE ]` summary; `--olo-strict-renderer-state` turns each into a failure.
 


### PR DESCRIPTION
## What this fixes

A full **single-process** run of `OloEngine-Tests.exe` failed **102 cases** that all pass under
their own `--gtest_filter`. CI cannot see this class of bug at all: `gtest_discover_tests` gives
every case its own ctest entry, so CI runs **one process per test** and no two of these tests ever
share an address space.

**Full single-process run: 102 failures → 0.** 7610 tests, 7567 passed, exit 0.

## Attribution (the issue's first open question)

Measured on a clean worktree at the merge-base `921bce094`: **102 failures, 0 crashes**, the same
count and the same per-suite distribution as the measurement taken on the #1013 branch. So these
**predate** PR #1066 — an accumulated backlog, not a recent regression. Recorded on #1074.

## The cause

`VulkanParallelRecordingTest.cpp` shuts down `CommandDispatch` and `GPUPassTimerPool`, both owned by
`Renderer3D::Init`. Standalone that is correct — the test owns them. In one process it drops the
camera / material / bone UBO references `Init` publishes exactly once, and every later rendering
test draws with nothing bound: the subject of a visual-evidence test is simply not rendered, with no
GL error and **engine logs identical to a passing run**.

Two poisoners were each *necessary* and neither *sufficient* — `FogVolumeSelfShadowVisualEvidenceTest`
and `VulkanParallelRecordingDevice`, plus ~150 suites of other work. A two-suite repro proves nothing
here.

**Guarding the teardown does not work.** Those objects are allocated against the Vulkan device the
test destroys, so they MUST be released first or VMA aborts the process. Restoring *eagerly* fails
too — it republishes GL-currency handles across the Vulkan suites that follow, the hazard
`VulkanPassSuiteTest` documents as *"no setter to re-home them onto this device"*.

So the renderer re-arms itself: `BeginScene` calls `ReclaimSharedRenderState()`, which re-publishes
the dispatcher bindings and re-creates the timer pool when it finds them gone, on its own backend, at
the moment it is about to draw. **Before this there was no way back from a `CommandDispatch::Shutdown()`
short of a full renderer restart** — the same sequence device-lost recovery or a runtime RHI switch
would need.

## The guard, and a disproved hypothesis

`RendererStateCheck` restores process-global renderer configuration after every test and names every
leaker in a `[ RENDERER STATE ]` summary (`--olo-strict-renderer-state` fails them).

It also settles what the issue was about. The stated hypothesis was a fixture leaking a settings
struct. Measured: **212 of 7610 tests leak configuration**, all of it scene-published per-frame state
the scene republishes anyway, none of it a rendering path or culling toggle — and restoring every
byte of it moved the failure count by **zero**. One run instead of five bisections.

## Ride-along fix (own commit)

`AssetSceneLoad` left a shut-down asset manager and a deleted project installed, which the seven
"if there is no project, make one" fixtures then adopted. `Project::Unload()` fixes it — and exposed
that those guards call `GetAssetManager()`, which **asserts on null**; they now use `HasAssetManager()`.

## Follow-up owned elsewhere

`docs/testing.md` §8.1 documents the monolithic run. A CI job that runs it (nightly) belongs to
**#1073**, which owns the workflow files — flagged there rather than edited here.

Closes #1074

## Review guide

**Where I'd look hardest**
1. `Renderer3DFrameSetup.cpp` — `ReclaimSharedRenderState()` now runs on **every** `BeginScene` in
   production, not just in tests. Two predicate checks; I judged that negligible, but it is the only
   change on a per-frame hot path.
2. `Renderer3DLifecycle.cpp:478` — `Init` now publishes through the new guarded helper. It is a
   no-op if `HasInitialized()` is false; `CoreInitialized` is set at line 172, so the ordering holds,
   but a future reorder of `Init` would silently stop publishing the UBOs.
3. `VulkanParallelRecordingTest.cpp` — the `GPUPassTimerPool::Shutdown()` moved *ahead* of the Vulkan
   selection deliberately (its queries are GL objects). Order is load-bearing in a way the compiler
   will not check.

**What I verified, and how** — full single-process run, 7610 tests, **0 failures, exit 0** (was 102).
A mode-verified reproducer (suites 1–519 + `VirtualGeometryVisualEvidence`) went 10/10 failures → 0.
Six new `RendererStateCheckTest` cases cover the guard's helpers. The Vulkan suites also pass
standalone, which is what catches the VMA abort.

**Least confident about** — whether `ParticleBatchRenderer` should get the same lazy re-arm. It is
still left shut down after the Vulkan suites (`VulkanPassSuiteTest` tears it down again later), so
particle rendering is dead for tests after that point. Nothing currently fails because of it, so I
did not add a third self-heal on speculation — but it is the same defect, unfixed.

**Deliberately not tested** — I did not re-run under ASan/TSan locally, and I did not verify the
per-frame cost of `ReclaimSharedRenderState()` with a profiler; I reasoned about it rather than
measuring. No live-editor check: this changes no rendering output, and the evidence PNGs were
deliberately reverted (a full run rewrites ~150 of them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renderer state now automatically recovers after shared rendering resources are shut down, preventing failures in later scenes.
  * Test cleanup more reliably releases project and asset-manager state between tests.

* **Tests**
  * Added renderer-state leak detection and restoration across test cases.
  * Added an optional strict mode to fail tests that modify global renderer settings.
  * Improved asset-manager availability checks across rendering tests.

* **Documentation**
  * Documented cross-test renderer-state contamination and monolithic test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->