### PR TITLE
ops(ci-host): a running job holds a shutdown inhibitor; runner cgroups get a memory ceiling

### DIFF
--- a/docs/ops/self-hosted-host-hygiene.md
+++ b/docs/ops/self-hosted-host-hygiene.md
@@ -101,6 +101,47 @@ The two missing-piece outcomes are NOT the same, which matters when you read a r
   first sanitizer link (`cannot find libclang_rt.asan.a`), so nothing is silently skipped —
   the warning just tells you why, several minutes earlier than the linker would.
 
+## 5. A running job holds a shutdown inhibitor
+
+**Rule: while a job executes on any runner, the host refuses to reboot; override it knowingly
+with `-i`, never by accident.** Section 1 guards one path -- the update timer. On 2026-09-07 at
+06:54 UTC the box was rebooted from a logged-in session under a running sanitizer job, and
+nothing stood in the way; `olo-ci-2` stayed down for the rest of the day.
+
+Two runner hooks, [`scripts/ci-host/job-started.sh`](../../scripts/ci-host/job-started.sh) and
+`job-completed.sh`, take and release a `systemd-inhibit --what=shutdown --mode=block` lock per
+job. `systemctl reboot` / `poweroff` and `shutdown` then refuse with *"Operation inhibited by
+actions-runner olo-ci-1 ..."* and Cockpit shows the same; `systemctl reboot -i` overrides. The
+runner user has no active seat, so a polkit rule grants it `inhibit-block-shutdown`;
+`setup-olo-ci-host.sh` installs the hooks to `/usr/local/lib/olo-ci/`, the rule, and the two
+`ACTIONS_RUNNER_HOOK_JOB_*` lines in each runner's `.env`. A hook never fails a job: a lock it
+cannot take is logged in the job's output and the job runs without it.
+
+Check it during any job: `systemd-inhibit --list` names the runner and the run id. A stale lock
+(runner crashed between hooks) is released by the next job's started hook.
+
+## 6. Runner memory ceilings: a job that runs out fails the job, not the runner
+
+**Rule: every runner unit carries `MemoryMax=` and `OOMPolicy=continue`; a runner cgroup at
+`memory.max=max` is a bug, not a default.** On 2026-09-07 at 09:01 UTC `systemd-oomd` killed
+both CI runner cgroups 16 s apart -- two sanitizer jobs plus the GPU nightly's arm on 31 GiB.
+A whole cgroup goes at once, listener included, and the jobs surface on GitHub as *"The
+self-hosted runner lost communication with the server"* with zero steps run.
+
+With a ceiling, the kernel OOM-kills the largest process *inside* the runner's cgroup first --
+a compiler or a test process, a few GB -- long before slice-wide pressure reaches oomd's
+threshold. `OOMPolicy=continue` keeps the service up when that happens (the default `stop`
+would take the runner down on every in-job OOM, which is the failure being fixed). The job
+fails visibly at the step that ran out. **Not `MemoryHigh`:** throttling works by forcing
+reclaim, reclaim is the pressure oomd measures, so a `MemoryHigh` ceiling makes the oomd kill
+*more* likely.
+
+The default is 14G per runner (`OLO_RUNNER_MEMORY_MAX=` overrides): a 4-wide instrumented
+build is ~12 GB and the sanitizer's symbolizer ~0.9 GB. Two CI runners and the GPU runner at
+14G is 42 GB against 31 GiB -- three peaks at once do not fit, and under that overlap the
+ceiling turns a runner kill into a red job. The script's report prints each runner cgroup's
+`memory.peak` since its last start; revise the default from that number, not from a guess.
+
 ## Root steps, once
 
 ```
@@ -109,8 +150,9 @@ sudo bash scripts/setup-olo-ci-host.sh
 
 Idempotent, and safe to re-run: everything it does is checked first and skipped when already
 in place. It installs the sanitizer runtimes and `lld` for the system clang, the update-timer
-drop-in, the GPU runtime-PM rule and the pinned clang-23 at `/opt/llvm-23.1.0`, then prints the
-resulting state. The compiler step is **last on purpose** -- it is the only one that needs the
+drop-in, the GPU runtime-PM rule, the job-inhibitor hooks and their polkit rule, the runner
+memory ceilings, and the pinned clang-23 at `/opt/llvm-23.1.0`, then prints the resulting
+state -- including whether a job lock is held right now and each runner cgroup's `memory.peak`. The compiler step is **last on purpose** -- it is the only one that needs the
 network and moves gigabytes, and under `set -e` anything after it would be skipped when a
 download fails. Budget ~20 minutes and ~16 GB of free space on the first run; a re-run with the
 prefix already present only re-verifies, which takes seconds.

--- a/scripts/ci-host/job-completed.sh
+++ b/scripts/ci-host/job-completed.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# GitHub Actions runner hook: ACTIONS_RUNNER_HOOK_JOB_COMPLETED.
+#
+# Releases the shutdown inhibitor job-started.sh took for this job. See that
+# file for why the inhibitor exists and where the pid lives.
+#
+# Like the started hook, this must never fail the job: a job whose work is
+# already done must not be reported red because a pid file was missing.
+
+runner="${RUNNER_NAME:-unknown-runner}"
+pidfile="${XDG_RUNTIME_DIR:-/tmp}/olo-runner-inhibit-${runner}.pid"
+
+if [ ! -f "$pidfile" ]; then
+  echo "olo-ci job-completed: no inhibitor was held for this job"
+  exit 0
+fi
+
+pid=$(cat "$pidfile" 2>/dev/null || true)
+rm -f "$pidfile"
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  # systemd-inhibit releases the lock when it exits; SIGTERM ends it and its
+  # `sleep infinity` child together.
+  kill "$pid" 2>/dev/null || true
+  echo "olo-ci job-completed: shutdown inhibitor released (pid ${pid})"
+else
+  echo "olo-ci job-completed: inhibitor pid ${pid:-<none>} was already gone"
+fi
+exit 0

--- a/scripts/ci-host/job-started.sh
+++ b/scripts/ci-host/job-started.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# GitHub Actions runner hook: ACTIONS_RUNNER_HOOK_JOB_STARTED.
+#
+# Holds a systemd shutdown inhibitor for the duration of the job, so that
+# `systemctl reboot` / `poweroff`, `shutdown`, and Cockpit refuse (or warn) while
+# a job is executing on this runner. The self-hosted box was rebooted from a
+# logged-in session at 2026-09-07 06:54 UTC under a running sanitizer job; the
+# only reboot guard at the time was an ExecCondition on the unattended-update
+# service, which a human, Cockpit, or any other path bypasses entirely.
+#
+# Installed to /usr/local/lib/olo-ci/ by scripts/setup-olo-ci-host.sh and pointed
+# at from each runner's .env. The runner runs it with its job environment
+# (RUNNER_NAME, GITHUB_REPOSITORY, GITHUB_RUN_ID, ...) and NO arguments.
+#
+# A JOB_STARTED hook that exits non-zero FAILS THE JOB. Nothing in here may do
+# that: every failure path prints a line and exits 0, because a job that cannot
+# take an inhibitor must still run -- the lock is protection, not a precondition.
+#
+# The lock is a `systemd-inhibit --mode=block` process whose child is
+# `sleep infinity`; killing it releases the lock. Its pid is recorded per runner
+# under XDG_RUNTIME_DIR so the JOB_COMPLETED hook -- and a later JOB_STARTED, if
+# a runner crash skipped the completed hook -- can find it.
+
+runner="${RUNNER_NAME:-unknown-runner}"
+why="GitHub Actions job is executing on ${runner}: ${GITHUB_REPOSITORY:-?} run ${GITHUB_RUN_ID:-?}"
+pidfile="${XDG_RUNTIME_DIR:-/tmp}/olo-runner-inhibit-${runner}.pid"
+
+if ! command -v systemd-inhibit >/dev/null 2>&1; then
+  echo "olo-ci job-started: systemd-inhibit not found; running without a shutdown inhibitor"
+  exit 0
+fi
+
+# A stale lock from a job whose completed hook never ran (runner crash, host
+# reboot mid-job) would hold the box un-rebootable forever. Release it first.
+if [ -f "$pidfile" ]; then
+  old=$(cat "$pidfile" 2>/dev/null || true)
+  if [ -n "$old" ] && kill -0 "$old" 2>/dev/null; then
+    echo "olo-ci job-started: releasing a stale inhibitor (pid ${old}) left by a previous job"
+    kill "$old" 2>/dev/null || true
+  fi
+  rm -f "$pidfile"
+fi
+
+# Probe synchronously before holding one in the background: a runner service
+# user has no active seat, so taking a BLOCK inhibitor needs the polkit rule
+# setup-olo-ci-host.sh installs. If that is missing, the background command
+# would fail after this hook has already returned, silently.
+if ! systemd-inhibit --what=shutdown --mode=block --who="olo-ci probe" --why="probe" true 2>/dev/null; then
+  echo "olo-ci job-started: cannot take a shutdown inhibitor (polkit denies inhibit-block-shutdown for $(id -un)?); running without one"
+  echo "olo-ci job-started: fix with  sudo bash scripts/setup-olo-ci-host.sh  on the host"
+  exit 0
+fi
+
+systemd-inhibit --what=shutdown --mode=block --who="actions-runner ${runner}" --why="${why}" \
+  sleep infinity >/dev/null 2>&1 &
+pid=$!
+echo "$pid" > "$pidfile"
+echo "olo-ci job-started: shutdown inhibitor held (pid ${pid}) -- ${why}"
+exit 0

--- a/scripts/setup-olo-ci-host.sh
+++ b/scripts/setup-olo-ci-host.sh
@@ -55,7 +55,37 @@
 #      minutes cold. Details at the step itself and in
 #      docs/ops/self-hosted-linux-toolchain.md.
 #
+#   5. A running job holds a systemd SHUTDOWN INHIBITOR (steps 3b below).
+#      Item 2 guards one reboot path -- the update timer. The box was rebooted
+#      from a logged-in session at 2026-09-07 06:54 UTC under a running
+#      sanitizer job, and nothing stood in the way. Two runner hooks
+#      (scripts/ci-host/job-started.sh, job-completed.sh) take and release a
+#      `systemd-inhibit --mode=block` lock per job, so `systemctl reboot`,
+#      `shutdown` and Cockpit refuse -- or warn, and need `-i` -- while a job
+#      runs. A service user has no active seat, so a polkit rule grants it
+#      inhibit-block-shutdown. The hooks never fail a job: a lock that cannot
+#      be taken is logged and the job runs without it.
+#
+#   6. RUNNER MEMORY CEILINGS (step 3c). On 2026-09-07 09:01 UTC systemd-oomd
+#      killed both CI runner cgroups 16 s apart under memory pressure -- two
+#      sanitizer jobs and the GPU nightly's arm on 31 GiB -- and the jobs
+#      surfaced as "runner lost communication". The runner units had
+#      memory.max=max: no ceiling, so nothing failed BEFORE the whole slice
+#      was under pressure and oomd picked the largest cgroup, which was a
+#      runner mid-job, listener and all. MemoryMax= per runner unit makes the
+#      kernel OOM-kill the largest process INSIDE that cgroup first -- a
+#      compiler or a test, ~3 GB, not the ~100 MB listener -- and
+#      OOMPolicy=continue keeps the service up when it does. The job fails
+#      visibly at the step that ran out; the runner survives. NOT MemoryHigh:
+#      throttling forces reclaim, reclaim is the pressure oomd measures, so a
+#      MemoryHigh ceiling makes the oomd kill MORE likely.
+#
 # Usage (as root, idempotent):  sudo bash scripts/setup-olo-ci-host.sh
+#
+#   Memory ceilings are overridable per run: OLO_RUNNER_MEMORY_MAX=14G (default)
+#   applies to actions-runner-ci-1/2 and actions-runner-olo alike. The report at
+#   the end prints each runner cgroup's memory.peak since its last start, which
+#   is the number to revise the default from.
 set -euo pipefail
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -133,6 +163,157 @@ if [ "$gpus" -eq 0 ]; then
   echo "no amdgpu PCI device found under /sys/bus/pci/drivers/amdgpu" >&2
   gpu_missing=1
 fi
+
+# --------------------------- 3b. a running job holds a shutdown inhibitor
+runner_user=gh-runner-olo
+runner_home="/home/${runner_user}"
+runner_uid=$(id -u "$runner_user" 2>/dev/null || true)
+if [ -z "$runner_uid" ]; then
+  echo "user ${runner_user} does not exist -- run scripts/setup-olo-ci-runners.sh first" >&2
+  exit 1
+fi
+# systemctl --user for the runner user, from root. The user manager lives under
+# uid 1004's session; without XDG_RUNTIME_DIR the call silently addresses the
+# SYSTEM manager and reports defaults for units that are not there.
+runner_systemctl() { sudo -u "$runner_user" XDG_RUNTIME_DIR="/run/user/${runner_uid}" systemctl --user "$@"; }
+
+hookdir=/usr/local/lib/olo-ci
+script_dir=$(cd "$(dirname "$0")" && pwd)
+install -d -m 0755 "$hookdir"
+hooks_changed=0
+for h in job-started.sh job-completed.sh; do
+  src="${script_dir}/ci-host/${h}"
+  [ -f "$src" ] || { echo "missing ${src} -- run this script from a repository checkout" >&2; exit 1; }
+  if ! cmp -s "$src" "${hookdir}/${h}"; then
+    install -m 0755 "$src" "${hookdir}/${h}"
+    hooks_changed=1
+  fi
+done
+
+# polkit: a service user has no active seat, and inhibit-block-shutdown is
+# auth_admin for inactive subjects by default. polkit reloads rules.d on change.
+rule=/etc/polkit-1/rules.d/50-olo-runner-inhibit.rules
+tmp=$(mktemp)
+cat > "$tmp" <<EOF
+// Let the CI runner user hold a BLOCK shutdown inhibitor for the duration of a
+// job (scripts/ci-host/job-started.sh, installed by setup-olo-ci-host.sh).
+polkit.addRule(function (action, subject) {
+    if (action.id == "org.freedesktop.login1.inhibit-block-shutdown" &&
+        subject.user == "${runner_user}") {
+        return polkit.Result.YES;
+    }
+});
+EOF
+if ! cmp -s "$tmp" "$rule" 2>/dev/null; then
+  install -d -m 0755 "$(dirname "$rule")"
+  install -m 0644 "$tmp" "$rule"
+fi
+rm -f "$tmp"
+
+# Point every runner's .env at the hooks. The runner reads .env once, at start,
+# so a changed .env is picked up at the next restart -- done below for runners
+# that are idle, deferred (and said so) for one with a job in flight.
+declare -A unit_of=()
+env_changed=()
+for dir in "${runner_home}/actions-runner" "${runner_home}"/actions-runner-ci-*; do
+  [ -x "${dir}/run.sh" ] || continue
+  case "$(basename "$dir")" in
+    actions-runner)      unit="actions-runner-olo.service" ;;
+    actions-runner-ci-*) unit="$(basename "$dir").service" ;;
+    *) continue ;;
+  esac
+  unit_of["$dir"]="$unit"
+  envf="${dir}/.env"
+  [ -f "$envf" ] || { install -o "$runner_user" -g "$runner_user" -m 600 /dev/null "$envf"; }
+  changed=0
+  for kv in "ACTIONS_RUNNER_HOOK_JOB_STARTED=${hookdir}/job-started.sh" \
+            "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=${hookdir}/job-completed.sh"; do
+    key=${kv%%=*}
+    if grep -q "^${key}=" "$envf"; then
+      grep -qxF "$kv" "$envf" || { sed -i "s|^${key}=.*|${kv}|" "$envf"; changed=1; }
+    else
+      printf '%s\n' "$kv" >> "$envf"
+      changed=1
+    fi
+  done
+  [ "$changed" -eq 1 ] && env_changed+=("$dir")
+done
+if [ "${#unit_of[@]}" -eq 0 ]; then
+  echo "no runner directories under ${runner_home} -- run scripts/setup-olo-ci-runners.sh first" >&2
+  exit 1
+fi
+for dir in "${env_changed[@]}"; do
+  unit="${unit_of[$dir]}"
+  if pgrep -f "^${dir}/bin/Runner.Worker" >/dev/null; then
+    echo "${unit}: .env updated; a job is executing, so the hooks apply at its next restart"
+  elif runner_systemctl is-active --quiet "$unit"; then
+    runner_systemctl restart "$unit"
+    echo "${unit}: .env updated and the runner restarted (idle)"
+  else
+    echo "${unit}: .env updated; unit is not active, nothing restarted"
+  fi
+done
+echo "job hooks: ${hookdir}/job-{started,completed}.sh, polkit rule ${rule}"
+
+# ------------------------------------------------ 3c. runner memory ceilings
+# One drop-in per runner unit, under /etc/systemd/user so the user manager sees
+# it without touching the runner's home. See item 6 in the header for why
+# MemoryMax + OOMPolicy=continue and not MemoryHigh.
+#
+# 14G: a 4-wide instrumented build is ~12 GB (asan.yml's own arithmetic for the
+# box), and the sanitizer's llvm-symbolizer is ~0.9 GB (#1111). Two CI runners
+# and the GPU runner at 14G is 42 GB against 31 GiB of RAM -- three peaks at
+# once do not fit, and under that overlap the ceiling fails the JOB at the step
+# that ran out instead of killing a runner. The report below prints memory.peak
+# per runner, which is the measurement to revise this from.
+mem_max="${OLO_RUNNER_MEMORY_MAX:-14G}"
+mem_changed=0
+for dir in "${!unit_of[@]}"; do
+  unit="${unit_of[$dir]}"
+  d="/etc/systemd/user/${unit}.d"
+  tmp=$(mktemp)
+  cat > "$tmp" <<EOF
+# Runner memory ceiling (scripts/setup-olo-ci-host.sh, item 6). The kernel
+# OOM-kills the largest process INSIDE this cgroup at the ceiling -- a compiler
+# or a test -- and OOMPolicy=continue keeps the runner service up when it does.
+# Without this, systemd-oomd killed whole runner cgroups under slice-wide
+# pressure (2026-09-07 09:01 UTC) and jobs died as "lost communication".
+[Service]
+MemoryMax=${mem_max}
+OOMPolicy=continue
+ManagedOOMPreference=avoid
+EOF
+  if ! cmp -s "$tmp" "${d}/olo-memory.conf" 2>/dev/null; then
+    install -d -m 0755 "$d"
+    install -m 0644 "$tmp" "${d}/olo-memory.conf"
+    mem_changed=1
+  fi
+  rm -f "$tmp"
+done
+runner_systemctl daemon-reload
+# Apply to the RUNNING units too, without a restart: daemon-reload loads the
+# drop-in for the next start; set-property --runtime pushes the same values
+# into the live cgroup now, so a job already executing is covered.
+for dir in "${!unit_of[@]}"; do
+  unit="${unit_of[$dir]}"
+  runner_systemctl is-active --quiet "$unit" || continue
+  runner_systemctl set-property --runtime "$unit" "MemoryMax=${mem_max}" OOMPolicy=continue ManagedOOMPreference=avoid
+done
+# VERIFY from the cgroup itself, not from systemctl show: the value that
+# matters is the one the kernel enforces.
+for dir in "${!unit_of[@]}"; do
+  unit="${unit_of[$dir]}"
+  cg="/sys/fs/cgroup/user.slice/user-${runner_uid}.slice/user@${runner_uid}.service/app.slice/${unit}"
+  if [ -r "${cg}/memory.max" ]; then
+    [ "$(cat "${cg}/memory.max")" != max ] \
+      || { echo "${unit}: memory.max is still 'max' after the drop-in and set-property; check ${cg}" >&2; exit 1; }
+  else
+    echo "${unit}: cgroup ${cg} not present (unit not running?) -- ceiling applies at its next start"
+  fi
+done
+units_capped=""
+for dir in "${!unit_of[@]}"; do units_capped="${units_capped}${units_capped:+ }${unit_of[$dir]}"; done
+echo "runner memory ceiling: MemoryMax=${mem_max} OOMPolicy=continue on ${units_capped}"
 
 # ----------------------------------- 4. the pinned clang-23 for the CI arm
 # LAST ON PURPOSE: this is the only step that needs the network and the only
@@ -402,6 +583,17 @@ echo "  fallback:  $(command -v clang++) -> $(clang++ --version | head -1)"
 echo "  runtimes:  $(clang++ -print-runtime-dir 2>/dev/null || echo '<unknown>')"
 echo "  timer:     $(systemctl list-timers dnf-automatic-install.timer --no-pager | sed -n 2p)"
 echo "  condition: $(grep ExecCondition "$dropin")"
+echo "  inhibitor: $(systemd-inhibit --list --no-legend 2>/dev/null | grep -c 'actions-runner' | sed 's/^0$/none held (no job executing)/; t; s/$/ job lock(s) held/')"
+for dir in "${!unit_of[@]}"; do
+  unit="${unit_of[$dir]}"
+  cg="/sys/fs/cgroup/user.slice/user-${runner_uid}.slice/user@${runner_uid}.service/app.slice/${unit}"
+  if [ -r "${cg}/memory.max" ]; then
+    printf '  %-32s max=%s current=%sMiB peak=%sMiB\n' "$unit" "$(cat "${cg}/memory.max")" \
+      "$(( $(cat "${cg}/memory.current") / 1048576 ))" "$(( $(cat "${cg}/memory.peak" 2>/dev/null || echo 0) / 1048576 ))"
+  else
+    printf '  %-32s (not running)\n' "$unit"
+  fi
+done
 echo "  gpu:       $(for dev in /sys/bus/pci/drivers/amdgpu/0000:*; do printf '%s control=%s status=%s ' "$(basename "$dev")" "$(cat "$dev/power/control")" "$(cat "$dev/power/runtime_status")"; done)"
 
 # Deferred from step 3 so that a host without the GPU driver loaded still gets


### PR DESCRIPTION
Follow-up to #1114. That PR fixed the one runner death that was ours (the `addr2line` fallback); this closes the two that were the host's, both from 2026-09-07 and both previously unguarded:

| when (UTC) | what happened | guard now |
|---|---|---|
| 06:54 | box rebooted **from a logged-in session** under a running sanitizer job; `olo-ci-2` down for the day | a running job holds a `systemd-inhibit --mode=block` shutdown lock |
| 09:01 | `systemd-oomd` killed **both** CI runner cgroups 16 s apart under memory pressure — two sanitizer jobs + the GPU nightly's arm on 31 GiB — surfacing as *"runner lost communication"*, zero steps | `MemoryMax=14G` + `OOMPolicy=continue` per runner unit |

## Inhibitor — `scripts/ci-host/job-started.sh`, `job-completed.sh`

Runner hooks (`ACTIONS_RUNNER_HOOK_JOB_STARTED` / `_COMPLETED` in each runner's `.env`) take and release a block inhibitor per job. `systemctl reboot` / `poweroff`, `shutdown`, and Cockpit then refuse — or need `-i` — while a job runs. A service user has no active seat, so a polkit rule grants `gh-runner-olo` `inhibit-block-shutdown`.

A hook **never fails a job**: polkit denial, no `systemd-inhibit`, and a stale lock from a crashed job are all handled and logged. All five paths are exercised against a stubbed `systemd-inhibit` (normal, release, stale-release, denied, absent).

## Ceiling — `/etc/systemd/user/<runner>.service.d/olo-memory.conf`

`MemoryMax=14G`, `OOMPolicy=continue`, `ManagedOOMPreference=avoid`, applied live to running units via `set-property --runtime` and **verified from the cgroup's own `memory.max`**, not from `systemctl show`. The kernel OOM-kills the largest process *inside* the runner's cgroup at the ceiling — a compiler or a test — and the service stays up; the job fails visibly at the step that ran out.

Deliberately **not `MemoryHigh`**: throttling forces reclaim, reclaim is the pressure oomd measures, so a `MemoryHigh` ceiling makes the oomd kill *more* likely. And `OOMPolicy=continue` matters as much as the limit: the default `stop` would take the runner down on every in-job OOM, which is the failure being fixed.

14G is a first setting from `asan.yml`'s own arithmetic (a 4-wide instrumented build ≈ 12 GB; the symbolizer ≈ 0.9 GB after #1114). Two CI runners plus the GPU runner at 14G is 42 GB against 31 GiB — three peaks at once still don't fit, and under that overlap the ceiling turns a runner kill into a red job. The script's report prints each runner cgroup's **`memory.peak`**, which is the number to revise the default from. `OLO_RUNNER_MEMORY_MAX=` overrides.

## What is and isn't verified

- Verified here: `bash -n` on all three scripts; the five hook paths against a stub; the one real bug found in the process (an invalid array expansion in the report) fixed and re-run.
- **Not exercised on the box** — there is no sudo from CI by design. To apply and confirm:
  ```
  sudo bash scripts/setup-olo-ci-host.sh          # from a checkout; idempotent
  systemd-inhibit --list                          # during any job: names the runner + run id
  ```
  and the report's last lines show `memory.max` ≠ `max` and a `peak=` per runner unit.

## Checked and left alone

The GPU sanitizer nightly's routing to `olo-ci` is by design and already `max-parallel: 1`, so it holds one PR slot at a time; the `asan.yml` comment about the nightly "owning its runner" refers to the *conformance* nightly on `gpu-amd`. The 03:15 UTC `olo-ci-1` drop today is still undiagnosed (05:15 CEST fits a scheduled reboot; the journal will say) — the inhibitor covers it if it was a reboot, the ceiling if it was oomd.

Docs: `docs/ops/self-hosted-host-hygiene.md` §5–6. Refs #1111, #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
