### PR TITLE
fix(shaders): a diamond include is not a circular include

### DIFF
--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1105,11 +1105,23 @@ namespace OloEngine
 
                     const std::string fullPathStr = fullPath.string();
 
-                    // Check for circular includes
+                    // INCLUDE-ONCE, not cycle detection. `includedFiles` accumulates
+                    // every header pulled in anywhere under this shader and is never
+                    // popped, so a second visit means the header is already in the
+                    // translation unit — which is what we want for GLSL, where there
+                    // is no #pragma once and a second copy is a redefinition error.
+                    //
+                    // The overwhelmingly common second visit is a DIAMOND, not a
+                    // cycle: two headers both including MathCommon.glsl. Reporting it
+                    // as "circular include detected" cried wolf 81 times in a single
+                    // editor session, on leaf headers that include nothing at all
+                    // (GPUScene.glsl 47x, MathCommon.glsl 21x) and so cannot be part
+                    // of a cycle by construction. Skipping is correct either way; only
+                    // the diagnostic was wrong.
                     if (includedFiles.find(fullPathStr) != includedFiles.end())
                     {
-                        OLO_CORE_WARN("Circular include detected for: {0}", fullPathStr);
-                        result << "// Circular include: " << includePath << "\n";
+                        OLO_CORE_TRACE("Shader include already present, skipping: {0}", fullPathStr);
+                        result << "// Already included: " << includePath << "\n";
                         continue;
                     }
 


### PR DESCRIPTION
Split out of #1188 at CodeRabbit's request — it flagged this as out of scope there, and it is: a diagnostic fix unrelated to the frame arena. Refs #1193's family of "correct path, wrong voice" diagnostics; no issue of its own.

## What was wrong

`OpenGLShader::ProcessIncludesInternal` threads one `includedFiles` set through the whole recursion and never pops it, so it implements **include-once** — the right behaviour for GLSL, which has no `#pragma once` and where a second copy of a header is a redefinition error.

The second visit it reported, though, is almost never a cycle. It is a **diamond**: two headers both including the same utility header. One editor session logged `Circular include detected` **81 times**, 47 of them for `include/GPUScene.glsl` and 21 for `include/MathCommon.glsl` — leaf headers that contain no `#include` at all and so cannot be part of a cycle by construction.

Skipping was correct; only the diagnostic was wrong.

## Change

Demoted to trace with an accurate message (`Shader include already present, skipping`), and the marker left in the generated source now reads `Already included` rather than `Circular include`.

## Verification

Cold shader cache (the include processing only runs on a cache miss, so a warm cache would have hidden nothing either way): a full editor start plus scene loads goes from **85 → 0** `Circular include` warnings, with 85 `already present, skipping` traces in their place — same events, correct severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader include diagnostics by treating repeated includes as already processed rather than reporting them as circular includes.
  * Reduced the severity of related log messages to trace level for less noisy output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->