### PR TITLE
feat(automation): editor command registry and an event bus an agent can wait on (#1131)

### DIFF
--- a/.agents/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.agents/skills/run-oloengine/mcp-smoke-test.ps1
@@ -270,17 +270,22 @@ $cursor = Show-Tool 'olo_events_tail' @{ count = 1 }
 $cursorObj = $cursor.result.content[0].text | ConvertFrom-Json
 $sinceId = [int64]$cursorObj.lastId
 Show-Tool 'olo_viewport_set_size' @{ width = 640; height = 360 } | Out-Null
-$waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
-$waitedObj = $waited.result.content[0].text | ConvertFrom-Json
-$completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
-if ($completed.Count -ge 1) {
-    Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
-} elseif ($waitedObj.timedOut) {
-    Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
-} else {
-    Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+try {
+    $waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
+    $waitedObj = $waited.result.content[0].text | ConvertFrom-Json
+    $completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
+    if ($completed.Count -ge 1) {
+        Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
+    } elseif ($waitedObj.timedOut) {
+        Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
+    } else {
+        Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+    }
+} finally {
+    # $ErrorActionPreference is Stop, so a failed check terminates the script:
+    # the override must still be cleared or the editor is left at 640x360.
+    Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 }
-Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 
 # olo_renderer_settings_set is a consented WRITE tool: with the editor's
 # "Allow writes" gate off (the default) the call must be REFUSED cleanly; with

--- a/.agents/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.agents/skills/run-oloengine/mcp-smoke-test.ps1
@@ -260,6 +260,28 @@ if ($snapAtOverride.result -and -not $snapAtOverride.result.isError) {
 }
 Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 
+# 18b. The automation event bus (#1131): a mutating command publishes
+# `command_completed`, and olo_events_wait BLOCKS for it instead of polling.
+# The cursor is taken BEFORE the action so an event landing between the two
+# calls cannot be missed, and the wait is bounded so a regression fails the
+# smoke test instead of hanging it. olo_viewport_set_size is not a project
+# write, so this runs with the default (writes disabled) consent.
+$cursor = Show-Tool 'olo_events_tail' @{ count = 1 }
+$cursorObj = $cursor.result.content[0].text | ConvertFrom-Json
+$sinceId = [int64]$cursorObj.lastId
+Show-Tool 'olo_viewport_set_size' @{ width = 640; height = 360 } | Out-Null
+$waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
+$waitedObj = $waited.result.content[0].text | ConvertFrom-Json
+$completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
+if ($completed.Count -ge 1) {
+    Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
+} elseif ($waitedObj.timedOut) {
+    Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
+} else {
+    Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+}
+Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
+
 # olo_renderer_settings_set is a consented WRITE tool: with the editor's
 # "Allow writes" gate off (the default) the call must be REFUSED cleanly; with
 # it on, the no-arg form lists every setting (upscale/tonemap/renderpath +

--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -270,17 +270,22 @@ $cursor = Show-Tool 'olo_events_tail' @{ count = 1 }
 $cursorObj = $cursor.result.content[0].text | ConvertFrom-Json
 $sinceId = [int64]$cursorObj.lastId
 Show-Tool 'olo_viewport_set_size' @{ width = 640; height = 360 } | Out-Null
-$waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
-$waitedObj = $waited.result.content[0].text | ConvertFrom-Json
-$completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
-if ($completed.Count -ge 1) {
-    Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
-} elseif ($waitedObj.timedOut) {
-    Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
-} else {
-    Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+try {
+    $waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
+    $waitedObj = $waited.result.content[0].text | ConvertFrom-Json
+    $completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
+    if ($completed.Count -ge 1) {
+        Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
+    } elseif ($waitedObj.timedOut) {
+        Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
+    } else {
+        Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+    }
+} finally {
+    # $ErrorActionPreference is Stop, so a failed check terminates the script:
+    # the override must still be cleared or the editor is left at 640x360.
+    Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 }
-Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 
 # olo_renderer_settings_set is a consented WRITE tool: with the editor's
 # "Allow writes" gate off (the default) the call must be REFUSED cleanly; with

--- a/.claude/skills/run-oloengine/mcp-smoke-test.ps1
+++ b/.claude/skills/run-oloengine/mcp-smoke-test.ps1
@@ -260,6 +260,28 @@ if ($snapAtOverride.result -and -not $snapAtOverride.result.isError) {
 }
 Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
 
+# 18b. The automation event bus (#1131): a mutating command publishes
+# `command_completed`, and olo_events_wait BLOCKS for it instead of polling.
+# The cursor is taken BEFORE the action so an event landing between the two
+# calls cannot be missed, and the wait is bounded so a regression fails the
+# smoke test instead of hanging it. olo_viewport_set_size is not a project
+# write, so this runs with the default (writes disabled) consent.
+$cursor = Show-Tool 'olo_events_tail' @{ count = 1 }
+$cursorObj = $cursor.result.content[0].text | ConvertFrom-Json
+$sinceId = [int64]$cursorObj.lastId
+Show-Tool 'olo_viewport_set_size' @{ width = 640; height = 360 } | Out-Null
+$waited = Show-Tool 'olo_events_wait' @{ sinceId = $sinceId; categories = @('command_completed'); waitMs = 5000 }
+$waitedObj = $waited.result.content[0].text | ConvertFrom-Json
+$completed = @($waitedObj.events | Where-Object { $_.data.command -eq 'olo_viewport_set_size' })
+if ($completed.Count -ge 1) {
+    Write-Host "  olo_events_wait returned command_completed for olo_viewport_set_size (id $($completed[0].id), $($completed[0].data.durationMs) ms) without polling" -ForegroundColor Green
+} elseif ($waitedObj.timedOut) {
+    Write-Error "olo_events_wait timed out: no command_completed event for olo_viewport_set_size arrived within 5 s (lastId $($waitedObj.lastId), dropped $($waitedObj.dropped))"
+} else {
+    Write-Error "olo_events_wait returned $($waitedObj.count) event(s) but none named olo_viewport_set_size: $($waited.result.content[0].text)"
+}
+Show-Tool 'olo_viewport_set_size' @{ reset = $true } | Out-Null
+
 # olo_renderer_settings_set is a consented WRITE tool: with the editor's
 # "Allow writes" gate off (the default) the call must be REFUSED cleanly; with
 # it on, the no-arg form lists every setting (upscale/tonemap/renderpath +

--- a/OloCtl/CoreSources.cmake
+++ b/OloCtl/CoreSources.cmake
@@ -18,6 +18,7 @@ set(OLOCTL_CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/OloCtl/CliRunner.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/OloCtl/CommandCatalogue.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/OloCtl/CommandTree.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/OloCtl/EventsFollow.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/OloCtl/HelpText.cpp
 )
 

--- a/OloCtl/src/OloCtl/CliRunner.cpp
+++ b/OloCtl/src/OloCtl/CliRunner.cpp
@@ -2,6 +2,7 @@
 
 #include "OloCtl/ArgumentBinder.h"
 #include "OloCtl/CommandTree.h"
+#include "OloCtl/EventsFollow.h"
 #include "OloCtl/HelpText.h"
 
 #include <algorithm>
@@ -144,7 +145,7 @@ namespace OloCtl
             for (const TreeGroup& group : tree.Groups())
             {
                 if (group.Name != "help" && group.Name != "version" && group.Name != "catalogue" &&
-                    group.Name != "call")
+                    group.Name != "call" && group.Name != "events")
                 {
                     continue;
                 }
@@ -386,6 +387,13 @@ namespace OloCtl
             out << kVersion << '\n';
             return ExitCode::Ok;
         }
+
+        // `events follow` needs no command tree - it loops one registry name it
+        // knows - so it is dispatched before the catalogue fetch, like `version`.
+        // An editor whose catalogue cannot be read can still be followed, and the
+        // fetch's cost is not paid on every follower start.
+        if (!rest.empty() && rest[0] == "events")
+            return RunEventsVerb(options, rest, source, out, err);
 
         const bool wantsRootHelp = rest.empty() || rest[0] == "help";
         const bool noArguments = rest.empty() && !options.Help;

--- a/OloCtl/src/OloCtl/EventsFollow.cpp
+++ b/OloCtl/src/OloCtl/EventsFollow.cpp
@@ -343,7 +343,16 @@ namespace OloCtl
 
                 for (const Json& event : *events)
                 {
+                    // Flushed per event and checked: a consumer that closed the pipe
+                    // (`| head`) must end the follow, not leave it polling the editor
+                    // forever with nowhere to write.
                     out << event.dump() << '\n';
+                    out.flush();
+                    if (!out)
+                    {
+                        err << "oloctl: stdout is closed; stopping the follow.\n";
+                        return ExitCode::CommandError;
+                    }
                     ++printed;
                     if (!follow.Until.empty() && CategoryOf(event) == follow.Until)
                     {

--- a/OloCtl/src/OloCtl/EventsFollow.cpp
+++ b/OloCtl/src/OloCtl/EventsFollow.cpp
@@ -1,0 +1,396 @@
+#include "OloCtl/EventsFollow.h"
+
+#include "OloCtl/HelpText.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <optional>
+#include <ostream>
+#include <string>
+
+namespace OloCtl
+{
+    namespace
+    {
+        using Json = nlohmann::json;
+
+        // DiagnosticEvent::CategoryToString's tokens, in enum order.
+        constexpr std::array<const char*, 12> kCategoryTokens{
+            "scene_load",
+            "play",
+            "stop",
+            "entity_spawn",
+            "entity_destroy",
+            "asset_reload",
+            "script_error",
+            "scene_save",
+            "scene_dirty",
+            "asset_import",
+            "compile_finished",
+            "command_completed",
+        };
+
+        // One poll waits at most this long, whatever --timeout allows: a follower
+        // that is interrupted should notice within seconds, not half a minute.
+        constexpr int kMaxWaitMs = 10000;
+        // ...and at least this long, so the loop never degenerates into a busy poll.
+        constexpr int kMinWaitMs = 1000;
+        // The HTTP read timeout must exceed the long-poll, or every idle poll is
+        // reported as the editor having gone away. waitMs is at most --timeout / 2.
+        constexpr int kMinTimeoutMs = 2 * kMinWaitMs;
+        // olo_events_wait's `count` maximum.
+        constexpr unsigned long long kServerMaxCount = 500;
+        // DiagnosticsEventLog::kCapacity: the ring the cursor can fall behind.
+        constexpr unsigned long long kRingWindow = 512;
+
+        struct FollowOptions
+        {
+            // Absent: omit sinceId and let the editor start at "now". Present,
+            // including 0: sent verbatim (0 is the editor's "no lower bound").
+            std::optional<unsigned long long> SinceId;
+            std::vector<std::string> Categories;
+            std::string Until;
+            std::optional<unsigned long long> Count;
+            std::optional<long long> ForSeconds;
+        };
+
+        bool IsCategoryToken(const std::string& token)
+        {
+            return std::find(kCategoryTokens.begin(), kCategoryTokens.end(), token) != kCategoryTokens.end();
+        }
+
+        std::string CategoryList()
+        {
+            std::string list;
+            for (const char* token : kCategoryTokens)
+            {
+                if (!list.empty())
+                    list += ", ";
+                list += token;
+            }
+            return list;
+        }
+
+        // Decimal digits only: no sign, no whitespace, no suffix.
+        bool ParseUnsigned(const std::string& text, unsigned long long& out)
+        {
+            if (text.empty() || !std::all_of(text.begin(), text.end(),
+                                             [](unsigned char c)
+                                             { return c >= '0' && c <= '9'; }))
+            {
+                return false;
+            }
+            errno = 0;
+            char* end = nullptr;
+            const unsigned long long value = std::strtoull(text.c_str(), &end, 10);
+            if (end == text.c_str() || *end != '\0' || errno == ERANGE)
+                return false;
+            out = value;
+            return true;
+        }
+
+        bool ParseFollowOptions(const std::vector<std::string>& flags, FollowOptions& out, std::string& outError)
+        {
+            const std::size_t flagCount = flags.size();
+            for (std::size_t i = 0; i < flagCount; ++i)
+            {
+                const std::string& token = flags[i];
+                if (token.size() < 3 || token.compare(0, 2, "--") != 0)
+                {
+                    outError = "`events follow` takes options only, got '" + token + "'.";
+                    return false;
+                }
+
+                std::string name = token.substr(2);
+                std::string value;
+                bool hasValue = false;
+                if (const std::size_t equals = name.find('='); equals != std::string::npos)
+                {
+                    value = name.substr(equals + 1);
+                    name = name.substr(0, equals);
+                    hasValue = true;
+                }
+
+                if (name != "since-id" && name != "category" && name != "until" && name != "count" && name != "for")
+                {
+                    outError = "unknown option --" + name + " for `events follow`.";
+                    return false;
+                }
+
+                if (!hasValue)
+                {
+                    if (i + 1 >= flagCount)
+                    {
+                        outError = "--" + name + " expects a value.";
+                        return false;
+                    }
+                    value = flags[++i];
+                    // The same rule as a command argument: a value never begins with
+                    // `--`, because swallowing the next option would run the loop with
+                    // a wrong bound and still exit 0.
+                    if (value.compare(0, 2, "--") == 0)
+                    {
+                        outError = "--" + name + " expects a value, got '" + value + "'. Use --" + name + "=" + value +
+                                   " if the value really starts with two dashes.";
+                        return false;
+                    }
+                }
+
+                if (name == "since-id")
+                {
+                    unsigned long long parsed = 0;
+                    if (!ParseUnsigned(value, parsed))
+                    {
+                        outError = "--since-id expects an event id (an integer >= 0), got '" + value + "'.";
+                        return false;
+                    }
+                    out.SinceId = parsed;
+                }
+                else if (name == "category" || name == "until")
+                {
+                    if (!IsCategoryToken(value))
+                    {
+                        outError = "--" + name + ": '" + value + "' is not an event category. One of: " +
+                                   CategoryList() + ".";
+                        return false;
+                    }
+                    if (name == "category")
+                        out.Categories.push_back(value);
+                    else
+                        out.Until = value;
+                }
+                else if (name == "count")
+                {
+                    unsigned long long parsed = 0;
+                    if (!ParseUnsigned(value, parsed) || parsed == 0)
+                    {
+                        outError = "--count expects a number of events (an integer >= 1), got '" + value + "'.";
+                        return false;
+                    }
+                    out.Count = parsed;
+                }
+                else // "for"
+                {
+                    unsigned long long parsed = 0;
+                    // Bounded so the deadline arithmetic below cannot overflow.
+                    if (!ParseUnsigned(value, parsed) || parsed == 0 || parsed > 86400ULL * 366ULL)
+                    {
+                        outError = "--for expects a number of seconds (an integer >= 1), got '" + value + "'.";
+                        return false;
+                    }
+                    out.ForSeconds = static_cast<long long>(parsed);
+                }
+            }
+            return true;
+        }
+
+        bool IsErrorResult(const Json& result)
+        {
+            const auto isError = result.find("isError");
+            return isError != result.end() && isError->is_boolean() && isError->get<bool>();
+        }
+
+        // Every `text` block of the result's `content`, joined with newlines.
+        std::string TextContent(const Json& result)
+        {
+            std::string text;
+            const auto content = result.find("content");
+            if (content == result.end() || !content->is_array())
+                return text;
+            for (const Json& block : *content)
+            {
+                if (!block.is_object())
+                    continue;
+                const auto blockText = block.find("text");
+                if (blockText == block.end() || !blockText->is_string())
+                    continue;
+                if (!text.empty())
+                    text += '\n';
+                text += blockText->get<std::string>();
+            }
+            return text;
+        }
+
+        bool ReadUnsignedField(const Json& object, const char* key, unsigned long long& out)
+        {
+            const auto field = object.find(key);
+            if (field == object.end())
+                return false;
+            if (field->is_number_unsigned())
+            {
+                out = field->get<unsigned long long>();
+                return true;
+            }
+            if (field->is_number_integer() && field->get<long long>() >= 0)
+            {
+                out = static_cast<unsigned long long>(field->get<long long>());
+                return true;
+            }
+            return false;
+        }
+
+        std::string CategoryOf(const Json& event)
+        {
+            if (!event.is_object())
+                return {};
+            const auto category = event.find("category");
+            if (category == event.end() || !category->is_string())
+                return {};
+            return category->get<std::string>();
+        }
+
+        int FollowEvents(const CliOptions& options, const FollowOptions& follow, ICommandSource& source,
+                         std::ostream& out, std::ostream& err)
+        {
+            if (options.TimeoutMs < kMinTimeoutMs)
+            {
+                err << "oloctl: `events follow` needs a read timeout of at least " << kMinTimeoutMs
+                    << " ms (--timeout " << options.TimeoutMs
+                    << " was given): each poll long-polls the editor for up to half of it.\n";
+                return ExitCode::Usage;
+            }
+
+            using Clock = std::chrono::steady_clock;
+            std::optional<Clock::time_point> deadline;
+            if (follow.ForSeconds)
+                deadline = Clock::now() + std::chrono::seconds(*follow.ForSeconds);
+
+            std::optional<unsigned long long> cursor = follow.SinceId;
+            unsigned long long printed = 0;
+
+            if (options.Verbose)
+            {
+                err << "oloctl: following events from ";
+                if (cursor)
+                    err << "id " << *cursor << (*cursor == 0 ? " (the oldest the editor still holds)" : "");
+                else
+                    err << "now (the editor's current last id; new events only)";
+                err << " via " << kEventsWaitCommand << '\n';
+            }
+
+            for (;;)
+            {
+                int waitMs = std::min(kMaxWaitMs, std::max(kMinWaitMs, options.TimeoutMs / 2));
+                if (deadline)
+                {
+                    const long long remainingMs =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(*deadline - Clock::now()).count();
+                    if (remainingMs <= 0)
+                        return ExitCode::Ok;
+                    waitMs = static_cast<int>(std::min<long long>(waitMs, remainingMs));
+                }
+
+                Json arguments{ { "waitMs", waitMs } };
+                if (cursor)
+                    arguments["sinceId"] = *cursor;
+                if (!follow.Categories.empty())
+                    arguments["categories"] = follow.Categories;
+                if (follow.Count)
+                    arguments["count"] = std::min<unsigned long long>(*follow.Count - printed, kServerMaxCount);
+
+                const ICommandSource::InvokeOutcome outcome = source.Invoke(kEventsWaitCommand, arguments);
+                if (!outcome.Ok)
+                {
+                    err << "oloctl: " << outcome.Error << '\n';
+                    return ExitCode::Connection;
+                }
+
+                if (IsErrorResult(outcome.Result))
+                {
+                    const std::string text = TextContent(outcome.Result);
+                    err << "oloctl: " << kEventsWaitCommand << " failed: "
+                        << (text.empty() ? outcome.Result.dump() : text) << '\n';
+                    if (text.find("Unknown tool") != std::string::npos)
+                    {
+                        err << "oloctl: this editor predates the automation event bus (#1131) and has no "
+                            << kEventsWaitCommand << ". Rebuild the editor from a tree that has it.\n";
+                    }
+                    return ExitCode::CommandError;
+                }
+
+                // A result without the contract's shape is not a quiet "no events":
+                // continuing without a cursor would re-poll from "now" and skip
+                // whatever the editor recorded meanwhile, silently.
+                const auto structured = outcome.Result.find("structuredContent");
+                unsigned long long lastId = 0;
+                const Json* events = nullptr;
+                if (structured != outcome.Result.end() && structured->is_object() &&
+                    ReadUnsignedField(*structured, "lastId", lastId))
+                {
+                    if (const auto found = structured->find("events"); found != structured->end() && found->is_array())
+                        events = &*found;
+                }
+                if (events == nullptr)
+                {
+                    err << "oloctl: " << kEventsWaitCommand
+                        << " returned no usable payload (expected structuredContent with `events` and `lastId`): "
+                        << outcome.Result.dump() << '\n';
+                    return ExitCode::NoStructured;
+                }
+
+                if (unsigned long long dropped = 0; ReadUnsignedField(*structured, "dropped", dropped) && dropped > 0)
+                {
+                    unsigned long long before = lastId;
+                    if (unsigned long long firstId = 0; !events->empty() && ReadUnsignedField(events->front(), "id", firstId))
+                        before = firstId;
+                    err << "oloctl: " << dropped << " event(s) were dropped before id " << before
+                        << ": the cursor fell behind the editor's " << kRingWindow << "-record window.\n";
+                }
+
+                for (const Json& event : *events)
+                {
+                    out << event.dump() << '\n';
+                    ++printed;
+                    if (!follow.Until.empty() && CategoryOf(event) == follow.Until)
+                    {
+                        out.flush();
+                        return ExitCode::Ok;
+                    }
+                    if (follow.Count && printed >= *follow.Count)
+                    {
+                        out.flush();
+                        return ExitCode::Ok;
+                    }
+                }
+                // A follower is read live: a line must not sit in a buffer for the
+                // length of the next long-poll.
+                out.flush();
+                cursor = lastId;
+            }
+        }
+    } // namespace
+
+    std::span<const char* const> EventCategoryTokens()
+    {
+        return kCategoryTokens;
+    }
+
+    int RunEventsVerb(const CliOptions& options, const std::vector<std::string>& rest, ICommandSource& source,
+                      std::ostream& out, std::ostream& err)
+    {
+        // rest[0] is "events".
+        if (rest.size() >= 2 && rest[1] != "follow")
+        {
+            err << "oloctl: `events` has one sub-verb, `follow`; got '" << rest[1] << "'. Run `oloctl events --help`.\n";
+            return ExitCode::Usage;
+        }
+        if (rest.size() < 2 || options.Help)
+        {
+            out << RenderEventsHelp();
+            return ExitCode::Ok;
+        }
+
+        FollowOptions follow;
+        std::string error;
+        if (!ParseFollowOptions({ rest.begin() + 2, rest.end() }, follow, error))
+        {
+            err << "oloctl: " << error << "\nRun `oloctl events --help`.\n";
+            return ExitCode::Usage;
+        }
+        return FollowEvents(options, follow, source, out, err);
+    }
+} // namespace OloCtl

--- a/OloCtl/src/OloCtl/EventsFollow.h
+++ b/OloCtl/src/OloCtl/EventsFollow.h
@@ -1,0 +1,53 @@
+#pragma once
+
+// `oloctl events follow`: the CLI consumer of the automation event bus
+// (issue #1131).
+//
+// It is a LOOP over one registry command, `olo_events_wait`, through the same
+// ICommandSource::Invoke every other verb uses. There is no second transport:
+// the editor's SSE push is for MCP clients, and a CLI that can long-poll needs
+// nothing more than the request/response path it already has. Each poll returns
+// the events recorded since a cursor, or times out empty; the verb prints what
+// came back, advances the cursor to the `lastId` the editor reported, and polls
+// again.
+//
+// OUTPUT DISCIPLINE, same as the rest of oloctl but stricter: stdout carries
+// one compact JSON object per line, one line per event, the editor's event
+// record verbatim - and NOTHING else, ever. No banner, no summary, no cursor.
+// `oloctl events follow | jq -c 'select(.category=="play")'` is the intended
+// shape. Warnings (dropped records), the verbose cursor report and every error
+// go to stderr.
+//
+// The verb runs BEFORE the catalogue is fetched: it needs no command tree, only
+// the one registry name it hard-codes, so an editor whose olo_tool_search is
+// unreachable can still be followed. An editor that predates olo_events_wait
+// answers the first poll with an isError result saying "Unknown tool"; that is
+// reported as such (exit 1) with a hint, not retried.
+
+#include "OloCtl/CliRunner.h"
+#include "OloCtl/CommandSource.h"
+
+#include <iosfwd>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace OloCtl
+{
+    // The registry name the verb loops over.
+    inline constexpr const char* kEventsWaitCommand = "olo_events_wait";
+
+    // The category tokens olo_events_wait accepts, in the editor's order. The
+    // ONE piece of registry knowledge oloctl carries: `--category` and `--until`
+    // are validated against it locally so a typo is a usage error (exit 2, the
+    // valid tokens named) rather than an error result from the first poll. The
+    // editor validates too, so a token missing here surfaces as its message.
+    [[nodiscard]] std::span<const char* const> EventCategoryTokens();
+
+    // `oloctl events ...`. `rest` is the positional tail starting AT "events";
+    // the verb parses its own flags from rest[2..] (they are not reserved
+    // options, so ParseCommandLine leaves them in place). Returns the process
+    // exit code.
+    [[nodiscard]] int RunEventsVerb(const CliOptions& options, const std::vector<std::string>& rest,
+                                    ICommandSource& source, std::ostream& out, std::ostream& err);
+} // namespace OloCtl

--- a/OloCtl/src/OloCtl/HelpText.cpp
+++ b/OloCtl/src/OloCtl/HelpText.cpp
@@ -19,6 +19,7 @@ namespace OloCtl
             "  oloctl [options] call <registry-name> [--option value ...]\n"
             "  oloctl [options] catalogue\n"
             "  oloctl [options] <group>\n"
+            "  oloctl [options] events follow [--since-id N] [--category C]... [--until C] [--count N] [--for S]\n"
             "  oloctl help | version\n"
             "\n"
             "The command tree is GENERATED from the editor's registry on every run: oloctl carries no\n"
@@ -52,6 +53,12 @@ namespace OloCtl
             "The payload goes to stdout and nothing else ever does, so `oloctl ... | jq` works from a\n"
             "CI step. Diagnostics, warnings and errors go to stderr.\n"
             "\n"
+            "Events:\n"
+            "  `oloctl events follow` streams the editor's diagnostics events to stdout as NDJSON, one\n"
+            "  compact JSON object per line, by looping the registry command olo_events_wait. --until,\n"
+            "  --count and --for bound the stream; with none of them it runs until interrupted.\n"
+            "  `oloctl events --help` has the details.\n"
+            "\n"
             "Values are typed by the command's declared schema: --count 3 sends a number, --name x a\n"
             "string. An option whose schema declares no type takes JSON if the text parses as JSON and\n"
             "the raw string otherwise. Repeat an option to build an array.\n"
@@ -63,8 +70,47 @@ namespace OloCtl
             "oloctl resolves nothing against the working directory. A path in an argument is resolved\n"
             "by the EDITOR, relative to the editor's own working directory (OloEditor/).\n"
             "\n"
-            "Exit codes: 0 ok - 1 the command reported an error - 2 usage - 3 cannot reach the editor\n"
-            "  - 4 refused (write path closed) - 5 no structured content in the result.\n";
+            "Exit codes: 0 ok (for `events follow`: stopped by --until, --count or --for) - 1 the command\n"
+            "  reported an error - 2 usage - 3 cannot reach the editor, or it stopped answering - 4 refused\n"
+            "  (write path closed) - 5 no structured content in the result.\n";
+
+        constexpr const char* kEventsUsage =
+            "oloctl events follow - stream the editor's diagnostics events to stdout as NDJSON.\n"
+            "\n"
+            "Usage:\n"
+            "  oloctl [connection options] events follow [--since-id N] [--category C]... [--until C]\n"
+            "                                            [--count N] [--for S]\n"
+            "\n"
+            "One compact JSON object per line, one line per event, and nothing else on stdout - ever.\n"
+            "Each object is the editor's event record verbatim: id, category, message, and when present\n"
+            "time, entity, context and data. --json, --structured and --compact do not change this\n"
+            "output. Warnings and errors go to stderr.\n"
+            "\n"
+            "  --since-id <id>   Start after this event id. 0 means from the oldest event the editor still\n"
+            "                    holds. Default: new events only, from the moment of the first poll.\n"
+            "  --category <c>    Print only this category; repeat the option for several. One of:\n"
+            "                    scene_load, play, stop, entity_spawn, entity_destroy, asset_reload,\n"
+            "                    script_error, scene_save, scene_dirty, asset_import, compile_finished,\n"
+            "                    command_completed.\n"
+            "  --until <c>       Exit 0 after printing an event of this category. It does not widen the\n"
+            "                    filter: with --category, only the categories you named are printed, so an\n"
+            "                    --until category outside that filter never arrives.\n"
+            "  --count <n>       Exit 0 after printing n events.\n"
+            "  --for <seconds>   Exit 0 after this much wall-clock time.\n"
+            "\n"
+            "With none of --until, --count and --for, it runs until interrupted (Ctrl+C).\n"
+            "\n"
+            "It is a loop over the registry command olo_events_wait, a long poll over the editor's\n"
+            "512-record event ring, through the same request path every other oloctl call takes. It\n"
+            "needs an editor that has that command: an older one answers \"Unknown tool\" and oloctl exits\n"
+            "1 saying so. Each poll waits at most 10 s, and at most half of --timeout, so --timeout must\n"
+            "be 2000 ms or more. When the editor reports that records were evicted before oloctl read\n"
+            "them (the cursor fell behind the ring), a warning naming the count goes to stderr and the\n"
+            "stream continues from the oldest record still held.\n"
+            "\n"
+            "Exit codes: 0 stopped by --until, --count or --for - 1 olo_events_wait reported an error\n"
+            "  - 2 usage - 3 the editor could not be reached, or stopped answering - 5 the result had\n"
+            "  no usable payload.\n";
 
         std::string FirstSentence(const std::string& description, std::size_t limit)
         {
@@ -161,6 +207,11 @@ namespace OloCtl
                 out << " Default " << fallback->dump() << '.';
         }
     } // namespace
+
+    std::string RenderEventsHelp()
+    {
+        return kEventsUsage;
+    }
 
     std::string RenderOfflineHelp(const std::string& connectionError)
     {

--- a/OloCtl/src/OloCtl/HelpText.h
+++ b/OloCtl/src/OloCtl/HelpText.h
@@ -8,7 +8,8 @@
 // for a command this build of oloctl has never heard of.
 //
 // Only the frame is static: the usage line, the connection options, and the
-// four built-in subcommands, which belong to the CLI rather than the registry.
+// five built-in subcommands (help, version, catalogue, call, events), which
+// belong to the CLI rather than the registry.
 
 #include "OloCtl/CommandCatalogue.h"
 #include "OloCtl/CommandTree.h"
@@ -32,4 +33,9 @@ namespace OloCtl
     // why, rather than printing an empty tree that looks like an editor with no
     // commands.
     [[nodiscard]] std::string RenderOfflineHelp(const std::string& connectionError);
+
+    // `oloctl events follow` in full: its flags, the NDJSON contract, the
+    // termination rules and its exit codes. Static, because the verb is oloctl's
+    // own rather than a registry command; needs no catalogue.
+    [[nodiscard]] std::string RenderEventsHelp();
 } // namespace OloCtl

--- a/OloEditor/src/Automation/AutomationAssetCommands.cpp
+++ b/OloEditor/src/Automation/AutomationAssetCommands.cpp
@@ -2,6 +2,7 @@
 #include "Automation/AutomationAssetCommands.h"
 
 #include "Automation/AutomationAssetIndex.h"
+#include "Automation/AutomationEvents.h"
 #include "Automation/AutomationFileWrite.h"
 #include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpServer.h"
@@ -1220,6 +1221,11 @@ namespace OloEngine::Automation
                 imported.RegistryKey = metadata.FilePath;
                 imported.AbsolutePath = Canonicalize(absolute);
                 imported.ExistsOnDisk = true;
+                // The file watcher's auto-import publishes the same event from
+                // EditorLayer::OnAssetImported; this path never raises the
+                // AssetImportedEvent, so it publishes for itself (#1131).
+                Events::PublishAssetImported(static_cast<u64>(handle), AssetUtils::AssetTypeToString(metadata.Type),
+                                             absolute, project.Root, "automation");
                 return Json::object(); });
             if (IsFailure(result))
                 return AutomationResult::Error(result.at("__error").get<std::string>());

--- a/OloEditor/src/Automation/AutomationBuildCommands.cpp
+++ b/OloEditor/src/Automation/AutomationBuildCommands.cpp
@@ -2,6 +2,7 @@
 #include "Automation/AutomationBuildCommands.h"
 
 #include "Automation/AutomationBuildInvocation.h"
+#include "Automation/AutomationEvents.h"
 #include "Automation/AutomationCommand.h"
 #include "Automation/AutomationHost.h"
 #include "Automation/AutomationRegistry.h"
@@ -1340,6 +1341,17 @@ namespace OloEngine::Automation
             // field instead of re-deriving the invariant, which is the same
             // contract olo_tests_run's `complete` carries.
             out["ok"] = allSucceeded;
+
+            // The automation event bus (#1131): one `compile_finished` for the
+            // whole invocation, named by its target list, so a subscriber waiting
+            // on a build does not have to hold the tools/call open for an hour.
+            {
+                std::string targetList;
+                for (const TargetSpec* spec : targets)
+                    targetList += (targetList.empty() ? "" : ",") + std::string(spec->Name);
+                Events::PublishCompileFinished("build", targetList, allSucceeded, static_cast<u32>(errors),
+                                               static_cast<u32>(warnings), wallSeconds);
+            }
 
             if (!allSucceeded)
             {

--- a/OloEditor/src/Automation/AutomationCommand.h
+++ b/OloEditor/src/Automation/AutomationCommand.h
@@ -148,8 +148,8 @@ namespace OloEngine::Automation
         // When set and it returns false, the command is not listed and cannot be
         // invoked — the host it would run against cannot serve it (no editor, no
         // GPU, a subsystem compiled out). Empty means always available, which is
-        // what every command says today, so this changes nothing observable until
-        // one declares otherwise.
+        // what every command said until the #1131 editor actions (pause, step,
+        // gizmo, shader pack) declared that they need an editor hook.
         //
         // This is NOT the exposure profile (#1124), which hides a command from
         // `tools/list` while keeping it dispatchable by name. Unavailable means

--- a/OloEditor/src/Automation/AutomationEditorCommands.cpp
+++ b/OloEditor/src/Automation/AutomationEditorCommands.cpp
@@ -1,0 +1,316 @@
+#include "OloEnginePCH.h"
+#include "Automation/AutomationEditorCommands.h"
+
+#include "Automation/AutomationCommand.h"
+#include "Automation/AutomationHost.h"
+#include "Automation/AutomationRegistry.h"
+#include "Automation/AutomationResult.h"
+#include "Automation/AutomationTransaction.h"
+#include "MCP/McpEditorActions.h"
+#include "MCP/McpServer.h"
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <utility>
+
+// The editor command registry (issue #1131, slice 1).
+//
+// Five commands, all in the `editor` toolset. olo_editor_actions is the
+// declaration: it walks MCP::EditorActions::kEditorActions and joins every row
+// with the registry it was registered into (the handler captures `registry`,
+// exactly as olo_transaction_apply does), so the answer carries the live facts
+// -- is the command available on THIS host, is it a project write, how is it
+// taken back -- rather than a copy of them that could drift. A row that names a
+// command the registry does not hold is still reported, marked unavailable and
+// annotated, never dropped: the table is checked against the real surface by
+// McpAutomationEditorCommandsTest, but a host that registers a subset (a test,
+// a future headless host) must not make a declared action silently vanish.
+//
+// The other four are the actions that had no hook at all before #1131. Their
+// authority classes follow what they touch, not what they resemble:
+//   * pause / step / gizmo are EPHEMERAL RUNTIME CONTROL of the editor session
+//     -- nothing they change is persisted, so they are ProjectWrite=false with
+//     mutating annotations, the same class as olo_viewport_set_size, not
+//     olo_scene_play (which runs the user's game scripts).
+//   * build_shader_pack WRITES assets/ShaderPack.osp into the project, so it is
+//     ProjectWrite=true, consent-gated, and Irreversible.
+
+namespace OloEngine::Automation
+{
+    namespace
+    {
+        using Json = nlohmann::json;
+        namespace EditorActions = MCP::EditorActions;
+
+        // MCP ToolAnnotations, hand-written like AutomationTransactionCommands.cpp
+        // does rather than pulling MCP/McpToolsCommon.h (a transport-side header)
+        // into the automation layer. Every command here acts on the local editor
+        // session, so openWorldHint is false throughout.
+        Json ReadOnlyAnnotations()
+        {
+            return Json{ { "readOnlyHint", true }, { "openWorldHint", false } };
+        }
+
+        Json MutatingAnnotations(bool idempotent)
+        {
+            Json annotations{ { "readOnlyHint", false }, { "openWorldHint", false }, { "destructiveHint", false } };
+            if (idempotent)
+                annotations["idempotentHint"] = true;
+            return annotations;
+        }
+
+        // A write that overwrites a file (the shader pack) but lands in the same
+        // state every time it runs: destructive AND idempotent.
+        Json DestructiveIdempotentAnnotations()
+        {
+            return Json{ { "readOnlyHint", false },
+                         { "destructiveHint", true },
+                         { "idempotentHint", true },
+                         { "openWorldHint", false } };
+        }
+
+        // ---- olo_editor_actions ---------------------------------------------
+
+        Json DescribeAction(const EditorActions::EditorActionDescriptor& action,
+                            const AutomationRegistry::CommandSnapshot& snapshot, const IAutomationHost& host)
+        {
+            Json entry{ { "name", std::string(action.Name) },
+                        { "menuPath", std::string(action.MenuPath) },
+                        { "shortcut", std::string(action.Shortcut) },
+                        { "note", std::string(action.Note) } };
+            if (action.Command.empty())
+                return entry;
+
+            const std::string commandName(action.Command);
+            entry["command"] = commandName;
+            if (const AutomationCommand* command = AutomationRegistry::Find(*snapshot, commandName); command != nullptr)
+            {
+                entry["available"] = command->AvailableOn(host);
+                entry["projectWrite"] = command->ProjectWrite;
+                // The same token olo_transaction_apply's reports use for the same
+                // enum, so a reader learns one spelling.
+                entry["undo"] = std::string(UndoToken(command->Undo));
+                return entry;
+            }
+
+            // Declared, but this registry does not hold it. Say so in the row
+            // rather than dropping the row: the declaration is the point.
+            entry["available"] = false;
+            std::string note = entry["note"].get<std::string>();
+            if (!note.empty())
+                note += ' ';
+            note += "(not registered on this host)";
+            entry["note"] = std::move(note);
+            return entry;
+        }
+
+        AutomationResult HandleEditorActions(const AutomationRegistry& registry, const IAutomationHost& host,
+                                             const Json& arguments)
+        {
+            if (arguments.contains("automatedOnly") && !arguments["automatedOnly"].is_boolean())
+                return AutomationResult::Error("Expected 'automatedOnly' (boolean).");
+            const bool automatedOnly = arguments.value("automatedOnly", false);
+
+            // ONE snapshot for the whole listing, so every row is joined against
+            // the same command vector.
+            const AutomationRegistry::CommandSnapshot snapshot = registry.Snapshot();
+
+            Json actions = Json::array();
+            sizet automated = 0;
+            for (const EditorActions::EditorActionDescriptor& action : EditorActions::kEditorActions)
+            {
+                const bool hasCommand = !action.Command.empty();
+                if (automatedOnly && !hasCommand)
+                    continue;
+                if (hasCommand)
+                    ++automated;
+                actions.push_back(DescribeAction(action, snapshot, host));
+            }
+
+            return AutomationResult::Structured(
+                Json{ { "count", actions.size() }, { "automated", automated }, { "actions", std::move(actions) } });
+        }
+
+        // ---- the four editor actions -------------------------------------------
+
+        AutomationResult HandleEditorPause(IAutomationHost& host, const Json& arguments)
+        {
+            if (!host.Context().SetScenePauseState)
+                return AutomationResult::Error("Pause/resume is not available in this host (no editor).");
+            if (!arguments.contains("paused") || !arguments["paused"].is_boolean())
+                return AutomationResult::Error("Expected 'paused' (boolean).");
+            const bool paused = arguments["paused"].get<bool>();
+
+            const Json result = host.MarshalRead([&host, paused]() -> Json
+                                                 { return EditorActions::ToJson(host.Context().SetScenePauseState(paused)); });
+            if (!result.value("ok", false))
+                return AutomationResult::Error(result.value("message", "Could not change the pause state."));
+            return AutomationResult::Structured(result);
+        }
+
+        AutomationResult HandleEditorStep(IAutomationHost& host, const Json& arguments)
+        {
+            if (!host.Context().StepScene)
+                return AutomationResult::Error("Stepping is not available in this host (no editor).");
+            int frames = 1;
+            if (arguments.contains("frames"))
+            {
+                if (!arguments["frames"].is_number_integer())
+                    return AutomationResult::Error("Expected 'frames' (integer, 1..60).");
+                frames = arguments["frames"].get<int>();
+            }
+            // The schema says 1..60 and the registry enforces it; a caller that
+            // reaches the handler directly gets the same refusal.
+            if (frames < 1 || frames > 60)
+                return AutomationResult::Error("'frames' must be between 1 and 60.");
+
+            const Json result = host.MarshalRead([&host, frames]() -> Json
+                                                 { return EditorActions::ToJson(host.Context().StepScene(frames)); });
+            if (!result.value("ok", false))
+                return AutomationResult::Error(result.value("message", "Could not step the scene."));
+            return AutomationResult::Structured(result);
+        }
+
+        AutomationResult HandleEditorGizmoSet(IAutomationHost& host, const Json& arguments)
+        {
+            if (!host.Context().SetGizmoMode)
+                return AutomationResult::Error("Gizmo control is not available in this host (no editor).");
+            if (!arguments.contains("mode") || !arguments["mode"].is_string())
+                return AutomationResult::Error("Expected 'mode' (one of none, translate, rotate, scale).");
+            const std::string mode = arguments["mode"].get<std::string>();
+            if (!EditorActions::IsGizmoMode(mode))
+                return AutomationResult::Error("Unknown gizmo mode '" + mode + "'; expected none, translate, rotate or scale.");
+
+            const Json result = host.MarshalRead([&host, mode]() -> Json
+                                                 { return EditorActions::ToJson(host.Context().SetGizmoMode(mode)); });
+            if (!result.value("ok", false))
+                return AutomationResult::Error(result.value("message", "Could not change the gizmo mode."));
+            return AutomationResult::Structured(result);
+        }
+
+        AutomationResult HandleEditorBuildShaderPack(IAutomationHost& host, const Json&)
+        {
+            if (!host.Context().BuildShaderPack)
+                return AutomationResult::Error("Building the shader pack is not available in this host (no editor).");
+
+            const Json result = host.MarshalRead([&host]() -> Json
+                                                 { return EditorActions::ToJson(host.Context().BuildShaderPack()); });
+            if (!result.value("ok", false))
+                return AutomationResult::Error(result.value("message", "Shader pack build failed."));
+            return AutomationResult::Structured(result);
+        }
+    } // namespace
+
+    void RegisterEditorCommands(AutomationRegistry& registry)
+    {
+        {
+            AutomationCommand command;
+            command.Name = "olo_editor_actions";
+            command.Toolset = "editor";
+            command.Title = "List editor actions";
+            command.Description =
+                "The editor command registry: every menu, toolbar and shortcut action the editor declares, each with "
+                "the registry command that performs it -- plus that command's availability on this host, its "
+                "authority class (projectWrite) and how it is taken back (undo) -- or a note saying why no command "
+                "does. automatedOnly:true lists only the actions that have a command.";
+            command.InputSchema = EditorActions::ActionsInputSchema();
+            command.OutputSchema = EditorActions::ActionsOutputSchema();
+            command.Annotations = ReadOnlyAnnotations();
+            command.ProjectWrite = false;
+            command.MainMarshaled = false;
+            command.Undo = AutomationUndo::None;
+            // Captures the registry it is registered into, like
+            // olo_transaction_apply: the listing must describe THIS registry's
+            // commands, not a fixed idea of them.
+            command.Handler = [&registry](IAutomationHost& host, const Json& arguments) -> AutomationResult
+            { return HandleEditorActions(registry, host, arguments); };
+            registry.Register(std::move(command));
+        }
+        {
+            AutomationCommand command;
+            command.Name = "olo_editor_pause";
+            command.Toolset = "editor";
+            command.Title = "Pause or resume the scene";
+            command.Description =
+                "Pause (paused:true) or resume (paused:false) the running Play or Simulate session -- the toolbar "
+                "Pause/Resume button. Idempotent: changed:false when already in the requested state. An error in "
+                "Edit mode, where there is nothing to pause; enter Play or Simulate first.";
+            command.InputSchema = EditorActions::PauseInputSchema();
+            command.OutputSchema = EditorActions::PauseOutputSchema();
+            command.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            // Ephemeral runtime control of the editor session, not project data:
+            // nothing here is persisted, so it is not a consented write. The
+            // same class as olo_viewport_set_size, not olo_scene_play.
+            command.ProjectWrite = false;
+            command.MainMarshaled = true;
+            command.Undo = AutomationUndo::None;
+            command.IsAvailable = [](const IAutomationHost& host)
+            { return static_cast<bool>(host.Context().SetScenePauseState); };
+            command.Handler = HandleEditorPause;
+            registry.Register(std::move(command));
+        }
+        {
+            AutomationCommand command;
+            command.Name = "olo_editor_step";
+            command.Toolset = "editor";
+            command.Title = "Step the paused scene";
+            command.Description =
+                "Advance a PAUSED Play or Simulate session by `frames` frames (1..60, default 1) -- the toolbar Step "
+                "button. An error when the session is not paused or the editor is in Edit mode.";
+            command.InputSchema = EditorActions::StepInputSchema();
+            command.OutputSchema = EditorActions::StepOutputSchema();
+            // Not idempotent: every call advances the simulation further.
+            command.Annotations = MutatingAnnotations(/*idempotent*/ false);
+            // Ephemeral runtime control, like olo_editor_pause: not a consented write.
+            command.ProjectWrite = false;
+            command.MainMarshaled = true;
+            command.Undo = AutomationUndo::None;
+            command.IsAvailable = [](const IAutomationHost& host)
+            { return static_cast<bool>(host.Context().StepScene); };
+            command.Handler = HandleEditorStep;
+            registry.Register(std::move(command));
+        }
+        {
+            AutomationCommand command;
+            command.Name = "olo_editor_gizmo_set";
+            command.Toolset = "editor";
+            command.Title = "Set the viewport gizmo";
+            command.Description =
+                "Select the viewport gizmo shown on the selected entity: none, translate, rotate or scale (the Q/W/E/R "
+                "shortcuts in order). Session UI state, not project data; changed:false when already in that mode.";
+            command.InputSchema = EditorActions::GizmoInputSchema();
+            command.OutputSchema = EditorActions::GizmoOutputSchema();
+            command.Annotations = MutatingAnnotations(/*idempotent*/ true);
+            // Editor UI state only: not a consented write.
+            command.ProjectWrite = false;
+            command.MainMarshaled = true;
+            command.Undo = AutomationUndo::None;
+            command.IsAvailable = [](const IAutomationHost& host)
+            { return static_cast<bool>(host.Context().SetGizmoMode); };
+            command.Handler = HandleEditorGizmoSet;
+            registry.Register(std::move(command));
+        }
+        {
+            AutomationCommand command;
+            command.Name = "olo_editor_build_shader_pack";
+            command.Toolset = "editor";
+            command.Title = "Build the shader pack";
+            command.Description =
+                "Build > Build Shader Pack: write assets/ShaderPack.osp from the live 2D and 3D shader libraries, "
+                "the same code path as the menu item. Synchronous; overwrites the previous pack; not undoable.";
+            command.InputSchema = EditorActions::ShaderPackInputSchema();
+            command.OutputSchema = EditorActions::ShaderPackOutputSchema();
+            command.Annotations = DestructiveIdempotentAnnotations();
+            // Writes a file into the project: a consented write, and there is no
+            // way to take it back from inside this process.
+            command.ProjectWrite = true;
+            command.MainMarshaled = true;
+            command.Undo = AutomationUndo::Irreversible;
+            command.IsAvailable = [](const IAutomationHost& host)
+            { return static_cast<bool>(host.Context().BuildShaderPack); };
+            command.Handler = HandleEditorBuildShaderPack;
+            registry.Register(std::move(command));
+        }
+    }
+} // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationEditorCommands.cpp
+++ b/OloEditor/src/Automation/AutomationEditorCommands.cpp
@@ -153,17 +153,19 @@ namespace OloEngine::Automation
         {
             if (!host.Context().StepScene)
                 return AutomationResult::Error("Stepping is not available in this host (no editor).");
-            int frames = 1;
+            long long requested = 1;
             if (arguments.contains("frames"))
             {
                 if (!arguments["frames"].is_number_integer())
                     return AutomationResult::Error("Expected 'frames' (integer, 1..60).");
-                frames = arguments["frames"].get<int>();
+                requested = arguments["frames"].get<long long>();
             }
             // The schema says 1..60 and the registry enforces it; a caller that
-            // reaches the handler directly gets the same refusal.
-            if (frames < 1 || frames > 60)
+            // reaches the handler directly gets the same refusal — checked on the
+            // wide value, so a huge count cannot wrap into range when narrowed.
+            if (requested < 1 || requested > 60)
                 return AutomationResult::Error("'frames' must be between 1 and 60.");
+            const int frames = static_cast<int>(requested);
 
             const Json result = host.MarshalRead([&host, frames]() -> Json
                                                  { return EditorActions::ToJson(host.Context().StepScene(frames)); });

--- a/OloEditor/src/Automation/AutomationEditorCommands.h
+++ b/OloEditor/src/Automation/AutomationEditorCommands.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace OloEngine::Automation
+{
+    class AutomationRegistry;
+
+    // The editor command registry (issue #1131, slice 1).
+    //
+    // Registers olo_editor_actions -- the DECLARED table of the editor's menu,
+    // toolbar and shortcut actions (MCP/McpEditorActions.h) joined with the live
+    // registry, so an agent can ask "what can this editor do, and which command
+    // does it?" -- and the four actions that had no automation hook before this
+    // slice: olo_editor_pause, olo_editor_step, olo_editor_gizmo_set and
+    // olo_editor_build_shader_pack.
+    //
+    // The four actions run through EditorMcpContext hooks that EditorLayer fills
+    // in with the SAME code path the button or menu item runs. A host that owns
+    // no editor leaves the hooks null; the commands then declare themselves
+    // unavailable (AutomationCommand::IsAvailable) rather than failing deeper.
+    void RegisterEditorCommands(AutomationRegistry& registry);
+} // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationEvents.cpp
+++ b/OloEditor/src/Automation/AutomationEvents.cpp
@@ -1,0 +1,100 @@
+#include "OloEnginePCH.h"
+#include "Automation/AutomationEvents.h"
+
+#include <string>
+#include <system_error>
+
+namespace OloEngine::Automation::Events
+{
+    std::string ProjectRelativePath(const std::filesystem::path& path, const std::filesystem::path& root)
+    {
+        if (path.empty())
+            return {};
+        if (!root.empty())
+        {
+            std::error_code ec;
+            const std::filesystem::path relative = std::filesystem::relative(path, root, ec);
+            // relative() answers ".." for a path outside the root and "" when the two
+            // are on different drives; both mean "not inside", and neither may be
+            // recorded as if it were a project path.
+            if (!ec && !relative.empty() && relative.native().rfind(std::filesystem::path("..").native(), 0) != 0)
+                return relative.generic_string();
+        }
+        return path.filename().generic_string();
+    }
+
+    u64 PublishSceneSaved(std::string_view sceneName, const std::filesystem::path& path,
+                          const std::filesystem::path& projectRoot, bool changed)
+    {
+        const std::string relative = ProjectRelativePath(path, projectRoot);
+        DiagnosticEventData data;
+        data.Set("scene", sceneName).Set("path", relative).Set("changed", changed);
+        return DiagnosticsEventLog::Get().Record(
+            DiagnosticEventCategory::SceneSave,
+            std::string(changed ? "Saved scene '" : "Scene already saved '") + std::string(sceneName) + "'", 0,
+            path.filename().string(), data);
+    }
+
+    u64 PublishSceneDirty(std::string_view sceneName, bool dirty)
+    {
+        DiagnosticEventData data;
+        data.Set("scene", sceneName).Set("dirty", dirty);
+        return DiagnosticsEventLog::Get().Record(
+            DiagnosticEventCategory::SceneDirty,
+            "Scene '" + std::string(sceneName) + (dirty ? "' has unsaved changes" : "' is clean again"), 0,
+            std::string(sceneName), data);
+    }
+
+    u64 PublishAssetImported(u64 handle, std::string_view assetType, const std::filesystem::path& path,
+                             const std::filesystem::path& projectRoot, std::string_view source)
+    {
+        const std::string relative = ProjectRelativePath(path, projectRoot);
+        DiagnosticEventData data;
+        data.Set("asset", relative).Set("type", assetType).Set("handle", handle).Set("source", source);
+        return DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::AssetImport,
+                                                 "Imported " + std::string(assetType) + " '" +
+                                                     path.filename().string() + "'",
+                                                 handle, relative, data);
+    }
+
+    u64 PublishCompileFinished(std::string_view kind, std::string_view target, bool ok, u32 errors, u32 warnings,
+                               f64 seconds)
+    {
+        DiagnosticEventData data;
+        data.Set("kind", kind)
+            .Set("target", target)
+            .Set("ok", ok)
+            .Set("errors", errors)
+            .Set("warnings", warnings)
+            .Set("seconds", seconds);
+        std::string message = std::string(kind) + " compile of '" + std::string(target) + "' " +
+                              (ok ? "succeeded" : "FAILED");
+        if (errors != 0 || warnings != 0)
+            message += " (" + std::to_string(errors) + " errors, " + std::to_string(warnings) + " warnings)";
+        return DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CompileFinished, std::move(message), 0,
+                                                 std::string(target), data);
+    }
+
+    bool EmitsCompletionEvent(const AutomationCommand& command)
+    {
+        if (!command.Annotations.is_object())
+            return true;
+        const auto hint = command.Annotations.find("readOnlyHint");
+        if (hint == command.Annotations.end() || !hint->is_boolean())
+            return true;
+        return !hint->get<bool>();
+    }
+
+    u64 PublishCommandCompleted(const AutomationCommand& command, const AutomationResult& result, f64 durationMs)
+    {
+        DiagnosticEventData data;
+        data.Set("command", command.Name)
+            .Set("ok", !result.IsError)
+            .Set("durationMs", durationMs)
+            .Set("projectWrite", command.ProjectWrite)
+            .Set("toolset", command.Toolset);
+        return DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CommandCompleted,
+                                                 "Command " + command.Name + (result.IsError ? " failed" : " completed"),
+                                                 0, command.Name, data);
+    }
+} // namespace OloEngine::Automation::Events

--- a/OloEditor/src/Automation/AutomationEvents.cpp
+++ b/OloEditor/src/Automation/AutomationEvents.cpp
@@ -12,13 +12,16 @@ namespace OloEngine::Automation::Events
             return {};
         if (!root.empty())
         {
-            std::error_code ec;
-            const std::filesystem::path relative = std::filesystem::relative(path, root, ec);
-            // relative() answers ".." for a path outside the root and "" when the two
-            // are on different drives; both mean "not inside", and neither may be
-            // recorded as if it were a project path.
-            if (!ec && !relative.empty() && relative.native().rfind(std::filesystem::path("..").native(), 0) != 0)
+            // Lexical, not std::filesystem::relative: that one canonicalizes both
+            // sides with filesystem calls on every event, and both callers already
+            // hand in absolute paths. lexically_relative answers ".." for a path
+            // outside the root and "" for one on another drive; both mean "not
+            // inside", and neither may be recorded as if it were a project path.
+            if (const std::filesystem::path relative = path.lexically_normal().lexically_relative(root.lexically_normal());
+                !relative.empty() && relative.native().rfind(std::filesystem::path("..").native(), 0) != 0)
+            {
                 return relative.generic_string();
+            }
         }
         return path.filename().generic_string();
     }
@@ -60,19 +63,10 @@ namespace OloEngine::Automation::Events
     u64 PublishCompileFinished(std::string_view kind, std::string_view target, bool ok, u32 errors, u32 warnings,
                                f64 seconds)
     {
-        DiagnosticEventData data;
-        data.Set("kind", kind)
-            .Set("target", target)
-            .Set("ok", ok)
-            .Set("errors", errors)
-            .Set("warnings", warnings)
-            .Set("seconds", seconds);
-        std::string message = std::string(kind) + " compile of '" + std::string(target) + "' " +
-                              (ok ? "succeeded" : "FAILED");
-        if (errors != 0 || warnings != 0)
-            message += " (" + std::to_string(errors) + " errors, " + std::to_string(warnings) + " warnings)";
-        return DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CompileFinished, std::move(message), 0,
-                                                 std::string(target), data);
+        // The record itself lives in the engine header, because two of the three
+        // compile paths (the script assembly, the shader libraries) are engine
+        // code; forwarding keeps one shape for all three.
+        return DiagnosticsEventLog::Get().RecordCompileFinished(kind, target, ok, errors, warnings, seconds);
     }
 
     bool EmitsCompletionEvent(const AutomationCommand& command)

--- a/OloEditor/src/Automation/AutomationEvents.h
+++ b/OloEditor/src/Automation/AutomationEvents.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// The publish side of the automation event bus (issue #1131).
+//
+// The bus itself is the engine's diagnostics ring (Debug/DiagnosticsEventLog.h):
+// one fixed window, monotonic ids, a cursor per consumer, a reported gap, and a
+// condition variable to block on. This header is the editor-side vocabulary over
+// it — one function per event the issue named, so a call site says WHAT happened
+// and this file decides how it is spelled, what its payload carries, and what it
+// deliberately leaves out.
+//
+// Consumers, all riding the same ring and the same cursor:
+//   * olo_events_wait  — the long-poll subscription (blocks for the next match);
+//   * olo_events_tail  — the incremental poll;
+//   * olo://events/recent + resources/subscribe — the era-proof push carrier;
+//   * the GET /mcp SSE stream — the legacy push carrier;
+//   * `oloctl events follow` — the CLI consumer, a loop over olo_events_wait.
+//
+// THE AUTHORITY RULE, stated once. A subscription is a read, at the authority of
+// any read-only command: it needs the session's bearer token and nothing more, it
+// is not consent-gated, and it is offered to read-only frontends. That is only
+// sound because of what an event may CARRY — see DiagnosticEventDataKeys in the
+// engine header: identities (a command name, a scene name, a project-relative
+// path, an outcome), never content (arguments, results, YAML, bytes, absolute
+// paths). Every publisher here builds its payload through that closed key set,
+// paths are made project-relative before they are recorded (ProjectRelativePath),
+// and every MCP carrier applies the session's path redaction on the way out — the
+// SSE stream did not before #1131, which was a real leak of what a redacted tool
+// result hides. A subscriber therefore cannot see through a read gate, because
+// nothing behind a read gate is ever put on the bus.
+//
+// BACKPRESSURE, stated once. There is no per-subscriber queue anywhere. A slow
+// or absent subscriber costs the editor nothing; when it resumes past the window
+// it is told how many records it lost (`dropped`). The push stream's only buffer
+// is the kernel socket buffer, and a client that stops reading fails its write
+// and is disconnected.
+
+#include "Automation/AutomationCommand.h"
+#include "Automation/AutomationResult.h"
+
+#include "OloEngine/Core/Base.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace OloEngine::Automation::Events
+{
+    // A path as an event may carry it: relative to `root` when it lies inside,
+    // otherwise the file name alone. Generic (forward-slash) form, so the same
+    // asset spells the same on every platform and never reveals a drive letter or
+    // a home directory. Empty in, empty out.
+    [[nodiscard]] std::string ProjectRelativePath(const std::filesystem::path& path, const std::filesystem::path& root);
+
+    // The authored scene was written to disk. `changed` is false when the bytes on
+    // disk were already identical (the save was a no-op that only re-marked the
+    // history clean). Returns the event id, or 0 when suppressed.
+    u64 PublishSceneSaved(std::string_view sceneName, const std::filesystem::path& path,
+                          const std::filesystem::path& projectRoot, bool changed);
+
+    // The scene's unsaved-changes state flipped. Recorded on BOTH edges (dirty and
+    // clean again) under one category, with Data.dirty telling them apart, so a
+    // subscriber filtering on `scene_dirty` sees every transition.
+    u64 PublishSceneDirty(std::string_view sceneName, bool dirty);
+
+    // An asset was registered. `source` names the path it came in by: "filewatch"
+    // for the content-directory watcher's auto-import, "automation" for
+    // olo_asset_import.
+    u64 PublishAssetImported(u64 handle, std::string_view assetType, const std::filesystem::path& path,
+                             const std::filesystem::path& projectRoot, std::string_view source);
+
+    // A compile ended. `kind` is "build" (a CMake target through olo_build_run),
+    // "script" (the C# assembly), or "shader" (a shader library reload); `target`
+    // names what was compiled. Counts and seconds may be 0 when the path does not
+    // measure them — say so in the message rather than inventing numbers.
+    u64 PublishCompileFinished(std::string_view kind, std::string_view target, bool ok, u32 errors, u32 warnings,
+                               f64 seconds);
+
+    // Whether running `command` records a CommandCompleted event. THE RULE: every
+    // command that is not annotated read-only does; a read-only one never does.
+    // Two reasons, both load-bearing. A read is not "something that happened" to
+    // the project, and a session that polls a dozen reads a second would evict
+    // the events worth waiting for from a 512-record ring. And the subscription
+    // command itself (olo_events_wait) is read-only: if its completion were an
+    // event, two agents waiting on each other's activity would wake each other
+    // forever. A command with no annotations at all is treated as not read-only,
+    // which is the conservative side (an event too many, never one too few).
+    [[nodiscard]] bool EmitsCompletionEvent(const AutomationCommand& command);
+
+    // A mutating automation command finished (see EmitsCompletionEvent). Carries
+    // the command's name, toolset, authority class, outcome and duration — and
+    // NOT its arguments or result, which are exactly the content the authority
+    // rule keeps off the bus.
+    u64 PublishCommandCompleted(const AutomationCommand& command, const AutomationResult& result, f64 durationMs);
+} // namespace OloEngine::Automation::Events

--- a/OloEditor/src/Automation/AutomationEvents.h
+++ b/OloEditor/src/Automation/AutomationEvents.h
@@ -72,8 +72,9 @@ namespace OloEngine::Automation::Events
 
     // A compile ended. `kind` is "build" (a CMake target through olo_build_run),
     // "script" (the C# assembly), or "shader" (a shader library reload); `target`
-    // names what was compiled. Counts and seconds may be 0 when the path does not
-    // measure them — say so in the message rather than inventing numbers.
+    // names what was compiled. Counts and seconds are 0 when the path does not
+    // measure them. Forwards to DiagnosticsEventLog::RecordCompileFinished, which
+    // the two engine-side compile paths call directly.
     u64 PublishCompileFinished(std::string_view kind, std::string_view target, bool ok, u32 errors, u32 warnings,
                                f64 seconds);
 

--- a/OloEditor/src/Automation/AutomationRegistry.cpp
+++ b/OloEditor/src/Automation/AutomationRegistry.cpp
@@ -1,12 +1,14 @@
 #include "OloEnginePCH.h"
 #include "Automation/AutomationRegistry.h"
 
+#include "Automation/AutomationEvents.h"
 #include "Automation/AutomationSchemaValidation.h"
 
 #include "OloEngine/Core/Assert.h"
 #include "OloEngine/Core/Log.h"
 
 #include <algorithm>
+#include <chrono>
 #include <exception>
 #include <utility>
 
@@ -221,6 +223,25 @@ namespace OloEngine::Automation
 
     AutomationResult AutomationRegistry::RunHandler(const AutomationCommand& command, IAutomationHost& host,
                                                     const Json& arguments)
+    {
+        const auto started = std::chrono::steady_clock::now();
+        AutomationResult result = RunHandlerUnobserved(command, host, arguments);
+        // The automation event bus (#1131) sees every mutating command complete
+        // from HERE, the one place a handler is entered, so a command invoked
+        // through the registry and one invoked through the MCP adapter publish
+        // the same event. Read-only commands publish nothing: see
+        // Events::EmitsCompletionEvent for the rule and the reason.
+        if (Events::EmitsCompletionEvent(command))
+        {
+            const f64 durationMs =
+                std::chrono::duration<f64, std::milli>(std::chrono::steady_clock::now() - started).count();
+            Events::PublishCommandCompleted(command, result, durationMs);
+        }
+        return result;
+    }
+
+    AutomationResult AutomationRegistry::RunHandlerUnobserved(const AutomationCommand& command,
+                                                              IAutomationHost& host, const Json& arguments)
     {
         try
         {

--- a/OloEditor/src/Automation/AutomationRegistry.h
+++ b/OloEditor/src/Automation/AutomationRegistry.h
@@ -183,7 +183,9 @@ namespace OloEngine::Automation
 
         // Run `command`'s handler, converting an escaping exception into an error
         // result. The single place a handler is entered, so the registry path and the
-        // MCP adapter cannot drift on what "running a command" means.
+        // MCP adapter cannot drift on what "running a command" means — including on
+        // the `command_completed` event a mutating command publishes to the
+        // automation event bus when it returns (#1131; see AutomationEvents.h).
         [[nodiscard]] static AutomationResult RunHandler(const AutomationCommand& command, IAutomationHost& host,
                                                          const nlohmann::json& arguments);
 
@@ -211,6 +213,11 @@ namespace OloEngine::Automation
         [[nodiscard]] static std::string ClientPrefix(const std::string& alias);
 
       private:
+        // RunHandler without the completion event: the exception boundary alone.
+        [[nodiscard]] static AutomationResult RunHandlerUnobserved(const AutomationCommand& command,
+                                                                   IAutomationHost& host,
+                                                                   const nlohmann::json& arguments);
+
         void Publish(std::shared_ptr<CommandList> next);
         // Bump the generation, then tell the transport its catalogue moved. Bump
         // FIRST: a listener that polls the generation must never observe a stale

--- a/OloEditor/src/Automation/AutomationSceneDocument.cpp
+++ b/OloEditor/src/Automation/AutomationSceneDocument.cpp
@@ -4,6 +4,7 @@
 
 #include "Automation/AutomationFileWrite.h"
 
+#include "OloEngine/Project/Project.h"
 #include "OloEngine/Scene/SceneSerializer.h"
 #include "UndoRedo/EditorCommand.h"
 
@@ -215,9 +216,13 @@ namespace OloEngine::Automation
         auto newBytes = SerializeDocument(after);
         // The one save path the editor menu, Ctrl+S and olo_scene_save* share, so
         // the `scene_save` event (#1131) is published here and nowhere else. The
-        // project root is what makes the recorded path project-relative rather
-        // than absolute (see Events::ProjectRelativePath).
-        const std::filesystem::path projectRoot = access.AssetDirectory ? access.AssetDirectory() : std::filesystem::path{};
+        // path is recorded relative to the PROJECT root — the spelling every
+        // olo_asset_* / olo_scene_open argument and the asset_import event use —
+        // so one file has one name on the bus; a host with no project (the tests)
+        // falls back to the asset directory the document access names.
+        const std::filesystem::path projectRoot =
+            Project::GetActive() ? Project::GetProjectDirectory()
+                                 : (access.AssetDirectory ? access.AssetDirectory() : std::filesystem::path{});
         const std::string savedName = after.Name;
         const std::filesystem::path savedPath = after.Path;
         if (oldBytes && *oldBytes == newBytes && before.Path == after.Path && before.Name == after.Name &&

--- a/OloEditor/src/Automation/AutomationSceneDocument.cpp
+++ b/OloEditor/src/Automation/AutomationSceneDocument.cpp
@@ -1,5 +1,6 @@
 #include "OloEnginePCH.h"
 #include "Automation/AutomationSceneDocument.h"
+#include "Automation/AutomationEvents.h"
 
 #include "Automation/AutomationFileWrite.h"
 
@@ -212,16 +213,25 @@ namespace OloEngine::Automation
             after.Name = after.Path.stem().string();
         auto oldBytes = ReadFileContents(after.Path);
         auto newBytes = SerializeDocument(after);
+        // The one save path the editor menu, Ctrl+S and olo_scene_save* share, so
+        // the `scene_save` event (#1131) is published here and nowhere else. The
+        // project root is what makes the recorded path project-relative rather
+        // than absolute (see Events::ProjectRelativePath).
+        const std::filesystem::path projectRoot = access.AssetDirectory ? access.AssetDirectory() : std::filesystem::path{};
+        const std::string savedName = after.Name;
+        const std::filesystem::path savedPath = after.Path;
         if (oldBytes && *oldBytes == newBytes && before.Path == after.Path && before.Name == after.Name &&
             SerializeDocument(before) == newBytes)
         {
             RequireFileContents(after.Path, oldBytes);
             history.MarkSaved();
+            Events::PublishSceneSaved(savedName, savedPath, projectRoot, /*changed=*/false);
             return false;
         }
         history.Execute(std::make_unique<SaveSceneDocumentCommand>(access, std::move(before), std::move(after),
                                                                    std::move(oldBytes), std::move(newBytes)),
                         true);
+        Events::PublishSceneSaved(savedName, savedPath, projectRoot, /*changed=*/true);
         return true;
     }
 } // namespace OloEngine::Automation

--- a/OloEditor/src/Automation/AutomationTransaction.cpp
+++ b/OloEditor/src/Automation/AutomationTransaction.cpp
@@ -570,12 +570,6 @@ namespace OloEngine::Automation
         const auto stepsIt = arguments.is_object() ? arguments.find("steps") : arguments.end();
         if (stepsIt != arguments.end() && stepsIt->is_array())
         {
-            // One transaction is ONE `command_completed` on the automation event bus
-            // (#1131): the steps run through the registry like any command, and
-            // without this each would publish its own — up to 64 records the batch's
-            // completion already summarises, enough to evict what a waiter is
-            // blocked on. Thread-local, so only the steps on this thread are quiet.
-            const DiagnosticsEventLog::SuppressCategoryScope oneCompletion(DiagnosticEventCategory::CommandCompleted);
             for (sizet index = 0; index < stepsIt->size(); ++index)
             {
                 const Json& raw = (*stepsIt)[index];
@@ -718,6 +712,14 @@ namespace OloEngine::Automation
 
         try
         {
+            // One transaction is ONE `command_completed` on the automation event bus
+            // (#1131): the steps run through the registry like any command, and
+            // without this each would publish its own — up to 64 records the batch's
+            // completion already summarises, enough to evict what a waiter is
+            // blocked on. Thread-local, so only the steps on this thread are quiet;
+            // the scope ends with this job, before the transaction command's own
+            // completion is published on the handler thread.
+            const DiagnosticsEventLog::SuppressCategoryScope oneCompletion(DiagnosticEventCategory::CommandCompleted);
             for (sizet index = 0; index < plan.Steps.size() && failedStep < 0; ++index)
             {
                 const TransactionStep& step = plan.Steps[index];

--- a/OloEditor/src/Automation/AutomationTransaction.cpp
+++ b/OloEditor/src/Automation/AutomationTransaction.cpp
@@ -4,6 +4,7 @@
 #include "Automation/AutomationSchemaValidation.h"
 #include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpServer.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "UndoRedo/EditorCommand.h"
 
 #include <algorithm>
@@ -569,6 +570,12 @@ namespace OloEngine::Automation
         const auto stepsIt = arguments.is_object() ? arguments.find("steps") : arguments.end();
         if (stepsIt != arguments.end() && stepsIt->is_array())
         {
+            // One transaction is ONE `command_completed` on the automation event bus
+            // (#1131): the steps run through the registry like any command, and
+            // without this each would publish its own — up to 64 records the batch's
+            // completion already summarises, enough to evict what a waiter is
+            // blocked on. Thread-local, so only the steps on this thread are quiet.
+            const DiagnosticsEventLog::SuppressCategoryScope oneCompletion(DiagnosticEventCategory::CommandCompleted);
             for (sizet index = 0; index < stepsIt->size(); ++index)
             {
                 const Json& raw = (*stepsIt)[index];

--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -45,6 +45,9 @@
 		"Automation/AutomationTransaction.cpp"
 		"Automation/AutomationTransactionCommands.h"
 		"Automation/AutomationTransactionCommands.cpp"
+		# The publish side of the automation event bus (issue #1131).
+		"Automation/AutomationEvents.h"
+		"Automation/AutomationEvents.cpp"
 
 		"MCP/McpServer.cpp"
 		"MCP/McpServer.h"

--- a/OloEditor/src/CMakeLists.txt
+++ b/OloEditor/src/CMakeLists.txt
@@ -26,6 +26,8 @@
 		"Automation/AutomationSceneAuthoring.h"
 		"Automation/AutomationComponentRegistry.h"
 		"Automation/AutomationComponentRegistry.cpp"
+		"Automation/AutomationEditorCommands.cpp"
+		"Automation/AutomationEditorCommands.h"
 		"Automation/AutomationComponentCommands.cpp"
 		"Automation/AutomationEntityCommands.cpp"
 		"Automation/AutomationEntityCommands.h"

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -4955,6 +4955,14 @@ namespace OloEngine
         // Reset hovered entity before changing scenes to prevent accessing stale registry
         m_HoveredEntity = Entity();
 
+        // UI open/new establishes a new history; an automation document command
+        // retains the stack so its scene replacement itself can be undone. Cleared
+        // BEFORE the swap: a dirty outgoing document becomes clean here, and the
+        // `scene_dirty` edge that publishes (#1131) must name the scene that had
+        // the unsaved changes, not the one arriving.
+        if (clearHistory)
+            m_CommandHistory.Clear();
+
         m_EditorScene = scene;
         Renderer3D::InvalidateTemporalHistories(TemporalHistoryInvalidationCause::SceneReset);
         m_SceneHierarchyPanel.SetContext(m_EditorScene);
@@ -4981,11 +4989,6 @@ namespace OloEngine
         m_AudioEventsPanel.SetActiveScene(m_EditorScene);
 
         m_ActiveScene = m_EditorScene;
-
-        // UI open/new establishes a new history; an automation document command
-        // retains the stack so its scene replacement itself can be undone.
-        if (clearHistory)
-            m_CommandHistory.Clear();
 
         // (The ephemeral MCP sun-direction override clear that used to live here
         // was retired by issue #633 — the MCP time-of-day tools now edit the

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -12,6 +12,7 @@
 #include "MCP/McpTools.h"
 #include "MCP/McpEditorPanels.h"
 #include "MCP/McpEditorDebugDraw.h"
+#include "MCP/McpEditorActions.h"
 #include "OloEngine/Renderer/Preview/AssetPreviewRenderer.h"
 #include "OloEngine/Core/SyntheticInput.h"
 
@@ -101,6 +102,11 @@
 
 namespace
 {
+    // Where Build > Build Shader Pack writes, relative to the editor's working
+    // directory. Shared by the menu item and the olo_editor_build_shader_pack
+    // hook (issue #1131) so the two cannot disagree about the path they report.
+    constexpr char kShaderPackOutputPath[] = "assets/ShaderPack.osp";
+
     // Interprets ImGui drag-drop payload bytes as a UTF-8 path.
     [[nodiscard]] std::filesystem::path PathFromUtf8Payload(const ImGuiPayload& payload)
     {
@@ -680,6 +686,157 @@ namespace OloEngine
                 result.Simulating = m_SceneState == SceneState::Simulate;
                 result.Mode = result.Playing ? "play" : (result.Simulating ? "simulate" : "edit");
                 result.SceneName = m_ActiveScene ? m_ActiveScene->GetName() : std::string{};
+                return result;
+            };
+            // ---- Editor command registry (issue #1131) ----------------------------
+            // The toolbar and menu actions that were mouse-only before #1131. Each
+            // runs the SAME statement the button, shortcut or menu item runs
+            // (UI_Toolbar, OnKeyPressed, the Build menu), so the command cannot
+            // drift from the click. All main-thread-only: the handlers call them
+            // from inside a MarshalRead job.
+            const auto sceneModeToken = [this]() -> std::string
+            {
+                switch (m_SceneState)
+                {
+                    case SceneState::Play:
+                        return "play";
+                    case SceneState::Simulate:
+                        return "simulate";
+                    case SceneState::Edit:
+                        break;
+                }
+                return "edit";
+            };
+            // olo_editor_pause: the toolbar Pause/Resume button
+            // (m_ActiveScene->SetPaused). Idempotent; nothing to pause in Edit mode.
+            mcpContext.SetScenePauseState = [this, sceneModeToken](bool paused) -> MCP::McpEditorPauseResult
+            {
+                MCP::McpEditorPauseResult result;
+                result.Available = true;
+                result.Mode = sceneModeToken();
+                result.SceneName = m_ActiveScene ? m_ActiveScene->GetName() : std::string{};
+                if (m_SceneState == SceneState::Edit)
+                {
+                    result.Message = "Nothing to pause: the editor is in Edit mode. Enter Play (olo_scene_play) or "
+                                     "Simulate (olo_scene_simulate) first.";
+                    return result;
+                }
+                if (!m_ActiveScene)
+                {
+                    result.Message = "No active scene.";
+                    return result;
+                }
+
+                const bool wasPaused = m_ActiveScene->IsPaused();
+                if (wasPaused != paused)
+                    m_ActiveScene->SetPaused(paused);
+                result.Ok = true;
+                result.Changed = wasPaused != paused;
+                result.Paused = m_ActiveScene->IsPaused();
+                if (!result.Changed)
+                    result.Message = paused ? "Already paused." : "Already running.";
+                else
+                    result.Message = (paused ? "Paused the " : "Resumed the ") + result.Mode + " session.";
+                return result;
+            };
+            // olo_editor_step: the toolbar Step button (m_ActiveScene->Step), with a
+            // frame count. The paused scene advances that many frames and stays paused.
+            mcpContext.StepScene = [this, sceneModeToken](int frames) -> MCP::McpEditorStepResult
+            {
+                MCP::McpEditorStepResult result;
+                result.Available = true;
+                result.FramesRequested = frames;
+                result.Mode = sceneModeToken();
+                result.SceneName = m_ActiveScene ? m_ActiveScene->GetName() : std::string{};
+                if (m_SceneState == SceneState::Edit)
+                {
+                    result.Message = "Nothing to step: the editor is in Edit mode. Enter Play or Simulate, then pause "
+                                     "(olo_editor_pause { paused: true }) first.";
+                    return result;
+                }
+                if (!m_ActiveScene)
+                {
+                    result.Message = "No active scene.";
+                    return result;
+                }
+                result.Paused = m_ActiveScene->IsPaused();
+                if (!result.Paused)
+                {
+                    result.Message = "Not paused: step only advances a paused session. Call olo_editor_pause "
+                                     "{ paused: true } first.";
+                    return result;
+                }
+                if (frames < 1)
+                {
+                    result.Message = "'frames' must be at least 1.";
+                    return result;
+                }
+
+                m_ActiveScene->Step(frames);
+                result.Ok = true;
+                result.Message = "Queued " + std::to_string(frames) +
+                                 " frame(s): the paused session advances that many frames and stays paused.";
+                return result;
+            };
+            // olo_editor_gizmo_set: the Q/W/E/R shortcuts (OnKeyPressed). Refused
+            // mid-drag, as the shortcuts are; the hover/Edit-mode guard the
+            // shortcuts add is about the keyboard focus, which an agent has no use
+            // for.
+            mcpContext.SetGizmoMode = [this](const std::string& mode) -> MCP::McpEditorGizmoResult
+            {
+                // ImGuizmo operation id -> the token olo_editor_gizmo_set speaks.
+                // Anything that is not one of the three operations draws no gizmo.
+                const auto gizmoToken = [](int gizmoType) -> std::string
+                {
+                    if (gizmoType == ImGuizmo::OPERATION::TRANSLATE)
+                        return "translate";
+                    if (gizmoType == ImGuizmo::OPERATION::ROTATE)
+                        return "rotate";
+                    if (gizmoType == ImGuizmo::OPERATION::SCALE)
+                        return "scale";
+                    return "none";
+                };
+
+                MCP::McpEditorGizmoResult result;
+                result.Available = true;
+                result.Mode = gizmoToken(m_GizmoType);
+                if (!MCP::EditorActions::IsGizmoMode(mode))
+                {
+                    result.Message = "Unknown gizmo mode '" + mode + "'; expected none, translate, rotate or scale.";
+                    return result;
+                }
+                if (ImGuizmo::IsUsing())
+                {
+                    result.Message = "The gizmo is being dragged; the mode can change once the drag ends.";
+                    return result;
+                }
+
+                int target = -1;
+                if (mode == "translate")
+                    target = ImGuizmo::OPERATION::TRANSLATE;
+                else if (mode == "rotate")
+                    target = ImGuizmo::OPERATION::ROTATE;
+                else if (mode == "scale")
+                    target = ImGuizmo::OPERATION::SCALE;
+
+                result.Changed = m_GizmoType != target;
+                m_GizmoType = target;
+                result.Ok = true;
+                result.Mode = gizmoToken(m_GizmoType);
+                result.Message = result.Changed ? "Gizmo mode set to " + result.Mode + "."
+                                                : "Gizmo mode already " + result.Mode + ".";
+                return result;
+            };
+            // olo_editor_build_shader_pack: the Build > Build Shader Pack menu item.
+            mcpContext.BuildShaderPack = [this]() -> MCP::McpEditorShaderPackResult
+            {
+                MCP::McpEditorShaderPackResult result;
+                result.Available = true;
+                result.OutputPath = kShaderPackOutputPath;
+                result.Ok = BuildShaderPack();
+                result.Message = result.Ok ? "Shader pack written to " + result.OutputPath + "."
+                                           : "Shader pack build failed: ShaderPack::CreateFromLibraries returned false "
+                                             "(see the engine log).";
                 return result;
             };
             // olo_input_inject (#607): synthetic mouse/keyboard input. All three run on
@@ -6280,14 +6437,14 @@ namespace OloEngine
                       result.BakedEntityCount, result.SkippedEntityCount, assetPath.string());
     }
 
-    void EditorLayer::BuildShaderPack() const
+    bool EditorLayer::BuildShaderPack() const
     {
         OLO_PROFILE_FUNCTION();
 
-        const std::filesystem::path outputPath = "assets/ShaderPack.osp";
+        const std::filesystem::path outputPath = kShaderPackOutputPath;
         OLO_CORE_INFO("Building Shader Pack to '{}'...", outputPath.string());
 
-        bool success = ShaderPack::CreateFromLibraries(
+        const bool success = ShaderPack::CreateFromLibraries(
             Renderer2D::GetShaderLibrary(),
             Renderer3D::GetShaderLibrary(),
             outputPath);
@@ -6300,6 +6457,7 @@ namespace OloEngine
         {
             OLO_CORE_ERROR("Shader Pack build failed");
         }
+        return success;
     }
 
     void EditorLayer::ValidateAssetReferences() const

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -3,6 +3,7 @@
 #include "OloEngine/Core/Interactivity.h"
 #include "OloEngine/Core/Environment.h"
 #include "EditorLayer.h"
+#include "Automation/AutomationEvents.h"
 #include "Automation/AutomationSceneDocument.h"
 #include "Panels/AssetPackBuilderPanel.h"
 #include "Panels/BuildGamePanel.h"
@@ -515,6 +516,16 @@ namespace OloEngine
             // their mutation through the same undo stack as the editor's own edits,
             // so an agent's change is a single Ctrl-Z. Main-thread-only, like the
             // readers above (the MCP server calls it from a MarshalRead job).
+            // The automation event bus (#1131): every edit, undo, redo, save and
+            // transaction on the scene history publishes a `scene_dirty` edge, so
+            // an agent can wait for "the document has unsaved changes" (or "is
+            // clean again") instead of polling olo_scene_status. Wired once, here,
+            // for the scene history only; the panels' own histories stay silent.
+            m_CommandHistory.OnDirtyChanged = [this](bool dirty)
+            {
+                Automation::Events::PublishSceneDirty(m_EditorScene ? m_EditorScene->GetName() : std::string{},
+                                                      dirty);
+            };
             mcpContext.GetCommandHistory = [this]() -> CommandHistory*
             {
                 // Only expose the undo stack in Edit mode. In Play / Simulate the
@@ -5753,11 +5764,15 @@ namespace OloEngine
             m_ContentBrowserPanel->OnAssetImported(e.GetPath());
         }
 
-        DiagnosticsEventLog::Get().Record(
-            DiagnosticEventCategory::AssetReload,
-            std::string("Auto-imported ") + AssetUtils::AssetTypeToString(e.GetAssetType()) + " '" +
-                e.GetPath().filename().string() + "'",
-            static_cast<u64>(e.GetHandle()), e.GetPath().string());
+        // `asset_import` on the automation event bus (#1131). This used to be
+        // recorded as `asset_reload` with the ABSOLUTE path in `context`; it is
+        // its own category now, and the path is project-relative — an event
+        // carries identities, never a path a redacted read would hide.
+        Automation::Events::PublishAssetImported(static_cast<u64>(e.GetHandle()),
+                                                 AssetUtils::AssetTypeToString(e.GetAssetType()), e.GetPath(),
+                                                 Project::GetActive() ? Project::GetProjectDirectory()
+                                                                      : std::filesystem::path{},
+                                                 "filewatch");
 
         OLO_TRACE("✨ Asset Imported Event Received!");
         OLO_TRACE("   Handle: {}", static_cast<u64>(e.GetHandle()));

--- a/OloEditor/src/EditorLayer.cpp
+++ b/OloEditor/src/EditorLayer.cpp
@@ -789,31 +789,55 @@ namespace OloEngine
                                  " frame(s): the paused session advances that many frames and stays paused.";
                 return result;
             };
-            // olo_editor_gizmo_set: the Q/W/E/R shortcuts (OnKeyPressed). Refused
-            // mid-drag, as the shortcuts are; the hover/Edit-mode guard the
-            // shortcuts add is about the keyboard focus, which an agent has no use
-            // for.
+            // olo_editor_gizmo_set: the Q/W/E/R shortcuts (OnKeyPressed). Same two
+            // refusals as the shortcuts: not mid-drag, and Edit mode only — the
+            // gizmo draws in any scene state, but only Edit-mode drags push an
+            // undo entry, so a gizmo shown in Play would move a runtime entity
+            // with nothing to take it back. The viewport-hover half of the
+            // shortcuts' guard is keyboard focus, which an agent has no use for.
             mcpContext.SetGizmoMode = [this](const std::string& mode) -> MCP::McpEditorGizmoResult
             {
-                // ImGuizmo operation id -> the token olo_editor_gizmo_set speaks.
+                // Token <-> ImGuizmo operation, both directions from one table.
                 // Anything that is not one of the three operations draws no gizmo.
+                static constexpr std::array<std::pair<std::string_view, int>, 4> kGizmoOps{ {
+                    { "none", -1 },
+                    { "translate", ImGuizmo::OPERATION::TRANSLATE },
+                    { "rotate", ImGuizmo::OPERATION::ROTATE },
+                    { "scale", ImGuizmo::OPERATION::SCALE },
+                } };
                 const auto gizmoToken = [](int gizmoType) -> std::string
                 {
-                    if (gizmoType == ImGuizmo::OPERATION::TRANSLATE)
-                        return "translate";
-                    if (gizmoType == ImGuizmo::OPERATION::ROTATE)
-                        return "rotate";
-                    if (gizmoType == ImGuizmo::OPERATION::SCALE)
-                        return "scale";
+                    for (const auto& [token, op] : kGizmoOps)
+                    {
+                        if (op == gizmoType)
+                            return std::string(token);
+                    }
                     return "none";
                 };
 
                 MCP::McpEditorGizmoResult result;
                 result.Available = true;
                 result.Mode = gizmoToken(m_GizmoType);
-                if (!MCP::EditorActions::IsGizmoMode(mode))
+                int target = -1;
+                bool known = false;
+                for (const auto& [token, op] : kGizmoOps)
+                {
+                    if (token == mode)
+                    {
+                        target = op;
+                        known = true;
+                    }
+                }
+                if (!known)
                 {
                     result.Message = "Unknown gizmo mode '" + mode + "'; expected none, translate, rotate or scale.";
+                    return result;
+                }
+                if (m_SceneState != SceneState::Edit)
+                {
+                    result.Message = "The gizmo mode can only be changed in Edit mode (the editor is in " +
+                                     std::string(m_SceneState == SceneState::Play ? "Play" : "Simulate") +
+                                     "); stop the session first.";
                     return result;
                 }
                 if (ImGuizmo::IsUsing())
@@ -821,14 +845,6 @@ namespace OloEngine
                     result.Message = "The gizmo is being dragged; the mode can change once the drag ends.";
                     return result;
                 }
-
-                int target = -1;
-                if (mode == "translate")
-                    target = ImGuizmo::OPERATION::TRANSLATE;
-                else if (mode == "rotate")
-                    target = ImGuizmo::OPERATION::ROTATE;
-                else if (mode == "scale")
-                    target = ImGuizmo::OPERATION::SCALE;
 
                 result.Changed = m_GizmoType != target;
                 m_GizmoType = target;

--- a/OloEditor/src/EditorLayer.h
+++ b/OloEditor/src/EditorLayer.h
@@ -155,8 +155,10 @@ namespace OloEngine
         void BuildAssetPack();
 
         // Shader Pack Building
-        // Bundles all compiled SPIR-V into a single binary file for distribution builds
-        void BuildShaderPack() const;
+        // Bundles all compiled SPIR-V into a single binary file for distribution builds.
+        // Returns whether the pack was written, so the olo_editor_build_shader_pack
+        // hook (issue #1131) can report the outcome; the menu item only logs it.
+        bool BuildShaderPack() const;
 
         // Asset reference validation (issue #455)
         // Sweeps the active asset manager's dependency registry for dangling

--- a/OloEditor/src/MCP/McpEditorActions.h
+++ b/OloEditor/src/MCP/McpEditorActions.h
@@ -1,0 +1,280 @@
+#pragma once
+
+// The editor command registry (issue #1131, slice 1): the editor's own actions,
+// DECLARED — menu items, toolbar buttons and shortcuts — each mapped to the
+// automation command that performs it, or to the reason none does.
+//
+// Why a table and not a parallel mechanism: the issue asked that editor actions
+// be "exposed through the same Automation Registry as everything else". Almost
+// every menu action already had a registry command by the time this landed
+// (scene new/open/save, play/simulate/stop, undo/redo, panels, reload). What was
+// missing was (a) the four that had no editor hook at all — pause/resume, step,
+// gizmo mode, Build Shader Pack — and (b) the DECLARATION: a single place an
+// agent can ask "what can this editor do, and which command does it?" without
+// reading EditorLayer.cpp. kEditorActions is that declaration; olo_editor_actions
+// serves it joined with the live registry (authority class, undo class,
+// availability on this host). An action listed with an empty Command is
+// declared NOT automated, and Note says why — a reader gets the honest gap, not
+// an absence they have to infer.
+//
+// Header-only and engine-free apart from McpServer.h's result structs and the
+// schema DSL, so the table, the schemas and the result shaping unit-test with no
+// editor (McpAutomationEditorCommandsTest.cpp); the actions themselves run
+// through EditorMcpContext hooks the editor fills in, like every other write.
+
+#include "MCP/McpSchemaBuilder.h"
+#include "MCP/McpServer.h"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace OloEngine::MCP::EditorActions
+{
+    using Json = nlohmann::json;
+
+    // ---- gizmo mode ---------------------------------------------------------
+
+    // The viewport gizmo modes the Q/W/E/R shortcuts select. Spelled as the
+    // strings olo_editor_gizmo_set accepts and reports; the editor maps them to
+    // ImGuizmo's operation ids in EditorLayer (kept out of here so the header
+    // needs no ImGuizmo).
+    inline constexpr std::array<std::string_view, 4> kGizmoModes{ "none", "translate", "rotate", "scale" };
+
+    [[nodiscard]] inline bool IsGizmoMode(std::string_view mode)
+    {
+        for (const std::string_view candidate : kGizmoModes)
+        {
+            if (candidate == mode)
+                return true;
+        }
+        return false;
+    }
+
+    // ---- the declared action table -----------------------------------------
+
+    struct EditorActionDescriptor
+    {
+        std::string_view Name;     // stable snake_case identity, e.g. "scene_save"
+        std::string_view MenuPath; // where a human finds it: "File > Save Scene", "Toolbar > Pause"
+        std::string_view Shortcut; // "" when there is none
+        std::string_view Command;  // the registry command that performs it, or "" when none does
+        std::string_view Note;     // for an un-automated action, why; otherwise a one-line hint
+    };
+
+    // Every action the editor's menu bar, toolbar and shortcut map expose, in
+    // menu order. The names are the identities olo_editor_actions reports; the
+    // Command column is checked against the real registry by
+    // McpAutomationEditorCommandsTest, so a renamed command breaks the build's
+    // tests rather than the table.
+    inline constexpr std::array kEditorActions{
+        // File
+        EditorActionDescriptor{ "project_new", "File > New Project", "", "",
+                                "Project switching restarts most of the editor; it is #1132's headless-host territory." },
+        EditorActionDescriptor{ "project_open", "File > Open Project", "", "",
+                                "Project switching restarts most of the editor; it is #1132's headless-host territory." },
+        EditorActionDescriptor{ "project_save", "File > Save Project", "", "",
+                                "EditorLayer::SaveProject is a stub today; nothing to automate until it does something." },
+        EditorActionDescriptor{ "scene_new", "File > New Scene", "Ctrl+N", "olo_scene_new", "" },
+        EditorActionDescriptor{ "scene_open", "File > Open Scene", "Ctrl+O", "olo_scene_open",
+                                "Takes a path instead of opening the file dialog." },
+        EditorActionDescriptor{ "scene_save", "File > Save Scene", "Ctrl+S", "olo_scene_save", "" },
+        EditorActionDescriptor{ "scene_save_as", "File > Save Scene As", "Ctrl+Shift+S", "olo_scene_save_as",
+                                "Takes a path instead of opening the file dialog." },
+        EditorActionDescriptor{ "mesh_export_gltf", "File > Export Mesh to glTF", "", "",
+                                "Drives a file dialog and the selection; no non-interactive path exists yet." },
+        EditorActionDescriptor{ "quick_save", "File > Quick Save", "F5", "",
+                                "A save-game slot of the running game, not an editor document; see the SaveGame panel." },
+        EditorActionDescriptor{ "quick_load", "File > Quick Load", "F9", "",
+                                "A save-game slot of the running game, not an editor document; see the SaveGame panel." },
+        EditorActionDescriptor{ "exit", "File > Exit", "", "", "Never automated: it prompts to discard unsaved work." },
+        // Edit
+        EditorActionDescriptor{ "undo", "Edit > Undo", "Ctrl+Z", "olo_editor_undo", "" },
+        EditorActionDescriptor{ "redo", "Edit > Redo", "Ctrl+Y", "olo_editor_redo", "" },
+        EditorActionDescriptor{ "preferences", "Edit > Preferences", "", "",
+                                "Opens a modal panel; the process-global settings it holds are olo_accessibility_get/set." },
+        EditorActionDescriptor{ "entity_duplicate", "Edit > Duplicate", "Ctrl+D", "olo_entity_duplicate",
+                                "Takes the entity explicitly rather than the current selection." },
+        EditorActionDescriptor{ "entity_copy", "Edit > Copy", "Ctrl+C", "",
+                                "Clipboard-only; olo_entity_duplicate covers the copy-then-paste use." },
+        EditorActionDescriptor{ "entity_paste", "Edit > Paste", "Ctrl+V", "",
+                                "Clipboard-only; olo_entity_duplicate covers the copy-then-paste use." },
+        EditorActionDescriptor{ "entity_delete", "Edit > Delete", "Delete", "olo_entity_destroy",
+                                "Takes the entity explicitly rather than the current selection." },
+        EditorActionDescriptor{ "entity_select", "Scene Hierarchy > click", "", "olo_editor_select_entity", "" },
+        EditorActionDescriptor{ "gizmo_mode", "Viewport > gizmo mode", "Q/W/E/R", "olo_editor_gizmo_set", "" },
+        EditorActionDescriptor{ "camera_frame_entity", "Viewport > frame selection", "F", "olo_camera_frame_entity",
+                                "Takes the entity explicitly rather than the current selection." },
+        // Toolbar
+        EditorActionDescriptor{ "play", "Toolbar > Play", "", "olo_scene_play", "" },
+        EditorActionDescriptor{ "simulate", "Toolbar > Simulate", "", "olo_scene_simulate", "" },
+        EditorActionDescriptor{ "stop", "Toolbar > Stop", "", "olo_scene_stop", "" },
+        EditorActionDescriptor{ "pause", "Toolbar > Pause / Resume", "", "olo_editor_pause", "" },
+        EditorActionDescriptor{ "step", "Toolbar > Step", "", "olo_editor_step", "Only while paused." },
+        // Script / Shaders
+        EditorActionDescriptor{ "script_reload", "Script > Reload assembly", "Ctrl+R", "olo_reload_script", "" },
+        EditorActionDescriptor{ "shader_reload", "Shaders > Reload shader", "", "olo_shader_reload",
+                                "Reloads one shader by name; the menu item reloads the whole 2D library." },
+        // Build
+        EditorActionDescriptor{ "asset_pack_build", "Build > Build Asset Pack", "", "",
+                                "Runs on a worker with progress and cancel through the Asset Pack Builder panel; "
+                                "not yet a command." },
+        EditorActionDescriptor{ "shader_pack_build", "Build > Build Shader Pack", "", "olo_editor_build_shader_pack", "" },
+        EditorActionDescriptor{ "lightmap_bake", "Build > Bake Lightmaps", "", "olo_lightmap_bake", "" },
+        EditorActionDescriptor{ "asset_references_validate", "Build > Validate Asset References", "",
+                                "olo_project_validate", "Composes the same validators the menu item runs." },
+        EditorActionDescriptor{ "build_game", "Build > Build Game...", "", "",
+                                "A panel; olo_editor_panel_set opens it and olo_build_run builds the CMake targets." },
+        // Window / Debug
+        EditorActionDescriptor{ "panel_toggle", "Window / Debug > (any panel)", "", "olo_editor_panel_set",
+                                "One command for every panel checkbox; olo_editor_panel_list names them." },
+    };
+
+    [[nodiscard]] inline const EditorActionDescriptor* Find(std::string_view name)
+    {
+        for (const EditorActionDescriptor& action : kEditorActions)
+        {
+            if (action.Name == name)
+                return &action;
+        }
+        return nullptr;
+    }
+
+    // ---- schemas ------------------------------------------------------------
+
+    [[nodiscard]] inline Json ActionsInputSchema()
+    {
+        return Schema::Object()
+            .Prop("automatedOnly", Schema::Bool().Desc("Only list actions that have a registry command (default false)."))
+            .NoAdditional();
+    }
+
+    // A Schema::Node rather than a Json: Schema::Array(const Node&) takes it, and
+    // Node's Json constructor is explicit by design.
+    [[nodiscard]] inline Schema::Node ActionSchema()
+    {
+        return Schema::Object()
+            .Prop("name", Schema::String())
+            .Prop("menuPath", Schema::String())
+            .Prop("shortcut", Schema::String().Desc("Empty when the action has no keyboard shortcut."))
+            .Prop("command", Schema::String().Desc("The registry command that performs the action; absent when none does."))
+            .Prop("available", Schema::Bool().Desc("Whether that command can run on this host right now; absent when there is no command."))
+            .Prop("projectWrite", Schema::Bool().Desc("The command's authority class; absent when there is no command."))
+            .Prop("undo", Schema::String().Desc("The command's declared AutomationUndo; absent when there is no command."))
+            .Prop("note", Schema::String().Desc("Why the action is not automated, or a hint about how the command differs from the click."))
+            .Required({ "name", "menuPath", "shortcut", "note" });
+    }
+
+    [[nodiscard]] inline Json ActionsOutputSchema()
+    {
+        return Schema::Object()
+            .Prop("count", Schema::Int().Min(0))
+            .Prop("automated", Schema::Int().Min(0).Desc("How many of the listed actions have a registry command."))
+            .Prop("actions", Schema::Array(ActionSchema()))
+            .Required({ "count", "automated", "actions" });
+    }
+
+    [[nodiscard]] inline Json PauseInputSchema()
+    {
+        return Schema::Object()
+            .Prop("paused", Schema::Bool().Desc("true pauses the running Play/Simulate session, false resumes it."))
+            .Required({ "paused" })
+            .NoAdditional();
+    }
+
+    [[nodiscard]] inline Json PauseOutputSchema()
+    {
+        return Schema::Object()
+            .Prop("available", Schema::Bool())
+            .Prop("ok", Schema::Bool())
+            .Prop("changed", Schema::Bool())
+            .Prop("paused", Schema::Bool())
+            .Prop("mode", Schema::String().Enum({ "edit", "play", "simulate" }))
+            .Prop("sceneName", Schema::String())
+            .Prop("message", Schema::String())
+            .Required({ "available", "ok", "changed", "paused", "mode", "message" });
+    }
+
+    [[nodiscard]] inline Json StepInputSchema()
+    {
+        return Schema::Object()
+            .Prop("frames", Schema::Int().Min(1).Max(60).Desc("How many frames to advance (default 1)."))
+            .NoAdditional();
+    }
+
+    [[nodiscard]] inline Json StepOutputSchema()
+    {
+        return Schema::Object()
+            .Prop("available", Schema::Bool())
+            .Prop("ok", Schema::Bool())
+            .Prop("paused", Schema::Bool())
+            .Prop("framesRequested", Schema::Int().Min(0))
+            .Prop("mode", Schema::String().Enum({ "edit", "play", "simulate" }))
+            .Prop("sceneName", Schema::String())
+            .Prop("message", Schema::String())
+            .Required({ "available", "ok", "paused", "framesRequested", "mode", "message" });
+    }
+
+    [[nodiscard]] inline Json GizmoInputSchema()
+    {
+        return Schema::Object()
+            .Prop("mode", Schema::String()
+                              .Enum({ "none", "translate", "rotate", "scale" })
+                              .Desc("The gizmo to show on the selected entity; the Q/W/E/R shortcuts in order."))
+            .Required({ "mode" })
+            .NoAdditional();
+    }
+
+    [[nodiscard]] inline Json GizmoOutputSchema()
+    {
+        return Schema::Object()
+            .Prop("available", Schema::Bool())
+            .Prop("ok", Schema::Bool())
+            .Prop("changed", Schema::Bool())
+            .Prop("mode", Schema::String().Enum({ "none", "translate", "rotate", "scale" }))
+            .Prop("message", Schema::String())
+            .Required({ "available", "ok", "changed", "mode", "message" });
+    }
+
+    [[nodiscard]] inline Json ShaderPackInputSchema()
+    {
+        return Schema::Object().NoAdditional();
+    }
+
+    [[nodiscard]] inline Json ShaderPackOutputSchema()
+    {
+        return Schema::Object()
+            .Prop("available", Schema::Bool())
+            .Prop("ok", Schema::Bool())
+            .Prop("outputPath", Schema::String().Desc("Where the pack was written, relative to the editor's working directory."))
+            .Prop("message", Schema::String())
+            .Required({ "available", "ok", "outputPath", "message" });
+    }
+
+    // ---- result shaping -----------------------------------------------------
+
+    [[nodiscard]] inline Json ToJson(const McpEditorPauseResult& r)
+    {
+        return Json{ { "available", r.Available }, { "ok", r.Ok }, { "changed", r.Changed }, { "paused", r.Paused }, { "mode", r.Mode }, { "sceneName", r.SceneName }, { "message", r.Message } };
+    }
+
+    [[nodiscard]] inline Json ToJson(const McpEditorStepResult& r)
+    {
+        return Json{ { "available", r.Available }, { "ok", r.Ok }, { "paused", r.Paused }, { "framesRequested", r.FramesRequested }, { "mode", r.Mode }, { "sceneName", r.SceneName }, { "message", r.Message } };
+    }
+
+    [[nodiscard]] inline Json ToJson(const McpEditorGizmoResult& r)
+    {
+        return Json{ { "available", r.Available }, { "ok", r.Ok }, { "changed", r.Changed }, { "mode", r.Mode }, { "message", r.Message } };
+    }
+
+    [[nodiscard]] inline Json ToJson(const McpEditorShaderPackResult& r)
+    {
+        return Json{ { "available", r.Available },
+                     { "ok", r.Ok },
+                     { "outputPath", r.OutputPath },
+                     { "message", r.Message } };
+    }
+} // namespace OloEngine::MCP::EditorActions

--- a/OloEditor/src/MCP/McpEditorActions.h
+++ b/OloEditor/src/MCP/McpEditorActions.h
@@ -105,8 +105,8 @@ namespace OloEngine::MCP::EditorActions
                                 "Takes the entity explicitly rather than the current selection." },
         EditorActionDescriptor{ "entity_select", "Scene Hierarchy > click", "", "olo_editor_select_entity", "" },
         EditorActionDescriptor{ "gizmo_mode", "Viewport > gizmo mode", "Q/W/E/R", "olo_editor_gizmo_set", "" },
-        EditorActionDescriptor{ "camera_frame_entity", "Viewport > frame selection", "F", "olo_camera_frame_entity",
-                                "Takes the entity explicitly rather than the current selection." },
+        EditorActionDescriptor{ "camera_frame_entity", "Viewport > frame entity", "", "olo_camera_frame_entity",
+                                "Takes the entity explicitly rather than the current selection; no shortcut exists." },
         // Toolbar
         EditorActionDescriptor{ "play", "Toolbar > Play", "", "olo_scene_play", "" },
         EditorActionDescriptor{ "simulate", "Toolbar > Simulate", "", "olo_scene_simulate", "" },
@@ -115,7 +115,7 @@ namespace OloEngine::MCP::EditorActions
         EditorActionDescriptor{ "step", "Toolbar > Step", "", "olo_editor_step", "Only while paused." },
         // Script / Shaders
         EditorActionDescriptor{ "script_reload", "Script > Reload assembly", "Ctrl+R", "olo_reload_script", "" },
-        EditorActionDescriptor{ "shader_reload", "Shaders > Reload shader", "", "olo_shader_reload",
+        EditorActionDescriptor{ "shader_reload", "Shaders > Reload shader", "Ctrl+Shift+R", "olo_shader_reload",
                                 "Reloads one shader by name; the menu item reloads the whole 2D library." },
         // Build
         EditorActionDescriptor{ "asset_pack_build", "Build > Build Asset Pack", "", "",
@@ -123,6 +123,8 @@ namespace OloEngine::MCP::EditorActions
                                 "not yet a command." },
         EditorActionDescriptor{ "shader_pack_build", "Build > Build Shader Pack", "", "olo_editor_build_shader_pack", "" },
         EditorActionDescriptor{ "lightmap_bake", "Build > Bake Lightmaps", "", "olo_lightmap_bake", "" },
+        EditorActionDescriptor{ "lightmap_bake_cancel", "Build > Cancel Lightmap Bake", "", "",
+                                "olo_lightmap_bake starts or polls a bake; cancelling one is not a command yet." },
         EditorActionDescriptor{ "asset_references_validate", "Build > Validate Asset References", "",
                                 "olo_project_validate", "Composes the same validators the menu item runs." },
         EditorActionDescriptor{ "build_game", "Build > Build Game...", "", "",
@@ -221,8 +223,8 @@ namespace OloEngine::MCP::EditorActions
     {
         return Schema::Object()
             .Prop("mode", Schema::String()
-                              .Enum({ "none", "translate", "rotate", "scale" })
-                              .Desc("The gizmo to show on the selected entity; the Q/W/E/R shortcuts in order."))
+                              .EnumFrom(kGizmoModes)
+                              .Desc("The gizmo to show on the selected entity; the Q/W/E/R shortcuts in order. Edit mode only."))
             .Required({ "mode" })
             .NoAdditional();
     }
@@ -233,7 +235,7 @@ namespace OloEngine::MCP::EditorActions
             .Prop("available", Schema::Bool())
             .Prop("ok", Schema::Bool())
             .Prop("changed", Schema::Bool())
-            .Prop("mode", Schema::String().Enum({ "none", "translate", "rotate", "scale" }))
+            .Prop("mode", Schema::String().EnumFrom(kGizmoModes))
             .Prop("message", Schema::String())
             .Required({ "available", "ok", "changed", "mode", "message" });
     }

--- a/OloEditor/src/MCP/McpEventStream.h
+++ b/OloEditor/src/MCP/McpEventStream.h
@@ -78,7 +78,9 @@ namespace OloEngine::MCP
         if (!event.Data.empty())
         {
             Json data = Json::parse(event.Data, nullptr, /*allow_exceptions=*/false);
-            j["data"] = data.is_discarded() ? Json(event.Data) : std::move(data);
+            // Not the raw text on failure: a string that failed to parse may be
+            // invalid UTF-8, and dump() would then throw inside every carrier.
+            j["data"] = data.is_discarded() ? Json{ { "error", "event data did not parse" } } : std::move(data);
         }
         return j;
     }
@@ -119,11 +121,20 @@ namespace OloEngine::MCP
     // notification (no `id`), so the client never replies. Spec-compliant means a
     // generic MCP client surfaces it without bespoke handling; clients that ignore
     // logging simply drop it.
-    [[nodiscard]] inline Json MakeEventNotification(const DiagnosticEvent& event)
+    // The bare `notifications/message` envelope under the "olo.events" logger:
+    // every frame the event stream pushes goes through here, the per-event one
+    // below and the gap warning the stream emits when a cursor fell behind the
+    // ring (#1131), so the logger name and the shape have one spelling.
+    [[nodiscard]] inline Json MakeLogNotification(const char* level, Json data)
     {
         return Json{ { "jsonrpc", "2.0" },
                      { "method", "notifications/message" },
-                     { "params", { { "level", EventLogLevel(event.Category) }, { "logger", "olo.events" }, { "data", EventToJson(event) } } } };
+                     { "params", { { "level", level }, { "logger", "olo.events" }, { "data", std::move(data) } } } };
+    }
+
+    [[nodiscard]] inline Json MakeEventNotification(const DiagnosticEvent& event)
+    {
+        return MakeLogNotification(EventLogLevel(event.Category), EventToJson(event));
     }
 
     // Frame a payload as one SSE event block: an `id:` line carrying the monotonic

--- a/OloEditor/src/MCP/McpEventStream.h
+++ b/OloEditor/src/MCP/McpEventStream.h
@@ -56,7 +56,7 @@ namespace OloEngine::MCP
     }
 
     // One diagnostics event as a JSON object — the SAME shape olo_events_tail emits
-    // per array entry (id, category, time, message, entity, context), so a push
+    // per array entry (id, category, time, message, entity, context, data), so a push
     // subscriber and an incremental poller see identical records. Optional fields
     // (time / entity / context) are omitted when absent, exactly like the poll path.
     [[nodiscard]] inline Json EventToJson(const DiagnosticEvent& event)
@@ -71,6 +71,15 @@ namespace OloEngine::MCP
             j["entity"] = std::to_string(event.Entity);
         if (!event.Context.empty())
             j["context"] = event.Context;
+        // The structured payload (#1131), present only for the categories that
+        // carry one. It is compact JSON text built by DiagnosticEventData, so it
+        // parses; if it ever did not, the raw text is emitted as a string so the
+        // defect is visible in the record rather than swallowed.
+        if (!event.Data.empty())
+        {
+            Json data = Json::parse(event.Data, nullptr, /*allow_exceptions=*/false);
+            j["data"] = data.is_discarded() ? Json(event.Data) : std::move(data);
+        }
         return j;
     }
 
@@ -87,10 +96,18 @@ namespace OloEngine::MCP
             case DiagnosticEventCategory::EntitySpawn:
             case DiagnosticEventCategory::EntityDestroy:
                 return "debug";
+            case DiagnosticEventCategory::CommandCompleted:
+                // As chatty as spawn/destroy on a busy session; a client that
+                // colours by severity should not see every command as news.
+                return "debug";
             case DiagnosticEventCategory::SceneLoad:
             case DiagnosticEventCategory::Play:
             case DiagnosticEventCategory::Stop:
             case DiagnosticEventCategory::AssetReload:
+            case DiagnosticEventCategory::SceneSave:
+            case DiagnosticEventCategory::SceneDirty:
+            case DiagnosticEventCategory::AssetImport:
+            case DiagnosticEventCategory::CompileFinished:
                 return "info";
         }
         return "info";

--- a/OloEditor/src/MCP/McpExposure.h
+++ b/OloEditor/src/MCP/McpExposure.h
@@ -128,6 +128,9 @@ namespace OloEngine::MCP
             std::string_view{ "olo_scene_list_entities" },
             std::string_view{ "olo_scene_get_entity" },
             std::string_view{ "olo_events_tail" },
+            // the subscription half of the tail (#1131): an agent that can list the
+            // tail but not the wait polls, which is the loop the bus exists to end
+            std::string_view{ "olo_events_wait" },
             // the two error channels
             std::string_view{ "olo_log_tail" },
             std::string_view{ "olo_shader_errors" },

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -375,16 +375,44 @@ namespace OloEngine::MCP
         // heartbeat once the stream has been idle. Returns false when a write fails
         // (client gone) so the caller ends the stream. Reads only the lock-safe event
         // log — no main-thread marshal needed (mirrors olo_events_tail).
+        //
+        // `redactPaths` applies the session's path redaction to every pushed
+        // record, exactly as tools/call and resources/read apply it to theirs
+        // (#1131). Before that, the stream was the one carrier that skipped it: a
+        // redacted `olo_events_tail` result and an unredacted push of the same
+        // record differed by precisely the paths redaction exists to hide.
         [[nodiscard]] bool ServiceEventStream(httplib::DataSink& sink, u64& cursor,
-                                              std::chrono::steady_clock::time_point& lastWrite)
+                                              std::chrono::steady_clock::time_point& lastWrite, bool redactPaths)
         {
             DiagnosticEventQuery query;
             query.SinceId = cursor;
             query.MaxCount = 0; // deliver every new event — no newest-N cap on a live stream.
             const DiagnosticEventQueryResult snap = DiagnosticsEventLog::Get().QueryWithCursor(query);
+            if (snap.Dropped != 0)
+            {
+                // The cursor fell behind the ring's window (a stalled client, or a
+                // Last-Event-ID too far back): say how many records are gone rather
+                // than resuming as if the history were continuous. A warning-level
+                // logging notification, so a client that only reads events cannot
+                // mistake it for one.
+                const u64 resumedAt = snap.Events.empty() ? snap.LastId + 1 : snap.Events.front().Id;
+                const std::string frame = FormatSseData(
+                    Json{ { "jsonrpc", "2.0" },
+                          { "method", "notifications/message" },
+                          { "params",
+                            Json{ { "level", "warning" },
+                                  { "logger", "olo.events" },
+                                  { "data", Json{ { "gap", snap.Dropped }, { "resumedAt", resumedAt } } } } } });
+                if (!sink.write(frame.data(), frame.size()))
+                    return false;
+                lastWrite = std::chrono::steady_clock::now();
+            }
             for (const auto& event : snap.Events)
             {
-                const std::string frame = FormatSseEvent(event.Id, MakeEventNotification(event));
+                Json notification = MakeEventNotification(event);
+                if (redactPaths)
+                    RedactStructuredContent(notification["params"]["data"]);
+                const std::string frame = FormatSseEvent(event.Id, notification);
                 if (!sink.write(frame.data(), frame.size()))
                     return false;
                 lastWrite = std::chrono::steady_clock::now();
@@ -1306,7 +1334,7 @@ namespace OloEngine::MCP
                     subscriptionTokens = std::move(stillSubscribed);
                 }
 
-                if (!ServiceEventStream(sink, cursor, lastWrite))
+                if (!ServiceEventStream(sink, cursor, lastWrite, RedactPaths()))
                     return false;
 
                 // Pace the loop (httplib calls the provider back-to-back).

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -766,6 +766,10 @@ namespace OloEngine::MCP
         }
 
         m_Port = port;
+        // A server that was stopped and started again must not report every call
+        // as cancelled: clear the flag Stop() set, now that the port is bound and
+        // nothing from the previous run can still be waiting on it.
+        m_Stopping.store(false, std::memory_order_release);
         m_Running.store(true, std::memory_order_release);
         m_ListenThread = std::thread([this]
                                      {

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -387,7 +387,15 @@ namespace OloEngine::MCP
             DiagnosticEventQuery query;
             query.SinceId = cursor;
             query.MaxCount = 0; // deliver every new event — no newest-N cap on a live stream.
-            const DiagnosticEventQueryResult snap = DiagnosticsEventLog::Get().QueryWithCursor(query);
+            // Block on the ring for one poll interval instead of scanning it and
+            // sleeping (#1131): a new record is pushed on the wake, and an idle
+            // stream spends the interval in a timed wait rather than a locked scan.
+            // The list-changed and subscription checks above still run every
+            // interval, because the wait returns after it whether or not anything
+            // arrived.
+            const DiagnosticEventQueryResult snap =
+                DiagnosticsEventLog::Get().WaitWithCursor(query, kStreamPollInterval, []
+                                                          { return false; });
             if (snap.Dropped != 0)
             {
                 // The cursor fell behind the ring's window (a stalled client, or a
@@ -397,12 +405,7 @@ namespace OloEngine::MCP
                 // mistake it for one.
                 const u64 resumedAt = snap.Events.empty() ? snap.LastId + 1 : snap.Events.front().Id;
                 const std::string frame = FormatSseData(
-                    Json{ { "jsonrpc", "2.0" },
-                          { "method", "notifications/message" },
-                          { "params",
-                            Json{ { "level", "warning" },
-                                  { "logger", "olo.events" },
-                                  { "data", Json{ { "gap", snap.Dropped }, { "resumedAt", resumedAt } } } } } });
+                    MakeLogNotification("warning", Json{ { "gap", snap.Dropped }, { "resumedAt", resumedAt } }));
                 if (!sink.write(frame.data(), frame.size()))
                     return false;
                 lastWrite = std::chrono::steady_clock::now();
@@ -803,6 +806,10 @@ namespace OloEngine::MCP
         // Signal first so handlers waiting on unclaimed main-thread jobs abort
         // instead of deadlocking against this thread (Stop runs on the game thread).
         m_Running.store(false, std::memory_order_release);
+        // ...and so every in-flight call reads as cancelled (IsCurrentCallCancelled):
+        // a blocked olo_events_wait returns within its next 250 ms slice instead of
+        // holding the pool join below for up to a minute.
+        m_Stopping.store(true, std::memory_order_release);
 
         // Release any worker blocked in RequestConsent as a Deny BEFORE joining the
         // http worker pool below — otherwise the join would wait forever on a thread
@@ -1334,11 +1341,10 @@ namespace OloEngine::MCP
                     subscriptionTokens = std::move(stillSubscribed);
                 }
 
+                // Also paces the loop: it blocks for kStreamPollInterval when the
+                // ring is quiet, so httplib's back-to-back provider calls never spin.
                 if (!ServiceEventStream(sink, cursor, lastWrite, RedactPaths()))
                     return false;
-
-                // Pace the loop (httplib calls the provider back-to-back).
-                std::this_thread::sleep_for(kStreamPollInterval);
                 return true;
             },
             [this](bool /*success*/)
@@ -1379,6 +1385,11 @@ namespace OloEngine::MCP
 
     bool McpServer::IsCurrentCallCancelled() const
     {
+        // A server that is stopping cancels every call: Stop() joins the worker
+        // pool, and a handler parked in a long wait (olo_events_wait polls this
+        // every 250 ms) would otherwise hold the game thread for its whole timeout.
+        if (m_Stopping.load(std::memory_order_acquire))
+            return true;
         const ActiveCallScope* scope = t_ActiveCall;
         return scope != nullptr && scope->CancelFlag && scope->CancelFlag->load(std::memory_order_acquire);
     }

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -1687,8 +1687,8 @@ namespace OloEngine::MCP
             // A tool this host cannot serve is not listed AND not callable — see
             // AutomationCommand::IsAvailable. Distinct from exposure below, and
             // checked first: advertising something that cannot run is worse than
-            // hiding something that can. No builtin declares one, so this changes
-            // nothing observable today.
+            // hiding something that can. The #1131 editor actions (pause, step,
+            // gizmo, shader pack) declare one: they need an editor hook.
             if (!tool.AvailableOn(*this))
                 continue;
             // Exposure is a LISTING filter only (issue #1124): a tool skipped here is
@@ -1902,7 +1902,8 @@ namespace OloEngine::MCP
         // A tool whose availability predicate says no on this host is not callable,
         // and reports the same way an unregistered one does: from the client's side
         // the two are the same fact, and a second error shape would only invite a
-        // client to retry. No builtin declares one (see AutomationCommand::IsAvailable).
+        // client to retry. The #1131 editor actions declare one (see
+        // AutomationCommand::IsAvailable): they are absent in a host with no editor.
         if (!tool->AvailableOn(*this))
             return MakeError(id, kInvalidParams, "Unknown tool: " + name);
 

--- a/OloEditor/src/MCP/McpServer.cpp
+++ b/OloEditor/src/MCP/McpServer.cpp
@@ -1237,7 +1237,10 @@ namespace OloEngine::MCP
                 startCursor = parsed;
         }
 
-        res.set_header("Cache-Control", "no-cache");
+        // no-store, not no-cache: the stream is authenticated and carries records
+        // shaped by the session's redaction setting, and no-cache still lets a
+        // private cache keep a copy it merely has to revalidate.
+        res.set_header("Cache-Control", "no-store");
         // Conventional SSE hint: tell any intermediary not to buffer the stream.
         res.set_header("X-Accel-Buffering", "no");
 
@@ -1400,7 +1403,7 @@ namespace OloEngine::MCP
 
     void McpServer::HandleStreamingPost(const std::string& body, httplib::Response& res)
     {
-        res.set_header("Cache-Control", "no-cache");
+        res.set_header("Cache-Control", "no-store"); // authenticated tool results: never storable, see HandleGetStream
         res.set_header("X-Accel-Buffering", "no");
         res.set_chunked_content_provider(
             "text/event-stream",

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -1469,6 +1469,10 @@ namespace OloEngine::MCP
         Scope<httplib::Server> m_Http;
         std::thread m_ListenThread;
         std::atomic<bool> m_Running{ false };
+        // Set at the top of Stop() and cleared by Start(): distinct from
+        // !m_Running, which is also the state before Start() and must not read as
+        // "cancelled" to a handler exercised through the dispatch seam in a test.
+        std::atomic<bool> m_Stopping{ false };
         u16 m_Port = DefaultPort;
         std::string m_Token;
 

--- a/OloEditor/src/MCP/McpServer.h
+++ b/OloEditor/src/MCP/McpServer.h
@@ -293,6 +293,52 @@ namespace OloEngine::MCP
         std::string Message;
     };
 
+    // ---- Editor command registry (issue #1131) -----------------------------
+    // Outcomes of the toolbar/menu actions that had no automation hook before
+    // #1131: pause/resume and single-step of a running Play/Simulate session,
+    // the gizmo mode, and the Build > Build Shader Pack menu item. Same shape
+    // discipline as McpScenePlayResult: `Available` false in a host with no
+    // editor, `Ok` for whether the action applied, `Changed` for whether the
+    // call altered anything, `Message` always filled in.
+    struct McpEditorPauseResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        bool Changed = false;
+        bool Paused = false;
+        std::string Mode = "edit"; // "edit" | "play" | "simulate"
+        std::string SceneName;
+        std::string Message;
+    };
+
+    struct McpEditorStepResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        bool Paused = false;
+        int FramesRequested = 0;
+        std::string Mode = "edit";
+        std::string SceneName;
+        std::string Message;
+    };
+
+    struct McpEditorGizmoResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        bool Changed = false;
+        std::string Mode; // "none" | "translate" | "rotate" | "scale" (see McpEditorActions.h)
+        std::string Message;
+    };
+
+    struct McpEditorShaderPackResult
+    {
+        bool Available = false;
+        bool Ok = false;
+        std::string OutputPath; // as the editor spells it (relative to its working directory)
+        std::string Message;
+    };
+
     // Outcome of a consented editor-selection write (issue #607), returned by
     // EditorMcpContext::SelectEntityInEditor. `Available` is false in a host with
     // no editor (headless attach / dispatch tests). `Ok` is true when the
@@ -644,6 +690,28 @@ namespace OloEngine::MCP
         // editor follows its normal toolbar path (stop Play, then simulate).
         // Main-thread-only and consent-gated by olo_scene_simulate.
         std::function<McpScenePlayResult()> SetSceneSimulateState;
+
+        // ---- Editor command registry (issue #1131) --------------------------
+        // The toolbar and menu actions that were reachable only by a mouse before
+        // #1131. Each is the SAME code path the button or menu item runs, so the
+        // registry command and the click cannot drift. All main-thread-only
+        // (scene state, editor members), so a handler calls them from a
+        // MarshalRead job. Null in a headless host; the command then reports "not
+        // available" through IsAvailable.
+        //
+        // Pause / resume the running Play or Simulate session (the toolbar pause
+        // button). Idempotent; Ok:false with a message in Edit mode, where there
+        // is nothing to pause.
+        std::function<McpEditorPauseResult(bool paused)> SetScenePauseState;
+        // Advance a PAUSED session by `frames` frames (the toolbar step button).
+        // Ok:false when not paused or in Edit mode. `frames` is 1..60.
+        std::function<McpEditorStepResult(int frames)> StepScene;
+        // Set the viewport gizmo mode (the Q/W/E/R shortcuts): "none",
+        // "translate", "rotate" or "scale". Session UI state, not project data.
+        std::function<McpEditorGizmoResult(const std::string& mode)> SetGizmoMode;
+        // Build > Build Shader Pack: write assets/ShaderPack.osp from the live
+        // shader libraries. Synchronous; Ok mirrors the menu item's log outcome.
+        std::function<McpEditorShaderPackResult()> BuildShaderPack;
 
         // Select / clear the Scene Hierarchy panel's selection — the "make the
         // Properties inspector draw entity X" write (issue #607). `clear` true

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -112,10 +112,12 @@ namespace OloEngine::MCP
                 // history has no reason to resume from `lastId`, and would silently
                 // miss everything older on a busy session.
                 resource.Description =
-                    "The most recent 'what just happened?' engine events (up to 200: scene load, play/stop, "
-                    "entity spawn/destroy, asset reload, script error) as JSON, newest last, with a 'lastId' "
-                    "cursor to resume from. Subscribable: resources/subscribe on this URI and the server "
-                    "pushes notifications/resources/updated whenever new events are recorded.";
+                    "The most recent 'what just happened?' engine events (up to 200: scene load/save/dirty, "
+                    "play/stop, entity spawn/destroy, asset import/reload, script error, compile finished, "
+                    "automation command completed) as JSON, newest last, with a 'lastId' cursor to resume from. "
+                    "Subscribable: resources/subscribe on this URI and the server pushes "
+                    "notifications/resources/updated whenever new events are recorded. To block for the next "
+                    "event in one call, use olo_events_wait.";
                 resource.MimeType = "application/json";
                 resource.Reader = [](McpServer& /*s*/) -> std::string
                 {

--- a/OloEditor/src/MCP/McpTools.cpp
+++ b/OloEditor/src/MCP/McpTools.cpp
@@ -5,6 +5,7 @@
 #include "MCP/McpServer.h"
 #include "Automation/AutomationAssetCommands.h"
 #include "Automation/AutomationBuildCommands.h"
+#include "Automation/AutomationEditorCommands.h"
 #include "Automation/AutomationSceneAuthoring.h"
 #include "Automation/AutomationTransactionCommands.h"
 
@@ -214,6 +215,10 @@ namespace OloEngine::MCP
         RegisterInputTools(registry);
         RegisterBenchmarkTools(registry);
         RegisterEditorTools(registry);
+        // The editor command registry (issue #1131): the declared action table
+        // and the four toolbar/menu actions that had no command. Same toolset as
+        // RegisterEditorTools, so they list next to the panel commands.
+        Automation::RegisterEditorCommands(registry);
         RegisterTestingTools(registry);
         Automation::RegisterBuildCommands(registry);
         RegisterValidationTools(registry);

--- a/OloEditor/src/MCP/McpToolsDiagnostics.cpp
+++ b/OloEditor/src/MCP/McpToolsDiagnostics.cpp
@@ -8,6 +8,7 @@
 #include "MCP/McpEventStream.h"
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -322,20 +323,34 @@ namespace OloEngine::MCP
             return ToolResult::Structured(out);
         }
 
-        // ---- olo_events_tail (lock-safe; unified diagnostics event ring buffer) -
+        // ---- olo_events_tail / olo_events_wait (lock-safe; the diagnostics ring) -
 
-        // A unified "what just happened?" timeline backed by the engine's diagnostics
-        // event ring buffer (Debug/DiagnosticsEventLog.h, mutex-guarded — safe from the
-        // handler thread). Supports incremental polling via sinceId: pass back the
-        // returned lastId to get only events that happened since the previous call.
-        ToolResult Handle_EventsTail(IAutomationHost& /*host*/, const Json& args)
+        // The comma-separated list of every category token, for error messages.
+        std::string CategoryTokenList()
         {
-            DiagnosticEventQuery query;
+            std::string list;
+            for (const auto token : DiagnosticEvent::AllCategoryTokens())
+            {
+                if (!list.empty())
+                    list += ", ";
+                list += token;
+            }
+            return list;
+        }
+
+        // The arguments olo_events_tail and olo_events_wait share: `count`,
+        // `sinceId` (number or decimal string) and `categories`. Returns an error
+        // message, or empty on success. `hasSinceId` reports whether the caller
+        // supplied a cursor at all, which the wait command turns into "from now".
+        [[nodiscard]] std::string ParseEventQueryArgs(const Json& args, DiagnosticEventQuery& query, bool& hasSinceId)
+        {
+            hasSinceId = false;
             if (args.contains("count") && args["count"].is_number_integer())
                 query.MaxCount = static_cast<std::size_t>(std::clamp<long long>(args["count"].get<long long>(), 1, 500));
 
             if (args.contains("sinceId"))
             {
+                hasSinceId = true;
                 const Json& since = args["sinceId"];
                 if (since.is_number_unsigned())
                     query.SinceId = since.get<u64>();
@@ -349,7 +364,7 @@ namespace OloEngine::MCP
                     }
                     catch (...)
                     {
-                        return ToolResult::Error("Invalid 'sinceId': expected a non-negative integer (an event id).");
+                        return "Invalid 'sinceId': expected a non-negative integer (an event id).";
                     }
                 }
             }
@@ -363,16 +378,17 @@ namespace OloEngine::MCP
                     if (DiagnosticEventCategory category; DiagnosticEvent::CategoryFromString(entry.get<std::string>(), category))
                         query.Categories.push_back(category);
                     else
-                        return ToolResult::Error(
-                            "Unknown category '" + entry.get<std::string>() +
-                            "'. Valid: scene_load, play, stop, entity_spawn, entity_destroy, asset_reload, script_error.");
+                        return "Unknown category '" + entry.get<std::string>() + "'. Valid: " + CategoryTokenList() + ".";
                 }
             }
+            return {};
+        }
 
-            // Events + cursor in one locked snapshot: reading LastId() separately would
-            // race a concurrent Record and skip an event on the next sinceId poll.
-            const DiagnosticEventQueryResult result = DiagnosticsEventLog::Get().QueryWithCursor(query);
-
+        // The shared result shape: `events` (the per-entry shape McpEventStream.h
+        // guarantees the push carriers use too), `count`, the `lastId` cursor and
+        // the `dropped` gap.
+        Json EventQueryResultJson(const DiagnosticEventQueryResult& result)
+        {
             Json arr = Json::array();
             for (const auto& event : result.Events)
                 arr.push_back(EventToJson(event)); // shared with the SSE push path (McpEventStream.h)
@@ -383,8 +399,85 @@ namespace OloEngine::MCP
             // call's sinceId to poll only what happened since. Consistent with the events
             // above (same lock), and stable even when no events matched the filter.
             out["lastId"] = result.LastId;
+            // How many records above sinceId were evicted before this call could
+            // return them (#1131). Non-zero means the caller's history has a hole
+            // it must not paper over.
+            out["dropped"] = result.Dropped;
             out["events"] = std::move(arr);
+            return out;
+        }
+
+        // A unified "what just happened?" timeline backed by the engine's diagnostics
+        // event ring buffer (Debug/DiagnosticsEventLog.h, mutex-guarded — safe from the
+        // handler thread). Supports incremental polling via sinceId: pass back the
+        // returned lastId to get only events that happened since the previous call.
+        ToolResult Handle_EventsTail(IAutomationHost& /*host*/, const Json& args)
+        {
+            DiagnosticEventQuery query;
+            bool hasSinceId = false;
+            if (const std::string error = ParseEventQueryArgs(args, query, hasSinceId); !error.empty())
+                return ToolResult::Error(error);
+
+            // Events + cursor in one locked snapshot: reading LastId() separately would
+            // race a concurrent Record and skip an event on the next sinceId poll.
+            return ToolResult::Structured(EventQueryResultJson(DiagnosticsEventLog::Get().QueryWithCursor(query)));
+        }
+
+        // The long-poll subscription (#1131): the same query as olo_events_tail,
+        // but the call BLOCKS on the ring's condition variable until a matching
+        // event exists, `waitMs` elapses, or the call is cancelled. Runs on the
+        // handler thread and never touches the game thread, so it cannot stall a
+        // frame however long it waits. A caller that passes no sinceId waits for
+        // events NEWER than the call — the "what happens next" question — and gets
+        // the cursor back either way.
+        ToolResult Handle_EventsWait(IAutomationHost& host, const Json& args)
+        {
+            DiagnosticEventQuery query;
+            query.MaxCount = 100;
+            bool hasSinceId = false;
+            if (const std::string error = ParseEventQueryArgs(args, query, hasSinceId); !error.empty())
+                return ToolResult::Error(error);
+            if (!hasSinceId)
+                query.SinceId = DiagnosticsEventLog::Get().LastId();
+
+            long long waitMs = 10000;
+            if (args.contains("waitMs") && args["waitMs"].is_number_integer())
+                waitMs = std::clamp<long long>(args["waitMs"].get<long long>(), 0, 60000);
+
+            const DiagnosticEventQueryResult result = DiagnosticsEventLog::Get().WaitWithCursor(
+                query, std::chrono::milliseconds(waitMs), [&host]
+                { return host.IsCurrentCallCancelled(); });
+
+            Json out = EventQueryResultJson(result);
+            const bool cancelled = host.IsCurrentCallCancelled();
+            out["cancelled"] = cancelled;
+            out["timedOut"] = result.Events.empty() && !cancelled;
             return ToolResult::Structured(out);
+        }
+
+        // The schema every event entry shares between the two commands; the same
+        // shape the push carriers emit (McpEventStream.h).
+        Schema::Node EventEntrySchema()
+        {
+            return Schema::Object()
+                .Prop("id", Schema::Int().Min(0))
+                .Prop("category", Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error", "scene_save", "scene_dirty", "asset_import", "compile_finished", "command_completed" }))
+                .Prop("time", Schema::String().Desc("UTC wall-clock HH:MM:SS.mmm; omitted when the event carries no timestamp."))
+                .Prop("message", Schema::String())
+                .Prop("entity", Schema::String().Desc("Entity UUID as a decimal string (u64 — beyond JSON integer precision); omitted when the event has no entity."))
+                .Prop("context", Schema::String().Desc("Scene name / asset path / script name; omitted when empty."))
+                .Prop("data", Schema::Object().Desc("Structured payload, present for the automation-bus categories only. scene_save: {scene, path, changed}; scene_dirty: {scene, dirty}; asset_import: {asset, type, handle, source}; compile_finished: {kind, target, ok, errors, warnings, seconds}; command_completed: {command, ok, durationMs, projectWrite, toolset}. Identities only — never a command's arguments or result."));
+        }
+
+        Schema::Node CategoriesFilterSchema()
+        {
+            return Schema::Array(Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error", "scene_save", "scene_dirty", "asset_import", "compile_finished", "command_completed" }))
+                .Desc("Only return events whose category is in this list. Omit for all categories.");
+        }
+
+        Schema::Node SinceIdSchema(const char* description)
+        {
+            return Schema::Raw(Json{ { "type", Json::array({ "integer", "string" }) } }).Min(0).Desc(description);
         }
 
     } // namespace
@@ -547,33 +640,67 @@ namespace OloEngine::MCP
             tool.Annotations = ReadOnlyAnnotations();
             tool.Description =
                 "Return the unified 'what just happened?' event timeline from the engine's diagnostics "
-                "ring buffer: scene loads, entering/leaving Play mode, runtime entity spawn/destroy, asset "
-                "hot-reloads, and script errors — newest last, each with a monotonic 'id'. The key use is "
-                "INCREMENTAL POLLING: do an action, then pass the previous call's 'lastId' as 'sinceId' to "
-                "get only what happened since. Filter with 'categories'. Bulk churn (scene-copy on Play, "
-                "deserialize on load) is collapsed into single scene_load/play events, not per-entity spam.";
+                "ring buffer: scene loads and saves, unsaved-changes edges, entering/leaving Play mode, "
+                "runtime entity spawn/destroy, asset imports and hot-reloads, script errors, build / script / "
+                "shader compiles finishing, and automation commands completing — newest last, each with a "
+                "monotonic 'id'. The key use is INCREMENTAL POLLING: do an action, then pass the previous "
+                "call's 'lastId' as 'sinceId' to get only what happened since; 'dropped' > 0 means the cursor "
+                "fell behind the 512-record window and that many records are gone. Filter with 'categories'. "
+                "To BLOCK for the next event instead of polling, use olo_events_wait. Bulk churn (scene-copy on "
+                "Play, deserialize on load) is collapsed into single scene_load/play events, not per-entity spam.";
             tool.InputSchema = Schema::Object()
                                    .Prop("count", Schema::Int().Min(1).Max(500).Desc("How many of the most recent matching events to return (default 50)."))
-                                   .Prop("sinceId", Schema::Raw(Json{ { "type", Json::array({ "integer", "string" }) } })
-                                                        .Min(0)
-                                                        .Desc("Only return events with id greater than this. Accepts the id as a number or its string form (for large cursors beyond JSON integer precision). Pass back the previous response's 'lastId' for incremental polling."))
-                                   .Prop("categories", Schema::Array(Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error" }))
-                                                           .Desc("Only return events whose category is in this list. Omit for all categories."))
+                                   .Prop("sinceId", SinceIdSchema("Only return events with id greater than this. Accepts the id as a number or its string form (for large cursors beyond JSON integer precision). Pass back the previous response's 'lastId' for incremental polling."))
+                                   .Prop("categories", CategoriesFilterSchema())
                                    .NoAdditional();
             tool.OutputSchema = Schema::Object()
                                     .Prop("count", Schema::Int().Min(0))
                                     .Prop("lastId", Schema::Int().Min(0).Desc("Highest event id in the buffer at snapshot time (0 when nothing was ever recorded) — pass back as the next call's sinceId; valid even when no events matched."))
-                                    .Prop("events", Schema::Array(Schema::Object()
-                                                                      .Prop("id", Schema::Int().Min(0))
-                                                                      .Prop("category", Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error" }))
-                                                                      .Prop("time", Schema::String().Desc("UTC wall-clock HH:MM:SS.mmm; omitted when the event carries no timestamp."))
-                                                                      .Prop("message", Schema::String())
-                                                                      .Prop("entity", Schema::String().Desc("Entity UUID as a decimal string (u64 — beyond JSON integer precision); omitted when the event has no entity."))
-                                                                      .Prop("context", Schema::String().Desc("Scene name / asset path / script name; omitted when empty.")))
-                                                        .Desc("Matching events, oldest first, newest last."))
-                                    .Required({ "count", "lastId", "events" });
+                                    .Prop("dropped", Schema::Int().Min(0).Desc("Records above sinceId that were evicted from the ring before this call; 0 unless the cursor fell behind the 512-record window."))
+                                    .Prop("events", Schema::Array(EventEntrySchema()).Desc("Matching events, oldest first, newest last."))
+                                    .Required({ "count", "lastId", "dropped", "events" });
             tool.MainMarshaled = false;
             tool.Handler = Handle_EventsTail;
+            registry.Register(std::move(tool));
+        }
+
+        {
+            ToolDef tool;
+            tool.Name = "olo_events_wait";
+            tool.Toolset = "diagnostics";
+            tool.Title = "Wait for diagnostics events";
+            tool.Annotations = ReadOnlyAnnotations();
+            // THE SUBSCRIPTION COMMAND of the automation event bus (#1131). A read at
+            // the authority of any read-only command — see AutomationEvents.h for
+            // why that is sound (identity-only payloads) — and deliberately NOT a
+            // completion-event source itself: EmitsCompletionEvent excludes
+            // read-only commands, or two waiting agents would wake each other
+            // forever.
+            tool.Description =
+                "BLOCK until the next matching diagnostics event, then return it — the subscription half of "
+                "olo_events_tail, for an agent that would otherwise poll. Returns as soon as at least one event "
+                "with id > 'sinceId' matches 'categories' (all such, oldest first, up to 'count'), or after "
+                "'waitMs' with count 0 and timedOut true. Omit 'sinceId' to wait for events NEWER than this call; "
+                "to not miss one that lands between your action and this call, take 'lastId' from a call made "
+                "BEFORE the action and pass it as 'sinceId'. The response's 'lastId' is always the cursor for the "
+                "next call. Runs on the handler thread only, so waiting never stalls the editor; cancel the call "
+                "to stop early. 'dropped' > 0 means the cursor fell behind the 512-record window.";
+            tool.InputSchema = Schema::Object()
+                                   .Prop("sinceId", SinceIdSchema("Wait for events with id greater than this. Omit to wait for events newer than the call. Accepts a number or its decimal string form."))
+                                   .Prop("categories", CategoriesFilterSchema())
+                                   .Prop("waitMs", Schema::Int().Min(0).Max(60000).Desc("How long to wait for a match before returning empty (default 10000, max 60000). 0 returns immediately, like olo_events_tail."))
+                                   .Prop("count", Schema::Int().Min(1).Max(500).Desc("Cap on how many matching events to return (default 100)."))
+                                   .NoAdditional();
+            tool.OutputSchema = Schema::Object()
+                                    .Prop("count", Schema::Int().Min(0))
+                                    .Prop("lastId", Schema::Int().Min(0).Desc("The cursor for the next call — valid whether or not anything matched."))
+                                    .Prop("dropped", Schema::Int().Min(0).Desc("Records above sinceId evicted before this call could return them; 0 unless the cursor fell behind the 512-record window."))
+                                    .Prop("timedOut", Schema::Bool().Desc("True when waitMs elapsed with no match."))
+                                    .Prop("cancelled", Schema::Bool().Desc("True when the call was cancelled before a match."))
+                                    .Prop("events", Schema::Array(EventEntrySchema()).Desc("Matching events, oldest first, newest last."))
+                                    .Required({ "count", "lastId", "dropped", "timedOut", "cancelled", "events" });
+            tool.MainMarshaled = false;
+            tool.Handler = Handle_EventsWait;
             registry.Register(std::move(tool));
         }
     }

--- a/OloEditor/src/MCP/McpToolsDiagnostics.cpp
+++ b/OloEditor/src/MCP/McpToolsDiagnostics.cpp
@@ -8,6 +8,7 @@
 #include "MCP/McpEventStream.h"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -350,23 +351,42 @@ namespace OloEngine::MCP
 
             if (args.contains("sinceId"))
             {
-                hasSinceId = true;
+                // A cursor that is present but malformed is REFUSED, never
+                // reinterpreted: "-1" read as 0 would turn a wait for what happens
+                // next into a dump of the whole ring, and stoull would read "-1" as
+                // ULLONG_MAX (a wait that can never match) and "12abc" as 12.
                 const Json& since = args["sinceId"];
+                constexpr const char* kBadCursor =
+                    "Invalid 'sinceId': expected a non-negative integer (an event id) or its decimal string form.";
                 if (since.is_number_unsigned())
+                {
                     query.SinceId = since.get<u64>();
-                else if (since.is_number_integer() && since.get<long long>() > 0)
-                    query.SinceId = static_cast<u64>(since.get<long long>());
+                }
+                else if (since.is_number_integer())
+                {
+                    // A signed integer (how a C++ int reaches nlohmann) is fine
+                    // when it is not negative.
+                    const auto signedId = since.get<long long>();
+                    if (signedId < 0)
+                        return kBadCursor;
+                    query.SinceId = static_cast<u64>(signedId);
+                }
                 else if (since.is_string())
                 {
-                    try
-                    {
-                        query.SinceId = std::stoull(since.get<std::string>());
-                    }
-                    catch (...)
-                    {
-                        return "Invalid 'sinceId': expected a non-negative integer (an event id).";
-                    }
+                    const std::string text = since.get<std::string>();
+                    u64 parsed = 0;
+                    const char* const first = text.data();
+                    const char* const last = first + text.size();
+                    const auto [ptr, ec] = std::from_chars(first, last, parsed);
+                    if (text.empty() || ec != std::errc{} || ptr != last)
+                        return kBadCursor;
+                    query.SinceId = parsed;
                 }
+                else
+                {
+                    return kBadCursor;
+                }
+                hasSinceId = true;
             }
 
             if (args.contains("categories") && args["categories"].is_array())
@@ -433,20 +453,32 @@ namespace OloEngine::MCP
         ToolResult Handle_EventsWait(IAutomationHost& host, const Json& args)
         {
             DiagnosticEventQuery query;
-            query.MaxCount = 100;
             bool hasSinceId = false;
             if (const std::string error = ParseEventQueryArgs(args, query, hasSinceId); !error.empty())
                 return ToolResult::Error(error);
             if (!hasSinceId)
                 query.SinceId = DiagnosticsEventLog::Get().LastId();
 
+            // The cap keeps the OLDEST matches, not the newest as a tail does: a
+            // subscription promises "everything after your cursor, in order", so
+            // when a burst outgrows `count` the caller gets its head and a cursor
+            // that stops at the last record delivered — never a cursor past
+            // records it was not shown.
+            const std::size_t count = args.contains("count") ? query.MaxCount : 100;
+            query.MaxCount = 0;
+
             long long waitMs = 10000;
             if (args.contains("waitMs") && args["waitMs"].is_number_integer())
                 waitMs = std::clamp<long long>(args["waitMs"].get<long long>(), 0, 60000);
 
-            const DiagnosticEventQueryResult result = DiagnosticsEventLog::Get().WaitWithCursor(
+            DiagnosticEventQueryResult result = DiagnosticsEventLog::Get().WaitWithCursor(
                 query, std::chrono::milliseconds(waitMs), [&host]
                 { return host.IsCurrentCallCancelled(); });
+            if (result.Events.size() > count)
+            {
+                result.Events.resize(count);
+                result.LastId = result.Events.back().Id;
+            }
 
             Json out = EventQueryResultJson(result);
             const bool cancelled = host.IsCurrentCallCancelled();
@@ -461,7 +493,7 @@ namespace OloEngine::MCP
         {
             return Schema::Object()
                 .Prop("id", Schema::Int().Min(0))
-                .Prop("category", Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error", "scene_save", "scene_dirty", "asset_import", "compile_finished", "command_completed" }))
+                .Prop("category", Schema::String().EnumFrom(DiagnosticEvent::AllCategoryTokens()))
                 .Prop("time", Schema::String().Desc("UTC wall-clock HH:MM:SS.mmm; omitted when the event carries no timestamp."))
                 .Prop("message", Schema::String())
                 .Prop("entity", Schema::String().Desc("Entity UUID as a decimal string (u64 — beyond JSON integer precision); omitted when the event has no entity."))
@@ -471,7 +503,7 @@ namespace OloEngine::MCP
 
         Schema::Node CategoriesFilterSchema()
         {
-            return Schema::Array(Schema::String().Enum({ "scene_load", "play", "stop", "entity_spawn", "entity_destroy", "asset_reload", "script_error", "scene_save", "scene_dirty", "asset_import", "compile_finished", "command_completed" }))
+            return Schema::Array(Schema::String().EnumFrom(DiagnosticEvent::AllCategoryTokens()))
                 .Desc("Only return events whose category is in this list. Omit for all categories.");
         }
 
@@ -689,11 +721,11 @@ namespace OloEngine::MCP
                                    .Prop("sinceId", SinceIdSchema("Wait for events with id greater than this. Omit to wait for events newer than the call. Accepts a number or its decimal string form."))
                                    .Prop("categories", CategoriesFilterSchema())
                                    .Prop("waitMs", Schema::Int().Min(0).Max(60000).Desc("How long to wait for a match before returning empty (default 10000, max 60000). 0 returns immediately, like olo_events_tail."))
-                                   .Prop("count", Schema::Int().Min(1).Max(500).Desc("Cap on how many matching events to return (default 100)."))
+                                   .Prop("count", Schema::Int().Min(1).Max(500).Desc("Cap on how many matching events to return (default 100). Keeps the OLDEST matches and moves 'lastId' back to the last one returned, so nothing is skipped."))
                                    .NoAdditional();
             tool.OutputSchema = Schema::Object()
                                     .Prop("count", Schema::Int().Min(0))
-                                    .Prop("lastId", Schema::Int().Min(0).Desc("The cursor for the next call — valid whether or not anything matched."))
+                                    .Prop("lastId", Schema::Int().Min(0).Desc("The cursor for the next call — valid whether or not anything matched. When 'count' truncated a burst it is the id of the LAST EVENT RETURNED, so resuming from it delivers the rest."))
                                     .Prop("dropped", Schema::Int().Min(0).Desc("Records above sinceId evicted before this call could return them; 0 unless the cursor fell behind the 512-record window."))
                                     .Prop("timedOut", Schema::Bool().Desc("True when waitMs elapsed with no match."))
                                     .Prop("cancelled", Schema::Bool().Desc("True when the call was cancelled before a match."))

--- a/OloEditor/src/UndoRedo/EditorCommand.h
+++ b/OloEditor/src/UndoRedo/EditorCommand.h
@@ -418,6 +418,7 @@ namespace OloEngine
         void Clear()
         {
             RefuseInsideTransaction("Clear");
+            const DirtyEdge edge(*this); // a dirty document cleared is a clean-again edge
             m_UndoStack.clear();
             m_RedoStack.clear();
             m_Version = 0;

--- a/OloEditor/src/UndoRedo/EditorCommand.h
+++ b/OloEditor/src/UndoRedo/EditorCommand.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <deque>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -149,11 +150,22 @@ namespace OloEngine
       public:
         static constexpr std::size_t MaxHistorySize = 128;
 
+        // Called whenever IsDirty() flips, with the new value, after the mutation
+        // that flipped it is complete. The automation event bus (#1131) publishes
+        // a `scene_dirty` event from here; the editor wires it once for its scene
+        // history and leaves panel-local histories unwired. Runs on the thread
+        // that mutated the history (the main thread), synchronously, from a
+        // destructor: it must not re-enter this object and it must not throw
+        // (a throw would terminate the process, which is the honest outcome for
+        // a hook that cannot report a scene edit).
+        std::function<void(bool dirty)> OnDirtyChanged;
+
         // Document operations (new/save) establish a checkpoint that belongs to
         // their resulting document. Undo restores the outgoing document's exact
         // checkpoint; ordinary edits retain the existing save-point semantics.
         void Execute(std::unique_ptr<EditorCommand> command, bool markSaved = false)
         {
+            const DirtyEdge edge(*this);
             command->Execute();
             if (m_Transaction)
             {
@@ -174,7 +186,7 @@ namespace OloEngine
             m_RedoStack.clear();
             ++m_Version;
             if (markSaved)
-                MarkSaved();
+                MarkSavedInternal();
 
             // Limit history size
             while (m_UndoStack.size() > MaxHistorySize)
@@ -187,6 +199,7 @@ namespace OloEngine
         // Push a command that has already been applied (e.g. ImGui widget already changed the value)
         void PushAlreadyExecuted(std::unique_ptr<EditorCommand> command)
         {
+            const DirtyEdge edge(*this);
             if (m_Transaction)
             {
                 m_Transaction->Commands->Add(std::move(command));
@@ -214,6 +227,7 @@ namespace OloEngine
             {
                 return;
             }
+            const DirtyEdge edge(*this);
 
             // A guarded disk restore can refuse an external modification. Do
             // not remove its entry or alter dirty state when the command throws.
@@ -237,13 +251,14 @@ namespace OloEngine
             {
                 return;
             }
+            const DirtyEdge edge(*this);
 
             m_RedoStack.back().Command->Execute();
             auto entry = std::move(m_RedoStack.back());
             m_RedoStack.pop_back();
             ++m_Version;
             if (entry.PreviousSavePoint)
-                MarkSaved();
+                MarkSavedInternal();
             m_UndoStack.push_back(std::move(entry));
         }
 
@@ -269,8 +284,8 @@ namespace OloEngine
         // Save-point tracking for unsaved-changes detection
         void MarkSaved()
         {
-            m_SavePointVersion = m_Version;
-            m_SavePointValid = true;
+            const DirtyEdge edge(*this);
+            MarkSavedInternal();
         }
 
         [[nodiscard]] bool IsDirty() const
@@ -341,6 +356,7 @@ namespace OloEngine
         {
             if (!m_Transaction)
                 throw std::logic_error("CommitTransaction: no command-history transaction is open.");
+            const DirtyEdge edge(*this);
             Transaction scope = std::move(*m_Transaction);
             m_Transaction.reset();
 
@@ -348,7 +364,7 @@ namespace OloEngine
             if (scope.Commands->IsEmpty())
             {
                 if (markSaved)
-                    MarkSaved();
+                    MarkSavedInternal();
                 return;
             }
 
@@ -370,7 +386,7 @@ namespace OloEngine
             m_RedoStack.clear();
             ++m_Version;
             if (markSaved)
-                MarkSaved();
+                MarkSavedInternal();
 
             while (m_UndoStack.size() > MaxHistorySize)
             {
@@ -389,6 +405,7 @@ namespace OloEngine
         {
             if (!m_Transaction)
                 throw std::logic_error("RollbackTransaction: no command-history transaction is open.");
+            const DirtyEdge edge(*this);
             Transaction scope = std::move(*m_Transaction);
             m_Transaction.reset();
 
@@ -448,6 +465,53 @@ namespace OloEngine
                 throw std::logic_error(std::string(operation) + " is not allowed while a command-history transaction is open.");
         }
 
+        // Sets the save point without firing OnDirtyChanged. Every public
+        // mutation holds a DirtyEdge across its whole body and fires once at the
+        // end, so an Execute(markSaved) that dirties and immediately cleans in one
+        // call reports no edge at all -- the state a subscriber can observe never
+        // flipped.
+        void MarkSavedInternal()
+        {
+            m_SavePointVersion = m_Version;
+            m_SavePointValid = true;
+        }
+
+        // Samples IsDirty() on construction and fires OnDirtyChanged on
+        // destruction if it moved. Constructed as the first statement of every
+        // public mutation, so nested mutations (a save inside a transaction, a
+        // command whose Execute pushes a sub-command) collapse into the outermost
+        // edge. A mutation that is unwinding on an exception (a guarded undo that
+        // refused, say) fires nothing: the caller sees the throw, and the hook
+        // must not run from an unwinding frame.
+        class DirtyEdge
+        {
+          public:
+            explicit DirtyEdge(CommandHistory& history)
+                : m_History(history), m_WasDirty(history.IsDirty()), m_Depth(history.m_EdgeDepth++),
+                  m_Exceptions(std::uncaught_exceptions())
+            {
+            }
+            ~DirtyEdge()
+            {
+                --m_History.m_EdgeDepth;
+                if (m_Depth != 0 || std::uncaught_exceptions() != m_Exceptions)
+                    return;
+                const bool dirty = m_History.IsDirty();
+                if (dirty != m_WasDirty && m_History.OnDirtyChanged)
+                    m_History.OnDirtyChanged(dirty);
+            }
+            DirtyEdge(const DirtyEdge&) = delete;
+            DirtyEdge& operator=(const DirtyEdge&) = delete;
+            DirtyEdge(DirtyEdge&&) = delete;
+            DirtyEdge& operator=(DirtyEdge&&) = delete;
+
+          private:
+            CommandHistory& m_History;
+            bool m_WasDirty;
+            std::size_t m_Depth;
+            int m_Exceptions;
+        };
+
         void TrimSavePoint()
         {
             // When oldest entry is discarded, check if save point is still reachable
@@ -466,6 +530,7 @@ namespace OloEngine
         std::deque<Entry> m_RedoStack;
         std::optional<Transaction> m_Transaction;
         std::size_t m_Version = 0;
+        std::size_t m_EdgeDepth = 0; // see DirtyEdge
         std::size_t m_SavePointVersion = 0;
         bool m_SavePointValid = true;
     };

--- a/OloEngine/src/OloEngine/Debug/DiagnosticsEventLog.h
+++ b/OloEngine/src/OloEngine/Debug/DiagnosticsEventLog.h
@@ -12,18 +12,44 @@
 // analysis. The MCP `olo_events_tail` tool serializes the records; any reasoning is
 // left to the agent reading them.
 //
+// Since #1131 this ring is ALSO the automation event bus. Three things were added
+// and the rest is unchanged:
+//
+//   * five categories for the editor's own lifecycle (scene saved / dirtied, asset
+//     imported, compile finished, automation command completed), each carrying a
+//     small structured `Data` object built from a CLOSED key set — see
+//     DiagnosticEventDataKeys and the rule above it;
+//   * a condition variable, so a subscriber can BLOCK for the next matching event
+//     (WaitWithCursor) instead of polling a tail;
+//   * a reported gap: a query whose cursor has fallen behind the ring learns how
+//     many records it lost (DiagnosticEventQueryResult::Dropped) instead of
+//     receiving a silently shortened history.
+//
+// THE SUBSCRIPTION MODEL IS A CURSOR, NOT A QUEUE. Every consumer — a poller, a
+// long-poll wait, the MCP push stream, a CLI follow loop — holds an event id and
+// asks for what came after it. There is no per-subscriber buffer anywhere, so a
+// subscriber that stops reading costs this process nothing: the ring is the one
+// fixed window (kCapacity), the oldest records are evicted regardless of who has
+// read them, and a consumer that resumes past the window is told the count it
+// missed. That is the whole backpressure answer #1131 asked for, and it is why a
+// separate "event bus" object was not built over this one.
+//
 // Header-only with an inline singleton: OloEngine is a static library, so the single
 // function-local static is shared across every translation unit in the final binary
 // (engine seams write it, the editor's MCP layer reads it).
 
+#include "OloEngine/Core/Assert.h"
 #include "OloEngine/Core/Base.h"
 
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
+#include <cstdio>
 #include <deque>
 #include <mutex>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -40,10 +66,219 @@ namespace OloEngine
         EntityDestroy,
         AssetReload,
         ScriptError,
+        // ---- automation event bus (#1131) ----------------------------------
+        SceneSave,        // the authored scene was written to disk (editor menu or olo_scene_save*).
+        SceneDirty,       // the scene's unsaved-changes state flipped; Data.dirty says which way.
+        AssetImport,      // an asset was registered (file-watch auto-import or olo_asset_import).
+        CompileFinished,  // a build target, script assembly or shader (re)compile ended; Data.ok says how.
+        CommandCompleted, // a mutating automation command ran (see AutomationEvents.h for the rule).
     };
 
     // Keep in sync with DiagnosticEventCategory; used to validate the enum/string maps.
-    inline constexpr std::size_t kDiagnosticEventCategoryCount = 7;
+    inline constexpr std::size_t kDiagnosticEventCategoryCount = 12;
+
+    // THE PAYLOAD RULE (#1131 design constraint: "an event subscription is an
+    // authority-bearing capability, not a free read: events can leak state a read
+    // tool would have gated").
+    //
+    // An event carries the IDENTITY of what happened — a command name, a scene
+    // name, a project-relative path, an entity id, an outcome — and never the
+    // CONTENT a read command would return for it: no arguments, no results, no
+    // serialized scene, no file bytes, no absolute paths. The content is exactly
+    // what a gated read protects; keep it out of the event and a subscription can
+    // honestly be offered at the authority of any read-only command (a bearer
+    // token, and nothing more — which is also what lets a read-only frontend like
+    // oloctl follow the stream).
+    //
+    // Enforced mechanically, not by review: the keys a category may carry are a
+    // closed set below, Record() refuses anything else, and every string value is
+    // truncated at kMaxDataValueChars so a payload physically cannot hold a
+    // document. Adding a key is a deliberate edit to this table, in a diff.
+    [[nodiscard]] inline std::span<const std::string_view> DiagnosticEventDataKeys(DiagnosticEventCategory category)
+    {
+        using namespace std::string_view_literals;
+        static constexpr std::string_view kSceneSave[] = { "scene"sv, "path"sv, "changed"sv };
+        static constexpr std::string_view kSceneDirty[] = { "scene"sv, "dirty"sv };
+        static constexpr std::string_view kAssetImport[] = { "asset"sv, "type"sv, "handle"sv, "source"sv };
+        static constexpr std::string_view kCompileFinished[] = { "kind"sv, "target"sv, "ok"sv,
+                                                                 "errors"sv, "warnings"sv, "seconds"sv };
+        static constexpr std::string_view kCommandCompleted[] = { "command"sv, "ok"sv, "durationMs"sv, "projectWrite"sv,
+                                                                  "toolset"sv };
+        switch (category)
+        {
+            case DiagnosticEventCategory::SceneSave:
+                return kSceneSave;
+            case DiagnosticEventCategory::SceneDirty:
+                return kSceneDirty;
+            case DiagnosticEventCategory::AssetImport:
+                return kAssetImport;
+            case DiagnosticEventCategory::CompileFinished:
+                return kCompileFinished;
+            case DiagnosticEventCategory::CommandCompleted:
+                return kCommandCompleted;
+            case DiagnosticEventCategory::SceneLoad:
+            case DiagnosticEventCategory::Play:
+            case DiagnosticEventCategory::Stop:
+            case DiagnosticEventCategory::EntitySpawn:
+            case DiagnosticEventCategory::EntityDestroy:
+            case DiagnosticEventCategory::AssetReload:
+            case DiagnosticEventCategory::ScriptError:
+                break;
+        }
+        return {};
+    }
+
+    // Builds the structured `Data` object of one event as compact JSON text, without
+    // pulling a JSON library into this engine-core header. Values are strings,
+    // booleans and numbers only — no nesting, by design (see the payload rule).
+    // Duplicate keys keep the last value. String values longer than
+    // kMaxDataValueChars are cut and end in "..." so the truncation is visible.
+    class DiagnosticEventData
+    {
+      public:
+        static constexpr std::size_t kMaxDataValueChars = 256;
+
+        DiagnosticEventData& Set(std::string_view key, std::string_view value)
+        {
+            std::string text = value.size() > kMaxDataValueChars
+                                   ? std::string(value.substr(0, kMaxDataValueChars)) + "..."
+                                   : std::string(value);
+            return Put(key, "\"" + Escape(text) + "\"");
+        }
+        DiagnosticEventData& Set(std::string_view key, const char* value)
+        {
+            return Set(key, std::string_view(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, const std::string& value)
+        {
+            return Set(key, std::string_view(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, bool value)
+        {
+            return Put(key, value ? "true" : "false");
+        }
+        DiagnosticEventData& Set(std::string_view key, u64 value)
+        {
+            return Put(key, std::to_string(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, i64 value)
+        {
+            return Put(key, std::to_string(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, int value)
+        {
+            return Put(key, std::to_string(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, u32 value)
+        {
+            return Put(key, std::to_string(value));
+        }
+        DiagnosticEventData& Set(std::string_view key, f64 value)
+        {
+            // JSON has no NaN/Inf; a non-finite measurement is reported as null
+            // rather than as a token no parser accepts.
+            if (!(value == value) || value > 1.7976931348623157e308 || value < -1.7976931348623157e308)
+                return Put(key, "null");
+            char buffer[32];
+            std::snprintf(buffer, sizeof(buffer), "%.6g", value);
+            return Put(key, buffer);
+        }
+
+        [[nodiscard]] bool Empty() const
+        {
+            return m_Fields.empty();
+        }
+
+        // The keys set so far, in insertion order. Record() checks them against the
+        // category's closed set.
+        [[nodiscard]] std::vector<std::string_view> Keys() const
+        {
+            std::vector<std::string_view> keys;
+            keys.reserve(m_Fields.size());
+            for (const auto& [key, value] : m_Fields)
+                keys.push_back(key);
+            return keys;
+        }
+
+        // Compact JSON object text, or "" when nothing was set.
+        [[nodiscard]] std::string Build() const
+        {
+            if (m_Fields.empty())
+                return {};
+            std::string out = "{";
+            for (std::size_t i = 0; i < m_Fields.size(); ++i)
+            {
+                if (i != 0)
+                    out += ',';
+                out += '"';
+                out += m_Fields[i].first;
+                out += "\":";
+                out += m_Fields[i].second;
+            }
+            out += '}';
+            return out;
+        }
+
+        // Minimal JSON string escaping: quotes, backslashes and control characters.
+        // Non-ASCII UTF-8 passes through untouched, which JSON permits.
+        [[nodiscard]] static std::string Escape(std::string_view text)
+        {
+            std::string out;
+            out.reserve(text.size() + 8);
+            for (const char c : text)
+            {
+                const auto byte = static_cast<unsigned char>(c);
+                switch (c)
+                {
+                    case '"':
+                        out += "\\\"";
+                        break;
+                    case '\\':
+                        out += "\\\\";
+                        break;
+                    case '\n':
+                        out += "\\n";
+                        break;
+                    case '\r':
+                        out += "\\r";
+                        break;
+                    case '\t':
+                        out += "\\t";
+                        break;
+                    default:
+                        if (byte < 0x20)
+                        {
+                            char buffer[8];
+                            std::snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned>(byte));
+                            out += buffer;
+                        }
+                        else
+                        {
+                            out += c;
+                        }
+                        break;
+                }
+            }
+            return out;
+        }
+
+      private:
+        DiagnosticEventData& Put(std::string_view key, std::string encoded)
+        {
+            for (auto& [existing, value] : m_Fields)
+            {
+                if (existing == key)
+                {
+                    value = std::move(encoded);
+                    return *this;
+                }
+            }
+            m_Fields.emplace_back(std::string(key), std::move(encoded));
+            return *this;
+        }
+
+        std::vector<std::pair<std::string, std::string>> m_Fields;
+    };
 
     struct DiagnosticEvent
     {
@@ -53,6 +288,11 @@ namespace OloEngine
         std::string Message; // short human-readable summary (always present).
         u64 Entity = 0;      // optional entity UUID value; 0 = not applicable.
         std::string Context; // optional structured secondary field: scene name / asset path / script name.
+        // Optional structured payload as compact JSON object text (see
+        // DiagnosticEventData), empty for the categories that carry none. Serialized
+        // under `data` by the MCP carriers; a consumer that only knows the six older
+        // fields still reads every record.
+        std::string Data;
 
         // Stable snake_case token used in MCP output and accepted by the category filter.
         [[nodiscard]] static const char* CategoryToString(DiagnosticEventCategory category)
@@ -73,6 +313,16 @@ namespace OloEngine
                     return "asset_reload";
                 case DiagnosticEventCategory::ScriptError:
                     return "script_error";
+                case DiagnosticEventCategory::SceneSave:
+                    return "scene_save";
+                case DiagnosticEventCategory::SceneDirty:
+                    return "scene_dirty";
+                case DiagnosticEventCategory::AssetImport:
+                    return "asset_import";
+                case DiagnosticEventCategory::CompileFinished:
+                    return "compile_finished";
+                case DiagnosticEventCategory::CommandCompleted:
+                    return "command_completed";
             }
             return "unknown";
         }
@@ -95,9 +345,44 @@ namespace OloEngine
                 out = DiagnosticEventCategory::AssetReload;
             else if (name == "script_error")
                 out = DiagnosticEventCategory::ScriptError;
+            else if (name == "scene_save")
+                out = DiagnosticEventCategory::SceneSave;
+            else if (name == "scene_dirty")
+                out = DiagnosticEventCategory::SceneDirty;
+            else if (name == "asset_import")
+                out = DiagnosticEventCategory::AssetImport;
+            else if (name == "compile_finished")
+                out = DiagnosticEventCategory::CompileFinished;
+            else if (name == "command_completed")
+                out = DiagnosticEventCategory::CommandCompleted;
             else
                 return false;
             return true;
+        }
+
+        // Every category token, in enum order — the single list the filters' error
+        // messages and the tools' schemas are generated from, so a new category
+        // cannot be accepted by the parser and missing from the documentation.
+        [[nodiscard]] static std::span<const std::string_view> AllCategoryTokens()
+        {
+            using namespace std::string_view_literals;
+            static constexpr std::string_view kTokens[] = {
+                "scene_load"sv,
+                "play"sv,
+                "stop"sv,
+                "entity_spawn"sv,
+                "entity_destroy"sv,
+                "asset_reload"sv,
+                "script_error"sv,
+                "scene_save"sv,
+                "scene_dirty"sv,
+                "asset_import"sv,
+                "compile_finished"sv,
+                "command_completed"sv,
+            };
+            static_assert(std::size(kTokens) == kDiagnosticEventCategoryCount,
+                          "AllCategoryTokens must list every DiagnosticEventCategory");
+            return kTokens;
         }
     };
 
@@ -118,6 +403,13 @@ namespace OloEngine
     {
         std::vector<DiagnosticEvent> Events;
         u64 LastId = 0; // highest Id assigned at snapshot time (0 if nothing recorded).
+        // How many records with an Id above SinceId were EVICTED before this query
+        // could return them — the gap a cursor that fell behind the ring is told
+        // about, counted before the category filter (an evicted record's category is
+        // unknown). Always 0 for a query with no cursor (SinceId == 0), which asks
+        // for the newest N by construction. A consumer that sees a non-zero value
+        // has lost history and should say so rather than continue as if complete.
+        u64 Dropped = 0;
     };
 
     class DiagnosticsEventLog
@@ -132,10 +424,34 @@ namespace OloEngine
         // Append an event, assigning it a monotonic Id and a wall-clock timestamp.
         // Returns the assigned Id, or 0 when suppressed (see SuppressScope) — the
         // suppression check happens before the lock, so bulk operations pay nothing.
+        // Wakes every WaitWithCursor blocked on the ring.
         u64 Record(DiagnosticEventCategory category, std::string message, u64 entity = 0, std::string context = {})
+        {
+            return Record(category, std::move(message), entity, std::move(context), DiagnosticEventData{});
+        }
+
+        // As above, with a structured payload. The payload's keys MUST all be in
+        // DiagnosticEventDataKeys(category); a key outside the closed set is a
+        // programmer error and the record is refused loudly (assert) rather than
+        // written with the key silently dropped — the payload rule is only worth
+        // anything if it cannot be bypassed by a typo.
+        u64 Record(DiagnosticEventCategory category, std::string message, u64 entity, std::string context,
+                   const DiagnosticEventData& data)
         {
             if (m_SuppressDepth.load(std::memory_order_relaxed) > 0)
                 return 0;
+
+            const std::span<const std::string_view> allowed = DiagnosticEventDataKeys(category);
+            for (const std::string_view key : data.Keys())
+            {
+                const bool permitted = std::find(allowed.begin(), allowed.end(), key) != allowed.end();
+                OLO_CORE_ASSERT(permitted,
+                                "[DiagnosticsEventLog] Event data key '{}' is not in the closed key set of "
+                                "category '{}' (see DiagnosticEventDataKeys). Record refused.",
+                                key, DiagnosticEvent::CategoryToString(category));
+                if (!permitted)
+                    return 0;
+            }
 
             DiagnosticEvent event;
             event.Timestamp = std::chrono::duration<f64>(std::chrono::system_clock::now().time_since_epoch()).count();
@@ -143,13 +459,20 @@ namespace OloEngine
             event.Message = std::move(message);
             event.Entity = entity;
             event.Context = std::move(context);
+            event.Data = data.Build();
 
-            std::lock_guard lock(m_Mutex);
-            event.Id = m_NextId++;
-            const u64 assignedId = event.Id;
-            m_Events.push_back(std::move(event));
-            while (m_Events.size() > kCapacity)
-                m_Events.pop_front();
+            u64 assignedId = 0;
+            {
+                std::lock_guard lock(m_Mutex);
+                event.Id = m_NextId++;
+                assignedId = event.Id;
+                m_Events.push_back(std::move(event));
+                while (m_Events.size() > kCapacity)
+                    m_Events.pop_front();
+            }
+            // Outside the lock: a waiter that wakes and immediately re-locks must not
+            // contend with the thread that woke it.
+            m_Changed.notify_all();
             return assignedId;
         }
 
@@ -168,7 +491,38 @@ namespace OloEngine
         [[nodiscard]] DiagnosticEventQueryResult QueryWithCursor(const DiagnosticEventQuery& query) const
         {
             std::lock_guard lock(m_Mutex);
-            return DiagnosticEventQueryResult{ QueryLocked(query), m_NextId - 1 };
+            return QueryWithCursorLocked(query);
+        }
+
+        // The long-poll subscription primitive (#1131). Blocks the calling thread
+        // until at least one event matches `query`, `timeout` elapses, or
+        // `cancelled()` returns true, and returns the same consistent snapshot
+        // QueryWithCursor would — so a caller that times out still gets the cursor to
+        // resume from, and one that matches gets every match recorded so far, not
+        // just the one that woke it.
+        //
+        // `cancelled` is polled at most every kWaitSlice while blocked, and is called
+        // WITH the ring's mutex held: it must be cheap and must not touch this log
+        // (an atomic flag read is the intended shape — a call scope's cancellation
+        // token). Never call from the game thread: the thread that records is the
+        // one this would wait on.
+        template<typename Cancelled>
+        [[nodiscard]] DiagnosticEventQueryResult WaitWithCursor(const DiagnosticEventQuery& query,
+                                                                std::chrono::milliseconds timeout,
+                                                                Cancelled&& cancelled) const
+        {
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            std::unique_lock lock(m_Mutex);
+            for (;;)
+            {
+                DiagnosticEventQueryResult result = QueryWithCursorLocked(query);
+                if (!result.Events.empty())
+                    return result;
+                const auto now = std::chrono::steady_clock::now();
+                if (now >= deadline || cancelled())
+                    return result;
+                m_Changed.wait_until(lock, std::min(deadline, now + kWaitSlice));
+            }
         }
 
         // Highest Id assigned so far (0 if nothing recorded). Lets a poller learn the
@@ -181,9 +535,12 @@ namespace OloEngine
 
         void Clear()
         {
-            std::lock_guard lock(m_Mutex);
-            m_Events.clear();
-            m_NextId = 1;
+            {
+                std::lock_guard lock(m_Mutex);
+                m_Events.clear();
+                m_NextId = 1;
+            }
+            m_Changed.notify_all();
         }
 
         // RAII suppression: Record() is a no-op while any scope is alive. Used to mute
@@ -208,8 +565,15 @@ namespace OloEngine
             SuppressScope& operator=(SuppressScope&&) = delete;
         };
 
+        // The ring's fixed window. Public so a consumer can state it ("the newest
+        // 512") instead of guessing.
+        static constexpr std::size_t kCapacity = 512;
+
       private:
         DiagnosticsEventLog() = default;
+
+        // How often a blocked WaitWithCursor re-checks its cancellation token.
+        static constexpr std::chrono::milliseconds kWaitSlice{ 250 };
 
         // Shared filter for Query / QueryWithCursor. Caller must hold m_Mutex (m_Mutex
         // is not recursive). Oldest-first; SinceId lower bound, then category filter,
@@ -232,8 +596,22 @@ namespace OloEngine
             return matched;
         }
 
-        static constexpr std::size_t kCapacity = 512;
+        [[nodiscard]] DiagnosticEventQueryResult QueryWithCursorLocked(const DiagnosticEventQuery& query) const
+        {
+            DiagnosticEventQueryResult result{ QueryLocked(query), m_NextId - 1, 0 };
+            if (query.SinceId != 0)
+            {
+                // The first id still retained. An empty ring means no gap: only
+                // Clear() empties it, and Clear() restarts the ids.
+                const u64 oldestRetained = m_Events.empty() ? m_NextId : m_Events.front().Id;
+                if (oldestRetained > query.SinceId + 1)
+                    result.Dropped = oldestRetained - query.SinceId - 1;
+            }
+            return result;
+        }
+
         mutable std::mutex m_Mutex;
+        mutable std::condition_variable m_Changed;
         std::deque<DiagnosticEvent> m_Events;
         u64 m_NextId = 1;
         std::atomic<u32> m_SuppressDepth{ 0 };

--- a/OloEngine/src/OloEngine/Debug/DiagnosticsEventLog.h
+++ b/OloEngine/src/OloEngine/Debug/DiagnosticsEventLog.h
@@ -42,8 +42,10 @@
 #include "OloEngine/Core/Base.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdio>
@@ -74,8 +76,28 @@ namespace OloEngine
         CommandCompleted, // a mutating automation command ran (see AutomationEvents.h for the rule).
     };
 
+    // Every category's stable snake_case token, indexed by the enum value. THE ONE
+    // spelling: CategoryToString and CategoryFromString read this table, the tool
+    // schemas' enums are generated from it, and the exhaustiveness tests compare
+    // the enum against it — so a category cannot be parseable, listable and
+    // documented in different sets.
+    inline constexpr std::array<std::string_view, 12> kDiagnosticEventCategoryTokens{
+        "scene_load",
+        "play",
+        "stop",
+        "entity_spawn",
+        "entity_destroy",
+        "asset_reload",
+        "script_error",
+        "scene_save",
+        "scene_dirty",
+        "asset_import",
+        "compile_finished",
+        "command_completed",
+    };
+
     // Keep in sync with DiagnosticEventCategory; used to validate the enum/string maps.
-    inline constexpr std::size_t kDiagnosticEventCategoryCount = 12;
+    inline constexpr std::size_t kDiagnosticEventCategoryCount = kDiagnosticEventCategoryTokens.size();
 
     // THE PAYLOAD RULE (#1131 design constraint: "an event subscription is an
     // authority-bearing capability, not a free read: events can leak state a read
@@ -132,7 +154,8 @@ namespace OloEngine
     // pulling a JSON library into this engine-core header. Values are strings,
     // booleans and numbers only — no nesting, by design (see the payload rule).
     // Duplicate keys keep the last value. String values longer than
-    // kMaxDataValueChars are cut and end in "..." so the truncation is visible.
+    // kMaxDataValueChars are cut (on a UTF-8 character boundary, so the text stays
+    // valid) and end in "..." so the truncation is visible.
     class DiagnosticEventData
     {
       public:
@@ -140,9 +163,20 @@ namespace OloEngine
 
         DiagnosticEventData& Set(std::string_view key, std::string_view value)
         {
-            std::string text = value.size() > kMaxDataValueChars
-                                   ? std::string(value.substr(0, kMaxDataValueChars)) + "..."
-                                   : std::string(value);
+            std::string text;
+            if (value.size() > kMaxDataValueChars)
+            {
+                // Back off from the cut point over UTF-8 continuation bytes so a
+                // multi-byte character is dropped whole rather than split.
+                std::size_t cut = kMaxDataValueChars;
+                while (cut > 0 && (static_cast<unsigned char>(value[cut]) & 0xC0u) == 0x80u)
+                    --cut;
+                text = std::string(value.substr(0, cut)) + "...";
+            }
+            else
+            {
+                text = std::string(value);
+            }
             return Put(key, "\"" + Escape(text) + "\"");
         }
         DiagnosticEventData& Set(std::string_view key, const char* value)
@@ -177,7 +211,7 @@ namespace OloEngine
         {
             // JSON has no NaN/Inf; a non-finite measurement is reported as null
             // rather than as a token no parser accepts.
-            if (!(value == value) || value > 1.7976931348623157e308 || value < -1.7976931348623157e308)
+            if (!std::isfinite(value))
                 return Put(key, "null");
             char buffer[32];
             std::snprintf(buffer, sizeof(buffer), "%.6g", value);
@@ -206,14 +240,16 @@ namespace OloEngine
             if (m_Fields.empty())
                 return {};
             std::string out = "{";
-            for (std::size_t i = 0; i < m_Fields.size(); ++i)
+            bool first = true;
+            for (const auto& [key, encoded] : m_Fields)
             {
-                if (i != 0)
+                if (!first)
                     out += ',';
+                first = false;
                 out += '"';
-                out += m_Fields[i].first;
+                out += key;
                 out += "\":";
-                out += m_Fields[i].second;
+                out += encoded;
             }
             out += '}';
             return out;
@@ -297,92 +333,32 @@ namespace OloEngine
         // Stable snake_case token used in MCP output and accepted by the category filter.
         [[nodiscard]] static const char* CategoryToString(DiagnosticEventCategory category)
         {
-            switch (category)
-            {
-                case DiagnosticEventCategory::SceneLoad:
-                    return "scene_load";
-                case DiagnosticEventCategory::Play:
-                    return "play";
-                case DiagnosticEventCategory::Stop:
-                    return "stop";
-                case DiagnosticEventCategory::EntitySpawn:
-                    return "entity_spawn";
-                case DiagnosticEventCategory::EntityDestroy:
-                    return "entity_destroy";
-                case DiagnosticEventCategory::AssetReload:
-                    return "asset_reload";
-                case DiagnosticEventCategory::ScriptError:
-                    return "script_error";
-                case DiagnosticEventCategory::SceneSave:
-                    return "scene_save";
-                case DiagnosticEventCategory::SceneDirty:
-                    return "scene_dirty";
-                case DiagnosticEventCategory::AssetImport:
-                    return "asset_import";
-                case DiagnosticEventCategory::CompileFinished:
-                    return "compile_finished";
-                case DiagnosticEventCategory::CommandCompleted:
-                    return "command_completed";
-            }
-            return "unknown";
+            const auto index = static_cast<std::size_t>(category);
+            // The tokens are string literals, so data() is NUL-terminated.
+            return index < kDiagnosticEventCategoryTokens.size() ? kDiagnosticEventCategoryTokens[index].data()
+                                                                 : "unknown";
         }
 
         // Parse a category token (as emitted by CategoryToString). Returns false on a
         // value that does not name a category, so callers can reject bad filters.
         [[nodiscard]] static bool CategoryFromString(std::string_view name, DiagnosticEventCategory& out)
         {
-            if (name == "scene_load")
-                out = DiagnosticEventCategory::SceneLoad;
-            else if (name == "play")
-                out = DiagnosticEventCategory::Play;
-            else if (name == "stop")
-                out = DiagnosticEventCategory::Stop;
-            else if (name == "entity_spawn")
-                out = DiagnosticEventCategory::EntitySpawn;
-            else if (name == "entity_destroy")
-                out = DiagnosticEventCategory::EntityDestroy;
-            else if (name == "asset_reload")
-                out = DiagnosticEventCategory::AssetReload;
-            else if (name == "script_error")
-                out = DiagnosticEventCategory::ScriptError;
-            else if (name == "scene_save")
-                out = DiagnosticEventCategory::SceneSave;
-            else if (name == "scene_dirty")
-                out = DiagnosticEventCategory::SceneDirty;
-            else if (name == "asset_import")
-                out = DiagnosticEventCategory::AssetImport;
-            else if (name == "compile_finished")
-                out = DiagnosticEventCategory::CompileFinished;
-            else if (name == "command_completed")
-                out = DiagnosticEventCategory::CommandCompleted;
-            else
-                return false;
-            return true;
+            for (std::size_t index = 0; index < kDiagnosticEventCategoryTokens.size(); ++index)
+            {
+                if (kDiagnosticEventCategoryTokens[index] == name)
+                {
+                    out = static_cast<DiagnosticEventCategory>(index);
+                    return true;
+                }
+            }
+            return false;
         }
 
         // Every category token, in enum order — the single list the filters' error
-        // messages and the tools' schemas are generated from, so a new category
-        // cannot be accepted by the parser and missing from the documentation.
+        // messages and the tools' schemas are generated from.
         [[nodiscard]] static std::span<const std::string_view> AllCategoryTokens()
         {
-            using namespace std::string_view_literals;
-            static constexpr std::string_view kTokens[] = {
-                "scene_load"sv,
-                "play"sv,
-                "stop"sv,
-                "entity_spawn"sv,
-                "entity_destroy"sv,
-                "asset_reload"sv,
-                "script_error"sv,
-                "scene_save"sv,
-                "scene_dirty"sv,
-                "asset_import"sv,
-                "compile_finished"sv,
-                "command_completed"sv,
-            };
-            static_assert(std::size(kTokens) == kDiagnosticEventCategoryCount,
-                          "AllCategoryTokens must list every DiagnosticEventCategory");
-            return kTokens;
+            return kDiagnosticEventCategoryTokens;
         }
     };
 
@@ -422,9 +398,10 @@ namespace OloEngine
         }
 
         // Append an event, assigning it a monotonic Id and a wall-clock timestamp.
-        // Returns the assigned Id, or 0 when suppressed (see SuppressScope) — the
-        // suppression check happens before the lock, so bulk operations pay nothing.
-        // Wakes every WaitWithCursor blocked on the ring.
+        // Returns the assigned Id, or 0 when suppressed (see SuppressScope and
+        // SuppressCategoryScope) — the suppression checks happen before the lock,
+        // so bulk operations pay nothing. Wakes every WaitWithCursor blocked on
+        // the ring.
         u64 Record(DiagnosticEventCategory category, std::string message, u64 entity = 0, std::string context = {})
         {
             return Record(category, std::move(message), entity, std::move(context), DiagnosticEventData{});
@@ -439,6 +416,8 @@ namespace OloEngine
                    const DiagnosticEventData& data)
         {
             if (m_SuppressDepth.load(std::memory_order_relaxed) > 0)
+                return 0;
+            if (t_CategorySuppressDepth[static_cast<std::size_t>(category)] > 0)
                 return 0;
 
             const std::span<const std::string_view> allowed = DiagnosticEventDataKeys(category);
@@ -476,6 +455,30 @@ namespace OloEngine
             return assignedId;
         }
 
+        // A `compile_finished` record with EVERY declared key filled, whichever of
+        // the three compile paths (a build target, the script assembly, a shader
+        // library) reports it. Lives here rather than in the editor's publisher
+        // set because two of the three sites are engine code; the editor's
+        // Events::PublishCompileFinished forwards to it, so the record has one
+        // shape. `kind` is "build", "script" or "shader"; counts and seconds are
+        // 0 when a path does not measure them.
+        u64 RecordCompileFinished(std::string_view kind, std::string_view target, bool ok, u32 errors, u32 warnings,
+                                  f64 seconds)
+        {
+            DiagnosticEventData data;
+            data.Set("kind", kind)
+                .Set("target", target)
+                .Set("ok", ok)
+                .Set("errors", errors)
+                .Set("warnings", warnings)
+                .Set("seconds", seconds);
+            std::string message = std::string(kind) + " compile of '" + std::string(target) + "' " +
+                                  (ok ? "succeeded" : "FAILED");
+            if (errors != 0 || warnings != 0)
+                message += " (" + std::to_string(errors) + " errors, " + std::to_string(warnings) + " warnings)";
+            return Record(DiagnosticEventCategory::CompileFinished, std::move(message), 0, std::string(target), data);
+        }
+
         // Filtered read, returned oldest-first (newest event last). Applies, in order:
         // the SinceId lower bound, the category filter, then keeps the newest MaxCount.
         [[nodiscard]] std::vector<DiagnosticEvent> Query(const DiagnosticEventQuery& query) const
@@ -499,7 +502,9 @@ namespace OloEngine
         // `cancelled()` returns true, and returns the same consistent snapshot
         // QueryWithCursor would — so a caller that times out still gets the cursor to
         // resume from, and one that matches gets every match recorded so far, not
-        // just the one that woke it.
+        // just the one that woke it. The ring is re-scanned only when something was
+        // recorded since the last scan; a wake that only re-checks the deadline or
+        // the cancellation token costs nothing.
         //
         // `cancelled` is polled at most every kWaitSlice while blocked, and is called
         // WITH the ring's mutex held: it must be cheap and must not touch this log
@@ -513,15 +518,21 @@ namespace OloEngine
         {
             const auto deadline = std::chrono::steady_clock::now() + timeout;
             std::unique_lock lock(m_Mutex);
+            DiagnosticEventQueryResult result = QueryWithCursorLocked(query);
+            u64 scannedNextId = m_NextId;
             for (;;)
             {
-                DiagnosticEventQueryResult result = QueryWithCursorLocked(query);
                 if (!result.Events.empty())
                     return result;
                 const auto now = std::chrono::steady_clock::now();
                 if (now >= deadline || cancelled())
                     return result;
                 m_Changed.wait_until(lock, std::min(deadline, now + kWaitSlice));
+                if (m_NextId != scannedNextId)
+                {
+                    result = QueryWithCursorLocked(query);
+                    scannedNextId = m_NextId;
+                }
             }
         }
 
@@ -565,6 +576,34 @@ namespace OloEngine
             SuppressScope& operator=(SuppressScope&&) = delete;
         };
 
+        // RAII suppression of ONE category, on the calling thread only. A
+        // transaction (#1127) runs its steps through the registry on the main
+        // thread inside one marshaled job; each step would otherwise publish its
+        // own `command_completed` — up to 64 records that the batch's own
+        // completion already summarises, and enough to evict what a waiter is
+        // blocked on. Thread-local so a command completing on a handler thread
+        // meanwhile is unaffected. Nests by depth.
+        class SuppressCategoryScope
+        {
+          public:
+            explicit SuppressCategoryScope(DiagnosticEventCategory category)
+                : m_Index(static_cast<std::size_t>(category))
+            {
+                ++t_CategorySuppressDepth[m_Index];
+            }
+            ~SuppressCategoryScope()
+            {
+                --t_CategorySuppressDepth[m_Index];
+            }
+            SuppressCategoryScope(const SuppressCategoryScope&) = delete;
+            SuppressCategoryScope& operator=(const SuppressCategoryScope&) = delete;
+            SuppressCategoryScope(SuppressCategoryScope&&) = delete;
+            SuppressCategoryScope& operator=(SuppressCategoryScope&&) = delete;
+
+          private:
+            std::size_t m_Index;
+        };
+
         // The ring's fixed window. Public so a consumer can state it ("the newest
         // 512") instead of guessing.
         static constexpr std::size_t kCapacity = 512;
@@ -576,19 +615,26 @@ namespace OloEngine
         static constexpr std::chrono::milliseconds kWaitSlice{ 250 };
 
         // Shared filter for Query / QueryWithCursor. Caller must hold m_Mutex (m_Mutex
-        // is not recursive). Oldest-first; SinceId lower bound, then category filter,
-        // then the newest-MaxCount cap.
+        // is not recursive). Oldest-first; SinceId lower bound (a binary search, since
+        // ids are monotonic in the deque), then category filter, then the
+        // newest-MaxCount cap.
         [[nodiscard]] std::vector<DiagnosticEvent> QueryLocked(const DiagnosticEventQuery& query) const
         {
-            std::vector<DiagnosticEvent> matched;
-            for (const auto& event : m_Events)
+            auto begin = m_Events.begin();
+            if (query.SinceId != 0)
             {
-                if (query.SinceId != 0 && event.Id <= query.SinceId)
-                    continue;
+                begin = std::upper_bound(m_Events.begin(), m_Events.end(), query.SinceId,
+                                         [](u64 id, const DiagnosticEvent& event)
+                                         { return id < event.Id; });
+            }
+
+            std::vector<DiagnosticEvent> matched;
+            for (auto it = begin; it != m_Events.end(); ++it)
+            {
                 if (!query.Categories.empty() &&
-                    std::find(query.Categories.begin(), query.Categories.end(), event.Category) == query.Categories.end())
+                    std::find(query.Categories.begin(), query.Categories.end(), it->Category) == query.Categories.end())
                     continue;
-                matched.push_back(event);
+                matched.push_back(*it);
             }
 
             if (query.MaxCount != 0 && matched.size() > query.MaxCount)
@@ -615,5 +661,7 @@ namespace OloEngine
         std::deque<DiagnosticEvent> m_Events;
         u64 m_NextId = 1;
         std::atomic<u32> m_SuppressDepth{ 0 };
+        // Per-thread, per-category suppression depth (SuppressCategoryScope).
+        inline static thread_local std::array<u32, kDiagnosticEventCategoryCount> t_CategorySuppressDepth{};
     };
 } // namespace OloEngine

--- a/OloEngine/src/OloEngine/Renderer/Shader.h
+++ b/OloEngine/src/OloEngine/Renderer/Shader.h
@@ -124,7 +124,11 @@ namespace OloEngine
         [[nodiscard("Store this!")]] virtual const std::string& GetName() const = 0;
         [[nodiscard("Store this!")]] virtual const std::string& GetFilePath() const = 0;
 
-        virtual void Reload() = 0;
+        // Recompile from the source on disk. Returns true when the NEW program (or
+        // modules) is live, false when the compile failed and the previous one was
+        // kept — the only honest signal of a failed hot-reload, since a backend
+        // may restore the previous compilation status on failure (#1131).
+        virtual bool Reload() = 0;
 
         // --- Async compilation status ---
         [[nodiscard]] virtual ShaderCompilationStatus GetCompilationStatus() const

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -181,27 +181,20 @@ namespace OloEngine
         u32 failed = 0;
         for (auto& [name, shader] : m_Shaders)
         {
-            shader->Reload();
-            if (shader->GetCompilationStatus() == ShaderCompilationStatus::Failed)
+            // Reload() answers whether the NEW program is live: a failed reload
+            // keeps the previous one and (on Vulkan) its previous status, so the
+            // status alone cannot tell a kept shader from a rebuilt one.
+            if (!shader->Reload())
                 ++failed;
         }
 
         // The automation event bus (#1131): one `compile_finished` per library
         // reload, whichever path asked for it (the Shaders menu, the Shader
-        // Debugger's Refresh All, the file watcher). A shader whose compile is
-        // still in flight is not counted as failed here; its own status is what
-        // olo_shader_errors reports.
-        DiagnosticEventData data;
+        // Debugger's Refresh All, the file watcher). Each shader that kept its
+        // previous program counts as one error; there is no warning count.
         const auto seconds = std::chrono::duration<f64>(std::chrono::steady_clock::now() - reloadStart).count();
-        data.Set("kind", "shader")
-            .Set("target", std::to_string(m_Shaders.size()) + " shaders")
-            .Set("ok", failed == 0)
-            .Set("errors", failed)
-            .Set("seconds", seconds);
-        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CompileFinished,
-                                          "Reloaded " + std::to_string(m_Shaders.size()) + " shaders" +
-                                              (failed == 0 ? "" : " (" + std::to_string(failed) + " failed)"),
-                                          0, "ShaderLibrary", data);
+        DiagnosticsEventLog::Get().RecordCompileFinished("shader", std::to_string(m_Shaders.size()) + " shaders",
+                                                         failed == 0, failed, 0, seconds);
     }
 
     bool ShaderLibrary::Exists(const std::string& name) const

--- a/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
+++ b/OloEngine/src/OloEngine/Renderer/ShaderLibrary.cpp
@@ -4,6 +4,7 @@
 #include "OloEngine/Renderer/ShaderPack.h"
 #include "OloEngine/Renderer/Renderer.h"
 #include "OloEngine/Renderer/Debug/ShaderDebugger.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "Platform/OpenGL/OpenGLShader.h"
 
 namespace OloEngine
@@ -176,10 +177,31 @@ namespace OloEngine
 
     void ShaderLibrary::ReloadShaders()
     {
+        const auto reloadStart = std::chrono::steady_clock::now();
+        u32 failed = 0;
         for (auto& [name, shader] : m_Shaders)
         {
             shader->Reload();
+            if (shader->GetCompilationStatus() == ShaderCompilationStatus::Failed)
+                ++failed;
         }
+
+        // The automation event bus (#1131): one `compile_finished` per library
+        // reload, whichever path asked for it (the Shaders menu, the Shader
+        // Debugger's Refresh All, the file watcher). A shader whose compile is
+        // still in flight is not counted as failed here; its own status is what
+        // olo_shader_errors reports.
+        DiagnosticEventData data;
+        const auto seconds = std::chrono::duration<f64>(std::chrono::steady_clock::now() - reloadStart).count();
+        data.Set("kind", "shader")
+            .Set("target", std::to_string(m_Shaders.size()) + " shaders")
+            .Set("ok", failed == 0)
+            .Set("errors", failed)
+            .Set("seconds", seconds);
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CompileFinished,
+                                          "Reloaded " + std::to_string(m_Shaders.size()) + " shaders" +
+                                              (failed == 0 ? "" : " (" + std::to_string(failed) + " failed)"),
+                                          0, "ShaderLibrary", data);
     }
 
     bool ShaderLibrary::Exists(const std::string& name) const

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
@@ -5,6 +5,7 @@
 
 #include "OloEngine/Scripting/C#/ScriptGlue.h"
 #include "OloEngine/Scripting/ScriptError.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "OloEngine/Core/Application.h"
 #include "OloEngine/Core/Buffer.h"
 #include "OloEngine/Core/FileSystem.h"
@@ -348,8 +349,29 @@ namespace OloEngine
         return true;
     }
 
+    namespace
+    {
+        // The automation event bus (#1131): a script assembly reload is a
+        // "compile finished" from an agent's point of view, whichever of the
+        // three editor paths (menu, Ctrl+R, olo_reload_script) triggered it.
+        void RecordAssemblyReload(const std::filesystem::path& assembly, bool ok, f64 seconds)
+        {
+            DiagnosticEventData data;
+            data.Set("kind", "script").Set("target", assembly.filename().string()).Set("ok", ok).Set("seconds", seconds);
+            DiagnosticsEventLog::Get().Record(
+                DiagnosticEventCategory::CompileFinished,
+                std::string(ok ? "Reloaded script assembly '" : "FAILED to reload script assembly '") +
+                    assembly.filename().string() + "'",
+                0, assembly.filename().string(), data);
+        }
+    } // namespace
+
     bool ScriptEngine::ReloadAssembly()
     {
+        const auto reloadStart = std::chrono::steady_clock::now();
+        const auto elapsedSeconds = [reloadStart]
+        { return std::chrono::duration<f64>(std::chrono::steady_clock::now() - reloadStart).count(); };
+
         // Same reasoning as ShutdownMono: the outgoing domain's RPC handlers must
         // not survive it. Scripts re-register on load. Lua's are untouched.
         RpcRegistry::ClearOwnedBy(ERpcOwner::CSharp);
@@ -370,6 +392,7 @@ namespace OloEngine
             // pre-reload contents (LoadAssemblyClasses ran only on the success path), so
             // report the failure to the caller rather than pretending the reload worked.
             OLO_CORE_ERROR("[ScriptEngine] Failed to reload app assembly: {}", s_Data->AppAssemblyFilepath.string());
+            RecordAssemblyReload(s_Data->AppAssemblyFilepath, false, elapsedSeconds());
             return false;
         }
         LoadAssemblyClasses();
@@ -378,6 +401,7 @@ namespace OloEngine
 
         // Retrieve and instantiate class
         s_Data->EntityClass = Ref<ScriptClass>::Create("OloEngine", "Entity", true);
+        RecordAssemblyReload(s_Data->AppAssemblyFilepath, true, elapsedSeconds());
         return true;
     }
 

--- a/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
+++ b/OloEngine/src/OloEngine/Scripting/C#/ScriptEngine.cpp
@@ -356,13 +356,8 @@ namespace OloEngine
         // three editor paths (menu, Ctrl+R, olo_reload_script) triggered it.
         void RecordAssemblyReload(const std::filesystem::path& assembly, bool ok, f64 seconds)
         {
-            DiagnosticEventData data;
-            data.Set("kind", "script").Set("target", assembly.filename().string()).Set("ok", ok).Set("seconds", seconds);
-            DiagnosticsEventLog::Get().Record(
-                DiagnosticEventCategory::CompileFinished,
-                std::string(ok ? "Reloaded script assembly '" : "FAILED to reload script assembly '") +
-                    assembly.filename().string() + "'",
-                0, assembly.filename().string(), data);
+            // Mono reports no error/warning counts for a reload; 0 is "not measured".
+            DiagnosticsEventLog::Get().RecordCompileFinished("script", assembly.filename().string(), ok, 0, 0, seconds);
         }
     } // namespace
 

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.cpp
@@ -2672,7 +2672,7 @@ namespace OloEngine
         }
     }
 
-    void OpenGLShader::Reload()
+    bool OpenGLShader::Reload()
     {
         // Capture the currently-live program up front. Every recompile path funnels
         // through FinalizeProgram, which reassigns m_RendererID to a fresh
@@ -2789,6 +2789,7 @@ namespace OloEngine
                                                               Shader::UnregisterProgram(oldProgram);
                                                               glDeleteProgram(oldProgram); });
         }
+        return success;
     }
 
     void OpenGLShader::Bind() const

--- a/OloEngine/src/Platform/OpenGL/OpenGLShader.h
+++ b/OloEngine/src/Platform/OpenGL/OpenGLShader.h
@@ -64,7 +64,7 @@ namespace OloEngine
             return m_FilePath;
         }
 
-        void Reload() override;
+        bool Reload() override;
 
         // --- Async compilation status (override base class) ---
         [[nodiscard]] ShaderCompilationStatus GetCompilationStatus() const override

--- a/OloEngine/src/Platform/Vulkan/VulkanShader.cpp
+++ b/OloEngine/src/Platform/Vulkan/VulkanShader.cpp
@@ -784,18 +784,20 @@ namespace OloEngine
         return s_CurrentlyBound;
     }
 
-    void VulkanShader::Reload()
+    bool VulkanShader::Reload()
     {
         OLO_PROFILE_FUNCTION();
         if (m_FilePath.empty())
         {
-            return; // Source-string shaders have nothing to re-read.
+            return true; // Source-string shaders have nothing to re-read; the live modules stay live.
         }
 
         const std::string raw = ReadWholeFile(m_FilePath);
         if (raw.empty())
         {
-            return;
+            OLO_CORE_ERROR("VulkanShader '{}': reload read nothing from '{}' — keeping the previous modules", m_Name,
+                           m_FilePath);
+            return false;
         }
         auto stages = SplitStages(raw);
         // Asked BEFORE the splice, as in the constructor — a reload that read the
@@ -821,7 +823,7 @@ namespace OloEngine
             m_Modules = std::move(oldModules);
             m_Status = previousStatus;
             OLO_CORE_ERROR("VulkanShader '{}': reload failed — keeping the previous modules", m_Name);
-            return;
+            return false;
         }
 
         const sizet invalidated = VulkanPipelineBuilder::Get().InvalidateShader(GetPipelineIndexKey());
@@ -836,6 +838,7 @@ namespace OloEngine
         m_Status = ShaderCompilationStatus::Ready;
         OLO_CORE_INFO("VulkanShader '{}': reloaded ({} dependent pipeline(s) invalidated, lazy recreation)",
                       m_Name, invalidated);
+        return true;
     }
 
     // Default-block uniforms do not exist on this backend (see header).

--- a/OloEngine/src/Platform/Vulkan/VulkanShader.h
+++ b/OloEngine/src/Platform/Vulkan/VulkanShader.h
@@ -152,7 +152,7 @@ namespace OloEngine
             return m_FilePath;
         }
 
-        void Reload() override;
+        bool Reload() override;
 
         [[nodiscard]] ShaderCompilationStatus GetCompilationStatus() const override
         {

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -899,12 +899,19 @@ add_executable(OloEngine-Tests
 		# batches against a scene with no server and no GL context.
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationTransaction.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationTransactionCommands.cpp
+		# The publish side of the automation event bus (issue #1131):
+		# AutomationRegistry::RunHandler publishes command completions through
+		# it, so every target that links the registry needs it.
+		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationEvents.cpp
 		MCP/McpAutomationTransactionTest.cpp
 		MCP/McpAutomationAssetIndexTest.cpp
 		MCP/McpAutomationAssetCommandsTest.cpp
 		MCP/McpAutomationComponentsTest.cpp
 		MCP/McpAutomationEntitiesTest.cpp
 		MCP/McpAutomationSceneLifecycleTest.cpp
+		# The automation event bus (issue #1131): publishers, the completion rule,
+		# olo_events_wait's cursor model, and CommandHistory's dirty edge.
+		MCP/McpAutomationEventsTest.cpp
 		MCP/McpAutomationEditorCommandsTest.cpp
 		MCP/McpMainThreadMarshalTest.cpp
 		MCP/McpParticleStatsTest.cpp

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -880,6 +880,11 @@ add_executable(OloEngine-Tests
 		# composes it, so the test binary needs the TU to link at all; its pure
 		# core is covered by McpAutomationBuildTest below.
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationBuildCommands.cpp
+		# The editor command registry (issue #1131): the declared action table
+		# joined with the live registry, plus pause/step/gizmo/shader-pack. The
+		# actions reach the editor only through EditorMcpContext hooks, so the
+		# test drives fakes and never opens a window.
+		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationEditorCommands.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationSceneCommands.cpp
 		${CMAKE_SOURCE_DIR}/OloEditor/src/Automation/AutomationSceneDocument.cpp
 		# Asset query / safe CRUD / import (issue #1128). The index is editor-free
@@ -900,6 +905,7 @@ add_executable(OloEngine-Tests
 		MCP/McpAutomationComponentsTest.cpp
 		MCP/McpAutomationEntitiesTest.cpp
 		MCP/McpAutomationSceneLifecycleTest.cpp
+		MCP/McpAutomationEditorCommandsTest.cpp
 		MCP/McpMainThreadMarshalTest.cpp
 		MCP/McpParticleStatsTest.cpp
 		# The outbound stdio MCP client (#673 Tier 1): McpServer's connection-

--- a/OloEngine/tests/MCP/McpAutomationEditorCommandsTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationEditorCommandsTest.cpp
@@ -1,0 +1,452 @@
+// OLO_TEST_LAYER: unit
+//
+// The editor command registry (issue #1131, slice 1).
+//
+// Pins three things:
+//   1. The DECLARED action table (MCP::EditorActions::kEditorActions) names only
+//      commands the real surface registers, so a renamed command fails here
+//      rather than leaving a stale row.
+//   2. olo_editor_actions reports every declared row, joined with the registry
+//      it runs in -- including a row whose command THIS registry does not hold,
+//      which is marked rather than dropped.
+//   3. The four actions that gained commands (pause, step, gizmo, shader pack)
+//      are unavailable on a host with no editor hooks, forward their arguments
+//      to the hooks when present, refuse bad arguments before touching a hook,
+//      and carry the authority class they declare (only the shader pack is a
+//      consented write).
+//
+// No editor, no window, no server: the host is a fake whose MarshalRead runs
+// the job inline and whose EditorMcpContext hooks record what they were given.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "Automation/AutomationCommand.h"
+#include "Automation/AutomationEditorCommands.h"
+#include "Automation/AutomationHost.h"
+#include "Automation/AutomationRegistry.h"
+#include "Automation/AutomationResult.h"
+#include "Automation/AutomationSchemaValidation.h"
+#include "MCP/McpEditorActions.h"
+#include "MCP/McpServer.h"
+#include "MCP/McpTools.h"
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace OloEngine::Automation::Tests
+{
+    namespace
+    {
+        using Json = nlohmann::json;
+        namespace EditorActions = MCP::EditorActions;
+
+        // A host with an editor context and nothing else. Hooks are installed
+        // per test; a test that installs none is the headless case.
+        class EditorHooksHost final : public IAutomationHost
+        {
+          public:
+            [[nodiscard]] const MCP::EditorMcpContext& Context() const override
+            {
+                return ContextData;
+            }
+            [[nodiscard]] bool IsCurrentCallCancelled() const override
+            {
+                return false;
+            }
+            [[nodiscard]] bool PublishArtifact(AutomationArtifact) override
+            {
+                return false;
+            }
+
+            MCP::EditorMcpContext ContextData;
+            int MarshalCount = 0;
+
+          protected:
+            Json MarshalReadOnMainThread(const std::function<Json()>& job, std::chrono::milliseconds) override
+            {
+                ++MarshalCount;
+                return job();
+            }
+            void EmitProgressUpdate(f64, f64, const std::string&) const override {}
+        };
+
+        const std::vector<std::string> kActionCommands{ "olo_editor_pause", "olo_editor_step", "olo_editor_gizmo_set",
+                                                        "olo_editor_build_shader_pack" };
+
+        const Json* FindAction(const Json& actions, const std::string& name)
+        {
+            for (const Json& action : actions)
+            {
+                if (action.value("name", std::string{}) == name)
+                    return &action;
+            }
+            return nullptr;
+        }
+    } // namespace
+
+    class McpAutomationEditorCommands : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            RegisterEditorCommands(m_Registry);
+        }
+
+        AutomationInvocation Call(const std::string& name, const Json& arguments = Json::object(),
+                                  AutomationWriteConsent consent = AutomationWriteConsent::Withheld)
+        {
+            return m_Registry.Invoke(m_Host, name, arguments, consent);
+        }
+
+        Json Success(const std::string& name, const Json& arguments = Json::object(),
+                     AutomationWriteConsent consent = AutomationWriteConsent::Withheld)
+        {
+            const auto result = Call(name, arguments, consent);
+            EXPECT_EQ(result.Outcome, AutomationInvocation::Status::Ok) << name << ": " << result.Message;
+            EXPECT_FALSE(result.Result.IsError) << name << ": " << result.Result.Content.dump();
+            return result.Result.StructuredContent;
+        }
+
+        // Fake editor hooks that record their arguments and answer with m_HookOk.
+        void InstallHooks()
+        {
+            m_Host.ContextData.SetScenePauseState = [this](bool paused)
+            {
+                m_PauseCalls.push_back(paused);
+                MCP::McpEditorPauseResult r;
+                r.Available = true;
+                r.Ok = m_HookOk;
+                r.Changed = m_HookOk;
+                r.Paused = m_HookOk && paused;
+                r.Mode = m_HookOk ? "play" : "edit";
+                r.SceneName = "Fake";
+                r.Message = m_HookOk ? "Paused the play session." : "Nothing to pause: the editor is in Edit mode.";
+                return r;
+            };
+            m_Host.ContextData.StepScene = [this](int frames)
+            {
+                m_StepFrames.push_back(frames);
+                MCP::McpEditorStepResult r;
+                r.Available = true;
+                r.Ok = m_HookOk;
+                r.Paused = true;
+                r.FramesRequested = frames;
+                r.Mode = "play";
+                r.SceneName = "Fake";
+                r.Message = m_HookOk ? "Stepping." : "Not paused.";
+                return r;
+            };
+            m_Host.ContextData.SetGizmoMode = [this](const std::string& mode)
+            {
+                m_GizmoModes.push_back(mode);
+                MCP::McpEditorGizmoResult r;
+                r.Available = true;
+                r.Ok = true;
+                r.Changed = true;
+                r.Mode = mode;
+                r.Message = "Gizmo mode set to " + mode + ".";
+                return r;
+            };
+            m_Host.ContextData.BuildShaderPack = [this]()
+            {
+                ++m_ShaderPackCalls;
+                MCP::McpEditorShaderPackResult r;
+                r.Available = true;
+                r.Ok = m_HookOk;
+                r.OutputPath = "assets/ShaderPack.osp";
+                r.Message = m_HookOk ? "Shader pack written." : "Shader pack build failed.";
+                return r;
+            };
+        }
+
+        EditorHooksHost m_Host;
+        AutomationRegistry m_Registry;
+
+        bool m_HookOk = true;
+        std::vector<bool> m_PauseCalls;
+        std::vector<int> m_StepFrames;
+        std::vector<std::string> m_GizmoModes;
+        int m_ShaderPackCalls = 0;
+    };
+
+    // ---- 1. the declaration against the real surface ------------------------
+
+    TEST_F(McpAutomationEditorCommands, EveryDeclaredCommandIsRegisteredByTheRealSurface)
+    {
+        AutomationRegistry registry;
+        MCP::RegisterBuiltinCommands(registry);
+        const AutomationRegistry::CommandSnapshot snapshot = registry.Snapshot();
+
+        for (const EditorActions::EditorActionDescriptor& action : EditorActions::kEditorActions)
+        {
+            if (action.Command.empty())
+                continue;
+            EXPECT_NE(AutomationRegistry::Find(*snapshot, std::string(action.Command)), nullptr)
+                << action.Name << " declares '" << action.Command << "', which RegisterBuiltinCommands does not register";
+        }
+        for (const std::string& name : kActionCommands)
+        {
+            const AutomationCommand* command = AutomationRegistry::Find(*snapshot, name);
+            ASSERT_NE(command, nullptr) << name;
+            EXPECT_EQ(command->Toolset, "editor") << name;
+        }
+        const AutomationCommand* actions = AutomationRegistry::Find(*snapshot, "olo_editor_actions");
+        ASSERT_NE(actions, nullptr);
+        EXPECT_EQ(actions->Toolset, "editor");
+    }
+
+    TEST_F(McpAutomationEditorCommands, DeclaredAuthorityMatchesWhatEachActionTouches)
+    {
+        const AutomationRegistry::CommandSnapshot snapshot = m_Registry.Snapshot();
+        ASSERT_EQ(snapshot->size(), 5u);
+        for (const AutomationCommand& command : *snapshot)
+        {
+            const bool isShaderPack = command.Name == "olo_editor_build_shader_pack";
+            EXPECT_EQ(command.ProjectWrite, isShaderPack) << command.Name;
+            EXPECT_EQ(command.Undo, isShaderPack ? AutomationUndo::Irreversible : AutomationUndo::None) << command.Name;
+            EXPECT_EQ(command.MainMarshaled, command.Name != "olo_editor_actions") << command.Name;
+            EXPECT_FALSE(command.OutputSchema.empty()) << command.Name;
+            EXPECT_EQ(command.Annotations.value("readOnlyHint", false), command.Name == "olo_editor_actions") << command.Name;
+            EXPECT_EQ(command.Annotations.value("openWorldHint", true), false) << command.Name;
+        }
+    }
+
+    // ---- 2. olo_editor_actions ------------------------------------------------
+
+    TEST_F(McpAutomationEditorCommands, ActionsReportsEveryDeclaredRowJoinedWithTheRegistry)
+    {
+        AutomationRegistry registry;
+        MCP::RegisterBuiltinCommands(registry);
+        const auto invoked = registry.Invoke(m_Host, "olo_editor_actions", Json::object());
+        ASSERT_EQ(invoked.Outcome, AutomationInvocation::Status::Ok) << invoked.Message;
+        ASSERT_FALSE(invoked.Result.IsError) << invoked.Result.Content.dump();
+        const Json& out = invoked.Result.StructuredContent;
+        // Read-only and not main-marshaled: it never touches the game thread.
+        EXPECT_EQ(m_Host.MarshalCount, 0);
+
+        EXPECT_FALSE(AutomationSchema::ValidateArguments(EditorActions::ActionsOutputSchema(), out).has_value());
+
+        sizet expectedAutomated = 0;
+        for (const auto& action : EditorActions::kEditorActions)
+            expectedAutomated += action.Command.empty() ? 0u : 1u;
+        EXPECT_EQ(out.at("count").get<sizet>(), EditorActions::kEditorActions.size());
+        EXPECT_EQ(out.at("automated").get<sizet>(), expectedAutomated);
+        ASSERT_EQ(out.at("actions").size(), EditorActions::kEditorActions.size());
+
+        for (const Json& row : out.at("actions"))
+        {
+            const auto* declared = EditorActions::Find(row.at("name").get<std::string>());
+            ASSERT_NE(declared, nullptr) << row.dump();
+            EXPECT_EQ(row.at("menuPath"), std::string(declared->MenuPath));
+            EXPECT_EQ(row.at("shortcut"), std::string(declared->Shortcut));
+            if (declared->Command.empty())
+            {
+                EXPECT_FALSE(row.contains("command")) << row.dump();
+                EXPECT_FALSE(row.contains("available")) << row.dump();
+                EXPECT_FALSE(row.at("note").get<std::string>().empty()) << row.dump();
+            }
+            else
+            {
+                EXPECT_EQ(row.at("command"), std::string(declared->Command));
+                EXPECT_TRUE(row.contains("available")) << row.dump();
+                EXPECT_TRUE(row.contains("projectWrite")) << row.dump();
+                EXPECT_TRUE(row.contains("undo")) << row.dump();
+            }
+        }
+
+        // Spot checks against known commands.
+        const Json* sceneNew = FindAction(out.at("actions"), "scene_new");
+        ASSERT_NE(sceneNew, nullptr);
+        EXPECT_TRUE(sceneNew->at("projectWrite").get<bool>());
+        EXPECT_EQ(sceneNew->at("undo"), "editorUndoStack");
+        EXPECT_TRUE(sceneNew->at("available").get<bool>());
+        const Json* exit = FindAction(out.at("actions"), "exit");
+        ASSERT_NE(exit, nullptr);
+        EXPECT_FALSE(exit->contains("command"));
+
+        // The pause action is declared automated but its command needs an editor
+        // hook: unavailable here, available once the hook exists.
+        const Json* pause = FindAction(out.at("actions"), "pause");
+        ASSERT_NE(pause, nullptr);
+        EXPECT_EQ(pause->at("command"), "olo_editor_pause");
+        EXPECT_FALSE(pause->at("available").get<bool>());
+        EXPECT_FALSE(pause->at("projectWrite").get<bool>());
+        EXPECT_EQ(pause->at("undo"), "none");
+        InstallHooks();
+        const auto again = registry.Invoke(m_Host, "olo_editor_actions", Json::object());
+        ASSERT_EQ(again.Outcome, AutomationInvocation::Status::Ok);
+        const Json* pauseNow = FindAction(again.Result.StructuredContent.at("actions"), "pause");
+        ASSERT_NE(pauseNow, nullptr);
+        EXPECT_TRUE(pauseNow->at("available").get<bool>());
+    }
+
+    TEST_F(McpAutomationEditorCommands, ActionsAutomatedOnlyDropsTheUnautomatedRows)
+    {
+        AutomationRegistry registry;
+        MCP::RegisterBuiltinCommands(registry);
+        const auto invoked = registry.Invoke(m_Host, "olo_editor_actions", Json{ { "automatedOnly", true } });
+        ASSERT_EQ(invoked.Outcome, AutomationInvocation::Status::Ok) << invoked.Message;
+        const Json& out = invoked.Result.StructuredContent;
+        EXPECT_EQ(out.at("count"), out.at("automated"));
+        EXPECT_LT(out.at("count").get<sizet>(), EditorActions::kEditorActions.size());
+        for (const Json& row : out.at("actions"))
+            EXPECT_TRUE(row.contains("command")) << row.dump();
+        EXPECT_EQ(FindAction(out.at("actions"), "exit"), nullptr);
+
+        const auto bad = registry.Invoke(m_Host, "olo_editor_actions", Json{ { "automatedOnly", "yes" } });
+        EXPECT_EQ(bad.Outcome, AutomationInvocation::Status::InvalidArguments);
+    }
+
+    TEST_F(McpAutomationEditorCommands, ActionsMarksACommandThisRegistryDoesNotHoldInsteadOfDroppingIt)
+    {
+        // m_Registry holds only the five editor commands, so every scene/entity
+        // row names a command that is declared but not registered here.
+        const Json out = Success("olo_editor_actions");
+        EXPECT_EQ(out.at("count").get<sizet>(), EditorActions::kEditorActions.size());
+
+        const Json* sceneNew = FindAction(out.at("actions"), "scene_new");
+        ASSERT_NE(sceneNew, nullptr);
+        EXPECT_EQ(sceneNew->at("command"), "olo_scene_new");
+        EXPECT_FALSE(sceneNew->at("available").get<bool>());
+        EXPECT_FALSE(sceneNew->contains("projectWrite"));
+        EXPECT_TRUE(sceneNew->at("note").get<std::string>().ends_with("(not registered on this host)")) << sceneNew->dump();
+
+        // A registered-but-hookless command is a different fact and says so differently.
+        const Json* pause = FindAction(out.at("actions"), "pause");
+        ASSERT_NE(pause, nullptr);
+        EXPECT_FALSE(pause->at("available").get<bool>());
+        EXPECT_TRUE(pause->contains("projectWrite"));
+        EXPECT_EQ(pause->at("note").get<std::string>().find("not registered"), std::string::npos);
+    }
+
+    // ---- 3. the four actions -----------------------------------------------
+
+    TEST_F(McpAutomationEditorCommands, ActionCommandsAreUnavailableWithoutEditorHooks)
+    {
+        for (const std::string& name : kActionCommands)
+        {
+            const auto result = Call(name, Json::object(), AutomationWriteConsent::Granted);
+            EXPECT_EQ(result.Outcome, AutomationInvocation::Status::Unavailable) << name << ": " << result.Message;
+        }
+        EXPECT_EQ(m_Host.MarshalCount, 0);
+        // The listing itself needs no editor.
+        EXPECT_EQ(Call("olo_editor_actions").Outcome, AutomationInvocation::Status::Ok);
+    }
+
+    TEST_F(McpAutomationEditorCommands, PauseForwardsTheFlagAndReturnsTheHookResult)
+    {
+        InstallHooks();
+        const Json out = Success("olo_editor_pause", Json{ { "paused", true } });
+        EXPECT_EQ(m_PauseCalls, std::vector<bool>{ true });
+        EXPECT_EQ(m_Host.MarshalCount, 1);
+        EXPECT_TRUE(out.at("ok").get<bool>());
+        EXPECT_TRUE(out.at("paused").get<bool>());
+        EXPECT_TRUE(out.at("changed").get<bool>());
+        EXPECT_EQ(out.at("mode"), "play");
+        EXPECT_EQ(out.at("sceneName"), "Fake");
+        EXPECT_FALSE(AutomationSchema::ValidateArguments(EditorActions::PauseOutputSchema(), out).has_value());
+
+        Success("olo_editor_pause", Json{ { "paused", false } });
+        EXPECT_EQ(m_PauseCalls, (std::vector<bool>{ true, false }));
+    }
+
+    TEST_F(McpAutomationEditorCommands, PauseRefusesBadArgumentsBeforeTouchingTheHook)
+    {
+        InstallHooks();
+        EXPECT_EQ(Call("olo_editor_pause", Json::object()).Outcome, AutomationInvocation::Status::InvalidArguments);
+        EXPECT_EQ(Call("olo_editor_pause", Json{ { "paused", "yes" } }).Outcome,
+                  AutomationInvocation::Status::InvalidArguments);
+        EXPECT_EQ(Call("olo_editor_pause", Json{ { "paused", true }, { "extra", 1 } }).Outcome,
+                  AutomationInvocation::Status::InvalidArguments);
+        EXPECT_TRUE(m_PauseCalls.empty());
+        EXPECT_EQ(m_Host.MarshalCount, 0);
+    }
+
+    TEST_F(McpAutomationEditorCommands, HookFailureBecomesAnErrorResultCarryingItsMessage)
+    {
+        InstallHooks();
+        m_HookOk = false;
+        const auto result = Call("olo_editor_pause", Json{ { "paused", true } });
+        ASSERT_EQ(result.Outcome, AutomationInvocation::Status::Ok) << result.Message;
+        EXPECT_TRUE(result.Result.IsError);
+        EXPECT_NE(result.Result.Content.dump().find("Nothing to pause"), std::string::npos) << result.Result.Content.dump();
+        EXPECT_EQ(m_PauseCalls, std::vector<bool>{ true });
+
+        const auto step = Call("olo_editor_step", Json::object());
+        ASSERT_EQ(step.Outcome, AutomationInvocation::Status::Ok) << step.Message;
+        EXPECT_TRUE(step.Result.IsError);
+        EXPECT_NE(step.Result.Content.dump().find("Not paused"), std::string::npos);
+    }
+
+    TEST_F(McpAutomationEditorCommands, StepValidatesTheFrameRangeAndForwardsTheCount)
+    {
+        InstallHooks();
+        EXPECT_EQ(Call("olo_editor_step", Json{ { "frames", 0 } }).Outcome, AutomationInvocation::Status::InvalidArguments);
+        EXPECT_EQ(Call("olo_editor_step", Json{ { "frames", 61 } }).Outcome, AutomationInvocation::Status::InvalidArguments);
+        EXPECT_EQ(Call("olo_editor_step", Json{ { "frames", "3" } }).Outcome, AutomationInvocation::Status::InvalidArguments);
+        EXPECT_TRUE(m_StepFrames.empty());
+
+        const Json one = Success("olo_editor_step");
+        EXPECT_EQ(one.at("framesRequested"), 1);
+        const Json five = Success("olo_editor_step", Json{ { "frames", 5 } });
+        EXPECT_EQ(five.at("framesRequested"), 5);
+        EXPECT_TRUE(five.at("paused").get<bool>());
+        EXPECT_EQ(m_StepFrames, (std::vector<int>{ 1, 5 }));
+        EXPECT_FALSE(AutomationSchema::ValidateArguments(EditorActions::StepOutputSchema(), five).has_value());
+    }
+
+    TEST_F(McpAutomationEditorCommands, GizmoRejectsUnknownModesAndForwardsKnownOnes)
+    {
+        InstallHooks();
+        EXPECT_EQ(Call("olo_editor_gizmo_set", Json{ { "mode", "twist" } }).Outcome,
+                  AutomationInvocation::Status::InvalidArguments);
+        EXPECT_EQ(Call("olo_editor_gizmo_set", Json::object()).Outcome, AutomationInvocation::Status::InvalidArguments);
+        EXPECT_TRUE(m_GizmoModes.empty());
+
+        for (const std::string_view mode : EditorActions::kGizmoModes)
+        {
+            const Json out = Success("olo_editor_gizmo_set", Json{ { "mode", std::string(mode) } });
+            EXPECT_EQ(out.at("mode"), std::string(mode));
+            EXPECT_FALSE(AutomationSchema::ValidateArguments(EditorActions::GizmoOutputSchema(), out).has_value());
+        }
+        EXPECT_EQ(m_GizmoModes, (std::vector<std::string>{ "none", "translate", "rotate", "scale" }));
+        EXPECT_TRUE(EditorActions::IsGizmoMode("rotate"));
+        EXPECT_FALSE(EditorActions::IsGizmoMode("Rotate"));
+    }
+
+    TEST_F(McpAutomationEditorCommands, ShaderPackNeedsConsentAndForwardsWhenGranted)
+    {
+        InstallHooks();
+        const auto refused = Call("olo_editor_build_shader_pack");
+        EXPECT_EQ(refused.Outcome, AutomationInvocation::Status::WriteConsentWithheld) << refused.Message;
+        EXPECT_EQ(m_ShaderPackCalls, 0);
+        EXPECT_EQ(m_Host.MarshalCount, 0);
+
+        const Json out = Success("olo_editor_build_shader_pack", Json::object(), AutomationWriteConsent::Granted);
+        EXPECT_EQ(m_ShaderPackCalls, 1);
+        EXPECT_TRUE(out.at("ok").get<bool>());
+        EXPECT_EQ(out.at("outputPath"), "assets/ShaderPack.osp");
+        EXPECT_FALSE(AutomationSchema::ValidateArguments(EditorActions::ShaderPackOutputSchema(), out).has_value());
+
+        m_HookOk = false;
+        const auto failed = Call("olo_editor_build_shader_pack", Json::object(), AutomationWriteConsent::Granted);
+        ASSERT_EQ(failed.Outcome, AutomationInvocation::Status::Ok);
+        EXPECT_TRUE(failed.Result.IsError);
+        EXPECT_EQ(m_ShaderPackCalls, 2);
+    }
+
+    TEST_F(McpAutomationEditorCommands, RuntimeControlCommandsRunWithoutWriteConsent)
+    {
+        InstallHooks();
+        // Withheld is the default consent in Call(); each of these must still run.
+        EXPECT_EQ(Call("olo_editor_pause", Json{ { "paused", true } }).Outcome, AutomationInvocation::Status::Ok);
+        EXPECT_EQ(Call("olo_editor_step", Json{ { "frames", 2 } }).Outcome, AutomationInvocation::Status::Ok);
+        EXPECT_EQ(Call("olo_editor_gizmo_set", Json{ { "mode", "scale" } }).Outcome, AutomationInvocation::Status::Ok);
+        EXPECT_EQ(Call("olo_editor_actions").Outcome, AutomationInvocation::Status::Ok);
+        EXPECT_EQ(m_Host.MarshalCount, 3);
+    }
+} // namespace OloEngine::Automation::Tests

--- a/OloEngine/tests/MCP/McpAutomationEventsTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationEventsTest.cpp
@@ -381,6 +381,59 @@ namespace OloEngine::Automation::Tests
         EXPECT_NE(text.find("scene_save"), std::string::npos);
     }
 
+    TEST_F(McpEventsWait, AMalformedCursorIsRefusedNotReinterpreted)
+    {
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "history");
+        const AutomationCommand* command = AutomationRegistry::Find(*m_Registry.Snapshot(), "olo_events_wait");
+        ASSERT_NE(command, nullptr);
+        // Each of these used to become cursor 0 ("the whole ring") or ULLONG_MAX
+        // ("nothing can ever match"); both are refusals now, naming the field.
+        for (const Json bad : { Json(-1), Json("-1"), Json("12abc"), Json(""), Json(true), Json(nullptr) })
+        {
+            const AutomationResult result = AutomationRegistry::RunHandler(
+                *command, m_Host, Json{ { "sinceId", bad }, { "waitMs", 0 } });
+            EXPECT_TRUE(result.IsError) << bad.dump();
+            EXPECT_NE(result.Content.dump().find("sinceId"), std::string::npos) << bad.dump();
+        }
+    }
+
+    TEST_F(McpEventsWait, CountKeepsTheOldestMatchesAndMovesTheCursorBack)
+    {
+        for (int i = 0; i < 5; ++i)
+            DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "burst " + std::to_string(i));
+        // A subscription promises "everything after the cursor, in order": with a
+        // cap smaller than the burst, the HEAD of the burst comes back and the
+        // cursor stops at the last record delivered, so nothing is skipped.
+        const Json first = Wait(Json{ { "sinceId", 0 }, { "waitMs", 0 }, { "count", 2 } });
+        ASSERT_EQ(first["count"], 2);
+        EXPECT_EQ(first["events"][0]["id"], 1);
+        EXPECT_EQ(first["events"][1]["id"], 2);
+        EXPECT_EQ(first["lastId"], 2) << "not the ring head (5): the caller has not seen 3..5 yet";
+        const Json rest = Wait(Json{ { "sinceId", first["lastId"] }, { "waitMs", 0 } });
+        EXPECT_EQ(rest["count"], 3);
+        EXPECT_EQ(rest["events"][0]["id"], 3);
+        EXPECT_EQ(rest["lastId"], 5);
+    }
+
+    TEST_F(McpEventsWait, TheSchemasEnumerateExactlyTheCategoryTable)
+    {
+        // The tail's and the wait's category enums are generated from
+        // AllCategoryTokens; pin that they are, so a new category cannot be parsed
+        // by the handler and refused by the schema gate.
+        for (const char* name : { "olo_events_tail", "olo_events_wait" })
+        {
+            const AutomationCommand* command = AutomationRegistry::Find(*m_Registry.Snapshot(), name);
+            ASSERT_NE(command, nullptr) << name;
+            const Json& filter = command->InputSchema["properties"]["categories"]["items"]["enum"];
+            const Json& entry = command->OutputSchema["properties"]["events"]["items"]["properties"]["category"]["enum"];
+            Json expected = Json::array();
+            for (const auto token : DiagnosticEvent::AllCategoryTokens())
+                expected.push_back(std::string(token));
+            EXPECT_EQ(filter, expected) << name;
+            EXPECT_EQ(entry, expected) << name;
+        }
+    }
+
     TEST_F(McpEventsWait, TailReportsTheGapAndTheDataToo)
     {
         Events::PublishSceneDirty("S", true);
@@ -444,6 +497,22 @@ namespace OloEngine::Automation::Tests
         EXPECT_TRUE(history.RollbackTransaction().empty());
         ASSERT_EQ(edges, (std::vector<bool>{ true, false, true, false }))
             << "rollback restored the save point, so the document is clean again";
+    }
+
+    TEST_F(McpAutomationEvents, CommandHistoryClearIsACleanAgainEdge)
+    {
+        CommandHistory history;
+        std::vector<bool> edges;
+        history.OnDirtyChanged = [&edges](bool dirty)
+        { edges.push_back(dirty); };
+        history.Execute(std::make_unique<NoopCommand>());
+        ASSERT_EQ(edges, (std::vector<bool>{ true }));
+        // File > New Scene / Open Scene clear the history; the document is clean
+        // afterwards and a subscriber must see that edge.
+        history.Clear();
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false }));
+        history.Clear();
+        EXPECT_EQ(edges.size(), 2u) << "clearing a clean history is not an edge";
     }
 
     TEST_F(McpAutomationEvents, CommandHistoryWithoutAHookStillWorks)

--- a/OloEngine/tests/MCP/McpAutomationEventsTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationEventsTest.cpp
@@ -1,0 +1,457 @@
+// OLO_TEST_LAYER: unit
+//
+// The automation event bus (issue #1131): the publish side, the subscription
+// command, and the two contracts the issue named as design constraints.
+//
+// What is pinned here, and why each is a test rather than a comment:
+//
+//   1. THE PAYLOAD RULE. Every publisher builds its record from the closed key
+//      set the engine header declares, and no key that could carry content
+//      (arguments, a result, a document) exists in any set. This is what makes a
+//      subscription offerable at read authority: nothing behind a read gate is
+//      ever on the bus.
+//   2. THE COMPLETION RULE. A mutating command publishes `command_completed`
+//      from AutomationRegistry::RunHandler; a read-only one never does. The
+//      second half is load-bearing: the subscription command is itself
+//      read-only, and if its completion were an event, two waiting agents would
+//      wake each other forever.
+//   3. THE CURSOR MODEL. olo_events_wait blocks until a match, times out with
+//      the cursor, is cancellable, and reports the gap when the cursor fell
+//      behind the ring — the whole backpressure answer, with no per-subscriber
+//      queue anywhere.
+//   4. THE DIRTY EDGE. CommandHistory fires OnDirtyChanged exactly on a
+//      transition, once per public mutation, including across a transaction.
+//
+// No editor, no server: a bare registry, the real diagnostics command
+// registrations, and a host that runs marshaled jobs inline.
+
+#include "OloEnginePCH.h"
+#include <gtest/gtest.h>
+
+#include "Automation/AutomationCommand.h"
+#include "Automation/AutomationEvents.h"
+#include "Automation/AutomationHost.h"
+#include "Automation/AutomationRegistry.h"
+#include "Automation/AutomationResult.h"
+#include "MCP/McpServer.h"
+#include "MCP/McpToolsCommon.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
+#include "UndoRedo/EditorCommand.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace OloEngine::Automation::Tests
+{
+    namespace
+    {
+        using Json = nlohmann::json;
+
+        class BusHost final : public IAutomationHost
+        {
+          public:
+            [[nodiscard]] const MCP::EditorMcpContext& Context() const override
+            {
+                return m_Context;
+            }
+            [[nodiscard]] bool IsCurrentCallCancelled() const override
+            {
+                return Cancelled.load();
+            }
+            [[nodiscard]] bool PublishArtifact(AutomationArtifact) override
+            {
+                return false;
+            }
+
+            std::atomic<bool> Cancelled{ false };
+
+          protected:
+            Json MarshalReadOnMainThread(const std::function<Json()>& job, std::chrono::milliseconds) override
+            {
+                return job();
+            }
+            void EmitProgressUpdate(f64, f64, const std::string&) const override {}
+
+          private:
+            MCP::EditorMcpContext m_Context;
+        };
+
+        class NoopCommand final : public EditorCommand
+        {
+          public:
+            void Execute() override {}
+            void Undo() override {}
+            [[nodiscard]] std::string GetDescription() const override
+            {
+                return "noop";
+            }
+        };
+
+        AutomationCommand MakeCommand(std::string name, Json annotations, bool projectWrite,
+                                      AutomationHandler handler)
+        {
+            AutomationCommand command;
+            command.Name = std::move(name);
+            command.Toolset = "fake";
+            command.Description = "A fake command.";
+            command.InputSchema = Json{ { "type", "object" } };
+            command.Annotations = std::move(annotations);
+            command.ProjectWrite = projectWrite;
+            command.Undo = projectWrite ? AutomationUndo::Irreversible : AutomationUndo::None;
+            command.Handler = std::move(handler);
+            return command;
+        }
+
+        std::vector<DiagnosticEvent> Recorded(DiagnosticEventCategory category)
+        {
+            DiagnosticEventQuery query;
+            query.MaxCount = 0;
+            query.Categories = { category };
+            return DiagnosticsEventLog::Get().Query(query);
+        }
+
+        Json DataOf(const DiagnosticEvent& event)
+        {
+            return Json::parse(event.Data);
+        }
+    } // namespace
+
+    class McpAutomationEvents : public ::testing::Test
+    {
+      protected:
+        void SetUp() override
+        {
+            DiagnosticsEventLog::Get().Clear();
+        }
+        void TearDown() override
+        {
+            DiagnosticsEventLog::Get().Clear();
+        }
+    };
+
+    // ---- 1. the publishers and the payload rule ---------------------------------
+
+    TEST_F(McpAutomationEvents, ProjectRelativePathNeverRecordsAnAbsolutePath)
+    {
+        const std::filesystem::path root = std::filesystem::path("C:/proj/Assets");
+        EXPECT_EQ(Events::ProjectRelativePath(root / "Scenes" / "A.olo", root), "Scenes/A.olo");
+        EXPECT_EQ(Events::ProjectRelativePath(std::filesystem::path("C:/elsewhere/B.olo"), root), "B.olo");
+        EXPECT_EQ(Events::ProjectRelativePath(std::filesystem::path("C:/elsewhere/B.olo"), {}), "B.olo");
+        EXPECT_EQ(Events::ProjectRelativePath({}, root), "");
+    }
+
+    TEST_F(McpAutomationEvents, SceneSavedCarriesIdentityOnly)
+    {
+        const std::filesystem::path root = std::filesystem::path("C:/proj/Assets");
+        const u64 id = Events::PublishSceneSaved("Level1", root / "Scenes" / "Level1.olo", root, true);
+        ASSERT_NE(0u, id);
+        const auto events = Recorded(DiagnosticEventCategory::SceneSave);
+        ASSERT_EQ(1u, events.size());
+        EXPECT_EQ(events[0].Context, "Level1.olo");
+        const Json data = DataOf(events[0]);
+        EXPECT_EQ(data["scene"], "Level1");
+        EXPECT_EQ(data["path"], "Scenes/Level1.olo");
+        EXPECT_EQ(data["changed"], true);
+        EXPECT_EQ(data.size(), 3u) << "exactly the declared keys";
+    }
+
+    TEST_F(McpAutomationEvents, SceneDirtyRecordsBothEdges)
+    {
+        Events::PublishSceneDirty("Level1", true);
+        Events::PublishSceneDirty("Level1", false);
+        const auto events = Recorded(DiagnosticEventCategory::SceneDirty);
+        ASSERT_EQ(2u, events.size());
+        EXPECT_EQ(DataOf(events[0])["dirty"], true);
+        EXPECT_EQ(DataOf(events[1])["dirty"], false);
+        EXPECT_NE(events[0].Message, events[1].Message);
+    }
+
+    TEST_F(McpAutomationEvents, AssetImportedCarriesHandleTypeAndSource)
+    {
+        const std::filesystem::path root = std::filesystem::path("C:/proj");
+        Events::PublishAssetImported(77, "Texture2D", root / "Assets" / "t.png", root, "automation");
+        const auto events = Recorded(DiagnosticEventCategory::AssetImport);
+        ASSERT_EQ(1u, events.size());
+        EXPECT_EQ(events[0].Entity, 77u);
+        const Json data = DataOf(events[0]);
+        EXPECT_EQ(data["asset"], "Assets/t.png");
+        EXPECT_EQ(data["type"], "Texture2D");
+        EXPECT_EQ(data["handle"], 77);
+        EXPECT_EQ(data["source"], "automation");
+    }
+
+    TEST_F(McpAutomationEvents, CompileFinishedSaysFailedInTheMessage)
+    {
+        Events::PublishCompileFinished("build", "OloEngine-Tests", false, 3, 1, 12.5);
+        const auto events = Recorded(DiagnosticEventCategory::CompileFinished);
+        ASSERT_EQ(1u, events.size());
+        EXPECT_NE(events[0].Message.find("FAILED"), std::string::npos);
+        const Json data = DataOf(events[0]);
+        EXPECT_EQ(data["kind"], "build");
+        EXPECT_EQ(data["target"], "OloEngine-Tests");
+        EXPECT_EQ(data["ok"], false);
+        EXPECT_EQ(data["errors"], 3);
+        EXPECT_EQ(data["warnings"], 1);
+        EXPECT_NEAR(data["seconds"].get<f64>(), 12.5, 1e-6);
+    }
+
+    // ---- 2. the completion rule --------------------------------------------------
+
+    TEST_F(McpAutomationEvents, ReadOnlyCommandsNeverEmitACompletionEvent)
+    {
+        EXPECT_FALSE(Events::EmitsCompletionEvent(MakeCommand("a", MCP::ReadOnlyAnnotations(), false, {})));
+        EXPECT_TRUE(Events::EmitsCompletionEvent(MakeCommand("b", MCP::MutatingAnnotations(true), false, {})));
+        EXPECT_TRUE(Events::EmitsCompletionEvent(MakeCommand("c", Json{}, true, {})))
+            << "no annotations at all is treated as not read-only";
+        EXPECT_TRUE(Events::EmitsCompletionEvent(MakeCommand("d", Json{ { "readOnlyHint", false } }, false, {})));
+    }
+
+    TEST_F(McpAutomationEvents, RunHandlerPublishesCompletionForMutatingCommandsOnly)
+    {
+        AutomationRegistry registry;
+        registry.Register(MakeCommand("olo_fake_write", MCP::MutatingAnnotations(false), true,
+                                      [](IAutomationHost&, const Json&)
+                                      { return AutomationResult::Structured(Json{ { "ok", true } }); }));
+        registry.Register(MakeCommand("olo_fake_read", MCP::ReadOnlyAnnotations(), false,
+                                      [](IAutomationHost&, const Json&)
+                                      { return AutomationResult::Structured(Json{ { "ok", true } }); }));
+        registry.Register(MakeCommand("olo_fake_throw", MCP::MutatingAnnotations(false), true,
+                                      [](IAutomationHost&, const Json&) -> AutomationResult
+                                      { throw std::runtime_error("boom"); }));
+
+        BusHost host;
+        ASSERT_TRUE(registry.Invoke(host, "olo_fake_read", Json::object()).Ran());
+        EXPECT_TRUE(Recorded(DiagnosticEventCategory::CommandCompleted).empty());
+
+        ASSERT_TRUE(registry.Invoke(host, "olo_fake_write", Json::object(), AutomationWriteConsent::Granted).Ran());
+        auto events = Recorded(DiagnosticEventCategory::CommandCompleted);
+        ASSERT_EQ(1u, events.size());
+        Json data = DataOf(events[0]);
+        EXPECT_EQ(data["command"], "olo_fake_write");
+        EXPECT_EQ(data["ok"], true);
+        EXPECT_EQ(data["projectWrite"], true);
+        EXPECT_EQ(data["toolset"], "fake");
+        EXPECT_GE(data["durationMs"].get<f64>(), 0.0);
+        EXPECT_FALSE(data.contains("arguments"));
+        EXPECT_FALSE(data.contains("result"));
+
+        const AutomationInvocation thrown =
+            registry.Invoke(host, "olo_fake_throw", Json::object(), AutomationWriteConsent::Granted);
+        ASSERT_TRUE(thrown.Ran());
+        EXPECT_TRUE(thrown.Result.IsError);
+        events = Recorded(DiagnosticEventCategory::CommandCompleted);
+        ASSERT_EQ(2u, events.size());
+        EXPECT_EQ(DataOf(events[1])["ok"], false) << "a handler that threw completed with ok:false";
+    }
+
+    TEST_F(McpAutomationEvents, TheSubscriptionCommandsAreReadOnlyAndSilent)
+    {
+        AutomationRegistry registry;
+        MCP::RegisterDiagnosticsTools(registry);
+        const auto snapshot = registry.Snapshot();
+        for (const char* name : { "olo_events_tail", "olo_events_wait" })
+        {
+            const AutomationCommand* command = AutomationRegistry::Find(*snapshot, name);
+            ASSERT_NE(command, nullptr) << name;
+            EXPECT_FALSE(command->ProjectWrite) << name;
+            EXPECT_FALSE(Events::EmitsCompletionEvent(*command))
+                << name << " must not publish its own completion, or waiters would wake each other";
+        }
+    }
+
+    // ---- 3. olo_events_wait: the cursor model ------------------------------------
+
+    class McpEventsWait : public McpAutomationEvents
+    {
+      protected:
+        void SetUp() override
+        {
+            McpAutomationEvents::SetUp();
+            MCP::RegisterDiagnosticsTools(m_Registry);
+        }
+
+        Json Wait(const Json& args)
+        {
+            const AutomationInvocation outcome = m_Registry.Invoke(m_Host, "olo_events_wait", args);
+            EXPECT_EQ(outcome.Outcome, AutomationInvocation::Status::Ok) << outcome.Message;
+            EXPECT_FALSE(outcome.Result.IsError) << outcome.Result.Content.dump();
+            return outcome.Result.StructuredContent;
+        }
+
+        AutomationRegistry m_Registry;
+        BusHost m_Host;
+    };
+
+    TEST_F(McpEventsWait, ReturnsExistingMatchesImmediately)
+    {
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "p", 0, "S");
+        const Json out = Wait(Json{ { "sinceId", 0 }, { "waitMs", 0 } });
+        EXPECT_EQ(out["count"], 1);
+        EXPECT_EQ(out["lastId"], 1);
+        EXPECT_EQ(out["dropped"], 0);
+        EXPECT_EQ(out["timedOut"], false);
+        EXPECT_EQ(out["cancelled"], false);
+        EXPECT_EQ(out["events"][0]["category"], "play");
+    }
+
+    TEST_F(McpEventsWait, DefaultsToWaitingForEventsNewerThanTheCall)
+    {
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "before the call");
+        const Json out = Wait(Json{ { "waitMs", 50 } });
+        EXPECT_EQ(out["count"], 0);
+        EXPECT_EQ(out["timedOut"], true);
+        EXPECT_EQ(out["lastId"], 1) << "the cursor to pass next, even on a timeout";
+    }
+
+    TEST_F(McpEventsWait, AcceptsTheCursorAsADecimalString)
+    {
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "one");
+        DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Stop, "two");
+        const Json out = Wait(Json{ { "sinceId", "1" }, { "waitMs", 0 } });
+        EXPECT_EQ(out["count"], 1);
+        EXPECT_EQ(out["events"][0]["id"], 2);
+    }
+
+    TEST_F(McpEventsWait, WakesOnAMatchingEventFromAnotherThread)
+    {
+        std::thread recorder(
+            []
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(40));
+                DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "filtered out");
+                DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Stop, "wake");
+            });
+        const auto started = std::chrono::steady_clock::now();
+        const Json out = Wait(Json{ { "categories", Json::array({ "stop" }) }, { "waitMs", 10000 } });
+        recorder.join();
+        EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::seconds(5));
+        EXPECT_EQ(out["count"], 1);
+        EXPECT_EQ(out["events"][0]["category"], "stop");
+        EXPECT_EQ(out["lastId"], 2);
+    }
+
+    TEST_F(McpEventsWait, StopsEarlyWhenTheCallIsCancelled)
+    {
+        std::thread canceller(
+            [this]
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(40));
+                m_Host.Cancelled.store(true);
+            });
+        const auto started = std::chrono::steady_clock::now();
+        const Json out = Wait(Json{ { "waitMs", 60000 } });
+        canceller.join();
+        EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::seconds(5));
+        EXPECT_EQ(out["count"], 0);
+        EXPECT_EQ(out["cancelled"], true);
+        EXPECT_EQ(out["timedOut"], false);
+    }
+
+    TEST_F(McpEventsWait, ReportsTheGapWhenTheCursorFellBehindTheRing)
+    {
+        for (std::size_t i = 0; i < DiagnosticsEventLog::kCapacity + 5; ++i)
+            DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::EntitySpawn, "e");
+        const Json out = Wait(Json{ { "sinceId", 2 }, { "waitMs", 0 }, { "count", 1 } });
+        EXPECT_EQ(out["dropped"], 3) << "ids 3, 4 and 5 were evicted";
+        EXPECT_EQ(out["count"], 1);
+    }
+
+    TEST_F(McpEventsWait, RejectsAnUnknownCategoryNamingTheValidOnes)
+    {
+        // Through the registry the schema enum refuses it before the handler runs.
+        const AutomationInvocation outcome =
+            m_Registry.Invoke(m_Host, "olo_events_wait", Json{ { "categories", Json::array({ "nope" }) } });
+        EXPECT_EQ(outcome.Outcome, AutomationInvocation::Status::InvalidArguments) << outcome.Message;
+
+        // A caller that reaches the handler directly gets the same refusal, naming
+        // every valid token (the bus categories included).
+        const AutomationCommand* command = AutomationRegistry::Find(*m_Registry.Snapshot(), "olo_events_wait");
+        ASSERT_NE(command, nullptr);
+        const AutomationResult result =
+            AutomationRegistry::RunHandler(*command, m_Host, Json{ { "categories", Json::array({ "nope" }) } });
+        EXPECT_TRUE(result.IsError);
+        const std::string text = result.Content.dump();
+        EXPECT_NE(text.find("command_completed"), std::string::npos);
+        EXPECT_NE(text.find("scene_save"), std::string::npos);
+    }
+
+    TEST_F(McpEventsWait, TailReportsTheGapAndTheDataToo)
+    {
+        Events::PublishSceneDirty("S", true);
+        const AutomationInvocation outcome = m_Registry.Invoke(m_Host, "olo_events_tail", Json::object());
+        ASSERT_TRUE(outcome.Ran());
+        const Json out = outcome.Result.StructuredContent;
+        EXPECT_EQ(out["dropped"], 0);
+        ASSERT_EQ(out["count"], 1);
+        EXPECT_EQ(out["events"][0]["category"], "scene_dirty");
+        EXPECT_EQ(out["events"][0]["data"]["dirty"], true);
+    }
+
+    // ---- 4. the dirty edge -------------------------------------------------------
+
+    TEST_F(McpAutomationEvents, CommandHistoryFiresOnDirtyChangedOnTransitionsOnly)
+    {
+        CommandHistory history;
+        std::vector<bool> edges;
+        history.OnDirtyChanged = [&edges](bool dirty)
+        { edges.push_back(dirty); };
+
+        history.Execute(std::make_unique<NoopCommand>());
+        ASSERT_EQ(edges, (std::vector<bool>{ true }));
+        history.Execute(std::make_unique<NoopCommand>());
+        EXPECT_EQ(edges.size(), 1u) << "still dirty: no second edge";
+        history.MarkSaved();
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false }));
+        history.MarkSaved();
+        EXPECT_EQ(edges.size(), 2u) << "already clean: no edge";
+
+        history.Undo();
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false, true }));
+        history.Redo();
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false, true, false }));
+
+        // A save that lands in the same mutation as the edit reports no edge: the
+        // observable state never flipped.
+        history.Execute(std::make_unique<NoopCommand>(), /*markSaved=*/true);
+        EXPECT_EQ(edges.size(), 4u);
+    }
+
+    TEST_F(McpAutomationEvents, CommandHistoryTransactionCollapsesToOneEdgeEachWay)
+    {
+        CommandHistory history;
+        std::vector<bool> edges;
+        history.OnDirtyChanged = [&edges](bool dirty)
+        { edges.push_back(dirty); };
+
+        history.BeginTransaction("batch");
+        history.Execute(std::make_unique<NoopCommand>());
+        history.Execute(std::make_unique<NoopCommand>());
+        ASSERT_EQ(edges, (std::vector<bool>{ true })) << "an open transaction with members is dirty";
+        history.CommitTransaction();
+        EXPECT_EQ(edges.size(), 1u) << "commit keeps it dirty: no edge";
+
+        history.MarkSaved();
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false }));
+        history.BeginTransaction("aborted");
+        history.Execute(std::make_unique<NoopCommand>());
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false, true }));
+        EXPECT_TRUE(history.RollbackTransaction().empty());
+        ASSERT_EQ(edges, (std::vector<bool>{ true, false, true, false }))
+            << "rollback restored the save point, so the document is clean again";
+    }
+
+    TEST_F(McpAutomationEvents, CommandHistoryWithoutAHookStillWorks)
+    {
+        CommandHistory history;
+        history.Execute(std::make_unique<NoopCommand>());
+        EXPECT_TRUE(history.IsDirty());
+        history.MarkSaved();
+        EXPECT_FALSE(history.IsDirty());
+    }
+} // namespace OloEngine::Automation::Tests

--- a/OloEngine/tests/MCP/McpAutomationRegistryTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationRegistryTest.cpp
@@ -322,18 +322,29 @@ TEST(McpAutomationRegistry, AnAvailabilityPredicateThatThrowsMeansUnavailable)
     EXPECT_FALSE(gated.AvailableOn(host));
 }
 
-TEST(McpAutomationRegistry, NoBuiltinCommandDeclaresAnAvailabilityPredicateYet)
+TEST(McpAutomationRegistry, OnlyTheEditorActionsDeclareAnAvailabilityPredicate)
 {
-    // The predicate is new machinery with a deliberately empty adopter set: #1123
-    // is a pure extraction, so tools/list must be byte-identical, and a command
-    // that opted in would change it. This pins that, so the first adopter is a
-    // deliberate act with a visible diff rather than a silent narrowing.
+    // The predicate shipped in #1123 with a deliberately empty adopter set (a pure
+    // extraction must leave tools/list byte-identical). The first adopters are
+    // #1131's four editor actions: each runs an editor toolbar/menu code path
+    // through an EditorMcpContext hook, so a host with no editor genuinely
+    // cannot serve them. This pins the set, so a further adopter is a deliberate
+    // act with a visible diff rather than a silent narrowing of the listing.
     AutomationRegistry registry;
     OloEngine::MCP::RegisterBuiltinCommands(registry);
 
+    const std::set<std::string> adopters{ "olo_editor_pause", "olo_editor_step", "olo_editor_gizmo_set",
+                                          "olo_editor_build_shader_pack" };
     const AutomationRegistry::CommandSnapshot snapshot = registry.Snapshot();
+    std::set<std::string> found;
     for (const AutomationCommand& command : *snapshot)
-        EXPECT_FALSE(static_cast<bool>(command.IsAvailable)) << command.Name << " declares an availability predicate";
+    {
+        EXPECT_EQ(static_cast<bool>(command.IsAvailable), adopters.contains(command.Name))
+            << command.Name << (command.IsAvailable ? " declares" : " lacks") << " an availability predicate";
+        if (command.IsAvailable)
+            found.insert(command.Name);
+    }
+    EXPECT_EQ(found, adopters);
 }
 
 TEST(McpAutomationRegistry, SceneAuthoringCommandsDeclareConsentAndUndoSemantics)
@@ -449,8 +460,16 @@ TEST(McpAutomationRegistry, EveryRegistryCommandIsReachableThroughTheMcpAdapterW
 
     const AutomationRegistry::CommandSnapshot snapshot = server.Registry().Snapshot();
     ASSERT_FALSE(snapshot->empty());
-    EXPECT_EQ(listed.size(), snapshot->size())
-        << "the full profile must list exactly the registry, no more and no fewer";
+    // The full profile lists exactly the registry MINUS what this host cannot
+    // serve (AutomationCommand::IsAvailable): the server here owns no editor, so
+    // the #1131 editor actions are registered but honestly absent from the
+    // listing, and unlisted-but-registered must mean exactly that and nothing else.
+    sizet available = 0;
+    for (const AutomationCommand& command : *snapshot)
+        available += command.AvailableOn(server) ? 1u : 0u;
+    EXPECT_LT(available, snapshot->size()) << "a hookless server should leave the editor actions unavailable";
+    EXPECT_EQ(listed.size(), available)
+        << "the full profile must list exactly the available registry, no more and no fewer";
 
     for (const AutomationCommand& command : *snapshot)
     {
@@ -462,6 +481,11 @@ TEST(McpAutomationRegistry, EveryRegistryCommandIsReachableThroughTheMcpAdapterW
                 entry = &candidate;
                 break;
             }
+        }
+        if (!command.AvailableOn(server))
+        {
+            EXPECT_EQ(entry, nullptr) << command.Name << " is unavailable on this host but the adapter lists it";
+            continue;
         }
         ASSERT_NE(entry, nullptr) << command.Name << " is registered but the adapter does not list it";
         // Byte-for-byte the entry the adapter builds from the command: the schema a

--- a/OloEngine/tests/MCP/McpAutomationTransactionTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationTransactionTest.cpp
@@ -125,6 +125,14 @@ namespace
     class McpAutomationTransaction : public ::testing::Test
     {
       protected:
+        // The diagnostics ring is process-wide; a test that records into it (the
+        // completion-count test below) must not leave its events for the next
+        // test, including when a fatal assertion returns early.
+        void TearDown() override
+        {
+            DiagnosticsEventLog::Get().Clear();
+        }
+
         McpAutomationTransaction()
             : m_Scene(Ref<Scene>::Create()), m_Host(MakeContext())
         {
@@ -283,7 +291,6 @@ TEST_F(McpAutomationTransaction, ABatchPublishesExactlyOneCompletionEvent)
     const auto completions = DiagnosticsEventLog::Get().Query(query);
     ASSERT_EQ(completions.size(), 1u) << "the steps' completions must be folded into the batch's";
     EXPECT_EQ(completions[0].Context, "olo_transaction_apply");
-    DiagnosticsEventLog::Get().Clear();
 }
 
 TEST_F(McpAutomationTransaction, AnIrreversibleStepIsRefusedBeforeAnyEarlierStepRuns)

--- a/OloEngine/tests/MCP/McpAutomationTransactionTest.cpp
+++ b/OloEngine/tests/MCP/McpAutomationTransactionTest.cpp
@@ -37,6 +37,7 @@
 #include "MCP/McpSchemaBuilder.h"
 #include "MCP/McpServer.h"
 #include "MCP/McpTools.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 #include "OloEngine/Scene/Entity.h"
 #include "OloEngine/Scene/Scene.h"
 #include "OloEngine/Scene/SceneSerializer.h"
@@ -263,6 +264,27 @@ TEST(McpAutomationTransactionBoundary, ASymbolReferenceIsAWholeStringOrNothingAt
 }
 
 // ---- acceptance 3: refused at batch-build time -------------------------------
+
+// The automation event bus (#1131): a batch is ONE command_completed, the
+// transaction's own. Its steps run through the registry too, and each would
+// publish its own completion without the suppression around the execution loop.
+TEST_F(McpAutomationTransaction, ABatchPublishesExactlyOneCompletionEvent)
+{
+    DiagnosticsEventLog::Get().Clear();
+    const auto applied = Apply(Json::array({ Step("olo_entity_create", Json{ { "name", "First" } }),
+                                             Step("olo_entity_create", Json{ { "name", "Second" } }) }));
+    ASSERT_TRUE(applied.Ran()) << applied.Message;
+    EXPECT_FALSE(applied.Result.IsError) << applied.Result.Content.dump(2);
+    EXPECT_EQ(EntityCount(), 2u);
+
+    DiagnosticEventQuery query;
+    query.MaxCount = 0;
+    query.Categories = { DiagnosticEventCategory::CommandCompleted };
+    const auto completions = DiagnosticsEventLog::Get().Query(query);
+    ASSERT_EQ(completions.size(), 1u) << "the steps' completions must be folded into the batch's";
+    EXPECT_EQ(completions[0].Context, "olo_transaction_apply");
+    DiagnosticsEventLog::Get().Clear();
+}
 
 TEST_F(McpAutomationTransaction, AnIrreversibleStepIsRefusedBeforeAnyEarlierStepRuns)
 {

--- a/OloEngine/tests/MCP/McpEventStreamTest.cpp
+++ b/OloEngine/tests/MCP/McpEventStreamTest.cpp
@@ -109,6 +109,12 @@ TEST(McpEventStreamLevel, MapsCategoryToSeverity)
     EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::Play), "info");
     EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::Stop), "info");
     EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::AssetReload), "info");
+    // #1131: the bus categories. A command completion is as chatty as a spawn.
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::SceneSave), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::SceneDirty), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::AssetImport), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::CompileFinished), "info");
+    EXPECT_STREQ(MCP::EventLogLevel(DiagnosticEventCategory::CommandCompleted), "debug");
 }
 
 // Every category must map to a recognised RFC-5424 severity token (no "unknown" or
@@ -123,6 +129,11 @@ TEST(McpEventStreamLevel, EveryCategoryHasAKnownLevel)
         DiagnosticEventCategory::EntityDestroy,
         DiagnosticEventCategory::AssetReload,
         DiagnosticEventCategory::ScriptError,
+        DiagnosticEventCategory::SceneSave,
+        DiagnosticEventCategory::SceneDirty,
+        DiagnosticEventCategory::AssetImport,
+        DiagnosticEventCategory::CompileFinished,
+        DiagnosticEventCategory::CommandCompleted,
     };
     static_assert(std::size(all) == OloEngine::kDiagnosticEventCategoryCount,
                   "update this list when DiagnosticEventCategory changes");
@@ -133,6 +144,36 @@ TEST(McpEventStreamLevel, EveryCategoryHasAKnownLevel)
         const std::string level = MCP::EventLogLevel(c);
         EXPECT_NE(std::find(valid.begin(), valid.end(), level), valid.end()) << "level: " << level;
     }
+}
+
+// ---- #1131: the structured payload rides under `data` ----------------------
+
+TEST(McpEventStreamJson, StructuredDataIsEmittedAsAnObjectWhenPresent)
+{
+    DiagnosticEvent e = MakeEvent(DiagnosticEventCategory::SceneSave, "Saved scene 'Level1'", 0, "Level1.olo");
+    e.Data = R"({"scene":"Level1","path":"Scenes/Level1.olo","changed":true})";
+    const Json j = MCP::EventToJson(e);
+    ASSERT_TRUE(j.contains("data"));
+    ASSERT_TRUE(j["data"].is_object());
+    EXPECT_EQ(j["data"]["scene"], "Level1");
+    EXPECT_EQ(j["data"]["path"], "Scenes/Level1.olo");
+    EXPECT_EQ(j["data"]["changed"], true);
+}
+
+TEST(McpEventStreamJson, NoDataKeyWhenTheEventCarriesNone)
+{
+    const Json j = MCP::EventToJson(MakeEvent(DiagnosticEventCategory::Play, "Entered Play mode"));
+    EXPECT_FALSE(j.contains("data")) << "the six legacy fields must serialize byte-identically to before";
+}
+
+TEST(McpEventStreamJson, UnparseableDataIsSurfacedAsTextNotDropped)
+{
+    DiagnosticEvent e = MakeEvent(DiagnosticEventCategory::SceneSave, "x");
+    e.Data = "{not json";
+    const Json j = MCP::EventToJson(e);
+    ASSERT_TRUE(j.contains("data"));
+    EXPECT_TRUE(j["data"].is_string());
+    EXPECT_EQ(j["data"], "{not json");
 }
 
 // ---- MakeEventNotification (JSON-RPC envelope) -----------------------------

--- a/OloEngine/tests/MCP/McpEventStreamTest.cpp
+++ b/OloEngine/tests/MCP/McpEventStreamTest.cpp
@@ -166,14 +166,31 @@ TEST(McpEventStreamJson, NoDataKeyWhenTheEventCarriesNone)
     EXPECT_FALSE(j.contains("data")) << "the six legacy fields must serialize byte-identically to before";
 }
 
-TEST(McpEventStreamJson, UnparseableDataIsSurfacedAsTextNotDropped)
+TEST(McpEventStreamJson, UnparseableDataIsSurfacedAsAnErrorNotDropped)
 {
     DiagnosticEvent e = MakeEvent(DiagnosticEventCategory::SceneSave, "x");
     e.Data = "{not json";
     const Json j = MCP::EventToJson(e);
     ASSERT_TRUE(j.contains("data"));
-    EXPECT_TRUE(j["data"].is_string());
-    EXPECT_EQ(j["data"], "{not json");
+    // An object naming the defect, never the raw text: that text may be invalid
+    // UTF-8, and dump() would then throw inside every carrier.
+    ASSERT_TRUE(j["data"].is_object());
+    EXPECT_TRUE(j["data"].contains("error"));
+    EXPECT_NO_THROW((void)j.dump());
+}
+
+// ---- MakeLogNotification (the envelope the gap warning shares) -------------
+
+TEST(McpEventStreamNotification, LogNotificationCarriesLevelLoggerAndData)
+{
+    const Json n = MCP::MakeLogNotification("warning", Json{ { "gap", 7 }, { "resumedAt", 120 } });
+    EXPECT_EQ(n["jsonrpc"], "2.0");
+    EXPECT_EQ(n["method"], "notifications/message");
+    EXPECT_FALSE(n.contains("id"));
+    EXPECT_EQ(n["params"]["level"], "warning");
+    EXPECT_EQ(n["params"]["logger"], "olo.events");
+    EXPECT_EQ(n["params"]["data"]["gap"], 7);
+    EXPECT_EQ(n["params"]["data"]["resumedAt"], 120);
 }
 
 // ---- MakeEventNotification (JSON-RPC envelope) -----------------------------

--- a/OloEngine/tests/MCP/McpEventsTailTest.cpp
+++ b/OloEngine/tests/MCP/McpEventsTailTest.cpp
@@ -340,30 +340,32 @@ TEST_F(DiagnosticsEventLogTest, LegacyCategoriesCarryNoData)
     EXPECT_TRUE(OloEngine::DiagnosticEventDataKeys(DiagnosticEventCategory::Play).empty());
 }
 
-TEST_F(DiagnosticsEventLogTest, EveryBusCategoryDeclaresAClosedKeySet)
+TEST_F(DiagnosticsEventLogTest, EveryCategoryDeclaresExactlyItsClosedKeySet)
 {
-    for (const DiagnosticEventCategory category :
-         { DiagnosticEventCategory::SceneSave, DiagnosticEventCategory::SceneDirty,
-           DiagnosticEventCategory::AssetImport, DiagnosticEventCategory::CompileFinished,
-           DiagnosticEventCategory::CommandCompleted })
+    // The payload rule, pinned as the exact table: a key added to a category
+    // (or one removed) fails here, in a diff a reviewer sees, rather than
+    // widening what a subscriber can be shown. The seven older categories carry
+    // no payload at all.
+    using Keys = std::vector<std::string_view>;
+    const std::vector<std::pair<DiagnosticEventCategory, Keys>> expected = {
+        { DiagnosticEventCategory::SceneLoad, {} },
+        { DiagnosticEventCategory::Play, {} },
+        { DiagnosticEventCategory::Stop, {} },
+        { DiagnosticEventCategory::EntitySpawn, {} },
+        { DiagnosticEventCategory::EntityDestroy, {} },
+        { DiagnosticEventCategory::AssetReload, {} },
+        { DiagnosticEventCategory::ScriptError, {} },
+        { DiagnosticEventCategory::SceneSave, { "scene", "path", "changed" } },
+        { DiagnosticEventCategory::SceneDirty, { "scene", "dirty" } },
+        { DiagnosticEventCategory::AssetImport, { "asset", "type", "handle", "source" } },
+        { DiagnosticEventCategory::CompileFinished, { "kind", "target", "ok", "errors", "warnings", "seconds" } },
+        { DiagnosticEventCategory::CommandCompleted, { "command", "ok", "durationMs", "projectWrite", "toolset" } },
+    };
+    ASSERT_EQ(expected.size(), OloEngine::kDiagnosticEventCategoryCount) << "add the new category's key set here";
+    for (const auto& [category, keys] : expected)
     {
-        EXPECT_FALSE(OloEngine::DiagnosticEventDataKeys(category).empty())
-            << DiagnosticEvent::CategoryToString(category);
-    }
-    // The payload rule in one assertion: no category may carry a key that
-    // could hold content rather than identity.
-    for (const auto token : DiagnosticEvent::AllCategoryTokens())
-    {
-        DiagnosticEventCategory category{};
-        ASSERT_TRUE(DiagnosticEvent::CategoryFromString(token, category));
-        for (const auto key : OloEngine::DiagnosticEventDataKeys(category))
-        {
-            EXPECT_NE(key, "arguments") << token;
-            EXPECT_NE(key, "result") << token;
-            EXPECT_NE(key, "content") << token;
-            EXPECT_NE(key, "yaml") << token;
-            EXPECT_NE(key, "bytes") << token;
-        }
+        const auto declared = OloEngine::DiagnosticEventDataKeys(category);
+        EXPECT_EQ(Keys(declared.begin(), declared.end()), keys) << DiagnosticEvent::CategoryToString(category);
     }
 }
 

--- a/OloEngine/tests/MCP/McpEventsTailTest.cpp
+++ b/OloEngine/tests/MCP/McpEventsTailTest.cpp
@@ -9,7 +9,10 @@
 // verified separately over the attach loop.
 #include "OloEngine/Debug/DiagnosticsEventLog.h"
 
+#include <atomic>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace
@@ -266,6 +269,11 @@ TEST(DiagnosticsEventCategory, StringRoundTripsForEveryCategory)
         DiagnosticEventCategory::EntityDestroy,
         DiagnosticEventCategory::AssetReload,
         DiagnosticEventCategory::ScriptError,
+        DiagnosticEventCategory::SceneSave,
+        DiagnosticEventCategory::SceneDirty,
+        DiagnosticEventCategory::AssetImport,
+        DiagnosticEventCategory::CompileFinished,
+        DiagnosticEventCategory::CommandCompleted,
     };
     static_assert(std::size(all) == OloEngine::kDiagnosticEventCategoryCount,
                   "update this list when DiagnosticEventCategory changes");
@@ -278,6 +286,198 @@ TEST(DiagnosticsEventCategory, StringRoundTripsForEveryCategory)
         ASSERT_TRUE(DiagnosticEvent::CategoryFromString(token, parsed)) << "token: " << token;
         EXPECT_EQ(category, parsed);
     }
+
+    // AllCategoryTokens is what the tool schemas and error messages are built
+    // from: it must list exactly these, in enum order.
+    const auto tokens = DiagnosticEvent::AllCategoryTokens();
+    ASSERT_EQ(tokens.size(), std::size(all));
+    for (std::size_t i = 0; i < tokens.size(); ++i)
+        EXPECT_EQ(tokens[i], DiagnosticEvent::CategoryToString(all[i]));
+}
+
+// ---- #1131: the structured payload and its closed key set ------------------
+
+TEST_F(DiagnosticsEventLogTest, DataBuilderEmitsCompactJsonWithEscapedStrings)
+{
+    OloEngine::DiagnosticEventData data;
+    EXPECT_TRUE(data.Empty());
+    EXPECT_EQ(data.Build(), "");
+    data.Set("scene", "Say \"hi\"\n").Set("changed", true).Set("handle", u64{ 42 }).Set("seconds", 1.5);
+    EXPECT_FALSE(data.Empty());
+    EXPECT_EQ(data.Build(), R"({"scene":"Say \"hi\"\n","changed":true,"handle":42,"seconds":1.5})");
+    // A repeated key replaces the value in place rather than duplicating it.
+    data.Set("changed", false);
+    EXPECT_EQ(data.Build(), R"({"scene":"Say \"hi\"\n","changed":false,"handle":42,"seconds":1.5})");
+}
+
+TEST_F(DiagnosticsEventLogTest, DataBuilderTruncatesLongValuesVisibly)
+{
+    const std::string document(OloEngine::DiagnosticEventData::kMaxDataValueChars * 3, 'x');
+    OloEngine::DiagnosticEventData data;
+    data.Set("scene", document);
+    const std::string built = data.Build();
+    EXPECT_LT(built.size(), document.size());
+    EXPECT_NE(built.find("..."), std::string::npos) << "truncation must be visible in the record";
+}
+
+TEST_F(DiagnosticsEventLogTest, RecordStoresDataForAnAllowedKeySet)
+{
+    OloEngine::DiagnosticEventData data;
+    data.Set("scene", "Level1").Set("dirty", true);
+    const u64 id = Log().Record(DiagnosticEventCategory::SceneDirty, "dirty", 0, "Level1", data);
+    ASSERT_EQ(1u, id);
+    const auto events = All();
+    ASSERT_EQ(1u, events.size());
+    EXPECT_EQ(events[0].Data, R"({"scene":"Level1","dirty":true})");
+}
+
+TEST_F(DiagnosticsEventLogTest, LegacyCategoriesCarryNoData)
+{
+    Log().Record(DiagnosticEventCategory::Play, "Entered Play mode", 0, "Scene");
+    const auto events = All();
+    ASSERT_EQ(1u, events.size());
+    EXPECT_TRUE(events[0].Data.empty());
+    EXPECT_TRUE(OloEngine::DiagnosticEventDataKeys(DiagnosticEventCategory::Play).empty());
+}
+
+TEST_F(DiagnosticsEventLogTest, EveryBusCategoryDeclaresAClosedKeySet)
+{
+    for (const DiagnosticEventCategory category :
+         { DiagnosticEventCategory::SceneSave, DiagnosticEventCategory::SceneDirty,
+           DiagnosticEventCategory::AssetImport, DiagnosticEventCategory::CompileFinished,
+           DiagnosticEventCategory::CommandCompleted })
+    {
+        EXPECT_FALSE(OloEngine::DiagnosticEventDataKeys(category).empty())
+            << DiagnosticEvent::CategoryToString(category);
+    }
+    // The payload rule in one assertion: no category may carry a key that
+    // could hold content rather than identity.
+    for (const auto token : DiagnosticEvent::AllCategoryTokens())
+    {
+        DiagnosticEventCategory category{};
+        ASSERT_TRUE(DiagnosticEvent::CategoryFromString(token, category));
+        for (const auto key : OloEngine::DiagnosticEventDataKeys(category))
+        {
+            EXPECT_NE(key, "arguments") << token;
+            EXPECT_NE(key, "result") << token;
+            EXPECT_NE(key, "content") << token;
+            EXPECT_NE(key, "yaml") << token;
+            EXPECT_NE(key, "bytes") << token;
+        }
+    }
+}
+
+// ---- #1131: the reported gap ------------------------------------------------
+
+TEST_F(DiagnosticsEventLogTest, CursorInsideTheWindowReportsNoGap)
+{
+    for (int i = 0; i < 5; ++i)
+        Log().Record(DiagnosticEventCategory::Play, "p");
+    DiagnosticEventQuery query;
+    query.SinceId = 2;
+    query.MaxCount = 0;
+    const DiagnosticEventQueryResult result = Log().QueryWithCursor(query);
+    EXPECT_EQ(0u, result.Dropped);
+    EXPECT_EQ(3u, result.Events.size());
+    // A cursor at the head, and a cursor with no lower bound, report no gap either.
+    query.SinceId = 5;
+    EXPECT_EQ(0u, Log().QueryWithCursor(query).Dropped);
+    query.SinceId = 0;
+    EXPECT_EQ(0u, Log().QueryWithCursor(query).Dropped);
+}
+
+TEST_F(DiagnosticsEventLogTest, CursorBehindTheWindowReportsHowManyWereEvicted)
+{
+    const std::size_t capacity = DiagnosticsEventLog::kCapacity;
+    for (std::size_t i = 0; i < capacity + 10; ++i)
+        Log().Record(DiagnosticEventCategory::EntitySpawn, "e");
+    // Ids 1..10 have been evicted; the oldest retained is 11.
+    DiagnosticEventQuery query;
+    query.SinceId = 3;
+    query.MaxCount = 0;
+    const DiagnosticEventQueryResult result = Log().QueryWithCursor(query);
+    EXPECT_EQ(7u, result.Dropped) << "ids 4..10 were above the cursor and are gone";
+    ASSERT_FALSE(result.Events.empty());
+    EXPECT_EQ(11u, result.Events.front().Id);
+    EXPECT_EQ(capacity + 10, result.LastId);
+    // The gap is counted before the category filter: a filter that matches
+    // nothing still reports the loss, because the lost records' categories are
+    // unknown.
+    query.Categories = { DiagnosticEventCategory::Play };
+    const DiagnosticEventQueryResult filtered = Log().QueryWithCursor(query);
+    EXPECT_TRUE(filtered.Events.empty());
+    EXPECT_EQ(7u, filtered.Dropped);
+}
+
+// ---- #1131: the long-poll wait ---------------------------------------------
+
+TEST_F(DiagnosticsEventLogTest, WaitReturnsImmediatelyWhenAMatchAlreadyExists)
+{
+    Log().Record(DiagnosticEventCategory::Play, "p");
+    DiagnosticEventQuery query;
+    query.SinceId = 0;
+    const auto started = std::chrono::steady_clock::now();
+    const DiagnosticEventQueryResult result =
+        Log().WaitWithCursor(query, std::chrono::seconds(5), []
+                             { return false; });
+    EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::seconds(2));
+    ASSERT_EQ(1u, result.Events.size());
+    EXPECT_EQ(1u, result.LastId);
+}
+
+TEST_F(DiagnosticsEventLogTest, WaitTimesOutWithTheCursorWhenNothingMatches)
+{
+    Log().Record(DiagnosticEventCategory::Play, "p");
+    DiagnosticEventQuery query;
+    query.SinceId = 1;
+    const DiagnosticEventQueryResult result =
+        Log().WaitWithCursor(query, std::chrono::milliseconds(50), []
+                             { return false; });
+    EXPECT_TRUE(result.Events.empty());
+    EXPECT_EQ(1u, result.LastId) << "a timeout still hands back the cursor to resume from";
+}
+
+TEST_F(DiagnosticsEventLogTest, WaitWakesWhenAMatchingEventIsRecorded)
+{
+    DiagnosticEventQuery query;
+    query.SinceId = 0;
+    query.Categories = { DiagnosticEventCategory::Stop };
+    std::thread recorder(
+        []
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Play, "ignored by the filter");
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::Stop, "the one");
+        });
+    const DiagnosticEventQueryResult result =
+        Log().WaitWithCursor(query, std::chrono::seconds(10), []
+                             { return false; });
+    recorder.join();
+    ASSERT_EQ(1u, result.Events.size());
+    EXPECT_EQ(DiagnosticEventCategory::Stop, result.Events[0].Category);
+    EXPECT_EQ(2u, result.LastId);
+}
+
+TEST_F(DiagnosticsEventLogTest, WaitStopsEarlyWhenCancelled)
+{
+    std::atomic<bool> cancelled{ false };
+    DiagnosticEventQuery query;
+    query.SinceId = 0;
+    std::thread canceller(
+        [&cancelled]
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            cancelled.store(true);
+        });
+    const auto started = std::chrono::steady_clock::now();
+    const DiagnosticEventQueryResult result = Log().WaitWithCursor(
+        query, std::chrono::seconds(30), [&cancelled]
+        { return cancelled.load(); });
+    canceller.join();
+    EXPECT_TRUE(result.Events.empty());
+    EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::seconds(5))
+        << "cancellation is polled every 250 ms, not at the deadline";
 }
 
 TEST(DiagnosticsEventCategory, FromStringRejectsUnknownToken)

--- a/OloEngine/tests/MCP/McpEventsTailTest.cpp
+++ b/OloEngine/tests/MCP/McpEventsTailTest.cpp
@@ -367,6 +367,39 @@ TEST_F(DiagnosticsEventLogTest, EveryBusCategoryDeclaresAClosedKeySet)
     }
 }
 
+TEST_F(DiagnosticsEventLogTest, SuppressCategoryScopeMutesOneCategoryOnThisThreadOnly)
+{
+    {
+        const DiagnosticsEventLog::SuppressCategoryScope quiet(DiagnosticEventCategory::CommandCompleted);
+        EXPECT_EQ(0u, Log().Record(DiagnosticEventCategory::CommandCompleted, "muted"));
+        EXPECT_EQ(1u, Log().Record(DiagnosticEventCategory::Play, "other categories still record"));
+        // Another thread is unaffected: the scope is thread-local by design.
+        u64 fromOtherThread = 0;
+        std::thread other([&fromOtherThread]
+                          { fromOtherThread = DiagnosticsEventLog::Get().Record(DiagnosticEventCategory::CommandCompleted, "elsewhere"); });
+        other.join();
+        EXPECT_EQ(2u, fromOtherThread);
+    }
+    EXPECT_EQ(3u, Log().Record(DiagnosticEventCategory::CommandCompleted, "scope ended"));
+}
+
+TEST_F(DiagnosticsEventLogTest, DataBuilderTruncatesOnAUtf8Boundary)
+{
+    // 90 three-byte characters = 270 bytes; the cut at 256 lands mid-character
+    // and must back off so the value stays valid UTF-8.
+    std::string text;
+    for (int i = 0; i < 90; ++i)
+        text += "\xE3\x81\x82"; // U+3042
+    OloEngine::DiagnosticEventData data;
+    data.Set("scene", text);
+    const std::string built = data.Build();
+    const std::size_t cut = built.find("...");
+    ASSERT_NE(cut, std::string::npos);
+    // Every character before the marker is whole: the byte count is a multiple of 3.
+    const std::size_t valueStart = built.find(':') + 2; // past `{"scene":"`
+    EXPECT_EQ((cut - valueStart) % 3, 0u);
+}
+
 // ---- #1131: the reported gap ------------------------------------------------
 
 TEST_F(DiagnosticsEventLogTest, CursorInsideTheWindowReportsNoGap)

--- a/OloEngine/tests/MCP/McpShaderReloadTest.cpp
+++ b/OloEngine/tests/MCP/McpShaderReloadTest.cpp
@@ -78,9 +78,10 @@ namespace
         {
             return m_Name;
         }
-        void Reload() override
+        bool Reload() override
         {
             ++m_ReloadCount;
+            return true;
         }
         OloEngine::ShaderResourceRegistry* GetResourceRegistry() override
         {

--- a/OloEngine/tests/OloCtl/OloCtlCommandTreeTest.cpp
+++ b/OloEngine/tests/OloCtl/OloCtlCommandTreeTest.cpp
@@ -174,7 +174,8 @@ TEST(OloCtlCommandTree, NoProductionGroupShadowsAnOloCtlSubcommand)
     const Catalogue catalogue = ProductionCatalogue(registry);
     const CommandTree tree = CommandTree::Build(catalogue);
 
-    const std::set<std::string> reserved{ "help", "version", "catalogue", "call" };
+    // Keep in step with ReportCatalogue's shadow list in OloCtl/CliRunner.cpp.
+    const std::set<std::string> reserved{ "help", "version", "catalogue", "call", "events" };
     for (const TreeGroup& group : tree.Groups())
         EXPECT_EQ(reserved.count(group.Name), 0u) << "group `" << group.Name << "` shadows an oloctl subcommand";
 }

--- a/OloEngine/tests/OloCtl/OloCtlGeneratedSurfaceTest.cpp
+++ b/OloEngine/tests/OloCtl/OloCtlGeneratedSurfaceTest.cpp
@@ -34,8 +34,10 @@
 #include "MCP/McpExposure.h"
 #include "MCP/McpServer.h"
 #include "MCP/McpTools.h"
+#include "MCP/McpToolsCommon.h"
 #include "OloCtl/CliRunner.h"
 #include "OloCtl/RegistryCommandSource.h"
+#include "OloEngine/Debug/DiagnosticsEventLog.h"
 
 #include <sstream>
 #include <string>
@@ -408,4 +410,46 @@ TEST(OloCtlGeneratedSurface, InvalidArgumentsAreRejectedByTheHostNotByTheCli)
     ASSERT_FALSE(payload.is_discarded()) << run.Out;
     EXPECT_EQ(payload["isError"], true);
     EXPECT_NE(payload.dump().find("thingId"), std::string::npos) << payload.dump(2);
+}
+
+// ---- 4. the event bus, followed from the CLI (#1131) ------------------------
+
+// `oloctl events follow` is a loop over the REAL olo_events_wait: the registry
+// command the diagnostics domain registers, over the engine's real event ring,
+// with no server and no socket. One recorded event comes out as one NDJSON line
+// carrying the id the ring assigned.
+TEST(OloCtlGeneratedSurface, EventsFollowStreamsARecordedEventThroughTheRealRegistry)
+{
+    AutomationRegistry registry;
+    OloEngine::MCP::RegisterDiagnosticsTools(registry);
+    HeadlessHost host;
+
+    OloEngine::DiagnosticsEventLog& log = OloEngine::DiagnosticsEventLog::Get();
+    log.Clear();
+    const u64 recorded = log.Record(OloEngine::DiagnosticEventCategory::Play, "runtime started");
+    ASSERT_NE(recorded, 0u) << "the ring refused the record";
+
+    // --since-id 0: from the oldest record held, so the event recorded BEFORE the
+    // first poll is returned rather than waited past. --until play ends the loop
+    // on it; --count 1 is the belt to that brace.
+    const CliRun run = RunOloCtl(registry, host, { "events", "follow", "--since-id", "0", "--until", "play", "--count", "1" });
+    log.Clear();
+
+    ASSERT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    EXPECT_TRUE(run.Err.empty()) << run.Err;
+
+    std::vector<std::string> lines;
+    std::istringstream in(run.Out);
+    for (std::string line; std::getline(in, line);)
+    {
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+        lines.push_back(line);
+    }
+    ASSERT_EQ(lines.size(), 1u) << "exactly one event, one line: " << run.Out;
+    const Json event = Json::parse(lines.front(), nullptr, false);
+    ASSERT_FALSE(event.is_discarded()) << lines.front();
+    EXPECT_EQ(event["category"], "play");
+    EXPECT_EQ(event["id"], recorded);
+    EXPECT_EQ(event["message"], "runtime started");
 }

--- a/OloEngine/tests/OloCtl/OloCtlGeneratedSurfaceTest.cpp
+++ b/OloEngine/tests/OloCtl/OloCtlGeneratedSurfaceTest.cpp
@@ -36,6 +36,7 @@
 #include "MCP/McpTools.h"
 #include "MCP/McpToolsCommon.h"
 #include "OloCtl/CliRunner.h"
+#include "OloCtl/EventsFollow.h"
 #include "OloCtl/RegistryCommandSource.h"
 #include "OloEngine/Debug/DiagnosticsEventLog.h"
 
@@ -418,6 +419,17 @@ TEST(OloCtlGeneratedSurface, InvalidArgumentsAreRejectedByTheHostNotByTheCli)
 // command the diagnostics domain registers, over the engine's real event ring,
 // with no server and no socket. One recorded event comes out as one NDJSON line
 // carrying the id the ring assigned.
+// oloctl links no engine code, so its category list is a copy by necessity; this
+// is the one place both trees are linked, so it is where the copy is pinned.
+TEST(OloCtlGeneratedSurface, EventsFollowCategoryListMatchesTheEngineTable)
+{
+    const auto cli = OloCtl::EventCategoryTokens();
+    const auto engine = OloEngine::DiagnosticEvent::AllCategoryTokens();
+    ASSERT_EQ(cli.size(), engine.size());
+    for (std::size_t i = 0; i < cli.size(); ++i)
+        EXPECT_EQ(std::string(cli[i]), std::string(engine[i])) << "index " << i;
+}
+
 TEST(OloCtlGeneratedSurface, EventsFollowStreamsARecordedEventThroughTheRealRegistry)
 {
     AutomationRegistry registry;

--- a/OloEngine/tests/OloCtl/OloCtlRunnerTest.cpp
+++ b/OloEngine/tests/OloCtl/OloCtlRunnerTest.cpp
@@ -19,8 +19,11 @@
 #include "OloCtl/CommandCatalogue.h"
 #include "OloCtl/CommandSource.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 using OloCtl::AuthorityClass;
@@ -66,7 +69,15 @@ namespace
                 return outcome;
             }
             outcome.Ok = true;
-            outcome.Result = m_Result;
+            if (m_Scripted.empty())
+            {
+                outcome.Result = m_Result;
+                return outcome;
+            }
+            // Scripted answers are handed out in order; once they run out the last
+            // one repeats, so a follower that keeps polling keeps getting an answer.
+            outcome.Result = m_Scripted[std::min(m_NextScripted, m_Scripted.size() - 1)];
+            ++m_NextScripted;
             return outcome;
         }
 
@@ -82,6 +93,11 @@ namespace
         {
             m_Result = std::move(result);
         }
+        void ScriptResults(std::vector<Json> results)
+        {
+            m_Scripted = std::move(results);
+            m_NextScripted = 0;
+        }
 
         struct Invocation
         {
@@ -95,6 +111,8 @@ namespace
         std::string m_ConnectionError;
         std::string m_TransportError;
         Json m_Result = Json{ { "content", Json::array() }, { "isError", false } };
+        std::vector<Json> m_Scripted;
+        std::size_t m_NextScripted = 0;
     };
 
     CatalogueEntry Entry(std::string name, std::string toolset, AuthorityClass authority)
@@ -144,6 +162,45 @@ namespace
         std::ostringstream err;
         const int code = RunCli(ParseCommandLine(args), source, out, err);
         return { code, out.str(), err.str() };
+    }
+
+    // ---- olo_events_wait answers, in the shape the editor's handler returns ----
+
+    Json Event(unsigned long long id, const char* category)
+    {
+        return Json{ { "id", id }, { "category", category }, { "message", std::string(category) + " happened" } };
+    }
+
+    Json WaitResponse(std::vector<Json> events, unsigned long long lastId, unsigned long long dropped = 0)
+    {
+        const bool timedOut = events.empty();
+        return Json{ { "content", Json::array() },
+                     { "isError", false },
+                     { "structuredContent",
+                       Json{ { "count", events.size() },
+                             { "lastId", lastId },
+                             { "dropped", dropped },
+                             { "timedOut", timedOut },
+                             { "cancelled", false },
+                             { "events", std::move(events) } } } };
+    }
+
+    // stdout split into lines; every line must parse as one JSON object.
+    std::vector<Json> NdjsonLines(const std::string& text)
+    {
+        std::vector<Json> lines;
+        std::istringstream in(text);
+        std::string line;
+        while (std::getline(in, line))
+        {
+            if (!line.empty() && line.back() == '\r')
+                line.pop_back();
+            Json parsed = Json::parse(line, nullptr, false);
+            EXPECT_FALSE(parsed.is_discarded()) << "not a JSON line: " << line;
+            EXPECT_TRUE(parsed.is_object()) << "not an event object: " << line;
+            lines.push_back(std::move(parsed));
+        }
+        return lines;
     }
 } // namespace
 
@@ -468,4 +525,258 @@ TEST(OloCtlRunner, NoArgumentsIsAUsageErrorWithHelpOnStderr)
     EXPECT_EQ(run.Code, ExitCode::Usage);
     EXPECT_TRUE(run.Out.empty()) << "an accidental bare `oloctl` must not put help into a pipe";
     EXPECT_NE(run.Err.find("Usage:"), std::string::npos);
+}
+
+// ---- events follow (#1131) --------------------------------------------------
+//
+// The CLI consumer of the event bus is a loop over olo_events_wait through the
+// same ICommandSource::Invoke as every other verb. What these pin: the NDJSON
+// discipline (one object per line, nothing else on stdout), the cursor
+// hand-back, the termination rules, and that a transport failure, an error
+// result and a usage slip land on the exit codes a script is told to expect.
+
+TEST(OloCtlRunner, EventsFollowPrintsOneJsonObjectPerEventAndNothingElse)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "scene_load"), Event(2, "entity_spawn") }, 2),
+                           WaitResponse({}, 2), // an idle poll: timed out, no events
+                           WaitResponse({ Event(3, "play") }, 3) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--count", "3" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    const std::vector<Json> lines = NdjsonLines(run.Out);
+    ASSERT_EQ(lines.size(), 3u) << run.Out;
+    EXPECT_EQ(lines[0]["id"], 1);
+    EXPECT_EQ(lines[1]["id"], 2);
+    EXPECT_EQ(lines[2]["category"], "play");
+    EXPECT_EQ(lines[2]["message"], "play happened") << "the event record is printed verbatim";
+    EXPECT_TRUE(run.Err.empty()) << run.Err;
+
+    ASSERT_EQ(source.Invocations.size(), 3u) << "an idle poll must be followed by another poll";
+    for (const FakeSource::Invocation& invocation : source.Invocations)
+        EXPECT_EQ(invocation.Name, "olo_events_wait");
+    EXPECT_EQ(source.Invocations.front().Arguments["waitMs"], 10000) << "the default long-poll is 10 s";
+    EXPECT_FALSE(source.Invocations.front().Arguments.contains("sinceId"))
+        << "without --since-id the first poll lets the editor start at now";
+}
+
+TEST(OloCtlRunner, EventsFollowUntilStopsAfterTheNamedCategory)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "scene_load"), Event(2, "play"), Event(3, "entity_spawn") }, 3) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--until", "play" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    const std::vector<Json> lines = NdjsonLines(run.Out);
+    ASSERT_EQ(lines.size(), 2u) << "the play event is printed, and nothing after it: " << run.Out;
+    EXPECT_EQ(lines.back()["category"], "play");
+    EXPECT_EQ(source.Invocations.size(), 1u);
+}
+
+TEST(OloCtlRunner, EventsFollowCountStopsAfterThatManyEvents)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "play"), Event(2, "stop"), Event(3, "play") }, 3) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--count", "2" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    EXPECT_EQ(NdjsonLines(run.Out).size(), 2u) << run.Out;
+    EXPECT_EQ(source.Invocations.front().Arguments["count"], 2) << "the server is asked for no more than needed";
+}
+
+TEST(OloCtlRunner, EventsFollowPassesTheLastIdBackAsTheNextSinceId)
+{
+    FakeSource source(TestCatalogue());
+    // The first answer's lastId (5) is past its last event (1): ids 2-5 were
+    // filtered out by the editor. The cursor is lastId, not the last printed id,
+    // or the next poll would re-fetch what the editor already skipped.
+    source.ScriptResults({ WaitResponse({ Event(1, "play") }, 5),
+                           WaitResponse({ Event(6, "stop"), Event(7, "play") }, 7) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--count", "3" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    ASSERT_EQ(source.Invocations.size(), 2u);
+    EXPECT_FALSE(source.Invocations[0].Arguments.contains("sinceId"));
+    EXPECT_EQ(source.Invocations[1].Arguments["sinceId"], 5);
+    EXPECT_EQ(source.Invocations[1].Arguments["count"], 2) << "the remaining budget after one printed event";
+}
+
+TEST(OloCtlRunner, EventsFollowSinceIdIsSentVerbatimIncludingZero)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "play") }, 1) });
+
+    const CliRun zero = Invoke(source, { "events", "follow", "--since-id", "0", "--count", "1" });
+    EXPECT_EQ(zero.Code, ExitCode::Ok) << zero.Err;
+    ASSERT_EQ(source.Invocations.size(), 1u);
+    EXPECT_EQ(source.Invocations[0].Arguments["sinceId"], 0) << "0 is the editor's no-lower-bound, so it is sent";
+
+    const CliRun forty = Invoke(source, { "events", "follow", "--since-id=40", "--count", "1" });
+    EXPECT_EQ(forty.Code, ExitCode::Ok) << forty.Err;
+    ASSERT_EQ(source.Invocations.size(), 2u);
+    EXPECT_EQ(source.Invocations[1].Arguments["sinceId"], 40);
+}
+
+TEST(OloCtlRunner, EventsFollowForwardsTheCategoryFilterAndUntilDoesNotWidenIt)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "play") }, 1) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--category", "play", "--category=stop", "--until",
+                                        "scene_load", "--count", "1" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    ASSERT_EQ(source.Invocations.size(), 1u);
+    EXPECT_EQ(source.Invocations.front().Arguments["categories"], (Json::array({ "play", "stop" })));
+    EXPECT_FALSE(source.Invocations.front().Arguments.contains("until"))
+        << "--until decides termination locally; it is not an argument of olo_events_wait";
+}
+
+TEST(OloCtlRunner, EventsFollowRejectsAnUnknownCategoryBeforePolling)
+{
+    FakeSource source(TestCatalogue());
+
+    const CliRun category = Invoke(source, { "events", "follow", "--category", "bogus" });
+    EXPECT_EQ(category.Code, ExitCode::Usage);
+    EXPECT_TRUE(category.Out.empty()) << category.Out;
+    EXPECT_NE(category.Err.find("bogus"), std::string::npos) << category.Err;
+    EXPECT_NE(category.Err.find("scene_load"), std::string::npos) << "the valid tokens are named: " << category.Err;
+    EXPECT_NE(category.Err.find("command_completed"), std::string::npos) << category.Err;
+
+    const CliRun until = Invoke(source, { "events", "follow", "--until", "Play" });
+    EXPECT_EQ(until.Code, ExitCode::Usage) << "--until is validated the same way";
+
+    EXPECT_TRUE(source.Invocations.empty()) << "a usage error must not reach the editor";
+}
+
+TEST(OloCtlRunner, EventsFollowUsageSlipsAreUsageErrors)
+{
+    FakeSource source(TestCatalogue());
+
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--count", "0" }).Code, ExitCode::Usage);
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--count", "-1" }).Code, ExitCode::Usage);
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--since-id", "x" }).Code, ExitCode::Usage);
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--for", "0" }).Code, ExitCode::Usage);
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--until" }).Code, ExitCode::Usage) << "a missing value";
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--until", "--count", "1" }).Code, ExitCode::Usage)
+        << "a value never begins with --";
+    EXPECT_EQ(Invoke(source, { "events", "follow", "--limit", "1" }).Code, ExitCode::Usage) << "an unknown option";
+    EXPECT_EQ(Invoke(source, { "events", "follow", "extra" }).Code, ExitCode::Usage) << "a stray positional";
+    EXPECT_EQ(Invoke(source, { "events", "bogus" }).Code, ExitCode::Usage) << "an unknown sub-verb";
+    EXPECT_TRUE(source.Invocations.empty());
+}
+
+TEST(OloCtlRunner, EventsFollowWarnsOnStderrWhenTheCursorFellBehind)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(600, "play") }, 600, /*dropped=*/3) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--since-id", "80", "--count", "1" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok);
+    EXPECT_NE(run.Err.find("3 event(s) were dropped before id 600"), std::string::npos) << run.Err;
+    EXPECT_NE(run.Err.find("512"), std::string::npos) << "the window size is named: " << run.Err;
+    EXPECT_EQ(NdjsonLines(run.Out).size(), 1u) << "the warning must not disturb stdout: " << run.Out;
+}
+
+TEST(OloCtlRunner, EventsFollowReportsATransportFailureAsAConnectionError)
+{
+    FakeSource source(TestCatalogue());
+    source.FailTransport("the editor stopped answering");
+
+    const CliRun run = Invoke(source, { "events", "follow" });
+
+    EXPECT_EQ(run.Code, ExitCode::Connection);
+    EXPECT_TRUE(run.Out.empty()) << run.Out;
+    EXPECT_NE(run.Err.find("the editor stopped answering"), std::string::npos) << run.Err;
+}
+
+// An editor older than the event bus has no olo_events_wait: tools/call answers
+// with an error result, and the follower says what that means rather than
+// retrying forever.
+TEST(OloCtlRunner, EventsFollowReportsAnErrorResultAndNamesAnEditorThatPredatesTheBus)
+{
+    FakeSource source(TestCatalogue());
+    source.SetResult(Json{ { "content", Json::array({ Json{ { "type", "text" },
+                                                            { "text", "Unknown tool: olo_events_wait" } } }) },
+                           { "isError", true } });
+
+    const CliRun run = Invoke(source, { "events", "follow" });
+
+    EXPECT_EQ(run.Code, ExitCode::CommandError);
+    EXPECT_TRUE(run.Out.empty()) << run.Out;
+    EXPECT_NE(run.Err.find("Unknown tool: olo_events_wait"), std::string::npos) << run.Err;
+    EXPECT_NE(run.Err.find("predates"), std::string::npos) << run.Err;
+    EXPECT_EQ(source.Invocations.size(), 1u) << "an error result is not retried";
+}
+
+// The verb is dispatched before the catalogue fetch: it hard-codes the one
+// registry name it needs, so it must work when the fetch would fail.
+TEST(OloCtlRunner, EventsFollowNeedsNoCatalogue)
+{
+    FakeSource source(TestCatalogue());
+    source.FailToConnect("olo_tool_search is unreachable");
+    source.ScriptResults({ WaitResponse({ Event(1, "play") }, 1) });
+
+    const CliRun run = Invoke(source, { "events", "follow", "--count", "1" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    EXPECT_EQ(NdjsonLines(run.Out).size(), 1u);
+    EXPECT_EQ(run.Err.find("olo_tool_search"), std::string::npos) << "the catalogue was never fetched: " << run.Err;
+}
+
+TEST(OloCtlRunner, EventsFollowRefusesATimeoutTooShortForTheLongPoll)
+{
+    FakeSource source(TestCatalogue());
+    source.ScriptResults({ WaitResponse({ Event(1, "play") }, 1) });
+
+    const CliRun tooShort = Invoke(source, { "--timeout", "1000", "events", "follow", "--count", "1" });
+    EXPECT_EQ(tooShort.Code, ExitCode::Usage);
+    EXPECT_TRUE(tooShort.Out.empty());
+    EXPECT_NE(tooShort.Err.find("2000"), std::string::npos) << tooShort.Err;
+    EXPECT_TRUE(source.Invocations.empty());
+
+    // Just above the floor: the long-poll is half the read timeout, never more.
+    const CliRun aboveFloor = Invoke(source, { "--timeout", "3000", "events", "follow", "--count", "1" });
+    EXPECT_EQ(aboveFloor.Code, ExitCode::Ok) << aboveFloor.Err;
+    ASSERT_EQ(source.Invocations.size(), 1u);
+    EXPECT_EQ(source.Invocations.front().Arguments["waitMs"], 1500);
+}
+
+TEST(OloCtlRunner, EventsHelpGoesToStdoutAndNeedsNoEditor)
+{
+    FakeSource source(TestCatalogue());
+    source.FailToConnect("no running editor found");
+
+    const std::vector<std::vector<std::string>> spellings{ { "events" },
+                                                           { "events", "--help" },
+                                                           { "events", "follow", "--help" } };
+    for (const std::vector<std::string>& args : spellings)
+    {
+        const CliRun run = Invoke(source, args);
+        EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+        EXPECT_NE(run.Out.find("events follow"), std::string::npos) << run.Out;
+        EXPECT_NE(run.Out.find("--since-id"), std::string::npos) << run.Out;
+        EXPECT_NE(run.Out.find("until interrupted"), std::string::npos) << run.Out;
+        EXPECT_TRUE(run.Err.empty()) << run.Err;
+    }
+    EXPECT_TRUE(source.Invocations.empty());
+}
+
+// A registry toolset named `events` can never be typed, because the verb is
+// dispatched first. The catalogue report says so, as it does for `call`.
+TEST(OloCtlRunner, AGroupNamedEventsIsReportedAsShadowed)
+{
+    Catalogue catalogue = TestCatalogue();
+    catalogue.Entries.push_back(Entry("olo_events_tail", "events", AuthorityClass::ReadOnly));
+    FakeSource source(std::move(catalogue));
+
+    const CliRun run = Invoke(source, { "scene", "list-entities" });
+
+    EXPECT_EQ(run.Code, ExitCode::Ok) << run.Err;
+    EXPECT_NE(run.Err.find("`events` shares its name with an oloctl subcommand"), std::string::npos) << run.Err;
 }

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -153,6 +153,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [mcp-setter-based-field-registry.md](mcp-setter-based-field-registry.md): copy-then-swap MCP writes are unsound when `operator=` cannot reproduce a setter's side effects.
 - [mcp-protocol-eras.md](mcp-protocol-eras.md): the stateless core is a second transport; adding `server/discover` alone breaks working clients.
 - [automation-build-invocation.md](automation-build-invocation.md): a build started from inside the editor goes through `build-lock.ps1` or it does not happen, the editor process is the lock's identity, cancellation kills the job object rather than the shim, and `OloEditor` is refused by allow-list.
+- [automation-event-bus.md](automation-event-bus.md): an event carries identities, never a read's content; a subscriber holds a cursor into the one 512-record ring and is told the count it lost; only a mutating command publishes its completion.
 
 ## Concurrency and memory
 
@@ -209,6 +210,7 @@ The dominant archetype here. If your change is in one of these areas, a passing 
 | [follow-camera-and-character-query-seams.md](follow-camera-and-character-query-seams.md) | A steady-state offset check passes with a full one-tick lag present. |
 | [parallelizable-mover-systems.md](parallelizable-mover-systems.md) | A position check passes on the scheduler tie-break alone, with the dependency edge missing. |
 | [mcp-protocol-eras.md](mcp-protocol-eras.md) | Adding `server/discover` alone keeps tests green and breaks the legacy fallback for real clients. |
+| [automation-event-bus.md](automation-event-bus.md) | The push stream served every event record unredacted while `olo_events_tail` served the same record scrubbed, and a cursor that fell behind the ring received a shorter history with no sign anything was missing. |
 | [notes-mcp-tool-authoring.md](notes-mcp-tool-authoring.md) | `tools/list` serves an exposure profile, not the registry, so a tool you just registered is callable but invisible — including to the agent you attach to check your work — and a test that registers a fake tool and lists it gets an empty array. |
 | [notes-mcp-tool-authoring.md](notes-mcp-tool-authoring.md) | An automation command that never declares `AutomationUndo` is silently refused from every transaction: the build is green, the tool works on its own, and the only symptom is a batch refusal read months later. |
 | [vulkan-command-ordered-buffer-writes.md](vulkan-command-ordered-buffer-writes.md) | Two scenes rendered skybox-only with zero errors because no test interleaved two SSBO uploads with draws. Later, the same snapshot applied to a GPU-output buffer made the mesh-shader raster arm launch `EmitMeshTasksEXT(0)` — a legal call, so nothing warned — while masking an out-of-bounds read that device-faults once you remove it. Later still, vertex streams turned out never to have been given the snapshot at all, under a comment asserting nothing streamed them. |

--- a/docs/agent-rules/automation-event-bus.md
+++ b/docs/agent-rules/automation-event-bus.md
@@ -1,0 +1,72 @@
+# Put identities on the event bus, never content, and subscribe with a cursor, never a queue
+
+Rules for the automation event bus (issue #1131), which is the engine's diagnostics ring
+(`Debug/DiagnosticsEventLog.h`) plus a long-poll command over it. Both rules exist because the
+alternatives each failed a design constraint the issue stated, and one of them had already
+failed silently in the code that shipped before.
+
+## 1. An event carries the identity of what happened, not what a read would return
+
+**Rule.** A record on the bus names the thing (a command name, a scene name, a project-relative
+path, an entity id, an outcome) and never carries the content a read command would return for
+it: no arguments, no results, no serialized scene, no file bytes, no absolute path. The keys a
+category may carry are a closed table (`DiagnosticEventDataKeys`), `Record()` refuses any other
+key, and string values are cut at 256 characters. Publish through `Automation/AutomationEvents.h`,
+which builds every payload from that table and makes paths project-relative first.
+
+**Why.** The issue's constraint was that a subscription is an authority-bearing capability
+because "events can leak state a read tool would have gated". The census found nothing that
+gates a read today beyond the bearer token, so the rule was made structural instead: keep
+gated content off the bus and there is nothing for a subscriber to see through. That is what
+lets `olo_events_wait` be a plain read-only command and lets `oloctl`, which refuses every write,
+follow the stream.
+
+**What had already leaked.** `tools/call` and `resources/read` scrub absolute paths when the
+session's redaction toggle is on. The `GET /mcp` push stream did not: it serialized each record
+straight from the ring, so the same `asset_reload` record arrived redacted through
+`olo_events_tail` and unredacted through the stream. Every carrier now applies the redaction
+(`ServiceEventStream` takes it as a parameter). When you add a carrier, route it through the
+same function.
+
+## 2. A subscriber holds a cursor; the ring is the only window
+
+**Rule.** There is no per-subscriber buffer. A consumer holds the last event id it saw and asks
+for what came after it (`olo_events_tail`, `olo_events_wait`, `Last-Event-ID` on the stream,
+`oloctl events follow`). The ring keeps the newest 512 records and evicts the rest whether or not
+anyone read them. A consumer whose cursor is older than the oldest retained record is told how
+many it lost (`dropped`), and must treat that as a hole in its history, not continue as if it
+were complete.
+
+**Why.** The issue's second constraint was that "a subscriber that stops reading must not grow
+the editor's memory without bound". A queue per subscriber answers it with a cap and a drop
+policy per queue; a shared cursor answers it with no memory at all and the same drop policy,
+counted. The gap count is the part that was missing: before #1131 a cursor that fell behind got a
+silently shortened history from `QueryWithCursor`, and the stream's "the oldest may already have
+been evicted" was a sentence in the guide rather than a number in the response.
+
+## 3. Only a mutating command publishes `command_completed`
+
+**Rule.** `AutomationRegistry::RunHandler` publishes a completion event for every command that is
+not annotated `readOnlyHint: true`. A read-only command never publishes one, and a command with
+no annotations counts as mutating.
+
+**Why.** Two reasons, and the second is the one to remember. A session that polls a dozen reads a
+second would evict everything worth waiting for from a 512-record ring. And the subscription
+command is itself read-only: if its completion were an event, two agents each waiting for "the
+next event" would wake each other forever. If you add a read-only command with no annotations,
+it will publish; give it `ReadOnlyAnnotations()`.
+
+## 4. Emission sites, so a new event lands where the others do
+
+| Event | Published from | Path it covers |
+|---|---|---|
+| `scene_save` | `Automation::SaveSceneDocument` | menu, Ctrl+S, `olo_scene_save`, `olo_scene_save_as` |
+| `scene_dirty` | `CommandHistory::OnDirtyChanged`, wired once in `EditorLayer` | every edit, undo, redo, save and transaction on the scene history |
+| `asset_import` | `EditorLayer::OnAssetImported` and the `olo_asset_import` handler | the file watcher does not fire the `AssetImportedEvent` for a command import, so both publish |
+| `compile_finished` | `ScriptEngine::ReloadAssembly`, `ShaderLibrary::ReloadShaders`, `Handle_BuildRun` | `kind` says which: `script`, `shader`, `build` |
+| `command_completed` | `AutomationRegistry::RunHandler` | every frontend, since every one runs a handler through it |
+
+A new site must record under an existing category or add one to the enum, the token maps, the
+`kDiagnosticEventCategoryCount` constant, the closed key table, and the two exhaustiveness tests
+(`McpEventsTailTest`, `McpEventStreamTest`). The compiler catches the switch statements; the
+tests catch the tables.

--- a/docs/agent-rules/automation-event-bus.md
+++ b/docs/agent-rules/automation-event-bus.md
@@ -11,8 +11,9 @@ failed silently in the code that shipped before.
 path, an entity id, an outcome) and never carries the content a read command would return for
 it: no arguments, no results, no serialized scene, no file bytes, no absolute path. The keys a
 category may carry are a closed table (`DiagnosticEventDataKeys`), `Record()` refuses any other
-key, and string values are cut at 256 characters. Publish through `Automation/AutomationEvents.h`,
-which builds every payload from that table and makes paths project-relative first.
+key, and string values are cut at 256 bytes, on a UTF-8 character boundary. Publish through
+`Automation/AutomationEvents.h`, which builds every payload from that table and makes paths
+project-relative first.
 
 **Why.** The issue's constraint was that a subscription is an authority-bearing capability
 because "events can leak state a read tool would have gated". The census found nothing that

--- a/docs/agent-rules/notes-mcp-tool-authoring.md
+++ b/docs/agent-rules/notes-mcp-tool-authoring.md
@@ -93,7 +93,7 @@ Two things this asks of you, both enforced by `OloCtlCommandTreeTest`:
   spelling ambiguous, and `oloctl` refuses it rather than picking
   (`NoTwoProductionCommandsDeriveTheSameSpelling`). The fix is a rename, and the moment
   to make it is before the tool ships. `oloctl call <registry-name>` still reaches both.
-- **Do not name a toolset `help`, `version`, `catalogue` or `call`.** Those are
+- **Do not name a toolset `help`, `version`, `catalogue`, `call` or `events`.** Those are
   `oloctl`'s own subcommands, so such a group cannot be reached by typing it
   (`NoProductionGroupShadowsAnOloCtlSubcommand`).
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -201,6 +201,10 @@ and for what to do when adding a tool.
 | `olo_scene_simulate` | **(consented write)** enter Simulate through the real editor toolbar path, running physics/runtime systems with the editor camera; reports `mode`, `playing`, and `simulating` and settles frames before returning |
 | `olo_reflection_probe_bake` | **(consented write)** synchronously run the real reflection-probe baker for one exact, uniquely named probe entity; non-undoable |
 | `olo_editor_panel_list` / `olo_editor_panel_set` | enumerate all 34 controllable ImGui panels and open/close one by stable name. `olo_editor_panel_set` is a **(consented write)** that changes session UI state and is gated behind **Agent writes** |
+| `olo_editor_actions` | the editor command registry (issue #1131): every menu, toolbar and shortcut action the editor declares, each with the registry command that performs it — plus that command's `available`, `projectWrite` and `undo` on this host — or a `note` saying why none does. `automatedOnly:true` lists only the rows that have a command. See [The editor command registry](#the-editor-command-registry-olo_editor_actions) |
+| `olo_editor_pause` / `olo_editor_step` | the toolbar Pause/Resume and Step buttons: pause or resume the running Play/Simulate session (idempotent, `changed:false` when already there; an error in Edit mode) and advance a **paused** session by `frames` (1..60, default 1), after which it stays paused. Ephemeral runtime control of the session, like `olo_viewport_set_size`, so neither needs write consent. Both report `mode` and `sceneName` |
+| `olo_editor_gizmo_set` | select the viewport gizmo — `none` / `translate` / `rotate` / `scale`, the Q/W/E/R shortcuts in order. Session UI state, not project data, so no write consent; refused while a gizmo drag is in progress |
+| `olo_editor_build_shader_pack` | **(consented write)** the Build > Build Shader Pack menu item: write `assets/ShaderPack.osp` from the live 2D and 3D shader libraries and report `ok` + `outputPath`. Synchronous; overwrites the previous pack; not undoable. Gated behind **Agent writes** |
 | `olo_accessibility_get` / `olo_accessibility_set` | read or set all nine process-global subtitle, text-scale, and color-vision settings. `olo_accessibility_set` is a **(consented write)**; writes return `restoreWith`, and color-blind mode changes rebuild the render graph. Setter gated behind **Agent writes** |
 | `olo_lightmap_bake` | **(consented write)** start/poll or block on the editor's actual baked-GI lightmap pipeline, with stable operation id, progress, counts, errors, and optional scene save after attachment |
 | `olo_editor_debug_draw_set` | **(consented write)** toggle eight editor overlay categories or the non-destructive `all` master across Edit/Play/Simulate; `all:false` produces a clean viewport capture |
@@ -656,7 +660,7 @@ appear under the `script` toolset — see "Script-defined tools" below):
 | `camera` | `olo_screenshot`, `olo_camera_get`, `olo_camera_set_pose`, `olo_camera_orbit`, `olo_camera_frame_entity`, `olo_camera_freeze_culling`, `olo_viewport_set_size` |
 | `physics` | `olo_physics_layer_matrix`, `olo_physics_list_colliders`, `olo_physics_contacts`, `olo_physics_raycast`, `olo_physics_overlap`, `olo_physics_why_no_collision`, `olo_set_collision_layer` |
 | `input` | `olo_input_inject` |
-| `editor` | `olo_editor_panel_list`, `olo_editor_panel_set`, `olo_accessibility_get`, `olo_accessibility_set`, `olo_lightmap_bake`, `olo_editor_debug_draw_set`, `olo_terrain_pick` |
+| `editor` | `olo_editor_panel_list`, `olo_editor_panel_set`, `olo_accessibility_get`, `olo_accessibility_set`, `olo_lightmap_bake`, `olo_editor_debug_draw_set`, `olo_terrain_pick`, `olo_editor_actions`, `olo_editor_pause`, `olo_editor_step`, `olo_editor_gizmo_set`, `olo_editor_build_shader_pack` |
 | `tests` | `olo_tests_list`, `olo_tests_run` |
 | `build` | `olo_build_list`, `olo_build_run` |
 | `validation` | `olo_project_validate` |
@@ -1163,6 +1167,35 @@ directly, since an agent explicitly asked for that scene.
 where Win32 injection cannot. But the env var stays the right answer for the
 recovery modal specifically: it removes the wedge at launch, before any tool call is
 possible, and needs no write consent.)
+
+### The editor command registry (`olo_editor_actions`)
+
+Call `olo_editor_actions` before reading `EditorLayer.cpp` to learn what the editor can
+do over automation. It is the declared list of the editor's menu, toolbar and shortcut
+actions (`kEditorActions` in `OloEditor/src/MCP/McpEditorActions.h`), and each row names
+the registry command that performs the action or says in `note` why none does. A row
+with a command also reports, read from the live registry at call time, that command's
+`available` (can it run on this host now), `projectWrite` (does it need write consent)
+and `undo` (its declared `AutomationUndo`, the same tokens `olo_transaction_apply`
+uses). A row whose command is not registered on this host is still listed, with
+`available:false` and the note extended, so a renamed or missing command shows up as a
+gap instead of vanishing. `automatedOnly:true` drops the rows that have no command.
+
+Issue #1131 added commands for the four actions that had none; each runs the same code
+path as the button, shortcut or menu item, and needs a live editor (a headless host
+lists them as unavailable):
+
+| action | command | note |
+|---|---|---|
+| Toolbar > Pause / Resume | `olo_editor_pause { paused }` | idempotent; an error in Edit mode |
+| Toolbar > Step | `olo_editor_step { frames? }` | only while paused; 1..60 frames, default 1 |
+| Viewport gizmo (Q/W/E/R) | `olo_editor_gizmo_set { mode }` | `none` / `translate` / `rotate` / `scale` |
+| Build > Build Shader Pack | `olo_editor_build_shader_pack` | a **(consented write)**; overwrites `assets/ShaderPack.osp` |
+
+The rows that stay un-automated (project switching, clipboard copy/paste, Exit, the
+asset-pack build) carry the reason in their `note`. `McpAutomationEditorCommandsTest`
+checks every declared command against the real registry, so the table cannot name a
+command that does not exist.
 
 ### Driving the Properties inspector (`olo_editor_select_entity`)
 

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -2210,7 +2210,7 @@ The five categories added by the automation event bus (issue #1131) carry a stru
 |---|---|---|
 | `scene_save` | `scene`, `path` (project-relative), `changed` | every save path: the menu, Ctrl+S, `olo_scene_save`, `olo_scene_save_as` |
 | `scene_dirty` | `scene`, `dirty` | the scene undo history, on both edges: the first unsaved edit, and clean again after a save, undo or rollback |
-| `asset_import` | `asset` (project-relative), `type`, `handle`, `source` (`filewatch` or `automation`) | the content-directory watcher and `olo_asset_import` |
+| `asset_import` | `asset` (project-relative), `type`, `handle`, `source` (`filewatch` or `automation`) | the content-directory watcher and `olo_asset_import`. Before #1131 the watcher's auto-import was recorded under `asset_reload` with the absolute path in `context`; a consumer filtering `asset_reload` for imports must filter `asset_import` now |
 | `compile_finished` | `kind` (`build`, `script`, `shader`), `target`, `ok`, `errors`, `warnings`, `seconds` | `olo_build_run`, a script assembly reload, a shader library reload |
 | `command_completed` | `command`, `ok`, `durationMs`, `projectWrite`, `toolset` | every mutating automation command, from the registry itself, whichever frontend ran it |
 
@@ -2368,7 +2368,10 @@ Four rules, each of which answers one of the issue's design constraints:
 
 `waitMs` is capped at 60 s per call and the wait runs on the handler thread only, so however
 long it blocks it never stalls a frame; cancel the call (`notifications/cancelled`) to return
-early with `cancelled: true`. From a shell, `oloctl events follow --until play` loops this
+early with `cancelled: true`, and a server that is stopping cancels every wait within 250 ms.
+Each blocked wait holds one of the server's HTTP worker threads (the same pool the push stream
+and every other call use), so keep concurrent waits to a few per session rather than one per
+category. From a shell, `oloctl events follow --until play` loops this
 command and prints one JSON object per event ([oloctl guide](oloctl.md#following-events)).
 The `run-oloengine` smoke test exercises the round trip (a `command_completed` for
 `olo_viewport_set_size` arriving through a wait that started before the call).

--- a/docs/guides/mcp-diagnostics-server.md
+++ b/docs/guides/mcp-diagnostics-server.md
@@ -196,7 +196,8 @@ and for what to do when adding a tool.
 | `olo_log_tail` | recent engine log lines, filterable by `minLevel` and `tag` |
 | `olo_debug_levers` | the engine's debug/diagnostic levers and their current values (`activeOnly` to see just the non-default ones). **Call this first when a session renders or performs unlike a clean one** — a lever left set is otherwise invisible, and explains a whole class of "it only misbehaves on this machine". Each seeds from an environment variable of the same name; `source` says whether the environment or code set it |
 | `olo_cvar_set` | **(consented write)** set any of those levers BY NAME against the running editor — the generalisation of `olo_render_debug_set`'s two special cases (issue #821). `name` + `value`, both strings; booleans take `on`/`off` (also `1/0`, `true/false`, `yes/no`), a tristate additionally takes `unset` (= "leave the hardware-derived default alone", **not** off), an int/float also takes `unset` to clear it. Out-of-range and non-finite values are refused with the reason rather than clamped; the read-only text levers are refused explicitly (they are consumed once at init). Subsystems that cached the value are re-notified at the **top of the next frame**, so re-capture with `olo_screenshot { forceFrame: true }` rather than trusting the frame you already have. `restoreWith` puts it back. Gated behind **Agent writes** |
-| `olo_events_tail` | unified "what just happened?" timeline — scene load, play/stop, entity spawn/destroy, asset reload, script error — newest last with a monotonic `id`; incremental polling via `sinceId`, plus a `categories` filter |
+| `olo_events_tail` | unified "what just happened?" timeline — scene load/save/dirty, play/stop, entity spawn/destroy, asset import/reload, script error, compile finished, automation command completed — newest last with a monotonic `id`; incremental polling via `sinceId`, a `categories` filter, and `dropped` (how many records above your cursor were evicted before you read them) |
+| `olo_events_wait` | **the subscription** of the automation event bus (issue #1131): block until the next event matching `categories` with `id` above `sinceId`, or until `waitMs`; returns the matches, the `lastId` cursor for the next call, `dropped`, `timedOut` and `cancelled`. Read-only, never stalls the editor, cancellable. See [The automation event bus](#the-automation-event-bus-olo_events_wait) |
 | `olo_scene_summary` | active scene name, play state, entity count |
 | `olo_scene_simulate` | **(consented write)** enter Simulate through the real editor toolbar path, running physics/runtime systems with the editor camera; reports `mode`, `playing`, and `simulating` and settles frames before returning |
 | `olo_reflection_probe_bake` | **(consented write)** synchronously run the real reflection-probe baker for one exact, uniquely named probe entity; non-undoable |
@@ -650,7 +651,7 @@ appear under the `script` toolset — see "Script-defined tools" below):
 
 | Toolset | Tools |
 |---|---|
-| `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_debug_levers`, `olo_cvar_set`, `olo_crash_list`, `olo_crash_get` |
+| `diagnostics` | `olo_log_tail`, `olo_events_tail`, `olo_events_wait`, `olo_debug_levers`, `olo_cvar_set`, `olo_crash_list`, `olo_crash_get` |
 | `scene` | `olo_scene_summary`, `olo_scene_list_entities`, `olo_scene_get_entity`, `olo_entity_list_fields`, `olo_entity_set_field`, `olo_scene_open`, `olo_scene_play`, `olo_scene_simulate`, `olo_scene_stop`, `olo_reflection_probe_bake`, `olo_editor_select_entity`, `olo_scheduler_graph` |
 | `perf` | `olo_memory_report`, `olo_perf_snapshot`, `olo_perf_bottlenecks`, `olo_perf_frame_history`, `olo_perf_capture_frame`, `olo_perf_pass_timings`, `olo_perf_cpu_scopes` |
 | `render` | `olo_render_frame_breakdown`, `olo_render_list_targets`, `olo_render_graph_topology_export`, `olo_render_capture_target`, `olo_render_probe_pixel`, `olo_render_target_stats`, `olo_render_validate`, `olo_render_toggle_pass`, `olo_postprocess_settings_get`, `olo_postprocess_settings_set`, `olo_render_transient_plan`, `olo_render_debug_set`, `olo_render_set_debug_view`, `olo_renderer_settings_set`, `olo_scene_set_time_of_day`, `olo_scene_set_sun_angle`, `olo_scene_set_weather`, `olo_scene_get_atmosphere`, `olo_render_compare_golden`, `olo_render_why_not_visible`, `olo_froxel_fog_probe`, `olo_cluster_grid_stats`, `olo_virtual_shadow_map_stats`, `olo_render_lod_stats`, `olo_rt_scene_stats`, `olo_pathtracer_stats`, `olo_restir_stats`, `olo_restir_gi_stats`, `olo_ddgi_probe_stats`, `olo_shadow_atlas_layout`, `olo_virtual_geometry_set`, `olo_virtual_geometry_stats`, `olo_particle_stats`, `olo_material_get`, `olo_shader_debug_draw`, `olo_terrain_virtual_texture_stats`, `olo_gpu_readback_stats`, `olo_gpu_resources` |
@@ -2196,8 +2197,26 @@ deserialization on load would otherwise flood the ring with hundreds of
 `entity_spawn` records, so those paths are suppressed and represented by the single
 `play` / `scene_load` event instead. Filter with `categories` (e.g.
 `["script_error", "asset_reload"]`) to narrow further. The ring holds the most recent
-512 events; older ones are evicted, but `sinceId` polling means an agent that checks
-in regularly never misses anything between checks.
+512 events; older ones are evicted. An agent that checks in regularly never misses
+anything between checks, and one that does not is told: `dropped` counts the records
+above `sinceId` that were evicted before the call could return them (0 unless the
+cursor fell behind the window). Treat a non-zero `dropped` as a hole in your history,
+not as "nothing happened".
+
+The five categories added by the automation event bus (issue #1131) carry a structured
+`data` object; the seven older ones do not:
+
+| category | `data` | published from |
+|---|---|---|
+| `scene_save` | `scene`, `path` (project-relative), `changed` | every save path: the menu, Ctrl+S, `olo_scene_save`, `olo_scene_save_as` |
+| `scene_dirty` | `scene`, `dirty` | the scene undo history, on both edges: the first unsaved edit, and clean again after a save, undo or rollback |
+| `asset_import` | `asset` (project-relative), `type`, `handle`, `source` (`filewatch` or `automation`) | the content-directory watcher and `olo_asset_import` |
+| `compile_finished` | `kind` (`build`, `script`, `shader`), `target`, `ok`, `errors`, `warnings`, `seconds` | `olo_build_run`, a script assembly reload, a shader library reload |
+| `command_completed` | `command`, `ok`, `durationMs`, `projectWrite`, `toolset` | every mutating automation command, from the registry itself, whichever frontend ran it |
+
+`data` carries the identity of what happened and never the content a read would return:
+no arguments, no results, no serialized scene, no absolute path. That is what lets a
+subscription be a plain read (see the event bus section below).
 
 > **Companion (issue #306, server-push half — done):** `olo_events_tail` is the
 > *poll-based* read of the ring buffer; the same buffer is now also **pushed live** over a
@@ -2236,6 +2255,15 @@ surface byte-identical event records.
   which also detects a vanished client. New events carry a worst-case latency of ~250 ms
   (the stream's internal poll cadence). The MCP panel shows how many push streams are
   connected.
+- **A gap is announced, not hidden.** When the stream's cursor has fallen behind the ring (a
+  stalled client, or a `Last-Event-ID` older than the window) the next cycle first pushes a
+  `notifications/message` at level `warning` whose `data` is `{ "gap": <n>, "resumedAt": <id> }`,
+  then the records that are still there. Before issue #1131 the missing records were simply
+  absent.
+- **Same redaction as every other carrier.** With the session's path redaction on, the pushed
+  records are scrubbed exactly as `olo_events_tail` and `resources/read` scrub theirs. The
+  stream used to skip this step, so the same `asset_reload` record arrived redacted through
+  the poll and unredacted through the push.
 
 ```jsonc
 // Wire format (one frame per event), pushed over GET /mcp:
@@ -2297,6 +2325,56 @@ Code opens the GET stream automatically alongside the POST channel). The threadi
 the same lock-safe path as `olo_events_tail`: the stream runs on an httplib worker
 thread and only touches the mutex-guarded event log, so it never marshals to or blocks
 the editor's main thread.
+
+### The automation event bus (`olo_events_wait`)
+
+Subscribe with a cursor: take `lastId` from `olo_events_tail`, do the thing, then call
+`olo_events_wait` with that id as `sinceId` and it returns the moment a matching event lands,
+or after `waitMs` with `timedOut: true` and the cursor to try again. That replaces a poll loop
+with one blocking call, over the same `tools/call` channel every client and `oloctl` already
+speak. Issue #1131.
+
+```jsonc
+// olo_events_tail { "count": 1 }                                   -> { "lastId": 312, ... }
+// olo_scene_play {}
+// olo_events_wait { "sinceId": 312, "categories": ["play"], "waitMs": 10000 }
+{
+  "count": 1, "lastId": 318, "dropped": 0, "timedOut": false, "cancelled": false,
+  "events": [ { "id": 313, "category": "play", "time": "14:02:11.418", "message": "Entered Play mode", "context": "MyScene" } ]
+}
+// olo_events_wait { "sinceId": 318, "categories": ["command_completed"] }
+{ "count": 1, ..., "events": [ { "id": 319, "category": "command_completed", "message": "Command olo_scene_play completed",
+                                 "context": "olo_scene_play", "data": { "command": "olo_scene_play", "ok": true, "durationMs": 412.7, "projectWrite": true, "toolset": "scene" } } ] }
+```
+
+Four rules, each of which answers one of the issue's design constraints:
+
+1. **Omit `sinceId` to wait for what happens next.** The default cursor is the ring's head at
+   the moment of the call, so a bare `olo_events_wait` returns nothing that already happened.
+   To catch an event that may land between your action and your wait, take the cursor
+   *before* the action, as above.
+2. **A subscription is a read, at read authority.** `olo_events_wait` needs the bearer token
+   and nothing else; it is not consent-gated and `oloctl`, which refuses every write, can run
+   it. That is sound only because of what an event may carry: identities, never content (see
+   the `data` table under the event timeline). Nothing behind a read gate is ever on the bus.
+3. **There is no per-subscriber queue.** Every consumer holds a cursor into the one 512-record
+   ring; a subscriber that stops reading costs the editor nothing, and when it resumes past the
+   window it is told how many records it lost (`dropped`). The push stream's only buffer is the
+   socket's, and a client that stops reading fails its write and is disconnected.
+4. **Only a mutating command publishes `command_completed`.** A command annotated read-only
+   (`olo_events_wait` itself, every `olo_*_get`, the tails) never does: reads would evict the
+   events worth waiting for, and a wait that published its own completion would wake every
+   other waiter forever.
+
+`waitMs` is capped at 60 s per call and the wait runs on the handler thread only, so however
+long it blocks it never stalls a frame; cancel the call (`notifications/cancelled`) to return
+early with `cancelled: true`. From a shell, `oloctl events follow --until play` loops this
+command and prints one JSON object per event ([oloctl guide](oloctl.md#following-events)).
+The `run-oloengine` smoke test exercises the round trip (a `command_completed` for
+`olo_viewport_set_size` arriving through a wait that started before the call).
+
+Design notes and the two bugs this fixed in the carriers that already existed:
+[`docs/agent-rules/automation-event-bus.md`](../agent-rules/automation-event-bus.md).
 
 ### Progress notifications & cancellation
 

--- a/docs/guides/oloctl.md
+++ b/docs/guides/oloctl.md
@@ -225,7 +225,7 @@ dropped ones are gone. A follower that keeps up never sees it; one started with 
 | exit | meaning |
 |---|---|
 | 0 | stopped by `--until`, `--count` or `--for` |
-| 1 | `olo_events_wait` reported an error, including the "editor too old" case |
+| 1 | `olo_events_wait` reported an error (including the "editor too old" case), or stdout was closed under the follow |
 | 2 | usage: bad flag, bad category, `--timeout` below 2 s |
 | 3 | the editor could not be reached, or stopped answering mid-stream |
 | 5 | a poll answered without the `events` / `lastId` payload the contract promises |

--- a/docs/guides/oloctl.md
+++ b/docs/guides/oloctl.md
@@ -39,6 +39,10 @@ which case `oloctl` reports the ambiguity instead of picking one.
 
 `oloctl catalogue` prints the whole mapping as JSON, so a script never has to guess it.
 
+A toolset may not be named `help`, `version`, `catalogue`, `call` or `events`: those are
+`oloctl`'s own subcommands and are dispatched first, so such a group can never be reached by
+typing it. `oloctl` warns about one on every run, and `OloCtlCommandTreeTest` refuses it.
+
 ## Arguments
 
 Options come from the command's declared `inputSchema`, and values are typed by it:
@@ -171,11 +175,71 @@ around the consent model rather than a convenience.
 When writes land, they go through the editor's consent gate, the same one an MCP call goes
 through. There will not be a CLI-specific bypass.
 
+## Following events
+
+`oloctl events follow` prints the editor's diagnostics events to stdout as they happen, one
+compact JSON object per line (NDJSON), until told to stop. It is the CLI consumer of the
+automation event bus (issue #1131).
+
+```bash
+oloctl events follow                                   # every event from now on, until Ctrl+C
+oloctl events follow --until play                      # exit 0 once Play has started
+oloctl events follow --category script_error --for 60  # script errors for the next minute
+oloctl events follow --since-id 0 --count 20           # the oldest 20 the editor still holds
+oloctl events follow | jq -c 'select(.category == "scene_save")'
+```
+
+| flag | meaning |
+|---|---|
+| `--since-id <id>` | start after this event id. `0` means from the oldest record the editor still holds. Default: new events only, from the first poll |
+| `--category <c>` | print only this category; repeat for several. One of `scene_load`, `play`, `stop`, `entity_spawn`, `entity_destroy`, `asset_reload`, `script_error`, `scene_save`, `scene_dirty`, `asset_import`, `compile_finished`, `command_completed` |
+| `--until <c>` | exit 0 after printing an event of this category. It only decides when to stop: with `--category`, the filter stays exactly what you asked for, so an `--until` category outside it never arrives |
+| `--count <n>` | exit 0 after printing `n` events |
+| `--for <seconds>` | exit 0 after this much wall-clock time |
+
+With none of `--until`, `--count` and `--for`, it runs until interrupted. A bad category is a
+usage error (exit 2) naming the valid ones; nothing is sent to the editor.
+
+**NDJSON, and nothing else on stdout.** Each line is the editor's event record verbatim
+(`id`, `category`, `message`, and when present `time`, `entity`, `context`, `data`), dumped
+compact. `--json`, `--structured` and `--compact` do not change this output. Every line is
+flushed as it is written, so a pipe sees an event when it happens, not when the buffer fills.
+Warnings and errors go to stderr, as everywhere in `oloctl`.
+
+**It is a loop over `olo_events_wait`**, the registry's long-poll over the engine's
+diagnostics event ring, through the same request path every other `oloctl` call takes: no
+SSE, no second transport. Each poll asks for events after a cursor and returns as soon as
+one exists, or empty after the wait; `oloctl` prints what came back, takes the `lastId` the
+editor reported as the next cursor, and polls again. A poll waits at most 10 s and at most
+half of `--timeout`, so the read timeout always outlasts the long-poll; `--timeout` below
+2000 ms is refused (exit 2). It needs an editor that has `olo_events_wait`: an older one
+answers "Unknown tool" and `oloctl` exits 1 saying the editor predates the event bus.
+
+**The dropped warning.** The ring holds 512 records. When the editor reports that records
+between the cursor and the oldest it still holds were evicted before `oloctl` read them, one
+line goes to stderr: `oloctl: N event(s) were dropped before id X: the cursor fell behind the
+editor's 512-record window.` The stream continues from the oldest record still held; the
+dropped ones are gone. A follower that keeps up never sees it; one started with a stale
+`--since-id`, or on a very busy editor, does.
+
+| exit | meaning |
+|---|---|
+| 0 | stopped by `--until`, `--count` or `--for` |
+| 1 | `olo_events_wait` reported an error, including the "editor too old" case |
+| 2 | usage: bad flag, bad category, `--timeout` below 2 s |
+| 3 | the editor could not be reached, or stopped answering mid-stream |
+| 5 | a poll answered without the `events` / `lastId` payload the contract promises |
+
+The verb is dispatched before the catalogue is fetched, so it works against an editor whose
+`olo_tool_search` is unreachable, and pays no catalogue round-trip on start.
+
 ## What it does not do
 
 - **It does not start an editor.** Driving a headless host is its own epic (#1132).
 - **It does not stream progress.** A long-running command blocks until it answers; the
   editor's progress notifications need the SSE transport, which this client does not speak.
+  It does follow the editor's **events** (`oloctl events follow`, above) — that is a loop
+  over a request/response command, not a push channel.
 - **It does not replace `.claude/skills/run-oloengine/driver.ps1`.** The driver launches the
   editor, waits for its window, screenshots it through Win32, and registers the MCP server
   with Claude Code. `oloctl` subsumes only the part after that — *talking* to a running


### PR DESCRIPTION
Epic I of the automation control plane: the editor's actions declared as a registry, and an event bus an agent can wait on instead of polling. One commit per slice, plus one commit of self-review fixes.

## Slice 1: the editor command registry (`08dae02ca`)

The census found that almost every menu, toolbar and shortcut action already had a registry command. What was missing was the declaration and four hooks:

- `MCP/McpEditorActions.h` declares every editor action (menu path, shortcut, the command that performs it, or why none does). `olo_editor_actions` serves the table joined with the live registry: availability on this host, authority class, undo class.
- Four actions had no editor hook at all and gain one each, running the same statement the click runs: `olo_editor_pause`, `olo_editor_step`, `olo_editor_gizmo_set` (ephemeral session control, not project writes), `olo_editor_build_shader_pack` (a consented, irreversible project write).
- They are the first builtins to declare `IsAvailable`: a host with no editor neither lists nor dispatches them.

## Slice 2: the automation event bus (`5032a2f12`)

The bus is the existing diagnostics ring (`Debug/DiagnosticsEventLog.h`) extended in three ways, not a new layer over it:

- Five categories for the editor's lifecycle: `scene_save`, `scene_dirty`, `asset_import`, `compile_finished`, `command_completed`, each with a structured `data` object built from a **closed key set**.
- `olo_events_wait`: a long-poll on a condition variable. Blocks on the handler thread until a match, a timeout or a cancellation, and always returns the cursor to resume from. `oloctl events follow` loops it and prints NDJSON; the `run-oloengine` smoke test exercises the round trip.
- A reported gap: a cursor that fell behind the 512-record window is told how many records it lost (`dropped`) on every carrier, instead of receiving a silently shorter history.

The issue's two design constraints, answered structurally:

1. **Authority.** A subscription is a read at read authority because an event carries identities only. No arguments, results, documents or absolute paths can be put on the bus: the keys per category are a closed table the engine refuses to exceed, string values are truncated, paths are made project-relative. Nothing behind a read gate is ever on the bus, so nothing can be seen through it. Enforced by `Record()` and pinned by tests.
2. **Backpressure.** A subscriber holds a cursor, not a queue. No per-subscriber memory exists anywhere; the ring is the one window; the loss is counted. Only a mutating command publishes `command_completed`, so the wait command cannot wake other waiters, and a transaction publishes once rather than once per step.

Two pre-existing carrier defects fixed on the way: the push stream served every record **unredacted** while `olo_events_tail` served the same record scrubbed (it now applies the session redaction like every other carrier), and a cursor that fell behind got a shorter history with no sign anything was missing.

Behaviour change to note: the file watcher's auto-import was recorded under `asset_reload` with the absolute path in `context`; it is now `asset_import` with a project-relative path. Documented in the guide's category table.

## Self-review fixes (third commit)

`/code-review` at high effort, eight angles. Fixed: `CommandHistory::Clear()` skipped the clean-again edge; the gizmo hook lacked the shortcuts' Edit-mode guard; a malformed `sinceId` (`-1`, `"12abc"`) was reinterpreted instead of refused; the wait's `count` cap kept the newest matches instead of the oldest and advanced the cursor past undelivered records; a blocked wait could hold editor shutdown for its whole timeout; byte-boundary truncation could produce invalid UTF-8 that made every carrier throw; `Shader::Reload()` now returns whether the new program is live (on Vulkan a failed reload restores the previous status, so status alone reported `ok: true`); transaction steps each published a completion (up to 64 per batch); the engine-side compile records lacked declared keys; three action-table rows had drifted from the menu; the schema enums, the push stream's envelope and the CLI's category list are now generated from or pinned to the one token table; the push stream blocks on the ring instead of scanning and sleeping; the two `std::filesystem::relative` syscalls per event became lexical.

Dismissed, with reasons: moving the pure header's schemas into the `.cpp` (the header-only split is the documented tool convention); the annotation helpers duplicated from `McpToolsCommon.h` (the other automation families hand-write them too, by the same layering choice); deriving the publish rule from a typed field instead of `readOnlyHint` (the hint is the declared contract, and deriving from `ProjectWrite` would misclassify ephemeral controls); making the menu bar dispatch through the registry (a real deeper change, out of this issue's scope); reusing `ArgumentBinder` for the follow verb's five flags (they are not a command schema); parsing `data` once per record instead of per carrier (the JSON-free engine header is the deliberate trade); the discovery gateway advertising commands `IsAvailable` rejects (documented as #1126's unification, and every real editor fills the hooks).

## Verification

- `OloEngine-Tests`, `oloctl` and `OloEditor` build clean (dev-cached, clang-cl, Debug).
- Full suite: 8255 ran, 8214 passed, 41 skipped, 0 failed. Affected suites re-run after the review fixes.
- New tests: `McpAutomationEventsTest` (publishers, payload rule, completion rule, wait cursor model incl. gap, cancellation, oldest-first cap, malformed cursor, schema parity, `CommandHistory` dirty edges incl. `Clear` and transactions), `McpAutomationEditorCommandsTest` (table vs registry, actions listing, availability, the four hooks, consent), additions to `McpEventsTailTest` (data builder, closed key sets, gap, wait, per-thread suppression, UTF-8 truncation), `McpEventStreamTest` (data field, levels, log envelope), and `OloCtlRunnerTest` / `OloCtlGeneratedSurfaceTest` (the follow verb over a scripted source and over the real registry; the category-table parity).
- **Live**, editor attached with the MCP server, two clients: one drove commands through `tools/call`, the other ran `oloctl events follow`. Every action produced its event and each `olo_events_wait` returned on arrival, including `scene_save` for a save-as, both `scene_dirty` edges across undo, `play`/`stop`, and `command_completed` for pause and step. An empty wait timed out at 3005 ms; a stale cursor reported `dropped`. The follow client printed all 38 events as NDJSON, then exited 3 when the editor was stopped under it. The `run-oloengine` smoke test passed with its new round trip ("returned command_completed for olo_viewport_set_size without polling").

Closes #1131

## Review guide

**Where I'd look hardest**
1. `OloEngine/src/OloEngine/Debug/DiagnosticsEventLog.h`: `WaitWithCursor` (the wake/rescan loop under the ring mutex) and `QueryWithCursorLocked` (the gap arithmetic at the window edge).
2. `OloEditor/src/UndoRedo/EditorCommand.h`: the `DirtyEdge` guard is now in every public mutation, including `Clear()`; a future mutation that forgets it silently misses an edge.
3. `OloEditor/src/MCP/McpToolsDiagnostics.cpp`: `Handle_EventsWait`'s oldest-first cap and the cursor it hands back when it truncates.

**What I verified, and how**: the live two-client transcript above; the full suite; the unit tests named above (each contract has a test that would fail if the rule were broken, e.g. `TheSubscriptionCommandsAreReadOnlyAndSilent`, `CursorBehindTheWindowReportsHowManyWereEvicted`, `CountKeepsTheOldestMatchesAndMovesTheCursorBack`).

**Least confident about**: the push stream now blocking on the ring's condition variable inside httplib's content provider; it works in the live run and returns within one poll interval on stop, but no unit test drives that loop (it never had one).

**Deliberately not tested**: the Vulkan branch of `Shader::Reload()` returning false (needs a broken shader on the Vulkan RHI); `olo_editor_build_shader_pack` writing the pack (it writes into the sandbox project's assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automation events for scene changes, asset imports, compilation, and mutating commands.
  * Added cancellable, cursor-based event subscriptions with filtering, timeouts, structured data, and dropped-event reporting.
  * Added `oloctl events follow` for NDJSON event streaming.
  * Added editor automation for pausing, stepping, gizmo modes, and shader-pack generation.
  * Shader reloads now report success or failure.

* **Bug Fixes**
  * Improved event-stream cancellation, shutdown handling, path redaction, and caching behavior.

* **Documentation**
  * Updated MCP diagnostics and `oloctl` guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->