### PR TITLE
build: put the four heaviest TUs in the heavy-compile pool (#822)

### DIFF
--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 # Heavy-TU compile pool (issue #822): see the matching block in OloEngine/src/CMakeLists.txt for
 # why the removal must stay conditional on the pool actually being available.
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
-	list(REMOVE_ITEM EDITOR_SOURCES "MCP/McpFieldRegistry.cpp")
+	list(REMOVE_ITEM EDITOR_SOURCES "MCP/McpFieldRegistry.cpp" "MCP/McpToolsRender.cpp")
 endif()
 
 add_executable(OloEditor
@@ -156,6 +156,9 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
 	olo_bind_heavy_compile_pool(OloEditor "${CMAKE_CURRENT_SOURCE_DIR}"
 		"MCP/McpFieldRegistry.cpp"
+		# 7,838 MB peak compiler RSS measured cold (issue #822 follow-up), and like
+		# McpFieldRegistry it is compiled into OloEngine-Tests as well, so the cost is paid twice.
+		"MCP/McpToolsRender.cpp"
 	)
 endif()
 

--- a/OloEngine/src/CMakeLists.txt
+++ b/OloEngine/src/CMakeLists.txt
@@ -1888,6 +1888,7 @@ endif()
 # drop the file from SOURCES with nothing re-adding it, silently removing it from the build.
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
 	list(REMOVE_ITEM SOURCES
+		"OloEngine/Scene/Prefab.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Core.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Environment.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Characters.cpp"
@@ -1996,6 +1997,10 @@ set(OLO_ENGINE_LIBRARY_PARTS OloEngine OloEngineRenderer OloEngineContent PARENT
 # ~25 GB, which is what the 31 GiB CI box could not survive.
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
 	olo_bind_heavy_compile_pool(OloEngineContent "${CMAKE_CURRENT_SOURCE_DIR}"
+		# 6,400 MB peak compiler RSS in 22 s — 573 lines, so the cost is header and template
+		# instantiation, not file size. It ranks 17th by compile time and 4th by memory, which
+		# is exactly why a duration-ranked survey missed it (issue #822 follow-up).
+		"OloEngine/Scene/Prefab.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Core.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Environment.cpp"
 		"OloEngine/Scripting/Lua/LuaScriptGlue_Characters.cpp"

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -5,9 +5,26 @@
 # matching block in OloEngine/src/CMakeLists.txt for why the exclusion must stay conditional. This
 # variable holds the one line so the huge inline source list below needs a single line touched,
 # not restructured into a separate variable (a collision point for parallel branches on its own).
+#
+# MEASURED, not inferred from compile time (issue #822 follow-up). Peak compiler RSS, cold,
+# clang-cl Debug with no sanitizer:
+#
+#     ComponentRoundTripTest.cpp   12,389 MB   <- the heaviest TU in the tree
+#     RenderGraphTest.cpp           8,619 MB
+#     McpToolsRender.cpp            7,838 MB
+#     McpFieldRegistry.cpp          5,065 MB   <- the only one #822 originally caught
+#
+# Compile TIME is a poor proxy for this and is how the first three were missed: they rank
+# 15th, 18th and 13th by duration. The pool is what bounds how many run at once.
 set(_olo_mcp_field_registry_src ${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpFieldRegistry.cpp)
+set(_olo_mcp_tools_render_src ${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsRender.cpp)
+set(_olo_component_round_trip_src ComponentRoundTripTest.cpp)
+set(_olo_render_graph_test_src Rendering/RenderGraphTest.cpp)
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
 	set(_olo_mcp_field_registry_src "")
+	set(_olo_mcp_tools_render_src "")
+	set(_olo_component_round_trip_src "")
+	set(_olo_render_graph_test_src "")
 endif()
 
 add_executable(OloEngine-Tests
@@ -58,7 +75,7 @@ add_executable(OloEngine-Tests
 		AssetRegistryInvariantsTest.cpp
 		RuntimeAssetManagerTest.cpp
 		AssetLoadedEventTest.cpp
-		ComponentRoundTripTest.cpp
+		${_olo_component_round_trip_src}
 		TilemapTest.cpp
 		TilesetSerializerTest.cpp
 		ComponentSerializerCoverageTest.cpp
@@ -261,7 +278,7 @@ add_executable(OloEngine-Tests
 		Rendering/RenderGraphParallelRecordingTest.cpp
 		Rendering/PODRenderStateChannelMaskTest.cpp
 		#Rendering/CommandDispatchTest.cpp  # Requires full engine (calls CommandDispatch::Initialize which pulls in OpenGL statics)
-		Rendering/RenderGraphTest.cpp
+		${_olo_render_graph_test_src}
 		# Phase 2 ratchet for the Vulkan-RHI epic (#691, ADR 0011): counts raw
 		# glXxx() outside Platform/OpenGL/ and fails when it rises above
 		# Rendering/rhi_boundary_baseline.json. Also the only TU that compiles the
@@ -779,7 +796,7 @@ add_executable(OloEngine-Tests
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsInput.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsPerf.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsPhysics.cpp
-		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsRender.cpp
+		${_olo_mcp_tools_render_src}
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsScene.cpp
 		# The generated writable-field registry TU (McpGenericFieldWrite.h's
 		# Registry() definition). Compiled once here instead of inline in every
@@ -1232,6 +1249,13 @@ add_executable(OloEngine-Tests
 if(OLO_HEAVY_COMPILE_POOL_AVAILABLE)
 	olo_bind_heavy_compile_pool(OloEngine-Tests "${CMAKE_SOURCE_DIR}/OloEditor/src"
 		"MCP/McpFieldRegistry.cpp"
+		"MCP/McpToolsRender.cpp"
+	)
+	# A second call for this target's OWN sources: a file set's FILES must sit under its
+	# BASE_DIRS, and these live here rather than under OloEditor/src.
+	olo_bind_heavy_compile_pool(OloEngine-Tests "${CMAKE_CURRENT_SOURCE_DIR}"
+		"ComponentRoundTripTest.cpp"
+		"Rendering/RenderGraphTest.cpp"
 	)
 endif()
 


### PR DESCRIPTION
## What and why

#822 created the heavy-compile pool from a **CPU-time** trace and named two outliers:
`LuaScriptGlue.cpp` and `McpFieldRegistry.cpp`. #1108 split the first one (12,439 MB → 5,043 MB
for the heaviest resulting part). Measuring the rest of the tree by **peak compiler RSS** — the
quantity that actually OOM-killed the CI runners on that PR — turns up three TUs heavier than
either originally-named outlier, none of them in the pool.

Peak compiler RSS, cold, clang-cl Debug, **no sanitizer**:

| TU | Peak RSS | Time | Pooled before? |
|---|---|---|---|
| **`ComponentRoundTripTest.cpp`** | **12,389 MB** | 81 s | ❌ |
| **`RenderGraphTest.cpp`** | **8,619 MB** | 74 s | ❌ |
| **`McpToolsRender.cpp`** | **7,838 MB** | 78 s | ❌ |
| **`Prefab.cpp`** | **6,400 MB** | 22 s | ❌ |
| `McpFieldRegistry.cpp` | 5,065 MB | 73 s | ✅ |
| `LuaScriptGlue_World.cpp` (post-#1108) | 5,043 MB | 27 s | ✅ |
| `PerfRegressionTests.cpp` | 3,175 MB | 70 s | ❌ |
| `SaveGameSerializer.cpp` | 2,616 MB | 30 s | ❌ |
| `Scene.cpp` | 2,498 MB | 23 s | ❌ |
| `SceneSerializer.cpp` | 1,848 MB | 19 s | ❌ |
| `ComponentFieldRegistry.cpp` | 1,823 MB | 19 s | ❌ |
| `ScriptGlue.cpp` | 1,811 MB | 30 s | ❌ |

`ComponentRoundTripTest.cpp` is now the heaviest TU in the tree, at essentially exactly what
`LuaScriptGlue.cpp` cost before it was split — so #1108 moved the crown rather than removing it,
and it lives in `OloEngine-Tests`, which is precisely what the Linux sanitizer jobs build.

## The transferable part: compile time is a poor proxy for compile memory

This is why a duration-ranked survey could not have found these. `Prefab.cpp` is **17th by
duration and 4th by memory**: 573 lines, 22 seconds, 6.4 GB. The cost is header and template
instantiation, not file size — so splitting it would *not* help the way splitting the Lua glue
did. The three new test/editor TUs rank 15th, 18th and 13th by time.

Worth stating for the next person: the **whole-program-optimization exclusion list is not a memory
ranking either.** `ScriptGlue.cpp`, `SceneSerializer.cpp` and `Scene.cpp` are all on it and are
among the *lighter* TUs measured here. That list is about IL and archive size (LNK1248, the 4 GiB
COFF ceiling) — a genuinely different axis, and correct for its own purpose.

## What this changes

The four are bound to the existing pool, capping them at `OLO_HEAVY_COMPILE_JOBS` (2) concurrent
compiles. `McpToolsRender.cpp` is compiled into both `OloEditor` and `OloEngine-Tests` — like
`McpFieldRegistry.cpp` — so it is bound in both, and its cost is paid twice.

No source file changes. Build-graph only.

## This mitigates; it does not fix

At depth 2 the worst admissible pair is now `ComponentRoundTripTest` + `RenderGraphTest` at
**~21 GB**, which is survivable on the 31 GiB CI box but not comfortable, and non-pool TUs still
compile alongside them at the job width. Actually reducing `ComponentRoundTripTest.cpp`'s 12.4 GB
is separate work and I have not diagnosed it — it is 4,757 lines with no obvious
`AllComponents`-style template fan-out, so it needs a real look rather than a guess.

## Review guide

**Where I'd look hardest**

1. `OloEngine/tests/CMakeLists.txt` — the source list is inline in `add_executable`, so entries
   cannot be `list(REMOVE_ITEM)`-ed. It uses the established variable-blanking idiom from
   `_olo_mcp_field_registry_src`; I added three more in the same shape. The hazard the pool's own
   comment names is a file being blanked with nothing re-adding it, i.e. **silently dropped from
   the build**.
2. The second `olo_bind_heavy_compile_pool` call on `OloEngine-Tests`. A file set's `FILES` must
   sit under its `BASE_DIRS`, and these sources live under `OloEngine/tests` rather than
   `OloEditor/src`, so they need their own call with a different base dir.

**What I verified, and how** — configure clean; then queried the generated
`CMakeFiles/impl-Debug.ninja` directly: each file has **exactly one build edge** (two for
`McpToolsRender`, one per target) and **every one carries `pool = olo_heavy`**, with the pool
declared at `depth = 2` in `rules.ninja`. So nothing is duplicated and nothing is dropped.
`OloEngine-Tests` and `OloEditor` both build and link. The decisive check against silent dropping:
the **472 tests in the two pooled test TUs still run and pass** — they could not if the TUs had
fallen out of the binary.

**Least confident about** — whether depth 2 is still the right number now that the pool's members
range from 1.3 GB to 12.4 GB. A single depth applied to a 10× spread is crude; a size-aware
scheduler would be better, and ninja has no such thing. If the box OOMs again, lowering
`OLO_HEAVY_COMPILE_JOBS` to 1 is the immediate lever, at a wall-clock cost.

**Deliberately not done** — `PerfRegressionTests.cpp` (3.2 GB) and below are left out. Every file
added to a depth-2 pool serialises against the others, so widening the membership past the genuine
outliers trades build wall-clock for headroom nobody needed. All measurements are single-sample on
clang-cl/Windows/Debug; Linux clang++ and the sanitizer builds will differ, and ASan added roughly
a gigabyte on top for the one TU measured both ways during #1108.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
