### PR TITLE
feat(process): model external blockers in the issue picker

### DIFF
--- a/docs/process/issue-scoring.md
+++ b/docs/process/issue-scoring.md
@@ -131,6 +131,24 @@ Two things that a number can't express but the picker needs:
   dependency graph WSJF cannot model. **A `blocked_by` that isn't empty
   excludes the issue from the picker entirely, regardless of score** — you
   can't pick what you can't start.
+- **External blockers** — `blocked_by_external: ["…", …]`, a list of free-text
+  reasons. Same effect on the picker as `blocked_by`, for everything the
+  in-repo tech tree cannot name: an upstream release we are waiting on, a
+  compiler feature that has not shipped, a vendor fix. Omit the field entirely
+  when there is none — an empty list on every issue is noise.
+
+  The picker's question is *"can I start this today?"*, and an issue waiting on
+  someone else's release answers no just as firmly as one waiting on a sibling
+  issue. Without this the two looked different: **#815 sat at rank 7** with an
+  empty `blocked_by` while waiting on two upstream `repowise` fixes, so every
+  sweep re-derived "oh, not that one" by hand and then discarded the finding.
+  Ranked rows carry an `external` flag so the demotion is visible rather than
+  mysterious.
+
+  Use it for a genuine external dependency, **not** to park work you simply do
+  not want — that is what the low-value floor and the axes are for (§6.3: fix
+  the inputs, don't hide the issue). A standing `Track:` watch item, which can
+  never be "done" and only ever waits on someone else, is the archetypal case.
 
 ---
 

--- a/scripts/issue_scores.py
+++ b/scripts/issue_scores.py
@@ -113,6 +113,10 @@ def render_section(d):
     lines.append(f"kano: {d.get('kano', 'table-stakes')}")
     lines.append(f"blocked_by: {json.dumps(d.get('blocked_by', []))}")
     lines.append(f"blocks: {json.dumps(d.get('blocks', []))}")
+    # Emitted only when set: an empty list on every issue would be noise, and the
+    # absent-means-empty default already reads correctly in parse_block.
+    if d.get("blocked_by_external"):
+        lines.append(f"blocked_by_external: {json.dumps(d['blocked_by_external'])}")
     block = "\n".join(lines)
     caption = ("<sub>Rated per [issue-scoring](" + DOC_URL + ") · "
                "score = confidence × (capability + craft + stability + decay) / effort, "
@@ -141,7 +145,21 @@ def score(d):
 
 
 def is_blocked(d):
-    return bool(d.get("blocked_by"))
+    """Blocked = cannot be started today, whatever holds it up.
+
+    `blocked_by` models the in-repo tech tree (issue numbers). `blocked_by_external`
+    models everything the tech tree cannot express: an upstream release we are waiting
+    on, a compiler feature that has not shipped, a vendor fix. Both drop the issue from
+    the picker, because the picker's question is "can I start this now?" and the answer
+    is no either way.
+
+    Before this existed, an externally-blocked issue carried an empty `blocked_by` and
+    therefore ranked as startable — #815 sat at rank 7 while waiting on two upstream
+    repowise releases, and had to be skipped by hand on every sweep. A human silently
+    re-deriving the same "oh, not that one" every time is exactly the cost this file
+    exists to remove.
+    """
+    return bool(d.get("blocked_by")) or bool(d.get("blocked_by_external"))
 
 
 def is_low_value(d):
@@ -186,8 +204,10 @@ def cmd_rank(args):
         flags = []
         if d.get("fun", 0) >= 8 and not is_blocked(d):
             flags.append("PULL")
-        if is_blocked(d):
+        if d.get("blocked_by"):
             flags.append("blocked:" + ",".join(map(str, d["blocked_by"])))
+        if d.get("blocked_by_external"):
+            flags.append("external")
         if floor and is_low_value(d):
             flags.append(f"low-value:{cod(d)}")
         print(f"{num:>5} {s:>5} {' '.join(flags):<20} {title[:64]}")


### PR DESCRIPTION
## What

Adds `blocked_by_external` to the `olo-score` block: a free-text list of reasons an issue
cannot be started that the in-repo tech tree cannot name — an upstream release, a compiler
feature that has not shipped, a vendor fix. It drops the issue from the picker exactly as
`blocked_by` does.

## Why

`blocked_by` only takes OloEngine issue numbers. An issue waiting on something outside the
repo therefore carried an empty list and **ranked as startable**:

- **#815** — waiting on `repowise-dev/repowise#1601` and `#1602` — sat at **rank 7**.
- **#688** and **#760** are standing `Track:` watch items that can never be "done" and only
  ever wait on someone else.

Every `/start-work` sweep re-derived "oh, not that one" by hand and then discarded the
finding. That silent re-derivation is exactly the cost `issue_scores.py` exists to remove.

## Measured effect

```
before: 805 1.5 | 815 1.33 | 1144 1.19 | 812 1.17 | 808 1.0
after:  805 1.5 | 1144 1.19 | 812 1.17 | 808 1.0  ...  815 1.33 external
```

#815 leaves the startable list; #1144 takes the slot. #688 and #760 render as
`external low-value:4`.

## Notes

- **Backward compatible.** Absent means empty, and `render_section` emits the field only when
  set, so no existing issue body changes and `apply` will not rewrite bodies that lack it.
- The `blocked:` and `external` flags are separate, so a row shows which kind of blocker it
  has rather than collapsing both into one label.
- The doc explicitly warns against using this to park work you merely do not want — that is
  what the low-value floor and the axes are for (§6.3: fix the inputs, don't hide the issue).
- The three issue bodies were updated ahead of this merging, so they carry the field but it is
  inert until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
