### PR TITLE
ci(vcpkg): key the binary cache on the runner image and the baseline; a hosted image bump was costing 55 min per Windows job

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -16,6 +16,12 @@ outputs:
   toolchain-args:
     description: 'CMake arguments selecting the vcpkg toolchain, triplet and overlays'
     value: ${{ steps.emit.outputs.toolchain-args }}
+  hash-prefix:
+    description: >-
+      The prefix every actions/cache key for this manifest+image starts with
+      (`vcpkg-<os>-<triplet>-<hash>-<image>-`). The restore step and the save decision
+      both read it from here so the two can never disagree.
+    value: ${{ steps.cachecfg.outputs.hash-prefix }}
   cache-key:
     description: >
       The actions/cache key this run should SAVE the binary cache under, or the empty
@@ -335,7 +341,11 @@ runs:
         OLO_VCPKG_READ_ONLY: ${{ inputs.read-only }}
         OLO_VCPKG_TRIPLET: ${{ inputs.triplet }}
         OLO_RUNNER_ENVIRONMENT: ${{ runner.environment }}
-        OLO_VCPKG_CACHE_HASH: ${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}
+        # vcpkg-configuration.json carries the registry BASELINE: a Renovate bump of
+        # the vcpkg digest changes every port's version set without touching
+        # vcpkg.json, so it must be in the hash or the key stays "exact" across a
+        # bump that rebuilds everything.
+        OLO_VCPKG_CACHE_HASH: ${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}
         # "true" exactly when this run cannot write the cache service: a
         # pull_request from a fork, whose GITHUB_TOKEN is read-only. Derived from
         # the event here rather than from the `read-only` input, because no caller
@@ -404,14 +414,33 @@ runs:
         #                   so a save step could only ever log a permission error at
         #                   the end of every fork PR;
         #   * read-only  -- the caller asked for restore-only semantics.
+        # THE RUNNER IMAGE IS PART OF THE KEY. vcpkg's per-port ABI hash covers the
+        # compiler, and a GitHub-hosted image bump (windows-2025-vs2026 20260819.586
+        # -> 20260828.587, between 2026-09-06 and 2026-09-10) changes it for every
+        # port: the archives in the store are then all for the OLD ABI. With the
+        # image outside the key that looked like this, for every Windows run from
+        # the bump until 2026-09-12:
+        #
+        #   restore  -> "Cache restored from key: vcpkg-Windows-...-<hash>-34400333427-1"
+        #   vcpkg    -> "Restored 0 package(s)" ... "Building zlib ...", 115 ports, 55 min
+        #   save     -> "restore matched ... this exact manifest hash ... skipping"
+        #
+        # An exact-hash match that restores nothing and never re-saves is a cache
+        # nothing can refresh: every run paid the full rebuild and the store kept
+        # handing out the same dead archives. `ImageVersion` is set by every
+        # GitHub-hosted runner; with it in the prefix an image bump is a MISS, the
+        # run rebuilds once, saves under the new prefix, and the fleet is warm again
+        # on the next run. Self-hosted runners never use this key (persistent cache).
+        prefix="vcpkg-${RUNNER_OS}-${OLO_VCPKG_TRIPLET}-${OLO_VCPKG_CACHE_HASH}-${ImageVersion:-noimage}-"
         key=""
         if [ "$persistent" = false ] \
            && [ "$OLO_VCPKG_FORK_PR" != "true" ] \
            && [ "$OLO_VCPKG_READ_ONLY" != "true" ]; then
-          key="vcpkg-${RUNNER_OS}-${OLO_VCPKG_TRIPLET}-${OLO_VCPKG_CACHE_HASH}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          key="${prefix}${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
         fi
+        echo "hash-prefix=$prefix" >> "$GITHUB_OUTPUT"
         echo "save-key=$key" >> "$GITHUB_OUTPUT"
-        echo "vcpkg binary cache: dir=$dir persistent=$persistent save-key=${key:-<none>}"
+        echo "vcpkg binary cache: dir=$dir persistent=$persistent prefix=$prefix save-key=${key:-<none>}"
 
     # NOT PRUNED BY DEFAULT, and that is the safe direction.
     #
@@ -500,9 +529,10 @@ runs:
     # combined-action one in the same cache list.
     #
     # Key on the inputs that change the ABI of every package: the manifest, the
-    # triplets and the overlay ports. run_id + run_attempt make each attempt save a
-    # fresh superset (actions/cache entries are immutable), and restore-keys falls
-    # back to the newest prior snapshot.
+    # registry baseline, the triplets, the overlay ports AND the runner image (its
+    # compiler is in every port's ABI hash -- see cachecfg). run_id + run_attempt
+    # make each attempt save a fresh superset (actions/cache entries are immutable),
+    # and restore-keys falls back to the newest prior snapshot.
     #
     # Skipped entirely on self-hosted runners: there the cache directory is durable
     # local disk, so a restore would only overwrite the live cache with an older
@@ -539,9 +569,14 @@ runs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.cachecfg.outputs.dir }}
-        key: vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        # The prefix comes from cachecfg (manifest hash + runner image); see the
+        # comment there. The last fallback is any snapshot for this OS/triplet: an
+        # older manifest or image still shares most ports' ABIs, and whatever it
+        # does not restore, this run builds and then SAVES (the save decision sees
+        # a non-exact match).
+        key: ${{ steps.cachecfg.outputs.hash-prefix }}${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
+          ${{ steps.cachecfg.outputs.hash-prefix }}
           vcpkg-${{ runner.os }}-${{ inputs.triplet }}-
 
     # A RUN THAT ALREADY GOT ITS MANIFEST DOES NOT NEED TO BANK IT AGAIN (#1073).
@@ -583,7 +618,7 @@ runs:
       env:
         CFG_KEY: ${{ steps.cachecfg.outputs.save-key }}
         MATCHED: ${{ steps.restore.outputs.cache-matched-key }}
-        HASH_PREFIX: vcpkg-${{ runner.os }}-${{ inputs.triplet }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/**', 'cmake/overlay-ports/**') }}-
+        HASH_PREFIX: ${{ steps.cachecfg.outputs.hash-prefix }}
       run: |
         set -euo pipefail
         key="${CFG_KEY}"

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -168,6 +168,10 @@ jobs:
           #   sccache-windows-2025-release-33993528874-1  -> sccache-windows-2025-release
           #   vcpkg-Windows-x64-windows-static-md-<64hex>-34021696485-1
           #                                              -> vcpkg-Windows-x64-windows-static-md
+          #   vcpkg-Windows-x64-windows-static-md-<64hex>-20260828.587-34700000000-1
+          #                                              -> vcpkg-Windows-x64-windows-static-md
+          #     (the `-<ImageVersion>` runner-image stamp setup-vcpkg adds after the hash,
+          #     stripped BEFORE the hash strip so an image bump supersedes like a hash bump)
           #   ffmpeg-Windows-n7.1-<64hex>                 -> ffmpeg-Windows-n7.1
           #   sccache-asan-windows-2025-vk1.4.357.0-34166829499-1
           #                                              -> sccache-asan-windows-2025
@@ -268,7 +272,7 @@ jobs:
           kept_bytes=0
           while IFS=$'\t' read -r id ref key size accessed; do
             [ -n "${id:-}" ] || continue
-            prefix=$(printf '%s' "$key" | sed -E 's/-[0-9]{6,}(-[0-9]+)?$//; s/-[0-9a-f]{32,}$//; s/-vk[0-9]+(\.[0-9]+)*$//')
+            prefix=$(printf '%s' "$key" | sed -E 's/-[0-9]{6,}(-[0-9]+)?$//; s/-([0-9]{8}\.[0-9]+|noimage)$//; s/-[0-9a-f]{32,}$//; s/-vk[0-9]+(\.[0-9]+)*$//')
             group="${ref}|${prefix}"
             closed_pr=0
             if [[ "$ref" =~ ^refs/pull/([0-9]+)/merge$ ]] && pr_is_closed "${BASH_REMATCH[1]}"; then


### PR DESCRIPTION
## Summary

Every Windows job has been rebuilding all 115 vcpkg ports from source on every run since the `windows-2025-vs2026` runner image moved from `20260819.586` to `20260828.587` (between 2026-09-06 and 2026-09-10). Measured on successful runs:

| step | 2026-09-04..08 (n=20) | 2026-09-10..12 (n=20) |
|---|---|---|
| `build` / Configure CMake | median **2 min** | median **54 min** |
| `build` / Build (sccache) | median 129 min | median 45 min |
| `ASan (Windows)` / Configure | median 2 min | median 48 min |
| `ASan (Windows)` / Build | median 112 min | median 126 min |

So the sccache work is paying (68 % hit rate on the last master build, 129 → 45 min), and the configure regression is eating most of it: ~110 minutes of hosted time per PR across the two Windows jobs.

## The wedge

The logs show it exactly, on master (run 34686722782) and on PRs alike:

```
Cache restored from key: vcpkg-Windows-x64-windows-static-md-<hash>-34400333427-1
Restored 0 package(s) from .../.vcpkg-binary-cache in 900 us
Building vcpkg-cmake-config ... Building zlib ... (115 ports, ~50 min)
restore matched '...-<hash>-34400333427-1', which carries this exact manifest hash;
saving would re-bank what it just read -- skipping.        vcpkg save-key: <none>
```

vcpkg's per-port ABI hash includes the compiler, so the image bump changed it for every port; every archive in the store is for the old ABI; and the save decision from #1073, seeing an exact manifest-hash match, refused to re-bank the rebuilt archives. The entry that "matches" can never be refreshed, and every run pays the full rebuild. The 09-05/06 runs on the old image restored 115 packages from the same key family.

## The fix

- The key prefix now carries the runner's `ImageVersion` (set on every GitHub-hosted runner; `noimage` elsewhere, and self-hosted runners never use this key) and hashes `vcpkg-configuration.json` too, the registry baseline a Renovate digest bump changes without touching `vcpkg.json`, which is the same wedge by another door.
- Restore, restore-keys and the save decision all read the one prefix from `cachecfg`'s new `hash-prefix` output, so they cannot disagree.
- `cache-prune` strips the image stamp before the hash strip, so a superseded image's entry is collected like a manifest-hash bump instead of living forever (verified on sample keys: old-shape and new-shape vcpkg keys both reduce to `vcpkg-Windows-x64-windows-static-md`; sccache and ffmpeg keys unchanged).

Behaviour after merge: the first run on the new key is a miss (falls back to the old-shape entry, restores 0, rebuilds once, and **saves** because the match is not exact); every run after that restores 115 packages and Configure is back to ~2 min.

## Not changed here

- Linux on the box: ccache sits at 76 % hits with its 30 GB store 99.97 % full; `Build tests` is 4 min when warm. The Linux job time increase since 09-09 is the `ctest --parallel 2` change (#1158), test steps 30–34 → 46–56 min, a deliberate memory trade.

## Test plan

- [x] `check-yaml` on both files; the prune's `sed` strip verified against old-shape, new-shape, Linux `noimage`, sccache and ffmpeg keys.
- [ ] This PR's own Windows runs still pay the rebuild once (new prefix, no entry yet) and must show `vcpkg save-key: vcpkg-Windows-...-20260828.587-<run>-1` and a saved entry.
- [ ] The next run after that restores 115 packages and its Configure step drops back to minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
