### PR TITLE
ci: dedupe vcpkg saves, prune on verified save, symbolize sanitizers, shard the Linux sanitizer jobs

### DIFF
--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -6,7 +6,9 @@ description: >
   WHY THIS EXISTS (#1073). Every cache key in this repo ends in `-<run_id>-<attempt>`
   so each save writes a fresh, immutable snapshot and `restore-keys` warms from the
   newest one. That shape is right and it is APPEND-ONLY: a save never replaces the
-  entry it supersedes, it sits beside it until the nightly `cache-prune` sweep.
+  entry it supersedes. This action deletes that predecessor as soon as the new entry is
+  VERIFIED present, so each lineage holds one entry per ref without waiting for the
+  `cache-prune` sweep -- which two crons a day could not keep up with (#1073).
 
   The repo's Actions cache store is capped at 10 GB, and past the cap GitHub does not
   evict -- it turns the WHOLE STORE READ-ONLY ("Cache reservation failed: You have
@@ -155,8 +157,23 @@ runs:
     # it -- a PR run's entry is visible to that PR alone, and only default-branch entries
     # are readable fleet-wide. Deleting across refs would let any branch wipe the master
     # snapshot every other branch restores from.
+    # RUNS ON A SUCCESSFUL SAVE TOO, not just a refused one (#1073 follow-up).
+    #
+    # This used to be gated on `landed == 'false'` alone, and the action's own header
+    # said the superseded entry "sits beside it until the nightly `cache-prune` sweep".
+    # Two crons a day cannot keep up with the save rate: measured 2026-09-07, the store
+    # stood at 10863 MiB against a ~9537 MiB measured wall, having accumulated six
+    # 706 MiB vcpkg entries and two 2044 MiB sccache entries since the 07:03 sweep.
+    #
+    # Pruning AFTER a confirmed save is strictly safer than the refusal path this step
+    # was written for. The caution in the header -- "if the retry were then refused
+    # anyway, we would have deleted the warm entry the next run needs" -- is about
+    # deleting BEFORE a save. Here the new entry is already verified present on this
+    # ref by the poll above, so every predecessor of this lineage is genuinely dead.
+    #
+    # `landed == 'unknown'` still prunes nothing: never delete on a guess.
     - name: Free room under this prefix on this ref
-      if: always() && steps.check.outputs.landed == 'false'
+      if: always() && (steps.check.outputs.landed == 'false' || steps.check.outputs.landed == 'true')
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -87,6 +87,14 @@ outputs:
       self-hosted, the CMAKE_PREFIX_PATH and Vulkan_LIBRARY that point at the
       LunarG SDK. Empty on GitHub-hosted.
     value: ${{ steps.toolchain.outputs.extra-cmake-args }}
+  symbolizer:
+    description: >
+      Absolute path to the `llvm-symbolizer` matching the compiler this action
+      chose, for ASAN_SYMBOLIZER_PATH. EMPTY if none was found -- a caller must
+      treat empty as "do not set the variable", because pointing
+      ASAN_SYMBOLIZER_PATH at a nonexistent file makes the sanitizer print
+      unsymbolized frames silently, which is the state this output exists to end.
+    value: ${{ steps.toolchain.outputs.symbolizer }}
 
 runs:
   using: 'composite'
@@ -453,11 +461,41 @@ runs:
           # compiler cache at all and paid a cold full build every run.
           extra="-DCMAKE_PREFIX_PATH=${VULKAN_SDK} -DVulkan_LIBRARY=${OLO_VULKAN_LIBRARY} -DOLO_ENABLE_COMPILER_CACHE=ON"
         fi
+        # THE SYMBOLIZER, BESIDE WHICHEVER COMPILER THE LADDER ABOVE CHOSE.
+        #
+        # Without ASAN_SYMBOLIZER_PATH, every sanitizer report in this repo is a
+        # column of bare hex offsets:
+        #     #1 0x55d5df68f658  (/home/runner/.../OloEngine-Tests+0xf12f658)
+        # The sanitizer runtime looks for `llvm-symbolizer` on PATH, and the pinned
+        # LLVM prefix is deliberately NOT on the system PATH (see the pin above), so
+        # it finds nothing and says nothing -- there is no warning, no non-zero exit,
+        # just an unreadable trace. Measured 2026-09-07: four LSan leaks on master
+        # that could not be attributed to a line of code at all, from run 34108719319.
+        #
+        # Derived from $cxx rather than taken as an input, for the reason the cache
+        # prefix in save-cache-pruned is derived from its key: a second spelling of
+        # the same toolchain drifts from the first, and the failure is silent.
+        symbolizer=""
+        _cxx_bin=$(command -v "$cxx" 2>/dev/null || true)
+        if [ -n "$_cxx_bin" ] && [ -x "$(dirname "$_cxx_bin")/llvm-symbolizer" ]; then
+          symbolizer="$(dirname "$_cxx_bin")/llvm-symbolizer"
+        else
+          # The distro fallback compiler may still have a suffixed symbolizer.
+          for _cand in llvm-symbolizer llvm-symbolizer-23; do
+            _found=$(command -v "$_cand" 2>/dev/null || true)
+            if [ -n "$_found" ]; then symbolizer="$_found"; break; fi
+          done
+        fi
+        if [ -z "$symbolizer" ]; then
+          echo "::warning title=no llvm-symbolizer::Found no llvm-symbolizer beside $cxx or on PATH. Sanitizer reports from this job will print unsymbolized hex offsets, which cannot be attributed to source. Install it beside the pinned prefix (scripts/setup-olo-ci-host.sh) or via the llvm package."
+        fi
         {
           echo "cc=$cc"
           echo "cxx=$cxx"
           echo "python-exe=$python_exe"
           echo "extra-cmake-args=$extra"
+          echo "symbolizer=$symbolizer"
         } >> "$GITHUB_OUTPUT"
         # The one line a same-commit hosted/self-hosted comparison reads first.
         echo "toolchain: $cxx ($("$cxx" --version | head -1)) / $python_exe ${extra:+(+ $extra)}"
+        echo "symbolizer: ${symbolizer:-<none -- sanitizer traces will be unsymbolized>}"

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -544,26 +544,39 @@ runs:
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-
 
-    # A PULL REQUEST THAT ALREADY GOT ITS MANIFEST DOES NOT NEED TO BANK IT AGAIN (#1073).
+    # A RUN THAT ALREADY GOT ITS MANIFEST DOES NOT NEED TO BANK IT AGAIN (#1073).
     #
-    # A cache entry written by a PR run is scoped to `refs/pull/N/merge` and readable by
-    # that one PR; a PR run restores from the default branch anyway. So when the restore
-    # matched the HASH-SPECIFIC prefix, this run's binary cache is byte-for-byte what it
-    # read: the manifest, triplets and overlay ports are all in that hash, so the port set
-    # cannot differ. Saving it writes ~700 MiB of nothing.
+    # When the restore matched the HASH-SPECIFIC prefix, this run's binary cache is
+    # byte-for-byte what it read: the manifest, triplets and overlay ports are all in
+    # that hash, so the port set cannot differ. Saving it writes ~700 MiB of nothing.
     #
-    # Measured on this very PR: eight vcpkg entries on `refs/pull/1075/merge` inside two
-    # hours -- two per push, because Windows.yml and asan.yml each save one -- totalling
-    # ~3.0 GiB of a ~9.3 GiB store, all of them copies of a snapshot master already held.
-    # That alone can put the store back into the read-only state this issue is about.
+    # THIS APPLIES TO EVERY EVENT, NOT JUST PULL REQUESTS. It used to be gated on
+    # `pull_request`, on the reasoning that "the nightly and dispatch runs write the
+    # default-branch snapshot the whole fleet restores from, and that one is refreshed
+    # unconditionally so a missing archive always gets banked." The premise is wrong in
+    # a way that cost more than it bought: a MISSING archive is exactly the case where
+    # the restore does NOT match the hash prefix, so the condition below already
+    # discriminates it. Refreshing unconditionally never banked a missing archive; it
+    # only ever re-banked a present one.
     #
-    # Kept for the cases that genuinely produce something new:
-    #   * a PR that BUMPS the manifest -- the restore then falls back to the bare
-    #     `vcpkg-<os>-<triplet>-` prefix or misses outright, this run really did build
-    #     ports, and its successors should not build them again;
-    #   * every non-PR event -- the nightly and dispatch runs write the default-branch
-    #     snapshot the whole fleet restores from, and that one is refreshed unconditionally
-    #     so a missing archive always gets banked.
+    # Measured 2026-09-07, the morning after the gate landed: SIX entries of the
+    # identical manifest hash `7d9ae677...`, 706 MiB each, created between 06:41 and
+    # 10:53 by six master-ref runs (pushes and dispatches). 4236 MiB of one 706 MiB
+    # snapshot, in a store whose measured read-only wall is ~9537 MiB and which stood
+    # at 10863 MiB when this was written. The vcpkg duplication WAS the overage.
+    #
+    # The append-only `-<run_id>-<attempt>` key shape is right for sccache, where each
+    # run's cache is a genuine superset of the last. vcpkg is not that: its content is
+    # fully determined by the manifest hash already IN the key, so a second save of the
+    # same hash is redundant by construction.
+    #
+    # Kept for the case that genuinely produces something new: a run that BUMPS the
+    # manifest. The restore then falls back to the bare `vcpkg-<os>-<triplet>-` prefix
+    # or misses outright, this run really did build ports, and its successors should not
+    # build them again.
+    #
+    # SELF-HEALING, so a stale skip cannot wedge the fleet: if the matched entry is ever
+    # evicted or pruned away, the next run's restore misses the hash prefix and banks it.
     - name: Decide whether there is anything new to save
       id: savedecision
       shell: bash
@@ -571,15 +584,14 @@ runs:
         CFG_KEY: ${{ steps.cachecfg.outputs.save-key }}
         MATCHED: ${{ steps.restore.outputs.cache-matched-key }}
         HASH_PREFIX: vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
-        EVENT: ${{ github.event_name }}
       run: |
         set -euo pipefail
         key="${CFG_KEY}"
-        if [ -n "$key" ] && [ "$EVENT" = "pull_request" ] && [ -n "${MATCHED:-}" ]; then
+        if [ -n "$key" ] && [ -n "${MATCHED:-}" ]; then
           case "$MATCHED" in
             "${HASH_PREFIX}"*)
               echo "restore matched '${MATCHED}', which carries this exact manifest hash;"
-              echo "a pull-request save would re-bank what it just read -- skipping."
+              echo "saving would re-bank what it just read -- skipping."
               key=""
               ;;
             *)

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -154,6 +154,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       native: ${{ steps.filter.outputs.native }}
+      # THE ONE PLACE THE LINUX ROUTING DECISION IS MADE (#1083 for Linux).
+      #
+      # The three Linux sanitizer jobs each carry a byte-identical `runs-on`
+      # expression, with a comment on two of them begging the next editor to keep
+      # them in step. Sharding needs the SAME predicate a fourth and fifth time --
+      # once to size the matrix, once to decide whether to stage an artifact at all --
+      # so it is computed once here and read as an output instead.
+      linux-self-hosted: ${{ steps.linuxplan.outputs.self-hosted }}
+      linux-shards: ${{ steps.linuxplan.outputs.shards }}
+      linux-shard-matrix: ${{ steps.linuxplan.outputs.matrix }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -190,6 +200,52 @@ jobs:
             - 'scripts/verify_test_shards.py'
             - 'scripts/Copy-ImportedDlls.ps1'
             - '.github/sanitizer-suppressions/**'
+
+    # SHARD ONLY WHERE THERE ARE RUNNERS TO ABSORB IT.
+    #
+    # Sharding is not free parallelism -- it is parallelism IF a runner slot exists
+    # per shard. The hosted arm has effectively unbounded slots, so 4 shards run
+    # four-wide. The self-hosted box does not: the `olo-ci` label was served by TWO
+    # runners and, measured 2026-09-07, by ONE (olo-ci-2 offline). Three sanitizer
+    # jobs already serialise there; splitting each into four would serialise TWELVE
+    # and hand the whole win back, plus an artifact round-trip per shard.
+    #
+    # So the box keeps the monolithic build-and-test job it has today, byte for byte,
+    # and only the hosted arm shards. `shards == 1` is the signal for that: the build
+    # job runs ctest itself and stages nothing.
+    #
+    # WHY 4 ON HOSTED. Measured on run 34108719319 (ASan + LSan, hosted): build 63 min,
+    # tests 48 min. Four shards take the test half to ~12 min against an artifact
+    # round-trip measured at 0.1 min each way on the Windows shards -- so the fixed
+    # cost is noise and the ceiling is the 63-minute build, which is #1095's problem,
+    # not this one's.
+    - name: Plan the Linux sanitizer sharding
+      id: linuxplan
+      shell: bash
+      env:
+        # Byte-identical to the `runs-on` expression on the three Linux jobs. It is
+        # written here ONCE and those jobs still carry their own copy, because
+        # `runs-on` cannot read a `needs` output on the job that produces it without
+        # making every sanitizer job wait on this one -- which they already do.
+        SELF_HOSTED: ${{ vars.OLO_LINUX_SELF_HOSTED == 'true'
+                         && github.event.inputs.force_hosted != 'true'
+                         && github.event_name != 'schedule'
+                         && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      run: |
+        set -euo pipefail
+        if [ "${SELF_HOSTED}" = "true" ]; then
+          shards=1
+          matrix='[1]'
+        else
+          shards=4
+          matrix='[1,2,3,4]'
+        fi
+        {
+          echo "self-hosted=${SELF_HOSTED}"
+          echo "shards=${shards}"
+          echo "matrix=${matrix}"
+        } >> "$GITHUB_OUTPUT"
+        echo "Linux sanitizer plan: self-hosted=${SELF_HOSTED}, ${shards} shard(s), matrix=${matrix}"
 
   asan-windows:
     # " build" since #1083: this job no longer runs the suite, it builds the tree the
@@ -1067,6 +1123,11 @@ jobs:
 
   asan-lsan-linux:
     name: ASan + LSan (Linux/Clang)
+    outputs:
+      # Read by the shard coverage proof. It comes from THIS job rather than
+      # from the artifact the shards were fed: a number that travels with the
+      # thing it is meant to check is not a check.
+      ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
     # SELF-HOSTED WHEN THE CODE IS OURS, hosted Ubuntu when it is not -- the same
@@ -1145,6 +1206,10 @@ jobs:
       actions: write
 
     env:
+      # ONE definition of the exclusion, read by the unsharded run, by the
+      # `ctest -N` total and by every shard's selection. Three literals that
+      # must agree is how a shard comes to COUNT one partition and RUN another.
+      OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
       # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
       # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
       # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
@@ -1357,7 +1422,74 @@ jobs:
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
 
+    # ---- sharded plan: measure, stamp and stage, then let the shards run -----
+    #
+    # All three steps are skipped when `linux-shards == 1` (the self-hosted arm),
+    # where this job runs the suite itself exactly as before.
+
+    # The unsharded total the coverage proof checks the shards against. `ctest -N`
+    # only LISTS -- discovery already happened at build time -- so this costs
+    # seconds and launches no test process. It reads the SAME exclude regex the
+    # shards do, from the job-level env var, because a total measured with a
+    # different filter than the shards ran with would prove nothing.
+    - name: Measure the unsharded case count
+      id: ctest-total
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}")
+        total=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only BEFORE the numeric comparison: `[ "$x" -le 0 ]` on a
+        # non-numeric $x errors rather than returning false, and a command that
+        # errors inside an `if` is exempt from `set -e` -- so anything that is not
+        # a number would fall straight through and get published as the total.
+        case "${total}" in
+          ''|*[!0-9]*)
+            echo "::error::ctest -N did not report a numeric total (got '${total:-<empty>}'); discovery is broken."
+            exit 1 ;;
+        esac
+        if [ "${total}" -le 0 ]; then
+          echo "::error::ctest -N reported ${total} tests; discovery is broken."
+          exit 1
+        fi
+        echo "total=${total}" >> "$GITHUB_OUTPUT"
+        echo "unsharded ctest entries: ${total}"
+
+    # THE EXECUTABLE BIT DOES NOT SURVIVE THE ARTIFACT. actions/upload-artifact
+    # stores POSIX modes as 0644, so the downloaded OloEngine-Tests is not
+    # executable and every one of ~7600 ctest entries would fail to launch. The
+    # Windows shards never hit this because a .exe needs no mode bit; the shard
+    # job below restores it explicitly and asserts the binary starts.
+    - name: Stamp the build workspace
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      run: |
+        set -euo pipefail
+        printf '%s' '${{github.workspace}}' > build/OloEngine/tests/olo-build-workspace.txt
+        ls -l build/OloEngine/tests/OloEngine-Tests
+
+    # ONLY WHAT CTEST READS: the generated *_tests.cmake entries, the workspace
+    # stamp and the instrumented binary. The Linux sanitizer runtimes are linked
+    # statically into the executable, so nothing else has to travel with it.
+    - name: Upload the instrumented test tree
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-lsan-linux-test-tree
+        path: |
+          build/OloEngine/tests/*.cmake
+          build/OloEngine/tests/olo-build-workspace.txt
+          build/OloEngine/tests/OloEngine-Tests
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 1
+
     - name: Run tests under ASan + LSan
+      # SHARDED PLAN RUNS THIS ELSEWHERE. `linux-shards` is 1 only on the
+      # self-hosted arm, where one runner cannot absorb a matrix; there this
+      # job stays exactly what it was. On the hosted arm the shards below run
+      # the suite instead and this step is skipped.
+      if: needs.detect-changes.outputs.linux-shards == '1'
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # WorkerRestartTest.RestartWorkersAndOversubscription is a tight-loop
       # stress test of FScheduler::RestartWorkers that the Windows ASan job
@@ -1401,17 +1533,30 @@ jobs:
       # a *compile-time* constraint (~3 GB per TU under clang+sanitizer) and does NOT
       # transfer to the test phase — don't "reconcile" the two numbers; they bound
       # different resources (peak compiler RSS vs. peak instrumented-test RSS).
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        ASAN_OPTIONS: halt_on_error=1:detect_leaks=1
-        LSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/lsan.txt
+        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        #
+        # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
+        # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
+        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
+        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
+        # could not be attributed to a single line of source because of this.
+        #
+        # setup-linux-build derives the path from the compiler it actually chose and
+        # warns if there is none; an empty value here leaves the variable effectively
+        # unset, which is the same behaviour as before rather than a new failure.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
+        ASAN_OPTIONS: halt_on_error=1:detect_leaks=1:symbolize=1
+        LSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/lsan.txt:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: always() && needs.detect-changes.outputs.linux-shards == '1'
+        && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: ASan + LSan (Linux)
@@ -1422,6 +1567,11 @@ jobs:
 
   ubsan-linux:
     name: UBSan (Linux/Clang)
+    outputs:
+      # Read by the shard coverage proof. It comes from THIS job rather than
+      # from the artifact the shards were fed: a number that travels with the
+      # thing it is meant to check is not a check.
+      ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
     # Routed exactly like asan-lsan-linux -- the reasoning, the security boundary
@@ -1447,6 +1597,10 @@ jobs:
       actions: write
 
     env:
+      # ONE definition of the exclusion, read by the unsharded run, by the
+      # `ctest -N` total and by every shard's selection. Three literals that
+      # must agree is how a shard comes to COUNT one partition and RUN another.
+      OLO_UBSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^NetworkManagerTest\.|^NetworkThreadDispatchTest\.|^ServerAuthoritativeLoopTest\.|^TaskConcurrencyLimiterTest\.|^LowLevelTaskUserDataTest\.|^WorkerRestartTest\.'
       # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
       # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
       # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
@@ -1637,7 +1791,74 @@ jobs:
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
 
+    # ---- sharded plan: measure, stamp and stage, then let the shards run -----
+    #
+    # All three steps are skipped when `linux-shards == 1` (the self-hosted arm),
+    # where this job runs the suite itself exactly as before.
+
+    # The unsharded total the coverage proof checks the shards against. `ctest -N`
+    # only LISTS -- discovery already happened at build time -- so this costs
+    # seconds and launches no test process. It reads the SAME exclude regex the
+    # shards do, from the job-level env var, because a total measured with a
+    # different filter than the shards ran with would prove nothing.
+    - name: Measure the unsharded case count
+      id: ctest-total
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}")
+        total=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only BEFORE the numeric comparison: `[ "$x" -le 0 ]` on a
+        # non-numeric $x errors rather than returning false, and a command that
+        # errors inside an `if` is exempt from `set -e` -- so anything that is not
+        # a number would fall straight through and get published as the total.
+        case "${total}" in
+          ''|*[!0-9]*)
+            echo "::error::ctest -N did not report a numeric total (got '${total:-<empty>}'); discovery is broken."
+            exit 1 ;;
+        esac
+        if [ "${total}" -le 0 ]; then
+          echo "::error::ctest -N reported ${total} tests; discovery is broken."
+          exit 1
+        fi
+        echo "total=${total}" >> "$GITHUB_OUTPUT"
+        echo "unsharded ctest entries: ${total}"
+
+    # THE EXECUTABLE BIT DOES NOT SURVIVE THE ARTIFACT. actions/upload-artifact
+    # stores POSIX modes as 0644, so the downloaded OloEngine-Tests is not
+    # executable and every one of ~7600 ctest entries would fail to launch. The
+    # Windows shards never hit this because a .exe needs no mode bit; the shard
+    # job below restores it explicitly and asserts the binary starts.
+    - name: Stamp the build workspace
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      run: |
+        set -euo pipefail
+        printf '%s' '${{github.workspace}}' > build/OloEngine/tests/olo-build-workspace.txt
+        ls -l build/OloEngine/tests/OloEngine-Tests
+
+    # ONLY WHAT CTEST READS: the generated *_tests.cmake entries, the workspace
+    # stamp and the instrumented binary. The Linux sanitizer runtimes are linked
+    # statically into the executable, so nothing else has to travel with it.
+    - name: Upload the instrumented test tree
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ubsan-linux-test-tree
+        path: |
+          build/OloEngine/tests/*.cmake
+          build/OloEngine/tests/olo-build-workspace.txt
+          build/OloEngine/tests/OloEngine-Tests
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 1
+
     - name: Run tests under UBSan
+      # SHARDED PLAN RUNS THIS ELSEWHERE. `linux-shards` is 1 only on the
+      # self-hosted arm, where one runner cannot absorb a matrix; there this
+      # job stays exactly what it was. On the hosted arm the shards below run
+      # the suite instead and this step is skipped.
+      if: needs.detect-changes.outputs.linux-shards == '1'
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # WorkerRestartTest.RestartWorkersAndOversubscription joins the
       # exclude list (matching ASan + TSan) — 100 iterations of a full
@@ -1669,16 +1890,29 @@ jobs:
       # UBSan now enables only the curated eight checks rather than the whole
       # `undefined` group, so vptr is no longer asked of `-fno-rtti` vendor code.
       # This exclusion covers the remaining, genuinely-GNS-side gap. See #636.
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^NetworkManagerTest\.|^NetworkThreadDispatchTest\.|^ServerAuthoritativeLoopTest\.|^TaskConcurrencyLimiterTest\.|^LowLevelTaskUserDataTest\.|^WorkerRestartTest\.'
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        #
+        # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
+        # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
+        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
+        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
+        # could not be attributed to a single line of source because of this.
+        #
+        # setup-linux-build derives the path from the compiler it actually chose and
+        # warns if there is none; an empty value here leaves the variable effectively
+        # unset, which is the same behaviour as before rather than a new failure.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
+        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: always() && needs.detect-changes.outputs.linux-shards == '1'
+        && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: UBSan (Linux)
@@ -1689,6 +1923,11 @@ jobs:
 
   tsan-linux:
     name: TSan (Linux/Clang)
+    outputs:
+      # Read by the shard coverage proof. It comes from THIS job rather than
+      # from the artifact the shards were fed: a number that travels with the
+      # thing it is meant to check is not a check.
+      ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
     # 180, not 120, not 90: the same cold-cache loop, measured twice.
@@ -1737,6 +1976,10 @@ jobs:
       actions: write
 
     env:
+      # ONE definition of the exclusion, read by the unsharded run, by the
+      # `ctest -N` total and by every shard's selection. Three literals that
+      # must agree is how a shard comes to COUNT one partition and RUN another.
+      OLO_TSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.'
       # OVERRIDES the workflow-level 1500M, DOWNWARDS (#1095). These three entries
       # were 1252 / 1231 / 1258 MiB at that cap -- 3741 MiB, 55 % of the steady set --
       # against a ~9.3 GiB wall and cache-prune.yml's 8800 MiB working ceiling. Rule 5
@@ -1927,7 +2170,74 @@ jobs:
     - name: Create test results directory
       run: mkdir -p "${GITHUB_WORKSPACE}/test_results"
 
+    # ---- sharded plan: measure, stamp and stage, then let the shards run -----
+    #
+    # All three steps are skipped when `linux-shards == 1` (the self-hosted arm),
+    # where this job runs the suite itself exactly as before.
+
+    # The unsharded total the coverage proof checks the shards against. `ctest -N`
+    # only LISTS -- discovery already happened at build time -- so this costs
+    # seconds and launches no test process. It reads the SAME exclude regex the
+    # shards do, from the job-level env var, because a total measured with a
+    # different filter than the shards ran with would prove nothing.
+    - name: Measure the unsharded case count
+      id: ctest-total
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}")
+        total=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only BEFORE the numeric comparison: `[ "$x" -le 0 ]` on a
+        # non-numeric $x errors rather than returning false, and a command that
+        # errors inside an `if` is exempt from `set -e` -- so anything that is not
+        # a number would fall straight through and get published as the total.
+        case "${total}" in
+          ''|*[!0-9]*)
+            echo "::error::ctest -N did not report a numeric total (got '${total:-<empty>}'); discovery is broken."
+            exit 1 ;;
+        esac
+        if [ "${total}" -le 0 ]; then
+          echo "::error::ctest -N reported ${total} tests; discovery is broken."
+          exit 1
+        fi
+        echo "total=${total}" >> "$GITHUB_OUTPUT"
+        echo "unsharded ctest entries: ${total}"
+
+    # THE EXECUTABLE BIT DOES NOT SURVIVE THE ARTIFACT. actions/upload-artifact
+    # stores POSIX modes as 0644, so the downloaded OloEngine-Tests is not
+    # executable and every one of ~7600 ctest entries would fail to launch. The
+    # Windows shards never hit this because a .exe needs no mode bit; the shard
+    # job below restores it explicitly and asserts the binary starts.
+    - name: Stamp the build workspace
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      run: |
+        set -euo pipefail
+        printf '%s' '${{github.workspace}}' > build/OloEngine/tests/olo-build-workspace.txt
+        ls -l build/OloEngine/tests/OloEngine-Tests
+
+    # ONLY WHAT CTEST READS: the generated *_tests.cmake entries, the workspace
+    # stamp and the instrumented binary. The Linux sanitizer runtimes are linked
+    # statically into the executable, so nothing else has to travel with it.
+    - name: Upload the instrumented test tree
+      if: needs.detect-changes.outputs.linux-shards != '1'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: tsan-linux-test-tree
+        path: |
+          build/OloEngine/tests/*.cmake
+          build/OloEngine/tests/olo-build-workspace.txt
+          build/OloEngine/tests/OloEngine-Tests
+        if-no-files-found: error
+        retention-days: 1
+        compression-level: 1
+
     - name: Run tests under TSan
+      # SHARDED PLAN RUNS THIS ELSEWHERE. `linux-shards` is 1 only on the
+      # self-hosted arm, where one runner cannot absorb a matrix; there this
+      # job stays exactly what it was. On the hosted arm the shards below run
+      # the suite instead and this step is skipped.
+      if: needs.detect-changes.outputs.linux-shards == '1'
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       # --timeout 600: covers two known-slow buckets under TSan instrumentation:
       #   1. AssetContentValidity.SandboxAssetRegistryDeserialisesAndPathsResolve
@@ -1976,23 +2286,678 @@ jobs:
       # ThreadState and its first intercepted malloc faults inside TSan's own
       # allocator — a bare SIGSEGV with no report. OloEngine/vendor/CMakeLists.txt
       # now filters that definition off the imported target; see the comment there.
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.'
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build
         # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
-        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1
+        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
+        # See the ASAN_SYMBOLIZER_PATH note in the ASan+LSan job: the variable is
+        # read by every sanitizer runtime, TSan included, and without it this job's
+        # race reports are unsymbolized too.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Test report
       # Fork PRs can't write checks (job-level `checks: write` is downgraded
       # to read for forks). Skip the reporter there; same-repo PRs and
       # push/workflow_dispatch runs retain full permissions.
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: always() && needs.detect-changes.outputs.linux-shards == '1'
+        && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
       with:
         name: TSan (Linux)
         path: test_results/*.xml
+        reporter: java-junit
+        fail-on-error: false
+        list-tests: 'failed'
+
+  # ---------------------------------------------------------------------------
+  # ASan + LSan (Linux) test run, spread across runners (#1083, Linux).
+  #
+  # EXISTS ONLY ON THE HOSTED ARM. `detect-changes` sets `linux-shards` to 1 when
+  # the run routes to the self-hosted box, and this whole job is skipped there --
+  # the `olo-ci` label is served by at most two runners and three sanitizer jobs
+  # already queue against them, so a matrix would serialise rather than parallelise.
+  # On the hosted arm the shard count is 4; see the plan step for the measurement.
+  #
+  # `runs-on` is a plain literal rather than the routing expression the build jobs
+  # carry, and that is not a shortcut: this job cannot run at all unless the plan
+  # already chose the hosted arm, so any other value would be unreachable.
+  # ---------------------------------------------------------------------------
+  asan-lsan-linux-tests:
+    name: ASan + LSan (Linux) tests ${{ matrix.shard }}/${{ needs.detect-changes.outputs.linux-shards }}
+    needs: [detect-changes, asan-lsan-linux]
+    if: ${{ !cancelled() && needs.asan-lsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      # A red shard must not cancel its siblings: they are independent partitions
+      # and the coverage proof wants every one of their counts.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.detect-changes.outputs.linux-shard-matrix) }}
+    env:
+      OLO_CTEST_SHARDS: ${{ needs.detect-changes.outputs.linux-shards }}
+      # The SAME exclusion the build job measured its total with. Copied from the
+      # build job's literal by construction -- see the note on that env var.
+      OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^WorkerRestartTest\.'
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # The shards need the Vulkan loader the instrumented binary links against and
+    # the llvm-symbolizer the sanitizer runtime resolves reports through, and the
+    # cheapest way to get exactly the build job's environment is to run the same
+    # action. Measured ~4 min, in parallel across shards, against ~36 min saved.
+    - name: Setup Linux build environment
+      id: linux
+      uses: ./.github/actions/setup-linux-build
+      with:
+        vulkan-sdk: 'false'
+        cache-name: asan-lsan-shard
+
+    - name: Download the instrumented test tree
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: asan-lsan-linux-test-tree
+        path: build/OloEngine/tests
+
+    # gtest_discover_tests bakes ABSOLUTE paths into the generated *_tests.cmake,
+    # so the tree cannot be moved between the build job and this one. If it were,
+    # every add_test() would name a binary that is not there and ctest would fail
+    # thousands of times with a confusing message instead of once with this one.
+    - name: Assert this runner matches the build job's layout
+      run: |
+        set -euo pipefail
+        built_at=$(cat build/OloEngine/tests/olo-build-workspace.txt)
+        here='${{github.workspace}}'
+        if [ "$built_at" != "$here" ]; then
+          echo "::error::This tree was built at '${built_at}' but this runner checked out at '${here}'. gtest_discover_tests bakes absolute paths into the generated test list, so the tree cannot be moved."
+          exit 1
+        fi
+        exe=build/OloEngine/tests/OloEngine-Tests
+        test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
+        # RESTORE THE EXECUTABLE BIT. actions/upload-artifact stores POSIX modes as
+        # 0644, so the binary arrives non-executable and all ~7600 ctest entries
+        # would fail to launch with a permission error that names no cause.
+        chmod +x "$exe"
+        # Prove it starts before running a shard against it (#1083). An instrumented
+        # binary that cannot load its runtime dies before main(), which would arrive
+        # as thousands of identical ctest failures rather than one readable line.
+        if ! "$exe" --gtest_list_tests > /dev/null 2>&1; then
+          echo "::error::$exe does not start on this runner. Either the artifact is missing something it needs at load time, or the environment does not match the build job."
+          "$exe" --gtest_list_tests || true
+          exit 1
+        fi
+
+    - name: Create test results directory
+      run: mkdir -p '${{github.workspace}}/test_results'
+
+    # A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by stride and
+    # silently yields an empty set if the stride is wrong, which would otherwise
+    # look like a green shard. The count is also written out for the coverage proof.
+    - name: Select this shard's cases
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      env:
+        OLO_CTEST_SHARD: ${{ matrix.shard }}
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N \
+                    -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
+                    --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}")
+        count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only before the numeric test, for the reason the build job's total
+        # spells out: a non-numeric value makes `[ -le ]` error, and an erroring
+        # command inside an `if` is exempt from `set -e`.
+        case "${count}" in
+          ''|*[!0-9]*)
+            echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} got a non-numeric ctest count ('${count:-<empty>}')."
+            exit 1 ;;
+        esac
+        if [ "${count}" -le 0 ]; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} did not match a positive number of ctest entries."
+          exit 1
+        fi
+        echo "shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS}: ${count} ctest entries"
+        mkdir -p '${{github.workspace}}/shard_counts'
+        {
+          echo "shard=${OLO_CTEST_SHARD}"
+          echo "shards=${OLO_CTEST_SHARDS}"
+          echo "count=${count}"
+        } > '${{github.workspace}}/shard_counts/shard-'"${OLO_CTEST_SHARD}"'.txt'
+
+    - name: Run tests under ASan + LSan
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
+      env:
+        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        #
+        # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
+        # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
+        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
+        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
+        # could not be attributed to a single line of source because of this.
+        #
+        # setup-linux-build derives the path from the compiler it actually chose and
+        # warns if there is none; an empty value here leaves the variable effectively
+        # unset, which is the same behaviour as before rather than a new failure.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
+        ASAN_OPTIONS: halt_on_error=1:detect_leaks=1:symbolize=1
+        LSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/lsan.txt:symbolize=1
+        GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
+
+    - name: Upload this shard's test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-lsan-linux-test-results-shard-${{ matrix.shard }}
+        path: test_results/*.xml
+        if-no-files-found: warn
+        retention-days: 1
+
+    - name: Upload this shard's case count
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: asan-lsan-linux-shard-count-${{ matrix.shard }}
+        path: shard_counts/shard-${{ matrix.shard }}.txt
+        if-no-files-found: warn
+        retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Proof that the shards partitioned the whole suite: every shard reported, all
+  # agreeing on N, none empty, and the counts summing to the unsharded total the
+  # build job measured. Without it, sharding introduces a way for the suite to
+  # shrink silently.
+  # ---------------------------------------------------------------------------
+  asan-lsan-linux-tests-verify:
+    name: ASan + LSan (Linux) shard coverage
+    needs: [detect-changes, asan-lsan-linux, asan-lsan-linux-tests]
+    # `!cancelled()` rather than `always()`: a cancelled run can leave the build
+    # job 'success' while the shards were killed mid-flight, and `always()` would
+    # then post a red "a shard did not complete" on a run nobody abandoned for a
+    # reason worth reading. Braced because a bare leading `!` is a YAML tag.
+    if: ${{ !cancelled() && needs.asan-lsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the shard case counts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: asan-lsan-linux-shard-count-*
+        path: shard_counts
+      # A shard that died before writing its count uploads nothing, and this step
+      # would then fail on "no artifacts found" -- a worse message than the
+      # script's. Let it through and let the union check name the missing shard.
+      continue-on-error: true
+
+    - name: Prove the shards covered the whole suite
+      run: >
+        python3 scripts/verify_test_shards.py
+        --dir shard_counts
+        --label "ASan + LSan (Linux)"
+        --expected-total ${{ needs.asan-lsan-linux.outputs.ctest-total }}
+
+    # NO `merge-multiple`. GTEST_OUTPUT writes into a directory and gtest names the
+    # files itself, so every shard produces the SAME filenames; merging would have
+    # them overwrite each other and the report would look complete while missing
+    # real failures. One directory per artifact, and a `**` glob below.
+    - name: Download the shard test results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: asan-lsan-linux-test-results-shard-*
+        path: test_results
+      continue-on-error: true
+
+    - name: Test report
+      # Fork PRs can't write checks (job-level `checks: write` is downgraded to
+      # read for forks). Skip the reporter there.
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+      with:
+        name: ASan + LSan (Linux)
+        path: test_results/**/*.xml
+        reporter: java-junit
+        fail-on-error: false
+        list-tests: 'failed'
+
+  # ---------------------------------------------------------------------------
+  # UBSan (Linux) test run, spread across runners (#1083, Linux).
+  #
+  # EXISTS ONLY ON THE HOSTED ARM. `detect-changes` sets `linux-shards` to 1 when
+  # the run routes to the self-hosted box, and this whole job is skipped there --
+  # the `olo-ci` label is served by at most two runners and three sanitizer jobs
+  # already queue against them, so a matrix would serialise rather than parallelise.
+  # On the hosted arm the shard count is 4; see the plan step for the measurement.
+  #
+  # `runs-on` is a plain literal rather than the routing expression the build jobs
+  # carry, and that is not a shortcut: this job cannot run at all unless the plan
+  # already chose the hosted arm, so any other value would be unreachable.
+  # ---------------------------------------------------------------------------
+  ubsan-linux-tests:
+    name: UBSan (Linux) tests ${{ matrix.shard }}/${{ needs.detect-changes.outputs.linux-shards }}
+    needs: [detect-changes, ubsan-linux]
+    if: ${{ !cancelled() && needs.ubsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      # A red shard must not cancel its siblings: they are independent partitions
+      # and the coverage proof wants every one of their counts.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.detect-changes.outputs.linux-shard-matrix) }}
+    env:
+      OLO_CTEST_SHARDS: ${{ needs.detect-changes.outputs.linux-shards }}
+      # The SAME exclusion the build job measured its total with. Copied from the
+      # build job's literal by construction -- see the note on that env var.
+      OLO_UBSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^NetworkManagerTest\.|^NetworkThreadDispatchTest\.|^ServerAuthoritativeLoopTest\.|^TaskConcurrencyLimiterTest\.|^LowLevelTaskUserDataTest\.|^WorkerRestartTest\.'
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # The shards need the Vulkan loader the instrumented binary links against and
+    # the llvm-symbolizer the sanitizer runtime resolves reports through, and the
+    # cheapest way to get exactly the build job's environment is to run the same
+    # action. Measured ~4 min, in parallel across shards, against ~36 min saved.
+    - name: Setup Linux build environment
+      id: linux
+      uses: ./.github/actions/setup-linux-build
+      with:
+        vulkan-sdk: 'false'
+        cache-name: ubsan-shard
+
+    - name: Download the instrumented test tree
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ubsan-linux-test-tree
+        path: build/OloEngine/tests
+
+    # gtest_discover_tests bakes ABSOLUTE paths into the generated *_tests.cmake,
+    # so the tree cannot be moved between the build job and this one. If it were,
+    # every add_test() would name a binary that is not there and ctest would fail
+    # thousands of times with a confusing message instead of once with this one.
+    - name: Assert this runner matches the build job's layout
+      run: |
+        set -euo pipefail
+        built_at=$(cat build/OloEngine/tests/olo-build-workspace.txt)
+        here='${{github.workspace}}'
+        if [ "$built_at" != "$here" ]; then
+          echo "::error::This tree was built at '${built_at}' but this runner checked out at '${here}'. gtest_discover_tests bakes absolute paths into the generated test list, so the tree cannot be moved."
+          exit 1
+        fi
+        exe=build/OloEngine/tests/OloEngine-Tests
+        test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
+        # RESTORE THE EXECUTABLE BIT. actions/upload-artifact stores POSIX modes as
+        # 0644, so the binary arrives non-executable and all ~7600 ctest entries
+        # would fail to launch with a permission error that names no cause.
+        chmod +x "$exe"
+        # Prove it starts before running a shard against it (#1083). An instrumented
+        # binary that cannot load its runtime dies before main(), which would arrive
+        # as thousands of identical ctest failures rather than one readable line.
+        if ! "$exe" --gtest_list_tests > /dev/null 2>&1; then
+          echo "::error::$exe does not start on this runner. Either the artifact is missing something it needs at load time, or the environment does not match the build job."
+          "$exe" --gtest_list_tests || true
+          exit 1
+        fi
+
+    - name: Create test results directory
+      run: mkdir -p '${{github.workspace}}/test_results'
+
+    # A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by stride and
+    # silently yields an empty set if the stride is wrong, which would otherwise
+    # look like a green shard. The count is also written out for the coverage proof.
+    - name: Select this shard's cases
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      env:
+        OLO_CTEST_SHARD: ${{ matrix.shard }}
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N \
+                    -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
+                    --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}")
+        count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only before the numeric test, for the reason the build job's total
+        # spells out: a non-numeric value makes `[ -le ]` error, and an erroring
+        # command inside an `if` is exempt from `set -e`.
+        case "${count}" in
+          ''|*[!0-9]*)
+            echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} got a non-numeric ctest count ('${count:-<empty>}')."
+            exit 1 ;;
+        esac
+        if [ "${count}" -le 0 ]; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} did not match a positive number of ctest entries."
+          exit 1
+        fi
+        echo "shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS}: ${count} ctest entries"
+        mkdir -p '${{github.workspace}}/shard_counts'
+        {
+          echo "shard=${OLO_CTEST_SHARD}"
+          echo "shards=${OLO_CTEST_SHARDS}"
+          echo "count=${count}"
+        } > '${{github.workspace}}/shard_counts/shard-'"${OLO_CTEST_SHARD}"'.txt'
+
+    - name: Run tests under UBSan
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
+      env:
+        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        #
+        # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
+        # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
+        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
+        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
+        # could not be attributed to a single line of source because of this.
+        #
+        # setup-linux-build derives the path from the compiler it actually chose and
+        # warns if there is none; an empty value here leaves the variable effectively
+        # unset, which is the same behaviour as before rather than a new failure.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
+        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
+        GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
+
+    - name: Upload this shard's test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ubsan-linux-test-results-shard-${{ matrix.shard }}
+        path: test_results/*.xml
+        if-no-files-found: warn
+        retention-days: 1
+
+    - name: Upload this shard's case count
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ubsan-linux-shard-count-${{ matrix.shard }}
+        path: shard_counts/shard-${{ matrix.shard }}.txt
+        if-no-files-found: warn
+        retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Proof that the shards partitioned the whole suite: every shard reported, all
+  # agreeing on N, none empty, and the counts summing to the unsharded total the
+  # build job measured. Without it, sharding introduces a way for the suite to
+  # shrink silently.
+  # ---------------------------------------------------------------------------
+  ubsan-linux-tests-verify:
+    name: UBSan (Linux) shard coverage
+    needs: [detect-changes, ubsan-linux, ubsan-linux-tests]
+    # `!cancelled()` rather than `always()`: a cancelled run can leave the build
+    # job 'success' while the shards were killed mid-flight, and `always()` would
+    # then post a red "a shard did not complete" on a run nobody abandoned for a
+    # reason worth reading. Braced because a bare leading `!` is a YAML tag.
+    if: ${{ !cancelled() && needs.ubsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the shard case counts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: ubsan-linux-shard-count-*
+        path: shard_counts
+      # A shard that died before writing its count uploads nothing, and this step
+      # would then fail on "no artifacts found" -- a worse message than the
+      # script's. Let it through and let the union check name the missing shard.
+      continue-on-error: true
+
+    - name: Prove the shards covered the whole suite
+      run: >
+        python3 scripts/verify_test_shards.py
+        --dir shard_counts
+        --label "UBSan (Linux)"
+        --expected-total ${{ needs.ubsan-linux.outputs.ctest-total }}
+
+    # NO `merge-multiple`. GTEST_OUTPUT writes into a directory and gtest names the
+    # files itself, so every shard produces the SAME filenames; merging would have
+    # them overwrite each other and the report would look complete while missing
+    # real failures. One directory per artifact, and a `**` glob below.
+    - name: Download the shard test results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: ubsan-linux-test-results-shard-*
+        path: test_results
+      continue-on-error: true
+
+    - name: Test report
+      # Fork PRs can't write checks (job-level `checks: write` is downgraded to
+      # read for forks). Skip the reporter there.
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+      with:
+        name: UBSan (Linux)
+        path: test_results/**/*.xml
+        reporter: java-junit
+        fail-on-error: false
+        list-tests: 'failed'
+
+  # ---------------------------------------------------------------------------
+  # TSan (Linux) test run, spread across runners (#1083, Linux).
+  #
+  # EXISTS ONLY ON THE HOSTED ARM. `detect-changes` sets `linux-shards` to 1 when
+  # the run routes to the self-hosted box, and this whole job is skipped there --
+  # the `olo-ci` label is served by at most two runners and three sanitizer jobs
+  # already queue against them, so a matrix would serialise rather than parallelise.
+  # On the hosted arm the shard count is 4; see the plan step for the measurement.
+  #
+  # `runs-on` is a plain literal rather than the routing expression the build jobs
+  # carry, and that is not a shortcut: this job cannot run at all unless the plan
+  # already chose the hosted arm, so any other value would be unreachable.
+  # ---------------------------------------------------------------------------
+  tsan-linux-tests:
+    name: TSan (Linux) tests ${{ matrix.shard }}/${{ needs.detect-changes.outputs.linux-shards }}
+    needs: [detect-changes, tsan-linux]
+    if: ${{ !cancelled() && needs.tsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      # A red shard must not cancel its siblings: they are independent partitions
+      # and the coverage proof wants every one of their counts.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.detect-changes.outputs.linux-shard-matrix) }}
+    env:
+      OLO_CTEST_SHARDS: ${{ needs.detect-changes.outputs.linux-shards }}
+      # The SAME exclusion the build job measured its total with. Copied from the
+      # build job's literal by construction -- see the note on that env var.
+      OLO_TSAN_LINUX_CTEST_EXCLUDE: '^NetworkIntegrationTest\.|^ServerAuthoritativeLoopTest\.|^WorkerRestartTest\.'
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    # The shards need the Vulkan loader the instrumented binary links against and
+    # the llvm-symbolizer the sanitizer runtime resolves reports through, and the
+    # cheapest way to get exactly the build job's environment is to run the same
+    # action. Measured ~4 min, in parallel across shards, against ~36 min saved.
+    - name: Setup Linux build environment
+      id: linux
+      uses: ./.github/actions/setup-linux-build
+      with:
+        vulkan-sdk: 'false'
+        cache-name: tsan-shard
+
+    - name: Download the instrumented test tree
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: tsan-linux-test-tree
+        path: build/OloEngine/tests
+
+    # gtest_discover_tests bakes ABSOLUTE paths into the generated *_tests.cmake,
+    # so the tree cannot be moved between the build job and this one. If it were,
+    # every add_test() would name a binary that is not there and ctest would fail
+    # thousands of times with a confusing message instead of once with this one.
+    - name: Assert this runner matches the build job's layout
+      run: |
+        set -euo pipefail
+        built_at=$(cat build/OloEngine/tests/olo-build-workspace.txt)
+        here='${{github.workspace}}'
+        if [ "$built_at" != "$here" ]; then
+          echo "::error::This tree was built at '${built_at}' but this runner checked out at '${here}'. gtest_discover_tests bakes absolute paths into the generated test list, so the tree cannot be moved."
+          exit 1
+        fi
+        exe=build/OloEngine/tests/OloEngine-Tests
+        test -f "$exe" || { echo "::error::$exe missing from the artifact"; exit 1; }
+        # RESTORE THE EXECUTABLE BIT. actions/upload-artifact stores POSIX modes as
+        # 0644, so the binary arrives non-executable and all ~7600 ctest entries
+        # would fail to launch with a permission error that names no cause.
+        chmod +x "$exe"
+        # Prove it starts before running a shard against it (#1083). An instrumented
+        # binary that cannot load its runtime dies before main(), which would arrive
+        # as thousands of identical ctest failures rather than one readable line.
+        if ! "$exe" --gtest_list_tests > /dev/null 2>&1; then
+          echo "::error::$exe does not start on this runner. Either the artifact is missing something it needs at load time, or the environment does not match the build job."
+          "$exe" --gtest_list_tests || true
+          exit 1
+        fi
+
+    - name: Create test results directory
+      run: mkdir -p '${{github.workspace}}/test_results'
+
+    # A SHARD THAT MATCHED NOTHING MUST FAIL. `ctest -I` selects by stride and
+    # silently yields an empty set if the stride is wrong, which would otherwise
+    # look like a green shard. The count is also written out for the coverage proof.
+    - name: Select this shard's cases
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      env:
+        OLO_CTEST_SHARD: ${{ matrix.shard }}
+      run: |
+        set -euo pipefail
+        listing=$(ctest -N \
+                    -I "${OLO_CTEST_SHARD},,${OLO_CTEST_SHARDS}" \
+                    --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}")
+        count=$(printf '%s\n' "$listing" | sed -n 's/^Total Tests: *//p' | tail -1)
+        # Digits-only before the numeric test, for the reason the build job's total
+        # spells out: a non-numeric value makes `[ -le ]` error, and an erroring
+        # command inside an `if` is exempt from `set -e`.
+        case "${count}" in
+          ''|*[!0-9]*)
+            echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} got a non-numeric ctest count ('${count:-<empty>}')."
+            exit 1 ;;
+        esac
+        if [ "${count}" -le 0 ]; then
+          echo "::error::shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS} did not match a positive number of ctest entries."
+          exit 1
+        fi
+        echo "shard ${OLO_CTEST_SHARD}/${OLO_CTEST_SHARDS}: ${count} ctest entries"
+        mkdir -p '${{github.workspace}}/shard_counts'
+        {
+          echo "shard=${OLO_CTEST_SHARD}"
+          echo "shards=${OLO_CTEST_SHARDS}"
+          echo "count=${count}"
+        } > '${{github.workspace}}/shard_counts/shard-'"${OLO_CTEST_SHARD}"'.txt'
+
+    - name: Run tests under TSan
+      working-directory: ${{github.workspace}}/build/OloEngine/tests
+      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+      env:
+        # suppressions: vendored-code races we accept rather than patch — see
+        # the rationale comments in tsan.txt (currently: Jolt's assert-build
+        # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
+        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
+        # See the ASAN_SYMBOLIZER_PATH note in the ASan+LSan job: the variable is
+        # read by every sanitizer runtime, TSan included, and without it this job's
+        # race reports are unsymbolized too.
+        ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
+        GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
+
+    - name: Upload this shard's test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: tsan-linux-test-results-shard-${{ matrix.shard }}
+        path: test_results/*.xml
+        if-no-files-found: warn
+        retention-days: 1
+
+    - name: Upload this shard's case count
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: tsan-linux-shard-count-${{ matrix.shard }}
+        path: shard_counts/shard-${{ matrix.shard }}.txt
+        if-no-files-found: warn
+        retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Proof that the shards partitioned the whole suite: every shard reported, all
+  # agreeing on N, none empty, and the counts summing to the unsharded total the
+  # build job measured. Without it, sharding introduces a way for the suite to
+  # shrink silently.
+  # ---------------------------------------------------------------------------
+  tsan-linux-tests-verify:
+    name: TSan (Linux) shard coverage
+    needs: [detect-changes, tsan-linux, tsan-linux-tests]
+    # `!cancelled()` rather than `always()`: a cancelled run can leave the build
+    # job 'success' while the shards were killed mid-flight, and `always()` would
+    # then post a red "a shard did not complete" on a run nobody abandoned for a
+    # reason worth reading. Braced because a bare leading `!` is a YAML tag.
+    if: ${{ !cancelled() && needs.tsan-linux.result == 'success'
+        && needs.detect-changes.outputs.linux-shards != '1' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download the shard case counts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: tsan-linux-shard-count-*
+        path: shard_counts
+      # A shard that died before writing its count uploads nothing, and this step
+      # would then fail on "no artifacts found" -- a worse message than the
+      # script's. Let it through and let the union check name the missing shard.
+      continue-on-error: true
+
+    - name: Prove the shards covered the whole suite
+      run: >
+        python3 scripts/verify_test_shards.py
+        --dir shard_counts
+        --label "TSan (Linux)"
+        --expected-total ${{ needs.tsan-linux.outputs.ctest-total }}
+
+    # NO `merge-multiple`. GTEST_OUTPUT writes into a directory and gtest names the
+    # files itself, so every shard produces the SAME filenames; merging would have
+    # them overwrite each other and the report would look complete while missing
+    # real failures. One directory per artifact, and a `**` glob below.
+    - name: Download the shard test results
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: tsan-linux-test-results-shard-*
+        path: test_results
+      continue-on-error: true
+
+    - name: Test report
+      # Fork PRs can't write checks (job-level `checks: write` is downgraded to
+      # read for forks). Skip the reporter there.
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+      with:
+        name: TSan (Linux)
+        path: test_results/**/*.xml
         reporter: java-junit
         fail-on-error: false
         list-tests: 'failed'

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -94,12 +94,28 @@ on:
     # That is fine — this job only deletes SUPERSEDED entries, so running before a
     # save simply means that entry is collected on the next sweep.)
     #
-    # Between sweeps, each heavy job also prunes its own lineage on its own ref if
-    # its save is refused (.github/actions/save-cache-pruned). A twice-daily janitor
-    # cannot fix a breach that happens between two saves thirty minutes apart; that
-    # action can, and this workflow collects everything it does not own.
+    # Between sweeps, each heavy job prunes its own lineage on its own ref as soon as
+    # its save is VERIFIED (.github/actions/save-cache-pruned, widened from refusal-only
+    # in this same change). That is the primary mechanism now: a twice-daily janitor
+    # cannot fix a breach that happens between two saves thirty minutes apart, and on
+    # 2026-09-07 it did not -- the store reached 10863 MiB against a ~9537 MiB wall on
+    # six duplicate vcpkg entries banked after the 07:03 sweep.
+    #
+    # THE EXTRA SWEEPS BELOW COVER WHAT POST-SAVE PRUNING STRUCTURALLY CANNOT: a
+    # lineage whose save is SKIPPED prunes nothing, because no save ran. vcpkg is now
+    # exactly that shape -- setup-vcpkg skips the save whenever the restore matched its
+    # manifest hash -- so its already-banked duplicates have no owner to collect them.
+    # Same for entries on a merged PR's ref, a deleted branch, and the 30-day age-out.
+    #
+    # Four-hourly, not two-hourly: the sweep is ~30 API calls and free, but each run is
+    # a workflow entry in the Actions list, and 12/day is enough noise to bury a real
+    # failure. Six sweeps bound the worst case at ~4 h of accumulation.
     - cron: '5 1 * * *'
+    - cron: '5 5 * * *'
     - cron: '41 6 * * *'
+    - cron: '5 13 * * *'
+    - cron: '5 17 * * *'
+    - cron: '5 21 * * *'
   workflow_dispatch:
 
 # The only write scope this workflow needs, and it needs it: deleting a cache entry


### PR DESCRIPTION
Four CI fixes that came out of measuring why PRs wait on CI (#1084), plus the instrumentation needed to diagnose #1109. Three commits, each self-contained.

## 1. vcpkg re-banked the same snapshot on every master run — `ef3243ce1`

The skip-save guard in `setup-vcpkg` was gated on `pull_request`. Every push/dispatch banked a fresh 706 MiB entry of the identical manifest hash: **six of `7d9ae677…` between 06:41 and 10:53 on 2026-09-07, 4,236 MiB in a store at 10,863 MiB.** That duplication was the entire overage.

The gate's own justification ("so a missing archive always gets banked") had it backwards — a *missing* archive is exactly the case where the restore doesn't match the hash prefix, which the guard already discriminates. Dropped. Self-healing on eviction.

## 2. Superseded cache entries waited for a twice-daily sweep — `4d9b6eff1`

`save-cache-pruned` only pruned when a save was **refused**. Two crons a day can't keep up with the master save rate. It now prunes the lineage as soon as the new entry is **verified present** — strictly safer than the refusal path it was written for, since the header's caution is about deleting *before* a save. `landed == unknown` still prunes nothing.

`cache-prune.yml` goes 2 → 6 sweeps/day for lineages that skip their save entirely (which vcpkg now does) and for dead refs.

## 3. Sanitizer reports were unsymbolized, and the Linux sanitizers now shard — `0f44a1449`

**Symbolization.** There was no `ASAN_SYMBOLIZER_PATH` anywhere in the repo, and the pinned LLVM is deliberately off PATH — so every sanitizer trace has been bare hex, silently. This also means every function-name `leak:` entry in `lsan.txt` has been inert (LSan matches those against symbolized frames). `setup-linux-build` now derives the symbolizer from the compiler it chose and verifies it.

**Sharding (#1083, Linux).** Each Linux sanitizer job splits into build + 4 shards + coverage proof, mirroring the Windows ASan shape, with the stride, the `ctest -N` total and each shard's selection all reading one job-level exclude regex. Two constraints the Windows shards didn't face:

- **The box has one runner online** (`olo-ci-2` is offline). A matrix there would serialise twelve jobs. `detect-changes` computes the plan once: `shards=1` on the box, where the build job runs the suite itself byte-for-byte as before; `shards=4` on the hosted arm.
- **Artifacts drop the executable bit on Linux.** Each shard restores it and proves the binary starts before selecting a stride.

Measured on the hosted arm (run 34108719319): build 63 min, tests 48 min. Sharding takes the test half to ~12 min against a ~0.1 min artifact round-trip. The 63-min build is the remaining ceiling and is #1095's problem.

## What is verified and what is not

- `actionlint` clean on both workflows; YAML parses; pre-commit passes.
- **The sharded hosted path has not run yet.** A `workflow_dispatch` of `asan.yml` on this branch with `force_hosted: true` is queued; it exercises the shards, the symbolizer, and the vcpkg skip in one run, and produces the symbolized trace #1109 needs.
- This PR does **not** fix #1109. It provides the trace that names the allocation site.

Refs #1109, #1083, #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
