### PR TITLE
fix(vulkan): stop the frame arena's per-item block tails exhausting the slot (#1185)

### DIFF
--- a/OloEngine/src/Platform/Vulkan/VulkanFrameArena.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanFrameArena.cpp
@@ -201,6 +201,8 @@ namespace OloEngine
         m_Slots[m_CurrentSlot].Cursor.store(0, std::memory_order_relaxed);
         ++m_FrameGeneration;
         m_AllocationsThisFrame.store(0, std::memory_order_relaxed);
+        // One line per affected frame — see the overflow reporter.
+        m_OverflowWarned.store(false, std::memory_order_relaxed);
     }
 
     VulkanFrameArenaAllocation VulkanFrameArena::Allocate(u64 sizeBytes, u64 alignment)
@@ -262,14 +264,23 @@ namespace OloEngine
                 // thread advanced it to; recompute against that.
             }
         };
-        const auto overflow = [&](const u64 at)
+        const auto overflow = [&]()
         {
-            m_OverflowCount.fetch_add(1, std::memory_order_relaxed);
+            const u64 total = m_OverflowCount.fetch_add(1, std::memory_order_relaxed) + 1u;
+            // Re-armed by BeginFrame, not latched for the process: an overflow
+            // that repeats every frame is a permanently wrong image, and a
+            // one-shot line made that look like a single transient hiccup
+            // (issue #1185). The cursor is READ here rather than passed in —
+            // the claim helper leaves its out-parameter untouched on failure,
+            // so the old call site reported a cursor of 0 next to a 16 MiB
+            // capacity and read as impossible.
             if (!m_OverflowWarned.exchange(true, std::memory_order_relaxed))
             {
-                OLO_CORE_ERROR("VulkanFrameArena: slot {} overflow ({} B requested at cursor {} of {} B) — "
-                               "root-data allocations are being DROPPED this frame",
-                               m_CurrentSlot, sizeBytes, at, kSlotCapacityBytes);
+                OLO_CORE_ERROR("VulkanFrameArena: slot {} overflow ({} B requested, cursor at {} of {} B; {} dropped "
+                               "since start) — root-data allocations are being DROPPED this frame, so draws will "
+                               "sample unbound buffers",
+                               m_CurrentSlot, sizeBytes, slot.Cursor.load(std::memory_order_relaxed),
+                               kSlotCapacityBytes, total);
             }
             return VulkanFrameArenaAllocation{};
         };
@@ -281,13 +292,22 @@ namespace OloEngine
         if (auto* worker = CurrentVulkanWorkerContext(); worker != nullptr && sizeBytes <= kWorkerBlockBytes / 2u)
         {
             auto& block = worker->Arena;
+            // A block claimed in an earlier frame points into a slot that
+            // BeginFrame has since rewound to 0, so reusing it would hand out
+            // memory another allocation already owns. Anything from THIS frame
+            // is still ours, whichever command buffer claimed it.
+            if (worker->ArenaFrameGeneration != m_FrameGeneration)
+            {
+                block = {};
+                worker->ArenaFrameGeneration = m_FrameGeneration;
+            }
             u64 aligned = Align(block.Cursor, alignment);
             if (block.End == 0u || aligned + sizeBytes > block.End)
             {
                 u64 blockOffset = 0;
                 if (!claimShared(kWorkerBlockBytes, std::max<u64>(alignment, 256u), blockOffset))
                 {
-                    return overflow(blockOffset);
+                    return overflow();
                 }
                 block.Cursor = blockOffset;
                 block.End = blockOffset + kWorkerBlockBytes;
@@ -305,7 +325,7 @@ namespace OloEngine
         u64 aligned = 0;
         if (!claimShared(sizeBytes, alignment, aligned))
         {
-            return overflow(slot.Cursor.load(std::memory_order_relaxed));
+            return overflow();
         }
         m_AllocationsThisFrame.fetch_add(1, std::memory_order_relaxed);
         return {

--- a/OloEngine/src/Platform/Vulkan/VulkanFrameArena.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanFrameArena.h
@@ -109,7 +109,22 @@ namespace OloEngine
         // Worker contexts claim this much from the shared cursor at a time
         // and bump inside it (VulkanRecordingContext::ArenaBlock). Requests
         // larger than half of it go to the shared cursor directly.
-        static constexpr u64 kWorkerBlockBytes = 64ull * 1024;
+        //
+        // SIZED AGAINST THE NUMBER OF BLOCKS A FRAME CLAIMS, not against one
+        // item's appetite. The block is per recording ITEM, and a deferred
+        // frame records on the order of 255 of them, so the slot pays this
+        // much per item whether the item pushes 80 bytes or fills the block.
+        // At the original 64 KiB that is 16.7 MiB of a 16.78 MiB slot — the
+        // whole budget, spent almost entirely on untouched block tails, after
+        // which every root-data push is dropped and the frame renders with
+        // unbound material and skybox buffers (issue #1185). Measured on the
+        // #1185 repro: 255 claims/frame, 16 719 616 B of cursor, 20 000+
+        // dropped allocations.
+        //
+        // 8 KiB keeps the property the block exists for — one shared CAS per
+        // item instead of one per draw, since a typical item's pushes are a
+        // few hundred bytes — while bounding a 255-item frame at ~2 MiB.
+        static constexpr u64 kWorkerBlockBytes = 8ull * 1024;
 
         // Make host writes visible to the GPU on a non-coherent placement
         // (no-op on coherent memory). Push() calls it itself; a caller that

--- a/OloEngine/src/Platform/Vulkan/VulkanRecordingContext.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanRecordingContext.h
@@ -394,13 +394,32 @@ namespace OloEngine
         // A worker claims 64 KiB from the slot's shared cursor once and bumps
         // inside it, so the per-draw root-data push touches no shared cache
         // line (VulkanFrameArena::Allocate). Offsets are absolute within the
-        // slot buffer. Dropped at every fork; the tail of a block is waste.
+        // slot buffer, which is rewound only by VulkanFrameArena::BeginFrame —
+        // so a block stays valid for the WHOLE frame, across as many command
+        // buffers as this context records.
+        //
+        // It used to be dropped at every fork, and the tail of each dropped
+        // block was waste. That is not a rounding error: a deferred frame forks
+        // once per parallel-recorded pass, so the waste is 64 KiB x (forks x
+        // workers), and a scene with enough passes exhausted the 16 MiB slot in
+        // a SINGLE frame (measured: 255 block claims, 16.72 MB of a 16.78 MB
+        // slot, 0 counted allocations). Past that point every root-data push is
+        // dropped and the frame renders with unbound material / skybox buffers —
+        // a silently wrong image, not a crash (issue #1185).
+        //
+        // The block therefore survives ResetForCommandBuffer and is instead
+        // keyed on the arena's frame generation: reused within a frame, dropped
+        // when the slot underneath it has been rewound. Keying on the slot index
+        // alone would alias frame N with frame N+2 — the same hazard
+        // VulkanFrameArena::GetFrameGeneration() exists to close.
         struct ArenaBlock
         {
             u64 Cursor = 0;
             u64 End = 0;
         };
         ArenaBlock Arena{};
+        /// Arena frame generation `Arena` was claimed in; 0 = never claimed.
+        u64 ArenaFrameGeneration = 0;
         u64 ArenaAllocations = 0; ///< Folded into the arena's frame tally at the join.
 
         // --- telemetry (workers) -------------------------------------------
@@ -443,7 +462,10 @@ namespace OloEngine
             NextDrawRootDataAddress = 0;
             Query = {};
             ConditionalRenderSkip = false;
-            Arena = {};
+            // `Arena` deliberately survives: it is frame-scoped, not
+            // command-buffer-scoped, and dropping it here is what exhausted the
+            // slot (see ArenaBlock above). VulkanFrameArena::Allocate discards it
+            // when the frame generation moves on.
             ArenaAllocations = 0;
             Recorded = false;
             RecordMs = 0.0;

--- a/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
@@ -1372,7 +1372,12 @@ TEST_F(VulkanParallelRecordingDevice, ItemCountDoesNotExhaustTheFrameArena)
     constexpr u64 kPushBytes = 352; // a representative per-draw root-data push
 
     arena.BeginFrame(0);
-    ASSERT_EQ(arena.GetOverflowCount(), u64{ 0 }) << "the arena must start this frame clean";
+    // The overflow count is cumulative for the PROCESS: BeginFrame re-arms only
+    // the warning, and ReleaseBuffers keeps the tally, so a device-gated test
+    // that ran earlier in this binary (VulkanRenderGraphExecutionTest) may
+    // already have bumped it. Measure this frame's contribution, not the total
+    // (CodeRabbit on #1188).
+    const u64 overflowsBefore = arena.GetOverflowCount();
 
     // One worker context per item, reset at each fork boundary exactly as
     // VulkanRecordingContext::ResetForCommandBuffer does between command buffers.
@@ -1391,7 +1396,7 @@ TEST_F(VulkanParallelRecordingDevice, ItemCountDoesNotExhaustTheFrameArena)
         }
     }
 
-    EXPECT_EQ(arena.GetOverflowCount(), u64{ 0 })
+    EXPECT_EQ(arena.GetOverflowCount(), overflowsBefore)
         << kItemsPerFrame << " items must not overflow a " << arena.GetSlotCapacityBytes() << " B slot";
 
     // The real assertion is the budget, not merely "no overflow": a future

--- a/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
+++ b/OloEngine/tests/Rendering/VulkanParallelRecordingTest.cpp
@@ -1354,4 +1354,84 @@ TEST_F(VulkanParallelRecordingDevice, FrameArenaClaimsFromSeveralThreadsNeverOve
     EXPECT_EQ(arena.GetCurrentSlotUsedBytes(), all.back().Offset + all.back().Size);
 }
 
+// A frame's root-data budget must not scale with the number of recording ITEMS
+// (issue #1185). The worker arena block is claimed per item, so at the original
+// 64 KiB a deferred frame's ~255 items claimed 16.7 MiB of a 16.78 MiB slot --
+// nearly all of it untouched block tails -- and every root-data push after that
+// was dropped. A dropped push is not a crash: the draw samples an unbound
+// buffer, so materials and the skybox render with no data and the frame is
+// silently wrong. Both halves of the fix are pinned here.
+TEST_F(VulkanParallelRecordingDevice, ItemCountDoesNotExhaustTheFrameArena)
+{
+    ScopedVulkanRenderCommandSelection renderCommandSelection;
+    auto& arena = VulkanFrameArena::Get();
+
+    // What a deferred frame actually records; the measured #1185 repro claimed
+    // 255 blocks in one frame.
+    constexpr u32 kItemsPerFrame = 255;
+    constexpr u64 kPushBytes = 352; // a representative per-draw root-data push
+
+    arena.BeginFrame(0);
+    ASSERT_EQ(arena.GetOverflowCount(), u64{ 0 }) << "the arena must start this frame clean";
+
+    // One worker context per item, reset at each fork boundary exactly as
+    // VulkanRecordingContext::ResetForCommandBuffer does between command buffers.
+    VulkanWorkerRecordingContext worker;
+    {
+        ScopedVulkanWorkerContext scoped(&worker);
+        for (u32 item = 0; item < kItemsPerFrame; ++item)
+        {
+            worker.ResetForCommandBuffer(VK_NULL_HANDLE);
+            for (u32 push = 0; push < 4u; ++push)
+            {
+                const auto allocation = arena.Allocate(kPushBytes, 16);
+                ASSERT_TRUE(allocation.IsValid())
+                    << "item " << item << " push " << push << " was DROPPED -- the draw would sample an unbound buffer";
+            }
+        }
+    }
+
+    EXPECT_EQ(arena.GetOverflowCount(), u64{ 0 })
+        << kItemsPerFrame << " items must not overflow a " << arena.GetSlotCapacityBytes() << " B slot";
+
+    // The real assertion is the budget, not merely "no overflow": a future
+    // block size that fits 255 items but not 600 would pass an overflow-only
+    // check while still scaling the frame's cost with the item count.
+    const u64 used = arena.GetCurrentSlotUsedBytes();
+    EXPECT_LT(used, arena.GetSlotCapacityBytes() / 4u)
+        << "a " << kItemsPerFrame << "-item frame consumed " << used << " B of the slot; the per-item block tail is "
+        << "the dominant cost and it must leave headroom, not most of the budget";
+}
+
+// The other half: a block claimed in an earlier frame must never be reused, or
+// it hands out memory that BeginFrame has already rewound and handed to someone
+// else. Reuse is keyed on the arena's frame generation, which is why the block
+// can safely survive ResetForCommandBuffer within a frame.
+TEST_F(VulkanParallelRecordingDevice, WorkerArenaBlockIsDroppedWhenTheFrameRewinds)
+{
+    ScopedVulkanRenderCommandSelection renderCommandSelection;
+    auto& arena = VulkanFrameArena::Get();
+
+    VulkanWorkerRecordingContext worker;
+    arena.BeginFrame(0);
+    u64 firstFrameOffset = 0;
+    {
+        ScopedVulkanWorkerContext scoped(&worker);
+        const auto allocation = arena.Allocate(128, 16);
+        ASSERT_TRUE(allocation.IsValid());
+        firstFrameOffset = allocation.Offset;
+        EXPECT_NE(worker.Arena.End, u64{ 0 }) << "the worker should be bumping inside a claimed block";
+    }
+
+    // Same slot, rewound. The stale block still names offsets inside it.
+    arena.BeginFrame(0);
+    {
+        ScopedVulkanWorkerContext scoped(&worker);
+        const auto allocation = arena.Allocate(128, 16);
+        ASSERT_TRUE(allocation.IsValid());
+        EXPECT_EQ(allocation.Offset, firstFrameOffset)
+            << "a rewound slot must hand out its first offset again, not continue inside last frame's block";
+    }
+}
+
 #endif // OLO_WITH_VULKAN


### PR DESCRIPTION
Fixes #1185.

## What was wrong

`VulkanFrameArena`'s worker root-data block was claimed **per recording item** and dropped at every fork, so a frame paid `kWorkerBlockBytes` (64 KiB) per item regardless of what the item actually pushed. A deferred frame records on the order of 255 items — 16.7 MiB of a 16.78 MiB slot, almost all of it untouched block tails. Past that the arena has nothing left and every root-data push is dropped, and a dropped push is not a crash: the draw samples an **unbound buffer**, so materials shade with no data and the skybox never gets its constants.

That is #1185, which presented as "Vulkan loses IBL and the skybox after two distinct scene loads". The scene count was a red herring — it takes a frame with enough recorded items, and `MaterialLab`'s 119 entities on the deferred path is simply the first scene in that sequence to get there.

Measured on the repro, by logging the previous frame before `BeginFrame` rewinds it:

| after opening | slot cursor at frame end | counted allocations | overflows |
|---|---|---|---|
| `SponzaCSM` | 0 | 461 | 0 |
| `WaterShowcase` | 90 960 | 105 | 0 |
| **`MaterialLab`** (3rd) | **16 727 056** | **0** | **22 398** |

`16 727 056 / 65 536 = 255.2` — one block per item. Counted allocations read 0 because the worker path tallies into the item's own counter and folds it only at the join, which is why no existing stat made this visible.

## The fix

- **The block is frame-scoped, not command-buffer-scoped.** It survives `ResetForCommandBuffer` and is keyed on the arena's frame generation instead — reused within a frame, dropped once the slot underneath has been rewound. Keying on the slot index alone would alias frame N with frame N+2, which is the hazard `GetFrameGeneration()` already exists to close.
- **`kWorkerBlockBytes` 64 KiB -> 8 KiB.** The block should be sized against how many blocks a frame claims, not against one item's appetite. 8 KiB keeps the property the block exists for — one shared CAS per item rather than per draw — while bounding a 255-item frame at ~2 MiB.
- **The overflow report was lying.** It printed the claim helper's out-parameter, which is left untouched on failure, so it read `at cursor 0 of 16777216 B` — impossible-looking next to a full slot, and easy to dismiss. It now reads the real cursor, says draws will sample unbound buffers, and re-arms per frame instead of latching for the process, because an overflow that repeats every frame is a permanently wrong image and one line made it look transient.

## Verification

Repro (`SponzaCSM` -> `WaterShowcase` -> `MaterialLab`, Vulkan, deferred), same camera pose:

| | viewport lum / stddev | arena overflows |
|---|---|---|
| before | 81.0 / **8.0** | 22 398 and climbing |
| after | 139.4 / **62.7** | **0** |

139.4 / 62.7 is bit-identical to a clean first-load frame, and the `'Skybox_GBuffer' buffer binding 0 has no published occupant` warning is gone.

A 9-scene x 3-path Vulkan matrix (27 captures: MaterialLab, LightingTest, SponzaDeferred, PBRModelTest, SSRTest, TerrainTest, DDGITest, WaterShowcase, SnowfallParticles on forward / forward+ / deferred) shows RMSE ~0 against the pre-fix captures for every frame that was already rendering correctly — nothing else moved.

Full suite green in Debug: **8178 ran, 8138 passed, 40 skipped, 0 failed**, exit 0. That is exactly +2 on the pre-change baseline, the two tests below.

## Tests

`VulkanParallelRecordingDevice.ItemCountDoesNotExhaustTheFrameArena` and `.WorkerArenaBlockIsDroppedWhenTheFrameRewinds` (layer `plumbing`, device-gated like the rest of that file).

They fail on the old code with `a 255-item frame consumed 16711680 B of the slot`. Note the budget assertion trips **before** an actual overflow: 255 x 64 KiB just barely fits a bare slot, and it was the additional shared-path allocations that pushed production over. Asserting only "no overflow" would let an equivalent regression through.

## Second commit — a ride-along, unrelated to the arena

`fix(shaders): a diamond include is not a circular include`.

`OpenGLShader::ProcessIncludesInternal` threads one `includedFiles` set through the whole recursion and never pops it, so it implements include-once — correct for GLSL, which has no `#pragma once`. The second visit it reported, though, is almost never a cycle; it is a diamond. One editor session logged "Circular include detected" 81 times, 47 of them for `include/GPUScene.glsl` and 21 for `include/MathCommon.glsl` — leaf headers that contain no `#include` at all and cannot be part of a cycle by construction. Skipping was correct; only the diagnostic was wrong. Demoted to trace with an accurate message; verified on a cold shader cache at 85 -> 0 warnings.

## Not addressed here

- `#1186` (GTAO transients always consumed-but-unbacked) and `#1187` (texture-probe logging at error level) are untouched.
- Eleven `has no published occupant` bindings survive this fix and are therefore independent of it — seven of them at error level. The set shrank from 26 to 11, so the other fifteen (`Skybox_GBuffer`, `Particle_Billboard_GPU` 0/2, GTAO, the PostProcess shaders) were symptoms of the arena exhaustion. `Particle_Billboard_GPU` disappearing may be relevant to #1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vulkan rendering reliability for complex frames with many parallel recording operations.
  * Prevented material and skybox data from being dropped when frame memory usage is high.
  * Fixed stale temporary memory being reused after a frame reset.
  * Improved overflow diagnostics, including accurate allocation details and per-frame warnings.
  * Reduced unnecessary memory consumption during parallel command recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->