### PR TITLE
fix(mesh): sphere pole rows emit a fan, and default primitives share one source per kind (#1191)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
@@ -1,10 +1,12 @@
 #include "OloEnginePCH.h"
 #include "MeshPrimitives.h"
+#include "OloEngine/Renderer/RenderCommand.h"
 #include "MeshSource.h"
 #include "OloEngine/Renderer/RendererAPI.h"
 #include "OloEngine/Renderer/VertexBuffer.h"
 #include "OloEngine/Renderer/IndexBuffer.h"
 
+#include <array>
 #include <iterator>
 
 namespace OloEngine
@@ -136,6 +138,64 @@ namespace OloEngine
     void MeshPrimitives::Shutdown()
     {
         s_FullscreenTriangleVA.Reset();
+    }
+
+    namespace
+    {
+        using SharedSourceTable = std::array<Ref<MeshSource>, static_cast<sizet>(MeshPrimitives::SharedDefault::Count)>;
+
+        SharedSourceTable& SharedDefaultSources()
+        {
+            static SharedSourceTable s_Sources;
+            return s_Sources;
+        }
+
+        Ref<Mesh> BuildDefault(MeshPrimitives::SharedDefault kind)
+        {
+            switch (kind)
+            {
+                case MeshPrimitives::SharedDefault::Cube:
+                    return MeshPrimitives::CreateCube();
+                case MeshPrimitives::SharedDefault::Sphere:
+                    return MeshPrimitives::CreateSphere();
+                case MeshPrimitives::SharedDefault::Plane:
+                    return MeshPrimitives::CreatePlane();
+                case MeshPrimitives::SharedDefault::Cylinder:
+                    return MeshPrimitives::CreateCylinder();
+                case MeshPrimitives::SharedDefault::Cone:
+                    return MeshPrimitives::CreateCone();
+                case MeshPrimitives::SharedDefault::Icosphere:
+                    return MeshPrimitives::CreateIcosphere();
+                case MeshPrimitives::SharedDefault::Torus:
+                    return MeshPrimitives::CreateTorus();
+                case MeshPrimitives::SharedDefault::Count:
+                    break;
+            }
+            OLO_CORE_ASSERT(false, "CreateSharedDefault: unknown primitive kind");
+            return nullptr;
+        }
+    } // namespace
+
+    Ref<Mesh> MeshPrimitives::CreateSharedDefault(SharedDefault kind)
+    {
+        if (!RenderCommand::IsDeviceAvailable())
+            return BuildDefault(kind);
+
+        auto& shared = SharedDefaultSources()[static_cast<sizet>(kind)];
+        if (!shared)
+        {
+            auto built = BuildDefault(kind);
+            if (!built)
+                return nullptr;
+            shared = built->GetMeshSource();
+        }
+        return Ref<Mesh>::Create(shared, 0);
+    }
+
+    void MeshPrimitives::ReleaseSharedSources()
+    {
+        for (auto& source : SharedDefaultSources())
+            source.Reset();
     }
 
     Ref<Mesh> MeshPrimitives::CreateCube()

--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
@@ -181,7 +181,12 @@ namespace OloEngine
         if (!RenderCommand::IsDeviceAvailable())
             return BuildDefault(kind);
 
-        auto& shared = SharedDefaultSources()[static_cast<sizet>(kind)];
+        auto& sources = SharedDefaultSources();
+        const auto index = static_cast<sizet>(kind);
+        OLO_CORE_ASSERT(index < sources.size(), "CreateSharedDefault: unknown primitive kind");
+        if (index >= sources.size())
+            return nullptr;
+        auto& shared = sources[index];
         if (!shared)
         {
             auto built = BuildDefault(kind);

--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.cpp
@@ -200,22 +200,59 @@ namespace OloEngine
             }
         }
 
-        // Generate indices
+        // Generate indices.
+        //
+        // THE POLE ROWS ARE A TRIANGLE FAN, NOT A QUAD STRIP. Ring 0 evaluates
+        // sin(pi * 0 * R) == 0 for every sector, so all `sectors` of its vertices
+        // are the same point (0, -radius, 0); the last ring collapses the same way
+        // onto (0, +radius, 0). A quad with two corners at one point is one real
+        // triangle plus one with zero area, so emitting both there produced a full
+        // sector's worth of degenerate triangles at each pole — 62 of 930 at the
+        // default segments = 16, submitted, transformed and rasterized to nothing
+        // on every draw of every sphere in the engine (issue #1191).
+        //
+        // Half of them were invisible to the import census as well: r * R is
+        // exactly 0 at the south pole so those triangles are exactly zero-area,
+        // while (rings - 1) * (1.0f / (rings - 1)) is not exactly 1.0f in float, so
+        // the north pole's are slivers of ~1e-7 area that pass a zero-area test.
+        // AnalyzeDegenerateTriangles reported 31, not 62, for exactly that reason.
+        //
+        // Dropping them cannot change the rendered image: a triangle with no area
+        // covers no pixels. It removes 62 triangles of the 930 and the index
+        // buffer shrinks to match.
         indices.reserve((rings - 1) * (sectors - 1) * 6);
         for (u32 r = 0; r < rings - 1; ++r)
         {
+            // rings == 2 would make one band both poles at once, leaving nothing to
+            // draw. That shape is already fully degenerate (both its rings ARE the
+            // poles), so leave it exactly as it was rather than emitting an empty
+            // index buffer for it.
+            const bool poleRowsAreSeparable = rings > 2;
+            const bool southPoleBand = poleRowsAreSeparable && r == 0;
+            const bool northPoleBand = poleRowsAreSeparable && r == rings - 2;
+
             for (u32 s = 0; s < sectors - 1; ++s)
             {
                 const u32 curRow = r * sectors;
                 const u32 nextRow = (r + 1) * sectors;
 
-                indices.push_back(curRow + s);
-                indices.push_back(nextRow + s);
-                indices.push_back(nextRow + (s + 1));
+                // Degenerate at the NORTH pole: nextRow + s and nextRow + (s + 1)
+                // are the same point there.
+                if (!northPoleBand)
+                {
+                    indices.push_back(curRow + s);
+                    indices.push_back(nextRow + s);
+                    indices.push_back(nextRow + (s + 1));
+                }
 
-                indices.push_back(curRow + s);
-                indices.push_back(nextRow + (s + 1));
-                indices.push_back(curRow + (s + 1));
+                // Degenerate at the SOUTH pole: curRow + s and curRow + (s + 1)
+                // are the same point there.
+                if (!southPoleBand)
+                {
+                    indices.push_back(curRow + s);
+                    indices.push_back(nextRow + (s + 1));
+                    indices.push_back(curRow + (s + 1));
+                }
             }
         }
 

--- a/OloEngine/src/OloEngine/Renderer/MeshPrimitives.h
+++ b/OloEngine/src/OloEngine/Renderer/MeshPrimitives.h
@@ -30,6 +30,35 @@ namespace OloEngine
 
         // @brief Create a unit cube mesh
         // @return Mesh with vertices from -0.5 to 0.5 on all axes
+        // ---- shared default primitives (issue #1191) ------------------------
+        // The seven defaults a scene entity can name in its MeshComponent. One
+        // MeshSource per kind is built on first use and SHARED by every entity
+        // that asks for it; each call still returns its own Mesh wrapper, so
+        // per-entity state on Mesh (submesh selection) stays per-entity while the
+        // geometry, its optimisation pass, its degenerate census and its GPU
+        // buffers are built once. Before this, MaterialLab's 119 sphere entities
+        // built 119 identical sources on every scene load.
+        //
+        // Headless (no device) callers get a fresh, uncached source: MeshSource::
+        // Build keeps CPU data only without a device, and caching one of those
+        // would hand a later device-backed caller a source with no GPU buffers.
+        enum class SharedDefault : u8
+        {
+            Cube,
+            Sphere,
+            Plane,
+            Cylinder,
+            Cone,
+            Icosphere,
+            Torus,
+            Count
+        };
+        [[nodiscard]] static Ref<Mesh> CreateSharedDefault(SharedDefault kind);
+        // Drop every shared source. Renderer3D::Shutdown calls this: the sources
+        // own GPU buffers, and a static Ref that outlives the renderer is exactly
+        // what RendererMemoryTracker's teardown check exists to catch.
+        static void ReleaseSharedSources();
+
         [[nodiscard]] static Ref<Mesh> CreateCube();
 
         // @brief Create a sphere mesh

--- a/OloEngine/src/OloEngine/Renderer/Renderer.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer.cpp
@@ -118,6 +118,15 @@ namespace OloEngine
         // deleted with the context still current; on Vulkan the destructors
         // enqueue into VulkanDeferredReclaim, which VulkanContext::Shutdown
         // drains a final time just before VulkanDevice::Shutdown.
+        //
+        // The shared default primitives (issue #1191) are the same class of object:
+        // SceneSerializer fills that cache whenever a scene names a built-in mesh, so
+        // a 2D-only or headless session can hold GPU-backed sources without ever
+        // bringing Renderer3D up, and Renderer3D::Shutdown() (which also releases
+        // them, ahead of its teardown census) is skipped for such a session. Release
+        // them here unconditionally, before the buffers' device goes away; the call
+        // is idempotent.
+        MeshPrimitives::ReleaseSharedSources();
         MeshPrimitives::Shutdown();
 
         // The process-wide default font's two Slug atlas textures. Same class as the

--- a/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
+++ b/OloEngine/src/OloEngine/Renderer/Renderer3DLifecycle.cpp
@@ -662,6 +662,12 @@ namespace OloEngine
 
         ParticleBatchRenderer::Shutdown();
 
+        // The shared default primitives own GPU buffers (issue #1191). Drop them
+        // here, before the memory tracker's teardown census, or each one reads as
+        // a Ref that outlived the renderer - and a test that restarts the renderer
+        // would be handed a source whose buffers died with the previous one.
+        MeshPrimitives::ReleaseSharedSources();
+
         if (s_Data.DecalVisibilityQueriesInitialized)
         {
             RenderCommand::DeleteQueries(s_Data.DecalReceiverIntersectionQueries);

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -338,24 +338,27 @@ namespace OloEngine
         }
     }
 
+    // One shared MeshSource per primitive kind (issue #1191): every entity that
+    // names the same default primitive gets its own Mesh over the same source,
+    // instead of building, optimising and uploading an identical one per entity.
     static Ref<Mesh> CreateMeshFromPrimitive(MeshPrimitive primitive)
     {
         switch (primitive)
         {
             case MeshPrimitive::Cube:
-                return MeshPrimitives::CreateCube();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Cube);
             case MeshPrimitive::Sphere:
-                return MeshPrimitives::CreateSphere();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Sphere);
             case MeshPrimitive::Plane:
-                return MeshPrimitives::CreatePlane();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Plane);
             case MeshPrimitive::Cylinder:
-                return MeshPrimitives::CreateCylinder();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Cylinder);
             case MeshPrimitive::Cone:
-                return MeshPrimitives::CreateCone();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Cone);
             case MeshPrimitive::Icosphere:
-                return MeshPrimitives::CreateIcosphere();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Icosphere);
             case MeshPrimitive::Torus:
-                return MeshPrimitives::CreateTorus();
+                return MeshPrimitives::CreateSharedDefault(MeshPrimitives::SharedDefault::Torus);
             default:
                 return nullptr;
         }

--- a/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
+++ b/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
@@ -1263,7 +1263,6 @@ TEST(MeshOptimization, MeasureModelExtentMatchesTheBoundingBox)
     EXPECT_FLOAT_EQ(MeshOptimization::MeasureModelExtent(*empty), 0.0f);
 }
 
-
 // =============================================================================
 // CreateSphere's pole rows (issue #1191)
 // =============================================================================

--- a/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
+++ b/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
@@ -11,6 +11,7 @@
 #include "OloEngine/Renderer/MeshOptimization.h"
 #include "OloEngine/Renderer/MeshSource.h"
 #include "OloEngine/Renderer/Mesh.h"
+#include "OloEngine/Renderer/MeshPrimitives.h"
 #include "OloEngine/Renderer/IndexBuffer.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/Vertex.h"
@@ -1260,4 +1261,66 @@ TEST(MeshOptimization, MeasureModelExtentMatchesTheBoundingBox)
     TArray<u32> noIndices;
     auto empty = Ref<MeshSource>::Create(MoveTemp(noVertices), MoveTemp(noIndices));
     EXPECT_FLOAT_EQ(MeshOptimization::MeasureModelExtent(*empty), 0.0f);
+}
+
+
+// =============================================================================
+// CreateSphere's pole rows (issue #1191)
+// =============================================================================
+//
+// Ring 0 evaluates sin(pi * 0 * R) == 0 for every sector, so all of its vertices
+// are the same point; the last ring collapses the same way. Emitting a full quad
+// per sector there gave one real triangle plus one with no area, at both poles.
+
+TEST(MeshPrimitivesSphere, PoleRowsEmitNoDegenerateTriangles)
+{
+    auto sphere = MeshPrimitives::CreateSphere(1.0f, 16);
+    ASSERT_TRUE(sphere);
+    const auto& source = *sphere->GetMeshSource();
+
+    const auto stats = MeshOptimization::AnalyzeDegenerateTriangles(source);
+    EXPECT_EQ(stats.ZeroAreaCount, 0u) << "a sphere should not ship triangles with no area";
+
+    // The census's zero-area test alone would not have caught the far pole:
+    // (rings - 1) * (1.0f / (rings - 1)) is not exactly 1.0f, so those triangles
+    // are slivers of ~1e-7 rather than exact zeros. Measure the smallest area
+    // directly so BOTH poles are pinned by this test.
+    const auto& vertices = source.GetVertices();
+    const auto& indices = source.GetIndices();
+    ASSERT_GT(indices.Num(), 0);
+    ASSERT_EQ(indices.Num() % 3, 0);
+
+    f32 smallestArea = std::numeric_limits<f32>::max();
+    for (i32 i = 0; i + 2 < indices.Num(); i += 3)
+    {
+        const glm::vec3& a = vertices[static_cast<i32>(indices[i])].Position;
+        const glm::vec3& b = vertices[static_cast<i32>(indices[i + 1])].Position;
+        const glm::vec3& c = vertices[static_cast<i32>(indices[i + 2])].Position;
+        smallestArea = std::min(smallestArea, 0.5f * glm::length(glm::cross(b - a, c - a)));
+    }
+    // A real band triangle on a unit sphere at segments = 16 is ~1e-2; the pole
+    // slivers were ~1e-7. Anything in between means a pole row came back.
+    EXPECT_GT(smallestArea, 1e-4f) << "smallest triangle area " << smallestArea << " — a pole row is degenerate";
+}
+
+TEST(MeshPrimitivesSphere, PoleRowsCostOneTriangleEachNotTwo)
+{
+    constexpr u32 kSegments = 16;
+    const u32 rings = kSegments;
+    const u32 sectors = kSegments * 2;
+
+    auto sphere = MeshPrimitives::CreateSphere(1.0f, kSegments);
+    ASSERT_TRUE(sphere);
+
+    // Every band contributes two triangles per sector except the two pole bands,
+    // which contribute one — that is the whole of the fix, stated as a count so a
+    // regression cannot quietly restore the degenerate half.
+    const u32 bands = rings - 1;
+    const u32 sectorSpans = sectors - 1;
+    const u32 expectedTriangles = (bands * 2u - 2u) * sectorSpans;
+    EXPECT_EQ(static_cast<u32>(sphere->GetMeshSource()->GetIndices().Num()), expectedTriangles * 3u);
+
+    // And it is strictly fewer than the old quad-everywhere count, so this cannot
+    // pass by the formula above happening to match what it replaced.
+    EXPECT_LT(expectedTriangles, bands * 2u * sectorSpans);
 }

--- a/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
+++ b/OloEngine/tests/Rendering/MeshOptimizationTest.cpp
@@ -12,6 +12,7 @@
 #include "OloEngine/Renderer/MeshSource.h"
 #include "OloEngine/Renderer/Mesh.h"
 #include "OloEngine/Renderer/MeshPrimitives.h"
+#include "OloEngine/Renderer/RenderCommand.h"
 #include "OloEngine/Renderer/IndexBuffer.h"
 #include "OloEngine/Renderer/VertexArray.h"
 #include "OloEngine/Renderer/Vertex.h"
@@ -1322,4 +1323,36 @@ TEST(MeshPrimitivesSphere, PoleRowsCostOneTriangleEachNotTwo)
     // And it is strictly fewer than the old quad-everywhere count, so this cannot
     // pass by the formula above happening to match what it replaced.
     EXPECT_LT(expectedTriangles, bands * 2u * sectorSpans);
+}
+
+// =============================================================================
+// Shared default primitives (issue #1191)
+// =============================================================================
+
+TEST(MeshPrimitivesShared, DefaultPrimitivesShareOneSourcePerKind)
+{
+    using Kind = MeshPrimitives::SharedDefault;
+    auto a = MeshPrimitives::CreateSharedDefault(Kind::Sphere);
+    auto b = MeshPrimitives::CreateSharedDefault(Kind::Sphere);
+    auto c = MeshPrimitives::CreateSharedDefault(Kind::Cube);
+    ASSERT_TRUE(a && b && c);
+    EXPECT_NE(a.Raw(), b.Raw()) << "every caller gets its own Mesh wrapper";
+
+    if (RenderCommand::IsDeviceAvailable())
+    {
+        EXPECT_EQ(a->GetMeshSource().Raw(), b->GetMeshSource().Raw()) << "same kind: one shared MeshSource";
+        EXPECT_NE(a->GetMeshSource().Raw(), c->GetMeshSource().Raw()) << "different kind: different source";
+
+        MeshPrimitives::ReleaseSharedSources();
+        auto d = MeshPrimitives::CreateSharedDefault(Kind::Sphere);
+        ASSERT_TRUE(d);
+        EXPECT_NE(d->GetMeshSource().Raw(), a->GetMeshSource().Raw())
+            << "release must drop the shared source so a restarted renderer never sees dead buffers";
+    }
+    else
+    {
+        // Headless: nothing is cached, because a source built without a device
+        // has no GPU buffers and must not be handed to a later device-backed caller.
+        EXPECT_NE(a->GetMeshSource().Raw(), b->GetMeshSource().Raw()) << "headless: no sharing";
+    }
 }


### PR DESCRIPTION
Closes #1191 — both halves: the pole-row degenerates (first commit) and the per-entity regeneration of identical primitives (second commit, below).

## What was wrong

`CreateSphere` builds a UV sphere from `rings x sectors` vertices and emits a full quad (two triangles) per sector in every band. But ring 0 evaluates `sin(pi * 0 * R) == 0` for every sector, so all `sectors` of its vertices are the same point `(0, -radius, 0)`; the last ring collapses the same way onto `(0, +radius, 0)`. A quad with two corners at one point is one real triangle plus one with no area — so every sphere in the engine shipped a full sector's worth of degenerate triangles at each pole.

At the default `segments = 16` that is **62 of 930 triangles** (~6.7% of the index buffer), submitted, transformed and rasterized to nothing on every draw of every sphere.

Half of them were invisible to the import census (issue #629), which is why its warning read `31 of 930` rather than 62: `r * R` is exactly `0` at the south pole so those triangles are exactly zero-area, but `(rings - 1) * (1.0f / (rings - 1))` is not exactly `1.0f` in float, so the north pole's are slivers of ~1e-7 that pass a zero-area test.

## The fix

The pole bands emit a triangle fan — the one real triangle per sector — instead of a quad. `rings == 2` is left exactly as it was: that shape is already fully degenerate (both its rings *are* the poles) and skipping both halves there would emit an empty index buffer.

## Verification

Removing a triangle with no area cannot change the rendered image, and it does not. A/B against **master's** `MeshPrimitives.cpp` on the same branch (not a hand-disabled arm), OpenGL + deferred, MaterialLab's 119 spheres from three poses including one looking straight down at the poles:

| pose | A (fixed) lum / std | B (master) lum / std | RMSE | max channel diff |
|---|---|---|---|---|
| yaw 35 | 130.77 / 60.63 | 130.77 / 60.63 | 0.000 | 0 |
| yaw 200 | 138.93 / 53.47 | 138.93 / 53.47 | 0.000 | 0 |
| top-down | 127.46 / 47.99 | 127.46 / 47.99 | 0.000 | 0 |

Pixel-identical. Index count drops 2790 -> 2604.

Full suite green in Debug: 8178 ran, 8138 passed, 40 skipped, 0 failed.

## Tests

`MeshPrimitivesSphere.PoleRowsEmitNoDegenerateTriangles` measures the **smallest triangle area directly**, so both poles are pinned — the census's zero-area count alone would miss the north pole's slivers. `MeshPrimitivesSphere.PoleRowsCostOneTriangleEachNotTwo` pins the count as a formula and asserts it is strictly below the old quad-everywhere count, so it cannot pass by coincidence.

Both fail on the old code: `ZeroAreaCount` 31, smallest area `0`, 2790 indices against the expected 2604.

## Second half: one `MeshSource` per default primitive kind

Every entity whose `MeshComponent` named a default primitive built its own `MeshSource` — geometry, optimisation pass, degenerate census, GPU buffers — per entity, on every scene load. MaterialLab's 119 sphere entities built 119 identical spheres.

`MeshPrimitives::CreateSharedDefault(kind)` builds one `MeshSource` per kind on first use and hands every caller its **own `Mesh` wrapper** over it, so per-entity state on `Mesh` stays per-entity while the geometry is built once. `SceneSerializer::CreateMeshFromPrimitive` is the consumer. Two rules keep it honest:

- **Headless callers get an uncached source.** A source built without a device has no GPU buffers and must never be handed to a later device-backed caller.
- **`Renderer3D::Shutdown` releases the shared sources** before the memory tracker's teardown census, so nothing reads as a `Ref` that outlived the renderer, and a test that restarts the renderer never sees dead buffers.

`MeshPrimitivesShared.DefaultPrimitivesShareOneSourcePerKind` pins the sharing, the per-caller wrapper, the release and the headless rule.

Live (OpenGL, Debug, MaterialLab, 119 entities): the optimisation census after the scene load is **one** line (the 12/12 zero-UV plane) where it was 110 before (108× the sphere pole census + 2); `olo_render_validate` hazards 0. Tests: the primitive / serializer suites and the 63 memory-tracker / lifecycle tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default cube, sphere, plane, cylinder, cone, icosphere, and torus meshes now share reusable resources, reducing duplicate memory and setup work.
  * Shared mesh resources are released automatically when rendering shuts down.
  * Primitive creation remains supported in headless environments without shared GPU resources.

* **Bug Fixes**
  * Sphere meshes no longer generate degenerate triangles at the poles, improving geometry quality and reducing unnecessary triangles.

* **Tests**
  * Added coverage for primitive sharing, resource release, headless behavior, and sphere geometry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->