### PR TITLE
fix(rendergraph): keep what the frame needed when trimming the transient pool (#1186)

### DIFF
--- a/OloEngine/src/OloEngine/Renderer/RenderGraph.h
+++ b/OloEngine/src/OloEngine/Renderer/RenderGraph.h
@@ -1070,7 +1070,9 @@ namespace OloEngine
         // Set the maximum number of pool objects retained per descriptor bucket
         // after each frame. Excess objects are evicted by TransientPool::Trim()
         // at the end of Execute(). Default = 2 (keeps one spare for same-descriptor
-        // overlapping transients; use 1 for the most aggressive trim).
+        // overlapping transients; use 1 for the most aggressive trim). A bucket
+        // the frame just drawn needed more of keeps that many regardless — the
+        // cap bounds idle buckets, never a frame's live demand (issue #1186).
         void SetTransientPoolMaxBucketSize(u32 maxPerBucket)
         {
             m_TransientPoolMaxBucketSize = maxPerBucket;

--- a/OloEngine/src/OloEngine/Renderer/TransientPool.cpp
+++ b/OloEngine/src/OloEngine/Renderer/TransientPool.cpp
@@ -127,30 +127,51 @@ namespace OloEngine
         // a confidently wrong "nothing was acquired", which is worse than no tool.
         m_LastFrameAcquireOrder = BuildAcquireOrder();
 
-        // Return all acquired objects to their pools
+        // A release with nothing acquired is not a frame: BuildFrameGraph makes
+        // one defensively at the START of every frame, right before its Trim.
+        // Resetting the demand there would let that trim evict to the cap what
+        // the end-of-frame trim had just kept, and the churn this exists to
+        // stop would simply move to the other end of the frame (every one of
+        // the four GTAO textures then re-created per frame, not two).
+        const bool acquiredAnything =
+            !m_AcquiredTextures.empty() || !m_AcquiredFramebuffers.empty() || !m_AcquiredBuffers.empty();
+        if (!acquiredAnything)
+            return;
+
+        // Return all acquired objects to their pools, counting the frame's
+        // demand per bucket on the way so Trim() knows what it must keep.
+        m_LastFrameTextureDemand.clear();
         for (const auto& tex : m_AcquiredTextures)
         {
             if (tex)
             {
-                m_TexturePool[BuildTextureKey(tex->GetSpecification())].push_back(tex);
+                const auto key = BuildTextureKey(tex->GetSpecification());
+                m_TexturePool[key].push_back(tex);
+                ++m_LastFrameTextureDemand[key];
             }
         }
         m_AcquiredTextures.clear();
 
+        m_LastFrameFramebufferDemand.clear();
         for (const auto& fb : m_AcquiredFramebuffers)
         {
             if (fb)
             {
-                m_FramebufferPool[BuildFramebufferKey(fb->GetSpecification())].push_back(fb);
+                const auto key = BuildFramebufferKey(fb->GetSpecification());
+                m_FramebufferPool[key].push_back(fb);
+                ++m_LastFrameFramebufferDemand[key];
             }
         }
         m_AcquiredFramebuffers.clear();
 
+        m_LastFrameBufferDemand.clear();
         for (const auto& buf : m_AcquiredBuffers)
         {
             if (buf)
             {
-                m_BufferPool[buf->GetSize()].push_back(buf);
+                const auto key = buf->GetSize();
+                m_BufferPool[key].push_back(buf);
+                ++m_LastFrameBufferDemand[key];
             }
         }
         m_AcquiredBuffers.clear();
@@ -158,38 +179,28 @@ namespace OloEngine
 
     void TransientPool::Trim(u32 maxPerBucket)
     {
-        for (auto it = m_TexturePool.begin(); it != m_TexturePool.end();)
+        // Keep max(cap, last frame's demand); evict from the front, where the
+        // objects nobody acquired this frame sit (see the header).
+        const auto trimBuckets = [maxPerBucket](auto& buckets, const auto& demandByKey)
         {
-            if (it->second.size() > maxPerBucket)
-                it->second.resize(maxPerBucket);
+            for (auto it = buckets.begin(); it != buckets.end();)
+            {
+                auto& bucket = it->second;
+                const auto demandIt = demandByKey.find(it->first);
+                const u32 keep = std::max(maxPerBucket, demandIt != demandByKey.end() ? demandIt->second : 0u);
+                if (bucket.size() > keep)
+                    bucket.erase(bucket.begin(), bucket.begin() + static_cast<std::ptrdiff_t>(bucket.size() - keep));
 
-            if (it->second.empty())
-                it = m_TexturePool.erase(it);
-            else
-                ++it;
-        }
+                if (bucket.empty())
+                    it = buckets.erase(it);
+                else
+                    ++it;
+            }
+        };
 
-        for (auto it = m_FramebufferPool.begin(); it != m_FramebufferPool.end();)
-        {
-            if (it->second.size() > maxPerBucket)
-                it->second.resize(maxPerBucket);
-
-            if (it->second.empty())
-                it = m_FramebufferPool.erase(it);
-            else
-                ++it;
-        }
-
-        for (auto it = m_BufferPool.begin(); it != m_BufferPool.end();)
-        {
-            if (it->second.size() > maxPerBucket)
-                it->second.resize(maxPerBucket);
-
-            if (it->second.empty())
-                it = m_BufferPool.erase(it);
-            else
-                ++it;
-        }
+        trimBuckets(m_TexturePool, m_LastFrameTextureDemand);
+        trimBuckets(m_FramebufferPool, m_LastFrameFramebufferDemand);
+        trimBuckets(m_BufferPool, m_LastFrameBufferDemand);
     }
 
     TransientPool::TextureDescriptorKey TransientPool::BuildTextureKey(const TextureSpecification& spec)
@@ -241,8 +252,11 @@ namespace OloEngine
         m_AcquiredBuffers.clear();
         // The snapshot describes objects that no longer exist after a Clear
         // (context loss, shutdown, a debug-flag flip evicting the pool), so drop
-        // it rather than report stale GL ids.
+        // it rather than report stale GL ids — and the demand it implies.
         m_LastFrameAcquireOrder.clear();
+        m_LastFrameTextureDemand.clear();
+        m_LastFrameFramebufferDemand.clear();
+        m_LastFrameBufferDemand.clear();
     }
 
     TransientPool::PoolStats TransientPool::GetStats() const

--- a/OloEngine/src/OloEngine/Renderer/TransientPool.h
+++ b/OloEngine/src/OloEngine/Renderer/TransientPool.h
@@ -55,12 +55,21 @@ namespace OloEngine
         // Called each frame after rendering completes.
         void ReleaseAll();
 
-        // Trim each descriptor bucket to at most maxPerBucket objects, evicting
-        // any excess from the back of each pool vector. Call after ReleaseAll()
-        // to prevent VRAM bloat from high-watermark frames where a feature was
-        // temporarily enabled (e.g., bloom on → off leaves bloom FBs in the pool).
-        // Default maxPerBucket = 2 tolerates one extra slot from same-descriptor
-        // overlapping transients; use 1 for the most aggressive trim.
+        // Trim each descriptor bucket to at most maxPerBucket objects — or to
+        // what the frame ReleaseAll() just closed acquired from it, whichever
+        // is larger. Call after ReleaseAll() to prevent VRAM bloat from
+        // high-watermark frames where a feature was temporarily enabled (e.g.,
+        // bloom on → off leaves bloom FBs in the pool).
+        //
+        // The cap is a ceiling for buckets nobody needs any more, not a bound
+        // on a bucket's steady-state demand. A cap below that demand does not
+        // save VRAM: the overflow is created fresh every frame and destroyed
+        // here, and every between-frames diagnostic then sees the evicted
+        // objects as consumed-but-unbacked (issue #1186 — the GTAO pass needs
+        // four same-spec R8 textures against the default cap of 2).
+        //
+        // Eviction takes the FRONT of a bucket first: ReleaseAll() appends the
+        // frame's returns, so the front is whatever nobody acquired this frame.
         void Trim(u32 maxPerBucket);
 
         // Clear all pooled objects (called during shutdown or context loss).
@@ -213,6 +222,14 @@ namespace OloEngine
         // Last COMPLETED frame's acquisition order, snapshotted by ReleaseAll()
         // just before it empties the lists above — see GetAcquireOrder().
         std::vector<AcquiredInfo> m_LastFrameAcquireOrder;
+
+        // How many objects each bucket handed out in the last frame ReleaseAll()
+        // closed that acquired anything at all. Trim() keeps at least that many
+        // per bucket — see there. A release with nothing acquired (the
+        // defensive one at the start of BuildFrameGraph) leaves it untouched.
+        std::unordered_map<TextureDescriptorKey, u32, TextureDescriptorKeyHash> m_LastFrameTextureDemand;
+        std::unordered_map<u64, u32> m_LastFrameFramebufferDemand;
+        std::unordered_map<u32, u32> m_LastFrameBufferDemand;
     };
 
 } // namespace OloEngine

--- a/OloEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/OloEngine/tests/Rendering/RenderGraphTest.cpp
@@ -40,6 +40,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <set>
 #include <iterator>
 #include <string>
 #include <utility>
@@ -4946,6 +4947,79 @@ TEST(RenderGraphTransientPool, ResizeEvictsPoolWhenNodeResizedButDisplayUnchange
     EXPECT_EQ(after.TexturePoolSize, 0u)
         << "A resize that restores a reduced-band node to full res must evict the "
            "transient texture pool even when the display size is unchanged (#563).";
+}
+
+TEST(RenderGraphTransientPool, TrimKeepsWhatTheLastFrameNeeded)
+{
+    // Issue #1186. Trim's cap is a ceiling for buckets nobody is using, not a
+    // bound on a bucket's steady-state demand: the GTAO pass needs four
+    // same-spec R8 textures every frame (AOBuffer, DenoisePing, DenoisePong,
+    // Edge) against the default cap of 2, so the pool created two fresh
+    // textures per frame and destroyed them at Trim. AO still rendered — the
+    // storage was live during Execute — but every between-frames diagnostic
+    // saw the two evicted objects as consumed-but-unbacked, and
+    // olo_render_validate never returned ok on any scene, path or backend.
+    if (RendererAPI::GetAPI() == RendererAPI::API::None)
+        GTEST_SKIP() << "TransientPool acquisition requires an active rendering backend";
+
+    OloEngine::Tests::RenderPropertyFixture::IsGpuAvailable();
+    OLO_ENSURE_GPU_OR_SKIP();
+
+    TransientPool pool;
+    TextureSpecification spec;
+    spec.Width = 64;
+    spec.Height = 64;
+    spec.Format = ImageFormat::R8;
+
+    // One frame: acquire `count` same-spec textures, return them, trim to the
+    // default cap. Returns the objects the frame was handed.
+    const auto frame = [&pool, &spec](const u32 count)
+    {
+        std::set<const Texture*> handed;
+        for (u32 i = 0; i < count; ++i)
+            handed.insert(pool.AcquireTexture(spec).Raw());
+        pool.ReleaseAll();
+        pool.Trim(2u);
+        return handed;
+    };
+
+    const auto first = frame(4u);
+    ASSERT_EQ(first.size(), 4u);
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 4u) << "a bucket the frame needed four of keeps four, cap or no cap";
+
+    const auto second = frame(4u);
+    EXPECT_EQ(second, first) << "steady state: the next frame is served entirely from the pool, nothing is created";
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 4u);
+
+    // Demand drops under the cap: the cap is the floor, and the object this
+    // frame actually used is the one that survives ahead of untouched leftovers.
+    const auto third = frame(1u);
+    ASSERT_EQ(third.size(), 1u);
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 2u) << "cap applies once demand is under it";
+    EXPECT_TRUE(first.contains(*third.begin())) << "served from the pool, not created";
+
+    const auto fourth = frame(2u);
+    EXPECT_TRUE(fourth.contains(*third.begin())) << "the object used last frame is kept ahead of untouched leftovers";
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 2u);
+
+    // A release with nothing acquired — BuildFrameGraph makes one at the
+    // start of every frame, followed by a Trim — must not reset the demand:
+    // otherwise that trim evicts to the cap what the frame-end trim kept and
+    // the churn just moves to the other end of the frame.
+    (void)frame(4u);
+    ASSERT_EQ(pool.GetStats().TexturePoolSize, 4u);
+    (void)frame(0u);
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 4u) << "an empty release is not a frame; the last real demand stands";
+
+    // A real frame that never touches this bucket trims it to the cap — the
+    // bloom-on-then-off case Trim exists for keeps working.
+    TextureSpecification otherSpec = spec;
+    otherSpec.Width = 32;
+    otherSpec.Height = 32;
+    (void)pool.AcquireTexture(otherSpec);
+    pool.ReleaseAll();
+    pool.Trim(2u);
+    EXPECT_EQ(pool.GetStats().TexturePoolSize, 2u + 1u) << "untouched bucket trimmed to the cap, the touched one keeps its one";
 }
 
 TEST(RenderGraphTransientPool, UnreachableTransientResourceIsNotPlannedForAllocation)


### PR DESCRIPTION
Closes #1186.

## What was actually wrong

`olo_render_validate` reported `GTAOEdge` and `GTAODenoisePong` as consumed-but-unbacked on every frame, on every scene, path and backend. The issue guessed at a validator false positive or an unused-transient leak. It is neither: the transient plan allocates all four GTAO scratch textures (`AOBuffer`, `GTAODenoisePing`, `GTAODenoisePong`, `GTAOEdge` — one alias group, `1:1:1411x942x1:m1:s1:q0`, slots 0–3), but `TransientPool::Trim()` runs after every frame with a cap of **2 per descriptor bucket**. Four same-spec textures against a cap of two means the two highest slots are created fresh every frame and destroyed at trim. The live plan showed it directly: the two unbacked objects carried identity generation **23441** — one create/destroy per frame for the life of the session — where their siblings sat at generation 3–5.

So AO rendered correctly (the storage is live during `Execute`), the validator was right (the objects are gone by the time a between-frames read looks), and the engine was allocating and freeing two 1.3 MB textures every frame.

## Fix

`TransientPool::ReleaseAll()` now counts what each bucket handed out in the frame it closes, and `Trim(cap)` keeps `max(cap, that demand)`. The cap still bounds buckets nobody needs any more (the bloom-on-then-off case it exists for); it no longer turns a bucket's steady-state demand into per-frame churn. Eviction also takes the **front** of a bucket first — `ReleaseAll` appends the frame's returns, so the front is whatever nobody used this frame. The old `resize()` kept the stale leftovers and dropped the object the frame had just used.

`RenderGraph::SetTransientPoolMaxBucketSize`'s doc says the same.

## Test

`RenderGraphTransientPool.TrimKeepsWhatTheLastFrameNeeded` (GPU-backed like its neighbours, skips headless): four same-spec acquisitions survive a `Trim(2)`; the next frame is served entirely from the pool (same four objects); a frame needing one trims to the cap and keeps the object it used; an idle frame trims to the cap.

## Verified live

- **OpenGL:** `olo_render_validate` → `ok: true` on MaterialLab and SponzaDeferred across forward / forward+ / deferred; the four GTAO identities hold generation 5/5/5/3 across three samples 10 s apart (before: 23441 and climbing ~340/s).
- **Vulkan:** the same matrix is clean with `OLO_VK_ASYNC_COMPUTE=0`. With async compute on, a live forward→forward+ switch on MaterialLab device-faults about two seconds later. That is **not this change**: master with nothing but `m_TransientPoolMaxBucketSize = 4u` faults identically, so the old cap of 2 — by re-creating two of the four GTAO scratch textures every frame — was masking a Vulkan async-compute bug. Fully bisected (11 arms) in #1198.

## Draft, blocked on #1198

Merging this without #1198 would turn a hidden bug into a device fault for anyone switching render paths on Vulkan with async compute enabled. Everything else in this PR stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
