### PR TITLE
test(ctest): register the light suites one process each — 8,205 launches become 1,741

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -736,13 +736,13 @@ jobs:
     # the `asan-windows-tests` matrix below: this job builds and hands the
     # instrumented tree over, and N separate runners each execute a stride of it.
     #
-    # WHY SHARDING RATHER THAN BATCHING. gtest_discover_tests registers every gtest
-    # case as its own ctest entry, so the suite is ~7,600 PROCESS LAUNCHES, each
-    # paying full engine static-init. Batching many cases into one process is the
-    # bigger win and it REMOVES the isolation that currently hides cross-test state
-    # corruption -- that is #1074's territory and must not be done from here.
-    # Sharding splits the same one-process-per-case run across more runners and
-    # changes the semantics not at all.
+    # SHARDING AND BATCHING, BOTH. The light majority of cases is now registered
+    # one ctest entry per SUITE (OloEngine/tests/cmake/OloSuiteDiscovery.cmake) --
+    # 75 % of a test step was per-process start-up, paid ~8,000x -- while the
+    # memory-heavy and long cases (OLO_HEAVY_TESTS) stay one process each, which is
+    # where the cross-test state corruption #1074 fixed used to hide. Sharding
+    # splits that same entry list across more runners and changes the semantics
+    # not at all.
     #
     # WHAT IT COSTS. Each shard is a whole runner: it pays job startup, a checkout
     # and an artifact download before it runs a single case. This TRADES
@@ -1044,10 +1044,11 @@ jobs:
       #     instrumentation; excluded on every sanitizer job.
       #
       # --parallel 4, RAISED FROM 2 ON A MEASUREMENT (#1083), not on the theory that
-      # made 2 look conservative. Every gtest case is its own ctest entry
-      # (gtest_discover_tests), so the suite is ~7,600 process launches each paying
-      # full engine static init, and the standing hypothesis was that a workload that
-      # startup-bound would scale well past the runner's 4 vCPUs. IT DOES NOT.
+      # made 2 look conservative. At the time every gtest case was its own ctest
+      # entry (~7,600 process launches each paying full engine static init; the
+      # light majority is one entry per suite now), and the standing hypothesis was
+      # that a workload that startup-bound would scale well past the runner's 4
+      # vCPUs. IT DOES NOT.
       #
       # Six timed passes over the same 380-case sample in ONE job on run 34061407329,
       # in palindrome order (2,3,4,4,3,2) so the cold-start warm-up is shared equally
@@ -1704,11 +1705,11 @@ jobs:
       # compile, and the cumulative work blows past the default 120 s.
       # 600 s gives reasonable headroom without masking actual hangs.
       #
-      # --parallel 4 (weighted; see the run line below): gtest_discover_tests registers every gtest case as its own
-      # ctest entry (one OloEngine-Tests process per case), so serial execution pays
-      # the engine's full static-init cost ~3,600× back-to-back — a large chunk of
-      # this job's wall-clock. Windows.yml already banks this win with
-      # `ctest --parallel 4`.
+      # --parallel 4 (weighted; see the run line below). The heavy cases are one
+      # ctest entry each and the light majority one entry per SUITE
+      # (OloEngine/tests/cmake/OloSuiteDiscovery.cmake), so the engine's start-up is
+      # paid once per suite rather than once per case -- it was 75 % of this step.
+      # Windows.yml already banks the parallel win with `ctest --parallel 4`.
       #
       # The suite is parallel-safe, and the property is ENFORCED rather than asserted
       # (issue #789 — this comment previously claimed "tests key their temp paths by
@@ -2138,10 +2139,10 @@ jobs:
       # shaderc, which is 3-5× slower under UBSan instrumentation.
       #
       # --parallel 4, weighted: see the ASan + LSan run step above for the measurement.
-      # One ctest entry per gtest case makes serial execution pay engine start-up
-      # ~8,000× over, and 75 % of the step is that start-up; the suite is
-      # parallel-safe (per-process temp roots keyed per case + a mesh-cache
-      # RESOURCE_LOCK). The width is a WEIGHTED budget: a light case counts 1, a case
+      # Engine start-up was 75 % of the step when every case was its own entry; the
+      # light majority is one entry per suite now and the heavy cases one each; the
+      # suite is parallel-safe (per-process temp roots keyed per case + a mesh-cache
+      # RESOURCE_LOCK). The width is a WEIGHTED budget: a light entry counts 1, a case
       # in OLO_HEAVY_TESTS (tests/CMakeLists.txt) counts 2 via `PROCESSORS 2`, so up
       # to four light cases run at once, or two heavy ones, or one heavy and two
       # light -- never four heavy -- which keeps four UBSan-instrumented processes
@@ -2574,9 +2575,10 @@ jobs:
       # only bites the known-slow cases — not a fig leaf over hangs.
       #
       # --parallel 4, weighted: see the ASan + LSan run step above for the measurement
-      # (one ctest entry per case → engine start-up paid ~8,000× serially, and 75 %
-      # of the step is that start-up; the suite is parallel-safe via per-process
-      # temp roots keyed per case + a mesh-cache RESOURCE_LOCK). The width is a
+      # (engine start-up was 75 % of the step when every case was its own entry;
+      # the light majority is one entry per suite now, the heavy cases one each;
+      # the suite is parallel-safe via per-process temp roots keyed per case + a
+      # mesh-cache RESOURCE_LOCK). The width is a
       # WEIGHTED budget: a light case counts 1 and a case in OLO_HEAVY_TESTS
       # (tests/CMakeLists.txt) counts 2 via `PROCESSORS 2`, so up to four light
       # cases run at once, or two heavy ones, or one heavy and two light -- never

--- a/OloEngine/tests/CMakeLists.txt
+++ b/OloEngine/tests/CMakeLists.txt
@@ -1595,10 +1595,14 @@ if(OLO_TESTS_CTEST_ARGS)
 	message(STATUS "OloEngine-Tests: ctest will launch every test with: ${OLO_TESTS_CTEST_ARGS}")
 endif()
 
-# Three discovery calls over one binary, each a disjoint slice by gtest filter
+# Three discovery passes over one binary, each a disjoint slice by gtest filter
 # (positive patterns, then `-` negatives): the mesh-cache offenders (serialised,
-# and they load a full model so they weigh double too), the heavy set (weighted
-# and scheduled first), and everything else. Every case lands in exactly one.
+# and they load a full model so they weigh double too) and the heavy set
+# (weighted and scheduled first) are registered PER CASE by gtest_discover_tests;
+# everything else -- the light majority whose whole cost is process start-up --
+# is registered PER SUITE by cmake/OloSuiteDiscovery.cmake, one process per
+# suite (sharded past 40 cases). Every case lands in exactly one pass; the
+# script's own filter is the negation of the other two.
 gtest_discover_tests(OloEngine-Tests
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
 	DISCOVERY_TIMEOUT 120
@@ -1613,10 +1617,56 @@ gtest_discover_tests(OloEngine-Tests
 	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
 	PROPERTIES PROCESSORS 2 COST 100
 )
-gtest_discover_tests(OloEngine-Tests
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor
-	DISCOVERY_TIMEOUT 120
-	TEST_FILTER "-${OLO_MESH_CACHE_TESTS}:${OLO_HEAVY_TESTS}"
-	EXTRA_ARGS ${OLO_TESTS_CTEST_ARGS}
+# The light majority, one ctest entry per SUITE. Wired the way gtest_discover_tests
+# wires POST_BUILD discovery: a -P script runs after every link of the target and
+# rewrites a per-config tests file, which a small include file pulls into ctest
+# through the directory's TEST_INCLUDE_FILES. The include file is generated at
+# configure time; the tests file only exists after a build, and until then ctest
+# sees one NOT_BUILT placeholder instead of silently nothing.
+set(_olo_suite_base "${CMAKE_CURRENT_BINARY_DIR}/OloEngine-Tests_suites")
+get_property(_olo_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_olo_is_multi_config)
+	string(APPEND _olo_suite_base "_$<CONFIG>")
+endif()
+set(_olo_suite_tests_file "${_olo_suite_base}_tests.cmake")
+set(_olo_suite_include_file "${_olo_suite_base}_include.cmake")
+add_custom_command(
+	TARGET OloEngine-Tests POST_BUILD
+	BYPRODUCTS "${_olo_suite_tests_file}"
+	COMMAND "${CMAKE_COMMAND}"
+		"-DTEST_EXECUTABLE=$<TARGET_FILE:OloEngine-Tests>"
+		"-DTEST_WORKING_DIR=${CMAKE_SOURCE_DIR}/OloEditor"
+		"-DTEST_EXTRA_ARGS=${OLO_TESTS_CTEST_ARGS}"
+		"-DTEST_EXCLUDE_FILTER=${OLO_MESH_CACHE_TESTS}:${OLO_HEAVY_TESTS}"
+		"-DCTEST_FILE=${_olo_suite_tests_file}"
+		-DTEST_DISCOVERY_TIMEOUT=120
+		-DCHUNK_SIZE=40
+		-DDEFAULT_TIMEOUT=600
+		-P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/OloSuiteDiscovery.cmake"
+	VERBATIM
 )
+# A POST_BUILD command only re-runs when the target relinks, so an edit to the
+# discovery script alone would leave a stale tests file behind; making the script
+# a link dependency forces the relink, and with it the re-discovery.
+set_property(TARGET OloEngine-Tests APPEND PROPERTY LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/OloSuiteDiscovery.cmake")
+file(GENERATE OUTPUT "${_olo_suite_include_file}" CONTENT
+"if(EXISTS \"${_olo_suite_tests_file}\")
+  include(\"${_olo_suite_tests_file}\")
+else()
+  add_test(OloEngine-Tests_suites_NOT_BUILT OloEngine-Tests_suites_NOT_BUILT)
+endif()
+")
+if(_olo_is_multi_config)
+	# TEST_INCLUDE_FILES takes no generator expressions: point it at a fixed file
+	# that forwards to the per-config one ctest is running, exactly as the
+	# GoogleTest module does for its own discovery.
+	string(REPLACE [[_$<CONFIG>]] [[_${CTEST_CONFIGURATION_TYPE}]] _olo_suite_include_cfg "${_olo_suite_include_file}")
+	string(REPLACE [[_$<CONFIG>]] "" _olo_suite_include_file "${_olo_suite_include_file}")
+	file(WRITE "${_olo_suite_include_file}"
+"if(EXISTS \"${_olo_suite_include_cfg}\")
+  include(\"${_olo_suite_include_cfg}\")
+endif()
+")
+endif()
+set_property(DIRECTORY APPEND PROPERTY TEST_INCLUDE_FILES "${_olo_suite_include_file}")
 

--- a/OloEngine/tests/cmake/OloSuiteDiscovery.cmake
+++ b/OloEngine/tests/cmake/OloSuiteDiscovery.cmake
@@ -1,0 +1,177 @@
+# Suite-level ctest discovery for OloEngine-Tests (run with `cmake -P` as a
+# POST_BUILD step of the target; see the wiring in OloEngine/tests/CMakeLists.txt).
+#
+# WHY NOT gtest_discover_tests FOR EVERYTHING. That module registers every gtest
+# case as its own ctest entry, so every case is its own process. Measured on the
+# self-hosted Linux runners (ASan, run 34686730577, 2026-09-12): 8,109 cases,
+# 111 min of summed case time, and 7,785 of the cases take under one second --
+# 83 of those 111 minutes is the engine's per-process start-up (0.64 s median,
+# the same 0.62 s an EMPTY run costs on the Windows dev box), paid once per
+# case. The cases that do real work are a few hundred, and they are the ones
+# OLO_HEAVY_TESTS and OLO_MESH_CACHE_TESTS keep on the per-case path.
+#
+# Everything else -- the light majority -- is registered here as ONE ctest
+# entry per gtest SUITE, running `--gtest_filter=<Suite>.*` minus the same
+# exclusions, so a suite of 60 one-second cases costs one start-up instead of
+# sixty. Suites larger than CHUNK_SIZE cases are split into gtest shards
+# (GTEST_TOTAL_SHARDS / GTEST_SHARD_INDEX in the entry's environment), so no
+# single entry grows past a few minutes under a sanitizer and the width stays
+# usable. Each entry's TIMEOUT scales with its case count, and its COST is its
+# case count so ctest schedules the big suites first.
+#
+# What stays the same for a test author: cases still get their own TempDir()
+# (keyed per case beneath a per-process root -- see
+# docs/agent-rules/shared-temp-dir-test-isolation.md), the renderer-state and
+# GL-error listeners still restore between cases, and the GTEST_OUTPUT XML the
+# CI report reads is still one record per case. What changes: a crash in one
+# case takes the rest of its suite's cases with it (that is why the crash-prone
+# GPU and long cases keep their own processes), and process-global state a case
+# leaks is now visible to the next case in the same suite -- which is the same
+# contract a local `--gtest_filter=Suite.*` run has always had.
+#
+# Arguments (all via -D):
+#   TEST_EXECUTABLE     the built test binary
+#   TEST_WORKING_DIR    working directory for every entry (OloEditor/)
+#   TEST_EXTRA_ARGS     ;-list of extra args for every entry (OLO_TESTS_CTEST_ARGS)
+#   TEST_EXCLUDE_FILTER gtest patterns (':'-separated) that must NOT run here
+#                       because they are registered per case elsewhere
+#   CTEST_FILE          the file to (re)write
+#   TEST_DISCOVERY_TIMEOUT  seconds allowed for the --gtest_list_tests run
+#   CHUNK_SIZE          cases per entry before a suite is split into shards
+#   DEFAULT_TIMEOUT     floor for each entry's TIMEOUT property (seconds)
+
+cmake_minimum_required(VERSION 3.29)
+
+foreach(required IN ITEMS TEST_EXECUTABLE TEST_WORKING_DIR TEST_EXCLUDE_FILTER CTEST_FILE)
+	if(NOT DEFINED ${required})
+		message(FATAL_ERROR "OloSuiteDiscovery: ${required} is required")
+	endif()
+endforeach()
+if(NOT DEFINED TEST_DISCOVERY_TIMEOUT)
+	set(TEST_DISCOVERY_TIMEOUT 120)
+endif()
+if(NOT DEFINED CHUNK_SIZE)
+	set(CHUNK_SIZE 40)
+endif()
+if(NOT DEFINED DEFAULT_TIMEOUT)
+	set(DEFAULT_TIMEOUT 600)
+endif()
+
+if(NOT EXISTS "${TEST_EXECUTABLE}")
+	message(FATAL_ERROR "OloSuiteDiscovery: test executable does not exist: '${TEST_EXECUTABLE}'")
+endif()
+
+# The negative half of every entry's filter. gtest's grammar is
+# `positive[-negative]`, so the exclusions ride on each suite's own positive
+# pattern; passing the same string to the listing below gives exactly the set of
+# cases these entries will run, and nothing the per-case discoveries also run.
+set(exclude "${TEST_EXCLUDE_FILTER}")
+
+execute_process(
+	COMMAND "${TEST_EXECUTABLE}" --gtest_list_tests "--gtest_filter=*-${exclude}"
+	WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+	TIMEOUT ${TEST_DISCOVERY_TIMEOUT}
+	OUTPUT_VARIABLE listing
+	RESULT_VARIABLE result
+)
+if(NOT result EQUAL 0)
+	message(FATAL_ERROR
+		"OloSuiteDiscovery: listing the tests failed (exit ${result}). The binary or the\n"
+		"working directory is wrong, or the listing took longer than ${TEST_DISCOVERY_TIMEOUT} s.\n"
+		"  Executable: '${TEST_EXECUTABLE}'\n"
+		"  Working dir: '${TEST_WORKING_DIR}'")
+endif()
+
+# Parse gtest's listing. Suites are the lines that do not start with a space and
+# end in '.' (after the "  # TypeParam = ..." comment is dropped); cases are the
+# indented lines beneath them. The engine prints a few log lines before the
+# listing ("[hh:mm:ss] OloEngine: ..."); they neither end in '.' nor start with
+# a space, so the shape test drops them.
+set(suites "")
+set(current "")
+string(REPLACE "\n" ";" lines "${listing}")
+foreach(line IN LISTS lines)
+	string(REGEX REPLACE "\r$" "" line "${line}")
+	if(line STREQUAL "")
+		continue()
+	endif()
+	string(REGEX REPLACE "^([^#]*[^ #])  *#.*$" "\\1" body "${line}")
+	if(body MATCHES "^  ")
+		if(NOT current STREQUAL "")
+			math(EXPR count_${current_id} "${count_${current_id}} + 1")
+		endif()
+	elseif(body MATCHES "^([^ ].*)\\.$")
+		set(current "${CMAKE_MATCH_1}")
+		string(MAKE_C_IDENTIFIER "${current}" current_id)
+		if(NOT DEFINED count_${current_id})
+			set(count_${current_id} 0)
+			set(name_${current_id} "${current}")
+			list(APPEND suites "${current_id}")
+		endif()
+	else()
+		set(current "")
+	endif()
+endforeach()
+
+if(suites STREQUAL "")
+	message(FATAL_ERROR
+		"OloSuiteDiscovery: the listing produced no suites. A filter that matches nothing, or a\n"
+		"binary whose gtest main did not run, both look like this; neither is a usable test set.")
+endif()
+
+set(script "")
+set(entries 0)
+set(cases 0)
+foreach(id IN LISTS suites)
+	set(suite "${name_${id}}")
+	set(count "${count_${id}}")
+	if(count EQUAL 0)
+		continue()
+	endif()
+	math(EXPR cases "${cases} + ${count}")
+	math(EXPR chunks "(${count} + ${CHUNK_SIZE} - 1) / ${CHUNK_SIZE}")
+	math(EXPR per_chunk "(${count} + ${chunks} - 1) / ${chunks}")
+	# Generous: a light case is ~1 s under ASan and ~2-3 s under TSan, and this is a
+	# ceiling for a hang, not a budget.
+	math(EXPR timeout "120 + 8 * ${per_chunk}")
+	if(timeout LESS DEFAULT_TIMEOUT)
+		set(timeout ${DEFAULT_TIMEOUT})
+	endif()
+	set(chunk 0)
+	while(chunk LESS chunks)
+		# The entry is named `<Suite>.*`, i.e. the gtest filter it runs, so every
+		# `^Suite\.`-shaped --exclude-regex the CI jobs already carry keeps matching
+		# it, and a chunk is `<Suite>.*[i/n]`. Suite names can hold '/' (type- and
+		# value-parameterised suites); bracket-quote everything.
+		if(chunks EQUAL 1)
+			set(entry "${suite}.*")
+		else()
+			math(EXPR shown "${chunk} + 1")
+			set(entry "${suite}.*[${shown}/${chunks}]")
+		endif()
+		set(command "add_test([==[${entry}]==] [==[${TEST_EXECUTABLE}]==] [==[--gtest_filter=${suite}.*-${exclude}]==]")
+		foreach(arg IN LISTS TEST_EXTRA_ARGS)
+			string(APPEND command " [==[${arg}]==]")
+		endforeach()
+		string(APPEND command ")\n")
+		string(APPEND script "${command}")
+		set(environment "")
+		if(chunks GREATER 1)
+			set(environment "ENVIRONMENT [==[GTEST_TOTAL_SHARDS=${chunks};GTEST_SHARD_INDEX=${chunk}]==]")
+		endif()
+		string(APPEND script
+			"set_tests_properties([==[${entry}]==] PROPERTIES\n"
+			"  WORKING_DIRECTORY [==[${TEST_WORKING_DIR}]==]\n"
+			"  TIMEOUT ${timeout}\n"
+			"  COST ${per_chunk}\n"
+			"  LABELS [==[suite]==]\n"
+			"  ${environment}\n"
+			")\n")
+		math(EXPR entries "${entries} + 1")
+		math(EXPR chunk "${chunk} + 1")
+	endwhile()
+endforeach()
+
+file(WRITE "${CTEST_FILE}" "# Generated by OloSuiteDiscovery.cmake; do not edit.\n${script}")
+list(LENGTH suites suite_count)
+message(STATUS "OloSuiteDiscovery: ${cases} cases in ${suite_count} suites -> ${entries} ctest entries (chunk ${CHUNK_SIZE})")

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -36,7 +36,7 @@ Each entry is one sentence stating the rule. The story that taught it is inside 
 - [procedural-generator-golden-coupling.md](procedural-generator-golden-coupling.md): a generator fix and its golden rebake ship in the same PR.
 - [timed-wait-test-assertions.md](timed-wait-test-assertions.md): measure timed waits in microseconds and assert one-sided.
 - [thread-local-lifetime-at-exit.md](thread-local-lifetime-at-exit.md): keep the "is it still alive?" signal in a trivially destructible `thread_local`; a destroyed one is not readable.
-- [shared-temp-dir-test-isolation.md](shared-temp-dir-test-isolation.md): use `TestTempDir.h`, never a fixed temp path; every test case is its own process.
+- [shared-temp-dir-test-isolation.md](shared-temp-dir-test-isolation.md): use `TestTempDir.h`, never a fixed temp path; heavy cases run one per process and light suites one per process, concurrently.
 - [cross-test-renderer-state.md](cross-test-renderer-state.md): never shut down a process-wide singleton you did not start, and leave the renderer configuration as you found it; plus the two traps that make single-process bisection lie.
 - [world-anchored-renderer-state-in-tests.md](world-anchored-renderer-state-in-tests.md): a fixture that builds a `Scene` per test must also reset the process-static renderer state scene load resets.
 - [ab-diff-peak-is-not-a-location.md](ab-diff-peak-is-not-a-location.md): place a measurement box by the highest-mean window of an A/B difference, never by its brightest pixel.

--- a/docs/agent-rules/testing-architecture.md
+++ b/docs/agent-rules/testing-architecture.md
@@ -104,9 +104,10 @@ If a feature touches multiple surfaces, write one test per surface — and write
 - **Golden rebase** (only when a deliberate visual change lands): `<test binary> --olo-golden-rebase --gtest_filter=GoldenImage*`.
 - **Perf rebase** (only when moving to new hardware or after an intentional optimisation): `<test binary> --olo-perf-rebase --gtest_filter=PerfRegression*`.
 
-**Working directory: prefer `OloEditor/`.** That is what `ctest` uses — both
-`gtest_discover_tests` calls in [OloEngine/tests/CMakeLists.txt](../../OloEngine/tests/CMakeLists.txt)
-pass `WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor`, because many tests call
+**Working directory: prefer `OloEditor/`.** That is what `ctest` uses — every
+discovery pass in [OloEngine/tests/CMakeLists.txt](../../OloEngine/tests/CMakeLists.txt)
+(the two `gtest_discover_tests` calls and `cmake/OloSuiteDiscovery.cmake`)
+passes `WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/OloEditor`, because many tests call
 `Shader::Create("assets/shaders/...")`.
 
 Running from the repo root also works — the engine finds those assets anyway, and
@@ -121,10 +122,28 @@ interleaved pairs, Debug:
 | repo root | 2.06 s |
 | `OloEditor/` | 0.71 s |
 
-That 1.35 s is per *process*, and `ctest` spawns one per case — which is why it
-sets the working directory rather than leaving it to chance. It is also the
-"~2 s" process startup quoted in the next section. `olo_tests_run` (issue #1130)
-runs its child from `OloEditor/` for the same reason.
+That 1.35 s is per *process*, and `ctest` spawns one per heavy case and one per
+light suite — which is why it sets the working directory rather than leaving it
+to chance. It is also the "~2 s" process startup quoted in the next section.
+`olo_tests_run` (issue #1130) runs its child from `OloEditor/` for the same reason.
+
+### How ctest slices the binary (three passes, one process each)
+
+Measured on the self-hosted Linux runners (ASan, 2026-09-12): 8,109 cases, 111 min
+of summed case time, and **7,785 cases under one second** — 83 of those minutes
+was the engine's per-process start-up (0.64 s a launch), paid once per case
+because every case used to be its own ctest entry. So the registration is now
+three disjoint passes over the one binary, each a gtest filter:
+
+| pass | cases | one process per | why |
+|---|---|---|---|
+| `OLO_MESH_CACHE_TESTS` (`gtest_discover_tests`) | a handful | case | share the on-disk mesh cache; serialised with `RESOURCE_LOCK`, weighted `PROCESSORS 2` |
+| `OLO_HEAVY_TESTS` (`gtest_discover_tests`) | ~560 | case | memory-heavy or long (visual evidence, GPU contracts, path tracer, fluids, benchmarks); `PROCESSORS 2` so `--parallel 4` never runs four of them, `COST 100` so they start first |
+| everything else (`cmake/OloSuiteDiscovery.cmake`) | ~7,600 | **suite** (`Suite.*`, sharded past 40 cases into `Suite.*[i/n]`) | their whole cost was start-up |
+
+A new heavy or long test goes into `OLO_HEAVY_TESTS` by suite pattern; a new light
+test needs nothing. The CI `--exclude-regex` lists are `^Suite\.` shaped and match
+both a per-case entry (`Suite.Case`) and a suite entry (`Suite.*`).
 
 ### Reproducing flaky CI-only core-starvation races
 
@@ -139,7 +158,7 @@ See the script header for parameters. Issue #281 (flaky Jolt physics-step crash)
 
 ## 6. Parallel-safety contract (`ctest --parallel`)
 
-CI runs the suite with `ctest --parallel` ([`.github/workflows/Windows.yml`](../../.github/workflows/Windows.yml)). Because `gtest_discover_tests` registers **every** `TEST` / `TEST_F` case as its own ctest entry, each case runs in its **own `OloEngine-Tests.exe` process** — and under `-j`, *different cases of the same fixture run concurrently in different processes*. Two rules follow for every test you write:
+CI runs the suite with `ctest --parallel` ([`.github/workflows/Windows.yml`](../../.github/workflows/Windows.yml)). The heavy set runs one case per **`OloEngine-Tests.exe` process** and the light majority one *suite* per process (see §5), so under `-j` *different suites — and different cases of a heavy fixture — run concurrently in different processes*, while the cases of a light suite run back to back in one. Two rules follow for every test you write (the first now also covers what a case leaves behind for the next case of its suite):
 
 ### 6.1 Never share a mutable OS resource between test cases
 


### PR DESCRIPTION
Stacked on #1207 (base is its branch; retarget to master once it merges).

## Summary

75 % of a Linux sanitizer test step on the box is the engine's per-process start-up: 7,785 of 8,109 cases take under a second, and each was its own ctest entry paying the 0.64 s launch (an empty run of the Debug binary on the dev box costs the same 0.62 s). #1207 widened the run; this removes most of the launches.

The registration is now **three disjoint passes** over the one binary:

| pass | cases | one process per |
|---|---|---|
| `OLO_MESH_CACHE_TESTS` (`gtest_discover_tests`) | a handful | case, serialised, weighted |
| `OLO_HEAVY_TESTS` (`gtest_discover_tests`) | ~560 | case, `PROCESSORS 2`, `COST 100` |
| everything else (`OloEngine/tests/cmake/OloSuiteDiscovery.cmake`) | 7,641 in 1,161 suites | **suite**: `--gtest_filter=<Suite>.*` minus the same exclusions, sharded past 40 cases via `GTEST_TOTAL_SHARDS` / `GTEST_SHARD_INDEX`, `TIMEOUT` scaled to the case count, `COST` equal to it |

1,741 ctest entries in all, down from 8,205. The heavy and crash-prone cases keep their own processes, which is where the cross-test state #1074 fixed used to hide.

## What stays the same for test authors

- `TempDir()` is still keyed per case beneath a per-process root; the renderer-state and GL-error listeners still restore between cases.
- `GTEST_OUTPUT` XML stays one record per case, so the CI test report and the GPU nightly's "did the GPU tests run" assertion see exactly what they saw.
- Suite entries are named `<Suite>.*`, the filter they run, so every `^Suite\.`-shaped `--exclude-regex` in the workflows keeps matching (verified: `NetworkIntegrationTest.*` and `WorkerRestartTest.*` drop out under the ASan exclude, 1,741 → 1,739).
- `ctest -N` totals still feed the shard-coverage proof unchanged; the Windows shards use `-I` over the same list.

What changes: a case's leaked process-global state is visible to the next case of its suite (the contract a local `--gtest_filter=Suite.*` run always had), and a crash takes the rest of its suite with it. Docs updated (`testing-architecture.md` §5 gets the three-pass table and §6's contract wording, README index line, the workflow comments that said one process per case).

Discovery runs as a `POST_BUILD` step like `gtest_discover_tests`, writes a per-config tests file included through `TEST_INCLUDE_FILES`, and the script is a `LINK_DEPENDS` of the target so an edit to it relinks and re-discovers (found the hard way: the first vetting run used stale names).

## Vetting

- Whole suite on the Windows dev box, Debug, `ctest -j6`, all GPU tests included: **1,738 entries, 100 % passed, 16 min wall** (3 disabled/skipped placeholders not run).
- Seven suite entries covering ~200 cases (`LuaBindingTest`, `McpDispatchTest`, `FastRandomTest`): 2.0 s, where the per-case form took ~40 s.
- Expected on the box, from #1207's profile: the 83 min of start-up becomes ~1,180 launches ≈ 13 min, so roughly 17–20 min per arm instead of 56 (before #1207) or ~35 (after it).

## Test plan

- [x] Local: entry count, no duplicates, exclude regex, sample run, full suite green.
- [ ] This PR's Linux arms: step times against #1207's, and the Test report still lists per-case results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved test execution efficiency by running lightweight test suites together in shared processes, while retaining isolated execution for heavy and mesh-cache tests.
  * Added automatic suite discovery and sharding for large suites to support faster, more scalable parallel test runs.

* **Documentation**
  * Updated testing guidance and workflow comments to reflect the revised test execution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->