### PR TITLE
fix(eh): never throw from inside a catch handler — all thirteen sites

### DIFF
--- a/OloEditor/src/Automation/AutomationAssetCommands.cpp
+++ b/OloEditor/src/Automation/AutomationAssetCommands.cpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <exception>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -747,7 +748,25 @@ namespace OloEngine::Automation
 
                 // Rewrite the referring files first, exactly as the forward move
                 // did, so a refusal happens before anything has moved.
+                //
+                // THE REFUSAL IS RETHROWN AFTER THE HANDLER, NOT INSIDE IT. This used
+                // to read `catch (...) { RevertRewrites(...); throw; }`, and that
+                // shape is the one build-trees-and-windows-asan.md §4b forbids: under
+                // clang-cl + ASan, a throw executed lexically inside a catch handler
+                // makes __CxxFrameHandler3 read the handler funclet's parent frame as
+                // NULL and fault. It presented as
+                //   SEH exception with code 0xc0000005 thrown in the test body
+                // from UndoRefusesWhenAReferringFileChangedUnderneath on every Windows
+                // ASan shard — no ASan report, no stack, because gtest's SEH catcher
+                // gets there first — while the same test passes in every other
+                // configuration. A 50-line standalone TU of exactly this frame shape
+                // (destructor-bearing locals in the try, a helper with its own
+                // try/catch in the handler, then the rethrow) reproduces the fault on
+                // clang 23.1.0; capturing the exception and rethrowing once the
+                // handler has been left passes. The rollback itself is unchanged and
+                // still runs before the exception reaches the caller.
                 sizet written = 0;
+                std::exception_ptr refusal;
                 try
                 {
                     for (; written < m_Record.Edits.size(); ++written)
@@ -760,8 +779,12 @@ namespace OloEngine::Automation
                 }
                 catch (...)
                 {
+                    refusal = std::current_exception();
+                }
+                if (refusal)
+                {
                     RevertRewrites(forward, written);
-                    throw;
+                    std::rethrow_exception(refusal);
                 }
 
                 std::error_code ec;

--- a/OloEditor/src/Automation/AutomationFileWrite.cpp
+++ b/OloEditor/src/Automation/AutomationFileWrite.cpp
@@ -96,7 +96,6 @@ namespace OloEngine::Automation
                 std::filesystem::remove(temporary, ignored);
             }
             std::rethrow_exception(writeFailure);
-            std::rethrow_exception(writeFailure);
         }
     }
 } // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationFileWrite.cpp
+++ b/OloEditor/src/Automation/AutomationFileWrite.cpp
@@ -3,6 +3,7 @@
 
 #include "OloEngine/Core/UUID.h"
 
+#include <exception>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -55,6 +56,10 @@ namespace OloEngine::Automation
         if (std::filesystem::exists(temporary))
             throw std::runtime_error("Temporary file already exists: " + temporary.string());
         bool temporaryOwned = false;
+        // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+        // executed lexically inside a catch handler faults in __CxxFrameHandler3
+        // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+        std::exception_ptr writeFailure;
         try
         {
             std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
@@ -81,12 +86,17 @@ namespace OloEngine::Automation
         }
         catch (...)
         {
+            writeFailure = std::current_exception();
+        }
+        if (writeFailure)
+        {
             if (temporaryOwned)
             {
                 std::error_code ignored;
                 std::filesystem::remove(temporary, ignored);
             }
-            throw;
+            std::rethrow_exception(writeFailure);
+            std::rethrow_exception(writeFailure);
         }
     }
 } // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationSceneDocument.cpp
+++ b/OloEditor/src/Automation/AutomationSceneDocument.cpp
@@ -6,6 +6,7 @@
 #include "OloEngine/Scene/SceneSerializer.h"
 #include "UndoRedo/EditorCommand.h"
 
+#include <exception>
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
@@ -91,6 +92,10 @@ namespace OloEngine::Automation
         std::string SerializeDocument(const SceneDocumentSnapshot& document)
         {
             const auto original = CaptureSceneDocument(document.SceneRef);
+            // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+            // executed lexically inside a catch handler faults in __CxxFrameHandler3
+            // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+            std::exception_ptr applyFailure;
             try
             {
                 ApplySceneDocument(document);
@@ -100,8 +105,12 @@ namespace OloEngine::Automation
             }
             catch (...)
             {
+                applyFailure = std::current_exception();
+            }
+            if (applyFailure)
+            {
                 ApplySceneDocument(original);
-                throw;
+                std::rethrow_exception(applyFailure);
             }
         }
 
@@ -146,28 +155,44 @@ namespace OloEngine::Automation
             void Execute() override
             {
                 ReplaceFileContents(m_After.Path, m_OldBytes, m_NewBytes);
+                // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+                // executed lexically inside a catch handler faults in __CxxFrameHandler3
+                // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+                std::exception_ptr undoFailure;
                 try
                 {
                     m_Access.Install(m_After);
                 }
                 catch (...)
                 {
+                    undoFailure = std::current_exception();
+                }
+                if (undoFailure)
+                {
                     ReplaceFileContents(m_After.Path, m_NewBytes, m_OldBytes);
-                    throw;
+                    std::rethrow_exception(undoFailure);
                 }
             }
 
             void Undo() override
             {
                 ReplaceFileContents(m_After.Path, m_NewBytes, m_OldBytes);
+                // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+                // executed lexically inside a catch handler faults in __CxxFrameHandler3
+                // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+                std::exception_ptr redoFailure;
                 try
                 {
                     m_Access.Install(m_Before);
                 }
                 catch (...)
                 {
+                    redoFailure = std::current_exception();
+                }
+                if (redoFailure)
+                {
                     ReplaceFileContents(m_After.Path, m_OldBytes, m_NewBytes);
-                    throw;
+                    std::rethrow_exception(redoFailure);
                 }
             }
 

--- a/OloEditor/src/MCP/McpToolsCamera.cpp
+++ b/OloEditor/src/MCP/McpToolsCamera.cpp
@@ -4,6 +4,7 @@
 #include "MCP/McpEditorLiveness.h"
 #include "MCP/McpSchemaBuilder.h"
 #include "OloEngine/Renderer/Renderer3D.h"
+#include <exception>
 #include <algorithm>
 #include <atomic>
 #include <memory>
@@ -215,6 +216,10 @@ namespace OloEngine::MCP
             };
 
             Json marshaled;
+            // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+            // executed lexically inside a catch handler faults in __CxxFrameHandler3
+            // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+            std::exception_ptr captureFailure;
             try
             {
                 u64 appliedFrame = 0;
@@ -296,6 +301,10 @@ namespace OloEngine::MCP
             }
             catch (...)
             {
+                captureFailure = std::current_exception();
+            }
+            if (captureFailure)
+            {
                 // Don't leave the user's camera stranded at the capture pose if a
                 // marshal failed mid-flow — including a step-1 apply that timed out
                 // here but whose job runs later. `restorePriorPose` (captured by value)
@@ -316,7 +325,7 @@ namespace OloEngine::MCP
                     {
                     }
                 }
-                throw;
+                std::rethrow_exception(captureFailure);
             }
 
             if (marshaled.is_object() && marshaled.contains("__error"))

--- a/OloEditor/src/MCP/McpToolsInput.cpp
+++ b/OloEditor/src/MCP/McpToolsInput.cpp
@@ -4,6 +4,7 @@
 #include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpToolsCommon.h"
 
+#include <exception>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -64,6 +65,10 @@ namespace OloEngine::MCP
             // `request` is captured BY VALUE: on the same timeout path, a reference to
             // this frame's local would already be dangling by the time the job ran.
             Json accepted;
+            // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+            // executed lexically inside a catch handler faults in __CxxFrameHandler3
+            // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+            std::exception_ptr marshalFailure;
             try
             {
                 accepted = host.MarshalRead(
@@ -146,11 +151,15 @@ namespace OloEngine::MCP
             }
             catch (...)
             {
+                marshalFailure = std::current_exception();
+            }
+            if (marshalFailure)
+            {
                 // MarshalRead gave up (timeout, or the server is stopping) but its job
                 // may still be queued. Disarm it before propagating, so it cannot
                 // inject after this call has reported failure.
                 abandoned->store(true, std::memory_order_release);
-                throw;
+                std::rethrow_exception(marshalFailure);
             }
 
             if (accepted.is_object() && accepted.contains("__error"))

--- a/OloEditor/src/MCP/McpToolsRender.cpp
+++ b/OloEditor/src/MCP/McpToolsRender.cpp
@@ -50,6 +50,7 @@
 #include "OloEngine/Renderer/Commands/RenderCommand.h"
 #include "OloEngine/Renderer/RenderCommand.h"
 
+#include <exception>
 #include <stb_image/stb_image_write.h>
 #include "OloEngine/Renderer/Framebuffer.h"
 #include "OloEngine/Renderer/Frustum.h"
@@ -2477,6 +2478,10 @@ namespace OloEngine::MCP
             // main-thread job). The bytes are written into `capturedPng` by
             // reference — MarshalRead runs synchronously, so this is safe.
             std::vector<u8> capturedPng;
+            // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+            // executed lexically inside a catch handler faults in __CxxFrameHandler3
+            // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+            std::exception_ptr captureFailure;
             try
             {
                 if (posed)
@@ -2496,6 +2501,10 @@ namespace OloEngine::MCP
             }
             catch (...)
             {
+                captureFailure = std::current_exception();
+            }
+            if (captureFailure)
+            {
                 if (posed)
                 {
                     try
@@ -2509,7 +2518,7 @@ namespace OloEngine::MCP
                     {
                     }
                 }
-                throw;
+                std::rethrow_exception(captureFailure);
             }
 
             namespace fs = std::filesystem;

--- a/OloEngine/src/OloEngine/Core/Application.cpp
+++ b/OloEngine/src/OloEngine/Core/Application.cpp
@@ -30,6 +30,8 @@
 #include "OloEngine/Task/NamedThreads.h"
 #include "Platform/Steam/SteamManager.h"
 
+#include <string>
+#include <exception>
 #include <chrono>
 #include <stdexcept>
 #include <ranges>
@@ -132,15 +134,29 @@ namespace OloEngine
         // to name the exact build it came from.
         OLO_CORE_INFO("[{}] Build: {}", m_Specification.Name, BuildInfo::GetBuildId());
 
+        // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+        // executed lexically inside a catch handler faults in __CxxFrameHandler3
+        // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+        std::exception_ptr initFailure;
         try
         {
             if (!m_Specification.IsHeadless)
             {
+                // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+                // executed lexically inside a catch handler faults in __CxxFrameHandler3
+                // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+                std::exception_ptr backendFailure;
+                std::string backendFailureWhat;
                 try
                 {
                     m_Window = Window::Create(WindowProps(m_Specification.Name));
                 }
                 catch (const std::exception& e)
+                {
+                    backendFailure = std::current_exception();
+                    backendFailureWhat = e.what();
+                }
+                if (backendFailure)
                 {
                     // #691: a Vulkan selection persisted in
                     // config/renderer.yaml must not brick the install on a
@@ -151,10 +167,10 @@ namespace OloEngine
                     // init); neither does a failure on the OpenGL arm.
                     if (!vulkanSelectedFromConfig)
                     {
-                        throw;
+                        std::rethrow_exception(backendFailure);
                     }
                     OLO_CORE_ERROR("[RHI] Vulkan selected by config file but initialisation failed: {}",
-                                   e.what());
+                                   backendFailureWhat);
                     const auto configPath = DefaultRendererConfigPath();
                     if (WriteRendererConfig(configPath, RendererAPI::API::OpenGL))
                     {
@@ -280,6 +296,10 @@ namespace OloEngine
         }
         catch (...)
         {
+            initFailure = std::current_exception();
+        }
+        if (initFailure)
+        {
             // Detach layers before shutting down subsystems they depend on.
             m_LayerStack.Clear();
             m_ImGuiLayer = nullptr;
@@ -327,7 +347,7 @@ namespace OloEngine
             // Shutdown task scheduler started before the try block.
             LowLevelTasks::FScheduler::Get().StopWorkers();
             Tasks::FNamedThreadManager::Get().DetachFromThread(Tasks::ENamedThread::GameThread);
-            throw;
+            std::rethrow_exception(initFailure);
         }
     }
     Application::~Application()

--- a/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
+++ b/OloEngine/src/OloEngine/Scene/SceneSerializer.cpp
@@ -27,6 +27,7 @@
 #include "OloEngine/Gameplay/Abilities/AbilityComponents.h"
 #include "OloEngine/Gameplay/Abilities/Effects/GameplayEffect.h"
 
+#include <exception>
 #include <algorithm>
 #include <bit>
 #include <fstream>
@@ -6922,15 +6923,23 @@ namespace OloEngine
         DiagnosticsEventLog::SuppressScope suppressSpawnFlood;
 
         Entity deserializedEntity = m_Scene->CreateEntityWithUUID(uuid, name);
+        // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+        // executed lexically inside a catch handler faults in __CxxFrameHandler3
+        // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+        std::exception_ptr entityFailure;
         try
         {
             DeserializeEntityComponents(deserializedEntity, entityNode, m_AnimatedModelCache);
         }
         catch (...)
         {
+            entityFailure = std::current_exception();
+        }
+        if (entityFailure)
+        {
             // Remove the half-initialized entity so the scene stays consistent
             m_Scene->DestroyEntity(deserializedEntity);
-            throw;
+            std::rethrow_exception(entityFailure);
         }
         return deserializedEntity;
     }

--- a/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanContext.cpp
@@ -21,6 +21,7 @@
 #include "Platform/Vulkan/VulkanSamplerHeap.h"
 #include "Platform/Vulkan/VulkanTransientResources.h"
 
+#include <exception>
 #include <GLFW/glfw3.h>
 
 #include <algorithm>
@@ -1237,11 +1238,21 @@ namespace OloEngine
                 d.SwapchainExtent.height,
             };
             bool callbackRendered = false;
+            // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+            // executed lexically inside a catch handler faults in __CxxFrameHandler3
+            // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+            std::exception_ptr callbackFailure;
+            std::string callbackFailureWhat;
             try
             {
                 callbackRendered = m_FrameRenderCallback(target);
             }
             catch (const std::exception& e)
+            {
+                callbackFailure = std::current_exception();
+                callbackFailureWhat = e.what();
+            }
+            if (callbackFailure)
             {
                 // #808 adds the second disqualifying state. A pass that throws
                 // INSIDE an async-compute batch leaves the segment open, and
@@ -1261,14 +1272,14 @@ namespace OloEngine
                     // into overlay/final submission with a closed recording
                     // bracket; preserve VkCheck's fatal error instead.
                     OLO_CORE_ERROR("[Vulkan] frame render callback failed after detaching its command buffer: {}",
-                                   e.what());
-                    throw;
+                                   callbackFailureWhat);
+                    std::rethrow_exception(callbackFailure);
                 }
                 // The callback runs arbitrary engine code inside an OPEN
                 // command buffer; letting an exception escape would leave the
                 // bracket unbalanced and take the process down with it. Log
                 // and fall back to the clear frame instead.
-                OLO_CORE_ERROR("[Vulkan] frame render callback threw: {} — falling back to the clear frame", e.what());
+                OLO_CORE_ERROR("[Vulkan] frame render callback threw: {} — falling back to the clear frame", callbackFailureWhat);
                 callbackRendered = false;
             }
             // --- ImGui overlay (#691) ------------------------------

--- a/OloEngine/src/Platform/Windows/WindowsWindow.cpp
+++ b/OloEngine/src/Platform/Windows/WindowsWindow.cpp
@@ -8,6 +8,7 @@
 #include "Platform/Windows/WindowsWindow.h"
 
 #define GLFW_EXPOSE_NATIVE_WIN32
+#include <exception>
 #include <GLFW/glfw3native.h>
 #include <dwmapi.h>
 
@@ -132,11 +133,19 @@ namespace OloEngine
             }
             throw std::runtime_error("Failed to create graphics context!");
         }
+        // Rethrown AFTER the handler, not inside it: under clang-cl + ASan a throw
+        // executed lexically inside a catch handler faults in __CxxFrameHandler3
+        // (build-trees-and-windows-asan.md §4b, issue #1193). Capture, clean up, rethrow.
+        std::exception_ptr createFailure;
         try
         {
             m_Context->Init();
         }
         catch (...)
+        {
+            createFailure = std::current_exception();
+        }
+        if (createFailure)
         {
             m_Context.reset();
             GLFWAPI::glfwDestroyWindow(m_Window);
@@ -146,7 +155,7 @@ namespace OloEngine
             {
                 GLFWAPI::glfwTerminate();
             }
-            throw;
+            std::rethrow_exception(createFailure);
         }
 
         GLFWAPI::glfwSetWindowUserPointer(m_Window, &m_Data);

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -495,13 +495,15 @@ compile-time `=never` removes it.
 
 ### Sites in the tree
 
-A throw inside a catch handler is a normal C++ idiom and there are about a dozen
-in `OloEngine/src` and `OloEditor/src`. Find them with a brace-matching scan for
-`throw` inside a `catch (…) { … }` body; a plain grep for `throw;` misses the
-`throw std::runtime_error(...)` ones and reports comments. They are latent, not
-live: with the flag in place none of them crash. `AssetMoveCommand::Apply` in
-`OloEditor/src/Automation/AutomationAssetCommands.cpp` is the one that actually
-fired, because it is the only such site the ASan suite executes.
+A throw inside a catch handler is a normal C++ idiom, and the scan for #1193
+found thirteen in `OloEngine/src` and `OloEditor/src` — all restructured in that
+PR (see the 2026-09-11 subsection below), so the tree holds none today. Find any
+new one with a brace-matching scan for `throw` inside a `catch (…) { … }` body,
+with comments stripped first; a plain grep for `throw;` misses the
+`throw std::runtime_error(...)` ones and reports comment text. Of the thirteen,
+`AssetMoveCommand::Apply` in `OloEditor/src/Automation/AutomationAssetCommands.cpp`
+was the one that actually fired, because it was the only such site the ASan
+suite executes.
 
 ### Reproducing it
 

--- a/docs/agent-rules/build-trees-and-windows-asan.md
+++ b/docs/agent-rules/build-trees-and-windows-asan.md
@@ -513,6 +513,22 @@ gtest's swallowed report, run the test binary under `cdb` with a script file
 (`-cf`), `sxd av`, `g`, `kn 60` — and pass `--gtest_catch_exceptions=0`, or
 gtest's SEH translator eats the exception and prints an empty "Stack trace:".
 
+### A masked site still crashes on a branch cut before the mask (2026-09-11)
+
+**When a Windows-ASan-only `SEH exception with code 0xc0000005` shows on a PR and not on
+master, run `git merge-base --is-ancestor 8e5050ad4 <branch>` before reading any code.**
+Master is not a control for this: the change-detection gate skips its Windows shards, so a
+green master workflow never ran the test.
+
+`AssetMoveCommand::Apply` — `catch (...) { RevertRewrites(...); throw; }` — killed
+`AutomationAssetCommandsTest.UndoRefusesWhenAReferringFileChangedUnderneath` on #1188 and
+#1189. Neither PR touched that code; both were cut from `75dd98f33` at 17:21, and the flag
+above landed at 18:01. Rebasing was the whole CI fix. A standalone TU of that exact shape —
+destructor-bearing locals in the `try`, a helper with its own try/catch inside the handler,
+then the rethrow — crashes without the flag and passes with it: one more row for the matrix,
+same verdict, the nesting changes nothing. All thirteen sites the scan in #1193 found were restructured
+per this section's rule in one pass regardless, because the flag masks and the rule fixes.
+
 ## 5. Instrumenting a build, and a per-file-set compile job pool (issues #759, #822)
 
 ### 5a. Use the native recipe (CMake 4.3+), not the manual gate below


### PR DESCRIPTION
Closes #1193.

## The rule, and why it exists

`docs/agent-rules/build-trees-and-windows-asan.md` §4b: **never execute a throw from inside a `catch` handler in code the Windows ASan build compiles.** Under clang-cl + ASan, a throw executed lexically inside a handler makes `__CxxFrameHandler3` read the handler funclet's parent frame as NULL and fault. `cmake/Sanitizers.cmake` masks it with `-fsanitize-address-use-after-return=never` (`8e5050ad4`), and the doc is explicit that the flag is a mask, not a fix.

A brace-balanced scan of every `catch` body in `OloEngine/src` and `OloEditor/src` found **thirteen** sites that rethrow inside the handler. This PR restructures all of them the same way:

```cpp
std::exception_ptr failure;
try { ... }
catch (...) { failure = std::current_exception(); }
if (failure) { /* the cleanup the handler did */ std::rethrow_exception(failure); }
```

The two typed handlers — `Application.cpp`'s config-selected-Vulkan retry and `VulkanContext.cpp`'s frame-callback bracket — keep their `catch (const std::exception&)`, save `e.what()` into a string, and run their conditional rethrow and recovery after the handler with identical control flow. Every cleanup runs exactly as before, before the exception reaches the caller.

| file | sites |
|---|---|
| `OloEditor/src/Automation/AutomationAssetCommands.cpp` | `AssetMoveCommand::Apply` |
| `OloEditor/src/Automation/AutomationFileWrite.cpp` | `ReplaceFileContents` |
| `OloEditor/src/Automation/AutomationSceneDocument.cpp` | 3 |
| `OloEditor/src/MCP/McpToolsCamera.cpp`, `McpToolsInput.cpp`, `McpToolsRender.cpp` | 1 each |
| `OloEngine/src/OloEngine/Scene/SceneSerializer.cpp` | 1 |
| `OloEngine/src/OloEngine/Core/Application.cpp` | 2 |
| `OloEngine/src/Platform/Vulkan/VulkanContext.cpp`, `Platform/Windows/WindowsWindow.cpp` | 1 each |

## The first site was not hypothetical

`AssetMoveCommand::Apply`'s `catch (...) { RevertRewrites(...); throw; }` killed `AutomationAssetCommandsTest.UndoRefusesWhenAReferringFileChangedUnderneath` on every Windows ASan shard run against a base **without** the flag — PRs #1188 and #1189, cut from `75dd98f33` forty minutes before `8e5050ad4` landed. `SEH exception with code 0xc0000005`, no ASan report, no stack, because gtest's SEH catcher gets there first.

A 50-line standalone TU of exactly that frame shape — destructor-bearing locals in the `try`, a helper with its own try/catch inside the handler, then the rethrow — reproduces it on clang 23.1.0 (`/EHsc /MD /O2 -fsanitize=address`):

| shape | default | `=never` |
|---|---|---|
| engine: throw inside the handler | **CRASH** — `access-violation on unknown address 0x54 ... in Apply(...)`, establisher frame `rcx = 0` | PASS |
| this PR: rethrow after the handler | PASS | PASS |

## Verification

- Local ASan build (clang 23.1.0, the same pin CI uses; binary confirmed instrumented), Automation / MCP / SceneSerializer fixtures with `--gtest_catch_exceptions=0` so a fault cannot be swallowed: **269 tests from 20 suites, all passed** (`ASAN_FIXTURES_EXIT=0`).
- Full Debug suite, which also launches the rebuilt editor, runtime and server through `AppLaunchSmoke` for the `Application` / `WindowsWindow` startup paths: **8193 tests ran, 8153 passed, 40 skipped, 0 failed** (`DEBUG_SUITE_EXIT=0`).
- The acceptance scan (comments stripped before matching) now finds **0** throw-inside-handler sites.

## Doc

§4b gains a short subsection: when this signature shows on a PR and not on master, run `git merge-base --is-ancestor 8e5050ad4 <branch>` before reading code — master's Windows shards are skipped by the change-detection gate and prove nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across scene editing, file operations, rendering, screenshots, input, and window initialization.
  * Preserved cleanup, rollback, state restoration, and error reporting when operations fail.
  * Prevented certain crashes during startup, scene deserialization, rendering callbacks, and automation workflows on Windows.

* **Documentation**
  * Added troubleshooting guidance for diagnosing sanitizer-related crashes and branch-specific build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->