### PR TITLE
fix(assets): don't log a texture-path probe as a load failure (#1187)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
@@ -1567,7 +1567,8 @@ namespace OloEngine
             }
             else
             {
-                // EXISTENCE FIRST, because the candidates below are PROBES and a
+                // REGULAR-FILE CHECK FIRST (a directory "exists" too, and would reach the
+                // same backend error), because the candidates below are PROBES and a
                 // probe miss is not a load failure. Handing a path that is not
                 // there to Texture2D::Create reaches the backend's
                 // "Image texture data is null! Failed to load" ERROR, so a load
@@ -1578,8 +1579,8 @@ namespace OloEngine
                 // honest line is the OLO_CORE_WARN at the end of the chain, when
                 // EVERY candidate has failed.
                 std::error_code probeEc;
-                auto texture = std::filesystem::exists(path, probeEc) ? Texture2D::Create(path.string(), srgb)
-                                                                      : Ref<Texture2D>{};
+                auto texture = std::filesystem::is_regular_file(path, probeEc) ? Texture2D::Create(path.string(), srgb)
+                                                                               : Ref<Texture2D>{};
                 // A probe that could not be ANSWERED is not the same as "absent":
                 // exists() returns false for a permission or I/O failure too and
                 // parks the reason in the error code. Say so, then continue the
@@ -1726,7 +1727,7 @@ namespace OloEngine
                             OLO_CORE_TRACE("AnimatedModel::LoadMaterialTextures: '{}' not found, trying fallback '{}'",
                                            path.string(), fallbackPathStr);
                             std::error_code fallbackEc;
-                            auto fallbackTexture = std::filesystem::exists(fallbackPathStr, fallbackEc)
+                            auto fallbackTexture = std::filesystem::is_regular_file(fallbackPathStr, fallbackEc)
                                                        ? Texture2D::Create(fallbackPathStr, srgb)
                                                        : Ref<Texture2D>{};
                             if (fallbackEc)

--- a/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
@@ -1567,7 +1567,19 @@ namespace OloEngine
             }
             else
             {
-                auto texture = Texture2D::Create(path.string(), srgb);
+                // EXISTENCE FIRST, because the candidates below are PROBES and a
+                // probe miss is not a load failure. Handing a path that is not
+                // there to Texture2D::Create reaches the backend's
+                // "Image texture data is null! Failed to load" ERROR, so a load
+                // that ultimately succeeds through the fallback chain still
+                // emitted errors on the way — Cerberus's FBX names .tga files
+                // while the directory holds .png, which is exactly the case the
+                // directory scan below exists to absorb (issue #1187). The one
+                // honest line is the OLO_CORE_WARN at the end of the chain, when
+                // EVERY candidate has failed.
+                std::error_code probeEc;
+                auto texture = std::filesystem::exists(path, probeEc) ? Texture2D::Create(path.string(), srgb)
+                                                                      : Ref<Texture2D>{};
                 if (texture && texture->IsLoaded())
                 {
                     textures.push_back(texture);
@@ -1701,9 +1713,12 @@ namespace OloEngine
                         }
                         else if (fallbackPathStr != path.string())
                         {
-                            OLO_CORE_WARN("AnimatedModel::LoadMaterialTextures: '{}' not found, trying fallback '{}'",
-                                          path.string(), fallbackPathStr);
-                            auto fallbackTexture = Texture2D::Create(fallbackPathStr, srgb);
+                            OLO_CORE_TRACE("AnimatedModel::LoadMaterialTextures: '{}' not found, trying fallback '{}'",
+                                           path.string(), fallbackPathStr);
+                            std::error_code fallbackEc;
+                            auto fallbackTexture = std::filesystem::exists(fallbackPathStr, fallbackEc)
+                                                       ? Texture2D::Create(fallbackPathStr, srgb)
+                                                       : Ref<Texture2D>{};
                             if (fallbackTexture && fallbackTexture->IsLoaded())
                             {
                                 textures.push_back(fallbackTexture);
@@ -1726,8 +1741,8 @@ namespace OloEngine
                         {
                             const std::string discoveredStr = discovered.string();
                             const std::string discoveredKey = discoveredStr + std::string(srgbSuffix);
-                            OLO_CORE_WARN("AnimatedModel::LoadMaterialTextures: Discovered '{}' via directory scan for '{}'",
-                                          discoveredStr, filenameOnly.string());
+                            OLO_CORE_TRACE("AnimatedModel::LoadMaterialTextures: Discovered '{}' via directory scan for '{}'",
+                                           discoveredStr, filenameOnly.string());
                             if (m_LoadedTextures.find(discoveredKey) != m_LoadedTextures.end())
                             {
                                 textures.push_back(m_LoadedTextures[discoveredKey]);

--- a/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
+++ b/OloEngine/src/OloEngine/Renderer/AnimatedModel.cpp
@@ -1580,6 +1580,16 @@ namespace OloEngine
                 std::error_code probeEc;
                 auto texture = std::filesystem::exists(path, probeEc) ? Texture2D::Create(path.string(), srgb)
                                                                       : Ref<Texture2D>{};
+                // A probe that could not be ANSWERED is not the same as "absent":
+                // exists() returns false for a permission or I/O failure too and
+                // parks the reason in the error code. Say so, then continue the
+                // chain — a later candidate may still land, but the anomaly must
+                // not vanish into a successful load (CodeRabbit on #1189).
+                if (probeEc)
+                {
+                    OLO_CORE_WARN("AnimatedModel::LoadMaterialTextures: could not probe '{}': {} — treating it as absent",
+                                  path.string(), probeEc.message());
+                }
                 if (texture && texture->IsLoaded())
                 {
                     textures.push_back(texture);
@@ -1719,6 +1729,11 @@ namespace OloEngine
                             auto fallbackTexture = std::filesystem::exists(fallbackPathStr, fallbackEc)
                                                        ? Texture2D::Create(fallbackPathStr, srgb)
                                                        : Ref<Texture2D>{};
+                            if (fallbackEc)
+                            {
+                                OLO_CORE_WARN("AnimatedModel::LoadMaterialTextures: could not probe '{}': {} — treating it as absent",
+                                              fallbackPathStr, fallbackEc.message());
+                            }
                             if (fallbackTexture && fallbackTexture->IsLoaded())
                             {
                                 textures.push_back(fallbackTexture);


### PR DESCRIPTION
Closes #1187.

`AnimatedModel::LoadMaterialTextures` deliberately probes several candidate paths for a material texture — the comment above its last fallback says so outright: *"Handles FBX referencing .tga when the actual file is .png, and case mismatches on Linux."* The probing is the design and it works.

What was wrong is that every failed probe reached `Texture2D::Create` and tripped the backend's error:

```cpp
OLO_CORE_ERROR("Image texture data is null! Failed to load: '{}'", path)
```

so a load that ultimately **succeeded** emitted errors on the way. On a cold mesh cache, opening `Scenes/PBRModelTest.olo` logged two of them —

```
[error] Image texture data is null! Failed to load: 'assets/models/Cerberus\Textures\Cerberus_A.tga'
[error] Image texture data is null! Failed to load: 'assets/models/Cerberus\Cerberus_A.tga'
```

— before the directory scan found the `cerberus_A.png` that was there all along. That directory contains no `.tga` at all; the names come from the FBX's embedded material, which is exactly the case the fallback chain exists to absorb.

These were the **only** error-level lines in an otherwise clean editor session, which is how "are there errors in the log?" stops being a useful question.

## Change

- The two speculative candidates test existence before entering the backend. A path that is not there is a probe miss, not a load failure.
- The directory-scan hit is a real find rather than a problem, so its `WARN` drops to `TRACE` alongside.
- The honest line at the end of the chain — the `OLO_CORE_WARN` fired when **every** candidate has failed — is untouched. That one means what it says.

## Verification

Needs a **cold** mesh cache; a warm `OloEditor/assets/cache/mesh/` skips texture loading entirely, which is why this only ever showed on a first load.

| | `Image texture data is null` errors | total `[error]` lines |
|---|---|---|
| before | 2 | 2 |
| after | **0** | **0** |

The three textures now resolve straight to the PNGs at trace level (`cerberus_A.png`, `cerberus_N.png`, `cerberus_R.png`), and the model still renders textured — captured the framed `Cerberus Gun` after the change to confirm the fallback chain still lands, rather than trusting the absence of an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented missing texture files from triggering backend texture-loading errors.
  * Missing textures now return safely without attempting to load nonexistent files.
  * Improved handling of alternate texture paths when the primary file is unavailable.
* **Logging**
  * Reduced the severity of routine texture fallback and discovery messages to trace-level logging.
  * Genuine texture path probe issues are now recorded as warnings for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->