### PR TITLE
ci: give the Windows ASan job a working compiler cache, and raise the ctest widths (#1082)

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -389,6 +389,41 @@ jobs:
         if ($failed) { exit 1 }
         Write-Host 'All shipped binaries passed the launch smoke test.'
 
+    # ============================================================================
+    # TEMPORARY MEASUREMENT SCAFFOLDING (#1083) - DELETE BEFORE THIS PR MERGES.
+    # ============================================================================
+    # The sibling of the sweep in asan.yml; that step's header owns the reasoning
+    # (why one job rather than six runs, why the width order is a palindrome, why
+    # a strided sample, and why a failing pass is recorded instead of fatal).
+    # Read it there. Only the numbers differ: this job is not sanitizer-
+    # instrumented, so its shard width is bounded by the 4 vCPUs rather than by
+    # RAM, and #1083 names 4 / 6 / 8 as the widths to try here.
+    - name: "Measure ctest --parallel widths (#1083, temporary)"
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      shell: bash
+      run: |
+        set -u
+        rows=()
+        for w in 4 6 8 8 6 4; do
+          start=$(date +%s)
+          out=$(ctest -I '1,,20' --parallel "$w" --timeout 120 -C "${BUILD_TYPE}" \
+                  --exclude-regex '^NetworkIntegrationTest\.' 2>&1) && code=0 || code=$?
+          elapsed=$(( $(date +%s) - start ))
+          tally=$(printf '%s\n' "$out" | grep -E 'tests passed' | tail -n 1 || true)
+          row="width=${w}  seconds=${elapsed}  exit=${code}  ${tally:-(no ctest summary line)}"
+          echo "::notice title=ctest width sweep::${row}"
+          rows+=("$row")
+          if [ "$code" -ne 0 ]; then
+            printf '%s\n' "$out" | grep -E '^[[:space:]]*[0-9]+ - .*\*\*\*' \
+              | sed "s/^/    FAILED at width ${w} : /" || true
+          fi
+        done
+        echo
+        echo "=== ctest --parallel sweep, Windows / build - sample: every 20th entry ==="
+        printf '%s\n' "${rows[@]}"
+        # Never fail the job on the sweep: the real test run below is the gate.
+        exit 0
+
     - name: Run tests with CTest
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # Execute tests defined by the CMake configuration.

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -414,7 +414,9 @@ jobs:
           echo "::notice title=ctest width sweep::${row}"
           rows+=("$row")
           if [ "$code" -ne 0 ]; then
-            printf '%s\n' "$out" | grep -E '^[[:space:]]*[0-9]+ - .*\*\*\*' \
+            # See the asan.yml sibling for why this matches ctest's
+            # "The following tests FAILED:" block and not the `***` progress lines.
+            printf '%s\n' "$out" | grep -E '^[[:space:]]*[0-9]+ - [^ ]+ [(]' \
               | sed "s/^/    FAILED at width ${w} : /" || true
           fi
         done

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -89,6 +89,21 @@ env:
   # The budget arithmetic and the rules that keep it solvent:
   # docs/agent-rules/actions-cache-budget.md.
   SCCACHE_CACHE_SIZE: "2G"
+  # PREVENTIVE, and copied from asan.yml where the same setting is a bug fix (#1082 --
+  # that file's env block carries the full mechanism and the measurement).
+  #
+  # In short: sccache's server exits after SCCACHE_IDLE_TIMEOUT seconds with no client
+  # request (default 600), link steps do not go through sccache, and a link longer than
+  # ten minutes therefore shuts the server down mid-build. The next compile connects to
+  # the socket the exiting server still holds, gets dropped, and fails the build with
+  # "os error 10054". sccache starts a server when none is running; it does not recover
+  # from one that accepts and then closes.
+  #
+  # This job has not hit it. That is a margin, not an immunity -- it links the same
+  # binaries, just without ASan inflating the link -- and the margin is unmeasured. The
+  # failure is silent until it is fatal and costs a whole ~3 h round to diagnose, so
+  # spend the one line.
+  SCCACHE_IDLE_TIMEOUT: "0"
 
 jobs:
   build:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -404,43 +404,6 @@ jobs:
         if ($failed) { exit 1 }
         Write-Host 'All shipped binaries passed the launch smoke test.'
 
-    # ============================================================================
-    # TEMPORARY MEASUREMENT SCAFFOLDING (#1083) - DELETE BEFORE THIS PR MERGES.
-    # ============================================================================
-    # The sibling of the sweep in asan.yml; that step's header owns the reasoning
-    # (why one job rather than six runs, why the width order is a palindrome, why
-    # a strided sample, and why a failing pass is recorded instead of fatal).
-    # Read it there. Only the numbers differ: this job is not sanitizer-
-    # instrumented, so its shard width is bounded by the 4 vCPUs rather than by
-    # RAM, and #1083 names 4 / 6 / 8 as the widths to try here.
-    - name: "Measure ctest --parallel widths (#1083, temporary)"
-      working-directory: ${{github.workspace}}/build/OloEngine/tests
-      shell: bash
-      run: |
-        set -u
-        rows=()
-        for w in 4 6 8 8 6 4; do
-          start=$(date +%s)
-          out=$(ctest -I '1,,20' --parallel "$w" --timeout 120 -C "${BUILD_TYPE}" \
-                  --exclude-regex '^NetworkIntegrationTest\.' 2>&1) && code=0 || code=$?
-          elapsed=$(( $(date +%s) - start ))
-          tally=$(printf '%s\n' "$out" | grep -E 'tests passed' | tail -n 1 || true)
-          row="width=${w}  seconds=${elapsed}  exit=${code}  ${tally:-(no ctest summary line)}"
-          echo "::notice title=ctest width sweep::${row}"
-          rows+=("$row")
-          if [ "$code" -ne 0 ]; then
-            # See the asan.yml sibling for why this matches ctest's
-            # "The following tests FAILED:" block and not the `***` progress lines.
-            printf '%s\n' "$out" | grep -E '^[[:space:]]*[0-9]+ - [^ ]+ [(]' \
-              | sed "s/^/    FAILED at width ${w} : /" || true
-          fi
-        done
-        echo
-        echo "=== ctest --parallel sweep, Windows / build - sample: every 20th entry ==="
-        printf '%s\n' "${rows[@]}"
-        # Never fail the job on the sweep: the real test run below is the gate.
-        exit 0
-
     - name: Run tests with CTest
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # Execute tests defined by the CMake configuration.
@@ -535,7 +498,30 @@ jobs:
       # full step on the hosted runner with zero failures. If a physics test ever
       # flakes here again, reinstate `--repeat until-pass:3` AND reopen #281.
       shell: bash
-      run: ctest --parallel 4 --output-on-failure --timeout 120 -C "${BUILD_TYPE}" --exclude-regex '^NetworkIntegrationTest\.'
+      # --parallel 6, RAISED FROM 4 ON A MEASUREMENT (#1083). Six timed passes over
+      # the same 382-case sample in one job (run 34061407328), palindrome order
+      # 4,6,8,8,6,4 so the cold-start warm-up is shared rather than credited to the
+      # widest width:
+      #
+      #     width 4    81 / 76 s     --
+      #     width 6    69 / 69 s    -12.1 %
+      #     width 8    66 / 66 s    -15.9 %
+      #
+      # 100 % passed at every width, 382 of 382, zero flakes.
+      #
+      # 6 AND NOT 8, DELIBERATELY, even though 8 measured fastest. 6 -> 8 is worth
+      # 3 s of 69 (~1 min on the real step) and costs a second full doubling of
+      # oversubscription on a 4-vCPU runner -- the exact condition #281 lived in
+      # (PhysicsLayerFilteringTest SEH 0xc0000005 under core starvation). #281 is
+      # fixed at the root, so this is not a live bug, but the sample cannot prove
+      # the margin: a 1-in-20 stride rarely co-schedules the RESOURCE_LOCK'd
+      # mesh-cache cases, so contention at width 8 is untested rather than shown
+      # safe. Take the 12 % that is cheap; leave the last 4 % that is not.
+      #
+      # The warm-up the palindrome caught is why the order matters: width 4 ran
+      # 81 s early and 76 s late, a 6.2 % drift. An ascending 4,6,8 sweep would
+      # have handed that drift to width 8 and overstated it.
+      run: ctest --parallel 6 --output-on-failure --timeout 120 -C "${BUILD_TYPE}" --exclude-regex '^NetworkIntegrationTest\.'
 
     - name: Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -735,11 +735,10 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
-      # full every save is refused, and the only way to land this job's snapshot
-      # is to delete the entry it supersedes first. Scoped to this ref by
-      # `save-cache-pruned`.
-      actions: write
+      # No `actions: write` here. It was granted for the sccache save, and that
+      # save is gone (#1082 -- see the note above this job's Setup sccache step).
+      # A permission kept past the step that needed it is a permission nobody will
+      # ever remove, so it goes with the step.
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -780,19 +779,53 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # Persist sccache's local-disk cache as one actions/cache entry, split into an
-    # explicit restore here and an `if: always()` save after the build (#1009 --
-    # see the save step for why the combined action loses it). Unique key per run
-    # attempt so every save writes a fresh snapshot; restore-keys warms from the
-    # most recent prior one. Key is per-sanitizer.
-    - name: Restore sccache storage
-      if: runner.environment == 'github-hosted'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-asan-lsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          sccache-asan-lsan-linux-
+    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
+    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
+    # entry. They are gone, and the reason is measured rather than assumed.
+    #
+    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
+    # these entries:
+    #
+    #     Compile requests   1558      Cache hits          0
+    #     Cache misses       1558      Cache hits rate     0.00 %
+    #     Cache read errors     0      Cache write errors  0
+    #
+    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
+    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
+    # of three.
+    #
+    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
+    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    #
+    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
+    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    #
+    # Every entry is therefore invalidated by the next apt refresh while still
+    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
+    # the same failure Windows.yml's own header documents for `windows-latest` image
+    # rolls, reproduced here by an unpinned rolling compiler.
+    #
+    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
+    # same-repo PR routes this job to the box, where it uses local-disk ccache and
+    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
+    # fork PRs ever touched the store -- neither is on the per-PR critical path.
+    #
+    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
+    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
+    # that IS on the critical path had no cache at all for want of room (#1082).
+    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
+    #
+    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
+    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
+    # job. That value is real and it is currently unreachable, because the key cannot
+    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
+    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
+    # by absolute path) or keying the entry on the clang build id -- issue #1095.
+    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
+    #
+    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
+    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
+    # every hosted run now, by construction rather than by accident.
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -877,35 +910,6 @@ jobs:
         else
           ccache --show-stats
         fi
-
-    # Paired with the restore above (#1009). `if: always()` is the point: the
-    # combined actions/cache action saves in a POST-JOB step, and post-job steps
-    # do NOT run when a job is cancelled -- which is how most PR runs in this repo
-    # end (`cancel-in-progress`; 17 of 27 Windows and 15 of 24 Sanitizer PR runs
-    # over the window measured in #1009). Every one of those recompiled everything
-    # and banked nothing, so the next run started just as cold.
-    - name: Save sccache storage
-      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
-      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
-      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
-      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
-      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
-      # shared with every other job. Say the condition instead of inheriting it from a
-      # routing expression three hundred lines away.
-      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
-      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
-      # must never fail the job it is attached to. `if: always()` means this runs on
-      # a CANCEL, where the path it is asked to save may not exist yet -- and
-      # actions/cache/save treats a missing path as a validation error, not a no-op.
-      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
-      # than the cold cache this is fixing. What the action adds over a bare
-      # actions/cache/save is noticing that the store refused the write, deleting
-      # this ref's superseded snapshot, and retrying -- see its own header.
-      uses: ./.github/actions/save-cache-pruned
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-asan-lsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -992,11 +996,10 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
-      # full every save is refused, and the only way to land this job's snapshot
-      # is to delete the entry it supersedes first. Scoped to this ref by
-      # `save-cache-pruned`.
-      actions: write
+      # No `actions: write` here. It was granted for the sccache save, and that
+      # save is gone (#1082 -- see the note above this job's Setup sccache step).
+      # A permission kept past the step that needed it is a permission nobody will
+      # ever remove, so it goes with the step.
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1028,19 +1031,53 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # Persist sccache's local-disk cache as one actions/cache entry, split into an
-    # explicit restore here and an `if: always()` save after the build (#1009 --
-    # see the save step for why the combined action loses it). Unique key per run
-    # attempt so every save writes a fresh snapshot; restore-keys warms from the
-    # most recent prior one. Key is per-sanitizer.
-    - name: Restore sccache storage
-      if: runner.environment == 'github-hosted'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-ubsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          sccache-ubsan-linux-
+    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
+    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
+    # entry. They are gone, and the reason is measured rather than assumed.
+    #
+    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
+    # these entries:
+    #
+    #     Compile requests   1558      Cache hits          0
+    #     Cache misses       1558      Cache hits rate     0.00 %
+    #     Cache read errors     0      Cache write errors  0
+    #
+    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
+    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
+    # of three.
+    #
+    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
+    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    #
+    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
+    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    #
+    # Every entry is therefore invalidated by the next apt refresh while still
+    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
+    # the same failure Windows.yml's own header documents for `windows-latest` image
+    # rolls, reproduced here by an unpinned rolling compiler.
+    #
+    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
+    # same-repo PR routes this job to the box, where it uses local-disk ccache and
+    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
+    # fork PRs ever touched the store -- neither is on the per-PR critical path.
+    #
+    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
+    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
+    # that IS on the critical path had no cache at all for want of room (#1082).
+    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
+    #
+    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
+    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
+    # job. That value is real and it is currently unreachable, because the key cannot
+    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
+    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
+    # by absolute path) or keying the entry on the clang build id -- issue #1095.
+    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
+    #
+    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
+    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
+    # every hosted run now, by construction rather than by accident.
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -1112,35 +1149,6 @@ jobs:
         else
           ccache --show-stats
         fi
-
-    # Paired with the restore above (#1009). `if: always()` is the point: the
-    # combined actions/cache action saves in a POST-JOB step, and post-job steps
-    # do NOT run when a job is cancelled -- which is how most PR runs in this repo
-    # end (`cancel-in-progress`; 17 of 27 Windows and 15 of 24 Sanitizer PR runs
-    # over the window measured in #1009). Every one of those recompiled everything
-    # and banked nothing, so the next run started just as cold.
-    - name: Save sccache storage
-      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
-      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
-      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
-      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
-      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
-      # shared with every other job. Say the condition instead of inheriting it from a
-      # routing expression three hundred lines away.
-      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
-      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
-      # must never fail the job it is attached to. `if: always()` means this runs on
-      # a CANCEL, where the path it is asked to save may not exist yet -- and
-      # actions/cache/save treats a missing path as a validation error, not a no-op.
-      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
-      # than the cold cache this is fixing. What the action adds over a bare
-      # actions/cache/save is noticing that the store refused the write, deleting
-      # this ref's superseded snapshot, and retrying -- see its own header.
-      uses: ./.github/actions/save-cache-pruned
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-ubsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -1237,11 +1245,10 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # Needed by the sccache save (#1073): when the repo's 10 GB cache store is
-      # full every save is refused, and the only way to land this job's snapshot
-      # is to delete the entry it supersedes first. Scoped to this ref by
-      # `save-cache-pruned`.
-      actions: write
+      # No `actions: write` here. It was granted for the sccache save, and that
+      # save is gone (#1082 -- see the note above this job's Setup sccache step).
+      # A permission kept past the step that needed it is a permission nobody will
+      # ever remove, so it goes with the step.
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1273,23 +1280,53 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # Persist sccache's local-disk cache. Explicit restore + save steps instead of
-    # the combined actions/cache action: the combined action saves in a POST-JOB
-    # step, and post-job steps are skipped when the job is cancelled — so a run
-    # that hit `timeout-minutes` saved nothing and left the next run just as cold
-    # (the cold → timeout → no-save → cold loop, see the timeout comment above).
-    # The explicit save below runs `if: always()`, which DOES execute on a
-    # timeout-cancel, banking even a partial build's objects. Key is unique per
-    # attempt so every save writes a fresh snapshot; restore-keys warms from the
-    # most recent prior one. Key is per-sanitizer.
-    - name: Restore sccache storage
-      if: runner.environment == 'github-hosted'
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-tsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          sccache-tsan-linux-
+    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
+    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
+    # entry. They are gone, and the reason is measured rather than assumed.
+    #
+    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
+    # these entries:
+    #
+    #     Compile requests   1558      Cache hits          0
+    #     Cache misses       1558      Cache hits rate     0.00 %
+    #     Cache read errors     0      Cache write errors  0
+    #
+    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
+    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
+    # of three.
+    #
+    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
+    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    #
+    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
+    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    #
+    # Every entry is therefore invalidated by the next apt refresh while still
+    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
+    # the same failure Windows.yml's own header documents for `windows-latest` image
+    # rolls, reproduced here by an unpinned rolling compiler.
+    #
+    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
+    # same-repo PR routes this job to the box, where it uses local-disk ccache and
+    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
+    # fork PRs ever touched the store -- neither is on the per-PR critical path.
+    #
+    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
+    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
+    # that IS on the critical path had no cache at all for want of room (#1082).
+    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
+    #
+    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
+    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
+    # job. That value is real and it is currently unreachable, because the key cannot
+    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
+    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
+    # by absolute path) or keying the entry on the clang build id -- issue #1095.
+    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
+    #
+    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
+    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
+    # every hosted run now, by construction rather than by accident.
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -1361,33 +1398,6 @@ jobs:
         else
           ccache --show-stats
         fi
-
-    # Deliberately BEFORE the test step (and `if: always()`): the tests don't
-    # write compile-cache entries, and saving here means a run whose TEST step
-    # later times out has already banked its build cache — while a cancel during
-    # the BUILD step still saves the partial objects via always().
-    - name: Save sccache storage
-      # NOT ON PULL REQUESTS (#1073), and `runner.environment` does not already imply
-      # that: this job routes to the self-hosted box only while OLO_LINUX_SELF_HOSTED
-      # is true and the PR is not from a fork. Flip that variable, or open a fork PR,
-      # and a PR run lands on a hosted runner and saves a ~1.25 GiB snapshot scoped to
-      # `refs/pull/N/merge` that only that one PR can read -- charged to a 10 GB store
-      # shared with every other job. Say the condition instead of inheriting it from a
-      # routing expression three hundred lines away.
-      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
-      # `save-cache-pruned` swallows every failure of its own (#1073): a cache save
-      # must never fail the job it is attached to. `if: always()` means this runs on
-      # a CANCEL, where the path it is asked to save may not exist yet -- and
-      # actions/cache/save treats a missing path as a validation error, not a no-op.
-      # Turning a cancelled run into a FAILED one would be a strictly worse outcome
-      # than the cold cache this is fixing. What the action adds over a bare
-      # actions/cache/save is noticing that the store refused the write, deleting
-      # this ref's superseded snapshot, and retrying -- see its own header.
-      uses: ./.github/actions/save-cache-pruned
-      with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-tsan-linux-${{ github.run_id }}-${{ github.run_attempt }}
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -452,6 +452,75 @@ jobs:
         key: sccache-asan-windows-2025-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    # ============================================================================
+    # TEMPORARY MEASUREMENT SCAFFOLDING (#1083) — DELETE BEFORE THIS PR MERGES.
+    # ============================================================================
+    # #1083 requires `--parallel` to be "chosen from a measurement across at least
+    # three widths ... not raised on the assumption that startup-bound implies
+    # oversubscribe". This step is that measurement, and it is a step rather than
+    # six workflow runs for one reason: six runs are six different runners. A
+    # windows-2025 runner's disk and CPU vary enough between allocations that a
+    # 15 % difference between two runs says nothing, and the effect being looked
+    # for here is exactly that size at the margin. Timing all widths inside ONE
+    # job removes the runner from the comparison entirely.
+    #
+    # THE ORDER IS A PALINDROME (2,3,4,4,3,2), not 2,3,4 repeated. The first pass
+    # over a subset is measurably slower than the second — the OS file cache is
+    # cold for the test binary, and the engine's repo-relative mesh cache is
+    # empty, so the RESOURCE_LOCK'd cases pay a real cold build. A monotonic drift
+    # like that biases an ascending sweep in favour of the LAST width tried, which
+    # is the answer this measurement most wants to be true. A palindrome cancels
+    # it: each width is sampled once early and once late, so their means carry the
+    # same amount of warm-up.
+    #
+    # `-I 1,,20` samples every 20th ctest entry (~345 of ~6,900) rather than
+    # running the full suite six times, which would add ~9 h to this job. The
+    # sample is strided, not a contiguous block, so it is spread across the whole
+    # ordered test list instead of over-weighting whichever suites happen to sort
+    # first. `-I` intersects with `--exclude-regex` (ctest unions them only under
+    # `-U`), so the exclusions below still apply.
+    #
+    # EXIT CODE AND FAILURE COUNT ARE PART OF THE MEASUREMENT, not noise to
+    # suppress: #1083 asks for flake behaviour at each width, not just the clock,
+    # because a wider `-j` on a 4-vCPU runner is exactly what #281 and the
+    # mesh-cache RESOURCE_LOCK are sensitive to. A width that is 30 % faster and
+    # flaky is not faster. `$ErrorActionPreference = 'Continue'` and the explicit
+    # `exit 0` are what let a failing pass be RECORDED rather than ending the job.
+    - name: "Measure ctest --parallel widths (#1083, temporary)"
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      shell: pwsh
+      env:
+        ASAN_OPTIONS: halt_on_error=1:detect_odr_violation=0
+      run: |
+        $ErrorActionPreference = 'Continue'
+        $widths = @(2, 3, 4, 4, 3, 2)
+        $rows = @()
+        foreach ($w in $widths) {
+          $sw = [Diagnostics.Stopwatch]::StartNew()
+          $out = & ctest -I '1,,20' --parallel $w -C Release --timeout 120 `
+                   --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.' 2>&1
+          $sw.Stop()
+          $code = $LASTEXITCODE
+          $tally = ($out | Select-String -Pattern 'tests passed' | Select-Object -Last 1)
+          $tally = if ($tally) { $tally.ToString().Trim() } else { '(no ctest summary line)' }
+          $row = ("width={0}  seconds={1}  exit={2}  {3}" -f `
+                  $w, [math]::Round($sw.Elapsed.TotalSeconds, 1), $code, $tally)
+          Write-Host "::notice title=ctest width sweep::$row"
+          $rows += $row
+          # Name every failing case, so a width that trades speed for flakes is
+          # identifiable rather than just a non-zero exit code.
+          if ($code -ne 0) {
+            $out | Select-String -Pattern '^\s*\d+ - .*\*\*\*' | ForEach-Object {
+              Write-Host "    FAILED at width $w : $($_.ToString().Trim())"
+            }
+          }
+        }
+        Write-Host ''
+        Write-Host '=== ctest --parallel sweep, ASan (Windows/clang-cl) - sample: every 20th entry ==='
+        $rows | ForEach-Object { Write-Host $_ }
+        # Never fail the job on the sweep: the real test run below is the gate.
+        exit 0
+
     - name: Create test results directory
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"
       shell: pwsh

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -138,8 +138,22 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
+      # Needed by the sccache save (#1082, same reason as Windows.yml and the Linux
+      # sanitizer jobs): when the repo's Actions cache store is full every save is
+      # refused, and the only way to land this job's snapshot is to delete the entry
+      # it supersedes first. Scoped to this ref by `save-cache-pruned`.
+      actions: write
 
     env:
+      # OVERRIDES the workflow-level 1500M (#1082). This job's objects are the
+      # largest in the fleet: ASan instrumentation plus /Z7 (the compiler cache
+      # switches MSVC debug info from a shared PDB to embedded — see
+      # cmake/CompilerCache.cmake) makes every .obj carry its own debug info.
+      # MEASURE BEFORE TRUSTING THIS NUMBER: the entry that lands in the Actions
+      # cache store is charged against a shared ~9.3 GiB cap, and the measured
+      # entries so far compress to 82-91 % of this cap, not far below it
+      # (docs/agent-rules/actions-cache-budget.md). Raising it raises the bill.
+      SCCACHE_CACHE_SIZE: "3G"
       # Disable ASan's ODR-violation checker for every instrumented binary run in
       # this job. Vendored protobuf trips a known false positive — its narrow and
       # wide "." string-literal globals (`"."` vs `L"."`, io_win32.cc vs
@@ -242,6 +256,56 @@ jobs:
         version: "23.1.0"
         sha256: "1aebf024b959b3835c3bd936da2fa58cd002c61ccf47fce1714447b900bd9837"
 
+    # RE-ADDED BY #1082, after d93b5af5b removed it on 2026-07-02. Read that commit
+    # before touching this: the Windows sccache SERVER died mid-build on the large
+    # ASan-instrumented GameNetworkingSockets TUs —
+    #
+    #     sccache: error: failed to execute compile
+    #     caused by: An existing connection was forcibly closed by the remote host.
+    #                (os error 10054)
+    #
+    # — on three consecutive retries, each on a different TU (tier0/dbg.cpp,
+    # steamnetworkingsockets_connections.cpp, _spew.cpp), so the retry wrapper that
+    # preceded the removal never cleared it. The diagnosis recorded there was memory:
+    # the server is an extra in-memory consumer on a 4-vCPU runner already holding
+    # several GB per instrumented TU.
+    #
+    # THE ISSUE'S OWN PREMISE — "the removal predates several releases" — IS WRONG,
+    # and it is worth stating so nobody re-runs the same experiment expecting a
+    # different answer: d93b5af5b was already pinned to sccache v0.15.0, which is
+    # still the fleet pin. What HAS changed since is the toolchain, not sccache:
+    # this job now builds with an absolute-path-pinned LLVM 23.1.0 (5b3a24d39,
+    # fde5e9d5a, 0277e2a0d) instead of whatever clang-cl the windows-2025 image
+    # shipped, and GNS moved to a post-1.6.0 snapshot (01fdffb70). That is why the
+    # first arm re-tests the pinned version unchanged rather than jumping straight
+    # to v0.17.0: if it no longer reproduces, the smallest possible diff is the fix.
+    #
+    # If it DOES reproduce, the next arm is sccache v0.17.0 with SCCACHE_CLIENT_SIDE,
+    # which moves the compile and the cache lookup out of the server process
+    # entirely (the server keeps only compiler info, dist client and stats) and so
+    # removes the exact consumer d93b5af5b blamed. Do not skip the retry-free arm to
+    # get there — "it still crashes" and "it crashes for the reason we assumed" are
+    # different findings.
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      with:
+        version: "v0.15.0"
+
+    # Explicit restore + an `if: always()` save after the build, not the combined
+    # action — same reasoning as every other job here (#1009; see the save step).
+    # The key carries the runner IMAGE and the SANITIZER: sccache hashes the
+    # compiler binary, so a windows-2025 image roll invalidates every entry while
+    # still restoring it, and `-fsanitize=address` is part of the command line, so
+    # this job's objects can never collide with `sccache-windows-2025-release-`.
+    # When `runs-on` is bumped, bump this string with it.
+    - name: Restore sccache storage
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-windows-2025-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          sccache-asan-windows-2025-
+
     - name: Setup vcpkg
       id: vcpkg
       uses: ./.github/actions/setup-vcpkg
@@ -256,12 +320,23 @@ jobs:
       # -G "Ninja Multi-Config": the build/ctest steps select Release via --config / -C.
       #   (Also avoids the VS/MSBuild generator, which would drag in the C# ScriptCore
       #   project; OloEngine-Tests never links it, so ASan coverage is intact.)
-      # OLO_ENABLE_COMPILER_CACHE is intentionally OMITTED here — see the note above the
-      #   (removed) sccache steps: the Windows sccache server crashes on large ASan TUs, so
-      #   this job compiles directly. debug info stays /Zi (a PDB), which is fine without a
-      #   cache to key on.
+      # -DOLO_ENABLE_COMPILER_CACHE=ON (#1082): wires sccache as the launcher. Read the
+      #   header on the Setup sccache step above for why this was off, and what changed.
+      #   Two side effects come with it, both from cmake/CompilerCache.cmake, and the
+      #   first makes a COLD build here SLOWER than the uncached one it replaces:
+      #     - PCH is forced off (sccache reports a /Yu compile non-cacheable), so a cold
+      #       run pays full per-TU header re-parsing that the 87.2 min baseline did not.
+      #       (Unity builds are forced off too, but OLO_ENABLE_UNITY_BUILD already
+      #       defaults OFF, so that one is a no-op for this job.)
+      #     - MSVC debug info switches /Zi -> /Z7, so each .obj carries its own debug
+      #       info and is self-contained enough to cache. That is what makes this
+      #       job's objects the largest in the fleet — see SCCACHE_CACHE_SIZE above.
+      #   The trade is deliberate and is the same one Windows.yml already took: the
+      #   cache optimizes the WARM case, which is every run after the nightly has
+      #   banked a master snapshot. Judge it on the warm hit rate, never on one run.
       # -DOLO_ENABLE_LTO=OFF: Release defaults LTO on; /GL + ASan is unsupported. CI binaries
-      #   are for testing, not shipping, so dropping LTO is free here.
+      #   are for testing, not shipping, so dropping LTO is free here. It also keeps /GL
+      #   away from sccache, which cannot cache an object compiled with it.
       run: >
         cmake -S . -B build
         -G "Ninja Multi-Config"
@@ -274,6 +349,7 @@ jobs:
         -DOLO_VIDEO_FFMPEG=OFF
         -DOLO_WITH_USD=OFF -DOLO_WITH_ALEMBIC=OFF -DOLO_WITH_MATERIALX=OFF
         -DOLO_ENABLE_LTO=OFF
+        -DOLO_ENABLE_COMPILER_CACHE=ON
         -DPython_EXECUTABLE="${{ steps.py.outputs.python-path }}"
         -DOLO_ENABLE_ASAN=ON
         -DBUILD_TESTS=ON
@@ -327,9 +403,54 @@ jobs:
     - name: Build (Release)
       # --parallel 2 matches the Linux sanitizer jobs: clang-cl under ASan uses several GB per
       # translation unit, and full concurrency exhausts runner memory on the largest instrumented
-      # TUs (GameNetworkingSockets' steamnetworkingsockets_*.cpp). Direct compile, no sccache
-      # (see the note above the removed sccache steps) — so a plain build, no retry needed.
+      # TUs (GameNetworkingSockets' steamnetworkingsockets_*.cpp).
+      #
+      # NO RETRY WRAPPER, deliberately (#1082). d93b5af5b removed one that retried on the
+      # "os error 10054" sccache-server-drop signature, having measured that it hit the
+      # crash on all three attempts. Re-adding it here would convert the reproduce arm's
+      # answer from "it crashed, on this TU" into "it went red after 3× the runner
+      # minutes", which is strictly less information for strictly more cost. If the crash
+      # does come back, the fix is the client-side mode named on the Setup sccache step,
+      # not a retry that was already measured not to work.
       run: cmake --build build --config Release --target OloEngine-Tests --parallel 2
+
+    # THE NUMBER THIS CHANGE IS JUDGED ON, and it is printed unconditionally because a
+    # cache that restores and hits on nothing looks exactly like a working one — that is
+    # the whole of docs/agent-rules/ci-cache-that-looks-alive.md. Two lines matter beyond
+    # the hit rate on this job specifically:
+    #   "Non-cacheable compilations" — whether clang-cl's ASan flags are cacheable at all;
+    #   "Cache size" vs "Max cache size" — whether SCCACHE_CACHE_SIZE above is evicting,
+    #     which silently caps the achievable hit rate no matter how warm the restore was.
+    # `if: always()` so a build that DID crash still reports where it got to.
+    - name: Show sccache stats
+      if: always()
+      run: sccache --show-stats
+
+    # Paired with the restore above. `if: always()` because the combined actions/cache
+    # action saves in a POST-JOB step, which a CANCELLED job skips — and most PR runs in
+    # this repo are cancelled (`cancel-in-progress`), so every one of them recompiled
+    # everything and banked nothing.
+    #
+    # NOT ON PULL REQUESTS (#1073's rule, and this job is the reason it is now load-
+    # bearing). A PR-run entry is scoped to `refs/pull/N/merge`, readable by that one PR,
+    # and charged to the whole repository for as long as the PR stays open. This is the
+    # FOURTH large Windows entry in a store with a ~9.3 GiB wall; see the arithmetic in
+    # docs/agent-rules/actions-cache-budget.md, which this change had to re-do before
+    # turning the cache on. The save is kept on `workflow_dispatch` so the cold/warm A/B
+    # can be measured on a branch — that is how #1073 was verified and how this was.
+    - name: Save sccache storage
+      if: always() && github.event_name != 'pull_request'
+      # `save-cache-pruned` swallows its own failures: a cache save must never fail the
+      # job it is attached to. `if: always()` means it also runs on a CANCEL, where the
+      # path may not exist yet, and actions/cache/save treats a missing path as a
+      # validation error rather than a no-op. What it adds over a bare save is noticing
+      # that the store REFUSED the write (which `actions/cache/save` reports as a warning
+      # and exits zero for), deleting this ref's superseded entries, and retrying.
+      uses: ./.github/actions/save-cache-pruned
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-windows-2025-${{ github.run_id }}-${{ github.run_attempt }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -510,7 +510,13 @@ jobs:
           # Name every failing case, so a width that trades speed for flakes is
           # identifiable rather than just a non-zero exit code.
           if ($code -ne 0) {
-            $out | Select-String -Pattern '^\s*\d+ - .*\*\*\*' | ForEach-Object {
+            # ctest's "The following tests FAILED:" block, whose lines are
+            # "<tab><n> - <Suite.Case> (Failed)". NOT the inline progress lines,
+            # which read "n/N Test #n: Suite.Case ...***Failed" -- an earlier
+            # revision of this step matched on `***` and would have printed
+            # nothing, silently turning "which cases flaked at this width" into
+            # "some did". Checked against real ctest output before it ran.
+            $out | Select-String -Pattern '^\s*\d+ - \S+ \(' | ForEach-Object {
               Write-Host "    FAILED at width $w : $($_.ToString().Trim())"
             }
           }

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -79,6 +79,45 @@ env:
   # caches (the four sccache dirs here, Windows.yml's, Vulkan, FFmpeg) share the
   # repo's single 10 GB Actions-cache cap.
   SCCACHE_CACHE_SIZE: "1500M"
+  # NEVER let the sccache server time out. This is the whole of #1082's crash, and it
+  # is not what the crash was believed to be for two months.
+  #
+  # sccache's server exits after SCCACHE_IDLE_TIMEOUT seconds without a client request
+  # (`DEFAULT_IDLE_TIMEOUT: u64 = 600` in its src/server.rs). LINK STEPS DO NOT GO
+  # THROUGH SCCACHE, so a link longer than ten minutes is ten minutes of silence, and
+  # the server shuts down in the middle of a running build. The next compile then
+  # connects to the socket the exiting server still holds and is dropped mid-handshake:
+  #
+  #     sccache: error: failed to execute compile
+  #     caused by: error reading compile response from server
+  #     caused by: Failed to read response header
+  #     caused by: An existing connection was forcibly closed by the remote host.
+  #                (os error 10054)
+  #
+  # sccache recovers from "no server running" by starting one. It does not recover from
+  # "server accepted my connection and then closed it", so this kills the build.
+  #
+  # MEASURED ON RUN 34048670103, which reproduced it exactly:
+  #
+  #     [1593/1596] Linking CXX static library ...   19:41:05
+  #     [1594/1596] Building CXX ...                 19:54:18   <- 13m 13s later, dead
+  #
+  # 793 s of link against a 600 s timeout. `sccache --show-stats` immediately afterwards
+  # reported "Compile requests 0" -- not 1593 -- because it had started a BRAND NEW
+  # server; that zero is the proof the original one was gone rather than merely unhappy.
+  #
+  # This retires the folklore in d93b5af5b, which blamed "an extra in-memory consumer
+  # that tips the huge instrumented TUs over" and named GameNetworkingSockets. The TU
+  # that died here is OloEditor/src/MCP/McpFieldRegistry.cpp: 100 lines, 5 KB, entirely
+  # unremarkable. It was not big. It was merely THE FIRST COMPILE AFTER A LONG LINK.
+  # That also explains the observation that made the memory theory convincing -- three
+  # retries each dying on a different TU. Every retry resumes near the end of the build,
+  # which is where the long links are, so each one hit the same race at whatever TU
+  # happened to follow the next >10-minute link.
+  #
+  # Set for all four sanitizer jobs, not just the Windows one. The race needs only a
+  # slow link, and every job here links sanitizer-instrumented binaries.
+  SCCACHE_IDLE_TIMEOUT: "0"
 
 permissions:
   contents: read
@@ -256,36 +295,29 @@ jobs:
         version: "23.1.0"
         sha256: "1aebf024b959b3835c3bd936da2fa58cd002c61ccf47fce1714447b900bd9837"
 
-    # RE-ADDED BY #1082, after d93b5af5b removed it on 2026-07-02. Read that commit
-    # before touching this: the Windows sccache SERVER died mid-build on the large
-    # ASan-instrumented GameNetworkingSockets TUs —
+    # RE-ADDED BY #1082, after d93b5af5b removed it on 2026-07-02. The removal was
+    # sound about the symptom and wrong about the cause, and the cause is now known:
+    # the sccache server was idling out during long link steps. The mechanism, the
+    # measurement and the fix all live on SCCACHE_IDLE_TIMEOUT in the workflow `env`
+    # block at the top of this file. Read that before touching anything here.
     #
-    #     sccache: error: failed to execute compile
-    #     caused by: An existing connection was forcibly closed by the remote host.
-    #                (os error 10054)
+    # Two beliefs died with it, both worth naming so they are not rediscovered:
     #
-    # — on three consecutive retries, each on a different TU (tier0/dbg.cpp,
-    # steamnetworkingsockets_connections.cpp, _spew.cpp), so the retry wrapper that
-    # preceded the removal never cleared it. The diagnosis recorded there was memory:
-    # the server is an extra in-memory consumer on a 4-vCPU runner already holding
-    # several GB per instrumented TU.
+    #   "A NEWER SCCACHE MIGHT FIX IT." There was never a version delta to test.
+    #   d93b5af5b was ALREADY pinned to v0.15.0, which is still the fleet pin --
+    #   the issue's premise that "the removal predates several releases" is simply
+    #   not what the diff says. v0.17.0's client-side mode (SCCACHE_CLIENT_SIDE) was
+    #   the planned second arm on the theory that the server was running out of
+    #   memory. It is not needed: the server was not out of memory, it was gone.
     #
-    # THE ISSUE'S OWN PREMISE — "the removal predates several releases" — IS WRONG,
-    # and it is worth stating so nobody re-runs the same experiment expecting a
-    # different answer: d93b5af5b was already pinned to sccache v0.15.0, which is
-    # still the fleet pin. What HAS changed since is the toolchain, not sccache:
-    # this job now builds with an absolute-path-pinned LLVM 23.1.0 (5b3a24d39,
-    # fde5e9d5a, 0277e2a0d) instead of whatever clang-cl the windows-2025 image
-    # shipped, and GNS moved to a post-1.6.0 snapshot (01fdffb70). That is why the
-    # first arm re-tests the pinned version unchanged rather than jumping straight
-    # to v0.17.0: if it no longer reproduces, the smallest possible diff is the fix.
+    #   "IT IS THE HUGE INSTRUMENTED GNS TUs." The TU that died on the reproduce run
+    #   was OloEditor/src/MCP/McpFieldRegistry.cpp -- 100 lines, 5 KB. Size had
+    #   nothing to do with it.
     #
-    # If it DOES reproduce, the next arm is sccache v0.17.0 with SCCACHE_CLIENT_SIDE,
-    # which moves the compile and the cache lookup out of the server process
-    # entirely (the server keeps only compiler info, dist client and stats) and so
-    # removes the exact consumer d93b5af5b blamed. Do not skip the retry-free arm to
-    # get there — "it still crashes" and "it crashes for the reason we assumed" are
-    # different findings.
+    # A RETRY WRAPPER IS STILL THE WRONG ANSWER, for a new reason. d93b5af5b's retry
+    # failed because each attempt resumed near the end of the build and met the next
+    # long link, so it re-armed the same race every time. With the timeout disabled
+    # there is nothing left to retry.
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       with:
@@ -425,6 +457,22 @@ jobs:
     - name: Show sccache stats
       if: always()
       run: sccache --show-stats
+
+    # THE SIZE THIS ENTRY WILL COST THE STORE, measured off the directory rather than
+    # asked of sccache. `--show-stats` cannot answer it reliably: if the server has
+    # exited, the client silently STARTS A NEW ONE and reports its zeros instead --
+    # which is exactly what happened on run 34048670103 ("Compile requests 0" after
+    # 1593 successful compiles). The directory is on disk either way.
+    #
+    # Needed because SCCACHE_CACHE_SIZE above is provisional (#1082): this job's
+    # objects carry embedded /Z7 debug info on top of ASan instrumentation, and the
+    # compressed actions/cache entry lands at 82-91 % of the cap, so the cap has to be
+    # set from a real footprint before this is charged to a shared ~9.3 GiB store.
+    - name: Measure the sccache directory
+      if: always()
+      shell: bash
+      run: |
+        du -sm "${SCCACHE_DIR}" 2>/dev/null || echo "SCCACHE_DIR not present"
 
     # Paired with the restore above. `if: always()` because the combined actions/cache
     # action saves in a POST-JOB step, which a CANCELLED job skips — and most PR runs in

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -188,11 +188,22 @@ jobs:
       # largest in the fleet: ASan instrumentation plus /Z7 (the compiler cache
       # switches MSVC debug info from a shared PDB to embedded — see
       # cmake/CompilerCache.cmake) makes every .obj carry its own debug info.
-      # MEASURE BEFORE TRUSTING THIS NUMBER: the entry that lands in the Actions
-      # cache store is charged against a shared ~9.3 GiB cap, and the measured
-      # entries so far compress to 82-91 % of this cap, not far below it
-      # (docs/agent-rules/actions-cache-budget.md). Raising it raises the bill.
-      SCCACHE_CACHE_SIZE: "3G"
+      # MEASURED, not guessed. The provisional value was 3G, chosen so the first
+      # successful run could report this job's real footprint instead of being
+      # capped at whatever was reserved. Run 34061407329 answered it:
+      #
+      #     Cache size    656 MiB       (du -sm agreed: 660)
+      #     Max cache size  3 GiB       -- nowhere near the cap, so nothing evicted
+      #
+      # Far smaller than the sibling `Windows / build` entry (1825 MiB at a 2G cap,
+      # i.e. capped), because this job builds ONLY the OloEngine-Tests target while
+      # that one also builds the editor, runtime and server.
+      #
+      # 1500M leaves ~2.3x headroom for the tree to grow without reserving budget
+      # this job does not use. Do not raise it to "be safe": measured entries here
+      # land at 82-91 % of their cap when they hit it, so the cap is the bill
+      # (docs/agent-rules/actions-cache-budget.md).
+      SCCACHE_CACHE_SIZE: "1500M"
       # Disable ASan's ODR-violation checker for every instrumented binary run in
       # this job. Vendored protobuf trips a known false positive — its narrow and
       # wide "." string-literal globals (`"."` vs `L"."`, io_win32.cc vs
@@ -500,81 +511,6 @@ jobs:
         key: sccache-asan-windows-2025-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    # ============================================================================
-    # TEMPORARY MEASUREMENT SCAFFOLDING (#1083) — DELETE BEFORE THIS PR MERGES.
-    # ============================================================================
-    # #1083 requires `--parallel` to be "chosen from a measurement across at least
-    # three widths ... not raised on the assumption that startup-bound implies
-    # oversubscribe". This step is that measurement, and it is a step rather than
-    # six workflow runs for one reason: six runs are six different runners. A
-    # windows-2025 runner's disk and CPU vary enough between allocations that a
-    # 15 % difference between two runs says nothing, and the effect being looked
-    # for here is exactly that size at the margin. Timing all widths inside ONE
-    # job removes the runner from the comparison entirely.
-    #
-    # THE ORDER IS A PALINDROME (2,3,4,4,3,2), not 2,3,4 repeated. The first pass
-    # over a subset is measurably slower than the second — the OS file cache is
-    # cold for the test binary, and the engine's repo-relative mesh cache is
-    # empty, so the RESOURCE_LOCK'd cases pay a real cold build. A monotonic drift
-    # like that biases an ascending sweep in favour of the LAST width tried, which
-    # is the answer this measurement most wants to be true. A palindrome cancels
-    # it: each width is sampled once early and once late, so their means carry the
-    # same amount of warm-up.
-    #
-    # `-I 1,,20` samples every 20th ctest entry (~345 of ~6,900) rather than
-    # running the full suite six times, which would add ~9 h to this job. The
-    # sample is strided, not a contiguous block, so it is spread across the whole
-    # ordered test list instead of over-weighting whichever suites happen to sort
-    # first. `-I` intersects with `--exclude-regex` (ctest unions them only under
-    # `-U`), so the exclusions below still apply.
-    #
-    # EXIT CODE AND FAILURE COUNT ARE PART OF THE MEASUREMENT, not noise to
-    # suppress: #1083 asks for flake behaviour at each width, not just the clock,
-    # because a wider `-j` on a 4-vCPU runner is exactly what #281 and the
-    # mesh-cache RESOURCE_LOCK are sensitive to. A width that is 30 % faster and
-    # flaky is not faster. `$ErrorActionPreference = 'Continue'` and the explicit
-    # `exit 0` are what let a failing pass be RECORDED rather than ending the job.
-    - name: "Measure ctest --parallel widths (#1083, temporary)"
-      working-directory: ${{github.workspace}}/build/OloEngine/tests
-      shell: pwsh
-      env:
-        ASAN_OPTIONS: halt_on_error=1:detect_odr_violation=0
-      run: |
-        $ErrorActionPreference = 'Continue'
-        $widths = @(2, 3, 4, 4, 3, 2)
-        $rows = @()
-        foreach ($w in $widths) {
-          $sw = [Diagnostics.Stopwatch]::StartNew()
-          $out = & ctest -I '1,,20' --parallel $w -C Release --timeout 120 `
-                   --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.' 2>&1
-          $sw.Stop()
-          $code = $LASTEXITCODE
-          $tally = ($out | Select-String -Pattern 'tests passed' | Select-Object -Last 1)
-          $tally = if ($tally) { $tally.ToString().Trim() } else { '(no ctest summary line)' }
-          $row = ("width={0}  seconds={1}  exit={2}  {3}" -f `
-                  $w, [math]::Round($sw.Elapsed.TotalSeconds, 1), $code, $tally)
-          Write-Host "::notice title=ctest width sweep::$row"
-          $rows += $row
-          # Name every failing case, so a width that trades speed for flakes is
-          # identifiable rather than just a non-zero exit code.
-          if ($code -ne 0) {
-            # ctest's "The following tests FAILED:" block, whose lines are
-            # "<tab><n> - <Suite.Case> (Failed)". NOT the inline progress lines,
-            # which read "n/N Test #n: Suite.Case ...***Failed" -- an earlier
-            # revision of this step matched on `***` and would have printed
-            # nothing, silently turning "which cases flaked at this width" into
-            # "some did". Checked against real ctest output before it ran.
-            $out | Select-String -Pattern '^\s*\d+ - \S+ \(' | ForEach-Object {
-              Write-Host "    FAILED at width $w : $($_.ToString().Trim())"
-            }
-          }
-        }
-        Write-Host ''
-        Write-Host '=== ctest --parallel sweep, ASan (Windows/clang-cl) - sample: every 20th entry ==='
-        $rows | ForEach-Object { Write-Host $_ }
-        # Never fail the job on the sweep: the real test run below is the gate.
-        exit 0
-
     - name: Create test results directory
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"
       shell: pwsh
@@ -624,15 +560,38 @@ jobs:
       #     stress test that exceeds the 120 s timeout under sanitizer
       #     instrumentation; excluded on every sanitizer job.
       #
-      # --parallel 2: every gtest case is its own ctest entry (gtest_discover_tests),
-      # so serial execution pays the engine's full static-init cost ~3,600× back-to-
-      # back — the same win Windows.yml's non-sanitizer job banks with `--parallel 4`.
+      # --parallel 4, RAISED FROM 2 ON A MEASUREMENT (#1083), not on the theory that
+      # made 2 look conservative. Every gtest case is its own ctest entry
+      # (gtest_discover_tests), so the suite is ~7,600 process launches each paying
+      # full engine static init, and the standing hypothesis was that a workload that
+      # startup-bound would scale well past the runner's 4 vCPUs. IT DOES NOT.
+      #
+      # Six timed passes over the same 380-case sample in ONE job on run 34061407329,
+      # in palindrome order (2,3,4,4,3,2) so the cold-start warm-up is shared equally
+      # rather than credited to the last width tried:
+      #
+      #     width 2   254.0 / 255.6 s     --
+      #     width 3   236.5 / 237.1 s     -7.1 %
+      #     width 4   216.4 / 218.5 s    -14.7 %
+      #
+      # Doubling the width buys ~15 %, not the ~2x "startup-bound" predicted. So this
+      # is much closer to CPU/memory-bandwidth bound than to launch-latency bound, and
+      # anyone tempted to go wider again should re-measure rather than reason.
+      # 100 % passed at every width -- 380 of 380, six passes, zero flakes -- so the
+      # raise costs no stability at this width.
+      #
+      # THE OLD CAP WAS AN ASSUMPTION. It read "capped at 2 (not 4) because ASan shadow
+      # memory inflates each test process's resident footprint; 2-wide stays comfortably
+      # inside the windows-2025 ~16 GB budget" -- plausible, and never measured. 4-wide
+      # ran 380 instrumented cases for 216 s here without incident. If a future run does
+      # start OOMing or timing out, 3 is the measured fallback and buys 7.1 %.
+      #
       # The suite is parallel-safe by construction: tests key their temp paths by
       # PID / gtest case name, and the handful that share the engine's repo-relative
       # mesh cache are serialized against each other with a ctest RESOURCE_LOCK
-      # (OloEngine/tests/CMakeLists.txt). Capped at 2 (not 4) because ASan
-      # shadow memory inflates each test process's resident footprint; 2-wide stays
-      # comfortably inside the windows-2025 ~16 GB budget.
+      # (OloEngine/tests/CMakeLists.txt). Note what the sample could NOT exercise: a
+      # 1-in-20 stride rarely co-schedules the RESOURCE_LOCK'd cases, so lock
+      # contention at this width is validated by the full run, not by the sweep.
       # TEN EH cases used to be excluded here and are not any more (issue #497).
       # They are the tests that trigger a real C++ throw+catch (malformed-input
       # robustness + MCP error handling), and clang-cl + ASan miscompiled MSVC-style
@@ -649,7 +608,7 @@ jobs:
       # again, the question is which clang the job resolved, not whether the engine
       # regressed.
       run: >
-        ctest --parallel 2 -C Release --output-on-failure --timeout 120
+        ctest --parallel 4 -C Release --output-on-failure --timeout 120
         --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
       env:
         # detect_odr_violation=0 must be repeated here — a step-level ASAN_OPTIONS

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -19,6 +19,15 @@ Issue [#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073).
 4. **Before redesigning a cache, add up what the fleet already stores.** The cap is
    ~9537 MiB. If the steady set does not leave room for the largest single snapshot, no
    key design will help.
+5. **The store exists to speed up GITHUB-HOSTED jobs on a PULL REQUEST. Nothing else has
+   a claim on it.** Everything else either has a better cache or has no one waiting:
+   a self-hosted job caches on local disk, which has no save step to refuse, no ref
+   scoping and no cap; a nightly is not on anyone's critical path. Spending the cap on
+   those is spending it on latency nobody experiences — and it is how the Windows ASan
+   job came to have no compiler cache at all while 3741 MiB sat in entries returning
+   0.00 % (see *A cache can be worth removing*). Work out which jobs are hosted **and**
+   PR-triggered before allocating anything; that list is much shorter than the workflow
+   list.
 
 ---
 
@@ -204,6 +213,33 @@ Re-adding the restore/save without doing one of those reproduces the 0.00 %.
 0 %-hit entry is not neutral; it costs quota, download time, and the room a working cache
 needed. Read `created_at`, `last_accessed_at` **and the hit rate** — the first two only
 tell you the entry is being written and read, not that it is worth anything.
+
+## Who actually has a claim on the cap
+
+Measured 2026-09-06 by reading every workflow's triggers and `runs-on`. Rule 5 above only
+means something once this table exists, and it is much shorter than the 17 workflow files
+suggest:
+
+| Job | Runner | Runs on a PR when | Cache it justifies |
+|---|---|---|---|
+| `Windows.yml / build` | windows-2025 | every native change | `sccache-windows-2025-release`, `vcpkg-Windows`, `Windows-vulkan-prebuilt-sdk`, `ffmpeg-Windows` |
+| `asan.yml / asan-windows` | windows-2025 | every native change | `sccache-asan-windows-2025` (#1082); shares the vcpkg and Vulkan entries above |
+| `dist-archive.yml / archive` | windows-2025 | only 4 paths (`CMakeLists.txt`, two `cmake/*.cmake`, its own file) | vcpkg only. A full Dist build with **no compiler cache**, and that is correct — a job that runs on a few percent of PRs should not hold ~2 GiB. |
+| `steam-stub.yml / single-valve-tu` | ubuntu-24.04 | only Steam-seam changes | none; it compiles one TU |
+| `pre-commit`, `detect-changes`, `cancel-merged-pr-runs` | ubuntu-latest | every PR | none; seconds |
+
+Everything else that runs on a PR is **self-hosted** — `asan.yml`'s three Linux sanitizer
+jobs, `vulkan-off.yml`, `steam-stub.yml / stub-build` — and caches on the box's local disk.
+Note the trap: a self-hosted runner still talks to the **remote** Actions cache service, so
+an `actions/cache` step there spends the shared cap exactly like a hosted one does. Being
+self-hosted does not make a cache free; using local disk does.
+
+And everything else in the fleet — `SonarCloud`, `cross-vendor`, `fuzz`, `video-ffmpeg`,
+`gpu-*`, `flaky-repro-281`, `release` — is `schedule` or `workflow_dispatch` only. It has no
+claim. `Linux-vulkan-prebuilt-sdk` (291 MiB) is the one survivor of that category: it is
+created solely by `video-ffmpeg.yml`'s linux matrix arm, which never runs on a PR. Left in
+place at 3 % of the cap because it works and removing it only slows a nightly — but it is
+the first thing to cut if the store gets tight again.
 
 ## Adding a cache to this repo
 

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -131,13 +131,14 @@ before compression:
 
 | Entry | Size |
 |---|---|
-| `sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux` | 1252 / 1231 / 1258 MiB |
+| ~~`sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux`~~ | ~~1252 / 1231 / 1258 MiB~~ — **removed 2026-09-06 (#1082)**, see *A cache can be worth removing* below |
 | `vcpkg-Windows-x64-windows-static-md` | 692 MiB |
 | `Linux-` / `Windows-vulkan-prebuilt-sdk` | 291 + 229 MiB |
 | `ffmpeg-Windows-n7.1` | 4 MiB |
-| **measured subtotal** | **4957 MiB** |
+| **measured subtotal** | **1216 MiB** (was 4957 MiB with the three Linux entries in it) |
 | `sccache-windows-2025-release` | **1825 MiB** — measured 2026-09-06 17:00 UTC, the day the fix landed. The row that used to sit here said "not measured, no entry has ever existed to measure" and guessed 0.9–2.0 GiB from `sccache-flaky-281`. The guess held; the entry came in at the top of it. |
-| **steady set** | **6782 MiB**, against a ~9.3 GiB wall — 2.7 GiB of margin, and ~2.0 GiB below `cache-prune.yml`'s 8800 MiB working ceiling |
+| `sccache-asan-windows-2025` | **not yet measured** — the job's first successful run has not banked one. `SCCACHE_CACHE_SIZE` is provisional; the workflow `du -sm`s `SCCACHE_DIR` so the cap can be set from a real footprint. Plan against the cap, per the 82–91 % rule below. |
+| **steady set** | **3041 MiB** measured, plus the pending ASan-Windows entry — against a ~9.3 GiB wall and `cache-prune.yml`'s 8800 MiB working ceiling. Was 6782 MiB before the three Linux entries came out. |
 
 `SCCACHE_CACHE_SIZE` bounds the local directory **before** compression, so it is not the
 entry size — but do not read that as "the entry will be much smaller". Every measured
@@ -150,6 +151,59 @@ the post-sweep store is over 8800 MiB: everything it deletes is provably superse
 unread, so if what remains is still that close to the wall, the fleet has outgrown the
 cap and a human has to shrink something. Raising the ceiling to silence the alarm
 re-creates this bug.
+
+## A cache can be worth removing, and this one was worth 3741 MiB
+
+Measured 2026-09-06 while looking for room for a fourth large Windows entry (#1082).
+The three Linux sanitizer sccache entries were **3741 MiB — 55 % of the steady set** —
+and on the nightly, the only runs that read them, all three reported:
+
+```
+Compile requests   1558      Cache hits          0
+Cache misses       1558      Cache hits rate     0.00 %
+Cache read errors     0      Cache write errors  0
+```
+
+The restore was healthy. `Cache restored from key: sccache-ubsan-linux-32225872289`,
+1232 MB at 180 MB/s. It restored perfectly and hit nothing, three jobs out of three.
+
+**The compiler was rolling underneath the key.** sccache hashes the compiler binary into
+every cache key, and the hosted arm builds with apt.llvm.org's *snapshot* clang-23:
+
+```
+nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
+nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+```
+
+so every entry died at the next apt refresh — while still restoring, still downloading
+1.2 GB, and still holding quota. This is the same failure `Windows.yml`'s header
+documents for `windows-latest` image rolls (§ *the key carries the runner IMAGE*),
+reproduced on Linux by an unpinned rolling compiler. **A pinned image is only half the
+rule: pin whatever the key is hashed over, and on Linux that is the compiler package.**
+
+Two things made it invisible. The hit rate was printed on every run and nobody read it —
+which `ci-cache-that-looks-alive.md` already warns about. And almost nothing read the
+entries at all: `OLO_LINUX_SELF_HOSTED` is true, so a same-repo PR routes these jobs to
+the box, where they use local-disk ccache and skip every sccache step. Only the nightly
+(a `schedule` run forces hosted) and fork PRs ever touched the store, and neither is on
+the per-PR critical path.
+
+So the store was spending 55 % of its steady set on jobs nobody waits for, for a measured
+zero, while the Windows ASan job that *is* on the critical path had no cache at all for
+want of room. The entries were removed and deleted.
+
+**What was given up, stated honestly:** at 1558 compilations × 6.283 s average, a
+*working* cache there would remove most of ~2 h 43 m of compiler time per job. That value
+is real and currently unreachable, because the key cannot be stable while the compiler is
+a rolling snapshot. Recovering it means pinning the hosted clang — the self-hosted box
+already pins `/opt/llvm-23.1.0` by absolute path — or keying the entry on the clang build
+id. That is issue [#1095](https://github.com/drsnuggles8/OloEngineBase/issues/1095).
+Re-adding the restore/save without doing one of those reproduces the 0.00 %.
+
+**The rule:** before adding a cache, check what the existing ones actually return. A
+0 %-hit entry is not neutral; it costs quota, download time, and the room a working cache
+needed. Read `created_at`, `last_accessed_at` **and the hit rate** — the first two only
+tell you the entry is being written and read, not that it is worth anything.
 
 ## Adding a cache to this repo
 

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -136,11 +136,14 @@ before compression:
 | `Linux-` / `Windows-vulkan-prebuilt-sdk` | 291 + 229 MiB |
 | `ffmpeg-Windows-n7.1` | 4 MiB |
 | **measured subtotal** | **4957 MiB** |
-| `sccache-windows-2025-release` | **not measured — no entry has ever existed to measure.** `SCCACHE_CACHE_SIZE` caps the local dir at 2 GiB; `sccache-flaky-281`, same cap and the same build, compressed to 886 MiB. Expect 0.9–2.0 GiB; plan against 2.0 until a real one lands. |
-| **steady set** | **5.7 GiB likely, 6.8 GiB worst case** (4.84 GiB measured + 0.87–2.0), against a ~9.3 GiB wall — so 2.5 GiB of margin even at the bound |
+| `sccache-windows-2025-release` | **1825 MiB** — measured 2026-09-06 17:00 UTC, the day the fix landed. The row that used to sit here said "not measured, no entry has ever existed to measure" and guessed 0.9–2.0 GiB from `sccache-flaky-281`. The guess held; the entry came in at the top of it. |
+| **steady set** | **6782 MiB**, against a ~9.3 GiB wall — 2.7 GiB of margin, and ~2.0 GiB below `cache-prune.yml`'s 8800 MiB working ceiling |
 
-Do not quote the sccache row as a measurement until an entry has been written and listed.
-The number that mattered here was one nobody had ever read.
+`SCCACHE_CACHE_SIZE` bounds the local directory **before** compression, so it is not the
+entry size — but do not read that as "the entry will be much smaller". Every measured
+sccache entry here lands at **82–91 % of its cap**: 2 G → 1825 MiB, 1500M → 1231–1258 MiB.
+sccache already stores each object compressed, so the tarball has almost nothing left to
+squeeze. Treat the cap as the bill, and size a new one by what it is allowed to cost.
 
 That is why `cache-prune.yml` now **fails** when
 the post-sweep store is over 8800 MiB: everything it deletes is provably superseded or

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -146,14 +146,22 @@ before compression:
 | `ffmpeg-Windows-n7.1` | 4 MiB |
 | **measured subtotal** | **1216 MiB** (was 4957 MiB with the three Linux entries in it) |
 | `sccache-windows-2025-release` | **1825 MiB** — measured 2026-09-06 17:00 UTC, the day the fix landed. The row that used to sit here said "not measured, no entry has ever existed to measure" and guessed 0.9–2.0 GiB from `sccache-flaky-281`. The guess held; the entry came in at the top of it. |
-| `sccache-asan-windows-2025` | **not yet measured** — the job's first successful run has not banked one. `SCCACHE_CACHE_SIZE` is provisional; the workflow `du -sm`s `SCCACHE_DIR` so the cap can be set from a real footprint. Plan against the cap, per the 82–91 % rule below. |
-| **steady set** | **3041 MiB** measured, plus the pending ASan-Windows entry — against a ~9.3 GiB wall and `cache-prune.yml`'s 8800 MiB working ceiling. Was 6782 MiB before the three Linux entries came out. |
+| `sccache-asan-windows-2025` | **~660 MiB** — the local `SCCACHE_DIR` measured 656 MiB (`--show-stats`) / 660 MiB (`du -sm`) on run 34061407329, well under its 3 GiB provisional cap, so nothing was evicted and this is the true footprint. Cap now set to 1500M. Much smaller than the sibling `sccache-windows-2025-release` because this job builds only `OloEngine-Tests`, not the editor/runtime/server too. |
+| **steady set** | **~3700 MiB** (1216 + 1825 + ~660) against a ~9.3 GiB wall and `cache-prune.yml`'s 8800 MiB working ceiling — **5.1 GiB of headroom**. Was 6782 MiB before the three Linux entries came out, and that was with the ASan Windows job holding nothing. |
 
 `SCCACHE_CACHE_SIZE` bounds the local directory **before** compression, so it is not the
-entry size — but do not read that as "the entry will be much smaller". Every measured
-sccache entry here lands at **82–91 % of its cap**: 2 G → 1825 MiB, 1500M → 1231–1258 MiB.
-sccache already stores each object compressed, so the tarball has almost nothing left to
-squeeze. Treat the cap as the bill, and size a new one by what it is allowed to cost.
+entry size — but do not read that as "the entry will be much smaller". Every sccache entry
+here that **reached** its cap landed at **82–91 % of it**: 2 G → 1825 MiB, 1500M →
+1231–1258 MiB. sccache already stores each object compressed, so the tarball has almost
+nothing left to squeeze. **Treat the cap as the bill for any cache that fills it.**
+
+The corollary, which the ASan Windows job demonstrates: a cache that does **not** reach its
+cap costs what it actually holds, and the only way to know which case you are in is to
+measure the directory. Its cap was set to 3 G deliberately so the first successful run
+would report an *uncapped* footprint — 656 MiB — instead of being clipped to whatever had
+been reserved. Set the provisional cap high, measure, then set it for real. And measure it
+with `du`, not `--show-stats`: if the sccache server has exited, the client silently starts
+a fresh one and reports its zeros (#1082).
 
 That is why `cache-prune.yml` now **fails** when
 the post-sweep store is over 8800 MiB: everything it deletes is provably superseded or


### PR DESCRIPTION
Two levers on the `ASan (Windows/clang-cl)` job, split out of umbrella #1084 by measurement and batched because they edit the same two files and the same cache-budget table.

Both questions are now answered, and neither answer was the expected one.

## #1082 — the sccache crash is an idle timeout, not memory

`asan.yml` had omitted `OLO_ENABLE_COMPILER_CACHE` since d93b5af5b (2026-07-02), which recorded the Windows sccache **server** dying on "the large ASan-instrumented GameNetworkingSockets TUs" with `os error 10054`, on all three attempts of a retry wrapper. Arm 1 reproduced it exactly — and the diagnosis was wrong.

```
[1593/1596] Linking CXX static library ...   19:41:05
[1594/1596] Building CXX ...                 19:54:18
```

**793 seconds of link** against sccache's `DEFAULT_IDLE_TIMEOUT` of 600 (`src/server.rs`). Link steps do not go through the compiler launcher, so a link longer than ten minutes is ten minutes of silence and the server shuts itself down **mid-build**. The next compile connects to the socket the exiting server still holds and is dropped mid-handshake. sccache starts a server when none is running; it has no recovery for one that accepts and then closes.

Proof the server was *gone* rather than unhappy: `--show-stats` four seconds later reported `Compile requests 0`, not 1593 — a brand new server reporting its zeros.

**Two beliefs retired**, both now written into the workflow so they are not rediscovered:

- *"The huge instrumented GNS TUs tip it over."* The TU that died was `OloEditor/src/MCP/McpFieldRegistry.cpp` — **100 lines, 5 KB**. Not big, not GNS. It was the first compile after a long link. That also explains the evidence that made the memory theory persuasive: three retries dying on three *different* TUs, because every retry resumes near the end of the build where the long links are.
- *"A newer sccache may have fixed it."* There was never a version delta — d93b5af5b was already on v0.15.0. v0.17.0's `SCCACHE_CLIENT_SIDE` was the planned arm 2 *on the memory theory* and is not needed.

Fix: `SCCACHE_IDLE_TIMEOUT=0`, one line, at workflow env level so all four sanitizer jobs get it, plus preventively in `Windows.yml`. No retry wrapper — with the timeout gone there is nothing to retry. **Verified:** `Build (Release): success` on run 34075629097, where arm 1 had died at object 1594 of 1596.

Also answered from the same run: **`Non-cacheable compilations: 0`** — clang-cl's ASan flags are fully cacheable, which the issue listed as an open question.

## #1083 — the "startup-bound" hypothesis is largely wrong

Six timed passes per job over one sample, inside a single job, in palindrome order so warm-up is shared rather than credited to the widest arm:

| ASan — 380-case sample | | | Windows — 382-case sample | | |
|---|---|---|---|---|---|
| width 2 | 254.0 / 255.6 s | — | width 4 | 81 / 76 s | — |
| width 3 | 236.5 / 237.1 s | −7.1 % | width 6 | 69 / 69 s | −12.1 % |
| width 4 | 216.4 / 218.5 s | −14.7 % | width 8 | 66 / 66 s | −15.9 % |

100 % passed at every width, twelve passes, zero flakes. **Doubling the width buys ~15 %, not the ~2x a genuinely startup-bound workload would give.** The palindrome earned its place: width 4 ran 81 s early and 76 s late, and an ascending sweep would have handed that 6.2 % drift to width 8.

Chosen: **ASan 2 to 4** (the old cap's "shadow memory" justification was an assumption, never measured; 3 is the measured fallback). **Windows 4 to 6, not 8** — 6 to 8 is worth ~1 min on the real step and costs a second doubling of oversubscription on a 4-vCPU runner, the exact condition #281 lived in; a 1-in-20 stride rarely co-schedules the `RESOURCE_LOCK`ed cases, so width 8 is untested rather than shown safe.

**Full-suite validation:** `Run tests under ASan` **89.0 to 75.3 min**, green, ~7,600 cases, no OOM, no flakes — better than the sample's 77.7 min prediction.

## The budget, which is what made #1082 possible

Looking for room for a fourth large Windows entry found 3741 MiB buying nothing. The three Linux sanitizer sccache entries were **55 % of the steady set**, and on the nightly — the only runs that read them — all three reported `1558 requests, 0 hits, 0.00 %`, with a perfectly healthy restore (1232 MB at 180 MB/s).

The compiler was rolling underneath the key: sccache hashes the compiler binary, and the hosted arm uses apt.llvm.org **snapshot** clang-23 (09-04 `++...5340f7cc8814`, then 09-05 `++...47bafb752202`). Same failure `Windows.yml` documents for `windows-latest` image rolls, reproduced on Linux by an unpinned rolling compiler. Removed; root cause filed as **#1095**.

| | before | after |
|---|---|---|
| steady set | 6782 MiB, ASan Windows holding nothing | **~3701 MiB** including the new entry |
| headroom to the 8800 MiB ceiling | ~2.0 GiB | **5.1 GiB** |

`SCCACHE_CACHE_SIZE` was set to 3G provisionally *so the first successful run would report an uncapped footprint* rather than being clipped to a guess. It reported **656 MiB** (`du`: 660); the cap is now 1500M.

New rule in `actions-cache-budget.md`: **the store exists to speed up github-hosted jobs on a pull request, and nothing else has a claim on it** — with the table of which jobs those actually are, and the trap that a self-hosted runner still uses the *remote* cache service, so an `actions/cache` step on the box spends the shared cap exactly like a hosted one.

## The open risk, stated plainly

On a **cold** run the cache makes this job **worse**: the build goes 87.2 to 142.9 min because `OLO_ENABLE_COMPILER_CACHE=ON` forces PCH off (`cmake/CompilerCache.cmake` — a `/Yu` compile is non-cacheable). Tests save 13.7 min, so cold is **net ~42 min worse**. It pays only if the warm build recovers that, and **the warm hit rate has not been measured yet** — PR runs never save, so only the nightly banks a snapshot.

The revert is one flag if the warm number disappoints. `SCCACHE_IDLE_TIMEOUT`, the Linux removal, the budget work and the width changes are all independent of that decision and stand either way.

## Scope note

**#1083 is referenced, not closed** — the `--parallel` half is done and measured, but sharding (a build job + N shard jobs + artifact plumbing + a coverage guard) is several more CI rounds and is proposed as its own issue with the measurement attached. The groundwork is recorded in #1083, including the verified fact that `ctest -I` intersects `--exclude-regex` and partitions cleanly (`-I k,,4` gives 1901/1901/1901/1900 = 7603 exactly).

Closes #1082

## Review guide

**Where I'd look hardest**

1. `.github/workflows/asan.yml` — `SCCACHE_IDLE_TIMEOUT` in the workflow `env` block. It is set for all four sanitizer jobs on the argument that the race needs only a slow link. If that reasoning is wrong for the Linux jobs, it is wrong quietly.
2. `.github/workflows/asan.yml` — the three Linux jobs lost their restore/save **and** their `actions: write`. Worth checking nothing else in those jobs needed that permission.
3. `--parallel 4` under ASan. Validated on one full run; memory pressure is the failure mode and one green run is one data point.

**What I verified, and how** — `Build (Release): success` on run 34075629097 where arm 1 died at 1594/1596; `Non-cacheable compilations: 0`; footprint 656 MiB (`--show-stats`) / 660 MiB (`du -sm`); full-suite ASan tests 89.0 to 75.3 min green; twelve sweep passes with 380/380 and 382/382 passing. `ctest -I` partitioning checked locally against a real 7,603-case list rather than read off the docs.

**Least confident about** — whether enabling the cache is right *at all*, because the warm hit rate does not exist yet and the cold case is measurably worse. Everything else here I would defend; that one is a bet.

**Deliberately not tested** — the warm/warm A/B (needs two `workflow_dispatch` runs on this branch); shard-width behaviour under `RESOURCE_LOCK` contention at widths the strided sample cannot co-schedule; whether the hosted Linux arm should drop the sccache launcher entirely and get PCH back (separate question, unmeasured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
