### PR TITLE
fix(tooling): the issue picker asks whether a blocker is still open (#1161)

### DIFF
--- a/.claude/commands/start-work.md
+++ b/.claude/commands/start-work.md
@@ -47,7 +47,7 @@ Then refresh the registry:
     gh pr list --state merged --limit 40  # recently FINISHED work — often still looks "open" in docs/TODOs
     gh issue list --state closed --limit 40     # closed issues — ditto
     python "$BASE/scripts/issue_scores.py" rank # scored, ranked backlog — canonical priority for GitHub issues (docs/process/issue-scoring.md)
-    python "$BASE/scripts/issue_scores.py" lint # UNSCORED open issues — absent from `rank`, therefore invisible to this command
+    python "$BASE/scripts/issue_scores.py" lint # UNSCORED open issues — absent from `rank`, therefore invisible to this command; also stale/unresolvable `blocked_by` edges
 Any topic represented by a worktree, a branch (local OR origin/*), an open PR, or an
 assigned issue is OFF-LIMITS as in-flight. Anything in a recently-merged PR or closed
 issue is OFF-LIMITS as already-done — this is your ground truth that a doc/TODO which

--- a/docs/process/issue-scoring.md
+++ b/docs/process/issue-scoring.md
@@ -128,9 +128,12 @@ Two things that a number can't express but the picker needs:
   favor of delighters. **Rule: the top of the ranked list must always carry
   table-stakes coverage** — completeness is a conscious budget, not an accident.
 - **Tech-tree edges** — `blocked_by: [#N, …]` / `blocks: [#N, …]`. The
-  dependency graph WSJF cannot model. **A `blocked_by` that isn't empty
-  excludes the issue from the picker entirely, regardless of score** — you
-  can't pick what you can't start.
+  dependency graph WSJF cannot model. **A `blocked_by` naming an issue that is
+  still open excludes the issue from the picker entirely, regardless of score**
+  — you can't pick what you can't start. **A closed blocker does not block**:
+  the picker resolves each number's state on every run, so an edge whose
+  blocker has merged stops holding its dependents back the moment it merges,
+  with no body edit. See §3.6.
 - **External blockers** — `blocked_by_external: ["…", …]`, a list of free-text
   reasons. Same effect on the picker as `blocked_by`, for everything the
   in-repo tech tree cannot name: an upstream release we are waiting on, a
@@ -159,7 +162,10 @@ CoD   = Capability + Craft + Stability + Decay
 Score = Confidence × CoD / Effort          # computed only over UNBLOCKED issues
 ```
 
-1. Drop every issue with a non-empty `blocked_by`.
+1. Drop every issue still held by a blocker — a `blocked_by` entry whose issue
+   is **open**, a blocker whose state could not be read, or any
+   `blocked_by_external`. A `blocked_by` entry whose issue is already **closed**
+   does not count (§3.6).
 2. Pick the **max `Score`**.
 3. Break ties with **Learning, then Fun**.
 4. **Pull override:** any issue with `Fun ≥ 8` may be pulled to the front
@@ -178,6 +184,41 @@ Score = Confidence × CoD / Effort          # computed only over UNBLOCKED issue
 
 The printed order is authoritative, and `next:` is simply the first unblocked
 row — so the recommendation can never disagree with what is printed at the top.
+
+### §3.6 — Blocker state is resolved, never assumed
+
+**A `blocked_by` entry blocks only while the issue it names is open.** The
+picker resolves every distinct blocker number on each run (one batched
+`gh api graphql` call, not one call per edge, and not cached between runs) and
+treats a closed issue — or a merged PR — as delivered. Three consequences:
+
+- **A blocker that merges unblocks its dependents immediately**, with no body
+  edit. The number stays written down; it just stops being believed.
+- **A partially-delivered tech tree stays blocked, and the `blocked:` flag names
+  only the edges still open.** An issue blocked by a closed #1123 and an open
+  #1126 prints `blocked:1126` — never the delivered one.
+- **`blocked_by_external` is unaffected** and still blocks unconditionally. It
+  is free text naming something outside this repo; there is no state to query.
+
+**If a blocker's state cannot be read, the issue stays blocked and says so.**
+An unresolvable edge — a number that does not exist, `gh` offline,
+unauthenticated or rate-limited — is flagged `blocked?:<N>` and counted in a
+banner above the table. The direction is chosen, not defaulted: assuming *open*
+recreates the bug below, and assuming *closed* invents startable work out of a
+network error, which costs a whole task slot. "We could not tell" must never
+read as "it is fine" (`CLAUDE.md` → *no silent fallbacks*).
+
+`issue_scores.py lint` reports stale edges (blocker already closed — tidy the
+body) and unresolvable ones, and exits non-zero on either, so neither waits for
+a sweep to trip over it. `issue_scores.py selftest` runs the blocker cases on
+their own; `rank` and `lint` run them too, on every invocation.
+
+Before this, a written-down number blocked forever. On 2026-09-09 the closed
+#1123 and #1139 were holding **seven** issues out of `rank` entirely, including
+#1126 and #1130, the two highest-scoring rows in the whole backlog. A stale row
+does not sort low, it is *absent* — so nothing in the picker's output could
+reveal it, and it took a `/start-work` sweep comparing the list against the
+tracker by hand to notice (#1161).
 
 ### Why the floor exists
 

--- a/scripts/issue_scores.py
+++ b/scripts/issue_scores.py
@@ -92,6 +92,10 @@ OPEN, CLOSED, UNRESOLVED = "OPEN", "CLOSED", "UNRESOLVED"
 # tech tree cannot silently trip the limit.
 _BLOCKER_CHUNK = 100
 
+# Per-chunk wall clock. The call normally answers in about a second; this is here
+# so a stalled connection degrades to UNRESOLVED instead of hanging `rank`.
+_BLOCKER_TIMEOUT_S = 30
+
 
 def blocker_key(raw):
     """Normalize one `blocked_by` entry to an int issue number.
@@ -104,7 +108,7 @@ def blocker_key(raw):
     take the whole chunk down with it.
     """
     try:
-        n = int(str(raw).lstrip("#").strip())
+        n = int(str(raw).strip().lstrip("#").strip())
     except ValueError:
         return str(raw)
     return n if n > 0 else str(raw)
@@ -112,6 +116,17 @@ def blocker_key(raw):
 
 def blocker_keys(d):
     return [blocker_key(raw) for raw in (d.get("blocked_by") or [])]
+
+
+def blocker_sort_key(k):
+    """Order blocker keys without ever comparing an int to a str.
+
+    A block can yield both — 1123 for a real edge, "n/a" for a malformed one —
+    and sorting the mixed list directly raises TypeError. Numbers sort first, in
+    numeric order; malformed entries follow, lexicographically. The second slot
+    is only reached when the first ties, which forces both sides to one type.
+    """
+    return (isinstance(k, str), k)
 
 
 def resolve_blocker_states(numbers):
@@ -130,7 +145,7 @@ def resolve_blocker_states(numbers):
     a number that does not exist, a `gh` that is offline, unauthenticated or
     rate-limited all land on UNRESOLVED, and every caller reports it.
     """
-    keys = sorted({k for k in numbers}, key=lambda k: (isinstance(k, str), str(k)))
+    keys = sorted(set(numbers), key=blocker_sort_key)
     # Only a positive int can become an alias. Callers normally pre-filter via
     # blocker_key, but one bad entry reaching the query text makes it invalid and
     # takes every real blocker in the chunk down with it, so re-check here.
@@ -146,11 +161,20 @@ def resolve_blocker_states(numbers):
                  f'{fields}\n  }}\n}}')
         # NOT gh_json(): a partial answer is useful and a total failure must not
         # kill the report. `gh` exits non-zero when *any* alias 404s while still
-        # writing the resolved ones to stdout, so parse stdout regardless.
-        out = subprocess.run(["gh", "api", "graphql", "-f", f"query={query}"],
-                             capture_output=True, text=True, encoding="utf-8")
+        # writing the resolved ones to stdout, so parse stdout regardless
+        # (check=False, spelled out because that is load-bearing here).
+        #
+        # The timeout matters as much as the parse: a stalled connection would
+        # otherwise hang `rank` forever with no output at all. A timeout leaves
+        # this chunk's keys unset, so the setdefault below makes them UNRESOLVED
+        # — the same loud, counted answer as any other unreadable state.
         try:
+            out = subprocess.run(["gh", "api", "graphql", "-f", f"query={query}"],
+                                 capture_output=True, text=True, encoding="utf-8",
+                                 check=False, timeout=_BLOCKER_TIMEOUT_S)
             repo = (json.loads(out.stdout) or {}).get("data", {}).get("repository") or {}
+        except subprocess.TimeoutExpired:
+            repo = {}
         except (ValueError, AttributeError):
             repo = {}
         for n in chunk:
@@ -346,7 +370,8 @@ def cmd_rank(args):
     # `blocked?:` flag somebody has to spot. See is_blocked.
     unresolved_edges = [(num, k) for num, _, _, d in rows for k in split_blockers(d, states)[1]]
     if unresolved_edges:
-        listed = ", ".join(f"#{k} (blocks #{num})" for num, k in sorted(unresolved_edges))
+        listed = ", ".join(f"#{k} (blocks #{num})" for num, k in
+                           sorted(unresolved_edges, key=lambda e: (e[0], blocker_sort_key(e[1]))))
         print(f"[!] blocker state UNRESOLVED for {len(unresolved_edges)} edge(s) across "
               f"{len({num for num, _ in unresolved_edges})} issue(s): {listed}\n"
               f"    These stay blocked and are flagged `blocked?:`. An unresolvable "
@@ -466,6 +491,13 @@ SELF_TEST_CASES = (
     # which would fail the whole chunk and take real blockers down with it.
     ("a non-positive number is unresolvable, never an alias",
      {"blocked_by": [-5, 0]}, True, ["blocked?:-5,0"]),
+    ("whitespace around a #-prefixed blocker still resolves",
+     {"blocked_by": [" #1123 "]}, False, []),
+    # One issue can yield an int key and a str key at once. `rank` sorts the
+    # unresolvable edges for its banner, and sorting that mix directly raises
+    # TypeError before a single row is printed — see blocker_sort_key.
+    ("a numeric and a malformed blocker on one issue coexist",
+     {"blocked_by": [4242, "n/a"]}, True, ["blocked?:4242,n/a"]),
     ("open + unresolvable are reported separately",
      {"blocked_by": [1126, "n/a"]}, True, ["blocked:1126", "blocked?:n/a"]),
     ("closed + unresolvable: the closed one is gone, the unknown one remains",
@@ -483,9 +515,28 @@ SELF_TEST_CASES = (
 )
 
 
+# `rank` sorts the unresolvable edges for its banner. A block yielding both an
+# int key and a str key made that sort raise TypeError before a single row was
+# printed, so the guard has to cover the ordering itself, not just the flags.
+SORT_CASES = (
+    ("numbers numerically, malformed entries after them",
+     [999, "n/a", 42, "x"], [42, 999, "n/a", "x"]),
+    ("ints never sort lexicographically", [999, 4242], [999, 4242]),
+)
+
+
 def self_test():
     """Guard the picker. Returns the failure count."""
     failures = 0
+    for description, keys, want in SORT_CASES:
+        try:
+            got = sorted(keys, key=blocker_sort_key)
+        except TypeError as exc:
+            got = f"TypeError: {exc}"
+        if got != want:
+            failures += 1
+            print(f"SELF-TEST FAILED (sort: {description}):\n"
+                  f"  want={want}\n  got ={got}", file=sys.stderr)
     for description, d, want_blocked, want_flags in SELF_TEST_CASES:
         got_blocked = is_blocked(d, _SELF_TEST_STATES)
         # floor=False: the low-value flag is orthogonal and every fragment here
@@ -502,7 +553,7 @@ def self_test():
 
 def cmd_selftest(args):
     failures = self_test()
-    print(f"{len(SELF_TEST_CASES)} case(s), {failures} failure(s)")
+    print(f"{len(SELF_TEST_CASES) + len(SORT_CASES)} case(s), {failures} failure(s)")
     sys.exit(1 if failures else 0)
 
 

--- a/scripts/issue_scores.py
+++ b/scripts/issue_scores.py
@@ -6,11 +6,16 @@ Scores live in each GitHub issue body inside an `olo-score` fenced block
 
     rank   pull every open issue, parse its block, print the ranked list
            (default lens; Pull-override applied). This is what /start-work calls.
-    lint   list open issues with no olo-score block (the "needs-score" nudge).
+    lint   list open issues with no olo-score block (the "needs-score" nudge),
+           plus stale tech-tree edges (a `blocked_by` naming an issue that is
+           already closed) and edges whose state could not be resolved at all.
+           Exits non-zero on any of the three.
     apply  one-time/migration: write blocks into issue bodies from a local
            JSON source (--from issue-scores.json). Supports --dry-run / --only.
 
-Requires the `gh` CLI authenticated against the repo.
+Requires the `gh` CLI authenticated against the repo. `rank` and `lint` each make
+exactly one extra `gh api graphql` call to resolve every distinct `blocked_by`
+number in one shot; see resolve_blocker_states.
 """
 import argparse
 import json
@@ -20,6 +25,7 @@ import sys
 import tempfile
 
 REPO = "drsnuggles8/OloEngineBase"
+REPO_OWNER, REPO_NAME = REPO.split("/")
 VALUE_AXES = ("capability", "craft", "stability", "decay")
 ALL_AXES = VALUE_AXES + ("effort", "confidence", "learning", "fun")
 KANO = ("table-stakes", "performance", "delighter")
@@ -74,6 +80,106 @@ def open_issues():
 
 def label_names(it):
     return {l["name"] for l in it.get("labels", [])}
+
+
+# ---- blocker state ----------------------------------------------------------
+# A blocker resolves to one of these. Anything that is not OPEN and not a clean
+# CLOSED/MERGED is UNRESOLVED — never guessed in either direction.
+OPEN, CLOSED, UNRESOLVED = "OPEN", "CLOSED", "UNRESOLVED"
+
+# Alias-per-number GraphQL, chunked. GitHub caps aliases per query well above
+# what a backlog's distinct blocker set reaches, but chunk anyway so a future
+# tech tree cannot silently trip the limit.
+_BLOCKER_CHUNK = 100
+
+
+def blocker_key(raw):
+    """Normalize one `blocked_by` entry to an int issue number.
+
+    Entries are written as bare numbers, but "#1123" turns up when a block is
+    hand-edited. Anything that is not a positive issue number comes back
+    unchanged as a string, so it resolves to UNRESOLVED and gets reported —
+    dropping it would be exactly the silent pass this change exists to remove,
+    and letting it through would put an invalid alias (`i-5`) into the query and
+    take the whole chunk down with it.
+    """
+    try:
+        n = int(str(raw).lstrip("#").strip())
+    except ValueError:
+        return str(raw)
+    return n if n > 0 else str(raw)
+
+
+def blocker_keys(d):
+    return [blocker_key(raw) for raw in (d.get("blocked_by") or [])]
+
+
+def resolve_blocker_states(numbers):
+    """Return {blocker key: OPEN | CLOSED | UNRESOLVED} covering every key given.
+
+    One `gh api graphql` call per chunk, resolving all distinct blocker numbers
+    at once — not one `gh issue view` per blocker per run. `issueOrPullRequest`
+    is used rather than `issue` because a `blocked_by` occasionally names a PR;
+    a merged PR is as delivered as a closed issue, so MERGED folds into CLOSED.
+
+    Nothing is cached across runs on purpose. A cache of "is #1123 still open?"
+    is a second copy of a fact that changes without us — the same shape as the
+    stale `blocked_by` body this function exists to stop trusting.
+
+    Unresolvable is a first-class answer, never a fallback to OPEN or CLOSED:
+    a number that does not exist, a `gh` that is offline, unauthenticated or
+    rate-limited all land on UNRESOLVED, and every caller reports it.
+    """
+    keys = sorted({k for k in numbers}, key=lambda k: (isinstance(k, str), str(k)))
+    # Only a positive int can become an alias. Callers normally pre-filter via
+    # blocker_key, but one bad entry reaching the query text makes it invalid and
+    # takes every real blocker in the chunk down with it, so re-check here.
+    nums = [k for k in keys if isinstance(k, int) and k > 0]
+    states = {}
+    for i in range(0, len(nums), _BLOCKER_CHUNK):
+        chunk = nums[i:i + _BLOCKER_CHUNK]
+        fields = "\n".join(
+            f'    i{n}: issueOrPullRequest(number: {n}) '
+            f'{{ ... on Issue {{ state }} ... on PullRequest {{ state }} }}'
+            for n in chunk)
+        query = (f'query {{\n  repository(owner: "{REPO_OWNER}", name: "{REPO_NAME}") {{\n'
+                 f'{fields}\n  }}\n}}')
+        # NOT gh_json(): a partial answer is useful and a total failure must not
+        # kill the report. `gh` exits non-zero when *any* alias 404s while still
+        # writing the resolved ones to stdout, so parse stdout regardless.
+        out = subprocess.run(["gh", "api", "graphql", "-f", f"query={query}"],
+                             capture_output=True, text=True, encoding="utf-8")
+        try:
+            repo = (json.loads(out.stdout) or {}).get("data", {}).get("repository") or {}
+        except (ValueError, AttributeError):
+            repo = {}
+        for n in chunk:
+            node = repo.get(f"i{n}") or {}
+            state = node.get("state")
+            if state == OPEN:
+                states[n] = OPEN
+            elif state in ("CLOSED", "MERGED"):
+                states[n] = CLOSED
+    for k in keys:
+        states.setdefault(k, UNRESOLVED)
+    return states
+
+
+def split_blockers(d, states):
+    """(still-open blockers, unresolvable blockers) for one score block.
+
+    Closed blockers appear in neither list — that is the whole point. The split
+    is what the `blocked:` flag prints, so a partially-delivered tech tree names
+    only the edges that are actually still holding the issue up.
+    """
+    still_open, unresolved = [], []
+    for k in blocker_keys(d):
+        state = states.get(k, UNRESOLVED)
+        if state == OPEN:
+            still_open.append(k)
+        elif state == UNRESOLVED:
+            unresolved.append(k)
+    return still_open, unresolved
 
 
 # ---- block parse / render ---------------------------------------------------
@@ -144,7 +250,7 @@ def score(d):
     return round(d.get("confidence", 1.0) * cod(d) / eff, 2)
 
 
-def is_blocked(d):
+def is_blocked(d, states):
     """Blocked = cannot be started today, whatever holds it up.
 
     `blocked_by` models the in-repo tech tree (issue numbers). `blocked_by_external`
@@ -158,8 +264,42 @@ def is_blocked(d):
     repowise releases, and had to be skipped by hand on every sweep. A human silently
     re-deriving the same "oh, not that one" every time is exactly the cost this file
     exists to remove.
+
+    A `blocked_by` entry only blocks while the issue it names is still OPEN — the
+    written-down number is a pointer, not a fact. This used to be assumed rather than
+    asked, so a blocker that had merged kept its dependents out of `rank` until a human
+    hand-edited the body: on 2026-09-09 the closed #1123 and #1139 were hiding seven
+    issues, including #1126 and #1130, the two highest-scoring rows in the whole
+    backlog. A stale row does not sort low, it is absent, so nothing in the output
+    could reveal it (#1161).
+
+    An UNRESOLVED blocker keeps blocking. That direction is chosen, not defaulted: the
+    other one invents startable work out of a network error, and a bad pick costs a
+    whole task slot. It is never silent — the row is flagged `blocked?:` and `rank`
+    prints a counted banner, so "we could not tell" never reads as "it is fine".
+
+    `blocked_by_external` is left blocking unconditionally: it is free text naming
+    things outside this repo (#1148), with no state to query.
     """
-    return bool(d.get("blocked_by")) or bool(d.get("blocked_by_external"))
+    still_open, unresolved = split_blockers(d, states)
+    return bool(still_open) or bool(unresolved) or bool(d.get("blocked_by_external"))
+
+
+def row_flags(d, states, floor):
+    """The `flags` column for one ranked row."""
+    still_open, unresolved = split_blockers(d, states)
+    flags = []
+    if d.get("fun", 0) >= 8 and not is_blocked(d, states):
+        flags.append("PULL")
+    if still_open:
+        flags.append("blocked:" + ",".join(map(str, still_open)))
+    if unresolved:
+        flags.append("blocked?:" + ",".join(map(str, unresolved)))
+    if d.get("blocked_by_external"):
+        flags.append("external")
+    if floor and is_low_value(d):
+        flags.append(f"low-value:{cod(d)}")
+    return flags
 
 
 def is_low_value(d):
@@ -179,6 +319,7 @@ def cmd_rank(args):
             continue
         rows.append((it["number"], it["title"], score(d), d))
     floor = not args.no_low_value_floor
+    states = resolve_blocker_states(k for _, _, _, d in rows for k in blocker_keys(d))
 
     # Sort order, outermost first (§3): Pull-override, then unblocked-before-blocked,
     # then normal-value-before-low-value, then score desc, then the documented
@@ -190,8 +331,8 @@ def cmd_rank(args):
     # pickable, so Pull is the documented exception to the floor's guarantee (§3.5) --
     # not an oversight. `next:` therefore just takes the first unblocked row, so the
     # recommendation can never disagree with the printed order.
-    rows.sort(key=lambda r: (not (r[3].get("fun", 0) >= 8 and not is_blocked(r[3])),
-                             is_blocked(r[3]),
+    rows.sort(key=lambda r: (not (r[3].get("fun", 0) >= 8 and not is_blocked(r[3], states)),
+                             is_blocked(r[3], states),
                              floor and is_low_value(r[3]),
                              -r[2],
                              -r[3].get("learning", 0), -r[3].get("fun", 0),
@@ -199,33 +340,69 @@ def cmd_rank(args):
     if args.freeze:
         print(f"[--freeze active: only {'/'.join(sorted(FREEZE_LABELS))} labels eligible; "
               f"{excluded} feature-only issue(s) excluded]\n")
+
+    # Loud and counted, above the table: an unresolvable blocker is the one case
+    # where the printed order may be wrong, and it must not be inferred from a
+    # `blocked?:` flag somebody has to spot. See is_blocked.
+    unresolved_edges = [(num, k) for num, _, _, d in rows for k in split_blockers(d, states)[1]]
+    if unresolved_edges:
+        listed = ", ".join(f"#{k} (blocks #{num})" for num, k in sorted(unresolved_edges))
+        print(f"[!] blocker state UNRESOLVED for {len(unresolved_edges)} edge(s) across "
+              f"{len({num for num, _ in unresolved_edges})} issue(s): {listed}\n"
+              f"    These stay blocked and are flagged `blocked?:`. An unresolvable "
+              f"blocker is never assumed delivered.\n"
+              f"    Check `gh auth status` / the network, or run "
+              f"`issue_scores.py lint` for the per-edge detail.\n")
+
     print(f"{'#':>5} {'score':>5} {'flags':<20} title")
     for num, title, s, d in rows:
-        flags = []
-        if d.get("fun", 0) >= 8 and not is_blocked(d):
-            flags.append("PULL")
-        if d.get("blocked_by"):
-            flags.append("blocked:" + ",".join(map(str, d["blocked_by"])))
-        if d.get("blocked_by_external"):
-            flags.append("external")
-        if floor and is_low_value(d):
-            flags.append(f"low-value:{cod(d)}")
-        print(f"{num:>5} {s:>5} {' '.join(flags):<20} {title[:64]}")
-    nxt = next((r for r in rows if not is_blocked(r[3])), None)
+        print(f"{num:>5} {s:>5} {' '.join(row_flags(d, states, floor)):<20} {title[:64]}")
+    nxt = next((r for r in rows if not is_blocked(r[3], states)), None)
     if nxt:
         why = " (Pull-override: fun>=8)" if nxt[3].get("fun", 0) >= 8 else ""
         print(f"\nnext: #{nxt[0]} — {nxt[1]}{why}")
 
 
 def cmd_lint(args):
-    missing = [(it["number"], it["title"]) for it in open_issues()
-               if parse_block(it.get("body")) is None]
-    if not missing:
-        print("all open issues have an olo-score block.")
+    missing, scored = [], []
+    for it in open_issues():
+        d = parse_block(it.get("body"))
+        if d is None:
+            missing.append((it["number"], it["title"]))
+        else:
+            scored.append((it["number"], d))
+
+    # A stale edge no longer hides its issue from `rank` — that is fixed at read
+    # time. It is still worth reporting: the body says something untrue, and the
+    # cheap moment to correct it is now, not the next time somebody reads it.
+    states = resolve_blocker_states(k for _, d in scored for k in blocker_keys(d))
+    stale, unresolved = [], []
+    for num, d in scored:
+        for k in blocker_keys(d):
+            state = states.get(k, UNRESOLVED)
+            if state == CLOSED:
+                stale.append((num, k))
+            elif state == UNRESOLVED:
+                unresolved.append((num, k))
+
+    if not (missing or stale or unresolved):
+        print("all open issues have an olo-score block; no stale blocker edges.")
         return
-    print(f"{len(missing)} open issue(s) need scoring:")
-    for num, title in missing:
-        print(f"  #{num} {title[:70]}")
+    if missing:
+        print(f"{len(missing)} open issue(s) need scoring:")
+        for num, title in missing:
+            print(f"  #{num} {title[:70]}")
+    if stale:
+        print(f"\n{len(stale)} stale blocker edge(s) — blocker already closed, "
+              f"drop it from `blocked_by`:")
+        for num, k in stale:
+            print(f"  #{num} blocked_by #{k} (closed)")
+    if unresolved:
+        print(f"\n{len(unresolved)} unresolvable blocker edge(s) — state could not be "
+              f"read, so these still block:")
+        for num, k in unresolved:
+            print(f"  #{num} blocked_by {k} (state unknown: no such issue/PR, or "
+                  f"`gh` offline / unauthenticated / rate-limited)")
     sys.exit(1)
 
 
@@ -250,7 +427,89 @@ def cmd_apply(args):
         print(f"#{num}: {'ok' if r.returncode == 0 else 'FAIL ' + r.stderr.strip()}")
 
 
+# ---- self-test --------------------------------------------------------------
+# Blocker handling is the one part of this file with no visible failure mode: a
+# wrongly-blocked issue is *absent* from the output, not wrong in it. #1161 sat
+# undetected until a sweep happened to compare the list against the tracker by
+# hand. So the cases live here and run on every invocation — they are pure
+# dict-in/flags-out and cost microseconds.
+#
+# The live data cannot stand in for them: the seven bodies #1161 found were
+# healed by hand when it was filed, so nothing in the real backlog still
+# exercises the stale case.
+_SELF_TEST_STATES = {1123: CLOSED, 1139: CLOSED, 1126: OPEN, 1131: OPEN, "n/a": UNRESOLVED}
+
+# (description, score-block fragment, expected is_blocked, expected flag list)
+SELF_TEST_CASES = (
+    ("no blockers at all", {}, False, []),
+    ("the #1161 case: the only blocker is closed",
+     {"blocked_by": [1123]}, False, []),
+    ("every blocker closed",
+     {"blocked_by": [1123, 1139]}, False, []),
+    ("a still-open blocker blocks",
+     {"blocked_by": [1126]}, True, ["blocked:1126"]),
+    # The easy one to get wrong: the flag must name the open blocker only, or the
+    # row tells you to go wait on work that already shipped.
+    ("mixed open and closed: blocked, and the flag names only the open one",
+     {"blocked_by": [1123, 1126]}, True, ["blocked:1126"]),
+    ("closed blocker written as a #-prefixed string",
+     {"blocked_by": ["#1123"]}, False, []),
+    ("open blocker written as a #-prefixed string",
+     {"blocked_by": ["#1126"]}, True, ["blocked:1126"]),
+    # Unresolvable never silently passes and never silently blocks: it blocks,
+    # under its own flag, so the row is distinguishable from a real edge.
+    ("unresolvable blocker still blocks, under its own flag",
+     {"blocked_by": ["n/a"]}, True, ["blocked?:n/a"]),
+    ("a number nobody resolved is unresolvable, not open and not closed",
+     {"blocked_by": [4242]}, True, ["blocked?:4242"]),
+    # Kept out of the query rather than emitted as the invalid alias `i-5`,
+    # which would fail the whole chunk and take real blockers down with it.
+    ("a non-positive number is unresolvable, never an alias",
+     {"blocked_by": [-5, 0]}, True, ["blocked?:-5,0"]),
+    ("open + unresolvable are reported separately",
+     {"blocked_by": [1126, "n/a"]}, True, ["blocked:1126", "blocked?:n/a"]),
+    ("closed + unresolvable: the closed one is gone, the unknown one remains",
+     {"blocked_by": [1123, "n/a"]}, True, ["blocked?:n/a"]),
+    # #1148: external blockers are free text with no state to query.
+    ("blocked_by_external keeps blocking even with every issue blocker closed",
+     {"blocked_by": [1123], "blocked_by_external": ["upstream release"]}, True, ["external"]),
+    ("blocked_by_external alone blocks",
+     {"blocked_by_external": ["vendor fix"]}, True, ["external"]),
+    # A closed blocker must restore the Pull-override too, not just the row.
+    ("Pull-override returns once the only blocker is closed",
+     {"blocked_by": [1123], "fun": 9}, False, ["PULL"]),
+    ("Pull-override stays suppressed while a blocker is open",
+     {"blocked_by": [1126], "fun": 9}, True, ["blocked:1126"]),
+)
+
+
+def self_test():
+    """Guard the picker. Returns the failure count."""
+    failures = 0
+    for description, d, want_blocked, want_flags in SELF_TEST_CASES:
+        got_blocked = is_blocked(d, _SELF_TEST_STATES)
+        # floor=False: the low-value flag is orthogonal and every fragment here
+        # has CoD 0, which would add `low-value:0` to all of them.
+        got_flags = row_flags(d, _SELF_TEST_STATES, floor=False)
+        if got_blocked != want_blocked or got_flags != list(want_flags):
+            failures += 1
+            print(f"SELF-TEST FAILED ({description}):\n"
+                  f"  block   {d}\n"
+                  f"  blocked want={want_blocked} got={got_blocked}\n"
+                  f"  flags   want={list(want_flags)} got={got_flags}", file=sys.stderr)
+    return failures
+
+
+def cmd_selftest(args):
+    failures = self_test()
+    print(f"{len(SELF_TEST_CASES)} case(s), {failures} failure(s)")
+    sys.exit(1 if failures else 0)
+
+
 def main():
+    if self_test():
+        sys.exit("\nissue_scores.py blocker handling is broken; fix it before trusting "
+                 "`rank` — a mis-blocked issue is missing from the output, not wrong in it.")
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = p.add_subparsers(dest="cmd", required=True)
     rp = sub.add_parser("rank")
@@ -266,6 +525,8 @@ def main():
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--only", type=int, nargs="*", help="limit to these issue numbers")
     ap.set_defaults(func=cmd_apply)
+    sub.add_parser("selftest", help="run the blocker-handling cases and report the count")\
+       .set_defaults(func=cmd_selftest)
     args = p.parse_args()
     args.func(args)
 


### PR DESCRIPTION
Closes #1161

`is_blocked()` treated `blocked_by` as blocking for as long as the number was written down, with no regard for whether the blocking issue was still open. A blocker that had merged kept its dependents out of `rank` forever, until a human hand-edited the body — and a stale row does not sort low, it is **absent**, so nothing in the picker's output could reveal it. On 2026-09-09 the closed #1123 and #1139 were hiding seven issues, including #1126 and #1130, the two highest-scoring rows in the whole backlog.

## What changed

**`resolve_blocker_states`** resolves every distinct blocker number in one batched `gh api graphql` call per run — not one `gh` call per edge. `issueOrPullRequest` rather than `issue`, because a `blocked_by` occasionally names a PR and a merged PR is as delivered as a closed issue (MERGED folds into CLOSED).

Nothing is cached across runs, deliberately. A cache of *"is #1123 still open?"* is a second copy of a fact that changes without us — the same shape as the stale `blocked_by` body this function exists to stop trusting. The cost is one extra `gh` call per `rank`; the whole command still runs in ~2s.

**`blocked_by_external` is untouched** (#1148) and still blocks unconditionally: free text naming things outside this repo, with no state to query.

## The offline / unresolvable policy, and why

Per `CLAUDE.md` → *no silent fallbacks*: **an unresolvable blocker keeps blocking, loudly and countably.**

A number that does not exist, a `gh` that is offline, unauthenticated or rate-limited, an entry that is not a positive issue number — all land on `UNRESOLVED`. The issue stays blocked, the row carries its own `blocked?:<N>` flag (visibly distinct from a real `blocked:` edge), and `rank` prints a counted banner **above** the table naming every unresolvable edge.

The direction is chosen, not defaulted. Assuming *open* recreates exactly the bug being fixed. Assuming *closed* invents startable work out of a network error, and a bad pick costs a whole task slot. Neither may be silent: "we could not tell" must never read as "it is fine". Both the code comment on `is_blocked` and issue-scoring.md §3.6 say so.

## `lint`

Now reports three things and exits non-zero on any: missing score blocks (as before), **stale edges** (blocker already closed — the body says something untrue, tidy it), and **unresolvable edges**. So the condition surfaces without waiting for a sweep to trip over it.

## Acceptance criteria — evidence

The seven affected bodies were healed by hand when #1161 was filed, so the live backlog no longer exercises the bug. Evidence below is a synthetic fixture carrying the exact stale edges #1161 measured, resolved by **real `gh` against the real repo** (#1123 and #1139 are genuinely closed, #1126 genuinely open).

```
    # score flags                title
 9001   6.3                      stale: only blocker is CLOSED #1123
 9002   6.3                      stale: both blockers CLOSED (#1123,#1139)
 9003   6.3 blocked:1126         partial: CLOSED #1123 + OPEN #1126
 9004   6.3 blocked?:999999      unresolvable: #999999 does not exist
 9005   6.3 external             external stays blocking

next: #9001 — stale: only blocker is CLOSED #1123
```

- [x] **An issue whose every `blocked_by` entry is closed appears in `rank` as unblocked, with no body edit.** — #9001, #9002 above: no flag, and #9001 is `next:`.
- [x] **An issue with a mix of open and closed blockers stays blocked, and its `blocked:` flag names only the ones still open.** — #9003 prints `blocked:1126`, not `blocked:1123,1126`.
- [x] **`lint` reports stale blocker edges and exits non-zero on them.** — on the same fixture: `5 stale blocker edge(s) — blocker already closed, drop it from blocked_by:` … `lint exit=1`.
- [x] **Blocker state that cannot be resolved is an explicit, counted diagnostic — never a silent pass.** — #9004 above, plus the banner:

```
[!] blocker state UNRESOLVED for 1 edge(s) across 1 issue(s): #999999 (blocks #9004)
    These stay blocked and are flagged `blocked?:`. An unresolvable blocker is never assumed delivered.
    Check `gh auth status` / the network, or run `issue_scores.py lint` for the per-edge detail.
```

Also verified with `gh` forced offline (`GH_HOST=nonexistent.invalid GH_TOKEN=bogus`): all 7 edges go `UNRESOLVED`, every row stays blocked under `blocked?:`, the banner counts them, `next:` is correctly suppressed, and `lint` exits 1. No crash, no silent unblock.

**Live data, unchanged behaviour where it should be:** `rank` still prints exactly the two real edges — `1129 blocked:1126` and `1132 blocked:1131`, both blockers genuinely open — and `lint` is clean. #979 is not fooled by the `[708]` that appears as prose inside a checklist item; its real block reads `blocked_by: []`.

## Tests

Followed the repo's existing convention for `scripts/` rather than inventing a harness: a table of cases plus a `self_test()`, as in `OloEngine/tests/scripts/check_temp_dir_isolation.py` and `.claude/hooks/claude-build-lock-guard.py`. 16 cases covering closed / open / mixed / unresolvable / non-positive / `#`-prefixed / external / Pull-override-restored.

They run on **every** invocation of `issue_scores.py` (pure dict-in/flags-out, microseconds) and are also exposed as `issue_scores.py selftest`. That matches `check_temp_dir_isolation.py`'s reasoning — a silently-broken checker is worse than no checker — and it matters more here than usual, because a mis-blocked issue is *missing* from the output rather than wrong in it.

Guarded the guard: putting the old one-line `is_blocked` back makes 4 of the 16 cases fail and the script refuse to run.

## Docs

- `docs/process/issue-scoring.md` §2 and §3 rule 1 now state that a closed blocker does not block.
- New **§3.6 — Blocker state is resolved, never assumed**: the three consequences, the unresolvable policy and why that direction was chosen, what `lint` does, and the #1161 story as the second paragraph.
- `.claude/commands/start-work.md` line 50: `lint`'s one-line description now mentions the new edge reporting.

## Scope notes

No build needed (Python + Markdown). No rendering change, so no visual verification applies. `apply --dry-run` fails identically on this branch and on master — its one-time `issue-scores.json` source is not in the repo; pre-existing and out of scope.

The known cp1252 mojibake in the bodies of #1126 and #1131 was left alone: this change never touches issue bodies, so fixing it here would be an unrelated widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue scoring now checks the current state of referenced blockers.
  * Closed or merged blockers no longer prevent dependent issues from being ranked.
  * Unresolved or unavailable blockers continue to block issues and are clearly flagged.
  * Added a self-test command and automatic validation when the scoring tool runs.

* **Bug Fixes**
  * Improved detection and reporting of stale, missing, or unreadable blocker relationships.

* **Documentation**
  * Expanded issue-scoring guidance to explain blocker resolution, partial delivery, failure handling, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->