### PR TITLE
ci: move the cache-prune working ceiling to track the 25 GB cap

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -1,4 +1,6 @@
-# Keep the Actions cache under the 10 GB repository cap (#1009 item D).
+# Keep the Actions cache under the repository cache cap (#1009 item D).
+# The cap was 10 GB until 2026-09-09 and is 25 GB now; the working-ceiling block in the
+# sweep step carries the wall arithmetic and why the margin is the size it is.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -319,28 +321,48 @@ jobs:
 
           # FAIL WHEN THE STORE IS STILL NEARLY FULL (#1073). Everything above deletes
           # only what is provably superseded or unread; if what remains still does not
-          # leave room for a night of saves, the fleet has outgrown the 10 GB cap and a
+          # leave room for a night of saves, the fleet has outgrown the cap and a
           # human has to shrink something -- an SCCACHE_CACHE_SIZE, a job's cache, or the
           # cap itself. The alternative is what actually happened: the store sat read-only
           # for weeks, every save was refused with a warning nobody read, and the only
           # visible symptom was a Windows build that had quietly stopped caching. This
           # job failing is the alarm that was missing.
           #
-          # WHERE THE NUMBER COMES FROM. The cap is 10 GB DECIMAL, not 10 GiB, and that
-          # is measured rather than read off the docs: saves were being refused with the
-          # store at 9,713,535,876 bytes = 9264 MiB. Had the cap been 10 GiB (10737 MiB)
-          # there would have been 1.4 GiB free and the 706 MiB vcpkg save in the same run
-          # would have landed. It did not. So the wall is ~9537 MiB.
+          # WHERE THE NUMBER COMES FROM. The cap is DECIMAL GB, not GiB, and that is
+          # measured rather than read off the docs: under the old 10 GB cap saves were
+          # refused with the store at 9,713,535,876 bytes = 9264 MiB. Had it been 10 GiB
+          # (10737 MiB) there would have been 1.4 GiB free and the 706 MiB vcpkg save in
+          # the same run would have landed. It did not.
           #
-          # Post-sweep the steady set measures ~7.9 GiB (2.0 Windows sccache, 3.7 across
-          # the three Linux sanitizer sccaches, 0.7 vcpkg, 0.5 Vulkan SDKs, and 0.9 of
-          # `sccache-flaky-281` which ages out now that its nightly is gone). 8800 MiB
-          # leaves that a working margin and still fires ~700 MiB before the wall --
-          # early enough that a human can act before the store goes read-only.
+          # THE CAP IS 25 GB SINCE 2026-09-09, so the wall is 25e9 / 1048576 = ~23841 MiB,
+          # where it used to be ~9537. This constant did not move with it, which made the
+          # raise inert: six sweeps a day went on enforcing a limit that no longer existed
+          # (#1084). Settings -> Actions -> General -> Cache settings; the mechanism and
+          # its billing are in docs/agent-rules/actions-cache-budget.md, "The cap moved".
           #
-          # Raise it only together with a re-measurement of the steady set. Raising it to
-          # silence the alarm is how #1073 happened.
-          headroom_floor_mib=8800
+          # THE MARGIN IS SIZED OFF THE LARGEST SINGLE ENTRY, not off a percentage, and
+          # that is the part the old number got wrong. 8800 against a 9537 MiB wall left
+          # 737 MiB -- less than `sccache-windows-2025-release` alone (2044 MiB measured),
+          # so one save landing after a sweep could clear the wall before the next sweep
+          # ever looked. A margin has to be bigger than what can arrive inside one sweep
+          # interval or it is not a margin. 20000 leaves 3841 MiB, ~1.9x that entry.
+          #
+          # Post-sweep the steady set measured 7968 MiB on 2026-09-09 (2044 Windows
+          # sccache, 3440 across the three Linux sanitizer sccaches at their 1300M caps,
+          # 1033 vcpkg, 776 Vulkan SDKs, 667 Windows ASan sccache). 20000 leaves that room
+          # to roughly double -- deliberate, because raising `SCCACHE_CACHE_SIZE` on the
+          # Windows build is a live proposal that the old cap made impossible.
+          #
+          # A BUDGET CAN BIND BEFORE THE CAP DOES. The read-only failure this alarm exists
+          # for quotes "you have reached your configured BUDGET"; storage above 10 GiB is
+          # billed hourly at $0.07/GiB-month, so a budget set too low goes read-only with
+          # the cap nowhere in sight. If that is ever the tighter of the two, this number
+          # has to be derived from the budget instead. It is not today.
+          #
+          # Raise it only together with a re-measurement of the steady set AND a cap that
+          # really moved. Raising it to silence the alarm under a FIXED cap is how #1073
+          # happened, and that is a different act from following a cap that moved.
+          headroom_floor_mib=20000
 
           # SUM THE LISTING, NOT `/actions/cache/usage` -- that endpoint LAGS behind
           # deletions, badly. Measured on run 34039757109: this sweep freed 5567 MiB and
@@ -356,7 +378,7 @@ jobs:
           used_mib=$((kept_bytes / 1048576))
           if [ "${used_mib}" -gt "${headroom_floor_mib}" ]; then
             echo "::error::Actions cache store is ${used_mib} MiB after pruning, over the ${headroom_floor_mib} MiB working ceiling."
-            echo "::error::Past the 10 GB cap GitHub does not evict -- it makes the whole store READ-ONLY and refuses every save in the repo, silently (actions/cache/save warns and exits 0). Nothing left here is superseded, so this needs a human: docs/agent-rules/actions-cache-budget.md."
+            echo "::error::Past the cap (25 GB, ~23841 MiB) GitHub does not evict -- it makes the whole store READ-ONLY and refuses every save in the repo, silently (actions/cache/save warns and exits 0). Nothing left here is superseded, so this needs a human: docs/agent-rules/actions-cache-budget.md."
             exit 1
           fi
           echo "headroom: $((headroom_floor_mib - used_mib)) MiB below the working ceiling."

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -18,7 +18,7 @@ Issue [#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073).
    immortal — and so is the entry it superseded.
 4. **Before redesigning a cache, add up what the fleet already stores.** The cap was
    ~9537 MiB until 2026-09-09 and is **25 GB** now (see *The cap moved* below); the
-   binding number today is `cache-prune.yml`'s 8800 MiB working ceiling, not the cap. If
+   binding number today is `cache-prune.yml`'s 20000 MiB working ceiling, not the cap. If
    the steady set does not leave room for the largest single snapshot, no key design
    will help.
 5. **The store exists to speed up GITHUB-HOSTED jobs on a PULL REQUEST. Nothing else has
@@ -127,8 +127,9 @@ Two things that do NOT follow from the raise:
   budget**" — that is the budget path, which goes read-only. Plain overflow of the free
   10 GB evicts LRU instead. A budget of $0 against a raised cap reproduces the original
   bug exactly, which is why the budget is set rather than merely the cap.
-* **`cache-prune.yml`'s 8800 MiB working ceiling did not move with it**, so the raise is
-  inert until that constant does. See the note on it below.
+* **`cache-prune.yml`'s working ceiling had to move with it**, and did not at first — for
+  a few hours the raise was inert, because six sweeps a day went on enforcing the old
+  limit. It is 20000 MiB as of 2026-09-09. See the note on it below.
 
 ### The janitor could not collect the biggest orphan
 
@@ -188,7 +189,7 @@ before compression:
 | **measured subtotal** | **1813 MiB** (4 + 229 + 256 + 291 + 327 + 706), measured 2026-09-09 |
 | `sccache-windows-2025-release` | **2044 MiB** — measured 2026-09-08 and again 2026-09-09. At its 2 G cap and evicting. Warm PR runs return 94.77 / 95.01 / 98.49 %, so the cap is not currently costing much, but it has no headroom left either. |
 | `sccache-asan-windows-2025-vk1.4.357.0` | **667 MiB measured** 2026-09-09 — down from **1230 MiB** on 2026-09-08, and the drop is the useful part. #1118 renamed the key to carry the SDK version, which started a **fresh lineage**: this entry holds one build's objects, where the old one had accumulated objects from many source generations in a single dir. **So an object set measured off a long-lived entry overstates what one build needs** — the `du -sm` 1241 MiB that rule 6's arithmetic used for this job was such a measurement. Its 1500M cap now has ~830 MiB spare. |
-| **steady set** | **7968 MiB measured** 2026-09-09 by summing `size_in_bytes` over the API listing, 11 entries (the floored rows above sum to 7964). Against a ~9537 MiB wall and `cache-prune.yml`'s 8800 MiB working ceiling that is **832 MiB of headroom to the ceiling** — down from 1738 MiB on 2026-09-08, because #1118's 1300M cap cost the sanitizer trio ~1200 MiB and the Vulkan SDK bump stranded another 229. **Against the 25 GB cap set the same day it is ~17 GB, and the 8800 MiB ceiling is the only thing still binding** (see *The cap moved*): the measurement stands, the "nothing sizeable can be added" conclusion it carried does not. That headroom, not any object set, is what a cap has to be sized against — see [sccache-cap-vs-object-set.md](sccache-cap-vs-object-set.md). |
+| **steady set** | **7968 MiB measured** 2026-09-09 by summing `size_in_bytes` over the API listing, 11 entries (the floored rows above sum to 7964). Against a ~9537 MiB wall and `cache-prune.yml`'s 8800 MiB working ceiling that is **832 MiB of headroom to the ceiling** — down from 1738 MiB on 2026-09-08, because #1118's 1300M cap cost the sanitizer trio ~1200 MiB and the Vulkan SDK bump stranded another 229. **Against the 25 GB cap set the same day it is ~17 GB** (see *The cap moved*): the measurement stands, the "nothing sizeable can be added" conclusion it carried does not. What binds is `cache-prune.yml`'s working ceiling, **20000 MiB**, leaving this set **12032 MiB** of room. That headroom, not any object set, is what a cap has to be sized against — see [sccache-cap-vs-object-set.md](sccache-cap-vs-object-set.md). |
 
 `SCCACHE_CACHE_SIZE` bounds the local directory **before** compression, so it is not the
 entry size — but do not read that as "the entry will be much smaller". Every sccache entry
@@ -205,17 +206,28 @@ with `du`, not `--show-stats`: if the sccache server has exited, the client sile
 a fresh one and reports its zeros (#1082).
 
 That is why `cache-prune.yml` now **fails** when
-the post-sweep store is over 8800 MiB: everything it deletes is provably superseded or
+the post-sweep store is over its working ceiling: everything it deletes is provably superseded or
 unread, so if what remains is still that close to the wall, the fleet has outgrown the
 cap and a human has to shrink something. Raising the ceiling to silence the alarm
 re-creates this bug.
 
-**That ceiling is now the binding constraint, and it is stale.** 8800 MiB was sized
-against a ~9537 MiB wall; the cap is 25 GB as of 2026-09-09, so six sweeps a day still
-enforce a limit that no longer exists. Raising it to track a cap that actually moved is
-not the mistake the paragraph above warns about — that mistake is raising it *under a
-fixed cap* to quiet an alarm that is telling the truth. Keep the ceiling a fixed margin
-below the real cap so the alarm still fires before saves start being refused.
+**That ceiling is the binding constraint, so it tracks the cap.** It was 8800 MiB against
+a ~9537 MiB wall; the cap became 25 GB on 2026-09-09 and the constant is **20000 MiB**
+since the same day. Moving it to follow a cap that really moved is not the mistake the paragraph
+above warns about — that mistake is raising it *under a fixed cap* to quiet an alarm that
+is telling the truth.
+
+**Size the margin off the largest single entry, not off a percentage.** That is what the
+old number got wrong: 8800 against 9537 left 737 MiB, which is less than
+`sccache-windows-2025-release` alone (2044 MiB), so one save landing after a sweep could
+clear the wall before the next sweep looked. 20000 against ~23841 leaves 3841 MiB, ~1.9x
+that entry. A margin smaller than what can arrive inside one sweep interval is not a
+margin.
+
+**And a budget can bind before the cap does.** The read-only failure quoted above says
+"you have reached your configured **budget**"; storage over 10 GiB bills hourly, so a
+budget set too low goes read-only with the cap nowhere in sight. If the budget is ever
+the tighter of the two, the ceiling has to be derived from it instead.
 
 ## A cache can be worth removing, and this one was worth 3741 MiB
 


### PR DESCRIPTION
`cache-prune.yml`'s `headroom_floor_mib` was **8800**, sized against the ~9537 MiB wall of
the old 10 GB cap. The cap became **25 GB** on 2026-09-09 and this constant did not move
with it, so six sweeps a day went on failing against a limit that no longer exists — the
raise was inert until this lands.

**8800 → 20000 MiB**, against a ~23841 MiB wall (`25e9 / 1048576`; the cap is decimal GB,
which this file already established by measurement rather than from the docs).

## The margin is sized off the largest single entry, not off a percentage

This is the part the old number got wrong, and it is worth not reproducing at the new
scale. 8800 against 9537 left **737 MiB** — less than `sccache-windows-2025-release` alone
at **2044 MiB measured**. One save landing after a sweep could clear the wall before the
next sweep ever looked, which is roughly what happened on 2026-09-07 (the store reached
10863 MiB on six duplicate vcpkg entries banked after the 07:03 sweep). A margin smaller
than what can arrive inside one sweep interval is not a margin.

20000 leaves **3841 MiB**, ~1.9× that entry.

A proportional raise would have kept the bug: holding the old 92.3 % ratio gives 22006 MiB
and a 1835 MiB margin, still under the largest entry.

## Headroom is deliberate, not slack

The steady set measured **7968 MiB** on 2026-09-09. 20000 leaves it room to roughly double,
which is wanted: raising `SCCACHE_CACHE_SIZE` on `Windows.yml / build` is a live proposal
(the entry is at its 2 G cap and evicting) that the old cap made impossible to consider.

## The one way this number can still be wrong

A configured Actions **budget** can bind before the cap does. The read-only failure this
alarm exists for quotes "you have reached your configured **budget**", and storage above
10 GiB is billed hourly — so a budget set too low goes read-only with the cap nowhere in
sight. That is not the case today, and it is recorded in both the workflow and the doc so
that if it ever is, the ceiling gets derived from the budget instead of from the cap.

## What is deliberately kept

The existing warning — *"Raising the ceiling to silence the alarm re-creates this bug"* —
stays, sharpened rather than removed. Following a cap that really moved is a different act
from quieting an honest alarm under a fixed one, and the file now says which is which.

Historical references to the 10 GB cap in the `WHY THIS EXISTS` header and the #1073
narrative are left alone: they describe what happened, and they were true.

## Verification

`cache-prune.yml` runs on a schedule and on `workflow_dispatch`. The next sweep prints
`headroom: <n> MiB below the working ceiling` — against the current 7968 MiB store that
should read ~12032 MiB rather than ~832. Happy to dispatch it once this is merged and post
the line, since a ceiling change that is never exercised is exactly the kind of thing that
sits wrong for weeks.

Refs #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
