### PR TITLE
feat(automation): structured test execution and whole-project validation

### DIFF
--- a/.claude/skills/run-oloengine/SKILL.md
+++ b/.claude/skills/run-oloengine/SKILL.md
@@ -251,15 +251,18 @@ Expected: `[Server] Listening on port 7777` (defaults: port 7777, 64 players,
 
 ## Test
 
-The test binary runs from the **repo root** (not `OloEditor\`):
+The test binary runs fine from the **repo root**, but prefer `OloEditor\` — that is what `ctest` uses, and startup is ~3x faster there (2.06 s vs 0.71 s; see [testing-architecture.md §5](../../../docs/agent-rules/testing-architecture.md#5-running-tests-locally)):
 
 ```powershell
-build\OloEngine\tests\Debug\OloEngine-Tests.exe --gtest_filter=FastRandomTest.*:ContainerSmoke.*
+cd OloEditor; ..\build\OloEngine\tests\Debug\OloEngine-Tests.exe --gtest_filter=FastRandomTest.*:ContainerSmoke.*
 ```
 
 → `[ PASSED ] 13 tests.` Drop the filter to run the whole suite. List suites with
 `--gtest_list_tests`. Note: a guessed filter that matches nothing exits 0 with a
-`did not match any test` warning — confirm tests actually ran.
+`did not match any test` warning — confirm tests actually ran. The
+`olo_tests_run` automation command (issue #1130) does that check for you: a
+selection matching nothing is an error there, and it returns per-case structured
+results instead of console text.
 
 ## Run the editor (human path)
 

--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -50,6 +50,11 @@
 		"MCP/McpFieldRegistry.cpp"
 		"MCP/McpToolsScripting.cpp"
 		"MCP/McpToolsShader.cpp"
+		# Structured test execution + whole-project validation (issue #1130).
+		"MCP/McpTestExecution.h"
+		"MCP/McpToolsTesting.cpp"
+		"MCP/McpProjectValidation.h"
+		"MCP/McpToolsValidation.cpp"
 		"MCP/McpToolsGateway.cpp"
 		"MCP/McpExposure.h"
 		"MCP/McpScriptTools.cpp"

--- a/OloEditor/src/MCP/McpProjectValidation.h
+++ b/OloEditor/src/MCP/McpProjectValidation.h
@@ -63,7 +63,7 @@ namespace OloEngine::MCP::ProjectValidation
         std::string Source;  // the command whose handler produced this, verbatim
         std::string Subject; // one sentence: what this section checks
         SectionStatus Status = SectionStatus::Unavailable;
-        std::string Reason;         // why, when Unavailable
+        std::string Reason; // why, when Unavailable
         Json Problems = Json::array();
     };
 

--- a/OloEditor/src/MCP/McpProjectValidation.h
+++ b/OloEditor/src/MCP/McpProjectValidation.h
@@ -1,0 +1,240 @@
+#pragma once
+
+// Pure shaping for olo_project_validate (issue #1130, Epic H slice 2): one
+// whole-project health check composed from the per-domain validators that
+// already exist, with a structured report instead of four separate calls a
+// caller has to remember to make and then merge.
+//
+// WHAT MAKES IT THE SAME ANSWER THE EDITOR GIVES. The composite does not
+// re-derive anything. Each section INVOKES the standalone command's own handler
+// (olo_assets_problems, olo_shader_errors, olo_script_get_last_errors,
+// olo_render_validate) and reshapes what comes back, so the two can never drift
+// — and those handlers read the very singletons the editor panels render from:
+// the project asset registry, ShaderDebugger, the script-error ring, the live
+// render graph. The functions here own only the reshaping.
+//
+// THE RULE THAT SHAPES THE REPORT: a validator that could not run is not a
+// clean bill of health. A headless host has no render graph; a session with no
+// project open has no asset manager. Either way the section comes back
+// `unavailable` WITH ITS REASON, it is counted, and the report's `ok` is false
+// — because the alternative, quietly dropping the section and totalling zero
+// problems, is exactly the silent fallback that makes a green result worthless.
+// `complete` says whether everything ran; `ok` says everything ran AND found
+// nothing.
+//
+// Free functions over JSON with no editor, renderer or engine dependency, so
+// they are unit tested headlessly (OloEngine/tests/MCP/McpProjectValidationTest.cpp).
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace OloEngine::MCP::ProjectValidation
+{
+    using Json = nlohmann::json;
+
+    enum class SectionStatus : u8
+    {
+        Ok = 0,      // the validator ran and found nothing
+        Problems,    // the validator ran and found something
+        Unavailable, // the validator could not run here — Reason says why
+    };
+
+    [[nodiscard]] inline const char* SectionStatusName(SectionStatus status)
+    {
+        switch (status)
+        {
+            case SectionStatus::Ok:
+                return "ok";
+            case SectionStatus::Problems:
+                return "problems";
+            case SectionStatus::Unavailable:
+                return "unavailable";
+        }
+        return "unknown";
+    }
+
+    struct Section
+    {
+        std::string Name;    // "assets", "shaders", "scripts", "renderGraph"
+        std::string Source;  // the command whose handler produced this, verbatim
+        std::string Subject; // one sentence: what this section checks
+        SectionStatus Status = SectionStatus::Unavailable;
+        std::string Reason;         // why, when Unavailable
+        Json Problems = Json::array();
+    };
+
+    // ---- per-source extraction ---------------------------------------------
+    //
+    // Each standalone command names its problem array differently (`problems`,
+    // `errors`), and olo_render_validate reports four kinds across four arrays.
+    // These normalize all of that into one array of objects that each carry a
+    // `kind`, so a caller iterates one shape.
+
+    [[nodiscard]] inline Json NamedArray(const Json& payload, const char* key)
+    {
+        if (!payload.is_object())
+            return Json::array();
+        const auto found = payload.find(key);
+        if (found == payload.end() || !found->is_array())
+            return Json::array();
+        return *found;
+    }
+
+    // olo_assets_problems: {"count":n, "problems":[{handle,type,path,status}]}
+    [[nodiscard]] inline Json ProblemsFromAssets(const Json& payload)
+    {
+        Json out = Json::array();
+        for (const Json& entry : NamedArray(payload, "problems"))
+        {
+            Json problem = entry;
+            problem["kind"] = "AssetLoadFailure";
+            out.push_back(std::move(problem));
+        }
+        return out;
+    }
+
+    // olo_shader_errors: {"count":n, "errors":[{name,errorMessage}]}
+    [[nodiscard]] inline Json ProblemsFromShaders(const Json& payload)
+    {
+        Json out = Json::array();
+        for (const Json& entry : NamedArray(payload, "errors"))
+        {
+            Json problem = entry;
+            problem["kind"] = "ShaderCompileError";
+            out.push_back(std::move(problem));
+        }
+        return out;
+    }
+
+    // olo_script_get_last_errors: {"count":n, "errors":[{language,scriptName,message,...}]}
+    [[nodiscard]] inline Json ProblemsFromScripts(const Json& payload)
+    {
+        Json out = Json::array();
+        for (const Json& entry : NamedArray(payload, "errors"))
+        {
+            Json problem = entry;
+            problem["kind"] = "ScriptError";
+            out.push_back(std::move(problem));
+        }
+        return out;
+    }
+
+    // olo_render_validate's default sweep. Its own `ok` verdict rests on
+    // hazards + resolveFailures + consumedButUnbacked, so those three are the
+    // problems; the barrier and build diagnostics are informational there and
+    // stay informational here rather than being promoted into failures.
+    [[nodiscard]] inline Json ProblemsFromRenderGraph(const Json& payload)
+    {
+        Json out = Json::array();
+        for (const Json& entry : NamedArray(payload, "hazards"))
+        {
+            Json problem = entry;
+            problem["kind"] = "RenderGraphHazard";
+            out.push_back(std::move(problem));
+        }
+        for (const Json& entry : NamedArray(payload, "resolveFailures"))
+        {
+            Json problem = entry;
+            problem["kind"] = "RenderGraphResolveFailure";
+            out.push_back(std::move(problem));
+        }
+        for (const Json& entry : NamedArray(payload, "consumedButUnbacked"))
+        {
+            Json problem;
+            problem["kind"] = "ResourceConsumedButUnbacked";
+            problem["resource"] = entry.is_string() ? entry.get<std::string>() : entry.dump();
+            out.push_back(std::move(problem));
+        }
+        return out;
+    }
+
+    // ---- report assembly ---------------------------------------------------
+
+    // Build a section that ran, from its extracted problem array.
+    [[nodiscard]] inline Section RanSection(std::string name, std::string source, std::string subject, Json problems)
+    {
+        Section section;
+        section.Name = std::move(name);
+        section.Source = std::move(source);
+        section.Subject = std::move(subject);
+        section.Status = problems.empty() ? SectionStatus::Ok : SectionStatus::Problems;
+        section.Problems = std::move(problems);
+        return section;
+    }
+
+    [[nodiscard]] inline Section UnavailableSection(std::string name, std::string source, std::string subject,
+                                                    std::string reason)
+    {
+        Section section;
+        section.Name = std::move(name);
+        section.Source = std::move(source);
+        section.Subject = std::move(subject);
+        section.Status = SectionStatus::Unavailable;
+        section.Reason = std::move(reason);
+        return section;
+    }
+
+    // Assemble the whole report. `maxPerSection` caps how many problems each
+    // section lists; anything past it is COUNTED in `omitted`, never dropped
+    // quietly — the count in `problemCount` always reflects everything found.
+    [[nodiscard]] inline Json BuildReport(const std::vector<Section>& sections, sizet maxPerSection)
+    {
+        Json out;
+        Json sectionArray = Json::array();
+        sizet problemCount = 0;
+        sizet unavailable = 0;
+
+        for (const Section& section : sections)
+        {
+            Json entry;
+            entry["name"] = section.Name;
+            entry["source"] = section.Source;
+            entry["subject"] = section.Subject;
+            entry["status"] = SectionStatusName(section.Status);
+
+            if (section.Status == SectionStatus::Unavailable)
+            {
+                ++unavailable;
+                entry["reason"] = section.Reason;
+                entry["problemCount"] = 0;
+                entry["problems"] = Json::array();
+                sectionArray.push_back(std::move(entry));
+                continue;
+            }
+
+            const sizet found = section.Problems.size();
+            problemCount += found;
+            entry["problemCount"] = found;
+
+            Json listed = Json::array();
+            for (const Json& problem : section.Problems)
+            {
+                if (listed.size() >= maxPerSection)
+                    break;
+                listed.push_back(problem);
+            }
+            const sizet omitted = found - listed.size();
+            entry["problems"] = std::move(listed);
+            entry["omitted"] = omitted;
+            if (omitted > 0)
+                entry["truncated"] = true;
+            sectionArray.push_back(std::move(entry));
+        }
+
+        out["sections"] = std::move(sectionArray);
+        out["sectionCount"] = sections.size();
+        out["sectionsUnavailable"] = unavailable;
+        out["problemCount"] = problemCount;
+        // `complete` and `ok` are deliberately two flags, not one. A caller that
+        // only wants "is anything broken?" reads `ok`; a caller that has to know
+        // whether the answer is trustworthy reads `complete` and, when it is
+        // false, the per-section `reason`.
+        out["complete"] = unavailable == 0;
+        out["ok"] = unavailable == 0 && problemCount == 0;
+        return out;
+    }
+} // namespace OloEngine::MCP::ProjectValidation

--- a/OloEditor/src/MCP/McpTestExecution.h
+++ b/OloEditor/src/MCP/McpTestExecution.h
@@ -205,7 +205,12 @@ namespace OloEngine::MCP::TestExecution
         if (ids.empty())
             return ids; // no declared layers => no range check at all
         ids.insert("unit");
-        ids.insert(catalogue.value("functional_tag", std::string("Functional")));
+        // is_string() first: value() THROWS type_error.302 on a wrong-typed
+        // field, and this document is read off disk, so a hand-edited
+        // `"functional_tag": 3` would abort the whole command with a generic
+        // "tool failed" instead of classifying what it can.
+        const auto tag = catalogue.find("functional_tag");
+        ids.insert(tag != catalogue.end() && tag->is_string() ? tag->get<std::string>() : std::string("Functional"));
         return ids;
     }
 
@@ -448,8 +453,15 @@ namespace OloEngine::MCP::TestExecution
                 if (entry.contains("time") && entry["time"].is_string())
                     result.Seconds = ParseGTestDuration(entry["time"].get<std::string>());
 
-                const std::string status = entry.value("status", std::string("RUN"));
-                const std::string outcome = entry.value("result", std::string("COMPLETED"));
+                // Same reason as functional_tag above: a non-string here would
+                // throw out of the parser rather than be reported as a bad report.
+                const auto statusField = entry.find("status");
+                const auto resultField = entry.find("result");
+                const std::string status =
+                    statusField != entry.end() && statusField->is_string() ? statusField->get<std::string>() : "RUN";
+                const std::string outcome = resultField != entry.end() && resultField->is_string()
+                                                ? resultField->get<std::string>()
+                                                : "COMPLETED";
                 if (status != "RUN" || outcome == "SUPPRESSED")
                     result.Status = CaseStatus::Disabled;
                 else if (outcome == "SKIPPED")

--- a/OloEditor/src/MCP/McpTestExecution.h
+++ b/OloEditor/src/MCP/McpTestExecution.h
@@ -1,0 +1,712 @@
+#pragma once
+
+// Pure parsing, classification and reconciliation for the structured test-run
+// commands olo_tests_list / olo_tests_run (issue #1130).
+//
+// The agent loop "change something, run the thing that proves it, read a
+// structured result" was closed: the only way to run OloEngine-Tests was to
+// shell out and scrape console text. These commands run the SAME binary but
+// take their answer from gtest's own JSON report (`--gtest_output=json:`),
+// which carries a per-case status, timing, source file/line and the verbatim
+// failure text — so no caller has to parse `[  FAILED  ]` banners.
+//
+// THE INVARIANT THIS FILE EXISTS FOR: a test run must never be silently
+// partial. Three things can make it one, and each is an error rather than a
+// green run with a small number in it:
+//
+//   1. The selection matched no cases at all (a typo'd filter reads as "this
+//      area is clean" otherwise).
+//   2. The child died — crashed, was killed on timeout, was cancelled — so
+//      gtest never wrote its report, or wrote a truncated one.
+//   3. The report is intact but does not account for every case the selection
+//      named. Reconcile() diffs the two sets by name and NAMES what is missing;
+//      a count alone cannot tell "nothing ran" from "everything passed".
+//
+// Point 3 is why every run does a LIST pass first: the list is the expected
+// set, and without it there is nothing to reconcile against. gtest's own
+// top-level `tests` field cannot serve — in list mode it reports the whole
+// registered count, ignoring the filter entirely (7616 for a one-suite
+// selection), so reading it as "how many I selected" would be wrong by three
+// orders of magnitude.
+//
+// Everything here is free functions over PODs with NO editor, renderer or
+// process dependency — only nlohmann::json and the stdlib — so it is unit
+// tested headlessly (OloEngine/tests/MCP/McpTestExecutionTest.cpp). The
+// process spawning, binary discovery and file reads live in the handler
+// (MCP/McpToolsTesting.cpp); this is the same split McpRenderValidate.h /
+// McpFrameBreakdown.h use.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace OloEngine::MCP::TestExecution
+{
+    using Json = nlohmann::json;
+
+    // The gtest filter is passed on the child's command line, and Windows caps
+    // one command line at 32767 characters including the executable path. A
+    // selection expanded to explicit case names (what `layer` does) can blow
+    // through that — 3000 unit-test names is ~135 KB — so it is checked against
+    // this ceiling and REFUSED with the arithmetic rather than truncated into a
+    // filter that silently runs a subset.
+    inline constexpr sizet kMaxFilterChars = 30000;
+
+    // ---- classification (test_catalogue.json + the in-file marker) ---------
+
+    // What an in-file `// OLO_TEST_LAYER: <id>` scan found. Mirrors
+    // generate_test_catalogue.py's extract_layer_marker: repeated IDENTICAL
+    // markers are tolerated, two different ones are a conflict and classify
+    // nothing.
+    struct LayerMarker
+    {
+        std::string Layer;     // the marker's value; empty when the file carries none
+        bool Conflict = false; // two or more markers disagreed
+    };
+
+    // Scan a test file's text for the marker. Recognizes the same shape the
+    // generator's regex does — `^[ \t]*//[ \t]*OLO_TEST_LAYER:[ \t]*([A-Za-z0-9_]+)`,
+    // anywhere in the file, not only near the top.
+    [[nodiscard]] inline LayerMarker ExtractLayerMarker(std::string_view fileText)
+    {
+        LayerMarker found;
+        sizet cursor = 0;
+        while (cursor <= fileText.size())
+        {
+            const sizet lineEnd = std::min(fileText.find('\n', cursor), fileText.size());
+            std::string_view line = fileText.substr(cursor, lineEnd - cursor);
+            cursor = lineEnd + 1;
+
+            sizet i = 0;
+            while (i < line.size() && (line[i] == ' ' || line[i] == '\t'))
+                ++i;
+            if (i + 1 >= line.size() || line[i] != '/' || line[i + 1] != '/')
+                continue;
+            i += 2;
+            while (i < line.size() && (line[i] == ' ' || line[i] == '\t'))
+                ++i;
+
+            constexpr std::string_view kKey = "OLO_TEST_LAYER:";
+            if (line.substr(i, kKey.size()) != kKey)
+                continue;
+            i += kKey.size();
+            while (i < line.size() && (line[i] == ' ' || line[i] == '\t'))
+                ++i;
+
+            const sizet valueStart = i;
+            while (i < line.size() &&
+                   ((line[i] >= 'A' && line[i] <= 'Z') || (line[i] >= 'a' && line[i] <= 'z') ||
+                    (line[i] >= '0' && line[i] <= '9') || line[i] == '_'))
+                ++i;
+            if (i == valueStart)
+                continue; // `// OLO_TEST_LAYER:` with no id is not a marker
+
+            const std::string value(line.substr(valueStart, i - valueStart));
+            if (found.Layer.empty())
+                found.Layer = value;
+            else if (found.Layer != value)
+            {
+                found.Conflict = true;
+                found.Layer.clear();
+                return found; // conflicting markers classify nothing, as in the generator
+            }
+        }
+        return found;
+    }
+
+    // A file's resolved layer, plus why it has none. `Problem` is a sentence for
+    // a human; it is REPORTED, never swallowed — an unclassified test file is
+    // exactly the blind spot the classification gate exists to prevent, and a
+    // command that quietly labelled it "" would hide it again.
+    struct LayerResolution
+    {
+        std::string Layer;
+        std::string Problem;
+    };
+
+    // Merge the two classification mechanisms under the repo's rule (see
+    // generate_test_catalogue.py::classify_files): a file uses an in-file marker
+    // OR a `file_layer_map` entry, never both; the marker wins where present;
+    // an unknown id and an unclassified file are both errors.
+    //
+    // `fileLayerMap` is test_catalogue.json's `file_layer_map` object and
+    // `knownIds` its layer ids (plus the unit / Functional tags).
+    [[nodiscard]] inline LayerResolution ResolveLayer(std::string_view repoRelativeFile, const LayerMarker& marker,
+                                                      const Json& fileLayerMap, const std::set<std::string>& knownIds)
+    {
+        LayerResolution out;
+        const std::string key(repoRelativeFile);
+
+        if (marker.Conflict)
+        {
+            out.Problem = key + ": multiple conflicting // OLO_TEST_LAYER markers.";
+            return out;
+        }
+
+        std::string mapped;
+        if (fileLayerMap.is_object())
+        {
+            if (const auto it = fileLayerMap.find(key); it != fileLayerMap.end() && it->is_string())
+                mapped = it->get<std::string>();
+        }
+
+        // Reported when a file carries BOTH mechanisms. It still classifies by
+        // the marker (the file IS classified; the duplicate registration is the
+        // defect), but it falls through to the same range check below rather
+        // than returning early — an unknown id must be rejected here exactly as
+        // it is on the single-mechanism path, or the two would disagree about
+        // what a valid layer is.
+        if (!marker.Layer.empty() && !mapped.empty())
+        {
+            out.Problem = key + ": has an // OLO_TEST_LAYER:" + marker.Layer +
+                          " marker AND a file_layer_map entry - remove the JSON entry (the marker supersedes it).";
+        }
+
+        out.Layer = !marker.Layer.empty() ? marker.Layer : mapped;
+        if (out.Layer.empty())
+        {
+            out.Problem = key + ": unclassified test file (no // OLO_TEST_LAYER marker and no file_layer_map entry).";
+            return out;
+        }
+        if (!knownIds.empty() && !knownIds.contains(out.Layer))
+        {
+            out.Problem = key + ": layer '" + out.Layer + "' is not a known id in test_catalogue.json.";
+            out.Layer.clear();
+        }
+        return out;
+    }
+
+    // The layer ids test_catalogue.json declares, plus the two tags the
+    // generator adds implicitly (`unit`, and `functional_tag`, normally
+    // "Functional"). An empty set means "do not range-check", which is what a
+    // caller with no catalogue gets.
+    [[nodiscard]] inline std::set<std::string> KnownLayerIds(const Json& catalogue)
+    {
+        std::set<std::string> ids;
+        if (!catalogue.is_object())
+            return ids;
+        if (const auto layers = catalogue.find("layers"); layers != catalogue.end() && layers->is_array())
+        {
+            for (const auto& layer : *layers)
+            {
+                if (layer.is_object() && layer.contains("id") && layer["id"].is_string())
+                    ids.insert(layer["id"].get<std::string>());
+            }
+        }
+        if (ids.empty())
+            return ids; // no declared layers => no range check at all
+        ids.insert("unit");
+        ids.insert(catalogue.value("functional_tag", std::string("Functional")));
+        return ids;
+    }
+
+    // Normalize gtest's `file` field to the repo-relative key `file_layer_map`
+    // is written in. gtest reports `__FILE__` exactly as the compiler saw it,
+    // which under a CMake build tree is a path relative to the BUILD directory
+    // with native separators: "..\\OloEngine\\tests\\Foo\\BarTest.cpp". Both the
+    // `..` prefixes and the separators have to go, so the anchor is the test
+    // root substring rather than any kind of path arithmetic — that also copes
+    // with an absolute `__FILE__` from a different generator.
+    //
+    // Returns empty when the path does not lie under `testRoot`, which the
+    // caller reports rather than guessing a key.
+    [[nodiscard]] inline std::string NormalizeTestFile(std::string_view rawPath, std::string_view testRoot)
+    {
+        std::string normalized(rawPath);
+        std::replace(normalized.begin(), normalized.end(), '\\', '/');
+        if (testRoot.empty())
+            return normalized;
+
+        std::string anchor(testRoot);
+        std::replace(anchor.begin(), anchor.end(), '\\', '/');
+        while (!anchor.empty() && anchor.back() == '/')
+            anchor.pop_back();
+        anchor.push_back('/');
+
+        const sizet at = normalized.find(anchor);
+        if (at == std::string::npos)
+            return {};
+        return normalized.substr(at);
+    }
+
+    // ---- the selected set (a `--gtest_list_tests` report) ------------------
+
+    struct TestCase
+    {
+        std::string Suite;
+        std::string Name;
+        std::string File; // repo-relative; empty when it could not be normalized
+        int Line = 0;
+        std::string Layer; // "" when unclassified — the report says which
+        bool Disabled = false;
+
+        [[nodiscard]] std::string FullName() const
+        {
+            return Suite + "." + Name;
+        }
+    };
+
+    // True for a name gtest treats as disabled: the DISABLED_ prefix on either
+    // half of the full name. Such a case is still LISTED and still appears in a
+    // run report (status NOTRUN / result SUPPRESSED), so it reconciles like any
+    // other — it just never executes.
+    [[nodiscard]] inline bool IsDisabledName(std::string_view suite, std::string_view name)
+    {
+        constexpr std::string_view kPrefix = "DISABLED_";
+        return suite.substr(0, kPrefix.size()) == kPrefix || name.substr(0, kPrefix.size()) == kPrefix;
+    }
+
+    // Parse the document `--gtest_list_tests --gtest_output=json:<file>` writes.
+    // Sets `error` and returns empty when the document is not that shape — a
+    // half-written file from a child that died mid-flush must not read as an
+    // empty selection.
+    [[nodiscard]] inline std::vector<TestCase> ParseListReport(const Json& doc, std::string& error)
+    {
+        error.clear();
+        std::vector<TestCase> cases;
+        if (!doc.is_object() || !doc.contains("testsuites") || !doc["testsuites"].is_array())
+        {
+            error = "gtest list report is missing its 'testsuites' array.";
+            return cases;
+        }
+        for (const auto& suite : doc["testsuites"])
+        {
+            if (!suite.is_object() || !suite.contains("name") || !suite["name"].is_string())
+                continue;
+            const std::string suiteName = suite["name"].get<std::string>();
+            if (!suite.contains("testsuite") || !suite["testsuite"].is_array())
+                continue;
+            for (const auto& entry : suite["testsuite"])
+            {
+                if (!entry.is_object() || !entry.contains("name") || !entry["name"].is_string())
+                    continue;
+                TestCase testCase;
+                testCase.Suite = suiteName;
+                testCase.Name = entry["name"].get<std::string>();
+                if (entry.contains("file") && entry["file"].is_string())
+                    testCase.File = entry["file"].get<std::string>();
+                if (entry.contains("line") && entry["line"].is_number_integer())
+                    testCase.Line = entry["line"].get<int>();
+                testCase.Disabled = IsDisabledName(testCase.Suite, testCase.Name);
+                cases.push_back(std::move(testCase));
+            }
+        }
+        return cases;
+    }
+
+    // ---- the run report ----------------------------------------------------
+
+    enum class CaseStatus : u8
+    {
+        Passed = 0,
+        Failed,
+        Skipped,  // GTEST_SKIP() at runtime — the GPU-absent guard every visual test uses
+        Disabled, // never ran: DISABLED_ prefix (gtest status NOTRUN / result SUPPRESSED)
+    };
+
+    [[nodiscard]] inline const char* CaseStatusName(CaseStatus status)
+    {
+        switch (status)
+        {
+            case CaseStatus::Passed:
+                return "passed";
+            case CaseStatus::Failed:
+                return "failed";
+            case CaseStatus::Skipped:
+                return "skipped";
+            case CaseStatus::Disabled:
+                return "disabled";
+        }
+        return "unknown";
+    }
+
+    struct CaseResult
+    {
+        std::string Suite;
+        std::string Name;
+        std::string File;
+        int Line = 0;
+        std::string Layer;
+        CaseStatus Status = CaseStatus::Passed;
+        f64 Seconds = 0.0;
+        // Verbatim gtest failure text (one entry per failed assertion), or the
+        // GTEST_SKIP reason for a skip. This is the whole point of the command:
+        // the caller reads the message instead of scraping the console.
+        std::vector<std::string> Messages;
+
+        [[nodiscard]] std::string FullName() const
+        {
+            return Suite + "." + Name;
+        }
+    };
+
+    // gtest writes a duration as "17.444s" / "0s". Returns 0 for anything else
+    // rather than throwing — a malformed duration is cosmetic, and the run's
+    // correctness never rests on it.
+    [[nodiscard]] inline f64 ParseGTestDuration(std::string_view text)
+    {
+        if (!text.empty() && text.back() == 's')
+            text.remove_suffix(1);
+        if (text.empty())
+            return 0.0;
+        try
+        {
+            sizet consumed = 0;
+            const f64 value = std::stod(std::string(text), &consumed);
+            if (consumed != text.size() || !std::isfinite(value) || value < 0.0)
+                return 0.0;
+            return value;
+        }
+        catch (...)
+        {
+            return 0.0;
+        }
+    }
+
+    // A failure gtest recorded OUTSIDE any test case — a fatal assertion in
+    // SetUpTestSuite / TearDownTestSuite, or in the global environment. gtest
+    // reports these as pseudo-entries with an EMPTY `name`, either inside the
+    // owning suite's array or under a synthetic `NonTestSuiteFailure` suite.
+    //
+    // They must be kept out of the case list. Read as cases they carry the full
+    // name "Suite." — which no listing ever contains — so reconciliation would
+    // call them `unexpected` and report a genuine SetUpTestSuite failure as
+    // "the run was PARTIAL", burying the real cause under a plumbing complaint.
+    struct SuiteFailure
+    {
+        std::string Suite; // "NonTestSuiteFailure" for a global-environment failure
+        std::vector<std::string> Messages;
+    };
+
+    // The synthetic suite gtest invents for a failure that belongs to no suite.
+    inline constexpr std::string_view kNonTestSuiteFailure = "NonTestSuiteFailure";
+
+    struct RunReport
+    {
+        std::vector<CaseResult> Cases;
+        std::vector<SuiteFailure> SuiteFailures;
+        std::string Error; // non-empty => the document was not the shape gtest emits
+    };
+
+    // Parse the document `--gtest_output=json:<file>` writes after a run.
+    [[nodiscard]] inline RunReport ParseRunReport(const Json& doc)
+    {
+        RunReport report;
+        if (!doc.is_object() || !doc.contains("testsuites") || !doc["testsuites"].is_array())
+        {
+            report.Error = "gtest run report is missing its 'testsuites' array.";
+            return report;
+        }
+        for (const auto& suite : doc["testsuites"])
+        {
+            if (!suite.is_object() || !suite.contains("name") || !suite["name"].is_string())
+                continue;
+            const std::string suiteName = suite["name"].get<std::string>();
+            if (!suite.contains("testsuite") || !suite["testsuite"].is_array())
+                continue;
+            for (const auto& entry : suite["testsuite"])
+            {
+                if (!entry.is_object() || !entry.contains("name") || !entry["name"].is_string())
+                    continue;
+
+                // A suite-level failure, not a case. See SuiteFailure.
+                if (const std::string entryName = entry["name"].get<std::string>();
+                    entryName.empty() || suiteName == kNonTestSuiteFailure)
+                {
+                    SuiteFailure suiteFailure;
+                    suiteFailure.Suite = suiteName;
+                    if (const auto failures = entry.find("failures");
+                        failures != entry.end() && failures->is_array())
+                    {
+                        for (const auto& failure : *failures)
+                        {
+                            if (failure.is_object() && failure.contains("failure") &&
+                                failure["failure"].is_string())
+                                suiteFailure.Messages.push_back(failure["failure"].get<std::string>());
+                        }
+                    }
+                    report.SuiteFailures.push_back(std::move(suiteFailure));
+                    continue;
+                }
+
+                CaseResult result;
+                result.Suite = suiteName;
+                result.Name = entry["name"].get<std::string>();
+                if (entry.contains("file") && entry["file"].is_string())
+                    result.File = entry["file"].get<std::string>();
+                if (entry.contains("line") && entry["line"].is_number_integer())
+                    result.Line = entry["line"].get<int>();
+                if (entry.contains("time") && entry["time"].is_string())
+                    result.Seconds = ParseGTestDuration(entry["time"].get<std::string>());
+
+                const std::string status = entry.value("status", std::string("RUN"));
+                const std::string outcome = entry.value("result", std::string("COMPLETED"));
+                if (status != "RUN" || outcome == "SUPPRESSED")
+                    result.Status = CaseStatus::Disabled;
+                else if (outcome == "SKIPPED")
+                    result.Status = CaseStatus::Skipped;
+                else
+                    result.Status = CaseStatus::Passed;
+
+                if (const auto failures = entry.find("failures");
+                    failures != entry.end() && failures->is_array() && !failures->empty())
+                {
+                    // A failure recorded against a case outranks its `result`
+                    // field: gtest reports a test that both skipped and failed
+                    // as SKIPPED, and calling that anything but a failure would
+                    // lose a real red.
+                    result.Status = CaseStatus::Failed;
+                    for (const auto& failure : *failures)
+                    {
+                        if (failure.is_object() && failure.contains("failure") && failure["failure"].is_string())
+                            result.Messages.push_back(failure["failure"].get<std::string>());
+                    }
+                }
+                else if (const auto skipped = entry.find("skipped");
+                         skipped != entry.end() && skipped->is_array())
+                {
+                    for (const auto& skip : *skipped)
+                    {
+                        if (skip.is_object() && skip.contains("message") && skip["message"].is_string())
+                            result.Messages.push_back(skip["message"].get<std::string>());
+                    }
+                }
+
+                report.Cases.push_back(std::move(result));
+            }
+        }
+        return report;
+    }
+
+    // ---- reconciliation: the "never silently partial" gate -----------------
+
+    struct Reconciliation
+    {
+        std::vector<std::string> Missing;    // selected by the filter, absent from the report
+        std::vector<std::string> Unexpected; // in the report, never selected
+        sizet Expected = 0;
+        sizet Reported = 0;
+
+        [[nodiscard]] bool Complete() const
+        {
+            return Missing.empty() && Unexpected.empty() && Expected == Reported;
+        }
+    };
+
+    // Diff the selected set against the reported one BY NAME. A count-only
+    // check passes a run that lost one case and gained another, and gives a
+    // caller nothing to act on when it does fail; the names are what turn "the
+    // run was partial" into "these 3 cases never reported, the last one to
+    // start was X".
+    [[nodiscard]] inline Reconciliation Reconcile(const std::vector<TestCase>& selected,
+                                                  const std::vector<CaseResult>& reported)
+    {
+        Reconciliation out;
+        out.Expected = selected.size();
+        out.Reported = reported.size();
+
+        std::set<std::string> reportedNames;
+        for (const auto& result : reported)
+            reportedNames.insert(result.FullName());
+
+        std::set<std::string> selectedNames;
+        for (const auto& testCase : selected)
+        {
+            const std::string full = testCase.FullName();
+            selectedNames.insert(full);
+            if (!reportedNames.contains(full))
+                out.Missing.push_back(full);
+        }
+        for (const auto& result : reported)
+        {
+            if (const std::string full = result.FullName(); !selectedNames.contains(full))
+                out.Unexpected.push_back(full);
+        }
+        return out;
+    }
+
+    // ---- filter assembly ---------------------------------------------------
+
+    // gtest filter tokens carry no escaping mechanism, so a name outside this
+    // set cannot be expressed in one at all. Every name gtest itself generates
+    // is within it (suite/case identifiers, the `Instantiation/Suite.Case/0`
+    // shape of a parameterized test). A name that is not is REFUSED by the
+    // caller rather than pasted into a filter that would silently select
+    // something else.
+    [[nodiscard]] inline bool IsFilterSafeName(std::string_view name)
+    {
+        if (name.empty())
+            return false;
+        return std::all_of(name.begin(), name.end(),
+                           [](char c)
+                           {
+                               return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                                      c == '_' || c == '.' || c == '/';
+                           });
+    }
+
+    // A whole gtest FILTER EXPRESSION, which additionally carries the wildcard
+    // and negation punctuation a bare name may not: `*` `?` `:` `-`.
+    //
+    // This is the one selection input a caller writes freehand, and it is pasted
+    // into the child's command line. A `"` in it would close the quoting and let
+    // the rest be read as further arguments — including a second
+    // `--gtest_output`, which redirects the report and makes the run fail as
+    // "exited without writing a report". So the charset is checked rather than
+    // the quoting made clever: there is no escape syntax inside a gtest filter
+    // anyway, so nothing legitimate is being refused.
+    [[nodiscard]] inline bool IsFilterSafeExpression(std::string_view filter)
+    {
+        if (filter.empty())
+            return false;
+        return std::all_of(filter.begin(), filter.end(),
+                           [](char c)
+                           {
+                               return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                                      c == '_' || c == '.' || c == '/' || c == '*' || c == '?' || c == ':' ||
+                                      c == '-';
+                           });
+    }
+
+    // Join full test names into one gtest positive filter.
+    [[nodiscard]] inline std::string JoinFilter(const std::vector<std::string>& fullNames)
+    {
+        std::string filter;
+        for (const auto& name : fullNames)
+        {
+            if (!filter.empty())
+                filter.push_back(':');
+            filter += name;
+        }
+        return filter;
+    }
+
+    // ---- console text (progress + the tail that explains a dead child) -----
+
+    // How many cases the child has STARTED, counted from gtest's `[ RUN      ]`
+    // banners in the captured console text. Progress only: the results
+    // themselves always come from the JSON report, never from this.
+    [[nodiscard]] inline sizet CountStartedCases(std::string_view consoleText)
+    {
+        constexpr std::string_view kBanner = "[ RUN      ]";
+        sizet count = 0;
+        for (sizet at = consoleText.find(kBanner); at != std::string_view::npos;
+             at = consoleText.find(kBanner, at + kBanner.size()))
+            ++count;
+        return count;
+    }
+
+    // The last `maxChars` of `text`, marked when anything was dropped. This is
+    // what a caller reads when the child died before writing a report, so it
+    // keeps the END of the log — where the crash is — not the start.
+    [[nodiscard]] inline std::string TailOf(std::string_view text, sizet maxChars)
+    {
+        if (maxChars == 0 || text.size() <= maxChars)
+            return std::string(text);
+        return "...[" + std::to_string(text.size() - maxChars) + " earlier characters omitted]...\n" +
+               std::string(text.substr(text.size() - maxChars));
+    }
+
+    // Clamp one failure message, marking the cut. A silently truncated
+    // assertion message reads as a complete one that simply did not say much.
+    [[nodiscard]] inline std::string Clamp(std::string_view text, sizet maxChars)
+    {
+        if (maxChars == 0 || text.size() <= maxChars)
+            return std::string(text);
+        return std::string(text.substr(0, maxChars)) + "\n...[truncated, " + std::to_string(text.size() - maxChars) +
+               " more characters]";
+    }
+
+    // ---- shaping -----------------------------------------------------------
+
+    [[nodiscard]] inline Json CaseJson(const CaseResult& result, sizet maxMessageChars)
+    {
+        Json entry;
+        entry["suite"] = result.Suite;
+        entry["name"] = result.Name;
+        entry["fullName"] = result.FullName();
+        entry["status"] = CaseStatusName(result.Status);
+        entry["seconds"] = result.Seconds;
+        if (!result.File.empty())
+        {
+            entry["file"] = result.File;
+            entry["line"] = result.Line;
+        }
+        if (!result.Layer.empty())
+            entry["layer"] = result.Layer;
+        if (!result.Messages.empty())
+        {
+            Json messages = Json::array();
+            for (const auto& message : result.Messages)
+                messages.push_back(Clamp(message, maxMessageChars));
+            entry["messages"] = std::move(messages);
+        }
+        return entry;
+    }
+
+    struct RunCounts
+    {
+        sizet Total = 0;
+        sizet Passed = 0;
+        sizet Failed = 0;
+        sizet Skipped = 0;
+        sizet Disabled = 0;
+
+        // The four buckets are exhaustive by construction, so a total that does
+        // not add up means the shaping lost a case — a bug, not a test result,
+        // and the caller reports it as one.
+        [[nodiscard]] bool AddsUp() const
+        {
+            return Passed + Failed + Skipped + Disabled == Total;
+        }
+    };
+
+    [[nodiscard]] inline RunCounts CountCases(const std::vector<CaseResult>& cases)
+    {
+        RunCounts counts;
+        counts.Total = cases.size();
+        for (const auto& result : cases)
+        {
+            switch (result.Status)
+            {
+                case CaseStatus::Passed:
+                    ++counts.Passed;
+                    break;
+                case CaseStatus::Failed:
+                    ++counts.Failed;
+                    break;
+                case CaseStatus::Skipped:
+                    ++counts.Skipped;
+                    break;
+                case CaseStatus::Disabled:
+                    ++counts.Disabled;
+                    break;
+            }
+        }
+        return counts;
+    }
+
+    // Cases grouped by their OLO_TEST_LAYER classification, for a caller that
+    // wants "how much of the renderer pyramid did this touch?" without walking
+    // the array. Unclassified cases are counted under an explicit key rather
+    // than dropped.
+    [[nodiscard]] inline Json LayerCountsJson(const std::vector<TestCase>& cases)
+    {
+        std::unordered_map<std::string, sizet> counts;
+        for (const auto& testCase : cases)
+            ++counts[testCase.Layer.empty() ? std::string("unclassified") : testCase.Layer];
+        Json out = Json::object();
+        for (const auto& [layer, count] : counts)
+            out[layer] = count;
+        return out;
+    }
+} // namespace OloEngine::MCP::TestExecution

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -206,6 +206,8 @@ namespace OloEngine::MCP
         RegisterInputTools(registry);
         RegisterBenchmarkTools(registry);
         RegisterEditorTools(registry);
+        RegisterTestingTools(registry);
+        RegisterValidationTools(registry);
     }
 
     void RegisterBuiltinTools(McpServer& server)

--- a/OloEditor/src/MCP/McpToolsAssets.cpp
+++ b/OloEditor/src/MCP/McpToolsAssets.cpp
@@ -126,6 +126,13 @@ namespace OloEngine::MCP
 
     } // namespace
 
+    // Composed by olo_project_validate (#1130) — the SAME handler the standalone
+    // command registers, so the two cannot disagree about what an asset problem is.
+    ToolResult CollectAssetProblems(IAutomationHost& host)
+    {
+        return Handle_AssetsProblems(host, Json::object());
+    }
+
     void RegisterAssetTools(AutomationRegistry& registry)
     {
         {

--- a/OloEditor/src/MCP/McpToolsAssets.cpp
+++ b/OloEditor/src/MCP/McpToolsAssets.cpp
@@ -26,7 +26,12 @@ namespace OloEngine::MCP
             int page = 0;
             int pageSize = 50;
             if (args.contains("page") && args["page"].is_number_integer())
-                page = static_cast<int>(std::max<long long>(0, args["page"].get<long long>()));
+                // CLAMPED, not floored: Pagination() declares `minimum: 0` and no
+                // maximum, so a legal 2147483648 narrows to int as -2147483648 on
+                // MSVC, `start` goes hugely negative and the loop below indexes
+                // the vector far out of bounds. Found by review on #1130, which
+                // had copied this shape.
+                page = static_cast<int>(std::clamp<long long>(args["page"].get<long long>(), 0, 1'000'000));
             if (args.contains("pageSize") && args["pageSize"].is_number_integer())
                 pageSize = static_cast<int>(std::clamp<long long>(args["pageSize"].get<long long>(), 1, 200));
 

--- a/OloEditor/src/MCP/McpToolsCommon.h
+++ b/OloEditor/src/MCP/McpToolsCommon.h
@@ -385,6 +385,29 @@ namespace OloEngine::MCP
     void RegisterInputTools(AutomationRegistry& registry);
     void RegisterBenchmarkTools(AutomationRegistry& registry);
     void RegisterEditorTools(AutomationRegistry& registry);
+    // ---- problem collectors composed by olo_project_validate (#1130) -------
+    //
+    // Each RUNS THE HANDLER of the standalone command named in its comment and
+    // returns that command's own ToolResult verbatim. That is deliberate: a
+    // composite that re-implemented the sweep would be a second opinion, and the
+    // acceptance criterion for the validation slice is that it reports the SAME
+    // problems the editor panels show. Composing by invocation makes drift
+    // impossible rather than merely unlikely. An error result means the section
+    // could not run here; its text is the reason.
+    ToolResult CollectAssetProblems(IAutomationHost& host);       // olo_assets_problems
+    ToolResult CollectShaderProblems(IAutomationHost& host);      // olo_shader_errors
+    ToolResult CollectScriptProblems(IAutomationHost& host);      // olo_script_get_last_errors
+    ToolResult CollectRenderGraphProblems(IAutomationHost& host); // olo_render_validate (default sweep)
+
+    // Structured test execution (issue #1130): olo_tests_list / olo_tests_run.
+    // These run OloEngine-Tests as a CHILD PROCESS from the handler thread and
+    // never marshal onto the game thread, which is how the "no renderer for the
+    // CPU-only suites" constraint is met structurally rather than by a guard.
+    void RegisterTestingTools(AutomationRegistry& registry);
+    // Whole-project validation (issue #1130): olo_project_validate, which
+    // composes the per-domain problem commands above by INVOKING THEM, so the
+    // composite report and each standalone command cannot drift.
+    void RegisterValidationTools(AutomationRegistry& registry);
     // The capability-discovery gateway (issue #1124). Registered LAST so the four
     // gateway tools sort after the domains in tools/list — they are the entry point
     // for a session that cannot see the rest, not part of any domain.

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -6318,6 +6318,14 @@ namespace OloEngine::MCP
 
     } // namespace
 
+    // Composed by olo_project_validate (#1130). Runs olo_render_validate's DEFAULT
+    // sweep — no compare, no forced frame — against the live graph, through the
+    // standalone command's own handler so the verdicts cannot drift.
+    ToolResult CollectRenderGraphProblems(IAutomationHost& host)
+    {
+        return Handle_RenderValidate(host, Json::object());
+    }
+
     void RegisterRenderTools(AutomationRegistry& registry)
     {
         {

--- a/OloEditor/src/MCP/McpToolsScene.cpp
+++ b/OloEditor/src/MCP/McpToolsScene.cpp
@@ -120,7 +120,12 @@ namespace OloEngine::MCP
             int page = 0;
             int pageSize = 50;
             if (args.contains("page") && args["page"].is_number_integer())
-                page = static_cast<int>(std::max<long long>(0, args["page"].get<long long>()));
+                // CLAMPED, not floored: Pagination() declares `minimum: 0` and no
+                // maximum, so a legal 2147483648 narrows to int as -2147483648 on
+                // MSVC, `start` goes hugely negative and the loop below indexes
+                // the vector far out of bounds. Found by review on #1130, which
+                // had copied this shape.
+                page = static_cast<int>(std::clamp<long long>(args["page"].get<long long>(), 0, 1'000'000));
             if (args.contains("pageSize") && args["pageSize"].is_number_integer())
                 pageSize = static_cast<int>(std::clamp<long long>(args["pageSize"].get<long long>(), 1, 200));
 

--- a/OloEditor/src/MCP/McpToolsScripting.cpp
+++ b/OloEditor/src/MCP/McpToolsScripting.cpp
@@ -95,7 +95,13 @@ namespace OloEngine::MCP
     // shows, through the standalone command's handler.
     ToolResult CollectScriptProblems(IAutomationHost& host)
     {
-        return Handle_ScriptGetLastErrors(host, Json::object());
+        // Ask for the tool's OWN maximum (64), not its console-tuned default of
+        // 20. The command reports only the size of the array it returns, never a
+        // "total available", so a default-capped 20 would sit under
+        // olo_project_validate's own maxPerSection of 50 and be counted as the
+        // whole truth — under-reporting with `omitted: 0`, which is exactly the
+        // silent partial the composite is built to refuse.
+        return Handle_ScriptGetLastErrors(host, Json{ { "count", 64 } });
     }
 
     void RegisterScriptingTools(AutomationRegistry& registry)

--- a/OloEditor/src/MCP/McpToolsScripting.cpp
+++ b/OloEditor/src/MCP/McpToolsScripting.cpp
@@ -91,6 +91,13 @@ namespace OloEngine::MCP
 
     } // namespace
 
+    // Composed by olo_project_validate (#1130): the script-error ring the console
+    // shows, through the standalone command's handler.
+    ToolResult CollectScriptProblems(IAutomationHost& host)
+    {
+        return Handle_ScriptGetLastErrors(host, Json::object());
+    }
+
     void RegisterScriptingTools(AutomationRegistry& registry)
     {
         {

--- a/OloEditor/src/MCP/McpToolsShader.cpp
+++ b/OloEditor/src/MCP/McpToolsShader.cpp
@@ -323,6 +323,13 @@ namespace OloEngine::MCP
 
     } // namespace
 
+    // Composed by olo_project_validate (#1130): the same ShaderDebugger sweep the
+    // Shader editor panel renders from, through the standalone command's handler.
+    ToolResult CollectShaderProblems(IAutomationHost& host)
+    {
+        return Handle_ShaderErrors(host, Json::object());
+    }
+
     void RegisterShaderTools(AutomationRegistry& registry)
     {
         {

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -1,0 +1,1423 @@
+#include "OloEnginePCH.h"
+#include "MCP/McpToolsCommon.h"
+#include "MCP/McpSchemaBuilder.h"
+#include "MCP/McpTestExecution.h"
+
+#include "OloEngine/Core/Environment.h"
+#include "OloEngine/Core/Log.h"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#else
+#include <csignal>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+// Structured test execution: olo_tests_list and olo_tests_run (issue #1130,
+// Epic H slice 1).
+//
+// WHERE THIS RUNS, and why that was the first decision. The commands execute
+// OloEngine-Tests as a CHILD PROCESS from the automation handler thread. They
+// never touch the editor's renderer, never MarshalRead onto the game thread,
+// and hold no GL/Vulkan state — which is the issue's "must not require the
+// editor's renderer for the CPU-only suites" constraint met structurally rather
+// than by a guard someone can forget. A GPU suite still skips or runs on its
+// own terms inside the child, exactly as it does from a shell.
+//
+// Results come from gtest's own JSON report, not from console text. The console
+// IS captured, but only for two things a JSON file cannot give: live progress
+// while the run is in flight (counting `[ RUN      ]` banners), and the tail of
+// the log when the child died before writing a report at all.
+//
+// The correctness rule, stated once here and enforced in three places below: a
+// run must never be silently partial. Zero matches is an error; a dead child is
+// an error; a report that does not account for every selected case is an error
+// naming the ones that went missing. See MCP/McpTestExecution.h.
+
+namespace OloEngine::MCP
+{
+    namespace
+    {
+        namespace fs = std::filesystem;
+        using namespace OloEngine::MCP::TestExecution;
+
+        // The repo marker that identifies the source tree: the test catalogue
+        // this command reads its classification from. Anchoring on the very file
+        // we need means a root we "found" without one is not a root at all.
+        constexpr const char* kCatalogueRelative = "OloEngine/tests/scripts/test_catalogue.json";
+        constexpr const char* kTestRoot = "OloEngine/tests";
+
+        // The child's working directory, relative to the repo root. This is what
+        // ctest uses — OloEngine/tests/CMakeLists.txt passes
+        // `WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor` to both
+        // gtest_discover_tests calls, because "many tests call
+        // Shader::Create("assets/shaders/...") which only works when CWD is
+        // OloEditor". Matching it means a run from here and a run from CI are
+        // the same run.
+        //
+        // Measured 2026-09-09: the engine also resolves those asset paths from
+        // the repo root (FluidVisualEvidenceTest wrote its PNGs into the tracked
+        // OloEditor/assets/tests/visual/ with CWD at the root, creating no stray
+        // directory), so this is not the difference between working and broken
+        // today. It is the difference between agreeing with CI and relying on a
+        // fallback nobody promised.
+        constexpr const char* kChildWorkingDirectory = "OloEditor";
+        constexpr const char* kTestBinaryName =
+#ifdef _WIN32
+            "OloEngine-Tests.exe";
+#else
+            "OloEngine-Tests";
+#endif
+
+        // How far up from the working directory to look for the repo root. The
+        // editor runs with cwd = OloEditor/, so one level suffices; the margin
+        // covers a caller that launched it from deeper (a per-scene subdirectory).
+        constexpr int kMaxRootSearchDepth = 8;
+
+        // Poll cadence while a child runs: often enough that a cancellation is
+        // acted on promptly, rarely enough that re-reading a growing console log
+        // costs nothing measurable next to a test suite.
+        constexpr auto kPollInterval = std::chrono::milliseconds(250);
+
+        // Console tail returned when a child dies. Big enough for a stack dump
+        // and the last few cases, small enough not to swamp a tool result.
+        constexpr sizet kConsoleTailChars = 8000;
+
+        // ---- filesystem helpers -------------------------------------------
+
+        [[nodiscard]] std::string ReadWholeFile(const fs::path& path, bool& ok)
+        {
+            ok = false;
+            std::ifstream stream(path, std::ios::binary);
+            if (!stream)
+                return {};
+            std::ostringstream buffer;
+            buffer << stream.rdbuf();
+            ok = true;
+            return buffer.str();
+        }
+
+        // Format a file's last-write time as an ISO-8601 UTC instant. Reported
+        // next to every binary this command runs: an exit code and a green
+        // summary look identical whether the binary under test is the one you
+        // just built or last week's, so the answer says WHICH artefact produced
+        // it and how old that artefact is.
+        [[nodiscard]] std::string FileModifiedUtc(const fs::path& path)
+        {
+            std::error_code ec;
+            const auto written = fs::last_write_time(path, ec);
+            if (ec)
+                return {};
+            const auto systemTime = std::chrono::clock_cast<std::chrono::system_clock>(written);
+            const std::time_t epoch = std::chrono::system_clock::to_time_t(systemTime);
+            std::tm utc{};
+#ifdef _WIN32
+            if (::gmtime_s(&utc, &epoch) != 0)
+                return {};
+#else
+            if (::gmtime_r(&epoch, &utc) == nullptr)
+                return {};
+#endif
+            std::ostringstream formatted;
+            formatted << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+            return formatted.str();
+        }
+
+        // Walk up from the working directory looking for the test catalogue.
+        [[nodiscard]] bool FindRepoRoot(fs::path& outRoot, std::string& outError)
+        {
+            std::error_code ec;
+            fs::path cursor = fs::current_path(ec);
+            if (ec)
+            {
+                outError = "Cannot determine the working directory: " + ec.message();
+                return false;
+            }
+            std::string searched;
+            for (int depth = 0; depth < kMaxRootSearchDepth; ++depth)
+            {
+                if (!searched.empty())
+                    searched += ", ";
+                searched += cursor.generic_string();
+                if (fs::exists(cursor / kCatalogueRelative, ec))
+                {
+                    outRoot = cursor;
+                    return true;
+                }
+                const fs::path parent = cursor.parent_path();
+                if (parent.empty() || parent == cursor)
+                    break;
+                cursor = parent;
+            }
+            outError = std::string("Could not locate the OloEngine source tree: no ") + kCatalogueRelative +
+                       " in any parent of the working directory (looked in " + searched + ").";
+            return false;
+        }
+
+        // ---- the test binary ----------------------------------------------
+
+        struct ResolvedBinary
+        {
+            fs::path Path;
+            u64 SizeBytes = 0;
+            std::string ModifiedUtc;
+            std::string Origin; // how it was chosen: "argument", "environment", "search"
+        };
+
+        [[nodiscard]] Json BinaryJson(const ResolvedBinary& binary)
+        {
+            Json j;
+            j["path"] = binary.Path.generic_string();
+            j["sizeBytes"] = binary.SizeBytes;
+            if (!binary.ModifiedUtc.empty())
+                j["modifiedUtc"] = binary.ModifiedUtc;
+            j["origin"] = binary.Origin;
+            return j;
+        }
+
+        // The build trees CMakePresets.json defines, newest artefact wins. The
+        // order here is only the order they are REPORTED in; selection is by
+        // modification time, because "the one I just built" is what a caller
+        // asking to run its tests means, and it is not always the default tree.
+        [[nodiscard]] std::vector<fs::path> CandidateBinaries(const fs::path& repoRoot)
+        {
+            std::vector<fs::path> candidates;
+            for (const char* tree : { "build-cached", "build", "build-clang" })
+            {
+                for (const char* config : { "Debug", "Release", "RelWithDebInfo", "" })
+                {
+                    fs::path candidate = repoRoot / tree / "OloEngine" / "tests";
+                    if (*config != '\0')
+                        candidate /= config;
+                    candidates.push_back(candidate / kTestBinaryName);
+                }
+            }
+            return candidates;
+        }
+
+        [[nodiscard]] bool DescribeBinary(const fs::path& path, ResolvedBinary& out, std::string& outError)
+        {
+            std::error_code ec;
+            if (!fs::is_regular_file(path, ec))
+            {
+                outError = "Not a file: " + path.generic_string();
+                return false;
+            }
+            out.Path = fs::weakly_canonical(path, ec);
+            if (ec)
+                out.Path = path;
+            out.SizeBytes = static_cast<u64>(fs::file_size(out.Path, ec));
+            if (ec)
+                out.SizeBytes = 0;
+            out.ModifiedUtc = FileModifiedUtc(out.Path);
+            return true;
+        }
+
+        // Resolve which OloEngine-Tests to run. An explicit `binary` argument or
+        // OLO_TESTS_BINARY wins and is NEVER silently replaced by a search hit:
+        // a caller that named a binary and got a different one's results has
+        // been lied to. Otherwise the newest build-tree artefact wins, and every
+        // path that was considered is reported either way.
+        [[nodiscard]] bool ResolveBinary(const Json& args, const fs::path& repoRoot, ResolvedBinary& out,
+                                         Json& outSearched, std::string& outError)
+        {
+            outSearched = Json::array();
+
+            const auto fromExplicitPath = [&](const std::string& raw, const char* origin) -> bool
+            {
+                fs::path path(raw);
+                if (path.is_relative())
+                    path = repoRoot / path;
+                outSearched.push_back(path.generic_string());
+                // The command exists to run THE TEST BINARY. Without this the
+                // `binary` argument is a way to execute any executable on the
+                // box through a command that is deliberately not consent-gated,
+                // which is a much larger authority than "run the tests" — and
+                // pointing it at anything else only ever produces the
+                // "exited without writing a report" error anyway.
+                if (path.filename() != kTestBinaryName)
+                {
+                    outError = std::string("Invalid ") + origin + " test binary '" + path.generic_string() +
+                               "': the file must be named " + kTestBinaryName + ".";
+                    return false;
+                }
+                if (!DescribeBinary(path, out, outError))
+                {
+                    outError = std::string("The ") + origin + " test binary does not exist: " + path.generic_string();
+                    return false;
+                }
+                out.Origin = origin;
+                return true;
+            };
+
+            if (args.contains("binary"))
+            {
+                if (!args["binary"].is_string() || args["binary"].get<std::string>().empty())
+                {
+                    outError = "Invalid 'binary': expected a non-empty path string.";
+                    return false;
+                }
+                return fromExplicitPath(args["binary"].get<std::string>(), "argument");
+            }
+            // Through the engine's one environment reader (Core/Environment.h),
+            // which also treats an empty variable as unset — never raw getenv.
+            if (const std::optional<std::string> fromEnv = Env::Get("OLO_TESTS_BINARY"); fromEnv.has_value())
+                return fromExplicitPath(*fromEnv, "environment");
+
+            ResolvedBinary newest;
+            std::string newestStamp;
+            for (const fs::path& candidate : CandidateBinaries(repoRoot))
+            {
+                std::error_code ec;
+                if (!fs::is_regular_file(candidate, ec))
+                    continue;
+                outSearched.push_back(candidate.generic_string());
+                ResolvedBinary described;
+                std::string ignored;
+                if (!DescribeBinary(candidate, described, ignored))
+                    continue;
+                // Lexicographic on an ISO-8601 UTC stamp is chronological.
+                if (newest.Path.empty() || described.ModifiedUtc > newestStamp)
+                {
+                    newest = described;
+                    newestStamp = described.ModifiedUtc;
+                }
+            }
+            if (newest.Path.empty())
+            {
+                std::string looked;
+                for (const fs::path& candidate : CandidateBinaries(repoRoot))
+                {
+                    if (!looked.empty())
+                        looked += ", ";
+                    looked += candidate.generic_string();
+                }
+                outError = "No " + std::string(kTestBinaryName) +
+                           " found. Build it first (target OloEngine-Tests), pass 'binary', or set "
+                           "OLO_TESTS_BINARY. Looked in: " +
+                           looked;
+                return false;
+            }
+            newest.Origin = "search";
+            out = newest;
+            return true;
+        }
+
+        // ---- the child process --------------------------------------------
+
+        enum class ChildOutcome : u8
+        {
+            Exited = 0,  // ran to completion; ExitCode is meaningful
+            SpawnFailed, // never started
+            TimedOut,    // killed at the deadline
+            Cancelled,   // killed because the caller cancelled the call
+        };
+
+        struct ChildResult
+        {
+            ChildOutcome Outcome = ChildOutcome::SpawnFailed;
+            int ExitCode = -1;
+            std::string Error;   // set for SpawnFailed
+            std::string Console; // whatever the child wrote before it stopped
+
+            [[nodiscard]] bool Completed() const
+            {
+                return Outcome == ChildOutcome::Exited;
+            }
+        };
+
+        [[nodiscard]] const char* ChildOutcomeName(ChildOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case ChildOutcome::Exited:
+                    return "exited";
+                case ChildOutcome::SpawnFailed:
+                    return "spawn-failed";
+                case ChildOutcome::TimedOut:
+                    return "timed-out";
+                case ChildOutcome::Cancelled:
+                    return "cancelled";
+            }
+            return "unknown";
+        }
+
+        // Emit progress from the child's console as it grows, and answer whether
+        // the call has been cancelled. Shared by both platform branches so the
+        // two cannot drift on when a run is abandoned.
+        struct RunWatch
+        {
+            IAutomationHost* Host = nullptr;
+            fs::path ConsolePath;
+            // 0 means "no progress to report" — the listing pass, which prints no
+            // per-case banners and would have the watch re-read a file for nothing.
+            sizet ExpectedCases = 0;
+
+            // Returns true when the caller has cancelled and the child should die.
+            [[nodiscard]] bool Tick()
+            {
+                if (Host == nullptr)
+                    return false;
+                if (ExpectedCases > 0)
+                    ReportProgress();
+                return Host->IsCurrentCallCancelled();
+            }
+
+          private:
+            // Count banners in what the child APPENDED since the last tick, not
+            // in the whole log. A full 7000-case run writes tens of megabytes and
+            // this fires four times a second for up to two hours; re-reading and
+            // re-scanning all of it every time is quadratic in the log size for
+            // no new information.
+            void ReportProgress()
+            {
+                std::error_code ec;
+                const auto size = static_cast<sizet>(fs::file_size(ConsolePath, ec));
+                if (ec || size <= m_ScannedBytes)
+                    return;
+
+                // Re-read the last few bytes of the previous window as well, so a
+                // banner split across two reads is still counted exactly once.
+                const sizet overlap = std::min(m_ScannedBytes, kBannerOverlap);
+                const sizet from = m_ScannedBytes - overlap;
+
+                std::ifstream stream(ConsolePath, std::ios::binary);
+                if (!stream)
+                    return;
+                stream.seekg(static_cast<std::streamoff>(from));
+                std::string chunk(size - from, '\0');
+                stream.read(chunk.data(), static_cast<std::streamsize>(chunk.size()));
+                chunk.resize(static_cast<sizet>(stream.gcount()));
+
+                const sizet before = CountStartedCases(std::string_view(chunk).substr(0, overlap));
+                m_Started += CountStartedCases(chunk) - before;
+                m_ScannedBytes = from + chunk.size();
+
+                if (const sizet started = std::min(m_Started, ExpectedCases); started > m_LastReported)
+                {
+                    m_LastReported = started;
+                    Host->EmitProgress(static_cast<f64>(started), static_cast<f64>(ExpectedCases),
+                                       "ran " + std::to_string(started) + "/" + std::to_string(ExpectedCases) +
+                                           " test cases");
+                }
+            }
+
+            // One banner is 12 characters; a comfortable multiple of that covers
+            // any split without re-counting a banner wholly inside the old window.
+            static constexpr sizet kBannerOverlap = 64;
+
+            sizet m_ScannedBytes = 0;
+            sizet m_Started = 0;
+            sizet m_LastReported = 0;
+        };
+
+#ifdef _WIN32
+        // One command-line string, each argument quoted only when it needs it.
+        // gtest arguments carry no spaces or quotes; the executable path can.
+        [[nodiscard]] std::string BuildCommandLine(const fs::path& exe, const std::vector<std::string>& arguments)
+        {
+            std::string command = "\"" + exe.string() + "\"";
+            for (const std::string& argument : arguments)
+            {
+                command.push_back(' ');
+                if (argument.find_first_of(" \t\"") == std::string::npos)
+                    command += argument;
+                else
+                    command += "\"" + argument + "\"";
+            }
+            return command;
+        }
+
+        [[nodiscard]] std::wstring Widen(const std::string& utf8)
+        {
+            if (utf8.empty())
+                return {};
+            const int length = ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+            if (length <= 0)
+                return {};
+            std::wstring wide(static_cast<sizet>(length), L'\0');
+            ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide.data(), length);
+            wide.resize(static_cast<sizet>(length - 1)); // drop the NUL the API appended
+            return wide;
+        }
+
+        [[nodiscard]] ChildResult RunChild(const fs::path& exe, const std::vector<std::string>& arguments,
+                                           const fs::path& workingDirectory, const fs::path& consolePath,
+                                           std::chrono::milliseconds timeout, RunWatch& watch)
+        {
+            ChildResult result;
+
+            SECURITY_ATTRIBUTES inheritable{};
+            inheritable.nLength = sizeof(inheritable);
+            inheritable.bInheritHandle = TRUE;
+
+            // stdout and stderr both go to one file rather than a pipe: a pipe
+            // nobody drains fills its buffer and BLOCKS the child, which for a
+            // chatty 7000-case run is a hang that looks exactly like a slow test.
+            // FILE_SHARE_READ is what lets the progress watch read the log while
+            // the child is still writing it.
+            const HANDLE console = ::CreateFileW(Widen(consolePath.string()).c_str(), GENERIC_WRITE,
+                                                 FILE_SHARE_READ | FILE_SHARE_WRITE, &inheritable, CREATE_ALWAYS,
+                                                 FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (console == INVALID_HANDLE_VALUE)
+            {
+                result.Error = "Could not create the console log " + consolePath.generic_string() + " (error " +
+                               std::to_string(::GetLastError()) + ").";
+                return result;
+            }
+
+            STARTUPINFOW startup{};
+            startup.cb = sizeof(startup);
+            startup.dwFlags = STARTF_USESTDHANDLES;
+            startup.hStdInput = nullptr;
+            startup.hStdOutput = console;
+            startup.hStdError = console;
+
+            std::wstring commandLine = Widen(BuildCommandLine(exe, arguments));
+            const std::wstring directory = Widen(workingDirectory.string());
+
+            PROCESS_INFORMATION process{};
+            if (!::CreateProcessW(nullptr, commandLine.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr,
+                                  directory.empty() ? nullptr : directory.c_str(), &startup, &process))
+            {
+                const DWORD error = ::GetLastError();
+                ::CloseHandle(console);
+                result.Error = "Could not start " + exe.generic_string() + " (CreateProcess error " +
+                               std::to_string(error) + ").";
+                return result;
+            }
+            // Our copy of the write handle must go, or the log would stay open
+            // for writing after the child exits.
+            ::CloseHandle(console);
+
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            result.Outcome = ChildOutcome::Exited;
+            for (;;)
+            {
+                const DWORD waited = ::WaitForSingleObject(process.hProcess, static_cast<DWORD>(kPollInterval.count()));
+                if (waited == WAIT_OBJECT_0)
+                    break;
+                if (watch.Tick())
+                {
+                    result.Outcome = ChildOutcome::Cancelled;
+                    ::TerminateProcess(process.hProcess, 1);
+                    ::WaitForSingleObject(process.hProcess, 5000);
+                    break;
+                }
+                if (std::chrono::steady_clock::now() >= deadline)
+                {
+                    result.Outcome = ChildOutcome::TimedOut;
+                    ::TerminateProcess(process.hProcess, 1);
+                    ::WaitForSingleObject(process.hProcess, 5000);
+                    break;
+                }
+            }
+
+            DWORD exitCode = 0;
+            if (::GetExitCodeProcess(process.hProcess, &exitCode))
+                result.ExitCode = static_cast<int>(exitCode);
+            ::CloseHandle(process.hThread);
+            ::CloseHandle(process.hProcess);
+
+            bool ok = false;
+            result.Console = ReadWholeFile(consolePath, ok);
+            return result;
+        }
+#else
+        [[nodiscard]] ChildResult RunChild(const fs::path& exe, const std::vector<std::string>& arguments,
+                                           const fs::path& workingDirectory, const fs::path& consolePath,
+                                           std::chrono::milliseconds timeout, RunWatch& watch)
+        {
+            ChildResult result;
+
+            // fork + exec rather than posix_spawn: redirecting to a file AND
+            // setting the working directory needs posix_spawn_file_actions_addchdir_np,
+            // which is a glibc extension behind _GNU_SOURCE. The child below does
+            // only async-signal-safe calls between fork and exec.
+            std::vector<std::string> owned;
+            owned.push_back(exe.string());
+            owned.insert(owned.end(), arguments.begin(), arguments.end());
+            std::vector<char*> argv;
+            argv.reserve(owned.size() + 1);
+            for (std::string& argument : owned)
+                argv.push_back(argument.data());
+            argv.push_back(nullptr);
+
+            const std::string exePath = exe.string();
+            const std::string consoleFile = consolePath.string();
+            const std::string directory = workingDirectory.string();
+
+            const pid_t pid = ::fork();
+            if (pid < 0)
+            {
+                result.Error = "Could not fork to start " + exe.generic_string() + ".";
+                return result;
+            }
+            if (pid == 0)
+            {
+                // Same reasoning as the Windows branch: one file, not a pipe —
+                // an undrained pipe would block the child mid-run.
+                if (::chdir(directory.c_str()) != 0)
+                    ::_exit(127);
+                const int log = ::open(consoleFile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+                if (log < 0)
+                    ::_exit(127);
+                (void)::dup2(log, STDOUT_FILENO);
+                (void)::dup2(log, STDERR_FILENO);
+                if (log > STDERR_FILENO)
+                    (void)::close(log);
+                ::execv(exePath.c_str(), argv.data());
+                ::_exit(127);
+            }
+
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            result.Outcome = ChildOutcome::Exited;
+            for (;;)
+            {
+                int status = 0;
+                const pid_t waited = ::waitpid(pid, &status, WNOHANG);
+                if (waited == pid)
+                {
+                    result.ExitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+                    break;
+                }
+                if (watch.Tick())
+                {
+                    result.Outcome = ChildOutcome::Cancelled;
+                    ::kill(pid, SIGKILL);
+                    (void)::waitpid(pid, &status, 0);
+                    break;
+                }
+                if (std::chrono::steady_clock::now() >= deadline)
+                {
+                    result.Outcome = ChildOutcome::TimedOut;
+                    ::kill(pid, SIGKILL);
+                    (void)::waitpid(pid, &status, 0);
+                    break;
+                }
+                std::this_thread::sleep_for(kPollInterval);
+            }
+
+            bool ok = false;
+            result.Console = ReadWholeFile(consolePath, ok);
+            return result;
+        }
+#endif
+
+        // ---- classification index -----------------------------------------
+
+        // Resolves a test file's OLO_TEST_LAYER, from the in-file marker first
+        // and test_catalogue.json's file_layer_map second, caching per file so a
+        // 7000-case listing reads each source once. Every classification defect
+        // it meets is collected in Problems and REPORTED with the result rather
+        // than smoothed into a blank layer.
+        class LayerIndex
+        {
+          public:
+            explicit LayerIndex(const fs::path& repoRoot) : m_RepoRoot(repoRoot)
+            {
+                bool ok = false;
+                const std::string text = ReadWholeFile(repoRoot / kCatalogueRelative, ok);
+                if (!ok)
+                {
+                    m_Problems.push_back(std::string("Could not read ") + kCatalogueRelative +
+                                         "; no test is classified.");
+                    return;
+                }
+                const Json catalogue = Json::parse(text, nullptr, false);
+                if (catalogue.is_discarded())
+                {
+                    m_Problems.push_back(std::string(kCatalogueRelative) + " is not valid JSON; no test is classified.");
+                    return;
+                }
+                if (catalogue.contains("file_layer_map"))
+                    m_FileLayerMap = catalogue["file_layer_map"];
+                m_KnownIds = KnownLayerIds(catalogue);
+            }
+
+            // `rawFile` is gtest's `file` field. Returns the layer, or empty when
+            // the file could not be classified (the reason lands in Problems).
+            [[nodiscard]] std::string LayerFor(const std::string& rawFile, std::string& outRepoRelative)
+            {
+                outRepoRelative = NormalizeTestFile(rawFile, kTestRoot);
+                if (outRepoRelative.empty())
+                {
+                    NoteProblem("Test source '" + rawFile + "' is not under " + kTestRoot +
+                                "; it cannot be classified.");
+                    return {};
+                }
+                if (const auto cached = m_Cache.find(outRepoRelative); cached != m_Cache.end())
+                    return cached->second;
+
+                bool ok = false;
+                const std::string text = ReadWholeFile(m_RepoRoot / outRepoRelative, ok);
+                const LayerMarker marker = ok ? ExtractLayerMarker(text) : LayerMarker{};
+                if (!ok)
+                    NoteProblem("Could not read " + outRepoRelative + " to look for its // OLO_TEST_LAYER marker.");
+
+                const LayerResolution resolved = ResolveLayer(outRepoRelative, marker, m_FileLayerMap, m_KnownIds);
+                if (!resolved.Problem.empty())
+                    NoteProblem(resolved.Problem);
+                m_Cache.emplace(outRepoRelative, resolved.Layer);
+                return resolved.Layer;
+            }
+
+            [[nodiscard]] const std::vector<std::string>& Problems() const
+            {
+                return m_Problems;
+            }
+
+          private:
+            void NoteProblem(std::string problem)
+            {
+                if (std::find(m_Problems.begin(), m_Problems.end(), problem) == m_Problems.end())
+                    m_Problems.push_back(std::move(problem));
+            }
+
+            fs::path m_RepoRoot;
+            Json m_FileLayerMap = Json::object();
+            std::set<std::string> m_KnownIds;
+            std::unordered_map<std::string, std::string> m_Cache;
+            std::vector<std::string> m_Problems;
+        };
+
+        // ---- shared selection plumbing ------------------------------------
+
+        // A scratch directory for one invocation's gtest report + console log,
+        // removed when the invocation ends however it ends.
+        class ScratchDirectory
+        {
+          public:
+            explicit ScratchDirectory(const char* stem)
+            {
+                std::error_code ec;
+                const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+                m_Path = fs::temp_directory_path(ec) /
+                         (std::string("olo-") + stem + "-" + std::to_string(static_cast<u64>(stamp)));
+                if (!ec)
+                    fs::create_directories(m_Path, ec);
+                if (ec)
+                    m_Path.clear();
+            }
+            ~ScratchDirectory()
+            {
+                if (m_Path.empty())
+                    return;
+                std::error_code ec;
+                fs::remove_all(m_Path, ec);
+            }
+
+            ScratchDirectory(const ScratchDirectory&) = delete;
+            ScratchDirectory& operator=(const ScratchDirectory&) = delete;
+            ScratchDirectory(ScratchDirectory&&) = delete;
+            ScratchDirectory& operator=(ScratchDirectory&&) = delete;
+
+            [[nodiscard]] bool Valid() const
+            {
+                return !m_Path.empty();
+            }
+            [[nodiscard]] fs::path File(const char* name) const
+            {
+                return m_Path / name;
+            }
+
+          private:
+            fs::path m_Path;
+        };
+
+        // Everything a run or a listing needs, resolved once.
+        struct Session
+        {
+            fs::path RepoRoot;
+            ResolvedBinary Binary;
+            // Every existing candidate the search considered. Reported only when
+            // there was more than one: that is the case where "newest wins" made
+            // a choice, and a caller staring at an unexpected result deserves to
+            // see the tree it did not get.
+            Json Candidates = Json::array();
+        };
+
+        [[nodiscard]] bool OpenSession(const Json& args, Session& out, std::string& outError)
+        {
+            if (!FindRepoRoot(out.RepoRoot, outError))
+                return false;
+            return ResolveBinary(args, out.RepoRoot, out.Binary, out.Candidates, outError);
+        }
+
+        // Stamp the resolved binary (and, when ambiguous, the trees it beat) onto
+        // a result payload. Shared so both commands report provenance the same way.
+        void DescribeSession(const Session& session, Json& out)
+        {
+            out["binary"] = BinaryJson(session.Binary);
+            out["repoRoot"] = session.RepoRoot.generic_string();
+            if (session.Candidates.is_array() && session.Candidates.size() > 1)
+                out["binaryCandidates"] = session.Candidates;
+        }
+
+        // Turn the caller's selection arguments into one gtest filter.
+        // `suite` and `cases` are conveniences over `filter`; giving more than
+        // one of the three is refused rather than silently ranked, because the
+        // caller who did it meant something specific and cannot tell which won.
+        [[nodiscard]] bool BuildSelectionFilter(const Json& args, std::string& outFilter, std::string& outError)
+        {
+            int given = 0;
+            for (const char* key : { "filter", "suite", "cases" })
+                given += args.contains(key) ? 1 : 0;
+            if (given > 1)
+            {
+                outError = "Give at most one of 'filter', 'suite' or 'cases' — they are three spellings of the same "
+                           "selection and cannot be combined.";
+                return false;
+            }
+
+            if (args.contains("filter"))
+            {
+                if (!args["filter"].is_string() || !IsFilterSafeExpression(args["filter"].get<std::string>()))
+                {
+                    // Charset-checked, not quoted-around: the filter is pasted
+                    // into the child's command line and a quote in it would let
+                    // the rest be read as further gtest flags.
+                    outError = "Invalid 'filter': expected a non-empty gtest filter expression of "
+                               "[A-Za-z0-9_./*?:-] (a gtest filter has no escape syntax, so nothing else is "
+                               "meaningful in one).";
+                    return false;
+                }
+                outFilter = args["filter"].get<std::string>();
+            }
+            else if (args.contains("suite"))
+            {
+                if (!args["suite"].is_string() || !IsFilterSafeName(args["suite"].get<std::string>()))
+                {
+                    outError = "Invalid 'suite': expected a test suite name ([A-Za-z0-9_./]).";
+                    return false;
+                }
+                outFilter = args["suite"].get<std::string>() + ".*";
+            }
+            else if (args.contains("cases"))
+            {
+                if (!args["cases"].is_array() || args["cases"].empty())
+                {
+                    outError = "Invalid 'cases': expected a non-empty array of 'Suite.Case' names.";
+                    return false;
+                }
+                std::vector<std::string> names;
+                for (const auto& entry : args["cases"])
+                {
+                    if (!entry.is_string() || !IsFilterSafeName(entry.get<std::string>()))
+                    {
+                        outError = "Invalid entry in 'cases': expected 'Suite.Case' names of [A-Za-z0-9_./].";
+                        return false;
+                    }
+                    names.push_back(entry.get<std::string>());
+                }
+                outFilter = JoinFilter(names);
+            }
+            else
+            {
+                outFilter = "*";
+            }
+
+            if (outFilter.size() > kMaxFilterChars)
+            {
+                outError = "The selection expands to a " + std::to_string(outFilter.size()) +
+                           "-character gtest filter, over the " + std::to_string(kMaxFilterChars) +
+                           "-character ceiling one command line can carry. Narrow it.";
+                return false;
+            }
+            return true;
+        }
+
+        // Run the LIST pass: what the selection actually names, classified.
+        // This is both the answer olo_tests_list returns and the expected set
+        // olo_tests_run reconciles against.
+        [[nodiscard]] bool ListSelection(const Session& session, const std::string& filter, IAutomationHost& host,
+                                         std::vector<TestCase>& outCases, LayerIndex& layers, std::string& outError)
+        {
+            const ScratchDirectory scratch("tests-list");
+            if (!scratch.Valid())
+            {
+                outError = "Could not create a temporary directory for the gtest listing.";
+                return false;
+            }
+            const fs::path reportPath = scratch.File("list.json");
+            const fs::path consolePath = scratch.File("list.log");
+
+            RunWatch watch;
+            watch.Host = &host;
+            watch.ConsolePath = consolePath;
+
+            const std::vector<std::string> arguments{ "--gtest_list_tests", "--gtest_filter=" + filter,
+                                                      "--gtest_output=json:" + reportPath.string() };
+            const ChildResult child = RunChild(session.Binary.Path, arguments, session.RepoRoot / kChildWorkingDirectory, consolePath,
+                                               std::chrono::seconds(300), watch);
+            if (!child.Completed())
+            {
+                outError = std::string("Listing the test cases ") + ChildOutcomeName(child.Outcome) + ". " +
+                           child.Error + (child.Console.empty() ? "" : "\n" + TailOf(child.Console, kConsoleTailChars));
+                return false;
+            }
+
+            bool ok = false;
+            const std::string reportText = ReadWholeFile(reportPath, ok);
+            if (!ok)
+            {
+                outError = "The test binary exited with code " + std::to_string(child.ExitCode) +
+                           " without writing its listing to " + reportPath.generic_string() + ".\n" +
+                           TailOf(child.Console, kConsoleTailChars);
+                return false;
+            }
+            const Json report = Json::parse(reportText, nullptr, false);
+            if (report.is_discarded())
+            {
+                outError = "The gtest listing at " + reportPath.generic_string() + " is not valid JSON.";
+                return false;
+            }
+            outCases = ParseListReport(report, outError);
+            if (!outError.empty())
+                return false;
+
+            for (TestCase& testCase : outCases)
+            {
+                std::string repoRelative;
+                testCase.Layer = layers.LayerFor(testCase.File, repoRelative);
+                testCase.File = repoRelative;
+            }
+            return true;
+        }
+
+        // Expand a layer-narrowed selection into a gtest filter.
+        //
+        // A layer is not expressible as a gtest pattern, so it has to become an
+        // explicit name list — and `layer:"unit"` alone is ~3000 names, ~135 KB,
+        // four times what one Windows command line can carry. So a suite whose
+        // cases ALL survived the narrowing collapses to `Suite.*`, which is what
+        // makes a whole-layer run possible at all.
+        //
+        // The collapse can only ever be exact: `listed` is the complete listing
+        // the same filter produced, so "every listed case of this suite
+        // survived" means the suite has no unselected case to widen into. The
+        // caller must still pass `listedIsEverything` — with a base filter
+        // narrower than `*`, `listed` is already a subset and `Suite.*` would
+        // reach cases the caller excluded. And if the collapse were ever wrong,
+        // the run's own reconciliation would name the extra cases rather than
+        // let them pass as part of the result.
+        [[nodiscard]] std::string BuildLayerFilter(const std::vector<TestCase>& listed,
+                                                   const std::vector<TestCase>& selected, bool listedIsEverything)
+        {
+            std::unordered_map<std::string, sizet> listedPerSuite;
+            for (const TestCase& testCase : listed)
+                ++listedPerSuite[testCase.Suite];
+            std::unordered_map<std::string, sizet> selectedPerSuite;
+            for (const TestCase& testCase : selected)
+                ++selectedPerSuite[testCase.Suite];
+
+            std::vector<std::string> terms;
+            std::set<std::string> collapsed;
+            for (const TestCase& testCase : selected)
+            {
+                if (listedIsEverything && selectedPerSuite[testCase.Suite] == listedPerSuite[testCase.Suite])
+                {
+                    if (collapsed.insert(testCase.Suite).second)
+                        terms.push_back(testCase.Suite + ".*");
+                    continue;
+                }
+                terms.push_back(testCase.FullName());
+            }
+            return JoinFilter(terms);
+        }
+
+        // The one place "the selection matched nothing" is turned into an error.
+        // A caller that reads `0 cases, 0 failures` out of a typo'd filter has
+        // been told its code is fine by a run that never happened.
+        [[nodiscard]] std::string EmptySelectionError(const std::string& filter, const Session& session)
+        {
+            return "The selection matched no test cases (filter '" + filter + "' against " +
+                   session.Binary.Path.generic_string() +
+                   "). That is an error, not an empty pass: check the suite spelling with olo_tests_list, or rebuild "
+                   "the binary if the test is new.";
+        }
+
+        // ---- olo_tests_list -----------------------------------------------
+
+        ToolResult Handle_TestsList(IAutomationHost& host, const Json& args)
+        {
+            Session session;
+            if (std::string error; !OpenSession(args, session, error))
+                return ToolResult::Error(error);
+
+            std::string filter;
+            if (std::string error; !BuildSelectionFilter(args, filter, error))
+                return ToolResult::Error(error);
+
+            LayerIndex layers(session.RepoRoot);
+            std::vector<TestCase> cases;
+            if (std::string error; !ListSelection(session, filter, host, cases, layers, error))
+                return ToolResult::Error(error);
+
+            std::string layerFilter;
+            if (args.contains("layer"))
+            {
+                if (!args["layer"].is_string() || args["layer"].get<std::string>().empty())
+                    return ToolResult::Error("Invalid 'layer': expected a classification id such as 'L1' or 'unit'.");
+                layerFilter = args["layer"].get<std::string>();
+                std::erase_if(cases, [&layerFilter](const TestCase& c) { return c.Layer != layerFilter; });
+            }
+
+            if (cases.empty())
+                return ToolResult::Error(layerFilter.empty()
+                                             ? EmptySelectionError(filter, session)
+                                             : "No test case in the selection carries layer '" + layerFilter +
+                                                   "'. That is an error, not an empty listing: check the id against "
+                                                   "test_catalogue.json's 'layers'.");
+
+            int page = 0;
+            int pageSize = 100;
+            if (args.contains("page") && args["page"].is_number_integer())
+                page = static_cast<int>(std::max<long long>(0, args["page"].get<long long>()));
+            if (args.contains("pageSize") && args["pageSize"].is_number_integer())
+                pageSize = static_cast<int>(std::clamp<long long>(args["pageSize"].get<long long>(), 1, 500));
+
+            Json out;
+            DescribeSession(session, out);
+            out["filter"] = filter;
+            if (!layerFilter.empty())
+                out["layer"] = layerFilter;
+            out["total"] = cases.size();
+            out["layerCounts"] = LayerCountsJson(cases);
+
+            const auto total = static_cast<long long>(cases.size());
+            const long long start = static_cast<long long>(page) * pageSize;
+            Json entries = Json::array();
+            for (long long i = start; i < total && i < start + pageSize; ++i)
+            {
+                const TestCase& testCase = cases[static_cast<sizet>(i)];
+                Json entry;
+                entry["suite"] = testCase.Suite;
+                entry["name"] = testCase.Name;
+                entry["fullName"] = testCase.FullName();
+                if (!testCase.File.empty())
+                {
+                    entry["file"] = testCase.File;
+                    entry["line"] = testCase.Line;
+                }
+                if (!testCase.Layer.empty())
+                    entry["layer"] = testCase.Layer;
+                if (testCase.Disabled)
+                    entry["disabled"] = true;
+                entries.push_back(std::move(entry));
+            }
+            out["page"] = page;
+            out["pageSize"] = pageSize;
+            out["returned"] = entries.size();
+            if (start + pageSize < total)
+                out["nextPage"] = page + 1;
+            out["cases"] = std::move(entries);
+
+            // Classification defects ride along instead of being logged and
+            // forgotten: an unclassified test file is invisible to every
+            // layer-scoped selection, which is exactly the silent partial this
+            // command exists to refuse.
+            if (!layers.Problems().empty())
+            {
+                out["classificationProblems"] = layers.Problems();
+                out["classificationProblemCount"] = layers.Problems().size();
+            }
+            return ToolResult::Structured(out);
+        }
+
+        // ---- olo_tests_run ------------------------------------------------
+
+        ToolResult Handle_TestsRun(IAutomationHost& host, const Json& args)
+        {
+            Session session;
+            if (std::string error; !OpenSession(args, session, error))
+                return ToolResult::Error(error);
+
+            std::string filter;
+            if (std::string error; !BuildSelectionFilter(args, filter, error))
+                return ToolResult::Error(error);
+
+            const bool includePassed = args.value("includePassed", false);
+            const auto maxCases =
+                static_cast<sizet>(std::clamp<long long>(args.value("maxCases", 200LL), 1LL, 2000LL));
+            const auto maxMessageChars =
+                static_cast<sizet>(std::clamp<long long>(args.value("maxMessageChars", 2000LL), 200LL, 20000LL));
+            const auto timeoutSeconds = std::clamp<long long>(args.value("timeoutSeconds", 1800LL), 10LL, 7200LL);
+
+            // ---- pass 1: what did the caller select? ----
+            LayerIndex layers(session.RepoRoot);
+            std::vector<TestCase> listed;
+            if (std::string error; !ListSelection(session, filter, host, listed, layers, error))
+                return ToolResult::Error(error);
+
+            std::vector<TestCase> selected = listed;
+            if (args.contains("layer"))
+            {
+                if (!args["layer"].is_string() || args["layer"].get<std::string>().empty())
+                    return ToolResult::Error("Invalid 'layer': expected a classification id such as 'L1' or 'unit'.");
+                const std::string layerFilter = args["layer"].get<std::string>();
+                std::erase_if(selected, [&layerFilter](const TestCase& c) { return c.Layer != layerFilter; });
+                if (selected.empty())
+                    return ToolResult::Error("No test case in the selection carries layer '" + layerFilter +
+                                             "'. That is an error, not an empty run.");
+                for (const TestCase& testCase : selected)
+                {
+                    if (!IsFilterSafeName(testCase.FullName()))
+                        return ToolResult::Error("Test case '" + testCase.FullName() +
+                                                 "' cannot be named in a gtest filter; select it with 'filter'.");
+                }
+                filter = BuildLayerFilter(listed, selected, /*listedIsEverything*/ filter == "*");
+                if (filter.size() > kMaxFilterChars)
+                    return ToolResult::Error(
+                        "Layer '" + layerFilter + "' selects " + std::to_string(selected.size()) +
+                        " cases, which expand to a " + std::to_string(filter.size()) +
+                        "-character gtest filter — over the " + std::to_string(kMaxFilterChars) +
+                        "-character ceiling one command line can carry. Narrow it with 'suite' or 'filter' as well.");
+            }
+
+            if (selected.empty())
+                return ToolResult::Error(EmptySelectionError(filter, session));
+
+            // ---- pass 2: run it ----
+            const ScratchDirectory scratch("tests-run");
+            if (!scratch.Valid())
+                return ToolResult::Error("Could not create a temporary directory for the gtest report.");
+            const fs::path reportPath = scratch.File("report.json");
+            const fs::path consolePath = scratch.File("console.log");
+
+            std::vector<std::string> arguments{ "--gtest_filter=" + filter,
+                                                "--gtest_output=json:" + reportPath.string() };
+            if (args.value("shuffle", false))
+            {
+                arguments.emplace_back("--gtest_shuffle");
+                if (args.contains("seed") && args["seed"].is_number_integer())
+                    arguments.push_back("--gtest_random_seed=" +
+                                        std::to_string(std::clamp<long long>(args["seed"].get<long long>(), 0, 99999)));
+            }
+            if (args.value("alsoRunDisabled", false))
+                arguments.emplace_back("--gtest_also_run_disabled_tests");
+
+            RunWatch watch;
+            watch.Host = &host;
+            watch.ConsolePath = consolePath;
+            watch.ExpectedCases = selected.size();
+
+            const auto started = std::chrono::steady_clock::now();
+            const ChildResult child = RunChild(session.Binary.Path, arguments, session.RepoRoot / kChildWorkingDirectory, consolePath,
+                                               std::chrono::seconds(timeoutSeconds), watch);
+            const f64 wallSeconds =
+                std::chrono::duration<f64>(std::chrono::steady_clock::now() - started).count();
+
+            // Everything the caller needs to see even when the run collapsed.
+            const auto failure = [&](const std::string& what) -> ToolResult
+            {
+                Json detail;
+                detail["binary"] = BinaryJson(session.Binary);
+                detail["filter"] = filter;
+                detail["selected"] = selected.size();
+                detail["outcome"] = ChildOutcomeName(child.Outcome);
+                detail["exitCode"] = child.ExitCode;
+                detail["startedCases"] = CountStartedCases(child.Console);
+                detail["wallSeconds"] = wallSeconds;
+                return ToolResult::Error(what + "\n\n" + detail.dump(2) + "\n\nConsole tail:\n" +
+                                         TailOf(child.Console, kConsoleTailChars));
+            };
+
+            if (!child.Completed())
+                return failure("The test run " + std::string(ChildOutcomeName(child.Outcome)) +
+                               " and produced no complete report. " + child.Error);
+
+            bool ok = false;
+            const std::string reportText = ReadWholeFile(reportPath, ok);
+            if (!ok)
+                return failure("The test binary exited with code " + std::to_string(child.ExitCode) +
+                               " without writing a report — it crashed or aborted mid-run, so no result here would "
+                               "account for the whole selection.");
+            const Json report = Json::parse(reportText, nullptr, false);
+            if (report.is_discarded())
+                return failure("The gtest report is not valid JSON — the run was cut short while writing it.");
+
+            RunReport parsed = ParseRunReport(report);
+            if (!parsed.Error.empty())
+                return failure(parsed.Error);
+
+            // ---- pass 3: does the report account for the whole selection? ----
+            const Reconciliation reconciliation = Reconcile(selected, parsed.Cases);
+            if (!reconciliation.Complete())
+            {
+                Json detail;
+                detail["expected"] = reconciliation.Expected;
+                detail["reported"] = reconciliation.Reported;
+                detail["missing"] = reconciliation.Missing;
+                detail["unexpected"] = reconciliation.Unexpected;
+                return failure("The run was PARTIAL: the report does not account for every selected case.\n" +
+                               detail.dump(2));
+            }
+
+            // Carry the classification across from the listing.
+            std::unordered_map<std::string, const TestCase*> byName;
+            for (const TestCase& testCase : selected)
+                byName.emplace(testCase.FullName(), &testCase);
+            for (CaseResult& result : parsed.Cases)
+            {
+                if (const auto found = byName.find(result.FullName()); found != byName.end())
+                {
+                    result.Layer = found->second->Layer;
+                    result.File = found->second->File;
+                    result.Line = found->second->Line;
+                }
+            }
+
+            const RunCounts counts = CountCases(parsed.Cases);
+            if (!counts.AddsUp())
+                return failure("Internal error: the per-status counts (" + std::to_string(counts.Passed) + " passed, " +
+                               std::to_string(counts.Failed) + " failed, " + std::to_string(counts.Skipped) +
+                               " skipped, " + std::to_string(counts.Disabled) + " disabled) do not sum to the " +
+                               std::to_string(counts.Total) + " reported cases.");
+
+            Json out;
+            DescribeSession(session, out);
+            out["filter"] = filter;
+            out["exitCode"] = child.ExitCode;
+            out["wallSeconds"] = wallSeconds;
+            out["passed"] = counts.Passed;
+            out["failed"] = counts.Failed;
+            out["skipped"] = counts.Skipped;
+            out["disabled"] = counts.Disabled;
+            out["total"] = counts.Total;
+            // The whole selection ran and every case is accounted for. This flag
+            // is only ever true alongside the reconciliation below, so a caller
+            // can trust one number instead of re-deriving the invariant.
+            out["complete"] = true;
+            out["reconciliation"] = Json{ { "expected", reconciliation.Expected },
+                                          { "reported", reconciliation.Reported },
+                                          { "missing", Json::array() },
+                                          { "unexpected", Json::array() } };
+
+            Json cases = Json::array();
+            sizet omitted = 0;
+            for (const CaseResult& result : parsed.Cases)
+            {
+                if (!includePassed && result.Status == CaseStatus::Passed)
+                    continue;
+                if (cases.size() >= maxCases)
+                {
+                    ++omitted;
+                    continue;
+                }
+                cases.push_back(CaseJson(result, maxMessageChars));
+            }
+            out["cases"] = std::move(cases);
+            out["casesIncludePassed"] = includePassed;
+
+            // A fatal failure in SetUpTestSuite / TearDownTestSuite / a global
+            // environment belongs to no case, so it is reported here rather than
+            // being counted among them — and, crucially, it is reported at all:
+            // read as a case it would have reconciled as `unexpected` and turned
+            // a real failure into a "the run was PARTIAL" complaint.
+            Json suiteFailures = Json::array();
+            for (const SuiteFailure& suiteFailure : parsed.SuiteFailures)
+            {
+                Json entry;
+                entry["suite"] = suiteFailure.Suite;
+                Json messages = Json::array();
+                for (const std::string& message : suiteFailure.Messages)
+                    messages.push_back(Clamp(message, maxMessageChars));
+                entry["messages"] = std::move(messages);
+                suiteFailures.push_back(std::move(entry));
+            }
+            out["suiteFailureCount"] = suiteFailures.size();
+            if (!suiteFailures.empty())
+                out["suiteFailures"] = std::move(suiteFailures);
+            // Truncation is stated and counted rather than left to be inferred
+            // from an array that happens to be exactly maxCases long.
+            out["casesOmitted"] = omitted;
+            if (omitted > 0)
+                out["casesTruncated"] = true;
+
+            if (!layers.Problems().empty())
+            {
+                out["classificationProblems"] = layers.Problems();
+                out["classificationProblemCount"] = layers.Problems().size();
+            }
+
+            OLO_CORE_INFO("[MCP] olo_tests_run: {} passed, {} failed, {} skipped, {} disabled in {:.1f}s ({})",
+                          counts.Passed, counts.Failed, counts.Skipped, counts.Disabled, wallSeconds,
+                          session.Binary.Path.generic_string());
+            return ToolResult::Structured(out);
+        }
+
+        // ---- schema fragments shared by both commands ----------------------
+
+        [[nodiscard]] Schema::Node SelectionProps(Schema::Node node)
+        {
+            return node
+                .Prop("filter", Schema::String().Desc(
+                                    "gtest filter expression, e.g. 'RenderGraphTest.*' or 'A.B:C.*-*Slow*'. "
+                                    "Mutually exclusive with 'suite' and 'cases'; omit all three for every case."))
+                .Prop("suite", Schema::String().Desc("A single suite name, shorthand for the filter '<suite>.*'."))
+                .Prop("cases", Schema::Array(Schema::String())
+                                   .Desc("Explicit 'Suite.Case' full names to select."))
+                .Prop("layer", Schema::String().Desc(
+                                   "Keep only cases carrying this OLO_TEST_LAYER classification (L1-L11, "
+                                   "plumbing, cullinglod, shaderpipe, integration, meta, Functional, unit). "
+                                   "An id that matches nothing in the selection is an error."))
+                .Prop("binary", Schema::String().Desc(
+                                    "Path to OloEngine-Tests (absolute, or relative to the repo root). Defaults "
+                                    "to OLO_TESTS_BINARY, then the newest build tree under the repo root."));
+        }
+    } // namespace
+
+    void RegisterTestingTools(AutomationRegistry& registry)
+    {
+        {
+            ToolDef tool;
+            tool.Name = "olo_tests_list";
+            tool.Toolset = "tests";
+            tool.Title = "List test cases";
+            tool.Annotations = ReadOnlyAnnotations();
+            tool.Description =
+                "Enumerate the GoogleTest cases OloEngine-Tests holds, with each case's source file, line and "
+                "OLO_TEST_LAYER classification (the renderer pyramid L1-L11 and the Functional / unit axes). "
+                "Filter by gtest expression, suite, explicit names or layer. A selection that matches nothing is "
+                "an ERROR, not an empty list.";
+            tool.InputSchema = SelectionProps(Schema::Object())
+                                   .Pagination("Cases per page (default 100, max 500).")
+                                   .NoAdditional();
+            tool.OutputSchema =
+                Schema::Object()
+                    .Prop("binary", Schema::Object().Desc("Which OloEngine-Tests was enumerated, and how old it is."))
+                    .Prop("repoRoot", Schema::String())
+                    .Prop("filter", Schema::String().Desc("The gtest filter that was applied."))
+                    .Prop("total", Schema::Int().Min(1).Desc("Cases the selection matched (never 0 — that errors)."))
+                    .Prop("layerCounts", Schema::Object().Desc("Case count per OLO_TEST_LAYER id; unclassified "
+                                                               "cases are counted under 'unclassified'."))
+                    .Prop("page", Schema::Int().Min(0))
+                    .Prop("pageSize", Schema::Int().Min(1))
+                    .Prop("returned", Schema::Int().Min(0))
+                    .Prop("nextPage", Schema::Int().Min(1).Desc("Omitted on the last page."))
+                    .Prop("cases", Schema::Array(Schema::Object()
+                                                     .Prop("suite", Schema::String())
+                                                     .Prop("name", Schema::String())
+                                                     .Prop("fullName", Schema::String())
+                                                     .Prop("file", Schema::String().Desc("Repo-relative source path."))
+                                                     .Prop("line", Schema::Int().Min(0))
+                                                     .Prop("layer", Schema::String())
+                                                     .Prop("disabled", Schema::Bool())))
+                    .Prop("classificationProblems",
+                          Schema::Array(Schema::String())
+                              .Desc("Test files the OLO_TEST_LAYER gate would reject. Reported, never swallowed."))
+                    .Required({ "binary", "repoRoot", "filter", "total", "page", "pageSize", "returned", "cases" });
+            tool.Handler = Handle_TestsList;
+            registry.Register(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_tests_run";
+            tool.Toolset = "tests";
+            tool.Title = "Run tests";
+            tool.DualAudienceContent = true;
+            // NOT read-only, and the distinction is not pedantic: a full run
+            // regenerates the tracked evidence PNGs under
+            // OloEditor/assets/tests/visual/, so the working tree moves. It is
+            // still not a ProjectWrite — it mutates nothing the user is
+            // AUTHORING (no scene, no component, no asset registry entry), and
+            // gating verification behind the write-consent toggle would make
+            // the loop this issue exists to open unusable by default.
+            // destructiveHint stays false: those PNGs are generated artefacts
+            // the run reproduces, not user data it destroys.
+            tool.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            tool.Description =
+                "Run a filtered selection of OloEngine-Tests as a child process and return STRUCTURED per-case "
+                "results — pass/fail/skip/disabled, the verbatim gtest failure text, per-case timings and each "
+                "case's OLO_TEST_LAYER — with no console parsing. Does not use the editor's renderer, so the "
+                "CPU-only suites do not inherit any GPU skip condition. Reports failures by default; set "
+                "includePassed for the whole set. A run is never silently partial: a selection matching nothing, "
+                "a child that crashed, timed out or was cancelled, and a report that does not account for every "
+                "selected case are all errors that name what is missing. Note that a run regenerates the tracked "
+                "evidence PNGs under OloEditor/assets/tests/visual/, so the working tree moves — never 'git add -A' "
+                "after one.";
+            tool.InputSchema =
+                SelectionProps(Schema::Object())
+                    .Prop("includePassed",
+                          Schema::Bool().Desc("Include passing cases in 'cases' (default false — failures only)."))
+                    .Prop("maxCases", Schema::Int().Min(1).Max(2000).Desc(
+                                          "Cap on reported cases (default 200). Any excess is counted in "
+                                          "'casesOmitted', never silently dropped."))
+                    .Prop("maxMessageChars", Schema::Int().Min(200).Max(20000).Desc(
+                                                 "Cap on one failure message (default 2000); a cut is marked."))
+                    .Prop("timeoutSeconds", Schema::Int().Min(10).Max(7200).Desc(
+                                                "Kill the run after this long (default 1800). A timeout is an "
+                                                "error, not a partial result."))
+                    .Prop("shuffle", Schema::Bool().Desc("Run in a random order (--gtest_shuffle)."))
+                    .Prop("seed", Schema::Int().Min(0).Max(99999).Desc("Shuffle seed (--gtest_random_seed)."))
+                    .Prop("alsoRunDisabled",
+                          Schema::Bool().Desc("Also run DISABLED_ cases (--gtest_also_run_disabled_tests)."))
+                    .NoAdditional();
+            tool.OutputSchema =
+                Schema::Object()
+                    .Prop("binary", Schema::Object().Desc("Which OloEngine-Tests ran, its size and its build time."))
+                    .Prop("repoRoot", Schema::String())
+                    .Prop("filter", Schema::String())
+                    .Prop("exitCode", Schema::Int().Desc("The test binary's own exit code."))
+                    .Prop("wallSeconds", Schema::Number())
+                    .Prop("passed", Schema::Int().Min(0))
+                    .Prop("failed", Schema::Int().Min(0))
+                    .Prop("skipped", Schema::Int().Min(0))
+                    .Prop("disabled", Schema::Int().Min(0))
+                    .Prop("total", Schema::Int().Min(1))
+                    .Prop("complete", Schema::Bool().Desc("Always true on success: every selected case reported."))
+                    .Prop("reconciliation", Schema::Object().Desc(
+                                                "expected/reported counts and the (always empty on success) "
+                                                "'missing' and 'unexpected' name lists."))
+                    .Prop("cases", Schema::Array(Schema::Object()
+                                                     .Prop("suite", Schema::String())
+                                                     .Prop("name", Schema::String())
+                                                     .Prop("fullName", Schema::String())
+                                                     .Prop("status", Schema::String().Enum({ "passed", "failed",
+                                                                                             "skipped", "disabled" }))
+                                                     .Prop("seconds", Schema::Number())
+                                                     .Prop("file", Schema::String())
+                                                     .Prop("line", Schema::Int().Min(0))
+                                                     .Prop("layer", Schema::String())
+                                                     .Prop("messages", Schema::Array(Schema::String())
+                                                                           .Desc("Verbatim gtest failure text, or "
+                                                                                 "the GTEST_SKIP reason."))))
+                    .Prop("casesOmitted", Schema::Int().Min(0).Desc("Cases past 'maxCases', counted not dropped."))
+                    .Prop("suiteFailureCount", Schema::Int().Min(0).Desc(
+                                                   "Failures belonging to no case — a fatal assertion in "
+                                                   "SetUpTestSuite/TearDownTestSuite or a global environment."))
+                    .Prop("suiteFailures", Schema::Array(Schema::Object()
+                                                             .Prop("suite", Schema::String())
+                                                             .Prop("messages", Schema::Array(Schema::String())))
+                                               .Desc("Present only when suiteFailureCount > 0."))
+                    .Required({ "binary", "filter", "exitCode", "passed", "failed", "skipped", "disabled", "total",
+                                "complete", "reconciliation", "cases", "suiteFailureCount" });
+            tool.Handler = Handle_TestsRun;
+            registry.Register(std::move(tool));
+        }
+    }
+} // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -257,12 +257,12 @@ namespace OloEngine::MCP
                 if (path.is_relative())
                     path = repoRoot / path;
                 outSearched.push_back(path.generic_string());
-                // The command exists to run THE TEST BINARY. Without this the
-                // `binary` argument is a way to execute any executable on the
-                // box through a command that is deliberately not consent-gated,
-                // which is a much larger authority than "run the tests" — and
-                // pointing it at anything else only ever produces the
-                // "exited without writing a report" error anyway.
+                // The command exists to run THE TEST BINARY OF THIS TREE, and it
+                // is deliberately not consent-gated, so "which executable" is the
+                // whole of its authority. Two checks, and the name alone is not
+                // enough — anyone able to drop a file called OloEngine-Tests.exe
+                // anywhere on the box would otherwise get arbitrary execution
+                // (CWE-114).
                 if (path.filename() != kTestBinaryName)
                 {
                     outError = std::string("Invalid ") + origin + " test binary '" + path.generic_string() +
@@ -272,6 +272,26 @@ namespace OloEngine::MCP
                 if (!DescribeBinary(path, out, outError))
                 {
                     outError = std::string("The ") + origin + " test binary does not exist: " + path.generic_string();
+                    return false;
+                }
+                // Containment is checked on the CANONICAL path, i.e. after
+                // symlinks are resolved, so a link inside the tree pointing out
+                // of it is refused too. DescribeBinary already canonicalized
+                // `out.Path`.
+                std::error_code ec;
+                const fs::path canonicalRoot = fs::weakly_canonical(repoRoot, ec);
+                if (ec)
+                {
+                    outError = "Could not canonicalize the repo root to validate the test binary path.";
+                    return false;
+                }
+                if (const fs::path relative = out.Path.lexically_relative(canonicalRoot);
+                    relative.empty() || *relative.begin() == "..")
+                {
+                    outError = std::string("Refusing the ") + origin + " test binary '" +
+                               out.Path.generic_string() + "': it resolves outside the source tree (" +
+                               canonicalRoot.generic_string() +
+                               "). Point it at a build tree inside the repo, or rebuild there.";
                     return false;
                 }
                 out.Origin = origin;
@@ -1273,7 +1293,29 @@ namespace OloEngine::MCP
             }
             out["suiteFailureCount"] = suiteFailures.size();
             if (!suiteFailures.empty())
+            {
+                // A suite-level failure makes the RUN's verdict untrustworthy, so
+                // it is an error rather than a field on a successful result —
+                // the same rule as a dead child or an unreconciled report.
+                //
+                // The case that forces this is TearDownTestSuite: every case has
+                // already passed by then, so the payload reads `failed: 0,
+                // complete: true` and a caller checking those two — which is
+                // exactly what a caller should check — calls it green. A
+                // SetUpTestSuite failure is less dangerous only by accident
+                // (gtest fails the suite's cases, so `failed` is non-zero).
+                //
+                // Nothing is lost by erroring: the whole structured payload goes
+                // into the error text, so the per-case results are still there.
                 out["suiteFailures"] = std::move(suiteFailures);
+                out["complete"] = false;
+                return ToolResult::Error(
+                    "The run reported " + std::to_string(parsed.SuiteFailures.size()) +
+                    " failure(s) outside any test case (a fatal assertion in SetUpTestSuite, TearDownTestSuite or a "
+                    "global environment). The per-case results below may still be complete, but the harness itself "
+                    "failed, so they are not a verdict.\n\n" +
+                    out.dump(2));
+            }
             // Truncation is stated and counted rather than left to be inferred
             // from an array that happens to be exactly maxCases long.
             out["casesOmitted"] = omitted;
@@ -1380,7 +1422,9 @@ namespace OloEngine::MCP
                 "CPU-only suites do not inherit any GPU skip condition. Reports failures by default; set "
                 "includePassed for the whole set. A run is never silently partial: a selection matching nothing, "
                 "a child that crashed, timed out or was cancelled, and a report that does not account for every "
-                "selected case are all errors that name what is missing. Note that a run regenerates the tracked "
+                "selected case are all errors that name what is missing — as is a fatal assertion in "
+                "SetUpTestSuite/TearDownTestSuite or a global environment, which would otherwise read as "
+                "'0 failed' after every case had already passed. Note that a run regenerates the tracked "
                 "evidence PNGs under OloEditor/assets/tests/visual/, so the working tree moves — never 'git add -A' "
                 "after one.";
             tool.InputSchema =
@@ -1430,9 +1474,11 @@ namespace OloEngine::MCP
                                                                            .Desc("Verbatim gtest failure text, or "
                                                                                  "the GTEST_SKIP reason."))))
                     .Prop("casesOmitted", Schema::Int().Min(0).Desc("Cases past 'maxCases', counted not dropped."))
-                    .Prop("suiteFailureCount", Schema::Int().Min(0).Desc(
-                                                   "Failures belonging to no case — a fatal assertion in "
-                                                   "SetUpTestSuite/TearDownTestSuite or a global environment."))
+                    .Prop("suiteFailureCount",
+                          Schema::Int().Min(0).Desc(
+                              "Always 0 on a successful result: a failure belonging to no case (a fatal assertion "
+                              "in SetUpTestSuite/TearDownTestSuite or a global environment) makes the whole call "
+                              "an error, because the harness failed and the numbers are not a verdict."))
                     .Prop("suiteFailures", Schema::Array(Schema::Object()
                                                              .Prop("suite", Schema::String())
                                                              .Prop("messages", Schema::Array(Schema::String())))

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -982,7 +982,8 @@ namespace OloEngine::MCP
                 if (!args["layer"].is_string() || args["layer"].get<std::string>().empty())
                     return ToolResult::Error("Invalid 'layer': expected a classification id such as 'L1' or 'unit'.");
                 layerFilter = args["layer"].get<std::string>();
-                std::erase_if(cases, [&layerFilter](const TestCase& c) { return c.Layer != layerFilter; });
+                std::erase_if(cases, [&layerFilter](const TestCase& c)
+                              { return c.Layer != layerFilter; });
             }
 
             if (cases.empty())
@@ -1078,7 +1079,8 @@ namespace OloEngine::MCP
                 if (!args["layer"].is_string() || args["layer"].get<std::string>().empty())
                     return ToolResult::Error("Invalid 'layer': expected a classification id such as 'L1' or 'unit'.");
                 const std::string layerFilter = args["layer"].get<std::string>();
-                std::erase_if(selected, [&layerFilter](const TestCase& c) { return c.Layer != layerFilter; });
+                std::erase_if(selected, [&layerFilter](const TestCase& c)
+                              { return c.Layer != layerFilter; });
                 if (selected.empty())
                     return ToolResult::Error("No test case in the selection carries layer '" + layerFilter +
                                              "'. That is an error, not an empty run.");

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -105,6 +105,12 @@ namespace OloEngine::MCP
         // and the last few cases, small enough not to swamp a tool result.
         constexpr sizet kConsoleTailChars = 8000;
 
+        // Upper bound on the `page` argument. Any page past the end simply
+        // returns an empty page, so this only has to be large enough to reach
+        // the end of any real listing and small enough that page * pageSize
+        // stays far inside i64.
+        constexpr long long kMaxPage = 1'000'000;
+
         // ---- filesystem helpers -------------------------------------------
 
         [[nodiscard]] std::string ReadWholeFile(const fs::path& path, bool& ok)
@@ -714,12 +720,21 @@ namespace OloEngine::MCP
             {
                 std::error_code ec;
                 const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-                m_Path = fs::temp_directory_path(ec) /
-                         (std::string("olo-") + stem + "-" + std::to_string(static_cast<u64>(stamp)));
-                if (!ec)
-                    fs::create_directories(m_Path, ec);
+                const fs::path candidate = fs::temp_directory_path(ec) /
+                                           (std::string("olo-") + stem + "-" + std::to_string(static_cast<u64>(stamp)));
                 if (ec)
-                    m_Path.clear();
+                    return;
+
+                // EXCLUSIVE creation: create_directory returns false (without an
+                // error) when the directory already exists, and a pre-existing
+                // one in a world-writable /tmp may have been planted — the POSIX
+                // child then opens console.log with O_CREAT|O_TRUNC through
+                // whatever symlink it finds there. Refusing an existing path
+                // costs nothing (the name carries a steady-clock tick, so a
+                // legitimate collision does not happen) and closes CWE-379.
+                if (!fs::create_directory(candidate, ec) || ec)
+                    return;
+                m_Path = candidate;
             }
             ~ScratchDirectory()
             {
@@ -995,8 +1010,14 @@ namespace OloEngine::MCP
 
             int page = 0;
             int pageSize = 100;
+            // CLAMPED, not just floored at 0. The shared Pagination() schema
+            // declares `minimum: 0` and no maximum, so a caller may legally send
+            // 2147483648; narrowing that to int is implementation-defined and on
+            // MSVC yields -2147483648, after which `start` goes hugely negative
+            // and cases[static_cast<sizet>(i)] indexes far out of bounds. The
+            // upper bound is chosen so page * pageSize cannot overflow i64.
             if (args.contains("page") && args["page"].is_number_integer())
-                page = static_cast<int>(std::max<long long>(0, args["page"].get<long long>()));
+                page = static_cast<int>(std::clamp<long long>(args["page"].get<long long>(), 0, kMaxPage));
             if (args.contains("pageSize") && args["pageSize"].is_number_integer())
                 pageSize = static_cast<int>(std::clamp<long long>(args["pageSize"].get<long long>(), 1, 500));
 

--- a/OloEditor/src/MCP/McpToolsValidation.cpp
+++ b/OloEditor/src/MCP/McpToolsValidation.cpp
@@ -106,7 +106,8 @@ namespace OloEngine::MCP
                         return ToolResult::Error("Invalid entry in 'sections': expected a section name string.");
                     const std::string name = entry.get<std::string>();
                     const bool known = std::any_of(std::begin(kSections), std::end(kSections),
-                                                   [&name](const SectionSpec& spec) { return name == spec.Name; });
+                                                   [&name](const SectionSpec& spec)
+                                                   { return name == spec.Name; });
                     if (!known)
                     {
                         std::string valid;
@@ -205,7 +206,7 @@ namespace OloEngine::MCP
                                         .Prop("problemCount", Schema::Int().Min(0))
                                         .Prop("omitted", Schema::Int().Min(0))
                                         .Prop("problems", Schema::Array(Schema::Object().Desc(
-                                                  "One problem; 'kind' says which validator classed it.")))))
+                                                              "One problem; 'kind' says which validator classed it.")))))
                 .Required({ "ok", "complete", "problemCount", "sectionCount", "sectionsUnavailable", "sections" });
         tool.Handler = Handle_ProjectValidate;
         registry.Register(std::move(tool));

--- a/OloEditor/src/MCP/McpToolsValidation.cpp
+++ b/OloEditor/src/MCP/McpToolsValidation.cpp
@@ -1,0 +1,213 @@
+#include "OloEnginePCH.h"
+#include "MCP/McpToolsCommon.h"
+#include "MCP/McpProjectValidation.h"
+#include "MCP/McpSchemaBuilder.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <vector>
+
+// Whole-project validation: olo_project_validate (issue #1130, Epic H slice 2).
+//
+// One call that runs every per-domain validator the editor already has and
+// returns one structured report, instead of four calls a caller has to remember
+// to make, in the right order, and then merge by hand.
+//
+// It composes by INVOKING the standalone commands' handlers (the Collect*
+// entry points in McpToolsCommon.h), never by re-deriving their verdicts — so
+// "the validation slice reports the same problems the editor panels show" holds
+// by construction. The reshaping into a single section vocabulary lives in
+// MCP/McpProjectValidation.h, which is where the report's rules about
+// incomplete answers are stated and unit tested.
+
+namespace OloEngine::MCP
+{
+    namespace
+    {
+        namespace PV = OloEngine::MCP::ProjectValidation;
+
+        // One section: its name, the command it runs, and one sentence on what
+        // it covers. The extractor turns that command's payload into the common
+        // problem shape; see McpProjectValidation.h for why each source needs
+        // its own (they name their arrays differently).
+        struct SectionSpec
+        {
+            const char* Name;
+            const char* Source;
+            const char* Subject;
+            ToolResult (*Collect)(IAutomationHost&);
+            Json (*Extract)(const Json&);
+        };
+
+        const SectionSpec kSections[] = {
+            { "assets", "olo_assets_problems",
+              "Registered assets that failed to load or are missing/invalid (what the Content Browser shows as a "
+              "bad asset).",
+              &CollectAssetProblems, &PV::ProblemsFromAssets },
+            { "shaders", "olo_shader_errors",
+              "Shaders whose last compile or link failed (what the Shader editor panel shows in red).",
+              &CollectShaderProblems, &PV::ProblemsFromShaders },
+            // The ring this reads is append-only for the session: ScriptErrorBuffer
+            // has a Clear() with no call site anywhere in the tree, so an error
+            // from a script that has since been fixed still counts. The subject
+            // says so rather than the section quietly implying "right now" —
+            // a stale `ok:false` a reader cannot explain is worse than a wordier
+            // sentence.
+            { "scripts", "olo_script_get_last_errors",
+              "C#/Lua script errors recorded SINCE THE EDITOR STARTED (the ring the console renders; it is never "
+              "cleared, so a fixed script's earlier error still counts).",
+              &CollectScriptProblems, &PV::ProblemsFromScripts },
+            { "renderGraph", "olo_render_validate",
+              "The live render graph's compiled resource hazards, execute-path resolve failures and "
+              "consumed-but-unbacked resources.",
+              &CollectRenderGraphProblems, &PV::ProblemsFromRenderGraph },
+        };
+
+        // The section names, derived from kSections so the declared schema's enum
+        // and the table dispatch actually walks cannot drift. A hand-restated
+        // copy of a table goes stale silently — #702 shipped a renderer setting
+        // that parsed, applied and described correctly while the schema gate
+        // still rejected it, which reads as a missing feature rather than as an
+        // un-updated list.
+        [[nodiscard]] std::vector<std::string> SectionNames()
+        {
+            std::vector<std::string> names;
+            names.reserve(std::size(kSections));
+            for (const SectionSpec& spec : kSections)
+                names.emplace_back(spec.Name);
+            return names;
+        }
+
+        // An error result carries its reason as text; that text is what the
+        // section reports as `reason`, so a caller learns WHY a validator could
+        // not run rather than seeing the section vanish.
+        [[nodiscard]] std::string ReasonFrom(const ToolResult& result)
+        {
+            if (result.Content.is_array() && !result.Content.empty())
+            {
+                const Json& block = result.Content.front();
+                if (block.is_object() && block.contains("text") && block["text"].is_string())
+                    return block["text"].get<std::string>();
+            }
+            return "The validator reported an error with no message.";
+        }
+
+        ToolResult Handle_ProjectValidate(IAutomationHost& host, const Json& args)
+        {
+            std::vector<std::string> requested;
+            if (args.contains("sections"))
+            {
+                if (!args["sections"].is_array() || args["sections"].empty())
+                    return ToolResult::Error("Invalid 'sections': expected a non-empty array of section names.");
+                for (const Json& entry : args["sections"])
+                {
+                    if (!entry.is_string())
+                        return ToolResult::Error("Invalid entry in 'sections': expected a section name string.");
+                    const std::string name = entry.get<std::string>();
+                    const bool known = std::any_of(std::begin(kSections), std::end(kSections),
+                                                   [&name](const SectionSpec& spec) { return name == spec.Name; });
+                    if (!known)
+                    {
+                        std::string valid;
+                        for (const SectionSpec& spec : kSections)
+                        {
+                            if (!valid.empty())
+                                valid += ", ";
+                            valid += spec.Name;
+                        }
+                        // The declared schema's enum is generated from kSections
+                        // (see SectionNames below), so dispatch normally rejects a
+                        // bad name before reaching here. This stays as the
+                        // enforcement rather than the schema: a typo'd section
+                        // would otherwise narrow the check silently and still
+                        // report `complete`, and a caller invoking through the
+                        // registry with a loosened schema must get the same
+                        // refusal the MCP adapter gives.
+                        return ToolResult::Error("Unknown section '" + name + "'. Valid sections: " + valid + ".");
+                    }
+                    requested.push_back(name);
+                }
+            }
+
+            const auto maxPerSection =
+                static_cast<sizet>(std::clamp<long long>(args.value("maxPerSection", 50LL), 1LL, 500LL));
+
+            std::vector<PV::Section> sections;
+            for (const SectionSpec& spec : kSections)
+            {
+                if (!requested.empty() &&
+                    std::find(requested.begin(), requested.end(), spec.Name) == requested.end())
+                    continue;
+
+                const ToolResult collected = spec.Collect(host);
+                if (collected.IsError)
+                {
+                    sections.push_back(
+                        PV::UnavailableSection(spec.Name, spec.Source, spec.Subject, ReasonFrom(collected)));
+                    continue;
+                }
+                if (!collected.StructuredContent.is_object())
+                {
+                    sections.push_back(PV::UnavailableSection(
+                        spec.Name, spec.Source, spec.Subject,
+                        std::string(spec.Source) + " returned no structured payload to validate against."));
+                    continue;
+                }
+                sections.push_back(PV::RanSection(spec.Name, spec.Source, spec.Subject,
+                                                  spec.Extract(collected.StructuredContent)));
+            }
+
+            return ToolResult::Structured(PV::BuildReport(sections, maxPerSection));
+        }
+    } // namespace
+
+    void RegisterValidationTools(AutomationRegistry& registry)
+    {
+        ToolDef tool;
+        tool.Name = "olo_project_validate";
+        tool.Toolset = "validation";
+        tool.Title = "Validate the project";
+        tool.DualAudienceContent = true;
+        tool.Annotations = ReadOnlyAnnotations();
+        tool.Description =
+            "Run every project validator at once — asset registry problems, shader compile/link errors, recent "
+            "script errors and the live render graph's hazard sweep — and return one structured report. Each "
+            "section invokes the standalone command's own handler (olo_assets_problems, olo_shader_errors, "
+            "olo_script_get_last_errors, olo_render_validate), so it reports exactly what the editor panels show. "
+            "A validator that cannot run here (no project open, no render graph in a headless or 2D session) comes "
+            "back as 'unavailable' with its reason and makes the report's 'ok' false — an unrun check is never a "
+            "clean bill of health.";
+        tool.InputSchema =
+            Schema::Object()
+                .Prop("sections", Schema::Array(Schema::String().EnumFrom(SectionNames()))
+                                      .Desc("Which sections to run. Omit for all of them; an unknown name is an "
+                                            "error, never a silently narrowed check."))
+                .Prop("maxPerSection", Schema::Int().Min(1).Max(500).Desc(
+                                           "Cap on problems listed per section (default 50). Any excess is counted "
+                                           "in the section's 'omitted', never dropped from 'problemCount'."))
+                .NoAdditional();
+        tool.OutputSchema =
+            Schema::Object()
+                .Prop("ok", Schema::Bool().Desc("Every requested section ran AND found nothing."))
+                .Prop("complete", Schema::Bool().Desc("Every requested section ran. False means the verdict is "
+                                                      "partial — read each section's 'reason'."))
+                .Prop("problemCount", Schema::Int().Min(0).Desc("Total problems across the sections that ran."))
+                .Prop("sectionCount", Schema::Int().Min(1))
+                .Prop("sectionsUnavailable", Schema::Int().Min(0))
+                .Prop("sections",
+                      Schema::Array(Schema::Object()
+                                        .Prop("name", Schema::String())
+                                        .Prop("source", Schema::String().Desc("The command that produced it."))
+                                        .Prop("subject", Schema::String())
+                                        .Prop("status", Schema::String().Enum({ "ok", "problems", "unavailable" }))
+                                        .Prop("reason", Schema::String().Desc("Present only when unavailable."))
+                                        .Prop("problemCount", Schema::Int().Min(0))
+                                        .Prop("omitted", Schema::Int().Min(0))
+                                        .Prop("problems", Schema::Array(Schema::Object().Desc(
+                                                  "One problem; 'kind' says which validator classed it.")))))
+                .Required({ "ok", "complete", "problemCount", "sectionCount", "sectionsUnavailable", "sections" });
+        tool.Handler = Handle_ProjectValidate;
+        registry.Register(std::move(tool));
+    }
+} // namespace OloEngine::MCP

--- a/OloEditor/src/MCP/McpToolsValidation.cpp
+++ b/OloEditor/src/MCP/McpToolsValidation.cpp
@@ -205,6 +205,8 @@ namespace OloEngine::MCP
                                         .Prop("reason", Schema::String().Desc("Present only when unavailable."))
                                         .Prop("problemCount", Schema::Int().Min(0))
                                         .Prop("omitted", Schema::Int().Min(0))
+                                        .Prop("truncated", Schema::Bool().Desc(
+                                                               "Present only when omitted > 0."))
                                         .Prop("problems", Schema::Array(Schema::Object().Desc(
                                                               "One problem; 'kind' says which validator classed it.")))))
                 .Required({ "ok", "complete", "problemCount", "sectionCount", "sectionsUnavailable", "sections" });

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -836,6 +836,12 @@ add_executable(OloEngine-Tests
 		${_olo_mcp_field_registry_src}
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsScripting.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsShader.cpp
+		# Structured test execution and whole-project validation (issue #1130).
+		# RegisterBuiltinCommands composes both, so the test binary needs the TUs
+		# to link at all; their pure cores are covered by McpTestExecutionTest /
+		# McpProjectValidationTest below.
+		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsTesting.cpp
+		${CMAKE_SOURCE_DIR}/OloEditor/src/MCP/McpToolsValidation.cpp
 		# The capability-discovery gateway (#1124): olo_capability / olo_tool_search /
 		# olo_tool_describe / olo_tool_execute. Registration-only from the tests'
 		# point of view, like the rest of this list — but its handlers are pure
@@ -870,6 +876,14 @@ add_executable(OloEngine-Tests
 		# Pure reasoning behind olo_render_why_not_visible (#306 item A, rendering
 		# half). Header-only (MCP/McpRenderExplain.h), no extra editor TU pulled in.
 		MCP/McpRenderExplainTest.cpp
+		# Structured test execution (#1130): gtest report parsing, the
+		# OLO_TEST_LAYER classification merge, and the reconciliation that makes a
+		# partial run an error. Header-only (MCP/McpTestExecution.h) — nothing here
+		# launches a child process.
+		MCP/McpTestExecutionTest.cpp
+		# Whole-project validation report shaping (#1130). Header-only
+		# (MCP/McpProjectValidation.h), no extra editor TU pulled in.
+		MCP/McpProjectValidationTest.cpp
 		# Pure image-diff core behind olo_render_compare_golden (#316 Part 4).
 		# Header-only (MCP/McpGoldenCompare.h), no extra editor TU pulled in.
 		MCP/McpGoldenCompareTest.cpp

--- a/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
+++ b/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
@@ -436,6 +436,8 @@ TEST(McpAudienceBlocks, BuiltinAdoptionMatchesTheDeliberateList)
         "olo_cluster_grid_stats",           // per-slice + histogram tables
         "olo_shadow_atlas_layout",          // granted vs starved casters
         "olo_physics_why_no_collision",     // explainer check list
+        "olo_tests_run",                    // per-case status/timing/failure table
+        "olo_project_validate",             // per-section problem table
     };
 
     const McpServer::ToolList& tools = BuiltinTools();

--- a/OloEngine/tests/MCP/McpProjectValidationTest.cpp
+++ b/OloEngine/tests/MCP/McpProjectValidationTest.cpp
@@ -110,7 +110,7 @@ TEST(McpProjectValidation, ProblemsMakeItNotOkButStillComplete)
 {
     const Json problems = ProblemsFromShaders(Json::parse(R"({"errors": [ { "name": "PBR" } ]})"));
     const Json report = BuildReport({ CleanSection("assets"), RanSection("shaders", "olo_shader_errors", "s",
-                                                                        problems) },
+                                                                         problems) },
                                     50);
     EXPECT_FALSE(report["ok"].get<bool>());
     EXPECT_TRUE(report["complete"].get<bool>()) << "everything ran; the project simply has a problem";

--- a/OloEngine/tests/MCP/McpProjectValidationTest.cpp
+++ b/OloEngine/tests/MCP/McpProjectValidationTest.cpp
@@ -1,0 +1,166 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Unit tests for the pure shaping behind olo_project_validate (issue #1130,
+// Epic H slice 2): turning four per-domain validator payloads into one report,
+// and the rule that a validator which could not run is never a clean bill of
+// health.
+//
+// The composition itself — invoking olo_assets_problems / olo_shader_errors /
+// olo_script_get_last_errors / olo_render_validate — lives in the editor target
+// and needs a live project and render graph. What is pinned here is everything
+// the report DECIDES: which payload keys are problems, what `ok` and `complete`
+// mean apart from each other, and that truncation is counted rather than
+// silent.
+#include "MCP/McpProjectValidation.h"
+
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::ProjectValidation::BuildReport;
+    using OloEngine::MCP::ProjectValidation::Json;
+    using OloEngine::MCP::ProjectValidation::ProblemsFromAssets;
+    using OloEngine::MCP::ProjectValidation::ProblemsFromRenderGraph;
+    using OloEngine::MCP::ProjectValidation::ProblemsFromScripts;
+    using OloEngine::MCP::ProjectValidation::ProblemsFromShaders;
+    using OloEngine::MCP::ProjectValidation::RanSection;
+    using OloEngine::MCP::ProjectValidation::Section;
+    using OloEngine::MCP::ProjectValidation::SectionStatus;
+    using OloEngine::MCP::ProjectValidation::UnavailableSection;
+
+    Section CleanSection(const char* name)
+    {
+        return RanSection(name, "olo_x", "subject", Json::array());
+    }
+} // namespace
+
+// ---- per-source extraction ----------------------------------------------
+
+TEST(McpProjectValidation, ExtractsAssetProblemsAndTagsTheirKind)
+{
+    const Json payload = Json::parse(R"({
+      "count": 1,
+      "problems": [ { "handle": "12", "type": "Texture2D", "path": "a.png", "status": "Invalid" } ]
+    })");
+    const Json problems = ProblemsFromAssets(payload);
+    ASSERT_EQ(problems.size(), 1u);
+    EXPECT_EQ(problems[0]["kind"], "AssetLoadFailure");
+    EXPECT_EQ(problems[0]["path"], "a.png") << "the source command's own fields ride through untouched";
+}
+
+TEST(McpProjectValidation, ExtractsShaderAndScriptErrorsFromTheirOwnArrayKey)
+{
+    const Json shaders = ProblemsFromShaders(Json::parse(R"({
+      "count": 1, "errors": [ { "name": "PBR", "errorMessage": "syntax error" } ] })"));
+    ASSERT_EQ(shaders.size(), 1u);
+    EXPECT_EQ(shaders[0]["kind"], "ShaderCompileError");
+
+    const Json scripts = ProblemsFromScripts(Json::parse(R"({
+      "count": 1, "errors": [ { "language": "csharp", "message": "NullReference" } ] })"));
+    ASSERT_EQ(scripts.size(), 1u);
+    EXPECT_EQ(scripts[0]["kind"], "ScriptError");
+}
+
+// olo_render_validate's own `ok` rests on these three arrays, so these three are
+// what the composite calls problems. The barrier/build diagnostics are
+// informational there and must stay informational here — promoting them would
+// make the composite disagree with the command it composes.
+TEST(McpProjectValidation, FlattensTheThreeRenderGraphVerdictsAndLeavesDiagnosticsAlone)
+{
+    const Json payload = Json::parse(R"({
+      "ok": false,
+      "hazardCount": 1,
+      "hazards": [ { "kind": "ReadAfterWrite", "resource": "HZB", "message": "m" } ],
+      "barrierDiagnostics": [ { "kind": "MissingProducer", "message": "informational" } ],
+      "buildDiagnostics": [ { "kind": "RegistrationOrderSensitivity", "message": "informational" } ],
+      "resolveFailures": [ { "pass": "GTAO", "reason": "no backing", "count": 2 } ],
+      "consumedButUnbacked": [ "SceneDepth" ]
+    })");
+    const Json problems = ProblemsFromRenderGraph(payload);
+    ASSERT_EQ(problems.size(), 3u);
+    EXPECT_EQ(problems[0]["kind"], "RenderGraphHazard");
+    EXPECT_EQ(problems[1]["kind"], "RenderGraphResolveFailure");
+    EXPECT_EQ(problems[2]["kind"], "ResourceConsumedButUnbacked");
+    EXPECT_EQ(problems[2]["resource"], "SceneDepth");
+}
+
+TEST(McpProjectValidation, AMissingOrWrongTypedArrayYieldsNoProblemsRatherThanThrowing)
+{
+    EXPECT_TRUE(ProblemsFromAssets(Json::object()).empty());
+    EXPECT_TRUE(ProblemsFromAssets(Json::parse(R"({"problems": "not an array"})")).empty());
+    EXPECT_TRUE(ProblemsFromShaders(Json::parse(R"("not an object")")).empty());
+}
+
+// ---- report assembly -----------------------------------------------------
+
+TEST(McpProjectValidation, AllClearIsOkAndComplete)
+{
+    const Json report = BuildReport({ CleanSection("assets"), CleanSection("shaders") }, 50);
+    EXPECT_TRUE(report["ok"].get<bool>());
+    EXPECT_TRUE(report["complete"].get<bool>());
+    EXPECT_EQ(report["problemCount"].get<int>(), 0);
+    EXPECT_EQ(report["sectionsUnavailable"].get<int>(), 0);
+    EXPECT_EQ(report["sections"][0]["status"], "ok");
+}
+
+TEST(McpProjectValidation, ProblemsMakeItNotOkButStillComplete)
+{
+    const Json problems = ProblemsFromShaders(Json::parse(R"({"errors": [ { "name": "PBR" } ]})"));
+    const Json report = BuildReport({ CleanSection("assets"), RanSection("shaders", "olo_shader_errors", "s",
+                                                                        problems) },
+                                    50);
+    EXPECT_FALSE(report["ok"].get<bool>());
+    EXPECT_TRUE(report["complete"].get<bool>()) << "everything ran; the project simply has a problem";
+    EXPECT_EQ(report["problemCount"].get<int>(), 1);
+    EXPECT_EQ(report["sections"][1]["status"], "problems");
+}
+
+// The rule the whole report is shaped around. A headless session has no render
+// graph; dropping that section and totalling zero problems would hand back a
+// green verdict for a check that never happened.
+TEST(McpProjectValidation, AnUnrunValidatorIsNeverACleanBillOfHealth)
+{
+    const Json report =
+        BuildReport({ CleanSection("assets"),
+                      UnavailableSection("renderGraph", "olo_render_validate", "s", "No active render graph.") },
+                    50);
+    EXPECT_FALSE(report["ok"].get<bool>()) << "ok must not survive a section that could not run";
+    EXPECT_FALSE(report["complete"].get<bool>());
+    EXPECT_EQ(report["problemCount"].get<int>(), 0) << "and it must not invent a problem either";
+    EXPECT_EQ(report["sectionsUnavailable"].get<int>(), 1);
+    EXPECT_EQ(report["sections"][1]["status"], "unavailable");
+    EXPECT_EQ(report["sections"][1]["reason"], "No active render graph.")
+        << "the caller has to be told WHY, or it cannot decide whether the gap matters";
+}
+
+TEST(McpProjectValidation, TruncationIsCountedAndTheTotalStillReflectsEverything)
+{
+    Json many = Json::array();
+    for (int i = 0; i < 7; ++i)
+        many.push_back(Json{ { "kind", "ShaderCompileError" }, { "name", "S" + std::to_string(i) } });
+
+    const Json report = BuildReport({ RanSection("shaders", "olo_shader_errors", "s", many) }, 3);
+    const Json& section = report["sections"][0];
+    EXPECT_EQ(section["problems"].size(), 3u);
+    EXPECT_EQ(section["problemCount"].get<int>(), 7) << "the count is of what was FOUND, not of what was listed";
+    EXPECT_EQ(section["omitted"].get<int>(), 4);
+    EXPECT_TRUE(section["truncated"].get<bool>());
+    EXPECT_EQ(report["problemCount"].get<int>(), 7);
+}
+
+TEST(McpProjectValidation, AnEmptySectionListIsVacuouslyOk)
+{
+    const Json report = BuildReport({}, 50);
+    EXPECT_TRUE(report["ok"].get<bool>());
+    EXPECT_EQ(report["sectionCount"].get<int>(), 0);
+}
+
+TEST(McpProjectValidation, SectionFactoriesSetTheStatusFromWhatWasFound)
+{
+    EXPECT_EQ(RanSection("a", "s", "d", Json::array()).Status, SectionStatus::Ok);
+    EXPECT_EQ(RanSection("a", "s", "d", Json::parse(R"([{"kind":"X"}])")).Status, SectionStatus::Problems);
+    EXPECT_EQ(UnavailableSection("a", "s", "d", "why").Status, SectionStatus::Unavailable);
+}

--- a/OloEngine/tests/MCP/McpTestExecutionTest.cpp
+++ b/OloEngine/tests/MCP/McpTestExecutionTest.cpp
@@ -215,6 +215,27 @@ TEST(McpTestExecution, AnUnclassifiedOrUnknownLayerIsReportedNotBlanked)
     EXPECT_NE(bothBogus.Problem.find("L99"), std::string::npos);
 }
 
+// A wrong-typed field in a document read off disk must not abort the command.
+// nlohmann's value() THROWS type_error.302 rather than returning the default, so
+// a hand-edited `"functional_tag": 3` would surface as a generic "tool failed"
+// instead of classifying everything it still can.
+TEST(McpTestExecution, AWrongTypedCatalogueOrReportFieldDoesNotThrow)
+{
+    const std::set<std::string> ids =
+        KnownLayerIds(Json::parse(R"({"functional_tag": 3, "layers": [ { "id": "L1" } ]})"));
+    EXPECT_TRUE(ids.contains("L1"));
+    EXPECT_TRUE(ids.contains("Functional")) << "a bad tag falls back to the default, it does not throw";
+
+    const auto report = ParseRunReport(Json::parse(R"({
+      "testsuites": [ { "name": "S", "testsuite": [
+        { "name": "A", "status": 7, "result": [ "nope" ], "time": "0s" }
+      ] } ]
+    })"));
+    ASSERT_TRUE(report.Error.empty());
+    ASSERT_EQ(report.Cases.size(), 1u);
+    EXPECT_EQ(report.Cases[0].Status, CaseStatus::Passed) << "unreadable status/result read as the defaults";
+}
+
 TEST(McpTestExecution, KnownLayerIdsAddsTheTwoImplicitTags)
 {
     const Json catalogue = Json::parse(R"({

--- a/OloEngine/tests/MCP/McpTestExecutionTest.cpp
+++ b/OloEngine/tests/MCP/McpTestExecutionTest.cpp
@@ -1,0 +1,475 @@
+// OLO_TEST_LAYER: unit
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+// Unit tests for the pure core of olo_tests_list / olo_tests_run (issue #1130):
+// gtest report parsing, OLO_TEST_LAYER classification, and the reconciliation
+// that makes a partial run an error instead of a small green number.
+//
+// The handler that spawns OloEngine-Tests is in the editor target and needs a
+// real child process; everything it decides WITH is here, in free functions
+// over JSON, so the invariant this issue exists for is pinned in CI rather than
+// only observed live. There is a mild irony in the test binary carrying the
+// tests for the thing that runs the test binary — the split is what keeps that
+// from being circular: nothing below launches anything.
+#include "MCP/McpTestExecution.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+namespace
+{
+    using OloEngine::MCP::TestExecution::CaseResult;
+    using OloEngine::MCP::TestExecution::CaseStatus;
+    using OloEngine::MCP::TestExecution::Clamp;
+    using OloEngine::MCP::TestExecution::CountCases;
+    using OloEngine::MCP::TestExecution::CountStartedCases;
+    using OloEngine::MCP::TestExecution::ExtractLayerMarker;
+    using OloEngine::MCP::TestExecution::IsDisabledName;
+    using OloEngine::MCP::TestExecution::IsFilterSafeExpression;
+    using OloEngine::MCP::TestExecution::IsFilterSafeName;
+    using OloEngine::MCP::TestExecution::Json;
+    using OloEngine::MCP::TestExecution::JoinFilter;
+    using OloEngine::MCP::TestExecution::KnownLayerIds;
+    using OloEngine::MCP::TestExecution::LayerCountsJson;
+    using OloEngine::MCP::TestExecution::LayerMarker;
+    using OloEngine::MCP::TestExecution::NormalizeTestFile;
+    using OloEngine::MCP::TestExecution::ParseGTestDuration;
+    using OloEngine::MCP::TestExecution::ParseListReport;
+    using OloEngine::MCP::TestExecution::ParseRunReport;
+    using OloEngine::MCP::TestExecution::Reconcile;
+    using OloEngine::MCP::TestExecution::ResolveLayer;
+    using OloEngine::MCP::TestExecution::TailOf;
+    using OloEngine::MCP::TestExecution::TestCase;
+
+    // A `--gtest_list_tests --gtest_output=json:` document, trimmed to the
+    // fields the parser reads. Captured from the real binary: the `file` value
+    // is a build-directory-relative __FILE__ with Windows separators, which is
+    // the shape the normalizer has to cope with.
+    Json ListDocument()
+    {
+        return Json::parse(R"({
+          "tests": 7616,
+          "name": "AllTests",
+          "testsuites": [
+            {
+              "name": "EmptySuite",
+              "tests": 0,
+              "testsuite": []
+            },
+            {
+              "name": "AccessibilitySettingsTest",
+              "tests": 2,
+              "testsuite": [
+                { "name": "DefaultsAreOffAndNeutral",
+                  "file": "..\\OloEngine\\tests\\Accessibility\\AccessibilitySettingsTest.cpp", "line": 64 },
+                { "name": "DISABLED_NotYet",
+                  "file": "..\\OloEngine\\tests\\Accessibility\\AccessibilitySettingsTest.cpp", "line": 90 }
+              ]
+            }
+          ]
+        })");
+    }
+
+    CaseResult MakeCase(std::string suite, std::string name, CaseStatus status)
+    {
+        CaseResult result;
+        result.Suite = std::move(suite);
+        result.Name = std::move(name);
+        result.Status = status;
+        return result;
+    }
+
+    TestCase MakeSelected(std::string suite, std::string name)
+    {
+        TestCase testCase;
+        testCase.Suite = std::move(suite);
+        testCase.Name = std::move(name);
+        return testCase;
+    }
+} // namespace
+
+// ---- listing -------------------------------------------------------------
+
+TEST(McpTestExecution, ParsesEveryCaseOutOfAListReport)
+{
+    std::string error;
+    const std::vector<TestCase> cases = ParseListReport(ListDocument(), error);
+    ASSERT_TRUE(error.empty()) << error;
+    ASSERT_EQ(cases.size(), 2u);
+    EXPECT_EQ(cases[0].FullName(), "AccessibilitySettingsTest.DefaultsAreOffAndNeutral");
+    EXPECT_EQ(cases[0].Line, 64);
+    EXPECT_FALSE(cases[0].Disabled);
+    EXPECT_TRUE(cases[1].Disabled);
+}
+
+// gtest's list mode reports the WHOLE registered count in its top-level `tests`
+// field, ignoring the filter — 7616 here for a two-case selection. Reading it as
+// "how many I selected" would make every reconciliation fail by three orders of
+// magnitude, so the parser counts entries and never touches that field.
+TEST(McpTestExecution, IgnoresTheUnfilteredTopLevelCountInAListReport)
+{
+    std::string error;
+    const std::vector<TestCase> cases = ParseListReport(ListDocument(), error);
+    ASSERT_TRUE(error.empty());
+    EXPECT_EQ(ListDocument()["tests"].get<int>(), 7616);
+    EXPECT_EQ(cases.size(), 2u);
+}
+
+// A truncated report from a child that died mid-flush must not read as "the
+// selection was empty" — that is the silent partial in its purest form.
+TEST(McpTestExecution, AMalformedListReportIsAnErrorNotAnEmptySelection)
+{
+    std::string error;
+    EXPECT_TRUE(ParseListReport(Json::parse(R"({"tests": 3})"), error).empty());
+    EXPECT_FALSE(error.empty());
+
+    error.clear();
+    EXPECT_TRUE(ParseListReport(Json::parse(R"("not an object")"), error).empty());
+    EXPECT_FALSE(error.empty());
+}
+
+TEST(McpTestExecution, DetectsTheDisabledPrefixOnEitherHalfOfAName)
+{
+    EXPECT_TRUE(IsDisabledName("Suite", "DISABLED_Case"));
+    EXPECT_TRUE(IsDisabledName("DISABLED_Suite", "Case"));
+    EXPECT_FALSE(IsDisabledName("Suite", "Case"));
+    EXPECT_FALSE(IsDisabledName("Suite", "NotDISABLED_Case"));
+}
+
+// ---- source-path normalization -------------------------------------------
+
+TEST(McpTestExecution, NormalizesAGTestFilePathToTheCatalogueKey)
+{
+    EXPECT_EQ(NormalizeTestFile("..\\OloEngine\\tests\\Rendering\\RenderGraphTest.cpp", "OloEngine/tests"),
+              "OloEngine/tests/Rendering/RenderGraphTest.cpp");
+    EXPECT_EQ(NormalizeTestFile("../../OloEngine/tests/Core/RefTest.cpp", "OloEngine/tests"),
+              "OloEngine/tests/Core/RefTest.cpp");
+    EXPECT_EQ(NormalizeTestFile("C:/repos/olo/OloEngine/tests/Core/RefTest.cpp", "OloEngine/tests"),
+              "OloEngine/tests/Core/RefTest.cpp");
+}
+
+// A path that is not under the test root cannot be given a catalogue key. The
+// normalizer says so with an empty string instead of guessing one, and the
+// caller reports it as a classification problem.
+TEST(McpTestExecution, RefusesToGuessAKeyForAPathOutsideTheTestRoot)
+{
+    EXPECT_TRUE(NormalizeTestFile("..\\OloEditor\\src\\Something.cpp", "OloEngine/tests").empty());
+}
+
+// ---- OLO_TEST_LAYER classification ---------------------------------------
+
+TEST(McpTestExecution, ReadsAnInFileLayerMarker)
+{
+    EXPECT_EQ(ExtractLayerMarker("// OLO_TEST_LAYER: L1\n#include <x>\n").Layer, "L1");
+    EXPECT_EQ(ExtractLayerMarker("\n\n\t//   OLO_TEST_LAYER:\tFunctional\n").Layer, "Functional");
+    EXPECT_EQ(ExtractLayerMarker("#include <x>\n").Layer, "");
+    // Duplicate identical markers are tolerated, as in generate_test_catalogue.py.
+    EXPECT_EQ(ExtractLayerMarker("// OLO_TEST_LAYER: unit\n// OLO_TEST_LAYER: unit\n").Layer, "unit");
+}
+
+TEST(McpTestExecution, TwoDisagreeingMarkersClassifyNothing)
+{
+    const LayerMarker marker = ExtractLayerMarker("// OLO_TEST_LAYER: L1\n// OLO_TEST_LAYER: L8\n");
+    EXPECT_TRUE(marker.Conflict);
+    EXPECT_TRUE(marker.Layer.empty());
+}
+
+TEST(McpTestExecution, TheMarkerWinsOverTheCatalogueAndTheDuplicateIsReported)
+{
+    const Json map = Json::parse(R"({"OloEngine/tests/A.cpp": "L8"})");
+    const std::set<std::string> known{ "L1", "L8", "unit" };
+
+    const auto both = ResolveLayer("OloEngine/tests/A.cpp", LayerMarker{ "L1", false }, map, known);
+    EXPECT_EQ(both.Layer, "L1");
+    EXPECT_FALSE(both.Problem.empty()) << "a file registered twice must be reported, not silently accepted";
+
+    const auto markerOnly = ResolveLayer("OloEngine/tests/B.cpp", LayerMarker{ "L1", false }, map, known);
+    EXPECT_EQ(markerOnly.Layer, "L1");
+    EXPECT_TRUE(markerOnly.Problem.empty());
+
+    const auto mapOnly = ResolveLayer("OloEngine/tests/A.cpp", LayerMarker{}, map, known);
+    EXPECT_EQ(mapOnly.Layer, "L8");
+    EXPECT_TRUE(mapOnly.Problem.empty());
+}
+
+TEST(McpTestExecution, AnUnclassifiedOrUnknownLayerIsReportedNotBlanked)
+{
+    const Json map = Json::object();
+    const std::set<std::string> known{ "L1", "unit" };
+
+    const auto none = ResolveLayer("OloEngine/tests/C.cpp", LayerMarker{}, map, known);
+    EXPECT_TRUE(none.Layer.empty());
+    EXPECT_NE(none.Problem.find("unclassified"), std::string::npos);
+
+    const auto bogus = ResolveLayer("OloEngine/tests/D.cpp", LayerMarker{ "L99", false }, map, known);
+    EXPECT_TRUE(bogus.Layer.empty());
+    EXPECT_NE(bogus.Problem.find("L99"), std::string::npos);
+
+    // The duplicate-registration branch must apply the same range check, or an
+    // unknown id is accepted on one path and rejected on the other.
+    const Json bothMap = Json::parse(R"({"OloEngine/tests/E.cpp": "L1"})");
+    const auto bothBogus = ResolveLayer("OloEngine/tests/E.cpp", LayerMarker{ "L99", false }, bothMap, known);
+    EXPECT_TRUE(bothBogus.Layer.empty());
+    EXPECT_NE(bothBogus.Problem.find("L99"), std::string::npos);
+}
+
+TEST(McpTestExecution, KnownLayerIdsAddsTheTwoImplicitTags)
+{
+    const Json catalogue = Json::parse(R"({
+      "functional_tag": "Functional",
+      "layers": [ { "id": "L1" }, { "id": "L8" } ]
+    })");
+    const std::set<std::string> ids = KnownLayerIds(catalogue);
+    EXPECT_TRUE(ids.contains("L1"));
+    EXPECT_TRUE(ids.contains("unit"));
+    EXPECT_TRUE(ids.contains("Functional"));
+    // No declared layers means no range check at all, rather than a check that
+    // rejects everything.
+    EXPECT_TRUE(KnownLayerIds(Json::object()).empty());
+}
+
+// ---- run reports ----------------------------------------------------------
+
+TEST(McpTestExecution, ParsesEveryOutcomeOutOfARunReport)
+{
+    const Json doc = Json::parse(R"({
+      "tests": 4, "failures": 1, "name": "AllTests",
+      "testsuites": [
+        { "name": "S", "tests": 4, "testsuite": [
+          { "name": "Passes", "status": "RUN", "result": "COMPLETED", "time": "0.25s",
+            "file": "..\\OloEngine\\tests\\S.cpp", "line": 10 },
+          { "name": "Fails", "status": "RUN", "result": "COMPLETED", "time": "1.5s",
+            "failures": [ { "failure": "S.cpp:12\nExpected equality\n", "type": "" } ] },
+          { "name": "Skips", "status": "RUN", "result": "SKIPPED", "time": "0s",
+            "skipped": [ { "message": "S.cpp:20\nNo GL 4.6 context" } ] },
+          { "name": "DISABLED_Off", "status": "NOTRUN", "result": "SUPPRESSED", "time": "0s" }
+        ] }
+      ]
+    })");
+
+    const auto report = ParseRunReport(doc);
+    ASSERT_TRUE(report.Error.empty()) << report.Error;
+    ASSERT_EQ(report.Cases.size(), 4u);
+
+    EXPECT_EQ(report.Cases[0].Status, CaseStatus::Passed);
+    EXPECT_DOUBLE_EQ(report.Cases[0].Seconds, 0.25);
+    EXPECT_EQ(report.Cases[0].Line, 10);
+
+    EXPECT_EQ(report.Cases[1].Status, CaseStatus::Failed);
+    ASSERT_EQ(report.Cases[1].Messages.size(), 1u);
+    EXPECT_NE(report.Cases[1].Messages[0].find("Expected equality"), std::string::npos)
+        << "the verbatim gtest message is the whole point — a caller must not have to scrape the console for it";
+
+    EXPECT_EQ(report.Cases[2].Status, CaseStatus::Skipped);
+    ASSERT_EQ(report.Cases[2].Messages.size(), 1u);
+    EXPECT_NE(report.Cases[2].Messages[0].find("No GL 4.6 context"), std::string::npos);
+
+    EXPECT_EQ(report.Cases[3].Status, CaseStatus::Disabled);
+}
+
+// gtest reports a case that skipped AND failed as SKIPPED. Taking that at face
+// value would turn a red into a benign skip, which on this repo — where the GPU
+// suites skip constantly — is the failure most likely to be missed.
+TEST(McpTestExecution, ARecordedFailureOutranksASkippedResult)
+{
+    const Json doc = Json::parse(R"({
+      "testsuites": [ { "name": "S", "testsuite": [
+        { "name": "SkippedThenFailed", "status": "RUN", "result": "SKIPPED", "time": "0s",
+          "skipped": [ { "message": "gave up" } ],
+          "failures": [ { "failure": "but asserted first", "type": "" } ] }
+      ] } ]
+    })");
+    const auto report = ParseRunReport(doc);
+    ASSERT_EQ(report.Cases.size(), 1u);
+    EXPECT_EQ(report.Cases[0].Status, CaseStatus::Failed);
+}
+
+// gtest reports a fatal failure in SetUpTestSuite / TearDownTestSuite / a global
+// environment as a pseudo-entry with an EMPTY name — inside the owning suite, or
+// under a synthetic `NonTestSuiteFailure` suite. Read as cases they become the
+// full name "Suite.", which no listing ever contains, so reconciliation would
+// call them `unexpected` and report a real setup failure as "the run was
+// PARTIAL" — burying the cause under a plumbing complaint.
+TEST(McpTestExecution, SuiteLevelFailuresAreKeptOutOfTheCaseList)
+{
+    const Json doc = Json::parse(R"({
+      "testsuites": [
+        { "name": "S", "tests": 1, "testsuite": [
+          { "name": "Real", "status": "RUN", "result": "COMPLETED", "time": "0s" },
+          { "name": "", "status": "RUN", "result": "COMPLETED", "time": "0s", "classname": "",
+            "failures": [ { "failure": "S.cpp:5\nSetUpTestSuite blew up", "type": "" } ] }
+        ] },
+        { "name": "NonTestSuiteFailure", "tests": 1, "testsuite": [
+          { "name": "", "status": "RUN", "result": "COMPLETED", "time": "0s", "classname": "",
+            "failures": [ { "failure": "env.cpp:9\nGlobal environment SetUp failed", "type": "" } ] }
+        ] }
+      ]
+    })");
+
+    const auto report = ParseRunReport(doc);
+    ASSERT_TRUE(report.Error.empty()) << report.Error;
+    ASSERT_EQ(report.Cases.size(), 1u) << "only the named case is a case";
+    EXPECT_EQ(report.Cases[0].FullName(), "S.Real");
+
+    ASSERT_EQ(report.SuiteFailures.size(), 2u);
+    EXPECT_EQ(report.SuiteFailures[0].Suite, "S");
+    ASSERT_EQ(report.SuiteFailures[0].Messages.size(), 1u);
+    EXPECT_NE(report.SuiteFailures[0].Messages[0].find("SetUpTestSuite blew up"), std::string::npos);
+    EXPECT_EQ(report.SuiteFailures[1].Suite, "NonTestSuiteFailure");
+
+    // And the run still reconciles, so the setup failure is reported as itself.
+    const auto reconciliation = Reconcile({ MakeSelected("S", "Real") }, report.Cases);
+    EXPECT_TRUE(reconciliation.Complete())
+        << "a suite-level failure must not be mistaken for an unexpected case";
+}
+
+TEST(McpTestExecution, AMalformedRunReportIsAnError)
+{
+    EXPECT_FALSE(ParseRunReport(Json::parse(R"({"tests": 0})")).Error.empty());
+}
+
+TEST(McpTestExecution, ParsesGTestDurations)
+{
+    EXPECT_DOUBLE_EQ(ParseGTestDuration("17.444s"), 17.444);
+    EXPECT_DOUBLE_EQ(ParseGTestDuration("0s"), 0.0);
+    EXPECT_DOUBLE_EQ(ParseGTestDuration(""), 0.0);
+    EXPECT_DOUBLE_EQ(ParseGTestDuration("garbage"), 0.0);
+    EXPECT_DOUBLE_EQ(ParseGTestDuration("-3s"), 0.0);
+}
+
+// ---- reconciliation: the invariant ---------------------------------------
+
+TEST(McpTestExecution, AFullyAccountedRunReconciles)
+{
+    const std::vector<TestCase> selected{ MakeSelected("S", "A"), MakeSelected("S", "B") };
+    const std::vector<CaseResult> reported{ MakeCase("S", "A", CaseStatus::Passed),
+                                            MakeCase("S", "B", CaseStatus::Failed) };
+    const auto reconciliation = Reconcile(selected, reported);
+    EXPECT_TRUE(reconciliation.Complete());
+    EXPECT_EQ(reconciliation.Expected, 2u);
+    EXPECT_EQ(reconciliation.Reported, 2u);
+}
+
+// The case this whole design exists for: the child crashed after two of three
+// cases, so gtest's report is short. The counts alone would read as a perfectly
+// ordinary two-case run; only the by-name diff says which case never reported.
+TEST(McpTestExecution, APartialRunIsIncompleteAndNamesWhatIsMissing)
+{
+    const std::vector<TestCase> selected{ MakeSelected("S", "A"), MakeSelected("S", "B"), MakeSelected("S", "C") };
+    const std::vector<CaseResult> reported{ MakeCase("S", "A", CaseStatus::Passed),
+                                            MakeCase("S", "B", CaseStatus::Passed) };
+    const auto reconciliation = Reconcile(selected, reported);
+    EXPECT_FALSE(reconciliation.Complete());
+    ASSERT_EQ(reconciliation.Missing.size(), 1u);
+    EXPECT_EQ(reconciliation.Missing[0], "S.C");
+    EXPECT_TRUE(reconciliation.Unexpected.empty());
+}
+
+// A count-only check passes this: two selected, two reported. The names do not.
+TEST(McpTestExecution, ASwappedCaseIsCaughtEvenThoughTheCountsMatch)
+{
+    const std::vector<TestCase> selected{ MakeSelected("S", "A"), MakeSelected("S", "B") };
+    const std::vector<CaseResult> reported{ MakeCase("S", "A", CaseStatus::Passed),
+                                            MakeCase("S", "Z", CaseStatus::Passed) };
+    const auto reconciliation = Reconcile(selected, reported);
+    EXPECT_EQ(reconciliation.Expected, reconciliation.Reported);
+    EXPECT_FALSE(reconciliation.Complete()) << "equal counts must not be mistaken for the same set";
+    EXPECT_EQ(reconciliation.Missing, std::vector<std::string>{ "S.B" });
+    EXPECT_EQ(reconciliation.Unexpected, std::vector<std::string>{ "S.Z" });
+}
+
+TEST(McpTestExecution, AnEmptyReportAgainstANonEmptySelectionIsIncomplete)
+{
+    const std::vector<TestCase> selected{ MakeSelected("S", "A") };
+    const auto reconciliation = Reconcile(selected, {});
+    EXPECT_FALSE(reconciliation.Complete());
+    EXPECT_EQ(reconciliation.Missing.size(), 1u);
+}
+
+// ---- counting -------------------------------------------------------------
+
+TEST(McpTestExecution, CountsEachStatusAndTheBucketsAddUp)
+{
+    const std::vector<CaseResult> cases{
+        MakeCase("S", "A", CaseStatus::Passed),  MakeCase("S", "B", CaseStatus::Failed),
+        MakeCase("S", "C", CaseStatus::Skipped), MakeCase("S", "D", CaseStatus::Disabled),
+        MakeCase("S", "E", CaseStatus::Passed),
+    };
+    const auto counts = CountCases(cases);
+    EXPECT_EQ(counts.Total, 5u);
+    EXPECT_EQ(counts.Passed, 2u);
+    EXPECT_EQ(counts.Failed, 1u);
+    EXPECT_EQ(counts.Skipped, 1u);
+    EXPECT_EQ(counts.Disabled, 1u);
+    EXPECT_TRUE(counts.AddsUp());
+}
+
+TEST(McpTestExecution, LayerCountsBucketTheUnclassifiedExplicitly)
+{
+    std::vector<TestCase> cases{ MakeSelected("S", "A"), MakeSelected("S", "B"), MakeSelected("S", "C") };
+    cases[0].Layer = "L1";
+    cases[1].Layer = "L1";
+    // cases[2] stays unclassified.
+    const Json counts = LayerCountsJson(cases);
+    EXPECT_EQ(counts["L1"].get<int>(), 2);
+    EXPECT_EQ(counts["unclassified"].get<int>(), 1)
+        << "an unclassified case must be counted somewhere visible, not dropped";
+}
+
+// ---- filters and truncation ----------------------------------------------
+
+TEST(McpTestExecution, AcceptsOnlyNamesAGTestFilterCanCarry)
+{
+    EXPECT_TRUE(IsFilterSafeName("Suite.Case"));
+    EXPECT_TRUE(IsFilterSafeName("Instantiation/Suite.Case/0"));
+    EXPECT_FALSE(IsFilterSafeName(""));
+    EXPECT_FALSE(IsFilterSafeName("Suite.Case With Space"));
+    EXPECT_FALSE(IsFilterSafeName("Suite.\"Quoted\""));
+    // ':' delimits filter terms, so a name containing one cannot be expressed.
+    EXPECT_FALSE(IsFilterSafeName("Suite.A:B"));
+}
+
+// The filter is the one selection input written freehand, and it is pasted into
+// the child's command line. A quote in it would close the quoting and let the
+// rest be read as further gtest flags — a second --gtest_output redirects the
+// report and the run then fails as "exited without writing a report".
+TEST(McpTestExecution, AFilterExpressionMayCarryWildcardsButNoQuoting)
+{
+    EXPECT_TRUE(IsFilterSafeExpression("*"));
+    EXPECT_TRUE(IsFilterSafeExpression("RenderGraphTest.*"));
+    EXPECT_TRUE(IsFilterSafeExpression("A.B:C.*-*Slow*"));
+    EXPECT_TRUE(IsFilterSafeExpression("Instantiation/Suite.Case/0"));
+    EXPECT_FALSE(IsFilterSafeExpression(""));
+    EXPECT_FALSE(IsFilterSafeExpression("a\" --gtest_output=json:evil.json \""));
+    EXPECT_FALSE(IsFilterSafeExpression("a b"));
+    EXPECT_FALSE(IsFilterSafeExpression("a&b"));
+}
+
+TEST(McpTestExecution, JoinsNamesWithTheFilterDelimiter)
+{
+    EXPECT_EQ(JoinFilter({ "A.B", "C.D" }), "A.B:C.D");
+    EXPECT_EQ(JoinFilter({}), "");
+}
+
+TEST(McpTestExecution, CountsRunBannersForProgress)
+{
+    EXPECT_EQ(CountStartedCases("[ RUN      ] S.A\n[       OK ] S.A\n[ RUN      ] S.B\n"), 2u);
+    EXPECT_EQ(CountStartedCases("no banners here"), 0u);
+}
+
+TEST(McpTestExecution, TruncationIsMarkedAndCounted)
+{
+    const std::string long_(100, 'x');
+    const std::string clamped = Clamp(long_, 10);
+    EXPECT_NE(clamped.find("truncated"), std::string::npos);
+    EXPECT_NE(clamped.find("90"), std::string::npos);
+    EXPECT_EQ(Clamp("short", 10), "short");
+
+    const std::string tail = TailOf(long_, 10);
+    EXPECT_NE(tail.find("omitted"), std::string::npos);
+    // A dead child's log is diagnosed from its END, so that is what is kept.
+    EXPECT_TRUE(tail.ends_with(std::string(10, 'x')));
+    EXPECT_EQ(TailOf("short", 10), "short");
+}

--- a/OloEngine/tests/MCP/McpTestExecutionTest.cpp
+++ b/OloEngine/tests/MCP/McpTestExecutionTest.cpp
@@ -29,8 +29,8 @@ namespace
     using OloEngine::MCP::TestExecution::IsDisabledName;
     using OloEngine::MCP::TestExecution::IsFilterSafeExpression;
     using OloEngine::MCP::TestExecution::IsFilterSafeName;
-    using OloEngine::MCP::TestExecution::Json;
     using OloEngine::MCP::TestExecution::JoinFilter;
+    using OloEngine::MCP::TestExecution::Json;
     using OloEngine::MCP::TestExecution::KnownLayerIds;
     using OloEngine::MCP::TestExecution::LayerCountsJson;
     using OloEngine::MCP::TestExecution::LayerMarker;
@@ -393,8 +393,10 @@ TEST(McpTestExecution, AnEmptyReportAgainstANonEmptySelectionIsIncomplete)
 TEST(McpTestExecution, CountsEachStatusAndTheBucketsAddUp)
 {
     const std::vector<CaseResult> cases{
-        MakeCase("S", "A", CaseStatus::Passed),  MakeCase("S", "B", CaseStatus::Failed),
-        MakeCase("S", "C", CaseStatus::Skipped), MakeCase("S", "D", CaseStatus::Disabled),
+        MakeCase("S", "A", CaseStatus::Passed),
+        MakeCase("S", "B", CaseStatus::Failed),
+        MakeCase("S", "C", CaseStatus::Skipped),
+        MakeCase("S", "D", CaseStatus::Disabled),
         MakeCase("S", "E", CaseStatus::Passed),
     };
     const auto counts = CountCases(cases);

--- a/docs/agent-rules/testing-architecture.md
+++ b/docs/agent-rules/testing-architecture.md
@@ -104,7 +104,27 @@ If a feature touches multiple surfaces, write one test per surface — and write
 - **Golden rebase** (only when a deliberate visual change lands): `<test binary> --olo-golden-rebase --gtest_filter=GoldenImage*`.
 - **Perf rebase** (only when moving to new hardware or after an intentional optimisation): `<test binary> --olo-perf-rebase --gtest_filter=PerfRegression*`.
 
-Working directory matters: run from the repo root so asset paths resolve.
+**Working directory: prefer `OloEditor/`.** That is what `ctest` uses — both
+`gtest_discover_tests` calls in [OloEngine/tests/CMakeLists.txt](../../OloEngine/tests/CMakeLists.txt)
+pass `WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor`, because many tests call
+`Shader::Create("assets/shaders/...")`.
+
+Running from the repo root also works — the engine finds those assets anyway, and
+a visual-evidence test still writes into the tracked
+`OloEditor/assets/tests/visual/` rather than creating a stray directory — but it
+is **~3x slower to start**, because the fallback search runs on every asset
+lookup. Measured 2026-09-09, `--gtest_filter=McpProjectValidation.*`, four
+interleaved pairs, Debug:
+
+| CWD | process wall time (median of 4) |
+|---|---:|
+| repo root | 2.06 s |
+| `OloEditor/` | 0.71 s |
+
+That 1.35 s is per *process*, and `ctest` spawns one per case — which is why it
+sets the working directory rather than leaving it to chance. It is also the
+"~2 s" process startup quoted in the next section. `olo_tests_run` (issue #1130)
+runs its child from `OloEditor/` for the same reason.
 
 ### Reproducing flaky CI-only core-starvation races
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -761,6 +761,11 @@ thing to check first if you are reviewing them:
   failed and the error names the missing cases. A count-only check would pass a
   run that lost one case and gained another, and would tell you nothing when it
   did fail.
+- A failure belonging to **no case** — a fatal assertion in `SetUpTestSuite`,
+  `TearDownTestSuite` or a global environment — is an error too. A teardown
+  failure is the dangerous one: every case has already passed by then, so the
+  payload would otherwise read `failed: 0, complete: true` and a caller checking
+  exactly those two fields would call it green.
 
 Two traps worth knowing if you touch this code. gtest's list-mode JSON reports
 the whole *registered* count in its top-level `tests` field, ignoring the filter

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -187,7 +187,7 @@ deliberate: `olo_log_tail` returns raw log lines (free text an `outputSchema` ca
 constrain), and the `format:"markdown"`/`"mermaid"` paths of the dual-format tools stay
 text-only (their schemas describe the json format).
 
-Eleven table-shaped tools additionally return **audience-tagged content blocks** — see
+Fourteen table-shaped tools additionally return **audience-tagged content blocks** — see
 [Audience-tagged content blocks](#audience-tagged-content-blocks-673-tier-2) for the list
 and for what to do when adding a tool.
 
@@ -725,8 +725,9 @@ suite from a session was to shell out to `OloEngine-Tests.exe` and parse
 It never touches the editor's renderer and never marshals onto the game thread,
 so the CPU-only suites do not inherit any GPU skip condition. The results come
 from gtest's own JSON report (`--gtest_output=json:`), so each case carries its
-status, its wall time, its source file and line, and the **verbatim** assertion
-text:
+status, its wall time, its source file and line, and the assertion text
+verbatim up to `maxMessageChars` (default 2000, and a cut is marked in the
+message itself):
 
 ```jsonc
 { "suite": "RenderGraphTest", "name": "HazardSweepFindsWriteAfterRead",
@@ -2215,10 +2216,16 @@ characters, inline lists at 12 items, each stating what it elided. The full payl
 in the assistant block and in `structuredContent`. Path redaction, when enabled, scrubs both
 blocks identically.
 
-**Current adopters (11):** `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_pass_timings`,
-`olo_perf_cpu_scopes`, `olo_render_frame_breakdown`, `olo_render_graph_topology_export`,
-`olo_render_why_not_visible`, `olo_render_target_stats`, `olo_cluster_grid_stats`,
-`olo_shadow_atlas_layout`, `olo_physics_why_no_collision`.
+**Current adopters (14):** `olo_gpu_resources`, `olo_memory_report`, `olo_perf_snapshot`,
+`olo_perf_pass_timings`, `olo_perf_cpu_scopes`, `olo_render_frame_breakdown`,
+`olo_render_graph_topology_export`, `olo_render_why_not_visible`, `olo_render_target_stats`,
+`olo_cluster_grid_stats`, `olo_shadow_atlas_layout`, `olo_physics_why_no_collision`,
+`olo_tests_run`, `olo_project_validate`.
+
+That list is ratcheted in both directions by
+`McpAudienceBlocksTest.BuiltinAdoptionMatchesTheDeliberateList`, which compares the real
+registry against an explicit set — so it is the test, not this paragraph, that fails when a
+tool opts in without being considered. Keep the two in step.
 
 #### Adding a tool — which side of the line are you on?
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -278,6 +278,9 @@ and for what to do when adding a tool.
 | `olo_physics_why_no_collision` | explain why two entities (`a`, `b`) are NOT colliding — the "player falls through the floor" debugger: root-cause `reasonCode`, summary, ordered checks, and per-entity facts |
 | `olo_set_collision_layer` | **(consented write)** set an entity's rigidbody collision layer (`entity`, `layer`). The counterpart to `olo_physics_why_no_collision`: that one explains why two bodies do not collide, this one fixes the common cause. Routed through the editor's undo stack, so an applied change is a single Ctrl-Z |
 | `olo_input_inject` | **(consented write)** inject synthetic mouse/keyboard input — `click` / `move` / `drag` / `mouseDelta` / `key` / `text` — into the editor's own input stream, so you can verify that an interactive handler actually FIRES (a viewport click selects the right entity; a panel button does what it claims), not merely that the editor renders. Synchronous: returns once the injected frames have been rendered, with the resulting selected/hovered entity in `after`. `mouseDelta` drives **delta-integrating** consumers (mouse-look rigs) that absolute injection provably cannot — see [Relative mouse movement](#relative-mouse-movement-mousedelta). Refuses loudly when the editor's loop is parked. Gated behind **Agent writes**. See [Interactive UI verification](#interactive-ui-verification-olo_input_inject) |
+| `olo_tests_list` | the GoogleTest cases `OloEngine-Tests` holds, each with source file, line and its `OLO_TEST_LAYER` classification (the renderer pyramid L1–L11 and the Functional / unit axes), plus a per-layer count. Filter by gtest expression, `suite`, explicit `cases` or `layer`. A selection that matches nothing is an **error**, not an empty list |
+| `olo_tests_run` | run a filtered selection as a child process and get **structured** per-case results — pass/fail/skip/disabled, the verbatim gtest failure text, per-case timings, each case's layer — with no console parsing. Runs the binary, not the editor's renderer, so the CPU-only suites inherit no GPU skip condition. Failures only by default (`includePassed` for the whole set). Never silently partial: a zero-match selection, a child that crashed / timed out / was cancelled, and a report that does not account for every selected case are all errors that **name** what is missing. See [Structured test execution](#structured-test-execution-olo_tests_list--olo_tests_run) |
+| `olo_project_validate` | every project validator in one call — asset-registry problems, shader compile/link errors, recent script errors, and the live render graph's hazard sweep — as one structured report. Each section invokes the standalone command's own handler, so it reports exactly what the editor panels show. A validator that cannot run here comes back `unavailable` **with its reason** and makes the report's `ok` false: an unrun check is never a clean bill of health |
 
 ### Write consent — Disabled / Prompt / Allow all (issue #306)
 
@@ -449,8 +452,8 @@ round-trip rather than looking like a write that quietly did nothing.
 
 ### Toolsets & on-demand tool discovery (`tools/search`)
 
-The tool surface is large enough (96 built-in tools; the full `tools/list` measures
-269 436 bytes ≈ 67k tokens) that paging the whole flat list to find the right one is
+The tool surface is large enough (102 built-in tools; the full `tools/list` measures
+281 836 bytes ≈ 70k tokens) that paging the whole flat list to find the right one is
 wasteful. Every tool is tagged with a **toolset** (grouping category), and a custom
 `tools/search` JSON-RPC method lets an agent discover tools by keyword and/or
 category instead of pulling the entire list (project Lua script tools additionally
@@ -469,6 +472,8 @@ appear under the `script` toolset — see "Script-defined tools" below):
 | `physics` | `olo_physics_layer_matrix`, `olo_physics_list_colliders`, `olo_physics_contacts`, `olo_physics_raycast`, `olo_physics_overlap`, `olo_physics_why_no_collision`, `olo_set_collision_layer` |
 | `input` | `olo_input_inject` |
 | `editor` | `olo_editor_panel_list`, `olo_editor_panel_set`, `olo_accessibility_get`, `olo_accessibility_set`, `olo_lightmap_bake`, `olo_editor_debug_draw_set`, `olo_terrain_pick` |
+| `tests` | `olo_tests_list`, `olo_tests_run` |
+| `validation` | `olo_project_validate` |
 
 `tools/search` params (both optional):
 
@@ -490,10 +495,10 @@ it lists is decided by the exposure profile below.
 
 ### Exposure profiles — `tools/list` shows a core set by default (issue #1124)
 
-**The default `tools/list` is not the whole surface.** The full catalogue is 96 tools /
-269 436 bytes / **~67k tokens** — a third of a 200k context window spent before the
+**The default `tools/list` is not the whole surface.** The full catalogue is 102 tools /
+281 836 bytes / **~70k tokens** — a third of a 200k context window spent before the
 session asks its first question, on a list of which three or four entries are ever
-called. The default `core` profile lists **16 tools / 38 144 bytes / ~9.5k tokens**, a
+called. The default `core` profile lists **18 tools / 39 362 bytes / ~9.8k tokens**, a
 7x reduction, and everything else is one search away. (Both figures are measured, not
 estimated: `McpExposureProfileTest` prints them on every test run and asserts a ceiling
 on the first. Token counts are bytes/4.)
@@ -708,6 +713,91 @@ component bindings.
   don't trust `scriptClassCount` on a failed reload. Rebuild the game assembly and retry.
 - **Lua is not reloaded here.** This tool targets the C# (Mono) app assembly; Lua scripts
   re-execute per entity on play and have no single global reload entry point.
+
+### Structured test execution (`olo_tests_list` / `olo_tests_run`)
+
+Issue #1130. The other half of the inner loop: change something, run the thing
+that proves it, read a structured result. Before these, the only way to run the
+suite from a session was to shell out to `OloEngine-Tests.exe` and parse
+`[  FAILED  ]` banners — which is why `.claude/skills/run-oloengine/` exists.
+
+`olo_tests_run` runs the binary as a **child process** from the handler thread.
+It never touches the editor's renderer and never marshals onto the game thread,
+so the CPU-only suites do not inherit any GPU skip condition. The results come
+from gtest's own JSON report (`--gtest_output=json:`), so each case carries its
+status, its wall time, its source file and line, and the **verbatim** assertion
+text:
+
+```jsonc
+{ "suite": "RenderGraphTest", "name": "HazardSweepFindsWriteAfterRead",
+  "fullName": "RenderGraphTest.HazardSweepFindsWriteAfterRead",
+  "status": "failed", "seconds": 0.31,
+  "file": "OloEngine/tests/Rendering/RenderGraphTest.cpp", "line": 212,
+  "layer": "L5",
+  "messages": ["...
+Expected equality of these values:
+  hazards.size()
+..."] }
+```
+
+The `layer` field is the repo's own `OLO_TEST_LAYER` classification, read from
+the in-file marker first and `OloEngine/tests/scripts/test_catalogue.json`'s
+`file_layer_map` second — the same two mechanisms, and the same precedence, that
+`generate_test_catalogue.py` enforces at pre-commit. `layer` is also a
+*selector*: `{ "suite": "VulkanPassSuite", "layer": "L8" }` runs that suite's
+golden-image cases only.
+
+**A run is never silently partial.** This is the point of the commands, and the
+thing to check first if you are reviewing them:
+
+- A selection matching **zero** cases is an error. A typo'd filter must not read
+  as "this area is clean".
+- A child that crashed, timed out or was cancelled is an error carrying the exit
+  code, how many cases had started, and the tail of its console log — never a
+  result with a small number in it.
+- Every run does a `--gtest_list_tests` pass first and **reconciles the two sets
+  by name**. If the report does not account for every selected case, the run
+  failed and the error names the missing cases. A count-only check would pass a
+  run that lost one case and gained another, and would tell you nothing when it
+  did fail.
+
+Two traps worth knowing if you touch this code. gtest's list-mode JSON reports
+the whole *registered* count in its top-level `tests` field, ignoring the filter
+entirely — 7616 for a two-case selection — so that field can never be read as
+"how many I selected". And a case that both skips and fails is reported by gtest
+as `SKIPPED`; taking that at face value turns a red into a benign skip, which on
+this repo's constantly-skipping GPU suites is the failure most likely to be
+missed. A recorded failure outranks the skip.
+
+Which binary ran is part of the answer (`binary.path`, `binary.modifiedUtc`,
+`binary.sizeBytes`): a green summary looks identical whether it came from the
+binary you just built or from last week's. By default the newest artefact across
+`build-cached/`, `build/` and `build-clang/` wins; `binary` (or
+`OLO_TESTS_BINARY`) names one explicitly and is never silently replaced.
+
+Long runs report progress through the standard mechanism and honour
+cancellation — see [Progress notifications & cancellation](#progress-notifications--cancellation).
+
+### Whole-project validation (`olo_project_validate`)
+
+Issue #1130. One call that runs every per-domain validator and returns one
+report: asset-registry problems, shader compile/link errors, recent script
+errors, and the live render graph's hazard sweep.
+
+It **composes by invoking** `olo_assets_problems`, `olo_shader_errors`,
+`olo_script_get_last_errors` and `olo_render_validate` — their actual handlers,
+not a reimplementation — so it reports exactly what the editor panels show and
+cannot drift from them.
+
+The report carries two flags, deliberately not one:
+
+- `complete` — every requested section actually ran.
+- `ok` — every requested section ran **and** found nothing.
+
+A validator that cannot run here (no project open, no render graph in a headless
+or 2D session) comes back as `unavailable` with its `reason`, is counted in
+`sectionsUnavailable`, and makes `ok` false. Dropping the section and totalling
+zero problems would hand back a green verdict for a check that never happened.
 
 ### Scriptable scene control (`olo_scene_open` / `olo_scene_play` / `olo_scene_stop`)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1079,6 +1079,14 @@ be a tracked file — so only this human-written guide is versioned; the rendere
 inventory is built on demand (and can be published as a CI artifact if a browsable
 copy is wanted).
 
+The classification is also read **at runtime**, not only at pre-commit: the
+automation commands `olo_tests_list` / `olo_tests_run` (issue #1130) resolve each
+gtest case's layer through the same two mechanisms, in the same precedence, and
+report every classification defect they meet alongside the results. `layer` is a
+selector there as well as a label, so "run this suite's L8 golden-image cases"
+is one call. See
+[the MCP guide](guides/mcp-diagnostics-server.md#structured-test-execution-olo_tests_list--olo_tests_run).
+
 ## 10. References
 
 Primary sources the strategy draws from:


### PR DESCRIPTION
Epic H of the Automation-Control-Plane roadmap. Closes the loop an agent session runs most: *change something, run the thing that proves it, read a structured result*. Until now the only way to run the suite from a session was to shell out to `OloEngine-Tests.exe` and scrape `[  FAILED  ]` banners — which is why `.claude/skills/run-oloengine/` exists, and why its own SKILL.md has to warn that "a guessed filter that matches nothing exits 0 with a `did not match any test` warning — confirm tests actually ran."

## Slice 1 — test catalogue + execution

**`olo_tests_list`** enumerates the GoogleTest cases the binary holds, each with source file, line and its `OLO_TEST_LAYER` classification, plus a per-layer count.

**`olo_tests_run`** runs a filtered selection and returns structured per-case results — status, verbatim gtest failure text, per-case timing, layer — taken from gtest's own JSON report (`--gtest_output=json:`), never from console text.

Selection is by gtest `filter`, `suite`, explicit `cases`, or `layer` (the repo's own classification, resolved from the in-file `// OLO_TEST_LAYER` marker first and `test_catalogue.json`'s `file_layer_map` second — the same two mechanisms and the same precedence `generate_test_catalogue.py` enforces at pre-commit).

### Where it runs — the constraint that shaped the design

The commands spawn `OloEngine-Tests` as a **child process from the automation handler thread**. No `MarshalRead`, no renderer, no GL/Vulkan state. That is the issue's "must not require the editor's renderer for the CPU-only suites" met structurally rather than by a guard someone can later forget.

### A run is never silently partial

The correctness constraint the issue is really about, enforced in three places:

1. **A selection matching zero cases is an error.** A typo'd filter must not read as "this area is clean."
2. **A child that crashed, timed out or was cancelled is an error** carrying the exit code, how many cases had started, and the tail of its console log — never a result with a small number in it.
3. **Every run does a `--gtest_list_tests` pass first and reconciles the two sets by name.** If the report does not account for every selected case, the run failed and the error *names* the missing cases.

Point 3 is the one worth arguing about, so: a count-only check passes a run that lost one case and gained another, and tells you nothing to act on when it does fail. `McpTestExecutionTest.ASwappedCaseIsCaughtEvenThoughTheCountsMatch` pins exactly that.

Two gtest traps the implementation has to know about, both pinned by tests:

- **List mode's top-level `tests` field is the whole registered count, ignoring the filter** — measured on this binary, a `McpTestExecution.*` listing enumerates 25 cases while that field reports 7825. Reading it as "how many I selected" would be wrong by three orders of magnitude, so the parser counts entries and never touches it.
- **A case that both skips and fails is reported by gtest as `SKIPPED`.** Taking that at face value turns a red into a benign skip, which on this repo's constantly-skipping GPU suites is the failure most likely to be missed. A recorded failure outranks the skip.

Which binary ran is part of the answer (`binary.path` / `.modifiedUtc` / `.sizeBytes` / `.origin`): a green summary looks identical whether it came from the binary you just built or last week's.

## Slice 2 — whole-project validation

**`olo_project_validate`** runs asset-registry problems, shader compile/link errors, recent script errors and the live render-graph hazard sweep in one call.

It composes **by invoking** `olo_assets_problems`, `olo_shader_errors`, `olo_script_get_last_errors` and `olo_render_validate` — their actual handlers, exposed as `Collect*` entry points — not by reimplementing their verdicts. That is what makes "reports the same problems the editor panels show" true by construction rather than by inspection.

The report carries two flags on purpose: `complete` (every requested section ran) and `ok` (every requested section ran **and** found nothing). A validator that cannot run here comes back `unavailable` with its `reason`, is counted, and makes `ok` false — dropping the section and totalling zero problems would hand back a green verdict for a check that never happened.

## Slice 3 — deliberately deferred, and filed

Build/package invocation is **not** in this PR. The issue itself ranks it "the least urgent" and "could be deferred indefinitely", and the reason is concrete: every build here goes through `build-lock.ps1`, which bounds concurrent builds across every worktree and kills its build if the launching session dies, with a `PreToolUse` hook enforcing it. A build command inside the editor is a second, unaudited way to start one, from a process the lock does not know about. That story needs working out before any code, and it is not what makes slices 1 and 2 valuable.

Filed as a scored issue so the deferral is a backlog row rather than a blind spot: **#1163**.

## Not done, and why

- `olo_tests_run` is **not** in the `core` exposure profile. The core criterion is "a session that cannot see it would be unable to work out what to ask next" — orientation, eyes on the frame, the two error channels. Running tests is not orientation, and the discovery gateway reaches it in one call. Arguable; happy to move it.
- `olo_tests_run` is **not** `ProjectWrite`, but it is **not** `readOnlyHint` either. A full run regenerates the tracked evidence PNGs under `OloEditor/assets/tests/visual/`, so the working tree moves — that is a real side effect and the annotation says so. It is still not a project write: it mutates nothing the user is authoring, and gating verification behind the write-consent toggle would make the loop this issue exists to open unusable by default.
- No log section in `olo_project_validate`. `olo_log_tail` returns free text, and re-parsing it to build a structured section would reintroduce exactly the console scraping this issue is against.

## Verification

Built `OloEngine-Tests` **and** `OloEditor` (the editor is not in the test build) — clean exit, both artefacts fresh.

**Unit** — 97 pass across the new and affected suites, including the ratchets this PR had to move:
`McpTestExecution.*` (28), `McpProjectValidation.*` (10), plus `McpAudienceBlocks.*`, `McpDocsCoverage.*`, `McpOutputSchemaCoverage.*`, `McpExposureProfile.*`, `McpAutomationRegistry.*`.

**Live, against a running editor over MCP** (raw JSON-RPC, `driver.ps1 -Action attach`) — each acceptance bullet with the call that shows it:

| Acceptance | Evidence |
|---|---|
| per-case structured results, no console parsing | `olo_tests_run {suite:"McpProjectValidation"}` → 10 cases with `status`/`seconds`/`file`/`line`/`layer:"unit"`, `reconciliation {expected:10, reported:10, missing:[], unexpected:[]}` |
| a filter matching nothing is an error | `{suite:"NoSuchSuiteXyzzy"}` → `isError`, naming the filter and the binary. Also caught a real near-miss during verification: `SteamStubOnPath` vs `SteamStubOnPathTest` |
| validation reports what the panels show | `olo_project_validate` → 16 asset problems (Content Browser), 0 shader errors, 0 script errors, 2 render-graph `ResourceConsumedButUnbacked`; `complete:true`, `ok:false` |

And the paths that are easy to get wrong:

- **Timeout** — `{suite:"VulkanPassSuite", timeoutSeconds:10}` → `outcome:"timed-out"`, `startedCases:20` of `selected:55`, plus the console tail. Not a partial pass.
- **Dead child** — the timeout leg above IS this branch (`!child.Completed()` → the same failure shaping). The narrower "child exited cleanly but wrote no report" case is not separately exercised: there is no cheap way to make the real binary do it, and pointing `binary` elsewhere is now refused by the name guard.
- **Bad `binary`** — a non-existent path and a path to another executable are both refused, by name and by existence.
- **Skips** — `{suite:"SteamStubOnPathTest"}` → 31 skipped / 0 passed, each with its verbatim `GTEST_SKIP` reason and `file:line`, `casesOmitted:21` under `maxCases:10`. A console-scraping caller sees `[  PASSED  ] 0 tests` and exit 0 here.
- **Layer selection** — `{suite:"VulkanPassSuite", layer:"plumbing"}` → 55 cases, `layerCounts {plumbing:55}`, paginated.
- **Whole suite** — `VulkanPassSuite` 55/55, reconciled, 27.6 s.

**Measured, not assumed:** the list pass costs ~3 s (engine startup, not enumeration), so the reconciliation pass is cheap next to any real run. And the list-mode count trap is real on this binary: a `McpTestExecution.*` listing enumerates **25** cases while the top-level `tests` field reports **7825**.

The working tree was clean of golden churn after every run.

## Self-review

Ran `/code-review` at `high` before opening this PR; nine findings, all folded in. The ones worth knowing about:

- **Suite-level failures were parsed as cases.** gtest reports a fatal `SetUpTestSuite`/`TearDownTestSuite`/global-environment failure as a pseudo-entry with an empty `name`, and under a synthetic `NonTestSuiteFailure` suite. Read as cases those become the full name `"Suite."`, which no listing contains — so reconciliation would have called them `unexpected` and reported a genuine setup failure as *"the run was PARTIAL"*, burying the cause. Now split into `suiteFailures`, kept out of reconciliation.
- **`filter` was pasted into the child command line unvalidated**, so a `"` could inject a second `--gtest_output`. Charset-checked now; a gtest filter has no escape syntax, so nothing legitimate is refused.
- **`binary` accepted any executable** on a command that is deliberately not consent-gated. It must now be named `OloEngine-Tests`.
- **The child ran from the repo root; ctest runs every test from `OloEditor/`.** I measured this one rather than assuming: `FluidVisualEvidenceTest` from the repo root wrote its PNGs into the *tracked* `OloEditor/assets/tests/visual/` and created no stray directory, so nothing was actually broken. Changed anyway — agreeing with CI beats relying on a fallback nobody promised. The measurement is in the comment.
- The progress watch re-read and re-scanned the whole console log every 250 ms (quadratic in log size over a two-hour run); it now scans only what was appended, with an overlap so a banner split across reads is counted once.

## Review guide

**Where I'd look hardest**

1. `OloEditor/src/MCP/McpTestExecution.h` — `ParseRunReport` / `Reconcile`. This is the correctness constraint the issue is about, and the suite-failure case above is exactly the kind of thing that turns a real failure into a confusing one. If the gtest report has another shape I have not accounted for, it surfaces here.
2. `OloEditor/src/MCP/McpToolsTesting.cpp` — `RunChild` and `RunWatch::ReportProgress`. Process lifetime, the kill-on-cancel/timeout paths, and the incremental log scan; the POSIX branch is the least-exercised code in the PR.
3. `OloEditor/src/MCP/McpToolsTesting.cpp` — `BuildLayerFilter`'s `Suite.*` collapse. It is exact only because `listedIsEverything` is checked; if that guard is wrong the run silently widens (though reconciliation would then name the extra cases).

**What I verified, and how** — the table above. The check that would have failed had the core idea been wrong is `McpTestExecution.ASwappedCaseIsCaughtEvenThoughTheCountsMatch`: equal counts, different sets, and the reconciliation still refuses.

**Least confident about** — the **POSIX `fork`/`exec` branch**. It compiles on Linux CI but nothing runs it there: `OloEditor` is Windows-only (ADR 0015), and no test spawns a child. It exists so #1125's `oloctl` has something to build on, and it is compile-verified only. Say the word and I will drop it to a clean "unsupported on this platform" error instead of shipping an untested path.

**Deliberately not tested** — cancellation mid-run. `IsCurrentCallCancelled()` is polled on the same 250 ms tick as the timeout and takes the same kill path, and the timeout leg is verified live; driving a real MCP cancellation notification against a long run was more harness than the extra coverage justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `olo_tests_list` for paginated, layer-aware test discovery with structured metadata.
  - Added `olo_tests_run` with filtering, timeouts, cancellation, progress, and per-test results.
  - Added `olo_project_validate` for consolidated asset, shader, script, and render validation reports.
  - Reports identify incomplete or unavailable checks and provide actionable failure details.

- **Bug Fixes**
  - Prevented excessively large pagination values from causing invalid results.

- **Documentation**
  - Updated testing guidance and documented the new diagnostics tools.

- **Tests**
  - Added coverage for structured test execution and project validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->