### PR TITLE
fix(test): lower the ReSTIR GI oracle's Jacobian floor to what its negative control survives on Linux

### DIFF
--- a/OloEngine/tests/Rendering/ReSTIR/ReSTIRGIOracleTest.cpp
+++ b/OloEngine/tests/Rendering/ReSTIR/ReSTIRGIOracleTest.cpp
@@ -350,7 +350,16 @@ namespace OloEngine::Tests
             // deviation. A geometry that barely moved J would leave the negative
             // control inside the Monte Carlo noise and it would pass whether or
             // not the Jacobian is applied.
-            EXPECT_GT(std::abs(j - 1.0f), 0.25f)
+            //
+            // The floor is 0.15, not 0.25: the probe's bounce vertex is one
+            // float-contraction away from platform-identical even with the
+            // seed stream pinned (Canonical01 above), and the same seed lands at
+            // J = 1.201 on Linux/clang (both sanitizer jobs) against J > 1.25 on
+            // MSVC. The negative control below was measured to hold at 1.20 —
+            // the 2x bias margin passed on every Linux run that tripped this
+            // floor — so 0.15 is a floor the control was actually observed to
+            // survive, where 0.25 was the Windows value with no margin at all.
+            EXPECT_GT(std::abs(j - 1.0f), 0.15f)
                 << "geometry too symmetric for this test to mean anything, J=" << j;
         }
 


### PR DESCRIPTION
## Why

Every Linux sanitizer job — ASan+LSan and UBSan — fails on the current master base at the ReSTIR GI oracle's geometry precondition, and has on every PR cut from it (#1188, #1189, #1192, #1194, #1195, #1196):

```
ReSTIRGIOracleTest.cpp:353: Failure
Expected: (std::abs(j - 1.0f)) > (0.25f), actual: 0.2012707 vs 0.25
geometry too symmetric for this test to mean anything, J=1.2012706995010376
```

`f4aa1ec54` (in #1174) pinned the seed stream (`Canonical01`), but the probe's bounce vertex is still one float contraction away from platform-identical: the same seed lands at **J = 1.201 on Linux/clang** and **J > 1.25 on MSVC**. The floor was the Windows value with no margin.

## What

The floor drops to 0.15 — not arbitrarily: the negative control it protects (dropping the Jacobian must bias the estimate by more than 2×) **held** on every Linux run that tripped the precondition; the precondition was the only failing assertion in both jobs. So 0.15 is a floor the control was observed to survive at, where 0.25 was a single platform's value.

Locally (Windows, Debug): `ReSTIRGIOracle.*` 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the geometry-symmetry validation threshold in a spatial-reuse rendering test to accommodate minor platform-specific numerical differences.
  * Added context documenting expected variation across supported compiler and sanitizer environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->