### PR TITLE
ci: --parallel 2 on the three remaining self-hosted Linux builds

### DIFF
--- a/.github/workflows/gpu-conformance-amd.yml
+++ b/.github/workflows/gpu-conformance-amd.yml
@@ -115,6 +115,17 @@ jobs:
       # repository. A nightly at ~02:47 local should normally find them idle,
       # but "normally" is not "always" — leave headroom so a concurrent build
       # elsewhere on the box doesn't turn into swap thrash or an OOM.
+      #
+      # The tighter neighbour is closer than that, though, and this width has
+      # never been measured against it: gh-runner-1/2/3 are separate accounts in
+      # separate cgroup slices, but olo-gpu-amd (this job's runner) shares ONE
+      # account -- and so ONE MemoryMax=19G slice -- with olo-ci-1 and olo-ci-2.
+      # An overlap with a sanitizer build on either of those slots is 6 ordinary
+      # TUs plus 2 instrumented ones at ~9 GB each, inside 19 G total. The 6 is
+      # left as-is here because it was set on a measurement (the --parallel 12
+      # that ran the job out of memory); lowering it on a guess is the mistake
+      # this file's neighbours just had to unwind. Measure it before an overlap
+      # does it for us.
       CMAKE_BUILD_PARALLEL_LEVEL: 6
       # CPM/FetchContent pull vendor sources into OloEngine/vendor/ *inside the
       # workspace*, which the wipe + checkout clears every run. Without a cache

--- a/.github/workflows/gpu-sanitizers-amd.yml
+++ b/.github/workflows/gpu-sanitizers-amd.yml
@@ -561,16 +561,26 @@ jobs:
           "-DOLO_TESTS_CTEST_ARGS=--olo-gl-backend=egl;--olo-require-gpu;--olo-golden-vendor=amd"
 
       - name: Build tests
-        # --parallel 4, where the twin pins 2. The twin's 2 is sized for a
-        # 4-vCPU / 16 GB hosted VM (clang++ under sanitizer instrumentation uses
-        # ~3 GB per TU). The box has 16 threads, 31 GiB and a persistent ccache
-        # that turns most of a warm build into hits; 4 leaves room for the other
-        # CI slot to be compiling at the same time (two arms of this job will
-        # be, 4 + 4 compiles ~ 24 GB peak) and for the conformance nightly's
-        # runner, should the schedules ever overlap. Links are capped separately
-        # at 1 per tree by OLO_LINK_JOBS above. Ninja's default without a
-        # width is cores + 2 = 18, so the flag is not optional.
-        run: cmake --build build --target OloEngine-Tests --parallel 4
+        # --parallel 2, matching the twin in asan.yml.
+        #
+        # This was 4 until 2026-09-09, on a rationale copied verbatim from that
+        # twin: "~3 GB per TU ... 16 threads, 31 GiB and a persistent ccache ...
+        # 4 + 4 compiles ~ 24 GB peak". Both numbers are wrong. A clang++ TU
+        # under sanitizer instrumentation measures 9.0 GB, with one observed at
+        # 13.9 GB, and this runner account is capped by cgroup at MemoryMax=19G
+        # -- the 24 GB it was sized against was never available.
+        #
+        # This job IS the overlap the old comment waved at ("should the
+        # schedules ever overlap"). It takes the same
+        # [self-hosted, linux, x64, olo-ci] slots, and so the same 19 G slice, as
+        # the asan.yml sanitizer jobs. On 2026-09-09 two concurrent sanitizer
+        # jobs on those slots ended with systemd-oomd killing the runners'
+        # systemd user manager and a 2 h 13 min outage of all three runners.
+        #
+        # Links are capped separately at 1 per tree by OLO_LINK_JOBS above.
+        # Ninja's default without a width is cores + 2 = 18, so the flag is not
+        # optional.
+        run: cmake --build build --target OloEngine-Tests --parallel 2
 
       # The number a cache is judged on: a cache that restores and hits on
       # nothing looks exactly like a working one, and the hit rate is the only

--- a/.github/workflows/steam-stub.yml
+++ b/.github/workflows/steam-stub.yml
@@ -294,10 +294,16 @@ jobs:
 
       # Capped parallelism, per CLAUDE.md — a bare --parallel forwards the omission to the native
       # tool and takes its default (cores + 2 for Ninja), which is wider, not narrower.
+      #
+      # 2 rather than 4 since 2026-09-09. This build is not sanitizer-instrumented, so its own
+      # per-TU footprint is unremarkable — the reason is the neighbour, not this job. On the
+      # self-hosted arm it takes an olo-ci slot, and both slots live in ONE cgroup-capped slice
+      # (MemoryMax=19G); the other slot is routinely holding a sanitizer build whose TUs measure
+      # 9 GB each. The cap is on the account, not on the job.
       - name: Build tests
         # No --config: this is the single-config Unix Makefiles generator, so the build type
         # comes from CMAKE_BUILD_TYPE at configure time and --config would be silently ignored.
-        run: cmake --build build --target OloEngine-Tests --parallel 4
+        run: cmake --build build --target OloEngine-Tests --parallel 2
 
       # Resolved ONCE and exported, rather than repeating the find in each test step: two lookups
       # can disagree (a stale binary from an earlier layout still on disk would be picked by one

--- a/.github/workflows/vulkan-off.yml
+++ b/.github/workflows/vulkan-off.yml
@@ -233,8 +233,14 @@ jobs:
       # OloServer and OloRuntime are built alongside the tests on purpose. #762/#834 split
       # OloEngine into three static archives, and the OFF configuration changes what lands in
       # them — a link-order or missing-symbol regression can hit one consumer and not another.
+      #
+      # 2 rather than 4 since 2026-09-09, for the neighbour rather than for this job: nothing here
+      # is sanitizer-instrumented, but on the self-hosted arm this takes an olo-ci slot, and both
+      # slots share ONE cgroup-capped slice (MemoryMax=19G) with a sanitizer build whose TUs
+      # measure 9 GB each. Three targets in one invocation also makes this the widest link step
+      # of the self-hosted set. See steam-stub.yml for the same note.
       - name: Build (engine, tests, runtime, server)
-        run: cmake --build build --target OloEngine-Tests OloRuntime OloServer --parallel 4
+        run: cmake --build build --target OloEngine-Tests OloRuntime OloServer --parallel 2
 
       # Resolved once and exported rather than re-found per step: two lookups can disagree, and a
       # single failure point is easier to read in the log. Same as steam-stub.yml.


### PR DESCRIPTION
Follow-up to #1158, which was scoped too narrowly. That PR fixed the file the incident analysis named; it was not the whole exposure.

Every workflow below resolves to `[self-hosted, linux, x64, olo-ci]` — **two runner slots inside one account, and therefore inside one `MemoryMax=19G` cgroup slice.** The cap is on the account, not the job.

## Changed

| File | Sanitized? | Why |
|---|---|---|
| `gpu-sanitizers-amd.yml` | **yes** | The one that matters — see below |
| `steam-stub.yml` | no | Capped for the neighbour |
| `vulkan-off.yml` | no | Capped for the neighbour |

**`gpu-sanitizers-amd.yml`** carried a *verbatim copy* of the rationale #1158 corrected — same `~3 GB per TU`, same `4 + 4 compiles ~ 24 GB peak`, same 16-threads/31-GiB framing. Measured, that TU is **9.0 GB** (one seen at 13.9 GB), and 24 GB was never available under a 19 G cap. It is also precisely the overlap its own comment waved at — *"should the schedules ever overlap"* — because it takes the same slots as the `asan.yml` sanitizer jobs.

**`steam-stub.yml` / `vulkan-off.yml`** are not instrumented, so their own TUs are unremarkable. They are capped because of what is in the *other* slot: routinely a 9-GB-per-TU sanitizer build.

## Documented, not changed

`gpu-conformance-amd.yml` runs at `CMAKE_BUILD_PARALLEL_LEVEL: 6` and justifies it against `gh-runner-1/2/3` — but those are **separate accounts in separate slices**. `olo-gpu-amd` shares its account, and its 19 G, with `olo-ci-1` and `olo-ci-2`. An overlap there is 6 ordinary TUs plus 2 instrumented ones inside 19 G total.

I left the `6` alone. It was set on a real measurement — a `--parallel 12` that ran the job out of memory — and lowering it on a guess is exactly the mistake the other three files just had to unwind. The comment now records what the real neighbour is and what to measure.

## Audit

Every workflow reachable on the Linux box was checked, not just the ones grep first suggested. After this, nothing that can land there builds wider than 2 except that documented 6. The remaining `--parallel 4`/`6` hits in the tree (`Windows.yml`, `video-ffmpeg.yml`, `dist-archive.yml`, `asan.yml`'s `asan-windows-tests`) are all Windows-hosted — `OLO_WINDOWS_SELF_HOSTED` is not set on this repo.

`actionlint` clean on all four files. The pre-existing `label "olo-ci" is unknown` warning on `gpu-sanitizers-amd.yml:265` is unrelated and untouched — it wants an `actionlint.yaml` declaring the custom labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1TqAmhX9eXCfPc8WY8Ai2
