### PR TITLE
ci(tests): Linux sanitizer suites four-wide with the heavy cases weighted — 75% of the box's test time is process start-up

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1704,7 +1704,7 @@ jobs:
       # compile, and the cumulative work blows past the default 120 s.
       # 600 s gives reasonable headroom without masking actual hangs.
       #
-      # --parallel 2: gtest_discover_tests registers every gtest case as its own
+      # --parallel 4 (weighted; see the run line below): gtest_discover_tests registers every gtest case as its own
       # ctest entry (one OloEngine-Tests process per case), so serial execution pays
       # the engine's full static-init cost ~3,600× back-to-back — a large chunk of
       # this job's wall-clock. Windows.yml already banks this win with
@@ -1723,17 +1723,25 @@ jobs:
       # (OloEngine/tests/CMakeLists.txt). See
       # docs/agent-rules/shared-temp-dir-test-isolation.md.
       #
-      # Why 2 here, not Windows' 4: these are SANITIZER-instrumented test processes
-      # with a much larger *resident* footprint (ASan shadow memory; TSan
-      # happens-before metadata), and the ubuntu runners have only ~16 GB / 4 vCPU.
-      # Two concurrent instrumented processes stay comfortably inside that budget;
-      # 4-wide risks the OOM reaper killing the runner mid-test.
+      # --parallel 4, WEIGHTED. This used to be 2, on the reasoning that four
+      # sanitizer-instrumented processes could exhaust the runner. Measured on the
+      # box (run 34686730577, ASan, 2026-09-12): 8,109 cases, 111 min summed for a
+      # 56 min step, and 7,785 of them under one second -- 83 of those minutes is
+      # the engine's per-process start-up, paid once per case. Width is what that
+      # majority needs, and memory is not what it costs: a light case sits at a
+      # few hundred MB. The cases that ARE memory-heavy or long carry
+      # `PROCESSORS 2` and `COST 100` (OloEngine/tests/CMakeLists.txt,
+      # OLO_HEAVY_TESTS), so ctest runs four light ones, or two heavy ones, or one
+      # heavy and two light, never four heavy -- inside the 14 GiB cgroup either
+      # way -- and starts the long ones first instead of leaving a 90 s case to
+      # dangle alone at the end. The test binary's own 6 GiB resident-set ceiling
+      # is the backstop for a case that outgrows the assumption.
       #
       # NOTE: this is unrelated to the build step's `--parallel 2` above. That pin is
       # a *compile-time* constraint (~9 GB per TU under clang+sanitizer, measured) and
       # does NOT transfer to the test phase — don't "reconcile" the two numbers; they
       # bound different resources (peak compiler RSS vs. peak instrumented-test RSS).
-      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
+      run: ctest --parallel 4 --output-on-failure --timeout 600 --exclude-regex "${OLO_ASAN_LSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -2129,7 +2137,7 @@ jobs:
       # ShaderReflectionBinding compiles ~100 shaders × ~3 stages via
       # shaderc, which is 3-5× slower under UBSan instrumentation.
       #
-      # --parallel 2: see the ASan + LSan run step above for the full rationale —
+      # --parallel 4, weighted: see the ASan + LSan run step above for the full rationale —
       # one ctest entry per gtest case makes serial execution pay engine static-init
       # ~3,600× over; the suite is parallel-safe (PID/case-name temp paths + a mesh-
       # cache RESOURCE_LOCK), and 2 (not Windows' 4) keeps two sanitizer-instrumented
@@ -2151,7 +2159,9 @@ jobs:
       # UBSan now enables only the curated eight checks rather than the whole
       # `undefined` group, so vptr is no longer asked of `-fno-rtti` vendor code.
       # This exclusion covers the remaining, genuinely-GNS-side gap. See #636.
-      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
+      # --parallel 4, weighted by PROCESSORS on the heavy set: see the ASan job's
+      # test step for the measurement.
+      run: ctest --parallel 4 --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
         #
@@ -2560,7 +2570,7 @@ jobs:
       # Every other test finishes in single-digit seconds, so the headroom
       # only bites the known-slow cases — not a fig leaf over hangs.
       #
-      # --parallel 2: see the ASan + LSan run step above for the full rationale
+      # --parallel 4, weighted: see the ASan + LSan run step above for the full rationale
       # (one ctest entry per case → engine static-init paid ~3,600× serially; the
       # suite is parallel-safe via PID/case-name temp paths + a mesh-cache
       # RESOURCE_LOCK). TSan is the most memory-heavy sanitizer — its happens-before
@@ -2595,7 +2605,9 @@ jobs:
       # ThreadState and its first intercepted malloc faults inside TSan's own
       # allocator — a bare SIGSEGV with no report. OloEngine/vendor/CMakeLists.txt
       # now filters that definition off the imported target; see the comment there.
-      run: ctest --parallel 2 --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
+      # --parallel 4, weighted by PROCESSORS on the heavy set: see the ASan job's
+      # test step for the measurement.
+      run: ctest --parallel 4 --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # suppressions: vendored-code races we accept rather than patch — see
         # the rationale comments in tsan.txt (currently: Jolt's assert-build

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2137,12 +2137,17 @@ jobs:
       # ShaderReflectionBinding compiles ~100 shaders × ~3 stages via
       # shaderc, which is 3-5× slower under UBSan instrumentation.
       #
-      # --parallel 4, weighted: see the ASan + LSan run step above for the full rationale —
-      # one ctest entry per gtest case makes serial execution pay engine static-init
-      # ~3,600× over; the suite is parallel-safe (PID/case-name temp paths + a mesh-
-      # cache RESOURCE_LOCK), and 2 (not Windows' 4) keeps two sanitizer-instrumented
-      # processes inside the ~16 GB / 4-vCPU runner. Independent of the build step's
-      # compile-time `--parallel 2` — that bounds compiler RSS, this bounds test RSS.
+      # --parallel 4, weighted: see the ASan + LSan run step above for the measurement.
+      # One ctest entry per gtest case makes serial execution pay engine start-up
+      # ~8,000× over, and 75 % of the step is that start-up; the suite is
+      # parallel-safe (per-process temp roots keyed per case + a mesh-cache
+      # RESOURCE_LOCK). The width is a WEIGHTED budget: a light case counts 1, a case
+      # in OLO_HEAVY_TESTS (tests/CMakeLists.txt) counts 2 via `PROCESSORS 2`, so up
+      # to four light cases run at once, or two heavy ones, or one heavy and two
+      # light -- never four heavy -- which keeps four UBSan-instrumented processes
+      # inside the 14 GiB self-hosted cgroup and the ~16 GB hosted runner alike.
+      # Independent of the build step's compile-time `--parallel 2` — that bounds
+      # compiler RSS, this bounds test RSS.
       #
       # ServerAuthoritativeLoopTest joins the three networking suites already
       # excluded here, for the same underlying reason: it drives live
@@ -2159,8 +2164,6 @@ jobs:
       # UBSan now enables only the curated eight checks rather than the whole
       # `undefined` group, so vptr is no longer asked of `-fno-rtti` vendor code.
       # This exclusion covers the remaining, genuinely-GNS-side gap. See #636.
-      # --parallel 4, weighted by PROCESSORS on the heavy set: see the ASan job's
-      # test step for the measurement.
       run: ctest --parallel 4 --output-on-failure --timeout 600 --exclude-regex "${OLO_UBSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # THE SYMBOLIZER IS NAMED IN *_OPTIONS, NOT ONLY IN ASAN_SYMBOLIZER_PATH.
@@ -2570,14 +2573,18 @@ jobs:
       # Every other test finishes in single-digit seconds, so the headroom
       # only bites the known-slow cases — not a fig leaf over hangs.
       #
-      # --parallel 4, weighted: see the ASan + LSan run step above for the full rationale
-      # (one ctest entry per case → engine static-init paid ~3,600× serially; the
-      # suite is parallel-safe via PID/case-name temp paths + a mesh-cache
-      # RESOURCE_LOCK). TSan is the most memory-heavy sanitizer — its happens-before
+      # --parallel 4, weighted: see the ASan + LSan run step above for the measurement
+      # (one ctest entry per case → engine start-up paid ~8,000× serially, and 75 %
+      # of the step is that start-up; the suite is parallel-safe via per-process
+      # temp roots keyed per case + a mesh-cache RESOURCE_LOCK). The width is a
+      # WEIGHTED budget: a light case counts 1 and a case in OLO_HEAVY_TESTS
+      # (tests/CMakeLists.txt) counts 2 via `PROCESSORS 2`, so up to four light
+      # cases run at once, or two heavy ones, or one heavy and two light -- never
+      # four heavy. TSan is the most memory-heavy sanitizer — its happens-before
       # shadow gives each test process the largest resident footprint of the three —
-      # so 2 is deliberately conservative. But two TSan test processes still sit well
-      # within the ~16 GB / 4-vCPU runner (each runs a single short-lived gtest case,
-      # not the whole suite at once), so 2-wide is safe rather than left serial.
+      # which is exactly why the heavy cases are the ones capped at two: a light
+      # case under TSan is still a few hundred MB, and four of those sit well within
+      # the 14 GiB self-hosted cgroup and the ~16 GB / 4-vCPU hosted runner alike.
       # Independent of the build step's compile-time `--parallel 2`: that bounds
       # peak compiler RSS, this bounds peak instrumented-test RSS.
       #
@@ -2605,8 +2612,6 @@ jobs:
       # ThreadState and its first intercepted malloc faults inside TSan's own
       # allocator — a bare SIGSEGV with no report. OloEngine/vendor/CMakeLists.txt
       # now filters that definition off the imported target; see the comment there.
-      # --parallel 4, weighted by PROCESSORS on the heavy set: see the ASan job's
-      # test step for the measurement.
       run: ctest --parallel 4 --output-on-failure --timeout 600 --exclude-regex "${OLO_TSAN_LINUX_CTEST_EXCLUDE}"
       env:
         # suppressions: vendored-code races we accept rather than patch — see

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1551,6 +1551,35 @@ include(GoogleTest)
 set(OLO_MESH_CACHE_TESTS
 	"ModelLoadDeterminism.Backpack_FreshVsCache:DataRoundTripTest.BackpackLegacyObjImportsPbrCompanionMaps:DataRoundTripTest.BackpackLegacyObjFlipsUvsToMatchTextureUploads:AllVariants/DeccerCubesLoaderFixture.*")
 
+# THE HEAVY SET: cases that are either memory-heavy or long, weighted so ctest can
+# run the other ~7,800 cases four-wide without four heavy ones ever landing at once.
+#
+# Measured 2026-09-12 on the self-hosted Linux runners (ASan, ctest --parallel 2,
+# run 34686730577): 8,109 cases, 111 min of summed case time for a 56 min step.
+# 7,785 of them take under one second -- 83 of those 111 minutes is the engine's
+# per-process start-up (0.64 s median here, 0.62 s on the Windows dev box),
+# paid once per case because every case is its own process. The 318 cases over a
+# second hold the other 28 minutes, and the ones over 10 s are all in the suites
+# below. Memory is the same shape: of the 8,205 cases on the Windows dev box, 265
+# peak above 1.2 GB committed or 20 s, all in these suites (the visual-evidence
+# and GPU-contract families, the path tracer, the fluid solver, the sailing
+# model, the benchmarks).
+#
+# `PROCESSORS 2` makes each of these count double against ctest's --parallel
+# budget, so `--parallel 4` runs four light cases or two heavy ones or one heavy
+# and two light -- never four heavy -- which keeps the runner inside its 14 GiB
+# cgroup while the light majority, whose whole cost is process start-up, gets
+# the extra width. `COST 100` makes ctest schedule them first, so the 90 s cases
+# do not start last and dangle alone at the end of the step (there is no
+# CTestCostData history on a fresh CI tree, and without COST the order is
+# discovery order). Over-inclusion here is the safe direction: a light case
+# wrongly listed only loses a little parallelism.
+#
+# The memory ceiling in the test binary (--olo-rss-ceiling-mb, default 6 GiB)
+# is the backstop for a case that grows past what this weighting assumes.
+set(OLO_HEAVY_TESTS
+	"*VisualEvidence*:*Evidence*:*VisualTest*:*GpuContract*:*GPUContract*:*Benchmark*:*PerfProbe*:*Perf.*:PathTracer*:ReSTIRDIOracle.*:ReSTIRGIOracle.*:DDGIReferenceParity*:DriftSailingTest.*:SailTest.*:CPUFluidSolver.*:FluidCouplingTest.*:GaussianSplat*:VulkanPassSuite.*:VulkanParallelRecordingDevice.*:AssetSceneLoad.*:RuntimeAssetPackTest.*:ProceduralSkyBake*:StarNestSkyBake*:ModelLoadDeterminism.*:VirtualGeometry*:OceanFFT*:LightmapBleedRoom.*:LightmapInstancedBleedRoom.*:AutoMeshLODScene.*:DeferredOccludedInstanceFieldScene.*:ModelComponentGPUSceneScene.*:GPUSceneRasterMigrationScene.*:SubmeshMaterialPathParity.*:ShaderDebugDraw*:TerrainGPUPick*:TerrainGPUQuadtree*:TwoSidedShadowCast.*:McpHeadlessAttachTest.*:SceneRenders3D.*:WorldTransformPropagation*:RenderPathDrift.*:BindlessShaderPipeline.*:GPUScene.*:GPUSceneAntiDuplicationRatchet.*:DebugLevers.*:FunctionalTestFixtureCoverage.*:FlockingViaSceneTickTest.*:ShaderUBOSizeConsistency.*:ShaderReflectionBinding.*:ShaderCrossConsistency.*")
+
 # --olo-* flags for every ctest-launched test process (a CMake list, so
 # `-DOLO_TESTS_CTEST_ARGS=--olo-gl-backend=none` is one flag and
 # `"--olo-gl-backend=egl;--olo-require-gpu"` is two). This is how a CI job that
@@ -1566,17 +1595,28 @@ if(OLO_TESTS_CTEST_ARGS)
 	message(STATUS "OloEngine-Tests: ctest will launch every test with: ${OLO_TESTS_CTEST_ARGS}")
 endif()
 
+# Three discovery calls over one binary, each a disjoint slice by gtest filter
+# (positive patterns, then `-` negatives): the mesh-cache offenders (serialised,
+# and they load a full model so they weigh double too), the heavy set (weighted
+# and scheduled first), and everything else. Every case lands in exactly one.
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
 	TEST_FILTER "${OLO_MESH_CACHE_TESTS}"
 	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
-	PROPERTIES RESOURCE_LOCK "olo_mesh_cache"
+	PROPERTIES RESOURCE_LOCK "olo_mesh_cache" PROCESSORS 2 COST 100
 )
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
-	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}"
+	TEST_FILTER "${OLO_HEAVY_TESTS}-${OLO_MESH_CACHE_TESTS}"
+	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+	PROPERTIES PROCESSORS 2 COST 100
+)
+gtest_discover_tests(OloEngine-Tests
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
+	DISCOVERY_TIMEOUT 120
+	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}:${OLO_HEAVY_TESTS}"
 	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
 )
 


### PR DESCRIPTION
## Summary

The Linux sanitizer test steps on the box are dominated by process start-up, not by tests. Profiled from #1188's ASan run (34686730577, `ctest --parallel 2`, 56 min for the step):

| | cases | summed time | share |
|---|---|---|---|
| all | 8,109 | 111 min | |
| under 1 s | 7,785 | 83 min | **75 %** — the engine's per-process start-up (0.64 s median; 0.62 s for an empty run on the Windows dev box) |
| over 1 s | 318 | 28 min | 25 % |
| over 10 s | 30 | 16 min | path tracer, sailing model, CPU fluid solver, shader contract scans, benchmarks |
| skipped (GPU-gated) | 741 | 8 min | start-up only |

Effective parallelism was 1.99 of 2, so the step is exactly the sum divided by the width. The light majority needs width; it does not need memory (a light case sits at a few hundred MB).

## The change

- The three Linux test steps run `ctest --parallel 4`.
- `OLO_HEAVY_TESTS` (tests/CMakeLists.txt) lists the suites that are memory-heavy or long — 564 cases, chosen from the per-case peak-memory sweep of all 8,205 cases on the dev box (the 265 cases above 1.2 GB committed or 20 s) and the per-case timings on the box. They get `PROCESSORS 2` and `COST 100`, so ctest runs four light cases, or two heavy, or one heavy and two light, never four heavy, and starts the long ones first instead of leaving a 90 s case to dangle alone at the end. The mesh-cache offenders keep their `RESOURCE_LOCK` and gain the same weight.
- Discovery is now three disjoint filter slices over the one binary; it still yields 8,205 entries with no duplicates. Spot checks: `FastRandomTest`, `WaterRendering`, `DDGIMath` carry no weight; `PathTracerCornellBox`, `DriftSailingTest`, `GPUScene`, `ModelLoadDeterminism` carry 2.

Expected effect, from the profile: the 83 min of start-up split four ways instead of two (about 21 min instead of 41), the heavy 28 min still effectively two-wide, so roughly 35 min per step instead of 56, on each of the three arms. The memory ceiling in the test binary (6 GiB, #1204) is the backstop for a case that outgrows the weighting.

## Not done here, and worth doing next

1. **Batch the light suites into one process each.** 75 % of the box's test time is start-up, so even `--parallel 4` leaves ~20 min per arm on the table. Registering the isolation-safe CPU suites as one ctest entry per suite (instead of per case) would take that to a couple of minutes, but it changes the one-process-per-case contract in `docs/agent-rules/testing-architecture.md` and needs the suites vetted for cross-case state. A separate PR.
2. **Do not launch the 741 GPU-gated cases on the box at all** when `--olo-gl-backend=none`: 8 min of start-up per arm to print `Skipped`. Needs a label per GPU-gated file (the test catalogue already classifies them).
3. Shave the 0.6 s start-up itself: it is the same on both platforms, so it is static initialisation plus the log set-up, not the sanitizer. Unprofiled so far.

## Test plan

- [x] Reconfigure + rebuild on the dev box: 8,205 ctest entries, 0 duplicates, properties verified via `ctest --show-only=json-v1`.
- [ ] This PR's own three Linux arms: step time vs the ~56 min baseline, and no OOM kill (the memory ceiling would name the case if one happened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test scheduling for Linux sanitizer builds by prioritizing longer-running checks and limiting concurrent execution of resource-intensive tests.
  - Added resource weighting and categorization for heavy and mesh-cache tests to improve stability and efficiency during test runs.
  - Increased parallel test execution capacity for unsharded Linux sanitizer checks.
  - Hosted ARM test jobs continue using their existing parallel execution settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->