### PR TITLE
feat(automation): build invocation with structured results (#1163)

### DIFF
--- a/OloEditor/src/Automation/AutomationBuildCommands.cpp
+++ b/OloEditor/src/Automation/AutomationBuildCommands.cpp
@@ -1,0 +1,1490 @@
+#include "OloEnginePCH.h"
+#include "Automation/AutomationBuildCommands.h"
+
+#include "Automation/AutomationBuildInvocation.h"
+#include "Automation/AutomationCommand.h"
+#include "Automation/AutomationHost.h"
+#include "Automation/AutomationRegistry.h"
+#include "Automation/AutomationResult.h"
+#include "MCP/McpSchemaBuilder.h"
+
+#include "OloEngine/Core/Environment.h"
+#include "OloEngine/Core/Log.h"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#else
+#include <csignal>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+// Structured build invocation: olo_build_list and olo_build_run (issue #1163,
+// Epic H slice 3, deferred out of #1130).
+//
+// THE CONCURRENCY CONTRACT, which is the substance of this slice. Full
+// derivation in docs/agent-rules/automation-build-invocation.md; the four
+// answers, and where each is enforced:
+//
+//   1. ACQUIRE, never bypass. Every build goes through build-lock.ps1, with a
+//      bounded, caller-set wait (`lockWaitSeconds`, default 300) mapped onto
+//      the script's own -TimeoutMinutes. The script takes a queue ticket, so we
+//      never jump anyone; when the budget expires the script names the holder
+//      and that becomes the error. None of OLO_BUILD_LOCK_OVERRIDE,
+//      OLO_BUILD_LOCK_BYPASS or OLO_NOT_A_BUILD appears anywhere in this file:
+//      this command must not become a third, unaudited way to start a build.
+//
+//   2. THE EDITOR PROCESS IS THE LOCK IDENTITY. build-lock.ps1's parent watch
+//      reads Win32_Process.ParentProcessId of the pwsh it runs in, so whatever
+//      spawns pwsh is the identity. We spawn it DIRECTLY — no cmd /c, no
+//      launcher shim — so the identity is this editor, pinned by (pid,
+//      StartTime), and the lock reaps the build when the editor dies.
+//
+//   3. CANCELLATION KILLS THE TREE, NOT THE SHIM. Killing pwsh alone would
+//      release the lock (the OS closes its handle) while ninja and its
+//      compilers kept running unbounded — the exact shape the lock exists to
+//      prevent. So the child is created suspended, assigned to a Win32 job
+//      object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, and then resumed;
+//      cancelling terminates the JOB. That also covers what the parent watch
+//      cannot: an editor killed outright runs no cleanup, but the OS closes the
+//      job handle on process exit and the whole build dies with it. POSIX gets
+//      the same shape from a process group.
+//
+//   4. THE EDITOR MAY NOT BUILD ITSELF, and the refusal is an ALLOW-LIST.
+//      Windows keeps a running image mapped, so linking OloEditor.exe fails
+//      with LNK1168 after all the compile work; Mono holds
+//      OloEngine-ScriptCore's assembly. A deny-list would leak through `all` /
+//      `ALL_BUILD` / `install` and through any target added later. The
+//      allow-list is also the injection boundary: target, configuration and
+//      build directory are interpolated into a PowerShell command string, so
+//      each is resolved against a fixed table in AutomationBuildInvocation.h
+//      and nothing freehand ever reaches it.
+//
+// AND THE RULE THE WHOLE RESULT SHAPE EXISTS FOR: a zero exit code is not
+// evidence that anything was built. build-lock.ps1 stands down with exit 0 when
+// an identical command was queued later; an incremental build with nothing to
+// do also exits 0; and a build that never started leaves last week's binary
+// exactly where a caller looks. So the verdict comes from the ARTEFACT — stat'd
+// before and after, compared against the moment the build started — and the
+// three cases are reported as three different outcomes, never merged into
+// "success".
+
+namespace OloEngine::Automation
+{
+    namespace
+    {
+        namespace fs = std::filesystem;
+        using namespace OloEngine::Automation::BuildInvocation;
+        namespace Schema = OloEngine::MCP::Schema;
+
+        // The repo marker: the lock script itself. Anchoring on the very file we
+        // need means a root we "found" without one is not a root we can build
+        // from — and there is deliberately no fallback that builds anyway.
+        constexpr const char* kLockScriptRelative = ".claude/skills/run-oloengine/build-lock.ps1";
+
+        // How far up from the working directory to look. The editor runs with
+        // cwd = OloEditor/, so one level suffices; the margin covers a caller
+        // that launched it from deeper.
+        constexpr int kMaxRootSearchDepth = 8;
+
+        // Poll cadence while the child runs. Often enough that a cancellation is
+        // acted on promptly, rarely enough that re-reading a growing log costs
+        // nothing next to a compile.
+        constexpr auto kPollInterval = std::chrono::milliseconds(250);
+
+        // Console tail returned when a build fails. Big enough for a template
+        // error and the ninja edges around it.
+        constexpr sizet kConsoleTailChars = 8000;
+
+        // Progress is reported on one permille scale so it stays monotonic
+        // across the two phases: queueing for the lock, then building. Queueing
+        // gets the first 5% — it is a wait, not work.
+        constexpr i64 kProgressTotal = 1000;
+        constexpr i64 kProgressQueueCeiling = 50;
+
+        // Which artefact naming the tables expand to. One constant rather than an
+        // #ifdef at each use, so the two call sites cannot disagree.
+        constexpr bool kWindowsArtifacts =
+#ifdef _WIN32
+            true;
+#else
+            false;
+#endif
+
+        // Grace added to the child's own deadline beyond the caller's budget, so
+        // build-lock.ps1's timeout fires FIRST and we report its message (which
+        // names the holder) instead of a blunt "the child was killed".
+        constexpr auto kChildDeadlineGrace = std::chrono::seconds(90);
+
+        // ---- filesystem helpers -------------------------------------------
+
+        [[nodiscard]] std::string ReadWholeFile(const fs::path& path, bool& ok)
+        {
+            ok = false;
+            std::ifstream stream(path, std::ios::binary);
+            if (!stream)
+                return {};
+            std::ostringstream buffer;
+            buffer << stream.rdbuf();
+            ok = true;
+            return buffer.str();
+        }
+
+        [[nodiscard]] std::string FormatUtc(std::chrono::system_clock::time_point when)
+        {
+            const std::time_t epoch = std::chrono::system_clock::to_time_t(when);
+            std::tm utc{};
+#ifdef _WIN32
+            if (::gmtime_s(&utc, &epoch) != 0)
+                return {};
+#else
+            if (::gmtime_r(&epoch, &utc) == nullptr)
+                return {};
+#endif
+            std::ostringstream formatted;
+            formatted << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+            return formatted.str();
+        }
+
+        // Stat one artefact. `buildStart` is the instant the build command was
+        // launched: the difference between it and the artefact's mtime is what
+        // separates "this build produced it" from "it was already there", and
+        // that comparison is the whole anti-stale mechanism.
+        [[nodiscard]] ArtifactState StatArtifact(const fs::path& absolute, const std::string& reportedPath,
+                                                 std::chrono::system_clock::time_point buildStart)
+        {
+            ArtifactState state;
+            state.Path = reportedPath;
+
+            std::error_code ec;
+            if (!fs::is_regular_file(absolute, ec))
+                return state;
+            state.Exists = true;
+            state.SizeBytes = static_cast<u64>(fs::file_size(absolute, ec));
+            if (ec)
+                state.SizeBytes = 0;
+
+            const auto written = fs::last_write_time(absolute, ec);
+            if (ec)
+                return state;
+            const auto systemTime = std::chrono::clock_cast<std::chrono::system_clock>(written);
+            state.ModifiedUtc = FormatUtc(systemTime);
+            state.AgeRelativeToStartSeconds = std::chrono::duration<f64>(systemTime - buildStart).count();
+            return state;
+        }
+
+        // Walk up from the working directory looking for the lock script.
+        [[nodiscard]] bool FindRepoRoot(fs::path& outRoot, std::string& outError)
+        {
+            std::error_code ec;
+            fs::path cursor = fs::current_path(ec);
+            if (ec)
+            {
+                outError = "Cannot determine the working directory: " + ec.message();
+                return false;
+            }
+            std::string searched;
+            for (int depth = 0; depth < kMaxRootSearchDepth; ++depth)
+            {
+                if (!searched.empty())
+                    searched += ", ";
+                searched += cursor.generic_string();
+                if (fs::exists(cursor / kLockScriptRelative, ec))
+                {
+                    outRoot = cursor;
+                    return true;
+                }
+                const fs::path parent = cursor.parent_path();
+                if (parent.empty() || parent == cursor)
+                    break;
+                cursor = parent;
+            }
+            outError = std::string("Could not locate ") + kLockScriptRelative +
+                       " in any parent of the working directory (looked in " + searched +
+                       "). Every build in this repo goes through that script, so there is no build to start without "
+                       "it — this command will not fall back to an unlocked cmake.";
+            return false;
+        }
+
+        // The directory every worktree of this repo shares — where the build lock
+        // lives. A worktree's `.git` is a FILE holding `gitdir: <path>`; the
+        // common dir is that path's `commondir` if it has one, else itself.
+        // Resolved by reading rather than by shelling out to git: the answer is a
+        // path, and spawning a process to learn it would be a second, slower way
+        // to be wrong.
+        [[nodiscard]] bool FindGitCommonDir(const fs::path& repoRoot, fs::path& outDir)
+        {
+            std::error_code ec;
+            const fs::path dotGit = repoRoot / ".git";
+            if (fs::is_directory(dotGit, ec))
+            {
+                outDir = dotGit;
+                return true;
+            }
+            if (!fs::is_regular_file(dotGit, ec))
+                return false;
+
+            bool ok = false;
+            const std::string text = ReadWholeFile(dotGit, ok);
+            constexpr std::string_view kPrefix = "gitdir:";
+            if (!ok || !std::string_view(text).starts_with(kPrefix))
+                return false;
+            std::string target = text.substr(kPrefix.size());
+            while (!target.empty() && (target.back() == '\n' || target.back() == '\r' || target.back() == ' '))
+                target.pop_back();
+            while (!target.empty() && (target.front() == ' ' || target.front() == '\t'))
+                target.erase(target.begin());
+            if (target.empty())
+                return false;
+
+            fs::path worktreeGitDir(target);
+            if (worktreeGitDir.is_relative())
+                worktreeGitDir = repoRoot / worktreeGitDir;
+
+            // A linked worktree's gitdir holds a `commondir` pointing at the real
+            // one; the main checkout's does not.
+            const fs::path commonMarker = worktreeGitDir / "commondir";
+            if (fs::is_regular_file(commonMarker, ec))
+            {
+                bool commonOk = false;
+                std::string common = ReadWholeFile(commonMarker, commonOk);
+                while (!common.empty() && (common.back() == '\n' || common.back() == '\r' || common.back() == ' '))
+                    common.pop_back();
+                if (commonOk && !common.empty())
+                {
+                    fs::path resolved(common);
+                    if (resolved.is_relative())
+                        resolved = worktreeGitDir / resolved;
+                    outDir = fs::weakly_canonical(resolved, ec);
+                    if (ec)
+                        outDir = resolved;
+                    return true;
+                }
+            }
+            outDir = worktreeGitDir;
+            return true;
+        }
+
+        // Is a lock slot free right now? Probe with the same exclusive open the
+        // script's own acquire uses, then close it at once. A file's EXISTENCE
+        // says nothing — every slot file outlives its holder — so the handle is
+        // the only honest answer.
+        //
+        // Inherently a snapshot: someone can take the slot a microsecond later.
+        // It is reported, never acted on — olo_build_run always goes through the
+        // real acquire.
+        // std::nullopt means NOT MEASURED, which is not the same as free — a
+        // command that reported an unmeasured slot as available would be telling
+        // a caller something it never checked.
+        [[nodiscard]] std::optional<bool> IsSlotFree(const fs::path& slot)
+        {
+#ifdef _WIN32
+            std::error_code ec;
+            if (!fs::exists(slot, ec))
+                return true; // never held since the last reboot
+            const std::wstring wide = slot.wstring();
+            const HANDLE handle = ::CreateFileW(wide.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                                                FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (handle != INVALID_HANDLE_VALUE)
+            {
+                ::CloseHandle(handle);
+                return true;
+            }
+            // ONLY a sharing/lock violation means somebody holds it. Every other
+            // failure — an ACL that denies us write, the file vanishing between
+            // the exists() check and here — is a probe that did not measure
+            // anything, and reporting it as "held" would be the same conflation
+            // the POSIX branch below refuses to make.
+            const DWORD error = ::GetLastError();
+            if (error == ERROR_SHARING_VIOLATION || error == ERROR_LOCK_VIOLATION)
+                return false;
+            return std::nullopt;
+#else
+            // The script's ownership is a Windows exclusive file handle; there is
+            // no POSIX probe with the same meaning, and this command has no POSIX
+            // caller today. Unknown, said plainly.
+            (void)slot;
+            return std::nullopt;
+#endif
+        }
+
+        // ---- the PowerShell host ------------------------------------------
+
+        [[nodiscard]] bool ResolvePowerShell(fs::path& outPath, std::string& outError)
+        {
+#ifdef _WIN32
+            for (const wchar_t* candidate : { L"pwsh.exe", L"powershell.exe" })
+            {
+                wchar_t resolved[MAX_PATH]{};
+                const DWORD length = ::SearchPathW(nullptr, candidate, nullptr, MAX_PATH, resolved, nullptr);
+                if (length > 0 && length < MAX_PATH)
+                {
+                    outPath = fs::path(resolved);
+                    return true;
+                }
+            }
+            outError = "Neither pwsh.exe nor powershell.exe is on PATH, so build-lock.ps1 cannot be run. "
+                       "Install PowerShell 7 (the repo's documented prerequisite) or build from a shell.";
+            return false;
+#else
+            for (const char* candidate : { "/usr/bin/pwsh", "/usr/local/bin/pwsh", "/snap/bin/pwsh" })
+            {
+                std::error_code ec;
+                if (fs::is_regular_file(candidate, ec))
+                {
+                    outPath = fs::path(candidate);
+                    return true;
+                }
+            }
+            outError = "pwsh was not found, so build-lock.ps1 cannot be run.";
+            return false;
+#endif
+        }
+
+        // ---- the child process ---------------------------------------------
+
+        enum class ChildOutcome : u8
+        {
+            Exited = 0,  // ran to completion; ExitCode is meaningful
+            SpawnFailed, // never started
+            TimedOut,    // killed at our deadline
+            Cancelled,   // killed because the caller cancelled the call
+        };
+
+        [[nodiscard]] const char* ChildOutcomeName(ChildOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case ChildOutcome::Exited:
+                    return "exited";
+                case ChildOutcome::SpawnFailed:
+                    return "spawn-failed";
+                case ChildOutcome::TimedOut:
+                    return "timed-out";
+                case ChildOutcome::Cancelled:
+                    return "cancelled";
+            }
+            return "unknown";
+        }
+
+        struct ChildResult
+        {
+            ChildOutcome Outcome = ChildOutcome::SpawnFailed;
+            int ExitCode = -1;
+            std::string Error;
+            std::string Console;
+
+            [[nodiscard]] bool Completed() const
+            {
+                return Outcome == ChildOutcome::Exited;
+            }
+        };
+
+        // Emit progress from the growing console log, and answer whether the
+        // call has been cancelled. Shared by both platform branches so the two
+        // cannot drift on when a build is abandoned.
+        struct RunWatch
+        {
+            IAutomationHost* Host = nullptr;
+            fs::path ConsolePath;
+            std::chrono::steady_clock::time_point Started{};
+            std::chrono::seconds LockBudget{ 0 };
+            std::string Target;
+
+            [[nodiscard]] bool Tick()
+            {
+                if (Host == nullptr)
+                    return false;
+                ReportProgress();
+                return Host->IsCurrentCallCancelled();
+            }
+
+            // When the transcript first showed the lock acquired, i.e. where the
+            // wall time stops being a queue wait and starts being a build.
+            // Unset when the child finished between two polls, or never acquired.
+            [[nodiscard]] std::optional<std::chrono::steady_clock::time_point> AcquiredAt() const
+            {
+                return m_AcquiredAt;
+            }
+
+          private:
+            // Re-reads the WHOLE log each tick, unlike the test runner's
+            // append-only scan. A build log is a few hundred KB where a
+            // 7000-case test run is tens of megabytes, and the two signals here
+            // (the last ninja edge, and whether the lock has been acquired yet)
+            // are both "state at the end", not counts to accumulate.
+            void ReportProgress()
+            {
+                bool ok = false;
+                const std::string text = ReadWholeFile(ConsolePath, ok);
+                if (!ok)
+                    return;
+
+                const LockTranscript lock = ReadLockTranscript(text);
+                if (!m_AcquiredAt.has_value() && lock.Outcome == LockOutcome::Acquired)
+                    m_AcquiredAt = std::chrono::steady_clock::now();
+
+                i64 permille = 0;
+                std::string message;
+
+                if (lock.Outcome != LockOutcome::Acquired)
+                {
+                    // Still queued. The bar creeps across the first 5% with the
+                    // wait, which is honest about it being a wait rather than
+                    // pretending nothing is happening.
+                    const f64 waited = std::chrono::duration<f64>(std::chrono::steady_clock::now() - Started).count();
+                    const f64 budget = std::max<f64>(1.0, static_cast<f64>(LockBudget.count()));
+                    permille = static_cast<i64>(std::min(1.0, waited / budget) * static_cast<f64>(kProgressQueueCeiling));
+                    message = "queued for the build lock";
+                    if (lock.HeldByPid > 0)
+                    {
+                        message += " (held by pid " + std::to_string(lock.HeldByPid);
+                        if (!lock.HeldByWorktree.empty())
+                            message += " in " + lock.HeldByWorktree;
+                        message += ")";
+                    }
+                }
+                else if (const BuildProgress build = ReadLastNinjaProgress(text); build.Known())
+                {
+                    permille = kProgressQueueCeiling +
+                               static_cast<i64>((static_cast<f64>(build.Done) / static_cast<f64>(build.Total)) *
+                                                static_cast<f64>(kProgressTotal - kProgressQueueCeiling));
+                    message = "building " + Target + " — " + std::to_string(build.Done) + "/" +
+                              std::to_string(build.Total) + " steps";
+                }
+                else
+                {
+                    // Acquired, but nothing countable yet — the MSVC generator
+                    // prints no edge counter at all, so this is its steady state
+                    // rather than a transient. Report the phase, not a fraction.
+                    permille = kProgressQueueCeiling;
+                    message = "building " + Target;
+                }
+
+                // Clamped monotonic: EmitProgress requires a non-decreasing
+                // value per call, and ninja's total can be revised downward
+                // mid-build when edges turn out to be up to date.
+                permille = std::clamp(permille, m_LastPermille, kProgressTotal);
+                if (m_EverEmitted && permille == m_LastPermille && message == m_LastMessage)
+                    return; // nothing new to say; EmitProgress must not go backwards or repeat
+
+                m_LastPermille = permille;
+                m_LastMessage = message;
+                m_EverEmitted = true;
+                Host->EmitProgress(static_cast<f64>(permille), static_cast<f64>(kProgressTotal), message);
+            }
+
+            i64 m_LastPermille = 0;
+            std::string m_LastMessage;
+            bool m_EverEmitted = false;
+            // Observed by the same poll that reports progress — there is no
+            // second place the acquire becomes visible.
+            std::optional<std::chrono::steady_clock::time_point> m_AcquiredAt;
+        };
+
+#ifdef _WIN32
+        [[nodiscard]] std::wstring Widen(const std::string& utf8)
+        {
+            if (utf8.empty())
+                return {};
+            const int length = ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+            if (length <= 0)
+                return {};
+            std::wstring wide(static_cast<sizet>(length), L'\0');
+            ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide.data(), length);
+            wide.resize(static_cast<sizet>(length - 1)); // drop the NUL the API appended
+            return wide;
+        }
+
+        // Owns the job object the build tree lives in. Closing it kills every
+        // process still inside — which is the point: see contract note 3.
+        class KillOnCloseJob
+        {
+          public:
+            KillOnCloseJob()
+            {
+                m_Handle = ::CreateJobObjectW(nullptr, nullptr);
+                if (m_Handle == nullptr)
+                    return;
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+                limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                if (!::SetInformationJobObject(m_Handle, JobObjectExtendedLimitInformation, &limits, sizeof(limits)))
+                {
+                    ::CloseHandle(m_Handle);
+                    m_Handle = nullptr;
+                }
+            }
+            ~KillOnCloseJob()
+            {
+                if (m_Handle != nullptr)
+                    ::CloseHandle(m_Handle);
+            }
+
+            KillOnCloseJob(const KillOnCloseJob&) = delete;
+            KillOnCloseJob& operator=(const KillOnCloseJob&) = delete;
+            KillOnCloseJob(KillOnCloseJob&&) = delete;
+            KillOnCloseJob& operator=(KillOnCloseJob&&) = delete;
+
+            [[nodiscard]] bool Valid() const
+            {
+                return m_Handle != nullptr;
+            }
+            [[nodiscard]] HANDLE Get() const
+            {
+                return m_Handle;
+            }
+            void KillTree() const
+            {
+                if (m_Handle != nullptr)
+                    ::TerminateJobObject(m_Handle, 1);
+            }
+
+          private:
+            HANDLE m_Handle = nullptr;
+        };
+
+        [[nodiscard]] ChildResult RunChild(const fs::path& exe, const std::wstring& commandLine,
+                                           const fs::path& workingDirectory, const fs::path& consolePath,
+                                           std::chrono::milliseconds timeout, RunWatch& watch)
+        {
+            ChildResult result;
+
+            const KillOnCloseJob job;
+            if (!job.Valid())
+            {
+                // Refused rather than run unjobbed. Without the job a cancelled
+                // build leaves ninja running with the lock already released,
+                // which is the failure mode the lock exists to prevent — and a
+                // build that quietly ran without its containment would be
+                // indistinguishable from one that had it.
+                result.Error = "Could not create the job object that contains the build (error " +
+                               std::to_string(::GetLastError()) +
+                               "). Refusing to start a build that cancellation could not fully stop.";
+                return result;
+            }
+
+            SECURITY_ATTRIBUTES inheritable{};
+            inheritable.nLength = sizeof(inheritable);
+            inheritable.bInheritHandle = TRUE;
+
+            // stdout and stderr both go to one file rather than a pipe: a pipe
+            // nobody drains fills its buffer and BLOCKS the child, and a chatty
+            // build would hang in a way that looks exactly like a slow compile.
+            // FILE_SHARE_READ is what lets the progress watch read the log while
+            // the child is still writing it.
+            // .wstring(), never Widen(.string()): path::string() encodes through
+            // the ANSI code page on MSVC, so a non-ASCII %TEMP% would be
+            // mis-decoded as UTF-8 and every build would fail before starting.
+            // The wide form is what the path already holds.
+            const HANDLE console = ::CreateFileW(consolePath.wstring().c_str(), GENERIC_WRITE,
+                                                 FILE_SHARE_READ | FILE_SHARE_WRITE, &inheritable, CREATE_ALWAYS,
+                                                 FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (console == INVALID_HANDLE_VALUE)
+            {
+                result.Error = "Could not create the console log " + consolePath.generic_string() + " (error " +
+                               std::to_string(::GetLastError()) + ").";
+                return result;
+            }
+
+            STARTUPINFOW startup{};
+            startup.cb = sizeof(startup);
+            startup.dwFlags = STARTF_USESTDHANDLES;
+            startup.hStdInput = nullptr;
+            startup.hStdOutput = console;
+            startup.hStdError = console;
+
+            std::wstring mutableCommandLine = commandLine;
+            const std::wstring directory = workingDirectory.wstring();
+
+            // SUSPENDED, then assigned to the job, then resumed. Starting it
+            // running and assigning afterwards leaves a window in which the
+            // child could spawn ninja outside the job, and those grandchildren
+            // would then survive a cancellation.
+            PROCESS_INFORMATION process{};
+            if (!::CreateProcessW(nullptr, mutableCommandLine.data(), nullptr, nullptr, TRUE,
+                                  CREATE_NO_WINDOW | CREATE_SUSPENDED, nullptr,
+                                  directory.empty() ? nullptr : directory.c_str(), &startup, &process))
+            {
+                const DWORD error = ::GetLastError();
+                ::CloseHandle(console);
+                result.Error = "Could not start " + exe.generic_string() + " (CreateProcess error " +
+                               std::to_string(error) + ").";
+                return result;
+            }
+            ::CloseHandle(console); // our copy; the child holds its own
+
+            if (!::AssignProcessToJobObject(job.Get(), process.hProcess))
+            {
+                const DWORD error = ::GetLastError();
+                ::TerminateProcess(process.hProcess, 1);
+                ::CloseHandle(process.hThread);
+                ::CloseHandle(process.hProcess);
+                result.Error = "Could not put the build into its job object (error " + std::to_string(error) +
+                               "). The build was killed before it started rather than run uncontained.";
+                return result;
+            }
+            ::ResumeThread(process.hThread);
+
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            result.Outcome = ChildOutcome::Exited;
+            for (;;)
+            {
+                const DWORD waited = ::WaitForSingleObject(process.hProcess, static_cast<DWORD>(kPollInterval.count()));
+                if (waited == WAIT_OBJECT_0)
+                    break;
+                if (watch.Tick())
+                {
+                    result.Outcome = ChildOutcome::Cancelled;
+                    job.KillTree();
+                    ::WaitForSingleObject(process.hProcess, 30000);
+                    break;
+                }
+                if (std::chrono::steady_clock::now() >= deadline)
+                {
+                    result.Outcome = ChildOutcome::TimedOut;
+                    job.KillTree();
+                    ::WaitForSingleObject(process.hProcess, 30000);
+                    break;
+                }
+            }
+
+            DWORD exitCode = 0;
+            if (::GetExitCodeProcess(process.hProcess, &exitCode))
+                result.ExitCode = static_cast<int>(exitCode);
+            ::CloseHandle(process.hThread);
+            ::CloseHandle(process.hProcess);
+
+            bool ok = false;
+            result.Console = ReadWholeFile(consolePath, ok);
+            return result;
+        }
+#else
+        [[nodiscard]] ChildResult RunChild(const fs::path& exe, const std::vector<std::string>& arguments,
+                                           const fs::path& workingDirectory, const fs::path& consolePath,
+                                           std::chrono::milliseconds timeout, RunWatch& watch)
+        {
+            ChildResult result;
+
+            std::vector<std::string> owned;
+            owned.push_back(exe.string());
+            owned.insert(owned.end(), arguments.begin(), arguments.end());
+            std::vector<char*> argv;
+            argv.reserve(owned.size() + 1);
+            for (std::string& argument : owned)
+                argv.push_back(argument.data());
+            argv.push_back(nullptr);
+
+            const std::string exePath = exe.string();
+            const std::string consoleFile = consolePath.string();
+            const std::string directory = workingDirectory.string();
+
+            const pid_t pid = ::fork();
+            if (pid < 0)
+            {
+                result.Error = "Could not fork to start " + exe.generic_string() + ".";
+                return result;
+            }
+            if (pid == 0)
+            {
+                // Its own process GROUP, so cancelling kills the build tree and
+                // not merely the shell in front of it — the POSIX half of
+                // contract note 3.
+                (void)::setpgid(0, 0);
+                if (::chdir(directory.c_str()) != 0)
+                    ::_exit(127);
+                const int log = ::open(consoleFile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+                if (log < 0)
+                    ::_exit(127);
+                (void)::dup2(log, STDOUT_FILENO);
+                (void)::dup2(log, STDERR_FILENO);
+                if (log > STDERR_FILENO)
+                    (void)::close(log);
+                ::execv(exePath.c_str(), argv.data());
+                ::_exit(127);
+            }
+            // Also in the parent: whichever runs first wins, and neither losing
+            // the race leaves the child outside its group.
+            (void)::setpgid(pid, pid);
+
+            const auto killTree = [pid]()
+            {
+                if (::killpg(pid, SIGKILL) != 0)
+                    (void)::kill(pid, SIGKILL);
+            };
+
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            result.Outcome = ChildOutcome::Exited;
+            for (;;)
+            {
+                int status = 0;
+                const pid_t waited = ::waitpid(pid, &status, WNOHANG);
+                if (waited == pid)
+                {
+                    result.ExitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+                    break;
+                }
+                if (watch.Tick())
+                {
+                    result.Outcome = ChildOutcome::Cancelled;
+                    killTree();
+                    (void)::waitpid(pid, &status, 0);
+                    break;
+                }
+                if (std::chrono::steady_clock::now() >= deadline)
+                {
+                    result.Outcome = ChildOutcome::TimedOut;
+                    killTree();
+                    (void)::waitpid(pid, &status, 0);
+                    break;
+                }
+                std::this_thread::sleep_for(kPollInterval);
+            }
+
+            bool ok = false;
+            result.Console = ReadWholeFile(consolePath, ok);
+            return result;
+        }
+#endif
+
+        // A scratch directory for one invocation's console log, removed when the
+        // invocation ends however it ends.
+        class ScratchDirectory
+        {
+          public:
+            explicit ScratchDirectory(const char* stem)
+            {
+                std::error_code ec;
+                const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+                const fs::path candidate = fs::temp_directory_path(ec) /
+                                           (std::string("olo-") + stem + "-" + std::to_string(static_cast<u64>(stamp)));
+                if (ec)
+                    return;
+                // EXCLUSIVE creation: create_directory returns false without an
+                // error when the directory already exists, and a pre-existing one
+                // in a world-writable /tmp may have been planted (CWE-379).
+                if (!fs::create_directory(candidate, ec) || ec)
+                    return;
+                m_Path = candidate;
+            }
+            ~ScratchDirectory()
+            {
+                if (m_Path.empty())
+                    return;
+                std::error_code ec;
+                fs::remove_all(m_Path, ec);
+            }
+
+            ScratchDirectory(const ScratchDirectory&) = delete;
+            ScratchDirectory& operator=(const ScratchDirectory&) = delete;
+            ScratchDirectory(ScratchDirectory&&) = delete;
+            ScratchDirectory& operator=(ScratchDirectory&&) = delete;
+
+            [[nodiscard]] bool Valid() const
+            {
+                return !m_Path.empty();
+            }
+            [[nodiscard]] fs::path File(const char* name) const
+            {
+                return m_Path / name;
+            }
+
+          private:
+            fs::path m_Path;
+        };
+
+        // ---- shared resolution ----------------------------------------------
+
+        struct Session
+        {
+            fs::path RepoRoot;
+            fs::path LockScript;
+            fs::path PowerShell;
+            std::string BuildDir;
+            std::string Config;
+        };
+
+        [[nodiscard]] bool ResolveTree(const Json& args, Session& out, std::string& outError)
+        {
+            out.BuildDir = args.value("buildDir", std::string(kBuildDirs.front()));
+            if (!IsKnownBuildDir(out.BuildDir))
+            {
+                std::string known;
+                for (const std::string_view dir : kBuildDirs)
+                {
+                    if (!known.empty())
+                        known += ", ";
+                    known += std::string(dir);
+                }
+                outError = "Unknown 'buildDir' '" + out.BuildDir + "'. This command only builds the trees "
+                                                                   "CMakePresets.json defines: " +
+                           known +
+                           ". (The name is interpolated into the command build-lock.ps1 executes, so it is "
+                           "matched against that list rather than escaped.)";
+                return false;
+            }
+            out.Config = args.value("config", std::string("Debug"));
+            if (!IsKnownConfig(out.Config))
+            {
+                outError = "Unknown 'config' '" + out.Config + "'. Expected Debug, Release or Dist.";
+                return false;
+            }
+            return true;
+        }
+
+        [[nodiscard]] bool OpenSession(const Json& args, Session& out, std::string& outError)
+        {
+            if (!FindRepoRoot(out.RepoRoot, outError))
+                return false;
+            out.LockScript = out.RepoRoot / kLockScriptRelative;
+            return ResolveTree(args, out, outError);
+        }
+
+        // Everything that must be true before a build can even be attempted.
+        // Each failure is a NAMED error, never an empty success — a caller that
+        // read "0 errors" out of a build that never started would take it as
+        // proof the tree compiles.
+        [[nodiscard]] bool CheckBuildPreconditions(const Session& session, std::string& outError)
+        {
+            std::error_code ec;
+            const fs::path treePath = session.RepoRoot / session.BuildDir;
+            if (!fs::is_directory(treePath, ec))
+            {
+                outError = "The build tree '" + session.BuildDir + "' does not exist at " +
+                           treePath.generic_string() + ". Configure it first: cmake --preset " +
+                           (session.BuildDir == "build-cached" ? "dev-cached"
+                                                               : (session.BuildDir == "build" ? "msvc" : "clangcl")) +
+                           ". This command never configures — a configure is a different decision with different "
+                           "costs, and doing it silently would hide it.";
+                return false;
+            }
+            if (!fs::is_regular_file(treePath / "CMakeCache.txt", ec))
+            {
+                outError = "The build tree '" + session.BuildDir + "' has no CMakeCache.txt, so it is not "
+                                                                   "configured. Run the matching cmake --preset first.";
+                return false;
+            }
+            // Checked even though we never configure: `cmake --build` re-runs the
+            // generator when the build system is out of date, and that hits the
+            // repo's VCPKG_ROOT guard (issue #773). Better a named refusal here
+            // than a cmake error deep in a build log.
+            if (!Env::Get("VCPKG_ROOT").has_value())
+            {
+                outError = "VCPKG_ROOT is not set in this editor's environment (issue #773). `cmake --build` "
+                           "re-runs the generator when the build system is stale, and that stops at the repo's "
+                           "guard. Set VCPKG_ROOT and restart the editor — an editor launched before the variable "
+                           "existed does not inherit it.";
+                return false;
+            }
+            std::error_code lockEc;
+            if (!fs::is_regular_file(session.LockScript, lockEc))
+            {
+                outError = "The build lock script is missing at " + session.LockScript.generic_string() +
+                           ". Refusing to build outside the lock.";
+                return false;
+            }
+            return true;
+        }
+
+        // ---- olo_build_list --------------------------------------------------
+
+        AutomationResult Handle_BuildList(IAutomationHost& /*host*/, const Json& args)
+        {
+            Session session;
+            if (std::string error; !OpenSession(args, session, error))
+                return AutomationResult::Error(error);
+
+            const auto now = std::chrono::system_clock::now();
+            std::error_code ec;
+
+            Json out;
+            out["repoRoot"] = session.RepoRoot.generic_string();
+            out["buildDir"] = session.BuildDir;
+            out["config"] = session.Config;
+
+            const fs::path treePath = session.RepoRoot / session.BuildDir;
+            const bool configured = fs::is_regular_file(treePath / "CMakeCache.txt", ec);
+            out["configured"] = configured;
+            out["vcpkgRootSet"] = Env::Get("VCPKG_ROOT").has_value();
+
+            // Advisory: whether a build could start right now without queueing.
+            // Reported, never acted on — olo_build_run always goes through the
+            // real acquire, where the answer is authoritative.
+            Json lock;
+            if (fs::path commonDir; FindGitCommonDir(session.RepoRoot, commonDir))
+            {
+                lock["directory"] = commonDir.generic_string();
+                Json slots = Json::array();
+                sizet free = 0;
+                bool measured = true;
+                for (const char* name : { "olo-build.lock", "olo-build.slot1.lock" })
+                {
+                    const std::optional<bool> slotFree = IsSlotFree(commonDir / name);
+                    Json entry{ { "slot", name } };
+                    if (slotFree.has_value())
+                    {
+                        entry["free"] = *slotFree;
+                        free += *slotFree ? 1 : 0;
+                    }
+                    else
+                    {
+                        measured = false;
+                    }
+                    slots.push_back(std::move(entry));
+                }
+                lock["slots"] = std::move(slots);
+                if (measured)
+                    lock["freeSlots"] = free;
+                lock["note"] =
+                    measured ? "A snapshot, not a reservation: another worktree can take a slot a microsecond "
+                               "later. olo_build_run always goes through build-lock.ps1 regardless."
+                             : "Slot state is not measurable on this platform, so it is reported as absent rather "
+                               "than as free. olo_build_run acquires through build-lock.ps1, where the answer is "
+                               "authoritative.";
+            }
+            else
+            {
+                lock["note"] = "Could not resolve the shared git directory, so the lock state is unknown here. "
+                               "That does not affect olo_build_run, which acquires through build-lock.ps1.";
+            }
+            out["lock"] = std::move(lock);
+
+            Json targets = Json::array();
+            for (const TargetSpec& spec : kTargets)
+            {
+                const std::string relative = ExpandArtifact(spec.Artifact, session.Config, kWindowsArtifacts);
+                const fs::path absolute = spec.ArtifactUnderBuildDir ? treePath / relative : session.RepoRoot / relative;
+                const std::string reported =
+                    spec.ArtifactUnderBuildDir ? session.BuildDir + "/" + relative : relative;
+
+                Json entry;
+                entry["target"] = std::string(spec.Name);
+                entry["buildable"] = spec.RefusedBecause.empty();
+                if (!spec.RefusedBecause.empty())
+                    entry["refusedBecause"] = std::string(spec.RefusedBecause);
+                entry["description"] = std::string(spec.Description);
+                // `now` as the reference instant, so `ageSeconds` reads as "how
+                // old is this artefact" rather than as a build verdict.
+                const ArtifactState state = StatArtifact(absolute, reported, now);
+                entry["artifact"] = ArtifactJson(state);
+                if (state.Exists)
+                    entry["artifactAgeSeconds"] = -state.AgeRelativeToStartSeconds;
+                targets.push_back(std::move(entry));
+            }
+            out["targets"] = std::move(targets);
+            return AutomationResult::Structured(out);
+        }
+
+        // ---- olo_build_run ---------------------------------------------------
+
+        // Resolve the caller's target list against the allow-list. Every refusal
+        // names its mechanism; "no targets" is one of them, because a default
+        // target would be `all`, which reaches OloEditor.
+        [[nodiscard]] bool ResolveTargets(const Json& args, std::vector<const TargetSpec*>& out, std::string& outError)
+        {
+            if (!args.contains("targets") || !args["targets"].is_array() || args["targets"].empty())
+            {
+                outError = "Give a non-empty 'targets' array. There is deliberately no default: the default "
+                           "target of a CMake build is 'all', which links OloEditor — the image this editor is "
+                           "running from, which the linker cannot replace. Buildable targets: " +
+                           BuildableTargetList() + ".";
+                return false;
+            }
+            std::set<std::string> seen;
+            for (const auto& entry : args["targets"])
+            {
+                if (!entry.is_string() || entry.get<std::string>().empty())
+                {
+                    outError = "Invalid entry in 'targets': expected non-empty CMake target names.";
+                    return false;
+                }
+                const std::string name = entry.get<std::string>();
+                const TargetSpec* spec = FindTarget(name);
+                if (spec == nullptr)
+                {
+                    outError = "Unknown target '" + name +
+                               "'. This command builds only the targets it has an artefact path and an "
+                               "in-editor safety verdict for, and the name is interpolated into the command "
+                               "build-lock.ps1 runs, so it is matched rather than escaped. Buildable: " +
+                               BuildableTargetList() + ".";
+                    return false;
+                }
+                if (!spec->RefusedBecause.empty())
+                {
+                    outError = "Refusing to build '" + name + "' from inside the editor. " +
+                               std::string(spec->RefusedBecause);
+                    return false;
+                }
+                if (!seen.insert(name).second)
+                {
+                    outError = "Target '" + name + "' is listed twice. Each target is built once, in order.";
+                    return false;
+                }
+                out.push_back(spec);
+            }
+            return true;
+        }
+
+        AutomationResult Handle_BuildRun(IAutomationHost& host, const Json& args)
+        {
+            Session session;
+            if (std::string error; !OpenSession(args, session, error))
+                return AutomationResult::Error(error);
+
+            std::vector<const TargetSpec*> targets;
+            if (std::string error; !ResolveTargets(args, targets, error))
+                return AutomationResult::Error(error);
+
+            if (std::string error; !CheckBuildPreconditions(session, error))
+                return AutomationResult::Error(error);
+
+            if (std::string error; !ResolvePowerShell(session.PowerShell, error))
+                return AutomationResult::Error(error);
+
+            const auto lockWaitSeconds =
+                std::clamp<long long>(args.value("lockWaitSeconds", 300LL), 0LL, 3600LL);
+            const auto timeoutSeconds = std::clamp<long long>(args.value("timeoutSeconds", 3600LL), 60LL, 14400LL);
+            const auto maxDiagnostics =
+                static_cast<sizet>(std::clamp<long long>(args.value("maxDiagnostics", 100LL), 1LL, 1000LL));
+
+            // -TimeoutMinutes is an int, and 0 is exactly the fail-fast the
+            // refusal path needs: the deadline is already past when the first
+            // acquisition attempt fails. Rounding UP for anything else means a
+            // caller asking for 30s gets a minute rather than a surprise
+            // fail-fast.
+            const long long lockWaitMinutes = lockWaitSeconds == 0 ? 0 : (lockWaitSeconds + 59) / 60;
+
+            Json out;
+            out["repoRoot"] = session.RepoRoot.generic_string();
+            out["buildDir"] = session.BuildDir;
+            out["config"] = session.Config;
+            out["lockScript"] = std::string(kLockScriptRelative);
+            out["lockWaitSeconds"] = lockWaitSeconds;
+            // The script's -TimeoutMinutes is integer minutes, so a sub-minute
+            // request is rounded UP. Reporting only what was asked for would
+            // misstate the budget a refusal was measured against.
+            out["lockWaitAppliedSeconds"] = lockWaitMinutes * 60;
+
+            Json requested = Json::array();
+            for (const TargetSpec* spec : targets)
+                requested.push_back(std::string(spec->Name));
+            out["targets"] = requested;
+
+            std::vector<TargetResult> results;
+            const auto overallStart = std::chrono::steady_clock::now();
+            bool aborted = false;
+            std::string abortReason;
+            std::string lastConsole;
+
+            for (const TargetSpec* target : targets)
+            {
+                const TargetSpec& spec = *target;
+                TargetResult result;
+                result.Target = std::string(spec.Name);
+
+                if (aborted)
+                {
+                    // Never silently dropped: a target that was never attempted
+                    // is reported as such, with the reason, rather than left out
+                    // of an array the caller would read as complete.
+                    result.Outcome = TargetOutcome::Skipped;
+                    result.Note = abortReason;
+                    results.push_back(std::move(result));
+                    continue;
+                }
+
+                const std::string relative = ExpandArtifact(spec.Artifact, session.Config, kWindowsArtifacts);
+                const fs::path treePath = session.RepoRoot / session.BuildDir;
+                const fs::path absolute = spec.ArtifactUnderBuildDir ? treePath / relative : session.RepoRoot / relative;
+                const std::string reported =
+                    spec.ArtifactUnderBuildDir ? session.BuildDir + "/" + relative : relative;
+
+                const ScratchDirectory scratch("build-run");
+                if (!scratch.Valid())
+                {
+                    // Reported as this target's failure, not as an early return:
+                    // an earlier target may already have rebuilt (and building
+                    // OloEngine runs GenerateBindings, which moves the working
+                    // tree), so throwing the collected results away would tell
+                    // the caller nothing happened when something did.
+                    result.Outcome = TargetOutcome::Failed;
+                    result.Note = "Could not create a temporary directory for the build log, so this target was "
+                                  "never started.";
+                    aborted = true;
+                    abortReason = "Not attempted: '" + result.Target + "' could not be given a scratch directory.";
+                    results.push_back(std::move(result));
+                    continue;
+                }
+                const fs::path consolePath = scratch.File("build.log");
+
+                // The instant the build starts, which every artefact mtime is
+                // compared against. Taken BEFORE the before-stat so a file
+                // written during the stat cannot read as pre-existing.
+                const auto buildStart = std::chrono::system_clock::now();
+                result.Before = StatArtifact(absolute, reported, buildStart);
+
+                const std::string buildCommand = BuildCommand(session.BuildDir, spec.Name, session.Config);
+                result.Command = buildCommand;
+
+                RunWatch watch;
+                watch.Host = &host;
+                watch.ConsolePath = consolePath;
+                watch.Started = std::chrono::steady_clock::now();
+                watch.LockBudget = std::chrono::seconds(lockWaitMinutes * 60);
+                watch.Target = result.Target;
+
+                // Our deadline is deliberately LATER than the lock's own, so a
+                // lock timeout is reported by the script (naming the holder)
+                // rather than by us as an anonymous kill.
+                const auto childTimeout =
+                    std::chrono::seconds(lockWaitMinutes * 60 + timeoutSeconds) + kChildDeadlineGrace;
+
+                const auto started = std::chrono::steady_clock::now();
+#ifdef _WIN32
+                // Quoted only where a value can contain a space: the script path
+                // and the build command. Target, config and build dir came from
+                // fixed tables, so they carry nothing that needs quoting — which
+                // is the point of the tables.
+                // Assembled from .wstring() parts for the same reason as the
+                // console handle above: the two PATHS must not round-trip
+                // through the ANSI code page. Only `buildCommand` is widened,
+                // and it is ASCII by construction (three fixed vocabularies).
+                const std::wstring commandLine = L"\"" + session.PowerShell.wstring() + L"\" -NoProfile -File \"" +
+                                                 session.LockScript.wstring() + L"\" -Command \"" +
+                                                 Widen(buildCommand) + L"\" -TimeoutMinutes " +
+                                                 Widen(std::to_string(lockWaitMinutes));
+                const ChildResult child =
+                    RunChild(session.PowerShell, commandLine, session.RepoRoot, consolePath, childTimeout, watch);
+#else
+                const std::vector<std::string> arguments{ "-NoProfile", "-File",
+                                                          session.LockScript.string(), "-Command",
+                                                          buildCommand, "-TimeoutMinutes",
+                                                          std::to_string(lockWaitMinutes) };
+                const ChildResult child =
+                    RunChild(session.PowerShell, arguments, session.RepoRoot, consolePath, childTimeout, watch);
+#endif
+                const auto finished = std::chrono::steady_clock::now();
+                result.WallSeconds = std::chrono::duration<f64>(finished - started).count();
+                if (const auto acquiredAt = watch.AcquiredAt())
+                {
+                    result.QueuedSeconds = std::chrono::duration<f64>(*acquiredAt - started).count();
+                    result.BuildSeconds = std::chrono::duration<f64>(finished - *acquiredAt).count();
+                }
+                result.ExitCode = child.ExitCode;
+                result.Lock = ReadLockTranscript(child.Console);
+                result.Diagnostics =
+                    ParseDiagnostics(child.Console, session.RepoRoot.generic_string(), session.BuildDir);
+                lastConsole = child.Console;
+
+                if (!child.Completed())
+                {
+                    // A child that never finished tells us nothing about the
+                    // tree, so it is a failure with the reason named — including
+                    // for cancellation, which is not a partial success.
+                    result.Outcome = TargetOutcome::Failed;
+                    result.Note = std::string("The build ") + ChildOutcomeName(child.Outcome) + ". " + child.Error +
+                                  (child.Outcome == ChildOutcome::Cancelled
+                                       ? " The whole build tree (pwsh, cmake, ninja and every compiler) was killed "
+                                         "with its job object, so the lock was released after the build stopped, "
+                                         "not before."
+                                       : "");
+                    result.After = StatArtifact(absolute, reported, buildStart);
+                    aborted = true;
+                    abortReason = "Not attempted: '" + result.Target + "' " + ChildOutcomeName(child.Outcome) + ".";
+                    results.push_back(std::move(result));
+                    continue;
+                }
+
+                result.After = StatArtifact(absolute, reported, buildStart);
+                result.Outcome = Verdict(result.Lock.Outcome, child.ExitCode, result.After);
+
+                switch (result.Outcome)
+                {
+                    case TargetOutcome::NotBuilt:
+                        result.Note =
+                            result.Lock.Outcome == LockOutcome::Superseded
+                                ? "build-lock.ps1 STOOD DOWN: an identical build for this worktree was queued "
+                                  "later, so this one exited 0 without building anything. The exit code is not a "
+                                  "verdict here — nothing ran."
+                                : "build-lock.ps1 never acquired the lock, so no build ran. Its own output "
+                                  "(see 'lock.transcript') says why: normally the " +
+                                      std::to_string(lockWaitSeconds) +
+                                      "s wait budget expired while another worktree held it. Raise "
+                                      "'lockWaitSeconds', or wait for the holder named there and in 'consoleTail'.";
+                        break;
+                    case TargetOutcome::MissingArtifact:
+                        result.Note = "The build reported success (exit 0) but there is no artefact at " + reported +
+                                      ". Exit codes, mtimes and empty logs can all fake a build; the artefact is "
+                                      "the evidence, and it is not there.";
+                        break;
+                    case TargetOutcome::UpToDate:
+                        result.Note = "Nothing to do: the artefact was already current and this build did not "
+                                      "replace it. Its timestamp is from an EARLIER build — check "
+                                      "'artifact.modifiedUtc' before treating it as containing your change.";
+                        break;
+                    case TargetOutcome::Failed:
+                        result.Note = result.Lock.Outcome == LockOutcome::Orphaned
+                                          ? "The lock's parent watch killed this build: the editor process that "
+                                            "launched it was gone. An orphaned build never succeeded, whatever the "
+                                            "kill reported."
+                                          : "The build failed. See 'diagnostics' for the records and 'consoleTail' "
+                                            "for the text around them.";
+                        break;
+                    case TargetOutcome::Rebuilt:
+                    case TargetOutcome::Skipped:
+                        break;
+                }
+
+                if (!IsSuccess(result.Outcome))
+                {
+                    aborted = true;
+                    abortReason = "Not attempted: '" + result.Target + "' did not succeed (" +
+                                  TargetOutcomeName(result.Outcome) + "), so the rest of the list was not built.";
+                }
+                results.push_back(std::move(result));
+            }
+
+            const f64 wallSeconds =
+                std::chrono::duration<f64>(std::chrono::steady_clock::now() - overallStart).count();
+
+            sizet errors = 0;
+            sizet warnings = 0;
+            sizet rebuilt = 0;
+            bool allSucceeded = true;
+            Json perTarget = Json::array();
+            for (const TargetResult& result : results)
+            {
+                const DiagnosticCounts counts = CountDiagnostics(result.Diagnostics);
+                errors += counts.Errors;
+                warnings += counts.Warnings;
+                rebuilt += result.Outcome == TargetOutcome::Rebuilt ? 1 : 0;
+                allSucceeded = allSucceeded && IsSuccess(result.Outcome);
+                perTarget.push_back(TargetResultJson(result, maxDiagnostics));
+            }
+
+            out["results"] = std::move(perTarget);
+            out["wallSeconds"] = wallSeconds;
+            out["errorCount"] = errors;
+            out["warningCount"] = warnings;
+            out["rebuilt"] = rebuilt;
+            // Only ever true when EVERY requested target reached a success
+            // outcome AND its artefact is on disk. A caller may check this one
+            // field instead of re-deriving the invariant, which is the same
+            // contract olo_tests_run's `complete` carries.
+            out["ok"] = allSucceeded;
+
+            if (!allSucceeded)
+            {
+                out["consoleTail"] = TailOf(lastConsole, kConsoleTailChars);
+                std::string summary;
+                for (const TargetResult& result : results)
+                {
+                    if (IsSuccess(result.Outcome))
+                        continue;
+                    if (!summary.empty())
+                        summary += " ";
+                    summary += result.Target + ": " + TargetOutcomeName(result.Outcome) + ".";
+                    if (!result.Note.empty())
+                        summary += " " + result.Note;
+                }
+                OLO_CORE_WARN("[Automation] olo_build_run failed after {:.1f}s: {}", wallSeconds, summary);
+                return AutomationResult::Error("The build did not succeed. " + summary + "\n\n" + out.dump(2));
+            }
+
+            OLO_CORE_INFO("[Automation] olo_build_run: {} target(s), {} rebuilt, {} warning(s) in {:.1f}s ({}/{})",
+                          results.size(), rebuilt, warnings, wallSeconds, session.BuildDir, session.Config);
+            return AutomationResult::Structured(out);
+        }
+
+        // ---- schema fragments shared by both commands ------------------------
+
+        [[nodiscard]] Schema::Node TreeProps(Schema::Node node)
+        {
+            return node
+                // EnumFrom, not a restated literal: the value set IS the table in
+                // AutomationBuildInvocation.h, and a hand-copied second spelling of
+                // it goes stale silently (the schema gate would then reject a tree
+                // the command happily builds).
+                .Prop("buildDir", Schema::String()
+                                      .EnumFrom(kBuildDirs)
+                                      .Desc("Which CMakePresets.json tree to use. Defaults to build-cached — the "
+                                            "compiler-cached Ninja tree, and the only kind the build lock will ever "
+                                            "run concurrently with another."))
+                .Prop("config",
+                      Schema::String().EnumFrom(kConfigs).Desc("Build configuration (default Debug)."));
+        }
+    } // namespace
+
+    void RegisterBuildCommands(AutomationRegistry& registry)
+    {
+        {
+            AutomationCommand command;
+            command.Name = "olo_build_list";
+            command.Toolset = "build";
+            command.Title = "List build targets";
+            command.Annotations = Json{ { "readOnlyHint", true }, { "openWorldHint", false } };
+            command.Undo = AutomationUndo::None;
+            command.Description =
+                "Enumerate the CMake targets olo_build_run can build, each with its artefact path, size and "
+                "build timestamp, plus whether the tree is configured and whether a build lock slot is free "
+                "right now. Builds nothing. Use it to answer 'is the binary I am about to run older than my "
+                "change?' — an exit code cannot tell a fresh artefact from last week's, and a timestamp can. "
+                "Targets the editor holds open (OloEditor itself, OloEngine-ScriptCore) are listed with "
+                "buildable:false and the mechanism that refuses them.";
+            command.InputSchema = TreeProps(Schema::Object()).NoAdditional();
+            command.OutputSchema =
+                Schema::Object()
+                    .Prop("repoRoot", Schema::String())
+                    .Prop("buildDir", Schema::String())
+                    .Prop("config", Schema::String())
+                    .Prop("configured", Schema::Bool().Desc("False when the tree has no CMakeCache.txt."))
+                    .Prop("vcpkgRootSet", Schema::Bool().Desc("False means a build would stop at the repo's guard."))
+                    .Prop("lock", Schema::Object().Desc("Build-lock slot state — advisory only, a snapshot."))
+                    .Prop("targets", Schema::Array(Schema::Object()
+                                                       .Prop("target", Schema::String())
+                                                       .Prop("buildable", Schema::Bool())
+                                                       .Prop("refusedBecause", Schema::String())
+                                                       .Prop("description", Schema::String())
+                                                       .Prop("artifact", Schema::Object())
+                                                       .Prop("artifactAgeSeconds", Schema::Number())))
+                    .Required({ "repoRoot", "buildDir", "config", "configured", "targets" });
+            command.Handler = Handle_BuildList;
+            registry.Register(std::move(command));
+        }
+
+        {
+            AutomationCommand command;
+            command.Name = "olo_build_run";
+            command.Toolset = "build";
+            command.Title = "Build targets";
+            command.DualAudienceContent = true;
+            // Mutating but NOT ProjectWrite: a build changes the build tree and
+            // bin/, not anything the user is AUTHORING (no scene, no component,
+            // no asset registry entry) — the same line olo_tests_run draws.
+            // destructiveHint stays false: the outputs are generated artefacts a
+            // rebuild reproduces, not user data.
+            command.Annotations =
+                Json{ { "readOnlyHint", false }, { "openWorldHint", false }, { "destructiveHint", false } };
+            // A build cannot be taken back from inside this process.
+            command.Undo = AutomationUndo::Irreversible;
+            command.Description =
+                "Build one or more CMake targets and return STRUCTURED per-target results: outcome, exit code, "
+                "wall time, the artefact's path AND timestamp, and every compiler/linker diagnostic as a record "
+                "with file, line, column and code — no console scraping. Runs through "
+                ".claude/skills/run-oloengine/build-lock.ps1, always: the lock bounds concurrent builds across "
+                "every worktree, sets the job count from free memory, and kills the build if this editor dies. "
+                "A build that could not start is an ERROR naming the reason (lock still held after "
+                "'lockWaitSeconds', tree not configured, VCPKG_ROOT unset) — never an empty success. So is a "
+                "zero exit code with no artefact, and a lock stand-down, which exits 0 having built nothing; "
+                "'up-to-date' is reported separately from 'rebuilt' because a stale artefact and a fresh one "
+                "look identical from an exit code. Targets are built one at a time, in order, each with its own "
+                "lock ticket, and the list stops at the first failure. OloEditor and OloEngine-ScriptCore are "
+                "REFUSED: this editor has them open and the linker cannot replace them. Note that building "
+                "OloEngine runs GenerateBindings, which can rewrite tracked generated sources.";
+            command.InputSchema =
+                TreeProps(Schema::Object())
+                    .Prop("targets",
+                          Schema::Array(Schema::String())
+                              .Desc("CMake targets to build, in order. Required and non-empty: there is no default, "
+                                    "because CMake's default target is 'all', which links the running editor. "
+                                    "Allowed: OloEngine, OloEngine-Tests, OloRuntime, OloServer, oloctl, "
+                                    "OloEngine-LuaScriptCore."))
+                    .Prop("lockWaitSeconds",
+                          Schema::Int().Min(0).Max(3600).Desc(
+                              "How long to queue for the build lock before giving up (default 300). 0 fails fast "
+                              "when the lock is held, naming the holder. The wait is a real FIFO ticket, so it "
+                              "never jumps another worktree."))
+                    .Prop("timeoutSeconds",
+                          Schema::Int().Min(60).Max(14400).Desc(
+                              "Kill the build after this long, on top of the lock wait (default 3600). A timeout "
+                              "is an error, not a partial result, and the whole process tree is killed."))
+                    .Prop("maxDiagnostics",
+                          Schema::Int().Min(1).Max(1000).Desc(
+                              "Cap on reported diagnostics per target (default 100). Errors are emitted before "
+                              "warnings so a cap never hides the reason a build failed; any excess is counted in "
+                              "'diagnosticsOmitted', never silently dropped."))
+                    .NoAdditional();
+            command.OutputSchema =
+                Schema::Object()
+                    .Prop("repoRoot", Schema::String())
+                    .Prop("buildDir", Schema::String())
+                    .Prop("config", Schema::String())
+                    .Prop("targets", Schema::Array(Schema::String()).Desc("What was requested, in order."))
+                    .Prop("ok", Schema::Bool().Desc("Always true on success: every requested target reached "
+                                                    "'rebuilt' or 'up-to-date' AND its artefact is on disk."))
+                    .Prop("rebuilt", Schema::Int().Min(0).Desc("Targets whose artefact this call actually replaced."))
+                    .Prop("wallSeconds", Schema::Number())
+                    .Prop("errorCount", Schema::Int().Min(0))
+                    .Prop("warningCount", Schema::Int().Min(0))
+                    .Prop("results",
+                          Schema::Array(
+                              Schema::Object()
+                                  .Prop("target", Schema::String())
+                                  .Prop("command", Schema::String().Desc(
+                                                       "The cmake line the lock was asked to run, verbatim — paste "
+                                                       "it into a shell to reproduce."))
+                                  .Prop("outcome", Schema::String().Enum({ "rebuilt", "up-to-date", "failed",
+                                                                           "missing-artifact", "not-built",
+                                                                           "skipped" }))
+                                  .Prop("success", Schema::Bool())
+                                  .Prop("exitCode", Schema::Int())
+                                  .Prop("wallSeconds", Schema::Number())
+                                  .Prop("queuedSeconds", Schema::Number().Desc(
+                                                             "Of 'wallSeconds', how long was spent waiting for the "
+                                                             "build lock. Omitted when the acquire was not observed."))
+                                  .Prop("buildSeconds", Schema::Number().Desc(
+                                                            "Of 'wallSeconds', how long the build itself took. A "
+                                                            "large 'queuedSeconds' means the machine was busy, not "
+                                                            "that the build is slow — opposite actions."))
+                                  .Prop("artifact", Schema::Object().Desc(
+                                                        "path, exists, sizeBytes and modifiedUtc AFTER the build — "
+                                                        "the evidence an exit code cannot give."))
+                                  .Prop("artifactBefore", Schema::Object().Desc("Present only when it moved."))
+                                  .Prop("lock", Schema::Object().Desc(
+                                                    "What build-lock.ps1 did: outcome, whether it was contended, "
+                                                    "the job count it chose, who held it, and its verbatim "
+                                                    "transcript."))
+                                  .Prop("diagnostics",
+                                        Schema::Array(Schema::Object()
+                                                          .Prop("severity",
+                                                                Schema::String().Enum({ "error", "warning", "note" }))
+                                                          .Prop("file", Schema::String().Desc("Repo-relative."))
+                                                          .Prop("line", Schema::Int().Min(1))
+                                                          .Prop("column", Schema::Int().Min(1))
+                                                          .Prop("code", Schema::String().Desc("C2065, LNK2019, ..."))
+                                                          .Prop("message", Schema::String())
+                                                          .Prop("occurrences",
+                                                                Schema::Int().Min(2).Desc(
+                                                                    "Present when one record came from several "
+                                                                    "translation units."))))
+                                  .Prop("diagnosticsOmitted", Schema::Int().Min(0))
+                                  .Prop("errorCount", Schema::Int().Min(0))
+                                  .Prop("warningCount", Schema::Int().Min(0))
+                                  .Prop("note", Schema::String().Desc("Why, for every outcome that needs a "
+                                                                      "sentence."))))
+                    .Required({ "repoRoot", "buildDir", "config", "targets", "ok", "rebuilt", "wallSeconds",
+                                "errorCount", "warningCount", "results" });
+            command.Handler = Handle_BuildRun;
+            registry.Register(std::move(command));
+        }
+    }
+} // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationBuildCommands.cpp
+++ b/OloEditor/src/Automation/AutomationBuildCommands.cpp
@@ -189,6 +189,7 @@ namespace OloEngine::Automation
                 return state;
             const auto systemTime = std::chrono::clock_cast<std::chrono::system_clock>(written);
             state.ModifiedUtc = FormatUtc(systemTime);
+            state.MtimeKnown = true;
             state.AgeRelativeToStartSeconds = std::chrono::duration<f64>(systemTime - buildStart).count();
             return state;
         }
@@ -369,6 +370,11 @@ namespace OloEngine::Automation
             SpawnFailed, // never started
             TimedOut,    // killed at our deadline
             Cancelled,   // killed because the caller cancelled the call
+            // The OS wait on the child FAILED. Distinct from a timeout because
+            // nothing about the build is known, including whether it is still
+            // running — so the tree is killed and this is reported, never
+            // reported as a timeout it was not.
+            MonitorFailed,
         };
 
         [[nodiscard]] const char* ChildOutcomeName(ChildOutcome outcome)
@@ -383,6 +389,8 @@ namespace OloEngine::Automation
                     return "timed-out";
                 case ChildOutcome::Cancelled:
                     return "cancelled";
+                case ChildOutcome::MonitorFailed:
+                    return "monitor-failed";
             }
             return "unknown";
         }
@@ -652,6 +660,22 @@ namespace OloEngine::Automation
                 const DWORD waited = ::WaitForSingleObject(process.hProcess, static_cast<DWORD>(kPollInterval.count()));
                 if (waited == WAIT_OBJECT_0)
                     break;
+                // WAIT_FAILED would otherwise fall through forever: the wait IS
+                // this loop's sleep, so a failing wait turns it into a busy spin
+                // that re-reads the console log as fast as it can until the
+                // deadline — up to four hours of a saturated core next to a
+                // build. Kill the tree and say what happened.
+                if (waited == WAIT_FAILED)
+                {
+                    const DWORD error = ::GetLastError();
+                    result.Outcome = ChildOutcome::MonitorFailed;
+                    result.Error = "Waiting on the build process failed (error " + std::to_string(error) +
+                                   "), so its state is unknown; the whole build tree was killed rather than left "
+                                   "running unwatched.";
+                    job.KillTree();
+                    ::WaitForSingleObject(process.hProcess, 30000);
+                    break;
+                }
                 if (watch.Tick())
                 {
                     result.Outcome = ChildOutcome::Cancelled;
@@ -1101,6 +1125,17 @@ namespace OloEngine::Automation
                 TargetResult result;
                 result.Target = std::string(spec.Name);
 
+                // Cancellation is only observed inside RunChild's poll loop, so
+                // without this a caller who cancels BETWEEN targets — or before
+                // the first child has started — would still have the next build
+                // acquire the lock and run to completion. Checked here so a
+                // cancelled call stops taking the machine.
+                if (!aborted && host.IsCurrentCallCancelled())
+                {
+                    aborted = true;
+                    abortReason = "Not attempted: the call was cancelled before this target started.";
+                }
+
                 if (aborted)
                 {
                     // Never silently dropped: a target that was never attempted
@@ -1184,7 +1219,15 @@ namespace OloEngine::Automation
 #endif
                 const auto finished = std::chrono::steady_clock::now();
                 result.WallSeconds = std::chrono::duration<f64>(finished - started).count();
-                if (const auto acquiredAt = watch.AcquiredAt())
+                // Reported only when the lock was actually acquired. The watch
+                // latches the acquire on a poll, but a LATER transcript line can
+                // still resolve the run to Superseded (nothing ran) — and a
+                // build duration for a build that did not run is a false
+                // measurement. An ORPHANED run keeps its split on purpose: the
+                // build genuinely ran for that long before the lock killed it.
+                if (const auto acquiredAt = watch.AcquiredAt();
+                    acquiredAt.has_value() && (result.Lock.Outcome == LockOutcome::Acquired ||
+                                               result.Lock.Outcome == LockOutcome::Orphaned))
                 {
                     result.QueuedSeconds = std::chrono::duration<f64>(*acquiredAt - started).count();
                     result.BuildSeconds = std::chrono::duration<f64>(finished - *acquiredAt).count();
@@ -1235,6 +1278,12 @@ namespace OloEngine::Automation
                         result.Note = "The build reported success (exit 0) but there is no artefact at " + reported +
                                       ". Exit codes, mtimes and empty logs can all fake a build; the artefact is "
                                       "the evidence, and it is not there.";
+                        break;
+                    case TargetOutcome::ArtifactUnverifiable:
+                        result.Note = "The build reported success and " + reported +
+                                      " exists, but its modification time could not be read, so whether THIS build "
+                                      "produced it is unknown. Reported as unverified rather than as a pass: a "
+                                      "measurement that did not happen is not evidence.";
                         break;
                     case TargetOutcome::UpToDate:
                         result.Note = "Nothing to do: the artefact was already current and this build did not "
@@ -1443,7 +1492,8 @@ namespace OloEngine::Automation
                                                        "The cmake line the lock was asked to run, verbatim — paste "
                                                        "it into a shell to reproduce."))
                                   .Prop("outcome", Schema::String().Enum({ "rebuilt", "up-to-date", "failed",
-                                                                           "missing-artifact", "not-built",
+                                                                           "missing-artifact",
+                                                                           "artifact-unverifiable", "not-built",
                                                                            "skipped" }))
                                   .Prop("success", Schema::Bool())
                                   .Prop("exitCode", Schema::Int())

--- a/OloEditor/src/Automation/AutomationBuildCommands.h
+++ b/OloEditor/src/Automation/AutomationBuildCommands.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace OloEngine::Automation
+{
+    class AutomationRegistry;
+
+    // Structured build invocation (issue #1163, Epic H slice 3): olo_build_list
+    // and olo_build_run.
+    //
+    // These spawn `.claude/skills/run-oloengine/build-lock.ps1` as a CHILD
+    // PROCESS from the automation handler thread. They never marshal onto the
+    // game thread and never touch the renderer — a build has nothing to do with
+    // a frame, and going through the game thread would stall the editor for the
+    // length of a build.
+    //
+    // The concurrency contract with the lock is the substance of the slice, not
+    // an implementation detail; it is stated in
+    // docs/agent-rules/automation-build-invocation.md and enforced here.
+    void RegisterBuildCommands(AutomationRegistry& registry);
+} // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationBuildInvocation.h
+++ b/OloEditor/src/Automation/AutomationBuildInvocation.h
@@ -43,6 +43,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace OloEngine::Automation::BuildInvocation
@@ -654,15 +655,39 @@ namespace OloEngine::Automation::BuildInvocation
     // error is the one that matters and a re-sorted list buries it.
     [[nodiscard]] inline std::vector<Diagnostic> Deduplicate(const std::vector<Diagnostic>& diagnostics)
     {
+        // Indexed rather than scanned. A linear `std::find` over the accumulated
+        // vector is quadratic in the UNIQUE count while comparing four strings
+        // per probe, and a /W4 full build can emit thousands of distinct
+        // warnings — a cliff in the log size, which no caller controls. The
+        // vector still decides ORDER; the map only finds the duplicate.
         std::vector<Diagnostic> out;
         out.reserve(diagnostics.size());
+        std::unordered_map<std::string, sizet> indexByKey;
+        indexByKey.reserve(diagnostics.size());
         for (const Diagnostic& diagnostic : diagnostics)
         {
-            const auto found = std::find(out.begin(), out.end(), diagnostic);
-            if (found != out.end())
-                ++found->Occurrences;
-            else
+            // The unit separator cannot appear in a path, a diagnostic id or a
+            // compiler message, so the concatenation is unambiguous.
+            constexpr char kSep = '';
+            std::string key;
+            key.reserve(diagnostic.File.size() + diagnostic.Code.size() + diagnostic.Message.size() + 24);
+            key += std::to_string(static_cast<int>(diagnostic.Level));
+            key += kSep;
+            key += diagnostic.File;
+            key += kSep;
+            key += std::to_string(diagnostic.Line);
+            key += kSep;
+            key += std::to_string(diagnostic.Column);
+            key += kSep;
+            key += diagnostic.Code;
+            key += kSep;
+            key += diagnostic.Message;
+
+            const auto [entry, inserted] = indexByKey.try_emplace(std::move(key), out.size());
+            if (inserted)
                 out.push_back(diagnostic);
+            else
+                ++out[entry->second].Occurrences;
         }
         return out;
     }
@@ -944,8 +969,15 @@ namespace OloEngine::Automation::BuildInvocation
         bool Exists = false;
         u64 SizeBytes = 0;
         std::string ModifiedUtc; // ISO-8601; empty when it could not be read
+        // Whether the mtime was actually READ. Separate from the value, because
+        // the value's default (0.0) is indistinguishable from "written the
+        // instant the build started" — so an unreadable timestamp would otherwise
+        // yield a positive `Rebuilt` verdict out of a measurement that never
+        // happened, which is the exact conflation this file exists to prevent.
+        bool MtimeKnown = false;
         // Seconds between the build STARTING and the artefact's mtime. Negative
         // means the artefact predates the build, i.e. nothing replaced it.
+        // Meaningless unless MtimeKnown.
         f64 AgeRelativeToStartSeconds = 0.0;
     };
 
@@ -955,8 +987,12 @@ namespace OloEngine::Automation::BuildInvocation
         UpToDate,        // the build ran, had nothing to do, and the artefact is the previous one
         Failed,          // the build reported failure
         MissingArtifact, // the build reported SUCCESS and there is no artefact — never a pass
-        NotBuilt,        // the lock stood down / never acquired: nothing ran at all
-        Skipped,         // an earlier target in the same call failed, so this one was never attempted
+        // The build reported success and the artefact is there, but its timestamp
+        // could not be read, so whether THIS build produced it is unknown. Not a
+        // success: an unverifiable claim is not a verified one.
+        ArtifactUnverifiable,
+        NotBuilt, // the lock stood down / never acquired: nothing ran at all
+        Skipped,  // an earlier target in the same call failed, so this one was never attempted
     };
 
     [[nodiscard]] inline const char* TargetOutcomeName(TargetOutcome outcome)
@@ -971,6 +1007,8 @@ namespace OloEngine::Automation::BuildInvocation
                 return "failed";
             case TargetOutcome::MissingArtifact:
                 return "missing-artifact";
+            case TargetOutcome::ArtifactUnverifiable:
+                return "artifact-unverifiable";
             case TargetOutcome::NotBuilt:
                 return "not-built";
             case TargetOutcome::Skipped:
@@ -1001,6 +1039,11 @@ namespace OloEngine::Automation::BuildInvocation
             return TargetOutcome::Failed;
         if (!after.Exists)
             return TargetOutcome::MissingArtifact;
+        // An UNREAD mtime is not a zero mtime. Without this the default 0.0
+        // sails through the comparison below as "written exactly when the build
+        // started" and reports Rebuilt.
+        if (!after.MtimeKnown)
+            return TargetOutcome::ArtifactUnverifiable;
         // The mtime is compared against the moment the build STARTED, not
         // against the previous stat. Comparing to the previous stat would call a
         // rebuild "up to date" whenever the compiler reproduced a byte-identical

--- a/OloEditor/src/Automation/AutomationBuildInvocation.h
+++ b/OloEditor/src/Automation/AutomationBuildInvocation.h
@@ -1,0 +1,1132 @@
+#pragma once
+
+// Pure parsing, classification and freshness reasoning for the structured build
+// command olo_build_run / olo_build_list (issue #1163, Epic H slice 3).
+//
+// Slice 1 (#1130) closed "run the thing that proves it, read a structured
+// result". This closes the half before it: PRODUCE the thing. Until now an
+// agent that wanted OloEngine-Tests built before running it had to leave the
+// control plane entirely.
+//
+// THE INVARIANT THIS FILE EXISTS FOR: a build's exit code is not evidence that
+// anything was built. Three separate mechanisms in this repo report a build that
+// did not happen as exit 0:
+//
+//   1. `build-lock.ps1` STANDS DOWN with exit 0 when an identical command from
+//      the same worktree was queued later (its Test-Superseded path). Nothing
+//      ran; the caller sees success.
+//   2. An incremental build with nothing to do exits 0 and touches no artefact.
+//      That is legitimate — but it is indistinguishable from (1) and from (3)
+//      unless the artefact is inspected.
+//   3. A build that never started at all (no configured tree, no VCPKG_ROOT)
+//      can still leave last week's binary sitting exactly where a caller looks.
+//
+// So the verdict is taken from the ARTEFACT, not the exit code: every target's
+// primary output is stat'd before and after, and the result says whether it was
+// replaced, was already up to date, or is missing. `Verdict()` below is the one
+// place those three inputs are combined.
+//
+// Everything here is free functions over PODs with NO editor, process or
+// filesystem dependency — only nlohmann::json and the stdlib — so it is unit
+// tested headlessly (OloEngine/tests/MCP/McpAutomationBuildTest.cpp). The
+// process spawning, the job object and the actual stat calls live in the
+// handler (Automation/AutomationBuildCommands.cpp). Same split as
+// MCP/McpTestExecution.h.
+
+#include "OloEngine/Core/Base.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace OloEngine::Automation::BuildInvocation
+{
+    using Json = nlohmann::json;
+
+    // ---- the three fixed vocabularies ------------------------------------
+    //
+    // Target, configuration and build directory are INTERPOLATED into a
+    // PowerShell command string that build-lock.ps1 writes to a script file and
+    // executes. There is no escaping scheme that makes freehand text safe there,
+    // so none is attempted: each of the three is resolved against a fixed table
+    // and anything not in it is refused by name. That is the injection boundary,
+    // and it is the same boundary that answers "may the editor build itself?".
+
+    // Where a target's primary artefact lands, and whether it may be built from
+    // inside a RUNNING editor.
+    //
+    // The layout is not guessed: `olo_configure_app` -> `olo_set_output_directories`
+    // (cmake/CommonProperties.cmake) puts every app and the engine archive under
+    // `<repo>/bin/<Config>/<target>/`, which is the SOURCE tree, not the build
+    // tree — so two build trees write the same file and the path alone cannot
+    // say which one produced it. OloEngine-Tests calls neither, so it keeps the
+    // Ninja-multi-config default under the build directory.
+    struct TargetSpec
+    {
+        std::string_view Name;
+        // Path relative to the repo root (ArtifactUnderBuildDir false) or to the
+        // build directory (true). `{CONFIG}` is substituted with the build
+        // configuration; `{EXE}` with the platform executable suffix, `{LIB}`
+        // with the static-library shape and `{DLL}` with the shared one.
+        std::string_view Artifact;
+        bool ArtifactUnderBuildDir = false;
+        // Empty => buildable from inside the editor. Non-empty => refused, and
+        // this is the sentence the caller gets.
+        std::string_view RefusedBecause;
+        std::string_view Description;
+    };
+
+    // Every target the root CMakeLists.txt defines that a caller might plausibly
+    // ask for. A name that is not here is refused as unknown rather than passed
+    // through — see the injection note above.
+    inline constexpr std::array<TargetSpec, 8> kTargets{ {
+        { "OloEngine", "bin/{CONFIG}/OloEngine/{LIB}OloEngine{LIBEXT}", false, "",
+          "The engine static library. Depends on GenerateBindings, so building it can rewrite the "
+          "tracked generated sources under OloEngine/src/Generated." },
+        { "OloEngine-Tests", "OloEngine/tests/{CONFIG}/OloEngine-Tests{EXE}", true, "",
+          "The GoogleTest binary olo_tests_run executes." },
+        { "OloRuntime", "bin/{CONFIG}/OloRuntime/OloRuntime{EXE}", false, "",
+          "The standalone game runtime. This is the binary BuildGamePanel copies into a packaged "
+          "game, and the one its 'Build OloRuntime first' error asks for." },
+        { "OloServer", "bin/{CONFIG}/OloServer/OloServer{EXE}", false, "", "The headless dedicated server." },
+        { "oloctl", "bin/{CONFIG}/oloctl/oloctl{EXE}", false, "", "The automation CLI frontend (#1125)." },
+        { "OloEngine-LuaScriptCore", "OloEditor/Resources/Scripts/{DLL}OloEngine-LuaScriptCore{DLLEXT}", false, "",
+          "The Lua scripting shared library. The editor does not load it, so replacing it is safe "
+          "while the editor runs." },
+        // ---- refused, with the mechanism named --------------------------
+        { "OloEditor", "bin/{CONFIG}/OloEditor/OloEditor{EXE}", false,
+          "OloEditor is the image this process is running from, and Windows keeps a running image "
+          "mapped — the linker cannot replace it. The build would compile everything and then fail "
+          "at link with LNK1168. Build it from a shell, or close the editor first.",
+          "The editor itself." },
+        { "OloEngine-ScriptCore", "OloEditor/Resources/Scripts/OloEngine-ScriptCore.dll", false,
+          "OloEngine-ScriptCore's assembly is loaded by Mono inside this running editor, so the C# "
+          "build cannot overwrite it. Build it from a shell, or close the editor first.",
+          "The C# scripting assembly." },
+    } };
+
+    [[nodiscard]] inline const TargetSpec* FindTarget(std::string_view name)
+    {
+        for (const TargetSpec& spec : kTargets)
+        {
+            if (spec.Name == name)
+                return &spec;
+        }
+        return nullptr;
+    }
+
+    // Every target name, for an error message that tells the caller what it may
+    // ask for instead of only what it may not.
+    [[nodiscard]] inline std::string BuildableTargetList()
+    {
+        std::string list;
+        for (const TargetSpec& spec : kTargets)
+        {
+            if (!spec.RefusedBecause.empty())
+                continue;
+            if (!list.empty())
+                list += ", ";
+            list += std::string(spec.Name);
+        }
+        return list;
+    }
+
+    // The build configurations CMakePresets.json declares. `Dist` is included
+    // because it is a real configuration of every preset, not because anything
+    // here is expected to ask for it.
+    inline constexpr std::array<std::string_view, 3> kConfigs{ "Debug", "Release", "Dist" };
+
+    [[nodiscard]] inline bool IsKnownConfig(std::string_view config)
+    {
+        return std::find(kConfigs.begin(), kConfigs.end(), config) != kConfigs.end();
+    }
+
+    // The build trees CMakePresets.json defines. `build-cached` is first because
+    // it is CLAUDE.md's default and the only kind eligible for a second
+    // concurrent slot under the lock; the other two are named so a caller
+    // investigating a clang-cl or MSVC-specific failure can reach them.
+    inline constexpr std::array<std::string_view, 3> kBuildDirs{ "build-cached", "build", "build-clang" };
+
+    [[nodiscard]] inline bool IsKnownBuildDir(std::string_view dir)
+    {
+        return std::find(kBuildDirs.begin(), kBuildDirs.end(), dir) != kBuildDirs.end();
+    }
+
+    // Substitute the placeholders in a TargetSpec::Artifact. Kept here rather
+    // than in the handler so the table and its expansion are tested together —
+    // a wrong path makes a SUCCESSFUL build report "no artefact", which is the
+    // safe direction but still a bug.
+    [[nodiscard]] inline std::string ExpandArtifact(std::string_view pattern, std::string_view config, bool windows)
+    {
+        const auto replaceAll = [](std::string& text, std::string_view token, std::string_view with)
+        {
+            for (sizet at = text.find(token); at != std::string::npos; at = text.find(token, at + with.size()))
+                text.replace(at, token.size(), with);
+        };
+        std::string out(pattern);
+        replaceAll(out, "{CONFIG}", config);
+        replaceAll(out, "{EXE}", windows ? ".exe" : "");
+        // MSVC names a static archive `Foo.lib`; the GNU/Clang toolchains name it
+        // `libFoo.a`. Same for a shared library: `Foo.dll` against `libFoo.so`.
+        replaceAll(out, "{LIBEXT}", windows ? ".lib" : ".a");
+        replaceAll(out, "{LIB}", windows ? "" : "lib");
+        replaceAll(out, "{DLLEXT}", windows ? ".dll" : ".so");
+        replaceAll(out, "{DLL}", windows ? "" : "lib");
+        return out;
+    }
+
+    // ---- the command line -------------------------------------------------
+
+    // The `cmake --build` command build-lock.ps1 is asked to run. One target per
+    // invocation on purpose: `--target A --target B` builds both under one
+    // `cmake` and there is then no honest way to attribute wall time — or a
+    // failure — to one of them. Per-target results are the deliverable, so the
+    // targets are built sequentially, each with its own lock ticket.
+    //
+    // `--parallel 6` is a HINT: the lock rewrites it from measured free memory
+    // at acquire time, in either direction. It is passed anyway so that a run
+    // with -Jobs -1 (verbatim) is still capped, never uncapped.
+    [[nodiscard]] inline std::string BuildCommand(std::string_view buildDir, std::string_view target,
+                                                  std::string_view config)
+    {
+        return "cmake --build " + std::string(buildDir) + " --target " + std::string(target) + " --config " +
+               std::string(config) + " --parallel 6";
+    }
+
+    // ---- compiler diagnostics ---------------------------------------------
+
+    enum class Severity : u8
+    {
+        Error = 0,
+        Warning,
+        Note,
+    };
+
+    [[nodiscard]] inline const char* SeverityName(Severity severity)
+    {
+        switch (severity)
+        {
+            case Severity::Error:
+                return "error";
+            case Severity::Warning:
+                return "warning";
+            case Severity::Note:
+                return "note";
+        }
+        return "unknown";
+    }
+
+    // One compiler, linker or CMake diagnostic as a RECORD. The whole point of
+    // the command: a caller reads `file`/`line`/`column`/`code`/`message`
+    // instead of scraping console text and guessing at the shape.
+    struct Diagnostic
+    {
+        Severity Level = Severity::Error;
+        std::string File; // repo-relative where it could be made so; empty for a linker error
+        int Line = 0;     // 0 when the diagnostic carries none
+        int Column = 0;   // 0 when the toolchain emits none (MSVC's cl does not)
+        std::string Code; // "C2065", "LNK2019", "C4996", ""; the toolchain's own id
+        std::string Message;
+        sizet Occurrences = 1; // >1 after Deduplicate(): the same record from N translation units
+
+        [[nodiscard]] bool operator==(const Diagnostic& other) const
+        {
+            return Level == other.Level && File == other.File && Line == other.Line && Column == other.Column &&
+                   Code == other.Code && Message == other.Message;
+        }
+    };
+
+    namespace Detail
+    {
+        [[nodiscard]] inline std::string_view TrimAscii(std::string_view text)
+        {
+            while (!text.empty() && (text.front() == ' ' || text.front() == '\t' || text.front() == '\r'))
+                text.remove_prefix(1);
+            while (!text.empty() && (text.back() == ' ' || text.back() == '\t' || text.back() == '\r'))
+                text.remove_suffix(1);
+            return text;
+        }
+
+        // Strip a leading separator dash and the space around it. Handles both
+        // the em dash build-lock.ps1's source carries (UTF-8 e2 80 94) and the
+        // ASCII '-' a redirected PowerShell log actually contains — the host
+        // transcodes to the console code page on the way out, so which one you
+        // get depends on where you read it from, not on the script.
+        [[nodiscard]] inline std::string_view TrimDashes(std::string_view text)
+        {
+            text = TrimAscii(text);
+            constexpr std::string_view kEmDash = "\xe2\x80\x94";
+            while (!text.empty())
+            {
+                if (text.front() == '-')
+                    text.remove_prefix(1);
+                else if (text.starts_with(kEmDash))
+                    text.remove_prefix(kEmDash.size());
+                else
+                    break;
+                text = TrimAscii(text);
+            }
+            return text;
+        }
+
+        // MSBuild appends the owning project to every diagnostic:
+        // `... error C2065: 'x' [C:\repos\...\OloEngine.vcxproj]`. It is noise in
+        // a per-file record, and leaving it in would make two otherwise identical
+        // diagnostics from two projects fail to deduplicate.
+        [[nodiscard]] inline std::string_view StripProjectSuffix(std::string_view message)
+        {
+            if (message.empty() || message.back() != ']')
+                return message;
+            const sizet open = message.rfind('[');
+            if (open == std::string_view::npos)
+                return message;
+            const std::string_view inside = message.substr(open + 1, message.size() - open - 2);
+            const bool isProject = inside.ends_with(".vcxproj") || inside.ends_with(".csproj") ||
+                                   inside.ends_with(".metaproj") || inside.ends_with(".sln");
+            return isProject ? TrimAscii(message.substr(0, open)) : message;
+        }
+
+        [[nodiscard]] inline bool IsDigits(std::string_view text)
+        {
+            return !text.empty() && std::all_of(text.begin(), text.end(), [](char c)
+                                                { return c >= '0' && c <= '9'; });
+        }
+
+        // Bounded so a pathological "12345678901234567890" cannot overflow; a
+        // line number that large is not a line number.
+        [[nodiscard]] inline int ToLineNumber(std::string_view text)
+        {
+            if (!IsDigits(text) || text.size() > 9)
+                return 0;
+            int value = 0;
+            for (const char c : text)
+                value = value * 10 + (c - '0');
+            return value;
+        }
+
+        // Split a leading `<file>(<line>)` / `<file>(<line>,<col>)` prefix.
+        // Returns false when the text does not start with one.
+        // Split a leading `<file>(<line>)` / `<file>(<line>,<col>)` prefix, where
+        // the closing paren is the one whose REMAINDER is a severity.
+        //
+        // Anchoring on the first ')' was wrong twice, and both are real lines:
+        //
+        //   C:\Program Files (x86)\Windows Kits\...\winnt.h(9): warning C4005: ...
+        //       -- the first ')' closes "(x86)", "x86" is not a line number, and
+        //          giving up there dropped the whole diagnostic;
+        //   /h/f.cpp:99:5: error: no matching function for call to 'foo(3)'
+        //       -- the first ')' closes "foo(3)" in the MESSAGE, which parses as
+        //          a line number, so a gcc error was mis-split and then discarded.
+        //
+        // Requiring the remainder to be a severity settles both without a path
+        // grammar: a parenthesis that is not a location prefix never has
+        // ": error"/": warning" immediately after it. Candidates are scanned
+        // LEFT to RIGHT so the FILE's parens are tried before the message's.
+        [[nodiscard]] inline bool SplitSeverity(std::string_view rest, Severity& outLevel, std::string_view& outCode,
+                                                std::string_view& outMessage);
+
+        [[nodiscard]] inline bool SplitMsvcLocation(std::string_view text, std::string_view& outFile, int& outLine,
+                                                    int& outColumn, std::string_view& outRest, Severity& outLevel,
+                                                    std::string_view& outCode, std::string_view& outMessage)
+        {
+            for (sizet close = text.find(')'); close != std::string_view::npos; close = text.find(')', close + 1))
+            {
+                const sizet open = text.rfind('(', close);
+                if (open == std::string_view::npos || open == 0)
+                    continue;
+
+                const std::string_view inside = text.substr(open + 1, close - open - 1);
+                const sizet comma = inside.find(',');
+                const std::string_view lineText = comma == std::string_view::npos ? inside : inside.substr(0, comma);
+                const std::string_view columnText =
+                    comma == std::string_view::npos ? std::string_view{} : inside.substr(comma + 1);
+                const int line = ToLineNumber(lineText);
+                if (line == 0)
+                    continue;
+                // A column that is present but unparseable means this was not a
+                // location prefix at all (e.g. a call like `foo(a,b)`).
+                if (!columnText.empty() && ToLineNumber(columnText) == 0)
+                    continue;
+
+                const std::string_view file = TrimAscii(text.substr(0, open));
+                if (file.empty())
+                    continue;
+                const std::string_view rest = TrimAscii(text.substr(close + 1));
+                if (!SplitSeverity(rest, outLevel, outCode, outMessage))
+                    continue;
+
+                outFile = file;
+                outLine = line;
+                outColumn = columnText.empty() ? 0 : ToLineNumber(columnText);
+                outRest = rest;
+                return true;
+            }
+            return false;
+        }
+
+        // `: error C2065: 'x': undeclared identifier` -> severity Error, code
+        // C2065, message "'x': undeclared identifier". Returns false when the
+        // text does not begin with a severity keyword.
+        inline bool SplitSeverity(std::string_view rest, Severity& outLevel, std::string_view& outCode,
+                                  std::string_view& outMessage)
+        {
+            rest = TrimAscii(rest);
+            if (!rest.empty() && rest.front() == ':')
+                rest = TrimAscii(rest.substr(1));
+
+            constexpr std::string_view kFatal = "fatal error";
+            if (rest.starts_with(kFatal))
+            {
+                outLevel = Severity::Error;
+                rest = TrimAscii(rest.substr(kFatal.size()));
+            }
+            else if (rest.starts_with("error"))
+            {
+                outLevel = Severity::Error;
+                rest = TrimAscii(rest.substr(5));
+            }
+            else if (rest.starts_with("warning"))
+            {
+                outLevel = Severity::Warning;
+                rest = TrimAscii(rest.substr(7));
+            }
+            else if (rest.starts_with("note"))
+            {
+                outLevel = Severity::Note;
+                rest = TrimAscii(rest.substr(4));
+            }
+            else
+            {
+                return false;
+            }
+
+            // An MSVC/clang-cl diagnostic id sits between the severity and the
+            // colon: `error C2065:`. GCC/Clang emit `error:` with no id.
+            outCode = {};
+            if (const sizet colon = rest.find(':'); colon != std::string_view::npos && colon > 0)
+            {
+                const std::string_view candidate = TrimAscii(rest.substr(0, colon));
+                const bool looksLikeCode =
+                    !candidate.empty() && candidate.size() <= 12 &&
+                    std::all_of(candidate.begin(), candidate.end(),
+                                [](char c)
+                                { return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'); }) &&
+                    std::any_of(candidate.begin(), candidate.end(), [](char c)
+                                { return c >= 'A' && c <= 'Z'; }) &&
+                    std::any_of(candidate.begin(), candidate.end(), [](char c)
+                                { return c >= '0' && c <= '9'; });
+                if (looksLikeCode)
+                {
+                    outCode = candidate;
+                    rest = rest.substr(colon + 1);
+                }
+            }
+            outMessage = TrimAscii(rest);
+            if (!outMessage.empty() && outMessage.front() == ':')
+                outMessage = TrimAscii(outMessage.substr(1));
+            return !outMessage.empty();
+        }
+    } // namespace Detail
+
+    // Parse ONE console line into a diagnostic record, or nothing.
+    //
+    // Four shapes are recognised, and they are the four this repo's toolchains
+    // actually emit:
+    //
+    //   MSVC cl        C:\p\f.cpp(42): error C2065: 'x': undeclared identifier
+    //   clang-cl       C:\p\f.cpp(42,9): warning: unused variable 'x' [-Wunused]
+    //   clang/gcc      /p/f.cpp:42:9: error: use of undeclared identifier 'x'
+    //   MSVC link      f.obj : error LNK2019: unresolved external symbol ...
+    //                  LINK : fatal error LNK1104: cannot open file 'x.lib'
+    //
+    // Nothing here tries to be a compiler-output grammar. A line that does not
+    // match is not a diagnostic as far as this command is concerned, and the
+    // console tail is still returned on failure so nothing is actually lost.
+    [[nodiscard]] inline std::optional<Diagnostic> ParseDiagnosticLine(std::string_view rawLine)
+    {
+        const std::string_view line = Detail::TrimAscii(Detail::StripProjectSuffix(Detail::TrimAscii(rawLine)));
+        if (line.empty())
+            return std::nullopt;
+
+        Diagnostic diagnostic;
+        std::string_view file;
+        std::string_view rest;
+        int lineNumber = 0;
+        int column = 0;
+
+        // 1/2. MSVC and clang-cl: `<file>(<line>[,<col>])<rest>`.
+        //
+        // The severity is validated INSIDE the split (it is how the right
+        // parenthesis is chosen), so a failure here means "not this shape" and
+        // must fall through to 3 and 4 rather than end the parse — a gcc line
+        // whose message contains `foo(3)` used to be mis-split here and then
+        // discarded before the gcc branch ever saw it.
+        {
+            Severity level = Severity::Error;
+            std::string_view code;
+            std::string_view message;
+            if (Detail::SplitMsvcLocation(line, file, lineNumber, column, rest, level, code, message))
+            {
+                diagnostic.Level = level;
+                diagnostic.File = std::string(file);
+                diagnostic.Line = lineNumber;
+                diagnostic.Column = column;
+                diagnostic.Code = std::string(code);
+                diagnostic.Message = std::string(message);
+                return diagnostic;
+            }
+        }
+
+        // 3. clang / gcc: `<file>:<line>:<col>: <severity>: <message>`. Scanned
+        //    from the RIGHT so a Windows drive letter (`C:\...`) cannot be read
+        //    as the first field separator.
+        {
+            const sizet third = line.find(": ");
+            if (third != std::string_view::npos && third >= 3)
+            {
+                const std::string_view head = line.substr(0, third);
+                const sizet lastColon = head.rfind(':');
+                if (lastColon != std::string_view::npos && lastColon > 0)
+                {
+                    const sizet firstColon = head.rfind(':', lastColon - 1);
+                    if (firstColon != std::string_view::npos && firstColon > 0)
+                    {
+                        const std::string_view lineText = head.substr(firstColon + 1, lastColon - firstColon - 1);
+                        const std::string_view columnText = head.substr(lastColon + 1);
+                        const int parsedLine = Detail::ToLineNumber(lineText);
+                        const int parsedColumn = Detail::ToLineNumber(columnText);
+                        if (parsedLine > 0 && parsedColumn > 0)
+                        {
+                            Severity level = Severity::Error;
+                            std::string_view code;
+                            std::string_view message;
+                            if (Detail::SplitSeverity(line.substr(third), level, code, message))
+                            {
+                                diagnostic.Level = level;
+                                diagnostic.File = std::string(head.substr(0, firstColon));
+                                diagnostic.Line = parsedLine;
+                                diagnostic.Column = parsedColumn;
+                                diagnostic.Code = std::string(code);
+                                diagnostic.Message = std::string(message);
+                                return diagnostic;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 4. The linker and the toolchain drivers: no location at all.
+        //    `f.obj : error LNK2019: ...` / `LINK : fatal error LNK1104: ...`
+        if (const sizet marker = line.find(" : "); marker != std::string_view::npos)
+        {
+            Severity level = Severity::Error;
+            std::string_view code;
+            std::string_view message;
+            if (Detail::SplitSeverity(line.substr(marker + 3), level, code, message))
+            {
+                diagnostic.Level = level;
+                // The left half is an object file or the literal "LINK", not a
+                // source location — reported as the file with no line, because
+                // "which object could not be linked" is the whole of what the
+                // linker knows.
+                const std::string_view origin = Detail::TrimAscii(line.substr(0, marker));
+                if (origin != "LINK" && origin != "link")
+                    diagnostic.File = std::string(origin);
+                diagnostic.Code = std::string(code);
+                diagnostic.Message = std::string(message);
+                return diagnostic;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    // Normalize a diagnostic's file to a repo-relative path with forward
+    // slashes. `repoRoot` is compared case-insensitively because MSVC and ninja
+    // disagree about the case of a Windows drive letter within one build.
+    // Returns the input unchanged when it does not lie under the root — never
+    // empty, because a path outside the tree (a vcpkg header) is still the
+    // truthful answer.
+    [[nodiscard]] inline std::string RelativizePath(std::string_view path, std::string_view repoRoot)
+    {
+        std::string normalized(path);
+        std::replace(normalized.begin(), normalized.end(), '\\', '/');
+        if (repoRoot.empty())
+            return normalized;
+
+        std::string root(repoRoot);
+        std::replace(root.begin(), root.end(), '\\', '/');
+        while (!root.empty() && root.back() == '/')
+            root.pop_back();
+        if (root.empty() || normalized.size() <= root.size())
+            return normalized;
+
+        const auto lower = [](char c)
+        { return static_cast<char>(c >= 'A' && c <= 'Z' ? c - 'A' + 'a' : c); };
+        for (sizet i = 0; i < root.size(); ++i)
+        {
+            if (lower(normalized[i]) != lower(root[i]))
+                return normalized;
+        }
+        if (normalized[root.size()] != '/')
+            return normalized;
+        return normalized.substr(root.size() + 1);
+    }
+
+    // Collapse a lexical path: split on '/', drop '.', pop on '..'. No
+    // filesystem access, so it works on a path whose file no longer exists and
+    // stays testable headlessly. Leading '..' that cannot be popped is kept, so
+    // a path that genuinely escapes the base is visibly unresolved rather than
+    // silently rebased.
+    [[nodiscard]] inline std::string CollapseLexicalPath(std::string_view path)
+    {
+        std::vector<std::string_view> parts;
+        sizet cursor = 0;
+        while (cursor <= path.size())
+        {
+            const sizet slash = std::min(path.find('/', cursor), path.size());
+            const std::string_view part = path.substr(cursor, slash - cursor);
+            cursor = slash + 1;
+            if (part.empty() || part == ".")
+                continue;
+            if (part == ".." && !parts.empty() && parts.back() != "..")
+                parts.pop_back();
+            else
+                parts.push_back(part);
+            if (slash == path.size())
+                break;
+        }
+        std::string out;
+        for (const std::string_view part : parts)
+        {
+            if (!out.empty())
+                out.push_back('/');
+            out += part;
+        }
+        return out;
+    }
+
+    // Turn a diagnostic's raw file into a path a caller can open.
+    //
+    // The two toolchains disagree about what a path is relative TO. ninja runs
+    // the compiler with the build directory as its working directory, so a
+    // compiler reports `__FILE__` relative to THAT: the live run of this command
+    // on 2026-09-10 produced `../OloEngine/src/OloEngine/Core/UUID.h` and
+    // `vcpkg_installed/x64-windows-static-md/include/entt/...`. Relativizing
+    // those against the repo root alone leaves them exactly as they arrived,
+    // which is not a path anything can open from the root.
+    //
+    // So a RELATIVE path is joined to the build directory and collapsed; an
+    // ABSOLUTE one is relativized against the repo root and otherwise left
+    // alone, because an absolute path outside the tree (an MSVC or vcpkg header)
+    // is the truthful answer.
+    [[nodiscard]] inline std::string ResolveDiagnosticFile(std::string_view rawPath, std::string_view repoRoot,
+                                                           std::string_view buildDirRelative)
+    {
+        std::string normalized(rawPath);
+        std::replace(normalized.begin(), normalized.end(), '\\', '/');
+        if (normalized.empty())
+            return normalized;
+
+        // "C:/..." or "/...": absolute either way.
+        const bool absolute = normalized.front() == '/' ||
+                              (normalized.size() > 2 && normalized[1] == ':' && normalized[2] == '/');
+        if (absolute)
+            return RelativizePath(normalized, repoRoot);
+        if (buildDirRelative.empty())
+            return CollapseLexicalPath(normalized);
+        return CollapseLexicalPath(std::string(buildDirRelative) + "/" + normalized);
+    }
+
+    // Collapse identical records, counting them. MSVC emits the same header
+    // warning once per translation unit that includes it — 40 copies of one
+    // `C4996` is one defect, and reporting it 40 times pushes the real error
+    // past any cap the caller set.
+    //
+    // Order is preserved (first occurrence wins its position), because the first
+    // error is the one that matters and a re-sorted list buries it.
+    [[nodiscard]] inline std::vector<Diagnostic> Deduplicate(const std::vector<Diagnostic>& diagnostics)
+    {
+        std::vector<Diagnostic> out;
+        out.reserve(diagnostics.size());
+        for (const Diagnostic& diagnostic : diagnostics)
+        {
+            const auto found = std::find(out.begin(), out.end(), diagnostic);
+            if (found != out.end())
+                ++found->Occurrences;
+            else
+                out.push_back(diagnostic);
+        }
+        return out;
+    }
+
+    // Scan a whole console log. Each record's file is resolved by
+    // ResolveDiagnosticFile — see there for why the build directory is needed
+    // as well as the repo root.
+    [[nodiscard]] inline std::vector<Diagnostic> ParseDiagnostics(std::string_view consoleText,
+                                                                  std::string_view repoRoot,
+                                                                  std::string_view buildDirRelative = {})
+    {
+        std::vector<Diagnostic> found;
+        sizet cursor = 0;
+        while (cursor <= consoleText.size())
+        {
+            const sizet lineEnd = std::min(consoleText.find('\n', cursor), consoleText.size());
+            const std::string_view line = consoleText.substr(cursor, lineEnd - cursor);
+            cursor = lineEnd + 1;
+            if (std::optional<Diagnostic> diagnostic = ParseDiagnosticLine(line))
+            {
+                if (!diagnostic->File.empty())
+                    diagnostic->File = ResolveDiagnosticFile(diagnostic->File, repoRoot, buildDirRelative);
+                found.push_back(std::move(*diagnostic));
+            }
+            if (lineEnd == consoleText.size())
+                break;
+        }
+        return Deduplicate(found);
+    }
+
+    struct DiagnosticCounts
+    {
+        sizet Errors = 0;
+        sizet Warnings = 0;
+        sizet Notes = 0;
+    };
+
+    // Counts UNIQUE records, not occurrences: "3 errors" should mean three
+    // things to fix, and a header warning included by 40 TUs is one.
+    [[nodiscard]] inline DiagnosticCounts CountDiagnostics(const std::vector<Diagnostic>& diagnostics)
+    {
+        DiagnosticCounts counts;
+        for (const Diagnostic& diagnostic : diagnostics)
+        {
+            switch (diagnostic.Level)
+            {
+                case Severity::Error:
+                    ++counts.Errors;
+                    break;
+                case Severity::Warning:
+                    ++counts.Warnings;
+                    break;
+                case Severity::Note:
+                    ++counts.Notes;
+                    break;
+            }
+        }
+        return counts;
+    }
+
+    [[nodiscard]] inline Json DiagnosticJson(const Diagnostic& diagnostic)
+    {
+        Json entry;
+        entry["severity"] = SeverityName(diagnostic.Level);
+        if (!diagnostic.File.empty())
+            entry["file"] = diagnostic.File;
+        if (diagnostic.Line > 0)
+            entry["line"] = diagnostic.Line;
+        if (diagnostic.Column > 0)
+            entry["column"] = diagnostic.Column;
+        if (!diagnostic.Code.empty())
+            entry["code"] = diagnostic.Code;
+        entry["message"] = diagnostic.Message;
+        if (diagnostic.Occurrences > 1)
+            entry["occurrences"] = diagnostic.Occurrences;
+        return entry;
+    }
+
+    // ---- what build-lock.ps1 said -----------------------------------------
+    //
+    // The lock writes its own story to the same stdout the build inherits, so
+    // the console log carries a transcript of the concurrency decision. Reading
+    // it is what turns "the lock is somewhere upstream of this" into a
+    // structured field the caller can act on — and it is the ONLY way to see
+    // the stand-down, which otherwise looks exactly like a successful build.
+
+    enum class LockOutcome : u8
+    {
+        Acquired = 0, // the build ran under the lock
+        Superseded,   // stood down with EXIT 0 and built NOTHING (Test-Superseded)
+        Orphaned,     // the launching process died; the lock killed the build tree
+        NeverStarted, // no `[build-lock] acquired` line at all: a wait that timed out, or a crash
+    };
+
+    [[nodiscard]] inline const char* LockOutcomeName(LockOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case LockOutcome::Acquired:
+                return "acquired";
+            case LockOutcome::Superseded:
+                return "superseded";
+            case LockOutcome::Orphaned:
+                return "orphaned";
+            case LockOutcome::NeverStarted:
+                return "never-started";
+        }
+        return "unknown";
+    }
+
+    struct LockTranscript
+    {
+        LockOutcome Outcome = LockOutcome::NeverStarted;
+        bool Waited = false;            // at least one `waiting —` line: the lock was contended
+        int Jobs = 0;                   // the parallelism the lock actually chose, 0 if unreported
+        int HeldByPid = 0;              // the holder we were queued behind, when it said
+        std::string HeldByWorktree;     // ditto
+        std::string ConcurrencyRefusal; // the `not building alongside` reason, when it gave one
+        std::vector<std::string> Lines; // every `[build-lock]` line, verbatim and in order
+    };
+
+    // Read every `[build-lock] ...` line out of a console log.
+    [[nodiscard]] inline LockTranscript ReadLockTranscript(std::string_view consoleText)
+    {
+        constexpr std::string_view kPrefix = "[build-lock]";
+        LockTranscript transcript;
+
+        sizet cursor = 0;
+        while (cursor <= consoleText.size())
+        {
+            const sizet lineEnd = std::min(consoleText.find('\n', cursor), consoleText.size());
+            const std::string_view raw = Detail::TrimAscii(consoleText.substr(cursor, lineEnd - cursor));
+            cursor = lineEnd + 1;
+
+            // The marker is FOUND, not required at column 0. The script's wait
+            // timeout is a PowerShell `throw`, and the host decorates a
+            // terminating error before printing it ("Exception: [build-lock]
+            // timed out after 5m waiting for pid=11 (...)"). That line is the
+            // one that names the holder, so anchoring at the start would drop
+            // precisely the refusal a caller needs to read.
+            const sizet marker = raw.find(kPrefix);
+            // A line still carrying an UNINTERPOLATED PowerShell variable is the
+            // host echoing the script's SOURCE, not something the script said.
+            // A terminating error prints the offending source line above the
+            // message, so a `throw "[build-lock] timed out after ${TimeoutMinutes}m …"`
+            // contributes a truncated look-alike right next to the real one.
+            // Observed 2026-09-10 driving the live editor. Real output can never
+            // contain "${" — PowerShell would have expanded it.
+            const bool isEchoedSource = raw.find("${") != std::string_view::npos;
+            if (marker == std::string_view::npos || isEchoedSource)
+            {
+                if (lineEnd == consoleText.size())
+                    break;
+                continue;
+            }
+            transcript.Lines.emplace_back(raw.substr(marker));
+            const std::string_view body = Detail::TrimAscii(raw.substr(marker + kPrefix.size()));
+
+            if (body.starts_with("acquired"))
+            {
+                // Guarded, not assigned: the stand-down path exits before ever
+                // acquiring, so the two cannot both appear in one run — but if
+                // they somehow did (two runs' output interleaved into one log),
+                // the safe reading is "nothing was built", and an unguarded
+                // assignment here would quietly pick the unsafe one. The comment
+                // on the branch below used to claim this without the code doing it.
+                if (transcript.Outcome != LockOutcome::Superseded && transcript.Outcome != LockOutcome::Orphaned)
+                    transcript.Outcome = LockOutcome::Acquired;
+            }
+            else if (body.starts_with("superseded"))
+            {
+                transcript.Outcome = LockOutcome::Superseded;
+            }
+            else if (body.starts_with("the process that launched this build"))
+            {
+                transcript.Outcome = LockOutcome::Orphaned;
+            }
+            // "timed out after 5m waiting for pid=11 (C:/repos/y)" carries the
+            // holder in the same `pid=` shape, and it is the ONLY line a refused
+            // acquire produces — the outcome stays NeverStarted, which is what
+            // the absence of an `acquired` line already says.
+            else if (body.starts_with("waiting") || body.starts_with("timed out"))
+            {
+                transcript.Waited = true;
+                // `waiting — next in line; held by pid=1234 in C:/repos/x`
+                if (const sizet at = body.find("pid="); at != std::string_view::npos)
+                {
+                    const std::string_view after = body.substr(at + 4);
+                    sizet digits = 0;
+                    while (digits < after.size() && after[digits] >= '0' && after[digits] <= '9')
+                        ++digits;
+                    if (transcript.HeldByPid == 0)
+                        transcript.HeldByPid = Detail::ToLineNumber(after.substr(0, digits));
+                    if (const sizet inAt = after.find(" in "); inAt != std::string_view::npos &&
+                                                               transcript.HeldByWorktree.empty())
+                        transcript.HeldByWorktree = std::string(Detail::TrimAscii(after.substr(inAt + 4)));
+                }
+            }
+            else if (constexpr std::string_view kNotAlongside = "not building alongside the current build";
+                     body.starts_with(kNotAlongside))
+            {
+                // The reason follows a dash — which is an EM dash in the script's
+                // source and a plain ASCII '-' by the time it reaches a redirected
+                // log, because the PowerShell host transcodes its output to the
+                // console code page on the way out (observed 2026-09-10 on this
+                // box: `not building alongside the current build - only 22.6 GB
+                // free`). So the separator is skipped by character class rather
+                // than matched as a literal; anything else here would silently
+                // return the whole line as the "reason" on one of the two.
+                transcript.ConcurrencyRefusal =
+                    std::string(Detail::TrimDashes(body.substr(kNotAlongside.size())));
+            }
+            else if (body.starts_with("parallelism: -j"))
+            {
+                const std::string_view after = body.substr(std::string_view("parallelism: -j").size());
+                sizet digits = 0;
+                while (digits < after.size() && after[digits] >= '0' && after[digits] <= '9')
+                    ++digits;
+                transcript.Jobs = Detail::ToLineNumber(after.substr(0, digits));
+            }
+
+            if (lineEnd == consoleText.size())
+                break;
+        }
+        return transcript;
+    }
+
+    // Ninja prints `[123/4567] Building CXX object ...` for every edge. Returns
+    // the most recent one, which is the only honest progress signal a build
+    // gives — MSBuild prints none, so a `build/` tree simply reports no fraction
+    // rather than a made-up one.
+    struct BuildProgress
+    {
+        sizet Done = 0;
+        sizet Total = 0;
+
+        [[nodiscard]] bool Known() const
+        {
+            return Total > 0 && Done <= Total;
+        }
+    };
+
+    [[nodiscard]] inline BuildProgress ReadLastNinjaProgress(std::string_view consoleText)
+    {
+        BuildProgress progress;
+        sizet at = consoleText.rfind('[');
+        while (at != std::string_view::npos)
+        {
+            const sizet close = consoleText.find(']', at);
+            if (close != std::string_view::npos && close - at <= 20)
+            {
+                const std::string_view inside = consoleText.substr(at + 1, close - at - 1);
+                if (const sizet slash = inside.find('/');
+                    slash != std::string_view::npos && Detail::IsDigits(inside.substr(0, slash)) &&
+                    Detail::IsDigits(inside.substr(slash + 1)))
+                {
+                    progress.Done = static_cast<sizet>(Detail::ToLineNumber(inside.substr(0, slash)));
+                    progress.Total = static_cast<sizet>(Detail::ToLineNumber(inside.substr(slash + 1)));
+                    if (progress.Known())
+                        return progress;
+                    progress = {};
+                }
+            }
+            if (at == 0)
+                break;
+            at = consoleText.rfind('[', at - 1);
+        }
+        return progress;
+    }
+
+    // ---- the freshness verdict --------------------------------------------
+    //
+    // The reason this file exists. See the header comment.
+
+    // A target's primary output, stat'd on both sides of the build.
+    struct ArtifactState
+    {
+        std::string Path; // repo-relative
+        bool Exists = false;
+        u64 SizeBytes = 0;
+        std::string ModifiedUtc; // ISO-8601; empty when it could not be read
+        // Seconds between the build STARTING and the artefact's mtime. Negative
+        // means the artefact predates the build, i.e. nothing replaced it.
+        f64 AgeRelativeToStartSeconds = 0.0;
+    };
+
+    enum class TargetOutcome : u8
+    {
+        Rebuilt = 0,     // the build ran and the artefact was replaced
+        UpToDate,        // the build ran, had nothing to do, and the artefact is the previous one
+        Failed,          // the build reported failure
+        MissingArtifact, // the build reported SUCCESS and there is no artefact — never a pass
+        NotBuilt,        // the lock stood down / never acquired: nothing ran at all
+        Skipped,         // an earlier target in the same call failed, so this one was never attempted
+    };
+
+    [[nodiscard]] inline const char* TargetOutcomeName(TargetOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case TargetOutcome::Rebuilt:
+                return "rebuilt";
+            case TargetOutcome::UpToDate:
+                return "up-to-date";
+            case TargetOutcome::Failed:
+                return "failed";
+            case TargetOutcome::MissingArtifact:
+                return "missing-artifact";
+            case TargetOutcome::NotBuilt:
+                return "not-built";
+            case TargetOutcome::Skipped:
+                return "skipped";
+        }
+        return "unknown";
+    }
+
+    // Only Rebuilt and UpToDate are successes, and they are distinguished
+    // rather than merged: "up to date" is the answer a caller must be able to
+    // see, because it is what a stale artefact looks like from the outside.
+    [[nodiscard]] inline bool IsSuccess(TargetOutcome outcome)
+    {
+        return outcome == TargetOutcome::Rebuilt || outcome == TargetOutcome::UpToDate;
+    }
+
+    // Combine the three independent inputs into one verdict.
+    //
+    // `lockOutcome` FIRST, because it can veto a zero exit code: a superseded
+    // stand-down exits 0 having built nothing, and an orphan kill exits with
+    // whatever the kill happened to report. Only then does the exit code
+    // matter, and only then the artefact.
+    [[nodiscard]] inline TargetOutcome Verdict(LockOutcome lockOutcome, int exitCode, const ArtifactState& after)
+    {
+        if (lockOutcome == LockOutcome::Superseded || lockOutcome == LockOutcome::NeverStarted)
+            return TargetOutcome::NotBuilt;
+        if (lockOutcome == LockOutcome::Orphaned || exitCode != 0)
+            return TargetOutcome::Failed;
+        if (!after.Exists)
+            return TargetOutcome::MissingArtifact;
+        // The mtime is compared against the moment the build STARTED, not
+        // against the previous stat. Comparing to the previous stat would call a
+        // rebuild "up to date" whenever the compiler reproduced a byte-identical
+        // file at the same timestamp granularity, and it needs the before-state
+        // to be readable, which it is not for a first build.
+        return after.AgeRelativeToStartSeconds >= 0.0 ? TargetOutcome::Rebuilt : TargetOutcome::UpToDate;
+    }
+
+    struct TargetResult
+    {
+        std::string Target;
+        // The cmake line the lock was asked to run, verbatim. Reported so a
+        // caller staring at a failure can reproduce it in a shell without
+        // reconstructing it from three separate fields.
+        std::string Command;
+        TargetOutcome Outcome = TargetOutcome::NotBuilt;
+        int ExitCode = -1;
+        f64 WallSeconds = 0.0;
+        // WallSeconds split at the moment the lock was acquired. Measured live
+        // on 2026-09-10: building a 15 KB DLL reported 1474 wall seconds, of
+        // which 1451 were queue. Reporting only the total invites a caller to
+        // conclude the build is slow when the machine was simply busy — and the
+        // two numbers lead to opposite actions. Negative => the acquire was
+        // never observed (the child finished between polls, or never acquired),
+        // and the fields are omitted rather than guessed.
+        f64 QueuedSeconds = -1.0;
+        f64 BuildSeconds = -1.0;
+        ArtifactState Before;
+        ArtifactState After;
+        LockTranscript Lock;
+        std::vector<Diagnostic> Diagnostics;
+        std::string Note; // why, for every outcome that needs a sentence
+    };
+
+    [[nodiscard]] inline Json ArtifactJson(const ArtifactState& state)
+    {
+        Json entry;
+        entry["path"] = state.Path;
+        entry["exists"] = state.Exists;
+        if (state.Exists)
+        {
+            entry["sizeBytes"] = state.SizeBytes;
+            if (!state.ModifiedUtc.empty())
+                entry["modifiedUtc"] = state.ModifiedUtc;
+        }
+        return entry;
+    }
+
+    [[nodiscard]] inline Json LockJson(const LockTranscript& lock)
+    {
+        Json entry;
+        entry["outcome"] = LockOutcomeName(lock.Outcome);
+        entry["contended"] = lock.Waited;
+        if (lock.Jobs > 0)
+            entry["jobs"] = lock.Jobs;
+        if (lock.HeldByPid > 0)
+        {
+            entry["heldByPid"] = lock.HeldByPid;
+            if (!lock.HeldByWorktree.empty())
+                entry["heldByWorktree"] = lock.HeldByWorktree;
+        }
+        if (!lock.ConcurrencyRefusal.empty())
+            entry["concurrencyRefusal"] = lock.ConcurrencyRefusal;
+        if (!lock.Lines.empty())
+            entry["transcript"] = lock.Lines;
+        return entry;
+    }
+
+    [[nodiscard]] inline Json TargetResultJson(const TargetResult& result, sizet maxDiagnostics)
+    {
+        Json entry;
+        entry["target"] = result.Target;
+        if (!result.Command.empty())
+            entry["command"] = result.Command;
+        entry["outcome"] = TargetOutcomeName(result.Outcome);
+        entry["success"] = IsSuccess(result.Outcome);
+        entry["exitCode"] = result.ExitCode;
+        entry["wallSeconds"] = result.WallSeconds;
+        if (result.QueuedSeconds >= 0.0)
+            entry["queuedSeconds"] = result.QueuedSeconds;
+        if (result.BuildSeconds >= 0.0)
+            entry["buildSeconds"] = result.BuildSeconds;
+        entry["artifact"] = ArtifactJson(result.After);
+        // The BEFORE state is reported too, and only when it differs, because
+        // "the artefact is 40 minutes old and this build did not touch it" is
+        // exactly the question an exit code cannot answer.
+        if (result.Before.Exists && result.Before.ModifiedUtc != result.After.ModifiedUtc)
+            entry["artifactBefore"] = ArtifactJson(result.Before);
+        entry["lock"] = LockJson(result.Lock);
+
+        const DiagnosticCounts counts = CountDiagnostics(result.Diagnostics);
+        entry["errorCount"] = counts.Errors;
+        entry["warningCount"] = counts.Warnings;
+
+        Json diagnostics = Json::array();
+        sizet omitted = 0;
+        // Errors before warnings: a cap that dropped the one error in favour of
+        // 200 warnings would hide the reason the build failed.
+        for (const Severity level : { Severity::Error, Severity::Warning, Severity::Note })
+        {
+            for (const Diagnostic& diagnostic : result.Diagnostics)
+            {
+                if (diagnostic.Level != level)
+                    continue;
+                if (diagnostics.size() >= maxDiagnostics)
+                {
+                    ++omitted;
+                    continue;
+                }
+                diagnostics.push_back(DiagnosticJson(diagnostic));
+            }
+        }
+        entry["diagnostics"] = std::move(diagnostics);
+        entry["diagnosticsOmitted"] = omitted;
+        if (!result.Note.empty())
+            entry["note"] = result.Note;
+        return entry;
+    }
+
+    // The last `maxChars` of a console log, marked when anything was dropped.
+    // Keeps the END, where the failure is.
+    [[nodiscard]] inline std::string TailOf(std::string_view text, sizet maxChars)
+    {
+        if (maxChars == 0 || text.size() <= maxChars)
+            return std::string(text);
+        return "...[" + std::to_string(text.size() - maxChars) + " earlier characters omitted]...\n" +
+               std::string(text.substr(text.size() - maxChars));
+    }
+} // namespace OloEngine::Automation::BuildInvocation

--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -9,6 +9,9 @@
 		# type, the registry that owns them, the host seam they run against, and
 		# the input-schema validator. Nothing in here knows what MCP is.
 		"Automation/AutomationAudienceReport.h"
+		"Automation/AutomationBuildCommands.cpp"
+		"Automation/AutomationBuildCommands.h"
+		"Automation/AutomationBuildInvocation.h"
 		"Automation/AutomationCatalogue.cpp"
 		"Automation/AutomationCatalogue.h"
 		"Automation/AutomationCommand.h"

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -3,6 +3,7 @@
 #include "MCP/McpEventStream.h"
 #include "MCP/McpToolsCommon.h"
 #include "MCP/McpServer.h"
+#include "Automation/AutomationBuildCommands.h"
 #include "Automation/AutomationSceneAuthoring.h"
 
 #include "OloEngine/Core/Log.h"
@@ -211,6 +212,7 @@ namespace OloEngine::MCP
         RegisterBenchmarkTools(registry);
         RegisterEditorTools(registry);
         RegisterTestingTools(registry);
+        Automation::RegisterBuildCommands(registry);
         RegisterValidationTools(registry);
     }
 

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -113,6 +113,17 @@ namespace OloEngine::MCP
 
         // ---- filesystem helpers -------------------------------------------
 
+        // A path as real UTF-8 bytes. `path::string()` encodes through the ANSI
+        // code page on MSVC, so any narrow string built from it and later widened
+        // as UTF-8 is corrupted for a non-ASCII path — which is how a non-ASCII
+        // %TEMP% silently broke the gtest report path. Only this conversion is
+        // lossless, and it is the one every narrow path below goes through.
+        [[nodiscard]] std::string Utf8Of(const fs::path& path)
+        {
+            const std::u8string utf8 = path.u8string();
+            return std::string(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+        }
+
         [[nodiscard]] std::string ReadWholeFile(const fs::path& path, bool& ok)
         {
             ok = false;
@@ -464,7 +475,7 @@ namespace OloEngine::MCP
         // gtest arguments carry no spaces or quotes; the executable path can.
         [[nodiscard]] std::string BuildCommandLine(const fs::path& exe, const std::vector<std::string>& arguments)
         {
-            std::string command = "\"" + exe.string() + "\"";
+            std::string command = "\"" + Utf8Of(exe) + "\"";
             for (const std::string& argument : arguments)
             {
                 command.push_back(' ');
@@ -908,7 +919,7 @@ namespace OloEngine::MCP
             watch.ConsolePath = consolePath;
 
             const std::vector<std::string> arguments{ "--gtest_list_tests", "--gtest_filter=" + filter,
-                                                      "--gtest_output=json:" + reportPath.string() };
+                                                      "--gtest_output=json:" + Utf8Of(reportPath) };
             const ChildResult child = RunChild(session.Binary.Path, arguments, session.RepoRoot / kChildWorkingDirectory, consolePath,
                                                std::chrono::seconds(300), watch);
             if (!child.Completed())
@@ -1155,7 +1166,7 @@ namespace OloEngine::MCP
             const fs::path consolePath = scratch.File("console.log");
 
             std::vector<std::string> arguments{ "--gtest_filter=" + filter,
-                                                "--gtest_output=json:" + reportPath.string() };
+                                                "--gtest_output=json:" + Utf8Of(reportPath) };
             if (args.value("shuffle", false))
             {
                 arguments.emplace_back("--gtest_shuffle");

--- a/OloEditor/src/MCP/McpToolsTesting.cpp
+++ b/OloEditor/src/MCP/McpToolsTesting.cpp
@@ -504,7 +504,11 @@ namespace OloEngine::MCP
             // chatty 7000-case run is a hang that looks exactly like a slow test.
             // FILE_SHARE_READ is what lets the progress watch read the log while
             // the child is still writing it.
-            const HANDLE console = ::CreateFileW(Widen(consolePath.string()).c_str(), GENERIC_WRITE,
+            // .wstring(), not Widen(.string()): path::string() encodes through the
+            // ANSI code page on MSVC, so a non-ASCII %TEMP% is mis-decoded as
+            // UTF-8 and the run fails before the child starts. The path already
+            // holds the wide form.
+            const HANDLE console = ::CreateFileW(consolePath.wstring().c_str(), GENERIC_WRITE,
                                                  FILE_SHARE_READ | FILE_SHARE_WRITE, &inheritable, CREATE_ALWAYS,
                                                  FILE_ATTRIBUTE_NORMAL, nullptr);
             if (console == INVALID_HANDLE_VALUE)
@@ -522,7 +526,7 @@ namespace OloEngine::MCP
             startup.hStdError = console;
 
             std::wstring commandLine = Widen(BuildCommandLine(exe, arguments));
-            const std::wstring directory = Widen(workingDirectory.string());
+            const std::wstring directory = workingDirectory.wstring();
 
             PROCESS_INFORMATION process{};
             if (!::CreateProcessW(nullptr, commandLine.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr,

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -851,6 +851,10 @@ add_executable(OloEngine-Tests
 		${_olo_automation_component_registry_src}
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationComponentCommands.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationEntityCommands.cpp
+		# Structured build invocation (issue #1163). RegisterBuiltinCommands
+		# composes it, so the test binary needs the TU to link at all; its pure
+		# core is covered by McpAutomationBuildTest below.
+		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationBuildCommands.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationSceneCommands.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationSceneDocument.cpp
 		MCP/McpAutomationComponentsTest.cpp
@@ -934,6 +938,13 @@ add_executable(OloEngine-Tests
 		# OLO_TEST_LAYER classification merge, and the reconciliation that makes a
 		# partial run an error. Header-only (MCP/McpTestExecution.h) — nothing here
 		# launches a child process.
+		# Structured build invocation (#1163): the target/config/build-dir
+		# tables that are also the injection boundary, compiler-diagnostic
+		# parsing, the build-lock transcript reader, and the freshness verdict
+		# that refuses to read a zero exit code as evidence of a build.
+		# Header-only (Automation/AutomationBuildInvocation.h) — nothing here
+		# launches a child process or takes the lock.
+		MCP/McpAutomationBuildTest.cpp
 		MCP/McpTestExecutionTest.cpp
 		# Whole-project validation report shaping (#1130). Header-only
 		# (MCP/McpProjectValidation.h), no extra editor TU pulled in.

--- a/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
+++ b/OloEngine/tests/MCP/McpAudienceBlocksTest.cpp
@@ -438,6 +438,7 @@ TEST(McpAudienceBlocks, BuiltinAdoptionMatchesTheDeliberateList)
         "olo_physics_why_no_collision",     // explainer check list
         "olo_tests_run",                    // per-case status/timing/failure table
         "olo_project_validate",             // per-section problem table
+        "olo_build_run",                    // per-target outcome + artefact + diagnostic tables
     };
 
     const McpServer::ToolList& tools = BuiltinTools();

--- a/OloEngine/tests/MCP/McpAutomationBuildTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationBuildTest.cpp
@@ -309,6 +309,41 @@ namespace OloEngine::Tests
         EXPECT_EQ(counts.Warnings, 1u) << "Counts are of UNIQUE records: '1 warning' means one thing to fix.";
     }
 
+    TEST(AutomationBuildDiagnosticsTest, DeduplicationIsIndexedNotScanned)
+    {
+        // Order must still be first-occurrence order, and counts must still be
+        // right, now that the duplicate lookup is a hash probe rather than a
+        // linear scan. 5000 unique records would be 12.5M four-string compares
+        // under the scan; this is here so the indexing cannot regress silently.
+        std::vector<Diagnostic> many;
+        constexpr sizet kUnique = 5000;
+        many.reserve(kUnique * 2);
+        for (sizet i = 0; i < kUnique; ++i)
+            many.push_back(Diagnostic{ Severity::Warning, "f" + std::to_string(i) + ".cpp", 1, 0, "C4996", "w", 1 });
+        for (sizet i = 0; i < kUnique; ++i) // every one again, in the same order
+            many.push_back(Diagnostic{ Severity::Warning, "f" + std::to_string(i) + ".cpp", 1, 0, "C4996", "w", 1 });
+
+        const std::vector<Diagnostic> unique = Build::Deduplicate(many);
+        ASSERT_EQ(unique.size(), kUnique);
+        EXPECT_EQ(unique.front().File, "f0.cpp") << "first-occurrence order must survive the indexing";
+        EXPECT_EQ(unique.back().File, "f" + std::to_string(kUnique - 1) + ".cpp");
+        for (const Diagnostic& diagnostic : unique)
+            EXPECT_EQ(diagnostic.Occurrences, 2u);
+        EXPECT_EQ(Build::CountDiagnostics(unique).Warnings, kUnique);
+
+        // Records differing in ONE equality field only must not collapse — the
+        // key is a concatenation, so a separator bug would merge them.
+        const std::vector<Diagnostic> neighbours = Build::Deduplicate(
+            { Diagnostic{ Severity::Warning, "a.cpp", 1, 0, "C1", "m", 1 },
+              Diagnostic{ Severity::Warning, "a.cpp", 1, 0, "C1", "m2", 1 },    // message
+              Diagnostic{ Severity::Warning, "a.cpp", 1, 0, "C11", "m", 1 },    // code
+              Diagnostic{ Severity::Warning, "a.cpp", 11, 0, "C1", "m", 1 },    // line
+              Diagnostic{ Severity::Warning, "a.cpp", 1, 10, "C1", "m", 1 },    // column
+              Diagnostic{ Severity::Error, "a.cpp", 1, 0, "C1", "m", 1 },       // severity
+              Diagnostic{ Severity::Warning, "a.cpp2", 1, 0, "C1", "m", 1 } }); // file
+        EXPECT_EQ(neighbours.size(), 7u);
+    }
+
     TEST(AutomationBuildDiagnosticsTest, RelativizesPathsUnderTheRepoRootOnly)
     {
         // MSVC and ninja disagree about the case of a Windows drive letter
@@ -409,7 +444,7 @@ namespace OloEngine::Tests
 
         const Build::LockTranscript lock = Build::ReadLockTranscript(log);
         EXPECT_EQ(lock.Outcome, LockOutcome::Superseded);
-        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", -5.0 }),
+        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", true, -5.0 }),
                   TargetOutcome::NotBuilt)
             << "Exit 0 with a present artefact is EXACTLY what a stand-down looks like from the outside. Reading "
                "it as success is the failure this whole result shape exists to prevent.";
@@ -444,7 +479,7 @@ namespace OloEngine::Tests
             "[build-lock] the process that launched this build (pid=5) is gone - killing the orphaned build tree "
             "and releasing the lock\n");
         EXPECT_EQ(orphan.Outcome, LockOutcome::Orphaned);
-        EXPECT_EQ(Build::Verdict(orphan.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", 5.0 }),
+        EXPECT_EQ(Build::Verdict(orphan.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", true, 5.0 }),
                   TargetOutcome::Failed)
             << "An orphaned build never succeeded, whatever the kill happened to report.";
 
@@ -529,6 +564,7 @@ namespace OloEngine::Tests
         // transcript must not read as a build.
         Build::ArtifactState stale;
         stale.Exists = true;
+        stale.MtimeKnown = true;
         stale.AgeRelativeToStartSeconds = -1562.0;
         EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 1, stale), TargetOutcome::NotBuilt);
     }
@@ -560,6 +596,33 @@ namespace OloEngine::Tests
         EXPECT_FALSE(Build::IsSuccess(TargetOutcome::MissingArtifact));
     }
 
+    TEST(AutomationBuildVerdictTest, AnUnreadableTimestampIsNotAPositiveVerdict)
+    {
+        // `StatArtifact` returns early when `fs::last_write_time` fails, leaving
+        // the age at its default 0.0 — which is indistinguishable from "written
+        // exactly when the build started". Read as a number that would be
+        // `Rebuilt`: a positive verdict out of a measurement that never happened,
+        // and the precise conflation this whole file exists to prevent. So the
+        // flag is separate from the value.
+        Build::ArtifactState unreadable;
+        unreadable.Path = "bin/Debug/OloServer/OloServer.exe";
+        unreadable.Exists = true;
+        unreadable.MtimeKnown = false;
+        unreadable.AgeRelativeToStartSeconds = 0.0;
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, /*exitCode*/ 0, unreadable),
+                  TargetOutcome::ArtifactUnverifiable);
+        EXPECT_FALSE(Build::IsSuccess(TargetOutcome::ArtifactUnverifiable));
+
+        // Flipping only the flag, with the same 0.0, flips the verdict — which is
+        // the point: the value was never the evidence.
+        unreadable.MtimeKnown = true;
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 0, unreadable), TargetOutcome::Rebuilt);
+
+        // A failed build still reports as failed: the exit code is decided first.
+        unreadable.MtimeKnown = false;
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 1, unreadable), TargetOutcome::Failed);
+    }
+
     TEST(AutomationBuildVerdictTest, RebuiltAndUpToDateAreDistinguishedByTheArtifactsAge)
     {
         // Both are successes and both exit 0, but they are NOT the same answer:
@@ -568,11 +631,13 @@ namespace OloEngine::Tests
         // code comes to be read as proof of a fresh build.
         Build::ArtifactState fresh;
         fresh.Exists = true;
+        fresh.MtimeKnown = true;
         fresh.AgeRelativeToStartSeconds = 12.0; // written after the build began
         EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 0, fresh), TargetOutcome::Rebuilt);
 
         Build::ArtifactState stale;
         stale.Exists = true;
+        stale.MtimeKnown = true;
         stale.AgeRelativeToStartSeconds = -3600.0; // an hour older than this call
         EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 0, stale), TargetOutcome::UpToDate);
 
@@ -588,6 +653,7 @@ namespace OloEngine::Tests
         // codes that would otherwise be believed.
         Build::ArtifactState present;
         present.Exists = true;
+        present.MtimeKnown = true;
         present.AgeRelativeToStartSeconds = 5.0;
 
         EXPECT_EQ(Build::Verdict(LockOutcome::Superseded, 0, present), TargetOutcome::NotBuilt);
@@ -609,8 +675,8 @@ namespace OloEngine::Tests
         result.Outcome = TargetOutcome::Rebuilt;
         result.ExitCode = 0;
         result.WallSeconds = 42.5;
-        result.Before = Build::ArtifactState{ "p", true, 100, "2026-09-01T00:00:00Z", -100.0 };
-        result.After = Build::ArtifactState{ "p", true, 120, "2026-09-10T00:00:00Z", 3.0 };
+        result.Before = Build::ArtifactState{ "p", true, 100, "2026-09-01T00:00:00Z", true, -100.0 };
+        result.After = Build::ArtifactState{ "p", true, 120, "2026-09-10T00:00:00Z", true, 3.0 };
         result.Lock.Outcome = LockOutcome::Acquired;
 
         const auto json = Build::TargetResultJson(result, 100);
@@ -642,7 +708,7 @@ namespace OloEngine::Tests
         result.WallSeconds = 1474.1;
         result.QueuedSeconds = 1451.4;
         result.BuildSeconds = 22.7;
-        result.After = Build::ArtifactState{ "p", true, 15872, "2026-09-10T18:13:59Z", 20.0 };
+        result.After = Build::ArtifactState{ "p", true, 15872, "2026-09-10T18:13:59Z", true, 20.0 };
 
         const auto json = Build::TargetResultJson(result, 100);
         EXPECT_DOUBLE_EQ(json.at("queuedSeconds").get<double>(), 1451.4);

--- a/OloEngine/tests/MCP/McpAutomationBuildTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationBuildTest.cpp
@@ -1,0 +1,661 @@
+// OLO_TEST_LAYER: unit
+// =============================================================================
+// McpAutomationBuildTest — structured build invocation (issue #1163, Epic H
+// slice 3).
+//
+// Two things are pinned here, and the second is the reason the slice was
+// deferred rather than built with the rest of #1130:
+//
+//   1. THE PURE CORE. Automation/AutomationBuildInvocation.h holds the target /
+//      configuration / build-directory tables, the compiler-diagnostic parser,
+//      the build-lock transcript reader, and the freshness verdict. Nothing here
+//      launches a process, takes the lock or touches a build tree.
+//
+//   2. THE CONCURRENCY CONTRACT, as far as it is expressible without a machine.
+//      In particular the verdict: `Verdict()` must never call a zero exit code
+//      evidence of a build. Three real mechanisms in this repo report a build
+//      that did not happen as exit 0 — build-lock.ps1's stand-down, an
+//      incremental build with nothing to do, and a build that never started at
+//      all — and each is a distinct outcome here, never merged into "success".
+//
+// The refusal path (the lock held by another worktree) and the live-editor path
+// are verified by hand against the real lock; they cannot be unit tested,
+// because a test that took the lock would be the very second unaudited build
+// this slice exists to prevent.
+//
+// Classification: unit (no GL, no editor, no live server, no child process).
+// =============================================================================
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "Automation/AutomationBuildInvocation.h"
+
+#include <string>
+#include <vector>
+
+namespace OloEngine::Tests
+{
+    namespace Build = OloEngine::Automation::BuildInvocation;
+    using Build::Diagnostic;
+    using Build::LockOutcome;
+    using Build::Severity;
+    using Build::TargetOutcome;
+
+    // ---- the three fixed vocabularies (also the injection boundary) --------
+
+    TEST(AutomationBuildTablesTest, TheEditorsOwnTargetsAreRefusedWithAMechanism)
+    {
+        // The footgun the issue asks about by name. Both are REFUSED, and each
+        // refusal names the mechanism rather than saying "not allowed" — a
+        // reader who does not know why cannot judge whether to work around it.
+        for (const char* name : { "OloEditor", "OloEngine-ScriptCore" })
+        {
+            const Build::TargetSpec* spec = Build::FindTarget(name);
+            ASSERT_NE(spec, nullptr) << name << " must be in the table so it can be refused BY NAME; a target "
+                                                "missing from the table is refused as 'unknown', which reads as a "
+                                                "typo rather than as a deliberate no.";
+            EXPECT_FALSE(spec->RefusedBecause.empty()) << name << " must be refused from inside a running editor.";
+        }
+
+        EXPECT_NE(std::string(Build::FindTarget("OloEditor")->RefusedBecause).find("LNK1168"), std::string::npos)
+            << "The OloEditor refusal should name the linker error, because that is the observable a caller who "
+               "tries it from a shell will hit.";
+    }
+
+    TEST(AutomationBuildTablesTest, TheBuildableSetIsExactlyWhatTheEditorDoesNotHoldOpen)
+    {
+        // A ratchet in BOTH directions. Widening it is a decision about what the
+        // editor holds open while it runs, and it should fail here rather than
+        // at a link step forty minutes into a build.
+        const std::vector<std::string> expected{ "OloEngine", "OloEngine-Tests", "OloRuntime",
+                                                 "OloServer", "oloctl", "OloEngine-LuaScriptCore" };
+        std::vector<std::string> actual;
+        for (const Build::TargetSpec& spec : Build::kTargets)
+        {
+            if (spec.RefusedBecause.empty())
+                actual.emplace_back(spec.Name);
+        }
+        EXPECT_EQ(actual, expected);
+
+        // Every buildable target must also carry an artefact path, or its
+        // freshness verdict could never be anything but "missing-artifact".
+        for (const Build::TargetSpec& spec : Build::kTargets)
+            EXPECT_FALSE(spec.Artifact.empty()) << spec.Name << " has no artefact path.";
+    }
+
+    TEST(AutomationBuildTablesTest, UnknownTargetsConfigsAndTreesAreNotResolvable)
+    {
+        // These three are interpolated into the PowerShell command build-lock.ps1
+        // executes. There is no escaping scheme that makes freehand text safe
+        // there, so the tables ARE the safety property — and the shapes below are
+        // exactly what an injection attempt looks like.
+        EXPECT_EQ(Build::FindTarget("all"), nullptr);
+        EXPECT_EQ(Build::FindTarget("ALL_BUILD"), nullptr);
+        EXPECT_EQ(Build::FindTarget("install"), nullptr);
+        EXPECT_EQ(Build::FindTarget("OloEngine-Tests\"; rm -rf /"), nullptr);
+        EXPECT_EQ(Build::FindTarget(""), nullptr);
+
+        EXPECT_TRUE(Build::IsKnownConfig("Debug"));
+        EXPECT_TRUE(Build::IsKnownConfig("Release"));
+        EXPECT_TRUE(Build::IsKnownConfig("Dist"));
+        EXPECT_FALSE(Build::IsKnownConfig("debug")) << "Configuration names are case-sensitive to CMake.";
+        EXPECT_FALSE(Build::IsKnownConfig("Debug; whoami"));
+
+        EXPECT_TRUE(Build::IsKnownBuildDir("build-cached"));
+        EXPECT_TRUE(Build::IsKnownBuildDir("build"));
+        EXPECT_TRUE(Build::IsKnownBuildDir("build-clang"));
+        EXPECT_FALSE(Build::IsKnownBuildDir("../../elsewhere"));
+        EXPECT_FALSE(Build::IsKnownBuildDir("build-cached extra"));
+    }
+
+    TEST(AutomationBuildTablesTest, ArtifactPathsExpandToTheRepoLayout)
+    {
+        // The layout is not folklore: olo_configure_app -> olo_set_output_directories
+        // (cmake/CommonProperties.cmake) puts every app under <repo>/bin/<Config>/<target>/,
+        // and OloEngine-Tests calls neither, so it keeps the Ninja-multi-config
+        // default under the BUILD directory. A wrong entry here makes a
+        // successful build report "missing-artifact", which is the safe
+        // direction but still a bug.
+        const Build::TargetSpec* tests = Build::FindTarget("OloEngine-Tests");
+        ASSERT_NE(tests, nullptr);
+        EXPECT_TRUE(tests->ArtifactUnderBuildDir);
+        EXPECT_EQ(Build::ExpandArtifact(tests->Artifact, "Debug", /*windows*/ true),
+                  "OloEngine/tests/Debug/OloEngine-Tests.exe");
+        EXPECT_EQ(Build::ExpandArtifact(tests->Artifact, "Release", /*windows*/ false),
+                  "OloEngine/tests/Release/OloEngine-Tests");
+
+        const Build::TargetSpec* runtime = Build::FindTarget("OloRuntime");
+        ASSERT_NE(runtime, nullptr);
+        EXPECT_FALSE(runtime->ArtifactUnderBuildDir)
+            << "bin/ is under the SOURCE tree, so every build tree writes the same file — the artefact path alone "
+               "cannot say which tree produced it, and reporting it as build-relative would claim it can.";
+        EXPECT_EQ(Build::ExpandArtifact(runtime->Artifact, "Debug", /*windows*/ true),
+                  "bin/Debug/OloRuntime/OloRuntime.exe");
+
+        const Build::TargetSpec* engine = Build::FindTarget("OloEngine");
+        ASSERT_NE(engine, nullptr);
+        EXPECT_EQ(Build::ExpandArtifact(engine->Artifact, "Debug", /*windows*/ true), "bin/Debug/OloEngine/OloEngine.lib");
+        EXPECT_EQ(Build::ExpandArtifact(engine->Artifact, "Debug", /*windows*/ false), "bin/Debug/OloEngine/libOloEngine.a");
+    }
+
+    TEST(AutomationBuildTablesTest, TheBuildCommandIsAlwaysParallelCapped)
+    {
+        const std::string command = Build::BuildCommand("build-cached", "OloEngine-Tests", "Debug");
+        EXPECT_EQ(command, "cmake --build build-cached --target OloEngine-Tests --config Debug --parallel 6");
+        // The lock rewrites the number from measured free memory, but only when
+        // it is asked to. An uncapped build has OOM'd this box before, so the
+        // flag is present even though it is usually overwritten.
+        EXPECT_NE(command.find("--parallel"), std::string::npos);
+        // One target per invocation: `--target A --target B` builds both under
+        // one cmake, and there is then no honest way to attribute wall time or a
+        // failure to one of them.
+        EXPECT_EQ(command.find("--target", command.find("--target") + 1), std::string::npos);
+    }
+
+    // ---- compiler diagnostics ---------------------------------------------
+
+    TEST(AutomationBuildDiagnosticsTest, ParsesMsvcClangClGccAndLinkerShapes)
+    {
+        // MSVC cl: (line) only — cl emits no column at all.
+        const auto msvc = Build::ParseDiagnosticLine(
+            R"(C:\repos\Olo\OloEngine\src\Foo.cpp(42): error C2065: 'x': undeclared identifier)");
+        ASSERT_TRUE(msvc.has_value());
+        EXPECT_EQ(msvc->Level, Severity::Error);
+        EXPECT_EQ(msvc->File, R"(C:\repos\Olo\OloEngine\src\Foo.cpp)");
+        EXPECT_EQ(msvc->Line, 42);
+        EXPECT_EQ(msvc->Column, 0);
+        EXPECT_EQ(msvc->Code, "C2065");
+        EXPECT_EQ(msvc->Message, "'x': undeclared identifier");
+
+        // clang-cl: (line,col).
+        const auto clangCl =
+            Build::ParseDiagnosticLine(R"(C:\repos\Olo\Bar.cpp(7,13): warning: unused variable 'y' [-Wunused-variable])");
+        ASSERT_TRUE(clangCl.has_value());
+        EXPECT_EQ(clangCl->Level, Severity::Warning);
+        EXPECT_EQ(clangCl->Line, 7);
+        EXPECT_EQ(clangCl->Column, 13);
+        EXPECT_TRUE(clangCl->Code.empty()) << "clang emits no MSVC-style diagnostic id.";
+        EXPECT_EQ(clangCl->Message, "unused variable 'y' [-Wunused-variable]");
+
+        // gcc / clang on Linux: file:line:col.
+        const auto gcc = Build::ParseDiagnosticLine("/home/r/OloEngine/src/Baz.cpp:99:5: error: expected ';'");
+        ASSERT_TRUE(gcc.has_value());
+        EXPECT_EQ(gcc->File, "/home/r/OloEngine/src/Baz.cpp");
+        EXPECT_EQ(gcc->Line, 99);
+        EXPECT_EQ(gcc->Column, 5);
+        EXPECT_EQ(gcc->Message, "expected ';'");
+
+        // The linker knows an object, not a source location.
+        const auto link = Build::ParseDiagnosticLine("Foo.obj : error LNK2019: unresolved external symbol \"void f(void)\"");
+        ASSERT_TRUE(link.has_value());
+        EXPECT_EQ(link->Level, Severity::Error);
+        EXPECT_EQ(link->File, "Foo.obj");
+        EXPECT_EQ(link->Line, 0);
+        EXPECT_EQ(link->Code, "LNK2019");
+
+        // ...and sometimes not even that.
+        const auto fatal = Build::ParseDiagnosticLine("LINK : fatal error LNK1104: cannot open file 'OloEngine.lib'");
+        ASSERT_TRUE(fatal.has_value());
+        EXPECT_EQ(fatal->Level, Severity::Error) << "A 'fatal error' is an error, not a fourth severity.";
+        EXPECT_TRUE(fatal->File.empty()) << "'LINK' is the linker naming itself, not a file.";
+        EXPECT_EQ(fatal->Code, "LNK1104");
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, LNK1168IsTheShapeBuildingTheEditorWouldProduce)
+    {
+        // Kept as a test rather than a comment: this is the exact failure the
+        // OloEditor refusal exists to pre-empt, and if it ever reaches the
+        // parser it must come back as an error record rather than as noise.
+        const auto locked = Build::ParseDiagnosticLine(
+            R"(LINK : fatal error LNK1168: cannot open bin\Debug\OloEditor\OloEditor.exe for writing)");
+        ASSERT_TRUE(locked.has_value());
+        EXPECT_EQ(locked->Code, "LNK1168");
+        EXPECT_EQ(locked->Level, Severity::Error);
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, ParenthesesInThePathAndInTheMessageDoNotDefeatTheSplit)
+    {
+        // Both of these are real lines this box can produce, and both were lost
+        // by anchoring on the FIRST ')'.
+        //
+        // A path with parentheses: the first ')' closes "(x86)", "x86" is not a
+        // line number, and giving up there dropped the diagnostic entirely.
+        const auto programFiles = Build::ParseDiagnosticLine(
+            R"(C:\Program Files (x86)\Windows Kits\10\include\um\winnt.h(9): warning C4005: 'X': macro redefinition)");
+        ASSERT_TRUE(programFiles.has_value());
+        EXPECT_EQ(programFiles->File, R"(C:\Program Files (x86)\Windows Kits\10\include\um\winnt.h)");
+        EXPECT_EQ(programFiles->Line, 9);
+        EXPECT_EQ(programFiles->Code, "C4005");
+        EXPECT_EQ(programFiles->Level, Severity::Warning);
+
+        // A gcc/clang message containing a call: "foo(3)" parses as a line
+        // number, so the line was MIS-split and then discarded before the
+        // gcc branch ever saw it. Falling through is what recovers it.
+        const auto call = Build::ParseDiagnosticLine(
+            "/h/f.cpp:99:5: error: no matching function for call to 'foo(3)'");
+        ASSERT_TRUE(call.has_value());
+        EXPECT_EQ(call->File, "/h/f.cpp");
+        EXPECT_EQ(call->Line, 99);
+        EXPECT_EQ(call->Column, 5);
+        EXPECT_EQ(call->Message, "no matching function for call to 'foo(3)'");
+
+        // Both at once, MSVC style: parens in the path AND in the message.
+        const auto both = Build::ParseDiagnosticLine(
+            R"(C:\Program Files (x86)\a\b.cpp(42,7): error C2660: 'f(int)': function does not take 2 arguments)");
+        ASSERT_TRUE(both.has_value());
+        EXPECT_EQ(both->Line, 42);
+        EXPECT_EQ(both->Column, 7);
+        EXPECT_EQ(both->Message, "'f(int)': function does not take 2 arguments");
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, StripsTheMsbuildProjectSuffix)
+    {
+        // MSBuild appends the owning project to every line. Left in, two
+        // otherwise identical diagnostics from two projects would fail to
+        // deduplicate, and the message would carry a path nobody asked for.
+        const auto withProject = Build::ParseDiagnosticLine(
+            R"(  C:\r\Foo.cpp(3): warning C4996: 'strcpy': deprecated [C:\r\build\OloEngine.vcxproj])");
+        ASSERT_TRUE(withProject.has_value());
+        EXPECT_EQ(withProject->Message, "'strcpy': deprecated");
+        EXPECT_EQ(withProject->Code, "C4996");
+
+        // A message that merely ENDS in a bracket is not a project suffix.
+        const auto notProject = Build::ParseDiagnosticLine(R"(C:\r\Foo.cpp(3): warning: unused 'y' [-Wunused])");
+        ASSERT_TRUE(notProject.has_value());
+        EXPECT_EQ(notProject->Message, "unused 'y' [-Wunused]");
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, NonDiagnosticLinesAreNotDiagnostics)
+    {
+        for (const char* line : { "",
+                                  "[42/1337] Building CXX object OloEngine/CMakeFiles/OloEngine.dir/src/Foo.cpp.obj",
+                                  "ninja: build stopped: subcommand failed.",
+                                  "[build-lock] acquired (pid=1234) -> cmake --build build-cached",
+                                  "Foo.cpp",
+                                  "  1 error generated." })
+        {
+            EXPECT_FALSE(Build::ParseDiagnosticLine(line).has_value()) << "misparsed: " << line;
+        }
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, DeduplicatesAndCountsUniqueRecords)
+    {
+        // MSVC emits a header warning once per translation unit that includes it.
+        // Forty copies is one defect; reporting it forty times pushes the real
+        // error past whatever cap the caller set.
+        const std::string log =
+            R"(C:\r\Shared.h(9): warning C4996: 'x': deprecated [C:\r\A.vcxproj])"
+            "\n"
+            R"(C:\r\Shared.h(9): warning C4996: 'x': deprecated [C:\r\B.vcxproj])"
+            "\n"
+            R"(C:\r\Shared.h(9): warning C4996: 'x': deprecated [C:\r\C.vcxproj])"
+            "\n"
+            R"(C:\r\Only.cpp(2): error C2065: 'z': undeclared identifier)"
+            "\n";
+
+        const std::vector<Diagnostic> parsed = Build::ParseDiagnostics(log, "C:/r");
+        ASSERT_EQ(parsed.size(), 2u);
+        EXPECT_EQ(parsed[0].Occurrences, 3u);
+        EXPECT_EQ(parsed[1].Occurrences, 1u);
+        // Order is first-occurrence order: the warning was seen first. What
+        // matters is that nothing is re-sorted, so the FIRST error keeps its
+        // position rather than being buried.
+        EXPECT_EQ(parsed[0].Code, "C4996");
+        EXPECT_EQ(parsed[1].Code, "C2065");
+
+        const Build::DiagnosticCounts counts = Build::CountDiagnostics(parsed);
+        EXPECT_EQ(counts.Errors, 1u);
+        EXPECT_EQ(counts.Warnings, 1u) << "Counts are of UNIQUE records: '1 warning' means one thing to fix.";
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, RelativizesPathsUnderTheRepoRootOnly)
+    {
+        // MSVC and ninja disagree about the case of a Windows drive letter
+        // within one build, so the comparison is case-insensitive.
+        EXPECT_EQ(Build::RelativizePath(R"(C:\repos\Olo\OloEngine\src\Foo.cpp)", "c:/repos/Olo"),
+                  "OloEngine/src/Foo.cpp");
+        EXPECT_EQ(Build::RelativizePath("C:/repos/Olo/A.cpp", "C:/repos/Olo/"), "A.cpp");
+        // A vcpkg header outside the tree keeps its absolute path: that is the
+        // truthful answer, and blanking it would lose the only clue to where the
+        // diagnostic came from.
+        EXPECT_EQ(Build::RelativizePath("C:/vcpkg/installed/x64/include/foo.h", "C:/repos/Olo"),
+                  "C:/vcpkg/installed/x64/include/foo.h");
+        // A sibling directory that merely shares a prefix is NOT under the root.
+        EXPECT_EQ(Build::RelativizePath("C:/repos/OloOther/A.cpp", "C:/repos/Olo"), "C:/repos/OloOther/A.cpp");
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, ResolvesTheBuildDirRelativePathsNinjaActuallyEmits)
+    {
+        // ninja runs the compiler with the BUILD directory as its working
+        // directory, so `__FILE__` comes back relative to that, not to the repo
+        // root. These three shapes are verbatim from a live OloServer build on
+        // 2026-09-10 — relativizing against the repo root alone left them
+        // exactly as they arrived, which is not a path anything can open.
+        EXPECT_EQ(Build::ResolveDiagnosticFile("../OloEngine/src/OloEngine/Core/UUID.h", "C:/repos/Olo",
+                                               "build-cached"),
+                  "OloEngine/src/OloEngine/Core/UUID.h");
+        EXPECT_EQ(Build::ResolveDiagnosticFile("vcpkg_installed/x64-windows-static-md/include/entt/entity/storage.hpp",
+                                               "C:/repos/Olo", "build-cached"),
+                  "build-cached/vcpkg_installed/x64-windows-static-md/include/entt/entity/storage.hpp")
+            << "a vcpkg header really is inside the build tree; rebasing it to the repo root would invent a path";
+        // An absolute path outside the tree stays absolute: that is the truthful
+        // answer, and blanking it would lose the only clue to where it came from.
+        EXPECT_EQ(Build::ResolveDiagnosticFile(
+                      "C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/MSVC/14.51.36231/include/xmemory",
+                      "C:/repos/Olo", "build-cached"),
+                  "C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/MSVC/14.51.36231/include/xmemory");
+        // An absolute path INSIDE the tree still relativizes, as MSVC's cl emits.
+        EXPECT_EQ(Build::ResolveDiagnosticFile(R"(C:\repos\Olo\OloEngine\src\Foo.cpp)", "c:/repos/Olo", "build"),
+                  "OloEngine/src/Foo.cpp");
+
+        // The collapse is lexical, so it never touches the filesystem — and a
+        // '..' it cannot pop is KEPT, so an escape is visible rather than
+        // silently rebased onto the repo root.
+        EXPECT_EQ(Build::CollapseLexicalPath("a/./b/../c"), "a/c");
+        EXPECT_EQ(Build::CollapseLexicalPath("../../x"), "../../x");
+        EXPECT_EQ(Build::ResolveDiagnosticFile("../../outside/x.h", "C:/repos/Olo", "build-cached"), "../outside/x.h");
+    }
+
+    TEST(AutomationBuildDiagnosticsTest, ErrorsAreEmittedBeforeWarningsUnderACap)
+    {
+        // A cap that dropped the one error in favour of two warnings would hide
+        // the reason the build failed.
+        Build::TargetResult result;
+        result.Target = "OloEngine-Tests";
+        result.Outcome = TargetOutcome::Failed;
+        result.Diagnostics = { Diagnostic{ Severity::Warning, "a.cpp", 1, 0, "C4996", "w1", 1 },
+                               Diagnostic{ Severity::Warning, "b.cpp", 2, 0, "C4996", "w2", 1 },
+                               Diagnostic{ Severity::Error, "c.cpp", 3, 0, "C2065", "boom", 1 } };
+
+        const auto json = Build::TargetResultJson(result, /*maxDiagnostics*/ 1);
+        ASSERT_EQ(json.at("diagnostics").size(), 1u);
+        EXPECT_EQ(json.at("diagnostics")[0].at("severity"), "error");
+        EXPECT_EQ(json.at("diagnostics")[0].at("message"), "boom");
+        EXPECT_EQ(json.at("diagnosticsOmitted"), 2u) << "Truncation is counted, never silent.";
+        EXPECT_EQ(json.at("errorCount"), 1u);
+        EXPECT_EQ(json.at("warningCount"), 2u);
+    }
+
+    // ---- what build-lock.ps1 said ------------------------------------------
+
+    TEST(AutomationBuildLockTest, ReadsTheAcquireTranscript)
+    {
+        const std::string log =
+            "[build-lock] waiting - 1 ahead of us; held by pid=4242 in C:/repos/OloEngine-other\n"
+            "[build-lock] parallelism: -j8 (free 31 GB); rewrote the caller's flag\n"
+            "[build-lock] acquired (pid=99) slot=0 of 2, 1 building -> cmake --build build-cached\n"
+            "[1/3] Building CXX object a.obj\n"
+            "[build-lock] released (pid=99)\n";
+
+        const Build::LockTranscript lock = Build::ReadLockTranscript(log);
+        EXPECT_EQ(lock.Outcome, LockOutcome::Acquired);
+        EXPECT_TRUE(lock.Waited);
+        EXPECT_EQ(lock.HeldByPid, 4242);
+        EXPECT_EQ(lock.HeldByWorktree, "C:/repos/OloEngine-other");
+        EXPECT_EQ(lock.Jobs, 8) << "The lock decides parallelism at acquire time; the caller's -j6 was a hint.";
+        EXPECT_EQ(lock.Lines.size(), 4u) << "Every [build-lock] line is kept verbatim, and only those.";
+    }
+
+    TEST(AutomationBuildLockTest, RecognisesTheStandDownThatExitsZeroWithoutBuilding)
+    {
+        // The case that makes an exit code worthless as evidence, and the one a
+        // reader of build-lock.ps1 is most likely to miss: Test-Superseded exits
+        // 0 having built nothing.
+        const std::string log =
+            "[build-lock] waiting - next in line; held by pid=7 in C:/repos/x\n"
+            "[build-lock] superseded - a newer build was queued for C:/repos/x; standing down so the slot is not "
+            "spent on a stale tree\n";
+
+        const Build::LockTranscript lock = Build::ReadLockTranscript(log);
+        EXPECT_EQ(lock.Outcome, LockOutcome::Superseded);
+        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", -5.0 }),
+                  TargetOutcome::NotBuilt)
+            << "Exit 0 with a present artefact is EXACTLY what a stand-down looks like from the outside. Reading "
+               "it as success is the failure this whole result shape exists to prevent.";
+    }
+
+    TEST(AutomationBuildLockTest, TheUnsafeReadingNeverOverridesTheSafeOne)
+    {
+        // A stand-down and an acquire cannot both happen in one run — the
+        // stand-down path exits before ever acquiring. But if two runs' output
+        // ever landed in one log, "nothing was built" must win, because the
+        // consequence of guessing wrong the other way is a caller trusting an
+        // artefact this call did not produce.
+        const Build::LockTranscript afterSuperseded = Build::ReadLockTranscript(
+            "[build-lock] superseded - a newer build was queued for C:/repos/x; standing down\n"
+            "[build-lock] acquired (pid=9) -> cmake --build build-cached\n");
+        EXPECT_EQ(afterSuperseded.Outcome, LockOutcome::Superseded);
+
+        const Build::LockTranscript afterOrphan = Build::ReadLockTranscript(
+            "[build-lock] the process that launched this build (pid=5) is gone - killing the orphaned build tree\n"
+            "[build-lock] acquired (pid=9) -> cmake --build build-cached\n");
+        EXPECT_EQ(afterOrphan.Outcome, LockOutcome::Orphaned);
+
+        // The ordinary case is unaffected.
+        EXPECT_EQ(Build::ReadLockTranscript("[build-lock] acquired (pid=9) -> cmake --build build-cached\n").Outcome,
+                  LockOutcome::Acquired);
+    }
+
+    TEST(AutomationBuildLockTest, RecognisesTheOrphanKillAndTheConcurrencyRefusal)
+    {
+        const Build::LockTranscript orphan = Build::ReadLockTranscript(
+            "[build-lock] acquired (pid=5) -> cmake --build build-cached\n"
+            "[build-lock] the process that launched this build (pid=5) is gone - killing the orphaned build tree "
+            "and releasing the lock\n");
+        EXPECT_EQ(orphan.Outcome, LockOutcome::Orphaned);
+        EXPECT_EQ(Build::Verdict(orphan.Outcome, /*exitCode*/ 0, Build::ArtifactState{ "p", true, 10, "t", 5.0 }),
+                  TargetOutcome::Failed)
+            << "An orphaned build never succeeded, whatever the kill happened to report.";
+
+        // BOTH dash encodings, and this is not hypothetical. build-lock.ps1's
+        // source writes an EM dash; a redirected log on this box contains a plain
+        // ASCII '-', because the PowerShell host transcodes its output to the
+        // console code page on the way out. Observed 2026-09-10, verbatim:
+        //   [build-lock] not building alongside the current build - only 22.6 GB free (need 24)
+        // A parser that matched the literal em dash would have returned the whole
+        // line as the "reason" on every real machine and passed every test that
+        // used the source spelling.
+        for (const char* line : {
+                 "[build-lock] not building alongside the current build - only 22.6 GB free (need 24)\n",
+                 "[build-lock] not building alongside the current build \xe2\x80\x94 only 22.6 GB free (need 24)\n" })
+        {
+            const Build::LockTranscript refused = Build::ReadLockTranscript(line);
+            EXPECT_EQ(refused.Outcome, LockOutcome::NeverStarted);
+            EXPECT_EQ(refused.ConcurrencyRefusal, "only 22.6 GB free (need 24)") << line;
+        }
+    }
+
+    TEST(AutomationBuildLockTest, ALogWithNoAcquireLineIsNeverStarted)
+    {
+        // The refusal path: the wait budget expired while another worktree held
+        // the lock. Nothing was built, and the ABSENCE of the acquire line is
+        // the evidence — the script's timeout is a PowerShell `throw`, so there
+        // is no positive marker to look for.
+        const Build::LockTranscript lock = Build::ReadLockTranscript(
+            "[build-lock] waiting - 2 ahead of us; held by pid=11 in C:/repos/y\n"
+            "Exception: [build-lock] timed out after 5m waiting for pid=11 (C:/repos/y).\n");
+        EXPECT_EQ(lock.Outcome, LockOutcome::NeverStarted);
+        EXPECT_TRUE(lock.Waited);
+        EXPECT_EQ(lock.HeldByPid, 11);
+        // The decorated line must still be captured: the host prefixes a
+        // terminating error ("Exception: "), so a reader anchored at column 0
+        // would drop exactly the line that names the holder.
+        ASSERT_EQ(lock.Lines.size(), 2u);
+        EXPECT_TRUE(lock.Lines[1].starts_with("[build-lock] timed out"))
+            << "captured: " << lock.Lines[1];
+        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 0, Build::ArtifactState{}), TargetOutcome::NotBuilt);
+        // ...and an exit code of 1 from the throw does not turn it into a plain
+        // failure: "nothing was built" is the more actionable fact, and it is
+        // what the caller must not confuse with "the tree does not compile".
+        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 1, Build::ArtifactState{}), TargetOutcome::NotBuilt);
+    }
+
+    TEST(AutomationBuildLockTest, TheRealRefusalTranscriptFromThisBox)
+    {
+        // Captured VERBATIM on 2026-09-10 by driving the live editor with
+        // lockWaitSeconds:0 while three other worktrees were queued. It is here
+        // rather than as a hand-written approximation because the hand-written
+        // one was wrong twice: the em dash is ASCII by the time it lands in a
+        // log, and a terminating error makes PowerShell echo the offending
+        // SOURCE line — a truncated look-alike carrying an uninterpolated
+        // ${TimeoutMinutes} — immediately above the real message.
+        const std::string log =
+            "[build-lock] waiting - 3 ahead of us; held by pid=36932 in C:\\repos\\OloEngine-parallel-recording-phase2-1013\r\n"
+            "Exception: C:\\repos\\OloEngine-x\\.claude\\skills\\run-oloengine\\build-lock.ps1:679\r\n"
+            "Line |\r\n"
+            " 679 |              throw \"[build-lock] timed out after ${TimeoutMinutes}m wa .\r\n"
+            "     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n"
+            "     | [build-lock] timed out after 0m waiting for pid=36932 (C:\\repos\\OloEngine-parallel-recording-phase2-1013). A\r\n"
+            "     | build that has held the lock this long is wedged - investigate it rather than overriding.\r\n";
+
+        const Build::LockTranscript lock = Build::ReadLockTranscript(log);
+        EXPECT_EQ(lock.Outcome, LockOutcome::NeverStarted);
+        EXPECT_TRUE(lock.Waited);
+        EXPECT_EQ(lock.HeldByPid, 36932);
+        EXPECT_EQ(lock.HeldByWorktree, "C:\\repos\\OloEngine-parallel-recording-phase2-1013");
+
+        // Exactly two real lines: the wait and the timeout. The echoed source
+        // line is dropped — it is the host quoting the script, not the script
+        // speaking, and it would show a caller a `${TimeoutMinutes}` that never
+        // appears in real output.
+        ASSERT_EQ(lock.Lines.size(), 2u) << "captured: " << (lock.Lines.empty() ? std::string{} : lock.Lines[0]);
+        EXPECT_TRUE(lock.Lines[0].starts_with("[build-lock] waiting"));
+        EXPECT_TRUE(lock.Lines[1].starts_with("[build-lock] timed out after 0m"));
+        for (const std::string& line : lock.Lines)
+            EXPECT_EQ(line.find("${"), std::string::npos) << line;
+
+        // And the whole point: a stale artefact sitting on disk next to this
+        // transcript must not read as a build.
+        Build::ArtifactState stale;
+        stale.Exists = true;
+        stale.AgeRelativeToStartSeconds = -1562.0;
+        EXPECT_EQ(Build::Verdict(lock.Outcome, /*exitCode*/ 1, stale), TargetOutcome::NotBuilt);
+    }
+
+    TEST(AutomationBuildLockTest, NinjaProgressComesFromTheLastEdgeCounter)
+    {
+        const Build::BuildProgress progress = Build::ReadLastNinjaProgress(
+            "[1/120] Building CXX object a.obj\n"
+            "[2/120] Building CXX object b.obj\n"
+            "[117/120] Linking CXX static library OloEngine.lib\n");
+        EXPECT_TRUE(progress.Known());
+        EXPECT_EQ(progress.Done, 117u);
+        EXPECT_EQ(progress.Total, 120u);
+
+        // MSBuild prints no edge counter at all, so a `build/` tree reports no
+        // fraction rather than a made-up one.
+        EXPECT_FALSE(Build::ReadLastNinjaProgress("Build succeeded.\n    0 Warning(s)\n").Known());
+        EXPECT_FALSE(Build::ReadLastNinjaProgress("[build-lock] acquired (pid=1)\n").Known());
+    }
+
+    // ---- the freshness verdict ---------------------------------------------
+
+    TEST(AutomationBuildVerdictTest, AZeroExitWithNoArtifactIsNeverASuccess)
+    {
+        Build::ArtifactState absent;
+        absent.Path = "build-cached/OloEngine/tests/Debug/OloEngine-Tests.exe";
+        absent.Exists = false;
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, /*exitCode*/ 0, absent), TargetOutcome::MissingArtifact);
+        EXPECT_FALSE(Build::IsSuccess(TargetOutcome::MissingArtifact));
+    }
+
+    TEST(AutomationBuildVerdictTest, RebuiltAndUpToDateAreDistinguishedByTheArtifactsAge)
+    {
+        // Both are successes and both exit 0, but they are NOT the same answer:
+        // "up to date" means the artefact predates this call, which is what a
+        // stale binary looks like from the outside. Merging them is how an exit
+        // code comes to be read as proof of a fresh build.
+        Build::ArtifactState fresh;
+        fresh.Exists = true;
+        fresh.AgeRelativeToStartSeconds = 12.0; // written after the build began
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 0, fresh), TargetOutcome::Rebuilt);
+
+        Build::ArtifactState stale;
+        stale.Exists = true;
+        stale.AgeRelativeToStartSeconds = -3600.0; // an hour older than this call
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 0, stale), TargetOutcome::UpToDate);
+
+        EXPECT_TRUE(Build::IsSuccess(TargetOutcome::Rebuilt));
+        EXPECT_TRUE(Build::IsSuccess(TargetOutcome::UpToDate));
+        EXPECT_NE(std::string(Build::TargetOutcomeName(TargetOutcome::Rebuilt)),
+                  std::string(Build::TargetOutcomeName(TargetOutcome::UpToDate)));
+    }
+
+    TEST(AutomationBuildVerdictTest, TheLockOutcomeOutranksTheExitCode)
+    {
+        // Ordering matters: a stand-down and an orphan kill both carry exit
+        // codes that would otherwise be believed.
+        Build::ArtifactState present;
+        present.Exists = true;
+        present.AgeRelativeToStartSeconds = 5.0;
+
+        EXPECT_EQ(Build::Verdict(LockOutcome::Superseded, 0, present), TargetOutcome::NotBuilt);
+        EXPECT_EQ(Build::Verdict(LockOutcome::NeverStarted, 0, present), TargetOutcome::NotBuilt);
+        EXPECT_EQ(Build::Verdict(LockOutcome::Orphaned, 0, present), TargetOutcome::Failed);
+        // And a non-zero exit is a failure even with a fresh artefact: a build
+        // can produce one target's output and then fail on the next edge.
+        EXPECT_EQ(Build::Verdict(LockOutcome::Acquired, 1, present), TargetOutcome::Failed);
+
+        EXPECT_FALSE(Build::IsSuccess(TargetOutcome::NotBuilt));
+        EXPECT_FALSE(Build::IsSuccess(TargetOutcome::Failed));
+        EXPECT_FALSE(Build::IsSuccess(TargetOutcome::Skipped));
+    }
+
+    TEST(AutomationBuildVerdictTest, TheResultReportsTheArtifactBeforeAndAfterWhenItMoved)
+    {
+        Build::TargetResult result;
+        result.Target = "OloEngine-Tests";
+        result.Outcome = TargetOutcome::Rebuilt;
+        result.ExitCode = 0;
+        result.WallSeconds = 42.5;
+        result.Before = Build::ArtifactState{ "p", true, 100, "2026-09-01T00:00:00Z", -100.0 };
+        result.After = Build::ArtifactState{ "p", true, 120, "2026-09-10T00:00:00Z", 3.0 };
+        result.Lock.Outcome = LockOutcome::Acquired;
+
+        const auto json = Build::TargetResultJson(result, 100);
+        EXPECT_EQ(json.at("outcome"), "rebuilt");
+        EXPECT_TRUE(json.at("success").get<bool>());
+        EXPECT_EQ(json.at("artifact").at("modifiedUtc"), "2026-09-10T00:00:00Z");
+        ASSERT_TRUE(json.contains("artifactBefore"))
+            << "'the artefact is 9 days old and this build did not touch it' is exactly the question an exit code "
+               "cannot answer.";
+        EXPECT_EQ(json.at("artifactBefore").at("modifiedUtc"), "2026-09-01T00:00:00Z");
+        EXPECT_EQ(json.at("lock").at("outcome"), "acquired");
+
+        // Unchanged artefact => no before block, so the field's presence itself
+        // carries the signal.
+        result.Before = result.After;
+        EXPECT_FALSE(Build::TargetResultJson(result, 100).contains("artifactBefore"));
+    }
+
+    TEST(AutomationBuildVerdictTest, WallTimeIsSplitIntoQueueAndBuild)
+    {
+        // Measured live on 2026-09-10: building a 15 KB DLL through the command
+        // reported 1474 wall seconds, of which ~1451 were spent queued behind
+        // three other worktrees. The total alone reads as "this build is
+        // pathologically slow"; the split reads as "the machine was busy" — and
+        // those two conclusions lead to opposite actions.
+        Build::TargetResult result;
+        result.Target = "OloEngine-LuaScriptCore";
+        result.Outcome = TargetOutcome::Rebuilt;
+        result.WallSeconds = 1474.1;
+        result.QueuedSeconds = 1451.4;
+        result.BuildSeconds = 22.7;
+        result.After = Build::ArtifactState{ "p", true, 15872, "2026-09-10T18:13:59Z", 20.0 };
+
+        const auto json = Build::TargetResultJson(result, 100);
+        EXPECT_DOUBLE_EQ(json.at("queuedSeconds").get<double>(), 1451.4);
+        EXPECT_DOUBLE_EQ(json.at("buildSeconds").get<double>(), 22.7);
+
+        // Unobserved => OMITTED, not zero. A zero would say "no queue wait",
+        // which is a claim, and the fields are only ever set from a poll that
+        // actually saw the acquire happen.
+        result.QueuedSeconds = -1.0;
+        result.BuildSeconds = -1.0;
+        const auto unknown = Build::TargetResultJson(result, 100);
+        EXPECT_FALSE(unknown.contains("queuedSeconds"));
+        EXPECT_FALSE(unknown.contains("buildSeconds"));
+        EXPECT_TRUE(unknown.contains("wallSeconds")) << "the total is always known";
+    }
+} // namespace OloEngine::Tests

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -150,6 +150,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [server-authoritative-networking-loop.md](server-authoritative-networking-loop.md): grep for callers of the entry point, not for tests.
 - [mcp-setter-based-field-registry.md](mcp-setter-based-field-registry.md): copy-then-swap MCP writes are unsound when `operator=` cannot reproduce a setter's side effects.
 - [mcp-protocol-eras.md](mcp-protocol-eras.md): the stateless core is a second transport; adding `server/discover` alone breaks working clients.
+- [automation-build-invocation.md](automation-build-invocation.md): a build started from inside the editor goes through `build-lock.ps1` or it does not happen, the editor process is the lock's identity, cancellation kills the job object rather than the shim, and `OloEditor` is refused by allow-list.
 
 ## Concurrency and memory
 
@@ -308,6 +309,7 @@ The check passes for a correct implementation and for a broken one.
 |---|---|
 | [live-verification-noise-floor.md](live-verification-noise-floor.md) | A crop check that a mirrored, wrong position scored better on; read tools that answer 200 with a stale frame from an iconified window. |
 | [gpu-readback-stats-channel.md](gpu-readback-stats-channel.md) | A GPU counter that stopped updating is byte-identical to one that is constant. |
+| [automation-build-invocation.md](automation-build-invocation.md) | A build's exit code is 0 three different ways without anything having been built — the lock's stand-down, a no-op incremental, and a build that never started next to last week's binary. |
 | [incomplete-texture-samples-as-zero.md](incomplete-texture-samples-as-zero.md) | A sampled zero is a value, not an error: the frame is wrong exactly where the feature is active and right where it is not, on one vendor only. |
 | [std-distributions-are-not-portable.md](std-distributions-are-not-portable.md) | Two platforms disagree about procedural content, or a test passes on one and fails on the other with no GPU difference behind it. |
 | [procedural-generator-golden-coupling.md](procedural-generator-golden-coupling.md) | A red that recurs every run gets normalised and blinds the suite. |

--- a/docs/agent-rules/automation-build-invocation.md
+++ b/docs/agent-rules/automation-build-invocation.md
@@ -1,10 +1,21 @@
 # A build started from inside the editor goes through the lock, or it does not happen
 
 Issue #1163. `olo_build_run` spawns `.claude/skills/run-oloengine/build-lock.ps1` and nothing else.
-It never runs `cmake --build` directly, never sets `OLO_BUILD_LOCK_OVERRIDE`, `OLO_BUILD_LOCK_BYPASS`
-or `OLO_NOT_A_BUILD`, and refuses to start at all when the script is missing. Those markers are the
-two audited opt-outs a human asks for per build; an automation command that used one would be a
-third, unaudited path, and the whole point of the lock is that there is no such thing.
+It never runs `cmake --build` directly, never sets `OLO_BUILD_LOCK_OVERRIDE`,
+`OLO_BUILD_LOCK_BYPASS` or `OLO_NOT_A_BUILD`, and refuses to start at all when the script is
+missing.
+
+Those three are **not one group**, and the difference is the point:
+
+- `OLO_BUILD_LOCK_OVERRIDE` (and the legacy `OLO_BUILD_LOCK_BYPASS`) permit a **real unlocked
+  build**. They are **audited** to `olo-build-metrics.jsonl`, and by policy a human asks for one
+  per build.
+- `OLO_NOT_A_BUILD` only allows a command that *mentions* a build tool without running one. It is a
+  silent allow and is **not** audited.
+
+So an automation command setting the first would be an unaudited build; setting the second would be
+a lie about what it is doing. Neither appears here, and the whole point of the lock is that there is
+no third path.
 
 The rest of this file is the contract that follows from that, and the reason the exit code of a build
 is not evidence that a build happened.
@@ -24,8 +35,12 @@ is not evidence that a build happened.
   nothing in the call scope watching it.
 
 So the caller sets a budget (`lockWaitSeconds`, default 300) and it becomes the script's
-`-TimeoutMinutes`. `0` is exact fail-fast: the deadline is already past when the first acquisition
-attempt fails. Never pass `-Priority` — jumping the queue is a decision the user makes, per build.
+`-TimeoutMinutes`. **That parameter is integer minutes, so the conversion is a ceiling division**:
+300 s becomes 5 minutes, and any non-zero value under a minute rounds **up** to 1 — a caller asking
+for 30 s waits 60. `0` is the one exact case, and it is exact fail-fast: the deadline is already
+past when the first acquisition attempt fails. Report the applied budget alongside the requested
+one, or a refusal is measured against a number the caller never sees. Never pass `-Priority` —
+jumping the queue is a decision the user makes, per build.
 
 When the budget expires the script throws naming the holder's pid and worktree; that text is the
 error. **A build that could not start is an error naming the reason, never an empty success.**

--- a/docs/agent-rules/automation-build-invocation.md
+++ b/docs/agent-rules/automation-build-invocation.md
@@ -1,0 +1,128 @@
+# A build started from inside the editor goes through the lock, or it does not happen
+
+Issue #1163. `olo_build_run` spawns `.claude/skills/run-oloengine/build-lock.ps1` and nothing else.
+It never runs `cmake --build` directly, never sets `OLO_BUILD_LOCK_OVERRIDE`, `OLO_BUILD_LOCK_BYPASS`
+or `OLO_NOT_A_BUILD`, and refuses to start at all when the script is missing. Those markers are the
+two audited opt-outs a human asks for per build; an automation command that used one would be a
+third, unaudited path, and the whole point of the lock is that there is no such thing.
+
+The rest of this file is the contract that follows from that, and the reason the exit code of a build
+is not evidence that a build happened.
+
+---
+
+## 1. Wait for the lock, bounded, and name the holder when you give up
+
+**Do not fail fast by default, and do not wait forever.** Both are wrong here, for opposite reasons:
+
+- Refusing whenever the lock is held would fail for a hold about to end in two seconds. Contention is
+  the normal state on this box — five worktrees is routine — which is exactly why the script has a
+  FIFO ticket queue rather than a refusal. Its own contract is *"a build that cannot start **queues**;
+  it does not fail"*.
+- Waiting the script's default `-TimeoutMinutes 180` turns an automation call into an indefinite
+  hang. The caller's own timeout fires first, it abandons the call, and the build keeps running with
+  nothing in the call scope watching it.
+
+So the caller sets a budget (`lockWaitSeconds`, default 300) and it becomes the script's
+`-TimeoutMinutes`. `0` is exact fail-fast: the deadline is already past when the first acquisition
+attempt fails. Never pass `-Priority` — jumping the queue is a decision the user makes, per build.
+
+When the budget expires the script throws naming the holder's pid and worktree; that text is the
+error. **A build that could not start is an error naming the reason, never an empty success.**
+
+## 2. `build-lock.ps1` exits 0 without building, and the case is easy to miss
+
+Its `Test-Superseded` path: when an identical command for the same worktree has been queued *later*,
+the older waiter stands down — `exit 0`, having built nothing. That is correct behaviour (the newer
+request supersedes a stale snapshot), and it is indistinguishable from a successful build if you only
+read the exit code.
+
+Two more ways to get a zero exit with no build: an incremental build with nothing to do, and a build
+that never started while last week's binary sat exactly where you look.
+
+**Therefore: take the verdict from the artefact, not the exit code.** Stat the target's primary output
+before and after, and compare its mtime against the instant the build *started* — not against the
+previous stat, which cannot tell a first build from a no-op and is fooled by a byte-identical rebuild
+at the same timestamp granularity. Keep `rebuilt` and `up-to-date` as separate answers. Merging them
+is how a stale binary comes to be reported as fresh, which has already burned this repo once
+(a stale prebuilt binary read as a successful build, and a crash was attributed to the wrong commit).
+
+`olo_build_run` reads the script's own `[build-lock] …` lines out of the captured console for this:
+the stand-down, the orphan kill, the concurrency refusal and the chosen job count are all only
+visible there.
+
+## 3. The launching process is the lock's identity — so spawn the child directly
+
+`Get-ParentIdentity` reads `Win32_Process.ParentProcessId` of the pwsh it runs in. Whatever spawns
+pwsh *is* the identity, pinned by (pid, StartTime), and the parent watch kills the whole build tree
+when that process disappears.
+
+So spawn pwsh **directly** from the editor. Inserting anything between them — a `cmd /c`, a detached
+launcher, a shell wrapper — silently moves the identity to the shim, and the editor dying then reaps
+nothing. Nothing warns you; the build simply keeps running and keeps the lock.
+
+The lock has no notion of a *call*, only of a process, so call-scoped cancellation is yours:
+
+## 4. Cancelling must kill the tree, not the shim
+
+Killing pwsh alone is worse than not cancelling. The OS closes its lock handle — releasing the lock —
+while ninja and its compilers keep running unbounded. That is precisely the shape the lock exists to
+prevent, and this box has been OOM-killed by an uncapped build.
+
+So the child is created **suspended**, assigned to a Win32 job object with
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, then resumed; cancelling terminates the *job*. Suspended-then-assign
+is not fussiness: start it running and there is a window in which it can spawn ninja outside the job,
+and those grandchildren survive the cancel.
+
+This is the "stronger version" `build-lock.ps1`'s own header says it wants and skipped because it
+needs P/Invoke from PowerShell. From C++ it is three Win32 calls, and it also covers what the parent
+watch cannot: an editor killed with `TerminateProcess` runs no cleanup, but the OS closes the job
+handle on process exit and the build dies with it — immediately, rather than after the ~10 s grace
+window, and without needing pwsh alive to notice. If the job object cannot be created, **refuse the
+build** rather than running it uncontained.
+
+## 5. The editor may not build itself, and the refusal is an allow-list
+
+Windows keeps a running image mapped, so the linker cannot replace `OloEditor.exe`: the build compiles
+everything and *then* fails with `LNK1168` — the most expensive possible way to say no. Mono holds
+`OloEngine-ScriptCore`'s assembly the same way.
+
+Refuse by allow-list, not deny-list. A deny-list leaks through `all`, `ALL_BUILD` and `install`, which
+reach `OloEditor` without naming it, and through any target added later. There is deliberately **no
+default target**, because CMake's default is `all`.
+
+The allow-list is also the injection boundary: target, configuration and build directory are
+interpolated into a PowerShell command string that the script writes to a file and executes. No
+escaping scheme makes freehand text safe there, so all three are matched against fixed tables in
+`OloEditor/src/Automation/AutomationBuildInvocation.h` and anything else is refused by name.
+
+## 6. A redirected PowerShell log is not UTF-8
+
+`build-lock.ps1`'s source writes an em dash in `waiting — …` and `not building alongside the current
+build — …`. By the time it reaches a redirected log it is a plain ASCII `-`: the host transcodes its
+output to the console code page on the way out. Verbatim, from this box on 2026-09-10:
+
+```
+[build-lock] not building alongside the current build - only 22.6 GB free (need 24)
+```
+
+A parser matching the literal em dash passes every test written from the script's source and returns
+garbage on every real machine. Anchor on the ASCII prefix and skip the separator by character class.
+
+## 7. Two facts about where artefacts land
+
+- **`bin/` is under the SOURCE tree**, not the build tree (`olo_configure_app` →
+  `olo_set_output_directories` in `cmake/CommonProperties.cmake`). `build-cached/` and `build/` write
+  the same `bin/Debug/OloRuntime/OloRuntime.exe`, so the artefact path can never say which tree
+  produced it. The timestamp can say when. `OloEngine-Tests` calls neither helper and keeps the
+  Ninja-multi-config default *inside* the build directory — the two layouts are not interchangeable.
+- **Building `OloEngine` runs `GenerateBindings`**, which rewrites tracked generated sources. A build
+  command moves the working tree; say so where a caller will read it.
+
+## 8. This is not a second `BuildGamePanel`
+
+`BuildGamePanel` **packages** a game: it copies a prebuilt `OloRuntime` and can only *warn* when that
+binary is stale. `olo_build_run` is what produces it — literally the answer to the panel's own
+*"Build OloRuntime in `<config>` configuration first"* error. They are two halves, not two opinions.
+Packaging stays out of scope for the build command (#1163 says so explicitly); if that changes, the
+panel's pipeline is the thing to invoke, not to reimplement.

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -290,6 +290,8 @@ and for what to do when adding a tool.
 | `olo_tests_list` | the GoogleTest cases `OloEngine-Tests` holds, each with source file, line and its `OLO_TEST_LAYER` classification (the renderer pyramid L1–L11 and the Functional / unit axes), plus a per-layer count. Filter by gtest expression, `suite`, explicit `cases` or `layer`. A selection that matches nothing is an **error**, not an empty list |
 | `olo_tests_run` | run a filtered selection as a child process and get **structured** per-case results — pass/fail/skip/disabled, the verbatim gtest failure text, per-case timings, each case's layer — with no console parsing. Runs the binary, not the editor's renderer, so the CPU-only suites inherit no GPU skip condition. Failures only by default (`includePassed` for the whole set). Never silently partial: a zero-match selection, a child that crashed / timed out / was cancelled, and a report that does not account for every selected case are all errors that **name** what is missing. See [Structured test execution](#structured-test-execution-olo_tests_list--olo_tests_run) |
 | `olo_project_validate` | every project validator in one call — asset-registry problems, shader compile/link errors, recent script errors, and the live render graph's hazard sweep — as one structured report. Each section invokes the standalone command's own handler, so it reports exactly what the editor panels show. A validator that cannot run here comes back `unavailable` **with its reason** and makes the report's `ok` false: an unrun check is never a clean bill of health |
+| `olo_build_list` | the CMake targets `olo_build_run` can build, each with its artefact path, size and **build timestamp**, plus whether the tree is configured and whether a build-lock slot is free right now. Builds nothing. This is how you answer *is the binary I am about to run older than my change?* — an exit code cannot tell a fresh artefact from last week's, a timestamp can. Targets the editor holds open (`OloEditor` itself, `OloEngine-ScriptCore`) are listed with `buildable:false` and the mechanism that refuses them |
+| `olo_build_run` | build one or more targets and get **structured** per-target results: outcome, exit code, wall time, the artefact's path and timestamp, and every compiler/linker diagnostic as a record with file, line, column and code — no console scraping. Always goes through `build-lock.ps1`. A build that could not start is an **error** naming the reason, never an empty success; so is exit 0 with no artefact, and so is the lock **stand-down** that exits 0 having built nothing. `up-to-date` is reported separately from `rebuilt`. See [Structured build invocation](#structured-build-invocation-olo_build_list--olo_build_run) |
 
 ### Write consent — Disabled / Prompt / Allow all (issue #306)
 
@@ -518,6 +520,7 @@ appear under the `script` toolset — see "Script-defined tools" below):
 | `input` | `olo_input_inject` |
 | `editor` | `olo_editor_panel_list`, `olo_editor_panel_set`, `olo_accessibility_get`, `olo_accessibility_set`, `olo_lightmap_bake`, `olo_editor_debug_draw_set`, `olo_terrain_pick` |
 | `tests` | `olo_tests_list`, `olo_tests_run` |
+| `build` | `olo_build_list`, `olo_build_run` |
 | `validation` | `olo_project_validate` |
 
 `tools/search` params (both optional):
@@ -828,6 +831,104 @@ binary you just built or from last week's. By default the newest artefact across
 
 Long runs report progress through the standard mechanism and honour
 cancellation — see [Progress notifications & cancellation](#progress-notifications--cancellation).
+
+### Structured build invocation (`olo_build_list` / `olo_build_run`)
+
+Issue #1163. The half of the loop before the tests: **produce** the thing, then
+run it. Until these existed, an agent that wanted `OloEngine-Tests` built before
+running it had to leave the control plane entirely.
+
+This slice was deferred out of #1130 on purpose, because the design question was
+unresolved and building it wrong is worse than not having it. Every build in this
+repo goes through `.claude/skills/run-oloengine/build-lock.ps1`, which bounds
+concurrent builds across every worktree, derives its job count from free memory,
+and kills its build if the launching session dies. The full derivation of the
+concurrency contract is in
+[automation-build-invocation.md](../agent-rules/automation-build-invocation.md);
+the four answers, in one line each:
+
+1. **Acquire, never bypass** — with a bounded, caller-set wait
+   (`lockWaitSeconds`, default 300; `0` fails fast). The wait is a real FIFO
+   ticket, so it never jumps another worktree, and when the budget expires the
+   error **names the holder**.
+2. **The editor process is the lock identity** — the child is spawned directly
+   from the editor, so `build-lock.ps1`'s parent watch pins `OloEditor.exe` and
+   reaps the build when the editor dies.
+3. **Cancellation kills the tree, not the shim** — the child lives in a Win32 job
+   object with `KILL_ON_JOB_CLOSE`, so cancelling stops pwsh, cmake, ninja and
+   every compiler together, and the lock releases *after* the build stopped
+   rather than before.
+4. **The editor may not build itself** — `OloEditor` and `OloEngine-ScriptCore`
+   are refused, and the refusal is an **allow-list** so `all` / `ALL_BUILD` /
+   `install` and any future target cannot leak through.
+
+**A zero exit code is not evidence that anything was built.** This is the rule
+the whole result shape exists for, and there are three separate ways to get one:
+
+- `build-lock.ps1` **stands down with exit 0** when an identical build for this
+  worktree was queued later (its `Test-Superseded` path). Nothing ran.
+- An incremental build with nothing to do also exits 0 and touches no artefact.
+  That is legitimate — and indistinguishable from the above without looking.
+- A build that never started leaves last week's binary exactly where you look.
+
+So the verdict comes from the **artefact**, stat'd on both sides of the build and
+compared against the instant it started, and the cases stay separate:
+
+| `outcome` | means |
+|---|---|
+| `rebuilt` | the artefact was replaced by this call |
+| `up-to-date` | the build ran, had nothing to do; the artefact is from an **earlier** build — check `artifact.modifiedUtc` before trusting it to contain your change |
+| `failed` | non-zero exit, or the lock's parent watch killed an orphan |
+| `missing-artifact` | exit 0 and **nothing at the artefact path**. Never a pass |
+| `not-built` | the lock stood down, or never acquired within the wait budget |
+| `skipped` | an earlier target in the same call failed, so this one was never attempted |
+
+Diagnostics come back as records, not text:
+
+```jsonc
+{ "severity": "error", "file": "OloEngine/src/OloEngine/Renderer/Foo.cpp",
+  "line": 212, "column": 9, "code": "C2065",
+  "message": "'hazards': undeclared identifier" }
+```
+
+MSVC `cl` emits no column, so `column` is omitted rather than faked. A record
+that came from several translation units (a header warning included forty times)
+is collapsed with an `occurrences` count — forty copies is one defect. Errors are
+emitted before warnings so `maxDiagnostics` can never hide the reason a build
+failed, and any excess is counted in `diagnosticsOmitted`.
+
+The `lock` block carries what the script actually did, including its verbatim
+transcript: whether the lock was contended, who held it, and the job count it
+chose (it rewrites your `--parallel`, in either direction, from measured free
+memory at acquire time).
+
+**Read `queuedSeconds` before concluding a build is slow.** `wallSeconds` covers
+the queue wait too, and on a busy box that is most of it — a measured run here
+built a 15 KB DLL in 22 s after 1451 s queued behind three other worktrees. The
+two numbers lead to opposite actions, so they are reported separately (and
+omitted, rather than zeroed, when the acquire was not observed).
+
+Targets are built **one at a time, in order**, each with its own lock ticket, and
+the list stops at the first failure. `--target A --target B` would build both
+under one `cmake`, and per-target wall time would then be a guess.
+
+Two things to know before using it:
+
+- **Building `OloEngine` runs `GenerateBindings`**, which can rewrite the tracked
+  generated sources under `OloEngine/src/Generated/`. The working tree moves.
+- **`bin/` is under the source tree**, not the build tree, so `build-cached/` and
+  `build/` write the same `bin/Debug/OloRuntime/OloRuntime.exe`. The artefact
+  path cannot say which tree produced it; the timestamp can say when.
+
+`olo_build_run` pairs with `BuildGamePanel`, it does not duplicate it: the panel
+**packages** a game by copying a prebuilt `OloRuntime` and can only warn when
+that binary is stale. This command is what produces it — literally the answer to
+the panel's own *"Build OloRuntime in <config> configuration first"* error.
+Packaging stays out of scope here.
+
+Long builds report progress through the standard mechanism (queueing for the lock
+across the first 5%, then ninja's own edge counter) and honour cancellation — see
+[Progress notifications & cancellation](#progress-notifications--cancellation).
 
 ### Whole-project validation (`olo_project_validate`)
 
@@ -2266,11 +2367,11 @@ characters, inline lists at 12 items, each stating what it elided. The full payl
 in the assistant block and in `structuredContent`. Path redaction, when enabled, scrubs both
 blocks identically.
 
-**Current adopters (14):** `olo_gpu_resources`, `olo_memory_report`, `olo_perf_snapshot`,
+**Current adopters (15):** `olo_gpu_resources`, `olo_memory_report`, `olo_perf_snapshot`,
 `olo_perf_pass_timings`, `olo_perf_cpu_scopes`, `olo_render_frame_breakdown`,
 `olo_render_graph_topology_export`, `olo_render_why_not_visible`, `olo_render_target_stats`,
 `olo_cluster_grid_stats`, `olo_shadow_atlas_layout`, `olo_physics_why_no_collision`,
-`olo_tests_run`, `olo_project_validate`.
+`olo_tests_run`, `olo_project_validate`, `olo_build_run`.
 
 That list is ratcheted in both directions by
 `McpAudienceBlocksTest.BuiltinAdoptionMatchesTheDeliberateList`, which compares the real


### PR DESCRIPTION
Epic H slice 3. `olo_build_run` / `olo_build_list` close the *produce the thing* half of the
agent loop that #1130's `olo_tests_run` left open: until now, building `OloEngine-Tests` before
running it meant leaving the control plane entirely.

#1130 deferred this deliberately — not scope fatigue, but because the concurrency question was
unresolved and building it wrong is worse than not having it. So the four answers come first.

## The four concurrency answers

Derived from `build-lock.ps1` and `run-oloengine/SKILL.md`, not assumed. Full derivation lives in
[`docs/agent-rules/automation-build-invocation.md`](docs/agent-rules/automation-build-invocation.md).

### 1. Does the command acquire the lock, or is it refused while one is held?

**It acquires — always through `build-lock.ps1`, never around it — with a bounded, caller-set wait
and a named refusal when that budget expires.**

Both extremes are wrong here, for opposite reasons. Refusing whenever the lock is held would fail
for a hold about to end in two seconds: contention is the *normal* state on this box (six worktrees
were building while I verified this), which is exactly why the script has a FIFO ticket queue rather
than a refusal — its own contract is *"a build that cannot start **queues**; it does not fail"*.
Waiting its `-TimeoutMinutes 180` default is equally wrong: the caller's own timeout fires first, it
abandons the call, and the build keeps running with nothing in the call scope watching it.

So `lockWaitSeconds` (default 300, `0` = exact fail-fast) becomes the script's `-TimeoutMinutes`. We
take a real ticket, so we never jump another worktree; when the budget expires the script throws
naming the holder's pid and worktree, and that becomes the error. `-Priority` is never passed (the
user asks for that, per build), `-NoParentWatch` never (answer 3 depends on it), and none of
`OLO_BUILD_LOCK_OVERRIDE` / `OLO_BUILD_LOCK_BYPASS` / `OLO_NOT_A_BUILD` appears anywhere in this
code. This must not become a third, unaudited path.

### 2. What is the editor's identity in the lock's accounting?

**The editor process** — arranged rather than chosen. `Get-ParentIdentity` reads
`Win32_Process.ParentProcessId` of the pwsh it runs in, so whatever spawns pwsh *is* the identity.
We spawn it **directly** with `CreateProcessW`, so the identity is `OloEditor.exe` pinned by
(pid, StartTime), and the parent watch reaps the build when the editor dies.

The automation *call* cannot be the identity — the lock has no notion of a call and no way to be told
about one. So the split is explicit: process-scoped liveness is the lock's, call-scoped cancellation
is ours. Any shim between the editor and pwsh (a `cmd /c`, a detached launcher) would silently move
the identity to the shim and break orphan reaping with no warning.

### 3. What happens on cancel, or when the editor exits?

- **Editor exits** → the parent watch sees the pinned parent gone for `ParentGracePolls` polls
  (~10 s), runs `Stop-ProcessTree` over cmake/ninja/cl, releases the lock. Preserved *for free*, and
  only because we are the direct parent.
- **Caller cancels** → killing pwsh alone would be worse than not cancelling: the OS closes its lock
  handle (**releasing the lock**) while ninja and its compilers keep running unbounded — the exact
  OOM shape the lock exists to prevent. So the child is created **suspended**, assigned to a Win32
  job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, then resumed; cancelling terminates the
  *job*. Suspended-then-assign is load-bearing: start it running and there is a window in which it
  can spawn ninja outside the job.

  This is the "stronger version" `build-lock.ps1`'s own header says it wants and skipped because it
  needs P/Invoke from PowerShell — from C++ it is three Win32 calls. It also covers what the parent
  watch cannot: an editor killed with `TerminateProcess` runs no cleanup, but the OS closes the job
  handle on process exit and the build dies with it, immediately rather than after the grace window.
  If the job object cannot be created, the build is **refused** rather than run uncontained.

### 4. May the editor build its own target?

**No — and the refusal is an allow-list, not a deny-list.** Windows keeps a running image mapped, so
linking `OloEditor.exe` fails with `LNK1168` *after* all the compile work; Mono holds
`OloEngine-ScriptCore`'s assembly the same way. A deny-list leaks through `all` / `ALL_BUILD` /
`install`, which reach `OloEditor` without naming it, and through any target added later — so there
is deliberately **no default target** (CMake's default *is* `all`).

The allow-list is also the **injection boundary**: target, configuration and build directory are
interpolated into a PowerShell command string the script writes to a file and executes. No escaping
scheme makes freehand text safe there, so all three are matched against fixed tables and anything
else is refused by name.

## And the rule the whole result shape exists for

**A zero exit code is not evidence that anything was built**, three separate ways:

1. `build-lock.ps1` **stands down with exit 0** when an identical build for this worktree was queued
   later (`Test-Superseded`). Nothing ran.
2. A no-op incremental build also exits 0 and touches no artefact — legitimate, and indistinguishable
   from (1) without looking.
3. A build that never started leaves last week's binary exactly where a caller looks.

So the verdict comes from the **artefact**, stat'd on both sides and compared against the instant the
build started, and the cases stay separate: `rebuilt` / `up-to-date` / `failed` / `missing-artifact`
(exit 0 with nothing there — never a pass) / `not-built` / `skipped`.

Diagnostics are records with file, line, column and code — not scraped text — deduplicated with an
`occurrences` count (one header warning included by 40 TUs is one defect), errors emitted before
warnings so a cap can never hide the reason a build failed, and any excess counted in
`diagnosticsOmitted`.

## Verified

Not a rendering change, so no visual contract — but the failure modes are real, and every one below
was exercised against the **live editor** over MCP, not just headlessly.

**Unit** — `OloEngine/tests/MCP/McpAutomationBuildTest.cpp` (`// OLO_TEST_LAYER: unit`) over the pure
core. Ran with the surrounding ratchets: `AutomationBuild*` + `McpTestExecution*` +
`McpAudienceBlocks.*` + `McpOutputSchemaCoverage.*` + `McpDocsCoverage*` + `McpAutomationRegistry*`
→ **86 passed**. Both `OloEngine-Tests` and `OloEditor` build green (the editor is not in the test
build, and two broken targets have reached master with CI green before).

**The refusal path, against the real lock** — not simulated. With the lock genuinely held by
`OloEngine-parallel-recording-phase2-1013`, `lockWaitSeconds: 0` returned in 2.6 s:

```
outcome: "not-built", ok: false, isError: true
lock: { outcome: "never-started", contended: true,
        heldByPid: 36932, heldByWorktree: "C:\repos\OloEngine-parallel-recording-phase2-1013" }
```

…while a **stale artefact from 40 minutes earlier sat on disk** and was reported without being read
as success. That is the whole point of the artefact-timestamp requirement.

**A real build end-to-end** — `OloEngine-LuaScriptCore` through the live editor: queued behind three
worktrees, drained to position 1, hit a concurrency refusal at 23.5 GB free, then
`acquired (pid=54264) slot=1 of 2, 2 building`, `jobs: 6`. Result `rebuilt`, artefact created at the
exact path the table predicted with a fresh timestamp. The editor stayed responsive for the whole
25 minutes.

**`up-to-date` vs `rebuilt` distinguished on real artefacts** — one call for two targets returned
`up-to-date` for the unchanged DLL (with the note warning its timestamp is from an earlier build) and
`rebuilt` for `OloServer`, with 10 real compiler warnings as records.

**Every refusal** — `OloEditor`, `OloEngine-ScriptCore`, `all`, empty targets, `buildDir: "../evil"`,
`config: "Debug; whoami"` — each returns a named error; the schema enum catches the last two before
the handler even runs.

**`olo_tests_run` re-smoked** after the ride-along fix touched its spawn path.

### Two live findings that changed the code

Both were caught by looking at real output rather than reasoning about it, and both now have tests
built from the verbatim capture:

- **A redirected PowerShell log is not UTF-8.** `build-lock.ps1` writes an em dash; the host
  transcodes to the console code page on the way out, so the log contains a plain ASCII `-`. A parser
  matching the literal em dash passes every test written from the script's source and returns garbage
  on every real machine.
- **A terminating error echoes the script's source line.** The timeout is a `throw`, so PowerShell
  prints the offending source — including an uninterpolated `${TimeoutMinutes}` — right above the real
  message, and it was landing in the transcript as a second, fake entry.

A third came from reading the output rather than the code: `wallSeconds` was 1474 for a 15 KB DLL,
almost all of it queue. `queuedSeconds` / `buildSeconds` are now reported separately, because "the
build is slow" and "the machine was busy" lead to opposite actions.

## Second commit

`fix(mcp)`: `Widen(path.string())` in `McpToolsTesting.cpp` decodes an ANSI-code-page string as UTF-8,
so a non-ASCII `%TEMP%` makes `olo_tests_run` fail before the child starts. Found while reviewing this
PR's own spawn code, which had copied the shape. Its own commit, per the house rule.

## Review guide

**Where I'd look hardest**

1. `OloEditor/src/Automation/AutomationBuildCommands.cpp` — the Windows spawn: create suspended →
   `AssignProcessToJobObject` → `ResumeThread`, and the refusal when the job object cannot be made.
   This is the only part where getting it wrong costs the *machine* rather than the call, and it is
   the part a unit test structurally cannot reach.
2. `AutomationBuildInvocation.h::Verdict` — the truth table that decides whether anything was built.
   The ordering matters: the lock outcome must veto the exit code, or a stand-down reads as success.
3. `AutomationBuildInvocation.h::ParseDiagnosticLine` — four toolchain shapes and no grammar. The
   self-review found it anchoring on the first `)`, which dropped every diagnostic under
   `C:\Program Files (x86)\...` and every gcc message containing a call like `foo(3)`.

**What I verified, and how** — named above. The check that would have failed if the central claim were
wrong: the fail-fast refusal returns `not-built` **while a stale artefact exists on disk**; a
verdict taken from the exit code would have said `up-to-date`.

**Least confident about** — the artefact table for `oloctl`, `OloServer` and `OloEngine` under a
`build` (MSVC) or `build-clang` tree. I verified every row against `build-cached` on real files, and
`OloEngine-LuaScriptCore`'s row by building it, but I did not build any target through the other two
trees. A wrong row fails **loudly** (`missing-artifact` on a successful build), never silently — but
it would be a wrong error.

**Deliberately not tested** — (a) cancellation and the job-object teardown under a *real* in-flight
build: proving it needs a 25-minute build killed mid-link, and the code path is shared with the
timeout path, which is exercised; (b) the POSIX branch, which compiles but has no caller today —
Linux has no editor ([ADR 0015](docs/adr/0015-editor-is-windows-only-linux-ships-runtime-only.md));
(c) the full test suite, since this adds an isolated command and touches no engine code — the
relevant suites and every ratchet are green above.

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `olo_build_list` to show buildable targets, configurations, artifact paths, sizes, timestamps, and build-lock availability.
  - Added `olo_build_run` for validated, ordered builds with progress reporting, cancellation, build-lock coordination, and structured results.
  - Build results now distinguish rebuilt, up-to-date, failed, missing-artifact, not-built, and skipped outcomes, with diagnostics and log details.
- **Bug Fixes**
  - Improved Windows handling for non-ASCII console-log and working-directory paths.
- **Documentation**
  - Documented the structured build tools, build-lock requirements, cancellation behavior, diagnostics, and outcome semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->