### PR TITLE
fix(asset,test): the two non-Vulkan deterministic master failures (#1098, #1094)

### DIFF
--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -772,7 +772,7 @@ namespace OloEngine
         // that is NOT itself present in the project (so a real "Assets/..." directory
         // can never be eaten), and the stripped remainder to actually exist there.
         [[nodiscard]] std::filesystem::path TryLegacyProjectPrefixedPath(const std::filesystem::path& projectPath,
-                                                                        const std::filesystem::path& filepath)
+                                                                         const std::filesystem::path& filepath)
         {
             if (projectPath.empty() || filepath.empty() || filepath.is_absolute())
                 return {};

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -743,6 +743,74 @@ namespace OloEngine
         return result;
     }
 
+    namespace
+    {
+        // The pre-#887 spelling, resolved against the PROJECT instead of the process
+        // working directory.
+        //
+        // Several shipped scenes still store a texture as
+        // "SandboxProject/Assets/Textures/Otter.png" — the project directory's own
+        // folder name, then the project-relative path. That spelling used to resolve
+        // only by coincidence: OloEditor runs with cwd = OloEditor/, which happens to
+        // be the parent of OloEditor/SandboxProject/, so std::filesystem::absolute()
+        // landed on the right file. Two things are wrong with leaning on that.
+        //
+        // First, it is not a property of the project, it is a property of where the
+        // process was started. Any tool, test or packaged runtime whose cwd is
+        // elsewhere resolves the same scene to nothing — or, worse, to a same-named
+        // file somewhere else on disk. The AssetSceneLoad round-trip test stages the
+        // project into a temp directory and the cwd fallback quietly resolved the
+        // texture to the ORIGINAL repository copy, outside the staged project entirely.
+        //
+        // Second, it registers the same file twice: once under "Assets/Textures/Otter.png"
+        // from a correctly-spelled reference and again under a cwd-derived key, so the
+        // two references never dedupe to one handle.
+        //
+        // So strip the leading component and retry against the project. Deliberately
+        // narrow, because a heuristic that fires when it should not is worse than one
+        // that does not fire: it needs at least two components, a leading component
+        // that is NOT itself present in the project (so a real "Assets/..." directory
+        // can never be eaten), and the stripped remainder to actually exist there.
+        [[nodiscard]] std::filesystem::path TryLegacyProjectPrefixedPath(const std::filesystem::path& projectPath,
+                                                                        const std::filesystem::path& filepath)
+        {
+            if (projectPath.empty() || filepath.empty() || filepath.is_absolute())
+                return {};
+
+            auto it = filepath.begin();
+            const auto end = filepath.end();
+            if (it == end)
+                return {};
+
+            const std::filesystem::path leading = *it;
+            if (leading.empty() || leading == "." || leading == "..")
+                return {};
+
+            std::filesystem::path remainder;
+            for (++it; it != end; ++it)
+                remainder /= *it;
+            if (remainder.empty())
+                return {};
+
+            std::error_code ec;
+            // A leading component that IS in the project is a real directory name, not
+            // a stale prefix — never strip it.
+            if (std::filesystem::exists(projectPath / leading, ec) || ec)
+                return {};
+
+            ec.clear();
+            std::filesystem::path candidate = projectPath / remainder;
+            if (!std::filesystem::exists(candidate, ec) || ec)
+                return {};
+
+            OLO_CORE_WARN("EditorAssetManager: asset path '{}' uses the legacy project-prefixed spelling; "
+                          "resolved it against the project root as '{}'. Re-save the scene to store the "
+                          "project-relative path instead.",
+                          filepath.generic_string(), remainder.generic_string());
+            return candidate;
+        }
+    } // namespace
+
     AssetHandle EditorAssetManager::ImportAsset(const std::filesystem::path& filepath)
     {
         OLO_PROFILER_SCOPE("EditorAssetManager::ImportAsset");
@@ -752,20 +820,21 @@ namespace OloEngine
         //   - project-relative ("Assets/Textures/Foo.png") — the current, documented
         //     contract (SceneSerializer::LoadSceneTexture resolves scene texture paths
         //     against the project asset root), used by newly-authored references.
-        //   - working-directory-relative ("SandboxProject/Assets/Textures/Foo.png") — an
-        //     older spelling several existing scenes still carry (PinkCubeWithTextures,
-        //     the Sponza scenes, VehiclesTest, Drift), which happens to resolve correctly
-        //     because OloEditor's actual cwd is OloEditor/, one level above the project
-        //     directory (OloEditor/SandboxProject/).
-        // Try the documented project-relative form first; only a path that doesn't exist
-        // there falls back to plain std::filesystem::absolute() (cwd-relative), so those
-        // older scenes keep resolving exactly as before until they're resaved. Resolving
-        // unconditionally against cwd (the previous behaviour) silently walked a
-        // project-relative input into the engine's own OloEditor/assets/ tree instead
-        // whenever a same-named file happened to exist there too — found, but keyed under
-        // a bogus "../assets/..." relative path that never matched a subsequent
-        // correctly-spelled lookup, and whose own load then failed because *that* path
-        // isn't valid from cwd either.
+        //   - project-PREFIXED ("SandboxProject/Assets/Textures/Foo.png") — an older
+        //     spelling several existing scenes still carry (PinkCubeWithTextures, the
+        //     Sponza scenes, VehiclesTest, Drift). It used to resolve only because
+        //     OloEditor's cwd is OloEditor/, one level above the project directory
+        //     (OloEditor/SandboxProject/) — a property of the launch, not the project.
+        //     It is now resolved against the project root instead (issue #1098).
+        // Try the documented project-relative form first. A path that doesn't exist
+        // there is then tried as the LEGACY project-prefixed spelling (see
+        // TryLegacyProjectPrefixedPath below), and only then falls back to plain
+        // std::filesystem::absolute() (cwd-relative). Resolving unconditionally against
+        // cwd (the pre-#887 behaviour) silently walked a project-relative input into the
+        // engine's own OloEditor/assets/ tree instead whenever a same-named file happened
+        // to exist there too — found, but keyed under a bogus "../assets/..." relative
+        // path that never matched a subsequent correctly-spelled lookup, and whose own
+        // load then failed because *that* path isn't valid from cwd either.
         std::filesystem::path absolutePath;
         if (filepath.is_absolute())
         {
@@ -775,9 +844,19 @@ namespace OloEngine
         {
             std::filesystem::path projectRelative = m_ProjectPath / filepath;
             std::error_code existsEc;
-            absolutePath = (std::filesystem::exists(projectRelative, existsEc) && !existsEc)
-                               ? projectRelative
-                               : std::filesystem::absolute(filepath);
+            if (std::filesystem::exists(projectRelative, existsEc) && !existsEc)
+            {
+                absolutePath = projectRelative;
+            }
+            else if (std::filesystem::path legacy = TryLegacyProjectPrefixedPath(m_ProjectPath, filepath);
+                     !legacy.empty())
+            {
+                absolutePath = legacy;
+            }
+            else
+            {
+                absolutePath = std::filesystem::absolute(filepath);
+            }
         }
 
         // Use error_code overload to handle filesystem errors gracefully
@@ -1147,18 +1226,65 @@ namespace OloEngine
     }
 #endif
 
-    std::filesystem::path EditorAssetManager::GetRelativePath(const std::filesystem::path& filepath) const
+    std::filesystem::path EditorAssetManager::MakeRegistryKey(const std::filesystem::path& filepath,
+                                                              const std::filesystem::path& projectPath)
     {
         // If the project path is empty, return the filepath as-is
-        if (m_ProjectPath.empty())
+        if (projectPath.empty())
             return filepath;
 
-        // Use weakly_canonical for robust path resolution with symlinks and ".." components
-        auto canonicalFile = std::filesystem::weakly_canonical(filepath);
-        auto canonicalProject = std::filesystem::weakly_canonical(m_ProjectPath);
+        // Use weakly_canonical for robust path resolution with symlinks and ".." components.
+        // The error_code overloads: a canonicalisation failure (a path on a
+        // disconnected network share, a permission error mid-walk) must degrade to
+        // the input rather than throw out of an import.
+        std::error_code ec;
+        std::filesystem::path canonicalFile = std::filesystem::weakly_canonical(filepath, ec);
+        if (ec || canonicalFile.empty())
+            canonicalFile = filepath;
+        ec.clear();
+        std::filesystem::path canonicalProject = std::filesystem::weakly_canonical(projectPath, ec);
+        if (ec || canonicalProject.empty())
+            canonicalProject = projectPath;
 
-        // Return relative path from project root
-        return std::filesystem::relative(canonicalFile, canonicalProject);
+        // Relative path from the project root — when one exists at all.
+        //
+        // std::filesystem::relative returns an EMPTY path when no relative path
+        // does exist, which on Windows means the two are on different drives:
+        // a project on D: and a texture on C: have no common root, so there is
+        // nothing to be relative to. That empty key was issue #1098, and every
+        // symptom of it is silent:
+        //   - the registry key is "", so GetHandleFromPath never matches and a
+        //     FRESH handle is minted on every import of the same file;
+        //   - every consumer spells the read `m_ProjectPath / metadata.FilePath`,
+        //     and `dir / ""` is the DIRECTORY, so the loader is handed a folder
+        //     to read pixels from and substitutes a placeholder texture whose
+        //     GetPath() is empty;
+        //   - SceneSerializer then round-trips that empty path into the scene,
+        //     and the next load drops the reference entirely.
+        // Keeping the absolute path is correct at every one of those consumers,
+        // because `dir / absolute` yields the absolute path unchanged — and
+        // three call sites in this file already branch on
+        // `metadata.FilePath.is_absolute()`, so an absolute key is a shape the
+        // registry was already written to carry.
+        ec.clear();
+        std::filesystem::path relativePath = std::filesystem::relative(canonicalFile, canonicalProject, ec);
+        if (!ec && !relativePath.empty())
+            return relativePath;
+
+        // Say so, and say it once per import rather than per read: an asset that
+        // cannot be named relative to the project is not portable — moving or
+        // packing the project will not bring it along — and that is worth a line
+        // in the log even though the load itself now succeeds.
+        OLO_CORE_WARN("EditorAssetManager: '{}' has no path relative to the project root '{}' "
+                      "(a different drive, on Windows). Registering it under its ABSOLUTE path, "
+                      "which is machine-specific: move the file inside the project to make it portable.",
+                      canonicalFile.string(), canonicalProject.string());
+        return canonicalFile;
+    }
+
+    std::filesystem::path EditorAssetManager::GetRelativePath(const std::filesystem::path& filepath) const
+    {
+        return MakeRegistryKey(filepath, m_ProjectPath);
     }
 
     AssetHandle EditorAssetManager::GetAssetHandleFromFilePath(const std::filesystem::path& filepath)

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -897,11 +897,18 @@ namespace OloEngine
         metadata.FilePath = relativePath;
         metadata.Type = type;
 
+        // Stamped from the RESOLVED path, not from the caller's spelling. `filepath`
+        // may be project-relative, and this call resolves a relative path against the
+        // process working directory — which is the project's parent in the editor and
+        // anything at all elsewhere. Every such read failed and stored the epoch, and
+        // an epoch timestamp is never "current", so EnsureCurrent and the watcher scan
+        // both force a reload of that asset on every check. `absolutePath` is the path
+        // the existence check three lines above already passed.
         // Use error_code overload to avoid exceptions (reuse existing ec variable)
-        metadata.LastWriteTime = std::filesystem::last_write_time(filepath, ec);
+        metadata.LastWriteTime = std::filesystem::last_write_time(absolutePath, ec);
         if (ec)
         {
-            OLO_CORE_WARN("Failed to get last write time for asset {}: {}", filepath.string(), ec.message());
+            OLO_CORE_WARN("Failed to get last write time for asset {}: {}", absolutePath.string(), ec.message());
             metadata.LastWriteTime = std::filesystem::file_time_type{}; // Default/empty timestamp
         }
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -1278,14 +1278,33 @@ namespace OloEngine
         if (!ec && !relativePath.empty())
             return relativePath;
 
-        // Say so, and say it once per import rather than per read: an asset that
-        // cannot be named relative to the project is not portable — moving or
-        // packing the project will not bring it along — and that is worth a line
-        // in the log even though the load itself now succeeds.
-        OLO_CORE_WARN("EditorAssetManager: '{}' has no path relative to the project root '{}' "
-                      "(a different drive, on Windows). Registering it under its ABSOLUTE path, "
-                      "which is machine-specific: move the file inside the project to make it portable.",
-                      canonicalFile.string(), canonicalProject.string());
+        // Say so: an asset that cannot be named relative to the project is not
+        // portable — moving or packing the project will not bring it along — and
+        // that is worth a line in the log even though the load itself now succeeds.
+        //
+        // Once per file, not once per call. This is not only reached from import:
+        // GetAssetHandleFromFilePath routes every ABSOLUTE-path lookup through here,
+        // and that is called from the script glue and the imported-material codec,
+        // so a cross-drive asset queried in a script would otherwise print on every
+        // frame. Same warned-set idiom as the missing-file report below.
+        //
+        // The dedupe is on the LOG only; the return value stays a pure function of
+        // the two inputs, which is what the unit tests pin.
+        static FMutex s_CrossDriveWarnMutex;
+        static std::unordered_set<std::string> s_CrossDriveWarned;
+        bool firstWarn = false;
+        {
+            TUniqueLock<FMutex> lock(s_CrossDriveWarnMutex);
+            firstWarn = s_CrossDriveWarned.insert(canonicalFile.string()).second;
+        }
+        if (firstWarn)
+        {
+            OLO_CORE_WARN("EditorAssetManager: '{}' has no path relative to the project root '{}' "
+                          "(a different drive, on Windows). Registering it under its ABSOLUTE path, "
+                          "which is machine-specific: move the file inside the project to make it "
+                          "portable. Reported once per file.",
+                          canonicalFile.string(), canonicalProject.string());
+        }
         return canonicalFile;
     }
 

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.h
@@ -189,6 +189,22 @@ namespace OloEngine
         std::filesystem::path GetRelativePath(const std::filesystem::path& filepath) const;
 
         /**
+         * @brief The registry key for a file, given a project root.
+         *
+         * Project-relative when a relative path exists, and the ABSOLUTE path
+         * when one does not — which on Windows is any file on a different
+         * drive from the project. Never empty for a non-empty input: an empty
+         * key is what issue #1098 was, and it is silent, because every consumer
+         * spells the read `projectDir / key` and an empty key resolves to the
+         * project directory itself rather than to nothing.
+         *
+         * Static and pure so the drive-crossing case is unit-testable without a
+         * second volume — `std::filesystem::relative` decides it lexically.
+         */
+        [[nodiscard]] static std::filesystem::path MakeRegistryKey(const std::filesystem::path& filepath,
+                                                                   const std::filesystem::path& projectPath);
+
+        /**
          * @brief Check if file exists for given metadata
          * @param metadata Asset metadata to check
          * @return True if file exists on disk

--- a/OloEngine/src/OloEngine/Renderer/IBLCache.cpp
+++ b/OloEngine/src/OloEngine/Renderer/IBLCache.cpp
@@ -40,7 +40,17 @@ namespace OloEngine
     // invalidates) an entry whose stored timestamp no longer matches the
     // source, so an in-place edit re-bakes on next load. The layout change
     // also makes older v1–v5 files unreadable, which is the intended reset.
-    constexpr u32 kIBLCacheVersion = 6;
+    // Version 7 invalidates every cubemap baked from an EQUIRECTANGULAR HDR
+    // before the vertical-flip fix. IBLPrecompute asked stb for a bottom-row-
+    // first load with the GLOBAL setter, and stb resolves that flag as
+    // `set ? local : global` where `set` latches the first time any code on the
+    // thread touches the thread-local setter — which every other loader in this
+    // engine does. The request was therefore ignored, the HDR loaded top-row-
+    // first, and the baked environment/irradiance/prefilter cubemaps came out
+    // UPSIDE DOWN: looking up showed the floor. Without this bump an existing
+    // cache keeps serving the inverted bake forever, because the key is
+    // source-path + config and neither changed.
+    constexpr u32 kIBLCacheVersion = 7;
 
     // Cache file header for version tracking
     // Use pragma pack to ensure consistent binary layout across compilers

--- a/OloEngine/src/OloEngine/Renderer/IBLPrecompute.cpp
+++ b/OloEngine/src/OloEngine/Renderer/IBLPrecompute.cpp
@@ -164,12 +164,31 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
         OLO_CORE_INFO("Converting equirectangular HDR to cubemap: {}", filePath);
 
-        // Load HDR image
-        stbi_set_flip_vertically_on_load(true);
-
+        // Load HDR image, bottom row first.
+        //
+        // The THREAD-LOCAL setter, not the global one, and that is the whole of
+        // this fix. stb resolves the flag as
+        //     set ? local : global
+        // where `set` latches to 1 the first time ANY code on this thread calls
+        // stbi_set_flip_vertically_on_load_thread — permanently, for the life of
+        // the thread. Every other loader in this engine uses the _thread setter
+        // (TextureSerializer, OpenGLTextureCubemap, TextureCompression), so by the
+        // time a scene bakes an environment map the latch is long since set and
+        // the global call here did nothing at all. The HDR loaded top-row-first,
+        // SampleSphericalMap maps +Y to v = 1, and the baked cubemap came out
+        // UPSIDE DOWN: looking up showed the floor and looking down the ceiling.
+        //
+        // It was intermittent in exactly the way that is hardest to place. A
+        // process that baked the environment before it loaded any other texture
+        // still saw the global flag, so the same scene rendered correctly or
+        // inverted depending only on load order — "some scenes look wrong".
+        //
+        // Toggling the global flag is not a way to test this: with the latch set,
+        // true and false produce a byte-identical frame.
         i32 width, height, channels;
+        stbi_set_flip_vertically_on_load_thread(1);
         f32* data = stbi_loadf(filePath.c_str(), &width, &height, &channels, 0);
-        stbi_set_flip_vertically_on_load(false); // reset global flag to avoid polluting later stbi calls
+        stbi_set_flip_vertically_on_load_thread(0); // restore; the latch stays set either way
 
         // OLO_ENV_BAKE_DUMP diagnostics (#797): CPU-side ground truth of the loaded HDR.
         if (data != nullptr && Levers::EnvironmentBakeDump())

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -167,6 +167,43 @@ namespace OloEngine
         return Texture2D::Create(texPath);
     }
 
+    // The roots a relative scene resource path is written against and read back
+    // from, most specific first.
+    //
+    // ONE list, shared by the writer (MakePortableSceneResourcePath) and the reader
+    // (ResolveSceneFontPath), because the two disagreeing is the whole of the font
+    // defect: the writer made a path relative to either root, the reader only ever
+    // prefixed the first, and every path written against the second was unreadable.
+    // Two functions deriving "the roots" separately is the shape that failure needs.
+    //
+    // The working directory is the STARTUP one where there is an Application, so a
+    // later chdir cannot move what a path means mid-session. There is no Application
+    // in the test binary or in a tool, and the static is then empty — fall back to
+    // the live cwd, which in a process that never chdir'd is the same value the
+    // Application would have captured.
+    static std::vector<std::filesystem::path> SceneResourceRoots()
+    {
+        std::vector<std::filesystem::path> roots;
+        if (Project::GetActive())
+        {
+            if (auto dir = Project::GetProjectDirectory(); !dir.empty())
+                roots.push_back(std::move(dir));
+        }
+
+        std::filesystem::path workingDir = Application::GetStartupWorkingDirectory();
+        if (workingDir.empty())
+        {
+            std::error_code ec;
+            workingDir = std::filesystem::current_path(ec);
+            if (ec)
+                workingDir.clear();
+        }
+        if (!workingDir.empty())
+            roots.push_back(std::move(workingDir));
+
+        return roots;
+    }
+
     // Runtime-facing resource paths must survive moving a project or launching a
     // packaged game on another machine. Font::Create stores the resolved absolute
     // path, so serializing GetPath() directly would rewrite a portable authored
@@ -178,14 +215,7 @@ namespace OloEngine
             return path.generic_string();
         }
 
-        std::vector<std::filesystem::path> roots;
-        if (Project::GetActive())
-        {
-            roots.push_back(Project::GetProjectDirectory());
-        }
-        roots.push_back(Application::GetStartupWorkingDirectory());
-
-        for (const auto& root : roots)
+        for (const auto& root : SceneResourceRoots())
         {
             std::error_code ec;
             const auto relative = std::filesystem::relative(path, root, ec);
@@ -197,14 +227,59 @@ namespace OloEngine
         return path.generic_string();
     }
 
+    // The read side of MakePortableSceneResourcePath, and it has to try the SAME
+    // roots that one writes against.
+    //
+    // The writer makes a font path relative to the project directory OR to the
+    // startup working directory, whichever it matches first. The reader only ever
+    // prefixed the project directory, so every path written against the second root
+    // was unreadable — and that is not a corner: the shipped scenes reference
+    // "assets/fonts/opensans/OpenSans-Regular.ttf", an ENGINE asset under
+    // OloEditor/assets/, which is startup-cwd-relative by construction. Drift,
+    // DriftMenu and FontRenderingTest all failed every font load, and the failure
+    // was quiet — Font::Create logs a miss and the text silently falls back to the
+    // default font, so the UI still draws, in the wrong typeface.
+    //
+    // Existence-checked rather than first-root-wins, because the two roots overlap
+    // (the project lives under the startup directory in this repo) and a path that
+    // exists under only the second one must still resolve. Project first, so a
+    // project-owned font continues to shadow an engine-owned one of the same name —
+    // the same precedence the writer encodes.
+    //
+    // When neither root has it, the project-rooted spelling is returned so
+    // Font::Create's existing error names a concrete path, and a warning here names
+    // every root actually tried — the missing half of the old message, which
+    // reported one root while the file was under another.
     static std::filesystem::path ResolveSceneFontPath(const std::filesystem::path& path)
     {
-        if (path.empty() || path.is_absolute() || !Project::GetActive())
+        if (path.empty() || path.is_absolute())
         {
             return path;
         }
 
-        return Project::GetProjectDirectory() / path;
+        const std::vector<std::filesystem::path> roots = SceneResourceRoots();
+        for (const auto& root : roots)
+        {
+            std::error_code ec;
+            if (std::filesystem::path candidate = root / path;
+                std::filesystem::exists(candidate, ec) && !ec)
+            {
+                return candidate;
+            }
+        }
+
+        std::string tried;
+        for (const auto& root : roots)
+        {
+            if (!tried.empty())
+                tried += "', '";
+            tried += (root / path).generic_string();
+        }
+        OLO_CORE_WARN("SceneSerializer: font '{}' was not found under any scene resource root (tried '{}'). "
+                      "The component will fall back to the default font.",
+                      path.generic_string(), tried);
+
+        return roots.empty() ? path : (roots.front() / path);
     }
 
     // ---------- Sanitization helpers (shared across all Deserialize* functions) ----------

--- a/OloEngine/tests/AssetRegistryInvariantsTest.cpp
+++ b/OloEngine/tests/AssetRegistryInvariantsTest.cpp
@@ -30,6 +30,7 @@
 
 #include <gtest/gtest.h>
 
+#include "OloEngine/Asset/AssetManager/EditorAssetManager.h"
 #include "OloEngine/Asset/AssetRegistry.h"
 #include "OloEngine/Asset/AssetMetadata.h"
 
@@ -180,4 +181,60 @@ namespace OloEngine::Tests
         EXPECT_EQ(textures.size(), 1u);
         EXPECT_EQ(static_cast<u64>(textures.front().Handle), 20ULL);
     }
+
+    // -------------------------------------------------------------------------
+    // The registry KEY itself (issue #1098).
+    //
+    // EditorAssetManager stores every asset under a path relative to the project
+    // root, and computes it with std::filesystem::relative — which returns an
+    // EMPTY path, not an error, when no relative path exists. On Windows that is
+    // any file on a different drive from the project: a project on D: and a
+    // texture on C: have no common root to be relative to.
+    //
+    // An empty key is silent at every consumer. GetHandleFromPath never matches
+    // it, so a fresh handle is minted per import; the readers all spell
+    // `projectDir / key`, and `dir / ""` is the DIRECTORY, so the loader is asked
+    // to read pixels out of a folder and substitutes a placeholder whose
+    // GetPath() is empty; SceneSerializer round-trips that empty path into the
+    // scene, and the NEXT load drops the reference entirely. That is exactly the
+    // two-different-sentinels failure #1098 reported
+    // ("" then "<null texture ref>").
+    //
+    // Pure and lexical, so the drive-crossing case needs no second volume.
+    // -------------------------------------------------------------------------
+    TEST(AssetRegistryKey, ProjectRelativeWhenARelativePathExists)
+    {
+        const auto key = EditorAssetManager::MakeRegistryKey(
+            std::filesystem::path{ "C:/proj/Assets/Textures/Foo.png" },
+            std::filesystem::path{ "C:/proj" });
+        EXPECT_EQ(key.generic_string(), "Assets/Textures/Foo.png");
+    }
+
+    TEST(AssetRegistryKey, NeverEmptyForAFileWithNoRelativePathToTheProject)
+    {
+#ifdef OLO_PLATFORM_WINDOWS
+        // Two different drive roots: there is no relative path between them.
+        const std::filesystem::path file{ "C:/elsewhere/Textures/Foo.png" };
+        const auto key = EditorAssetManager::MakeRegistryKey(file, std::filesystem::path{ "D:/proj" });
+
+        ASSERT_FALSE(key.empty())
+            << "an empty registry key resolves to the PROJECT DIRECTORY at every reader "
+               "(`projectDir / \"\"`), so the asset loads as a folder and its path round-trips "
+               "as empty — issue #1098";
+        EXPECT_TRUE(key.is_absolute())
+            << "with no relative spelling available the absolute path is the only correct key: "
+               "`projectDir / absolute` yields the absolute path unchanged at every reader";
+        EXPECT_EQ(key.filename().generic_string(), "Foo.png");
+#else
+        GTEST_SKIP() << "POSIX has a single filesystem root, so every pair of paths has a "
+                        "relative spelling and this case cannot be constructed.";
+#endif
+    }
+
+    TEST(AssetRegistryKey, EmptyProjectPathLeavesTheInputAlone)
+    {
+        const std::filesystem::path file{ "Assets/Textures/Foo.png" };
+        EXPECT_EQ(EditorAssetManager::MakeRegistryKey(file, {}), file);
+    }
+
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/AssetSceneLoadTest.cpp
+++ b/OloEngine/tests/AssetSceneLoadTest.cpp
@@ -721,4 +721,121 @@ namespace OloEngine::Tests
         }
     }
 
+    // -------------------------------------------------------------------------------
+    // A scene's font path resolves against the SAME roots the serializer writes it
+    // against.
+    //
+    // `MakePortableSceneResourcePath` makes a font path relative to the project
+    // directory OR to the process working directory, whichever matches first;
+    // `ResolveSceneFontPath` used to prefix only the project directory. Every path
+    // written against the second root was therefore unreadable — and that is not a
+    // corner case: the shipped scenes reference "assets/fonts/opensans/...", an
+    // ENGINE asset under OloEditor/assets/, which is working-directory-relative by
+    // construction. Drift, DriftMenu and FontRenderingTest failed every font load.
+    //
+    // The failure was quiet, which is why no test caught it: Font::Create returns a
+    // non-null Ref whose IsLoaded() is false, the text still draws in the fallback
+    // typeface, and the only signal is a "Failed to open font file" line naming a
+    // path under the project — a root the font was never under. So this asserts
+    // IsLoaded(), not non-null; non-null was always true.
+    //
+    // AssetContentValidity already checks the scene CONTENT resolves, and passed
+    // throughout, because it tries several candidate roots. That is the gap: the
+    // content was fine and the runtime resolver was not.
+    // -------------------------------------------------------------------------------
+    TEST(AssetSceneLoad, SceneFontPathsResolveAgainstTheWorkingDirectoryRootToo)
+    {
+        // Font::Create rasterises an MSDF atlas into a GPU texture.
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        if (!Renderer3D::IsInitialized())
+        {
+            Renderer::Init(RendererType::Renderer3D, /*loadingWindow=*/nullptr);
+        }
+
+        GLStateGuard glGuard("AssetSceneLoad.SceneFontPaths", GLStateGuard::Policy::Restore);
+
+        // The engine-owned font tree is reached through the working directory, and
+        // ctest runs this suite with WORKING_DIRECTORY = <repo>/OloEditor (see
+        // OloEngine/tests/CMakeLists.txt). Assert rather than skip: a wrong cwd is an
+        // environment error worth reporting, and silently skipping here would hide
+        // exactly the root this test exists to cover.
+        const fs::path engineFont = fs::path("assets") / "fonts" / "opensans" / "OpenSans-Regular.ttf";
+        ASSERT_TRUE(fs::exists(engineFont))
+            << "Expected the engine font tree relative to the working directory, but '"
+            << engineFont.string() << "' does not exist from cwd '"
+            << fs::current_path().string() << "'. Run this suite from OloEditor/.";
+
+        std::string stageError;
+        const fs::path tempRoot = StageSandboxProjectIntoTemp(stageError);
+        ASSERT_FALSE(tempRoot.empty())
+            << "Failed to stage SandboxProject into temp dir: " << stageError;
+
+        struct Cleanup
+        {
+            fs::path Dir;
+            ~Cleanup()
+            {
+                std::error_code ec;
+                for (int attempt = 0; attempt < 3; ++attempt)
+                {
+                    ec.clear();
+                    fs::remove_all(Dir, ec);
+                    std::error_code existsEc;
+                    if (!fs::exists(Dir, existsEc))
+                        return;
+                }
+                OLO_CORE_WARN("AssetSceneLoad: could not remove staging dir '{}': {}", Dir.string(), ec.message());
+            }
+        } cleanup{ tempRoot };
+
+        const fs::path projectFile = FindProjectFile(tempRoot);
+        ASSERT_FALSE(projectFile.empty())
+            << "No .oloproj found inside staged temp project at " << tempRoot.string();
+        ASSERT_TRUE(Project::Load(projectFile)) << "Project::Load failed on staged temp project.";
+
+        auto assetManager = Ref<EditorAssetManager>::Create();
+        assetManager->Initialize(/*startFileWatcher=*/false);
+        Project::SetAssetManager(assetManager);
+
+        struct AssetManagerShutdown
+        {
+            Ref<EditorAssetManager> Mgr;
+            ~AssetManagerShutdown()
+            {
+                if (Mgr)
+                    Mgr->Shutdown();
+                // See DecalAndSpriteTexturePathsSurviveRoundTrip: a shut-down manager
+                // left installed poisons every later test in the process (#1074).
+                Project::Unload();
+            }
+        } assetManagerShutdown{ assetManager };
+
+        // The staged project's copy is what loads; the FONT it names lives outside it.
+        const fs::path scenePath = tempRoot / "Assets" / "Scenes" / "FontRenderingTest.olo";
+        ASSERT_TRUE(fs::exists(scenePath)) << scenePath.string();
+
+        auto scene = Scene::Create();
+        SceneSerializer serializer(scene);
+        ASSERT_TRUE(serializer.Deserialize(scenePath)) << "Deserialize() of " << scenePath.string() << " failed.";
+
+        u32 checked = 0;
+        auto view = scene->GetAllEntitiesWith<TagComponent, TextComponent>();
+        for (auto entity : view)
+        {
+            const auto& [tag, text] = view.get<TagComponent, TextComponent>(entity);
+            ASSERT_TRUE(text.FontAsset) << "entity '" << tag.Tag << "' has a null font ref";
+            EXPECT_TRUE(text.FontAsset->IsLoaded())
+                << "entity '" << tag.Tag << "': the scene's font did not load. Font::Create hands back a "
+                                            "non-null, UNLOADED Font on a miss and the text falls back to the default typeface, "
+                                            "so a null check would not have caught this. Resolved path: '"
+                << text.FontAsset->GetPath() << "'";
+            ++checked;
+        }
+
+        EXPECT_GT(checked, 0u)
+            << "FontRenderingTest.olo carries no TextComponent any more — this test is asserting nothing. "
+               "Point it at another scene with a FontPath, or delete it.";
+    }
+
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/AssetSceneLoadTest.cpp
+++ b/OloEngine/tests/AssetSceneLoadTest.cpp
@@ -682,6 +682,21 @@ namespace OloEngine::Tests
                 return result;
             };
 
+            // THE DECISION (issue #1098), so it is not re-litigated: the legacy
+            // "SandboxProject/Assets/..." spelling STAYS SUPPORTED. It is carried by
+            // eleven shipped scenes and by any user scene authored before #887, and
+            // dropping it loses their textures with only a warning thousands of log
+            // lines away. What changed is WHERE it resolves against: the project
+            // root, not the process working directory. The cwd spelling only ever
+            // worked because OloEditor happens to run one directory above the
+            // project — a property of the launch, not of the project — and under it
+            // this very test resolved to the ORIGINAL repository texture rather than
+            // to the staged copy, and registered the same file under two handles.
+            //
+            // So the assertion is not merely "non-empty": it is that the texture
+            // resolves INSIDE the project it was loaded from. That is the property
+            // the cwd fallback could not provide, and asserting only non-emptiness
+            // is what let it look correct for a year.
             auto [firstPath, secondPath] = loadTwiceAndGetPath(scenePath, findFirstSpriteTexture);
             EXPECT_FALSE(firstPath.empty())
                 << "SpriteRendererComponent::Texture had an empty GetPath() on the FIRST load — "
@@ -689,6 +704,20 @@ namespace OloEngine::Tests
             EXPECT_FALSE(secondPath.empty())
                 << "SpriteRendererComponent::Texture had an empty GetPath() on the SECOND load.";
             EXPECT_EQ(firstPath, secondPath);
+
+            // Project-relative, and pointing at the STAGED tree. A path that is
+            // absolute, or that climbs out with "..", is the cwd resolution coming
+            // back.
+            const fs::path resolved = fs::path(firstPath);
+            EXPECT_FALSE(resolved.is_absolute())
+                << "the sprite texture resolved to an ABSOLUTE path (" << firstPath
+                << ") — scene texture references must stay project-relative to be portable.";
+            EXPECT_EQ(firstPath.find(".."), std::string::npos)
+                << "the sprite texture resolved OUTSIDE the project (" << firstPath
+                << ") — the legacy spelling must resolve against the project root, not the cwd.";
+            EXPECT_TRUE(fs::exists(tempRoot / resolved))
+                << "the sprite texture path '" << firstPath
+                << "' does not name a file inside the staged project at " << tempRoot.string();
         }
     }
 

--- a/OloEngine/tests/Rendering/PropertyTests/ShaderUnitTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/ShaderUnitTests.cpp
@@ -23,6 +23,9 @@
 
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
 #include "OloEngine/Renderer/ComputeShader.h"
+#include "OloEngine/Renderer/EnvironmentMap.h"
+#include "OloEngine/Renderer/Renderer.h"
+#include "OloEngine/Renderer/Renderer3D.h"
 #include "OloEngine/Renderer/IBLPrecompute.h"
 #include "OloEngine/Renderer/LightCulling/ClusteredLighting.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
@@ -33,11 +36,13 @@
 
 #define GLFW_INCLUDE_NONE
 #include <glad/gl.h>
+#include <stb_image/stb_image.h>
 #include <GLFW/glfw3.h>
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <numbers>
 #include <array>
 #include <bit>
 #include <cmath>
@@ -456,6 +461,154 @@ namespace OloEngine::Tests
 
         skybox.Reset();
         FrameResourceManager::Get().FlushAllDeletionQueues();
+    }
+
+    // =========================================================================
+    // Equirectangular bake orientation: a cubemap baked from an HDR panorama
+    // must keep the panorama's OWN vertical mapping.
+    //
+    // SamplingKeepsSkyAboveGround above covers the six-JPG cubemap path, which is
+    // a different loader with a different row convention (it explicitly does NOT
+    // flip). The equirectangular path had no orientation test at all, and it was
+    // upside down: looking up showed the floor, looking down showed the ceiling.
+    //
+    // The cause is worth recording because it is invisible at the call site.
+    // IBLPrecompute asked for a bottom-row-first load with the GLOBAL setter
+    // stbi_set_flip_vertically_on_load, but stb resolves the flag as
+    //     set ? local : global
+    // and `set` latches to 1 the first time ANY code on the thread calls the
+    // THREAD-LOCAL setter, which TextureSerializer, OpenGLTextureCubemap and
+    // TextureCompression all do. By the time a scene baked an environment map the
+    // latch was long since set, so the global call did nothing at all. Toggling it
+    // true/false produces a byte-identical frame, which is what makes this
+    // resistant to being found by experiment.
+    //
+    // Asserted as an A/B rather than against absolute values: each GPU probe is
+    // compared with a CPU lookup of the SOURCE panorama at the same direction, and
+    // with the same lookup at the vertically MIRRORED direction. The upright
+    // reading must fit better. That is immune to exposure, filtering and mip
+    // choice, which an absolute threshold would not be.
+    // =========================================================================
+    TEST(ShaderUnitSkyboxTest, EquirectangularBakeKeepsThePanoramaUpright)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        // The bake runs through the renderer's shader library, which
+        // EnvironmentMap::InitializeIBLSystem installs from Renderer3D bring-up.
+        // Without it CreateFromEquirectangular returns a map whose cubemap is null.
+        if (!Renderer3D::IsInitialized())
+        {
+            Renderer::Init(RendererType::Renderer3D, /*loadingWindow=*/nullptr);
+        }
+
+        const char* kHdrPath = "assets/textures/hdr/newport_loft.hdr";
+        std::error_code ec;
+        ASSERT_TRUE(std::filesystem::exists(kHdrPath, ec)) << "Missing HDR fixture: " << kHdrPath;
+
+        // Read the source WITHOUT any flip: row 0 is the panorama's top row, which
+        // is what "upright" is defined against. Through the thread-local setter,
+        // for the same reason the fix uses it -- the global one may already be
+        // latched out by an earlier loader on this thread.
+        ::stbi_set_flip_vertically_on_load_thread(0);
+        int srcW = 0;
+        int srcH = 0;
+        int srcCh = 0;
+        f32* src = ::stbi_loadf(kHdrPath, &srcW, &srcH, &srcCh, 3);
+        ASSERT_NE(src, nullptr) << "stbi_loadf failed for " << kHdrPath;
+        struct FreeSrc
+        {
+            f32* P;
+            ~FreeSrc()
+            {
+                ::stbi_image_free(P);
+            }
+        } freeSrc{ src };
+        ASSERT_GT(srcW, 0);
+        ASSERT_GT(srcH, 0);
+
+        // The CPU mirror of EquirectangularToCubemap.glsl's SampleSphericalMap,
+        // with row 0 = top (no flip), so v = 1 (up) reads the top of the image.
+        const auto sampleSource = [&](glm::vec3 dir) -> glm::vec3
+        {
+            dir = glm::normalize(dir);
+            const f32 u = 0.5f + std::atan2(dir.z, dir.x) / (2.0f * std::numbers::pi_v<f32>);
+            const f32 v = 0.5f + std::asin(std::clamp(dir.y, -1.0f, 1.0f)) / std::numbers::pi_v<f32>;
+            const int x = std::clamp(static_cast<int>(u * static_cast<f32>(srcW)), 0, srcW - 1);
+            const int y = std::clamp(static_cast<int>((1.0f - v) * static_cast<f32>(srcH)), 0, srcH - 1);
+            const sizet i = (static_cast<sizet>(y) * static_cast<sizet>(srcW) + static_cast<sizet>(x)) * 3u;
+            return { src[i], src[i + 1], src[i + 2] };
+        };
+
+        Ref<EnvironmentMap> env = EnvironmentMap::CreateFromEquirectangular(kHdrPath);
+        ASSERT_TRUE(env != nullptr) << "CreateFromEquirectangular returned null";
+        const Ref<TextureCubemap>& cubemap = env->GetEnvironmentMap();
+        ASSERT_TRUE(cubemap != nullptr) << "environment cubemap is null";
+
+        struct OutputColor
+        {
+            f32 r = 0.0f;
+            f32 g = 0.0f;
+            f32 b = 0.0f;
+            f32 a = 0.0f;
+        };
+
+        constexpr u32 kProbeCount = 4;
+        ScopedBuffer outputBuffer(static_cast<GLsizeiptr>(sizeof(OutputColor) * kProbeCount),
+                                  GL_DYNAMIC_STORAGE_BIT | GL_MAP_READ_BIT);
+
+        auto cs = ComputeShader::Create("assets/shaders/tests/ShaderUnit_SkyboxOrientation.glsl");
+        ASSERT_TRUE(cs && cs->IsValid()) << "skybox orientation compute shader failed to compile";
+        cs->Bind();
+        cubemap->Bind(ShaderBindingLayout::TEX_ENVIRONMENT);
+        ::glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, outputBuffer);
+        ::glDispatchCompute(kProbeCount, 1, 1);
+        ::glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT | GL_BUFFER_UPDATE_BARRIER_BIT |
+                          GL_TEXTURE_FETCH_BARRIER_BIT);
+
+        std::array<OutputColor, kProbeCount> outputs{};
+        ::glGetNamedBufferSubData(outputBuffer, 0,
+                                  static_cast<GLsizeiptr>(sizeof(OutputColor) * outputs.size()),
+                                  outputs.data());
+
+        // The two WORLD-space probes the shader defines (see its
+        // GetProbeDirection): mostly-up and mostly-down, each nudged off the pole
+        // so neither lands on the degenerate seam where every panorama column meets.
+        const std::array<glm::vec3, 2> probeDirs = { glm::vec3(0.0f, 1.0f, -0.15f),
+                                                     glm::vec3(0.0f, -1.0f, -0.15f) };
+        const std::array<const char*, 2> probeNames = { "mostly-up", "mostly-down" };
+
+        f64 uprightError = 0.0;
+        f64 mirroredError = 0.0;
+        for (sizet probe = 0; probe < probeDirs.size(); ++probe)
+        {
+            const OutputColor& out = outputs[probe + 2u]; // indices 2 and 3 are the world probes
+            const glm::vec3 baked{ out.r, out.g, out.b };
+            const glm::vec3 dir = probeDirs[probe];
+            const glm::vec3 upright = sampleSource(dir);
+            const glm::vec3 mirrored = sampleSource(glm::vec3(dir.x, -dir.y, dir.z));
+
+            const f64 distUpright = static_cast<f64>(glm::length(baked - upright));
+            const f64 distMirrored = static_cast<f64>(glm::length(baked - mirrored));
+            uprightError += distUpright;
+            mirroredError += distMirrored;
+
+            std::cout << "[equirect-orientation] " << probeNames[probe] << " baked=(" << baked.r << ", "
+                      << baked.g << ", " << baked.b << ") upright=(" << upright.r << ", " << upright.g
+                      << ", " << upright.b << ") mirrored=(" << mirrored.r << ", " << mirrored.g << ", "
+                      << mirrored.b << ") distUpright=" << distUpright
+                      << " distMirrored=" << distMirrored << std::endl;
+        }
+
+        // A real separation, not a tie broken by noise: this panorama's ceiling and
+        // floor differ enough that the wrong orientation is far off. Measured on
+        // the fixed bake (RTX 4090, 2026-09-07): upright 0.0045 summed over the two
+        // probes, mirrored 0.142 -- a 31x separation against a 2x bar.
+        EXPECT_LT(uprightError, mirroredError * 0.5)
+            << "the cubemap baked from " << kHdrPath
+            << " matches the panorama sampled UPSIDE DOWN at least as well as upright, so the "
+               "equirectangular bake has lost the source's vertical mapping. Check that "
+               "IBLPrecompute uses stbi_set_flip_vertically_on_load_THREAD: the global setter is "
+               "latched out by every other loader in this engine.";
     }
 
     // =========================================================================

--- a/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
@@ -154,8 +154,8 @@ namespace OloEngine::Tests
 
         struct DiffStats
         {
-            f32 m_Max = 0.0f;      ///< the single strongest pixel, ANYWHERE — a liveness signal only
-            u32 m_PeakX = 0;       ///< centre of the strongest BOX (see AnalyseDiff)
+            f32 m_Max = 0.0f; ///< the single strongest pixel, ANYWHERE — a liveness signal only
+            u32 m_PeakX = 0;  ///< centre of the strongest BOX (see AnalyseDiff)
             u32 m_PeakY = 0;
             f64 m_GlobalMean = 0.0;
             f64 m_LocalMean = 0.0; ///< mean difference inside that box

--- a/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
@@ -687,8 +687,13 @@ namespace OloEngine::Tests
                       << (stats.m_GlobalMean > 1e-6 ? stats.m_LocalMean / stats.m_GlobalMean : 0.0)
                       << std::endl;
 
-            // 1. The wake changes the frame.
-            EXPECT_GT(stats.m_Max, 4.0f)
+            // 1. The wake changes the frame. On the window MEAN, for the reason
+            //    the footprint case below uses it: `m_Max` is one pixel, and a
+            //    single-pixel statistic against a fixed bar is a flake waiting
+            //    for a quantisation step (issue #1094). Measured across these
+            //    five poses (RTX 4090, 2026-09-07): 1.21 (Stopped, the weakest
+            //    by design) to 8.89 (Close).
+            EXPECT_GT(stats.m_LocalMean, 0.5)
                 << "pose '" << pose.m_Name
                 << "': enabling the wake changed no pixel by more than driver noise — the surface is "
                    "not being displaced at all";
@@ -812,6 +817,23 @@ namespace OloEngine::Tests
         // The earlier recorded figures (1.10 / 0.69, 2026-08-30) came from a box
         // the single-pixel argmax happened to place, which is why they moved when
         // the estimator was fixed for #1094. They described the same frames.
+        //
+        // TWO THINGS TO KNOW BEFORE RETUNING THIS, both measured rather than
+        // assumed. The 0.85 bar has less headroom than it did: 0.744 against a
+        // bar of 0.797, ~7%, where the old box gave ~26%. That is deliberate and
+        // it is not a knife edge — the same box on the same frames reproduces to
+        // three significant figures across every test ordering (0.744048 vs
+        // 0.745533, 0.2%), so the margin is ~35x the observed spread. The old
+        // box's larger headroom was not a better test; it was a box that had
+        // landed on the strongest part of the difference by accident.
+        //
+        // And the ratio is NOT monotonic in `kHalf` — measured 0.71 / 0.87 /
+        // 0.78 / 0.73 / 0.88 at half = 20 / 30 / 45 / 60 / 80, because each size
+        // selects a different window and the stddev depends on how much
+        // unflattened sea the window also contains. So kHalf is left at the 45
+        // this test has always used. Do NOT tune it to buy margin: a size picked
+        // because it produced a comfortable number is the same guess this whole
+        // section exists to replace.
         ASSERT_GT(insideOff, 0.5)
             << "the sea has no structure inside the footprint — this test cannot detect flattening";
 

--- a/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
@@ -68,6 +68,8 @@
 #include "OloEngine/Renderer/ResourceHandle.h"
 #include "OloEngine/Physics3D/BoatWakeSystem.h"
 #include "OloEngine/Renderer/Water/WaterDisturbanceSystem.h"
+#include "OloEngine/Renderer/Water/WaterRainRippleSystem.h"
+#include "OloEngine/Renderer/Water/WaterSpraySystem.h"
 #include "OloEngine/Renderer/Water/WaterWake.h"
 #include "OloEngine/Renderer/Water/WaterWakeSystem.h"
 #include "OloEngine/Scene/Components.h"
@@ -152,11 +154,11 @@ namespace OloEngine::Tests
 
         struct DiffStats
         {
-            f32 m_Max = 0.0f;
-            u32 m_MaxX = 0;
-            u32 m_MaxY = 0;
+            f32 m_Max = 0.0f;      ///< the single strongest pixel, ANYWHERE — a liveness signal only
+            u32 m_PeakX = 0;       ///< centre of the strongest BOX (see AnalyseDiff)
+            u32 m_PeakY = 0;
             f64 m_GlobalMean = 0.0;
-            f64 m_LocalMean = 0.0; ///< inside a box around the strongest difference
+            f64 m_LocalMean = 0.0; ///< mean difference inside that box
         };
 
         /// Where the difference is, and how concentrated it is.
@@ -165,6 +167,30 @@ namespace OloEngine::Tests
         /// raised the whole water plane produces a large max AND a large global
         /// mean, so `local / global` is near 1 — while a real, local wake puts
         /// the difference in one place and the ratio is many times that.
+        ///
+        /// WHERE the difference is means the centre of the box with the highest
+        /// MEAN difference, NOT the position of the single brightest pixel.
+        ///
+        /// This distinction is the whole of issue #1094, so it is worth stating
+        /// plainly. The hull footprint's A/B difference is broad and faint —
+        /// hundreds of pixels across, peaking at 3-8 out of 255 on a smoothly
+        /// shaded sea. A single-pixel argmax over a field like that is not an
+        /// estimator of where the footprint is; it is an estimator of where the
+        /// brightest speck is, and any stray speck outranks the real signal.
+        /// EIGHT pixels of foam were enough: with them the argmax sat at
+        /// (644, 327) and the footprint measurement read 0.69 / 1.10 (a pass),
+        /// without them it moved 63 px to (581, 305) and read 1.30 / 0.61 — an
+        /// apparently INVERTED A/B, from frames that are otherwise identical to
+        /// the byte. Both numbers were true; they were measured in different
+        /// places, one of them off the footprint.
+        ///
+        /// A window mean is the estimator that matches what the caller then
+        /// measures (a box of the same size), and eight outlier pixels move it
+        /// by 8/(2*half)^2 of their value — nothing. Computed through a summed-area
+        /// table so the exhaustive search stays O(W*H) rather than O(W*H*half^2).
+        ///
+        /// `m_Max` is still the true global maximum, but it is only ever a
+        /// LIVENESS signal ("the wake changed some pixel"), never a location.
         [[nodiscard]] DiffStats AnalyseDiff(const std::vector<f32>& diff, u32 boxHalfSize = 60)
         {
             DiffStats s;
@@ -175,31 +201,53 @@ namespace OloEngine::Tests
                 {
                     const f32 d = diff[static_cast<std::size_t>(y) * kWidth + x];
                     sum += d;
-                    if (d > s.m_Max)
-                    {
-                        s.m_Max = d;
-                        s.m_MaxX = x;
-                        s.m_MaxY = y;
-                    }
+                    s.m_Max = std::max(s.m_Max, d);
                 }
             }
             s.m_GlobalMean = sum / static_cast<f64>(diff.size());
 
-            const u32 x0 = (s.m_MaxX > boxHalfSize) ? (s.m_MaxX - boxHalfSize) : 0u;
-            const u32 y0 = (s.m_MaxY > boxHalfSize) ? (s.m_MaxY - boxHalfSize) : 0u;
-            const u32 x1 = std::min(kWidth, s.m_MaxX + boxHalfSize);
-            const u32 y1 = std::min(kHeight, s.m_MaxY + boxHalfSize);
-            f64 local = 0.0;
-            u64 count = 0;
-            for (u32 y = y0; y < y1; ++y)
+            // Summed-area table: sat[(y+1)*(W+1) + (x+1)] is the sum over
+            // [0,x] x [0,y]. f64 because kWidth*kHeight*255 overflows f32's
+            // integer-exact range long before the last row.
+            std::vector<f64> sat(static_cast<std::size_t>(kWidth + 1u) * (kHeight + 1u), 0.0);
+            const auto satAt = [&sat](u32 x, u32 y) -> f64&
+            { return sat[static_cast<std::size_t>(y) * (kWidth + 1u) + x]; };
+            for (u32 y = 0; y < kHeight; ++y)
             {
-                for (u32 x = x0; x < x1; ++x)
+                f64 rowSum = 0.0;
+                for (u32 x = 0; x < kWidth; ++x)
                 {
-                    local += diff[static_cast<std::size_t>(y) * kWidth + x];
-                    ++count;
+                    rowSum += diff[static_cast<std::size_t>(y) * kWidth + x];
+                    satAt(x + 1u, y + 1u) = satAt(x + 1u, y) + rowSum;
                 }
             }
-            s.m_LocalMean = count ? local / static_cast<f64>(count) : 0.0;
+            const auto boxMean = [&satAt](u32 x0, u32 y0, u32 x1, u32 y1) -> f64
+            {
+                const f64 area = static_cast<f64>(x1 - x0) * static_cast<f64>(y1 - y0);
+                if (area <= 0.0)
+                    return 0.0;
+                return (satAt(x1, y1) - satAt(x0, y1) - satAt(x1, y0) + satAt(x0, y0)) / area;
+            };
+
+            // Search every FULL-SIZE window, so every candidate is scored over
+            // the same area — a partial window at the frame edge would win on a
+            // smaller denominator rather than on more difference.
+            const u32 half = std::min(boxHalfSize, std::min(kWidth, kHeight) / 2u);
+            f64 bestMean = -1.0;
+            for (u32 cy = half; cy + half <= kHeight; ++cy)
+            {
+                for (u32 cx = half; cx + half <= kWidth; ++cx)
+                {
+                    const f64 m = boxMean(cx - half, cy - half, cx + half, cy + half);
+                    if (m > bestMean)
+                    {
+                        bestMean = m;
+                        s.m_PeakX = cx;
+                        s.m_PeakY = cy;
+                    }
+                }
+            }
+            s.m_LocalMean = (bestMean > 0.0) ? bestMean : 0.0;
             return s;
         }
 
@@ -255,6 +303,30 @@ namespace OloEngine::Tests
     class WaterWakeShapeVisualEvidenceTest : public RendererAttachedTest
     {
       protected:
+        /// Enter on clean water state, and reset ALL FOUR services, not the two
+        /// this file happens to drive.
+        ///
+        /// docs/agent-rules/world-anchored-renderer-state-in-tests.md already
+        /// states both halves of this rule, and this file followed neither: it
+        /// reset WaterWakeSystem and WaterDisturbanceSystem only, and only on the
+        /// way OUT. The other two are world-anchored too, and
+        /// `Scene::OnRuntimeStart` resets the four together for that reason.
+        /// WaterSpraySystem in particular retains particles across a Scene
+        /// boundary, and eight of the sibling test's spray specks surviving into
+        /// this one is what made issue #1094's two orderings disagree at all.
+        ///
+        /// On the way IN rather than only on the way out, because a test can only
+        /// guarantee the state it starts from — what ran before it in the process
+        /// is not its to control, and `--gtest_filter` reorders it freely.
+        void SetUp() override
+        {
+            WaterDisturbanceSystem::Reset();
+            WaterWakeSystem::Reset();
+            WaterRainRippleSystem::Reset();
+            WaterSpraySystem::Reset();
+            RendererAttachedTest::SetUp();
+        }
+
         void BuildScene() override
         {
             Scene& scene = GetScene();
@@ -548,8 +620,10 @@ namespace OloEngine::Tests
             ~ScopedMockTime()
             {
                 Time::ClearMockTime();
-                WaterWakeSystem::Reset();
                 WaterDisturbanceSystem::Reset();
+                WaterWakeSystem::Reset();
+                WaterRainRippleSystem::Reset();
+                WaterSpraySystem::Reset();
             }
         } scopedClock;
 
@@ -607,8 +681,8 @@ namespace OloEngine::Tests
             // capture looks wrong, and the bands any future assertion should be
             // measured from rather than guessed at (docs/agent-rules/
             // persistent-world-space-fields.md section 4).
-            std::cout << "[wake-shape] pose=" << pose.m_Name << " maxDiff=" << stats.m_Max << " at ("
-                      << stats.m_MaxX << ", " << stats.m_MaxY << ") globalMean=" << stats.m_GlobalMean
+            std::cout << "[wake-shape] pose=" << pose.m_Name << " maxDiff=" << stats.m_Max << " peak at ("
+                      << stats.m_PeakX << ", " << stats.m_PeakY << ") globalMean=" << stats.m_GlobalMean
                       << " localMean=" << stats.m_LocalMean << " ratio="
                       << (stats.m_GlobalMean > 1e-6 ? stats.m_LocalMean / stats.m_GlobalMean : 0.0)
                       << std::endl;
@@ -645,8 +719,10 @@ namespace OloEngine::Tests
             ~ScopedMockTime()
             {
                 Time::ClearMockTime();
-                WaterWakeSystem::Reset();
                 WaterDisturbanceSystem::Reset();
+                WaterWakeSystem::Reset();
+                WaterRainRippleSystem::Reset();
+                WaterSpraySystem::Reset();
             }
         } scopedClock;
 
@@ -682,21 +758,33 @@ namespace OloEngine::Tests
         // persistent-world-space-fields.md section 4. The strongest A/B
         // difference IS the footprint (nothing else in this frame changed), so
         // the box follows it.
+        //
+        // "Strongest" means the strongest BOX, not the strongest pixel — see
+        // AnalyseDiff, and issue #1094, which was nothing but this distinction.
+        constexpr u32 kHalf = 45;
         const std::vector<f32> diff = DiffMap(withWake, withoutWake);
         WriteDiffImage("HullFootprint", diff);
-        const DiffStats stats = AnalyseDiff(diff, 45);
-        std::cout << "[wake-shape] footprint diff max=" << stats.m_Max << " at (" << stats.m_MaxX
-                  << ", " << stats.m_MaxY << ") globalMean=" << stats.m_GlobalMean << std::endl;
+        const DiffStats stats = AnalyseDiff(diff, kHalf);
+        std::cout << "[wake-shape] footprint diff max=" << stats.m_Max << " peak at (" << stats.m_PeakX
+                  << ", " << stats.m_PeakY << ") globalMean=" << stats.m_GlobalMean
+                  << " localMean=" << stats.m_LocalMean << std::endl;
 
-        ASSERT_GT(stats.m_Max, 4.0f)
+        // LIVENESS, on the local mean rather than on the global maximum.
+        //
+        // The old form was ASSERT_GT(m_Max, 4.0f), and m_Max is a single pixel:
+        // measured 4.33 in the ordering issue #1094 reported, i.e. 8% above its
+        // own bar, and 8.0 in the other — a bar that a quantisation step could
+        // cross either way. The window mean over the footprint is the same
+        // quantity the assertions below are about and it is stable to three
+        // digits across orderings: measured 2.90 (RTX 4090, 2026-09-07) in both.
+        ASSERT_GT(stats.m_LocalMean, 1.0)
             << "the hull footprint changes no pixel — the ocean is not being suppressed under the hull, "
                "so a crest can rise through the deck";
 
-        constexpr u32 kHalf = 45;
-        const u32 x0 = (stats.m_MaxX > kHalf) ? stats.m_MaxX - kHalf : 0u;
-        const u32 y0 = (stats.m_MaxY > kHalf) ? stats.m_MaxY - kHalf : 0u;
-        const u32 x1 = std::min(kWidth, stats.m_MaxX + kHalf);
-        const u32 y1 = std::min(kHeight, stats.m_MaxY + kHalf);
+        const u32 x0 = (stats.m_PeakX > kHalf) ? stats.m_PeakX - kHalf : 0u;
+        const u32 y0 = (stats.m_PeakY > kHalf) ? stats.m_PeakY - kHalf : 0u;
+        const u32 x1 = std::min(kWidth, stats.m_PeakX + kHalf);
+        const u32 y1 = std::min(kHeight, stats.m_PeakY + kHalf);
         const f64 insideOn = LumaStdDev(withWake, x0, y0, x1, y1);
         const f64 insideOff = LumaStdDev(withoutWake, x0, y0, x1, y1);
 
@@ -704,7 +792,7 @@ namespace OloEngine::Tests
         // where the footprint cannot reach. Its variance must be UNCHANGED, or
         // what the measurement above found was a global shading difference
         // rather than a locally flattened surface.
-        const u32 cx = (stats.m_MaxX < kWidth / 2u) ? (kWidth - kHalf - 60u) : (kHalf + 60u);
+        const u32 cx = (stats.m_PeakX < kWidth / 2u) ? (kWidth - kHalf - 60u) : (kHalf + 60u);
         const f64 outsideOn = LumaStdDev(withWake, cx - kHalf, y0, cx + kHalf, y1);
         const f64 outsideOff = LumaStdDev(withoutWake, cx - kHalf, y0, cx + kHalf, y1);
 
@@ -713,13 +801,17 @@ namespace OloEngine::Tests
 
         // NEGATIVE CONTROL: a flat-calm fixture would satisfy "variance fell"
         // trivially at 0 -> 0.
-        // Measured on this fixture (RTX 4090, 2026-08-30): inside 1.10 without
-        // the wake, 0.69 with it — a 37% fall — against a control box that is
-        // bit-identical at 1.27. The bar is set from that measurement, not from
-        // a guess: water shades smoothly even at 0.55 m amplitude, so a
-        // stddev of "tens" (which the #967 foam captures see, because foam is
-        // near-white against blue) is not available here and a threshold
-        // borrowed from that test would fail on a working feature.
+        // Measured on this fixture (RTX 4090, 2026-09-07, box placed by window
+        // mean): inside 0.95 without the wake, 0.74 with it — a 22% fall —
+        // against a control box that is bit-identical. The bar is set from that
+        // measurement, not from a guess: water shades smoothly even at 0.55 m
+        // amplitude, so a stddev of "tens" (which the #967 foam captures see,
+        // because foam is near-white against blue) is not available here and a
+        // threshold borrowed from that test would fail on a working feature.
+        //
+        // The earlier recorded figures (1.10 / 0.69, 2026-08-30) came from a box
+        // the single-pixel argmax happened to place, which is why they moved when
+        // the estimator was fixed for #1094. They described the same frames.
         ASSERT_GT(insideOff, 0.5)
             << "the sea has no structure inside the footprint — this test cannot detect flattening";
 

--- a/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/WaterWakeShapeVisualEvidenceTest.cpp
@@ -310,10 +310,14 @@ namespace OloEngine::Tests
         /// states both halves of this rule, and this file followed neither: it
         /// reset WaterWakeSystem and WaterDisturbanceSystem only, and only on the
         /// way OUT. The other two are world-anchored too, and
-        /// `Scene::OnRuntimeStart` resets the four together for that reason.
-        /// WaterSpraySystem in particular retains particles across a Scene
-        /// boundary, and eight of the sibling test's spray specks surviving into
-        /// this one is what made issue #1094's two orderings disagree at all.
+        /// `Scene::OnRuntimeStart` resets the four together for that reason, and
+        /// WaterSpraySystem in particular retains particles across a Scene boundary.
+        ///
+        /// This is a correctness fix on its own terms, NOT the cause of #1094: the
+        /// eight-pixel difference between orderings survives resetting all four
+        /// services, so it is not state these resets hold. What fixed #1094 is the
+        /// box placement in AnalyseDiff. The residual difference is unexplained —
+        /// see the issue.
         ///
         /// On the way IN rather than only on the way out, because a test can only
         /// guarantee the state it starts from — what ran before it in the process

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -38,6 +38,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [shared-temp-dir-test-isolation.md](shared-temp-dir-test-isolation.md): use `TestTempDir.h`, never a fixed temp path; every test case is its own process.
 - [cross-test-renderer-state.md](cross-test-renderer-state.md): never shut down a process-wide singleton you did not start, and leave the renderer configuration as you found it; plus the two traps that make single-process bisection lie.
 - [world-anchored-renderer-state-in-tests.md](world-anchored-renderer-state-in-tests.md): a fixture that builds a `Scene` per test must also reset the process-static renderer state scene load resets.
+- [ab-diff-peak-is-not-a-location.md](ab-diff-peak-is-not-a-location.md): place a measurement box by the highest-mean window of an A/B difference, never by its brightest pixel.
 
 ## Build and dependencies
 
@@ -176,6 +177,7 @@ The dominant archetype here. If your change is in one of these areas, a passing 
 | [single-mesh-visual-test-lighting.md](single-mesh-visual-test-lighting.md) | A bright material rendered near-black and the test asserted nothing about it. |
 | [scene-copy-must-carry-scene-level-settings.md](scene-copy-must-carry-scene-level-settings.md) | Settings reset on Play, and headless tests never call `Scene::Copy()`. |
 | [world-anchored-renderer-state-in-tests.md](world-anchored-renderer-state-in-tests.md) | A visual golden passes in file order and fails in a shard, because it encoded the previous test's residue. |
+| [ab-diff-peak-is-not-a-location.md](ab-diff-peak-is-not-a-location.md) | An A/B visual assertion reads BACKWARDS in one test ordering, from frames that are identical to the byte. |
 | [light-path-photometric-parity.md](light-path-photometric-parity.md) | Two lighting bugs survived 4300 green tests. |
 | [component-serializer-codegen.md](component-serializer-codegen.md) | A corrupt drive mode clamped to a different valid mode, and the car still drove. |
 | [asset-degradation-and-constructor-preconditions.md](asset-degradation-and-constructor-preconditions.md) | "Load the scene, does it crash?" passes because the trigger is resolution, not loading. |

--- a/docs/agent-rules/ab-diff-peak-is-not-a-location.md
+++ b/docs/agent-rules/ab-diff-peak-is-not-a-location.md
@@ -82,6 +82,7 @@ about the estimator changes; only the margin does.
 Related: [persistent-world-space-fields.md](persistent-world-space-fields.md) §4 (where
 to sample), [world-anchored-renderer-state-in-tests.md](world-anchored-renderer-state-in-tests.md)
 (reset all four water services in the fixture — this file's test reset two, on the way
-out only, and that is what let the two orderings differ at all),
+out only; fixed alongside #1094, though it is not what made the orderings differ: the
+residual eight pixels survive resetting all four),
 [live-verification-noise-floor.md](live-verification-noise-floor.md) (the A/B exists to
 put the noise floor at zero; a fragile box puts it back).

--- a/docs/agent-rules/ab-diff-peak-is-not-a-location.md
+++ b/docs/agent-rules/ab-diff-peak-is-not-a-location.md
@@ -1,0 +1,87 @@
+# Place a measurement box by a window MEAN, never by the brightest pixel
+
+An A/B visual test that finds "where the feature is" with the argmax of the per-pixel
+difference is not measuring where the feature is. It is measuring where the brightest
+speck is. On a broad, faint difference field those are different places, and a handful
+of stray pixels decides which one you get.
+
+Use the **mean over a window of the size you are about to measure**, found with a
+summed-area table so the exhaustive search stays O(W·H). It is the same quantity the
+assertion is about, and outliers move it by their value divided by the window area.
+
+Issue #1094 is the worked example. It is the complement of
+[persistent-world-space-fields.md](persistent-world-space-fields.md) §4, which says to
+measure the sampling bands off a real capture rather than from fractions of the frame:
+that rule is right, and an argmax is one more way of guessing.
+
+## The failure, with the numbers
+
+`WaterWakeShapeVisualEvidenceTest.TheHullFootprintFlattensTheSeaBeneathIt` failed
+deterministically whenever it was the **first water test in the process** — which is
+what `ctest` always does, since every case runs in its own process.
+
+```
+Expected: (insideOn) < (insideOff * 0.85), actual: 1.29915 vs 0.51864
+```
+
+The A/B was not merely noisy, it was **backwards**: with the wake on the sea inside the
+box was *more* textured than with it off, and the issue reasonably read that as a
+first-frame state bug in the water fields.
+
+It was not. The hull footprint's difference is hundreds of pixels wide and peaks at
+**3–8 out of 255** on a smoothly shaded sea. Eight foam-speck pixels — 0.0009% of the
+frame — moved the argmax 63 px, off the footprint and onto its edge:
+
+| box centre | inside on / off | verdict |
+|---|---|---|
+| (644, 327) — argmax with the specks | 0.691 / 1.097 | passes |
+| (581, 305) — argmax without them | 1.299 / 0.610 | fails |
+| (608, 357) — highest-mean 90×90 window | 0.744 / 0.937 | passes, in **every** ordering |
+
+Both of the first two numbers are true statements about the same frames. One of the
+boxes is on the flattened footprint; the other is on its rim, where the wake's ridge
+genuinely *adds* structure.
+
+## The cheap check that settles it
+
+**Re-measure one ordering's frames inside the other ordering's box.** If the numbers
+move with the box, the bug is the box, and no amount of renderer archaeology will find
+anything.
+
+Three more tells pointed the same way before any code was read:
+
+- the **global mean** of the difference was unchanged to five digits (0.147134 vs
+  0.147145) — the feature's total effect is identical;
+- the **golden RMSE passed** in both orderings;
+- dumping both halves of the A/B showed the two orderings differ at **8 pixels out of
+  921,600**, everything else bit-identical.
+
+## Assert liveness on the window mean too
+
+The same test guarded liveness with `ASSERT_GT(stats.m_Max, 4.0f)` on the global
+maximum. Measured: **4.33** in one ordering — 8% above its own bar — and 8.0 in the
+other. A single-pixel statistic sitting that close to its threshold is a flake already
+written down. The window mean over the footprint was 2.90 in every ordering, stable to
+three digits.
+
+## The residue, which is real but was not the bug
+
+The first water render in a process genuinely does differ from every later one, by
+those 8 speck pixels; `--gtest_repeat=3` shows iteration 1 differing and 2 and 3
+identical. It survives resetting all four world-anchored water services, so it is not
+field state. It is ~0.001% of one frame and it is gone by the second scene, but it is
+not nothing — see #1094 for the open note.
+
+## Reach
+
+Any A/B visual test whose difference is broad and low-amplitude. The high-contrast ones
+(foam is near-white against blue) are safe by luck, not by construction: their argmax
+sits inside the feature because the feature *is* the brightest thing in frame. Nothing
+about the estimator changes; only the margin does.
+
+Related: [persistent-world-space-fields.md](persistent-world-space-fields.md) §4 (where
+to sample), [world-anchored-renderer-state-in-tests.md](world-anchored-renderer-state-in-tests.md)
+(reset all four water services in the fixture — this file's test reset two, on the way
+out only, and that is what let the two orderings differ at all),
+[live-verification-noise-floor.md](live-verification-noise-floor.md) (the A/B exists to
+put the noise floor at zero; a fragile box puts it back).


### PR DESCRIPTION
Fixes the two tests that fail deterministically on `origin/master` and are not Vulkan RHI defects. Both were **misdiagnosed in their issues**, and in both cases the evidence points somewhere other than where the issue looked. Details below, because the wrong answer was plausible in each.

Two commits, one per issue; they touch disjoint files.

---

## #1098 — the empty registry key, not the retired path spelling

### The decision the issue asks for: back-compat STAYS, and it was never actually broken

The issue framed this as a fork — keep the legacy `SandboxProject/Assets/...` spelling, or retire it and re-save the shipped scenes. **Neither branch is the bug.** The legacy spelling still resolved perfectly well on `master`; the test passes unmodified on `master` in this worktree.

What actually breaks it is one line, older than both suspects the issue named:

```cpp
return std::filesystem::relative(canonicalFile, canonicalProject);   // EditorAssetManager::GetRelativePath
```

`std::filesystem::relative` returns an **empty path — not an error** — when no relative path exists. On Windows that is any file on a different drive from the project. The test stages the project into `%TEMP%`, so the moment `%TEMP%` and the repo are on different drives, the registry key is `""`.

That also explains the phantom regression window. Both suspect commits are dated 2026-09-06; so is the base repo's move from `D:` to `C:\repos`. Before the move the staged project and the repository were on different drives; after it they are not. Nothing in either suspect commit touches the scene-load path.

**Reproduced deterministically both ways**, same binary, same box:

```
TMP=D:\...  ->  FAILED  firstPath "" / secondPath "<null texture ref>"   (the issue's exact output)
TMP=C:\...  ->  OK
```

An empty key is silent at every consumer, and produces exactly the two different sentinels the issue flagged:

- `GetHandleFromPath("")` never matches, so a **fresh handle is minted per import** — the failing log shows three handles for one texture;
- every reader spells `projectDir / metadata.FilePath`, and `dir / ""` is the **directory**, so the loader is asked to read pixels out of a folder and substitutes a placeholder whose `GetPath()` is empty, giving `firstPath == ""`;
- `SceneSerializer` round-trips that empty path into the `.scenebin`, and the next load resolves it to nothing, giving `secondPath == "<null texture ref>"`.

`MakeRegistryKey` now keeps the **absolute** path when no relative one exists. That is correct at every reader (`dir / absolute` is the absolute path unchanged) and is a shape three call sites in this file already branch on. It logs, because an asset outside the project is not portable. It is `static` and pure, so the drive-crossing case is unit-testable without a second volume.

### The second half: the legacy spelling is now anchored to the project, not the cwd

Keeping back-compat is not the same as keeping *cwd* resolution. The old spelling only ever worked because OloEditor happens to launch one directory above the project — a property of the launch, not of the project. Two things were wrong with that, and both are visible in this repo today:

- under it, **this very test resolved to the original repository texture rather than the staged copy** — outside the project it had just loaded;
- the same file registered **twice**, once as `Assets/Textures/Otter.png` and again under a cwd-derived key, so the two references never deduped.

`TryLegacyProjectPrefixedPath` strips the leading component and retries against the project root. Deliberately narrow: two components minimum, the leading component must be **absent** from the project (so a real `Assets/...` directory can never be eaten), and the remainder must exist. Same file found in the editor, now keyed portably, with a warning telling the user to re-save.

The eleven shipped scenes carrying the old spelling are **not** re-saved here — they keep working, and re-saving them is a content change that belongs on its own.

The test now asserts the texture resolves **inside the project it was loaded from**, not merely that its path is non-empty. Non-emptiness is what let cwd resolution look correct for a year.

---

## #1094 — the measurement box, not the water fields

The issue reports an *inverted* A/B (`insideOn` 1.30 > `insideOff` 0.61) whenever the test is the first water test in the process, and concludes the isolated run renders a different frame. It does not. **The frames are right in both orderings; the box is in the wrong place.**

`AnalyseDiff` located the footprint with the **argmax of the per-pixel difference**. That difference is hundreds of pixels wide and peaks at **3-8 out of 255** on a smoothly shaded sea, so the argmax is not an estimator of where the footprint is — it is an estimator of where the brightest speck is. Eight foam-speck pixels (0.0009% of the frame) moved it 63 px onto the footprint's rim, where the wake's ridge genuinely *adds* structure:

| box centre | inside on / off | verdict |
|---|---|---|
| (644, 327) — argmax with the specks | 0.691 / 1.097 | passes |
| (581, 305) — argmax without them | 1.299 / 0.610 | fails |
| (608, 357) — highest-mean 90x90 window | 0.744 / 0.937 | passes, **every ordering** |

The check that settles it, and the one to reach for next time: **re-measuring the failing run's frames inside the passing run's box reproduces the passing numbers** (0.684 / 1.092) and passes. Three tells pointed the same way beforehand — the difference's global mean is unchanged to five digits (0.147134 vs 0.147145), the golden RMSE passes in both orderings, and dumping both halves of the A/B shows the two orderings differ at **8 pixels out of 921,600**, everything else bit-identical.

So the box is placed at the centre of the highest-**mean** window, found through a summed-area table (linear in the pixel count). Same quantity the assertion is about; outliers move it by their value over the window area. Liveness moves off the global maximum for the same reason — `ASSERT_GT(m_Max, 4.0f)` was reading **4.33** in one ordering, 8% above its own bar.

**No golden was rebased and no threshold was loosened.** The recorded measurement is re-stated for the new box (0.95 down to 0.74, a 22% fall, against 0.85).

Separately, per `docs/agent-rules/world-anchored-renderer-state-in-tests.md`, the fixture now resets all **four** world-anchored water services rather than the two this file drives, and does it on the way *in* as well as out.

### Is the engine also wrong?

Marginally, and not about the wake. The first water render in a process genuinely does differ from every later one by those 8 speck pixels — `--gtest_repeat=3` shows iteration 1 differing, 2 and 3 identical. It survives resetting all four services, so it is not field state. It is about 0.001% of one frame and gone by the second scene. **Root cause not found**, and not chased here: it is not what made the test fail, and finding it means walking the whole first-frame water path. Recorded on #1094 as a residual note.

---

## Verification

Both suites are GPU-gated and skip on every CI runner, so **CI going green is not evidence for this PR.** All of the below is local, RTX 4090, `dev-cached` Debug.

| check | before | after |
|---|---|---|
| `AssetSceneLoad.DecalAndSpriteTexturePathsSurviveRoundTrip`, temp on the project's drive | OK | OK |
| ...temp on a **different** drive (the issue's configuration) | **FAILED** `"" / "<null texture ref>"` | OK |
| `WaterWakeShape...HullFootprint...` alone | **FAILED** 1.29915 / 0.61017 | OK 0.744 / 0.937 |
| ...after its sibling | OK 0.691 / 1.097 | OK 0.746 / 0.940 |
| ...after the whole `WaterFoamSprayRain` file | OK | OK 0.746 / 0.940 |
| `Asset*:*Water*:*Ocean*` sweep (422 tests) | — | **421 passed, 1 pre-existing skip, 0 failed** |

New tests: three `AssetRegistryKey.*` cases pinning the key contract, including the drive-crossing one (lexical, so it needs no second volume; skipped on POSIX, which has a single root and cannot express the case).

**Visual evidence** (#1094 is under *Rendering changes must be visually verified*): both halves of the A/B were dumped and compared pixel-by-pixel across orderings; the amplified difference images are visually identical broad footprints; the committed goldens pass RMSE in every ordering and **no golden PNG changed**.

**Live editor** (#1098): opened `PinkCubeWithTextures.olo` — the scene whose sprites carry the legacy spelling — via the MCP diagnostics server. `olo_scene_get_entity` now reports `TexturePath: Assets/Textures/Otter.png`, and the log shows one resolution and one handle:

```
EditorAssetManager: asset path 'SandboxProject/Assets/Textures/Otter.png' uses the legacy
project-prefixed spelling; resolved it against the project root as 'Assets/Textures/Otter.png'.
Asset already imported: Assets\Textures\Otter.png
```

`olo_shader_errors` reported 0. The only `[error]` lines are three pre-existing missing-font warnings (see below).

## Found on the way, not fixed here

`SceneSerializer::ResolveSceneFontPath` roots every relative font path at the project directory unconditionally, but the sandbox scenes reference `assets/fonts/opensans/...`, which is an **engine** asset under `OloEditor/assets/`. Every such font fails to open. It is the same class of bug as #1098 — a relative path resolved against the wrong base — but a different resolver, provably untouched by this branch, and fixing it means deciding how scenes reference engine-owned assets. Say the word and I will file it.

---

## Review guide

**Where I'd look hardest**

1. `EditorAssetManager.cpp` — `TryLegacyProjectPrefixedPath`. It is a heuristic on a path string, and it is the only change here that can make a *previously-failing* lookup succeed. The guards are meant to make it unable to fire on anything but the legacy spelling (leading component absent from the project, remainder present); if there is a project layout where that is wrong, this is where.
2. `EditorAssetManager.cpp` — `MakeRegistryKey` returning an **absolute** key. I checked that `dir / absolute` is the absolute path at every reader and that three sites already branch on `is_absolute()`, but the registry is also **serialized to `AssetRegistry.oar`**, so an absolute key is machine-specific on disk. That is strictly better than the empty key it replaces, and it only happens for assets outside the project, but it is a real property change worth a second opinion.
3. `WaterWakeShapeVisualEvidenceTest.cpp` — `AnalyseDiff` now reports `m_PeakX`/`m_PeakY` (highest-mean window) where it reported `m_MaxX`/`m_MaxY` (argmax). The sibling acceptance test shares it: its local/global ratios moved from 3.0-14.0 to 12.5-26.1 against a `> 2.0` bar, which is the estimator doing its job, but it is a shared-helper change with two callers.

**What I verified, and how** — the table above. The load-bearing pieces: the #1098 failure reproduced *and* fixed by flipping only `TMP` between drives, with nothing else changed; and for #1094, re-measuring the failing run's frames in the passing run's box (0.684 / 1.092, passes), which proves the frames were never the problem.

**Least confident about** — the 8-pixel first-water-frame difference. I proved what it is *not* (not the wake, not any of the four world-anchored services, not first-frame GPU warmup in general) and that it cannot affect the assertion any more, but I did not find what it *is*. If a reviewer recognises it, that is the most useful thing they could tell me.

**Deliberately not tested** — the eleven shipped scenes were not re-saved to the new spelling (that is a content change, and the legacy spelling keeps working). The font-path defect above is untouched. Vulkan was not exercised: neither change is backend-specific — one is `std::filesystem`, one is test-side arithmetic on a CPU readback.

Closes #1098
Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asset importing for legacy project paths and files outside the project directory.
  - Asset modification times now use the resolved file location.
  - Fixed scene resources, including fonts and sprite textures, failing to load from project or working-directory paths.
  - Improved scene path resolution across directory layouts and operating systems.
  - Corrected vertical orientation when converting HDR panoramas into environment maps.

- **Testing**
  - Expanded coverage for asset keys, scene loading, and visual water effects.
  - Added verification for upright environment-map panoramas.

- **Chores**
  - Existing environment-map caches will be regenerated when next loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->