### PR TITLE
ci(cache): stamp the Windows sccache key with the SDK, and warm master per merge

### DIFF
--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -233,10 +233,15 @@ runs:
         fi
         freed=0
         n=0
+        own_id=''
+        own_size=0
+        newer_key=''
+        newer_run=0
         while IFS=$'\t' read -r id size key ref; do
           [ -n "${id:-}" ] || continue
-          # Never delete the key we are trying to write (it is not there, but be exact).
-          if [ "$key" = "${KEY}" ]; then continue; fi
+          # Never delete the key we are trying to write, in this loop. Its id is kept
+          # because the reconciliation after the loop may retire it -- see there.
+          if [ "$key" = "${KEY}" ]; then own_id="$id"; own_size="$size"; continue; fi
           # Delete ONLY entries of literally this lineage: `<prefix>-<run_id>[-<attempt>]`.
           # A bare prefix match is not good enough. `key=` is a plain string prefix, so if
           # a sibling key `sccache-windows-2025-release-debug-…` is ever added, a prefix
@@ -272,6 +277,10 @@ runs:
           # attempt of this run.
           if [ "$sibling_run" -gt "${RUN_ID}" ]; then
             printf 'skip (not older than this run)  %s\n' "$key"
+            if [ "$sibling_run" -gt "$newer_run" ]; then
+              newer_run="$sibling_run"
+              newer_key="$key"
+            fi
             continue
           fi
           if gh api -X DELETE "repos/${GH_REPO}/actions/caches/${id}" >/dev/null 2>&1; then
@@ -283,6 +292,43 @@ runs:
           fi
         done < superseded.tsv
         rm -f superseded.tsv err.txt
+
+        # AND IF A NEWER SIBLING EXISTS, THIS RUN'S OWN ENTRY IS THE SUPERSEDED ONE.
+        #
+        # The two skips above are each right on their own and wrong together: a run
+        # with a LOWER id that saves after a higher-id run has already pruned keeps the
+        # sibling (it is newer) and keeps its own (it is its own), so the lineage holds
+        # two multi-GiB entries. Worse than the size: `restore-keys` returns the most
+        # recently CREATED match, and so does `cache-prune.yml` when it keeps the newest
+        # per (ref, prefix) -- both of which pick the entry this run just wrote, built
+        # from OLDER source than the sibling it lost the race to. Retiring our own entry
+        # is what actually restores one-entry-per-lineage, and it keeps the fresher of
+        # the two.
+        #
+        # RE-CHECK THE SIBLING FIRST. The listing above is seconds old, and a
+        # `cache-prune` sweep in that window would have kept ours and deleted the
+        # sibling -- deleting ours on the strength of a stale listing is how the lineage
+        # ends up EMPTY, which is the whole failure this guard exists to prevent. If the
+        # re-check cannot confirm the sibling, keep both: two entries cost room until the
+        # next sweep, zero entries cost every branch a cold build.
+        if [ -n "${newer_key}" ] && [ -n "${own_id}" ]; then
+          still=$(gh api -X GET "repos/${GH_REPO}/actions/caches" \
+                    -f "key=${newer_key}" -f "ref=${REF}" \
+                    --jq '.actions_caches[].key' 2>/dev/null || echo '')
+          if printf '%s\n' "$still" | grep -Fxq "${newer_key}"; then
+            if gh api -X DELETE "repos/${GH_REPO}/actions/caches/${own_id}" >/dev/null 2>&1; then
+              printf 'retired this run%s own entry (%s MiB); %s is newer and stays\n' \
+                     "'s" "$((own_size / 1048576))" "${newer_key}"
+              freed=$((freed + own_size))
+              n=$((n + 1))
+            else
+              printf 'could not retire this run%s own entry  %s\n' "'s" "${KEY}"
+            fi
+          else
+            echo "::warning::'${newer_key}' is gone since the listing; keeping '${KEY}' rather than emptying the lineage."
+          fi
+        fi
+
         echo "freed $((freed / 1048576)) MiB from $n superseded entries under '${PREFIX}' on ${REF}"
 
     - name: Save (retry after freeing room)

--- a/.github/actions/save-cache-pruned/action.yml
+++ b/.github/actions/save-cache-pruned/action.yml
@@ -172,6 +172,26 @@ runs:
     # ref by the poll above, so every predecessor of this lineage is genuinely dead.
     #
     # `landed == 'unknown'` still prunes nothing: never delete on a guess.
+    #
+    # AND IT ONLY DELETES ENTRIES OLDER THAN ITS OWN (#1084). The loop below skips
+    # any sibling whose run id is greater than this run's. Without that, two producers
+    # writing one lineage on one ref can each delete the other's entry and leave the
+    # lineage with NONE -- every save here is scoped to the ref, and "every sibling
+    # except my own key" does not distinguish a superseded entry from one written
+    # thirty seconds ago by a run that is still going.
+    #
+    # It was close to unreachable while a workflow's default-branch runs all shared
+    # one concurrency group and none of them was cancellable, because then only one
+    # could be in flight. #1084 split the `push` warm and the `schedule` nightly into
+    # separate groups -- they have to be separate, or a merge cancels a pending
+    # nightly -- so two producers on `refs/heads/master` can now overlap.
+    #
+    # RUN ID, NOT A TIMESTAMP. Run ids are assigned in increasing order and this key
+    # shape already carries one, so the comparison needs no second API call and no
+    # date parsing on two different shells. If the ordering ever failed to hold, the
+    # loop keeps an entry it could have deleted -- which `cache-prune.yml` collects on
+    # its next sweep -- rather than deleting one it should have kept. The error is on
+    # the safe side by construction.
     - name: Free room under this prefix on this ref
       if: always() && (steps.check.outputs.landed == 'false' || steps.check.outputs.landed == 'true')
       shell: bash
@@ -230,6 +250,28 @@ runs:
           # will happily delete an entry on any ref if the listing ever hands us one.
           if [ "$ref" != "${REF}" ]; then
             printf 'skip (wrong ref: %s)  %s\n' "$ref" "$key"
+            continue
+          fi
+          # NEWER THAN OURS IS NOT SUPERSEDED. See the note above the step: a
+          # concurrent producer on this ref writes the same lineage, and deleting its
+          # entry is how a lineage ends up empty. The run id is the segment after the
+          # prefix; the attempt, if present, is dropped.
+          sibling_run=${key#"${PREFIX}"-}
+          sibling_run=${sibling_run%%-*}
+          case "$sibling_run" in
+            ''|*[!0-9]*)
+              # Cannot order it, so do not delete it. The regex above already proved
+              # the shape, so this is belt and braces rather than an expected branch.
+              printf 'skip (no run id to compare)  %s\n' "$key"
+              continue
+              ;;
+          esac
+          # -gt, not -ge: a RE-RUN writes attempt 2 under the SAME run id, and
+          # attempt 1's entry is genuinely superseded. This run's own exact key was
+          # already skipped by name above, so equality can only mean an earlier
+          # attempt of this run.
+          if [ "$sibling_run" -gt "${RUN_ID}" ]; then
+            printf 'skip (not older than this run)  %s\n' "$key"
             continue
           fi
           if gh api -X DELETE "repos/${GH_REPO}/actions/caches/${id}" >/dev/null 2>&1; then

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,7 +1,9 @@
 name: Windows
 on:
-  # NO `push: [master]` -- deliberately, and replaced by the nightly cron below
-  # (#1009 item E). Two things are going on and the second is the easy one to miss.
+  # NO FULL `push: [master]` RUN -- deliberately, and replaced by the nightly cron
+  # below (#1009 item E). What a master push DOES get, since #1084, is the `build`
+  # job on its own as a cache warm: no shards, no test tree, no shader pack. Three
+  # things are going on and the second is the easy one to miss.
   #
   # 1. It was mostly a second opinion on identical code. GitHub's `pull_request`
   #    event builds `refs/pull/N/merge` -- the PR merged into master -- so by the
@@ -22,6 +24,25 @@ on:
   #    active cache entries on this repo were `ref=refs/heads/master`. Delete the
   #    master trigger outright and no PR could ever restore a warm cache again --
   #    a change that reads as a pure saving and is in fact the opposite.
+  #
+  #    ONE WARM A DAY IS NOT ENOUGH, AND THE SHORTFALL IS MEASURED (#1084). The
+  #    snapshot decays with SOURCE DRIFT, not with the clock, and this repo merges
+  #    ~12 pull requests a day. Restoring the 04:39 nightly at 12:46 gave 46.76 %
+  #    hits and a 123.8 min `Build with CMake`; the same job restoring a 12:46 warm
+  #    at 18:10 gave 99.88 % and 19.6 min. The runs in between, 0.8-3.5 h after the
+  #    nightly, sat at 94.77-98.49 % and 30.3-38.3 min. The `push` trigger below
+  #    exists to keep the default-branch snapshot near master's head, and it runs
+  #    the BUILD ONLY -- the part that produces the cache.
+  #
+  #    WHAT A WARM COSTS, stated rather than hoped: one hosted windows-2025 job, and
+  #    NO extra cache entry. `save-cache-pruned` deletes the superseded entry on a
+  #    confirmed save, so each lineage still holds one entry per ref and the store
+  #    total is unchanged (docs/agent-rules/actions-cache-budget.md). The rest is
+  #    bounded by `cancel-in-progress` being FALSE for a push: GitHub keeps at most
+  #    one PENDING run per concurrency group and cancels the previous pending one,
+  #    so a burst of merges collapses to the run in flight plus the newest commit
+  #    rather than a queue of twelve. Nothing starves, because the run in flight is
+  #    never the one cancelled.
   #
   # The cron therefore has to run to COMPLETION, which is what the
   # `cancel-in-progress` expression below guarantees by excluding non-PR events.
@@ -46,6 +67,30 @@ on:
       - '.markdownlint-cli2.jsonc'
       - '.gitignore'
 
+  # THE CACHE WARM (#1084). Build only: `tests`, `tests-verify` and every artifact
+  # step below are gated off on `github.event_name != 'push'`. Same paths-ignore as
+  # the PR trigger, because a docs-only merge changes no object and needs no warm.
+  #
+  # IT HAS TO BE THE DEFAULT BRANCH. An `actions/cache` entry written on a PR ref is
+  # readable by that one pull request, so a warm banked anywhere else is invisible to
+  # every other branch -- the same property that makes the nightly this workflow's
+  # only cache producer today, and the reason a `workflow_dispatch` on a feature
+  # branch cannot serve as the warmer.
+  #
+  # One piece of item 1's trade comes back with it: the merge commit is compiled and
+  # the three apps are smoke-launched within minutes of the merge, so a semantic
+  # conflict between two PRs that breaks the BUILD surfaces then rather than at
+  # 01:53. The tests still do not re-run; that half of the trade stands.
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.claude/**'
+      - '.markdownlint-cli2.jsonc'
+      - '.gitignore'
+
   schedule:
     - cron: '53 1 * * *' # nightly 01:53 UTC — off the on-the-hour surge, and clear
                          # of the Sanitizers nightly (01:23) and cross-vendor (03:47).
@@ -54,13 +99,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # THE EVENT NAME IS PART OF THE GROUP (#1084). A `push` warm and the `schedule`
+  # nightly both run on `refs/heads/master`, so without it they share one group --
+  # and because `cancel-in-progress` is false for both, GitHub would hold the nightly
+  # PENDING behind a warm and then cancel it as soon as the next merge landed, since
+  # a group keeps at most one pending run. The nightly is the full test run and must
+  # never be cancelled, so the two lanes are kept apart. Splitting `workflow_dispatch`
+  # off as well is the same reasoning applied to a dispatch fired beside either.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   # PULL REQUESTS ONLY. A cancelled run banks no cache -- `actions/cache/save` runs
   # `if: always()`, which survives a cancel, but the run still stops mid-build, so
-  # what it banks is a partial snapshot at best. The nightly is this workflow's only
-  # default-branch cache producer (see the trigger note above), so it must never be
-  # cancellable. Under the old expression a `push` run was cancellable too, which is
-  # how the master sccache snapshot came to be six days stale while every PR run
+  # what it banks is a partial snapshot at best. The nightly and the `push` warm are
+  # this workflow's default-branch cache producers (see the trigger note above), so
+  # neither may be cancellable. That is history, not caution: while a `push` run WAS
+  # cancellable, the master sccache snapshot went six days stale and every PR run
   # restored it and reported a 0% hit rate.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -177,14 +229,17 @@ jobs:
     # high enough that it must not land on a box already running Linux sanitizer jobs
     # by accident, and a distinct label is the only thing that prevents it.
     #
-    # THE NIGHTLY STAYS HOSTED, deliberately, and for the same reason the Linux
-    # sanitizers keep theirs there: it is this workflow's ONLY fleet-wide cache
-    # warmer. actions/cache entries created on a PR branch are scoped to that ref;
-    # only default-branch entries are readable by every branch. Route the cron to the
-    # box and the hosted fallback -- every fork PR, and every run with the switch off
-    # -- goes permanently cold.
+    # THE NIGHTLY AND THE PUSH WARM STAY HOSTED, deliberately, and for the same
+    # reason the Linux sanitizers keep theirs there: they are this workflow's only
+    # fleet-wide cache warmers. actions/cache entries created on a PR branch are
+    # scoped to that ref; only default-branch entries are readable by every branch.
+    # Route either to the box and the hosted fallback -- every fork PR, and every run
+    # with the switch off -- goes permanently cold. The failure would be silent: every
+    # sccache step here is gated on `runner.environment == 'github-hosted'`, so a warm
+    # routed to the box banks NOTHING to the shared store and still reports success.
     runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
                  && github.event_name != 'schedule'
+                 && github.event_name != 'push'
                  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
                  && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
 
@@ -225,7 +280,10 @@ jobs:
         python -m pip install jinja2==3.1.6
         python -c "import jinja2; print(f'jinja2 {jinja2.__version__} installed at {jinja2.__file__}')"
     
+    # `id: vulkan` so the sccache key below can carry the version this action
+    # actually installed -- see the restore step for why it has to.
     - name: Setup Vulkan SDK
+      id: vulkan
       uses: ./.github/actions/setup-vulkan
 
     # We build with the Ninja generator (not the default Visual Studio generator)
@@ -348,6 +406,30 @@ jobs:
     # against a snapshot taken six days earlier. `runs-on` is pinned to the same
     # image; when it is bumped, bump this string with it so the dead entries age
     # out instead of being restored forever.
+    #
+    # AND IT CARRIES THE VULKAN SDK VERSION (#1084), for the reason asan.yml's key
+    # has carried it since #1118: sccache hashes the PREPROCESSED output, so every TU
+    # that reaches a Vulkan header changes when the SDK does. Without the stamp this
+    # key restores a pre-bump entry cleanly and then misses on all of those -- the
+    # measured shape on PR #1112's ASan build, 923 misses of 1588 under a
+    # `-1.4.321.0` key while the same log said `found version "1.4.357"`.
+    #
+    # WHAT IS AND IS NOT MEASURED HERE, because #1084 walked this back once. Run
+    # 34302705537 restored the 09-08 nightly (`VULKAN_SDK_VERSION: 1.4.321.0`) and
+    # returned 4.09 % against 94.8-98.5 % on stamped runs -- but that entry was ~22 h
+    # and ~50 commits old, and 8 h of drift alone was later measured at ~50 points of
+    # hit rate. So the version mismatch is confirmed by key shape and by the two
+    # versions in the logs; its SHARE of that 4.09 % is not, and the payoff cannot be
+    # measured until the next SDK bump. This is a key-shape bug fixed on its own
+    # terms, not a lever with a number on it.
+    #
+    # `restore-keys` carries the version too, deliberately, and that is the half that
+    # does the work: a bare `sccache-windows-2025-release-` fallback would keep
+    # finding the pre-bump entry and reproduce the half-stale restore above. The cost
+    # is ONE cold build per SDK bump, taken visibly -- and cache-prune.yml strips a
+    # trailing `-vk<version>` when it groups, so the bump supersedes the old entry
+    # rather than stranding 2044 MiB of it for thirty days. That same strip is what
+    # collects the unstamped lineage this rename leaves behind.
     - name: Restore sccache storage
       # HOSTED ONLY (#1076). On a persistent runner the sccache directory below is on
       # local disk and simply stays there between runs: no upload, no download, no
@@ -357,9 +439,9 @@ jobs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-windows-2025-release-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-windows-2025-release-vk${{ steps.vulkan.outputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          sccache-windows-2025-release-
+          sccache-windows-2025-release-vk${{ steps.vulkan.outputs.version }}-
 
     # Third-party dependencies come from the vcpkg manifest (vcpkg.json) since
     # issue #773. Ports are restored from the Actions-backed binary cache; only a
@@ -444,6 +526,25 @@ jobs:
       if: always()
       run: sccache --show-stats
 
+    # WHICH TUs MISSED, NOT HOW MANY (#1084). A hit rate is the wrong metric for this
+    # build and the numbers say so: 99.88 % (2 misses of 1668) built in 19.6 min while
+    # 98.49 % (25 misses of 1661) took 30.3 -- 1.4 points worth ten minutes, because
+    # the two `OloEditor/src/MCP/Mcp*.cpp` objects are ~5.4 min SERIALIZED at the very
+    # end of the build. Whether those particular TUs hit decides the tail on its own,
+    # and `--show-stats` cannot tell you. `.ninja_log` can: it records a start and end
+    # millisecond per edge, so the report below turns the tail into a number on every
+    # run instead of a log-forensics exercise after the fact.
+    #
+    # A REPORT, NOT A GATE. Edge timings move with runner variance and a threshold on
+    # them would go red for reasons nobody could act on. It writes to the job summary
+    # so the number is on the run page rather than buried in a 60 MB log.
+    - name: Report the build tail
+      if: always()
+      shell: pwsh
+      run: >
+        & "${{github.workspace}}/scripts/Report-NinjaBuildTail.ps1"
+        -BuildDir "${{github.workspace}}/build"
+
     # Paired with the restore above (#1009). `if: always()` is the point: the
     # combined actions/cache action saves in a POST-JOB step, and post-job steps
     # do NOT run when a job is cancelled -- which is how most PR runs in this repo
@@ -469,7 +570,7 @@ jobs:
       uses: ./.github/actions/save-cache-pruned
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: sccache-windows-2025-release-${{ github.run_id }}-${{ github.run_attempt }}
+        key: sccache-windows-2025-release-vk${{ steps.vulkan.outputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     # Banked here rather than by the combined actions/cache action's post-job
@@ -599,6 +700,10 @@ jobs:
     # *_tests.cmake), so this launches no test process and costs seconds.
     - name: Measure the unsharded case count
       id: ctest-total
+      # NOT ON THE CACHE WARM (#1084). A `push` run exists to bank the sccache
+      # entry; everything from here to the end of the job feeds the test shards or
+      # publishes an artifact, and no shard runs on a warm.
+      if: github.event_name != 'push'
       shell: bash
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       run: |
@@ -648,6 +753,7 @@ jobs:
     # is exactly the assumption that turns into a silent 100 %-skip later, so the
     # shard asserts it rather than trusting it.
     - name: Record the build workspace for the shards
+      if: github.event_name != 'push'
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
@@ -678,6 +784,7 @@ jobs:
     #
     # retention-days 1: scratch, not a deliverable.
     - name: Upload the test tree
+      if: github.event_name != 'push'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: windows-test-tree
@@ -701,6 +808,7 @@ jobs:
     # this flag drives so the rest of the suite (already run above) doesn't
     # execute a second time.
     - name: Bake shader pack (issue #908)
+      if: github.event_name != 'push'
       shell: pwsh
       working-directory: ${{github.workspace}}
       run: |
@@ -710,6 +818,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Shader pack bake failed (exit $LASTEXITCODE)" }
 
     - name: Upload shader pack artifact
+      if: github.event_name != 'push'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ShaderPack
@@ -734,6 +843,11 @@ jobs:
   tests:
     name: Windows tests ${{ matrix.shard }}/3
     needs: build
+    # NOT ON THE CACHE WARM (#1084). A `push` run builds and banks the sccache entry
+    # and stops there; the suite already ran on the pull request that produced this
+    # merge commit, and re-running it per merge is the ~1,400 runner-min/day #1009
+    # removed. The nightly is still the full run.
+    if: github.event_name != 'push'
     # THE SHARDS FOLLOW THE BUILD JOB, and they have to: gtest_discover_tests bakes
     # the absolute exe and WORKING_DIRECTORY paths into the generated test list, and
     # a self-hosted runner's `_work` tree is not at the hosted runner's path. The
@@ -1016,7 +1130,9 @@ jobs:
     # killed mid-flight, and `always()` would then run this job and post a red
     # "a shard did not complete" on a run nobody abandoned for a reason worth
     # reading. Braced because a bare leading `!` is a YAML tag indicator.
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    # `github.event_name != 'push'` for the same reason `tests` carries it: on a
+    # cache warm there are no shards, so there is no coverage to prove.
+    if: ${{ !cancelled() && needs.build.result == 'success' && github.event_name != 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,7 +1,10 @@
 name: Sanitizers
 on:
-  # NO `push: [master]` -- deliberately, and replaced by the nightly cron below
-  # (#1009 item E). Two things are going on and the second is the easy one to miss.
+  # NO FULL `push: [master]` RUN -- deliberately, and replaced by the nightly cron
+  # below (#1009 item E). What a master push DOES get, since #1084, is the
+  # `asan-windows` build job on its own as a cache warm: no shards, no Linux
+  # sanitizers, no test tree. Two things are going on and the second is the easy one
+  # to miss.
   #
   # 1. It was mostly a second opinion on identical code. GitHub's `pull_request`
   #    event builds `refs/pull/N/merge` -- the PR merged into master -- so by the
@@ -23,6 +26,25 @@ on:
   #    master trigger outright and no PR could ever restore a warm cache again --
   #    a change that reads as a pure saving and is in fact the opposite.
   #
+  #    ONE WARM A DAY IS NOT ENOUGH (#1084). The snapshot decays with SOURCE DRIFT,
+  #    not with the clock, and this repo merges ~12 pull requests a day. Windows.yml
+  #    carries the measurement -- its binding step ran 123.8 min off an eight-hour-old
+  #    nightly and 19.6 min off a five-hour-old warm on the same afternoon -- and the
+  #    trigger note there owns the full reasoning and the cost.
+  #
+  #    THIS JOB IS WARMED FOR A SPECIFIC REASON, not for symmetry. The two Windows
+  #    jobs are within 6-8 min of each other on a warm PR, so whichever one is colder
+  #    binds the wait. Warming only Windows.yml would hand the critical path to this
+  #    one every afternoon. Its afternoon hit rate has never been sampled, which is
+  #    the honest state: the exposure is structural (same store, same daily producer,
+  #    same drift), the number is not measured.
+  #
+  #    ONLY `asan-windows` runs on a push. The three Linux sanitizer jobs are
+  #    self-hosted and cache on the box's local disk, so a warm would buy them
+  #    nothing -- and they are the run's largest wait already (queue p90 128 min,
+  #    max 304), so putting twelve more of them a day into that queue would be a
+  #    straight loss.
+  #
   # The cron therefore has to run to COMPLETION, which is what the
   # `cancel-in-progress` expression below guarantees by excluding non-PR events.
   pull_request:
@@ -31,6 +53,18 @@ on:
       - 'docs/**'
       - '**/*.md'
       - 'LICENSE'
+
+  # THE CACHE WARM (#1084) -- `asan-windows` only; every other job below is gated off
+  # on `github.event_name != 'push'`. It has to be the DEFAULT BRANCH: an
+  # `actions/cache` entry written on a PR ref is readable by that one pull request,
+  # so a warm banked anywhere else is invisible to every other branch.
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+
   schedule:
     - cron: '23 1 * * *' # nightly 01:23 UTC — off the on-the-hour surge, and clear
                          # of gpu-conformance (00:47) and cross-vendor (03:47).
@@ -64,12 +98,17 @@ concurrency:
   # flake. Keyed on the input, the two arms are independent runs.
   # `only` is in the key for the same reason `force_hosted` is (below): a TSan-only
   # dispatch fired beside a full one on the same ref must not cancel it.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.force_hosted || 'default' }}-${{ github.event.inputs.only || 'all' }}
+  # `github.event_name` is in the key for a third instance of the same reason: the
+  # `push` warm and the `schedule` nightly both run on `refs/heads/master`, and since
+  # neither is cancellable they would share one group -- where a group holds at most
+  # one PENDING run, so the next merge would cancel the pending nightly. The nightly
+  # is the full sanitizer run and must never be cancelled.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}-${{ github.event.inputs.force_hosted || 'default' }}-${{ github.event.inputs.only || 'all' }}
   # PULL REQUESTS ONLY. A cancelled run banks no cache -- `actions/cache/save` runs
   # `if: always()`, which survives a cancel, but the run still stops mid-build, so
-  # what it banks is a partial snapshot at best. The nightly is this workflow's only
-  # default-branch cache producer (see the trigger note above), so it must never be
-  # cancellable. Under the old expression a `push` run was cancellable too, which is
+  # what it banks is a partial snapshot at best. The nightly and the `push` warm are
+  # this workflow's default-branch cache producers (see the trigger note above), so
+  # neither may be cancellable. Under the old expression a `push` run was cancellable too, which is
   # how the master sccache snapshot came to be six days stale while every PR run
   # restored it and reported a 0% hit rate.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -279,8 +318,14 @@ jobs:
     # the entire cache in one step -- silently, because it still restores and the
     # build still goes green. The key below carries the image string for the same
     # reason; when `runs-on` is bumped, bump it with it.
+    #
+    # `!= 'push'` alongside `!= 'schedule'` (#1084): both are cache warms for the whole
+    # fleet, and every sccache step here is gated on
+    # `runner.environment == 'github-hosted'`, so a warm routed to the box would bank
+    # nothing to the shared store and still report success.
     runs-on: ${{ vars.OLO_WINDOWS_SELF_HOSTED == 'true'
                  && github.event_name != 'schedule'
+                 && github.event_name != 'push'
                  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
                  && fromJSON('["self-hosted","windows","x64","olo-ci-win"]') || 'windows-2025' }}
 
@@ -712,6 +757,9 @@ jobs:
     # launches no test process and costs seconds.
     - name: Measure the unsharded case count
       id: ctest-total
+      # NOT ON THE CACHE WARM (#1084). A `push` run exists to bank the sccache entry;
+      # this step and the two below feed the shards, and no shard runs on a warm.
+      if: github.event_name != 'push'
       shell: bash
       working-directory: ${{github.workspace}}/build/OloEngine/tests
       run: |
@@ -757,6 +805,7 @@ jobs:
     #     in practice -- but "in practice" is exactly the kind of assumption that
     #     turns into a silent 100 %-skip later, so the shard asserts it.
     - name: Package the instrumented test tree
+      if: github.event_name != 'push'
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
@@ -788,6 +837,7 @@ jobs:
     # retention-days 1: this is scratch, not a deliverable. A multi-hundred-MB
     # artifact per run held for 90 days is a storage bill for nothing.
     - name: Upload the instrumented test tree
+      if: github.event_name != 'push'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: asan-windows-test-tree
@@ -819,6 +869,10 @@ jobs:
   asan-windows-tests:
     name: ASan (Windows) tests ${{ matrix.shard }}/4
     needs: asan-windows
+    # NOT ON THE CACHE WARM (#1084). A `push` run builds and banks the sccache entry
+    # and stops there; the suite already ran on the pull request that produced this
+    # merge commit. The nightly is still the full run.
+    if: github.event_name != 'push'
     # THE SHARDS FOLLOW THE BUILD JOB (#1076 x #1083). gtest_discover_tests bakes the
     # absolute exe and WORKING_DIRECTORY paths into the generated test list, so a
     # shard on a different runner kind would be pointing at a path that is not there.
@@ -1092,7 +1146,10 @@ jobs:
     # killed mid-flight, and `always()` would then run this job and post a red
     # "a shard did not complete" on a run nobody abandoned for a reason worth
     # reading. Braced because a bare leading `!` is a YAML tag indicator.
-    if: ${{ !cancelled() && needs.asan-windows.result == 'success' }}
+    # `github.event_name != 'push'` for the same reason the shards carry it: on a
+    # cache warm there are no shards, so there is no coverage to prove -- and without
+    # this clause the job would run and post a red "no shard reports found".
+    if: ${{ !cancelled() && needs.asan-windows.result == 'success' && github.event_name != 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1165,7 +1222,11 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+    # `!= 'push'`: the cache warm (#1084) runs `asan-windows` alone. This job is
+    # self-hosted and caches on the box's local disk, so a warm would bank nothing --
+    # it would only add to the queue that is already this run's largest wait.
+    if: ${{ github.event_name != 'push'
+        && (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
         && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'asan-lsan') }}
     # SELF-HOSTED WHEN THE CODE IS OURS, hosted Ubuntu when it is not -- the same
     # expression as vulkan-off.yml, whose comment owns the security reasoning:
@@ -1707,7 +1768,11 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+    # `!= 'push'`: the cache warm (#1084) runs `asan-windows` alone. This job is
+    # self-hosted and caches on the box's local disk, so a warm would bank nothing --
+    # it would only add to the queue that is already this run's largest wait.
+    if: ${{ github.event_name != 'push'
+        && (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
         && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'ubsan') }}
     # Routed exactly like asan-lsan-linux -- the reasoning, the security boundary
     # and the `force_hosted` A/B live on that job. Keep the three expressions
@@ -2103,7 +2168,11 @@ jobs:
       # thing it is meant to check is not a check.
       ctest-total: ${{ steps.ctest-total.outputs.total }}
     needs: detect-changes
-    if: ${{ (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
+    # `!= 'push'`: the cache warm (#1084) runs `asan-windows` alone. This job is
+    # self-hosted and caches on the box's local disk, so a warm would bank nothing --
+    # it would only add to the queue that is already this run's largest wait.
+    if: ${{ github.event_name != 'push'
+        && (github.event_name != 'pull_request' || needs.detect-changes.outputs.native == 'true')
         && (github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'tsan') }}
     # 180, not 120, not 90: the same cold-cache loop, measured twice.
     #

--- a/docs/agent-rules/actions-cache-budget.md
+++ b/docs/agent-rules/actions-cache-budget.md
@@ -44,6 +44,20 @@ Issue [#1073](https://github.com/drsnuggles8/OloEngineBase/issues/1073).
    worst case, not from the set. Both halves, measured, with the arithmetic:
    [sccache-cap-vs-object-set.md](sccache-cap-vs-object-set.md).
 
+7. **A cache is only as warm as its producer's cadence, and only a default-branch run
+   is a producer.** The snapshot decays with **source drift**, not with the clock, so
+   size the cadence against the merge rate — ~12 a day here. One nightly was not
+   enough: restoring the 04:39 nightly at 12:46 gave **46.76 %** hits and a
+   **123.8 min** build, restoring a 12:46 warm at 18:10 gave **99.88 %** and
+   **19.6 min** (#1084, same job, same afternoon). Warming spends runner time, not
+   cap — *Warming costs runner time, not cap*, below.
+8. **Judge a warm by WHICH translation units hit, not by the hit rate.** 99.88 %
+   (2 misses of 1668) built in 19.6 min; 98.49 % (25 misses of 1661) took 30.3, because
+   the `OloEditor/src/MCP/Mcp*.cpp` objects are ~5.4 min and run serialized at the end.
+   `sccache --show-stats` cannot answer that;
+   [`scripts/Report-NinjaBuildTail.ps1`](../../scripts/Report-NinjaBuildTail.ps1) reads
+   it out of `.ninja_log` on every `Windows / build` run.
+
 ---
 
 ## What happened
@@ -187,7 +201,7 @@ before compression:
 | `Windows-vulkan-prebuilt-sdk-true-1.4.357.0` **and** `-1.4.321.0` | **256 + 229 MiB measured** 2026-09-09 — **one dependency, two live entries.** This is the version-in-the-key case rule 6's bullet list warns about: `cache-prune.yml` strips a trailing *hex* hash, and `1.4.321.0` is not hex, so the bump superseded nothing and the old entry sits until the 30-day age-out collects it (created 2026-07-07, last read 2026-09-08). 485 MiB for one SDK is the measured price of that key shape. |
 | `ffmpeg-Windows-n7.1-637be53f…` | **4 MiB, and dead.** Its hash no longer matches any workflow, so nothing will ever restore it; the age-out collects it. The FFmpeg cache had in fact **never been saved on any run** — the path cached was not the path CMake installs into, so every save exited zero on a `Path Validation Error` (#1141). The working lineage that replaces it is keyed `ffmpeg-<os>-<hash of build-ffmpeg.sh + cmake/ffmpeg.cmake>` and banks ~19 MB uncompressed. |
 | **measured subtotal** | **1813 MiB** (4 + 229 + 256 + 291 + 327 + 706), measured 2026-09-09 |
-| `sccache-windows-2025-release` | **2044 MiB** — measured 2026-09-08 and again 2026-09-09. At its 2 G cap and evicting. Warm PR runs return 94.77 / 95.01 / 98.49 %, so the cap is not currently costing much, but it has no headroom left either. |
+| `sccache-windows-2025-release-vk<sdk>` | **2044 MiB** — measured 2026-09-08 and again 2026-09-09 under the key's old, unstamped spelling. At its 2 G cap and evicting. Warm PR runs return 94.77 / 95.01 / 98.49 %, so the cap is not currently costing much, but it has no headroom left either. **#1084 put the Vulkan SDK version in the key**, mirroring what #1118 did to the ASan sibling and for the same reason: sccache hashes the preprocessed output, so a key without the stamp restores a pre-bump entry cleanly and misses on every TU that reaches a Vulkan header. Two consequences for this table. The rename starts a **fresh lineage**, so the first stamped entry holds one build's objects rather than an accumulation — expect it to measure *under* 2044 MiB at first, as `sccache-asan-windows-2025` did (1230 → 667 MiB), and do not read that drop as a saving. And the unstamped predecessor is collected by `cache-prune.yml`'s `-vk<version>` strip, which groups both spellings together, rather than being stranded for thirty days. |
 | `sccache-asan-windows-2025-vk1.4.357.0` | **667 MiB measured** 2026-09-09 — down from **1230 MiB** on 2026-09-08, and the drop is the useful part. #1118 renamed the key to carry the SDK version, which started a **fresh lineage**: this entry holds one build's objects, where the old one had accumulated objects from many source generations in a single dir. **So an object set measured off a long-lived entry overstates what one build needs** — the `du -sm` 1241 MiB that rule 6's arithmetic used for this job was such a measurement. Its 1500M cap now has ~830 MiB spare. |
 | **steady set** | **7968 MiB measured** 2026-09-09 by summing `size_in_bytes` over the API listing, 11 entries (the floored rows above sum to 7964). Against a ~9537 MiB wall and `cache-prune.yml`'s 8800 MiB working ceiling that is **832 MiB of headroom to the ceiling** — down from 1738 MiB on 2026-09-08, because #1118's 1300M cap cost the sanitizer trio ~1200 MiB and the Vulkan SDK bump stranded another 229. **Against the 25 GB cap set the same day it is ~17 GB** (see *The cap moved*): the measurement stands, the "nothing sizeable can be added" conclusion it carried does not. What binds is `cache-prune.yml`'s working ceiling, **20000 MiB**, leaving this set **12032 MiB** of room. That headroom, not any object set, is what a cap has to be sized against — see [sccache-cap-vs-object-set.md](sccache-cap-vs-object-set.md). |
 
@@ -297,6 +311,33 @@ green check** — this section is what happens when that distinction is not made
 needed. Read `created_at`, `last_accessed_at` **and the hit rate** — the first two only
 tell you the entry is being written and read, not that it is worth anything.
 
+## Warming costs runner time, not cap
+
+#1084 added a build-only `push: master` run to `Windows.yml` (`build`) and `asan.yml`
+(`asan-windows`). It is worth being precise about which budget that spends, because the
+instinct is to check it against the cap and the cap is not what it touches.
+
+**Entries: unchanged.** Every key here ends in `-<run_id>-<attempt>` and is saved through
+`save-cache-pruned`, which deletes this ref's superseded entries under the same lineage
+prefix on a **confirmed save** — not only on a refused one. So the store holds one entry
+per (lineage, ref) whether that lineage is written once a day or fifteen times. Warming
+raises the **save rate**, and the save rate was never the thing the cap counted.
+
+**Runner time: one hosted `windows-2025` job per workflow per warm**, plus `asan.yml`'s
+seconds-long `detect-changes`. The shards, the test tree, the shader pack and the three
+self-hosted Linux sanitizer jobs are all gated off on `github.event_name != 'push'`. The
+Linux jobs are excluded on their own merits, not for tidiness: they cache on the box's
+local disk, so a warm would bank nothing, and their queue is already the largest single
+term in the per-PR wait (p90 128 min, max 304).
+
+**And the burst is bounded by concurrency, not by hope.** `cancel-in-progress` is false
+for a push, and a concurrency group holds at most one PENDING run — a third merge cancels
+the second's pending run and takes its place. So a burst of twelve merges collapses to
+"the warm in flight, plus the newest commit", and the run in flight is never the one
+cancelled, so nothing starves. The `push` and `schedule` lanes are kept in **separate**
+groups (`github.event_name` is part of the group) precisely so this cannot reach the
+nightly: sharing a group would let the next merge cancel a pending full test run.
+
 ## Who actually has a claim on the cap
 
 Measured 2026-09-06 by reading every workflow's triggers and `runs-on`. Rule 5 above only
@@ -310,6 +351,13 @@ suggest:
 | `dist-archive.yml / archive` | windows-2025 | only 4 paths (`CMakeLists.txt`, two `cmake/*.cmake`, its own file) | vcpkg only. A full Dist build with **no compiler cache**, and that is correct — a job that runs on a few percent of PRs should not hold ~2 GiB. |
 | `steam-stub.yml / single-valve-tu` | ubuntu-24.04 | only Steam-seam changes | none; it compiles one TU |
 | `pre-commit`, `detect-changes`, `cancel-merged-pr-runs` | ubuntu-latest | every PR | none; seconds |
+
+Rule 5 says the store exists for hosted jobs on a pull request, and the two `windows-2025`
+rows are the only ones that qualify. The **producers** of what those rows restore have a
+claim by extension and are not on this table because they never run on a PR: the nightly
+cron, and since #1084 the build-only `push: master` warm in the same two workflows. A
+producer that is throttled to protect the cap simply moves the cost onto every PR that
+restores what it did not write.
 
 The two `windows-2025` rows are conditional as of #1076: `Windows.yml` and `asan.yml` carry the
 routing to send them to a self-hosted runner behind `vars.OLO_WINDOWS_SELF_HOSTED`, and every

--- a/scripts/Report-NinjaBuildTail.ps1
+++ b/scripts/Report-NinjaBuildTail.ps1
@@ -92,52 +92,89 @@ try {
     exit 0
 }
 
-# `# ninja log vN` header, then one tab-separated record per edge:
+# `# ninja log vN` header, then one tab-separated record per OUTPUT:
 #   start_ms  end_ms  output_mtime  output_path  command_hash
 # Only edges ninja RAN this build are present, which is the right set: an edge ninja
 # skipped as up to date cost nothing. A compiler-cache hit is still a run edge -- the
 # launcher is the compiler as far as ninja is concerned -- so cache hits appear here
 # with their real, small durations, which is exactly what makes the tail readable.
-$edges = foreach ($line in $lines) {
+#
+# ONE RECORD PER OUTPUT IS NOT ONE RECORD PER EDGE, and this tree has multi-output
+# edges: gtest_discover_tests' POST_BUILD step writes the `*_tests.cmake` files beside
+# `OloEngine-Tests.exe`, so that one 109 s edge appends FOUR identical records. Summed
+# naively it is counted four times, and it took four of the five rows in the
+# last-to-finish table on the first local run of this script -- crowding out the very
+# tail the table exists to show. Group on (start, end, command hash), which is what an
+# edge is.
+$records = foreach ($line in $lines) {
     if ($line.Length -eq 0 -or $line[0] -eq '#') { continue }
     $f = $line.Split("`t")
     if ($f.Count -lt 4) { continue }
     $start = 0L; $end = 0L
     if (-not [long]::TryParse($f[0], [ref] $start)) { continue }
     if (-not [long]::TryParse($f[1], [ref] $end)) { continue }
+    # No command hash recorded -> fall back to the output path, which is unique per
+    # record. That makes the key unique too, so records are never merged on a guess:
+    # the failure direction is "reports an edge twice", not "silently drops one".
+    $hash = if ($f.Count -ge 5 -and $f[4]) { $f[4] } else { $f[3] }
     [pscustomobject]@{
-        Output   = $f[3]
-        Seconds  = [math]::Round(($end - $start) / 1000.0, 1)
-        EndSec   = [math]::Round($end / 1000.0, 1)
-        StartSec = [math]::Round($start / 1000.0, 1)
+        Output  = $f[3]
+        StartMs = $start
+        EndMs   = $end
+        Key     = '{0}:{1}:{2}' -f $start, $end, $hash
+    }
+}
+
+$records = @($records)
+if ($records.Count -eq 0) {
+    Write-Host "::warning::'$logPath' holds no edge records -- no build-tail report for this run."
+    exit 0
+}
+
+# MILLISECONDS ARE KEPT RAW HERE AND ROUNDED ONLY WHEN FORMATTED. Rounding each record
+# to a tenth before summing puts up to 0.05 s of error into every one of ~1700 rows --
+# over a minute on the total, on a figure whose whole job is to be compared between
+# runs.
+$edges = foreach ($g in ($records | Group-Object -Property Key)) {
+    $first = $g.Group[0]
+    [pscustomobject]@{
+        Output  = $first.Output
+        Outputs = @($g.Group | ForEach-Object { $_.Output })
+        Extra   = $g.Count - 1
+        DurMs   = $first.EndMs - $first.StartMs
+        EndMs   = $first.EndMs
     }
 }
 
 $edges = @($edges)
-if ($edges.Count -eq 0) {
-    Write-Host "::warning::'$logPath' holds no edge records -- no build-tail report for this run."
-    exit 0
-}
 
 # Ninja rewrites .ninja_log in place and keeps records from earlier builds in it, so
 # on an incremental tree the file spans more than one build. The span below is
 # therefore "the widest window these records cover", not necessarily one build's wall
 # clock; on CI, where the tree is created and built once, they are the same thing.
-$span = ($edges | Measure-Object -Property EndSec -Maximum).Maximum
-$busy = ($edges | Measure-Object -Property Seconds -Sum).Sum
+$span = ($edges | Measure-Object -Property EndMs -Maximum).Maximum / 1000.0
+$busy = ($edges | Measure-Object -Property DurMs -Sum).Sum / 1000.0
+
+# `+N more` rather than N rows: a multi-output edge is ONE unit of build time, and the
+# other outputs are worth knowing about without letting them fill the table.
+function Format-Output {
+    param($Edge, [string] $Name)
+    $label = if ($Name) { $Name } else { $Edge.Output }
+    if ($Edge.Extra -gt 0) { '`{0}` (+{1} more)' -f $label, $Edge.Extra } else { '`{0}`' -f $label }
+}
 
 Add-Line '## Build tail (`.ninja_log`)'
 Add-Line ''
-Add-Line ('{0} edges recorded, widest span {1:N1} min, {2:N1} min of edge time.' -f `
-    $edges.Count, ($span / 60.0), ($busy / 60.0))
+Add-Line ('{0} edges recorded ({1} output records), widest span {2:N1} min, {3:N1} min of edge time.' -f `
+    $edges.Count, $records.Count, ($span / 60.0), ($busy / 60.0))
 Add-Line ''
 
 Add-Line ('### Slowest {0} edges' -f $Top)
 Add-Line ''
 Add-Line '| sec | ends at (s) | output |'
 Add-Line '|---:|---:|---|'
-foreach ($e in ($edges | Sort-Object -Property Seconds -Descending | Select-Object -First $Top)) {
-    Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.Seconds, $e.EndSec, $e.Output)
+foreach ($e in ($edges | Sort-Object -Property DurMs -Descending | Select-Object -First $Top)) {
+    Add-Line ('| {0:N1} | {1:N1} | {2} |' -f ($e.DurMs / 1000.0), ($e.EndMs / 1000.0), (Format-Output $e))
 }
 Add-Line ''
 
@@ -147,20 +184,31 @@ Add-Line ('### Last {0} edges to finish' -f $Top)
 Add-Line ''
 Add-Line '| ends at (s) | sec | output |'
 Add-Line '|---:|---:|---|'
-foreach ($e in ($edges | Sort-Object -Property EndSec -Descending | Select-Object -First $Top)) {
-    Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.EndSec, $e.Seconds, $e.Output)
+foreach ($e in ($edges | Sort-Object -Property EndMs -Descending | Select-Object -First $Top)) {
+    Add-Line ('| {0:N1} | {1:N1} | {2} |' -f ($e.EndMs / 1000.0), ($e.DurMs / 1000.0), (Format-Output $e))
 }
 Add-Line ''
 
-$watched = @($edges | Where-Object { $_.Output -like $Watch } | Sort-Object -Property Seconds -Descending)
+# ANY output of the edge matching counts, and the matching one is what gets shown --
+# an edge whose first-recorded output is a `.cmake` stamp can still be the MCP compile
+# the pattern is looking for.
+$watched = @(
+    $edges |
+        ForEach-Object {
+            $hit = @($_.Outputs | Where-Object { $_ -like $Watch })[0]
+            if ($null -ne $hit) { $_ | Add-Member -NotePropertyName Match -NotePropertyValue $hit -Force -PassThru }
+        } |
+        Sort-Object -Property DurMs -Descending
+)
 Add-Line ('### Watched edges (`{0}`)' -f $Watch)
 Add-Line ''
 if ($watched.Count -eq 0) {
     Add-Line ('No edge output matched `{0}` in this build.' -f $Watch)
 } else {
-    $slow = @($watched | Where-Object { $_.Seconds -ge $SlowSeconds })
+    $slowMs = $SlowSeconds * 1000.0
+    $slow = @($watched | Where-Object { $_.DurMs -ge $slowMs })
     Add-Line ('{0} matched; {1} took {2}s or more, totalling {3:N1} min.' -f `
-        $watched.Count, $slow.Count, $SlowSeconds, (($slow | Measure-Object -Property Seconds -Sum).Sum / 60.0))
+        $watched.Count, $slow.Count, $SlowSeconds, (($slow | Measure-Object -Property DurMs -Sum).Sum / 60000.0))
     Add-Line ''
     # Capped at -Top. The pattern matches every MCP object in the tree, tests included,
     # and a 186-row table on the run page is not a report anyone reads. The count line
@@ -168,7 +216,7 @@ if ($watched.Count -eq 0) {
     Add-Line '| sec | ends at (s) | output |'
     Add-Line '|---:|---:|---|'
     foreach ($e in ($watched | Select-Object -First $Top)) {
-        Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.Seconds, $e.EndSec, $e.Output)
+        Add-Line ('| {0:N1} | {1:N1} | {2} |' -f ($e.DurMs / 1000.0), ($e.EndMs / 1000.0), (Format-Output $e $e.Match))
     }
     if ($watched.Count -gt $Top) {
         Add-Line ''

--- a/scripts/Report-NinjaBuildTail.ps1
+++ b/scripts/Report-NinjaBuildTail.ps1
@@ -1,0 +1,180 @@
+<#
+.SYNOPSIS
+  Report which Ninja edges the build actually spent its time on, and how much of that
+  time was serialized at the end.
+
+.DESCRIPTION
+  Issue #1084. A compiler-cache hit rate is the wrong metric for this build, and the
+  measurements say so: `Windows / build` at 99.88 % (2 misses of 1668) finished
+  `Build with CMake` in 19.6 min, while the same job at 98.49 % (25 misses of 1661)
+  took 30.3. One and a half points of hit rate was worth ten minutes, because the two
+  `OloEditor/src/MCP/Mcp*.cpp` objects are ~5.4 min and they run SERIALIZED at the very
+  end of the build. WHICH translation units miss decides the tail; how many miss does
+  not. `sccache --show-stats` reports only the count.
+
+  `.ninja_log` has what is missing. Ninja appends one line per edge it ran, with a
+  start and an end millisecond relative to the start of that build, so every question
+  above is arithmetic on a file the build already wrote. This script reads it and
+  prints three things: the slowest edges, the last edges to finish, and the duration
+  of every edge matching -Watch (the MCP objects by default).
+
+  It is a REPORT, not a gate. Edge timings move with runner variance, and a threshold
+  on them would go red for reasons nobody could act on. It writes the same tables to
+  $GITHUB_STEP_SUMMARY when that is set, so the numbers land on the run page instead of
+  in a 60 MB log.
+
+  It never fails the build. A missing or unreadable `.ninja_log` is reported as a
+  workflow warning -- loud and countable -- and the script still exits 0: a report that
+  turned a green build red would be strictly worse than the missing report.
+
+.PARAMETER BuildDir
+  The ninja build directory holding `.ninja_log`. Defaults to build-cached next to the
+  repository root.
+
+.PARAMETER Top
+  How many rows each of the two ranked tables carries. Default 12.
+
+.PARAMETER Watch
+  Wildcard pattern matched against each edge's output path. Every match is reported
+  with its duration regardless of rank. Default `*Mcp*`.
+
+.PARAMETER SlowSeconds
+  Duration at or above which a -Watch match is called out in the summary line as a real
+  compile rather than a cache hit. Default 30. Stated so the reader can disagree with
+  it; the table prints the durations either way.
+
+.EXAMPLE
+  pwsh -File scripts/Report-NinjaBuildTail.ps1 -BuildDir build
+#>
+[CmdletBinding()]
+param(
+    [string] $BuildDir = (Join-Path (Split-Path -Parent $PSScriptRoot) 'build-cached'),
+    [int]    $Top = 12,
+    [string] $Watch = '*Mcp*',
+    [double] $SlowSeconds = 30
+)
+
+# Continue, not Stop: every exit from this script is a report or a warning, never a
+# failure, so an unexpected error must not become one through the preference.
+$ErrorActionPreference = 'Continue'
+
+$summaryPath = $env:GITHUB_STEP_SUMMARY
+$summary = [System.Collections.Generic.List[string]]::new()
+
+function Add-Line {
+    param([string] $Text = '')
+    Write-Host $Text
+    $summary.Add($Text) | Out-Null
+}
+
+function Save-Summary {
+    if (-not $summaryPath) { return }
+    try {
+        Add-Content -Path $summaryPath -Value ($summary -join "`n") -Encoding utf8
+    } catch {
+        Write-Host "::warning::could not write the job summary: $($_.Exception.Message)"
+    }
+}
+
+$logPath = Join-Path $BuildDir '.ninja_log'
+if (-not (Test-Path -LiteralPath $logPath)) {
+    # Countable, not silent. The usual causes are a build that never reached ninja and
+    # a generator that is not ninja at all; both make every number below meaningless,
+    # so say which file was looked for rather than printing an empty table.
+    Write-Host "::warning::no .ninja_log at '$logPath' -- no build-tail report for this run."
+    exit 0
+}
+
+try {
+    $lines = [System.IO.File]::ReadAllLines($logPath)
+} catch {
+    Write-Host "::warning::could not read '$logPath': $($_.Exception.Message)"
+    exit 0
+}
+
+# `# ninja log vN` header, then one tab-separated record per edge:
+#   start_ms  end_ms  output_mtime  output_path  command_hash
+# Only edges ninja RAN this build are present, which is the right set: an edge ninja
+# skipped as up to date cost nothing. A compiler-cache hit is still a run edge -- the
+# launcher is the compiler as far as ninja is concerned -- so cache hits appear here
+# with their real, small durations, which is exactly what makes the tail readable.
+$edges = foreach ($line in $lines) {
+    if ($line.Length -eq 0 -or $line[0] -eq '#') { continue }
+    $f = $line.Split("`t")
+    if ($f.Count -lt 4) { continue }
+    $start = 0L; $end = 0L
+    if (-not [long]::TryParse($f[0], [ref] $start)) { continue }
+    if (-not [long]::TryParse($f[1], [ref] $end)) { continue }
+    [pscustomobject]@{
+        Output   = $f[3]
+        Seconds  = [math]::Round(($end - $start) / 1000.0, 1)
+        EndSec   = [math]::Round($end / 1000.0, 1)
+        StartSec = [math]::Round($start / 1000.0, 1)
+    }
+}
+
+$edges = @($edges)
+if ($edges.Count -eq 0) {
+    Write-Host "::warning::'$logPath' holds no edge records -- no build-tail report for this run."
+    exit 0
+}
+
+# Ninja rewrites .ninja_log in place and keeps records from earlier builds in it, so
+# on an incremental tree the file spans more than one build. The span below is
+# therefore "the widest window these records cover", not necessarily one build's wall
+# clock; on CI, where the tree is created and built once, they are the same thing.
+$span = ($edges | Measure-Object -Property EndSec -Maximum).Maximum
+$busy = ($edges | Measure-Object -Property Seconds -Sum).Sum
+
+Add-Line '## Build tail (`.ninja_log`)'
+Add-Line ''
+Add-Line ('{0} edges recorded, widest span {1:N1} min, {2:N1} min of edge time.' -f `
+    $edges.Count, ($span / 60.0), ($busy / 60.0))
+Add-Line ''
+
+Add-Line ('### Slowest {0} edges' -f $Top)
+Add-Line ''
+Add-Line '| sec | ends at (s) | output |'
+Add-Line '|---:|---:|---|'
+foreach ($e in ($edges | Sort-Object -Property Seconds -Descending | Select-Object -First $Top)) {
+    Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.Seconds, $e.EndSec, $e.Output)
+}
+Add-Line ''
+
+# The tail is what a serialized end-of-build costs, and it is only visible in FINISH
+# order: an edge can be slow and still free if it ran alongside a thousand others.
+Add-Line ('### Last {0} edges to finish' -f $Top)
+Add-Line ''
+Add-Line '| ends at (s) | sec | output |'
+Add-Line '|---:|---:|---|'
+foreach ($e in ($edges | Sort-Object -Property EndSec -Descending | Select-Object -First $Top)) {
+    Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.EndSec, $e.Seconds, $e.Output)
+}
+Add-Line ''
+
+$watched = @($edges | Where-Object { $_.Output -like $Watch } | Sort-Object -Property Seconds -Descending)
+Add-Line ('### Watched edges (`{0}`)' -f $Watch)
+Add-Line ''
+if ($watched.Count -eq 0) {
+    Add-Line ('No edge output matched `{0}` in this build.' -f $Watch)
+} else {
+    $slow = @($watched | Where-Object { $_.Seconds -ge $SlowSeconds })
+    Add-Line ('{0} matched; {1} took {2}s or more, totalling {3:N1} min.' -f `
+        $watched.Count, $slow.Count, $SlowSeconds, (($slow | Measure-Object -Property Seconds -Sum).Sum / 60.0))
+    Add-Line ''
+    # Capped at -Top. The pattern matches every MCP object in the tree, tests included,
+    # and a 186-row table on the run page is not a report anyone reads. The count line
+    # above covers the whole set; the table covers the part that costs anything.
+    Add-Line '| sec | ends at (s) | output |'
+    Add-Line '|---:|---:|---|'
+    foreach ($e in ($watched | Select-Object -First $Top)) {
+        Add-Line ('| {0:N1} | {1:N1} | `{2}` |' -f $e.Seconds, $e.EndSec, $e.Output)
+    }
+    if ($watched.Count -gt $Top) {
+        Add-Line ''
+        Add-Line ('{0} further matches not listed.' -f ($watched.Count - $Top))
+    }
+}
+
+Save-Summary
+exit 0


### PR DESCRIPTION
Takes #1084's two remaining open levers, batched, plus the measurement discipline the
umbrella exists to enforce. **#1084 is an umbrella and this does not close it** — see the
progress comment posted there.

## Lever 1 — the Vulkan SDK stamp on `sccache-windows-2025-release`

`asan.yml` has carried `-vk<version>` in its sccache key and its restore-keys prefix since
#1118; `Windows.yml` did not. sccache hashes the **preprocessed** output, so every TU that
reaches a Vulkan header changes when the SDK does, and an unstamped restore-keys prefix
keeps finding the pre-bump entry — restoring cleanly and missing on all of them.

`Windows.yml` now mirrors the `asan.yml` pattern exactly: key, restore-keys prefix and save
key, with `id: vulkan` on the setup step so the version comes from the action that installed
it rather than from a literal.

**What is not claimed.** #1084 offered this as the explanation for a 4.09 % run and then
walked it back, because that entry was ~22 h and ~50 commits old and 8 h of source drift
alone was later measured at ~50 points of hit rate. So: the exposure is confirmed by key
shape and by two different SDK versions in the two logs; its **share** of that 4.09 % is not
measured, and cannot be until the next SDK bump. This is a key-shape bug fixed on its own
terms, not a lever with a number on it.

`cache-prune.yml` already strips a trailing `-vk<version>` when it groups, so the rename
supersedes the unstamped lineage rather than stranding 2044 MiB of it for thirty days —
verified by running that workflow's own `sed` against both spellings.

## Lever 2 — warming cadence

The fleet was warmed once a day. The snapshot decays with **source drift**, not with the
clock, and this repo merged 8–21 PRs a day over the last fortnight (median 12, measured on
`git log --merges`). #1084's numbers, same job, same afternoon:

| run | started | restored | hit rate | `Build with CMake` |
|---|---|---|---|---|
| 34352951303 | 12:46 | the 04:39 nightly | 46.76 % | 123.8 min |
| 34355769151 | 13:13 | the 04:39 nightly | 46.76 % | 134.9 min |
| 34387372936 | 18:10 | the 12:46 warm | 99.88 % | 19.6 min |

`Windows.yml` and `asan.yml` now run their **build job alone** on a push to `master`. Not the
shards, not the test tree, not the shader pack, not the three Linux sanitizer jobs.

**Why a push and not a cron.** Drift is per-merge, so a per-merge trigger tracks the thing
that actually decays and spends nothing on a quiet day. It also covers the generated MCP TUs
by construction rather than by luck: a warm compiles the exact master tree, including
whatever OloHeaderTool generated from it, so the objects a PR based on that master needs are
the objects the warm banked.

**What it costs, stated rather than hoped.**

- **Cache entries: none added.** Every key ends in `-<run_id>-<attempt>` and is written
  through `save-cache-pruned`, which deletes the ref's superseded entry on a *confirmed*
  save. Warming raises the save rate; the cap never counted the save rate.
- **Runner time: one hosted `windows-2025` job per workflow per warm**, plus `asan.yml`'s
  seconds-long `detect-changes`.
- **Bursts are bounded by concurrency, not by hope.** `cancel-in-progress` is false for a
  push and a group holds at most one *pending* run, so a third merge cancels the second's
  pending run and takes its place. Twelve merges collapse to "the warm in flight, plus the
  newest commit", and the run in flight is never the one cancelled, so nothing starves.
- **The `push` and `schedule` lanes are separate concurrency groups.** Sharing one would let
  a merge cancel a *pending nightly*, which is the full test run.
- **Both stay hosted.** Every sccache step is gated on
  `runner.environment == 'github-hosted'`, so a warm routed to a self-hosted runner would
  bank nothing to the shared store and still report success. `runs-on` now excludes `push`
  alongside `schedule` for that reason, in both workflows.

The Linux sanitizer jobs are excluded on their merits, not for tidiness: they cache on the
box's local disk, so a warm banks nothing, and their queue is already the largest single term
in the per-PR wait (p90 128 min, max 304).

One thing comes back that #1009 traded away: the merge commit is compiled and the three apps
are smoke-launched within minutes of the merge, so a semantic conflict between two PRs that
breaks the **build** surfaces then instead of at 01:53. The tests still do not re-run.

## Measurement — `scripts/Report-NinjaBuildTail.ps1`

A hit rate is the wrong metric for this build. 99.88 % (2 misses of 1668) built in 19.6 min;
98.49 % (25 misses of 1661) took 30.3 — because the `OloEditor/src/MCP/Mcp*.cpp` objects are
~5.4 min and run serialized at the end, so whether *those* hit decides the tail on its own.
`sccache --show-stats` cannot answer that. `.ninja_log` can: it records a start and end
millisecond per edge.

The new step on `Windows / build` reports the slowest edges, the last edges to finish (where a
serialized tail is visible) and every edge matching `*Mcp*`, into the job summary. It is a
**report, not a gate** — edge timings move with runner variance — and it never fails the
build; a missing `.ninja_log` is a `::warning::`, loud and countable, with exit 0.

## Ride-along fix — `save-cache-pruned` ordering (own commit, `b0df1c689`)

Found by self-reviewing the workflow change before this PR existed. The prune deleted every
sibling of the lineage on the ref except its own key, with no ordering check. Two producers
writing one lineage on one ref can each delete the other's entry and leave the lineage with
**none**, and the last to finish wins regardless of which commit it built. That was close to
unreachable while a workflow's default-branch runs shared one non-cancellable group — only
one could be in flight — and the lane split in the first commit makes it reachable. The guard
is the run id already in the key: delete only entries whose run id is lower than this run's.

## Also

- `docs/agent-rules/actions-cache-budget.md`: two new rules (cadence, and judging a warm by
  *which* TUs hit), the `sccache-windows-2025-release-vk<sdk>` row rewritten for the rename
  and its fresh-lineage effect on size, and a *Warming costs runner time, not cap* section.
- **Four stale remote branches to delete, all yours to call:** `origin/ci-cap-discovery`,
  `origin/ci-cap-probe-du`, `origin/ci-ubsan-fix-verify`, `origin/ci-win-cap-control` — all
  2026-09-08 probe branches from the ASan sccache-cap investigation that #1118 concluded.
  They carry `saves off` probe configs and **must never be merged**.

## Expect this PR's own Windows build to be cold

`sccache-windows-2025-release-vk1.4.357.0-` has never been written, so this PR's
`Build with CMake` restores nothing. That is the one cold cycle the stamp costs, taken
visibly. It is also why the two levers are in one PR: the merge is itself a push to master, so
the warm it triggers banks the first stamped entry immediately instead of leaving every PR
cold until the next nightly.

## Review guide

**Where I'd look hardest**

1. `.github/workflows/Windows.yml:109` and `.github/workflows/asan.yml:106` — adding
   `github.event_name` to the concurrency group. It is what protects the nightly from being
   cancelled by a merge, and it is also what lets two default-branch producers overlap, which
   is the whole reason for the `save-cache-pruned` commit. If the reasoning about GitHub
   holding exactly one pending run per group is wrong, both halves of that trade change.
2. `.github/actions/save-cache-pruned/action.yml:255-276` — the ordering guard. It rests on
   run ids being assigned in increasing order. I chose the direction of the error
   deliberately: if that ever fails, it keeps an entry it could have deleted (collected by
   the next `cache-prune` sweep) rather than deleting one it should have kept.
3. The gating sweep — `tests`, `tests-verify`, `asan-windows-tests`,
   `asan-windows-tests-verify`, the three Linux sanitizer jobs, and the five artifact/`ctest -N`
   steps. A missed gate means a warm run does work nobody asked for, or posts a red
   "no shard reports found" on a job with no shards.

**What I verified, and how** — both workflows and the action parse (`yaml.safe_load`);
`actionlint` reports only one pre-existing warning that is present on `master` at
`Windows.yml:987`; every embedded bash step in the action passes `bash -n`; the ordering guard
was run against four key shapes including the attempt-less form and a re-run's second attempt;
`cache-prune.yml`'s prefix `sed` was run against the stamped key, the unstamped key and the
ASan sibling and collapses all three correctly; `steps.vulkan.outputs.version` was confirmed to
exist on `.github/actions/setup-vulkan`; `Report-NinjaBuildTail.ps1` was run against a real
1527-edge `.ninja_log` and against a missing directory, exiting 0 on both.

**Least confident about** — the *size* of the warming win as it will actually land. The 19.6 min
figure is one measured dispatch pair from #1084, not something I re-measured, and I have **no
afternoon sample of the ASan job's hit rate at all** — that job is warmed here because it is
structurally exposed the same way (same store, same daily producer, same drift) and because it
is within 6–8 min of the binding job, not because its decay was measured. The post-merge
numbers are what settle it, and they go on #1084.

**Deliberately not tested** — nothing here can be exercised locally; a `push: master` trigger and
a fleet-visible cache entry only exist after merge. I also did not add the build-tail report to
`asan.yml`, only to `Windows.yml` where the MCP tail was actually measured. And I did not touch
`cache-prune.yml`'s `headroom_floor_mib` (#1157 moved it) or anything to do with #1076.

Refs #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD**
  - Added build-only cache warming for pushes to `master` on Windows and AddressSanitizer workflows.
  - Improved cache isolation and retention for concurrent builds, including Vulkan SDK version tracking.
  - Nightly workflows continue to run full test and artifact-generation jobs.
  - Added build-tail reporting with summaries of slow and recently completed build tasks.
  - Improved cache pruning to prevent concurrent builds from removing newer cache entries.

- **Documentation**
  - Expanded cache-budget guidance with recommendations for source drift, cache warming, and Vulkan-versioned cache lineages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->