### PR TITLE
diag(vulkan): report each queue's last pass checkpoint on a device loss

### DIFF
--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -566,6 +566,7 @@ namespace OloEngine
         bool hasDeferredHostOpsExtension = false;
         bool hasRayQueryExtension = false;
         bool hasRayPipelineExtension = false;
+        bool hasCheckpointsExtension = false;
         {
             u32 extCount = 0;
             vkEnumerateDeviceExtensionProperties(m_PhysicalDevice, nullptr, &extCount, nullptr);
@@ -578,6 +579,7 @@ namespace OloEngine
             };
             hasEds3Extension = listed(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
             hasDeviceFaultExtension = listed(VK_EXT_DEVICE_FAULT_EXTENSION_NAME);
+            hasCheckpointsExtension = listed(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
             hasMeshShaderExtension = listed(VK_EXT_MESH_SHADER_EXTENSION_NAME);
             hasAccelStructExtension = listed(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
             hasDeferredHostOpsExtension = listed(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
@@ -781,6 +783,14 @@ namespace OloEngine
             // deviceFaultVendorBinary deliberately left off: it gates a
             // vendor blob dump we have no decoder for.
         }
+        // Checkpoints (NVIDIA only, no feature struct): a fault report names an
+        // address; the checkpoints name the PASS each queue was executing. Free
+        // when unused, and the difference between "READ of invalid address"
+        // and knowing which dispatch issued it (issue #1198).
+        if (hasCheckpointsExtension)
+        {
+            deviceExtensions.push_back(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
+        }
 
         // Mesh shaders (issue #813): OPTIONAL — enabled when the extension is
         // listed AND the driver supports both stages; never an ADR 0010 gate
@@ -911,6 +921,7 @@ namespace OloEngine
         // device — commit the flag the pipeline builder branches on.
         m_DynamicBlendStateEnabled = wantDynamicBlend;
         m_DeviceFaultEnabled = wantDeviceFault;
+        m_CheckpointsEnabled = hasCheckpointsExtension;
         // Same commit-after-create rule: the flag describes the LOGICAL
         // device's enabled features, which exist only once the create returns.
         m_MeshShaderEnabled = wantMeshShader;
@@ -1397,6 +1408,37 @@ namespace OloEngine
         {
             OLO_CORE_ERROR("[Vulkan]   vendor fault: '{}' code={:#x} data={:#x}", v.description,
                            static_cast<u64>(v.vendorFaultCode), static_cast<u64>(v.vendorFaultData));
+        }
+
+        // The checkpoints: the last pass marker each queue reached before the
+        // loss. `pCheckpointMarker` is the interned pass name the renderer API
+        // passed to vkCmdSetCheckpointNV (VulkanRendererAPI::PushDebugGroup).
+        if (m_CheckpointsEnabled && vkGetQueueCheckpointDataNV != nullptr)
+        {
+            const auto dump = [](const VkQueue queue, const char* queueName)
+            {
+                if (queue == VK_NULL_HANDLE)
+                    return;
+                u32 count = 0;
+                vkGetQueueCheckpointDataNV(queue, &count, nullptr);
+                std::vector<VkCheckpointDataNV> data(count);
+                for (auto& d : data)
+                    d.sType = VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV;
+                vkGetQueueCheckpointDataNV(queue, &count, data.data());
+                if (count == 0)
+                {
+                    OLO_CORE_ERROR("[Vulkan]   checkpoints ({}): none reached", queueName);
+                    return;
+                }
+                for (u32 i = 0; i < count; ++i)
+                {
+                    const char* marker = static_cast<const char*>(data[i].pCheckpointMarker);
+                    OLO_CORE_ERROR("[Vulkan]   checkpoint ({}): stage={:#x} pass='{}'", queueName,
+                                   static_cast<u64>(data[i].stage), marker != nullptr ? marker : "(null)");
+                }
+            };
+            dump(m_Queue, "graphics");
+            dump(m_AsyncComputeQueue, "async compute");
         }
     }
 

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.cpp
@@ -1335,6 +1335,15 @@ namespace OloEngine
 
     void VulkanDevice::LogDeviceFaultInfo() const
     {
+        // Two independent sources, each behind its own extension: a missing
+        // or failed fault query must not silence the checkpoints, and vice
+        // versa. Either alone is worth having on a device loss.
+        LogDeviceFaultRecords();
+        LogQueueCheckpoints();
+    }
+
+    void VulkanDevice::LogDeviceFaultRecords() const
+    {
         if (!m_DeviceFaultEnabled || m_Device == VK_NULL_HANDLE || vkGetDeviceFaultInfoEXT == nullptr)
         {
             return;
@@ -1409,11 +1418,17 @@ namespace OloEngine
             OLO_CORE_ERROR("[Vulkan]   vendor fault: '{}' code={:#x} data={:#x}", v.description,
                            static_cast<u64>(v.vendorFaultCode), static_cast<u64>(v.vendorFaultData));
         }
+    }
 
+    void VulkanDevice::LogQueueCheckpoints() const
+    {
         // The checkpoints: the last pass marker each queue reached before the
         // loss. `pCheckpointMarker` is the interned pass name the renderer API
         // passed to vkCmdSetCheckpointNV (VulkanRendererAPI::PushDebugGroup).
-        if (m_CheckpointsEnabled && vkGetQueueCheckpointDataNV != nullptr)
+        if (!m_CheckpointsEnabled || m_Device == VK_NULL_HANDLE || vkGetQueueCheckpointDataNV == nullptr)
+        {
+            return;
+        }
         {
             const auto dump = [](const VkQueue queue, const char* queueName)
             {

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -342,6 +342,9 @@ namespace OloEngine
         // pending. (#691 — added to diagnose the foliage device
         // loss, kept as a permanent post-mortem instrument.)
         void LogDeviceFaultInfo() const;
+        // The two halves of LogDeviceFaultInfo, each behind its own extension.
+        void LogDeviceFaultRecords() const;
+        void LogQueueCheckpoints() const;
 
         // Validation-error counter: the debug messenger increments this on
         // every ERROR-severity validation message. Tests assert it stays 0.

--- a/OloEngine/src/Platform/Vulkan/VulkanDevice.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanDevice.h
@@ -125,6 +125,10 @@ namespace OloEngine
         {
             return m_AsyncComputeQueueFamily;
         }
+        [[nodiscard]] bool AreCheckpointsEnabled() const
+        {
+            return m_CheckpointsEnabled;
+        }
         [[nodiscard]] VkQueue GetAsyncComputeQueue() const
         {
             return m_AsyncComputeQueue;
@@ -380,6 +384,11 @@ namespace OloEngine
         f32 m_MaxSamplerAnisotropy = 1.0f;
         bool m_ShaderDrawParametersEnabled = false;
         bool m_DeviceFaultEnabled = false;
+        /// VK_NV_device_diagnostic_checkpoints: every pass drops a checkpoint into
+        /// its command buffer, and a device loss reports the last one each queue
+        /// reached — the one thing VK_EXT_device_fault's address records do not
+        /// say (issue #1198).
+        bool m_CheckpointsEnabled = false;
         bool m_MeshShaderEnabled = false;
         bool m_HostImageCopyEnabled = false;
         // Host-image-copy layout lists, read once after device creation.

--- a/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanRendererAPI.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <atomic>
 #include <mutex>
+#include <unordered_set>
 #include <exception>
 #include <chrono>
 #include <array>
@@ -1403,10 +1404,33 @@ namespace OloEngine
 
     // --- Debug labels / device queries -------------------------------------
 
+    namespace
+    {
+        // vkCmdSetCheckpointNV stores a raw pointer the driver hands back on a
+        // device loss, so the marker must outlive every command buffer that
+        // names it: intern the pass names for the process lifetime.
+        const char* InternCheckpointMarker(const std::string_view label)
+        {
+            static std::mutex s_Mutex;
+            static std::unordered_set<std::string> s_Markers;
+            const std::lock_guard lock(s_Mutex);
+            return s_Markers.emplace(label).first->c_str();
+        }
+    } // namespace
+
     void VulkanRendererAPI::PushDebugGroup(u32 /*id*/, const std::string_view label)
     {
         auto& ctx = Ctx();
         ctx.DebugLabels.emplace_back(label);
+        // A checkpoint per pass, on whichever queue's buffer is recording — the
+        // async-compute segment included. Read back by
+        // VulkanDevice::LogDeviceFaultInfo (issue #1198).
+        if (ctx.Cmd != VK_NULL_HANDLE && vkCmdSetCheckpointNV != nullptr)
+        {
+            const VulkanDevice* device = VulkanDevice::Get();
+            if (device != nullptr && device->AreCheckpointsEnabled())
+                vkCmdSetCheckpointNV(ctx.Cmd, InternCheckpointMarker(label));
+        }
         // vkCmdBeginDebugUtilsLabelEXT is loaded only when the debug-utils
         // extension was enabled (debug builds with the validation layer) —
         // the pointer probe IS the capability check under volk.


### PR DESCRIPTION
Refs #1198.

`VK_EXT_device_fault` names an address; it does not say which pass, on which queue, issued the read. `VK_NV_device_diagnostic_checkpoints` does:

- every `PushDebugGroup` drops a `vkCmdSetCheckpointNV` into whichever command buffer is recording — the async-compute segment included — with the pass name interned for the process lifetime (the driver hands the raw pointer back on the loss);
- `VulkanDevice::LogDeviceFaultInfo` reads `vkGetQueueCheckpointDataNV` for the graphics and async-compute queues right after the address records.

On the #1198 fault this turned

```
[Vulkan]   fault address: 0x3ee400000 (precision ±0x1000) — READ of invalid address
[Vulkan]   fault address: 0x200720ee0 (precision ±0x10) — instruction pointer (faulting)
```

into

```
[Vulkan]   checkpoint (graphics): stage=0x1 pass='ScenePass'
[Vulkan]   checkpoint (graphics): stage=0x2000 pass='ScenePass'
[Vulkan]   checkpoint (async compute): stage=0x1 pass='VolumetricFogPass'
[Vulkan]   checkpoint (async compute): stage=0x2000 pass='VolumetricFogPass'
```

on the first attempt (TOP = last checkpoint started, BOTTOM = last completed; the fault is at or after it). The extension is NVIDIA-only and has no feature struct; where it is absent nothing changes and nothing is logged.

Compile-checked on Debug (editor + tests); `Vulkan*Device*`, `VulkanAsyncCompute*`, `VulkanDrawPath*` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA Vulkan device diagnostic checkpoints when supported.
  * Debug markers now record rendering progress across graphics and asynchronous compute queues.
  * Device-loss diagnostics can report the most recently reached rendering checkpoints, helping identify where failures occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->