### PR TITLE
ci(sanitizers): --parallel 2 on self-hosted too, the 4 was never affordable

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1448,16 +1448,29 @@ jobs:
         path: ${{ steps.vcpkg.outputs.cache-path }}
 
     - name: Build tests
-      # Pinned to --parallel 2 on the hosted arm: higher concurrency has been
-      # observed to exhaust runner memory (clang++ under sanitizer
-      # instrumentation uses ~3 GB per translation unit), causing `The hosted
-      # runner lost communication with the server` failures. 4 on the
-      # self-hosted box (16 threads, 31 GiB, a persistent ccache): two of these
-      # jobs run there at once, and 4 + 4 compiles is ~24 GB peak. The same
-      # width is used for ctest below -- with --olo-gl-backend=none the test
-      # phase is CPU-only there, and the box has the memory for four
-      # instrumented processes per job.
-      run: cmake --build build --target OloEngine-Tests --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }}
+      # Pinned to --parallel 2 on both arms: higher concurrency exhausts runner
+      # memory, which on the hosted arm surfaces as `The hosted runner lost
+      # communication with the server`. The self-hosted box is the tighter of
+      # the two constraints despite being the larger machine, because two of
+      # these jobs run on it at once.
+      #
+      # This was 4 on self-hosted until 2026-09-09, justified as "16 threads,
+      # 31 GiB, a persistent ccache ... 4 + 4 compiles is ~24 GB peak". Both
+      # halves of that were wrong. The ~3 GB per translation unit it assumed is
+      # 9.0 GB measured, with a single TU observed at 13.9 GB; and the runner
+      # account is capped by cgroup at MemoryMax=19G, so a 24 GB budget was
+      # never satisfiable. What actually happened was five OOM kills in 36
+      # hours and a 2 h 13 min outage of all three self-hosted runners, when
+      # systemd-oomd resolved the pressure by killing their systemd user
+      # manager.
+      #
+      # So 2 here is the affordable width, not a conservative one: 2 + 2
+      # concurrent instrumented compiles against a 19 G cap. Raising it again
+      # means raising that cap first (the host's
+      # /etc/systemd/system/user-1004.slice.d/50-resource-caps.conf) and
+      # measuring per-TU RSS rather than assuming it. The same width is used
+      # for ctest below, which bounds test RSS rather than compiler RSS.
+      run: cmake --build build --target OloEngine-Tests --parallel 2
 
     # Read the cache hit rate. A cold cache (first run / after a real source
     # change) is mostly misses + writes; a warm cache shows a high hit rate,
@@ -1630,10 +1643,10 @@ jobs:
       # 4-wide risks the OOM reaper killing the runner mid-test.
       #
       # NOTE: this is unrelated to the build step's `--parallel 2` above. That pin is
-      # a *compile-time* constraint (~3 GB per TU under clang+sanitizer) and does NOT
-      # transfer to the test phase — don't "reconcile" the two numbers; they bound
-      # different resources (peak compiler RSS vs. peak instrumented-test RSS).
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
+      # a *compile-time* constraint (~9 GB per TU under clang+sanitizer, measured) and
+      # does NOT transfer to the test phase — don't "reconcile" the two numbers; they
+      # bound different resources (peak compiler RSS vs. peak instrumented-test RSS).
+      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -1855,9 +1868,9 @@ jobs:
     - name: Build tests
       # Pinned to --parallel 2: higher concurrency has been observed to
       # exhaust runner memory (clang++ under sanitizer instrumentation uses
-      # ~3 GB per translation unit), causing `The hosted runner lost
+      # ~9 GB per translation unit, measured), causing `The hosted runner lost
       # communication with the server` failures.
-      run: cmake --build build --target OloEngine-Tests --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }}
+      run: cmake --build build --target OloEngine-Tests --parallel 2
 
     # Read the cache hit rate. A cold cache (first run / after a real source
     # change) is mostly misses + writes; a warm cache shows a high hit rate,
@@ -2021,7 +2034,7 @@ jobs:
       # UBSan now enables only the curated eight checks rather than the whole
       # `undefined` group, so vptr is no longer asked of `-fno-rtti` vendor code.
       # This exclusion covers the remaining, genuinely-GNS-side gap. See #636.
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
+      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -2252,9 +2265,9 @@ jobs:
     - name: Build tests
       # Pinned to --parallel 2: higher concurrency has been observed to
       # exhaust runner memory (clang++ under sanitizer instrumentation uses
-      # ~3 GB per translation unit), causing `The hosted runner lost
+      # ~9 GB per translation unit, measured), causing `The hosted runner lost
       # communication with the server` failures.
-      run: cmake --build build --target OloEngine-Tests --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }}
+      run: cmake --build build --target OloEngine-Tests --parallel 2
 
     # Read the cache hit rate. A cold cache (first run / after a real source
     # change) is mostly misses + writes; a warm cache shows a high hit rate,
@@ -2435,7 +2448,7 @@ jobs:
       # ThreadState and its first intercepted malloc faults inside TSan's own
       # allocator — a bare SIGSEGV with no report. OloEngine/vendor/CMakeLists.txt
       # now filters that definition off the imported target; see the comment there.
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build
@@ -2582,7 +2595,7 @@ jobs:
 
     - name: Run tests under ASan + LSan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
+      run: ctest --parallel 2 --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -2813,7 +2826,7 @@ jobs:
 
     - name: Run tests under UBSan
       working-directory: ${{github.workspace}}/build/OloEngine/tests
-      run: ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
+      run: ctest --parallel 2 --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -3061,7 +3074,7 @@ jobs:
           done
         ) &
         sampler=$!
-        ctest --parallel ${{ runner.environment == 'github-hosted' && 2 || 4 }} --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+        ctest --parallel 2 --output-on-failure --timeout 600 -I "${{ matrix.shard }},,${OLO_CTEST_SHARDS}" --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
         rc=$?
         kill "$sampler" 2>/dev/null || true
         exit "$rc"


### PR DESCRIPTION
The Linux sanitizer jobs build and test at `--parallel 4` on the self-hosted arm. This drops all nine sites to `2`, which is what the box can actually afford.

## Why

The ASan build step justified the 4 as *"16 threads, 31 GiB, a persistent ccache ... 4 + 4 compiles is ~24 GB peak"*. Both halves were wrong:

| Number | Claimed | Actual |
|---|---|---|
| Per translation unit | ~3 GB | **9.0 GB** measured, one TU at 13.9 GB |
| Job budget | ~24 GB peak | cgroup `MemoryMax=19G` — never satisfiable |

Three numbers, none of which agreed with each other.

## What it cost, in 36 hours

- **Five cgroup OOM kills** — `cc1plus` at 3.0 GB; `OloEngine-Tests` up to 14.5 GB anon-rss (09-09 05:51, 07:51, 07:54, 08:08, 08:14).
- **One oomd kill of the entire GPU runner service** (09-08 05:36).
- **A 2 h 13 min outage of all three self-hosted runners** (09-09 17:40). With two of these jobs concurrent, `systemd-oomd` resolved the pressure by killing the runner account's `systemd --user` manager (`init.scope`) instead of a job — which tears down every runner in the account at once. Lingering does not restart a user manager that was `SIGKILL`ed, so it stayed down until someone SSHed in.

## Scope

Nine sites: 3 build, 6 `ctest`. **Six of them only bring the code back in line with comments that already said `--parallel 2`** — the ctest steps and the UBSan/TSan build steps were documented as 2 and running at 4. Only the ASan build step ever argued for 4, and that rationale block is rewritten with the measured figures.

The stale `~3 GB per TU` figure is also corrected in the three other places it appeared. Not load-bearing now the width is 2, but it is the exact number that justified the raise.

`actionlint` clean; hosted arm behaviour is unchanged (it was already 2).

## Not in this PR

Host-side guards against that last failure mode are deployed separately on the runner box — `Restart=on-failure` on `user@<uid>.service` (upstream ships `Restart=no`, which is why the outage was open-ended) and `user.oomd_omit` on each user manager's `init.scope`, so oomd falls through to the runner services instead. Those stop a memory event becoming an outage; **this PR is what stops the memory event.**

Raising this again means raising the cgroup cap first and measuring per-TU RSS rather than assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1TqAmhX9eXCfPc8WY8Ai2
