### PR TITLE
test(localization): overlap the concurrent-Get readers with the writer (#1146)

### DIFF
--- a/OloEngine/tests/LocalizationTest.cpp
+++ b/OloEngine/tests/LocalizationTest.cpp
@@ -25,7 +25,9 @@
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Scene.h"
 
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -411,6 +413,16 @@ TEST_F(LocalizationFixture, ConcurrentGetIsSafeAcrossLocaleSwitch)
     // Smoke-test concurrent reads racing against a writer. Validates that
     // returning std::string-by-value rather than const-ref from Get() is
     // sound — refs would dangle the moment the writer swaps tables.
+    //
+    // The overlap between the readers and the locale-flip storm is established
+    // explicitly, not assumed: the writer waits for every reader to be live
+    // before it starts flipping, and keeps flipping until every reader has done
+    // a floor of work *inside* the storm. An earlier version bounded the writer
+    // with 50 sleeps of 200 us and asserted only that the total read count was
+    // non-zero, so a slow thread start made the test either vacuous or red
+    // (issue #1146). Nothing here is timing-dependent for correctness; the two
+    // timeouts exist only so a genuinely stuck run fails loudly instead of
+    // hanging CI.
     auto enPath = OloEngine::Tests::TempFile("olo_en_race.ololocale");
     auto dePath = OloEngine::Tests::TempFile("olo_de_race.ololocale");
     {
@@ -424,15 +436,21 @@ TEST_F(LocalizationFixture, ConcurrentGetIsSafeAcrossLocaleSwitch)
     ASSERT_TRUE(LocalizationManager::LoadLocale(enPath));
     ASSERT_TRUE(LocalizationManager::LoadLocale(dePath));
 
-    std::atomic<bool> stop{ false };
-    std::atomic<u64> readCount{ 0 };
     constexpr int kReaderCount = 4;
+    constexpr int kMinFlips = 50;
+    constexpr u64 kMinReadsPerReader = 64;
+    constexpr auto kStartupTimeout = std::chrono::seconds(30);
+    constexpr auto kProgressTimeout = std::chrono::seconds(60);
+
+    std::atomic<bool> stop{ false };
+    std::array<std::atomic<u64>, kReaderCount> reads{};
+
     std::vector<std::thread> readers;
     readers.reserve(kReaderCount);
     for (int i = 0; i < kReaderCount; ++i)
     {
         readers.emplace_back(
-            [&]
+            [&reads, &stop, i]
             {
                 while (!stop.load(std::memory_order_relaxed))
                 {
@@ -441,24 +459,89 @@ TEST_F(LocalizationFixture, ConcurrentGetIsSafeAcrossLocaleSwitch)
                     // between switches left no active locale, which shouldn't
                     // happen with our lock discipline.
                     EXPECT_TRUE(s == "Play" || s == "Spielen") << "got: " << s;
-                    readCount.fetch_add(1, std::memory_order_relaxed);
+                    reads[static_cast<sizet>(i)].fetch_add(1, std::memory_order_relaxed);
                 }
             });
     }
 
-    for (int i = 0; i < 50; ++i)
+    // Phase 1: wait until every reader has completed at least one read, so
+    // the flip storm below is guaranteed to overlap live readers.
+    bool allStarted = true;
     {
-        LocalizationManager::SetCurrentLocale((i % 2 == 0) ? "en" : "de");
-        std::this_thread::sleep_for(std::chrono::microseconds(200));
+        const auto deadline = std::chrono::steady_clock::now() + kStartupTimeout;
+        for (sizet i = 0; i < static_cast<sizet>(kReaderCount) && allStarted; ++i)
+        {
+            while (reads[i].load(std::memory_order_relaxed) == 0)
+            {
+                if (std::chrono::steady_clock::now() > deadline)
+                {
+                    allStarted = false;
+                    break;
+                }
+                std::this_thread::yield();
+            }
+        }
     }
+
+    // Phase 2: flip the locale until both floors are met: a minimum number of
+    // switches, and a minimum number of reads per reader observed since the
+    // flipping began. The loop exit is driven by observed progress, never by
+    // elapsed time.
+    std::array<u64, kReaderCount> baseline{};
+    int flips = 0;
+    bool metFloors = false;
+    if (allStarted)
+    {
+        for (sizet i = 0; i < static_cast<sizet>(kReaderCount); ++i)
+            baseline[i] = reads[i].load(std::memory_order_relaxed);
+
+        const auto deadline = std::chrono::steady_clock::now() + kProgressTimeout;
+        while (true)
+        {
+            LocalizationManager::SetCurrentLocale((flips % 2 == 0) ? "en" : "de");
+            ++flips;
+
+            if (flips >= kMinFlips)
+            {
+                bool enough = true;
+                for (sizet i = 0; i < static_cast<sizet>(kReaderCount); ++i)
+                    enough = enough && (reads[i].load(std::memory_order_relaxed) - baseline[i]) >= kMinReadsPerReader;
+                if (enough)
+                {
+                    metFloors = true;
+                    break;
+                }
+            }
+
+            if (std::chrono::steady_clock::now() > deadline)
+                break;
+
+            // Give the readers a chance at the shared lock. A scheduling hint
+            // only; the loop above decides when to stop.
+            std::this_thread::yield();
+        }
+    }
+
     stop.store(true, std::memory_order_relaxed);
     for (auto& t : readers)
         t.join();
 
-    EXPECT_GT(readCount.load(), 0u);
-
     std::filesystem::remove(enPath);
     std::filesystem::remove(dePath);
+
+    ASSERT_TRUE(allStarted) << "reader threads did not complete a single read within "
+                            << kStartupTimeout.count() << "s; the locale-flip storm would not "
+                                                          "have overlapped them";
+    ASSERT_TRUE(metFloors) << "readers made too little progress within " << kProgressTimeout.count()
+                           << "s across " << flips << " locale flips";
+
+    for (sizet i = 0; i < static_cast<sizet>(kReaderCount); ++i)
+    {
+        const u64 done = reads[i].load(std::memory_order_relaxed) - baseline[i];
+        EXPECT_GE(done, kMinReadsPerReader)
+            << "reader " << i << " completed only " << done << " reads across " << flips
+            << " locale flips";
+    }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1146.

`LocalizationFixture.ConcurrentGetIsSafeAcrossLocaleSwitch` red `ASan (Windows) tests 4/4` on
master dispatch
[34341826035](https://github.com/drsnuggles8/OloEngineBase/actions/runs/34341826035) with
`Expected: (readCount.load()) > (0u), actual: 0 vs 0`.

## What was wrong

The test spawned four reader threads and then immediately opened the writer's window — 50 locale
flips paced by `sleep_for(200us)`, nominally about 10 ms — before setting `stop`. Nothing made the
readers start inside that window. On a loaded Windows runner under ASan, thread startup can outlast
it: every reader sees `stop == true` on its first check, exits with zero iterations, and
`EXPECT_GT(readCount, 0u)` fails.

The failure is the visible half. The worse half is that when it passed it was often close to
vacuous: a handful of iterations already satisfies `> 0`, so how much of the locale-switch race the
test actually covered was decided by scheduling luck. A `sleep_for` is a floor, not a bound, so the
window's real length was never the 10 ms the code implied.

## What changed

`OloEngine/tests/LocalizationTest.cpp` only — no engine code, no other test.

- Each reader keeps **its own** counter instead of sharing one.
- **Phase 1:** the writer waits until *every* reader has completed at least one read before it
  starts flipping, so the storm is guaranteed to overlap live readers.
- **Phase 2:** the flip loop runs until both floors are met — 50 flips, and 64 reads per reader
  *counted from the moment flipping began* — so the exit condition is observed progress, not an
  elapsed-time budget.
- The assertion is now a per-reader floor. `EXPECT_GT(readCount, 0u)` could not have failed once
  Phase 1 is in place, which is precisely the trap #1146 is about, so it is gone.
- Both waits are bounded (30 s / 60 s) and fail with a message naming the timeout and the observed
  counts, so a genuinely stuck run reds rather than hanging CI.
- **No `sleep_for` remains.** The only pacing left is a `std::this_thread::yield()` between flips,
  which lets readers at the shared lock but which no loop condition depends on.
- The `s == "Play" || s == "Spielen"` invariant, which is the point of the test, is untouched.

`ConcurrentGetIsSafeAcrossLocaleSwitch` is the only test in the file that spawns threads, so there
is no sibling instance of the pattern to fix.

## Evidence

**The mechanism, reproduced locally.** A standalone probe modelling the old shape (four readers, a
`shared_mutex` + map + string copy for `Get`, the same 50 x 200 us writer window), pinned to two
cores with 24 competing CPU threads, hit `readCount == 0` in **10 of 40 trials**. The same probe
running the new shape under identical conditions never dipped below the per-reader floor: **0 of
40**, worst reader 28 358 reads.

The old shape is bimodal, which is the interesting part: every thin trial was a *zero* trial —
there were no in-between runs of, say, 50 reads. It either did millions of reads or none at all,
depending on whether the four threads happened to start inside the writer's window. That is the
same coin-flip that decides, on a passing run, whether the test covered the locale-switch race or
merely reported success.

**The fixed test.**

| run | result |
|---|---|
| `--gtest_repeat=200`, unloaded | 200 / 200 pass |
| `--gtest_repeat=40`, binary pinned to 2 cores under 24 competing CPU threads | 40 / 40 pass |
| whole `LocalizationFixture` (33 tests) | 33 / 33 pass |

Per-iteration runtime dropped from about 10 ms of sleeping to about 5 ms, because the test now stops
as soon as the work floors are met.

**Honest limit:** the *real* test binary built from `origin/master` also passed 40/40 under that same
pinned-and-loaded run, so this workstation is not a direct reproducer for the CI failure — as the
issue predicted. The reproduction above is of the mechanism, not of the CI run. The decisive check is
a green `ASan (Windows)` arm, which this PR's own Sanitizers run exercises.

Test-only change, so the visual-verification contract does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
