### PR TITLE
refactor(editor): migrate ShaderGraphEditorPanel onto the shared GraphCanvas

### DIFF
--- a/OloEditor/src/Panels/Graph/GraphCanvas.cpp
+++ b/OloEditor/src/Panels/Graph/GraphCanvas.cpp
@@ -8,10 +8,15 @@ namespace OloEngine::EditorUI
 {
     namespace
     {
-        // Sample count for the wire hit-test. 16 is enough that a 2px-wide wire
-        // never has a gap a mouse can slip through at any zoom we allow, and
-        // cheap enough to run for every wire, every frame.
-        constexpr i32 kWireHitSamples = 16;
+        // The wire hit-test walks the curve in fixed-size steps rather than a
+        // fixed NUMBER of steps. A constant 16 samples spaces them wireLength/16
+        // apart, so the gap grows with the wire: a 600px wire developed ~37px
+        // holes that a click fell straight through, and only short wires were
+        // reliably clickable. The bounds keep a short wire cheap and a very long
+        // one from walking hundreds of samples per wire per frame.
+        constexpr f32 kWireHitSampleSpacing = 6.0f;
+        constexpr i32 kWireHitMinSamples = 16;
+        constexpr i32 kWireHitMaxSamples = 256;
 
         ImVec2 Bezier(ImVec2 p0, ImVec2 c0, ImVec2 c1, ImVec2 p1, f32 t)
         {
@@ -284,10 +289,18 @@ namespace OloEngine::EditorUI
         const ImVec2 c0(from.x + offset.x, from.y);
         const ImVec2 c1(to.x - offset.x, to.y);
 
+        // The control polygon bounds the curve's arc length from above, so this
+        // never under-samples however far the wire bows.
+        const f32 chordX = to.x - from.x;
+        const f32 chordY = to.y - from.y;
+        const f32 bound = std::sqrt(chordX * chordX + chordY * chordY) + 2.0f * offset.x;
+        const i32 samples = std::clamp(static_cast<i32>(std::ceil(bound / kWireHitSampleSpacing)),
+                                       kWireHitMinSamples, kWireHitMaxSamples);
+
         f32 best = std::numeric_limits<f32>::max();
-        for (i32 i = 0; i <= kWireHitSamples; ++i)
+        for (i32 i = 0; i <= samples; ++i)
         {
-            const ImVec2 p = Bezier(from, c0, c1, to, static_cast<f32>(i) / static_cast<f32>(kWireHitSamples));
+            const ImVec2 p = Bezier(from, c0, c1, to, static_cast<f32>(i) / static_cast<f32>(samples));
             const f32 ddx = p.x - point.x;
             const f32 ddy = p.y - point.y;
             best = std::min(best, std::sqrt(ddx * ddx + ddy * ddy));

--- a/OloEditor/src/Panels/Graph/GraphCanvas.cpp
+++ b/OloEditor/src/Panels/Graph/GraphCanvas.cpp
@@ -12,8 +12,8 @@ namespace OloEngine::EditorUI
         // fixed NUMBER of steps. A constant 16 samples spaces them wireLength/16
         // apart, so the gap grows with the wire: a 600px wire developed ~37px
         // holes that a click fell straight through, and only short wires were
-        // reliably clickable. The bounds keep a short wire cheap and a very long
-        // one from walking hundreds of samples per wire per frame.
+        // reliably clickable. Bounds keep a short wire cheap and a very long one
+        // from walking hundreds of samples per wire per frame.
         constexpr f32 kWireHitSampleSpacing = 6.0f;
         constexpr i32 kWireHitMinSamples = 16;
         constexpr i32 kWireHitMaxSamples = 256;
@@ -93,12 +93,25 @@ namespace OloEngine::EditorUI
 
     void GraphCanvas::HandleViewInput()
     {
+        // Cleared before the early return, not after it: a stale true would fire
+        // the consumer's context menu on some later frame in which the pointer
+        // merely happened to be somewhere else.
+        m_WasRightClicked = false;
+
         if (!m_IsHovered && !m_IsPanning)
         {
             return;
         }
 
         const ImGuiIO& io = ImGui::GetIO();
+
+        // Both sampled BEFORE the latch block below clears them. On the release
+        // frame `panHeld` is already false, so that block resets each of these in
+        // this same function — testing them afterwards would report every
+        // right-drag as a right-click and pop the context menu at the end of
+        // every pan.
+        const bool wasPanning = m_IsPanning;
+        const bool hadPressOnCanvas = m_PanButtonDown;
 
         // Pan on middle OR right drag. Right-drag is what most artists reach for;
         // middle exists because some mice/tablets have no usable right-drag.
@@ -115,8 +128,14 @@ namespace OloEngine::EditorUI
             m_PanButtonDown = false;
             m_IsPanning = false;
         }
-        else if (!m_PanButtonDown && m_IsHovered)
+        else if (!m_PanButtonDown && m_IsHovered &&
+                 (ImGui::IsMouseClicked(ImGuiMouseButton_Middle) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)))
         {
+            // Latch on the PRESS, not merely on the first frame the button is
+            // held over the canvas. Without the IsMouseClicked test, a press that
+            // began outside the canvas and was dragged in latched here with a
+            // press position already inside it, so releasing counted as a
+            // stationary click and popped the consumer's context menu.
             m_PanButtonDown = true;
             m_PanPressPos = io.MousePos;
         }
@@ -154,6 +173,14 @@ namespace OloEngine::EditorUI
             const glm::vec2 after = ToGraph(io.MousePos);
             m_Pan += after - anchor;
         }
+
+        // A right-click is the release, over the canvas, of a right press that
+        // STARTED on the canvas and never crossed the pan threshold. Reusing the
+        // pan latch rather than a second stored press position keeps ONE
+        // definition of "far enough to be a drag" in the codebase, so the context
+        // menu and the pan can never disagree about which gesture was made.
+        m_WasRightClicked = m_IsHovered && ImGui::IsMouseReleased(ImGuiMouseButton_Right) &&
+                            hadPressOnCanvas && !wasPanning;
     }
 
     void GraphCanvas::DrawGrid() const

--- a/OloEditor/src/Panels/Graph/GraphCanvas.h
+++ b/OloEditor/src/Panels/Graph/GraphCanvas.h
@@ -95,6 +95,19 @@ namespace OloEngine::EditorUI
         {
             return m_IsHovered;
         }
+        /// True for the single frame in which a right press-and-release over the
+        /// canvas finished WITHOUT having become a pan. This is how a consumer
+        /// opens its context menu: because the canvas pans on right-drag, the two
+        /// gestures share a button and only the widget knows which one happened —
+        /// it owns the drag threshold that separates them.
+        ///
+        /// Every consumer needs this, so it lives here rather than being
+        /// re-derived per panel against ImGui's internal drag bookkeeping, which
+        /// has moved between versions.
+        [[nodiscard]] bool WasRightClicked() const
+        {
+            return m_WasRightClicked;
+        }
 
         //-- View controls --------------------------------------------------------
         void CenterOn(glm::vec2 graphPos);
@@ -144,6 +157,8 @@ namespace OloEngine::EditorUI
         /// right-CLICK still reaches the consumer's context menu.
         bool m_PanButtonDown = false;
         ImVec2 m_PanPressPos{ 0.0f, 0.0f };
+        /// Set for one frame by HandleViewInput; see WasRightClicked().
+        bool m_WasRightClicked = false;
 
         static constexpr f32 s_MinZoom = 0.15f;
         static constexpr f32 s_MaxZoom = 3.0f;

--- a/OloEditor/src/Panels/ShaderGraphEditorPanel.cpp
+++ b/OloEditor/src/Panels/ShaderGraphEditorPanel.cpp
@@ -78,9 +78,7 @@ namespace OloEngine
                                     : availWidth;
 
         // Left: node canvas
-        ImGui::BeginChild("##SGCanvas", ImVec2(canvasWidth, 0), ImGuiChildFlags_None, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove);
-        DrawCanvas();
-        ImGui::EndChild();
+        DrawCanvas(canvasWidth);
 
         // Right: property panel + preview
         if (m_SelectedNodeID != 0 || m_LastCompileResult.Success)
@@ -178,72 +176,46 @@ namespace OloEngine
     // Canvas
     // =========================================================================
 
-    void ShaderGraphEditorPanel::DrawCanvas()
+    void ShaderGraphEditorPanel::DrawCanvas(f32 width)
     {
-        ImVec2 const canvasOrigin = ImGui::GetCursorScreenPos();
-        ImVec2 const canvasSize = ImGui::GetContentRegionAvail();
-        ImVec2 const canvasEnd = ImVec2(canvasOrigin.x + canvasSize.x, canvasOrigin.y + canvasSize.y);
+        // Begin() paints the background and grid, consumes pan/zoom, and clips to
+        // its own child region — everything this function used to do by hand.
+        if (!m_Canvas.Begin("##SGCanvas", ImVec2(width, 0.0f)))
+            return;
 
-        ImDrawList* drawList = ImGui::GetWindowDrawList();
+        DrawConnections();
+        DrawNodes();
+        DrawConnectionInProgress();
 
-        drawList->AddRectFilled(canvasOrigin, canvasEnd, IM_COL32(30, 30, 35, 255));
-        drawList->PushClipRect(canvasOrigin, canvasEnd, true);
+        // A click that cut a wire must not also select or start dragging the
+        // node the wire happened to pass under — wires are drawn behind nodes,
+        // so the two hit-tests can both match the same pixel.
+        if (!HandleCanvasInput())
+            HandleNodeInteraction();
+        HandleConnectionDrag();
+        DrawContextMenu();
 
-        DrawGrid(drawList, canvasOrigin, canvasSize);
-        DrawConnections(drawList, canvasOrigin);
-        DrawNodes(drawList, canvasOrigin);
-        DrawConnectionInProgress(drawList, canvasOrigin);
-
-        drawList->PopClipRect();
-
-        ImGui::SetCursorScreenPos(canvasOrigin);
-        ImGui::InvisibleButton("##sgcanvas", canvasSize, ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle);
-
-        HandleCanvasInput(canvasOrigin, canvasSize);
-        HandleNodeInteraction(canvasOrigin);
-        HandleConnectionDrag(canvasOrigin);
-        DrawContextMenu(canvasOrigin);
-    }
-
-    void ShaderGraphEditorPanel::DrawGrid(ImDrawList* drawList, const ImVec2& canvasOrigin, const ImVec2& canvasSize) const
-    {
-        f32 const gridStep = s_GridSize * m_Zoom;
-        ImU32 const gridColor = IM_COL32(50, 50, 55, 255);
-        ImU32 const gridColorMajor = IM_COL32(60, 60, 70, 255);
-
-        f32 const offX = std::fmod(m_ScrollOffset.x * m_Zoom, gridStep);
-        f32 const offY = std::fmod(m_ScrollOffset.y * m_Zoom, gridStep);
-
-        for (f32 x = canvasOrigin.x + offX; x < canvasOrigin.x + canvasSize.x; x += gridStep)
-        {
-            int lineIndex = static_cast<int>((x - canvasOrigin.x - offX) / gridStep);
-            drawList->AddLine(ImVec2(x, canvasOrigin.y), ImVec2(x, canvasOrigin.y + canvasSize.y),
-                              (lineIndex % 4 == 0) ? gridColorMajor : gridColor);
-        }
-        for (f32 y = canvasOrigin.y + offY; y < canvasOrigin.y + canvasSize.y; y += gridStep)
-        {
-            int lineIndex = static_cast<int>((y - canvasOrigin.y - offY) / gridStep);
-            drawList->AddLine(ImVec2(canvasOrigin.x, y), ImVec2(canvasOrigin.x + canvasSize.x, y),
-                              (lineIndex % 4 == 0) ? gridColorMajor : gridColor);
-        }
+        m_Canvas.End();
     }
 
     // =========================================================================
     // Node rendering
     // =========================================================================
 
-    void ShaderGraphEditorPanel::DrawNodes(ImDrawList* drawList, const ImVec2& canvasOrigin)
+    void ShaderGraphEditorPanel::DrawNodes()
     {
         if (!m_GraphAsset)
             return;
 
         for (auto& node : m_GraphAsset->GetGraph().GetNodes())
-            DrawNode(drawList, canvasOrigin, *node);
+            DrawNode(*node);
     }
 
-    void ShaderGraphEditorPanel::DrawNode(ImDrawList* drawList, const ImVec2& canvasOrigin, ShaderGraphNode& node)
+    void ShaderGraphEditorPanel::DrawNode(ShaderGraphNode& node)
     {
-        ImVec2 const nodePos = WorldToScreen(node.EditorPosition, canvasOrigin);
+        ImDrawList* drawList = m_Canvas.GetDrawList();
+        f32 const zoom = m_Canvas.GetZoom();
+        ImVec2 const nodePos = m_Canvas.ToScreen(node.EditorPosition);
         ImVec2 const nodeSize = GetNodeSize(node);
         ImVec2 const nodeEnd = ImVec2(nodePos.x + nodeSize.x, nodePos.y + nodeSize.y);
         bool const isSelected = (m_SelectedNodeID == node.ID);
@@ -252,7 +224,7 @@ namespace OloEngine
         drawList->AddRectFilled(nodePos, nodeEnd, GetNodeColor(node.Category), 4.0f);
 
         // Header
-        ImVec2 const headerEnd = ImVec2(nodeEnd.x, nodePos.y + s_HeaderHeight * m_Zoom);
+        ImVec2 const headerEnd = ImVec2(nodeEnd.x, nodePos.y + s_HeaderHeight * zoom);
         drawList->AddRectFilled(nodePos, headerEnd, GetNodeHeaderColor(node.Category), 4.0f, ImDrawFlags_RoundCornersTop);
 
         // Selection border
@@ -260,18 +232,18 @@ namespace OloEngine
             drawList->AddRect(nodePos, nodeEnd, IM_COL32(255, 200, 50, 255), 4.0f, 0, 2.0f);
 
         // Title text
-        f32 const fontSize = 13.0f * m_Zoom;
-        ImVec2 const textPos = ImVec2(nodePos.x + 8.0f * m_Zoom, nodePos.y + 5.0f * m_Zoom);
+        f32 const fontSize = 13.0f * zoom;
+        ImVec2 const textPos = ImVec2(nodePos.x + 8.0f * zoom, nodePos.y + 5.0f * zoom);
         drawList->AddText(nullptr, fontSize, textPos, IM_COL32(255, 255, 255, 255), node.TypeName.c_str());
 
         // Per-node preview thumbnail (color swatch for color/vector parameter nodes)
         if (!node.ParameterName.empty() || node.TypeName == ShaderGraphNodeTypes::CustomFunction)
         {
             constexpr f32 swatchSize = 16.0f;
-            f32 const swatchSizeScaled = swatchSize * m_Zoom;
+            f32 const swatchSizeScaled = swatchSize * zoom;
             ImVec2 const swatchPos = ImVec2(
-                nodeEnd.x - swatchSizeScaled - 4.0f * m_Zoom,
-                nodePos.y + (s_HeaderHeight - swatchSize) * 0.5f * m_Zoom);
+                nodeEnd.x - swatchSizeScaled - 4.0f * zoom,
+                nodePos.y + (s_HeaderHeight - swatchSize) * 0.5f * zoom);
             ImVec2 const swatchEnd = ImVec2(swatchPos.x + swatchSizeScaled, swatchPos.y + swatchSizeScaled);
 
             // Determine preview color from first output or first input default
@@ -315,23 +287,23 @@ namespace OloEngine
         for (const auto& pin : pins)
         {
             ImU32 color = GetPinColor(pin.Type);
-            drawList->AddCircleFilled(pin.Position, s_PinRadius * m_Zoom, color);
-            drawList->AddCircle(pin.Position, s_PinRadius * m_Zoom, IM_COL32(200, 200, 200, 255));
+            drawList->AddCircleFilled(pin.Position, s_PinRadius * zoom, color);
+            drawList->AddCircle(pin.Position, s_PinRadius * zoom, IM_COL32(200, 200, 200, 255));
 
             // Pin label
-            f32 const labelFontSize = 11.0f * m_Zoom;
+            f32 const labelFontSize = 11.0f * zoom;
             if (pin.IsOutput)
             {
                 ImVec2 textSize = ImGui::CalcTextSize(pin.Name.c_str());
                 textSize.x *= (labelFontSize / ImGui::GetFontSize());
                 drawList->AddText(nullptr, labelFontSize,
-                                  ImVec2(pin.Position.x - s_PinRadius * m_Zoom - 4.0f * m_Zoom - textSize.x, pin.Position.y - labelFontSize * 0.5f),
+                                  ImVec2(pin.Position.x - s_PinRadius * zoom - 4.0f * zoom - textSize.x, pin.Position.y - labelFontSize * 0.5f),
                                   IM_COL32(200, 200, 200, 255), pin.Name.c_str());
             }
             else
             {
                 drawList->AddText(nullptr, labelFontSize,
-                                  ImVec2(pin.Position.x + s_PinRadius * m_Zoom + 4.0f * m_Zoom, pin.Position.y - labelFontSize * 0.5f),
+                                  ImVec2(pin.Position.x + s_PinRadius * zoom + 4.0f * zoom, pin.Position.y - labelFontSize * 0.5f),
                                   IM_COL32(200, 200, 200, 255), pin.Name.c_str());
             }
         }
@@ -341,7 +313,7 @@ namespace OloEngine
     {
         f32 const pinCount = static_cast<f32>(std::max(node.Inputs.size(), node.Outputs.size()));
         f32 const bodyHeight = s_HeaderHeight + (pinCount + 1) * s_PinSpacing;
-        return ImVec2(s_NodeWidth * m_Zoom, bodyHeight * m_Zoom);
+        return ImVec2(s_NodeWidth * m_Canvas.GetZoom(), bodyHeight * m_Canvas.GetZoom());
     }
 
     std::vector<ShaderGraphEditorPanel::PinInfo> ShaderGraphEditorPanel::GetNodePins(const ShaderGraphNode& node, const ImVec2& nodeScreenPos) const
@@ -353,7 +325,7 @@ namespace OloEngine
         for (size_t i = 0; i < node.Inputs.size(); ++i)
         {
             PinInfo pin;
-            pin.Position = ImVec2(nodeScreenPos.x, nodeScreenPos.y + (s_HeaderHeight + (static_cast<f32>(i) + 1) * s_PinSpacing) * m_Zoom);
+            pin.Position = ImVec2(nodeScreenPos.x, nodeScreenPos.y + (s_HeaderHeight + (static_cast<f32>(i) + 1) * s_PinSpacing) * m_Canvas.GetZoom());
             pin.PinID = node.Inputs[i].ID;
             pin.NodeID = node.ID;
             pin.Name = node.Inputs[i].Name;
@@ -366,7 +338,7 @@ namespace OloEngine
         for (size_t i = 0; i < node.Outputs.size(); ++i)
         {
             PinInfo pin;
-            pin.Position = ImVec2(nodeScreenPos.x + nodeSize.x, nodeScreenPos.y + (s_HeaderHeight + (static_cast<f32>(i) + 1) * s_PinSpacing) * m_Zoom);
+            pin.Position = ImVec2(nodeScreenPos.x + nodeSize.x, nodeScreenPos.y + (s_HeaderHeight + (static_cast<f32>(i) + 1) * s_PinSpacing) * m_Canvas.GetZoom());
             pin.PinID = node.Outputs[i].ID;
             pin.NodeID = node.ID;
             pin.Name = node.Outputs[i].Name;
@@ -382,61 +354,58 @@ namespace OloEngine
     // Connection rendering
     // =========================================================================
 
-    void ShaderGraphEditorPanel::DrawConnections(ImDrawList* drawList, const ImVec2& canvasOrigin)
+    bool ShaderGraphEditorPanel::GetLinkEndpoints(const ShaderGraphLink& link, WireEndpoints& out) const
+    {
+        const auto* outNode = m_GraphAsset->GetGraph().FindNodeByPinID(link.OutputPinID);
+        const auto* inNode = m_GraphAsset->GetGraph().FindNodeByPinID(link.InputPinID);
+        if (!outNode || !inNode)
+            return false;
+
+        bool foundSrc = false;
+        for (const auto& pin : GetNodePins(*outNode, m_Canvas.ToScreen(outNode->EditorPosition)))
+        {
+            if (pin.PinID == link.OutputPinID)
+            {
+                out.Source = pin.Position;
+                out.SourceType = pin.Type;
+                foundSrc = true;
+                break;
+            }
+        }
+        if (!foundSrc)
+            return false;
+
+        for (const auto& pin : GetNodePins(*inNode, m_Canvas.ToScreen(inNode->EditorPosition)))
+        {
+            if (pin.PinID == link.InputPinID)
+            {
+                out.Target = pin.Position;
+                return true;
+            }
+        }
+        // A link naming a pin its node no longer has: the compiler rejects it
+        // too, and skipping it keeps the canvas readable.
+        return false;
+    }
+
+    void ShaderGraphEditorPanel::DrawConnections()
     {
         if (!m_GraphAsset)
             return;
 
         for (const auto& link : m_GraphAsset->GetGraph().GetLinks())
         {
-            // Find source and target pin positions
-            const auto* outNode = m_GraphAsset->GetGraph().FindNodeByPinID(link.OutputPinID);
-            const auto* inNode = m_GraphAsset->GetGraph().FindNodeByPinID(link.InputPinID);
-            if (!outNode || !inNode)
-                continue;
-
-            ImVec2 srcPos{}, dstPos{};
-            ShaderGraphPinType srcType = ShaderGraphPinType::Float;
-            bool foundSrc = false;
-            bool foundDst = false;
-
-            auto srcPins = GetNodePins(*outNode, WorldToScreen(outNode->EditorPosition, canvasOrigin));
-            for (const auto& pin : srcPins)
+            if (WireEndpoints wire; GetLinkEndpoints(link, wire))
             {
-                if (pin.PinID == link.OutputPinID)
-                {
-                    srcPos = pin.Position;
-                    srcType = pin.Type;
-                    foundSrc = true;
-                    break;
-                }
+                // Thickness in SCREEN pixels, deliberately not scaled by zoom: a
+                // hairline at the canvas' minimum zoom is both invisible and
+                // impossible to click. See GraphCanvas::DrawWire.
+                m_Canvas.DrawWire(wire.Source, wire.Target, GetPinColor(wire.SourceType), 2.0f);
             }
-
-            auto dstPins = GetNodePins(*inNode, WorldToScreen(inNode->EditorPosition, canvasOrigin));
-            for (const auto& pin : dstPins)
-            {
-                if (pin.PinID == link.InputPinID)
-                {
-                    dstPos = pin.Position;
-                    foundDst = true;
-                    break;
-                }
-            }
-
-            if (!foundSrc || !foundDst)
-                continue;
-
-            // Bezier curve
-            f32 const curvature = 50.0f * m_Zoom;
-            ImVec2 const cp1 = ImVec2(srcPos.x + curvature, srcPos.y);
-            ImVec2 const cp2 = ImVec2(dstPos.x - curvature, dstPos.y);
-
-            ImU32 color = GetPinColor(srcType);
-            drawList->AddBezierCubic(srcPos, cp1, cp2, dstPos, color, 2.0f * m_Zoom);
         }
     }
 
-    void ShaderGraphEditorPanel::DrawConnectionInProgress(ImDrawList* drawList, const ImVec2& canvasOrigin)
+    void ShaderGraphEditorPanel::DrawConnectionInProgress()
     {
         if (!m_IsDraggingConnection)
             return;
@@ -447,7 +416,7 @@ namespace OloEngine
             const auto* node = m_GraphAsset->GetGraph().FindNodeByPinID(m_DragStartPinID);
             if (node)
             {
-                auto pins = GetNodePins(*node, WorldToScreen(node->EditorPosition, canvasOrigin));
+                auto pins = GetNodePins(*node, m_Canvas.ToScreen(node->EditorPosition));
                 for (const auto& pin : pins)
                 {
                     if (pin.PinID == m_DragStartPinID)
@@ -459,110 +428,131 @@ namespace OloEngine
             }
         }
 
-        ImVec2 endPos = ImGui::GetMousePos();
-        f32 const curvature = 50.0f * m_Zoom;
+        ImVec2 const endPos = ImGui::GetMousePos();
+        constexpr ImU32 pendingColor = IM_COL32(200, 200, 200, 180);
 
+        // DrawWire always leaves `from` rightwards and enters `to` leftwards, so
+        // a wire dragged BACKWARDS out of an input pin is the same curve with the
+        // endpoints swapped rather than a second set of mirrored control points.
         if (m_DragStartIsOutput)
-        {
-            ImVec2 const cp1 = ImVec2(startPos.x + curvature, startPos.y);
-            ImVec2 const cp2 = ImVec2(endPos.x - curvature, endPos.y);
-            drawList->AddBezierCubic(startPos, cp1, cp2, endPos, IM_COL32(200, 200, 200, 180), 2.0f * m_Zoom);
-        }
+            m_Canvas.DrawWire(startPos, endPos, pendingColor, 2.0f);
         else
-        {
-            ImVec2 const cp1 = ImVec2(startPos.x - curvature, startPos.y);
-            ImVec2 const cp2 = ImVec2(endPos.x + curvature, endPos.y);
-            drawList->AddBezierCubic(startPos, cp1, cp2, endPos, IM_COL32(200, 200, 200, 180), 2.0f * m_Zoom);
-        }
+            m_Canvas.DrawWire(endPos, startPos, pendingColor, 2.0f);
     }
 
     // =========================================================================
     // Input handling
     // =========================================================================
 
-    void ShaderGraphEditorPanel::HandleCanvasInput([[maybe_unused]] const ImVec2& canvasOrigin, [[maybe_unused]] const ImVec2& canvasSize)
+    bool ShaderGraphEditorPanel::HandleCanvasInput()
     {
-        bool const isHovered = ImGui::IsItemHovered();
+        // Pan and zoom were handled here by hand; GraphCanvas::Begin has already
+        // consumed both by the time this runs. While a pan is in progress the
+        // panel must keep its hands off the mouse entirely, or a drag of the
+        // background also deselects.
+        if (m_Canvas.IsPanning())
+            return false;
 
-        // Pan with middle mouse
-        if (isHovered && ImGui::IsMouseDragging(ImGuiMouseButton_Middle))
-        {
-            ImVec2 const delta = ImGui::GetIO().MouseDelta;
-            m_ScrollOffset.x += delta.x / m_Zoom;
-            m_ScrollOffset.y += delta.y / m_Zoom;
-        }
+        bool const isHovered = m_Canvas.IsHovered();
 
-        // Zoom with scroll
-        if (isHovered)
-        {
-            f32 const scroll = ImGui::GetIO().MouseWheel;
-            // Bit-exact zero sentinel — see cpp-coding-quality §2a.
-            constexpr f32 noScroll = 0.0f;
-            if (std::memcmp(&scroll, &noScroll, sizeof(f32)) != 0)
-            {
-                f32 const zoomDelta = scroll * 0.1f;
-                m_Zoom = std::clamp(m_Zoom + zoomDelta, 0.25f, 3.0f);
-            }
-        }
-
-        // Deselect on click in empty space
         if (isHovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !m_IsDraggingConnection && !m_IsDraggingNode)
         {
+            ImVec2 const mousePos = ImGui::GetMousePos();
+
+            // Alt+click a wire cuts it. The panel had no wire hit-testing at all
+            // before this — DeleteLink existed with no caller — because getting
+            // the bezier distance right per panel is exactly the duplicated maths
+            // the shared canvas exists to hold.
+            if (ImGui::GetIO().KeyAlt)
+            {
+                if (UUID const link = HitTestLink(mousePos); link != 0)
+                {
+                    DeleteLink(link);
+                    return true;
+                }
+            }
+
+            // Deselect on click in empty space. HandleNodeInteraction runs after
+            // this and re-selects if the click actually landed on a node.
             m_SelectedNodeID = 0;
         }
 
-        // Context menu on right click
-        if (isHovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+        // Right-CLICK, not right-press: the canvas pans on right-DRAG, and only
+        // it knows which gesture this was.
+        if (m_Canvas.WasRightClicked())
         {
             m_ShowContextMenu = true;
-            m_ContextMenuPos = ImGui::GetMousePos();
+            m_ContextMenuGraphPos = m_Canvas.ToGraph(ImGui::GetMousePos());
         }
+        return false;
     }
 
-    void ShaderGraphEditorPanel::HandleNodeInteraction(const ImVec2& canvasOrigin)
+    UUID ShaderGraphEditorPanel::HitTestLink(ImVec2 screenPos) const
+    {
+        if (!m_GraphAsset)
+            return 0;
+
+        UUID best = 0;
+        f32 bestDistance = s_WireHitDistance;
+        for (const auto& link : m_GraphAsset->GetGraph().GetLinks())
+        {
+            WireEndpoints wire;
+            if (!GetLinkEndpoints(link, wire))
+                continue;
+
+            // The canvas samples the SAME curve it drew, so the clickable wire and
+            // the visible wire cannot drift apart at zoom.
+            if (f32 const distance = m_Canvas.DistanceToWire(wire.Source, wire.Target, screenPos); distance < bestDistance)
+            {
+                bestDistance = distance;
+                best = link.ID;
+            }
+        }
+        return best;
+    }
+
+    void ShaderGraphEditorPanel::HandleNodeInteraction()
     {
         if (!m_GraphAsset)
             return;
 
         ImVec2 const mousePos = ImGui::GetMousePos();
 
-        // Check pin hover for connection start
-        for (auto& node : m_GraphAsset->GetGraph().GetNodes())
+        // Only NEW presses are suppressed while the canvas is panning. The
+        // release handling below is what pushes the MoveNodeCommand, so returning
+        // early here would strand an in-flight node drag whenever a pan latched
+        // mid-drag (a second button going down): m_IsDraggingNode would stay true
+        // with a stale start position, and the next left-drag anywhere would
+        // teleport the node.
+        if (!m_Canvas.IsPanning() && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
         {
-            ImVec2 const nodeScreenPos = WorldToScreen(node->EditorPosition, canvasOrigin);
-            auto pins = GetNodePins(*node, nodeScreenPos);
-
-            for (const auto& pin : pins)
+            if (PinInfo const* pin = HitTestPin(mousePos); pin != nullptr)
             {
-                f32 const dist = std::sqrt(
-                    (mousePos.x - pin.Position.x) * (mousePos.x - pin.Position.x) +
-                    (mousePos.y - pin.Position.y) * (mousePos.y - pin.Position.y));
-
-                if (dist <= s_PinRadius * m_Zoom * 2.0f)
-                {
-                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left))
-                    {
-                        m_IsDraggingConnection = true;
-                        m_DragStartPinID = pin.PinID;
-                        m_DragStartIsOutput = pin.IsOutput;
-                        return;
-                    }
-                }
+                m_IsDraggingConnection = true;
+                m_DragStartPinID = pin->PinID;
+                m_DragStartIsOutput = pin->IsOutput;
+                return;
             }
 
-            // Node selection and dragging
-            ImVec2 const nodeSize = GetNodeSize(*node);
-            bool const isInNode = mousePos.x >= nodeScreenPos.x && mousePos.x <= nodeScreenPos.x + nodeSize.x &&
-                                  mousePos.y >= nodeScreenPos.y && mousePos.y <= nodeScreenPos.y + nodeSize.y;
-
-            if (isInNode && ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !m_IsDraggingConnection)
+            // The node body, only once no pin matched: pins are drawn on top of
+            // the node and sit on its edge, so a pin has to win over the body
+            // underneath it.
+            for (auto& node : m_GraphAsset->GetGraph().GetNodes())
             {
-                m_SelectedNodeID = node->ID;
-                m_IsDraggingNode = true;
-                m_DragNodeID = node->ID;
-                m_DragNodeStartPos = node->EditorPosition;
-                m_DragMouseStartPos = mousePos;
-                return;
+                ImVec2 const nodeScreenPos = m_Canvas.ToScreen(node->EditorPosition);
+                ImVec2 const nodeSize = GetNodeSize(*node);
+                bool const isInNode = mousePos.x >= nodeScreenPos.x && mousePos.x <= nodeScreenPos.x + nodeSize.x &&
+                                      mousePos.y >= nodeScreenPos.y && mousePos.y <= nodeScreenPos.y + nodeSize.y;
+
+                if (isInNode)
+                {
+                    m_SelectedNodeID = node->ID;
+                    m_IsDraggingNode = true;
+                    m_DragNodeID = node->ID;
+                    m_DragNodeStartPos = node->EditorPosition;
+                    m_DragMouseStartPos = mousePos;
+                    return;
+                }
             }
         }
 
@@ -572,9 +562,12 @@ namespace OloEngine
             auto* node = m_GraphAsset->GetMutableGraph().FindNode(m_DragNodeID);
             if (node)
             {
+                // The drag is a SCREEN delta and EditorPosition is graph space,
+                // so it must be divided by zoom, not applied raw.
                 ImVec2 const delta = ImVec2(mousePos.x - m_DragMouseStartPos.x, mousePos.y - m_DragMouseStartPos.y);
-                node->EditorPosition.x = m_DragNodeStartPos.x + delta.x / m_Zoom;
-                node->EditorPosition.y = m_DragNodeStartPos.y + delta.y / m_Zoom;
+                f32 const zoom = m_Canvas.GetZoom();
+                node->EditorPosition.x = m_DragNodeStartPos.x + delta.x / zoom;
+                node->EditorPosition.y = m_DragNodeStartPos.y + delta.y / zoom;
                 m_IsDirty = true;
             }
         }
@@ -600,42 +593,57 @@ namespace OloEngine
         }
     }
 
-    void ShaderGraphEditorPanel::HandleConnectionDrag(const ImVec2& canvasOrigin)
+    const ShaderGraphEditorPanel::PinInfo* ShaderGraphEditorPanel::HitTestPin(ImVec2 screenPos, PinDirectionFilter filter) const
+    {
+        // The hit radius has a screen-pixel floor, so below roughly 0.8 zoom the
+        // circles of adjacent pins overlap: their spacing scales with zoom, the
+        // floor does not. Taking the FIRST pin inside the radius therefore
+        // grabbed a neighbour at low zoom; the nearest one is what was aimed at.
+        f32 const radius = std::max(s_PinHitRadiusMin, m_Canvas.Scaled(s_PinRadius * 2.0f));
+        f32 bestDistance = radius;
+        m_HitPin.reset();
+
+        for (auto& node : m_GraphAsset->GetGraph().GetNodes())
+        {
+            for (const auto& pin : GetNodePins(*node, m_Canvas.ToScreen(node->EditorPosition)))
+            {
+                if (filter == PinDirectionFilter::OutputsOnly && !pin.IsOutput)
+                    continue;
+                if (filter == PinDirectionFilter::InputsOnly && pin.IsOutput)
+                    continue;
+
+                f32 const dx = screenPos.x - pin.Position.x;
+                f32 const dy = screenPos.y - pin.Position.y;
+                if (f32 const dist = std::sqrt(dx * dx + dy * dy); dist <= bestDistance)
+                {
+                    bestDistance = dist;
+                    m_HitPin = pin;
+                }
+            }
+        }
+        return m_HitPin.has_value() ? &*m_HitPin : nullptr;
+    }
+
+    void ShaderGraphEditorPanel::HandleConnectionDrag()
     {
         if (!m_IsDraggingConnection || !m_GraphAsset)
             return;
 
         if (ImGui::IsMouseReleased(ImGuiMouseButton_Left))
         {
-            ImVec2 const mousePos = ImGui::GetMousePos();
-
-            // Find target pin
-            bool connected = false;
-            for (auto& node : m_GraphAsset->GetGraph().GetNodes())
+            // Only pins facing the other way can terminate the wire, so they are
+            // the only candidates the nearest-pin search may consider: an
+            // unusable pin must not shadow a usable one just behind it.
+            PinDirectionFilter const wanted = m_DragStartIsOutput ? PinDirectionFilter::InputsOnly
+                                                                  : PinDirectionFilter::OutputsOnly;
+            if (PinInfo const* target = HitTestPin(ImGui::GetMousePos(), wanted); target != nullptr)
             {
-                ImVec2 const nodeScreenPos = WorldToScreen(node->EditorPosition, canvasOrigin);
-                auto pins = GetNodePins(*node, nodeScreenPos);
+                UUID const outPin = m_DragStartIsOutput ? m_DragStartPinID : target->PinID;
+                UUID const inPin = m_DragStartIsOutput ? target->PinID : m_DragStartPinID;
 
-                for (const auto& pin : pins)
-                {
-                    f32 const dist = std::sqrt(
-                        (mousePos.x - pin.Position.x) * (mousePos.x - pin.Position.x) +
-                        (mousePos.y - pin.Position.y) * (mousePos.y - pin.Position.y));
-
-                    if (dist <= s_PinRadius * m_Zoom * 2.0f && pin.IsOutput != m_DragStartIsOutput)
-                    {
-                        UUID outPin = m_DragStartIsOutput ? m_DragStartPinID : pin.PinID;
-                        UUID inPin = m_DragStartIsOutput ? pin.PinID : m_DragStartPinID;
-
-                        auto cmd = CreateScope<AddLinkCommand>(outPin, inPin);
-                        m_CommandHistory.Execute(std::move(cmd), m_GraphAsset->GetMutableGraph());
-                        m_IsDirty = true;
-                        connected = true;
-                        break;
-                    }
-                }
-                if (connected)
-                    break;
+                auto cmd = CreateScope<AddLinkCommand>(outPin, inPin);
+                m_CommandHistory.Execute(std::move(cmd), m_GraphAsset->GetMutableGraph());
+                m_IsDirty = true;
             }
 
             m_IsDraggingConnection = false;
@@ -647,7 +655,7 @@ namespace OloEngine
     // Context menu
     // =========================================================================
 
-    void ShaderGraphEditorPanel::DrawContextMenu(const ImVec2& canvasOrigin)
+    void ShaderGraphEditorPanel::DrawContextMenu()
     {
         if (m_ShowContextMenu)
         {
@@ -658,7 +666,7 @@ namespace OloEngine
 
         if (ImGui::BeginPopup("##SGContextMenu"))
         {
-            glm::vec2 const worldPos = ScreenToWorld(m_ContextMenuPos, canvasOrigin);
+            glm::vec2 const worldPos = m_ContextMenuGraphPos;
 
             // Search filter
             ImGui::SetNextItemWidth(-1.0f);
@@ -1060,24 +1068,6 @@ namespace OloEngine
     }
 
     // =========================================================================
-    // Coordinate transforms
-    // =========================================================================
-
-    ImVec2 ShaderGraphEditorPanel::WorldToScreen(const glm::vec2& worldPos, const ImVec2& canvasOrigin) const
-    {
-        return ImVec2(
-            canvasOrigin.x + (worldPos.x + m_ScrollOffset.x) * m_Zoom,
-            canvasOrigin.y + (worldPos.y + m_ScrollOffset.y) * m_Zoom);
-    }
-
-    glm::vec2 ShaderGraphEditorPanel::ScreenToWorld(const ImVec2& screenPos, const ImVec2& canvasOrigin) const
-    {
-        return glm::vec2(
-            (screenPos.x - canvasOrigin.x) / m_Zoom - m_ScrollOffset.x,
-            (screenPos.y - canvasOrigin.y) / m_Zoom - m_ScrollOffset.y);
-    }
-
-    // =========================================================================
     // Node operations
     // =========================================================================
 
@@ -1377,8 +1367,7 @@ namespace OloEngine
         m_CurrentAssetHandle = 0;
         m_IsDirty = false;
         m_SelectedNodeID = 0;
-        m_ScrollOffset = { 0.0f, 0.0f };
-        m_Zoom = 1.0f;
+        m_Canvas.ResetView();
         m_LastCompileResult = {};
         m_CommandHistory.Clear();
     }
@@ -1482,8 +1471,7 @@ namespace OloEngine
 
         m_IsDirty = false;
         m_SelectedNodeID = 0;
-        m_ScrollOffset = { 0.0f, 0.0f };
-        m_Zoom = 1.0f;
+        m_Canvas.ResetView();
         m_LastCompileResult = {};
         m_CommandHistory.Clear();
     }

--- a/OloEditor/src/Panels/ShaderGraphEditorPanel.h
+++ b/OloEditor/src/Panels/ShaderGraphEditorPanel.h
@@ -5,10 +5,12 @@
 #include "OloEngine/Renderer/ShaderGraph/ShaderGraphCompiler.h"
 #include "OloEngine/Renderer/ShaderGraph/ShaderGraphCommand.h"
 #include "OloEngine/Asset/Asset.h"
+#include "Panels/Graph/GraphCanvas.h"
 
 #include <glm/glm.hpp>
 #include <imgui.h>
 #include <filesystem>
+#include <optional>
 
 namespace OloEngine
 {
@@ -55,14 +57,13 @@ namespace OloEngine
 
       private:
         // Canvas
-        void DrawCanvas();
-        void DrawGrid(ImDrawList* drawList, const ImVec2& canvasOrigin, const ImVec2& canvasSize) const;
-        void DrawNodes(ImDrawList* drawList, const ImVec2& canvasOrigin);
-        void DrawConnections(ImDrawList* drawList, const ImVec2& canvasOrigin);
-        void DrawConnectionInProgress(ImDrawList* drawList, const ImVec2& canvasOrigin);
+        void DrawCanvas(f32 width);
+        void DrawNodes();
+        void DrawConnections();
+        void DrawConnectionInProgress();
 
         // Node rendering
-        void DrawNode(ImDrawList* drawList, const ImVec2& canvasOrigin, ShaderGraphNode& node);
+        void DrawNode(ShaderGraphNode& node);
         ImVec2 GetNodeSize(const ShaderGraphNode& node) const;
         ImU32 GetNodeColor(ShaderGraphNodeCategory category) const;
         ImU32 GetNodeHeaderColor(ShaderGraphNodeCategory category) const;
@@ -80,10 +81,41 @@ namespace OloEngine
         };
         std::vector<PinInfo> GetNodePins(const ShaderGraphNode& node, const ImVec2& nodeScreenPos) const;
 
+        enum class PinDirectionFilter
+        {
+            Any,
+            InputsOnly,
+            OutputsOnly
+        };
+        /// The pin NEAREST `screenPos` within the hit radius, or nullptr. Nearest
+        /// rather than first-found because the radius has a screen-pixel floor,
+        /// so adjacent pins' hit circles overlap once zoomed out far enough.
+        /// The result points at a member scratch slot and is invalidated by the
+        /// next call.
+        [[nodiscard]] const PinInfo* HitTestPin(ImVec2 screenPos, PinDirectionFilter filter = PinDirectionFilter::Any) const;
+
+        /// A link resolved to the two SCREEN points its wire runs between.
+        struct WireEndpoints
+        {
+            ImVec2 Source{};
+            ImVec2 Target{};
+            ShaderGraphPinType SourceType = ShaderGraphPinType::Float;
+        };
+        /// False when either end names a pin that no longer exists, in which case
+        /// `out` is untouched and the wire is neither drawn nor clickable — the
+        /// two must agree, which is why they share this lookup.
+        [[nodiscard]] bool GetLinkEndpoints(const ShaderGraphLink& link, WireEndpoints& out) const;
+
         // Interaction
-        void HandleCanvasInput(const ImVec2& canvasOrigin, const ImVec2& canvasSize);
-        void HandleNodeInteraction(const ImVec2& canvasOrigin);
-        void HandleConnectionDrag(const ImVec2& canvasOrigin);
+        /// Returns true when the click was consumed here (a wire was cut), so
+        /// the caller skips node hit-testing for this frame.
+        bool HandleCanvasInput();
+        void HandleNodeInteraction();
+        void HandleConnectionDrag();
+        /// The link whose wire passes nearest `screenPos`, or 0 if none is close
+        /// enough to have been aimed at. Uses the canvas' own bezier sampling so
+        /// the hit curve is the curve that was drawn.
+        [[nodiscard]] UUID HitTestLink(ImVec2 screenPos) const;
 
         // Toolbar & property panel
         void DrawToolbar();
@@ -92,7 +124,7 @@ namespace OloEngine
         void DrawPreviewPanel();
 
         // Context menu
-        void DrawContextMenu(const ImVec2& canvasOrigin);
+        void DrawContextMenu();
 
         // Serialization
         void SaveShaderGraph();
@@ -115,10 +147,6 @@ namespace OloEngine
         // Auto-layout
         void AutoLayoutNodes();
 
-        // Coordinate transforms
-        ImVec2 WorldToScreen(const glm::vec2& worldPos, const ImVec2& canvasOrigin) const;
-        glm::vec2 ScreenToWorld(const ImVec2& screenPos, const ImVec2& canvasOrigin) const;
-
       private:
         bool m_IsOpen = true;
         bool m_IsFocused = false;
@@ -134,13 +162,16 @@ namespace OloEngine
         AssetHandle m_PendingLoadHandle = 0;
         int m_PendingLoadFrameDelay = 0;
 
-        // Canvas state
-        glm::vec2 m_ScrollOffset = { 0.0f, 0.0f };
-        f32 m_Zoom = 1.0f;
-        bool m_IsPanning = false;
+        // Canvas view: pan, zoom, grid, the screen<->graph transforms and wire
+        // drawing/hit-testing all live in the shared widget, not here.
+        EditorUI::GraphCanvas m_Canvas;
 
         // Selection
         UUID m_SelectedNodeID = 0;
+
+        /// Storage behind the pointer HitTestPin returns; not state, just a slot
+        /// that outlives the call.
+        mutable std::optional<PinInfo> m_HitPin;
 
         // Connection dragging
         bool m_IsDraggingConnection = false;
@@ -156,7 +187,10 @@ namespace OloEngine
 
         // Context menu
         bool m_ShowContextMenu = false;
-        ImVec2 m_ContextMenuPos = {};
+        // Captured in GRAPH space at click time. Storing the screen position and
+        // converting it when the popup is drawn placed the new node wrongly
+        // whenever the view moved between the two.
+        glm::vec2 m_ContextMenuGraphPos = {};
         char m_NodeSearchFilter[128] = {};
 
         // Compile preview
@@ -183,12 +217,17 @@ namespace OloEngine
         bool m_HasCopiedNode = false;
 
         // Layout constants
-        static constexpr f32 s_GridSize = 32.0f;
         static constexpr f32 s_NodeWidth = 180.0f;
         static constexpr f32 s_PinRadius = 5.0f;
         static constexpr f32 s_PinSpacing = 22.0f;
         static constexpr f32 s_HeaderHeight = 26.0f;
         static constexpr f32 s_PropertyPanelWidth = 300.0f;
+        /// Screen pixels. A pin hit box that scales with zoom shrinks to 1.5px at
+        /// the canvas' minimum zoom, which no mouse can hit; a floor keeps every
+        /// pin reachable at every zoom.
+        static constexpr f32 s_PinHitRadiusMin = 9.0f;
+        /// Screen pixels from a wire that still counts as clicking it.
+        static constexpr f32 s_WireHitDistance = 8.0f;
     };
 
 } // namespace OloEngine

--- a/OloEditor/src/Panels/VisualScriptEditorPanel.cpp
+++ b/OloEditor/src/Panels/VisualScriptEditorPanel.cpp
@@ -1114,18 +1114,10 @@ namespace OloEngine
         }
 
         //-- Context menu ----------------------------------------------------------
-        // Right-CLICK, meaning a press and release that did not move. GraphCanvas
-        // treats a right DRAG as a pan, so the two gestures must be told apart —
-        // and tracking the press position here avoids depending on ImGui's
-        // internal drag bookkeeping, which has moved between versions.
-        if (ImGui::IsMouseClicked(ImGuiMouseButton_Right))
-        {
-            m_RightPressPos = mouse;
-        }
-        const f32 rightDx = mouse.x - m_RightPressPos.x;
-        const f32 rightDy = mouse.y - m_RightPressPos.y;
-        if (m_Canvas.IsHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Right) &&
-            (rightDx * rightDx + rightDy * rightDy) < 16.0f)
+        // Right-CLICK, meaning a press and release that did not become a pan.
+        // GraphCanvas owns that distinction now (it owns the drag threshold), so
+        // this no longer tracks its own press position.
+        if (m_Canvas.WasRightClicked())
         {
             m_ContextMenuOpen = true;
             m_ContextMenuGraphPos = m_Canvas.ToGraph(mouse);

--- a/OloEditor/src/Panels/VisualScriptEditorPanel.h
+++ b/OloEditor/src/Panels/VisualScriptEditorPanel.h
@@ -245,11 +245,6 @@ namespace OloEngine
         /// a hash lookup per node per frame for a value that cannot change
         /// mid-frame.
         const VisualScript::VisualScriptInstance* m_FrameDebugInstance = nullptr;
-        /// Where the right button went down, so a right-DRAG (pan) and a
-        /// right-CLICK (context menu) can be told apart at release without
-        /// reaching into ImGui's internal drag state, which has moved between
-        /// versions.
-        ImVec2 m_RightPressPos{ 0.0f, 0.0f };
         Entity m_DebugEntity;
         bool m_TraceEnabled = true;
         bool m_ShowPinValues = true;


### PR DESCRIPTION
Panel **1 of 7** in #1070. `ShaderGraphEditorPanel` is now a consumer of
`EditorUI::GraphCanvas` instead of carrying its own copy of the viewport maths.

#1070 stays **open** — six panels to go, `AnimationGraphEditorPanel` next.

## What moved, and what deliberately did not

The issue's one load-bearing line is which half moves, so that is the shape of the diff:

| | |
|---|---|
| **Moved to the widget** | background + grid, pan, zoom, both screen↔graph transforms (`WorldToScreen`/`ScreenToWorld`), bezier wire drawing, the clip rect and invisible button that made the canvas hoverable |
| **Left in the panel** | node layout and sizing, pin layout, node/pin hit-testing, selection, dragging, link semantics, toolbar, property panel, serialization, undo/redo, copy/paste, auto-layout |

`ShaderGraphEditorPanel.cpp` loses its `DrawGrid`, both transforms, its pan/zoom
input handling and its duplicated `AddBezierCubic` calls.

## What I added to GraphCanvas, and why it is general

**`WasRightClicked()`** — one accessor. The canvas pans on right-drag, so only the
canvas can distinguish a context-menu right-*click* from a pan: it owns the drag
threshold that separates them. Every one of the remaining six panels needs this
gesture. `VisualScriptEditorPanel` hand-rolled it with its own `m_RightPressPos` and
a squared-distance test; it is switched onto the shared one and that duplicate state
is deleted, so there is now exactly one definition of "far enough to be a drag".

Latching that press on `IsMouseClicked` rather than on the first held-and-hovered
frame also fixes a case **both** old implementations got wrong: a right press begun
outside the canvas and dragged in released as a stationary "click" and popped the
context menu.

## Behaviour that deliberately changed

All of it is the widget's rules replacing the panel's, and all of it is an
improvement, but it is behaviour change and reviewers should see it listed:

- pan on right-drag as well as middle-drag
- zoom is multiplicative over `[0.15, 3.0]` and anchors on the **cursor**, not
  additive over `[0.25, 3.0]` anchored on the canvas corner
- wire thickness is screen pixels, not `2 * zoom` — a hairline at minimum zoom is
  both invisible and unclickable
- grid majors every 5, indexed in graph space, so they stay on the lattice while
  panning instead of sliding across the minor grid
- context menu opens on right-release-without-drag, not on right-press

## Bugs fixed on the way

- **Context menu placed nodes wrongly.** It stored a *screen* position at click time
  and converted it to graph space when the popup was drawn, so a node landed in the
  wrong place if the view moved in between. The graph position is captured at click
  time now.
- **Pin hit-testing grabbed the wrong pin when zoomed out.** The hit radius needs a
  screen-pixel floor (a 5px pin at 0.15 zoom is a 1.5px target), which makes adjacent
  pins' circles overlap; taking the *first* pin inside the radius then grabbed a
  neighbour. It picks the nearest now, and the release path only considers pins facing
  the right way so an unusable pin cannot shadow a usable one.
- **Wire hit-test sampling** — separate commit (88298fa), because it is the widget's
  own pre-existing bug and `VisualScriptEditorPanel` alt+clicks wires through it
  today. `DistanceToWire` sampled at a fixed 16 points, so sample spacing grew with
  the wire and a ~600px wire had ~37px holes a click fell through. It steps at a
  fixed 6px now.

Alt+click on a wire cuts it — that is what gives the previously-dead `DeleteLink` a
caller, and it exercises `DistanceToWire` from a second consumer, which is the point
of taking this panel first.

## On the third-party alternative

The issue asks whether adopting `imgui-node-editor` should be argued *before* the
migration gets far. Having done panel 1: **no, keep going.** The viewport half is
about 90 lines and it transplanted cleanly; what is bulky and panel-specific is node
layout, link semantics and the property panel, none of which a third-party canvas
would take off our hands, and all of which we would have to rewrite against its
model. I would not spend an ADR on it on this evidence.

## Review guide

**Where I'd look hardest**

1. `OloEditor/src/Panels/ShaderGraphEditorPanel.cpp` — `GetLinkEndpoints` /
   `DrawConnections` / `HitTestLink`. This is the one path I could **not** get in
   front of a live editor (see below), so it is verified by reading only. It is also
   the newly-shared lookup: drawing and hit-testing must agree about where a wire is,
   which is exactly why they now go through one function.
2. `OloEditor/src/Panels/ShaderGraphEditorPanel.cpp` — `HandleNodeInteraction`. Only
   *new presses* are suppressed while the canvas is panning; the release must always
   run or an in-flight node drag is stranded with a stale start position and the next
   drag teleports the node. An earlier revision of this PR had exactly that bug.
3. `OloEditor/src/Panels/Graph/GraphCanvas.cpp` — `HandleViewInput`. `wasPanning` and
   `hadPressOnCanvas` are both sampled *before* the latch block clears them; reading
   either afterwards reports every right-drag as a right-click.

**What I verified, and how**

- `ShaderGraphCommandTest` — 60/60 pass (`--gtest_filter='ShaderGraph*'`), before and
  after.
- Live in the editor, driven through the MCP diagnostics server, on the final binary:
  grid and background render; `ToScreen` puts the seeded `PBROutput` at exactly the
  computed pixel; `ToGraph` creates a context-menu node exactly under the cursor;
  node selection; node drag moves exactly the drag delta (+200,+85) and selects;
  right-**click** opens the node-search menu; right-**drag** pans exactly the drag
  delta (+130,+120) with the grid following, and does **not** open the menu — that
  last pair is the whole point of `WasRightClicked()`.
- `olo_shader_errors` clean; `OloEngine.log` has no errors but pre-existing
  missing-font warnings (that asset directory is not in the repo).

**Least confident about**

Wire *rendering* and the new alt+click cut. I could not get a link to exist in a live
editor: dragging between two compatible pins does not create one — and it does not on
`master` either. I built the editor from `master`, ran the identical injected drag,
and got the identical no-op, then confirmed the injection itself is faithful by
dragging a node on that same baseline (it moved correctly). So this is **pre-existing
and not a regression**, but I did not diagnose it and it means `DrawWire`,
`GetLinkEndpoints` and `HitTestLink` are code-reviewed rather than seen working.
Loading the sample `DemoMetallic.olosg` (which has 3 links) would have covered it, but
Content Browser navigation resisted synthetic input and four editor instances were
killed out from under me by parallel sessions on this box.

**Deliberately not tested**

Zoom, at all. `olo_input_inject` has no scroll-wheel action, so scroll-to-zoom cannot
be driven from an agent session; logged on #607. The risk is bounded: `GraphCanvas`'s
zoom code is untouched by this PR and already has a live consumer, so what is new here
is only whether the panel consumes `GetZoom()`/`Scaled()` correctly, which is visible
in the diff and was exercised at zoom 1.

Part of #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)