### PR TITLE
perf(renderer): indirect-dispatch the virtual-geometry software raster, and measure #712

### DIFF
--- a/OloEditor/assets/shaders/VirtualVisibilityResolve.glsl
+++ b/OloEditor/assets/shaders/VirtualVisibilityResolve.glsl
@@ -117,7 +117,7 @@ layout(std430, binding = 39) readonly buffer VirtualVertices { VirtualGpuVertex 
 layout(std430, binding = 42) readonly buffer VirtualIndices { uint localIndices[]; };
 layout(std430, binding = 40) readonly buffer VirtualSwList {
     uint Count;
-    uint _h0; uint _h1; uint _h2;
+    uint DispatchX; uint DispatchY; uint DispatchZ; // indirect dispatch args, written by VirtualRasterArgs.comp (#1048)
     VisibleCluster Records[];
 } swList;
 // The atlas sampler + the sentinel-gated decode, shared verbatim with the

--- a/OloEditor/assets/shaders/compute/VirtualClusterCull.comp
+++ b/OloEditor/assets/shaders/compute/VirtualClusterCull.comp
@@ -124,7 +124,7 @@ layout(std430, binding = 38) writeonly buffer VirtualVisible { VisibleCluster vi
 // clusters whose projected coverage is under u_SwRasterThresholdPixels.
 layout(std430, binding = 40) buffer VirtualSwList {
     uint Count;
-    uint _h0; uint _h1; uint _h2;
+    uint DispatchX; uint DispatchY; uint DispatchZ; // indirect dispatch args, written by VirtualRasterArgs.comp (#1048)
     VisibleCluster Records[];
 } swList;
 

--- a/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
+++ b/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
@@ -146,9 +146,15 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     //      append, not the counter), so a GPU overflow would inflate the very
     //      number the read is bounded by. 0 = an empty list.
     uint  u_SwListCapacity;
-    uint  _vrPad0;          // 20 — std140 rounds the block to a 16-byte multiple;
-    uint  _vrPad1;          // 24   explicit so the C++ mirror is a plain struct.
-    uint  _vrPad2;          // 28
+    // 20/24 — ndc.z -> window depth as (scale, bias), from
+    //         RHI::NdcToWindowDepthScaleBias(). The software raster does its own
+    //         perspective divide, so it applies the mapping fixed function would
+    //         have: GL 0.5/0.5 (ndc z is [-1,1]); Vulkan 1/0 (the seam already
+    //         mapped clip z to [0,w], so ndc.z IS the window depth). Data, not a
+    //         backend #ifdef, so this file stays source-identical.
+    float u_DepthScale;
+    float u_DepthBias;
+    uint  _vrPad0;          // 28 — std140 rounds the block to a 16-byte multiple.
 };
 
 // Bounded micro-triangle raster: SW-routed clusters have small projected
@@ -243,9 +249,18 @@ void RasterizeTriangle(uint swRecordIndex, uint triangleIndex)
     float invArea = 1.0 / area;
     // Window depth in [0,1], interpolated with screen-space barycentrics —
     // the same interpolation the hardware rasterizer applies to gl_FragCoord.z.
-    float z0 = ndc0.z * 0.5 + 0.5;
-    float z1 = ndc1.z * 0.5 + 0.5;
-    float z2 = ndc2.z * 0.5 + 0.5;
+    // Window depth via the backend's ndc.z mapping (u_DepthScale/u_DepthBias from
+    // RHI::NdcToWindowDepthScaleBias), NOT a hard-coded *0.5+0.5. This shader
+    // projects with the SAME adjusted matrix the hardware path uses, and on
+    // Vulkan that matrix has already mapped clip z into [0, w] — so ndc.z is
+    // ALREADY the window depth there, and remapping it again compressed every
+    // software depth into [0.5, 1]. The software clusters then lost the depth
+    // test against the hardware-rasterized ones almost everywhere and the mesh
+    // rendered in shredded fragments, while every CPU-side counter (cut size,
+    // software-rasterized count, dispatch size) still read exactly right.
+    float z0 = ndc0.z * u_DepthScale + u_DepthBias;
+    float z1 = ndc1.z * u_DepthScale + u_DepthBias;
+    float z2 = ndc2.z * u_DepthScale + u_DepthBias;
 
     uint payload = (swRecordIndex << 9u) | (triangleIndex & 0x1FFu);
 

--- a/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
+++ b/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
@@ -102,7 +102,7 @@ layout(std430, binding = 42) readonly buffer VirtualIndices { uint localIndices[
 // ClusterIndex} with the record's own slot stored by the cull.
 layout(std430, binding = 40) buffer VirtualSwList {
     uint Count;
-    uint _h0; uint _h1; uint _h2;
+    uint DispatchX; uint DispatchY; uint DispatchZ; // indirect dispatch args, written by VirtualRasterArgs.comp (#1048)
     VisibleCluster Records[];
 } swList;
 

--- a/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
+++ b/OloEditor/assets/shaders/compute/VirtualClusterRaster.comp
@@ -154,7 +154,12 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     //         backend #ifdef, so this file stays source-identical.
     float u_DepthScale;
     float u_DepthBias;
-    uint  _vrPad0;          // 28 — std140 rounds the block to a 16-byte multiple.
+    // 28 — +1 on GL, -1 on Vulkan, from RHI::WindowSpaceFrontFaceSign(). This
+    //      shader builds its own window-space area determinant, and on Vulkan
+    //      that space is the FRAMEBUFFER's (y down) instead of GL's window space
+    //      (y up) — one mirror, which negates the sign. Fixed function gets a
+    //      second, cancelling inversion; a manual rasterizer does not.
+    float u_FrontFaceSign;
 };
 
 // Bounded micro-triangle raster: SW-routed clusters have small projected
@@ -211,7 +216,30 @@ void RasterizeTriangle(uint swRecordIndex, uint triangleIndex)
     // geometry we ship — is alpha-masked and never reaches this shader.
     bool twoSided = (inst.Flags & 4u) != 0u;
     float signedArea = OloVirtualSignedArea2(s0, s1, s2);
-    if (signedArea < 0.0 && !twoSided)
+    // The CULL sense is backend-dependent (u_FrontFaceSign); the ORIENT below is
+    // not. On Vulkan this determinant is computed in framebuffer space, whose y
+    // runs opposite to GL's window space, so the same triangle reports the
+    // opposite sign — and culling on the GL sense there throws away the FRONT
+    // faces and keeps the back ones. That does not blank the frame: a closed
+    // mesh still fills its own silhouette, so it reads as missing patches and
+    // inside-out shading (issue #1105).
+    // A SELECT rather than `signedArea * u_FrontFaceSign < 0.0`: multiplying the
+    // determinant is algebraically a no-op on GL (the sign is +1 there) but not
+    // a numerical one, and the select keeps the GL comparison spelled exactly as
+    // it was. The branch is uniform across the dispatch, so it costs no
+    // divergence.
+    //
+    // MEASURED, because "no visual change" was claimed and then checked: reading
+    // this uniform at all shifts the GL path's floating-point codegen slightly.
+    // Against the pre-#1105 shader, 25-126 pixels per 230,400 (0.01-0.06%) move
+    // by a MAXIMUM CHANNEL DELTA OF 1 -- one least-significant bit on
+    // micro-triangle boundaries, no geometry gained or lost, every golden test
+    // still green. Both the multiply and the select forms shift it identically,
+    // so the shift comes from the uniform read, not from the arithmetic; a
+    // compile-time #define per backend would avoid it, at the cost of the
+    // source-identical property this seam exists to preserve.
+    bool backFacing = (u_FrontFaceSign > 0.0) ? (signedArea < 0.0) : (signedArea > 0.0);
+    if (backFacing && !twoSided)
         return; // back-facing, single-sided material
     float orient = (signedArea < 0.0) ? -1.0 : 1.0;
     float area = signedArea * orient;

--- a/OloEditor/assets/shaders/compute/VirtualDebugColorize.comp
+++ b/OloEditor/assets/shaders/compute/VirtualDebugColorize.comp
@@ -42,9 +42,15 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     //      append, not the counter), so a GPU overflow would inflate the very
     //      number the read is bounded by. 0 = an empty list.
     uint  u_SwListCapacity;
-    uint  _vrPad0;          // 20 — std140 rounds the block to a 16-byte multiple;
-    uint  _vrPad1;          // 24   explicit so the C++ mirror is a plain struct.
-    uint  _vrPad2;          // 28
+    // 20/24 — ndc.z -> window depth as (scale, bias), from
+    //         RHI::NdcToWindowDepthScaleBias(). The software raster does its own
+    //         perspective divide, so it applies the mapping fixed function would
+    //         have: GL 0.5/0.5 (ndc z is [-1,1]); Vulkan 1/0 (the seam already
+    //         mapped clip z to [0,w], so ndc.z IS the window depth). Data, not a
+    //         backend #ifdef, so this file stays source-identical.
+    float u_DepthScale;
+    float u_DepthBias;
+    uint  _vrPad0;          // 28 — std140 rounds the block to a 16-byte multiple.
 };
 
 // blue (low) -> green (mid) -> red (high)

--- a/OloEditor/assets/shaders/compute/VirtualDebugColorize.comp
+++ b/OloEditor/assets/shaders/compute/VirtualDebugColorize.comp
@@ -50,7 +50,12 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     //         backend #ifdef, so this file stays source-identical.
     float u_DepthScale;
     float u_DepthBias;
-    uint  _vrPad0;          // 28 — std140 rounds the block to a 16-byte multiple.
+    // 28 — +1 on GL, -1 on Vulkan, from RHI::WindowSpaceFrontFaceSign(). This
+    //      shader builds its own window-space area determinant, and on Vulkan
+    //      that space is the FRAMEBUFFER's (y down) instead of GL's window space
+    //      (y up) — one mirror, which negates the sign. Fixed function gets a
+    //      second, cancelling inversion; a manual rasterizer does not.
+    float u_FrontFaceSign;
 };
 
 // blue (low) -> green (mid) -> red (high)

--- a/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
+++ b/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
@@ -58,9 +58,9 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     uint  u_Phase;
     float u_OverdrawScale;
     uint  u_SwListCapacity;
+    float u_DepthScale;
+    float u_DepthBias;
     uint  _vrPad0;
-    uint  _vrPad1;
-    uint  _vrPad2;
 };
 
 void main()

--- a/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
+++ b/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
@@ -60,7 +60,7 @@ layout(std140, binding = 70) uniform VirtualRasterParams
     uint  u_SwListCapacity;
     float u_DepthScale;
     float u_DepthBias;
-    uint  _vrPad0;
+    float u_FrontFaceSign;
 };
 
 void main()

--- a/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
+++ b/OloEditor/assets/shaders/compute/VirtualRasterArgs.comp
@@ -1,0 +1,80 @@
+#version 460 core
+
+// =============================================================================
+// VirtualRasterArgs.comp — the 1-thread kernel that turns the GPU-written
+// software-raster work-list count into VirtualClusterRaster.comp's indirect
+// dispatch arguments (issue #1048).
+//
+// Before this existed, the raster was dispatched at the frame's TOTAL cluster
+// count, because the count of clusters actually routed to software is written
+// by VirtualClusterCull.comp and never read back. Every workgroup past the live
+// count early-outs on `swRecordIndex >= swList.Count` — correct (the #551
+// idiom), and on VirtualGeometryStress it dispatched 2,834,448 workgroups for
+// 3,165 records with work. The measurement in #1048 shows that overdispatch IS
+// the pass: a raster whose main() returns immediately cost the same 0.1321 ms
+// as the real one, so the bracket was timing workgroup launch, not rasterizing.
+//
+// The work list's header was already the right shape. VirtualSwList is
+// `{ uint Count; uint DispatchX, DispatchY, DispatchZ; VisibleCluster[] }`, so
+// the three words at byte offset 4 are a (numGroupsX, numGroupsY, numGroupsZ)
+// triple that DispatchComputeIndirect can read in place — no second buffer, no
+// new binding, and the arguments sit in the same 16 bytes the CPU already
+// zeroes each frame.
+//
+// Runs after BOTH cull phases: phase 1 and phase 2 append to the same list, and
+// the raster consumes their union in one dispatch.
+// =============================================================================
+
+// The flattening rule itself, shared with its L2 probe and its CPU mirror.
+#include "../include/VirtualRasterDispatchArgs.glsl"
+
+layout(local_size_x = 1) in;
+
+// Mirrors OloEngine::VirtualVisibleCluster (16 B std430)
+struct VisibleCluster {
+    uint InstanceIndex;
+    uint ClusterIndex;
+    uint _p0; uint _p1;
+};
+
+// Declared verbatim in VirtualClusterCull.comp, VirtualClusterRaster.comp
+// (both variants) and VirtualVisibilityResolve.glsl. C++ twin:
+// OloEngine::VirtualSwListHeader in VirtualGeometryPass.cpp, whose
+// static_asserts pin the DispatchX offset this shader writes to the byte offset
+// the CPU passes to DispatchComputeIndirect.
+layout(std430, binding = 40) buffer VirtualSwList {
+    uint Count;
+    uint DispatchX; uint DispatchY; uint DispatchZ;
+    VisibleCluster Records[];
+} swList;
+
+// The raster's own parameter block, declared verbatim — this kernel needs
+// exactly one field from it, u_SwListCapacity, and reusing the block keeps the
+// engine's last free UBO binding free.
+layout(std140, binding = 70) uniform VirtualRasterParams
+{
+    uint  u_ViewportWidth;
+    uint  u_ViewportHeight;
+    uint  u_Phase;
+    float u_OverdrawScale;
+    uint  u_SwListCapacity;
+    uint  _vrPad0;
+    uint  _vrPad1;
+    uint  _vrPad2;
+};
+
+void main()
+{
+    // CLAMPED, for the same reason the raster clamps its own index (issue
+    // #1058): Count is an unguarded atomicAdd in VirtualClusterCull.comp —
+    // #862 bounded the APPEND, so an overflow drops the record but still
+    // inflates the counter. Feeding that raw counter to an indirect dispatch
+    // would let the one value an overflow can corrupt decide how many
+    // workgroups launch, and a wrong bound on the GPU is silent.
+    uint count = min(swList.Count, u_SwListCapacity);
+
+    uvec3 args = OloVirtualRasterDispatchArgs(count);
+    swList.DispatchX = args.x;
+    swList.DispatchY = args.y;
+    swList.DispatchZ = args.z;
+}

--- a/OloEditor/assets/shaders/include/VirtualRasterDispatchArgs.glsl
+++ b/OloEditor/assets/shaders/include/VirtualRasterDispatchArgs.glsl
@@ -1,0 +1,57 @@
+#ifndef VIRTUAL_RASTER_DISPATCH_ARGS_GLSL
+#define VIRTUAL_RASTER_DISPATCH_ARGS_GLSL
+
+// =============================================================================
+// VirtualRasterDispatchArgs.glsl — the ONE spelling of the virtual-geometry
+// software rasterizer's record-count -> workgroup-grid flattening (issue #1048).
+//
+// The raster consumes a work list whose length is written on the GPU by
+// VirtualClusterCull.comp and never read back, so the grid it runs on is
+// computed on the GPU too, by VirtualRasterArgs.comp, and read by
+// DispatchComputeIndirect.
+//
+// A header rather than inline code for the same reason
+// VirtualRasterCoverage.glsl is one: the rule has to agree EXACTLY across
+// three places, and here a disagreement is silent — a grid that is too small
+// drops clusters with no error anywhere, and an indirect dispatch has no CPU
+// to notice:
+//   * compute/VirtualRasterArgs.comp — writes the arguments
+//   * tests/ShaderUnit_VirtualRasterArgs.comp — the L2 probe that runs THIS file
+//   * OloEngine/tests/Rendering/VirtualRasterDispatchArgsMirror.h — the CPU
+//     mirror, pinned against the raster's own index recovery by
+//     VirtualRasterDispatchArgsTest.
+//
+// The INVERSE of this function lives in VirtualClusterRaster.comp's main():
+//
+//     swRecordIndex = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x
+//
+// so a grid of (gx, gy) covers record indices [0, gx*gy) exactly once. Every
+// record must therefore land inside the grid — gx * gy >= count — and the
+// surplus (at most gx - 1 groups) early-outs on the raster's own bound.
+// =============================================================================
+
+// The x-axis split. Two constraints meet here:
+//   * a compute grid axis is capped at 65535 by GL and by every Vulkan
+//     maxComputeWorkGroupCount we target, so a work list longer than that
+//     cannot be a 1D dispatch at all;
+//   * the surplus a 2D split wastes is at most (gx - 1) groups, so a SMALLER
+//     gx wastes less at the tail.
+// 4096 keeps both comfortably: it is the value the CPU-side bound used before
+// this was on the GPU, so the grid shape did not change when the count did.
+const uint kOloVirtualRasterMaxGroupsX = 4096u;
+
+// Workgroup grid for `count` software-raster records, in the layout
+// VirtualClusterRaster.comp flattens back to a record index.
+//
+// count == 0 yields (0, 0, 1): a zero-group dispatch is legal and does nothing,
+// which is exactly what a frame that routed nothing to software should cost.
+// The divisor is guarded rather than the whole branch, so that case costs no
+// divergence.
+uvec3 OloVirtualRasterDispatchArgs(uint count)
+{
+    uint groupsX = min(count, kOloVirtualRasterMaxGroupsX);
+    uint groupsY = (count + max(groupsX, 1u) - 1u) / max(groupsX, 1u);
+    return uvec3(groupsX, groupsY, 1u);
+}
+
+#endif // VIRTUAL_RASTER_DISPATCH_ARGS_GLSL

--- a/OloEditor/assets/shaders/tests/ShaderUnit_VirtualRasterArgs.comp
+++ b/OloEditor/assets/shaders/tests/ShaderUnit_VirtualRasterArgs.comp
@@ -1,0 +1,23 @@
+// Layer-2 GPU contract for the virtual-geometry raster's indirect-dispatch
+// flattening (issue #1048) — runs the SHIPPED include, not a copy of it, so a
+// divergence between VirtualRasterDispatchArgs.glsl and the CPU mirror in
+// VirtualRasterDispatchArgsMirror.h fails here rather than as silently dropped
+// clusters in a frame nobody is looking at.
+#version 460 core
+
+#include "../include/VirtualRasterDispatchArgs.glsl"
+
+layout(local_size_x = 1) in;
+
+// One record count per case.
+layout(std430, binding = 0) readonly buffer Inputs { uint counts[]; };
+
+// One per case: xyz = the workgroup grid, w = the clamped count it came from.
+layout(std430, binding = 1) writeonly buffer Args { uvec4 args[]; };
+
+void main()
+{
+    uint i = gl_GlobalInvocationID.x;
+    uint count = counts[i];
+    args[i] = uvec4(OloVirtualRasterDispatchArgs(count), count);
+}

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.cpp
@@ -59,6 +59,14 @@ namespace OloEngine::RHI
         return glm::inverse(AdjustProjectionForShaderReconstruction(forward));
     }
 
+    glm::vec2 NdcToWindowDepthScaleBias()
+    {
+        // Derived from the SAME predicate the matrices use, so the depth mapping
+        // and the projection that produced it can never disagree about which
+        // convention is live.
+        return BackendFlips() ? glm::vec2(1.0f, 0.0f) : glm::vec2(0.5f, 0.5f);
+    }
+
     glm::mat4 AdjustCaptureProjectionForBackend(const glm::mat4& projection)
     {
         // See the header: the z remap WITHOUT the y flip, so a

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.cpp
@@ -59,6 +59,13 @@ namespace OloEngine::RHI
         return glm::inverse(AdjustProjectionForShaderReconstruction(forward));
     }
 
+    f32 WindowSpaceFrontFaceSign()
+    {
+        // Same predicate as the matrices and the depth mapping, so a backend
+        // cannot be flipped in one of the three and not the others.
+        return BackendFlips() ? -1.0f : 1.0f;
+    }
+
     glm::vec2 NdcToWindowDepthScaleBias()
     {
         // Derived from the SAME predicate the matrices use, so the depth mapping

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.h
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.h
@@ -64,6 +64,8 @@
 // the notes, NOT solved by sprinkling extra flips at call sites.
 // =============================================================================
 
+#include "OloEngine/Core/Base.h"
+
 #include <glm/glm.hpp>
 
 namespace OloEngine::RHI
@@ -127,6 +129,34 @@ namespace OloEngine::RHI
     // ones almost everywhere, and the mesh renders in shredded fragments while
     // every CPU-side counter still reads correct.
     [[nodiscard]] glm::vec2 NdcToWindowDepthScaleBias();
+
+    // The seam's fourth consumer, and the other half of the manual-rasterizer
+    // problem: the SIGN a hand-computed window-space area determinant gives a
+    // FRONT face.
+    //
+    // Fixed function needs no help here and the header's A1 note explains why --
+    // Vulkan evaluates facing in FRAMEBUFFER coordinates, whose y points down
+    // where GL's window y points up, and that inversion composes with the seam's
+    // clip-y negation to identity, so a triangle GL calls front-facing is
+    // front-facing on Vulkan too.
+    //
+    // A shader that computes the determinant ITSELF gets no such composition.
+    // VirtualClusterRaster.comp builds its screen positions as
+    // `(ndc.xy * 0.5 + 0.5) * viewport` from the ALREADY-ADJUSTED matrix, so on
+    // Vulkan its y axis is the framebuffer's (down) while GL's is the window's
+    // (up) -- one mirror, applied once, which negates the determinant. Only the
+    // second inversion is present, so the two no longer cancel.
+    //
+    // Returns +1 on GL and -1 on Vulkan: a triangle is front-facing when
+    // `signedArea * WindowSpaceFrontFaceSign() > 0`. Getting this wrong does not
+    // blank the frame -- it culls the FRONT faces and keeps the back ones, so a
+    // closed mesh still fills roughly its own silhouette and the damage reads as
+    // missing patches and inside-out shading rather than as an obvious failure.
+    //
+    // NOTE this is the CULL sense only. The winding used to orient the edge
+    // functions must stay derived from the raw signed area, or the interior test
+    // inverts and the triangle stops covering anything.
+    [[nodiscard]] f32 WindowSpaceFrontFaceSign();
 
     // The ROW-ORDER half of the same seam (#691, ADR 0011 amendment
     // (85)): every off-screen target is bottom-up on GL and top-down on

--- a/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.h
+++ b/OloEngine/src/OloEngine/Renderer/RHI/RHIProjectionSeam.h
@@ -105,6 +105,29 @@ namespace OloEngine::RHI
     // today and is called out here rather than guessed at.
     [[nodiscard]] glm::mat4 AdjustCaptureProjectionForBackend(const glm::mat4& projection);
 
+    // The seam's third consumer: shader code that RASTERIZES BY HAND and has to
+    // reproduce what fixed function would have done to ndc.z.
+    //
+    // The virtual-geometry compute software rasterizer (VirtualClusterRaster.comp)
+    // projects with the SAME adjusted matrix the hardware path uses, then does its
+    // own perspective divide and writes a window depth into the visibility buffer
+    // that the resolve replays through gl_FragDepth. So it must apply exactly the
+    // ndc.z -> window-depth mapping the fixed-function stage would have applied,
+    // and that mapping is NOT the same on the two backends:
+    //
+    //   GL      ndc.z is [-1, 1] (glDepthRange 0..1)  ->  window = ndc.z * 0.5 + 0.5
+    //   Vulkan  AdjustProjectionForBackend already mapped clip z to [0, w], so
+    //           ndc.z IS the window depth                ->  window = ndc.z * 1 + 0
+    //
+    // Returned as (scale, bias) rather than branched on in the shader, so the GLSL
+    // stays source-identical between backends like every other consumer of this
+    // seam. Hard-coding GL's 0.5/0.5 (which the raster did until this existed)
+    // compresses every software-rasterized depth into [0.5, 1] on Vulkan: the
+    // software clusters then lose the depth test against the hardware-rasterized
+    // ones almost everywhere, and the mesh renders in shredded fragments while
+    // every CPU-side counter still reads correct.
+    [[nodiscard]] glm::vec2 NdcToWindowDepthScaleBias();
+
     // The ROW-ORDER half of the same seam (#691, ADR 0011 amendment
     // (85)): every off-screen target is bottom-up on GL and top-down on
     // Vulkan, so this one predicate answers "does a top-left-origin consumer

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -1285,9 +1285,17 @@ namespace OloEngine
             // read is bounded by, and Records[] is reached by a bare device
             // address with no bounds. 0 = an empty list.
             u32 SwListCapacity;
-            u32 Pad0; // 20 — std140 rounds the block to a 16-byte multiple;
-            u32 Pad1; // 24   the pads are explicit so this stays a plain
-            u32 Pad2; // 28   struct the GLSL twins mirror byte for byte.
+            // 20/24 — ndc.z -> window depth, as (scale, bias), from
+            // RHI::NdcToWindowDepthScaleBias(). The software rasterizer does its
+            // own perspective divide, so it must apply the mapping fixed function
+            // would have applied, and that differs per backend (GL 0.5/0.5;
+            // Vulkan 1/0, because AdjustProjectionForBackend already mapped clip
+            // z to [0, w]). Passed as data so the GLSL stays source-identical.
+            f32 DepthScale;
+            f32 DepthBias;
+            u32 Pad0; // 28 — std140 rounds the block to a 16-byte multiple; the
+                      //      pad is explicit so this stays a plain struct the
+                      //      GLSL twins mirror byte for byte.
 
             static constexpr u32 GetSize()
             {

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -2710,11 +2710,17 @@ namespace OloEngine
         static constexpr u32 SSBO_VIRTUAL_DRAW_ARGS = 37;     // VirtualDrawArgs[instance]: draw count (also bound as GL_PARAMETER_BUFFER) + cull stats
         static constexpr u32 SSBO_VIRTUAL_VISIBLE = 38;       // VirtualVisibleCluster[]: per-draw (instance, cluster) records indexed via gl_BaseInstance
         static constexpr u32 SSBO_VIRTUAL_VERTICES = 39;      // VirtualGpuVertex[]: cluster-owned packed vertices (positionU, normalV)
-        static constexpr u32 SSBO_VIRTUAL_SW_LIST = 40;       // { uint Count; pad[3]; VirtualVisibleCluster[] }: clusters routed to the software rasterizer
-        static constexpr u32 SSBO_VIRTUAL_VISBUFFER = 41;     // uvec2[width*height] visibility buffer: .y = depth bits (atomicMin), .x = (visibleSlot << 9 | tri)
-        static constexpr u32 SSBO_VIRTUAL_INDICES = 42;       // u32[]: pooled cluster-local index buffer (same GL buffer the MDI path uses as element array)
-        static constexpr u32 SSBO_VIRTUAL_GROUP_STATES = 43;  // u32[group]: bit0 = page resident (CPU), bit1 = page requested (GPU atomicOr), bit2 = touched for LRU (GPU atomicOr)
-        static constexpr u32 SSBO_VIRTUAL_REJECTED = 44;      // { uint Count; pad[3]; VirtualVisibleCluster[] }: clusters the two-phase cull's phase 1 found hidden by the PREVIOUS frame's Hi-Z, re-tested by phase 2 (issue #682)
+        // { uint Count; uvec3 DispatchArgs; VirtualVisibleCluster[] }: clusters routed to the
+        // software rasterizer. The three words after Count are NOT padding -- they are the
+        // raster's indirect dispatch arguments, written on the GPU by VirtualRasterArgs.comp
+        // and read by DispatchComputeIndirect at byte offset 4 (issue #1048; the offset is
+        // static_asserted in VirtualGeometryPass.cpp). Repurposing them silently drops or
+        // multiplies raster workgroups, and a wrong group count on the GPU raises nothing.
+        static constexpr u32 SSBO_VIRTUAL_SW_LIST = 40;
+        static constexpr u32 SSBO_VIRTUAL_VISBUFFER = 41;    // uvec2[width*height] visibility buffer: .y = depth bits (atomicMin), .x = (visibleSlot << 9 | tri)
+        static constexpr u32 SSBO_VIRTUAL_INDICES = 42;      // u32[]: pooled cluster-local index buffer (same GL buffer the MDI path uses as element array)
+        static constexpr u32 SSBO_VIRTUAL_GROUP_STATES = 43; // u32[group]: bit0 = page resident (CPU), bit1 = page requested (GPU atomicOr), bit2 = touched for LRU (GPU atomicOr)
+        static constexpr u32 SSBO_VIRTUAL_REJECTED = 44;     // { uint Count; pad[3]; VirtualVisibleCluster[] }: clusters the two-phase cull's phase 1 found hidden by the PREVIOUS frame's Hi-Z, re-tested by phase 2 (issue #682)
         // The shader-visible descriptor heap (issue #691). uvec2[] of
         // ARB_bindless_texture handles, indexed by an RHI::HeapOffset that
         // travels to the shader as ordinary UBO data. This is the binding that

--- a/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
+++ b/OloEngine/src/OloEngine/Renderer/ShaderBindingLayout.h
@@ -1293,9 +1293,12 @@ namespace OloEngine
             // z to [0, w]). Passed as data so the GLSL stays source-identical.
             f32 DepthScale;
             f32 DepthBias;
-            u32 Pad0; // 28 — std140 rounds the block to a 16-byte multiple; the
-                      //      pad is explicit so this stays a plain struct the
-                      //      GLSL twins mirror byte for byte.
+            // 28 — +1 on GL, -1 on Vulkan, from RHI::WindowSpaceFrontFaceSign().
+            // The software raster computes its own window-space area determinant,
+            // and on Vulkan that space is the framebuffer's (y down) rather than
+            // GL's window space (y up) — one mirror, which negates the sign. A
+            // triangle is front-facing when signedArea * FrontFaceSign > 0.
+            f32 FrontFaceSign;
 
             static constexpr u32 GetSize()
             {

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
@@ -855,6 +855,13 @@ namespace OloEngine
                 argsParams.ViewportWidth = registry.GetVisbufferWidth();
                 argsParams.ViewportHeight = registry.GetVisbufferHeight();
                 argsParams.SwListCapacity = maxSwRecords;
+                // Unread by the args kernel; set so every upload of this block
+                // carries a coherent value rather than a zeroed depth mapping.
+                {
+                    const glm::vec2 depthMap = RHI::NdcToWindowDepthScaleBias();
+                    argsParams.DepthScale = depthMap.x;
+                    argsParams.DepthBias = depthMap.y;
+                }
                 UploadRasterParams(argsParams);
                 RenderCommand::DispatchCompute(1, 1, 1);
                 // ShaderStorage orders the SSBO write itself; Command is the one
@@ -915,6 +922,15 @@ namespace OloEngine
             // bounds its work-list index by this rather than by the list's own
             // unguarded Count (issue #1058).
             rasterParams.SwListCapacity = maxSwRecords;
+            // The ndc.z -> window-depth mapping this backend's fixed function
+            // would apply. The software raster does its own perspective divide,
+            // so it has to be told; hard-coding GL's 0.5/0.5 shredded every
+            // Vulkan frame while leaving all the counters correct.
+            {
+                const glm::vec2 depthMap = RHI::NdcToWindowDepthScaleBias();
+                rasterParams.DepthScale = depthMap.x;
+                rasterParams.DepthBias = depthMap.y;
+            }
             if (useInt64)
             {
                 // One atomicMin per covered pixel resolves depth + payload

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
@@ -46,6 +46,31 @@ namespace OloEngine
                 return source;
             return source.substr(0, lineEnd + 1) + define + "\n" + source.substr(lineEnd + 1);
         }
+
+        // C++ twin of the `VirtualSwList` header declared in
+        // VirtualClusterCull.comp, VirtualClusterRaster.comp (both variants),
+        // VirtualVisibilityResolve.glsl and VirtualRasterArgs.comp — the 16
+        // bytes that precede the work list's records, and the 16 bytes the CPU
+        // zeroes each frame.
+        //
+        // The three Dispatch words are the software rasterizer's indirect
+        // dispatch arguments (issue #1048), written on the GPU by
+        // VirtualRasterArgs.comp from the GPU-written Count. Their byte offset
+        // is passed straight to DispatchComputeIndirect, so it is part of the
+        // contract rather than an implementation detail — hence the asserts.
+        struct VirtualSwListHeader
+        {
+            u32 Count = 0;
+            u32 DispatchX = 0;
+            u32 DispatchY = 0;
+            u32 DispatchZ = 0;
+        };
+        static_assert(sizeof(VirtualSwListHeader) == 16,
+                      "VirtualSwListHeader must match the std430 VirtualSwList header in the four shaders that declare it");
+        static_assert(offsetof(VirtualSwListHeader, DispatchX) == 4,
+                      "the SW-raster dispatch-args offset is part of the DispatchComputeIndirect contract");
+
+        constexpr u32 kSwDispatchArgsOffset = static_cast<u32>(offsetof(VirtualSwListHeader, DispatchX));
     } // namespace
 
     VirtualGeometryPass::VirtualGeometryPass()
@@ -58,9 +83,26 @@ namespace OloEngine
         m_FramebufferSpec = spec;
         m_CullShader = ComputeShader::Create("assets/shaders/compute/VirtualClusterCull.comp");
         m_RasterShader = ComputeShader::Create("assets/shaders/compute/VirtualClusterRaster.comp");
+        m_RasterArgsShader = ComputeShader::Create("assets/shaders/compute/VirtualRasterArgs.comp");
         m_GBufferShader = Shader::Create("assets/shaders/VirtualMeshGBuffer.glsl");
         m_ResolveShader = Shader::Create("assets/shaders/VirtualVisibilityResolve.glsl");
         m_ColorizeShader = ComputeShader::Create("assets/shaders/compute/VirtualDebugColorize.comp");
+
+        // Same three-layer demotion shape as the int64 raster variant and the
+        // mesh-shader path below: the decision is made ONCE here and logged, so
+        // a frame that silently fell back to the conservative CPU bound cannot
+        // be mistaken for a measurement of the indirect path (issue #1048).
+        if (!m_RasterArgsShader || !m_RasterArgsShader->IsValid())
+        {
+            OLO_CORE_WARN("VirtualGeometryPass: VirtualRasterArgs.comp failed to compile; the software "
+                          "rasterizer falls back to the conservative CPU-side dispatch bound "
+                          "(correct, but ~300-900x overdispatched on a dense scene - issue #1048)");
+            m_RasterArgsShader = nullptr;
+        }
+        else
+        {
+            OLO_CORE_INFO("VirtualGeometryPass: software raster dispatches indirectly from the GPU-written work-list count");
+        }
 
         // Single-pass 64-bit visibility path: only when the driver exposes both
         // 64-bit shader ints and 64-bit atomics. Compiled as a define-injected
@@ -750,16 +792,35 @@ namespace OloEngine
             // bracket below is its CONTROL: the resolve's work is a function of
             // the visibility buffer, which this change leaves identical, so a
             // reading where BOTH moved is the box drifting, not the shader.
-            auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
-            gpuSubTimers.BeginSubPass("SwRaster");
             registry.GetVertexBuffer()->Bind();
             registry.GetVisbufferBuffer()->Bind();
+            // Re-bound explicitly, on the same rule as the three above: SSBO
+            // binding points are process-global state, and the hardware phase-1
+            // draw block between the cull and here rebinds its own set. The args
+            // kernel below WRITES through this binding, so a stale one would
+            // hand the indirect fetch another buffer's bytes as a group count.
+            registry.GetSwListBuffer()->Bind();
             RenderCommand::BindStorageBuffer(ShaderBindingLayout::SSBO_VIRTUAL_INDICES,
                                              registry.GetIndexBuffer());
 
             u32 const maxSwRecords = frameClusterCount;
-            u32 const groupsX = std::min(maxSwRecords, 4096u);
-            u32 const groupsY = (maxSwRecords + groupsX - 1u) / std::max(groupsX, 1u);
+            // The CPU-side conservative bound (the #551 idiom), kept ONLY as the
+            // fallback for a frame where the args kernel is unavailable. It is
+            // the number issue #1048 measured as ~300-900x too large on
+            // VirtualGeometryStress: 2,834,448 workgroups for 3,165 records with
+            // work, which the same issue's bracket showed WAS the pass's whole
+            // cost (an empty main() cost the same 0.1321 ms as the real raster).
+            u32 const fallbackGroupsX = std::min(maxSwRecords, 4096u);
+            // BOTH operands guarded, not just the divisor. With maxSwRecords = 0
+            // (instances submitted, no clusters resident yet) fallbackGroupsX is
+            // 0 and `0 + 0 - 1` underflows to 4294967295 — a four-billion-group
+            // dispatch, which GL rejects with GL_INVALID_VALUE and Vulkan hands
+            // straight to vkCmdDispatch. That is the identical bug the phase-2
+            // cull above is explicitly BRACED against, and the one
+            // VirtualRasterDispatchArgsTest.EmptyListDispatchesNothing pins on
+            // the GPU side of the same rule.
+            u32 const fallbackGroupsY =
+                fallbackGroupsX == 0u ? 0u : (maxSwRecords + fallbackGroupsX - 1u) / fallbackGroupsX;
 
             // Single-pass 64-bit atomic path when the driver supports it and the
             // parity/force-portable override is off; the portable two-pass 2x32
@@ -768,6 +829,81 @@ namespace OloEngine
             bool const useInt64 =
                 m_Int64AtomicsSupported && m_RasterShaderInt64 && !registry.GetForcePortableSwRaster();
             const Ref<ComputeShader>& rasterShader = useInt64 ? m_RasterShaderInt64 : m_RasterShader;
+
+            // ── Indirect dispatch arguments, written on the GPU (issue #1048) ──
+            // The SW work-list count is GPU-written and deliberately never read
+            // back — a readback is either a stall or a frame late, and "a frame
+            // late" silently UNDER-dispatches on a camera cut, dropping clusters.
+            // So a 1-thread kernel converts the count into the (x, y, z) triple
+            // living in the work list's own header, and the raster dispatches
+            // from there.
+            //
+            // Nullness is the "unavailable" encoding (the m_RasterShaderInt64
+            // convention): if the args kernel did not compile, the raster still
+            // runs at the conservative CPU bound — slow, but never wrong, and the
+            // demotion is warned once at Init rather than silently rasterizing
+            // nothing.
+            bool const useIndirect = m_RasterArgsShader && m_RasterArgsShader->IsValid();
+            if (useIndirect)
+            {
+                m_RasterArgsShader->Bind();
+                // The kernel reads exactly one field of this block,
+                // u_SwListCapacity, and clamps the count by it — so the upload
+                // has to happen BEFORE the args dispatch, not just before the
+                // raster's.
+                UBOStructures::VirtualRasterUBO argsParams{};
+                argsParams.ViewportWidth = registry.GetVisbufferWidth();
+                argsParams.ViewportHeight = registry.GetVisbufferHeight();
+                argsParams.SwListCapacity = maxSwRecords;
+                UploadRasterParams(argsParams);
+                RenderCommand::DispatchCompute(1, 1, 1);
+                // ShaderStorage orders the SSBO write itself; Command is the one
+                // that matters here — it is what makes the written words visible
+                // to the indirect-command fetch (GL_COMMAND_BARRIER_BIT; on
+                // Vulkan the RHI lowers this to an ALL_COMMANDS /
+                // MEMORY_READ|WRITE global barrier, which covers
+                // VK_ACCESS_INDIRECT_COMMAND_READ_BIT). Dropping Command here is
+                // the classic wrong-but-passing-on-one-API bug: the fetch would
+                // race the write and read a stale group count.
+                RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage | MemoryBarrierFlags::Command);
+            }
+
+            // Every raster dispatch below goes through this, so the indirect and
+            // the fallback path cannot drift apart between the int64 and portable
+            // variants.
+            //
+            // Vulkan note, because this looks like #1080's territory and is not:
+            // the arguments are written through the SSBO binding and read back by
+            // vkCmdDispatchIndirect from the buffer's own VkBuffer, so the two
+            // must agree on WHICH allocation they mean. They do — the SW list is
+            // created StorageBufferUsage::DynamicCopy, and
+            // VulkanStorageBuffer::PushSnapshot returns early for exactly that
+            // usage (issue #1058), so a DynamicCopy buffer is never versioned
+            // into the frame arena and both sides address the persistent
+            // allocation. A snapshotting buffer here would have split in two: the
+            // dispatch writing persistent, the indirect fetch reading a stale CPU
+            // snapshot, and a group count of zero is a legal dispatch with
+            // nothing to name it.
+            RHI::ResourceHandle const swListHandle = registry.GetSwListBuffer()->GetRHIHandle();
+            const auto dispatchRaster = [&]()
+            {
+                if (useIndirect)
+                    RenderCommand::DispatchComputeIndirect(swListHandle, kSwDispatchArgsOffset);
+                else
+                    RenderCommand::DispatchCompute(fallbackGroupsX, fallbackGroupsY, 1);
+            };
+
+            // Bracket opens HERE, after the args kernel and its barrier, not before
+            // them. The barrier above is a Command barrier, which lowers to a
+            // full pipeline flush on both backends (Vulkan issues an
+            // unconditional ALL_COMMANDS -> ALL_COMMANDS vkCmdPipelineBarrier2).
+            // Inside the bracket that flush would charge SwRaster for draining
+            // every pass before it — work the master arm's bracket never sees —
+            // so the A/B would compare a stage cost against a stage cost plus a
+            // serialisation point. The args kernel itself is one workgroup of one
+            // thread; what is excluded here is the flush artefact, not the work.
+            auto& gpuSubTimers = GPUPassTimerPool::GetInstance();
+            gpuSubTimers.BeginSubPass("SwRaster");
 
             rasterShader->Bind();
             // Former bare uniforms, one std140 block (issue #691).
@@ -786,20 +922,23 @@ namespace OloEngine
                 // still carries it (declared verbatim in both), so it simply
                 // stays at its zeroed value.
                 UploadRasterParams(rasterParams);
-                RenderCommand::DispatchCompute(groupsX, groupsY, 1);
+                dispatchRaster();
                 RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
             }
             else
             {
                 // Phase 0 atomic-min-compacts the depth word; phase 1 plain-writes
-                // the winning payload where the depth bits match.
+                // the winning payload where the depth bits match. Both read the
+                // SAME indirect arguments — nothing between them rewrites the
+                // count, so the two phases cover an identical record set, which
+                // is what makes the depth-bits match in phase 1 meaningful.
                 rasterParams.Phase = 0;
                 UploadRasterParams(rasterParams);
-                RenderCommand::DispatchCompute(groupsX, groupsY, 1);
+                dispatchRaster();
                 RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
                 rasterParams.Phase = 1;
                 UploadRasterParams(rasterParams);
-                RenderCommand::DispatchCompute(groupsX, groupsY, 1);
+                dispatchRaster();
                 RenderCommand::MemoryBarrier(MemoryBarrierFlags::ShaderStorage);
             }
             gpuSubTimers.EndSubPass();

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
@@ -862,6 +862,7 @@ namespace OloEngine
                     argsParams.DepthScale = depthMap.x;
                     argsParams.DepthBias = depthMap.y;
                 }
+                argsParams.FrontFaceSign = RHI::WindowSpaceFrontFaceSign();
                 UploadRasterParams(argsParams);
                 RenderCommand::DispatchCompute(1, 1, 1);
                 // ShaderStorage orders the SSBO write itself; Command is the one
@@ -931,6 +932,10 @@ namespace OloEngine
                 rasterParams.DepthScale = depthMap.x;
                 rasterParams.DepthBias = depthMap.y;
             }
+            // The other half of the same problem: the raster's own window-space
+            // area determinant changes sign with the backend, so the BACKFACE
+            // cull needs the sense told to it too (issue #1105).
+            rasterParams.FrontFaceSign = RHI::WindowSpaceFrontFaceSign();
             if (useInt64)
             {
                 // One atomicMin per covered pixel resolves depth + payload

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.h
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.h
@@ -98,7 +98,12 @@ namespace OloEngine
         Ref<ComputeShader> m_CullShader;
         Ref<ComputeShader> m_RasterShader;      // portable two-pass 2x32 visibility-buffer rasterizer
         Ref<ComputeShader> m_RasterShaderInt64; // single-pass 64-bit atomic-min variant (null if unsupported)
-        bool m_Int64AtomicsSupported = false;   // driver exposes GL_ARB_gpu_shader_int64 + GL_NV_shader_atomic_int64
+        // 1-thread kernel that turns the GPU-written SW work-list count into the
+        // raster's indirect dispatch arguments (issue #1048). Null only if it
+        // failed to compile, which forces the CPU-side conservative bound back
+        // on rather than skipping the raster.
+        Ref<ComputeShader> m_RasterArgsShader;
+        bool m_Int64AtomicsSupported = false; // driver exposes GL_ARB_gpu_shader_int64 + GL_NV_shader_atomic_int64
         Ref<Shader> m_GBufferShader;
         // Mesh-shader raster path (issue #813, VK_EXT_mesh_shader): a
         // task+mesh+fragment pipeline that replays the same per-instance

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -150,6 +150,7 @@ add_executable(OloEngine-Tests
 		Rendering/VirtualClusterTwoPhaseOcclusionTest.cpp
 		Rendering/VirtualMeshletEligibilityTest.cpp
 		Rendering/VirtualRasterCoverageTest.cpp
+		Rendering/VirtualRasterDispatchArgsTest.cpp
 		Rendering/MeshSourceBoundsTest.cpp
 		Rendering/MeshBVHRaycastTest.cpp
 		Rendering/PathTracing/ReferenceBRDFTest.cpp

--- a/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
@@ -1835,10 +1835,24 @@ namespace OloEngine::Tests
 
         ::testing::Test::RecordProperty("vg_swraster_subpass_ms", std::to_string(bestSw));
         ::testing::Test::RecordProperty("vg_resolve_subpass_ms", std::to_string(bestResolve));
+        // The overdispatch ratio is issue #1048's headline number and the thing
+        // this bracket is most often used to check, so publish it rather than
+        // leaving it to be recomputed by hand: before the raster dispatched
+        // indirectly it launched one workgroup per TESTED cluster, and only the
+        // SoftwareRasterized ones had any work to do (2,834,448 : 3,165 on
+        // VirtualGeometryStress). With the indirect dispatch live the raster
+        // launches at the second number, so this ratio describes the work the
+        // CPU-side bound WOULD have dispatched, not what it now does.
+        const f64 overdispatch = stats.SoftwareRasterized > 0u
+                                     ? static_cast<f64>(stats.TestedClusters) / static_cast<f64>(stats.SoftwareRasterized)
+                                     : 0.0;
+        ::testing::Test::RecordProperty("vg_swraster_conservative_overdispatch", std::to_string(overdispatch));
         GTEST_LOG_(INFO) << "[nanite] swraster-subpass " << bestSw << " ms GPU (min of " << swSamples
                          << "), resolve-control " << bestResolve << " ms GPU (min of " << resolveSamples
                          << "), swClusters=" << stats.SoftwareRasterized
-                         << ", hwDraws=" << stats.HardwareDraws;
+                         << ", hwDraws=" << stats.HardwareDraws
+                         << ", testedClusters=" << stats.TestedClusters
+                         << ", conservative-bound overdispatch=" << overdispatch << "x";
     }
 
     // =========================================================================

--- a/OloEngine/tests/Rendering/PropertyTests/ShaderUnitTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/ShaderUnitTests.cpp
@@ -20,6 +20,7 @@
 
 #include "RenderPropertyTest.h"
 #include "VirtualRasterCoverageMirror.h"
+#include "VirtualRasterDispatchArgsMirror.h"
 
 #include "OloEngine/Renderer/Commands/FrameResourceManager.h"
 #include "OloEngine/Renderer/ComputeShader.h"
@@ -1344,6 +1345,89 @@ namespace OloEngine::Tests
         // comparison above passed against one branch of the rule.
         EXPECT_GT(kept, 0u);
         EXPECT_LT(kept, count);
+    }
+
+    // Layer-2 for the virtual-geometry raster's indirect-dispatch flattening
+    // (issue #1048). The probe includes the SHIPPED
+    // VirtualRasterDispatchArgs.glsl, so this is what fails when the GLSL and
+    // the CPU mirror in VirtualRasterDispatchArgsMirror.h drift — the rule's own
+    // correctness is pinned, without a GL context, by
+    // VirtualRasterDispatchArgsTest.
+    //
+    // Worth running on the GPU rather than trusting the mirror alone: the count
+    // that reaches this function in production is GPU-written and never read
+    // back, so a divergence between the shipped GLSL and anything the CPU
+    // believes shows up only as silently missing clusters.
+    TEST(ShaderUnitVirtualRasterArgsTest, DispatchArgsMatchTheCpuMirror)
+    {
+        OLO_ENSURE_GPU_OR_SKIP();
+
+        namespace Mirror = OloEngine::Tests::VirtualRasterDispatchArgs;
+
+        // Both sides of the 4096 x-split, the sizes #1048 measured on
+        // VirtualGeometryStress (3,165 software records out of 2,834,448
+        // clusters), and the empty list that must dispatch nothing.
+        const std::vector<u32> counts{ 0u,
+                                       1u,
+                                       2u,
+                                       64u,
+                                       3165u,
+                                       9632u,
+                                       Mirror::kMaxGroupsX - 1u,
+                                       Mirror::kMaxGroupsX,
+                                       Mirror::kMaxGroupsX + 1u,
+                                       Mirror::kMaxGroupsX * 2u,
+                                       Mirror::kMaxGroupsX * 2u + 1u,
+                                       2834448u };
+
+        const auto count = static_cast<u32>(counts.size());
+        const auto inputBytes = static_cast<GLsizeiptr>(counts.size() * sizeof(u32));
+        ScopedBuffer input(inputBytes, GL_DYNAMIC_STORAGE_BIT);
+        ::glNamedBufferSubData(input.m_Id, 0, inputBytes, counts.data());
+        ScopedBuffer args(static_cast<GLsizeiptr>(count * sizeof(glm::uvec4)),
+                          GL_DYNAMIC_STORAGE_BIT | GL_MAP_READ_BIT);
+
+        auto shader = ComputeShader::Create("assets/shaders/tests/ShaderUnit_VirtualRasterArgs.comp");
+        ASSERT_TRUE(shader && shader->IsValid())
+            << "ShaderUnit_VirtualRasterArgs failed to compile/link — "
+               "include/VirtualRasterDispatchArgs.glsl does not build as included";
+
+        shader->Bind();
+        ::glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, input.m_Id);
+        ::glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, args.m_Id);
+        ::glDispatchCompute(count, 1, 1);
+        ::glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT | GL_BUFFER_UPDATE_BARRIER_BIT);
+
+        std::vector<glm::uvec4> gpuArgs(count);
+        ::glGetNamedBufferSubData(args.m_Id, 0,
+                                  static_cast<GLsizeiptr>(count * sizeof(glm::uvec4)),
+                                  gpuArgs.data());
+        ::glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, 0);
+        ::glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, 0);
+        shader->Unbind();
+
+        u32 twoDimensional = 0;
+        for (u32 i = 0; i < count; ++i)
+        {
+            SCOPED_TRACE(::testing::Message() << "count " << counts[i]);
+            const Mirror::DispatchArgs expected = Mirror::FromCount(counts[i]);
+            EXPECT_EQ(gpuArgs[i].x, expected.X);
+            EXPECT_EQ(gpuArgs[i].y, expected.Y);
+            EXPECT_EQ(gpuArgs[i].z, expected.Z);
+
+            // Restated on the GPU's own numbers rather than the mirror's: this
+            // is the property that keeps clusters from being dropped, and it
+            // must hold for what the DEVICE computed.
+            EXPECT_GE(static_cast<u64>(gpuArgs[i].x) * static_cast<u64>(gpuArgs[i].y),
+                      static_cast<u64>(counts[i]));
+            if (gpuArgs[i].y > 1u)
+                ++twoDimensional;
+        }
+
+        // Anti-vacuous: the table must exercise the 2D split, or every
+        // comparison above passed against the trivial one-row branch.
+        EXPECT_GT(twoDimensional, 0u);
+        EXPECT_LT(twoDimensional, count);
     }
 
 } // namespace OloEngine::Tests

--- a/OloEngine/tests/Rendering/VirtualRasterDispatchArgsMirror.h
+++ b/OloEngine/tests/Rendering/VirtualRasterDispatchArgsMirror.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// =============================================================================
+// CPU mirror of OloEditor/assets/shaders/include/VirtualRasterDispatchArgs.glsl
+// — the virtual-geometry software rasterizer's record-count -> workgroup-grid
+// flattening (issue #1048).
+//
+// Two consumers, so the mirror is a header rather than a local copy in either:
+//   * VirtualRasterDispatchArgsTest.cpp — pins the rule itself against the
+//     raster's own index recovery, with no GL context (so it runs in CI);
+//   * ShaderUnitTests.cpp — dispatches the SHIPPED include through
+//     tests/ShaderUnit_VirtualRasterArgs.comp and compares against this, which
+//     is what catches the GLSL and the mirror drifting apart.
+//
+// Line-for-line with the GLSL. If you change one, change both.
+// =============================================================================
+
+#include "OloEngine/Core/Base.h"
+
+namespace OloEngine::Tests::VirtualRasterDispatchArgs
+{
+    // Mirror of kOloVirtualRasterMaxGroupsX.
+    inline constexpr u32 kMaxGroupsX = 4096u;
+
+    struct DispatchArgs
+    {
+        u32 X{ 0 };
+        u32 Y{ 0 };
+        u32 Z{ 0 };
+    };
+
+    // Mirror of OloVirtualRasterDispatchArgs.
+    inline DispatchArgs FromCount(u32 count)
+    {
+        u32 const groupsX = count < kMaxGroupsX ? count : kMaxGroupsX;
+        u32 const divisor = groupsX > 1u ? groupsX : 1u;
+        u32 const groupsY = (count + divisor - 1u) / divisor;
+        return { groupsX, groupsY, 1u };
+    }
+
+    // Mirror of VirtualClusterRaster.comp's main():
+    //     swRecordIndex = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x
+    // This is the INVERSE the flattening has to satisfy, and the reason the two
+    // must be read together: the grid is only correct relative to how the raster
+    // turns a workgroup back into a record.
+    inline u32 RecordIndexOf(u32 workgroupX, u32 workgroupY, u32 numGroupsX)
+    {
+        return workgroupX + workgroupY * numGroupsX;
+    }
+} // namespace OloEngine::Tests::VirtualRasterDispatchArgs

--- a/OloEngine/tests/Rendering/VirtualRasterDispatchArgsTest.cpp
+++ b/OloEngine/tests/Rendering/VirtualRasterDispatchArgsTest.cpp
@@ -1,0 +1,169 @@
+// OLO_TEST_LAYER: cullinglod
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "VirtualRasterDispatchArgsMirror.h"
+
+#include <algorithm>
+#include <vector>
+
+// =============================================================================
+// Indirect dispatch arguments for the virtual-geometry software raster — CPU
+// contract tests (issue #1048).
+//
+// The rule under test ships in
+// `OloEditor/assets/shaders/include/VirtualRasterDispatchArgs.glsl`
+// (`OloVirtualRasterDispatchArgs`) and is written to the work list's header by
+// `compute/VirtualRasterArgs.comp`, which the pass then reads with
+// `DispatchComputeIndirect`.
+//
+// Why this is worth a contract test at all: the count is GPU-written, so the
+// CPU never sees the grid it dispatched. A grid that is too SMALL drops
+// clusters with no error raised anywhere — no GL error, no validation-layer
+// message, nothing but slightly-missing geometry. The single property that
+// prevents it is
+//
+//     gx * gy >= count
+//
+// read together with the raster's own index recovery,
+//
+//     swRecordIndex = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x
+//
+// which is why the mirror carries both halves and every test below checks them
+// against each other rather than against a hard-coded table.
+//
+// The GPU half of this contract — that the SHIPPED GLSL agrees with this mirror
+// — is ShaderUnitVirtualRasterArgsTest in ShaderUnitTests.cpp.
+// =============================================================================
+
+namespace
+{
+    namespace Args = OloEngine::Tests::VirtualRasterDispatchArgs;
+
+    // Grid axis cap in GL, and in every Vulkan maxComputeWorkGroupCount we
+    // target. Exceeding it is a dispatch that does not happen.
+    constexpr u32 kGridAxisCap = 65535u;
+
+    // The counts worth checking exhaustively-ish: every boundary of the 4096
+    // split, plus the sizes real frames produce. #1048 measured 3,165 software
+    // records against 2,834,448 clusters on VirtualGeometryStress, so the
+    // interesting range spans both sides of kMaxGroupsX.
+    std::vector<u32> InterestingCounts()
+    {
+        std::vector<u32> counts{ 0u, 1u, 2u, 63u, 64u, 65u, 3165u, 9632u };
+        for (u32 const base : { Args::kMaxGroupsX, Args::kMaxGroupsX * 2u, Args::kMaxGroupsX * 7u })
+        {
+            for (u32 const delta : { 2u, 1u, 0u })
+                counts.push_back(base - delta);
+            counts.push_back(base + 1u);
+            counts.push_back(base + 2u);
+        }
+        // The real upper bound: the SW list capacity is the frame's total
+        // cluster count, and the stress scene's is nearly three million.
+        counts.push_back(2834448u);
+        return counts;
+    }
+} // namespace
+
+// The property the whole scheme rests on. A grid smaller than the count is
+// silently dropped geometry; this is the only place that can catch it.
+TEST(VirtualRasterDispatchArgsTest, GridCoversEveryRecord)
+{
+    for (u32 const count : InterestingCounts())
+    {
+        const auto args = Args::FromCount(count);
+        const u64 covered = static_cast<u64>(args.X) * static_cast<u64>(args.Y);
+        EXPECT_GE(covered, static_cast<u64>(count))
+            << "count " << count << " -> grid " << args.X << "x" << args.Y
+            << " covers only " << covered << " records: the raster would silently skip the rest";
+    }
+}
+
+// The surplus is what the raster's own `swRecordIndex >= Count` guard
+// early-outs on. It must stay bounded by one x-row, or the overdispatch this
+// issue removed creeps back in.
+TEST(VirtualRasterDispatchArgsTest, SurplusIsAtMostOneRowOfGroups)
+{
+    for (u32 const count : InterestingCounts())
+    {
+        const auto args = Args::FromCount(count);
+        const u64 covered = static_cast<u64>(args.X) * static_cast<u64>(args.Y);
+        const u64 surplus = covered - count;
+        EXPECT_LT(surplus, static_cast<u64>(std::max(args.X, 1u)))
+            << "count " << count << " -> grid " << args.X << "x" << args.Y
+            << " wastes " << surplus << " groups, more than one x-row";
+    }
+}
+
+// The inverse. Walking the grid the way VirtualClusterRaster.comp does must
+// reach every record index in [0, count) exactly once — this is what makes
+// "covers" above mean "rasterizes" rather than merely "launches enough
+// threads".
+TEST(VirtualRasterDispatchArgsTest, GridWalkReachesEveryRecordExactlyOnce)
+{
+    // Bounded so the walk stays cheap; the flattening is periodic in gx, so
+    // the counts either side of kMaxGroupsX exercise every distinct shape.
+    for (u32 const count : { 0u, 1u, 2u, 64u, 3165u, Args::kMaxGroupsX - 1u, Args::kMaxGroupsX,
+                             Args::kMaxGroupsX + 1u, Args::kMaxGroupsX * 2u + 3u })
+    {
+        const auto args = Args::FromCount(count);
+        std::vector<u8> seen(count, 0u);
+        for (u32 y = 0; y < args.Y; ++y)
+        {
+            for (u32 x = 0; x < args.X; ++x)
+            {
+                const u32 record = Args::RecordIndexOf(x, y, args.X);
+                if (record < count)
+                {
+                    EXPECT_EQ(seen[record], 0u) << "record " << record << " reached twice (count " << count << ")";
+                    seen[record] = 1u;
+                }
+            }
+        }
+        for (u32 i = 0; i < count; ++i)
+            EXPECT_EQ(seen[i], 1u) << "record " << i << " never reached (count " << count << ")";
+    }
+}
+
+// Both axes must stay dispatchable. gx is capped by construction; gy is the
+// one that grows, and at the stress scene's capacity it is still far under.
+TEST(VirtualRasterDispatchArgsTest, BothAxesStayUnderTheGridCap)
+{
+    for (u32 const count : InterestingCounts())
+    {
+        const auto args = Args::FromCount(count);
+        EXPECT_LE(args.X, kGridAxisCap) << "count " << count;
+        EXPECT_LE(args.Y, kGridAxisCap) << "count " << count;
+        EXPECT_EQ(args.Z, 1u) << "count " << count;
+    }
+}
+
+// An empty work list must dispatch nothing at all. Before this was indirect
+// the equivalent CPU expression had exactly this bug: groupsX = 0 made
+// groupsY = (0 + 0 - 1) / 1 = 4294967295, a four-billion-group dispatch on
+// an empty frame (the braced-guard comment in VirtualGeometryPass.cpp is the
+// scar). The GLSL guards the divisor instead, and this pins it.
+TEST(VirtualRasterDispatchArgsTest, EmptyListDispatchesNothing)
+{
+    const auto args = Args::FromCount(0u);
+    EXPECT_EQ(args.X, 0u);
+    EXPECT_EQ(args.Y, 0u);
+    EXPECT_EQ(args.Z, 1u);
+    EXPECT_EQ(static_cast<u64>(args.X) * static_cast<u64>(args.Y), 0u);
+}
+
+// A 1D dispatch for everything that fits, so the common frame keeps the
+// simplest possible grid and the surplus is exactly zero.
+TEST(VirtualRasterDispatchArgsTest, ShortListsAreExactAndOneDimensional)
+{
+    // Strictly <= kMaxGroupsX: past that the split is 2D by construction and
+    // the exactness below is not the contract (9632, the wider shot in #1048,
+    // is deliberately NOT here — it needs three rows).
+    for (u32 const count : { 1u, 2u, 64u, 3165u, Args::kMaxGroupsX })
+    {
+        const auto args = Args::FromCount(count);
+        EXPECT_EQ(args.X, count) << "count " << count;
+        EXPECT_EQ(args.Y, 1u) << "count " << count;
+        EXPECT_EQ(static_cast<u64>(args.X) * static_cast<u64>(args.Y), static_cast<u64>(count));
+    }
+}

--- a/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanPassSuiteTest.cpp
@@ -10292,6 +10292,7 @@ namespace
         "assets/shaders/compute/LightCulling.comp",
         "assets/shaders/compute/VirtualClusterCull.comp",
         "assets/shaders/compute/VirtualClusterRaster.comp",
+        "assets/shaders/compute/VirtualRasterArgs.comp",
         "assets/shaders/compute/VirtualDebugColorize.comp",
         "assets/shaders/compute/InstanceOcclusionCull.comp",
         "assets/shaders/compute/InstanceFrustumCull.comp",


### PR DESCRIPTION
Lands #1048 and #712 as a pair, because they were measurement-coupled: until the
overdispatch was gone, nothing inside the software rasterizer could be measured
at all.

## #1048 — dispatch indirectly from the GPU-written count

The raster was dispatched at the frame's **total cluster count**, because the
count of clusters actually routed to software is GPU-written and never read
back. Workgroups past the live count early-out (the #551 idiom, correct) — but
on `VirtualGeometryStress` that is **2,834,448 workgroups launched for 3,165
records with work**, reproduced live here at **895.6x** via
`olo_virtual_geometry_stats`.

A one-thread kernel now turns the count into a workgroup grid written to the
work list's own header, and the raster dispatches from there. No readback (a
readback is a stall or a frame late, and a frame late silently *under*-dispatches
on a camera cut). No new binding — the header's three pad words at byte offset 4
are already the shape `DispatchComputeIndirect` wants, and the kernel reads its
capacity from the raster's existing parameter block, so the engine's last free
UBO stays free.

The flattening rule lives in one include shared by the kernel, an L2 GPU probe
and a CPU mirror, because a grid that is too small drops clusters **with no
error raised anywhere**. The `>= Count` guard stays as belt-and-braces; the CPU
bound stays as a loud fallback.

### Measured — `VirtualGeometryPerf`, Release, 4 interleaved rounds, min-of-24

Arms are selected at runtime, so one binary serves all four and no rebuild sits
between them.

| Arm | | SwRaster | vs A |
|---|---|---|---|
| A | CPU bound (master) | 0.1280 ms | — |
| B | **indirect** | **0.0748 ms** | **−41.6%** |
| C | indirect + empty `main()` | 0.0092 ms | |
| D | CPU bound + empty `main()` | 0.1270 ms | |

**D == A reproduces the premise**: with the CPU bound, a shader whose `main()`
returns immediately costs what the real rasterizer costs — the pass was
launch-bound, not raster-bound. **C now separates from A**, so the bracket has
gone from timing workgroup launch to timing rasterization. That flip is the
result; the −41.6% is a consequence of it.

Output unchanged: every virtual-geometry visual capture is **byte-identical**
between arms A and B, while the run-to-run noise floor (B vs B) moves one file.
The `Resolve` control moves −1.6% between A and B while dropping ~40% in the
arms that rasterize nothing — its cost follows the visibility buffer, so an
unchanged Resolve is independent evidence the buffer content is unchanged.

## #712 — the rejects, finally measurable

**#712's reject logic was already on master** (`bd82ab48c`); its acceptance
criteria were measurements, and the measurement was impossible. With the launch
cost gone it is possible. All arms below run with the indirect dispatch on:

| Arm | | SwRaster | vs B |
|---|---|---|---|
| B | both rejects (master today) | 0.0778 ms | — |
| E | no sub-sample reject | 0.0891 ms | **+12.6%** |
| F | no backface reject | 0.0778 ms | **0.0%** |
| G | neither | 0.0860 ms | +9.5% |

**The sub-sample-miss reject is worth ~12.6% of software-raster GPU time.** It
measured exactly 0.0% before #1048.

**The backface reject measures 0.0%** on this corpus — arms B and F are
identical across all four rounds. Reported rather than dressed up. The likely
reason is structural: the signed area is computed regardless (`orient`, `area`,
`invArea` all need it), so the early return removes loop iterations but no math,
and the triangles it would reject are largely ones the sub-sample test rejects
anyway.

Caveat stated plainly: this scene routes **338** clusters to software, not the
3,165 of the stress scene. The 12.6% is real but measured on a modest corpus.

One arm-E round read 0.1516 instead of ~0.0900 with its Resolve control spiking
at the same time; per the instrument's own design note, a reading where *both*
brackets move is the box drifting, and it was excluded.

## Ride-along fixes (own commits): Vulkan virtual geometry was broken two ways

Found while verifying #1048 on Vulkan, **neither caused by it** — the indirect
dispatch and the old CPU-side bound produce byte-identical Vulkan frames at
every stage of this investigation. Both are in `VirtualClusterRaster.comp`,
which hand-rolls the two things fixed function would otherwise do for it.

**1. Window depth (`5d55f4b83`).** The raster hard-coded GL's `ndc.z*0.5+0.5`;
on Vulkan `AdjustProjectionForBackend` has already mapped clip z to `[0, w]`, so
the second remap compressed every software depth into `[0.5, 1]` and software
clusters lost the depth test against hardware-rasterized ones.

**2. Front-face sign (`6c11c9b94`, closes #1105).** The raster culls back faces
on the sign of a determinant it computes itself. Fixed function needs no help —
Vulkan evaluates facing in framebuffer coordinates (y down) and that composes
with the seam's clip-y negation to identity — but a shader that builds the
determinant itself gets only one of those inversions, so the cull was discarding
the **front** faces and keeping the back ones.

Both are now members of the projection seam (`NdcToWindowDepthScaleBias()`,
`WindowSpaceFrontFaceSign()`), derived from the same `BackendFlips()` predicate
the matrices use, so the GLSL stays source-identical. Both ride in existing pad
words: no layout change, no new binding.

### Measured — covered pixels in the raster's own debug target, fixed camera and viewport

| | Covered px |
|---|---|
| GL (reference) | 101,293 |
| Vulkan, before | 84,765 (83.7%) |
| Vulkan, after both fixes | **101,292** |

**Vulkan virtual geometry now matches GL.** Bisected, not guessed: disabling the
backface guard alone took Vulkan to 101,295, and 68% of the missing pixels had
no covered neighbour — solid regions, not edge erosion.

Worth recording, because it cost time: an earlier probe that negated
`signedArea` outright appeared to exonerate the winding. It did not — negating
the value also flips `orient`, which inverts the edge functions so triangles
stop covering anything (27,588 px). The cull sense and the winding that orients
the edge functions must move independently. Eyeballing lit frames could not have
found this; a closed mesh looks broadly similar whether you draw its front or
its back faces, and only the pixel-coverage metric separated them.

**GL is not bit-identical, and the shader comment says so with numbers.**
Reading the new uniform shifts GL's floating-point codegen: 25–126 pixels per
230,400 (0.01–0.06%) move by a maximum channel delta of **1**. No geometry
gained or lost; all 143 GL virtual-geometry tests green. Both a multiply and a
select form shift it identically, so it is the uniform read rather than the
arithmetic; a per-backend `#define` would avoid it at the cost of the
source-identical property the seam exists to preserve.

Also ruled out along the way, each by test rather than argument: the
mesh-shader path (`forcemdi` byte-identical), int64-vs-portable atomics
(byte-identical), and #1080 (its in-flight fix from
`feature/vulkan-rhi-lifetime-1080-1087-1059` applied here changed nothing,
twice).

## Verification

- 361/363 pass across `Vulkan*` / `Virtual*` / `ShaderUnit*` / `RHI*`
- The one failure, `VulkanDrawPath.EngineHeapServesShaderReachableSlotsAndPoisonsFreedOnes`, is **#1087** — pre-existing, reproduced with this branch's `VirtualGeometryPass` change reverted and rebuilt, and owned by `feature/vulkan-rhi-lifetime-1080-1087-1059`. A config data point was added to that issue.
- New CPU contract tests pin `gx*gy >= count` against the raster's own index recovery; a new L2 GPU probe pins the shipped GLSL against the CPU mirror.
- Live editor on **both** backends: indirect path confirmed active in the log, 0 shader errors, multi-angle captures inspected.
- Vulkan virtual geometry verified against GL by pixel coverage, not by eye.

Self-review found and fixed two real defects before this PR existed: a
four-billion-group dispatch on an empty frame (`0 + 0 - 1u` underflow in the
fallback bound — the same bug the phase-2 cull is braced against), and an args
dispatch sitting inside the timed bracket, whose `Command` barrier is a full
pipeline flush the master arm never pays. The second inflated arm B, so the
numbers above are the corrected re-measurement.

`blocked_by` cleared on #712.

Closes #1048
Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Software rasterization now uses GPU-generated indirect dispatch sizing for improved workload handling.
  - Added backend-aware depth mapping and front-face orientation support for consistent rendering across graphics APIs.
  - Added safe fallback dispatch behavior when GPU argument generation is unavailable.

- **Bug Fixes**
  - Corrected empty and large work-list dispatch handling, including boundary cases.

- **Tests**
  - Added coverage for dispatch sizing, shader compilation, cross-backend behavior, and over-dispatch diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->