### PR TITLE
fix(vsm): bind inert sampling stubs when virtual shadow maps never initialised (#1190)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
@@ -2097,10 +2097,53 @@ namespace OloEngine
     // Binding + diagnostics
     // -------------------------------------------------------------------------
 
+    // Inert stand-ins for the three sampling bindings, for the case where VSM was
+    // never initialised at all (Init() returns before CreateResources() when the
+    // feature is off). Sized to one entry each: the shader is guaranteed not to
+    // index them, because vsmShadowFactor returns on VSM_ENABLED == 0 and the
+    // globals block below sets exactly that. The point is that the guarantee now
+    // rests on a bound buffer rather than on the RHI's null block happening to
+    // read zeros (#1190).
+    void VirtualShadowMap::EnsureInertSamplingBindings()
+    {
+        if (m_InertGlobalsUBO)
+            return;
+
+        using SB = StorageBuffer;
+        m_InertPageTable = SB::Create(sizeof(u32), ShaderBindingLayout::SSBO_VSM_PAGE_TABLE);
+        m_InertLocalLights = SB::Create(sizeof(glm::vec4), ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS);
+        m_InertGlobalsUBO = UniformBuffer::Create(VSM::GlobalsUBO::GetSize(), ShaderBindingLayout::UBO_VIRTUAL_SHADOW);
+
+        // UBO 82 (VirtualShadowPass) is DELIBERATELY not covered here, though the
+        // shared header declares it beside the globals. It belongs to the VSM
+        // DRAW pass, and ResolveRecordingUpload asserts
+        // "Unprepared recording upload binding 82" when a pass that never
+        // declared it tries to publish one — tried, and it takes the editor down
+        // on the first frame. Feeding it needs the draw pass's prepared-upload
+        // set, not a stub from here; it reads defined zeros from the null block
+        // meanwhile, which for a UBO is the survivable half of #1052.
+    }
+
     void VirtualShadowMap::BindForSampling()
     {
         if (!m_Initialized)
+        {
+            // Not "nothing to do": the shared header declares SSBO 68 / 78 and
+            // UBO 81 whether or not this system ever ran, so returning here left
+            // three bindings with no occupant in every PBR and deferred shader.
+            EnsureInertSamplingBindings();
+
+            VSM::GlobalsUBO disabled{};
+            disabled.Params2.x = 0; // VSM_ENABLED
+            disabled.Params4.x = 0; // local lights
+            auto inertUBO = CommandDispatch::ResolveRecordingUpload(ShaderBindingLayout::UBO_VIRTUAL_SHADOW,
+                                                                    m_InertGlobalsUBO);
+            inertUBO->SetData(&disabled, VSM::GlobalsUBO::GetSize());
+            inertUBO->Bind();
+            m_InertPageTable->Bind();
+            m_InertLocalLights->Bind();
             return;
+        }
 
         // Params2.x is what the shader branches on, so an inactive VSM uploads a
         // disabled block rather than relying on every consumer remembering to ask.

--- a/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
@@ -388,6 +388,14 @@ namespace OloEngine
     {
         OLO_PROFILE_FUNCTION();
         DestroyResources();
+        // The inert sampling buffers are created lazily by EnsureInertSamplingBindings
+        // and gated on m_InertGlobalsUBO alone, so they must go here too: Renderer3D
+        // keeps this object across a shutdown/reinitialise, and buffers from the
+        // previous RHI lifetime would otherwise be bound as if they were current.
+        m_InertPageTable.Reset();
+        m_InertLocalLights.Reset();
+        m_InertGlobalsUBO.Reset();
+        m_InertPassUBO.Reset();
         m_Initialized = false;
         m_FullInvalidate = true;
     }

--- a/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.cpp
@@ -107,6 +107,14 @@ namespace OloEngine
         OLO_PROFILE_FUNCTION();
 
         m_Settings = settings;
+        // The inert sampling stubs are created HERE, on the main thread and before
+        // the disabled early-return, so that BindForSampling never has to create
+        // or upload anything from inside a recorded item. Everything they hold is
+        // constant (a disabled globals block, an all-zero pass block, one-entry
+        // SSBOs), so they are filled exactly once and only ever bound — no
+        // per-frame ResolveRecordingUpload, which asserts for UBO 82 because the
+        // sampling pass never prepared it (#1190).
+        EnsureInertSamplingBindings();
         if (!m_Settings.Enabled)
             return;
 
@@ -2104,6 +2112,20 @@ namespace OloEngine
     // globals block below sets exactly that. The point is that the guarantee now
     // rests on a bound buffer rather than on the RHI's null block happening to
     // read zeros (#1190).
+    // Inert stand-ins for the four sampling-side bindings the shared header
+    // declares, for the case where VSM was never initialised at all (Init()
+    // returns before CreateResources() when the feature is off). One entry each;
+    // the shader is guaranteed not to index the two SSBOs because vsmShadowFactor
+    // returns on VSM_ENABLED == 0, and the globals block below sets exactly that.
+    // The point is that the guarantee rests on bound buffers rather than on the
+    // RHI's null block happening to read zeros (#1190).
+    //
+    // Created once, on the main thread, from Init(); their contents never change,
+    // so they are uploaded here and only bound afterwards. That is what lets
+    // BindForSampling run inside a parallel-recorded item without a recording
+    // seam: ResolveRecordingUpload is for buffers whose data changes mid-frame,
+    // and it asserts "Unprepared recording upload binding 82" for the pass block,
+    // which only the VSM draw pass ever prepared.
     void VirtualShadowMap::EnsureInertSamplingBindings()
     {
         if (m_InertGlobalsUBO)
@@ -2112,16 +2134,16 @@ namespace OloEngine
         using SB = StorageBuffer;
         m_InertPageTable = SB::Create(sizeof(u32), ShaderBindingLayout::SSBO_VSM_PAGE_TABLE);
         m_InertLocalLights = SB::Create(sizeof(glm::vec4), ShaderBindingLayout::SSBO_VSM_LOCAL_LIGHTS);
-        m_InertGlobalsUBO = UniformBuffer::Create(VSM::GlobalsUBO::GetSize(), ShaderBindingLayout::UBO_VIRTUAL_SHADOW);
 
-        // UBO 82 (VirtualShadowPass) is DELIBERATELY not covered here, though the
-        // shared header declares it beside the globals. It belongs to the VSM
-        // DRAW pass, and ResolveRecordingUpload asserts
-        // "Unprepared recording upload binding 82" when a pass that never
-        // declared it tries to publish one — tried, and it takes the editor down
-        // on the first frame. Feeding it needs the draw pass's prepared-upload
-        // set, not a stub from here; it reads defined zeros from the null block
-        // meanwhile, which for a UBO is the survivable half of #1052.
+        VSM::GlobalsUBO disabled{};
+        disabled.Params2.x = 0; // VSM_ENABLED
+        disabled.Params4.x = 0; // local lights
+        m_InertGlobalsUBO = UniformBuffer::Create(VSM::GlobalsUBO::GetSize(), ShaderBindingLayout::UBO_VIRTUAL_SHADOW);
+        m_InertGlobalsUBO->SetData(&disabled, VSM::GlobalsUBO::GetSize());
+
+        const VSM::PassUBO inertPass{};
+        m_InertPassUBO = UniformBuffer::Create(VSM::PassUBO::GetSize(), ShaderBindingLayout::UBO_VIRTUAL_SHADOW_DRAW);
+        m_InertPassUBO->SetData(&inertPass, VSM::PassUBO::GetSize());
     }
 
     void VirtualShadowMap::BindForSampling()
@@ -2129,17 +2151,12 @@ namespace OloEngine
         if (!m_Initialized)
         {
             // Not "nothing to do": the shared header declares SSBO 68 / 78 and
-            // UBO 81 whether or not this system ever ran, so returning here left
-            // three bindings with no occupant in every PBR and deferred shader.
+            // UBO 81 / 82 whether or not this system ever ran, so returning here
+            // left four bindings with no occupant in every PBR and deferred
+            // shader. The stubs were created and filled by Init(); bind them.
             EnsureInertSamplingBindings();
-
-            VSM::GlobalsUBO disabled{};
-            disabled.Params2.x = 0; // VSM_ENABLED
-            disabled.Params4.x = 0; // local lights
-            auto inertUBO = CommandDispatch::ResolveRecordingUpload(ShaderBindingLayout::UBO_VIRTUAL_SHADOW,
-                                                                    m_InertGlobalsUBO);
-            inertUBO->SetData(&disabled, VSM::GlobalsUBO::GetSize());
-            inertUBO->Bind();
+            m_InertGlobalsUBO->Bind();
+            m_InertPassUBO->Bind();
             m_InertPageTable->Bind();
             m_InertLocalLights->Bind();
             return;

--- a/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.h
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.h
@@ -1032,6 +1032,7 @@ namespace OloEngine
         Ref<StorageBuffer> m_InertPageTable;
         Ref<StorageBuffer> m_InertLocalLights;
         Ref<UniformBuffer> m_InertGlobalsUBO;
+        Ref<UniformBuffer> m_InertPassUBO;
 
         Ref<StorageBuffer> m_PageTable;     // kTotalVirtualPages uints
         Ref<StorageBuffer> m_MetaTable;     // physical page -> owner

--- a/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.h
+++ b/OloEngine/src/OloEngine/Renderer/Shadow/VirtualShadowMap.h
@@ -770,6 +770,15 @@ namespace OloEngine
         // consumer (the lit pass, DDGI relight, the fog scatter). Safe to call when
         // inactive: it uploads a disabled globals block and binds the 1x1
         // placeholder pool so a shader that samples unconditionally reads "lit".
+        //
+        // Also safe — and REQUIRED — when VSM was never initialised at all. Init()
+        // returns before CreateResources() when the feature is off, so none of the
+        // buffers below exist; this used to return early and leave SSBO 68 / 78 and
+        // UBO 81 with no occupant at all. VirtualShadowResources.glsl declares them
+        // unconditionally (it is a shared header included by PBR_MultiLight,
+        // PBR_GBuffer and DeferredLighting), so the RHI substituted its null block
+        // and logged an error per shader (#1190). Inert stubs make the binding
+        // honest instead (see EnsureInertSamplingBindings).
         void BindForSampling();
 
         [[nodiscard]] RHI::ResourceHandle GetPhysicalPoolHandle() const
@@ -1012,6 +1021,18 @@ namespace OloEngine
 
         // Page state (all std430 SSBOs — SSBO atomics are core GL 4.6, whereas the
         // reference's R64_UINT meta image would need int64 image atomics).
+        // --- inert sampling stubs (VSM off) ----------------------------------
+        // Minimal stand-ins bound at SSBO 68 / 78 and UBO 81 when the feature is
+        // off, so the bindings the shared header declares always have a real
+        // occupant. A few hundred bytes, created once and only when VSM never
+        // initialised. The shader cannot index the two SSBOs in this state —
+        // vsmShadowFactor returns early on VSM_ENABLED == 0 — but "cannot" should
+        // rest on a bound buffer, not on the null block happening to read zeros.
+        void EnsureInertSamplingBindings();
+        Ref<StorageBuffer> m_InertPageTable;
+        Ref<StorageBuffer> m_InertLocalLights;
+        Ref<UniformBuffer> m_InertGlobalsUBO;
+
         Ref<StorageBuffer> m_PageTable;     // kTotalVirtualPages uints
         Ref<StorageBuffer> m_MetaTable;     // physical page -> owner
         Ref<StorageBuffer> m_HPB;           // kHPBTotalEntries uints

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -2669,7 +2669,30 @@ namespace OloEngine
                         // was fed correctly, so the read lands outside it and
                         // loses the device. That asymmetry is the whole of
                         // #1052, so the two cases do not get the same voice.
-                        if (isStorage)
+                        // A VERTEX-PULL stream that the VAO does not carry is a
+                        // DESIGNED absence, not an unfed binding: the arm above
+                        // resolves it to the zero address on purpose, and the
+                        // shader gates the read (a skinned shader on a static
+                        // mesh; an unbaked mesh with no lightmap UV stream, whose
+                        // all-zero LightmapScaleOffset gates sampling). Telling
+                        // someone to "bind it" there would mean a dummy buffer per
+                        // non-skinned, non-lightmapped mesh in every scene.
+                        //
+                        // It still goes through this path rather than skipping the
+                        // accounting, because the null-block substitution and the
+                        // counter below are what make the state observable at all —
+                        // only the voice changes (issue #1190). Every other unfed
+                        // STORAGE binding keeps the error: that is #1052's case,
+                        // where the index comes from a buffer that WAS fed and the
+                        // read lands outside the small null block.
+                        const bool expectedAbsentPullStream = pullStream != ~sizet{ 0 };
+                        if (expectedAbsentPullStream)
+                        {
+                            OLO_CORE_TRACE("[RHI/Vulkan] '{}' pull stream {} (binding {}) is absent for this VAO — "
+                                           "null block, read is gated by the shader",
+                                           shaderName, pullStream, binding.Binding);
+                        }
+                        else if (isStorage)
                         {
                             OLO_CORE_ERROR("[RHI/Vulkan] '{}' STORAGE binding {} has no published occupant — "
                                            "substituting the null block, which a shader that indexes this buffer "


### PR DESCRIPTION
**Stacked on #1188** — base it there, or merge #1188 first. The diff against `master` would otherwise include #1188's two commits, and the verification numbers below assume its frame-arena fix is present.

Refs #1190 (does not close it — five of the eleven bindings remain, see below).

## What was wrong

`VirtualShadowMap::Init()` returns before `CreateResources()` when the feature is off, so none of its buffers exist — and `BindForSampling()` then returned early, leaving **SSBO 68** (`VSMPageTable`), **SSBO 78** (`VSMLocalLights`) and **UBO 81** (`VirtualShadowGlobals`) with no occupant at all.

`include/VirtualShadowResources.glsl` declares all three unconditionally, and it is a shared header pulled into `PBR_MultiLight`, `PBR_GBuffer` and `DeferredLighting`. So each of those shaders reported:

```
[RHI/Vulkan] '<shader>' STORAGE binding 68 has no published occupant — substituting the
null block, which a shader that indexes this buffer will read past (issue #1052).
Bind it, or stop declaring it.
```

Six lines in total, four of them at error level.

## Nothing was actually reading out of bounds

Worth being precise, because it changes what the fix is for. `vsmShadowFactor` returns on `VSM_ENABLED == 0` before any `b_PageTable[]` index, and `VSM_ENABLED` comes from the globals block — which read zeros from the null block. So the guard held.

But it held *incidentally*: only because the unbound UBO happened to read zeros, and indistinguishable from the real hazard #1052 exists to catch. `BindForSampling` now allocates one-entry stubs on first use and publishes an explicitly disabled globals block, so the guarantee rests on a bound buffer. A few hundred bytes, created only when VSM never initialised.

## UBO 82 is deliberately not covered

It is declared in the same shared header, so stubbing it beside the globals was the obvious next step. It takes the editor down on the first frame:

```
Assertion Failed: Unprepared recording upload binding 82
```

`ResolveRecordingUpload` requires the binding to be in the recording pass's prepared-upload set, and 82 belongs to the VSM **draw** pass rather than the sampling pass. Feeding it needs that pass's set, not a stub from here. Left alone, with a comment in the code recording the attempt and why — it reads defined zeros meanwhile, which for a UBO is the survivable half of #1052.

## Verification

Vulkan + deferred, `SponzaCSM -> WaterShowcase -> MaterialLab`:

| | distinct `no published occupant` | assertions | MaterialLab lum / stddev |
|---|---|---|---|
| before | 11 | 0 | 139.4 / 62.7 |
| after | **5** | 0 | 139.4 / 62.7 |

68, 78 and 81 are gone across both shaders each. MaterialLab is unchanged from the #1188 baseline, so the stubs cost nothing visually.

Full suite green in Debug: **8178 ran, 8138 passed, 40 skipped, 0 failed**, exit 0 — same as #1188's baseline, no new tests here.

## What remains on #1190, and why it is not the same fix

I filed #1190 saying all seven errors were "declared unconditionally, bound conditionally" and that binding an inert buffer fitted all of them. That is **wrong for the three that remain**, and I have corrected the issue.

`SSBO 63` (`OloLightmapUVPull`, x2) and `SSBO 17` (x1) are absent **by design**. `PBR_MultiLight.glsl` says so where 63 is declared:

> A VAO with no lightmap UV buffer (unbaked static mesh) leaves stream 1 short — `AssembleAndPushRootData` resolves it to the zero address, and `LightmapScaleOffset`'s all-zero default gates sampling regardless.

The engine *intends* address 0 for an unbaked mesh; the null block is the safety net that turns that into defined zeros; the shader is gated by a separate zero default. Binding a stub would mean a dummy vertex-pull buffer for every non-lightmapped mesh in every scene. What is wrong for those three is the **severity** — an expected steady state reported at error level — which wants an optional-binding concept rather than a buffer.

## Second commit: UBO 82 inert too, and the absent pull stream stops being an error

The first commit's inert stubs covered SSBO 68/78 and UBO 81 but not the per-pass `UBO_VIRTUAL_SHADOW_DRAW` (82); a first attempt at 82 went through `CommandDispatch::ResolveRecordingUpload`, which only knows five recording-upload bindings and asserted. The stubs are now created once in `Init()` before the `Enabled` early-out, filled once with `SetData`, and the inert branch of `BindForSampling` just `Bind()`s all four — no per-frame upload path.

SSBO 63 (`OloLightmapUVPull`) is a vertex-pull stream that is absent for every draw whose vertex format has no lightmap UVs, by design; the dispatcher substituted the null block correctly but logged it at ERROR per draw. An expected absence is a TRACE now; every other raw-buffer null-block substitution keeps its ERROR (#1052's case).

Live (Vulkan, Debug, MaterialLab forward): **zero** `no published occupant` lines across bindings 63 / 68 / 78 / 81 / 82 where there were four per draw. The `VirtualShadow*` suites: 52 pass, 1 skip. (The session then hit the pre-existing path-switch fault #1198 on its first render-path switch — that fault reproduces on plain master 2 of 3 runs and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability when virtual shadow maps are disabled or have not yet been initialized.
  * Ensured valid fallback resources are available for shadow sampling in uninitialized states and after renderer shutdown/reinitialization.
  * Reduced misleading error reporting for shaders that intentionally omit a vertex-pull stream, while preserving errors for genuinely missing storage bindings.
  * Improved handling of renderer resource lifecycles to prevent stale shadow-sampling bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->