### PR TITLE
perf(renderer): close FSR2's 3x NVIDIA gap — the GL SPIR-V front end spilled private arrays to local memory (#925)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,14 @@
 *.bat text eol=crlf
 *.ps1 text eol=crlf
 
+# Patches applied to fetched third-party trees are checked out byte-for-byte.
+# `* text=auto` above would rewrite them to CRLF on Windows, and a patch whose
+# line endings were rewritten after it was authored is a patch that may no
+# longer apply — which surfaces as a FATAL_ERROR in the middle of a configure,
+# on a fresh clone only. See cmake/fsr2-apply-patches.cmake.
+*.patch -text
+*.diff -text
+
 # Mark vendor as vendored (hides from GitHub linguist and other tooling)
 vendor/** linguist-vendored
 

--- a/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
@@ -2046,15 +2046,21 @@ namespace OloEngine::Tests
     // with resolution is fixed overhead, which is a different and much less
     // alarming story than a flat one.
     //
-    // This test is what found, and now guards, the NVIDIA private-array spill
-    // (#925): the GL SPIR-V front end lowered three fixed-size arrays in the
-    // depth-clip and accumulate passes to local memory, which is device memory,
-    // and that WAS the upstream "3x slower than expected" VRAM-throughput
-    // problem (https://juandiegomontoya.github.io/porting_fsr2.html#performance).
-    // With cmake/fsr2-patches/0001 applied this reads ~0.10-0.12 ms/MPix on an
-    // RTX 4090; without it, ~0.19-0.23. A reading back up at the high figure
-    // means the patch stopped applying or the permutations went stale — see
-    // docs/agent-rules/notes-renderer.md for the one-grep driver-IR check.
+    // This test is what found the NVIDIA private-array spill (#925): the GL
+    // SPIR-V front end lowered three fixed-size arrays in the depth-clip and
+    // accumulate passes to local memory, which is device memory, and that WAS
+    // the upstream "3x slower than expected" VRAM-throughput problem
+    // (https://juandiegomontoya.github.io/porting_fsr2.html#performance).
+    //
+    // It does NOT guard the fix, and cannot: the only assertion here is that a
+    // timing was published at all, for the reason the sibling test below spells
+    // out — a GPU timing on this box is not a gate. With
+    // cmake/fsr2-patches/0001 applied the number READS ~0.10-0.12 ms/MPix on an
+    // RTX 4090 and ~0.19-0.23 without it, so a regression is visible to a human
+    // reading the log and invisible to CI. What actually fails loudly if the
+    // patch stops applying is the configure, in cmake/fsr2-apply-patches.cmake.
+    // To confirm which shader really ran, grep the driver IR — see
+    // docs/agent-rules/notes-renderer.md.
     TEST_F(FSR2Perf, UpscaleCostPerMegapixelAcrossOutputResolutions)
     {
         OLO_ENSURE_GPU_OR_SKIP();

--- a/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
+++ b/OloEngine/tests/Rendering/PropertyTests/PerfRegressionTests.cpp
@@ -2042,11 +2042,19 @@ namespace OloEngine::Tests
     //
     // The reference to compare against: AMD quotes FSR2 at roughly 1.1-1.2 ms for
     // 4K output on an RX 6800 XT, i.e. about 0.145 ms per megapixel on hardware
-    // slower than anything this runs on. A flat cost-per-megapixel well above
-    // that, holding as resolution rises, is the upstream VRAM-throughput problem
-    // (https://juandiegomontoya.github.io/porting_fsr2.html#performance). A
-    // per-megapixel cost that FALLS steeply with resolution is fixed overhead,
-    // which is a different and much less alarming story.
+    // slower than anything this runs on. A per-megapixel cost that FALLS steeply
+    // with resolution is fixed overhead, which is a different and much less
+    // alarming story than a flat one.
+    //
+    // This test is what found, and now guards, the NVIDIA private-array spill
+    // (#925): the GL SPIR-V front end lowered three fixed-size arrays in the
+    // depth-clip and accumulate passes to local memory, which is device memory,
+    // and that WAS the upstream "3x slower than expected" VRAM-throughput
+    // problem (https://juandiegomontoya.github.io/porting_fsr2.html#performance).
+    // With cmake/fsr2-patches/0001 applied this reads ~0.10-0.12 ms/MPix on an
+    // RTX 4090; without it, ~0.19-0.23. A reading back up at the high figure
+    // means the patch stopped applying or the permutations went stale — see
+    // docs/agent-rules/notes-renderer.md for the one-grep driver-IR check.
     TEST_F(FSR2Perf, UpscaleCostPerMegapixelAcrossOutputResolutions)
     {
         OLO_ENSURE_GPU_OR_SKIP();

--- a/cmake/fsr2-apply-patches.cmake
+++ b/cmake/fsr2-apply-patches.cmake
@@ -1,0 +1,58 @@
+# =============================================================================
+# FetchContent PATCH_COMMAND for the FSR2 OpenGL tree.
+#
+# Run in script mode (`cmake -P`) with the source tree as the working directory,
+# which is what FetchContent's patch step gives us. Applies every
+# cmake/fsr2-patches/*.patch in sorted order.
+#
+# IT MUST BE IDEMPOTENT. FetchContent re-runs the patch step on every configure
+# while FETCHCONTENT_UPDATES_DISCONNECTED is OFF, so a plain `git apply` would
+# fail the second time round and take the whole configure with it. Each patch is
+# therefore probed with `git apply --reverse --check` first: that succeeds only
+# when the patch is ALREADY in the tree, in which case there is nothing to do.
+#
+# Consequence worth knowing before you go debugging a shader: a hand edit to the
+# fetched tree that collides with one of these patches is reverted on the next
+# configure. Investigate in the patch file, not in OloEngine/vendor/clang/.
+# =============================================================================
+
+if(NOT DEFINED OLO_FSR2_PATCH_DIR)
+	message(FATAL_ERROR "OLO_FSR2_PATCH_DIR must be set")
+endif()
+
+find_package(Git QUIET REQUIRED)
+
+file(GLOB OLO_FSR2_PATCHES "${OLO_FSR2_PATCH_DIR}/*.patch")
+list(SORT OLO_FSR2_PATCHES)
+
+foreach(_patch IN LISTS OLO_FSR2_PATCHES)
+	get_filename_component(_name "${_patch}" NAME)
+
+	execute_process(
+		COMMAND "${GIT_EXECUTABLE}" apply --reverse --check "${_patch}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE _already
+		OUTPUT_QUIET ERROR_QUIET)
+
+	if(_already EQUAL 0)
+		message(STATUS "FSR2 patch already applied: ${_name}")
+		continue()
+	endif()
+
+	execute_process(
+		COMMAND "${GIT_EXECUTABLE}" apply --verbose "${_patch}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE _result
+		ERROR_VARIABLE _stderr)
+
+	if(NOT _result EQUAL 0)
+		message(FATAL_ERROR
+			"FSR2 patch failed to apply: ${_name}\n"
+			"Tree: ${CMAKE_CURRENT_SOURCE_DIR}\n"
+			"${_stderr}\n"
+			"If the pin in cmake/fsr2.cmake moved, the patch may already be upstream — "
+			"delete it, or rebase it onto the new pin.")
+	endif()
+
+	message(STATUS "FSR2 patch applied: ${_name}")
+endforeach()

--- a/cmake/fsr2-apply-patches.cmake
+++ b/cmake/fsr2-apply-patches.cmake
@@ -2,18 +2,32 @@
 # FetchContent PATCH_COMMAND for the FSR2 OpenGL tree.
 #
 # Run in script mode (`cmake -P`) with the source tree as the working directory,
-# which is what FetchContent's patch step gives us. Applies every
-# cmake/fsr2-patches/*.patch in sorted order.
+# which is what FetchContent's patch step gives us.
 #
-# IT MUST BE IDEMPOTENT. FetchContent re-runs the patch step on every configure
-# while FETCHCONTENT_UPDATES_DISCONNECTED is OFF, so a plain `git apply` would
-# fail the second time round and take the whole configure with it. Each patch is
-# therefore probed with `git apply --reverse --check` first: that succeeds only
-# when the patch is ALREADY in the tree, in which case there is nothing to do.
+# THE CONTRACT IS "TREE == PIN + cmake/fsr2-patches/*.patch", and it is enforced
+# by RESTORING the tracked files to the pin before applying anything. Three
+# things fall out of that, all of which an apply-only script gets wrong:
 #
-# Consequence worth knowing before you go debugging a shader: a hand edit to the
-# fetched tree that collides with one of these patches is reverted on the next
-# configure. Investigate in the patch file, not in OloEngine/vendor/clang/.
+#   * It is idempotent, which it has to be -- FetchContent re-runs its patch step
+#     on every configure while FETCHCONTENT_UPDATES_DISCONNECTED is OFF, so a
+#     plain `git apply` would fail the second time and take the configure with it.
+#   * DELETING a patch file actually un-patches the tree. Without the restore,
+#     removing a patch whose fix has landed upstream leaves the tree carrying
+#     shader edits that exist in no tracked file in this repo -- the worst
+#     possible state, because nothing reports it.
+#   * A hand edit to the fetched tree is reverted rather than colliding. Debug in
+#     the patch file; edits under OloEngine/vendor/clang/fsr2gl-src do not
+#     survive a configure.
+#
+# The restore only covers TRACKED files, so a patch that ADDS a file would leave
+# it behind on removal. None of ours do; if one ever does, extend this.
+#
+# The price is that restore-then-apply rewrites the patched headers on EVERY
+# configure, so their mtimes move and the permutations they feed regenerate --
+# about two minutes of shader compiles on a configure that changed nothing.
+# That is deliberate: a configure is rare, and the alternative (skip the work
+# when the tree looks already-patched) is precisely the apply-only behaviour
+# whose failure modes are listed above.
 # =============================================================================
 
 if(NOT DEFINED OLO_FSR2_PATCH_DIR)
@@ -22,22 +36,25 @@ endif()
 
 find_package(Git QUIET REQUIRED)
 
+# Back to the pin, whatever the tree currently holds.
+execute_process(
+	COMMAND "${GIT_EXECUTABLE}" checkout -- .
+	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+	RESULT_VARIABLE _restore
+	ERROR_VARIABLE _restore_err)
+
+if(NOT _restore EQUAL 0)
+	message(FATAL_ERROR
+		"FSR2: could not restore the fetched tree to its pin\n"
+		"Tree: ${CMAKE_CURRENT_SOURCE_DIR}\n"
+		"${_restore_err}")
+endif()
+
 file(GLOB OLO_FSR2_PATCHES "${OLO_FSR2_PATCH_DIR}/*.patch")
 list(SORT OLO_FSR2_PATCHES)
 
 foreach(_patch IN LISTS OLO_FSR2_PATCHES)
 	get_filename_component(_name "${_patch}" NAME)
-
-	execute_process(
-		COMMAND "${GIT_EXECUTABLE}" apply --reverse --check "${_patch}"
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-		RESULT_VARIABLE _already
-		OUTPUT_QUIET ERROR_QUIET)
-
-	if(_already EQUAL 0)
-		message(STATUS "FSR2 patch already applied: ${_name}")
-		continue()
-	endif()
 
 	execute_process(
 		COMMAND "${GIT_EXECUTABLE}" apply --verbose "${_patch}"
@@ -50,9 +67,14 @@ foreach(_patch IN LISTS OLO_FSR2_PATCHES)
 			"FSR2 patch failed to apply: ${_name}\n"
 			"Tree: ${CMAKE_CURRENT_SOURCE_DIR}\n"
 			"${_stderr}\n"
-			"If the pin in cmake/fsr2.cmake moved, the patch may already be upstream — "
-			"delete it, or rebase it onto the new pin.")
+			"If the pin in cmake/fsr2.cmake just moved, the fix is probably upstream now — "
+			"delete the patch file, or rebase it onto the new pin.")
 	endif()
 
 	message(STATUS "FSR2 patch applied: ${_name}")
 endforeach()
+
+list(LENGTH OLO_FSR2_PATCHES _count)
+if(_count EQUAL 0)
+	message(STATUS "FSR2: no local patches; the fetched tree is the pin as-is")
+endif()

--- a/cmake/fsr2-patches/0001-avoid-nvidia-private-array-spills.patch
+++ b/cmake/fsr2-patches/0001-avoid-nvidia-private-array-spills.patch
@@ -18,6 +18,12 @@ byte-identical (see FSR2VisualEvidenceTest).
 DROP THIS FILE when the pin in cmake/fsr2.cmake moves to a commit that already
 carries the change.
 
+DEVIATION FROM THE UPSTREAM PR: its final hunk only adds the missing newline at
+the end of ffx_fsr2_depth_clip.h. That hunk is dropped here. It changes no code,
+and a hunk anchored on the end-of-file newline state is the one most likely to
+stop applying for a reason unrelated to the fix — which, because the applier
+treats a failed patch as a hard configure error, would take the whole build down.
+
 diff --git a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h b/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
 index fa4c975..7b24904 100644
 --- a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
@@ -222,13 +228,6 @@ index fa4c975..7b24904 100644
      }
  
      StoreDilatedReactiveMasks(iPxLrPos, fReactiveFactor);
-@@ -255,4 +290,4 @@ void DepthClip(FfxInt32x2 iPxPos)
-     PreProcessReactiveMasks(iPxPos, ffxMax(fTemporalMotionDifference, fMotionDivergence));
- }
- 
--#endif //!defined( FFX_FSR2_DEPTH_CLIPH )
-\ No newline at end of file
-+#endif //!defined( FFX_FSR2_DEPTH_CLIPH )
 diff --git a/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h b/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h
 index abdb888..a974794 100644
 --- a/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h

--- a/cmake/fsr2-patches/0001-avoid-nvidia-private-array-spills.patch
+++ b/cmake/fsr2-patches/0001-avoid-nvidia-private-array-spills.patch
@@ -1,0 +1,344 @@
+Avoid NVIDIA OpenGL private-array spills in the depth-clip and upsample passes.
+
+Upstream PR: https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/14
+Upstream issue: https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/issues/8
+OloEngine issue: #925
+
+ComputeDepthClip, PreProcessReactiveMasks and ComputeUpsampledColorAndWeight
+index fixed-size private arrays with a loop variable. Every bound is constant,
+but NVIDIA's OpenGL SPIR-V front end still lowers those arrays to local memory,
+which is backed by device memory -- that is the "high VRAM throughput in the
+depth-clip and reproject/accumulate passes" the port's author documented and
+could not explain. Expanding the loops keeps every index literal, so glslang
+scalarises the arrays and the driver has nothing to spill.
+
+The math and the evaluation order are unchanged; the rendered output is
+byte-identical (see FSR2VisualEvidenceTest).
+
+DROP THIS FILE when the pin in cmake/fsr2.cmake moves to a commit that already
+carries the change.
+
+diff --git a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h b/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
+index fa4c975..7b24904 100644
+--- a/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
++++ b/src/ffx-fsr2-api/shaders/ffx_fsr2_depth_clip.h
+@@ -32,47 +32,60 @@ FfxFloat32 ComputeDepthClip(FfxFloat32x2 fUvSample, FfxFloat32 fCurrentDepthSamp
+     FfxFloat32 fDilatedSum = 0.0f;
+     FfxFloat32 fDepth = 0.0f;
+     FfxFloat32 fWeightSum = 0.0f;
+-    for (FfxInt32 iSampleIndex = 0; iSampleIndex < 4; iSampleIndex++) {
+-
+-        const FfxInt32x2 iOffset = bilinearInfo.iOffsets[iSampleIndex];
+-        const FfxInt32x2 iSamplePos = bilinearInfo.iBasePos + iOffset;
+-
+-        if (IsOnScreen(iSamplePos, RenderSize())) {
+-            const FfxFloat32 fWeight = bilinearInfo.fWeights[iSampleIndex];
+-            if (fWeight > fReconstructedDepthBilinearWeightThreshold) {
+-
+-                const FfxFloat32 fPrevDepthSample = LoadReconstructedPrevDepth(iSamplePos);
+-                const FfxFloat32 fPrevNearestDepthViewSpace = GetViewSpaceDepth(fPrevDepthSample);
+-
+-                const FfxFloat32 fDepthDiff = fCurrentDepthViewSpace - fPrevNearestDepthViewSpace;
+-
+-                if (fDepthDiff > 0.0f) {
+ 
++    // Keep the indices literal. NVIDIA's OpenGL compiler otherwise places these
++    // private arrays in local memory even though every loop bound is constant.
+ #if FFX_FSR2_OPTION_INVERTED_DEPTH
+-                    const FfxFloat32 fPlaneDepth = ffxMin(fPrevDepthSample, fCurrentDepthSample);
++#define FFX_FSR2_DEPTH_PLANE(PREV_DEPTH, CURRENT_DEPTH) ffxMin((PREV_DEPTH), (CURRENT_DEPTH))
+ #else
+-                    const FfxFloat32 fPlaneDepth = ffxMax(fPrevDepthSample, fCurrentDepthSample);
++#define FFX_FSR2_DEPTH_PLANE(PREV_DEPTH, CURRENT_DEPTH) ffxMax((PREV_DEPTH), (CURRENT_DEPTH))
+ #endif
+-                    
+-                    const FfxFloat32x3 fCenter = GetViewSpacePosition(FfxInt32x2(RenderSize() * 0.5f), RenderSize(), fPlaneDepth);
+-                    const FfxFloat32x3 fCorner = GetViewSpacePosition(FfxInt32x2(0, 0), RenderSize(), fPlaneDepth);
+-
+-                    const FfxFloat32 fHalfViewportWidth = length(FfxFloat32x2(RenderSize()));
+-                    const FfxFloat32 fDepthThreshold = ffxMax(fCurrentDepthViewSpace, fPrevNearestDepthViewSpace);
+-
+-                    const FfxFloat32 Ksep = 1.37e-05f;
+-                    const FfxFloat32 Kfov = length(fCorner) / length(fCenter);
+-                    const FfxFloat32 fRequiredDepthSeparation = Ksep * Kfov * fHalfViewportWidth * fDepthThreshold;
+-
+-                    const FfxFloat32 fResolutionFactor = ffxSaturate(length(FfxFloat32x2(RenderSize())) / length(FfxFloat32x2(1920.0f, 1080.0f)));
+-                    const FfxFloat32 fPower = ffxLerp(1.0f, 3.0f, fResolutionFactor);
+-                    fDepth += ffxPow(ffxSaturate(FfxFloat32(fRequiredDepthSeparation / fDepthDiff)), fPower) * fWeight;
+-                    fWeightSum += fWeight;
+-                }
+-            }
+-        }
++
++#define FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE(SAMPLE_INDEX)                                             \
++    {                                                                                              \
++        const FfxInt32x2 iOffset = bilinearInfo.iOffsets[(SAMPLE_INDEX)];                           \
++        const FfxInt32x2 iSamplePos = bilinearInfo.iBasePos + iOffset;                              \
++        if (IsOnScreen(iSamplePos, RenderSize())) {                                                 \
++            const FfxFloat32 fWeight = bilinearInfo.fWeights[(SAMPLE_INDEX)];                        \
++            if (fWeight > fReconstructedDepthBilinearWeightThreshold) {                             \
++                const FfxFloat32 fPrevDepthSample = LoadReconstructedPrevDepth(iSamplePos);          \
++                const FfxFloat32 fPrevNearestDepthViewSpace = GetViewSpaceDepth(fPrevDepthSample);   \
++                const FfxFloat32 fDepthDiff = fCurrentDepthViewSpace - fPrevNearestDepthViewSpace;   \
++                if (fDepthDiff > 0.0f) {                                                             \
++                    const FfxFloat32 fPlaneDepth =                                                   \
++                        FFX_FSR2_DEPTH_PLANE(fPrevDepthSample, fCurrentDepthSample);                  \
++                    const FfxFloat32x3 fCenter = GetViewSpacePosition(                               \
++                        FfxInt32x2(RenderSize() * 0.5f), RenderSize(), fPlaneDepth);                  \
++                    const FfxFloat32x3 fCorner =                                                     \
++                        GetViewSpacePosition(FfxInt32x2(0, 0), RenderSize(), fPlaneDepth);           \
++                    const FfxFloat32 fHalfViewportWidth = length(FfxFloat32x2(RenderSize()));        \
++                    const FfxFloat32 fDepthThreshold =                                               \
++                        ffxMax(fCurrentDepthViewSpace, fPrevNearestDepthViewSpace);                   \
++                    const FfxFloat32 Ksep = 1.37e-05f;                                               \
++                    const FfxFloat32 Kfov = length(fCorner) / length(fCenter);                        \
++                    const FfxFloat32 fRequiredDepthSeparation =                                      \
++                        Ksep * Kfov * fHalfViewportWidth * fDepthThreshold;                           \
++                    const FfxFloat32 fResolutionFactor = ffxSaturate(                                \
++                        length(FfxFloat32x2(RenderSize())) /                                        \
++                        length(FfxFloat32x2(1920.0f, 1080.0f)));                                    \
++                    const FfxFloat32 fPower = ffxLerp(1.0f, 3.0f, fResolutionFactor);                \
++                    fDepth += ffxPow(                                                               \
++                        ffxSaturate(FfxFloat32(fRequiredDepthSeparation / fDepthDiff)),              \
++                        fPower) * fWeight;                                                           \
++                    fWeightSum += fWeight;                                                           \
++                }                                                                                   \
++            }                                                                                       \
++        }                                                                                           \
+     }
+ 
++    FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE(0)
++    FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE(1)
++    FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE(2)
++    FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE(3)
++
++#undef FFX_FSR2_ACCUMULATE_DEPTH_SAMPLE
++#undef FFX_FSR2_DEPTH_PLANE
++
+     return (fWeightSum > 0) ? ffxSaturate(1.0f - fDepth / fWeightSum) : 0.0f;
+ }
+ 
+@@ -158,46 +171,68 @@ void PreProcessReactiveMasks(FfxInt32x2 iPxLrPos, FfxFloat32 fMotionDivergence)
+     FfxFloat32 fReactiveSamples[9];
+     FfxFloat32 fTransparencyAndCompositionSamples[9];
+ 
+-    FFX_UNROLL
+-    for (FfxInt32 y = -1; y < 2; y++) {
+-        FFX_UNROLL
+-        for (FfxInt32 x = -1; x < 2; x++) {
+-
+-            const FfxInt32x2 sampleCoord = ClampLoad(iPxLrPos, FfxInt32x2(x, y), FfxInt32x2(RenderSize()));
+-
+-            FfxInt32 sampleIdx = (y + 1) * 3 + x + 1;
+-
+-            FfxFloat32x3 fColorSample = LoadInputColor(sampleCoord).xyz;
+-            FfxFloat32 fReactiveSample = LoadReactiveMask(sampleCoord);
+-            FfxFloat32 fTransparencyAndCompositionSample = LoadTransparencyAndCompositionMask(sampleCoord);
++    // FFX_UNROLL is empty for GLSL, and dynamic private-array indexing spills on
++    // NVIDIA OpenGL. Explicit expansion lets glslang scalarize all three arrays.
++#define FFX_FSR2_LOAD_REACTIVE_SAMPLE(X, Y)                                                              \
++    {                                                                                                    \
++        const FfxInt32x2 sampleCoord =                                                                   \
++            ClampLoad(iPxLrPos, FfxInt32x2((X), (Y)), FfxInt32x2(RenderSize()));                         \
++        const FfxInt32 sampleIdx = ((Y) + 1) * 3 + (X) + 1;                                             \
++        const FfxFloat32x3 fColorSample = LoadInputColor(sampleCoord).xyz;                              \
++        const FfxFloat32 fReactiveSample = LoadReactiveMask(sampleCoord);                               \
++        const FfxFloat32 fTransparencyAndCompositionSample =                                            \
++            LoadTransparencyAndCompositionMask(sampleCoord);                                             \
++        fColorSamples[sampleIdx] = fColorSample;                                                         \
++        fReactiveSamples[sampleIdx] = fReactiveSample;                                                   \
++        fTransparencyAndCompositionSamples[sampleIdx] = fTransparencyAndCompositionSample;              \
++        fMasksSum += (fReactiveSample + fTransparencyAndCompositionSample);                              \
++    }
+ 
+-            fColorSamples[sampleIdx] = fColorSample;
+-            fReactiveSamples[sampleIdx] = fReactiveSample;
+-            fTransparencyAndCompositionSamples[sampleIdx] = fTransparencyAndCompositionSample;
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE(-1, -1)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 0, -1)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 1, -1)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE(-1,  0)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 0,  0)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 1,  0)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE(-1,  1)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 0,  1)
++    FFX_FSR2_LOAD_REACTIVE_SAMPLE( 1,  1)
+ 
+-            fMasksSum += (fReactiveSample + fTransparencyAndCompositionSample);
+-        }
+-    }
++#undef FFX_FSR2_LOAD_REACTIVE_SAMPLE
+ 
+     if (fMasksSum > 0)
+     {
+-        for (FfxInt32 sampleIdx = 0; sampleIdx < 9; sampleIdx++)
+-        {
+-            FfxFloat32x3 fColorSample = fColorSamples[sampleIdx];
+-            FfxFloat32 fReactiveSample = fReactiveSamples[sampleIdx];
+-            FfxFloat32 fTransparencyAndCompositionSample = fTransparencyAndCompositionSamples[sampleIdx];
+-
+-            const FfxFloat32 fMaxLenSq = ffxMax(dot(fReferenceColor, fReferenceColor), dot(fColorSample, fColorSample));
+-            const FfxFloat32 fSimilarity = dot(fReferenceColor, fColorSample) / fMaxLenSq;
+-
+-            // Increase power for non-similar samples
+-            const FfxFloat32 fPowerBiasMax = 6.0f;
+-            const FfxFloat32 fSimilarityPower = 1.0f + (fPowerBiasMax - fSimilarity * fPowerBiasMax);
+-            const FfxFloat32 fWeightedReactiveSample = ffxPow(fReactiveSample, fSimilarityPower);
+-            const FfxFloat32 fWeightedTransparencyAndCompositionSample = ffxPow(fTransparencyAndCompositionSample, fSimilarityPower);
+-
+-            fReactiveFactor = ffxMax(fReactiveFactor, FfxFloat32x2(fWeightedReactiveSample, fWeightedTransparencyAndCompositionSample));
+-        }
++#define FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(SAMPLE_IDX)                                              \
++    {                                                                                                \
++        const FfxFloat32x3 fColorSample = fColorSamples[(SAMPLE_IDX)];                               \
++        const FfxFloat32 fReactiveSample = fReactiveSamples[(SAMPLE_IDX)];                           \
++        const FfxFloat32 fTransparencyAndCompositionSample =                                        \
++            fTransparencyAndCompositionSamples[(SAMPLE_IDX)];                                        \
++        const FfxFloat32 fMaxLenSq =                                                                 \
++            ffxMax(dot(fReferenceColor, fReferenceColor), dot(fColorSample, fColorSample));          \
++        const FfxFloat32 fSimilarity = dot(fReferenceColor, fColorSample) / fMaxLenSq;               \
++        const FfxFloat32 fPowerBiasMax = 6.0f;                                                       \
++        const FfxFloat32 fSimilarityPower =                                                         \
++            1.0f + (fPowerBiasMax - fSimilarity * fPowerBiasMax);                                    \
++        const FfxFloat32 fWeightedReactiveSample = ffxPow(fReactiveSample, fSimilarityPower);        \
++        const FfxFloat32 fWeightedTransparencyAndCompositionSample =                                \
++            ffxPow(fTransparencyAndCompositionSample, fSimilarityPower);                             \
++        fReactiveFactor = ffxMax(                                                                    \
++            fReactiveFactor,                                                                         \
++            FfxFloat32x2(fWeightedReactiveSample, fWeightedTransparencyAndCompositionSample));       \
++    }
++
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(0)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(1)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(2)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(3)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(4)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(5)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(6)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(7)
++        FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE(8)
++
++#undef FFX_FSR2_ACCUMULATE_REACTIVE_SAMPLE
+     }
+ 
+     StoreDilatedReactiveMasks(iPxLrPos, fReactiveFactor);
+@@ -255,4 +290,4 @@ void DepthClip(FfxInt32x2 iPxPos)
+     PreProcessReactiveMasks(iPxPos, ffxMax(fTemporalMotionDifference, fMotionDivergence));
+ }
+ 
+-#endif //!defined( FFX_FSR2_DEPTH_CLIPH )
+\ No newline at end of file
++#endif //!defined( FFX_FSR2_DEPTH_CLIPH )
+diff --git a/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h b/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h
+index abdb888..a974794 100644
+--- a/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h
++++ b/src/ffx-fsr2-api/shaders/ffx_fsr2_upsample.h
+@@ -97,8 +97,6 @@ FfxFloat32x4 ComputeUpsampledColorAndWeight(const AccumulationPassCommonParams p
+     #include "ffx_fsr2_force16_end.h"
+     #endif
+ 
+-    FfxFloat32x3 fSamples[iLanczos2SampleCount];
+-
+     FfxFloat32x2 fSrcUnjitteredPos = (FfxFloat32x2(iSrcInputPos) + FfxFloat32x2(0.5f, 0.5f)) - Jitter(); // This is the un-jittered position of the sample at offset 0,0
+ 
+     FfxInt32x2 offsetTL;
+@@ -114,21 +112,25 @@ FfxFloat32x4 ComputeUpsampledColorAndWeight(const AccumulationPassCommonParams p
+ 
+     FfxFloat32x2 fOffsetTL = FfxFloat32x2(offsetTL);
+ 
+-    FFX_UNROLL
+-    for (FfxInt32 row = 0; row < 3; row++) {
+-
+-        FFX_UNROLL
+-            for (FfxInt32 col = 0; col < 3; col++) {
+-                FfxInt32 iSampleIndex = col + (row << 2);
+-
+-                FfxInt32x2 sampleColRow = FfxInt32x2(bFlipCol ? (3 - col) : col, bFlipRow ? (3 - row) : row);
+-                FfxInt32x2 iSrcSamplePos = FfxInt32x2(iSrcInputPos) + offsetTL + sampleColRow;
+-
+-                const FfxInt32x2 sampleCoord = ClampLoad(iSrcSamplePos, FfxInt32x2(0, 0), FfxInt32x2(RenderSize()));
+-
+-                fSamples[iSampleIndex] = LoadPreparedInputColor(FfxInt32x2(sampleCoord));
+-            }
+-    }
++    // Keep the sample indices literal. NVIDIA's OpenGL compiler otherwise puts
++    // this private array in local memory despite the constant loop bounds.
++    #define FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(row, col, sampleIndex)                                                   \
++        FfxInt32x2 sampleColRow##sampleIndex = FfxInt32x2(bFlipCol ? (3 - col) : col, bFlipRow ? (3 - row) : row); \
++        FfxInt32x2 iSrcSamplePos##sampleIndex = FfxInt32x2(iSrcInputPos) + offsetTL + sampleColRow##sampleIndex;    \
++        const FfxInt32x2 sampleCoord##sampleIndex = ClampLoad(iSrcSamplePos##sampleIndex, FfxInt32x2(0, 0), FfxInt32x2(RenderSize())); \
++        FfxFloat32x3 fSample##sampleIndex = LoadPreparedInputColor(FfxInt32x2(sampleCoord##sampleIndex));
++
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(0, 0, 0)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(0, 1, 1)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(0, 2, 2)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(1, 0, 4)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(1, 1, 5)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(1, 2, 6)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(2, 0, 8)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(2, 1, 9)
++    FFX_FSR2_LOAD_UPSAMPLE_SAMPLE(2, 2, 10)
++
++    #undef FFX_FSR2_LOAD_UPSAMPLE_SAMPLE
+ 
+     FfxFloat32x4 fColorAndWeight = FfxFloat32x4(0.0f, 0.0f, 0.0f, 0.0f);
+ 
+@@ -144,33 +146,32 @@ FfxFloat32x4 ComputeUpsampledColorAndWeight(const AccumulationPassCommonParams p
+ 
+     const FfxFloat32 fRectificationCurveBias = ffxLerp(-2.0f, -3.0f, ffxSaturate(params.fHrVelocity / 50.0f));
+ 
+-    FFX_UNROLL
+-    for (FfxInt32 row = 0; row < 3; row++) {
+-        FFX_UNROLL
+-        for (FfxInt32 col = 0; col < 3; col++) {
+-            FfxInt32 iSampleIndex = col + (row << 2);
+-
+-            const FfxInt32x2 sampleColRow = FfxInt32x2(bFlipCol ? (3 - col) : col, bFlipRow ? (3 - row) : row);
+-            const FfxFloat32x2 fOffset = fOffsetTL + FfxFloat32x2(sampleColRow);
+-            FfxFloat32x2 fSrcSampleOffset = fBaseSampleOffset + fOffset;
+-
+-            FfxInt32x2 iSrcSamplePos = FfxInt32x2(iSrcInputPos) + FfxInt32x2(offsetTL) + sampleColRow;
+-
+-            const FfxFloat32 fOnScreenFactor = FfxFloat32(IsOnScreen(FfxInt32x2(iSrcSamplePos), FfxInt32x2(RenderSize())));
+-            FfxFloat32 fSampleWeight = fOnScreenFactor * FfxFloat32(GetUpsampleLanczosWeight(fSrcSampleOffset, fKernelBias));
+-
+-            fColorAndWeight += FfxFloat32x4(fSamples[iSampleIndex] * fSampleWeight, fSampleWeight);
+-
+-            // Update rectification box
+-            {
+-                const FfxFloat32 fSrcSampleOffsetSq = dot(fSrcSampleOffset, fSrcSampleOffset);
+-                const FfxFloat32 fBoxSampleWeight = exp(fRectificationCurveBias * fSrcSampleOffsetSq);
+-
+-                const FfxBoolean bInitialSample = (row == 0) && (col == 0);
+-                RectificationBoxAddSample(bInitialSample, clippingBox, fSamples[iSampleIndex], fBoxSampleWeight);
+-            }
++    #define FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(row, col, sampleIndex)                                             \
++        {                                                                                                          \
++            const FfxInt32x2 sampleColRow = FfxInt32x2(bFlipCol ? (3 - col) : col, bFlipRow ? (3 - row) : row);    \
++            const FfxFloat32x2 fOffset = fOffsetTL + FfxFloat32x2(sampleColRow);                                    \
++            FfxFloat32x2 fSrcSampleOffset = fBaseSampleOffset + fOffset;                                            \
++            FfxInt32x2 iSrcSamplePos = FfxInt32x2(iSrcInputPos) + FfxInt32x2(offsetTL) + sampleColRow;              \
++            const FfxFloat32 fOnScreenFactor = FfxFloat32(IsOnScreen(FfxInt32x2(iSrcSamplePos), FfxInt32x2(RenderSize()))); \
++            FfxFloat32 fSampleWeight = fOnScreenFactor * FfxFloat32(GetUpsampleLanczosWeight(fSrcSampleOffset, fKernelBias)); \
++            fColorAndWeight += FfxFloat32x4(fSample##sampleIndex * fSampleWeight, fSampleWeight);                   \
++            const FfxFloat32 fSrcSampleOffsetSq = dot(fSrcSampleOffset, fSrcSampleOffset);                          \
++            const FfxFloat32 fBoxSampleWeight = exp(fRectificationCurveBias * fSrcSampleOffsetSq);                 \
++            const FfxBoolean bInitialSample = (row == 0) && (col == 0);                                             \
++            RectificationBoxAddSample(bInitialSample, clippingBox, fSample##sampleIndex, fBoxSampleWeight);        \
+         }
+-    }
++
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(0, 0, 0)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(0, 1, 1)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(0, 2, 2)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(1, 0, 4)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(1, 1, 5)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(1, 2, 6)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(2, 0, 8)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(2, 1, 9)
++    FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE(2, 2, 10)
++
++    #undef FFX_FSR2_ACCUMULATE_UPSAMPLE_SAMPLE
+ 
+     RectificationBoxComputeVarianceBoxData(clippingBox);
+ 

--- a/cmake/fsr2.cmake
+++ b/cmake/fsr2.cmake
@@ -49,6 +49,24 @@ endif()
 
 include(FetchContent)
 
+# -----------------------------------------------------------------------------
+# Local patches on top of the pin.
+#
+# The pinned tree is patched in place by cmake/fsr2-apply-patches.cmake, which is
+# idempotent because FetchContent re-runs its patch step on every configure. Each
+# patch file names the upstream PR it carries and says when to drop it.
+#
+# CMAKE_CONFIGURE_DEPENDS on the patch files, not just CONFIGURE_DEPENDS on the
+# glob: adding or removing a patch has to re-configure, and so does EDITING one,
+# or the tree keeps the previous version with nothing to warn you. Regenerating
+# the permutations then follows for free, because the patches edit shared headers
+# that OLO_FSR2_SHADER_INCLUDES already globs and every permutation DEPENDS on.
+# -----------------------------------------------------------------------------
+set(OLO_FSR2_PATCH_DIR "${CMAKE_CURRENT_LIST_DIR}/fsr2-patches")
+file(GLOB OLO_FSR2_PATCH_FILES CONFIGURE_DEPENDS "${OLO_FSR2_PATCH_DIR}/*.patch")
+set_property(DIRECTORY "${CMAKE_SOURCE_DIR}"
+	APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${OLO_FSR2_PATCH_FILES})
+
 # Pinned to a full commit SHA, never a tag — see the pinning discipline note in
 # OloEngine/vendor/CMakeLists.txt. GIT_SHALLOW must be FALSE for a SHA pin.
 #
@@ -68,7 +86,10 @@ FetchContent_Declare(fsr2gl
 	GIT_TAG f188a0d839665cf110957c1510dfeba4e746aa98  # main @ 2026-08-26
 	GIT_SHALLOW FALSE
 	GIT_SUBMODULES ""
-	SOURCE_SUBDIR olo-does-not-build-upstream-cmake)
+	SOURCE_SUBDIR olo-does-not-build-upstream-cmake
+	PATCH_COMMAND "${CMAKE_COMMAND}"
+		"-DOLO_FSR2_PATCH_DIR=${OLO_FSR2_PATCH_DIR}"
+		-P "${CMAKE_CURRENT_LIST_DIR}/fsr2-apply-patches.cmake")
 
 FetchContent_MakeAvailable(fsr2gl)
 

--- a/cmake/fsr2.cmake
+++ b/cmake/fsr2.cmake
@@ -65,7 +65,7 @@ include(FetchContent)
 # would fail (or worse, succeed) inside our build. We want the sources only.
 FetchContent_Declare(fsr2gl
 	GIT_REPOSITORY https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL.git
-	GIT_TAG 7fb8c92d18e300b84975f2f609b58713b8bde4a7  # main @ 2026-05-04
+	GIT_TAG f188a0d839665cf110957c1510dfeba4e746aa98  # main @ 2026-08-26
 	GIT_SHALLOW FALSE
 	GIT_SUBMODULES ""
 	SOURCE_SUBDIR olo-does-not-build-upstream-cmake)

--- a/cmake/fsr2.cmake
+++ b/cmake/fsr2.cmake
@@ -76,6 +76,20 @@ file(GLOB OLO_FSR2_PATCH_FILES CONFIGURE_DEPENDS "${OLO_FSR2_PATCH_DIR}/*.patch"
 set_property(DIRECTORY "${CMAKE_SOURCE_DIR}"
 	APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${OLO_FSR2_PATCH_FILES})
 
+# FETCHCONTENT_FULLY_DISCONNECTED skips population entirely, patch step included,
+# so the fetched tree keeps whatever it happened to hold and nothing says so. Both
+# halves of that were measured here, because they do NOT behave the same way:
+# with FETCHCONTENT_UPDATES_DISCONNECTED=ON the patch step still runs (a marker
+# planted in the tree was reverted), so it needs no warning and gets none.
+if(OLO_FSR2_PATCH_FILES AND FETCHCONTENT_FULLY_DISCONNECTED)
+	message(WARNING
+		"FSR2: FETCHCONTENT_FULLY_DISCONNECTED is ON, so the patch step will NOT run and "
+		"OloEngine/vendor/clang/fsr2gl-src keeps whatever it currently holds — possibly "
+		"unpatched, possibly patched with an older version of cmake/fsr2-patches/*.patch. "
+		"The FSR2 dispatch cost is the tell (see notes-renderer.md). Turn it off for one "
+		"configure to re-sync the tree.")
+endif()
+
 # Pinned to a full commit SHA, never a tag — see the pinning discipline note in
 # OloEngine/vendor/CMakeLists.txt. GIT_SHALLOW must be FALSE for a SHA pin.
 #

--- a/cmake/fsr2.cmake
+++ b/cmake/fsr2.cmake
@@ -52,9 +52,18 @@ include(FetchContent)
 # -----------------------------------------------------------------------------
 # Local patches on top of the pin.
 #
-# The pinned tree is patched in place by cmake/fsr2-apply-patches.cmake, which is
-# idempotent because FetchContent re-runs its patch step on every configure. Each
-# patch file names the upstream PR it carries and says when to drop it.
+# The pinned tree is patched in place by cmake/fsr2-apply-patches.cmake, which
+# restores the tree to the pin before applying so that "tree == pin + patches"
+# holds however the tree got to its current state. Each patch file names the
+# upstream PR it carries and says when to drop it.
+#
+# THE SHARP EDGE IS BUMPING THE PIN while a patch is carried. The tree is
+# permanently dirty between configures, so ExternalProject's update step
+# stashes / checks out / pops — and that pops into a conflict exactly when the
+# patched hunks are the ones that moved, which is the day the fix lands
+# upstream. It fails inside the update step, BEFORE the applier gets a chance to
+# say anything useful. Recovery: delete OloEngine/vendor/clang/fsr2gl-src and
+# re-configure, having first deleted any patch whose change is now in the pin.
 #
 # CMAKE_CONFIGURE_DEPENDS on the patch files, not just CONFIGURE_DEPENDS on the
 # glob: adding or removing a patch has to re-configure, and so does EDITING one,

--- a/docs/agent-rules/notes-renderer.md
+++ b/docs/agent-rules/notes-renderer.md
@@ -514,10 +514,19 @@ if the local-memory shape changed, the new SPIR-V reached the GPU.
 fetched tree by `cmake/fsr2-apply-patches.cmake`. It is [upstream PR
 #14](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/14), **still open** — drop the
 file when the pin moves past it, and the applier fails the configure loudly if it ever stops applying.
-The applier is idempotent because FetchContent re-runs its patch step on every configure. One
-consequence worth knowing before you debug a shader: **a hand edit to
-`OloEngine/vendor/clang/fsr2gl-src` that collides with the patch is reverted on the next configure.**
-Investigate in the patch file, not in the fetched tree.
+
+The applier enforces **tree == pin + patches** by restoring the tracked files to the pin *before*
+applying, which buys three things an apply-only script gets wrong: it is idempotent (FetchContent
+re-runs its patch step on every configure), deleting a patch actually un-patches the tree rather than
+stranding edits that exist in no tracked file, and **every hand edit under
+`OloEngine/vendor/clang/fsr2gl-src` is silently reverted on the next configure.** Investigate in the
+patch file, not in the fetched tree.
+
+**Bumping the pin while a patch is carried has one sharp edge.** The tree is permanently dirty
+between configures, so ExternalProject's update step stashes, checks out and pops — and that pops
+into a conflict exactly when the patched hunks are the ones that moved, which is the day the fix
+lands upstream. The recovery is to delete `OloEngine/vendor/clang/fsr2gl-src` and re-configure, after
+deleting the patch file if its change is now in the pin.
 
 **The alternative we did not take.** [Upstream PR
 #13](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/13) attacks the same root cause

--- a/docs/agent-rules/notes-renderer.md
+++ b/docs/agent-rules/notes-renderer.md
@@ -463,51 +463,102 @@ numbers exactly, so both were discarded rather than read as evidence.
 disoccluded** (`fWeightSum == 0` falls through to `return 0.0f`). A depth-clip factor of ~0 across a static
 frame is CORRECT, not evidence of a broken reconstructed-depth buffer.
 
+### Keep private-array indices literal in GLSL headed for NVIDIA's GL SPIR-V path — that was FSR2's 3x
 
-### FSR2 on NVIDIA is a known upstream performance problem — budget for it before promising a win
+**The rule.** A fixed-size local array indexed by a loop variable is scalarised by every compiler you
+would expect to scalarise it — except NVIDIA's OpenGL SPIR-V front end, which lowers it to *local
+memory*, and local memory is device memory. A constant loop bound is not enough; the index has to be
+literal by the time glslang sees it. Expand the loop, or pay the VRAM traffic.
 
-The port's author measured **FSR2 running "about 3x slower than expected" on an RTX 3070**, attributing it
-to high VRAM throughput in the **depth-clip** and **reproject & accumulate** passes. The Vulkan backend's
-workaround (disabling FP16 for NVIDIA's accumulate pass) was tried in GL and **did not help**; so did
-varying the input colour format. The cause is **unresolved** — the author's guess is that the shader
-compiler generates different code per API. **AMD (RX 6800) behaves as expected.**
-<https://juandiegomontoya.github.io/porting_fsr2.html#performance>
+**This was FSR2's unexplained "3x slower than expected on NVIDIA".** The port's author measured it on
+an RTX 3070, localised it to abnormally high VRAM throughput in the **depth-clip** and **reproject &
+accumulate** passes, and guessed the shader compiler generated different code per API. The guess was
+right and this is the mechanism: three functions index fixed-size private arrays with a loop
+variable — `ComputeDepthClip`, `PreProcessReactiveMasks` and `ComputeUpsampledColorAndWeight`.
 
-**Measured here on an RTX 4090, driver 610.88, four years and many drivers later — it is still true.**
-`FSR2Perf.UpscaleCostPerMegapixelAcrossOutputResolutions` reports FSR2's own dispatch cost, which is the
-only measurement that can answer this (a whole-frame number moves the scene cost at the same time):
+Measured here on an RTX 4090, driver 616.64, `FSR2Perf.UpscaleCostPerMegapixelAcrossOutputResolutions`,
+min of 5 interleaved runs per arm:
 
-| output | FSR2Pass | ms/MPix |
+| output | stock | loops expanded | |
+|---|---|---|---|
+| 1280x720 | 0.214 ms (0.232 ms/MPix) | 0.114 ms (0.123 ms/MPix) | 1.88x |
+| 1920x1080 | 0.415 ms (0.200 ms/MPix) | 0.231 ms (0.112 ms/MPix) | 1.80x |
+| 2560x1440 | 0.666 ms (0.187 ms/MPix) | 0.366 ms (0.102 ms/MPix) | 1.83x |
+
+AMD quotes FSR2 at ~1.1-1.2 ms for 4K on an RX 6800 XT, about 0.145 ms/MPix on hardware several
+times slower. At 0.102 ms/MPix the GL path is now inside that envelope, so the vendor gap is closed
+rather than merely reduced — which is what the AMD comparison in #925 existed to establish, and it
+was answered without needing AMD hardware.
+
+**The driver IR is the evidence that turns a timing into a diagnosis, and it is one grep.** NVIDIA's
+OpenGL disk cache stores each compiled program as text. Point it somewhere private so the cache holds
+only this run, then count the local arrays:
+
+```bash
+__GL_SHADER_DISK_CACHE=1 __GL_SHADER_DISK_CACHE_PATH=<scratch>/glcache <run the workload>
+grep -rao "TEMP lmem0\[[0-9]*\]" <scratch>/glcache | sort | uniq -c
+```
+
+`TEMP lmem0[N]` is an N-slot local-memory array. Across the same 43 compute programs, stock gave
+`lmem0[31]` x1 (depth clip) and `lmem0[20]` x2 (both accumulate permutations); expanded gives no
+`lmem0[31]` at all and `lmem0[4]` in its place — the unrelated deringing array, which is not worth
+chasing. **Do not try to attribute a blob to a named pass by grepping it for that pass's uniform
+names**: the name tables do not live inside the program segments, so the markers bleed across and
+you get five passes all confidently claiming the same array. Diff the two arms instead.
+
+**A second use for that grep: it proves the shader you edited is the one that ran.** The stale-blob
+trap documented above ("the tell is a result identical to the last digit") has a positive test now —
+if the local-memory shape changed, the new SPIR-V reached the GPU.
+
+**What we ship.** `cmake/fsr2-patches/0001-avoid-nvidia-private-array-spills.patch`, applied to the
+fetched tree by `cmake/fsr2-apply-patches.cmake`. It is [upstream PR
+#14](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/14), **still open** — drop the
+file when the pin moves past it, and the applier fails the configure loudly if it ever stops applying.
+The applier is idempotent because FetchContent re-runs its patch step on every configure. One
+consequence worth knowing before you debug a shader: **a hand edit to
+`OloEngine/vendor/clang/fsr2gl-src` that collides with the patch is reverted on the next configure.**
+Investigate in the patch file, not in the fetched tree.
+
+**The alternative we did not take.** [Upstream PR
+#13](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/13) attacks the same root cause
+from the other end — bypass NVIDIA's SPIR-V front end entirely and compile the `.glsl2` sources
+through the driver's GLSL front end at runtime (RTX 3080, whole effect 4.24 ms -> 1.49 ms). It is the
+larger win, but it carries an embedded-source generator, an include expander and runtime binding
+fix-up; upstream rejected it on maintenance grounds, so taking it means forking. Revisit only if a
+residual gap ever justifies that.
+
+**Two levers that were tested and do NOT help.** Recorded so nobody re-runs them:
+
+* **FP16 for the accumulate pass.** The backend disables it on NVIDIA ("reduced occupancy and high
+  VRAM throughput") and that looked like stale Turing-era tuning worth revisiting on Ada. Re-enabling
+  it made FSR2 **3.4-8.9x SLOWER** at every resolution (1080p: 0.42 -> 1.55 ms). The workaround is
+  correct and load-bearing.
+* **The `rw_prepared_input_color` `rgba16`-over-`RGBA16F` mismatch.** Performance-neutral (within
+  0.5%). Still worth having as correctness — it is undefined behaviour — and it is upstream as PR
+  #12, which the pin now includes.
+
+**`useLut` is a dead end, and the reason usually given for it is wrong.** It is gated on
+`waveLaneCountMax == 64`. `GetDeviceCapabilitiesGL` initialises that field to 0 but then **overwrites
+it with `GL_SUBGROUP_SIZE_KHR`**, so on NVIDIA it is 32, not 0 — the engine logs it as
+`FSR2: device supports temporal upscaling (wave size 32-32, fp16 true)`. The reproject pass takes the
+reference Lanczos because the device is wave32, exactly as DX12/Vulkan on the same GPU would. Do not
+repeat "the GL backend hardcodes it to 0"; that describes an older revision, not the pin.
+
+**#684's acceptance criterion is met, and was already met before this change — the earlier "FSR2
+saved nothing" reading was the binding-scope bug below.** At 1920x1080 on the `FSR2Perf` scene, min
+of the uncontended interleaved rounds:
+
+| | stock | loops expanded |
 |---|---|---|
-| 1280x720 | 0.210 ms | 0.228 |
-| 1920x1080 | 0.427 ms | 0.206 |
-| 2560x1440 | 0.711 ms | 0.193 |
+| native (1.00) | 2.705 ms | 2.706 ms |
+| spatial Quality (0.667) | 1.719 ms | 1.721 ms |
+| temporal Quality (0.667) | 2.113 ms | **1.928 ms** |
+| temporal Balanced (0.59) | 1.862 ms | **1.686 ms** |
 
-Almost perfectly linear in output pixels — **0.178 ms/MPix marginal, ~0.05 ms fixed** — so it is
-throughput-bound rather than dominated by small-dispatch overhead, which is the reading that would have
-excused it. Extrapolated to 4K that is **~1.5 ms on a 4090**, against AMD's quoted ~1.1-1.2 ms at 4K on an
-RX 6800 XT. Roughly 3x slower than the hardware class implies, matching the author's figure.
-
-**Two levers were tested and neither helps.** Recorded so nobody re-runs them:
-
-* **FP16 for the accumulate pass.** The backend disables it on NVIDIA ("reduced occupancy and high VRAM
-  throughput") and that looked like stale Turing-era tuning worth revisiting on Ada. Re-enabling it made
-  FSR2 **3.4-8.9x SLOWER** at every resolution (1080p: 0.42 -> 1.55 ms). The workaround is correct and
-  load-bearing, and the result corroborates the author's VRAM-throughput diagnosis rather than
-  undermining it.
-* **The `rw_prepared_input_color` `rgba16`-over-`RGBA16F` mismatch.** Fixing it is **performance-neutral**
-  (within 0.5%). Still worth fixing as correctness — it is undefined behaviour — but it is not a speed
-  lever. (Measured properly here; an earlier "inert" verdict on this was taken against BRIGHTNESS during
-  the window when the stale-shader build trap could have voided it.)
-
-`useLut` is a third candidate and probably not worth the trip: it is gated on `waveLaneCountMax == 64`
-while the GL backend hardcodes that to 0, so the reproject pass always takes the reference Lanczos — but
-DX12/Vulkan on NVIDIA (wave32) picks the same path, so it is not a GL-specific regression.
-
-**The consequence for #684's acceptance criterion is real:** "a GPU frame-time reduction at 67%/59%" may
-not be achievable on NVIDIA with this backend at all, and that is an upstream problem rather than an
-integration one. Anyone picking this up should measure on AMD before concluding the integration is at
-fault, and should not promise the win on NVIDIA without re-measuring on an idle machine.
+Native and spatial are the control and do not move. Temporal Quality goes from saving 21.9% of GPU
+frame time against native to saving 28.7%, and the whole-frame delta (0.185 ms) reconciles with the
+isolated dispatch delta (0.184 ms) — which is the check that says the two measurements are describing
+the same thing. FSR1 spatial is still cheaper in absolute terms and always will be; it does far less.
 
 ### A state restore that is free in an isolated test can be the most expensive thing in the frame
 


### PR DESCRIPTION
## What this is

#925 asked whether FSR2's ~3x cost on NVIDIA could be closed, and framed "we measured it and it cannot be" as an acceptable outcome. It can be closed, and this closes it.

**The handover for this task was stale.** The root cause was already found and lives in two upstream PRs, neither of which was in our tree:

- [JuanDiegoMontoya/FidelityFX-FSR2-OpenGL#14](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/14) — ours, **still open** — the private-array spill. This PR carries it as a local patch.
- [#13](https://github.com/JuanDiegoMontoya/FidelityFX-FSR2-OpenGL/pull/13) (aardappel, rejected on maintenance grounds) — same root cause from the other end: bypass NVIDIA's SPIR-V front end entirely. Larger win, much larger fork. Not taken; documented.

## The mechanism

`ComputeDepthClip`, `PreProcessReactiveMasks` and `ComputeUpsampledColorAndWeight` index fixed-size private arrays with a loop variable. Every bound is constant, but NVIDIA's OpenGL SPIR-V front end still lowers those arrays to **local memory, which is device memory** — so the port author's "abnormally high VRAM throughput in the depth-clip and reproject/accumulate passes" was literally true. Expanding the loops keeps every index literal, glslang scalarises the arrays, and there is nothing to spill. Math and evaluation order unchanged.

## Measured — RTX 4090, driver 616.64, min of 5 interleaved runs per arm

`FSR2Perf.UpscaleCostPerMegapixelAcrossOutputResolutions`:

| output | stock | expanded | |
|---|---|---|---|
| 1280x720 | 0.214 ms (0.232/MPix) | 0.114 ms (0.123/MPix) | 1.88x |
| 1920x1080 | 0.415 ms (0.200/MPix) | 0.231 ms (0.112/MPix) | 1.80x |
| 2560x1440 | 0.666 ms (0.187/MPix) | 0.366 ms (0.102/MPix) | 1.83x |

AMD quotes ~0.145 ms/MPix on an RX 6800 XT. At 0.102 the vendor gap is **closed, not narrowed** — which is what #925's proposed AMD measurement existed to establish, reached without AMD hardware. (That measurement was structurally unavailable anyway: FSR2 is Windows-only here by construction, and the Linux AMD runner cannot build it.)

`FSR2Perf.ReportsTemporalUpscaleGpuFrameTimeAtQualityAndBalanced` @1920x1080, uncontended rounds — **this is #684's acceptance criterion**:

| | stock | expanded |
|---|---|---|
| native (1.00) | 2.705 ms | 2.706 ms |
| spatial Quality (0.667) | 1.719 ms | 1.721 ms |
| temporal Quality (0.667) | 2.113 ms | **1.928 ms** |
| temporal Balanced (0.59) | 1.862 ms | **1.686 ms** |

Native and spatial are the control and do not move. Temporal Quality goes from saving 21.9% of GPU frame time to 28.7%; the whole-frame delta (0.185 ms) reconciles with the isolated dispatch delta (0.184 ms).

## Also in here

- **Pin bump** to upstream `f188a0d8` (own commit). Our pin was two commits behind and did not carry our own merged PR #12 (`rw_prepared_input_color` `rgba16`-over-`RGBA16F`, undefined store). Verified byte-identical output and unchanged timings.
- **Patch machinery** — `cmake/fsr2-apply-patches.cmake` enforces *tree == pin + patches* by restoring to the pin before applying. `*.patch -text` in `.gitattributes` is load-bearing: under `* text=auto` a fresh Windows checkout rewrites the patch to CRLF, and a patch whose line endings changed after authoring may stop applying.
- **Two corrections to the issue's own premises**: `waveLaneCountMax` is *not* hardcoded to 0 — `GetDeviceCapabilitiesGL` overwrites it with `GL_SUBGROUP_SIZE_KHR` (the engine logs `wave size 32-32`), so `useLut` is unreachable because the device is wave32, exactly as DX12/Vulkan would be. And the GL and Vulkan backends do *not* compile the same GLSL: `.glsl2` vs `.glsl`, with combined samplers instead of separate texture+sampler.

## Review guide

**Where I'd look hardest**
1. `cmake/fsr2-apply-patches.cmake` — the restore-then-apply contract. It rewrites files in a fetched tree on every configure and silently discards hand edits there. I verified all three paths against real configures (patch present / hand edit / patch deleted), but this is the piece with the most ways to be subtly wrong.
2. `cmake/fsr2.cmake:90` `PATCH_COMMAND` — the tree is permanently dirty between configures, so a future pin bump routes through ExternalProject's stash/checkout/pop and will conflict precisely when the patched hunks are what moved upstream. Documented with a recovery, not fixed; I could not find a fix that doesn't stop patching in place.
3. `cmake/fsr2-patches/0001-*.patch` — the upsample index map (`col + (row << 2)` → 0,1,2,4,5,6,8,9,10) has three skipped slots and `bInitialSample` must fire only for (0,0).

**What I verified, and how**
- Output neutrality: all eight `FSR2VisualEvidenceTest` PNGs byte-identical across arms, against a run-to-run noise floor I measured at **exactly zero** (two runs of the same binary are byte-identical). I also looked at `FSR2_Quality` and `FSR2_MotionSettled`.
- The mechanism, and that the new shaders actually reached the GPU: isolated NVIDIA GL shader cache per arm, same 43 compute programs both sides. `TEMP lmem0[31]` (depth clip) disappears; `lmem0[20]` x2 (both accumulate permutations) becomes `lmem0[4]`. This is also a positive test against the documented stale-blob trap.
- `OloEngine-Tests` and `OloEditor` both built Debug, exit 0.

**Least confident about** — the frame-time table. The box hosts CI runners for another repo and three of eight rounds were visibly contaminated (native jumping 2.70 → 5.5 ms); I quote only the uncontended rounds. The dispatch-cost table is much more robust and the two reconcile, but a re-run on a quiet machine would be worth having. Also: the 1.8-1.9x is Ada-specific — upstream #8 reports the original 3x on an RTX 3070, and nobody has tested this on Ampere.

**Deliberately not tested** — `useLut` (ruled out by reasoning plus the measured wave32, not by an A/B), FP16 re-enable (already measured 3.4-8.9x slower, per the issue's do-not-re-run list), and AMD (structurally cannot build). No new test: the file documents why a GPU timing cannot be a gate here, and what does fail loudly is the configure.

**Pre-existing, not touched**: the committed `FSR2_Native.png` / `FSR2_Quality.png` no longer match what master produces on this box — deterministically, in a 4-scanline horizon band (max 168/255). They are written evidence, not asserted goldens, so nothing fails. Not rebased here; say the word and I'll file it.

Closes #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved FSR2 performance on NVIDIA hardware by addressing shader behavior that could cause significant slowdowns.
  - Updated the bundled FSR2 integration and applied compatibility fixes automatically during configuration.

- **Documentation**
  - Updated rendering documentation with performance measurements, troubleshooting guidance, and details about the NVIDIA-specific improvement.
  - Clarified FSR2 performance-test behavior and configuration-time validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->