### PR TITLE
ci: shard the Windows test steps, pin the hosted Linux clang, and route Windows self-hosted (#1083, #1095, #1076)

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -138,13 +138,36 @@ runs:
         # by libvulkan-dev/vulkan-validationlayers, which cost seconds; a single
         # list is worth far more than those seconds, because a per-job list is how
         # one job quietly acquires a dependency the others do not have.
+        # NO `clang-23` HERE ANY MORE (#1095). The compiler now comes from the
+        # official LLVM release tarball in the step below, at the same absolute
+        # prefix the self-hosted box uses. apt.llvm.org publishes only the newest
+        # SNAPSHOT of a branch, so the package rolls every few days -- and sccache
+        # hashes the compiler binary into every cache key, which is how three Linux
+        # sanitizer cache entries came to restore 1.2 GB each and return 0.00 %.
+        #
+        # `lld-23` STAYS, and not for linking in the normal case: it is the fallback
+        # the pinned prefix needs when the release's own ld.lld will not start on
+        # this image. See .github/actions/setup-llvm-linux.
         sudo apt-get install -y \
-          clang-23 lld-23 \
+          lld-23 \
           libvulkan-dev vulkan-validationlayers \
           libgl-dev libglu1-mesa-dev \
           libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev \
           libwayland-dev wayland-protocols libxkbcommon-dev \
           glslang-dev libshaderc-dev libspirv-cross-c-shared-dev spirv-tools
+
+    # THE PIN THE CACHE KEY NEEDS (#1095), and the one that makes the two arms
+    # twins. Installs the same official LLVM release the box carries, at the same
+    # /opt/llvm-<version> path, so the ladder below resolves one prefix on either
+    # runner kind and a same-commit hosted/self-hosted A/B compares like with like.
+    # The version and checksum are kept in step with scripts/setup-olo-ci-host.sh;
+    # moving one without the other splits the arms again, silently.
+    - name: Install pinned LLVM (hosted)
+      if: runner.environment == 'github-hosted'
+      uses: ./.github/actions/setup-llvm-linux
+      with:
+        version: "23.1.0"
+        sha256: "18da30f77f475688a18f7704d23f9f155ae007ed9922dbed6850a9419d9fec8c"
 
     # ----------------------------------------------------------- self-hosted
     #
@@ -272,10 +295,30 @@ runs:
       run: |
         set -euo pipefail
         if [ "$OLO_RUNNER_ENVIRONMENT" = "github-hosted" ]; then
-          # clang-23 from apt.llvm.org. The engine needs a C++23 STANDARD LIBRARY,
-          # not merely a C++23 compiler: Core/Reflection uses std::forward_like,
-          # which ubuntu-24.04's default libstdc++ does not provide.
-          cc=clang-23; cxx=clang++-23
+          # THE PINNED LLVM RELEASE, at the same absolute prefix the box uses
+          # (#1095). It used to be `clang-23` from apt.llvm.org, which is a rolling
+          # snapshot: it built fine and it made every sccache entry unreachable,
+          # because sccache hashes the compiler binary into the key.
+          #
+          # NO FALLBACK LADDER HERE, and that asymmetry with the self-hosted branch
+          # below is deliberate. The pin on the box degrades to the system clang
+          # because a hard failure there would block every same-repo PR's sanitizer
+          # jobs on one maintainer running one script. A hosted runner has no
+          # provisioning to preserve: the action installs the prefix in this same
+          # run and ASSERTS it -- version, a linker that starts, and a complete
+          # compiler-rt -- so if it is not here, the right outcome is a red step
+          # naming that, not a quiet fall back to whatever clang the image ships.
+          #
+          # (The engine needs a C++23 STANDARD LIBRARY, not merely a C++23
+          # compiler: Core/Reflection uses std::forward_like. That comes from the
+          # image's libstdc++, unchanged by this.)
+          llvm_prefix=/opt/llvm-23.1.0
+          cc="$llvm_prefix/bin/clang"
+          cxx="$llvm_prefix/bin/clang++"
+          if [ ! -x "$cxx" ]; then
+            echo "::error::$cxx is missing. .github/actions/setup-llvm-linux should have installed it earlier in this job; a job that calls this action without it cannot build."
+            exit 1
+          fi
           python_exe="$OLO_HOSTED_PYTHON"
           extra=""
         else

--- a/.github/actions/setup-llvm-linux/action.yml
+++ b/.github/actions/setup-llvm-linux/action.yml
@@ -1,0 +1,154 @@
+name: 'Install a pinned LLVM toolchain (Linux)'
+description: >
+  Download, checksum-verify and unpack an official LLVM release for Linux at the
+  SAME absolute prefix the self-hosted box uses, then PROVE the resulting clang is
+  the version that was asked for and can actually link a sanitized binary.
+
+  IT EXISTS TO MAKE A CACHE KEY STOP MOVING (#1095). sccache hashes the compiler
+  binary into every cache key. The hosted Linux sanitizer arm compiled with
+  apt.llvm.org's SNAPSHOT clang-23, whose build id rolls every few days:
+
+      nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
+      nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+
+  so every cache entry was invalidated by the next apt refresh -- while still
+  restoring 1.2 GB and still holding quota against a shared ~9.3 GiB store. Three
+  jobs, three nightlies, 1558 compile requests, 0 hits, 0.00 %. #1082 removed the
+  entries rather than keep paying for that; this action is how they come back.
+
+  A PINNED IMAGE IS ONLY HALF THE RULE. Windows.yml already pins `windows-2025`
+  because rolling the image swaps cl.exe. The same rule on Linux means pinning the
+  COMPILER PACKAGE, because that is what the key is hashed over -- and apt.llvm.org
+  publishes only the newest snapshot of a branch, so no apt version pin can hold.
+  The official release tarball can.
+
+  IT ALSO MAKES THE TWO ARMS TWINS. scripts/setup-olo-ci-host.sh unpacks this exact
+  release at /opt/llvm-<version> on the self-hosted box, and this action installs it
+  at the same path on a hosted runner, so `setup-linux-build` resolves ONE prefix on
+  both and the `toolchain:` line a same-commit A/B reads first reports the same
+  build on both. #1015/#1036 went to real trouble to make those arms comparable and
+  a rolling snapshot quietly undid it.
+
+  The bytes live on /mnt -- the runner's large scratch disk -- with a symlink at the
+  /opt path. The unpacked tree is ~12 GB and the root filesystem is where the build,
+  vcpkg and the sccache directory already compete; asan.yml records "No space left
+  on device" during the OloEngine-Tests link on this image, so this is not a
+  hypothetical.
+
+inputs:
+  version:
+    description: 'Full LLVM release version, e.g. 23.1.0. Must match scripts/setup-olo-ci-host.sh.'
+    required: true
+  sha256:
+    description: >
+      SHA256 of LLVM-<version>-Linux-X64.tar.xz, lowercase hex. Pinned rather than
+      trusted from the URL: a re-tagged or replaced asset would otherwise change a
+      sanitizer gate's compiler with nothing saying so. LLVM publishes no
+      SHA256SUMS, but it does publish a sigstore bundle whose SLSA in-toto statement
+      carries the artifact digest -- that is where this value comes from, and
+      scripts/setup-olo-ci-host.sh carries the same one.
+    required: true
+  fallback-lld:
+    description: >
+      Absolute path to an ld.lld to use if the tarball's own will not start. The
+      release is built on an Ubuntu with ICU 70 and its ld.lld drags ICU in through
+      a statically linked libxml2; ubuntu-24.04 has ICU 74, whose symbols are
+      suffixed per major, so no soname bridge exists. It surfaces at the FIRST LINK
+      as `clang++: error: unable to execute command`, forty minutes into a build,
+      not at configure -- which is exactly why this action checks it up front.
+    required: false
+    default: '/usr/bin/ld.lld-23'
+
+outputs:
+  prefix:
+    description: 'Absolute prefix the pinned toolchain is installed at.'
+    value: ${{ steps.install.outputs.prefix }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install pinned LLVM ${{ inputs.version }}
+      id: install
+      shell: bash
+      env:
+        OLO_LLVM_VERSION: ${{ inputs.version }}
+        OLO_LLVM_SHA256: ${{ inputs.sha256 }}
+        OLO_FALLBACK_LLD: ${{ inputs.fallback-lld }}
+      run: |
+        set -euo pipefail
+        dirname="LLVM-${OLO_LLVM_VERSION}-Linux-X64"
+        tarball="${dirname}.tar.xz"
+        url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${OLO_LLVM_VERSION}/${tarball}"
+        # The /opt path is the CONTRACT with setup-linux-build and with the box:
+        # both arms resolve the same absolute prefix. /mnt holds the bytes.
+        prefix="/opt/llvm-${OLO_LLVM_VERSION}"
+        store="/mnt/olo-llvm-${OLO_LLVM_VERSION}"
+
+        if [ -x "${prefix}/bin/clang++" ]; then
+          echo "already provisioned: ${prefix}"
+          echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        df -h / /mnt || true
+        work=$(mktemp -d /mnt/.olo-llvm.XXXXXX)
+        trap 'rm -rf "$work"' EXIT
+
+        echo "downloading ${url} (~2 GB) ..."
+        curl -fL --retry 3 --retry-delay 5 -o "${work}/${tarball}" "$url"
+        # The checksum IS the pin. Without it the "pin" is only a URL, and a
+        # replaced asset would swap a sanitizer gate's compiler silently.
+        echo "${OLO_LLVM_SHA256}  ${work}/${tarball}" | sha256sum -c -
+
+        echo "unpacking (~12 GB, a few minutes) ..."
+        tar --no-same-owner -xf "${work}/${tarball}" -C "${work}"
+        rm -f "${work}/${tarball}"
+        test -x "${work}/${dirname}/bin/clang++" \
+          || { echo "::error::${tarball} did not contain ${dirname}/bin/clang++"; exit 1; }
+
+        sudo rm -rf "${store}"
+        sudo mv "${work}/${dirname}" "${store}"
+        sudo ln -sfn "${store}" "${prefix}"
+        echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
+        df -h / /mnt || true
+
+        # ---------------------------------------------------------------- assert
+        #
+        # EVERY WRONG COMPILER IS GREEN UNTIL SOMETHING ASSERTS. That is the whole
+        # lesson of .github/actions/setup-llvm-windows, whose two failed attempts
+        # both installed nothing and said so in a way that read like success. The
+        # checks below are the same three this repository already learned to make:
+        # the compiler is the version asked for, the LINKER beside it runs, and the
+        # sanitizer runtimes exist -- a clang without compiler-rt configures fine
+        # and fails every sanitizer link on "cannot find libclang_rt.asan.a".
+        got=$("${prefix}/bin/clang++" -dumpversion)
+        if [ "${got}" != "${OLO_LLVM_VERSION}" ]; then
+          echo "::error::${prefix}/bin/clang++ reports '${got}', not ${OLO_LLVM_VERSION}"
+          exit 1
+        fi
+
+        if ! "${prefix}/bin/ld.lld" --version >/dev/null 2>&1; then
+          # Not a warning and not a failure: a documented, expected substitution.
+          # clang resolves ld.lld from its OWN bin directory before PATH, so the
+          # replacement has to live there -- putting the fallback on PATH does
+          # nothing. LLD from apt.llvm.org is the same major as this clang, so it
+          # accepts its bitcode; the mismatch that cost the self-hosted box LTO
+          # (LLD 21 against clang 23) does not apply.
+          if [ ! -x "${OLO_FALLBACK_LLD}" ]; then
+            echo "::error::${prefix}/bin/ld.lld does not run (the release links ICU 70; this image has a newer one) and the fallback ${OLO_FALLBACK_LLD} is not installed. Every -fuse-ld=lld link would fail at the first link, ~40 minutes in."
+            exit 1
+          fi
+          echo "the release's ld.lld does not start here; pointing ${prefix}/bin/ld.lld at ${OLO_FALLBACK_LLD}"
+          sudo ln -sfn "${OLO_FALLBACK_LLD}" "${prefix}/bin/ld.lld"
+          "${prefix}/bin/ld.lld" --version
+        fi
+
+        rt=$("${prefix}/bin/clang++" -print-runtime-dir)
+        for san in asan tsan ubsan; do
+          ls "${rt}"/libclang_rt.${san}*.a >/dev/null 2>&1 \
+            || { echo "::error::no libclang_rt.${san}*.a under ${rt}; every sanitizer link would fail"; exit 1; }
+        done
+
+        echo "pinned clang: $("${prefix}/bin/clang++" --version | head -1)"
+        echo "        lld: $("${prefix}/bin/ld.lld" --version)"
+        echo "  compiler-rt: ${rt}"

--- a/.github/actions/setup-llvm-linux/action.yml
+++ b/.github/actions/setup-llvm-linux/action.yml
@@ -56,8 +56,15 @@ inputs:
       suffixed per major, so no soname bridge exists. It surfaces at the FIRST LINK
       as `clang++: error: unable to execute command`, forty minutes into a build,
       not at configure -- which is exactly why this action checks it up front.
+
+      DEFAULTS TO `/usr/bin/ld.lld-<major of `version`>`, derived rather than
+      written down, because the two must not be able to drift: apt's `lld-NN` comes
+      from setup-llvm-apt's own `version` default, and pairing clang 24 with LLD 23
+      because one literal moved and another did not is the exact class of silent
+      mismatch this action exists to remove. Override only to point at an lld that
+      is not from apt.llvm.org.
     required: false
-    default: '/usr/bin/ld.lld-23'
+    default: ''
 
 outputs:
   prefix:
@@ -76,6 +83,9 @@ runs:
         OLO_FALLBACK_LLD: ${{ inputs.fallback-lld }}
       run: |
         set -euo pipefail
+        major="${OLO_LLVM_VERSION%%.*}"
+        # Derived, not written down -- see the input's description.
+        fallback_lld="${OLO_FALLBACK_LLD:-/usr/bin/ld.lld-${major}}"
         dirname="LLVM-${OLO_LLVM_VERSION}-Linux-X64"
         tarball="${dirname}.tar.xz"
         url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${OLO_LLVM_VERSION}/${tarball}"
@@ -91,7 +101,14 @@ runs:
         fi
 
         df -h / /mnt || true
-        work=$(mktemp -d /mnt/.olo-llvm.XXXXXX)
+        # /mnt IS ROOT-OWNED on this image, so the staging directory has to be made
+        # with sudo and handed over -- an unprivileged `mktemp -d /mnt/...` fails, and
+        # under `set -e` that takes out every hosted Linux job in the fleet at once.
+        # Staging under /mnt rather than $RUNNER_TEMP is what makes the final move a
+        # rename on one filesystem instead of a 12 GB copy that can half-finish.
+        sudo mkdir -p /mnt/olo-work
+        sudo chown "$(id -u):$(id -g)" /mnt/olo-work
+        work=$(mktemp -d /mnt/olo-work/llvm.XXXXXX)
         trap 'rm -rf "$work"' EXIT
 
         echo "downloading ${url} (~2 GB) ..."
@@ -134,12 +151,12 @@ runs:
           # nothing. LLD from apt.llvm.org is the same major as this clang, so it
           # accepts its bitcode; the mismatch that cost the self-hosted box LTO
           # (LLD 21 against clang 23) does not apply.
-          if [ ! -x "${OLO_FALLBACK_LLD}" ]; then
-            echo "::error::${prefix}/bin/ld.lld does not run (the release links ICU 70; this image has a newer one) and the fallback ${OLO_FALLBACK_LLD} is not installed. Every -fuse-ld=lld link would fail at the first link, ~40 minutes in."
+          if [ ! -x "${fallback_lld}" ]; then
+            echo "::error::${prefix}/bin/ld.lld does not run (the release links ICU 70; this image has a newer one) and the fallback ${fallback_lld} is not installed. Every -fuse-ld=lld link would fail at the first link, ~40 minutes in. setup-llvm-apt installs lld-${major}; if its version default no longer matches ${OLO_LLVM_VERSION}, that is the mismatch to fix."
             exit 1
           fi
-          echo "the release's ld.lld does not start here; pointing ${prefix}/bin/ld.lld at ${OLO_FALLBACK_LLD}"
-          sudo ln -sfn "${OLO_FALLBACK_LLD}" "${prefix}/bin/ld.lld"
+          echo "the release's ld.lld does not start here; pointing ${prefix}/bin/ld.lld at ${fallback_lld}"
+          sudo ln -sfn "${fallback_lld}" "${prefix}/bin/ld.lld"
           "${prefix}/bin/ld.lld" --version
         fi
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -66,6 +66,13 @@ concurrency:
 
 env:
   BUILD_TYPE: Release
+  # ONE DEFINITION OF WHAT THE SHARDED RUN EXCLUDES (#1083). Read in three places --
+  # the `ctest -N` total in the build job, each shard's `ctest -N` count, and each
+  # shard's actual run -- and the coverage proof compares the first against the sum of
+  # the second. A shard filtering differently from the total would present as an
+  # arithmetic failure with no obvious cause, so the regex is not allowed to exist in
+  # three copies. Why NetworkIntegrationTest is excluded: see the run step.
+  OLO_WINDOWS_CTEST_EXCLUDE: '^NetworkIntegrationTest\.'
   # sccache uses a LOCAL-DISK cache (SCCACHE_DIR), persisted across runs as a
   # SINGLE actions/cache entry (see the "Restore/Save sccache storage" steps below).
   # We deliberately do NOT use sccache's GitHub Actions cache backend
@@ -121,6 +128,14 @@ jobs:
     # makes an image bump a deliberate, reviewable commit that we can pair with the
     # cache-key bump below.
     runs-on: windows-2025
+
+    # The unsharded case count, measured after the build and consumed by
+    # `tests-verify` (#1083). A JOB OUTPUT rather than a file inside the test-tree
+    # artifact, so the coverage proof reads it from the job that measured it and not
+    # from the same artifact the shards were fed -- a number that travels with the
+    # thing it is meant to check is not a check.
+    outputs:
+      ctest-total: ${{ steps.ctest-total.outputs.total }}
 
     # `actions: write` is needed by the sccache save (#1073): when the repo's 10 GB
     # cache store is full every save is refused, and the only way to land this job's
@@ -404,6 +419,231 @@ jobs:
         if ($failed) { exit 1 }
         Write-Host 'All shipped binaries passed the launch smoke test.'
 
+    # ---------------------------------------------------------------- #1083
+    #
+    # THE TEST RUN LEFT THIS JOB. It used to be a `Run tests with CTest` step here
+    # that took 28.1 MINUTES of a 236-minute job (measured, #1084's table). It is now
+    # the `tests` matrix below: this job builds and hands the test tree over, and N
+    # separate runners each execute a stride of it.
+    #
+    # WHY THIS JOB TOO, when the ASan job's test step is three times bigger. #1084's
+    # governing fact: the PR is `max()` of these two Windows jobs and they were within
+    # 12 seconds of each other, so ANY PLAN THAT DOES NOT MOVE BOTH MOVES THE PR BY
+    # ZERO. Sharding only the ASan side would make that job finish earlier and leave
+    # the PR waiting exactly as long on this one.
+    #
+    # WHY SHARDING RATHER THAN BATCHING: see the same note in asan.yml. Batching cases
+    # per process is the larger win and removes the isolation that hides cross-test
+    # state corruption; that is #1074's, not this.
+    #
+    # WHAT IT COSTS. Each shard is a whole runner and pays job startup, a checkout and
+    # an artifact download before it runs a case. This TRADES RUNNER-MINUTES FOR
+    # WALL-CLOCK; the exchange rate is stated on the PR.
+    # ---------------------------------------------------------------------------
+
+    # THE NUMBER THE SHARDS HAVE TO ADD UP TO -- measured here, with the same
+    # --exclude-regex the shards use, so the coverage proof compares like with like.
+    # `ctest -N` only LISTS: discovery already happened at build time
+    # (gtest_discover_tests' POST_BUILD mode writes the entries into the generated
+    # *_tests.cmake), so this launches no test process and costs seconds.
+    - name: Measure the unsharded case count
+      id: ctest-total
+      shell: bash
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N -C "${BUILD_TYPE}" --exclude-regex "${OLO_WINDOWS_CTEST_EXCLUDE}")
+        total=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # A ctest that lists nothing is the same failure archetype the shards guard
+        # against, one level up: it would leave each shard's "count > 0" check as the
+        # only thing between a broken discovery and a green matrix.
+        if [ -z "${total}" ] || [ "${total}" -le 0 ] 2>/dev/null; then
+          echo "::error::ctest -N reported no tests. Discovery did not produce a test list, so nothing below can be trusted."
+          printf '%s\n' "$listing" | tail -20
+          exit 1
+        fi
+        echo "unsharded ctest entries: ${total}"
+        echo "total=${total}" >> "$GITHUB_OUTPUT"
+
+    # WHAT A SHARD NEEDS, AND WHAT IT DOES NOT.
+    #
+    # Needs: the generated ctest lists, the exe, and the DLLs CMake staged beside it
+    # (FFmpeg's av*/sw*, steam_api64) -- OloEngine links those as static PE imports,
+    # so the suite does not start without them.
+    #
+    # Does NOT need `bin/<config>/`: AppLaunchSmoke's three cases take their target
+    # paths from OLO_TEST_OLO{SERVER,EDITOR,RUNTIME}_EXE, which nothing in the build
+    # defines, so they already GTEST_SKIP on every runner -- the explicit
+    # `Smoke-test app launches` step above is what actually covers that ground, and it
+    # stays in this job where the shipped binaries are. Shipping ~1 GB of editor,
+    # runtime and server to every shard to make three cases skip somewhere else would
+    # be paying the whole cost of this change for nothing.
+    #
+    # Records the workspace path because gtest_discover_tests bakes ABSOLUTE paths
+    # into the generated *_tests.cmake (the exe, and the WORKING_DIRECTORY that makes
+    # repo-relative shaders and assets resolvable). Both runners are `windows-2025`
+    # checking out the same repository, so it matches in practice -- and "in practice"
+    # is exactly the assumption that turns into a silent 100 %-skip later, so the
+    # shard asserts it rather than trusting it.
+    - name: Record the build workspace for the shards
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $wsFile = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/olo-build-workspace.txt'
+        Set-Content -Path $wsFile -Value '${{github.workspace}}' -NoNewline
+        Get-ChildItem (Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}') |
+          ForEach-Object { '{0,12:N0}  {1}' -f $_.Length, $_.Name }
+
+    # ONLY WHAT CTEST READS. The PDB is deliberately absent -- OloEngine-Tests.pdb is
+    # the largest single file in the tree (the local Debug build measures ~1.9 GB) and
+    # ctest never opens it. The cost is that a crashing test's stack in a shard log is
+    # unsymbolised where the unsharded step's was symbolised; that is the one real
+    # regression here and it is named on the PR. `*.lib` and `CMakeFiles/` go for the
+    # same reason.
+    #
+    # compression-level 1: this transfer happens once up and once per shard down, so
+    # it sits directly on the wall-clock this issue is about. Level 1 on an
+    # already-packed PE gives up little and is several times faster than the default.
+    #
+    # retention-days 1: scratch, not a deliverable.
+    - name: Upload the test tree
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: windows-test-tree
+        path: |
+          build/OloEngine/tests/*.cmake
+          build/OloEngine/tests/olo-build-workspace.txt
+          build/OloEngine/tests/${{env.BUILD_TYPE}}/*.exe
+          build/OloEngine/tests/${{env.BUILD_TYPE}}/*.dll
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 1
+
+    # Issue #908: bake a CI-portable SPIR-V shader pack and publish it as a
+    # build artifact for anyone who wants it (a packaged game's build step
+    # pulls it in explicitly — see docs/agent-rules/shader-pack-bake.md — a
+    # fresh worktree does NOT fetch it automatically). This runs the test
+    # binary's own `--olo-bake-shader-pack` mode rather than a full editor
+    # launch: no GL context is created anywhere in that path (verified — see
+    # ShaderPackBakeTest.cpp), so it needs nothing this hosted, GPU-less
+    # runner doesn't already have. `--gtest_filter` isolates the one test
+    # this flag drives so the rest of the suite (already run above) doesn't
+    # execute a second time.
+    - name: Bake shader pack (issue #908)
+      shell: pwsh
+      working-directory: ${{github.workspace}}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $testExe = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}/OloEngine-Tests.exe'
+        & $testExe --gtest_filter=ShaderPackBakeTest.* --olo-bake-shader-pack="OloEditor/assets/ShaderPack.osp"
+        if ($LASTEXITCODE -ne 0) { throw "Shader pack bake failed (exit $LASTEXITCODE)" }
+
+    - name: Upload shader pack artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ShaderPack
+        path: ${{github.workspace}}/OloEditor/assets/ShaderPack.osp
+        if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # #1083: the CTest run, spread across runners.
+  #
+  # The stride count lives in TWO places that must agree -- `matrix.shard` and the
+  # `-I` stride -- because GitHub offers no way to derive one from the other in an
+  # expression. That hazard is not defended by a comment: every shard reports the
+  # count it believed it was part of, and `tests-verify` fails if they disagree or if
+  # 1..N is not exactly covered. Edit one without the other and the matrix goes red.
+  #
+  # WHY 3. The unsharded step measured 28.1 min, so the per-shard fixed cost (job
+  # startup + checkout + artifact download, a few minutes) is a much larger share here
+  # than on the ASan side, and a fourth shard would buy little for a whole extra
+  # runner. The right number is re-measurable from the shard durations in any run; it
+  # was NOT tuned by a sweep, because a sweep costs a full CI round each.
+  # ---------------------------------------------------------------------------
+  tests:
+    name: Windows tests ${{ matrix.shard }}/3
+    needs: build
+    runs-on: windows-2025
+    permissions:
+      contents: read
+    env:
+      # ONE stride, read by the `ctest -N` count AND by the run below. Keeping them
+      # in separate literals is how a shard comes to COUNT one partition and RUN
+      # another -- the counts would still add up and a third of the suite would never
+      # execute. The matrix list is the other half of the pair; `tests-verify`
+      # catches a drift between the two.
+      OLO_CTEST_SHARDS: 3
+    strategy:
+      # A red shard must not cancel its siblings -- three shards are three independent
+      # samples of the same suite, and cancelling two of them to react to the first
+      # failure is how a run comes back knowing about one bug instead of three.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+    # Not optional, and not for the build: every test's WORKING_DIRECTORY is
+    # <workspace>/OloEditor, and the suite loads shaders, scenes and models from the
+    # source tree by repo-relative path.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the test tree
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: windows-test-tree
+        path: build/OloEngine/tests
+
+    # THE ASSERTION THE BAKED ABSOLUTE PATHS DESERVE. A workspace mismatch would make
+    # every add_test() name an exe that is not there; ctest would fail loudly, but it
+    # would fail thousands of times, and a future runner-image or path change would
+    # land as "the Windows tests are all broken" rather than as this one line.
+    - name: Assert this runner matches the build job's layout
+      shell: bash
+      run: |
+        set -euo pipefail
+        built_at=$(cat build/OloEngine/tests/olo-build-workspace.txt)
+        here="${GITHUB_WORKSPACE}"
+        # Both separators normalised: GITHUB_WORKSPACE reaches bash as a Windows path
+        # here, and the recorded value was written by pwsh.
+        if [ "${built_at//\\//}" != "${here//\\//}" ]; then
+          echo "::error::This tree was built at '${built_at}' but this runner checked out at '${here}'. gtest_discover_tests bakes absolute paths into the generated test list, so the tree cannot be moved. Run the shards on the same runner image and path as the build job, or re-run discovery here."
+          exit 1
+        fi
+        exe="build/OloEngine/tests/${BUILD_TYPE}/OloEngine-Tests.exe"
+        test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
+        echo "workspace matches: ${here}"
+
+    # GUARD 1 OF 2: A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by
+    # index, so a stride that does not line up with the list silently produces an
+    # empty run -- which passes in about a second and is indistinguishable in the
+    # check list from a shard that ran 2,300 cases. The count is also written out for
+    # guard 2, the union check in `tests-verify`.
+    - name: Select this shard's cases
+      id: select
+      shell: bash
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      env:
+        OLO_CTEST_SHARD: ${{ matrix.shard }}
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N -C "${BUILD_TYPE}" \
+                    -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
+                    --exclude-regex "${OLO_WINDOWS_CTEST_EXCLUDE}")
+        count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        if [ -z "${count}" ] || [ "${count}" -le 0 ] 2>/dev/null; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} matched ZERO ctest entries."
+          printf '%s\n' "$listing" | tail -20
+          exit 1
+        fi
+        echo "shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS}: ${count} ctest entries"
+        mkdir -p "${GITHUB_WORKSPACE}/shard_counts"
+        {
+          echo "shard=${OLO_CTEST_SHARD}"
+          echo "shards=${OLO_CTEST_SHARDS}"
+          echo "count=${count}"
+        } > "${GITHUB_WORKSPACE}/shard_counts/shard-${OLO_CTEST_SHARD}.txt"
+
     - name: Run tests with CTest
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # Execute tests defined by the CMake configuration.
@@ -414,7 +654,9 @@ jobs:
       # on a multi-config generator (here Ninja Multi-Config) — without it CTest
       # can't locate the per-config test binaries.
       #
-      # --exclude-regex skips only one case:
+      # The exclusion lives in OLO_WINDOWS_CTEST_EXCLUDE at the top of this file, in
+      # ONE copy, read by this step and by the `ctest -N` total the coverage proof
+      # compares against. It skips exactly one case:
       #   NetworkIntegrationTest        — drives a live Steam (GameNetworkingSockets)
       #     client/server socket; excluded on every sanitizer job too.
       #
@@ -432,10 +674,11 @@ jobs:
       # seconds — especially in a repo whose dominant failure archetype is exactly
       # that.
       #
-      # The real lever, if this step is ever worth attacking: it is ~6,900 PROCESS
-      # LAUNCHES, one per test, each paying full engine static-init
-      # (gtest_discover_tests). Cutting the test COUNT by a few percent cannot
-      # move that; batching tests per process would. Out of scope for #1009.
+      # THE REAL LEVER, named in that same note, was that this is ~6,900 PROCESS
+      # LAUNCHES each paying full engine static-init, and that cutting the test COUNT
+      # by a few percent cannot move it. #1083 takes the other half of it: keep every
+      # launch, run them on more runners. `-I <shard>,,3` is that split, and it
+      # changes one-process-per-case semantics not at all.
       #
       # CancellationTokenTest.MultipleTasks was previously also excluded (issue
       # #359): it intermittently DEADLOCKED under `--parallel` oversubscription —
@@ -461,11 +704,10 @@ jobs:
       # single genuine fault. See the "Parallel-safety contract" in
       # docs/agent-rules/testing-architecture.md §6.3.
       #
-      # --parallel 4 runs up to 4 test processes at once (windows-2025 has 4
-      # vCPUs). Every test is its own ctest entry (gtest_discover_tests → one
-      # OloEngine-Tests.exe per test), so serial execution pays full engine
-      # static-init ~3,200x back-to-back; a 4-wide run is a large per-PR
-      # wall-clock win.
+      # --parallel 6 runs up to 6 test processes at once on a 4-vCPU windows-2025
+      # runner. Every test is its own ctest entry (gtest_discover_tests → one
+      # OloEngine-Tests.exe per test), so serial execution would pay full engine
+      # static-init thousands of times back-to-back.
       #
       # The suite is parallel-safe, and the property is ENFORCED rather than
       # asserted (issue #789 — this comment previously claimed "tests key their
@@ -477,9 +719,13 @@ jobs:
       # direct temp_directory_path() call in the test tree. The one resource that
       # is not test-controlled and cannot be process-keyed — the engine's
       # repo-relative mesh cache — is serialized with a ctest RESOURCE_LOCK
-      # (OloEngine/tests/CMakeLists.txt). Functional/Jolt tests oversubscribe cores
-      # under -j but run stable (verified to 16x locally). See the "Parallel-safety
-      # contract" in docs/agent-rules/testing-architecture.md and
+      # (OloEngine/tests/CMakeLists.txt). SHARDING DOES NOT WEAKEN THAT LOCK and in
+      # one respect strengthens it: each shard is a separate runner with its own
+      # checkout, so two shards cannot contend over one mesh cache at all, and within
+      # a shard ctest serializes the locked cases exactly as before.
+      # Functional/Jolt tests oversubscribe cores under -j but run stable (verified
+      # to 16x locally). See the "Parallel-safety contract" in
+      # docs/agent-rules/testing-architecture.md and
       # docs/agent-rules/shared-temp-dir-test-isolation.md.
       #
       # --output-on-failure replaces -V: full verbosity interleaves illegibly
@@ -521,37 +767,71 @@ jobs:
       # The warm-up the palindrome caught is why the order matters: width 4 ran
       # 81 s early and 76 s late, a 6.2 % drift. An ascending 4,6,8 sweep would
       # have handed that drift to width 8 and overstated it.
-      run: ctest --parallel 6 --output-on-failure --timeout 120 -C "${BUILD_TYPE}" --exclude-regex '^NetworkIntegrationTest\.'
+      #
+      # THE WIDTH AND THE SHARD COUNT ARE INDEPENDENT KNOBS and measure different
+      # things: the width sweep above says this workload stops scaling on ONE 4-vCPU
+      # runner, which is precisely why the remaining lever is more runners.
+      run: >
+        ctest --parallel 6 --output-on-failure --timeout 120 -C "${BUILD_TYPE}"
+        -I ${{ matrix.shard }},,${OLO_CTEST_SHARDS}
+        --exclude-regex "${OLO_WINDOWS_CTEST_EXCLUDE}"
 
+    # `if: always()` on both uploads: a shard that FAILED is the one whose results
+    # matter most, and its count is what proves the failure was not an empty run.
     - name: Upload test results
+      if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: googletest_results_xml
+        name: googletest_results_xml_shard_${{ matrix.shard }}
         path: ${{runner.workspace}}/OloEngineBase/test_results/*.xml
         if-no-files-found: 'warn'
 
-    # Issue #908: bake a CI-portable SPIR-V shader pack and publish it as a
-    # build artifact for anyone who wants it (a packaged game's build step
-    # pulls it in explicitly — see docs/agent-rules/shader-pack-bake.md — a
-    # fresh worktree does NOT fetch it automatically). This runs the test
-    # binary's own `--olo-bake-shader-pack` mode rather than a full editor
-    # launch: no GL context is created anywhere in that path (verified — see
-    # ShaderPackBakeTest.cpp), so it needs nothing this hosted, GPU-less
-    # runner doesn't already have. `--gtest_filter` isolates the one test
-    # this flag drives so the rest of the suite (already run above) doesn't
-    # execute a second time.
-    - name: Bake shader pack (issue #908)
-      shell: pwsh
-      working-directory: ${{github.workspace}}
-      run: |
-        $ErrorActionPreference = 'Stop'
-        $testExe = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}/OloEngine-Tests.exe'
-        & $testExe --gtest_filter=ShaderPackBakeTest.* --olo-bake-shader-pack="OloEditor/assets/ShaderPack.osp"
-        if ($LASTEXITCODE -ne 0) { throw "Shader pack bake failed (exit $LASTEXITCODE)" }
-
-    - name: Upload shader pack artifact
+    - name: Upload this shard's case count
+      if: always() && steps.select.outcome == 'success'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ShaderPack
-        path: ${{github.workspace}}/OloEditor/assets/ShaderPack.osp
+        name: windows-shard-count-${{ matrix.shard }}
+        path: ${{github.workspace}}/shard_counts/shard-${{ matrix.shard }}.txt
         if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # #1083 GUARD 2 OF 2.
+  #
+  # `ctest -I <shard>,,3` partitions the list by construction -- on paper. This job
+  # checks that the run which actually happened WAS that partition: every shard
+  # reported, all agreeing on the stride, none empty, and the counts summing to the
+  # unsharded `ctest -N` total the build job measured. Without it, sharding introduces
+  # a way for the suite to shrink silently, which is the failure this repository has
+  # the most history with.
+  #
+  # `if: always()` so a RED shard is still coverage-checked. It cannot launder a
+  # failure: the shard job itself stays red.
+  # ---------------------------------------------------------------------------
+  tests-verify:
+    name: Windows test shard coverage
+    needs: [build, tests]
+    if: always() && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the shard case counts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: windows-shard-count-*
+        path: shard_counts
+      # A shard that died before writing its count uploads nothing, and this step
+      # would then fail on "no artifacts found" -- a worse message than the script's.
+      # Let it through and let the union check name the missing shard.
+      continue-on-error: true
+
+    - name: Prove the shards covered the whole suite
+      run: >
+        python3 scripts/verify_test_shards.py
+        --dir shard_counts
+        --label "Windows / build"
+        --expected-total ${{ needs.build.outputs.ctest-total }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -726,6 +726,16 @@ jobs:
         test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
         echo "workspace matches: ${here}"
 
+        # AND PROVE IT STARTS. OloEngine carries static PE imports on the FFmpeg and
+        # Steam DLLs staged beside the exe, so one missing from the artifact fails in
+        # the OS loader before main() -- arriving as ~2,300 identical ctest failures
+        # with no message worth reading. One launch, seconds, and it names itself.
+        if ! "$exe" --gtest_list_tests > /dev/null; then
+          echo "::error::$exe does not start on this runner. Either the artifact is missing something it needs at load time (a runtime DLL), or the tree does not match this runner."
+          exit 1
+        fi
+        echo "the test binary starts here"
+
     # GUARD 1 OF 2: A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by
     # index, so a stride that does not line up with the list silently produces an
     # empty run -- which passes in about a second and is indistinguishable in the

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -591,6 +591,15 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $wsFile = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/olo-build-workspace.txt'
         Set-Content -Path $wsFile -Value '${{github.workspace}}' -NoNewline
+        # NOT every DLL the exe needs is already beside it. CMake stages FFmpeg and
+        # steam_api64 there, but `shaderc_shared.dll` is a static PE import resolved
+        # from the Vulkan SDK's bin directory on PATH -- which a shard job does not
+        # have. The list is read out of the binary rather than written down here,
+        # because a written list would have missed exactly that one.
+        $outDir = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}'
+        & "${{github.workspace}}/scripts/Copy-ImportedDlls.ps1" `
+            -Exe (Join-Path $outDir 'OloEngine-Tests.exe') -Destination $outDir
+        if ($LASTEXITCODE -ne 0) { throw "could not stage the exe's imported DLLs" }
         Get-ChildItem (Join-Path '${{github.workspace}}' 'build/OloEngine/tests/${{env.BUILD_TYPE}}') |
           ForEach-Object { '{0,12:N0}  {1}' -f $_.Length, $_.Name }
 
@@ -957,3 +966,15 @@ jobs:
         --dir shard_counts
         --label "Windows / build"
         --expected-total ${{ needs.build.outputs.ctest-total }}
+
+    # THE COUNTS ARE RECORDED BEFORE THE RUN, so the check above proves the shards'
+    # SELECTIONS partition the suite -- not that every selected case executed. A shard
+    # whose ctest died a third of the way through still uploaded a full count. The
+    # shard job is red in that case and so is the run, but this check must not read
+    # green beside it, because "shard coverage" going green is precisely the sentence
+    # someone will trust later.
+    - name: Fail if any shard did not complete
+      if: needs.tests.result != 'success'
+      run: |
+        echo "::error::A test shard did not complete (matrix result: ${{ needs.tests.result }}). The counts prove the selection partitioned the suite; they cannot prove every selected case ran."
+        exit 1

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -127,7 +127,47 @@ jobs:
     # requests / 0 hits against a snapshot taken six days earlier. A pinned image
     # makes an image bump a deliberate, reviewable commit that we can pair with the
     # cache-key bump below.
-    runs-on: windows-2025
+    # SELF-HOSTED WHEN THE CODE IS OURS AND THE SWITCH IS ON, hosted windows-2025
+    # otherwise -- the same expression shape asan.yml's Linux jobs have used since
+    # #1009, and the security reasoning is theirs verbatim: the fork boundary is
+    # `head.repo.full_name`, never a `pull_request_target` that checks out the PR
+    # head, and `vars.OLO_WINDOWS_SELF_HOSTED` is the kill switch that comes FIRST so
+    # it can only ever move a job OFF the box.
+    #
+    # WHY (#1076). These two Windows jobs are the per-PR critical path on every PR --
+    # the Linux sanitizers finish 86 minutes earlier -- and almost everything that has
+    # gone wrong with their caches is a property of the Actions cache STORE rather
+    # than of caching: a 10 GB cap that turns the whole store read-only when exceeded
+    # and reports the refusal as a warning with exit 0 (#1073); entries scoped to
+    # refs/pull/N/merge that six concurrent PRs cannot fit inside; a post-job save
+    # that a cancelled run skips, which is 60 %+ of PR runs here. A persistent runner
+    # has none of those, because its disk IS the cache. It also takes the two largest
+    # Windows entries out of a store that the four-entry steady set already fills to
+    # ~6.1 GiB of a ~9.3 GiB wall.
+    #
+    # DEFAULT OFF, AND HONESTLY SO. `vars.OLO_WINDOWS_SELF_HOSTED` is unset, and no
+    # Windows runner is registered on this repository -- `gh api .../actions/runners`
+    # lists three Linux ones. Everything below is the routing, the gating and the
+    # guard; NONE of it has run on a self-hosted Windows runner, and the measurements
+    # #1076 asks for cannot exist until one is provisioned. See
+    # docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md for what
+    # provisioning it involves and what it costs.
+    #
+    # `olo-ci-win`, not `olo-ci`: runner GROUPS are unavailable on a user account, so
+    # isolation from the Linux runners is by LABEL only. A Windows engine build peaks
+    # high enough that it must not land on a box already running Linux sanitizer jobs
+    # by accident, and a distinct label is the only thing that prevents it.
+    #
+    # THE NIGHTLY STAYS HOSTED, deliberately, and for the same reason the Linux
+    # sanitizers keep theirs there: it is this workflow's ONLY fleet-wide cache
+    # warmer. actions/cache entries created on a PR branch are scoped to that ref;
+    # only default-branch entries are readable by every branch. Route the cron to the
+    # box and the hosted fallback -- every fork PR, and every run with the switch off
+    # -- goes permanently cold.
+    runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
+                 && github.event_name != 'schedule'
+                 && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+                 && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
 
     # The unsharded case count, measured after the build and consumed by
     # `tests-verify` (#1083). A JOB OUTPUT rather than a file inside the test-tree
@@ -187,6 +227,10 @@ jobs:
     # (scripts/build-ffmpeg.sh). That needs nasm + a bash + Visual Studio; windows-2025
     # has Git-bash + Strawberry Perl (gmake), and we provision nasm here.
     - name: Install nasm
+      # Hosted only (#1076). `choco install` needs an elevated shell and mutates the
+      # machine; on a persistent runner nasm is provisioned once and the preflight
+      # above fails the job loudly if it is not.
+      if: runner.environment == 'github-hosted'
       run: choco install nasm -y --no-progress
 
     # Cache the built FFmpeg so only the first (or post-bump) run pays the ~10-15 min build.
@@ -207,6 +251,57 @@ jobs:
     # read: ... services aren't available") and, because sccache is the compiler
     # launcher, every compile fails. v0.10.0+ speaks the new cache service (ghac
     # v2, via opendal 0.52); we pin the current stable release for reproducibility.
+    # SCCACHE_DIR IS INSIDE THE WORKSPACE, AND actions/checkout WIPES THE WORKSPACE.
+    # On a hosted runner that costs nothing -- the VM dies anyway and actions/cache is
+    # what carries the directory across runs. On a persistent runner it would throw
+    # the cache away on every checkout while looking exactly like a working one, which
+    # is the whole subject of docs/agent-rules/ci-cache-that-looks-alive.md. So point
+    # it at the runner user's home instead, the same shape setup-linux-build uses for
+    # ccache on the Linux box.
+    #
+    # THE CONSTRAINT THIS CARRIES INTO PROVISIONING: sccache is a per-USER DAEMON. The
+    # first client to start it fixes the server's environment, and every later client
+    # on that account is served by it whatever SCCACHE_DIR that client set. Two runner
+    # instances sharing one Windows account would therefore silently share one
+    # directory -- tolerable, since the key space is disjoint by command line, but not
+    # something to discover. The Linux box avoids it by using ccache, which has no
+    # daemon; there is no equivalent drop-in for clang-cl here. One compiling runner
+    # instance per account. See the ADR.
+    - name: Point sccache at persistent disk (self-hosted)
+      if: runner.environment != 'github-hosted'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $dir = Join-Path $env:USERPROFILE '.cache\olo\sccache'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        "SCCACHE_DIR=$dir" >> $env:GITHUB_ENV
+        Write-Host "persistent sccache: $dir"
+
+    # VERIFY, NEVER INSTALL -- the convention .github/actions/setup-linux-build states
+    # for the Linux box, applied here for the same reason: a self-hosted runner is
+    # provisioned system-wide, ahead of time, and a step that installs mutates a
+    # machine nobody meant to touch. This one only reports, and it reports EARLY: each
+    # of these missing surfaces otherwise as a confusing failure tens of minutes into
+    # a configure or a link.
+    - name: Preflight -- toolchain (self-hosted)
+      if: runner.environment != 'github-hosted'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Continue'
+        $missing = @()
+        foreach ($tool in @('cmake', 'ninja', 'nasm', 'python', 'cl')) {
+          $found = (Get-Command $tool -ErrorAction SilentlyContinue)
+          if ($found) { Write-Host ('  {0,-8} {1}' -f $tool, $found.Source) }
+          else { Write-Host "::error::$tool is not on PATH"; $missing += $tool }
+        }
+        if (-not $env:VULKAN_SDK) { Write-Host '::error::VULKAN_SDK is not set'; $missing += 'VULKAN_SDK' }
+        python -c 'import jinja2' 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Host '::error::python module jinja2 is not importable'; $missing += 'jinja2' }
+        if ($missing.Count -gt 0) {
+          Write-Host '::error::Provision the runner -- see docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md'
+          exit 1
+        }
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       with:
@@ -228,6 +323,11 @@ jobs:
     # image; when it is bumped, bump this string with it so the dead entries age
     # out instead of being restored forever.
     - name: Restore sccache storage
+      # HOSTED ONLY (#1076). On a persistent runner the sccache directory below is on
+      # local disk and simply stays there between runs: no upload, no download, no
+      # slice of the shared cap, and -- the part that matters most here -- no post-job
+      # save for a cancellation to skip.
+      if: runner.environment == 'github-hosted'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -337,7 +437,7 @@ jobs:
     # behind. The save is kept on workflow_dispatch so a warm/cold A/B can be measured
     # on a branch (that is how the fix for #1073 was verified).
     - name: Save sccache storage
-      if: always() && github.event_name != 'pull_request'
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
       uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -563,7 +663,19 @@ jobs:
   tests:
     name: Windows tests ${{ matrix.shard }}/3
     needs: build
-    runs-on: windows-2025
+    # THE SHARDS FOLLOW THE BUILD JOB, and they have to: gtest_discover_tests bakes
+    # the absolute exe and WORKING_DIRECTORY paths into the generated test list, and
+    # a self-hosted runner's `_work` tree is not at the hosted runner's path. The
+    # `Assert this runner matches the build job's layout` step below turns a mismatch
+    # into one line rather than thousands, but the routing is what prevents it.
+    #
+    # PROVISIONING NOTE, and it is the one that decides whether #1076 and #1083 can
+    # coexist: three shards want three runner SLOTS. On a box with one, they queue and
+    # the sharding win is handed straight back. See the ADR.
+    runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
+                 && github.event_name != 'schedule'
+                 && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+                 && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
     permissions:
       contents: read
     env:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -557,8 +557,19 @@ jobs:
         # A ctest that lists nothing is the same failure archetype the shards guard
         # against, one level up: it would leave each shard's "count > 0" check as the
         # only thing between a broken discovery and a green matrix.
-        if [ -z "${total}" ] || [ "${total}" -le 0 ] 2>/dev/null; then
-          echo "::error::ctest -N reported no tests. Discovery did not produce a test list, so nothing below can be trusted."
+        #
+        # DIGITS-ONLY BEFORE THE NUMERIC COMPARISON, and the order is the whole point:
+        # `[ "$x" -le 0 ]` on a non-numeric $x ERRORS rather than returning false, and
+        # a command that errors inside an `if` condition is exempt from `set -e` -- so
+        # anything that is not a number fell straight through this guard and got
+        # published as the total. A guard that exists for the case where discovery
+        # printed something unexpected must not be the thing that trusts its output.
+        case "${total}" in
+          ''|*[!0-9]*) valid=no ;;
+          *) if [ "${total}" -gt 0 ]; then valid=yes; else valid=no; fi ;;
+        esac
+        if [ "${valid}" != yes ]; then
+          echo "::error::ctest -N did not report a positive test count (got '${total}'). Discovery did not produce a usable test list, so nothing below can be trusted."
           printf '%s\n' "$listing" | tail -20
           exit 1
         fi
@@ -762,8 +773,16 @@ jobs:
                     -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
                     --exclude-regex "${OLO_WINDOWS_CTEST_EXCLUDE}")
         count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
-        if [ -z "${count}" ] || [ "${count}" -le 0 ] 2>/dev/null; then
-          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} matched ZERO ctest entries."
+        # Digits-only before the numeric comparison -- see the same guard on the build
+        # job's total. `[ "$x" -le 0 ]` errors on a non-number and an erroring `if`
+        # condition is exempt from `set -e`, so garbage would pass this check and then
+        # be written into the shard count the coverage proof adds up.
+        case "${count}" in
+          ''|*[!0-9]*) valid=no ;;
+          *) if [ "${count}" -gt 0 ]; then valid=yes; else valid=no; fi ;;
+        esac
+        if [ "${valid}" != yes ]; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} did not match a positive number of ctest entries (got '${count}')."
           printf '%s\n' "$listing" | tail -20
           exit 1
         fi
@@ -941,7 +960,12 @@ jobs:
   tests-verify:
     name: Windows test shard coverage
     needs: [build, tests]
-    if: always() && needs.build.result == 'success'
+    # `!cancelled()` rather than `always()`: a cancelled run (cancel-in-progress on
+    # the next push) can leave `build` already 'success' while the shards were
+    # killed mid-flight, and `always()` would then run this job and post a red
+    # "a shard did not complete" on a run nobody abandoned for a reason worth
+    # reading. Braced because a bare leading `!` is a YAML tag indicator.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -119,6 +119,14 @@ env:
   # slow link, and every job here links sanitizer-instrumented binaries.
   SCCACHE_IDLE_TIMEOUT: "0"
 
+  # ONE DEFINITION OF WHAT THE WINDOWS ASan RUN EXCLUDES (#1083). It is read in three
+  # places -- the `ctest -N` total in the build job, each shard's `ctest -N` count,
+  # and each shard's actual run -- and the coverage proof compares the first against
+  # the sum of the second. A shard filtering differently from the total would present
+  # as an arithmetic failure with no obvious cause, so the regex cannot be allowed to
+  # exist in three copies. The reasoning for each exclusion is on the run step.
+  OLO_ASAN_WINDOWS_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
+
 permissions:
   contents: read
   # dorny/paths-filter@v4 falls back to the GitHub REST API for PR-base
@@ -167,16 +175,33 @@ jobs:
             - '.github/sanitizer-suppressions/**'
 
   asan-windows:
-    name: ASan (Windows/clang-cl)
+    # " build" since #1083: this job no longer runs the suite, it builds the tree the
+    # `ASan (Windows) tests N/4` jobs execute. The name says so, because a check named
+    # for a sanitizer run that only compiles is exactly the kind of green nobody reads
+    # twice.
+    name: ASan (Windows/clang-cl) build
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
     runs-on: windows-2025
+
+    # The unsharded case count, measured after the build and consumed by
+    # `asan-windows-tests-verify` (#1083). It is a JOB OUTPUT rather than a file in
+    # the test-tree artifact so that the coverage proof reads it from the job that
+    # measured it, not from the same artifact the shards were fed -- a number that
+    # travels with the thing it is meant to check is not a check.
+    outputs:
+      ctest-total: ${{ steps.ctest-total.outputs.total }}
+
     permissions:
-      # Job-level permissions replace the workflow-level block entirely,
-      # so re-declare contents: read alongside checks: write. Without it
-      # actions/checkout@v6 would fail on fork PRs.
+      # Job-level permissions replace the workflow-level block entirely, so
+      # contents: read is re-declared here. Without it actions/checkout would fail on
+      # fork PRs.
+      #
+      # NO `checks: write` any more (#1083). It was here for dorny/test-reporter, and
+      # the reporter moved to `asan-windows-tests-verify` with the test run. A
+      # permission kept past the step that needed it is a permission nobody will ever
+      # remove.
       contents: read
-      checks: write
       # Needed by the sccache save (#1082, same reason as Windows.yml and the Linux
       # sanitizer jobs): when the repo's Actions cache store is full every save is
       # refused, and the only way to land this job's snapshot is to delete the entry
@@ -424,6 +449,12 @@ jobs:
         }
         Write-Host "clang-cl ASan runtime dir: $rtDir"
         echo "$rtDir" >> $env:GITHUB_PATH
+        # Also exported as a variable because the test SHARDS (#1083) run in
+        # separate jobs that never install LLVM: the packaging step below copies
+        # this DLL next to the instrumented exe so a shard needs nothing but the
+        # artifact. GITHUB_PATH would not survive the job boundary; a DLL beside
+        # the exe does, and Windows resolves it from there first.
+        echo "OLO_ASAN_RUNTIME_DIR=$rtDir" >> $env:GITHUB_ENV
 
     # The other half of setup-vcpkg's restore/save split (#1009). `if: always()`
     # is the whole point: the combined actions/cache action saves in a POST-JOB
@@ -511,9 +542,219 @@ jobs:
         key: sccache-asan-windows-2025-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    # ---------------------------------------------------------------- #1083
+    #
+    # THE TEST RUN LEFT THIS JOB. It used to be a `Run tests under ASan` step here
+    # that took 89.0 MINUTES of a 236-minute job (measured, #1084's table). It is now
+    # the `asan-windows-tests` matrix below: this job builds and hands the
+    # instrumented tree over, and N separate runners each execute a stride of it.
+    #
+    # WHY SHARDING RATHER THAN BATCHING. gtest_discover_tests registers every gtest
+    # case as its own ctest entry, so the suite is ~7,600 PROCESS LAUNCHES, each
+    # paying full engine static-init. Batching many cases into one process is the
+    # bigger win and it REMOVES the isolation that currently hides cross-test state
+    # corruption -- that is #1074's territory and must not be done from here.
+    # Sharding splits the same one-process-per-case run across more runners and
+    # changes the semantics not at all.
+    #
+    # WHAT IT COSTS. Each shard is a whole runner: it pays job startup, a checkout
+    # and an artifact download before it runs a single case. This TRADES
+    # RUNNER-MINUTES FOR WALL-CLOCK and the exchange rate is stated on the PR.
+    # ---------------------------------------------------------------------------
+
+    # THE NUMBER THE SHARDS HAVE TO ADD UP TO. Measured here, in the job that owns
+    # the build, with the same --exclude-regex every shard uses -- so the coverage
+    # proof in `asan-windows-tests-verify` compares like with like. `ctest -N` only
+    # LISTS: discovery already happened at build time (gtest_discover_tests'
+    # POST_BUILD mode writes the entries into the generated *_tests.cmake), so this
+    # launches no test process and costs seconds.
+    - name: Measure the unsharded case count
+      id: ctest-total
+      shell: bash
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N -C Release --exclude-regex "${OLO_ASAN_WINDOWS_CTEST_EXCLUDE}")
+        total=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # A ctest that lists nothing is the same failure archetype the shards guard
+        # against, one level up: it would make each shard's "count > 0" check the only
+        # thing between a broken discovery and a green matrix.
+        if [ -z "${total}" ] || [ "${total}" -le 0 ] 2>/dev/null; then
+          echo "::error::ctest -N reported no tests. Discovery did not produce a test list, so nothing below can be trusted."
+          printf '%s\n' "$listing" | tail -20
+          exit 1
+        fi
+        echo "unsharded ctest entries: ${total}"
+        echo "total=${total}" >> "$GITHUB_OUTPUT"
+
+    # THE SHARDS INSTALL NO TOOLCHAIN, so everything they need to RUN the suite has
+    # to be inside the artifact. Two things are not there by default:
+    #
+    #   * clang_rt.asan_dynamic-x86_64.dll. clang-cl links the DYNAMIC ASan runtime,
+    #     so the instrumented exe does not start without it. This job has it on PATH
+    #     from the LLVM install; a shard job does not, and re-installing a 2 GB LLVM
+    #     four times to obtain one DLL would eat the saving. Windows resolves a DLL
+    #     from the executable's own directory first, so copying it beside the exe is
+    #     both sufficient and version-correct -- it is the runtime of the very
+    #     clang-cl that instrumented these objects.
+    #   * the workspace path this tree was built at. gtest_discover_tests bakes
+    #     ABSOLUTE paths into the generated *_tests.cmake (the exe, and the
+    #     WORKING_DIRECTORY that makes assets/shaders resolvable). Both runners are
+    #     `windows-2025` checking out the same repository, so the path is identical
+    #     in practice -- but "in practice" is exactly the kind of assumption that
+    #     turns into a silent 100 %-skip later, so the shard asserts it.
+    - name: Package the instrumented test tree
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $outDir = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/Release'
+        $dll = Join-Path "$env:OLO_ASAN_RUNTIME_DIR" 'clang_rt.asan_dynamic-x86_64.dll'
+        if (-not (Test-Path $dll)) { Write-Error "ASan runtime DLL not at $dll"; exit 1 }
+        Copy-Item $dll -Destination $outDir -Force
+        Write-Host "copied $(Split-Path -Leaf $dll) next to the test exe"
+        # Recorded, not asserted here -- the shard is where a mismatch matters.
+        $wsFile = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/olo-build-workspace.txt'
+        Set-Content -Path $wsFile -Value '${{github.workspace}}' -NoNewline
+        Get-ChildItem $outDir | ForEach-Object { '{0,12:N0}  {1}' -f $_.Length, $_.Name }
+
+    # ONLY WHAT CTEST READS. The PDB is deliberately absent: the ASan Release tree's
+    # OloEngine-Tests.pdb is the largest single file in the build (the local Debug
+    # tree measures ~1.9 GB) and ctest never opens it. The ASan runtime symbolises
+    # from it when present, so a failing shard's stack is less readable than the
+    # unsharded step's was -- the one real regression in this change, named on the
+    # PR. `*.lib` and `CMakeFiles/` are dropped for the same reason.
+    #
+    # compression-level 1: the exe is a few hundred MB and this transfer happens once
+    # up and once per shard down, so it sits directly on the wall-clock this issue is
+    # about. Level 1 on an already-packed PE gives up little and is several times
+    # faster than the default 6.
+    #
+    # retention-days 1: this is scratch, not a deliverable. A multi-hundred-MB
+    # artifact per run held for 90 days is a storage bill for nothing.
+    - name: Upload the instrumented test tree
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-windows-test-tree
+        path: |
+          build/OloEngine/tests/*.cmake
+          build/OloEngine/tests/olo-build-workspace.txt
+          build/OloEngine/tests/Release/*.exe
+          build/OloEngine/tests/Release/*.dll
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 1
+
+  # ---------------------------------------------------------------------------
+  # #1083: the ASan test run, spread across runners.
+  #
+  # The stride count lives in TWO places that must agree -- `matrix.shard` below and
+  # OLO_CTEST_SHARDS -- because GitHub offers no way to derive one from the other in
+  # an expression. That is a real hazard, so it is not defended by a comment: every
+  # shard reports the count it believed it was part of, and
+  # `asan-windows-tests-verify` fails if they disagree or if 1..N is not exactly
+  # covered. Edit one without the other and the matrix goes red, not green.
+  #
+  # WHY 4. The unsharded step measured 89.0 min. Four shards keeps the per-shard
+  # fixed cost (job startup + checkout + artifact download, a few minutes) small
+  # against the per-shard test time. The right number is re-measurable from the shard
+  # durations in any run; it was NOT tuned by a sweep, because a sweep here costs a
+  # full CI round each.
+  # ---------------------------------------------------------------------------
+  asan-windows-tests:
+    name: ASan (Windows) tests ${{ matrix.shard }}/4
+    needs: asan-windows
+    runs-on: windows-2025
+    strategy:
+      # A red shard must not cancel its siblings. Four shards are four independent
+      # samples of the same suite, and cancelling three of them to react to the
+      # first failure is how a run comes back knowing about one bug instead of four
+      # -- the same reasoning as docs/process/task-loop.md's "do not act on the
+      # first red".
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      # ONE stride, read by the `ctest -N` count AND by the run below. Keeping them in
+      # separate literals is how a shard comes to COUNT one partition and RUN another
+      # -- the counts would still add up and a quarter of the suite would never
+      # execute. The matrix list is the other half of the pair; `asan-windows-tests-verify`
+      # catches a drift between the two.
+      OLO_CTEST_SHARDS: 4
+      # detect_odr_violation=0 for the same reason as the build job: vendored
+      # protobuf trips a known ASan false positive on its narrow/wide "." literals,
+      # which aborts the instrumented exe at startup. Repeated on the run step below,
+      # because a step-level ASAN_OPTIONS REPLACES this rather than merging.
+      ASAN_OPTIONS: detect_odr_violation=0
+    steps:
+    # The checkout is not optional and it is not for the build: every test's
+    # WORKING_DIRECTORY is <workspace>/OloEditor, and the suite loads shaders,
+    # scenes and models from the source tree by repo-relative path.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the instrumented test tree
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: asan-windows-test-tree
+        path: build/OloEngine/tests
+
+    # THE ASSERTION THE BAKED ABSOLUTE PATHS DESERVE. If the build job's workspace
+    # differed from this one's, every add_test() would name an exe that is not there
+    # and ctest would fail loudly -- but it would fail thousands of times with a
+    # confusing message, and a future runner-image or path change would land as "the
+    # ASan tests are all broken" rather than as this one line.
+    - name: Assert this runner matches the build job's layout
+      shell: bash
+      run: |
+        set -euo pipefail
+        built_at=$(cat build/OloEngine/tests/olo-build-workspace.txt)
+        here="${GITHUB_WORKSPACE}"
+        # Compare with both separators normalised: GITHUB_WORKSPACE reaches bash as a
+        # Windows path here, and the recorded one was written by pwsh.
+        if [ "${built_at//\\//}" != "${here//\\//}" ]; then
+          echo "::error::This tree was built at '${built_at}' but this runner checked out at '${here}'. gtest_discover_tests bakes absolute paths into the generated test list, so the tree cannot be moved. Run the shards on the same runner image and path as the build job, or re-run discovery here."
+          exit 1
+        fi
+        exe=build/OloEngine/tests/Release/OloEngine-Tests.exe
+        test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
+        test -f build/OloEngine/tests/Release/clang_rt.asan_dynamic-x86_64.dll \
+          || { echo "::error::ASan runtime DLL missing from the artifact; the instrumented exe will not start"; exit 1; }
+        echo "workspace matches: ${here}"
+
     - name: Create test results directory
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"
       shell: pwsh
+
+    # GUARD 1 OF 2: A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by
+    # index, so a stride that does not line up with the list silently produces an
+    # empty run -- which passes in about a second and is indistinguishable in the
+    # check list from a shard that ran 1,900 cases. The count is also written out
+    # for guard 2, the union check in `asan-windows-tests-verify`.
+    - name: Select this shard's cases
+      id: select
+      shell: bash
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N -C Release \
+                    -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
+                    --exclude-regex "${OLO_ASAN_WINDOWS_CTEST_EXCLUDE}")
+        count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        if [ -z "${count}" ] || [ "${count}" -le 0 ] 2>/dev/null; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} matched ZERO ctest entries."
+          printf '%s\n' "$listing" | tail -20
+          exit 1
+        fi
+        echo "shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS}: ${count} ctest entries"
+        mkdir -p "${GITHUB_WORKSPACE}/shard_counts"
+        {
+          echo "shard=${OLO_CTEST_SHARD}"
+          echo "shards=${OLO_CTEST_SHARDS}"
+          echo "count=${count}"
+        } > "${GITHUB_WORKSPACE}/shard_counts/shard-${OLO_CTEST_SHARD}.txt"
+      env:
+        OLO_CTEST_SHARD: ${{ matrix.shard }}
 
     - name: Run tests under ASan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
@@ -528,14 +769,14 @@ jobs:
       # FIXED UPSTREAM: ValveSoftware/GameNetworkingSockets#418, by PR #420 (merged
       # to master 2026-08-24). The overlay port now pins a post-1.6.0 master
       # snapshot carrying it (cmake/overlay-ports/gamenetworkingsockets/portfile.cmake
-      # — v1.6.0 is still the newest tag and predates the fix), and both the
+      # -- v1.6.0 is still the newest tag and predates the fix), and both the
       # NetworkManager::Init gate and ServerAuthoritativeLoopTest's GTEST_SKIP are
       # gone, so the live init runs here and ServerAuthoritativeLoopTest's 17 cases
       # execute instead of skipping.
       #
       # BE PRECISE ABOUT WHAT THAT COVERS. GNS is a vcpkg port built with cl.exe and
-      # no sanitizer flags -- see the triplet note on the vcpkg step above, "vcpkg
-      # ports are NOT sanitizer-instrumented", which is deliberate. So ASan
+      # no sanitizer flags -- see the triplet note on the vcpkg step in the build job,
+      # "vcpkg ports are NOT sanitizer-instrumented", which is deliberate. So ASan
       # instruments the engine and the test process, NOT GNS internals: allocations
       # and interceptors crossing the boundary are covered, stack and global redzones
       # inside GNS are not. What this change buys is sanitizer coverage of OloEngine's
@@ -547,16 +788,20 @@ jobs:
       # gate back.
       #
       # The Task* and Shader* suites were excluded here on a since-disproven "the
-      # task system starts the Steam service thread" theory — they never touched
+      # task system starts the Steam service thread" theory -- they never touched
       # GNS (the ICF-folded stacks just looked like it) and all pass under MSVC
       # ASan, so they are no longer excluded. See issue #317.
       #
-      # Remaining exclusions match the Linux ASan job exactly:
-      #   NetworkIntegrationTest — needs real client/server socket plumbing that CI
+      # Remaining exclusions live in OLO_ASAN_WINDOWS_CTEST_EXCLUDE at the top of this
+      # file -- ONE definition, read by this step and by the `ctest -N` total the
+      # coverage proof compares against, because a shard filtering differently from
+      # the total is a coverage hole that presents as an arithmetic bug. They match
+      # the Linux ASan job exactly:
+      #   NetworkIntegrationTest -- needs real client/server socket plumbing that CI
       #     environments do not provide; excluded on EVERY job in this repo, the
       #     non-sanitizer ones included (Windows.yml, gpu-conformance-amd.yml). Not
       #     related to the removed ASan gate, and not something the GNS pin changes.
-      #   WorkerRestartTest — a tight 100-iteration worker-pool teardown/recreate
+      #   WorkerRestartTest -- a tight 100-iteration worker-pool teardown/recreate
       #     stress test that exceeds the 120 s timeout under sanitizer
       #     instrumentation; excluded on every sanitizer job.
       #
@@ -576,22 +821,27 @@ jobs:
       #
       # Doubling the width buys ~15 %, not the ~2x "startup-bound" predicted. So this
       # is much closer to CPU/memory-bandwidth bound than to launch-latency bound, and
-      # anyone tempted to go wider again should re-measure rather than reason.
+      # anyone tempted to go wider again should re-measure rather than reason. THAT
+      # MEASUREMENT IS ALSO WHY SHARDING IS THE REMAINING LEVER: a step that is
+      # CPU-bound on a 4-vCPU runner does not get much faster by asking that runner
+      # for more, it gets faster by adding runners.
       # 100 % passed at every width -- 380 of 380, six passes, zero flakes -- so the
       # raise costs no stability at this width.
       #
       # THE OLD CAP WAS AN ASSUMPTION. It read "capped at 2 (not 4) because ASan shadow
       # memory inflates each test process's resident footprint; 2-wide stays comfortably
       # inside the windows-2025 ~16 GB budget" -- plausible, and never measured. 4-wide
-      # ran 380 instrumented cases for 216 s here without incident. If a future run does
+      # ran 380 instrumented cases for 216 s without incident. If a future run does
       # start OOMing or timing out, 3 is the measured fallback and buys 7.1 %.
       #
       # The suite is parallel-safe by construction: tests key their temp paths by
       # PID / gtest case name, and the handful that share the engine's repo-relative
       # mesh cache are serialized against each other with a ctest RESOURCE_LOCK
-      # (OloEngine/tests/CMakeLists.txt). Note what the sample could NOT exercise: a
-      # 1-in-20 stride rarely co-schedules the RESOURCE_LOCK'd cases, so lock
-      # contention at this width is validated by the full run, not by the sweep.
+      # (OloEngine/tests/CMakeLists.txt). SHARDING DOES NOT WEAKEN THAT LOCK and in
+      # one respect strengthens it: each shard is a separate runner with its own
+      # checkout, so two shards cannot contend over one mesh cache at all, and within
+      # a shard ctest serializes the locked cases exactly as before.
+      #
       # TEN EH cases used to be excluded here and are not any more (issue #497).
       # They are the tests that trigger a real C++ throw+catch (malformed-input
       # robustness + MCP error handling), and clang-cl + ASan miscompiled MSVC-style
@@ -603,18 +853,90 @@ jobs:
       # -asan-globals=0, -fno-strict-aliasing, /Od, detect_stack_use_after_return=0,
       # driver-vs-lld-link), and the old MSVC-cl.exe ASan job passed all of them.
       #
-      # FIXED by the LLVM 23.1.0 pin added above -- see that step for the measured
+      # FIXED by the LLVM 23.1.0 pin in the build job -- see that step for the measured
       # before/after on #497's own three-line repro. If these cases start failing
-      # again, the question is which clang the job resolved, not whether the engine
-      # regressed.
+      # again, the question is which clang the build job resolved, not whether the
+      # engine regressed.
       run: >
         ctest --parallel 4 -C Release --output-on-failure --timeout 120
-        --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
+        -I ${{ matrix.shard }},,${OLO_CTEST_SHARDS}
+        --exclude-regex "${OLO_ASAN_WINDOWS_CTEST_EXCLUDE}"
+      shell: bash
       env:
-        # detect_odr_violation=0 must be repeated here — a step-level ASAN_OPTIONS
+        # detect_odr_violation=0 must be repeated here -- a step-level ASAN_OPTIONS
         # replaces the job-level one rather than merging (see the job `env` above).
         ASAN_OPTIONS: halt_on_error=1:detect_odr_violation=0
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
+
+    # `if: always()` on both uploads: a shard that FAILED is the one whose XML the
+    # reporter most needs, and its count is what proves the failure was not simply an
+    # empty run.
+    - name: Upload this shard's test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-windows-test-results-shard-${{ matrix.shard }}
+        path: ${{github.workspace}}/test_results/*.xml
+        if-no-files-found: 'warn'
+
+    - name: Upload this shard's case count
+      if: always() && steps.select.outcome == 'success'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-windows-shard-count-${{ matrix.shard }}
+        path: ${{github.workspace}}/shard_counts/shard-${{ matrix.shard }}.txt
+        if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # #1083 GUARD 2 OF 2, and the report.
+  #
+  # `ctest -I <shard>,,<N>` partitions the list by construction -- on paper. What
+  # this job checks is that the run that actually happened WAS that partition: every
+  # shard reported, all agreeing on N, none empty, and the counts summing to the
+  # unsharded `ctest -N` total the build job measured. Without it, sharding
+  # introduces a way for the suite to shrink silently, which is the failure this
+  # repository has the most history with.
+  #
+  # `if: always()` so a RED shard still gets reported and still gets its coverage
+  # checked. It cannot launder a failure: the shard job itself stays red.
+  # ---------------------------------------------------------------------------
+  asan-windows-tests-verify:
+    name: ASan (Windows) shard coverage
+    needs: [asan-windows, asan-windows-tests]
+    if: always() && needs.asan-windows.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the shard case counts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: asan-windows-shard-count-*
+        path: shard_counts
+      # A shard that died before writing its count uploads nothing, and this step
+      # would then fail on "no artifacts found" -- a worse message than the script's.
+      # Let it through and let the union check name the missing shard.
+      continue-on-error: true
+
+    - name: Prove the shards covered the whole suite
+      run: >
+        python3 scripts/verify_test_shards.py
+        --dir shard_counts
+        --label "ASan (Windows)"
+        --expected-total ${{ needs.asan-windows.outputs.ctest-total }}
+
+    - name: Download the shard test results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: asan-windows-test-results-shard-*
+        path: test_results
+        merge-multiple: true
+      continue-on-error: true
 
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -182,7 +182,21 @@ jobs:
     name: ASan (Windows/clang-cl) build
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
-    runs-on: windows-2025
+    # SELF-HOSTED WHEN THE CODE IS OURS AND THE SWITCH IS ON (#1076) -- the same
+    # expression, the same kill switch and the same fork boundary as Windows.yml's
+    # `build` job, whose comment owns the reasoning. DEFAULT OFF: the variable is
+    # unset and no Windows runner is registered, so every run today lands on
+    # windows-2025 exactly as before.
+    #
+    # windows-2025 is PINNED rather than windows-latest on the hosted arm: sccache
+    # hashes the compiler binary into every cache key, so an image roll invalidates
+    # the entire cache in one step -- silently, because it still restores and the
+    # build still goes green. The key below carries the image string for the same
+    # reason; when `runs-on` is bumped, bump it with it.
+    runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
+                 && github.event_name != 'schedule'
+                 && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+                 && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
 
     # The unsharded case count, measured after the build and consumed by
     # `asan-windows-tests-verify` (#1083). It is a JOB OUTPUT rather than a file in
@@ -354,6 +368,21 @@ jobs:
     # failed because each attempt resumed near the end of the build and met the next
     # long link, so it re-armed the same race every time. With the timeout disabled
     # there is nothing left to retry.
+    # SCCACHE_DIR is a WORKSPACE path and actions/checkout wipes the workspace, so on
+    # a persistent runner it has to move out of the way or the cache is discarded on
+    # every checkout while looking perfectly healthy. Same step, same reasoning, as
+    # Windows.yml's -- read the longer note there, including the per-user-daemon
+    # constraint it puts on provisioning.
+    - name: Point sccache at persistent disk (self-hosted)
+      if: runner.environment != 'github-hosted'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $dir = Join-Path $env:USERPROFILE '.cache\olo\sccache-asan'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        "SCCACHE_DIR=$dir" >> $env:GITHUB_ENV
+        Write-Host "persistent sccache: $dir"
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       with:
@@ -367,6 +396,10 @@ jobs:
     # this job's objects can never collide with `sccache-windows-2025-release-`.
     # When `runs-on` is bumped, bump this string with it.
     - name: Restore sccache storage
+      # HOSTED ONLY (#1076): a persistent runner keeps SCCACHE_DIR on local disk, with
+      # no upload, no download, no slice of the shared cap and no post-job save for a
+      # cancellation to skip.
+      if: runner.environment == 'github-hosted'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -529,7 +562,7 @@ jobs:
     # turning the cache on. The save is kept on `workflow_dispatch` so the cold/warm A/B
     # can be measured on a branch — that is how #1073 was verified and how this was.
     - name: Save sccache storage
-      if: always() && github.event_name != 'pull_request'
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
       # `save-cache-pruned` swallows its own failures: a cache save must never fail the
       # job it is attached to. `if: always()` means it also runs on a CANCEL, where the
       # path may not exist yet, and actions/cache/save treats a missing path as a
@@ -663,7 +696,16 @@ jobs:
   asan-windows-tests:
     name: ASan (Windows) tests ${{ matrix.shard }}/4
     needs: asan-windows
-    runs-on: windows-2025
+    # THE SHARDS FOLLOW THE BUILD JOB (#1076 x #1083). gtest_discover_tests bakes the
+    # absolute exe and WORKING_DIRECTORY paths into the generated test list, so a
+    # shard on a different runner kind would be pointing at a path that is not there.
+    # The `Assert this runner matches the build job's layout` step turns that into one
+    # line; the routing is what prevents it. Four shards want four runner SLOTS -- on
+    # a box with fewer they queue and the sharding win is handed back. See the ADR.
+    runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
+                 && github.event_name != 'schedule'
+                 && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+                 && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
     strategy:
       # A red shard must not cancel its siblings. Four shards are four independent
       # samples of the same suite, and cancelling three of them to react to the

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -172,6 +172,9 @@ jobs:
             - 'cmake/**'
             - '.github/actions/**'
             - '.github/workflows/asan.yml'
+            # The shard coverage proof is part of this gate (#1083); a change to it
+            # has to run the jobs it guards.
+            - 'scripts/verify_test_shards.py'
             - '.github/sanitizer-suppressions/**'
 
   asan-windows:
@@ -763,6 +766,17 @@ jobs:
         test -f build/OloEngine/tests/Release/clang_rt.asan_dynamic-x86_64.dll \
           || { echo "::error::ASan runtime DLL missing from the artifact; the instrumented exe will not start"; exit 1; }
         echo "workspace matches: ${here}"
+
+        # AND PROVE IT STARTS. A missing runtime DLL fails in the OS loader before
+        # main(), so it would arrive as ~1,900 identical ctest failures with no
+        # message worth reading. One launch, seconds, and the failure names itself.
+        # `--gtest_list_tests` pays the same static-init the real cases do and runs
+        # no test body.
+        if ! "$exe" --gtest_list_tests > /dev/null; then
+          echo "::error::$exe does not start on this runner. Either the artifact is missing something it needs at load time (a runtime DLL), or the tree does not match this runner."
+          exit 1
+        fi
+        echo "the instrumented test binary starts here"
 
     - name: Create test results directory
       run: New-Item -ItemType Directory -Force -Path "${{github.workspace}}/test_results"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -172,9 +172,10 @@ jobs:
             - 'cmake/**'
             - '.github/actions/**'
             - '.github/workflows/asan.yml'
-            # The shard coverage proof is part of this gate (#1083); a change to it
-            # has to run the jobs it guards.
+            # The shard coverage proof and the artifact's DLL staging are part of this
+            # gate (#1083); a change to either has to run the jobs it guards.
             - 'scripts/verify_test_shards.py'
+            - 'scripts/Copy-ImportedDlls.ps1'
             - '.github/sanitizer-suppressions/**'
 
   asan-windows:
@@ -648,6 +649,9 @@ jobs:
         if (-not (Test-Path $dll)) { Write-Error "ASan runtime DLL not at $dll"; exit 1 }
         Copy-Item $dll -Destination $outDir -Force
         Write-Host "copied $(Split-Path -Leaf $dll) next to the test exe"
+        & "${{github.workspace}}/scripts/Copy-ImportedDlls.ps1" `
+            -Exe (Join-Path $outDir 'OloEngine-Tests.exe') -Destination $outDir
+        if ($LASTEXITCODE -ne 0) { throw "could not stage the exe's imported DLLs" }
         # Recorded, not asserted here -- the shard is where a mismatch matters.
         $wsFile = Join-Path '${{github.workspace}}' 'build/OloEngine/tests/olo-build-workspace.txt'
         Set-Content -Path $wsFile -Value '${{github.workspace}}' -NoNewline
@@ -986,12 +990,17 @@ jobs:
         --label "ASan (Windows)"
         --expected-total ${{ needs.asan-windows.outputs.ctest-total }}
 
+    # NO `merge-multiple`, deliberately. GTEST_OUTPUT writes into a directory and
+    # gtest names the files itself -- OloEngine-Tests.xml, then _1, _2, ... per
+    # process -- so all four shards produce the SAME filenames. Merging them into one
+    # directory would have shards silently overwrite each other and the report would
+    # be missing real failures while looking complete. One directory per artifact,
+    # and a `**` glob below.
     - name: Download the shard test results
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: asan-windows-test-results-shard-*
         path: test_results
-        merge-multiple: true
       continue-on-error: true
 
     - name: Test report
@@ -1002,10 +1011,22 @@ jobs:
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: ASan (Windows)
-        path: test_results/*.xml
+        path: test_results/**/*.xml
         reporter: java-junit
         fail-on-error: false
         list-tests: 'failed'
+
+    # THE COUNTS ARE RECORDED BEFORE THE RUN, so the check above proves the shards'
+    # SELECTIONS partition the suite -- not that every selected case executed. A shard
+    # whose ctest died a third of the way through still uploaded a full count. The
+    # shard job is red in that case and so is the run, but this check must not read
+    # green beside it, because "shard coverage" going green is precisely the sentence
+    # someone will trust later. Last step, so the report above still gets posted.
+    - name: Fail if any shard did not complete
+      if: needs.asan-windows-tests.result != 'success'
+      run: |
+        echo "::error::A test shard did not complete (matrix result: ${{ needs.asan-windows-tests.result }}). The counts prove the selection partitioned the suite; they cannot prove every selected case ran."
+        exit 1
 
   asan-lsan-linux:
     name: ASan + LSan (Linux/Clang)

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -977,17 +977,24 @@ jobs:
     #      a separate scheduled job with its own baseline (gpu-sanitizers-amd.yml).
     #   2. The box's compiler was clang 21 against gcc-toolset-15's libstdc++,
     #      not the hosted arm's clang, and UBSan reported inside the standard
-    #      library. Both arms now build with clang-23 (#1036): hosted from
-    #      apt.llvm.org, the box from an LLVM release tarball pinned by absolute
-    #      path at /opt/llvm-23.1.0, since Rocky 10's EPEL tops out at clang20
-    #      and no package can match. setup-linux-build ASSERTS that pin -- present,
-    #      executable, reporting major 23 -- and warns down to the system clang
-    #      rather than failing when it is not, because a hard failure would block
-    #      every same-repo PR's sanitizer jobs. It also verifies compiler-rt for
+    #      library. Both arms now build with THE SAME clang -- the official LLVM
+    #      23.1.0 release tarball at /opt/llvm-23.1.0, on the box since #1036 and
+    #      on the hosted runner since #1095. Rocky 10's EPEL tops out at clang20,
+    #      so no package pin was ever possible on the box; and apt.llvm.org, which
+    #      the hosted arm used to install from, publishes only the newest SNAPSHOT
+    #      of a branch, so no package pin was possible there either. The tarball is
+    #      what both can hold still.
+    #
+    #      setup-linux-build ASSERTS that pin on the box -- present, executable,
+    #      reporting major 23 -- and warns down to the system clang rather than
+    #      failing when it is not, because a hard failure would block every
+    #      same-repo PR's sanitizer jobs. It also verifies compiler-rt for
     #      whichever compiler it chose: an incomplete asan/tsan/ubsan set WARNS
-    #      too. Read the "toolchain:" line of a self-hosted job before comparing
-    #      it with a hosted one -- it names the absolute path when the pin is in
-    #      effect, and a bare clang++ when it fell back.
+    #      too. The hosted arm has no ladder: the prefix is installed in the same
+    #      run and its absence is a hard error. Read the "toolchain:" line of a
+    #      self-hosted job before comparing it with a hosted one -- it names the
+    #      absolute path when the pin is in effect, and a bare clang++ when it fell
+    #      back. Since #1095 the two lines should be identical on a green run.
     #
     # The acceptance test for this routing is a same-commit A/B: dispatch the
     # workflow once normally and once with `force_hosted: true`, then compare
@@ -1016,10 +1023,33 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # No `actions: write` here. It was granted for the sccache save, and that
-      # save is gone (#1082 -- see the note above this job's Setup sccache step).
-      # A permission kept past the step that needed it is a permission nobody will
-      # ever remove, so it goes with the step.
+      # `actions: write` is BACK (#1095), with the sccache save it belongs to.
+      # #1082 removed both when the entries were measured returning 0.00 %; the
+      # compiler underneath them is pinned now, so the save is worth having again
+      # and `save-cache-pruned` needs the permission to delete the entry it
+      # supersedes when the store is full.
+      actions: write
+
+    env:
+      # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
+      # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
+      # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
+      # of docs/agent-rules/actions-cache-budget.md is that the store exists for
+      # GITHUB-HOSTED jobs on a PULL REQUEST, and these are neither: same-repo PRs
+      # route them to the box, so only the nightly and fork PRs read these entries and
+      # nobody waits on either.
+      #
+      # So they come back at a smaller share: ~800 MiB each, ~2400 MiB for the set,
+      # leaving the fleet ~2.7 GiB under the ceiling instead of ~1.4.
+      #
+      # BE HONEST ABOUT WHAT THAT COSTS. sccache evicts LRU at the cap, and the object
+      # set at 1500M filled 1500M, so a 900M cache cannot hold all of it and the
+      # ACHIEVABLE hit rate is capped below 100 % by this line, not by the pin. That is
+      # a budget decision, not a measurement, and the entry to watch is "Cache size" vs
+      # "Max cache size" in the stats step. If a measured run shows the eviction is
+      # costing more than the room is worth, the argument to make is which existing
+      # entry gives way -- not that this one should quietly grow.
+      SCCACHE_CACHE_SIZE: "900M"
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1060,53 +1090,49 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
-    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
-    # entry. They are gone, and the reason is measured rather than assumed.
+    # THE ACTIONS-CACHE ENTRY IS BACK, AND THE REASON IT WAS GONE IS FIXED (#1095).
     #
-    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
-    # these entries:
+    # #1082 deleted the restore and the save here after measuring what they returned
+    # on nightly 34004436875 -- all three Linux sanitizer jobs, the only runs that read
+    # them:
     #
     #     Compile requests   1558      Cache hits          0
     #     Cache misses       1558      Cache hits rate     0.00 %
-    #     Cache read errors     0      Cache write errors  0
     #
-    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
-    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
-    # of three.
+    # The restore was healthy: 1232 MB at 180 MB/s, "Cache restored from key: ...".
+    # It restored perfectly and hit NOTHING, three jobs out of three. THE COMPILER WAS
+    # ROLLING UNDERNEATH THE KEY -- sccache hashes the compiler binary into every key
+    # and the hosted arm built with apt.llvm.org's SNAPSHOT clang-23, whose build id
+    # moves every few days.
     #
-    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
-    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    # WHAT CHANGED: setup-linux-build now installs the official LLVM 23.1.0 release
+    # tarball at /opt/llvm-23.1.0 on the hosted arm -- the same build, at the same
+    # path, as the self-hosted box. Re-adding these steps WITHOUT that would reproduce
+    # the 0.00 % exactly, which is why #1082's note said not to.
     #
-    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
-    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    # THE LLVM VERSION IS IN THE KEY, on the same rule Windows.yml applies to the
+    # runner image: put whatever the key is hashed over into the key, so a bump is a
+    # deliberate, reviewable commit and not a silent 0 % run. Bumping it starts a new
+    # prefix and orphans the old entry; cache-prune.yml's 30-day unread age-out
+    # collects that.
     #
-    # Every entry is therefore invalidated by the next apt refresh while still
-    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
-    # the same failure Windows.yml's own header documents for `windows-latest` image
-    # rolls, reproduced here by an unpinned rolling compiler.
+    # HOSTED ONLY. On the self-hosted box this job caches to a persistent local ccache
+    # directory with no save step, no ref scoping and no cap -- and a self-hosted
+    # runner still talks to the REMOTE Actions cache service, so an actions/cache step
+    # there would spend the shared ~9.3 GiB cap for nothing.
     #
-    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
-    # same-repo PR routes this job to the box, where it uses local-disk ccache and
-    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
-    # fork PRs ever touched the store -- neither is on the per-PR critical path.
-    #
-    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
-    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
-    # that IS on the critical path had no cache at all for want of room (#1082).
-    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
-    #
-    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
-    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
-    # job. That value is real and it is currently unreachable, because the key cannot
-    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
-    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
-    # by absolute path) or keying the entry on the clang build id -- issue #1095.
-    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
-    #
-    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
-    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
-    # every hosted run now, by construction rather than by accident.
+    # NOT ON PULL REQUESTS: a PR-run entry is scoped to refs/pull/N/merge, readable by
+    # that one PR, and charged to the repository for as long as the PR stays open.
+    # These jobs route to the box for same-repo PRs anyway; the writer is the nightly.
+    - name: Restore sccache storage
+      if: runner.environment == 'github-hosted'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-lsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          sccache-asan-lsan-linux-llvm-23.1.0-
+
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -1191,6 +1217,28 @@ jobs:
         else
           ccache --show-stats
         fi
+
+    # THE NUMBER THIS CHANGE IS JUDGED ON is the "Cache hits rate" line printed
+    # immediately above, on the SECOND nightly after this lands -- not on a green
+    # check. #1095's whole subject is an entry that restored perfectly, went green
+    # every run and returned zero; see docs/agent-rules/ci-cache-that-looks-alive.md.
+    #
+    # `save-cache-pruned` rather than a bare save: actions/cache/save reports a
+    # REFUSED write (the store past its cap goes read-only) as a warning and exits
+    # zero, so the step's own status cannot tell you. This one asks the API whether
+    # the save landed and, if it did not, deletes this ref's superseded entries under
+    # the same prefix and retries.
+    #
+    # `if: always()` because most PR runs here are cancelled and a post-job step is
+    # skipped on a cancel -- though on this gate that mostly matters for the
+    # workflow_dispatch A/B, since pull_request runs do not save at all.
+    - name: Save sccache storage
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
+      uses: ./.github/actions/save-cache-pruned
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-asan-lsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -1277,10 +1325,33 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # No `actions: write` here. It was granted for the sccache save, and that
-      # save is gone (#1082 -- see the note above this job's Setup sccache step).
-      # A permission kept past the step that needed it is a permission nobody will
-      # ever remove, so it goes with the step.
+      # `actions: write` is BACK (#1095), with the sccache save it belongs to.
+      # #1082 removed both when the entries were measured returning 0.00 %; the
+      # compiler underneath them is pinned now, so the save is worth having again
+      # and `save-cache-pruned` needs the permission to delete the entry it
+      # supersedes when the store is full.
+      actions: write
+
+    env:
+      # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
+      # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
+      # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
+      # of docs/agent-rules/actions-cache-budget.md is that the store exists for
+      # GITHUB-HOSTED jobs on a PULL REQUEST, and these are neither: same-repo PRs
+      # route them to the box, so only the nightly and fork PRs read these entries and
+      # nobody waits on either.
+      #
+      # So they come back at a smaller share: ~800 MiB each, ~2400 MiB for the set,
+      # leaving the fleet ~2.7 GiB under the ceiling instead of ~1.4.
+      #
+      # BE HONEST ABOUT WHAT THAT COSTS. sccache evicts LRU at the cap, and the object
+      # set at 1500M filled 1500M, so a 900M cache cannot hold all of it and the
+      # ACHIEVABLE hit rate is capped below 100 % by this line, not by the pin. That is
+      # a budget decision, not a measurement, and the entry to watch is "Cache size" vs
+      # "Max cache size" in the stats step. If a measured run shows the eviction is
+      # costing more than the room is worth, the argument to make is which existing
+      # entry gives way -- not that this one should quietly grow.
+      SCCACHE_CACHE_SIZE: "900M"
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1312,53 +1383,49 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
-    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
-    # entry. They are gone, and the reason is measured rather than assumed.
+    # THE ACTIONS-CACHE ENTRY IS BACK, AND THE REASON IT WAS GONE IS FIXED (#1095).
     #
-    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
-    # these entries:
+    # #1082 deleted the restore and the save here after measuring what they returned
+    # on nightly 34004436875 -- all three Linux sanitizer jobs, the only runs that read
+    # them:
     #
     #     Compile requests   1558      Cache hits          0
     #     Cache misses       1558      Cache hits rate     0.00 %
-    #     Cache read errors     0      Cache write errors  0
     #
-    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
-    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
-    # of three.
+    # The restore was healthy: 1232 MB at 180 MB/s, "Cache restored from key: ...".
+    # It restored perfectly and hit NOTHING, three jobs out of three. THE COMPILER WAS
+    # ROLLING UNDERNEATH THE KEY -- sccache hashes the compiler binary into every key
+    # and the hosted arm built with apt.llvm.org's SNAPSHOT clang-23, whose build id
+    # moves every few days.
     #
-    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
-    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    # WHAT CHANGED: setup-linux-build now installs the official LLVM 23.1.0 release
+    # tarball at /opt/llvm-23.1.0 on the hosted arm -- the same build, at the same
+    # path, as the self-hosted box. Re-adding these steps WITHOUT that would reproduce
+    # the 0.00 % exactly, which is why #1082's note said not to.
     #
-    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
-    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    # THE LLVM VERSION IS IN THE KEY, on the same rule Windows.yml applies to the
+    # runner image: put whatever the key is hashed over into the key, so a bump is a
+    # deliberate, reviewable commit and not a silent 0 % run. Bumping it starts a new
+    # prefix and orphans the old entry; cache-prune.yml's 30-day unread age-out
+    # collects that.
     #
-    # Every entry is therefore invalidated by the next apt refresh while still
-    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
-    # the same failure Windows.yml's own header documents for `windows-latest` image
-    # rolls, reproduced here by an unpinned rolling compiler.
+    # HOSTED ONLY. On the self-hosted box this job caches to a persistent local ccache
+    # directory with no save step, no ref scoping and no cap -- and a self-hosted
+    # runner still talks to the REMOTE Actions cache service, so an actions/cache step
+    # there would spend the shared ~9.3 GiB cap for nothing.
     #
-    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
-    # same-repo PR routes this job to the box, where it uses local-disk ccache and
-    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
-    # fork PRs ever touched the store -- neither is on the per-PR critical path.
-    #
-    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
-    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
-    # that IS on the critical path had no cache at all for want of room (#1082).
-    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
-    #
-    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
-    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
-    # job. That value is real and it is currently unreachable, because the key cannot
-    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
-    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
-    # by absolute path) or keying the entry on the clang build id -- issue #1095.
-    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
-    #
-    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
-    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
-    # every hosted run now, by construction rather than by accident.
+    # NOT ON PULL REQUESTS: a PR-run entry is scoped to refs/pull/N/merge, readable by
+    # that one PR, and charged to the repository for as long as the PR stays open.
+    # These jobs route to the box for same-repo PRs anyway; the writer is the nightly.
+    - name: Restore sccache storage
+      if: runner.environment == 'github-hosted'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-ubsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          sccache-ubsan-linux-llvm-23.1.0-
+
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -1430,6 +1497,28 @@ jobs:
         else
           ccache --show-stats
         fi
+
+    # THE NUMBER THIS CHANGE IS JUDGED ON is the "Cache hits rate" line printed
+    # immediately above, on the SECOND nightly after this lands -- not on a green
+    # check. #1095's whole subject is an entry that restored perfectly, went green
+    # every run and returned zero; see docs/agent-rules/ci-cache-that-looks-alive.md.
+    #
+    # `save-cache-pruned` rather than a bare save: actions/cache/save reports a
+    # REFUSED write (the store past its cap goes read-only) as a warning and exits
+    # zero, so the step's own status cannot tell you. This one asks the API whether
+    # the save landed and, if it did not, deletes this ref's superseded entries under
+    # the same prefix and retries.
+    #
+    # `if: always()` because most PR runs here are cancelled and a post-job step is
+    # skipped on a cancel -- though on this gate that mostly matters for the
+    # workflow_dispatch A/B, since pull_request runs do not save at all.
+    - name: Save sccache storage
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
+      uses: ./.github/actions/save-cache-pruned
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-ubsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
@@ -1526,10 +1615,33 @@ jobs:
       # actions/checkout@v6 would fail on fork PRs.
       contents: read
       checks: write
-      # No `actions: write` here. It was granted for the sccache save, and that
-      # save is gone (#1082 -- see the note above this job's Setup sccache step).
-      # A permission kept past the step that needed it is a permission nobody will
-      # ever remove, so it goes with the step.
+      # `actions: write` is BACK (#1095), with the sccache save it belongs to.
+      # #1082 removed both when the entries were measured returning 0.00 %; the
+      # compiler underneath them is pinned now, so the save is worth having again
+      # and `save-cache-pruned` needs the permission to delete the entry it
+      # supersedes when the store is full.
+      actions: write
+
+    env:
+      # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
+      # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
+      # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
+      # of docs/agent-rules/actions-cache-budget.md is that the store exists for
+      # GITHUB-HOSTED jobs on a PULL REQUEST, and these are neither: same-repo PRs
+      # route them to the box, so only the nightly and fork PRs read these entries and
+      # nobody waits on either.
+      #
+      # So they come back at a smaller share: ~800 MiB each, ~2400 MiB for the set,
+      # leaving the fleet ~2.7 GiB under the ceiling instead of ~1.4.
+      #
+      # BE HONEST ABOUT WHAT THAT COSTS. sccache evicts LRU at the cap, and the object
+      # set at 1500M filled 1500M, so a 900M cache cannot hold all of it and the
+      # ACHIEVABLE hit rate is capped below 100 % by this line, not by the pin. That is
+      # a budget decision, not a measurement, and the entry to watch is "Cache size" vs
+      # "Max cache size" in the stats step. If a measured run shows the eviction is
+      # costing more than the room is worth, the argument to make is which existing
+      # entry gives way -- not that this one should quietly grow.
+      SCCACHE_CACHE_SIZE: "900M"
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1561,53 +1673,49 @@ jobs:
       with:
         version: "v0.15.0"
 
-    # NO ACTIONS-CACHE ENTRY FOR THIS JOB (#1082). There used to be a restore here and
-    # a `save-cache-pruned` after the build, persisting SCCACHE_DIR as a ~1.25 GiB
-    # entry. They are gone, and the reason is measured rather than assumed.
+    # THE ACTIONS-CACHE ENTRY IS BACK, AND THE REASON IT WAS GONE IS FIXED (#1095).
     #
-    # Nightly 34004436875, all three Linux sanitizer jobs, the ONLY runs that read
-    # these entries:
+    # #1082 deleted the restore and the save here after measuring what they returned
+    # on nightly 34004436875 -- all three Linux sanitizer jobs, the only runs that read
+    # them:
     #
     #     Compile requests   1558      Cache hits          0
     #     Cache misses       1558      Cache hits rate     0.00 %
-    #     Cache read errors     0      Cache write errors  0
     #
-    # The restore was not broken -- "Cache restored from key: sccache-ubsan-linux-...",
-    # 1232 MB pulled at 180 MB/s. It restored perfectly and hit NOTHING, three jobs out
-    # of three.
+    # The restore was healthy: 1232 MB at 180 MB/s, "Cache restored from key: ...".
+    # It restored perfectly and hit NOTHING, three jobs out of three. THE COMPILER WAS
+    # ROLLING UNDERNEATH THE KEY -- sccache hashes the compiler binary into every key
+    # and the hosted arm built with apt.llvm.org's SNAPSHOT clang-23, whose build id
+    # moves every few days.
     #
-    # WHY: sccache hashes the compiler binary into every cache key, and the hosted arm
-    # compiles with apt.llvm.org's SNAPSHOT clang-23, which rolls every few days:
+    # WHAT CHANGED: setup-linux-build now installs the official LLVM 23.1.0 release
+    # tarball at /opt/llvm-23.1.0 on the hosted arm -- the same build, at the same
+    # path, as the self-hosted box. Re-adding these steps WITHOUT that would reproduce
+    # the 0.00 % exactly, which is why #1082's note said not to.
     #
-    #     nightly 09-04   Ubuntu clang 23.1.1 (++20260901122056+5340f7cc8814)
-    #     nightly 09-05   Ubuntu clang 23.1.1 (++20260903063729+47bafb752202)
+    # THE LLVM VERSION IS IN THE KEY, on the same rule Windows.yml applies to the
+    # runner image: put whatever the key is hashed over into the key, so a bump is a
+    # deliberate, reviewable commit and not a silent 0 % run. Bumping it starts a new
+    # prefix and orphans the old entry; cache-prune.yml's 30-day unread age-out
+    # collects that.
     #
-    # Every entry is therefore invalidated by the next apt refresh while still
-    # restoring, still downloading 1.2 GB, and still occupying the shared quota. It is
-    # the same failure Windows.yml's own header documents for `windows-latest` image
-    # rolls, reproduced here by an unpinned rolling compiler.
+    # HOSTED ONLY. On the self-hosted box this job caches to a persistent local ccache
+    # directory with no save step, no ref scoping and no cap -- and a self-hosted
+    # runner still talks to the REMOTE Actions cache service, so an actions/cache step
+    # there would spend the shared ~9.3 GiB cap for nothing.
     #
-    # AND ALMOST NOTHING READ THEM ANYWAY. `OLO_LINUX_SELF_HOSTED` is true, so a
-    # same-repo PR routes this job to the box, where it uses local-disk ccache and
-    # skips every sccache step. Only the nightly (a `schedule` run forces hosted) and
-    # fork PRs ever touched the store -- neither is on the per-PR critical path.
-    #
-    # THE BUDGET IS THE POINT. Three entries, 3741 MiB, 55 % of a 6782 MiB steady set
-    # against a ~9.3 GiB wall, buying a measured zero -- while the Windows ASan job
-    # that IS on the critical path had no cache at all for want of room (#1082).
-    # docs/agent-rules/actions-cache-budget.md has the arithmetic.
-    #
-    # THIS IS NOT "THE LINUX CACHE IS WORTHLESS". At 1558 compilations x 6.283 s
-    # average, a WORKING cache here would remove most of ~2 h 43 m of compiler time per
-    # job. That value is real and it is currently unreachable, because the key cannot
-    # be stable while the compiler underneath it is a rolling snapshot. Recovering it
-    # means pinning the hosted clang (the self-hosted box already pins /opt/llvm-23.1.0
-    # by absolute path) or keying the entry on the clang build id -- issue #1095.
-    # Do NOT simply re-add the restore/save: that is what measured 0.00 %.
-    #
-    # sccache itself is still the launcher on the hosted arm, so `Show compiler cache
-    # stats` below keeps working and keeps printing the hit rate. It will read 0 % on
-    # every hosted run now, by construction rather than by accident.
+    # NOT ON PULL REQUESTS: a PR-run entry is scoped to refs/pull/N/merge, readable by
+    # that one PR, and charged to the repository for as long as the PR stays open.
+    # These jobs route to the box for same-repo PRs anyway; the writer is the nightly.
+    - name: Restore sccache storage
+      if: runner.environment == 'github-hosted'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          sccache-tsan-linux-llvm-23.1.0-
+
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
     # sanitizer-instrumented, which is what these jobs want — see the note in the
@@ -1679,6 +1787,28 @@ jobs:
         else
           ccache --show-stats
         fi
+
+    # THE NUMBER THIS CHANGE IS JUDGED ON is the "Cache hits rate" line printed
+    # immediately above, on the SECOND nightly after this lands -- not on a green
+    # check. #1095's whole subject is an entry that restored perfectly, went green
+    # every run and returned zero; see docs/agent-rules/ci-cache-that-looks-alive.md.
+    #
+    # `save-cache-pruned` rather than a bare save: actions/cache/save reports a
+    # REFUSED write (the store past its cap goes read-only) as a warning and exits
+    # zero, so the step's own status cannot tell you. This one asks the API whether
+    # the save landed and, if it did not, deletes this ref's superseded entries under
+    # the same prefix and retries.
+    #
+    # `if: always()` because most PR runs here are cancelled and a post-job step is
+    # skipped on a cancel -- though on this gate that mostly matters for the
+    # workflow_dispatch A/B, since pull_request runs do not save at all.
+    - name: Save sccache storage
+      if: always() && runner.environment == 'github-hosted' && github.event_name != 'pull_request'
+      uses: ./.github/actions/save-cache-pruned
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -125,6 +125,19 @@ env:
   # the sum of the second. A shard filtering differently from the total would present
   # as an arithmetic failure with no obvious cause, so the regex cannot be allowed to
   # exist in three copies. The reasoning for each exclusion is on the run step.
+  # THE LLVM VERSION THE THREE LINUX sccache KEYS CARRY (#1095), in ONE place.
+  # sccache hashes the compiler binary into every key, so an entry taken with a
+  # different clang is a guaranteed miss that still restores, still downloads 1.2 GB
+  # and still holds quota -- the exact 0.00 % this issue is about. Putting the version
+  # in the key makes a toolchain bump a deliberate, reviewable commit instead of a run
+  # that quietly returns nothing.
+  #
+  # It was NINE literals (a restore key, a restore-keys prefix and a save key for each
+  # of the three jobs) and is now one, because a bump that moves setup-linux-build and
+  # forgets these keys reintroduces the bug it fixes. Move it WITH the version/sha256
+  # inputs in .github/actions/setup-linux-build; the full bump checklist is in
+  # docs/ops/self-hosted-linux-toolchain.md.
+  OLO_LINUX_LLVM_VERSION: "23.1.0"
   OLO_ASAN_WINDOWS_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
 
 permissions:
@@ -616,8 +629,19 @@ jobs:
         # A ctest that lists nothing is the same failure archetype the shards guard
         # against, one level up: it would make each shard's "count > 0" check the only
         # thing between a broken discovery and a green matrix.
-        if [ -z "${total}" ] || [ "${total}" -le 0 ] 2>/dev/null; then
-          echo "::error::ctest -N reported no tests. Discovery did not produce a test list, so nothing below can be trusted."
+        #
+        # DIGITS-ONLY BEFORE THE NUMERIC COMPARISON, and the order is the whole point:
+        # `[ "$x" -le 0 ]` on a non-numeric $x ERRORS rather than returning false, and
+        # a command that errors inside an `if` condition is exempt from `set -e` -- so
+        # anything that is not a number fell straight through this guard and got
+        # published as the total. A guard that exists for the case where discovery
+        # printed something unexpected must not be the thing that trusts its output.
+        case "${total}" in
+          ''|*[!0-9]*) valid=no ;;
+          *) if [ "${total}" -gt 0 ]; then valid=yes; else valid=no; fi ;;
+        esac
+        if [ "${valid}" != yes ]; then
+          echo "::error::ctest -N did not report a positive test count (got '${total}'). Discovery did not produce a usable test list, so nothing below can be trusted."
           printf '%s\n' "$listing" | tail -20
           exit 1
         fi
@@ -801,8 +825,16 @@ jobs:
                     -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
                     --exclude-regex "${OLO_ASAN_WINDOWS_CTEST_EXCLUDE}")
         count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
-        if [ -z "${count}" ] || [ "${count}" -le 0 ] 2>/dev/null; then
-          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} matched ZERO ctest entries."
+        # Digits-only before the numeric comparison -- see the same guard on the build
+        # job's total. `[ "$x" -le 0 ]` errors on a non-number and an erroring `if`
+        # condition is exempt from `set -e`, so garbage would pass this check and then
+        # be written into the shard count the coverage proof adds up.
+        case "${count}" in
+          ''|*[!0-9]*) valid=no ;;
+          *) if [ "${count}" -gt 0 ]; then valid=yes; else valid=no; fi ;;
+        esac
+        if [ "${valid}" != yes ]; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} did not match a positive number of ctest entries (got '${count}')."
           printf '%s\n' "$listing" | tail -20
           exit 1
         fi
@@ -963,7 +995,12 @@ jobs:
   asan-windows-tests-verify:
     name: ASan (Windows) shard coverage
     needs: [asan-windows, asan-windows-tests]
-    if: always() && needs.asan-windows.result == 'success'
+    # `!cancelled()` rather than `always()`: a cancelled run (cancel-in-progress on
+    # the next push) can leave asan-windows already 'success' while the shards were
+    # killed mid-flight, and `always()` would then run this job and post a red
+    # "a shard did not complete" on a run nobody abandoned for a reason worth
+    # reading. Braced because a bare leading `!` is a YAML tag indicator.
+    if: ${{ !cancelled() && needs.asan-windows.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1206,9 +1243,9 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-asan-lsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-asan-lsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          sccache-asan-lsan-linux-llvm-23.1.0-
+          sccache-asan-lsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-
 
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
@@ -1314,7 +1351,7 @@ jobs:
       uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-asan-lsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-asan-lsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
@@ -1499,9 +1536,9 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-ubsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-ubsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          sccache-ubsan-linux-llvm-23.1.0-
+          sccache-ubsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-
 
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
@@ -1594,7 +1631,7 @@ jobs:
       uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-ubsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-ubsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory
@@ -1789,9 +1826,9 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-tsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-tsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          sccache-tsan-linux-llvm-23.1.0-
+          sccache-tsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-
 
 
     # Third-party deps come from the vcpkg manifest (issue #773). Ports are not
@@ -1884,7 +1921,7 @@ jobs:
       uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-tsan-linux-llvm-23.1.0-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-tsan-linux-llvm-${{ env.OLO_LINUX_LLVM_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create test results directory

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@ The three workflow slash commands live in [`.claude/commands/`](../.claude/comma
 - [adr/0013-destructible-debris-asset-swap-not-runtime-fracture.md](adr/0013-destructible-debris-asset-swap-not-runtime-fracture.md) — destructible objects swap in pre-authored debris assets; no runtime mesh fracture.
 - [adr/0017-windows-ci-critical-path-measure-before-a-self-hosted-runner.md](adr/0017-windows-ci-critical-path-measure-before-a-self-hosted-runner.md) — the Windows CI critical path is measured on a writable cache before any self-hosted Windows runner is built, and never on the interactive workstation.
 - [adr/0018-gaussian-splats-gpu-ordering-and-merge-lod.md](adr/0018-gaussian-splats-gpu-ordering-and-merge-lod.md) — Gaussian splats order per view on the GPU and coarsen by merging; a CPU sort and a selection budget are both dead ends.
+- [adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md](adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md) — the Windows jobs can be routed to a self-hosted runner behind a `vars.` kill switch and a fork guard; the switch stays off until a runner exists and both paths are measured.
 
 ## bug-investigations/ — postmortems & deep-dives
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ The three workflow slash commands live in [`.claude/commands/`](../.claude/comma
 - [ops/deployment.md](ops/deployment.md) — OloServer deployment / packaging.
 - [ops/self-hosted-gpu-runner.md](ops/self-hosted-gpu-runner.md) — the self-hosted AMD GPU CI runner.
 - [ops/self-hosted-host-hygiene.md](ops/self-hosted-host-hygiene.md) — the box behind the runners: the update timer must not reboot under a job, the GPU resets during the suite, one host is shared.
-- [ops/self-hosted-linux-toolchain.md](ops/self-hosted-linux-toolchain.md) — both Linux arms pin clang-23 and LLD 23: hosted from apt.llvm.org, the box from an LLVM tarball at `/opt/llvm-23.1.0` with its own ICU 70 beside it; a missing pin or sanitizer runtime warns and falls back, never installs.
+- [ops/self-hosted-linux-toolchain.md](ops/self-hosted-linux-toolchain.md) — both Linux arms take clang-23 and LLD 23 from the same LLVM release tarball at `/opt/llvm-23.1.0` (the box keeps its own ICU 70 beside it); on the box a missing pin or sanitizer runtime warns and falls back, never installs.
 
 ## adr/ — architecture decision records
 

--- a/docs/adr/0017-windows-ci-critical-path-measure-before-a-self-hosted-runner.md
+++ b/docs/adr/0017-windows-ci-critical-path-measure-before-a-self-hosted-runner.md
@@ -10,6 +10,13 @@ is what the critical-path question is about; the remaining 62 are `push` runs of
 workflows (Windows 30, Sanitizers 28, medians 171 and 170), and they are what the nightly
 cache-warming argument rests on.
 
+> **Extended by [ADR 0019](0019-windows-ci-self-hosted-routing-lands-switched-off.md) (#1076).**
+> The `runs-on` routing, the `vars.` kill switch, the fork guard and the `runner.environment`
+> cache gating described in §2.3 below now exist in `Windows.yml` and `asan.yml` —
+> **switched off**, because no Windows runner is registered. The decision in §2.1 is
+> unchanged and §3 still stands. 0019 records what provisioning one would cost and what
+> has to be measured before the switch is flipped.
+
 ---
 
 ## 1. What the post-#1010 runs actually measured

--- a/docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md
+++ b/docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md
@@ -76,7 +76,10 @@ after an unconditional `sudo apt-get` once kept the nightly red for days.
 1. **The routing lands switched off.** It is reviewable now, alongside the sharding and cache work
    it interacts with, rather than as a separate change later against a moved target.
 2. **Enabling it is the maintainer's call, not CI's.** Setting `vars.OLO_WINDOWS_SELF_HOSTED` and
-   registering a runner are the two acts this ADR does not perform.
+   registering a runner are the two acts this ADR does not perform. **Asked and answered on
+   2026-09-07: no spare machine is available, so it stays off.** That is a hardware answer, not a
+   verdict on the idea — §4 is the bill it would have to be worth, and §5 is what would make it
+   worth reopening.
 3. **Nothing here is measured on a self-hosted Windows runner, and none of it can be until one
    exists.** #1076's acceptance — build-step duration and sccache hit rate on both paths, and the
    Windows cache entries gone from the store — is unmet by construction. The issue stays open.
@@ -106,6 +109,25 @@ after an unconditional `sudo apt-get` once kept the nightly red for days.
   first client to start it fixes the server's environment and every later client on that account is
   served by it whatever `SCCACHE_DIR` that client set. The Linux box sidesteps this by using
   ccache, which has no daemon; there is no equivalent drop-in for clang-cl here.
+
+## 5. What would make this worth reopening
+
+Not a principle — a number. ADR 0017 deferred the runner on the arithmetic that *a runner which
+takes 40 minutes off one workflow while its sibling sits at 170 does not move the PR*, and two
+things have happened since that make the old figure unusable in either direction:
+[#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073) fixed the caches the 236-minute
+measurement was taken against, and #1083 has just changed the shape of both Windows jobs. **Whatever
+#1076 is worth, it is worth less than the measurement it was filed against, and by an unknown
+amount.**
+
+So reopen it when all three hold:
+
+1. Several PRs have run through the sharded jobs, and #1084's table carries a current per-PR
+   wall-clock and a current sccache hit rate for **both** Windows jobs.
+2. Windows is still the ceiling by a margin a persistent runner would plausibly close — judged
+   against `max()` of the two jobs, never against one of them.
+3. There is hardware that can hold the shard count, or a decision to lower the shard count on the
+   self-hosted path. §4 is why that is not an afterthought.
 
 ## Considered options
 

--- a/docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md
+++ b/docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md
@@ -1,0 +1,121 @@
+# The Windows jobs can be routed to a self-hosted runner, and the switch stays off until a runner exists and both paths are measured
+
+Issue [#1076](https://github.com/drsnuggles8/OloEngineBase/issues/1076), under the umbrella
+[#1084](https://github.com/drsnuggles8/OloEngineBase/issues/1084). Extends
+[ADR 0017](0017-windows-ci-critical-path-measure-before-a-self-hosted-runner.md), which deferred
+the runner and named the preconditions for reopening the question. This ADR records what landed
+now — the routing, the gating and the fork guard, all inert — and what has to be true before
+`vars.OLO_WINDOWS_SELF_HOSTED` is set to `true`.
+
+**This changes where PR CI *can* execute, which is why it is an ADR. It does not change where PR
+CI *does* execute: no Windows runner is registered on this repository and the variable is unset,
+so every run today lands on `windows-2025` exactly as before.**
+
+---
+
+## 1. Why route at all
+
+The two Windows jobs are the per-PR critical path on every PR — the Linux sanitizers finish 86
+minutes earlier — and almost everything that has gone wrong with their caches is a property of the
+**Actions cache store** rather than of caching:
+
+- the store is a **wall, not an eviction threshold**. Past ~9537 MiB the whole store goes
+  read-only and every save in the repository is refused; `actions/cache/save` reports that as a
+  warning and exits zero, so the step's own status cannot tell you
+  ([#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073)).
+- an entry written on a `pull_request` run is scoped to `refs/pull/N/merge` and readable by that
+  one PR. Six concurrent PRs is a routine day here and does not fit.
+- the save is a post-job step, and a cancelled run skips it. `cancel-in-progress` cancels most PR
+  runs here.
+
+A persistent runner has none of those, because **its disk is the cache**: no upload, no download,
+no cap, no ref scoping, no post-job step. That is the same move `asan.yml` made for the Linux
+sanitizer jobs in #1009, and `setup-vcpkg` already implements the two-sided version of it — on a
+self-hosted runner it uses a persistent directory in the runner user's home and skips
+`actions/cache` entirely.
+
+It also frees budget. The steady set is ~6.1 GiB of a ~9.3 GiB wall
+([actions-cache-budget.md](../agent-rules/actions-cache-budget.md)); the two Windows sccache
+entries are 1825 MiB and ~660 MiB of that.
+
+## 2. What landed
+
+In `Windows.yml` (`build`, `tests`) and `asan.yml` (`asan-windows`, `asan-windows-tests`):
+
+```yaml
+runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
+             && github.event_name != 'schedule'
+             && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+             && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
+```
+
+Read left to right, because the order is the safety property:
+
+1. **The kill switch comes first**, so unsetting the variable can only ever move a job *off* the
+   box, never onto it.
+2. **The nightly stays hosted.** It is this workflow's only fleet-wide cache warmer — `actions/cache`
+   entries created on a PR branch are scoped to that ref, and only default-branch entries are
+   readable by every branch. Route the cron to the box and the hosted fallback goes permanently
+   cold. (The Linux sanitizers keep their nightly hosted for the same reason.)
+3. **The fork boundary is `head.repo.full_name`**, never a `pull_request_target` that checks out
+   the PR head. An untrusted fork PR must never execute on a persistent machine.
+4. **`olo-ci-win`, not `olo-ci`.** Runner **groups are unavailable on a user account**, so
+   isolation from the existing Linux runners is by label only.
+
+Alongside it: `runner.environment == 'github-hosted'` now gates every Windows sccache restore and
+save; `SCCACHE_DIR` is repointed out of the workspace on a self-hosted runner, because
+`actions/checkout` wipes the workspace and would otherwise discard the cache on every run while
+looking perfectly healthy; `choco install nasm` is hosted-only; and a self-hosted **preflight**
+verifies `cmake`, `ninja`, `nasm`, `python`, `cl`, `jinja2` and `VULKAN_SDK` and fails the job
+naming what is missing — *verify, never install*, the convention
+[`setup-linux-build`](../../.github/actions/setup-linux-build/action.yml) states for the Linux box
+after an unconditional `sudo apt-get` once kept the nightly red for days.
+
+## 3. Decision
+
+1. **The routing lands switched off.** It is reviewable now, alongside the sharding and cache work
+   it interacts with, rather than as a separate change later against a moved target.
+2. **Enabling it is the maintainer's call, not CI's.** Setting `vars.OLO_WINDOWS_SELF_HOSTED` and
+   registering a runner are the two acts this ADR does not perform.
+3. **Nothing here is measured on a self-hosted Windows runner, and none of it can be until one
+   exists.** #1076's acceptance — build-step duration and sccache hit rate on both paths, and the
+   Windows cache entries gone from the store — is unmet by construction. The issue stays open.
+4. **ADR 0017 §3 still stands: not the interactive workstation.** Its four reasons are unchanged —
+   toolchain parity becomes a CI-visible event on every VS update; a runner service is not an
+   agent shell and so runs outside `build-lock.ps1`; the RTX 4090 would execute the ~200 GL-gated
+   tests that skip on `windows-2025`, which is how routing changed *what was tested* on the Linux
+   box (215 failures on one commit, #1010); and a public repo where the same-repo condition is the
+   only isolation should not share an account with the worktrees, the SSH keys and the `gh` login.
+
+## 4. What provisioning it costs, stated before anyone agrees to it
+
+- A Windows host that is **not** the workstation, with the VS 2022/2026 build tools, the Windows
+  SDK, the Vulkan SDK, nasm and Python + jinja2 — what `Windows.yml` currently provisions per run,
+  provisioned once and kept in step with the hosted image by hand.
+- **Memory.** The box that would host it already runs the Linux runners and is memory-bound; a
+  Windows engine build peaks high enough that concurrency limits have to be set deliberately
+  rather than discovered. It has been OOM-killed by an uncapped build before.
+- **Runner slots, and this is the one that decides whether #1076 and #1083 can coexist.**
+  [#1083](https://github.com/drsnuggles8/OloEngineBase/issues/1083) split the test steps across a
+  matrix — 4 shards for ASan, 3 for `Windows / build`. Shards follow the build job's routing
+  because `gtest_discover_tests` bakes absolute paths into the generated test list. **On a box with
+  fewer runner slots than shards they queue, and the wall-clock the sharding bought is handed
+  straight back.** Seven concurrent Windows jobs on one machine is not a small ask; a smaller shard
+  count on the self-hosted path is the obvious trade and is unmeasured.
+- **One compiling runner instance per Windows account.** sccache is a per-**user daemon**: the
+  first client to start it fixes the server's environment and every later client on that account is
+  served by it whatever `SCCACHE_DIR` that client set. The Linux box sidesteps this by using
+  ccache, which has no daemon; there is no equivalent drop-in for clang-cl here.
+
+## Considered options
+
+- **Enable it in this change.** Rejected: there is no runner, so it would be a switch pointing at
+  nothing, and #1076's acceptance is measurements from both paths.
+- **Leave `Windows.yml` alone until a runner exists.** Rejected: the same files are being
+  restructured for #1083 right now, and writing the routing later means writing it against a tree
+  that has moved, in a PR with no other reason to touch these jobs.
+- **Route the nightly to the box as well.** Rejected: it is the only producer of the default-branch
+  cache entries the hosted fallback and every fork PR restore from.
+- **Reuse the `olo-ci` label.** Rejected: no runner groups on a user account, so the label is the
+  only isolation there is between a Windows engine build and three Linux sanitizer jobs on a
+  memory-bound box.

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -140,14 +140,14 @@ before compression:
 
 | Entry | Size |
 |---|---|
-| ~~`sccache-asan-lsan-linux` / `sccache-ubsan-linux` / `sccache-tsan-linux`~~ | ~~1252 / 1231 / 1258 MiB~~ — **removed 2026-09-06 (#1082)**, see *A cache can be worth removing* below |
+| `sccache-asan-lsan-linux-llvm-23.1.0` / `-ubsan-` / `-tsan-` | **~800 MiB each, ~2400 MiB — reserved, not yet measured (#1095)**. Removed 2026-09-06 by #1082 at 1252 / 1231 / 1258 MiB returning 0.00 % (see *A cache can be worth removing*), and re-added once the compiler underneath the key stopped rolling. Cap lowered 1500M → 900M because these jobs are neither hosted nor PR-waited-on (rule 5): the smaller share is deliberate and caps the achievable hit rate. Replace this row with the measured entry sizes on the second nightly after it lands. |
 | `vcpkg-Windows-x64-windows-static-md` | 692 MiB |
 | `Linux-` / `Windows-vulkan-prebuilt-sdk` | 291 + 229 MiB |
 | `ffmpeg-Windows-n7.1` | 4 MiB |
-| **measured subtotal** | **1216 MiB** (was 4957 MiB with the three Linux entries in it) |
+| **measured subtotal** | **1216 MiB** (excluding the three Linux entries, whose new size is reserved rather than measured) |
 | `sccache-windows-2025-release` | **1825 MiB** — measured 2026-09-06 17:00 UTC, the day the fix landed. The row that used to sit here said "not measured, no entry has ever existed to measure" and guessed 0.9–2.0 GiB from `sccache-flaky-281`. The guess held; the entry came in at the top of it. |
 | `sccache-asan-windows-2025` | **~660 MiB** — the local `SCCACHE_DIR` measured 656 MiB (`--show-stats`) / 660 MiB (`du -sm`) on run 34061407329, well under its 3 GiB provisional cap, so nothing was evicted and this is the true footprint. Cap now set to 1500M. Much smaller than the sibling `sccache-windows-2025-release` because this job builds only `OloEngine-Tests`, not the editor/runtime/server too. |
-| **steady set** | **~3700 MiB** (1216 + 1825 + ~660) against a ~9.3 GiB wall and `cache-prune.yml`'s 8800 MiB working ceiling — **5.1 GiB of headroom**. Was 6782 MiB before the three Linux entries came out, and that was with the ASan Windows job holding nothing. |
+| **steady set** | **~6100 MiB** (1216 + 1825 + ~660 + ~2400) against a ~9.3 GiB wall and `cache-prune.yml`'s 8800 MiB working ceiling — **~2.7 GiB of headroom**. It was 3700 MiB with the Linux entries gone and 6782 MiB with them at their old 1500M cap; the 900M cap is what buys the difference. The ~2400 MiB is the only reserved number in this table, so re-measure it before spending the headroom on anything else. |
 
 `SCCACHE_CACHE_SIZE` bounds the local directory **before** compression, so it is not the
 entry size — but do not read that as "the entry will be much smaller". Every sccache entry
@@ -216,6 +216,17 @@ a rolling snapshot. Recovering it means pinning the hosted clang — the self-ho
 already pins `/opt/llvm-23.1.0` by absolute path — or keying the entry on the clang build
 id. That is issue [#1095](https://github.com/drsnuggles8/OloEngineBase/issues/1095).
 Re-adding the restore/save without doing one of those reproduces the 0.00 %.
+
+**#1095 did the first one, and the entries are back.** `setup-linux-build` now installs
+the official LLVM 23.1.0 release tarball at `/opt/llvm-23.1.0` on the hosted arm — the
+same build, at the same path, as the self-hosted box — so the compiler the key is hashed
+over holds still, and the version is in the cache key so a bump is a reviewable commit
+rather than a silent 0 % run. Two things came back smaller than they went out: the cap is
+900M rather than 1500M, because rule 5 says these jobs have no claim on the cap and a
+2400 MiB share leaves the fleet 2.7 GiB of headroom rather than 1.4; and the save is
+gated on `github.event_name != 'pull_request'`, so only the nightly writes. **The
+acceptance is the "Cache hits rate" line on the second nightly after it lands, not a
+green check** — this section is what happens when that distinction is not made.
 
 **The rule:** before adding a cache, check what the existing ones actually return. A
 0 %-hit entry is not neutral; it costs quota, download time, and the room a working cache

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -224,7 +224,11 @@ over holds still, and the version is in the cache key so a bump is a reviewable 
 rather than a silent 0 % run. Two things came back smaller than they went out: the cap is
 900M rather than 1500M, because rule 5 says these jobs have no claim on the cap and a
 2400 MiB share leaves the fleet 2.7 GiB of headroom rather than 1.4; and the save is
-gated on `github.event_name != 'pull_request'`, so only the nightly writes. **The
+gated on `github.event_name != 'pull_request'`, so **hosted non-PR runs write** — in
+practice the nightly, plus a `workflow_dispatch` when someone is measuring a cold/warm
+A/B on a branch, which is deliberately kept open because that is how #1073's fix was
+verified and how this one has to be. It is *not* nightly-only, and the difference
+matters when you are counting who can fill the store. **The
 acceptance is the "Cache hits rate" line on the second nightly after it lands, not a
 green check** — this section is what happens when that distinction is not made.
 

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -247,6 +247,14 @@ suggest:
 | `steam-stub.yml / single-valve-tu` | ubuntu-24.04 | only Steam-seam changes | none; it compiles one TU |
 | `pre-commit`, `detect-changes`, `cancel-merged-pr-runs` | ubuntu-latest | every PR | none; seconds |
 
+The two `windows-2025` rows are conditional as of #1076: `Windows.yml` and `asan.yml` carry the
+routing to send them to a self-hosted runner behind `vars.OLO_WINDOWS_SELF_HOSTED`, and every
+Windows sccache step is gated on `runner.environment == 'github-hosted'`. The variable is unset and
+no Windows runner is registered, so today they are hosted and the entries above are real. **If that
+switch is ever flipped, `sccache-windows-2025-release` (1825 MiB) and `sccache-asan-windows-2025`
+(~660 MiB) leave the store on the PR path, and this table has to be redone** — see
+[ADR 0019](../adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md).
+
 Everything else that runs on a PR is **self-hosted** — `asan.yml`'s three Linux sanitizer
 jobs, `vulkan-off.yml`, `steam-stub.yml / stub-build` — and caches on the box's local disk.
 Note the trap: a self-hosted runner still talks to the **remote** Actions cache service, so

--- a/docs/ops/self-hosted-gpu-runner.md
+++ b/docs/ops/self-hosted-gpu-runner.md
@@ -488,11 +488,14 @@ X/Wayland `-devel` set; creates the `~/.cache/olo/*` directories from §1c; and
 registers `olo-ci-1` and `olo-ci-2` with labels `self-hosted,linux,x64,olo-ci`
 under user systemd, exactly like the GPU runner.
 
-**Both Linux arms build with clang-23** (#1036). Hosted takes it from apt.llvm.org,
-because ubuntu-24.04's default libstdc++ lacks `std::forward_like`; the box takes
-it from the official LLVM release tarball at `/opt/llvm-23.1.0`, installed by
+**Both Linux arms build with clang-23** (#1036, #1095), from the same official LLVM
+release tarball at the same `/opt/llvm-23.1.0` prefix: on the box installed by
 `scripts/setup-olo-ci-host.sh`, because EPEL on Rocky 10 tops out at `clang20` and
-ships no `clang22` or `clang23`. The prefix is versioned and deliberately off the
+ships no `clang22` or `clang23`; on a hosted runner installed per run by
+`.github/actions/setup-llvm-linux`, because apt.llvm.org — which is where the hosted
+arm used to get it — publishes only a rolling *snapshot*, and sccache hashes the
+compiler into every cache key. (ubuntu-24.04's default libstdc++ still supplies
+`std::forward_like`; only the compiler moved.) The prefix is versioned and deliberately off the
 system `PATH`, so Rocky's clang 21 stays the default for everything else on this
 host — including the other repository's runners.
 

--- a/docs/ops/self-hosted-linux-toolchain.md
+++ b/docs/ops/self-hosted-linux-toolchain.md
@@ -1,4 +1,4 @@
-# Self-hosted Linux runners: the box builds with a pinned clang-23, and a job verifies but never installs
+# Both Linux arms build with a pinned clang-23 from one tarball; on the box a job verifies but never installs
 
 Issues [#1015](https://github.com/drsnuggles8/OloEngineBase/issues/1015) item A and
 [#1036](https://github.com/drsnuggles8/OloEngineBase/issues/1036). Applies to every job that
@@ -12,12 +12,20 @@ regression.
 
 ## The rule
 
-1. **Both Linux arms build with clang-23.** Hosted takes it from apt.llvm.org; the box takes it
-   from the official LLVM release tarball, unpacked at **`/opt/llvm-23.1.0`** by
-   [`scripts/setup-olo-ci-host.sh`](../../scripts/setup-olo-ci-host.sh) and referenced by
-   absolute path. The prefix is versioned and is **not** on the system `PATH`: Rocky's clang
-   21.1.8 stays the default for everything else on the host, including another repository's
-   runners.
+1. **Both Linux arms build with the same clang, from the same tarball, at the same path.**
+   `/opt/llvm-23.1.0`, unpacked from the official LLVM release: on the box by
+   [`scripts/setup-olo-ci-host.sh`](../../scripts/setup-olo-ci-host.sh), and on a GitHub-hosted
+   runner by [`setup-llvm-linux`](../../.github/actions/setup-llvm-linux/action.yml) (bytes on
+   `/mnt`, symlinked to the `/opt` path). Both are referenced by absolute path. The prefix is
+   versioned and is **not** on the system `PATH`: Rocky's clang 21.1.8 stays the default for
+   everything else on the host, including another repository's runners.
+
+   The hosted arm took it from **apt.llvm.org until #1095**, and that is worth knowing rather
+   than forgetting: apt.llvm.org publishes only the newest *snapshot* of a branch, so the
+   compiler rolled every few days. sccache hashes the compiler binary into every cache key, so
+   three sanitizer cache entries restored 1.2 GB each and returned **0.00 %** — measured, on
+   three jobs, on three nightlies. A pinned runner image is only half the rule: **pin whatever
+   the key is hashed over, and on Linux that is the compiler.**
 2. **A package pin is impossible; that is not the same as no pin.** EPEL on Rocky 10 tops out at
    `clang20` (20.1.8) and ships no `clang22`/`clang23`. This doc previously concluded from that
    that the skew was permanent. It was not -- LLVM publishes prebuilt tarballs, so the skew was
@@ -154,9 +162,13 @@ the toolchain is no longer on the list of explanations.
 One number in three places, in this order: `llvm_version` in `scripts/setup-olo-ci-host.sh` plus
 its `llvm_sha256` (take the digest from the release's `.jsonl` sigstore bundle, then confirm it
 against a `sha256sum` of the download); `llvm_prefix` and `llvm_major` in
-[`setup-linux-build`](../../.github/actions/setup-linux-build/action.yml); and the `version`
-default in [`setup-llvm-apt`](../../.github/actions/setup-llvm-apt/action.yml) for the hosted
-arm. Run the script on the box **before** merging the action change: the old prefix keeps working
+[`setup-linux-build`](../../.github/actions/setup-linux-build/action.yml), which is also where
+the hosted arm's `version` + `sha256` inputs to
+[`setup-llvm-linux`](../../.github/actions/setup-llvm-linux/action.yml) live. Move all of them
+together: the two arms sharing one prefix is what makes a hosted/self-hosted A/B mean anything,
+and a half-done bump splits them silently. The version is in the Linux sccache **cache key**
+too — that is deliberate, so a bump is a reviewable commit rather than a run that quietly
+returns 0 %. Run the script on the box **before** merging the action change: the old prefix keeps working
 until then, and the warn-and-fall-back path means a mismatch degrades rather than breaks.
 
 A bump changes the prefix path, so the previous one is orphaned rather than replaced — 12 GB

--- a/docs/ops/self-hosted-linux-toolchain.md
+++ b/docs/ops/self-hosted-linux-toolchain.md
@@ -171,9 +171,16 @@ the hosted arm's `lld-NN` package comes from — the fallback linker
 runner image. (That fallback path is *derived* from the LLVM version rather than written down,
 so it cannot silently drift from this one; the apt `version` still has to move.) Move all of them
 together: the two arms sharing one prefix is what makes a hosted/self-hosted A/B mean anything,
-and a half-done bump splits them silently. The version is in the Linux sccache **cache key**
-too — that is deliberate, so a bump is a reviewable commit rather than a run that quietly
-returns 0 %. Run the script on the box **before** merging the action change: the old prefix keeps working
+and a half-done bump splits them silently.
+
+**And `OLO_LINUX_LLVM_VERSION` in [`asan.yml`](../../.github/workflows/asan.yml)'s workflow
+`env`.** The three Linux sccache keys carry the LLVM version, deliberately — sccache hashes the
+compiler binary, so an entry taken with a different clang is a guaranteed miss that still
+restores, still downloads 1.2 GB and still holds quota, which is exactly the 0.00 % #1095 fixed.
+It is one value rather than the nine literals it started as (a restore key, a `restore-keys`
+prefix and a save key per job), so this is one line — but **forgetting it re-creates the bug the
+pin exists to remove, and the run stays green while it does.** Run the script on the box
+**before** merging the action change: the old prefix keeps working
 until then, and the warn-and-fall-back path means a mismatch degrades rather than breaks.
 
 A bump changes the prefix path, so the previous one is orphaned rather than replaced — 12 GB

--- a/docs/ops/self-hosted-linux-toolchain.md
+++ b/docs/ops/self-hosted-linux-toolchain.md
@@ -164,7 +164,12 @@ its `llvm_sha256` (take the digest from the release's `.jsonl` sigstore bundle, 
 against a `sha256sum` of the download); `llvm_prefix` and `llvm_major` in
 [`setup-linux-build`](../../.github/actions/setup-linux-build/action.yml), which is also where
 the hosted arm's `version` + `sha256` inputs to
-[`setup-llvm-linux`](../../.github/actions/setup-llvm-linux/action.yml) live. Move all of them
+[`setup-llvm-linux`](../../.github/actions/setup-llvm-linux/action.yml) live; and the `version`
+default in [`setup-llvm-apt`](../../.github/actions/setup-llvm-apt/action.yml), which is where
+the hosted arm's `lld-NN` package comes from — the fallback linker
+`setup-llvm-linux` falls back to when the release tarball's own `ld.lld` will not start on the
+runner image. (That fallback path is *derived* from the LLVM version rather than written down,
+so it cannot silently drift from this one; the apt `version` still has to move.) Move all of them
 together: the two arms sharing one prefix is what makes a hosted/self-hosted A/B mean anything,
 and a half-done bump splits them silently. The version is in the Linux sccache **cache key**
 too — that is deliberate, so a bump is a reviewable commit rather than a run that quietly

--- a/scripts/Copy-ImportedDlls.ps1
+++ b/scripts/Copy-ImportedDlls.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Stage every non-system DLL a Windows binary imports next to that binary.
+
+.DESCRIPTION
+    Issue #1083 moved the two Windows test runs into shard jobs that receive the
+    test tree as an artifact and install no toolchain. That works only if the
+    artifact carries everything OloEngine-Tests.exe needs AT LOAD TIME, and the
+    list is not obvious: CMake stages the FFmpeg and Steam DLLs beside the exe, so
+    those travel for free -- but `shaderc_sharedd.dll` is a STATIC PE IMPORT
+    resolved from the Vulkan SDK's bin directory on PATH. A shard without it dies
+    in the OS loader with 0xC0000135 before main(), which reads as every case
+    failing for no stated reason.
+
+    A hand-written list of DLLs to copy would have missed exactly that one, and
+    would rot the next time a dependency moves. So the list is READ FROM THE
+    BINARY instead, with `dumpbin /dependents` (on PATH after the MSVC dev
+    environment step every Windows job here already runs).
+
+    THE RULE: a DLL that resolves under %SystemRoot% belongs to the runner image
+    and is left alone; anything else is copied. An import that resolves NOWHERE
+    fails this script -- if the exe cannot load on the machine that built it, a
+    shard has no chance, and the failure should be named here rather than
+    discovered as a loader error somewhere else.
+
+.PARAMETER Exe
+    The binary to inspect. Its own directory is searched first, exactly as the
+    Windows loader does.
+
+.PARAMETER Destination
+    Where to copy the DLLs. Normally the exe's own directory.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $Exe,
+    [Parameter(Mandatory = $true)][string] $Destination
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $Exe)) { throw "no such binary: $Exe" }
+$exeDir = Split-Path -Parent (Resolve-Path -LiteralPath $Exe)
+
+if (-not (Get-Command dumpbin -ErrorAction SilentlyContinue)) {
+    throw "dumpbin is not on PATH. Run this after the MSVC dev environment step."
+}
+
+# `dumpbin /dependents` prints one indented DLL name per line inside an
+# "Image has the following dependencies:" block. Matching the names directly is
+# simpler and just as precise: nothing else in that output looks like `*.dll`.
+$out = & dumpbin /nologo /dependents $Exe 2>&1
+if ($LASTEXITCODE -ne 0) { throw "dumpbin failed on ${Exe}:`n$out" }
+
+$imports = $out |
+    Select-String -Pattern '^\s{4}(\S+\.dll)\s*$' |
+    ForEach-Object { $_.Matches[0].Groups[1].Value } |
+    Sort-Object -Unique
+
+if (-not $imports) { throw "dumpbin reported no imports for $Exe -- that cannot be right" }
+
+$system = [Environment]::GetFolderPath('Windows')
+$copied = @()
+$missing = @()
+
+foreach ($name in $imports) {
+    # An api-ms-win-* / ext-ms-* name is an API SET, not a file: the loader resolves
+    # it through the OS's api-set schema to whatever system DLL currently implements
+    # it. Skipped BEFORE resolution, not after -- stray physical copies of these do
+    # exist on a developer box (one turned up under the Windows Performance Toolkit
+    # while testing this), and shipping one beside the exe would shadow the
+    # redirection with a stub from some other SDK's install.
+    if ($name -like 'api-ms-*' -or $name -like 'ext-ms-*') { continue }
+
+    # The loader looks in the exe's own directory first; anything already there
+    # (CMake stages FFmpeg and steam_api64 there) needs no help.
+    if (Test-Path -LiteralPath (Join-Path $exeDir $name)) { continue }
+
+    $resolved = (Get-Command $name -CommandType Application -ErrorAction SilentlyContinue |
+                 Select-Object -First 1).Source
+    if (-not $resolved) {
+        $missing += $name
+        continue
+    }
+    if ($resolved.StartsWith($system, [StringComparison]::OrdinalIgnoreCase)) { continue }
+
+    Copy-Item -LiteralPath $resolved -Destination $Destination -Force
+    $copied += "$name  <- $resolved"
+}
+
+if ($missing.Count -gt 0) {
+    Write-Host "::error::$Exe imports DLLs that resolve nowhere on this runner: $($missing -join ', '). It would not load here either."
+    exit 1
+}
+
+if ($copied.Count -eq 0) {
+    Write-Host "no extra imported DLLs to stage; everything resolves from $exeDir or the system"
+} else {
+    Write-Host "staged $($copied.Count) imported DLL(s) into ${Destination}:"
+    $copied | ForEach-Object { Write-Host "  $_" }
+}

--- a/scripts/Copy-ImportedDlls.ps1
+++ b/scripts/Copy-ImportedDlls.ps1
@@ -48,21 +48,37 @@ if (-not (Get-Command dumpbin -ErrorAction SilentlyContinue)) {
 # `dumpbin /dependents` prints one indented DLL name per line inside an
 # "Image has the following dependencies:" block. Matching the names directly is
 # simpler and just as precise: nothing else in that output looks like `*.dll`.
-$out = & dumpbin /nologo /dependents $Exe 2>&1
-if ($LASTEXITCODE -ne 0) { throw "dumpbin failed on ${Exe}:`n$out" }
-
-$imports = $out |
-    Select-String -Pattern '^\s{4}(\S+\.dll)\s*$' |
-    ForEach-Object { $_.Matches[0].Groups[1].Value } |
-    Sort-Object -Unique
-
-if (-not $imports) { throw "dumpbin reported no imports for $Exe -- that cannot be right" }
+function Get-Dependents([string] $Image) {
+    $out = & dumpbin /nologo /dependents $Image 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "dumpbin failed on ${Image}:`n$out" }
+    $names = $out |
+        Select-String -Pattern '^\s{4}(\S+\.dll)\s*$' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value } |
+        Sort-Object -Unique
+    if (-not $names) { throw "dumpbin reported no imports for $Image -- that cannot be right" }
+    return $names
+}
 
 $system = [Environment]::GetFolderPath('Windows')
 $copied = @()
 $missing = @()
 
-foreach ($name in $imports) {
+# TRANSITIVE, via a worklist. A copied DLL has imports of its own, and one of those
+# resolving only on the build runner's PATH would fail in the shard's loader exactly
+# as the direct case did -- with the same unreadable symptom, one level deeper. Today
+# this changes nothing (shaderc_shared.dll imports only KERNEL32, the MSVC redist and
+# api-set CRT names, all of them system), and that is the point: the direct list was
+# also fine right up until it was not, and reasoning about a dependency graph is the
+# thing this script exists to stop doing.
+$queue = [System.Collections.Generic.Queue[string]]::new()
+$queue.Enqueue((Resolve-Path -LiteralPath $Exe).Path)
+$seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+
+while ($queue.Count -gt 0) {
+$image = $queue.Dequeue()
+if (-not $seen.Add($image)) { continue }
+
+foreach ($name in (Get-Dependents $image)) {
     # An api-ms-win-* / ext-ms-* name is an API SET, not a file: the loader resolves
     # it through the OS's api-set schema to whatever system DLL currently implements
     # it. Skipped BEFORE resolution, not after -- stray physical copies of these do
@@ -72,8 +88,10 @@ foreach ($name in $imports) {
     if ($name -like 'api-ms-*' -or $name -like 'ext-ms-*') { continue }
 
     # The loader looks in the exe's own directory first; anything already there
-    # (CMake stages FFmpeg and steam_api64 there) needs no help.
-    if (Test-Path -LiteralPath (Join-Path $exeDir $name)) { continue }
+    # (CMake stages FFmpeg and steam_api64 there) needs no help -- but it still has
+    # imports of its own, so it goes on the queue rather than being dropped.
+    $beside = Join-Path $exeDir $name
+    if (Test-Path -LiteralPath $beside) { $queue.Enqueue((Resolve-Path -LiteralPath $beside).Path); continue }
 
     $resolved = (Get-Command $name -CommandType Application -ErrorAction SilentlyContinue |
                  Select-Object -First 1).Source
@@ -81,10 +99,14 @@ foreach ($name in $imports) {
         $missing += $name
         continue
     }
+    # A system DLL is on the runner already and its own dependencies are the OS's
+    # problem, so it is neither copied nor walked.
     if ($resolved.StartsWith($system, [StringComparison]::OrdinalIgnoreCase)) { continue }
 
     Copy-Item -LiteralPath $resolved -Destination $Destination -Force
     $copied += "$name  <- $resolved"
+    $queue.Enqueue($resolved)
+}
 }
 
 if ($missing.Count -gt 0) {

--- a/scripts/verify_test_shards.py
+++ b/scripts/verify_test_shards.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prove that a sharded ctest run covered every case the unsharded run would have.
+"""Prove that a sharded ctest run SELECTED every case the unsharded run would have.
 
 Issue #1083 split the two Windows test steps across a matrix of runners. That trades
 runner-minutes for wall-clock, and it introduces one failure mode the unsharded step
@@ -20,8 +20,15 @@ matched. This script reads them all and fails unless:
   * no shard matched zero cases -- the guard the issue names explicitly;
   * the counts sum to the total the build job measured with a plain ``ctest -N``.
 
-The last one is the real coverage proof. The first three are there so that when it
-fails, the message says which shard is wrong instead of only that the arithmetic is.
+The last one is the partition proof. The first three are there so that when it fails,
+the message says which shard is wrong instead of only that the arithmetic is.
+
+WHAT THIS DOES NOT PROVE, stated here because the distinction is the whole point of
+the check: each count comes from ``ctest -N`` BEFORE that shard runs anything, so a
+shard whose ctest died a third of the way through still uploaded a full count. This
+proves the SELECTION was a partition, not that every selected case executed. The
+calling job pairs it with a check on the shard matrix's own result, which covers the
+other half.
 """
 
 from __future__ import annotations
@@ -113,7 +120,12 @@ def main() -> int:
               f"{'skipped' if total < args.expected_total else 'double-counted'}.")
         return 1
 
-    print(f"{args.label}: coverage proven -- the shards partition all {total} ctest entries.")
+    print(f"{args.label}: the shards' selections partition all {total} ctest entries.")
+    # Deliberately NOT "coverage proven". Each count is recorded from "ctest -N"
+    # BEFORE that shard runs anything, so this proves the partition and not the
+    # execution: a shard whose ctest died a third of the way through still uploaded a
+    # full count. The workflow pairs this with a check on the shard matrix's own
+    # result, which is what covers the other half.
     return 0
 
 

--- a/scripts/verify_test_shards.py
+++ b/scripts/verify_test_shards.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Prove that a sharded ctest run covered every case the unsharded run would have.
+
+Issue #1083 split the two Windows test steps across a matrix of runners. That trades
+runner-minutes for wall-clock, and it introduces one failure mode the unsharded step
+did not have: a shard whose ``-I`` range matched nothing, or a shard job that never
+started, is INVISIBLE. Every remaining shard passes, the matrix goes green, and the
+cases in the gap were never executed. This repository's dominant failure archetype is
+a green run that tested nothing, so the sharding is not allowed to exist without a
+check that says otherwise.
+
+Each shard writes one small file (see ``--dir``) recording the shard index, the shard
+count it believed it was part of, and how many ctest entries its own ``-I`` selection
+matched. This script reads them all and fails unless:
+
+  * every shard reported in -- 1..N present exactly once, so a job that was skipped,
+    cancelled or never scheduled is caught rather than averaged away;
+  * every shard agreed on N -- a matrix list edited out of step with the stride passed
+    to ``ctest -I`` would otherwise silently double-run some cases and skip others;
+  * no shard matched zero cases -- the guard the issue names explicitly;
+  * the counts sum to the total the build job measured with a plain ``ctest -N``.
+
+The last one is the real coverage proof. The first three are there so that when it
+fails, the message says which shard is wrong instead of only that the arithmetic is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def parse_shard_file(path: pathlib.Path) -> dict[str, int]:
+    """Read a ``key=value`` shard report. Every value here is an integer by
+    construction (the shard writes them from ctest's own output), so a non-integer
+    is a corrupted or truncated upload and is worth failing on rather than skipping."""
+    fields: dict[str, int] = {}
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            raise SystemExit(f"{path}:{lineno}: expected key=value, got {raw!r}")
+        try:
+            fields[key.strip()] = int(value.strip())
+        except ValueError as exc:
+            raise SystemExit(f"{path}:{lineno}: {key.strip()} is not an integer: {value.strip()!r}") from exc
+    missing = {"shard", "shards", "count"} - fields.keys()
+    if missing:
+        raise SystemExit(f"{path}: missing {', '.join(sorted(missing))}")
+    return fields
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir",
+        required=True,
+        type=pathlib.Path,
+        help="Directory the shard-count artifacts were downloaded into. Searched recursively, "
+        "because actions/download-artifact with a pattern nests each artifact in its own folder.",
+    )
+    parser.add_argument(
+        "--expected-total",
+        required=True,
+        type=int,
+        help="Case count the build job measured with an unsharded `ctest -N`, under the same "
+        "--exclude-regex the shards use. This is the number the shards have to add up to.",
+    )
+    parser.add_argument("--label", default="test shards", help="Name used in the messages.")
+    args = parser.parse_args()
+
+    files = sorted(args.dir.rglob("shard-*.txt"))
+    if not files:
+        print(f"::error::{args.label}: no shard reports found under {args.dir}. Every shard job "
+              f"either failed before its guard ran or its upload was lost; either way nothing "
+              f"here proves the suite was executed.")
+        return 1
+
+    reports = [parse_shard_file(p) for p in files]
+
+    declared = {r["shards"] for r in reports}
+    if len(declared) != 1:
+        print(f"::error::{args.label}: shards disagree on the shard count: {sorted(declared)}. The "
+              f"matrix list and the stride passed to `ctest -I` have drifted apart, so the shards "
+              f"do not partition the suite.")
+        return 1
+    shard_count = declared.pop()
+
+    seen = sorted(r["shard"] for r in reports)
+    if seen != list(range(1, shard_count + 1)):
+        print(f"::error::{args.label}: expected reports from shards 1..{shard_count}, got {seen}. "
+              f"A missing shard means its cases ran nowhere.")
+        return 1
+
+    empty = [r["shard"] for r in reports if r["count"] <= 0]
+    if empty:
+        print(f"::error::{args.label}: shard(s) {empty} matched ZERO ctest entries. A shard that "
+              f"selects nothing passes instantly and looks identical to one that passed.")
+        return 1
+
+    total = sum(r["count"] for r in reports)
+    print(f"{args.label}: {shard_count} shards, "
+          + ", ".join(f"#{r['shard']}={r['count']}" for r in sorted(reports, key=lambda r: r["shard"]))
+          + f" -> {total} (build job measured {args.expected_total})")
+
+    if total != args.expected_total:
+        print(f"::error::{args.label}: shards covered {total} ctest entries but the unsharded run "
+              f"has {args.expected_total}. The shards are not a partition of the suite -- "
+              f"{abs(args.expected_total - total)} case(s) were "
+              f"{'skipped' if total < args.expected_total else 'double-counted'}.")
+        return 1
+
+    print(f"{args.label}: coverage proven -- the shards partition all {total} ctest entries.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three CI issues that all edit the same two workflow files, so they land together rather than as three guaranteed conflicts.

## `#1083` — shard the two Windows test steps

117 min of the per-PR critical path was test execution: `Run tests under ASan` 89.0 min and `Run tests with CTest` 28.1 min (measured, run 33993528874/33993528877). PR #1091 already did the `--parallel` half of this issue — widths 4/6/8 and 2/3/4 swept in palindrome order — and its answer is what makes sharding the remaining lever: **the step stops scaling on one 4-vCPU runner.** Doubling the ASan width bought ~15 %, not the ~2× a launch-latency-bound workload would give. A workload that is CPU-bound on four vCPUs gets faster by adding runners, not by asking that runner for more.

So both jobs now build, hand the test tree over as an artifact, and run the suite across a matrix — **ASan 4-wide, `Windows / build` 3-wide**.

**Both, and that is the point.** #1084's governing fact is that the PR is `max()` of these two jobs and they were within 12 seconds of each other. Sharding only the bigger one would make the ASan job finish earlier and leave the PR waiting exactly as long on the other.

**Nothing about the test semantics changes.** `ctest -I <shard>,,<stride>` selects by index over the same list, so it stays one process per case. Batching cases per process is the bigger win and removes the isolation that hides cross-test state corruption — that is #1074's territory and is not touched here.

**The exchange rate, stated explicitly:** each shard is a whole runner and pays job startup, a checkout and an artifact download before it runs a case. Seven extra Windows jobs per run. This buys wall-clock with runner-minutes; the real figures for both come from the first green run and go on #1083.

Two guards, because a shard that matched nothing passes in a second and looks identical to one that ran 1,900 cases:

- each shard fails if its own `ctest -N` count is zero;
- `scripts/verify_test_shards.py` fails the run unless every shard reported, all agreed on the stride, none was empty, and the counts sum to the unsharded `ctest -N` total the build job measured. It says *the selections partition the suite* and not *coverage proven*, because the counts are recorded before the run — the verify job separately fails when the shard matrix did not succeed, which is the other half.

The exclude-regex has one definition per workflow, so the total and the shards cannot filter differently; the stride likewise has one definition per job, so a shard cannot count one partition and run another.

## `#1095` — the Linux sanitizer cache that measured 0.00 %

1558 compile requests, 0 hits, three jobs out of three, while restoring 1.2 GB each and holding 3741 MiB of a ~9.3 GiB store. sccache hashes the compiler binary into every key, and the hosted arm built with apt.llvm.org's **snapshot** clang-23, whose build id rolls every few days. apt.llvm.org publishes only the newest snapshot of a branch, so no apt version pin can hold it still.

The official release tarball can, and the box has been unpacking exactly that at `/opt/llvm-23.1.0` since #1036. So the hosted arm now installs the same tarball at the same prefix, via a new `setup-llvm-linux` action modelled on `setup-llvm-windows`: sha256 pinned from the release's sigstore bundle (the same value `scripts/setup-olo-ci-host.sh` carries), unpacked on `/mnt` and symlinked to the `/opt` path because the tree is ~12 GB and the root filesystem is where the build already competes. It asserts the version, that the linker starts, and that compiler-rt is complete — the tarball's own `ld.lld` links ICU 70 and will not start on noble, so it falls back to apt's `lld-NN`, checked up front rather than discovered at the first link forty minutes in.

The two arms now resolve one prefix, so their `toolchain:` lines report the same clang build — which is what #1015/#1036 wanted and a rolling snapshot was quietly undoing.

The entries come back **smaller than they went out**: cap 1500M → 900M, ~2400 MiB for the set instead of 3741, leaving the fleet ~2.7 GiB under `cache-prune`'s ceiling rather than ~1.4. Rule 5 of `actions-cache-budget.md` says the store exists for hosted jobs on a PR and these are neither, so they get the smaller share — which caps the achievable hit rate by eviction, and is written down as the budget decision it is. The LLVM version is in the key; the save stays off `pull_request` runs.

**Not measured, and not forecast: the hit rate.** #1095's acceptance is a non-zero rate on a *second* nightly, since the first only writes. It goes on the issue when a real run produces it.

## `#1076` — Windows self-hosted routing, **switched off**

The `runs-on` routing, the `vars.OLO_WINDOWS_SELF_HOSTED` kill switch, the fork guard, the `runner.environment == 'github-hosted'` cache gating, a persistent `SCCACHE_DIR` and a self-hosted preflight are all here, in the shape `asan.yml`'s Linux jobs have used since #1009 and in that order, because the order is the safety property.

**No Windows runner is registered on this repository and the variable is unset**, so every run still lands on `windows-2025`. #1076's acceptance is measurements from both paths and the Windows entries gone from the store; none of that can exist until a runner does. **The issue stays open and nothing is forecast.**

[ADR 0019](docs/adr/0019-windows-ci-self-hosted-routing-lands-switched-off.md) records the decision and the provisioning bill — including that seven shard jobs want seven runner slots or the #1083 win is handed straight back, and that sccache's per-user daemon means one compiling runner instance per account. ADR 0017 §3 still stands: not the interactive workstation.

## What I need from you

**Provisioning a Windows runner and flipping `vars.OLO_WINDOWS_SELF_HOSTED` are your calls, and I have not made either.** If you don't want to provision one now, #1083 and #1095 stand on their own and #1076 stays open with the routing written but not enabled.

---

## Review guide

**Where I'd look hardest**

1. **`.github/workflows/asan.yml` / `Windows.yml` — what the shard artifact contains.** This is where the change actually fails or doesn't. The self-review found the artifact was missing `shaderc_shared.dll`, a static PE import resolved from the Vulkan SDK on PATH, which would have killed all seven shards in the loader. The fix reads the list out of the binary with `dumpbin` instead of writing it down. If something else the exe needs at load time is not an import — a data file, a DLL loaded by name at runtime — this misses it, and the `--gtest_list_tests` start guard is what turns that into one line instead of thousands.
2. **`scripts/verify_test_shards.py` and the two verify jobs.** The whole justification for sharding is that the coverage guard is trustworthy. Check the split I drew: the script proves the *selection* was a partition; the `Fail if any shard did not complete` step covers execution. If that pair has a hole, the sharding should not land.
3. **`.github/actions/setup-llvm-linux/action.yml` — a 12 GB install on every hosted Linux job.** It also runs for `vulkan-off` and `steam-stub`'s self-hosted-with-hosted-fallback jobs, so a fork PR there now pays the download. I judged that acceptable and worth the toolchain parity; disagree if you think a `pinned`/`apt` input is better than one shared decision.

**What I verified, and how**

- **`ctest -I <shard>,,<stride>` really partitions.** Ran `ctest -N` against a real 7,607-entry generated list: 2536/2536/2535 three ways and 1901/1901/1901/1900 four ways with the ASan exclusions, sums exact.
- **`shaderc_sharedd.dll` really is a static import.** Parsed the PE import directory of a local `OloEngine-Tests.exe`; it is in the import table, `vulkan-1.dll` is not (volk dlopens it), which is why only one DLL needed staging.
- **`scripts/Copy-ImportedDlls.ps1` runs.** Executed against that same real exe: it staged `shaderc_sharedd.dll` and nothing else, and skipping api-set names is a fix for it having also copied a stray `api-ms-win-core-synch-l1-2-0.dll` out of the Windows Performance Toolkit.
- **`scripts/verify_test_shards.py` runs.** Exercised the pass case and all four failure cases (sum mismatch, missing shard, empty directory, stride disagreement).
- Both workflows and all three actions parse as YAML; `master` has no required status checks, so the `ASan (Windows/clang-cl) build` rename breaks nothing.

**Least confident about**

**The self-hosted Windows path — none of it has ever run.** No such runner exists, so the preflight, the `SCCACHE_DIR` repoint and the routing expression itself are unexercised code. That is why the switch is off and why #1076 stays open, but it is real untested YAML in this diff.

Close behind: **the first sharded ASan run is the first time an instrumented test tree crosses a job boundary.** The workspace assertion and the start guard are there because I expect the first attempt at this to find something.

**Deliberately not tested**

- **Every measurement this PR exists to produce.** Wall-clock, runner-minutes, and the Linux cache hit rate all require real runs; the hit rate specifically needs a *second* nightly. Nothing is forecast anywhere in the diff.
- The `900M` sccache cap is a budget choice, not a measurement. It caps the achievable hit rate by eviction and says so.
- The shard counts (4 and 3) were not tuned by a sweep, because a sweep costs a full CI round each. They are re-measurable from any run's shard durations.

**One thing I noticed and did not change:** `Windows.yml`'s `Upload test results` points at `test_results/*.xml` with `if-no-files-found: warn`, but that job sets no `GTEST_OUTPUT`, so nothing writes there and the artifact is empty. Pre-existing and out of scope for these three issues; I kept parity in the shards rather than quietly fixing it. Say the word and it is a one-line follow-up.

Closes #1083
Closes #1095

Advances #1084 (measurements to follow on the issue) and #1076 (routing landed, switched off — not closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Linux builds now use a verified, pinned LLVM 23.1.0 toolchain for more consistent results.
  * Windows and Windows sanitizer tests are split across parallel shards, with validation that all tests are covered.
  * Windows jobs can support self-hosted runners while retaining hosted-runner behavior by default.
  * Windows build artifacts now include required imported DLLs for test execution.

* **Documentation**
  * Updated CI and toolchain documentation to describe pinned LLVM usage, test sharding, caching, and optional self-hosted Windows runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->