### PR TITLE
fix(ci): TSan fell back to addr2line at 7.5 GB per process and took the hosted runner down (#1111)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1549,19 +1549,31 @@ jobs:
       # different resources (peak compiler RSS vs. peak instrumented-test RSS).
       run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
         # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
         # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
-        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
-        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
-        # could not be attributed to a single line of source because of this.
+        # Finding nothing, it does NOT print bare hex and move on -- it falls back to
+        # binutils `addr2line`, one process per test process, and addr2line reads the
+        # ENTIRE DWARF of the binary. For a Debug sanitizer build of OloEngine-Tests
+        # that is ~7.5 GB each. MEASURED on run 34160911722 (#1111): two of them at
+        # 7.2-8.0 GB with MemAvailable at 41 MiB, then `The runner has received a
+        # shutdown signal`. The test processes were at ~0.2 GB. Every hosted TSan run
+        # since the pin died this way, at the physics block, because that is where
+        # tsan.txt's suppressed Jolt races make TSan symbolize during PASSING tests.
         #
-        # setup-linux-build derives the path from the compiler it actually chose and
-        # warns if there is none; an empty value here leaves the variable effectively
-        # unset, which is the same behaviour as before rather than a new failure.
+        # ASAN_SYMBOLIZER_PATH alone did not prevent it: the same run had it set to
+        # the right path and still spawned addr2line -- the TSan runtime does not read
+        # that variable. `external_symbolizer_path` is the common-runtime flag every
+        # sanitizer honours, so it goes into each *_OPTIONS; the env var stays for
+        # ASan, which does read it.
+        #
+        # AN EMPTY VALUE DISABLES SYMBOLIZATION rather than falling back to addr2line
+        # ("External symbolizer is explicitly disabled"). That is the failure mode
+        # wanted here: a job whose toolchain cannot symbolize should print hex, not
+        # eat the VM. setup-linux-build already warns when it resolves nothing.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
-        ASAN_OPTIONS: halt_on_error=1:detect_leaks=1:symbolize=1
+        ASAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:halt_on_error=1:detect_leaks=1:symbolize=1
         LSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/lsan.txt:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
@@ -1907,19 +1919,31 @@ jobs:
       # This exclusion covers the remaining, genuinely-GNS-side gap. See #636.
       run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
         # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
         # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
-        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
-        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
-        # could not be attributed to a single line of source because of this.
+        # Finding nothing, it does NOT print bare hex and move on -- it falls back to
+        # binutils `addr2line`, one process per test process, and addr2line reads the
+        # ENTIRE DWARF of the binary. For a Debug sanitizer build of OloEngine-Tests
+        # that is ~7.5 GB each. MEASURED on run 34160911722 (#1111): two of them at
+        # 7.2-8.0 GB with MemAvailable at 41 MiB, then `The runner has received a
+        # shutdown signal`. The test processes were at ~0.2 GB. Every hosted TSan run
+        # since the pin died this way, at the physics block, because that is where
+        # tsan.txt's suppressed Jolt races make TSan symbolize during PASSING tests.
         #
-        # setup-linux-build derives the path from the compiler it actually chose and
-        # warns if there is none; an empty value here leaves the variable effectively
-        # unset, which is the same behaviour as before rather than a new failure.
+        # ASAN_SYMBOLIZER_PATH alone did not prevent it: the same run had it set to
+        # the right path and still spawned addr2line -- the TSan runtime does not read
+        # that variable. `external_symbolizer_path` is the common-runtime flag every
+        # sanitizer honours, so it goes into each *_OPTIONS; the env var stays for
+        # ASan, which does read it.
+        #
+        # AN EMPTY VALUE DISABLES SYMBOLIZATION rather than falling back to addr2line
+        # ("External symbolizer is explicitly disabled"). That is the failure mode
+        # wanted here: a job whose toolchain cannot symbolize should print hex, not
+        # eat the VM. setup-linux-build already warns when it resolves nothing.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
-        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
+        UBSAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:halt_on_error=1:print_stacktrace=1:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Test report
@@ -2307,10 +2331,12 @@ jobs:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build
         # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
-        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
-        # See the ASAN_SYMBOLIZER_PATH note in the ASan+LSan job: the variable is
-        # read by every sanitizer runtime, TSan included, and without it this job's
-        # race reports are unsymbolized too.
+        TSAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
+        # See the symbolizer note in the ASan+LSan job. The claim that used to sit
+        # here -- that ASAN_SYMBOLIZER_PATH "is read by every sanitizer runtime, TSan
+        # included" -- was measured false on run 34160911722: TSan ignored it and
+        # spawned addr2line. `external_symbolizer_path` in TSAN_OPTIONS above is
+        # what TSan reads; this variable is kept only so the two jobs look alike.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
@@ -2449,19 +2475,31 @@ jobs:
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
         # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
         # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
-        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
-        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
-        # could not be attributed to a single line of source because of this.
+        # Finding nothing, it does NOT print bare hex and move on -- it falls back to
+        # binutils `addr2line`, one process per test process, and addr2line reads the
+        # ENTIRE DWARF of the binary. For a Debug sanitizer build of OloEngine-Tests
+        # that is ~7.5 GB each. MEASURED on run 34160911722 (#1111): two of them at
+        # 7.2-8.0 GB with MemAvailable at 41 MiB, then `The runner has received a
+        # shutdown signal`. The test processes were at ~0.2 GB. Every hosted TSan run
+        # since the pin died this way, at the physics block, because that is where
+        # tsan.txt's suppressed Jolt races make TSan symbolize during PASSING tests.
         #
-        # setup-linux-build derives the path from the compiler it actually chose and
-        # warns if there is none; an empty value here leaves the variable effectively
-        # unset, which is the same behaviour as before rather than a new failure.
+        # ASAN_SYMBOLIZER_PATH alone did not prevent it: the same run had it set to
+        # the right path and still spawned addr2line -- the TSan runtime does not read
+        # that variable. `external_symbolizer_path` is the common-runtime flag every
+        # sanitizer honours, so it goes into each *_OPTIONS; the env var stays for
+        # ASan, which does read it.
+        #
+        # AN EMPTY VALUE DISABLES SYMBOLIZATION rather than falling back to addr2line
+        # ("External symbolizer is explicitly disabled"). That is the failure mode
+        # wanted here: a job whose toolchain cannot symbolize should print hex, not
+        # eat the VM. setup-linux-build already warns when it resolves nothing.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
-        ASAN_OPTIONS: halt_on_error=1:detect_leaks=1:symbolize=1
+        ASAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:halt_on_error=1:detect_leaks=1:symbolize=1
         LSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/lsan.txt:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
@@ -2668,19 +2706,31 @@ jobs:
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
-        # WITHOUT THIS EVERY SANITIZER TRACE IN THIS JOB IS BARE HEX (#1073 follow-up).
+        # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
         # The sanitizer runtime resolves `llvm-symbolizer` from PATH, and the pinned
         # LLVM prefix is deliberately kept OFF the system PATH (see setup-linux-build).
-        # It finds nothing, prints `Module+0xf12f658` frames, and exits normally -- no
-        # warning anywhere. Run 34108719319 reported four LSan leaks on master that
-        # could not be attributed to a single line of source because of this.
+        # Finding nothing, it does NOT print bare hex and move on -- it falls back to
+        # binutils `addr2line`, one process per test process, and addr2line reads the
+        # ENTIRE DWARF of the binary. For a Debug sanitizer build of OloEngine-Tests
+        # that is ~7.5 GB each. MEASURED on run 34160911722 (#1111): two of them at
+        # 7.2-8.0 GB with MemAvailable at 41 MiB, then `The runner has received a
+        # shutdown signal`. The test processes were at ~0.2 GB. Every hosted TSan run
+        # since the pin died this way, at the physics block, because that is where
+        # tsan.txt's suppressed Jolt races make TSan symbolize during PASSING tests.
         #
-        # setup-linux-build derives the path from the compiler it actually chose and
-        # warns if there is none; an empty value here leaves the variable effectively
-        # unset, which is the same behaviour as before rather than a new failure.
+        # ASAN_SYMBOLIZER_PATH alone did not prevent it: the same run had it set to
+        # the right path and still spawned addr2line -- the TSan runtime does not read
+        # that variable. `external_symbolizer_path` is the common-runtime flag every
+        # sanitizer honours, so it goes into each *_OPTIONS; the env var stays for
+        # ASan, which does read it.
+        #
+        # AN EMPTY VALUE DISABLES SYMBOLIZATION rather than falling back to addr2line
+        # ("External symbolizer is explicitly disabled"). That is the failure mode
+        # wanted here: a job whose toolchain cannot symbolize should print hex, not
+        # eat the VM. setup-linux-build already warns when it resolves nothing.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
-        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:symbolize=1
+        UBSAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:halt_on_error=1:print_stacktrace=1:symbolize=1
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 
     - name: Upload this shard's test results
@@ -2910,10 +2960,12 @@ jobs:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build
         # lock-ownership bookkeeping in JPH::Mutex/SharedMutex).
-        TSAN_OPTIONS: suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
-        # See the ASAN_SYMBOLIZER_PATH note in the ASan+LSan job: the variable is
-        # read by every sanitizer runtime, TSan included, and without it this job's
-        # race reports are unsymbolized too.
+        TSAN_OPTIONS: external_symbolizer_path=${{ steps.linux.outputs.symbolizer }}:suppressions=${{github.workspace}}/.github/sanitizer-suppressions/tsan.txt:halt_on_error=1:second_deadlock_stack=1:symbolize=1
+        # See the symbolizer note in the ASan+LSan job. The claim that used to sit
+        # here -- that ASAN_SYMBOLIZER_PATH "is read by every sanitizer runtime, TSan
+        # included" -- was measured false on run 34160911722: TSan ignored it and
+        # spawned addr2line. `external_symbolizer_path` in TSAN_OPTIONS above is
+        # what TSan reads; this variable is kept only so the two jobs look alike.
         ASAN_SYMBOLIZER_PATH: ${{ steps.linux.outputs.symbolizer }}
         GTEST_OUTPUT: xml:${{github.workspace}}/test_results/
 

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -44,6 +44,16 @@ on:
         description: 'Run the Linux sanitizer jobs on GitHub-hosted ubuntu-24.04 even when the self-hosted box is enabled'
         type: boolean
         default: false
+      only:
+        # ONE SANITIZER PER DISPATCH, for a diagnosis loop. Every other job is
+        # skipped at its gate, so a TSan-only run on a warm cache is ~20 min and
+        # banks one sccache entry on the dispatching ref instead of four -- which
+        # matters on a branch, where nothing prunes those entries until the branch
+        # dies (#1111 was diagnosed this way). Default runs everything.
+        description: 'Run only this sanitizer job (and its shards)'
+        type: choice
+        options: [all, asan-lsan, ubsan, tsan, asan-windows]
+        default: all
 
 concurrency:
   # The `force_hosted` input is PART OF THE KEY, not decoration. The parity A/B
@@ -52,7 +62,9 @@ concurrency:
   # most one PENDING run and silently cancels the other. The first attempt at the
   # A/B lost its routed arm exactly this way and looked like an infrastructure
   # flake. Keyed on the input, the two arms are independent runs.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.force_hosted || 'default' }}
+  # `only` is in the key for the same reason `force_hosted` is (below): a TSan-only
+  # dispatch fired beside a full one on the same ref must not cancel it.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.force_hosted || 'default' }}-${{ github.event.inputs.only || 'all' }}
   # PULL REQUESTS ONLY. A cancelled run banks no cache -- `actions/cache/save` runs
   # `if: always()`, which survives a cancel, but the run still stops mid-build, so
   # what it banks is a partial snapshot at best. The nightly is this workflow's only
@@ -254,7 +266,8 @@ jobs:
     # twice.
     name: ASan (Windows/clang-cl) build
     needs: detect-changes
-    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+        && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'asan-windows') }}
     # SELF-HOSTED WHEN THE CODE IS OURS AND THE SWITCH IS ON (#1076) -- the same
     # expression, the same kill switch and the same fork boundary as Windows.yml's
     # `build` job, whose comment owns the reasoning. DEFAULT OFF: the variable is
@@ -1129,7 +1142,8 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+        && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'asan-lsan') }}
     # SELF-HOSTED WHEN THE CODE IS OURS, hosted Ubuntu when it is not -- the same
     # expression as vulkan-off.yml, whose comment owns the security reasoning:
     # the fork boundary is `head.repo.full_name`, never a `pull_request_target`
@@ -1573,7 +1587,8 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+        && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'ubsan') }}
     # Routed exactly like asan-lsan-linux -- the reasoning, the security boundary
     # and the `force_hosted` A/B live on that job. Keep the three expressions
     # byte-identical: a job that drifts onto a label set nobody serves does not
@@ -1929,7 +1944,8 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+        && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'tsan') }}
     # 180, not 120, not 90: the same cold-cache loop, measured twice.
     #
     # A cold sccache restore (concurrent runs evict each other under the 10 GB
@@ -2868,7 +2884,28 @@ jobs:
 
     - name: Run tests under TSan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+      # A MEMORY SAMPLER STREAMS BESIDE CTEST, one line per 10 s (#1111). When the
+      # hosted VM is taken down under memory pressure the job ends with
+      # `The runner has received a shutdown signal` and NO `if: always()` step runs
+      # afterwards -- so anything that is going to explain the kill has to be in the
+      # log already. `MEM` lines carry MemAvailable and the three largest resident
+      # processes; the last one before the shutdown is the measurement. On a run
+      # that does not die they are ~90 lines of noise, which is the price.
+      run: |
+        set -uo pipefail
+        (
+          while sleep 10; do
+            printf 'MEM %s avail=%sMiB top:' "$(date -u +%H:%M:%S)" \
+              "$(awk '/MemAvailable/ {printf "%d", $2/1024}' /proc/meminfo)"
+            ps -eo rss=,comm= --sort=-rss | head -3 | awk '{printf " %s=%dMiB", $2, $1/1024}'
+            echo
+          done
+        ) &
+        sampler=$!
+        ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+        rc=$?
+        kill "$sampler" 2>/dev/null || true
+        exit "$rc"
       env:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1371,57 +1371,6 @@ if(OLO_TESTS_CTEST_ARGS)
 	message(STATUS "OloEngine-Tests: ctest will launch every test with: ${OLO_TESTS_CTEST_ARGS}")
 endif()
 
-# UNDER TSAN, THE FUNCTIONAL PHYSICS TESTS RUN ONE AT A TIME (issue #1111).
-#
-# Every fixture in tests/Functional/AnimationPhysics/ drives a real JoltScene
-# through Scene::OnUpdateRuntime -- a height-field or cloth, a job system on the
-# engine's worker pool, and a per-step temp allocator. Under TSan each of those
-# processes carries shadow memory and per-thread history on top, and the hosted
-# CI runner has 16 GB with no swap. Two of them side by side is the whole VM:
-# the runner is killed with `The runner has received a shutdown signal` and no
-# sanitizer output, on every hosted run since 2026-09-06, always with two of
-# these fixtures in flight. The self-hosted box (31 GB) passes the same block.
-#
-# `PROCESSORS 2` says "this test occupies two of ctest's --parallel slots". On
-# the hosted arm (--parallel 2) that is "alone"; on the box (--parallel 4) two
-# may still overlap, which is the scaling the two machines actually have. It is
-# NOT an exclusion: every case still runs, and the property is only applied to
-# the TSan tree -- the ASan tree runs the same block at the same width and
-# fits.
-#
-# THE FIXTURE LIST IS DERIVED, NOT MAINTAINED. Every TEST/TEST_F/TEST_P in that
-# directory is read at configure time and its suite becomes `Suite.*` in the
-# filter, so a new physics fixture is covered by being put in the directory.
-# The two lists this file already keeps by hand (OLO_MESH_CACHE_TESTS above) are
-# small and cross-cutting; this one is 50+ names in one directory, which is a
-# list nobody would keep in sync.
-set(OLO_TSAN_HEAVY_TESTS "")
-if(OLO_ENABLE_TSAN)
-	file(GLOB _olo_physics_sources CONFIGURE_DEPENDS
-		"${CMAKE_CURRENT_SOURCE_DIR}/Functional/AnimationPhysics/*.cpp")
-	set(_olo_physics_fixtures "")
-	foreach(_src IN LISTS _olo_physics_sources)
-		file(STRINGS "${_src}" _lines REGEX "^[ \t]*TEST(_F|_P)?\\([A-Za-z_][A-Za-z0-9_]*,")
-		foreach(_line IN LISTS _lines)
-			string(REGEX REPLACE "^[ \t]*TEST(_F|_P)?\\(([A-Za-z_][A-Za-z0-9_]*),.*$" "\\2" _fixture "${_line}")
-			list(APPEND _olo_physics_fixtures "${_fixture}")
-		endforeach()
-	endforeach()
-	list(REMOVE_DUPLICATES _olo_physics_fixtures)
-	list(SORT _olo_physics_fixtures)
-	list(LENGTH _olo_physics_fixtures _olo_physics_count)
-	if(_olo_physics_count EQUAL 0)
-		# A glob that finds nothing is the property silently no longer applying.
-		message(FATAL_ERROR "OloEngine-Tests: OLO_ENABLE_TSAN is ON but no fixtures were found under tests/Functional/AnimationPhysics/ -- the PROCESSORS guard for #1111 would apply to nothing.")
-	endif()
-	set(_olo_physics_patterns "")
-	foreach(_f IN LISTS _olo_physics_fixtures)
-		list(APPEND _olo_physics_patterns "${_f}.*")
-	endforeach()
-	list(JOIN _olo_physics_patterns ":" OLO_TSAN_HEAVY_TESTS)
-	message(STATUS "OloEngine-Tests: TSan -- ${_olo_physics_count} physics fixtures get PROCESSORS 2 (#1111)")
-endif()
-
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
@@ -1429,26 +1378,10 @@ gtest_discover_tests(OloEngine-Tests
 	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
 	PROPERTIES RESOURCE_LOCK "olo_mesh_cache"
 )
-if(OLO_TSAN_HEAVY_TESTS)
-	gtest_discover_tests(OloEngine-Tests
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
-		DISCOVERY_TIMEOUT 120
-		TEST_FILTER "${OLO_TSAN_HEAVY_TESTS}"
-		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
-		PROPERTIES PROCESSORS 2
-	)
-	gtest_discover_tests(OloEngine-Tests
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
-		DISCOVERY_TIMEOUT 120
-		TEST_FILTER "-${OLO_MESH_CACHE_TESTS}:${OLO_TSAN_HEAVY_TESTS}"
-		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
-	)
-else()
-	gtest_discover_tests(OloEngine-Tests
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
-		DISCOVERY_TIMEOUT 120
-		TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
-		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
-	)
-endif()
+gtest_discover_tests(OloEngine-Tests
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+	DISCOVERY_TIMEOUT 120
+	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
+	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+)
 

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1371,6 +1371,57 @@ if(OLO_TESTS_CTEST_ARGS)
 	message(STATUS "OloEngine-Tests: ctest will launch every test with: ${OLO_TESTS_CTEST_ARGS}")
 endif()
 
+# UNDER TSAN, THE FUNCTIONAL PHYSICS TESTS RUN ONE AT A TIME (issue #1111).
+#
+# Every fixture in tests/Functional/AnimationPhysics/ drives a real JoltScene
+# through Scene::OnUpdateRuntime -- a height-field or cloth, a job system on the
+# engine's worker pool, and a per-step temp allocator. Under TSan each of those
+# processes carries shadow memory and per-thread history on top, and the hosted
+# CI runner has 16 GB with no swap. Two of them side by side is the whole VM:
+# the runner is killed with `The runner has received a shutdown signal` and no
+# sanitizer output, on every hosted run since 2026-09-06, always with two of
+# these fixtures in flight. The self-hosted box (31 GB) passes the same block.
+#
+# `PROCESSORS 2` says "this test occupies two of ctest's --parallel slots". On
+# the hosted arm (--parallel 2) that is "alone"; on the box (--parallel 4) two
+# may still overlap, which is the scaling the two machines actually have. It is
+# NOT an exclusion: every case still runs, and the property is only applied to
+# the TSan tree -- the ASan tree runs the same block at the same width and
+# fits.
+#
+# THE FIXTURE LIST IS DERIVED, NOT MAINTAINED. Every TEST/TEST_F/TEST_P in that
+# directory is read at configure time and its suite becomes `Suite.*` in the
+# filter, so a new physics fixture is covered by being put in the directory.
+# The two lists this file already keeps by hand (OLO_MESH_CACHE_TESTS above) are
+# small and cross-cutting; this one is 50+ names in one directory, which is a
+# list nobody would keep in sync.
+set(OLO_TSAN_HEAVY_TESTS "")
+if(OLO_ENABLE_TSAN)
+	file(GLOB _olo_physics_sources CONFIGURE_DEPENDS
+		"${CMAKE_CURRENT_SOURCE_DIR}/Functional/AnimationPhysics/*.cpp")
+	set(_olo_physics_fixtures "")
+	foreach(_src IN LISTS _olo_physics_sources)
+		file(STRINGS "${_src}" _lines REGEX "^[ \t]*TEST(_F|_P)?\\([A-Za-z_][A-Za-z0-9_]*,")
+		foreach(_line IN LISTS _lines)
+			string(REGEX REPLACE "^[ \t]*TEST(_F|_P)?\\(([A-Za-z_][A-Za-z0-9_]*),.*$" "\\2" _fixture "${_line}")
+			list(APPEND _olo_physics_fixtures "${_fixture}")
+		endforeach()
+	endforeach()
+	list(REMOVE_DUPLICATES _olo_physics_fixtures)
+	list(SORT _olo_physics_fixtures)
+	list(LENGTH _olo_physics_fixtures _olo_physics_count)
+	if(_olo_physics_count EQUAL 0)
+		# A glob that finds nothing is the property silently no longer applying.
+		message(FATAL_ERROR "OloEngine-Tests: OLO_ENABLE_TSAN is ON but no fixtures were found under tests/Functional/AnimationPhysics/ -- the PROCESSORS guard for #1111 would apply to nothing.")
+	endif()
+	set(_olo_physics_patterns "")
+	foreach(_f IN LISTS _olo_physics_fixtures)
+		list(APPEND _olo_physics_patterns "${_f}.*")
+	endforeach()
+	list(JOIN _olo_physics_patterns ":" OLO_TSAN_HEAVY_TESTS)
+	message(STATUS "OloEngine-Tests: TSan -- ${_olo_physics_count} physics fixtures get PROCESSORS 2 (#1111)")
+endif()
+
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
@@ -1378,10 +1429,26 @@ gtest_discover_tests(OloEngine-Tests
 	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
 	PROPERTIES RESOURCE_LOCK "olo_mesh_cache"
 )
-gtest_discover_tests(OloEngine-Tests
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
-	DISCOVERY_TIMEOUT 120
-	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
-	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
-)
+if(OLO_TSAN_HEAVY_TESTS)
+	gtest_discover_tests(OloEngine-Tests
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+		DISCOVERY_TIMEOUT 120
+		TEST_FILTER "${OLO_TSAN_HEAVY_TESTS}"
+		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+		PROPERTIES PROCESSORS 2
+	)
+	gtest_discover_tests(OloEngine-Tests
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+		DISCOVERY_TIMEOUT 120
+		TEST_FILTER "-${OLO_MESH_CACHE_TESTS}:${OLO_TSAN_HEAVY_TESTS}"
+		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+	)
+else()
+	gtest_discover_tests(OloEngine-Tests
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+		DISCOVERY_TIMEOUT 120
+		TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
+		EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+	)
+endif()
 


### PR DESCRIPTION
Every hosted `TSan (Linux/Clang)` run since 2026-09-06 has been killed at the physics tests with `The runner has received a shutdown signal`, exit 143, no sanitizer output. This measures what held the memory, names the symbolizer where the runtime actually reads it, and proves the fix on the same job that was dying.

## What was holding the VM — measured, not inferred

A memory sampler streamed beside the TSan shard's ctest (one `MEM` line per 10 s: MemAvailable plus the three largest resident processes). Last samples before each kill on run [34160911722](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34160911722):

```
MEM 21:17:24 avail=41MiB  top: addr2line=7961MiB addr2line=7181MiB provjobd=61MiB
MEM 21:17:37 avail=86MiB  top: addr2line=7749MiB addr2line=7323MiB provjobd=72MiB
```

The test processes sat at ~0.2 GB throughout. What filled the 16 GB runner was **two `addr2line` processes at 7.2–8.0 GB each** — the sanitizer runtime's fallback symbolizer when `llvm-symbolizer` is not on `PATH`, one per concurrent test, each reading the entire DWARF of a Debug TSan binary. TSan symbolizes during *passing* tests because every suppressed race in `tsan.txt` (Jolt's `JPH::Mutex` bookkeeping) has to be symbolized to be matched — which is why it fires at the physics tests and why the tests themselves are innocent.

The #1095 clang pin took `llvm-symbolizer` off `PATH` (the tarball prefix is deliberately off `PATH`); the apt clang before it had it on. That is the whole "regression". The box survives only because it has 31 GB.

## The fix

`external_symbolizer_path=<resolved llvm-symbolizer>` now leads each of the six `ASAN_OPTIONS` / `UBSAN_OPTIONS` / `TSAN_OPTIONS` lines. #1110 had set `ASAN_SYMBOLIZER_PATH` in these jobs and claimed the TSan runtime reads it — the diagnostic run had that variable set to the right path and still spawned `addr2line`, so that claim was wrong and its comment is corrected here. `external_symbolizer_path` is the common-runtime flag every sanitizer honours. An empty value there *disables* symbolization rather than falling back to `addr2line` — the failure mode wanted: print hex, don't eat the VM.

## Verified on the same job — run [34163128007](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34163128007)

| | before | after |
|---|---|---|
| symbolizer in samples | `addr2line` × 2 | `llvm-symbolizer`, peak **870 MiB** |
| MemAvailable, minimum | **41 MiB** | **13.7 GB** |
| result | killed at 7085–7104, every run | **100 % passed, all four shards, full `--parallel 2`** |
| coverage proof | no shard reports | 4 shards → 7,637 = build total |
| shard wall | killed at 15–18 min | 13–15 min |

## What was tried and rejected — kept in history on purpose

`a723e2767` put `PROCESSORS 2` on the `Functional/AnimationPhysics` fixtures under TSan (one at a time on hosted). Run [34161169105](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34161169105) got past that block and **died at 7269–7275** instead — `WorldOriginRebase*`, `PhysicsTransformReplicationTest`, Jolt users in other directories — with two `addr2line`s again. Serialising by directory moves the kill; it doesn't remove the process that causes it. Worse, three shards ran **4–5 hours** under one `addr2line` and a page-cache-starved VM before dying. Reverted in `26bb3d565` so the real fix was tested alone.

## Also in this PR

- The `MEM` sampler stays on the TSan shard step: `if: always()` steps never run after a shutdown signal, so a VM kill can only ever be explained by what the step log already contains. ~90 lines per green shard.
- `workflow_dispatch` gains `only: [all, asan-lsan, ubsan, tsan, asan-windows]` — a TSan-only iteration is ~20 min and banks one sccache entry on the dispatching ref instead of four. `only` joins `force_hosted` in the concurrency key.

Closes #1111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to manually run all sanitizer checks or select a specific sanitizer.
  * Improved concurrent workflow handling so targeted runs do not cancel full runs.

* **Bug Fixes**
  * Sanitizer tests now use the configured symbolizer for more reliable diagnostics.
  * Added memory usage logging during ThreadSanitizer test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->