### PR TITLE
fix(engine): answer the #763 static-init audit, and clear 15 clang-cl warning classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,12 @@ option(OLO_ENABLE_LTO "Enable Link Time Optimization" ON)
 option(OLO_ENABLE_PCH "Enable Precompiled Headers" ON)
 option(OLO_ENABLE_UNITY_BUILD "Enable Unity (Jumbo) Builds for faster compilation" OFF)
 
+# Static-initialisation audit (issue #763). clang-cl only, warnings only, never -Werror.
+# OFF by default: ~220 distinct sites are deliberate process-lifetime singletons, so
+# always-on would be noise rather than signal. See cmake/CommonProperties.cmake and
+# docs/agent-rules/static-initialisation.md.
+option(OLO_WARN_STATIC_INIT "Warn on global constructors / exit-time destructors (clang-cl only)" OFF)
+
 # Asset-import format options (#655). All default ON — importing USD / Alembic / MaterialX works
 # out of the box, matching UE5's USD-by-default posture. Alembic + MaterialX are small static
 # FetchContent builds. OpenUSD is large + install-centric: it is built from source once via

--- a/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
+++ b/OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp
@@ -143,7 +143,15 @@ namespace OloEngine
                     "EditorAssetManager_FileWatcher",
                     [this, currentGeneration]()
                     {
-                        FileWatcherThreadFunction();
+                        // Shutdown() bumps m_FileWatcherGeneration to "invalidate any active
+                        // task", but nothing ever read the captured generation, so that bump
+                        // did nothing and a superseded task still ran the whole watch loop.
+                        // The flag is cleared either way: Shutdown() spin-waits on it, so an
+                        // early return that skipped the store would hang shutdown instead.
+                        if (m_FileWatcherGeneration.load(std::memory_order_acquire) == currentGeneration)
+                        {
+                            FileWatcherThreadFunction();
+                        }
                         m_FileWatcherTaskActive.store(false, std::memory_order_release);
                     },
                     Tasks::ETaskPriority::BackgroundNormal);

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/CompilerCache.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/CompilerCache.cpp
@@ -758,7 +758,7 @@ namespace OloEngine::Audio::SoundGraph
                 file.write(reinterpret_cast<const char*>(bytes), 8);
             };
 
-            auto write_f64 = [&file, &write_u64](f64 value)
+            auto write_f64 = [&write_u64](f64 value)
             {
                 // Reinterpret double as u64 bit pattern, then write in little-endian
                 u64 bits;
@@ -858,7 +858,7 @@ namespace OloEngine::Audio::SoundGraph
                        (static_cast<u64>(bytes[7]) << 56);
             };
 
-            auto read_f64 = [&file, &read_u64]() -> f64
+            auto read_f64 = [&read_u64]() -> f64
             {
                 // Read u64 bit pattern in little-endian, then reinterpret as double
                 u64 bits = read_u64();

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/GraphGeneration.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/GraphGeneration.h
@@ -37,7 +37,7 @@ namespace OloEngine::Audio::SoundGraph
     // pseudo-node; the compiler turns these into the appropriate typed Prototype
     // connection (NodeValue_GraphValue etc.).
     inline constexpr u64 kGraphPseudoNodeIDValue = 0ULL;
-    inline const UUID kGraphPseudoNodeID{ kGraphPseudoNodeIDValue };
+    inline constexpr UUID kGraphPseudoNodeID{ kGraphPseudoNodeIDValue };
 
     /** Compile a SoundGraphAsset's node + connection data into an executable Prototype.
         This is what the editor calls on Save and what Scene::InitAudioRuntime calls

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSerializer.cpp
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSerializer.cpp
@@ -504,7 +504,7 @@ namespace OloEngine::Audio::SoundGraph
     void SoundGraphFactory::ApplyNodeProperties(NodeProcessor* node, const SoundGraphNodeData& nodeData)
     {
         // Apply type-specific properties
-        if (auto wavePlayer = dynamic_cast<WavePlayer*>(node))
+        if (dynamic_cast<WavePlayer*>(node) != nullptr)
         {
             auto it = nodeData.m_Properties.find("WaveAsset");
             if (it != nodeData.m_Properties.end())

--- a/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
+++ b/OloEngine/src/OloEngine/Audio/SoundGraph/SoundGraphSound.h
@@ -366,7 +366,12 @@ namespace OloEngine
                 void SyncSpatialPositionToSource();
 
               private:
-                friend class AudioEngine;
+                // Qualified deliberately: AudioEngine lives in ::OloEngine, not in this
+                // nested namespace. Unqualified, it declares a NEW SoundGraph-local class on
+                // a conforming compiler and only reaches the outer one through an MSVC
+                // extension (-Wmicrosoft-unqualified-friend), so the friendship silently
+                // would not apply off-MSVC.
+                friend class OloEngine::AudioEngine;
                 friend class SourceManager;
 
                 std::function<void()> m_OnPlaybackComplete;

--- a/OloEngine/src/OloEngine/Containers/Array.h
+++ b/OloEngine/src/OloEngine/Containers/Array.h
@@ -360,15 +360,25 @@ namespace OloEngine
          *
          * Uses overload resolution to detect inheritance from TArray.
          */
-        template<typename ElementType, typename AllocatorType>
-        static char (&ResolveIsTArrayPtr(const volatile TArray<ElementType, AllocatorType>*))[2];
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#elif defined(__clang__)
+// Both overloads exist only to be named inside sizeof(): never called, never defined.
+// Every TU therefore reports them as unused, so the guard has to wrap BOTH declarations
+// (the template included) rather than just the varargs one.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-template"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
 #endif
+        template<typename ElementType, typename AllocatorType>
+        static char (&ResolveIsTArrayPtr(const volatile TArray<ElementType, AllocatorType>*))[2];
         static char (&ResolveIsTArrayPtr(...))[1];
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
         /**
@@ -661,7 +671,7 @@ namespace OloEngine
          * Only callable by TOptional. Creates an array in the "unset" state
          * using ArrayMax == -1 as a sentinel value.
          */
-        [[nodiscard]] explicit TArray(FIntrusiveUnsetOptionalState Tag)
+        [[nodiscard]] explicit TArray(FIntrusiveUnsetOptionalState)
             : m_ArrayNum(0), m_ArrayMax(-1)
         {
             // Use ArrayMax == -1 as our intrusive state.
@@ -675,7 +685,7 @@ namespace OloEngine
          *
          * Only used by TOptional to check if the optional is set.
          */
-        [[nodiscard]] bool operator==(FIntrusiveUnsetOptionalState Tag) const
+        [[nodiscard]] bool operator==(FIntrusiveUnsetOptionalState) const
         {
             return m_ArrayMax == -1;
         }

--- a/OloEngine/src/OloEngine/Containers/BitArray.h
+++ b/OloEngine/src/OloEngine/Containers/BitArray.h
@@ -2049,11 +2049,17 @@ namespace OloEngine
         }
         [[nodiscard]] OLO_FINLINE FReverseIterator rend()
         {
-            return FReverseIterator(*this, 0);
+            // INDEX_NONE, not 0: FRelativeBitReference::operator== compares WordIndex and
+            // Mask, never Index, and FRelativeBitReference(0) IS the representation of bit 0.
+            // Passing 0 here would make rend() compare equal to the bit-0 iterator, ending a
+            // reverse loop one bit early. -1 gives (WordIndex -1, Mask 1<<31), which is exactly
+            // what operator++ produces after it steps off bit 0.
+            return FReverseIterator(*this, INDEX_NONE);
         }
         [[nodiscard]] OLO_FINLINE FConstReverseIterator rend() const
         {
-            return FConstReverseIterator(*this, 0);
+            // See the non-const rend() above for why this is INDEX_NONE and not 0.
+            return FConstReverseIterator(*this, INDEX_NONE);
         }
 
         // ========================================================================

--- a/OloEngine/src/OloEngine/Containers/BitArray.h
+++ b/OloEngine/src/OloEngine/Containers/BitArray.h
@@ -1910,7 +1910,7 @@ namespace OloEngine
             }
 
             [[nodiscard]] OLO_FINLINE explicit FReverseIterator(TBitArray& InArray, i32 StartIndex)
-                : FRelativeBitReference(-1), Array(InArray), Index(-1)
+                : FRelativeBitReference(StartIndex), Array(InArray), Index(StartIndex)
             {
             }
 
@@ -1970,7 +1970,7 @@ namespace OloEngine
             }
 
             [[nodiscard]] OLO_FINLINE explicit FConstReverseIterator(const TBitArray& InArray, i32 StartIndex)
-                : FRelativeBitReference(-1), Array(InArray), Index(-1)
+                : FRelativeBitReference(StartIndex), Array(InArray), Index(StartIndex)
             {
             }
 

--- a/OloEngine/src/OloEngine/Containers/CompactSet.h
+++ b/OloEngine/src/OloEngine/Containers/CompactSet.h
@@ -831,7 +831,7 @@ namespace OloEngine
             const FConstCompactHashTableView HashTable = GetConstHashTableView();
 
             for (u32 Index = HashTable.GetFirst(KeyHash);
-                 Index != INDEX_NONE;
+                 Index != static_cast<u32>(INDEX_NONE);
                  Index = HashTable.GetNext(Index, this->NumElements))
             {
                 if (KeyFuncs::Matches(KeyFuncs::GetSetKey(GetData()[Index]), Key))
@@ -1535,7 +1535,7 @@ namespace OloEngine
             const ElementType* Data = GetData();
 
             for (u32 Index = HashTable.GetFirst(KeyHash);
-                 Index != INDEX_NONE;
+                 Index != static_cast<u32>(INDEX_NONE);
                  Index = HashTable.GetNext(Index, this->NumElements))
             {
                 if (KeyFuncs::Matches(KeyFuncs::GetSetKey(Data[Index]), Key))
@@ -1572,7 +1572,7 @@ namespace OloEngine
                 const FConstCompactHashTableView HashTable = GetConstHashTableView();
 
                 for (u32 Index = HashTable.GetFirst(KeyHash);
-                     Index != INDEX_NONE;
+                     Index != static_cast<u32>(INDEX_NONE);
                      Index = HashTable.GetNext(Index, this->NumElements))
                 {
                     // Skip the element we just added
@@ -1795,7 +1795,7 @@ namespace OloEngine
         }
 
         template<typename ElementType, typename KeyFuncs, typename Allocator>
-        u32 IntrinsicAppendHash(const TCompactSet<ElementType, KeyFuncs, Allocator>* DummyObject,
+        u32 IntrinsicAppendHash(const TCompactSet<ElementType, KeyFuncs, Allocator>*,
                                 const FTypeLayoutDesc& TypeDesc,
                                 const FPlatformTypeLayoutParameters& LayoutParams,
                                 FSHA1& Hasher)

--- a/OloEngine/src/OloEngine/Containers/CompactSetBase.h
+++ b/OloEngine/src/OloEngine/Containers/CompactSetBase.h
@@ -54,7 +54,7 @@ namespace OloEngine
         /**
          * @brief Check if set is in unset optional state
          */
-        [[nodiscard]] bool operator==(FIntrusiveUnsetOptionalState Tag) const
+        [[nodiscard]] bool operator==(FIntrusiveUnsetOptionalState) const
         {
             return MaxElements == INDEX_NONE;
         }
@@ -129,7 +129,7 @@ namespace OloEngine
         /**
          * @brief Constructor for intrusive optional unset state
          */
-        [[nodiscard]] explicit TCompactSetBase(FIntrusiveUnsetOptionalState Tag)
+        [[nodiscard]] explicit TCompactSetBase(FIntrusiveUnsetOptionalState)
             : NumElements(0), MaxElements(INDEX_NONE)
         {
         }

--- a/OloEngine/src/OloEngine/Containers/Map.h
+++ b/OloEngine/src/OloEngine/Containers/Map.h
@@ -2123,7 +2123,7 @@ namespace OloEngine
         }
 
         template<typename KeyType, typename ValueType, typename SetAllocator, typename KeyFuncs>
-        u32 IntrinsicAppendHash(const TMap<KeyType, ValueType, SetAllocator, KeyFuncs>* DummyObject, const FTypeLayoutDesc& TypeDesc, const FPlatformTypeLayoutParameters& LayoutParams, FSHA1& Hasher)
+        u32 IntrinsicAppendHash(const TMap<KeyType, ValueType, SetAllocator, KeyFuncs>*, const FTypeLayoutDesc& TypeDesc, const FPlatformTypeLayoutParameters& LayoutParams, FSHA1& Hasher)
         {
             TMap<KeyType, ValueType, SetAllocator, KeyFuncs>::AppendHash(LayoutParams, Hasher);
             return DefaultAppendHash(TypeDesc, LayoutParams, Hasher);
@@ -2143,7 +2143,7 @@ namespace OloEngine
         }
 
         template<typename KeyType, typename ValueType, typename SetAllocator, typename KeyFuncs>
-        u32 IntrinsicAppendHash(const TMultiMap<KeyType, ValueType, SetAllocator, KeyFuncs>* DummyObject, const FTypeLayoutDesc& TypeDesc, const FPlatformTypeLayoutParameters& LayoutParams, FSHA1& Hasher)
+        u32 IntrinsicAppendHash(const TMultiMap<KeyType, ValueType, SetAllocator, KeyFuncs>*, const FTypeLayoutDesc& TypeDesc, const FPlatformTypeLayoutParameters& LayoutParams, FSHA1& Hasher)
         {
             TMultiMap<KeyType, ValueType, SetAllocator, KeyFuncs>::AppendHash(LayoutParams, Hasher);
             return DefaultAppendHash(TypeDesc, LayoutParams, Hasher);

--- a/OloEngine/src/OloEngine/Core/DebugLevers.cpp
+++ b/OloEngine/src/OloEngine/Core/DebugLevers.cpp
@@ -140,16 +140,16 @@ namespace OloEngine::Levers
         // All four are constant-initialized, so there is no static-init order
         // question between them and no lever can be read before its storage
         // exists.
-        Storage s_Values;
-        Overridden s_Overridden;
-        Handles s_Handles;
-        std::once_flag s_SeedOnce;
+        constinit Storage s_Values;
+        constinit Overridden s_Overridden;
+        constinit Handles s_Handles;
+        constinit std::once_flag s_SeedOnce;
 
         // Seeding is LAZY — first access — which can be arbitrarily early,
         // possibly before Log::Initialize(). So a malformed value is recorded
         // here and reported by LogActive() once the logger is definitely up,
         // rather than logged from inside the seed.
-        std::vector<std::string> s_SeedWarnings;
+        constinit std::vector<std::string> s_SeedWarnings;
 
         // "0"/"false" off, "1"/"true" on, anything else leaves the caller's own
         // computed default alone. Deliberately NOT Env::IsTruthy: for these the

--- a/OloEngine/src/OloEngine/Core/InputActionManager.cpp
+++ b/OloEngine/src/OloEngine/Core/InputActionManager.cpp
@@ -400,7 +400,7 @@ namespace OloEngine
     bool InputActionManager::IsActionJustReleased(std::string_view actionName)
     {
         auto currentIt = s_CurrentState.find(actionName);
-        if (bool currentlyPressed = (currentIt != s_CurrentState.end()) && currentIt->second)
+        if ((currentIt != s_CurrentState.end()) && currentIt->second)
         {
             return false;
         }

--- a/OloEngine/src/OloEngine/Core/UUID.cpp
+++ b/OloEngine/src/OloEngine/Core/UUID.cpp
@@ -13,9 +13,4 @@ namespace OloEngine
         : m_UUID(s_UniformDistribution(s_Engine))
     {
     }
-
-    UUID::UUID(const u64 uuid)
-        : m_UUID(uuid)
-    {
-    }
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Core/UUID.h
+++ b/OloEngine/src/OloEngine/Core/UUID.h
@@ -8,7 +8,13 @@ namespace OloEngine
     {
       public:
         UUID();
-        explicit(false) UUID(u64 uuid);
+        // constexpr and defined inline so a UUID constant can be constant-initialised
+        // rather than needing a global constructor (issue #763). The default ctor stays
+        // out of line: it needs real OS entropy and cannot be constexpr.
+        explicit(false) constexpr UUID(u64 uuid)
+            : m_UUID(uuid)
+        {
+        }
         UUID(const UUID&) = default;
 
         operator u64()

--- a/OloEngine/src/OloEngine/HAL/LowLevelMemTracker.cpp
+++ b/OloEngine/src/OloEngine/HAL/LowLevelMemTracker.cpp
@@ -316,20 +316,19 @@ namespace OloEngine
 
     i64 FLowLevelMemTracker::GetTagSize(ELLMTag Tag) const
     {
-        if (u8 Index = static_cast<u8>(std::to_underlying(Tag)); Index < LLM_TAG_COUNT)
-        {
-            return m_TagData[Index].CurrentSize.load(std::memory_order_relaxed);
-        }
-        return 0;
+        // A u8 index cannot leave the table: the bound is the whole u8 range, so the old
+        // `Index < LLM_TAG_COUNT` test was always true. The static_assert keeps that an
+        // enforced property rather than a silent assumption if the count ever shrinks.
+        static_assert(LLM_TAG_COUNT == 256, "a u8 tag index is only in range by construction while the table spans the full u8 range");
+        const u8 Index = static_cast<u8>(std::to_underlying(Tag));
+        return m_TagData[Index].CurrentSize.load(std::memory_order_relaxed);
     }
 
     i64 FLowLevelMemTracker::GetTagPeakSize(ELLMTag Tag) const
     {
-        if (u8 Index = static_cast<u8>(std::to_underlying(Tag)); Index < LLM_TAG_COUNT)
-        {
-            return m_TagData[Index].PeakSize.load(std::memory_order_relaxed);
-        }
-        return 0;
+        static_assert(LLM_TAG_COUNT == 256, "a u8 tag index is only in range by construction while the table spans the full u8 range");
+        const u8 Index = static_cast<u8>(std::to_underlying(Tag));
+        return m_TagData[Index].PeakSize.load(std::memory_order_relaxed);
     }
 
     void FLowLevelMemTracker::GetAllTagSizes(i64* OutSizes, u32 MaxTags) const

--- a/OloEngine/src/OloEngine/HAL/ThreadManager.h
+++ b/OloEngine/src/OloEngine/HAL/ThreadManager.h
@@ -177,7 +177,10 @@ namespace OloEngine
         bool m_IsThreadListDirty = false;
 
         /** Static empty string for unknown threads */
-        inline static std::string s_UnknownThreadName = "UnknownThread";
+        // const, and short enough for the SSO buffer, so it is constant-initialised:
+        // no global constructor and no exit-time destructor (issue #763). It is only
+        // ever returned by reference, never written.
+        inline static const std::string s_UnknownThreadName = "UnknownThread";
     };
 
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -165,8 +165,10 @@ namespace OloEngine
         // Remove cloth soft bodies while m_JoltSystem is still alive.
         DestroyAllClothBodies();
 
-        // Destroy all bodies. clear() runs each Body destructor, which does the Jolt
-        // cleanup; the empty range-for that used to sit here did nothing at all.
+        // Release all bodies. clear() drops this container's Ref to each JoltBody, which
+        // destroys it (and runs the Jolt cleanup) as long as nothing else still holds one;
+        // every other holder is a short-lived local. The empty range-for that used to sit
+        // here did nothing at all -- it was never what performed the cleanup.
         m_Bodies.clear();
         m_BodyIDToEntity.clear(); // Clear reverse lookup map
         m_BodiesToSync.clear();

--- a/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/JoltScene.cpp
@@ -165,20 +165,13 @@ namespace OloEngine
         // Remove cloth soft bodies while m_JoltSystem is still alive.
         DestroyAllClothBodies();
 
-        // Destroy all bodies
-        for (const auto& [entityID, body] : m_Bodies)
-        {
-            // Body destructor will handle Jolt cleanup
-        }
+        // Destroy all bodies. clear() runs each Body destructor, which does the Jolt
+        // cleanup; the empty range-for that used to sit here did nothing at all.
         m_Bodies.clear();
         m_BodyIDToEntity.clear(); // Clear reverse lookup map
         m_BodiesToSync.clear();
 
-        // Destroy all character controllers
-        for (const auto& [entityID, characterController] : m_CharacterControllers)
-        {
-            // Character controller destructor will handle Jolt cleanup
-        }
+        // Same here: clear() is what runs the character-controller destructors.
         m_CharacterControllers.clear();
         m_CharacterControllersToUpdate.clear();
 

--- a/OloEngine/src/OloEngine/Physics3D/MeshColliderCache.cpp
+++ b/OloEngine/src/OloEngine/Physics3D/MeshColliderCache.cpp
@@ -432,7 +432,10 @@ namespace OloEngine
         auto now = std::chrono::system_clock::now();
         auto entryAge = std::chrono::duration_cast<std::chrono::milliseconds>(now - data.m_LastAccessed);
 
-        return entryAge.count() > s_MinCacheEntryLifetimeMs;
+        // Signed comparison on purpose. system_clock is not monotonic, so a backwards clock
+        // step makes entryAge NEGATIVE; against an unsigned sizet that converted to a huge
+        // value and reported every fresh entry as evictable.
+        return entryAge.count() > static_cast<i64>(s_MinCacheEntryLifetimeMs);
     }
 
     sizet MeshColliderCache::CalculateDataSize(const CachedColliderData& data) const

--- a/OloEngine/src/OloEngine/Physics3D/SceneQueries.h
+++ b/OloEngine/src/OloEngine/Physics3D/SceneQueries.h
@@ -100,7 +100,7 @@ namespace OloEngine
       protected:
         // Protected constructor for derived classes to initialize all common parameters
         ShapeCastInfo(ShapeCastType castType, const glm::vec3& origin, const glm::vec3& direction, f32 maxDistance)
-            : m_Type(castType), m_Origin(origin), m_Direction(direction), m_MaxDistance(maxDistance) {}
+            : m_Origin(origin), m_Direction(direction), m_MaxDistance(maxDistance), m_Type(castType) {}
 
       private:
         ShapeCastType m_Type;
@@ -167,7 +167,7 @@ namespace OloEngine
         }
 
       protected:
-        ShapeOverlapInfo(ShapeCastType castType, const glm::vec3& origin) : m_Type(castType), m_Origin(origin) {}
+        ShapeOverlapInfo(ShapeCastType castType, const glm::vec3& origin) : m_Origin(origin), m_Type(castType) {}
 
       private:
         ShapeCastType m_Type;

--- a/OloEngine/src/OloEngine/Renderer/BoundingVolume.h
+++ b/OloEngine/src/OloEngine/Renderer/BoundingVolume.h
@@ -16,7 +16,7 @@ namespace OloEngine
 
         BoundingBox() = default;
 
-        BoundingBox(const glm::vec3& min, const glm::vec3& max)
+        constexpr BoundingBox(const glm::vec3& min, const glm::vec3& max)
             : Min(min), Max(max) {}
 
         // Create a bounding box from an array of points
@@ -92,7 +92,7 @@ namespace OloEngine
     };
 
     // Sentinel value: WorldBounds.Min == FLT_MAX means "no bounds — include in every view".
-    inline const BoundingBox NoBounds{
+    inline constexpr BoundingBox NoBounds{
         glm::vec3(std::numeric_limits<f32>::max()),
         glm::vec3(-std::numeric_limits<f32>::max())
     };

--- a/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
+++ b/OloEngine/src/OloEngine/Renderer/Camera/EditorCamera.h
@@ -126,7 +126,7 @@ namespace OloEngine
         {
             return m_Projection * m_ViewMatrix;
         }
-        [[nodiscard("Store this!")]] const f32 GetDistance() const
+        [[nodiscard("Store this!")]] f32 GetDistance() const
         {
             return m_Distance;
         }
@@ -134,11 +134,11 @@ namespace OloEngine
         {
             return m_Position;
         }
-        [[nodiscard("Store this!")]] const f32 GetPitch() const
+        [[nodiscard("Store this!")]] f32 GetPitch() const
         {
             return m_Pitch;
         }
-        [[nodiscard("Store this!")]] const f32 GetYaw() const
+        [[nodiscard("Store this!")]] f32 GetYaw() const
         {
             return m_Yaw;
         }

--- a/OloEngine/src/OloEngine/Renderer/Material.h
+++ b/OloEngine/src/OloEngine/Renderer/Material.h
@@ -70,11 +70,15 @@ namespace OloEngine
         // Assignment operator for value semantics
         Material& operator=(const Material& other);
 
-        // Move constructor for efficient transfers
-        Material(Material&& other) = default;
-
-        // Move assignment operator for efficient transfers
-        Material& operator=(Material&& other) = default;
+        // No move operations, deliberately. The RendererResource base has a deleted move
+        // constructor, so `Material(Material&&) = default;` was defined as deleted and the
+        // "efficient transfers" the old comment promised never existed: a defaulted-as-deleted
+        // move is IGNORED by overload resolution, so every std::move(Material) already bound
+        // to the copy constructor above. Declaring them `= delete` instead would change that
+        // -- an explicit delete does participate, turning those calls into hard errors.
+        // Leaving them undeclared keeps the copy fallback and drops the misleading
+        // -Wdefaulted-function-deleted. Making Material movable means making
+        // RendererResource movable first.
 
         static Ref<Material> Create(const Ref<OloEngine::Shader>& shader, const std::string& name = "");
         static Ref<Material> Copy(const Ref<Material>& other, const std::string& name = "");

--- a/OloEngine/src/OloEngine/Renderer/MaterialAsset.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MaterialAsset.cpp
@@ -7,17 +7,21 @@
 namespace OloEngine
 {
 
-    static const std::string s_AlbedoColorUniform = "u_MaterialUniforms.AlbedoColor";
-    static const std::string s_UseNormalMapUniform = "u_MaterialUniforms.UseNormalMap";
-    static const std::string s_MetalnessUniform = "u_MaterialUniforms.Metalness";
-    static const std::string s_RoughnessUniform = "u_MaterialUniforms.Roughness";
-    static const std::string s_EmissionUniform = "u_MaterialUniforms.Emission";
-    static const std::string s_TransparencyUniform = "u_MaterialUniforms.Transparency";
+    // Uniform names are compile-time literals; `const char*` keeps them constant-initialised
+    // so they cost no global constructor and no exit-time destructor (issue #763).
+    // Not `std::string_view`: every consumer below takes `const std::string&`, and
+    // std::string's converting constructor from a string_view is explicit.
+    constexpr const char* s_AlbedoColorUniform = "u_MaterialUniforms.AlbedoColor";
+    constexpr const char* s_UseNormalMapUniform = "u_MaterialUniforms.UseNormalMap";
+    constexpr const char* s_MetalnessUniform = "u_MaterialUniforms.Metalness";
+    constexpr const char* s_RoughnessUniform = "u_MaterialUniforms.Roughness";
+    constexpr const char* s_EmissionUniform = "u_MaterialUniforms.Emission";
+    constexpr const char* s_TransparencyUniform = "u_MaterialUniforms.Transparency";
 
-    static const std::string s_AlbedoMapUniform = "u_AlbedoTexture";
-    static const std::string s_NormalMapUniform = "u_NormalTexture";
-    static const std::string s_MetalnessMapUniform = "u_MetalnessTexture";
-    static const std::string s_RoughnessMapUniform = "u_RoughnessTexture";
+    constexpr const char* s_AlbedoMapUniform = "u_AlbedoTexture";
+    constexpr const char* s_NormalMapUniform = "u_NormalTexture";
+    constexpr const char* s_MetalnessMapUniform = "u_MetalnessTexture";
+    constexpr const char* s_RoughnessMapUniform = "u_RoughnessTexture";
 
     MaterialAsset::MaterialAsset(bool transparent)
         : m_Transparent(transparent)

--- a/OloEngine/src/OloEngine/Renderer/MaterialAsset.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MaterialAsset.cpp
@@ -11,6 +11,14 @@ namespace OloEngine
     // so they cost no global constructor and no exit-time destructor (issue #763).
     // Not `std::string_view`: every consumer below takes `const std::string&`, and
     // std::string's converting constructor from a string_view is explicit.
+    //
+    // The trade this makes, stated plainly: each accessor call now builds a std::string
+    // temporary, and these names are 25-31 characters so they miss MSVC's 15-char SSO
+    // buffer and heap-allocate. Accepted because every caller is cold -- asset
+    // (de)serialization, PlaceholderAsset setup, preview-thumbnail rendering, no
+    // per-frame path -- and each of those calls already allocates anyway, converting the
+    // key to the FString that Material's uniform TMaps are keyed on. If a hot caller
+    // ever appears, give Material std::string_view overloads rather than reverting this.
     constexpr const char* s_AlbedoColorUniform = "u_MaterialUniforms.AlbedoColor";
     constexpr const char* s_UseNormalMapUniform = "u_MaterialUniforms.UseNormalMap";
     constexpr const char* s_MetalnessUniform = "u_MaterialUniforms.Metalness";

--- a/OloEngine/src/OloEngine/Renderer/Passes/DeferredLightingPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/DeferredLightingPass.cpp
@@ -51,7 +51,7 @@ namespace OloEngine
             return;
 
         m_UseMSAAShading = m_PerSampleLighting && m_GBuffer->GetSampleCount() > 1u && static_cast<bool>(m_ShaderMSAA);
-        if (const bool useMSAAShading = m_UseMSAAShading)
+        if (m_UseMSAAShading)
         {
             m_SelectedInputs.GBufferAlbedo = blackboard.GBuffer.GBufferAlbedoMS;
             m_SelectedInputs.GBufferNormal = blackboard.GBuffer.GBufferNormalMS;

--- a/OloEngine/src/OloEngine/Renderer/Passes/PlanarReflectionRenderPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Passes/PlanarReflectionRenderPass.cpp
@@ -103,7 +103,7 @@ namespace OloEngine
         }
     }
 
-    void PlanarReflectionRenderPass::Execute(RGCommandContext& context)
+    void PlanarReflectionRenderPass::Execute([[maybe_unused]] RGCommandContext& context)
     {
         OLO_PROFILE_FUNCTION();
 

--- a/OloEngine/src/OloEngine/Renderer/RGBuilder.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RGBuilder.cpp
@@ -94,8 +94,6 @@ namespace OloEngine
     void RGBuilder::RecordRead(std::string_view resourceName, const RGReadUsage usage, const RGSubresourceRange& range)
     {
         // Defensive: validate the builder references are sane
-        OLO_CORE_ASSERT(&m_Graph != nullptr, "RGBuilder::RecordRead: m_Graph reference is null");
-        OLO_CORE_ASSERT(&m_Blackboard != nullptr, "RGBuilder::RecordRead: m_Blackboard reference is null");
 
         if (resourceName.empty())
             return;
@@ -115,8 +113,6 @@ namespace OloEngine
     void RGBuilder::RecordWrite(std::string_view resourceName, const RGWriteUsage usage, const RGSubresourceRange& range)
     {
         // Defensive: validate the builder references are sane
-        OLO_CORE_ASSERT(&m_Graph != nullptr, "RGBuilder::RecordWrite: m_Graph reference is null");
-        OLO_CORE_ASSERT(&m_Blackboard != nullptr, "RGBuilder::RecordWrite: m_Blackboard reference is null");
 
         if (resourceName.empty())
             return;

--- a/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraphHandleAllocator.h
@@ -74,8 +74,6 @@ namespace OloEngine::RenderGraphHandleAllocator
                   std::vector<u32>& freeIndices,
                   MakeHandleFn makeHandle)
     {
-        // HandleT is deduced from the lambda's return type.
-        using HandleT = std::invoke_result_t<MakeHandleFn, u32, u32>;
         const auto ensurePhysicalCapacity = [&physicals](const u32 index)
         {
             if (index >= physicals.size())

--- a/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
+++ b/OloEngine/src/OloEngine/Renderer/RendererAPI.cpp
@@ -7,7 +7,13 @@
 
 namespace OloEngine
 {
-    RendererAPI::API RendererAPI::s_API = RendererAPI::API::OpenGL;
+    // constinit is load-bearing, not decoration: RenderCommand.cpp's namespace-scope
+    // `s_RendererAPI = RendererAPI::Create()` reads s_API from ANOTHER TU during static
+    // initialisation. That read is only well-defined because s_API is constant-initialised
+    // and therefore already has its value before any dynamic initialiser runs. Giving s_API
+    // a dynamic initialiser would turn that into an unordered cross-TU read -- the Tracy /
+    // entt failure shape (issue #763). This annotation makes the compiler enforce it.
+    constinit RendererAPI::API RendererAPI::s_API = RendererAPI::API::OpenGL;
 
     void RendererAPI::BindTexture(u32 slot, RHI::ResourceHandle texture, const RHI::SamplerDesc& /*sampler*/)
     {

--- a/OloEngine/src/OloEngine/Renderer/ShaderGraph/ShaderGraphCompiler.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderGraph/ShaderGraphCompiler.cpp
@@ -123,7 +123,7 @@ namespace OloEngine
             return ResolveInputExpression(graph, *pin, pinVarNames);
         };
 
-        auto emitOutputVar = [this, &node, &code, &pinVarNames](const std::string& pinName, ShaderGraphPinType type, const std::string& expr)
+        auto emitOutputVar = [&node, &code, &pinVarNames](const std::string& pinName, ShaderGraphPinType type, const std::string& expr)
         {
             const auto* pin = node.FindPinByName(pinName, ShaderGraphPinDirection::Output);
             if (!pin)
@@ -274,7 +274,7 @@ namespace OloEngine
 
             // If the Texture input is unconnected, tex resolves to a non-sampler fallback — emit zero
             const auto* texPin = node.FindPinByName("Texture", ShaderGraphPinDirection::Input);
-            if (bool texConnected = texPin && graph.GetLinkForInputPin(texPin->ID))
+            if (texPin != nullptr && graph.GetLinkForInputPin(texPin->ID))
                 code << "    vec4 " << sampleVar << " = texture(" << tex << ", " << uv << ");\n";
             else
                 code << "    vec4 " << sampleVar << " = vec4(0.0);\n";
@@ -301,7 +301,7 @@ namespace OloEngine
             std::string var = MakeVarName(node, *node.FindPinByName("Normal", ShaderGraphPinDirection::Output));
 
             const auto* texPin = node.FindPinByName("Texture", ShaderGraphPinDirection::Input);
-            if (bool texConnected = texPin && graph.GetLinkForInputPin(texPin->ID))
+            if (texPin != nullptr && graph.GetLinkForInputPin(texPin->ID))
             {
                 code << "    vec3 " << var << " = normalize(texture(" << tex << ", " << uv << ").rgb * 2.0 - 1.0);\n";
                 code << "    " << var << ".xy *= " << strength << ";\n";

--- a/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderPack.cpp
@@ -33,24 +33,6 @@ namespace OloEngine
             }
         }
 
-        constexpr unsigned int U8ToStage(u8 packed)
-        {
-            switch (packed)
-            {
-                case 1:
-                    return 0x8B31; // GL_VERTEX_SHADER
-                case 2:
-                    return 0x8B30; // GL_FRAGMENT_SHADER
-                case 3:
-                    return 0x8E88; // GL_TESS_CONTROL_SHADER
-                case 4:
-                    return 0x8E87; // GL_TESS_EVALUATION_SHADER
-                case 5:
-                    return 0x91B9; // GL_COMPUTE_SHADER
-                default:
-                    return 0;
-            }
-        }
     } // namespace
 
     // =========================================================================
@@ -78,39 +60,6 @@ namespace OloEngine
         bool ReadRaw(std::ifstream& in, T& value)
         {
             in.read(reinterpret_cast<char*>(&value), sizeof(T));
-            return in.good();
-        }
-
-        void WriteU32Array(std::ofstream& out, const std::vector<u32>& data)
-        {
-            u64 count = data.size();
-            WriteRaw(out, count);
-            if (count > 0)
-            {
-                out.write(reinterpret_cast<const char*>(data.data()),
-                          static_cast<std::streamsize>(count * sizeof(u32)));
-            }
-        }
-
-        bool ReadU32Array(std::ifstream& in, std::vector<u32>& data)
-        {
-            u64 count = 0;
-            if (!ReadRaw(in, count))
-            {
-                return false;
-            }
-            // Sanity check: reject absurdly large arrays
-            constexpr u64 maxWords = 64 * 1024 * 1024; // 256 MB of SPIR-V
-            if (count > maxWords)
-            {
-                return false;
-            }
-            data.resize(static_cast<size_t>(count));
-            if (count > 0)
-            {
-                in.read(reinterpret_cast<char*>(data.data()),
-                        static_cast<std::streamsize>(count * sizeof(u32)));
-            }
             return in.good();
         }
 

--- a/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
+++ b/OloEngine/src/OloEngine/Renderer/VirtualGeometry/VirtualGeometryPass.cpp
@@ -404,7 +404,7 @@ namespace OloEngine
         // slot 0 still holds the last albedo it bound — and then SKIP the real bind for any
         // material whose albedo has that same GL ID, leaving the HZB depth pyramid live in
         // u_AlbedoMap. Tell the cache the slot is dirty so the next material bind is real.
-        const auto bindOcclusionInputs = [this, &cullParams](const GPUFrustumCuller::HZBOcclusionInputs& hzb)
+        const auto bindOcclusionInputs = [&cullParams](const GPUFrustumCuller::HZBOcclusionInputs& hzb)
         {
             cullParams.OcclusionEnabled = hzb.IsUsable() ? 1 : 0;
             if (!hzb.IsUsable())

--- a/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
+++ b/OloEngine/src/OloEngine/Renderer/WaterSurface.cpp
@@ -23,7 +23,6 @@ namespace OloEngine::WaterSurface
     {
         constexpr f32 kPi = 3.14159265f;
         constexpr f32 kTwoPi = 2.0f * kPi;
-        constexpr f32 kGravity = 9.81f;        // dispersion relation constant (matches gerstnerWave)
         constexpr f32 kGoldenAngle = 2.39996f; // pi * (3 - sqrt(5))
 
         [[nodiscard]] f32 Fract(f32 x)

--- a/OloEngine/src/OloEngine/Scene/Components.h
+++ b/OloEngine/src/OloEngine/Scene/Components.h
@@ -2497,7 +2497,18 @@ namespace OloEngine
         AudioListenerComponent() = default;
         AudioListenerComponent(const AudioListenerComponent&) = default;
 
-        auto operator==(const AudioListenerComponent&) const -> bool = default;
+        // Equality for undo/redo -- compares serialized/editor-visible fields only.
+        // This was `= default`, which AudioListenerConfig (three bare floats, no
+        // operator==) silently made a DELETED function, dropping the component to
+        // SceneHierarchyPanel::DrawComponent's "no undo" tier: edits to a listener were
+        // not undoable and nothing said so. Ref<AudioListener> is runtime state
+        // (OLO_SERIALIZE(Skip)) and stays out of the comparison, per
+        // cpp-coding-quality.md section 7; Config goes through Math::BitwiseEqual because
+        // it is float-valued and this is bit-exact change detection, not tolerance.
+        auto operator==(const AudioListenerComponent& other) const -> bool
+        {
+            return Active == other.Active && Math::BitwiseEqual(Config, other.Config);
+        }
     };
 
     // Plays a sound graph (.olosoundgraph) asset on an entity. Mirrors the AudioSourceComponent

--- a/OloEngine/src/OloEngine/Scene/Scene.cpp
+++ b/OloEngine/src/OloEngine/Scene/Scene.cpp
@@ -7298,7 +7298,7 @@ namespace OloEngine
 
     void Scene::ProcessScene3DSharedLogic(const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix,
                                           const glm::vec3& cameraPosition,
-                                          f32 cameraNearClip, f32 cameraFarClip)
+                                          [[maybe_unused]] f32 cameraNearClip, [[maybe_unused]] f32 cameraFarClip)
     {
         OLO_PROFILE_FUNCTION();
 

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -78,7 +78,7 @@ namespace OloEngine
     // seeds the version field, no schema has changed yet -- but this is
     // where a future breaking change adds a Migrate_VN_to_VNplus1(node) step
     // and a matching `case N:` below.
-    static void MigrateSceneYAML(YAML::Node& data, u32 fromVersion)
+    static void MigrateSceneYAML([[maybe_unused]] YAML::Node& data, u32 fromVersion)
     {
         if (fromVersion >= SceneSerializer::CurrentVersion)
             return;

--- a/OloEngine/src/OloEngine/Serialization/MeshBinarySerializer.cpp
+++ b/OloEngine/src/OloEngine/Serialization/MeshBinarySerializer.cpp
@@ -139,11 +139,6 @@ namespace OloEngine
             return static_cast<u64>(out.tellp());
         }
 
-        u64 StreamPos(std::istream& in)
-        {
-            return static_cast<u64>(in.tellg());
-        }
-
         // ── zlib compression ────────────────────────────────────────
         // Deflate/inflate lives in the shared, allocation-hardened
         // Serialization/ZlibSection helper (also used by the .olmap
@@ -344,7 +339,7 @@ namespace OloEngine
             }
 
             // Validate skeleton array sizes — reject mismatches
-            auto const validateSize = [&boneCount, &path](sizet actual, const char* name) -> bool
+            auto const validateSize = [&boneCount](sizet actual, const char* name) -> bool
             {
                 if (static_cast<u32>(actual) != boneCount)
                 {

--- a/OloEngine/src/OloEngine/Task/CancellationToken.h
+++ b/OloEngine/src/OloEngine/Task/CancellationToken.h
@@ -38,11 +38,17 @@ namespace OloEngine::Tasks
       public:
         FCancellationToken() = default;
 
-        // Non-copyable but movable
+        // Neither copyable nor movable. The moves were `= default` and therefore implicitly
+        // DELETED, because m_Canceled is a std::atomic<bool> and std::atomic is not movable,
+        // so "but movable" was never true. A token is observed by other threads through the
+        // shared state, so moving one is not something to add casually -- pass it by
+        // reference, or hold it in a Ref/Scope.
         FCancellationToken(const FCancellationToken&) = delete;
         FCancellationToken& operator=(const FCancellationToken&) = delete;
-        FCancellationToken(FCancellationToken&&) = default;
-        FCancellationToken& operator=(FCancellationToken&&) = default;
+        // Move operations are intentionally not declared: m_Canceled is a std::atomic<bool>,
+        // which is not movable, so `= default` defined them as deleted and they were ignored
+        // by overload resolution anyway. Copy is deleted above, so a move attempt still fails
+        // -- same behaviour, without the -Wdefaulted-function-deleted noise.
 
         // @brief Request cancellation
         //

--- a/OloEngine/src/OloEngine/Task/TaskPrivate.h
+++ b/OloEngine/src/OloEngine/Task/TaskPrivate.h
@@ -273,10 +273,9 @@ namespace OloEngine::Tasks
             template<typename PrerequisiteCollectionType, decltype(std::declval<PrerequisiteCollectionType>().begin())* = nullptr>
             void AddPrerequisites(const PrerequisiteCollectionType& InPrerequisites)
             {
-                i32 NumAdded = 0;
                 i32 NumPrereqs = 0;
 
-                for (const auto& Prereq : InPrerequisites)
+                for ([[maybe_unused]] const auto& Prereq : InPrerequisites)
                 {
                     ++NumPrereqs;
                 }

--- a/OloEngine/src/OloEngine/Templates/Tuple.h
+++ b/OloEngine/src/OloEngine/Templates/Tuple.h
@@ -114,7 +114,7 @@ namespace OloEngine
         struct TTupleElementGetterByIndex
         {
             template<typename DeducedType, typename TupleType>
-            static inline decltype(auto) GetImpl(const volatile TTupleBaseElement<DeducedType, Index, TupleSize>& Element, TupleType&& Tuple)
+            static inline decltype(auto) GetImpl(const volatile TTupleBaseElement<DeducedType, Index, TupleSize>&, TupleType&& Tuple)
             {
                 // Brackets are important here - we want a reference type to be returned, not object type
                 decltype(auto) Result = (ForwardAsBase<TupleType, TTupleBaseElement<DeducedType, Index, TupleSize>>(Tuple).Value);
@@ -137,8 +137,6 @@ namespace OloEngine
             template<typename TupleType>
             static inline decltype(auto) Get(TupleType&& Tuple)
             {
-                using KeyType = decltype(std::decay_t<TupleType>::Key);
-
                 // Brackets are important here - we want a reference type to be returned, not object type
                 decltype(auto) Result = (ForwardAsBase<TupleType, TTupleBaseElement<decltype(Tuple.Key), 0, 2>>(Tuple).Key);
 
@@ -154,8 +152,6 @@ namespace OloEngine
             template<typename TupleType>
             static inline decltype(auto) Get(TupleType&& Tuple)
             {
-                using ValueType = decltype(std::decay_t<TupleType>::Value);
-
                 // Brackets are important here - we want a reference type to be returned, not object type
                 decltype(auto) Result = (ForwardAsBase<TupleType, TTupleBaseElement<decltype(Tuple.Value), 1, 2>>(Tuple).Value);
 
@@ -202,7 +198,7 @@ namespace OloEngine
         struct FEqualityHelper<ArgCount, ArgCount>
         {
             template<typename TupleType>
-            OLO_FINLINE static bool Compare(const TupleType& Lhs, const TupleType& Rhs)
+            OLO_FINLINE static bool Compare(const TupleType&, const TupleType&)
             {
                 return true;
             }
@@ -232,7 +228,7 @@ namespace OloEngine
         struct TLessThanHelper<NumArgs, NumArgs, false>
         {
             template<typename TupleType>
-            OLO_FINLINE static bool Do(const TupleType& Lhs, const TupleType& Rhs)
+            OLO_FINLINE static bool Do(const TupleType&, const TupleType&)
             {
                 return false;
             }
@@ -487,7 +483,7 @@ namespace OloEngine
         // ========================================================================
 
         template<typename LhsType, typename RhsType, u32... Indices>
-        static void Assign(LhsType& Lhs, RhsType&& Rhs, TIntegerSequence<u32, Indices...>)
+        void Assign(LhsType& Lhs, RhsType&& Rhs, TIntegerSequence<u32, Indices...>)
         {
             int Temp[] = { 0, (Lhs.template Get<Indices>() = Forward<RhsType>(Rhs).template Get<Indices>(), 0)... };
             (void)Temp;
@@ -610,7 +606,7 @@ namespace OloEngine
         struct TGetTupleHashHelper<ArgIndex, ArgIndex>
         {
             template<typename TupleType>
-            OLO_FINLINE static u32 Do(u32 Hash, const TupleType& Tuple)
+            OLO_FINLINE static u32 Do(u32 Hash, const TupleType&)
             {
                 return Hash;
             }

--- a/OloEngine/src/OloEngine/Terrain/Editor/TerrainErosion.cpp
+++ b/OloEngine/src/OloEngine/Terrain/Editor/TerrainErosion.cpp
@@ -12,7 +12,10 @@
 namespace OloEngine
 {
     TerrainErosion::TerrainErosion()
-        : m_IterationSeed(static_cast<u32>(RandomUtils::Int32(0, std::numeric_limits<i32>::max()))), m_ErosionShader(ComputeShader::Create("assets/shaders/compute/Terrain_Erosion.comp"))
+        // Declaration order is m_ErosionShader then m_IterationSeed, and that is the order
+        // members are actually initialised in; the list now says so.
+        : m_ErosionShader(ComputeShader::Create("assets/shaders/compute/Terrain_Erosion.comp")),
+          m_IterationSeed(static_cast<u32>(RandomUtils::Int32(0, std::numeric_limits<i32>::max())))
     {
         OLO_PROFILE_FUNCTION();
     }

--- a/OloEngine/src/OloEngine/Terrain/Voxel/VoxelGreedyMesher.cpp
+++ b/OloEngine/src/OloEngine/Terrain/Voxel/VoxelGreedyMesher.cpp
@@ -9,7 +9,6 @@ namespace OloEngine
     namespace
     {
         constexpr u32 CS = VoxelNeighbourhood::CS;
-        constexpr u32 CS_P = VoxelNeighbourhood::CS_P;
 
         // Which axis each face direction runs along: X = 0, Y = 1, Z = 2.
         constexpr u32 kFaceAxis[6] = { 0, 0, 1, 1, 2, 2 };

--- a/OloEngine/src/OloEngine/UI/UILayoutSystem.cpp
+++ b/OloEngine/src/OloEngine/UI/UILayoutSystem.cpp
@@ -53,7 +53,6 @@ namespace OloEngine
         // Anchor-based layout resolution (Unity-style)
         const glm::vec2 anchorMinPos = parentPos + rt.m_AnchorMin * parentSize;
         const glm::vec2 anchorMaxPos = parentPos + rt.m_AnchorMax * parentSize;
-        const glm::vec2 anchorSize = anchorMaxPos - anchorMinPos;
 
         glm::vec2 resolvedSize;
         glm::vec2 resolvedPos;

--- a/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLRendererAPI.h
@@ -108,6 +108,10 @@ namespace OloEngine
 
         void BindDefaultFramebuffer() override;
         void BlitFramebufferToDefault(RHI::ResourceHandle srcFramebuffer, u32 width, u32 height) override;
+        // Un-hide the base overloads. The raw-GL-handle overload below is a name in this
+        // scope, which otherwise hides RendererAPI::BindTexture(slot, handle, sampler)
+        // from lookup on an OpenGLRendererAPI* (-Woverloaded-virtual).
+        using RendererAPI::BindTexture;
         void BindTexture(u32 slot, u32 textureID);
         void BindTexture(u32 slot, RHI::ResourceHandle texture) override;
         void BindImageTexture(u32 unit, u32 textureID, u32 mipLevel, bool layered, u32 layer,

--- a/OloEngine/src/Platform/OpenGL/OpenGLUtilities.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLUtilities.cpp
@@ -45,7 +45,7 @@ namespace OloEngine
                              format == GL_DEPTH24_STENCIL8 || format == GL_DEPTH_COMPONENT32F),
                             "Invalid format.");
 
-            if (const bool multisampled = samples > 1)
+            if (samples > 1)
             {
                 glTextureStorage2DMultisample(id, samples, format, width, height, GL_FALSE);
             }

--- a/OloEngine/src/Platform/Windows/MinWindows.h
+++ b/OloEngine/src/Platform/Windows/MinWindows.h
@@ -28,13 +28,15 @@
 #endif
 
 // Exclude additional unused services
-#define NOGDICAPMASKS    // CC_*, LC_*, PC_*, CP_*, TC_*, RC_
-#define OEMRESOURCE      // OEM Resource values
-#define NOATOM           // Atom Manager routines
-#define NOKERNEL         // All KERNEL #defines and routines
-#define NOMEMMGR         // GMEM_*, LMEM_*, GHND, LHND, associated routines
-#define NOMETAFILE       // typedef METAFILEPICT
-#define NOMINMAX         // Macros min(a,b) and max(a,b)
+#define NOGDICAPMASKS // CC_*, LC_*, PC_*, CP_*, TC_*, RC_
+#define OEMRESOURCE   // OEM Resource values
+#define NOATOM        // Atom Manager routines
+#define NOKERNEL      // All KERNEL #defines and routines
+#define NOMEMMGR      // GMEM_*, LMEM_*, GHND, LHND, associated routines
+#define NOMETAFILE    // typedef METAFILEPICT
+#ifndef NOMINMAX
+#define NOMINMAX // Macros min(a,b) and max(a,b)
+#endif
 #define NOOPENFILE       // OpenFile(), OemToAnsi, AnsiToOem, and OF_*
 #define NOSCROLL         // SB_* and scrolling routines
 #define NOSERVICE        // All Service Controller routines, SERVICE_ equates, etc.

--- a/OloEngine/tests/BitwiseEqualLayoutTest.cpp
+++ b/OloEngine/tests/BitwiseEqualLayoutTest.cpp
@@ -6,6 +6,7 @@
 #include "OloEngine/Animation/IKTargetComponent.h"
 #include "OloEngine/Animation/NoiseAnimationComponent.h"
 #include "OloEngine/Animation/SpringBoneComponent.h"
+#include "OloEngine/Audio/AudioListener.h"
 #include "OloEngine/Audio/AudioSource.h"
 #include "OloEngine/Math/Math.h"
 #include "OloEngine/Physics3D/ColliderMaterial.h"
@@ -87,6 +88,8 @@ namespace
     X(OloEngine::SpringBoneComponent)                       \
     /* Audio (nested in AudioSourceColdData::operator==) */ \
     X(OloEngine::AudioSourceConfig)                         \
+    /* Audio (nested in AudioListenerComponent) */          \
+    X(OloEngine::AudioListenerConfig)                       \
     /* Physics3D */                                         \
     X(OloEngine::ColliderMaterial)                          \
     /* Renderer/GPUScene (GPUScene::RecordsEqual) */        \

--- a/OloEngine/tests/ContainerTest.cpp
+++ b/OloEngine/tests/ContainerTest.cpp
@@ -41,6 +41,34 @@ TEST(ContainerSmoke, TBitArrayBasicInitAndIndexing)
     EXPECT_TRUE(bits[0]);
 }
 
+TEST(ContainerSmoke, TBitArrayReverseIterationVisitsEveryBitIncludingBitZero)
+{
+    // Guards the reverse-end sentinel. FRelativeBitReference::operator== compares
+    // WordIndex and Mask, never Index, and FRelativeBitReference(0) is bit 0 exactly.
+    // So rend() built from 0 rather than INDEX_NONE compares equal to the bit-0
+    // iterator and a reverse loop stops one bit early -- silently, and with nothing
+    // else in the suite touching rbegin()/rend().
+    TBitArray<> bits;
+    bits.Init(false, 40); // spans two words, so the word-boundary step is covered too
+    bits[0] = true;
+    bits[1] = true;
+    bits[31] = true;
+    bits[32] = true;
+    bits[39] = true;
+
+    i32 visited = 0;
+    i32 setBits = 0;
+    for (auto it = bits.rbegin(); it != bits.rend(); ++it)
+    {
+        ++visited;
+        if (*it)
+            ++setBits;
+    }
+
+    EXPECT_EQ(visited, 40);
+    EXPECT_EQ(setBits, 5);
+}
+
 TEST(ContainerSmoke, TSparseArrayAddAndIterate)
 {
     TSparseArray<i32> arr;

--- a/cmake/CommonProperties.cmake
+++ b/cmake/CommonProperties.cmake
@@ -124,6 +124,26 @@ function(olo_set_compiler_options target_name)
             /Zc:inline        # Remove unreferenced COMDAT functions (reduces linker work)
             /bigobj           # Increase COFF section limit for large translation units
         )
+        # Static-initialisation audit (issue #763), OPT-IN and off by default.
+        #
+        # Why opt-in rather than always on: the audit measured 220 distinct sites that
+        # survive after every free fix has been taken, because the engine legitimately
+        # keeps process-lifetime singletons, caches and warn-once sets (Task/, Networking/,
+        # Renderer/, Project/). These flags cannot tell those apart from an accidental
+        # global, so leaving them on would add ~4900 raw warnings to every clang-cl build
+        # -- signal that trains people to ignore the log rather than read it.
+        #
+        # Turn it on to repeat the audit:
+        #   cmake --preset dev-cached -DOLO_WARN_STATIC_INIT=ON
+        # Warnings only, never -Werror, and clang-cl only: clang-cl reports as MSVC, so
+        # this nests inside the MSVC branch and never reaches the cl.exe path, which has
+        # no equivalent flag.
+        if(OLO_WARN_STATIC_INIT AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            target_compile_options(${target_name} PRIVATE
+                -Wglobal-constructors
+                -Wexit-time-destructors
+            )
+        endif()
         # Use multi-threaded DLL runtime library.
         # When ASan or fuzzing is on, force the release CRT (/MD) for ALL
         # configurations — MSVC ASan's runtime links against release CRT,


### PR DESCRIPTION
Answers all three follow-up items in #763, then — at the maintainer's request mid-flight — widens into a general clang-cl warning cleanup of engine code.

## 1. The list, regenerated

The flags were not in the tree (the audit branch reverted them), so the 200-site list had to be rebuilt before it could be trusted.

| | issue (2026-08-08, clang 21.1.8) | now (clang 23.1.0) |
|---|---|---|
| distinct `-Wglobal-constructors` | 118 | **140** |
| distinct `-Wexit-time-destructors` | 191 | **220** |
| **union distinct** | **200** | **231** |

**The +31 drift is new code, not the compiler upgrade.** `git blame` puts 45 of the 231 sites on lines last changed after the issue was filed, which more than accounts for the growth.

## 2. Triage, and the two buckets that got fixed

The issue predicted the trivial-win bucket would be "probably a large fraction". **It is about 5%.** Only 12 of 231 sites were free; the other 219 are deliberate process-lifetime state — GPU `Ref<>` handles, renderer `s_Data` blocks, registries, warn-once sets, caches, thread-locals and Meyers singletons, none of which can be made trivially destructible.

**Fixed (231 → 219 distinct, 4919 → 4588 raw, both full builds):** ten `MaterialAsset` uniform names, `BoundingVolume::NoBounds`, a `constexpr` `UUID(u64)`, and `ThreadManager`'s fallback name. The UUID change also fixed `AssetRegistry`'s `s_EmptyMetadata` for free — once `AssetMetadata` could be constant-initialised, clang could prove its destructor was a no-op.

**Left alone, deliberately:** the `Task/` subsystem is the dominant `-Wexit-time-destructors` source and is *already* hardened — [thread-local-lifetime-at-exit.md](docs/agent-rules/thread-local-lifetime-at-exit.md) documents a real heap-use-after-free that clang 23 exposed there. `UUID.cpp`'s RNG and `NetworkManager`'s singletons stay as the issue predicted. `AssetPreviewRenderer`'s shader path is static-local on purpose (to back a `const&` default argument) and `AudioLoader`'s extension list is returned by reference, so neither is free.

**Ordering-risk bucket: no live bug.** Two places *depend* on a global being constant-initialised and documented it in a comment nothing checked — `DebugLevers` (read from `SystemScheduler`'s and `TerrainChunkManager`'s own global initialisers) and `RendererAPI::s_API` (read cross-TU by `RenderCommand.cpp`). Both are now `constinit`, so the compiler enforces it.

> **Method note for future audits:** clang's wording cannot distinguish the two cases. A declaration needing *both* a dynamic constructor and a destructor reports only `declaration requires a global destructor` — identical to a constant-initialised one. `constinit` is the only reliable discriminator. I initially misread this and nearly reported `DebugLevers` as a live bug.

## 3. Do the flags stay? No — opt-in instead

With ~219 sites surviving after every free fix, always-on would add ~4600 raw warnings to every clang-cl build: noise that trains people to ignore the log. New `OLO_WARN_STATIC_INIT` option, **default OFF**, clang-cl only, never `-Werror`. Verified: 782 compile edges carry the flags with it ON, **0** with it OFF.

`clangcl` is not a per-PR CI job, so this is local signal only — no CI coverage is claimed.

## Scope widening: general warning cleanup

| | before | after |
|---|---|---|
| warning classes | 29 | **14** |
| distinct locations | 2,023 | **1,931** |
| raw warnings | 18,353 | **8,421** (−54%) |

15 classes eliminated entirely. These are not gated by the new option — they are on in every clang-cl build today, and `dev-cached` is the default preset.

### Real bugs found on the way (each its own commit)

- **`FReverseIterator(array, StartIndex)` silently discarded `StartIndex`.** Now honoured, and `rend()` passes `INDEX_NONE` so the reverse-end sentinel is preserved. Covered by a new regression test.
  - **Correction, and credit to CodeRabbit for catching it.** My first attempt here was wrong and introduced an off-by-one: the original `-1` was the deliberate reverse-end sentinel, not an oversight. `FRelativeBitReference::operator==` compares `WordIndex` and `Mask` and never `Index`, so honouring `StartIndex` while `rend()` still passed `0` made `rend()` equal the bit-0 iterator and every reverse loop would have stopped one bit early. The commit also claimed "zero callers" — false: `rend()` calls it from inside `BitArray.h`, which the grep behind that claim had excluded. Fixed in 769ad7c93.
- **The file-watcher generation guard was never checked.** `Shutdown()` bumps the generation to "invalidate any active task"; the task captured it and never read it, so the invalidation was a no-op. The obvious fix hangs shutdown — `Shutdown()` spin-waits on `m_FileWatcherTaskActive` — so the guard skips the watch loop but still clears the flag.
- **`AudioListenerComponent` had no working `operator==`.** `= default` was implicitly deleted (`AudioListenerConfig` has none), dropping the component to `DrawComponent`'s "no undo" tier: listener edits were silently not undoable.
- **Collider-cache eviction misread a backwards clock.** Signed age vs `sizet` constant, so a non-monotonic `system_clock` step made every fresh entry look evictable.
- **`OpenGLRendererAPI` hid the base `BindTexture(slot, handle, sampler)`** overload.
- **`friend class AudioEngine;`** in a nested namespace reached the outer class only via an MSVC extension — the friendship would silently not apply off-MSVC, and Linux is a CI target.
- Four `OLO_CORE_ASSERT(&reference != nullptr, ...)` that can never fire; a `u8 < 256` bound check that is always true; two **empty** range-for loops in `JoltScene` destruction.

A note on one fix that is subtler than it looks: `Material` and `FCancellationToken` advertised move operations that were implicitly *deleted*. The declarations are **removed** rather than spelled `= delete`, because a defaulted move defined as deleted is **ignored by overload resolution** (so `std::move` already bound to the copy), whereas an explicit `= delete` participates and turns those calls into hard errors. Spelling it `= delete` broke the build when tried.

### Deliberately not included

`-Wmicrosoft-cast` (1,434 sites, concentrated in the C# scripting glue — an investigation, not a sweep), `-Wdeprecated-copy` (75), `-Wunused-private-field` (15), `-Wmissing-designated-field-initializers` (23), `-Wswitch` (16, needs a per-enum decision). Each deserves its own focused change; folding them in would make this unreviewable.

Also excluded on purpose: `ShaderBindingLayout.h` carries static-init sites but is modified by both PR #1112 and the in-flight #805 work. None of the four TUs the CI-throughput branch will split are touched.

## Verification

- **Full suite: 7,659 ran, 7,615 passed, 44 skipped, 0 failed** (`GTEST_EXIT=0`; 7615 + 44 = 7659 balances).
- Clean full rebuild, `NINJA_EXIT=0`, zero errors, 1,612 edges.
- `BitwiseEqualLayoutTest` 34/34 (the 34th is the new `AudioListenerConfig` entry).
- `ContainerSmoke` 6/6 including the new `TBitArrayReverseIterationVisitsEveryBitIncludingBitZero`.
- Every risky edit was probe-compiled as a single TU with the real build flags before the batch build.
- The 159 golden PNGs the test run regenerated were **reverted, not committed** — no rendering change here.

## Review guide

**Where I'd look hardest**

1. `OloEngine/src/OloEngine/Asset/AssetManager/EditorAssetManager.cpp` — the only change with real runtime consequences. It makes a previously dead shutdown guard live. I argued it cannot hang (the flag store is unconditional, and `Shutdown()` is the only bumper), but this is concurrent shutdown code.
2. `OloEngine/src/OloEngine/Containers/BitArray.h` — a behaviour change to a container primitive. I already got this wrong once (see the correction above), so the sentinel reasoning deserves a fresh pair of eyes rather than trust. It now has a regression test; it had none before.
3. `OloEngine/src/OloEngine/Scene/Components.h` — the undo path. `Listener` is excluded as runtime state per cpp-coding-quality.md §7; if that judgement is wrong, undo compares the wrong field set.

**What I verified, and how** — full suite green (named above); `BitwiseEqualLayoutTest` for the new equality; before/after warning censuses taken on *full* builds only (an incremental build's census is meaningless — it only re-emits recompiled TUs, which I hit and discarded); `constinit` compile-probes as the discriminator for constant initialisation; option ON/OFF edge counts.

**Least confident about** — the `MaterialAsset` trade. `constexpr const char*` removes 8 static-init sites but adds a `std::string` temporary per accessor call. I checked that every caller is cold and already allocates an `FString` for the same key, and the code now states this, but it is a real (small) runtime cost traded for a warning count, and reasonable people could prefer the revert.

**Deliberately not tested** — the editor was not launched. Nothing here changes what the screen shows: no shader, pass, or render-graph topology change. The `AudioListenerComponent` undo fix is the one user-visible behaviour change, and it is covered by contract rather than by a live editor check.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)
